### PR TITLE
fix(scroll): scroll to new message marker when entering room with unread

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -139,6 +139,7 @@ export function MessageList<T extends BaseMessage>({
     conversationId,
     messageCount: messages.length,
     firstMessageId,
+    firstNewMessageId,
     externalScrollerRef,
     externalIsAtBottomRef,
     onScrollToTop,


### PR DESCRIPTION
## Summary

When entering a room/conversation with unread messages, the view now scrolls to show the new message marker with context above it, rather than scrolling to the absolute bottom which only showed the new messages without the conversation context.

Changes:
- Added `firstNewMessageId` prop to `useMessageListScroll` hook
- On conversation switch with unread messages, scroll to position the new message marker ~1/3 from the top
- Properly update `isAtBottom` state after scrolling to marker (based on actual distance from bottom)
- Use `CSS.escape()` for safe DOM queries with special characters in message IDs
- Multiple deferred scroll attempts (RAF + timeouts) to handle async message rendering