### PR TITLE
add ARM64 RPM builds and standardize release asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,15 +230,9 @@ jobs:
           # Build the .deb package (-d skips build dependency check since we use pre-built binary)
           dpkg-buildpackage -d -uc -us -b
 
-          # Move .deb to a known location
+          # Move .deb to a known location (dpkg already includes architecture in filename)
           mkdir -p dist
           mv ../fluux-messenger_*.deb dist/
-
-          # Rename to include architecture
-          cd dist
-          for f in fluux-messenger_*.deb; do
-            mv "$f" "${f%.deb}_${{ matrix.deb_arch }}.deb"
-          done
 
       - name: Upload .deb to Release
         uses: softprops/action-gh-release@v1
@@ -249,10 +243,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-linux-rpm:
-    name: Build Linux RPM (x86_64)
-    runs-on: ubuntu-22.04
+    name: Build Linux RPM (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout
@@ -276,11 +281,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/fluux/src-tauri
+          key: ${{ matrix.target }}
 
       - name: Install dependencies
         run: npm ci
@@ -314,3 +322,25 @@ jobs:
           releaseDraft: false
           prerelease: false
           args: --bundles rpm
+
+  # Final job to rename all assets to consistent, user-friendly names
+  rename-assets:
+    name: Rename Release Assets
+    runs-on: ubuntu-latest
+    needs: [build-macos, build-windows, build-linux, build-linux-rpm]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Rename assets and update latest.json
+        run: node scripts/rename-release-assets.js ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "10.13",
-      "bundleVersion": "7b65ef1",
+      "bundleVersion": "f81be69",
       "entitlements": "Entitlements.plist",
       "signingIdentity": null
     },
@@ -75,6 +75,13 @@
           "libwebkit2gtk-4.1-0",
           "libgtk-3-0",
           "libayatana-appindicator3-1"
+        ]
+      },
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "libappindicator-gtk3"
         ]
       }
     }

