### PR TITLE
feat(sdk): add 'verifying' connection status for wake-from-sleep UX

### DIFF
--- a/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
+++ b/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
@@ -213,6 +213,15 @@ export function StatusDisplay({
 }: StatusDisplayProps) {
   const { t } = useTranslation()
 
+  if (status === 'verifying') {
+    return (
+      <p className="text-xs text-fluux-yellow truncate flex items-center gap-1">
+        <RefreshCw className="w-3 h-3 animate-spin" />
+        {t('status.verifying')}
+      </p>
+    )
+  }
+
   if (status === 'reconnecting') {
     return (
       <p className="text-xs text-fluux-yellow truncate flex items-center gap-1">

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -73,6 +73,7 @@
     "reconnecting": "Verbindung wird wiederhergestellt...",
     "reconnectingIn": "Erneuter Verbindungsversuch in {{seconds}}s (Versuch {{attempt}})",
     "connecting": "Verbinden...",
+    "verifying": "Verbindung wird überprüft...",
     "connectionError": "Verbindungsfehler",
     "disconnected": "Getrennt",
     "cancelReconnection": "Wiederverbindung abbrechen"

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -73,6 +73,7 @@
     "reconnecting": "Reconnecting...",
     "reconnectingIn": "Reconnecting in {{seconds}}s (attempt {{attempt}})",
     "connecting": "Connecting...",
+    "verifying": "Verifying connection...",
     "connectionError": "Connection error",
     "disconnected": "Disconnected",
     "cancelReconnection": "Cancel reconnection"

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -73,6 +73,7 @@
     "reconnecting": "Reconectando...",
     "reconnectingIn": "Reconectando en {{seconds}}s (intento {{attempt}})",
     "connecting": "Conectando...",
+    "verifying": "Verificando conexión...",
     "connectionError": "Error de conexion",
     "disconnected": "Desconectado",
     "cancelReconnection": "Cancelar reconexion",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -73,6 +73,7 @@
     "reconnecting": "Reconnexion...",
     "reconnectingIn": "Reconnexion dans {{seconds}}s (tentative {{attempt}})",
     "connecting": "Connexion...",
+    "verifying": "Vérification de la connexion...",
     "connectionError": "Erreur de connexion",
     "disconnected": "Déconnecté",
     "cancelReconnection": "Annuler la reconnexion"

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -73,6 +73,7 @@
     "reconnecting": "Riconnessione...",
     "reconnectingIn": "Riconnessione tra {{seconds}}s (tentativo {{attempt}})",
     "connecting": "Connessione...",
+    "verifying": "Verifica connessione...",
     "connectionError": "Errore di connessione",
     "disconnected": "Disconnesso",
     "cancelReconnection": "Annulla riconnessione"

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -73,6 +73,7 @@
     "reconnecting": "Opnieuw verbinden...",
     "reconnectingIn": "Opnieuw verbinden over {{seconds}}s (poging {{attempt}})",
     "connecting": "Verbinden...",
+    "verifying": "Verbinding verifiëren...",
     "connectionError": "Verbindingsfout",
     "disconnected": "Verbinding verbroken",
     "cancelReconnection": "Opnieuw verbinden annuleren"

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -73,6 +73,7 @@
     "reconnecting": "Ponowne laczenie...",
     "reconnectingIn": "Ponowne laczenie za {{seconds}}s (proba {{attempt}})",
     "connecting": "Laczenie...",
+    "verifying": "Weryfikacja połączenia...",
     "connectionError": "Blad polaczenia",
     "disconnected": "Rozlaczony",
     "cancelReconnection": "Anuluj ponowne laczenie"

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -73,6 +73,7 @@
     "reconnecting": "A reconectar...",
     "reconnectingIn": "A reconectar em {{seconds}}s (tentativa {{attempt}})",
     "connecting": "A ligar...",
+    "verifying": "A verificar ligação...",
     "connectionError": "Erro de ligação",
     "disconnected": "Desligado",
     "cancelReconnection": "Cancelar reconexão"

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -449,6 +449,12 @@ export class Connection extends BaseModule {
   async verifyConnection(): Promise<boolean> {
     if (!this.xmpp) return false
 
+    // Set status to 'verifying' to show we're checking connection health
+    const previousStatus = this.stores.connection.getStatus()
+    if (previousStatus === 'online') {
+      this.stores.connection.setStatus('verifying')
+    }
+
     try {
       // Send a Stream Management request (<r/>) if available, otherwise a ping
       const sm = this.xmpp.streamManagement as any
@@ -463,6 +469,11 @@ export class Connection extends BaseModule {
           xml('ping', { xmlns: 'urn:xmpp:ping' })
         )
         await this.xmpp.send(ping)
+      }
+
+      // Connection verified - restore to online
+      if (this.stores.connection.getStatus() === 'verifying') {
+        this.stores.connection.setStatus('online')
       }
       return true
     } catch (err) {

--- a/packages/fluux-sdk/src/core/types/connection.ts
+++ b/packages/fluux-sdk/src/core/types/connection.ts
@@ -12,11 +12,13 @@
  * Status transitions:
  * - `disconnected` → `connecting` → `online`
  * - `online` → `reconnecting` → `online` (on temporary disconnect)
+ * - `online` → `verifying` → `online` (after wake from sleep, connection alive)
+ * - `online` → `verifying` → `reconnecting` (after wake from sleep, connection dead)
  * - `online` → `error` → `disconnected` (on fatal error)
  *
  * @category Connection
  */
-export type ConnectionStatus = 'disconnected' | 'connecting' | 'online' | 'reconnecting' | 'error'
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'online' | 'reconnecting' | 'verifying' | 'error'
 
 /**
  * System state changes that the app can signal to the SDK.


### PR DESCRIPTION
## Summary

After waking from sleep, the WebSocket connection may be stale but there's no immediate TCP error. The app was incorrectly showing "Online" status during the ~1 minute window where the connection health is being verified.

This PR adds a new `verifying` connection status that provides honest UX feedback:

- **Before:** `online` → (dead socket detected) → `reconnecting`
- **After:** `online` → `verifying` → `online` (if alive) or `reconnecting` (if dead)

## Changes

- Add `'verifying'` to `ConnectionStatus` type with documentation
- Update `verifyConnection()` to set/restore status appropriately
- Update `StatusDisplay` in PresenceSelector to show spinner with "Verifying connection..."
- Add i18n translations for all 8 locales (en, fr, de, es, it, nl, pl, pt)
- Add unit tests for status transitions