### PR TITLE
feat(sdk): make Quick Chat room history transient with XEP-0334 noStore hint

### DIFF
--- a/SUPPORTED_XEPS.md
+++ b/SUPPORTED_XEPS.md
@@ -65,7 +65,7 @@ This document lists the XMPP Extension Protocols (XEPs) and related RFCs impleme
 | [XEP-0203](https://xmpp.org/extensions/xep-0203.html) | Delayed Delivery | ✅ Implemented | Offline message timestamps |
 | [XEP-0297](https://xmpp.org/extensions/xep-0297.html) | Stanza Forwarding | ✅ Implemented | Used by Message Carbons |
 | [XEP-0313](https://xmpp.org/extensions/xep-0313.html) | Message Archive Management | ✅ Implemented | History fetch for 1:1 chats and MUC rooms with scroll-up lazy loading, IndexedDB caching with MAM fallback, RSM pagination |
-| [XEP-0334](https://xmpp.org/extensions/xep-0334.html) | Message Processing Hints | ✅ Implemented | Used for chat states and reactions (no-store hint to avoid MAM archival) |
+| [XEP-0334](https://xmpp.org/extensions/xep-0334.html) | Message Processing Hints | ✅ Implemented | `<no-store/>` hint for transient messages (Quick Chat rooms), chat states and reactions |
 
 ## PubSub & PEP
 

--- a/packages/fluux-sdk/src/core/sideEffects.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.ts
@@ -272,6 +272,12 @@ export function setupRoomSideEffects(
         return
       }
 
+      // Quick Chat rooms don't persist history - skip cache loading
+      if (room.isQuickChat) {
+        if (debug) console.log('[SideEffects] Room: Skipping cache for Quick Chat')
+        return
+      }
+
       // Already loaded for this room
       if (cacheLoaded.has(activeRoomJid)) {
         if (debug) console.log('[SideEffects] Room: Cache already loaded')

--- a/packages/fluux-sdk/src/core/types/message-base.ts
+++ b/packages/fluux-sdk/src/core/types/message-base.ts
@@ -65,4 +65,10 @@ export interface BaseMessage {
   attachment?: FileAttachment
   /** XEP-0422 + OGP: Link preview metadata for URLs in message */
   linkPreview?: LinkPreview
+  /**
+   * XEP-0334: Message Processing Hint - do not store this message.
+   * When true, the message should not be persisted to local cache or server archives.
+   * Automatically set for messages in Quick Chat (transient) rooms.
+   */
+  noStore?: boolean
 }

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -377,8 +377,9 @@ export function useRoom() {
         getActiveId: () => roomStore.getState().activeRoomJid,
         isValidTarget: (id) => {
           // Room just needs to exist - MAM queries don't require being joined
+          // Quick Chat rooms don't persist history, so skip MAM for them
           const room = roomStore.getState().rooms.get(id)
-          return !!room
+          return !!room && !room.isQuickChat
         },
         getMAMState: (id) => roomStore.getState().getRoomMAMQueryState(id),
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),


### PR DESCRIPTION
## Summary

- Add `noStore?: boolean` property to `BaseMessage` following XEP-0334 `<no-store/>` hint semantics
- Messages with `noStore: true` are not persisted to IndexedDB cache
- Quick Chat rooms automatically set `noStore: true` on all their messages
- Unread counts still increment normally (noStore only affects storage, not UI behavior)

## Changes

**Type changes:**
- `BaseMessage`: Add `noStore?: boolean` for XEP-0334 hint

**Store changes (chatStore & roomStore):**
- `addMessage`: Check `noStore` before saving to IndexedDB
- `mergeMAMMessages`: Filter out `noStore` messages before batch save
- `roomStore.addMessage`: Set `noStore=true` on messages for Quick Chat rooms

**Side effects:**
- Skip cache loading for Quick Chat rooms
- Skip MAM queries for Quick Chat rooms

**Tests:** 9 new tests covering noStore behavior in both stores

**Docs:** Updated XEP-0334 description in SUPPORTED_XEPS.md