### PR TITLE
fix(ci): use correct binary path for native Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,8 @@ jobs:
       - name: Build Tauri binary
         run: |
           cd apps/fluux
-          npm run tauri build -- --target ${{ matrix.target }} --no-bundle
+          # Native build on matching runner (x86 on ubuntu-22.04, arm on ubuntu-22.04-arm)
+          npm run tauri build -- --no-bundle
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -219,7 +220,8 @@ jobs:
       - name: Build .deb package
         run: |
           # Point to pre-built binary (debian/rules will skip build)
-          export FLUUX_BINARY="apps/fluux/src-tauri/target/${{ matrix.target }}/release/fluux"
+          # Native builds output to target/release/, not target/<triple>/release/
+          export FLUUX_BINARY="apps/fluux/src-tauri/target/release/fluux"
 
           # Update debian/changelog version from release tag
           VERSION="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## Summary

- Fix .deb build failing because binary path was incorrect
- Native builds output to `target/release/` not `target/<triple>/release/`
- Remove unnecessary `--target` flag since each arch runs on matching native runner