### PR TITLE
fix(ux): show avatar in reply quotes for own messages and fallbacks

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -427,6 +427,7 @@ const ChatMessageList = memo(function ChatMessageList({
       message={msg}
       showAvatar={shouldShowAvatar(groupMessages, idx)}
       avatar={msg.isOutgoing ? ownAvatar ?? undefined : contactsByJid.get(msg.from)?.avatar}
+      ownAvatar={ownAvatar}
       ownNickname={ownNickname}
       ownPresence={ownPresence}
       conversationId={conversationId}
@@ -490,6 +491,7 @@ interface ChatMessageBubbleProps {
   message: Message
   showAvatar: boolean
   avatar?: string
+  ownAvatar?: string | null
   ownNickname?: string | null
   ownPresence?: 'online' | 'away' | 'dnd' | 'offline'
   conversationId: string
@@ -520,6 +522,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   message,
   showAvatar,
   avatar,
+  ownAvatar,
   ownNickname,
   ownPresence,
   conversationId,
@@ -600,6 +603,13 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     },
     (originalMsg, fallbackId) => {
       const senderId = originalMsg?.from.split('/')[0] || fallbackId?.split('/')[0]
+      // If the quoted message is from the current user, use own avatar
+      if (senderId === myBareJid) {
+        return {
+          avatarUrl: ownAvatar || undefined,
+          avatarIdentifier: senderId || 'unknown',
+        }
+      }
       const contact = senderId ? contactsByJid.get(senderId) : undefined
       return {
         avatarUrl: contact?.avatar,
@@ -607,7 +617,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       }
     },
     isDarkMode
-  ), [message, messagesById, contactsByJid, isDarkMode])
+  ), [message, messagesById, contactsByJid, isDarkMode, myBareJid, ownAvatar])
 
   // Get reactor display name (contact name, or username if not in roster)
   const getReactorName = useCallback((jid: string) => {

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -615,6 +615,13 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
     },
     (originalMsg, fallbackId) => {
       const nick = originalMsg?.nick || (fallbackId ? fallbackId.split('/').pop() : undefined)
+      // If the quoted message is from the current user, use own avatar
+      if (nick === myNick) {
+        return {
+          avatarUrl: ownAvatar || undefined,
+          avatarIdentifier: nick || 'unknown',
+        }
+      }
       // Try to get contact avatar if occupant's real JID is known
       const occupantForReply = nick ? room.occupants.get(nick) : undefined
       const senderBareJid = occupantForReply?.jid
@@ -627,7 +634,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
       }
     },
     isDarkMode
-  ), [message, messagesById, isDarkMode, room.occupants, room.nickToJidCache, contactsByJid])
+  ), [message, messagesById, isDarkMode, room.occupants, room.nickToJidCache, contactsByJid, myNick, ownAvatar])
 
   // Get reactor display name (for rooms, nicks are shown as-is)
   // Note: MAM-loaded reactions may use full MUC JID (room@server/nick), so extract nick

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -297,16 +297,13 @@ export const MessageBubble = memo(function MessageBubble({
             className="flex items-start gap-1.5 pb-1 pl-2 border-l-2 border-fluux-brand text-left w-full hover:bg-fluux-hover/50 rounded-r transition-colors cursor-pointer select-none"
           >
             <CornerUpLeft className="w-3.5 h-3.5 text-fluux-muted flex-shrink-0 mt-0.5" />
-            {/* Only show avatar if we have an actual image, not just the default fallback */}
-            {replyContext.avatarUrl && (
-              <Avatar
-                identifier={replyContext.avatarIdentifier}
-                name={replyContext.senderName}
-                avatarUrl={replyContext.avatarUrl}
-                size="xs"
-                className="flex-shrink-0"
-              />
-            )}
+            <Avatar
+              identifier={replyContext.avatarIdentifier}
+              name={replyContext.senderName}
+              avatarUrl={replyContext.avatarUrl}
+              size="xs"
+              className="flex-shrink-0"
+            />
             <div className="text-sm text-fluux-muted min-w-0 flex-1">
               <span
                 className="font-medium"


### PR DESCRIPTION
## Summary

- Always render Avatar component in reply quotes (shows letter fallback when no image URL)
- Use own avatar when the quoted message is from the current user
- Fixes avatar display for users without custom avatars
