### PR TITLE
fix: disable profile editing when offline

### DIFF
--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "10.13",
-      "bundleVersion": "fcacf41",
+      "bundleVersion": "ae567a3",
       "entitlements": "Entitlements.plist",
       "signingIdentity": null
     },

--- a/apps/fluux/src/components/ProfileModal.tsx
+++ b/apps/fluux/src/components/ProfileModal.tsx
@@ -15,7 +15,7 @@ interface ProfileModalProps {
 
 export function ProfileModal({ onClose }: ProfileModalProps) {
   const { t } = useTranslation()
-  const { jid, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
+  const { jid, isConnected, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
   const { presenceStatus: presenceShow, statusMessage } = usePresence()
   const modalRef = useRef<HTMLDivElement>(null)
 
@@ -163,11 +163,19 @@ export function ProfileModal({ onClose }: ProfileModalProps) {
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
           <div className="p-6 flex flex-col items-center">
+            {/* Offline notice */}
+            {!isConnected && (
+              <div className="w-full max-w-xs mb-4 px-3 py-2 bg-fluux-bg rounded-lg text-center">
+                <p className="text-sm text-fluux-muted">{t('profile.offlineNotice')}</p>
+              </div>
+            )}
+
             {/* Large avatar - clickable to change */}
             <Tooltip content={t('profile.changeAvatar')}>
               <button
                 onClick={() => setShowAvatarModal(true)}
-                className="relative mb-2 group"
+                disabled={!isConnected}
+                className="relative mb-2 group disabled:opacity-50 disabled:cursor-not-allowed"
               >
               <Avatar
                 identifier={jid || ''}
@@ -189,8 +197,8 @@ export function ProfileModal({ onClose }: ProfileModalProps) {
             {ownAvatar && (
               <button
                 onClick={handleClearAvatar}
-                disabled={clearing === 'avatar'}
-                className="text-xs text-fluux-muted hover:text-fluux-red mb-4 disabled:opacity-50"
+                disabled={!isConnected || clearing === 'avatar'}
+                className="text-xs text-fluux-muted hover:text-fluux-red mb-4 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {clearing === 'avatar' ? t('profile.removingAvatar') : t('profile.removeAvatar')}
               </button>
@@ -221,7 +229,8 @@ export function ProfileModal({ onClose }: ProfileModalProps) {
                   <Tooltip content={t('profile.editNickname')}>
                     <button
                       onClick={handleStartEdit}
-                      className="p-1 text-fluux-muted hover:text-fluux-text rounded"
+                      disabled={!isConnected}
+                      className="p-1 text-fluux-muted hover:text-fluux-text rounded disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <Pencil className="w-4 h-4" />
                     </button>
@@ -230,8 +239,8 @@ export function ProfileModal({ onClose }: ProfileModalProps) {
                     <Tooltip content={t('profile.resetToUsername')}>
                       <button
                         onClick={handleClearNickname}
-                        disabled={clearing === 'nickname'}
-                        className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50"
+                        disabled={!isConnected || clearing === 'nickname'}
+                        className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>
@@ -314,7 +323,7 @@ export function ProfileModal({ onClose }: ProfileModalProps) {
               <h3 className="text-xs font-semibold text-fluux-muted uppercase tracking-wide mb-2">
                 {t('profile.account')}
               </h3>
-              {supportsPasswordChange ? (
+              {supportsPasswordChange && isConnected ? (
                 <button
                   onClick={() => setShowPasswordModal(true)}
                   className="w-full flex items-center gap-2 px-3 py-2 bg-fluux-bg hover:bg-fluux-hover rounded-lg transition-colors text-fluux-text"
@@ -323,7 +332,7 @@ export function ProfileModal({ onClose }: ProfileModalProps) {
                   <span className="text-sm">{t('profile.changePassword')}</span>
                 </button>
               ) : (
-                <Tooltip content={t('profile.passwordChangeNotSupported')}>
+                <Tooltip content={!isConnected ? t('profile.offlineNotice') : t('profile.passwordChangeNotSupported')}>
                   <div
                     className="w-full flex items-center gap-2 px-3 py-2 bg-fluux-bg rounded-lg text-fluux-muted opacity-50"
                   >

--- a/apps/fluux/src/components/ProfileView.tsx
+++ b/apps/fluux/src/components/ProfileView.tsx
@@ -16,7 +16,7 @@ interface ProfileViewProps {
 
 export function ProfileView({ onClose }: ProfileViewProps) {
   const { t } = useTranslation()
-  const { jid, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
+  const { jid, isConnected, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
   const { presenceStatus: presenceShow, statusMessage } = usePresence()
   const { titleBarClass, dragRegionProps } = useWindowDrag()
 
@@ -142,11 +142,19 @@ export function ProfileView({ onClose }: ProfileViewProps) {
       {/* Profile content */}
       <div className="flex-1 overflow-y-auto">
         <div className="p-6 flex flex-col items-center">
+          {/* Offline notice */}
+          {!isConnected && (
+            <div className="w-full max-w-xs mb-4 px-3 py-2 bg-fluux-bg rounded-lg text-center">
+              <p className="text-sm text-fluux-muted">{t('profile.offlineNotice')}</p>
+            </div>
+          )}
+
           {/* Large avatar - clickable to change */}
           <Tooltip content={t('profile.changeAvatar')} position="bottom">
             <button
               onClick={() => setShowAvatarModal(true)}
-              className="relative mb-2 group"
+              disabled={!isConnected}
+              className="relative mb-2 group disabled:opacity-50 disabled:cursor-not-allowed"
               aria-label={t('profile.changeAvatar')}
             >
               <Avatar
@@ -169,8 +177,8 @@ export function ProfileView({ onClose }: ProfileViewProps) {
           {ownAvatar && (
             <button
               onClick={handleClearAvatar}
-              disabled={clearing === 'avatar'}
-              className="text-xs text-fluux-muted hover:text-fluux-red mb-4 disabled:opacity-50"
+              disabled={!isConnected || clearing === 'avatar'}
+              className="text-xs text-fluux-muted hover:text-fluux-red mb-4 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {clearing === 'avatar' ? t('profile.removingAvatar') : t('profile.removeAvatar')}
             </button>
@@ -201,7 +209,8 @@ export function ProfileView({ onClose }: ProfileViewProps) {
                 <Tooltip content={t('profile.editNickname')} position="top">
                   <button
                     onClick={handleStartEdit}
-                    className="p-1 text-fluux-muted hover:text-fluux-text rounded"
+                    disabled={!isConnected}
+                    className="p-1 text-fluux-muted hover:text-fluux-text rounded disabled:opacity-50 disabled:cursor-not-allowed"
                     aria-label={t('profile.editNickname')}
                   >
                     <Pencil className="w-4 h-4" />
@@ -211,8 +220,8 @@ export function ProfileView({ onClose }: ProfileViewProps) {
                   <Tooltip content={t('profile.resetToUsername')} position="top">
                     <button
                       onClick={handleClearNickname}
-                      disabled={clearing === 'nickname'}
-                      className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50"
+                      disabled={!isConnected || clearing === 'nickname'}
+                      className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50 disabled:cursor-not-allowed"
                       aria-label={t('profile.resetToUsername')}
                     >
                       <Trash2 className="w-4 h-4" />
@@ -296,7 +305,7 @@ export function ProfileView({ onClose }: ProfileViewProps) {
             <h3 className="text-xs font-semibold text-fluux-muted uppercase tracking-wide mb-2">
               {t('profile.account')}
             </h3>
-            {supportsPasswordChange ? (
+            {supportsPasswordChange && isConnected ? (
               <button
                 onClick={() => setShowPasswordModal(true)}
                 className="w-full flex items-center gap-2 px-3 py-2 bg-fluux-bg hover:bg-fluux-hover rounded-lg transition-colors text-fluux-text"
@@ -305,10 +314,10 @@ export function ProfileView({ onClose }: ProfileViewProps) {
                 <span className="text-sm">{t('profile.changePassword')}</span>
               </button>
             ) : (
-              <Tooltip content={t('profile.passwordChangeNotSupported')} position="top">
+              <Tooltip content={!isConnected ? t('profile.offlineNotice') : t('profile.passwordChangeNotSupported')} position="top">
                 <div
                   className="w-full flex items-center gap-2 px-3 py-2 bg-fluux-bg rounded-lg text-fluux-muted opacity-50"
-                  aria-label={t('profile.passwordChangeNotSupported')}
+                  aria-label={!isConnected ? t('profile.offlineNotice') : t('profile.passwordChangeNotSupported')}
                 >
                   <Key className="w-4 h-4" />
                   <span className="text-sm">{t('profile.changePassword')}</span>

--- a/apps/fluux/src/components/settings-components/ProfileSettings.tsx
+++ b/apps/fluux/src/components/settings-components/ProfileSettings.tsx
@@ -15,7 +15,7 @@ import { Tooltip } from '../Tooltip'
  */
 export function ProfileSettings() {
   const { t } = useTranslation()
-  const { jid, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
+  const { jid, isConnected, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
   const { presenceStatus: presenceShow, statusMessage } = usePresence()
 
   const [isEditing, setIsEditing] = useState(false)
@@ -124,11 +124,19 @@ export function ProfileSettings() {
   return (
     <div className="max-w-md mx-auto">
       <div className="flex flex-col items-center">
+        {/* Offline notice */}
+        {!isConnected && (
+          <div className="w-full max-w-xs mb-4 px-3 py-2 bg-fluux-bg rounded-lg text-center">
+            <p className="text-sm text-fluux-muted">{t('profile.offlineNotice')}</p>
+          </div>
+        )}
+
         {/* Large avatar - clickable to change */}
         <Tooltip content={t('profile.changeAvatar')} position="bottom">
           <button
             onClick={() => setShowAvatarModal(true)}
-            className="relative mb-2 group"
+            disabled={!isConnected}
+            className="relative mb-2 group disabled:opacity-50 disabled:cursor-not-allowed"
             aria-label={t('profile.changeAvatar')}
           >
             <Avatar
@@ -151,8 +159,8 @@ export function ProfileSettings() {
         {ownAvatar && (
           <button
             onClick={handleClearAvatar}
-            disabled={clearing === 'avatar'}
-            className="text-xs text-fluux-muted hover:text-fluux-red mb-4 disabled:opacity-50"
+            disabled={!isConnected || clearing === 'avatar'}
+            className="text-xs text-fluux-muted hover:text-fluux-red mb-4 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {clearing === 'avatar' ? t('profile.removingAvatar') : t('profile.removeAvatar')}
           </button>
@@ -183,7 +191,8 @@ export function ProfileSettings() {
               <Tooltip content={t('profile.editNickname')} position="top">
                 <button
                   onClick={handleStartEdit}
-                  className="p-1 text-fluux-muted hover:text-fluux-text rounded"
+                  disabled={!isConnected}
+                  className="p-1 text-fluux-muted hover:text-fluux-text rounded disabled:opacity-50 disabled:cursor-not-allowed"
                   aria-label={t('profile.editNickname')}
                 >
                   <Pencil className="w-4 h-4" />
@@ -193,8 +202,8 @@ export function ProfileSettings() {
                 <Tooltip content={t('profile.resetToUsername')} position="top">
                   <button
                     onClick={handleClearNickname}
-                    disabled={clearing === 'nickname'}
-                    className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50"
+                    disabled={!isConnected || clearing === 'nickname'}
+                    className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50 disabled:cursor-not-allowed"
                     aria-label={t('profile.resetToUsername')}
                   >
                     <Trash2 className="w-4 h-4" />
@@ -278,7 +287,7 @@ export function ProfileSettings() {
           <h3 className="text-xs font-semibold text-fluux-muted uppercase tracking-wide mb-2">
             {t('profile.account')}
           </h3>
-          {supportsPasswordChange ? (
+          {supportsPasswordChange && isConnected ? (
             <button
               onClick={() => setShowPasswordModal(true)}
               className="w-full flex items-center gap-2 px-3 py-2 bg-fluux-bg hover:bg-fluux-hover rounded-lg transition-colors text-fluux-text"
@@ -287,10 +296,10 @@ export function ProfileSettings() {
               <span className="text-sm">{t('profile.changePassword')}</span>
             </button>
           ) : (
-            <Tooltip content={t('profile.passwordChangeNotSupported')} position="top">
+            <Tooltip content={!isConnected ? t('profile.offlineNotice') : t('profile.passwordChangeNotSupported')} position="top">
               <div
                 className="w-full flex items-center gap-2 px-3 py-2 bg-fluux-bg rounded-lg text-fluux-muted opacity-50"
-                aria-label={t('profile.passwordChangeNotSupported')}
+                aria-label={!isConnected ? t('profile.offlineNotice') : t('profile.passwordChangeNotSupported')}
               >
                 <Key className="w-4 h-4" />
                 <span className="text-sm">{t('profile.changePassword')}</span>

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "Passwort muss mindestens 6 Zeichen haben",
     "failedToChangePassword": "Passwort konnte nicht geändert werden",
     "passwordChangeNotSupported": "Passwortänderung wird von diesem Server nicht unterstützt",
-    "priority": "Priorität"
+    "priority": "Priorität",
+    "offlineNotice": "Profilbearbeitung ist offline nicht verfügbar"
   },
   "console": {
     "title": "XMPP-Konsole",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "Password must be at least 6 characters",
     "failedToChangePassword": "Failed to change password",
     "passwordChangeNotSupported": "Password change is not supported by this server",
-    "priority": "Priority"
+    "priority": "Priority",
+    "offlineNotice": "Profile editing is unavailable while offline"
   },
   "console": {
     "title": "XMPP Console",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -413,7 +413,8 @@
     "passwordTooShort": "La contrasena debe tener al menos 6 caracteres",
     "failedToChangePassword": "Error al cambiar contrasena",
     "passwordChangeNotSupported": "El cambio de contrasena no es compatible con este servidor",
-    "priority": "Prioridad"
+    "priority": "Prioridad",
+    "offlineNotice": "La edición del perfil no está disponible sin conexión"
   },
   "console": {
     "title": "Consola XMPP",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "Le mot de passe doit contenir au moins 6 caractères",
     "failedToChangePassword": "Échec du changement de mot de passe",
     "passwordChangeNotSupported": "Le changement de mot de passe n'est pas pris en charge par ce serveur",
-    "priority": "Priorité"
+    "priority": "Priorité",
+    "offlineNotice": "La modification du profil n'est pas disponible hors ligne"
   },
   "console": {
     "title": "Console XMPP",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "La password deve avere almeno 6 caratteri",
     "failedToChangePassword": "Impossibile cambiare la password",
     "passwordChangeNotSupported": "Il cambio password non e supportato da questo server",
-    "priority": "Priorita"
+    "priority": "Priorita",
+    "offlineNotice": "La modifica del profilo non è disponibile offline"
   },
   "console": {
     "title": "Console XMPP",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "Wachtwoord moet minimaal 6 tekens zijn",
     "failedToChangePassword": "Wachtwoord wijzigen mislukt",
     "passwordChangeNotSupported": "Wachtwoord wijzigen wordt niet ondersteund door deze server",
-    "priority": "Prioriteit"
+    "priority": "Prioriteit",
+    "offlineNotice": "Profielbewerking is niet beschikbaar terwijl u offline bent"
   },
   "console": {
     "title": "XMPP Console",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "Hasło musi mieć co najmniej 6 znaków",
     "failedToChangePassword": "Nie udało się zmienić hasła",
     "passwordChangeNotSupported": "Zmiana hasła nie jest obsługiwana przez ten serwer",
-    "priority": "Priorytet"
+    "priority": "Priorytet",
+    "offlineNotice": "Edycja profilu jest niedostępna w trybie offline"
   },
   "console": {
     "title": "Konsola XMPP",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -415,7 +415,8 @@
     "passwordTooShort": "A palavra-passe deve ter pelo menos 6 caracteres",
     "failedToChangePassword": "Falha ao alterar palavra-passe",
     "passwordChangeNotSupported": "A alteração de palavra-passe não é suportada por este servidor",
-    "priority": "Prioridade"
+    "priority": "Prioridade",
+    "offlineNotice": "A edição do perfil não está disponível offline"
   },
   "console": {
     "title": "Consola XMPP",


### PR DESCRIPTION
## Summary

- Disable avatar, nickname, and password editing actions when the user is offline, preventing errors from failed XMPP requests
- Show a localized offline notice banner at the top of the profile view when disconnected
- Add `profile.offlineNotice` translation to all 8 locale files (en, fr, es, de, it, pt, pl, nl)

Closes #104