### PR TITLE
fix(sdk): detect own MUC messages using server-reflected nickname

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1030,7 +1030,8 @@ export class Chat extends BaseModule {
     const room = this.deps.stores?.room.getRoom(roomJid)
     if (!room) return null
 
-    const isOutgoing = isSentCarbon || (room.nickname === nick)
+    // Case-insensitive nickname comparison - some servers may change case
+    const isOutgoing = isSentCarbon || (room.nickname.toLowerCase() === nick.toLowerCase())
     const parsed = parseMessageContent({ messageEl: stanza, body, preserveFullReplyToJid: true })
     const isCorrection = !!stanza.getChild('replace', NS_CORRECTION)
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -906,7 +906,8 @@ export class MAM extends BaseModule {
     if (!body && !messageEl.getChild('x', NS_OOB)) return null
 
     const nick = getResource(from) || ''
-    const isOutgoing = nick === myNickname
+    // Case-insensitive nickname comparison - some servers may change case
+    const isOutgoing = nick.toLowerCase() === myNickname.toLowerCase()
     const parsed = parseMessageContent({ messageEl, body: body || '', delayEl, forceDelayed: true, preserveFullReplyToJid: true })
 
     return {


### PR DESCRIPTION
## Summary

- Fix own MUC messages incorrectly triggering badges and new message markers
- Update `setSelfOccupant` to store server-reflected nickname for accurate comparison
- Add case-insensitive nickname comparison as safety net
- **Clear unread counts when sending a message** (user is actively engaging)