### PR TITLE
fix(tauri): check isTauri dynamically to fix CORS upload errors

### DIFF
--- a/apps/fluux/src/hooks/useFileUpload.ts
+++ b/apps/fluux/src/hooks/useFileUpload.ts
@@ -14,8 +14,14 @@ import {
   type ThumbnailResult,
 } from '@/utils/thumbnail'
 
-// Detect if running in Tauri
-const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+/**
+ * Check if running in Tauri dynamically.
+ * IMPORTANT: Must be checked at call time, not module load time,
+ * because __TAURI_INTERNALS__ may not be available when the module first loads.
+ */
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+}
 
 interface UploadState {
   isUploading: boolean
@@ -284,7 +290,7 @@ async function uploadWithProgress(
   headers?: Record<string, string>,
   onProgress?: (progress: number) => void
 ): Promise<void> {
-  if (isTauri) {
+  if (isTauri()) {
     return uploadWithTauri(url, file, contentType, headers, onProgress)
   }
   return uploadWithXHR(url, file, contentType, headers, onProgress)


### PR DESCRIPTION
## Summary

- Fix CORS errors when uploading files in Tauri desktop app
- The `isTauri` check was evaluated at module load time, before Tauri's `__TAURI_INTERNALS__` was available
- Changed from a constant to a function that checks dynamically at call time
- Now file uploads correctly use `tauri-plugin-http` which bypasses CORS restrictions