### PR TITLE
fix(sdk): prevent double reconnection race condition after wake

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -581,6 +581,13 @@ export class Connection extends BaseModule {
     this.stores.console.addEvent('Dead connection detected, will reconnect', 'connection')
     this.stores.connection.setStatus('reconnecting')
 
+    // IMPORTANT: Set isReconnecting BEFORE stopping the client.
+    // When clientToClean.stop() fires the 'disconnect' event, the handler checks
+    // isReconnecting and skips calling scheduleReconnect() if true. Without this,
+    // both handleDeadSocket() and the 'disconnect' handler would call scheduleReconnect(),
+    // causing double reconnection attempts (showing "attempt 2" immediately).
+    this.isReconnecting = true
+
     // IMPORTANT: Null the client reference SYNCHRONOUSLY before any async operations.
     // This prevents a race condition where the old client's 'online' event fires
     // during cleanup, causing handleConnectionSuccess to run and set status='online'


### PR DESCRIPTION
## Summary

- Fix race condition causing double reconnection attempts after wake from sleep
- Set `isReconnecting=true` before stopping old client to prevent disconnect handler from scheduling duplicate reconnect
- Fixes "Reconnecting (attempt 2)" appearing immediately and messages disappearing mid-load

## Problem

When `handleDeadSocket()` was called after detecting a dead connection:
1. It called `clientToClean.stop()` (fire-and-forget)
2. Then called `scheduleReconnect()` which sets `isReconnecting=true`
3. But `.stop()` also fires a 'disconnect' event
4. The disconnect handler checks `isReconnecting` - but it was still `false` at that point
5. Both paths called `scheduleReconnect()`, causing double reconnection

This resulted in:
- "Reconnecting (attempt 2, ...)" showing immediately after "attempt 1"
- `resetRoomMAMStates()` called twice, clearing MAM query states mid-load
- Room messages loading then disappearing (had to switch rooms to reload)

## Solution

Set `isReconnecting=true` **before** calling `.stop()`, so when the disconnect event fires, the handler sees the flag and skips the duplicate `scheduleReconnect()` call.