### PR TITLE
fix(sdk): don't fallback to service MAM when room explicitly disables MAM

### DIFF
--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -302,6 +302,8 @@ vi.mock('lucide-react', () => ({
   Loader2: () => <span data-testid="icon-loader">Loader</span>,
   LogIn: () => <span data-testid="icon-login">LogIn</span>,
   AlertCircle: () => <span data-testid="icon-alert">Alert</span>,
+  Clock: () => <span data-testid="icon-clock">Clock</span>,
+  ChevronUp: () => <span data-testid="icon-chevron-up">ChevronUp</span>,
 }))
 
 // Create hoisted mock for MessageComposer that uses forwardRef

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -150,7 +150,7 @@ export function RoomView({ onBack, mainContentRef, composerRef }: RoomViewProps)
   } = useMessageSelection(activeMessages, scrollRef, isAtBottomRef, {
     onReachedFirstMessage: fetchOlderHistory,
     isLoadingOlder: activeMAMState?.isLoading,
-    isHistoryComplete: activeMAMState?.isHistoryComplete,
+    isHistoryComplete: !activeRoom?.supportsMAM || activeMAMState?.isHistoryComplete,
   })
 
   // Format copied messages with sender headers
@@ -264,7 +264,7 @@ export function RoomView({ onBack, mainContentRef, composerRef }: RoomViewProps)
             onMediaLoad={handleMediaLoad}
             onScrollToTop={fetchOlderHistory}
             isLoadingOlder={activeMAMState?.isLoading}
-            isHistoryComplete={activeMAMState?.isHistoryComplete}
+            isHistoryComplete={!activeRoom.supportsMAM || activeMAMState?.isHistoryComplete}
           />
         </div>
 

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -1044,31 +1044,17 @@ describe('MUC Module', () => {
       expect(result).toBeNull()
     })
 
-    it('falls back to service-level MAM when room disco fails', async () => {
+    it('returns null when room disco fails (no service-level fallback)', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       mockSendIQ.mockRejectedValue(new Error('Room disco timeout'))
 
-      // Mock that MUC service supports MAM globally
+      // Even if MUC service supports MAM globally, we don't fallback
+      // because the room may have MAM explicitly disabled
       mockStores.admin.getMucServiceSupportsMAM.mockReturnValue(true)
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: true, isServiceLevelFallback: true })
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Using service-level MAM support'))
-      warnSpy.mockRestore()
-      logSpy.mockRestore()
-    })
-
-    it('returns null when both room disco and service MAM are unavailable', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      mockSendIQ.mockRejectedValue(new Error('Room disco timeout'))
-
-      // Mock that MUC service does NOT support MAM
-      mockStores.admin.getMucServiceSupportsMAM.mockReturnValue(false)
-
-      const result = await muc.queryRoomFeatures('room@conference.example.org')
-
+      // Should return null, not fallback to service MAM
       expect(result).toBeNull()
       warnSpy.mockRestore()
     })


### PR DESCRIPTION
## Summary

Two fixes related to room MAM support:

**1. Remove service-level MAM fallback in `queryRoomFeatures()`**
- When room disco#info query fails, don't assume MAM is supported
- Previously fell back to service-level MAM which could be wrong for rooms that explicitly have MAM disabled (e.g., ejabberd with per-room MAM configuration)

**2. Show "beginning of conversation" for rooms without MAM**
- When room doesn't support MAM, `isHistoryComplete` is now treated as `true`
- UI shows "Beginning of conversation" marker instead of "Load more messages" button
- This prevents confusing UX where button exists but can't actually load anything

Also simplifies `joinRoom()` history logic: if room supports MAM use `maxstanzas=0`, otherwise use `maxstanzas=50`.