--- a/scripts/rename-release-assets.js
+++ b/scripts/rename-release-assets.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Rename release assets to consistent user-friendly names and update latest.json
+ *
+ * Usage: node scripts/rename-release-assets.js <tag>
+ * Requires: GITHUB_TOKEN environment variable
+ */
+
+const https = require('https');
+
+const OWNER = 'processone';
+const REPO = 'fluux-messenger';
+
+// Mapping from old naming patterns to new names
+// Uses regex patterns to match and extract version
+function getNewName(oldName, version) {
+  const v = version.replace(/^v/, '');
+
+  const mappings = [
+    // macOS DMG
+    { pattern: /^Fluux\.Messenger_[\d.]+_aarch64\.dmg$/, newName: `Fluux-Messenger_${v}_macOS_arm64.dmg` },
+    { pattern: /^Fluux\.Messenger_[\d.]+_x64\.dmg$/, newName: `Fluux-Messenger_${v}_macOS_x64.dmg` },
+
+    // macOS app.tar.gz (updater)
+    { pattern: /^Fluux\.Messenger_aarch64\.app\.tar\.gz$/, newName: `Fluux-Messenger_${v}_macOS_arm64.app.tar.gz` },
+    { pattern: /^Fluux\.Messenger_x64\.app\.tar\.gz$/, newName: `Fluux-Messenger_${v}_macOS_x64.app.tar.gz` },
+    { pattern: /^Fluux\.Messenger_aarch64\.app\.tar\.gz\.sig$/, newName: `Fluux-Messenger_${v}_macOS_arm64.app.tar.gz.sig` },
+    { pattern: /^Fluux\.Messenger_x64\.app\.tar\.gz\.sig$/, newName: `Fluux-Messenger_${v}_macOS_x64.app.tar.gz.sig` },
+
+    // Windows
+    { pattern: /^Fluux\.Messenger_[\d.]+_x64-setup\.exe$/, newName: `Fluux-Messenger_${v}_Windows_x64-setup.exe` },
+    { pattern: /^Fluux\.Messenger_[\d.]+_x64-setup\.exe\.sig$/, newName: `Fluux-Messenger_${v}_Windows_x64-setup.exe.sig` },
+    { pattern: /^Fluux\.Messenger_[\d.]+_x64_en-US\.msi$/, newName: `Fluux-Messenger_${v}_Windows_x64.msi` },
+    { pattern: /^Fluux\.Messenger_[\d.]+_x64_en-US\.msi\.sig$/, newName: `Fluux-Messenger_${v}_Windows_x64.msi.sig` },
+
+    // Linux DEB - fix the double architecture issue
+    { pattern: /^fluux-messenger_[\d.]+-\d+_amd64.*\.deb$/, newName: `Fluux-Messenger_${v}_Linux_x64.deb` },
+    { pattern: /^fluux-messenger_[\d.]+-\d+_arm64.*\.deb$/, newName: `Fluux-Messenger_${v}_Linux_arm64.deb` },
+
+    // Linux RPM
+    { pattern: /^Fluux\.Messenger-[\d.]+-\d+\.x86_64\.rpm$/, newName: `Fluux-Messenger_${v}_Linux_x64.rpm` },
+    { pattern: /^Fluux\.Messenger-[\d.]+-\d+\.x86_64\.rpm\.sig$/, newName: `Fluux-Messenger_${v}_Linux_x64.rpm.sig` },
+    { pattern: /^Fluux\.Messenger-[\d.]+-\d+\.aarch64\.rpm$/, newName: `Fluux-Messenger_${v}_Linux_arm64.rpm` },
+    { pattern: /^Fluux\.Messenger-[\d.]+-\d+\.aarch64\.rpm\.sig$/, newName: `Fluux-Messenger_${v}_Linux_arm64.rpm.sig` },
+  ];
+
+  for (const { pattern, newName } of mappings) {
+    if (pattern.test(oldName)) {
+      return newName;
+    }
+  }
+
+  return null; // No rename needed (e.g., latest.json, source archives)
+}
+
+function makeRequest(method, path, data = null) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      path,
+      method,
+      headers: {
+        'User-Agent': 'fluux-release-script',
+        'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    };
+
+    if (data) {
+      options.headers['Content-Type'] = 'application/json';
+    }
+
+    const req = https.request(options, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(body ? JSON.parse(body) : null);
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}: ${body}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+
+    if (data) {
+      req.write(JSON.stringify(data));
+    }
+    req.end();
+  });
+}
+
+async function downloadAsset(url) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      headers: {
+        'User-Agent': 'fluux-release-script',
+        'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+        'Accept': 'application/octet-stream',
+      },
+    };
+
+    https.get(url, options, (res) => {
+      if (res.statusCode === 302 || res.statusCode === 301) {
+        // Follow redirect
+        https.get(res.headers.location, (res2) => {
+          let data = '';
+          res2.on('data', chunk => data += chunk);
+          res2.on('end', () => resolve(data));
+        }).on('error', reject);
+      } else {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => resolve(data));
+      }
+    }).on('error', reject);
+  });
+}
+
+async function main() {
+  const tag = process.argv[2];
+  if (!tag) {
+    console.error('Usage: node rename-release-assets.js <tag>');
+    process.exit(1);
+  }
+
+  if (!process.env.GITHUB_TOKEN) {
+    console.error('Error: GITHUB_TOKEN environment variable required');
+    process.exit(1);
+  }
+
+  const version = tag.replace(/^v/, '');
+  console.log(`Processing release ${tag} (version ${version})...`);
+
+  // Get release by tag
+  const release = await makeRequest('GET', `/repos/${OWNER}/${REPO}/releases/tags/${tag}`);
+  console.log(`Found release: ${release.name} with ${release.assets.length} assets`);
+
+  // Build rename map and track URL changes for latest.json
+  const urlMap = {}; // oldUrl -> newUrl
+  const renames = [];
+
+  for (const asset of release.assets) {
+    const newName = getNewName(asset.name, version);
+    if (newName && newName !== asset.name) {
+      renames.push({ asset, newName });
+      const oldUrl = asset.browser_download_url;
+      const newUrl = oldUrl.replace(asset.name, newName);
+      urlMap[oldUrl] = newUrl;
+      console.log(`  ${asset.name} -> ${newName}`);
+    }
+  }
+
+  if (renames.length === 0) {
+    console.log('No assets need renaming.');
+    return;
+  }
+
+  // Rename assets via GitHub API
+  console.log('\nRenaming assets...');
+  for (const { asset, newName } of renames) {
+    await makeRequest('PATCH', `/repos/${OWNER}/${REPO}/releases/assets/${asset.id}`, {
+      name: newName,
+    });
+    console.log(`  Renamed: ${asset.name} -> ${newName}`);
+  }
+
+  // Download and update latest.json
+  console.log('\nUpdating latest.json...');
+  const latestJsonAsset = release.assets.find(a => a.name === 'latest.json');
+  if (latestJsonAsset) {
+    const latestJsonContent = await downloadAsset(latestJsonAsset.url);
+    const latestJson = JSON.parse(latestJsonContent);
+
+    // Update all URLs in the platforms
+    for (const [platform, data] of Object.entries(latestJson.platforms)) {
+      if (urlMap[data.url]) {
+        console.log(`  Updating ${platform}: ${data.url} -> ${urlMap[data.url]}`);
+        latestJson.platforms[platform].url = urlMap[data.url];
+      }
+    }
+
+    // Delete old latest.json and upload new one
+    await makeRequest('DELETE', `/repos/${OWNER}/${REPO}/releases/assets/${latestJsonAsset.id}`);
+
+    // Upload updated latest.json
+    const uploadUrl = release.upload_url.replace('{?name,label}', `?name=latest.json`);
+    const uploadOptions = {
+      hostname: 'uploads.github.com',
+      path: uploadUrl.replace('https://uploads.github.com', ''),
+      method: 'POST',
+      headers: {
+        'User-Agent': 'fluux-release-script',
+        'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    };
+
+    await new Promise((resolve, reject) => {
+      const req = https.request(uploadOptions, (res) => {
+        let body = '';
+        res.on('data', chunk => body += chunk);
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve();
+          } else {
+            reject(new Error(`Upload failed: HTTP ${res.statusCode}: ${body}`));
+          }
+        });
+      });
+      req.on('error', reject);
+      req.write(JSON.stringify(latestJson));
+      req.end();
+    });
+
+    console.log('  Uploaded updated latest.json');
+  }
+
+  console.log('\nDone! Assets renamed successfully.');
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add ARM64 RPM builds to release workflow using `ubuntu-22.04-arm` runner
- Add `rpm.depends` to tauri.conf.json with Fedora/RHEL package names
- Fix DEB naming (was duplicating architecture suffix)
- Add `rename-assets` job to standardize all artifact names to user-friendly format

