### PR TITLE
fix(mobile): sync Android status bar color with app theme setting

### DIFF
--- a/apps/fluux/index.html
+++ b/apps/fluux/index.html
@@ -7,12 +7,13 @@
     <title>Fluux Messenger</title>
 
     <!-- PWA Meta Tags - theme-color for Android status bar -->
+    <!-- Using bg-secondary colors to match icon rail (darker area at top-left) -->
     <!-- Dark mode (default) -->
-    <meta name="theme-color" content="#1e1f22" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#1a1b1e" media="(prefers-color-scheme: dark)" />
     <!-- Light mode -->
-    <meta name="theme-color" content="#e3e5e8" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#d8dadf" media="(prefers-color-scheme: light)" />
     <!-- Fallback for browsers that don't support media queries in meta -->
-    <meta name="theme-color" content="#1e1f22" />
+    <meta name="theme-color" content="#1a1b1e" />
     <meta name="description" content="Modern XMPP chat client - pleasant to use" />
 
     <!-- iOS PWA -->

--- a/apps/fluux/src/hooks/useMode.ts
+++ b/apps/fluux/src/hooks/useMode.ts
@@ -1,6 +1,13 @@
 import { useEffect } from 'react'
 import { useSettingsStore, type ThemeMode } from '@/stores/settingsStore'
 
+/** Theme colors for status bar - using bg-secondary for better visual continuity */
+/** In dark mode, this matches the icon rail which is at the top-left corner */
+const THEME_COLORS = {
+  dark: '#1a1b1e',  // --fluux-bg-secondary (darker, matches icon rail)
+  light: '#d8dadf', // --fluux-bg-secondary for light mode
+} as const
+
 /**
  * Resolves the actual mode (light/dark) based on setting and system preference
  */
@@ -9,6 +16,18 @@ function resolveMode(mode: ThemeMode): 'light' | 'dark' {
     return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
   }
   return mode
+}
+
+/**
+ * Updates the theme-color meta tag to match the current mode.
+ * This controls the Android status bar color and PWA title bar color.
+ */
+function updateThemeColorMeta(resolved: 'light' | 'dark') {
+  const color = THEME_COLORS[resolved]
+  // Update all theme-color meta tags (there may be multiple with media queries)
+  document.querySelectorAll('meta[name="theme-color"]').forEach((meta) => {
+    meta.setAttribute('content', color)
+  })
 }
 
 /**
@@ -35,6 +54,9 @@ export function useMode() {
         root.classList.add('light')
       }
       // No class needed for dark (it's the default in :root)
+
+      // Sync Android/PWA status bar color with app theme
+      updateThemeColorMeta(resolved)
     }
 
     applyMode()


### PR DESCRIPTION
## Summary

Fix mismatch between Android status bar color and app theme.

### Problem
The `theme-color` meta tag was using CSS media queries (`prefers-color-scheme`) to detect the **system** preference, but the app has its own theme setting. This caused mismatches where:
- System is in light mode + user configured dark theme → light status bar, dark UI
- System is in dark mode + user configured light theme → dark status bar, light UI

### Solution
The `useMode` hook now dynamically updates all `theme-color` meta tags when:
- The app loads (based on stored preference)
- The user changes their theme setting  
- System preference changes (when in 'system' mode)

The meta tags in HTML still provide initial values based on system preference before JS loads, which is a reasonable fallback.