### PR TITLE
feat(sdk): sort MUC rooms by last message time with read-to-update behavior

### DIFF
--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -169,6 +169,13 @@ export interface RoomMetadata {
   firstNewMessageId?: string
   /** Most recent message for sidebar preview */
   lastMessage?: RoomMessage
+  /**
+   * When user last interacted with this room (opened it).
+   * Used for sorting rooms in sidebar - rooms sort by this timestamp
+   * so high-traffic rooms don't constantly jump to the top.
+   * Only updates when user explicitly opens the room, not when messages arrive.
+   */
+  lastInteractedAt?: Date
 }
 
 /**


### PR DESCRIPTION
## Summary

Implement Conversations-style room ordering in the sidebar where:
- Rooms are sorted by their last message timestamp (most recent first)
- BUT a room's position only updates when the user opens (reads) it
- New incoming messages do NOT cause rooms to jump to the top
- This prevents high-traffic rooms from constantly dominating the list