## New naming convention

All release assets will follow: `Fluux-Messenger_VERSION_PLATFORM_ARCH.EXT`

| Before | After |
|--------|-------|
| `Fluux.Messenger_0.12.0_aarch64.dmg` | `Fluux-Messenger_0.12.0_macOS_arm64.dmg` |
| `Fluux.Messenger_0.12.0_x64.dmg` | `Fluux-Messenger_0.12.0_macOS_x64.dmg` |
| `Fluux.Messenger_0.12.0_x64-setup.exe` | `Fluux-Messenger_0.12.0_Windows_x64-setup.exe` |
| `Fluux.Messenger_0.12.0_x64_en-US.msi` | `Fluux-Messenger_0.12.0_Windows_x64.msi` |
| `fluux-messenger_0.12.0-1_amd64_amd64.deb` | `Fluux-Messenger_0.12.0_Linux_x64.deb` |
| `fluux-messenger_0.12.0-1_arm64_arm64.deb` | `Fluux-Messenger_0.12.0_Linux_arm64.deb` |
| `Fluux.Messenger-0.12.0-1.x86_64.rpm` | `Fluux-Messenger_0.12.0_Linux_x64.rpm` |
| *(new)* | `Fluux-Messenger_0.12.0_Linux_arm64.rpm` |

The rename script also updates `latest.json` URLs to ensure Tauri auto-update continues to work.