### PR TITLE
fix: show unique user count in room header instead of connection count

### DIFF
--- a/apps/fluux/src/components/RoomHeader.test.tsx
+++ b/apps/fluux/src/components/RoomHeader.test.tsx
@@ -75,6 +75,18 @@ vi.mock('@/utils/messageStyles', () => ({
 // Mock SDK
 vi.mock('@fluux/sdk', () => ({
   generateConsistentColorHexSync: () => '#4a90d9',
+  getUniqueOccupantCount: (occupants: Iterable<{ jid?: string }>) => {
+    const bareJids = new Set<string>()
+    let noJidCount = 0
+    for (const occ of occupants) {
+      if (occ.jid) {
+        bareJids.add(occ.jid.split('/')[0])
+      } else {
+        noJidCount++
+      }
+    }
+    return bareJids.size + noJidCount
+  },
 }))
 
 // Helper to create a test room
@@ -238,9 +250,9 @@ describe('RoomHeader', () => {
     it('shows occupant count', () => {
       const room = createRoom({
         occupantsList: [
-          createOccupant({ nick: 'Alice' }),
-          createOccupant({ nick: 'Bob' }),
-          createOccupant({ nick: 'Me' }),
+          createOccupant({ nick: 'Alice', jid: 'alice@example.com' }),
+          createOccupant({ nick: 'Bob', jid: 'bob@example.com' }),
+          createOccupant({ nick: 'Me', jid: 'me@example.com' }),
         ],
       })
 

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -6,10 +6,10 @@
  * - Room management (owners/admins): settings, subject, avatar, members
  * - Occupant panel toggle
  */
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Room } from '@fluux/sdk'
-import { generateConsistentColorHexSync } from '@fluux/sdk'
+import { generateConsistentColorHexSync, getUniqueOccupantCount } from '@fluux/sdk'
 import { Avatar } from './Avatar'
 import { Tooltip } from './Tooltip'
 import { useWindowDrag, useClickOutside } from '@/hooks'
@@ -87,6 +87,12 @@ export function RoomHeader({
     return 'mentions'
   }
   const notifyMode = getNotifyMode()
+
+  // Count unique users by bare JID (multiple connections from same user count as one)
+  const uniqueOccupantCount = useMemo(
+    () => getUniqueOccupantCount(room.occupants.values()),
+    [room.occupants]
+  )
 
   // Get icon based on mode
   const NotifyIcon = notifyMode === 'mentions' ? BellOff
@@ -369,7 +375,7 @@ export function RoomHeader({
           aria-label={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')}
         >
           <Users className="w-4 h-4" />
-          <span className="text-sm font-medium">{room.occupants.size}</span>
+          <span className="text-sm font-medium">{uniqueOccupantCount}</span>
           <ChevronRight className={`w-4 h-4 transition-transform ${showOccupants ? '' : 'rotate-180'}`} />
         </button>
       </Tooltip>

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -103,6 +103,18 @@ vi.mock('@fluux/sdk', () => ({
     isConnected: true,
   }),
   getBareJid: (jid: string) => jid.split('/')[0],
+  getUniqueOccupantCount: (occupants: Iterable<{ jid?: string }>) => {
+    const bareJids = new Set<string>()
+    let noJidCount = 0
+    for (const occ of occupants) {
+      if (occ.jid) {
+        bareJids.add(occ.jid.split('/')[0])
+      } else {
+        noJidCount++
+      }
+    }
+    return bareJids.size + noJidCount
+  },
   generateConsistentColorHexSync: () => '#4a90d9',
   getBestPresenceShow: () => 'online',
   getPresenceFromShow: () => 'online',
@@ -417,8 +429,8 @@ describe('RoomView', () => {
       mockActiveRoom = createRoom({
         joined: false,
         occupantsList: [
-          createOccupant({ nick: 'Alice' }),
-          createOccupant({ nick: 'Bob' }),
+          createOccupant({ nick: 'Alice', jid: 'alice@example.com' }),
+          createOccupant({ nick: 'Bob', jid: 'bob@example.com' }),
         ],
       })
 

--- a/packages/fluux-sdk/src/core/jid.test.ts
+++ b/packages/fluux-sdk/src/core/jid.test.ts
@@ -8,6 +8,7 @@ import {
   splitFullJid,
   hasResource,
   createFullJid,
+  getUniqueOccupantCount,
 } from './jid'
 
 describe('JID utilities', () => {
@@ -219,6 +220,39 @@ describe('JID utilities', () => {
 
     it('should handle MUC JID', () => {
       expect(createFullJid('room@conf.example.com', 'nickname')).toBe('room@conf.example.com/nickname')
+    })
+  })
+
+  describe('getUniqueOccupantCount', () => {
+    it('should count unique users by bare JID', () => {
+      const occupants = [
+        { jid: 'alice@example.com/mobile' },
+        { jid: 'alice@example.com/desktop' },
+        { jid: 'bob@example.com/web' },
+      ]
+      expect(getUniqueOccupantCount(occupants)).toBe(2)
+    })
+
+    it('should count occupants without JID individually', () => {
+      const occupants = [
+        { jid: 'alice@example.com' },
+        { jid: undefined },
+        { jid: undefined },
+      ]
+      expect(getUniqueOccupantCount(occupants)).toBe(3)
+    })
+
+    it('should return 0 for empty list', () => {
+      expect(getUniqueOccupantCount([])).toBe(0)
+    })
+
+    it('should work with Map values iterator', () => {
+      const map = new Map([
+        ['Alice', { jid: 'alice@example.com/mobile' }],
+        ['Alice2', { jid: 'alice@example.com/desktop' }],
+        ['Bob', { jid: 'bob@example.com' }],
+      ])
+      expect(getUniqueOccupantCount(map.values())).toBe(2)
     })
   })
 })

--- a/packages/fluux-sdk/src/core/jid.ts
+++ b/packages/fluux-sdk/src/core/jid.ts
@@ -143,6 +143,33 @@ export function isQuickChatJid(roomJid: string): boolean {
 }
 
 /**
+ * Count unique users from an iterable of occupants by bare JID.
+ * Multiple connections from the same user (same bare JID) are counted once.
+ * Occupants without a JID are each counted individually.
+ *
+ * @param occupants - Iterable of objects with optional jid field
+ * @returns Number of unique users
+ *
+ * @example
+ * ```typescript
+ * const count = getUniqueOccupantCount(room.occupants.values())
+ * // 2 connections from alice@example.com + 1 from bob@example.com = 2
+ * ```
+ */
+export function getUniqueOccupantCount(occupants: Iterable<{ jid?: string }>): number {
+  const bareJids = new Set<string>()
+  let noJidCount = 0
+  for (const occupant of occupants) {
+    if (occupant.jid) {
+      bareJids.add(getBareJid(occupant.jid))
+    } else {
+      noJidCount++
+    }
+  }
+  return bareJids.size + noJidCount
+}
+
+/**
  * Check if a search query matches a JID by username only (not domain).
  * This prevents matching on common domains like "example.com" or "gmail.com".
  *

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -307,6 +307,7 @@ export {
   createFullJid,
   matchJidUsername,
   matchNameOrJid,
+  getUniqueOccupantCount,
 } from './core/jid'
 export type { ParsedJid } from './core/jid'
 


### PR DESCRIPTION
## Summary

- Fix room header showing total occupant entries (nicks) instead of unique users when a user has multiple connections (e.g. mobile + desktop)
- Add `getUniqueOccupantCount()` SDK utility that deduplicates by bare JID
- Header count now matches the occupant panel which already groups by bare JID