### PR TITLE
fix(sdk): skip retraction/correction/reaction messages in MAM preview

### DIFF
--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -703,6 +703,9 @@ export class MAM extends BaseModule {
     onMessage: (forwarded: Element, messageEl: Element) => void
   ): (stanza: Element) => void {
     return (stanza: Element) => {
+      // Skip error stanzas - server may return error with stale MAM result inside
+      if (stanza.attrs.type === 'error') return
+
       const result = stanza.getChild('result', NS_MAM)
       if (!result || result.attrs.queryid !== queryId) return
 
@@ -878,6 +881,12 @@ export class MAM extends BaseModule {
     const from = messageEl.attrs.from
     const body = messageEl.getChildText('body')
 
+    // Skip modification messages (retractions, corrections, reactions)
+    // These are handled separately by detectAndCollectModification()
+    if (messageEl.getChild('retract', NS_RETRACT)) return null
+    if (messageEl.getChild('replace', NS_CORRECTION)) return null
+    if (messageEl.getChild('reactions', NS_REACTIONS)) return null
+
     // Accept messages with body OR OOB attachment (file-only messages have no body)
     if (!from) return null
     if (!body && !messageEl.getChild('x', NS_OOB)) return null
@@ -912,6 +921,12 @@ export class MAM extends BaseModule {
 
     const from = messageEl.attrs.from
     const body = messageEl.getChildText('body')
+
+    // Skip modification messages (retractions, corrections, reactions)
+    // These are handled separately by detectAndCollectModification()
+    if (messageEl.getChild('retract', NS_RETRACT)) return null
+    if (messageEl.getChild('replace', NS_CORRECTION)) return null
+    if (messageEl.getChild('reactions', NS_REACTIONS)) return null
 
     // Accept messages with body OR OOB attachment (file-only messages have no body)
     if (!from) return null


### PR DESCRIPTION
## Summary

Three fixes to prevent modification message fallback bodies from displaying:

1. **Skip error stanzas in `createMessageCollector()`**
   - Server may return error with stale MAM result inside (e.g., when not yet joined to room)
   - These error results should be ignored

2. **Skip modification messages in `parseArchiveMessage()` (1:1 chat)**
   - Check for `<retract>`, `<replace>`, `<reactions>` elements before parsing

3. **Skip modification messages in `parseRoomArchiveMessage()` (MUC room)**
   - Same checks for room messages

This prevents the retraction fallback body ("This person attempted to retract a previous message, but it's unsupported by your client.") from being displayed as conversation preview or in the main message view.

The fix addresses both the sidebar preview and the main conversation view.