### PR TITLE
fix: render disabled room header menu items in full width

### DIFF
--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -253,7 +253,7 @@ export function RoomHeader({
           {showOwnerMenu && (
             <div className="absolute right-0 top-full mt-1 w-56 bg-fluux-bg border border-fluux-hover rounded-lg shadow-lg z-30 py-1">
               {/* Room Settings (placeholder) */}
-              <Tooltip content={t('common.comingSoon')} position="left">
+              <Tooltip content={t('common.comingSoon')} position="left" className='w-full'>
                 <button
                   onClick={() => {
                     // TODO: Open room settings modal
@@ -271,7 +271,7 @@ export function RoomHeader({
               </Tooltip>
 
               {/* Change Room Subject (placeholder) */}
-              <Tooltip content={t('common.comingSoon')} position="left">
+              <Tooltip content={t('common.comingSoon')} position="left" className='w-full'>
                 <button
                   onClick={() => {
                     // TODO: Open change subject modal
@@ -341,7 +341,7 @@ export function RoomHeader({
 
               {/* Kick/Ban Member (placeholder) - owner only */}
               {isOwner && (
-                <Tooltip content={t('common.comingSoon')} position="left">
+                <Tooltip content={t('common.comingSoon')} position="left" className='w-full'>
                   <button
                     onClick={() => {
                       // TODO: Open kick/ban member modal


### PR DESCRIPTION
Room header menu items don't span full width if they are disabled. This is due to `Tooltip` wrapping disabled elements into a `inline-flex` div to still display a tooltip while the original tooltip source element is disabled.

| before | after |
| -- | -- |
|<img width="456" height="408" alt="image" src="https://github.com/user-attachments/assets/7bb9c525-f3bc-496b-96e7-abfb38243ff4" /> | <img width="456" height="408" alt="image" src="https://github.com/user-attachments/assets/b05af0f0-ed21-4874-890e-64836fabe027" /> |
