### PR TITLE
fix(mobile): improve mobile layout on e/OS and Android

### DIFF
--- a/apps/fluux/index.html
+++ b/apps/fluux/index.html
@@ -3,11 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Fluux Messenger</title>
 
-    <!-- PWA Meta Tags -->
-    <meta name="theme-color" content="#4a90d9" />
+    <!-- PWA Meta Tags - theme-color for Android status bar -->
+    <!-- Dark mode (default) -->
+    <meta name="theme-color" content="#1e1f22" media="(prefers-color-scheme: dark)" />
+    <!-- Light mode -->
+    <meta name="theme-color" content="#e3e5e8" media="(prefers-color-scheme: light)" />
+    <!-- Fallback for browsers that don't support media queries in meta -->
+    <meta name="theme-color" content="#1e1f22" />
     <meta name="description" content="Modern XMPP chat client - pleasant to use" />
 
     <!-- iOS PWA -->

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -133,6 +133,18 @@ html, body {
   height: 100%;
 }
 
+/* Safe area insets for mobile devices with gesture bars (e/OS, iOS, etc.) */
+/* This allows the app background to extend behind the gesture bar while */
+/* keeping interactive content above it */
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  body {
+    /* Extend background into safe areas */
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+}
+
 /* Allow native rubber band effect within scrollable elements (macOS) */
 /* Using 'auto' enables the visual bounce, while 'none' on html/body prevents whole-page bounce */
 /* -webkit-overflow-scrolling: touch enables momentum/bounce scrolling in WebKit */


### PR DESCRIPTION
## Summary

Fix mobile appearance issues on e/OS (Murena) and Android devices:

### Bottom gesture bar
The system gesture bar at the bottom was showing as a white area instead of blending with the app.

- Add `viewport-fit=cover` to viewport meta tag to allow app to extend into safe areas
- Add CSS safe area inset padding to body so content stays above gesture bar while background extends behind it

### Top status bar  
The Android status bar was light blue (`#4a90d9`) instead of matching the app's theme colors.

- Update `theme-color` meta tags to match app background colors
- Dark mode: `#1e1f22`
- Light mode: `#e3e5e8`
- Use CSS media queries for automatic theme detection