### PR TITLE
fix(sdk): silence item-not-found error when room has no avatar

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -206,7 +206,11 @@ export class Profile extends BaseModule {
         })
       }
     } catch (err) {
-      console.error('Failed to fetch room avatar:', err)
+      // item-not-found is expected when a room has no avatar set
+      const isNotFound = err instanceof Error && err.message.includes('item-not-found')
+      if (!isNotFound) {
+        console.error('Failed to fetch room avatar:', err)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Rooms without avatars return `item-not-found` from vCard queries, which is expected behavior
- Only log actual errors to console, not missing avatar data