### PR TITLE
fix(sdk): prevent MUC room JIDs from being added to roster

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -1,6 +1,7 @@
 import { xml, Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
 import { getBareJid, getLocalPart, getResource } from '../jid'
+import { isMucJid } from '../../utils/xmppUri'
 import { generateUUID } from '../../utils/uuid'
 import { calculateCapsHash, getCapsNode } from '../caps'
 import { getClientName } from '../clients'
@@ -148,6 +149,11 @@ export class Roster extends BaseModule {
   }
 
   private handleSubscribe(bareFrom: string): void {
+    // Ignore subscription requests from MUC JIDs - rooms should never be contacts
+    if (isMucJid(bareFrom)) {
+      return
+    }
+
     // Auto-accept if they're already in our roster (mutual subscription flow)
     if (this.deps.stores?.roster.hasContact(bareFrom)) {
       this.deps.sendStanza(xml('presence', { to: bareFrom, type: 'subscribed' }))


### PR DESCRIPTION
## Summary

When accepting a MUC room invitation, the room JID was incorrectly being added to the roster as a contact, appearing in both "Messages" and "Contacts" views.

This happened due to three issues:

1. **Missing invite 'from' attribute**: Mediated invitations (XEP-0045) with missing `from` attribute on the `<invite>` element weren't being processed, causing them to fall through to stranger message handling

2. **MUC JIDs as stranger messages**: Messages from MUC JIDs not in roster were treated as stranger messages, triggering roster addition prompts

3. **MUC subscription requests**: Subscription requests from MUC JIDs weren't filtered out

## Fixes

- Use room JID as fallback when invite `from` attribute is missing
- Add `isMucJid()` check before treating messages as stranger messages
- Add `isMucJid()` check to ignore subscription requests from MUC JIDs

## Testing

Added tests for:
- Mediated invitation with missing `from` attribute
- MUC JID not being treated as stranger message
- Subscription requests from MUC JIDs being ignored
- Regular subscription requests still being processed