### PR TITLE
fix(sdk): restore room avatar caching for bookmarked rooms

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -993,13 +993,14 @@ describe('XMPPClient', () => {
       expect(fetchRoomAvatarSpy).toHaveBeenCalledWith('room@conference.example.com')
     })
 
-    it('should wire roomAvatarUpdate to profile.fetchRoomAvatar', async () => {
+    it('should wire roomAvatarUpdate to profile.fetchRoomAvatar with hash', async () => {
       const fetchRoomAvatarSpy = vi.spyOn(xmppClient.profile, 'fetchRoomAvatar').mockResolvedValue()
 
       // Emit roomAvatarUpdate
       ;(xmppClient as any).emit('roomAvatarUpdate', 'room@conference.example.com', 'newhash123')
 
-      expect(fetchRoomAvatarSpy).toHaveBeenCalledWith('room@conference.example.com')
+      // Should pass the hash to fetchRoomAvatar for cache lookup
+      expect(fetchRoomAvatarSpy).toHaveBeenCalledWith('room@conference.example.com', 'newhash123')
     })
 
     it('should NOT call fetchRoomAvatar on mucJoined if room already has avatar from presence', async () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -488,8 +488,8 @@ export class XMPPClient {
       })
 
       // Listen for room avatar updates from presence
-      this.on('roomAvatarUpdate', (roomJid, _photoHash) => {
-        this.profile.fetchRoomAvatar(roomJid).catch(() => {})
+      this.on('roomAvatarUpdate', (roomJid, photoHash) => {
+        this.profile.fetchRoomAvatar(roomJid, photoHash).catch(() => {})
       })
 
       // Listen for avatar metadata updates (XEP-0084)
@@ -1097,6 +1097,9 @@ export class XMPPClient {
     // Continue setup for new sessions
     if (!isResumption) {
       const { roomsToAutojoin } = await this.muc.fetchBookmarks()
+
+      // Restore cached room avatars for bookmarked rooms
+      this.profile.restoreAllRoomAvatarHashes().catch(() => {})
 
       // Rejoin rooms BEFORE server info fetch - server info can block on slow/unresponsive servers
       // Two scenarios: reconnect (previouslyJoinedRooms provided) vs fresh connect


### PR DESCRIPTION
Room avatars were not being cached to IndexedDB, causing them to disappear after leaving a room or restarting the app. The issue was:

1. fetchRoomAvatar() didn't cache avatars or save hash mappings
2. The roomAvatarUpdate event handler ignored the hash from presence
3. No restoreAllRoomAvatarHashes() method existed (unlike contacts)

Changes:
- fetchRoomAvatar(): Accept optional knownHash param, check cache first, cache avatar blob, save hash mapping to IndexedDB
- Add restoreAllRoomAvatarHashes() to restore cached avatars for bookmarked rooms on app startup (mirrors contact avatar restoration)
- Pass hash from presence to fetchRoomAvatar in roomAvatarUpdate handler
- Call restoreAllRoomAvatarHashes() after fetchBookmarks()

Add 7 unit tests covering room avatar caching scenarios.