### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Fluux Messenger are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-02-06
+
+### Added
+
+- XEP-0398: MUC occupant avatars displayed in room participant list
+- Message styling for bullet points and support for markdown bold
+- Toast notifications for room invites and error feedback
+
+### Changed
+
+- File drag-and-drop now stages files for preview before sending
+- XMPP Console keyboard interaction and feedback improvements
+
+### Fixed
+
+- Scroll behavior for typing indicators and reactions
+- Performance: improvements
+- URL parsing for angle-bracketed URLs
+- Profile editing disabled when offline
+- Disabled room menu items render at full width
+- Missing media files handled gracefully (404 errors)
+- Update check no longer auto-triggers when viewing settings
+
 ## [0.11.3] - 2026-02-03
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,36 +1,25 @@
-## What's New in v0.11.3
+## What's New in v0.12.0
 
 ### Added
 
-- ARM64 builds for Linux
-- Password visibility toggle on login screen
+- XEP-0398: MUC occupant avatars displayed in room participant list
+- Message styling for bullet points and support for markdown bold
+- Toast notifications for room invites and error feedback
 
 ### Changed
 
-- Reply quote border uses quoted person's XEP-0392 consistent color and user's avatar
-- MUC rooms now sorted by last message time
-- Copy behavior preserved for single message selection
-- Show room info in tooltip instead of inline preview
-- Standardized release asset names across platforms
+- File drag-and-drop now stages files for preview before sending
+- XMPP Console keyboard interaction and feedback improvements
 
 ### Fixed
 
-- Rooms with MAM disabled no longer fallback to service-level MAM
-- Scroll to new message marker when entering room with unread messages
-- Emoji picker buttons no longer submit form accidentally
-- Own MUC message detection improved for unread clearing
-- Double reconnection race condition after wake from sleep
-- Restored keychain credentials saving on login
-- Android status bar color syncs with app theme
-- Mobile layout improvements for e/OS/ and Android
-- Image loading no longer proxied via Tauri HTTP plugin
-- Date separator and cursor alignment in message list
-- MAM catchup reliability improvements
-- Sidebar message preview shows correct content
-- OOB attachment URL stripped from message body
-- Room avatar fetch no longer logs error when avatar missing
-- Reply quotes show avatar for own messages
-- Quick Chats section spacing in sidebar
+- Scroll behavior for typing indicators and reactions
+- Performance: improvements
+- URL parsing for angle-bracketed URLs
+- Profile editing disabled when offline
+- Disabled room menu items render at full width
+- Missing media files handled gracefully (404 errors)
+- Update check no longer auto-triggers when viewing settings
 
 ---
 [Full Changelog](https://github.com/processone/fluux-messenger/blob/main/CHANGELOG.md)

--- a/apps/fluux/package.json
+++ b/apps/fluux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmpp/fluux",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluux"
-version = "0.11.3"
+version = "0.12.0"
 description = "A powerful, productive messaging client that's pleasant to use."
 authors = ["ProcessOne"]
 license = "AGPL-3.0-or-later"

--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fluux Messenger",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "identifier": "com.processone.fluux",
   "plugins": {
     "deep-link": {
@@ -57,7 +57,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "10.13",
-      "bundleVersion": "ae567a3",
+      "bundleVersion": "2869c84",
       "entitlements": "Entitlements.plist",
       "signingIdentity": null
     },

--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -14,6 +14,39 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.12.0',
+    date: '2026-02-06',
+    sections: [
+      {
+        type: 'added',
+        items: [
+          'XEP-0398: MUC occupant avatars displayed in room participant list',
+          'Message styling for bullet points and support for markdown bold',
+          'Toast notifications for room invites and error feedback',
+        ],
+      },
+      {
+        type: 'changed',
+        items: [
+          'File drag-and-drop now stages files for preview before sending',
+          'XMPP Console keyboard interaction and feedback improvements',
+        ],
+      },
+      {
+        type: 'fixed',
+        items: [
+          'Scroll behavior for typing indicators and reactions',
+          'Performance: improvements',
+          'URL parsing for angle-bracketed URLs',
+          'Profile editing disabled when offline',
+          'Disabled room menu items render at full width',
+          'Missing media files handled gracefully (404 errors)',
+          'Update check no longer auto-triggers when viewing settings',
+        ],
+      },
+    ],
+  },
+  {
     version: '0.11.3',
     date: '2026-02-03',
     sections: [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fluux",
   "private": true,
   "license": "AGPL-3.0-or-later",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "type": "module",
   "workspaces": [
     "packages/*",

--- a/packages/fluux-sdk/package.json
+++ b/packages/fluux-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluux/sdk",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.12.0 with new features and bug fixes.

### Added
- XEP-0398: MUC occupant avatars displayed in room participant list
- Message styling for bullet points and support for markdown bold
- Toast notifications for room invites and error feedback

### Changed
- File drag-and-drop now stages files for preview before sending
- XMPP Console keyboard interaction and feedback improvements

### Fixed
- Scroll behavior for typing indicators and reactions
- Performance improvements
- URL parsing for angle-bracketed URLs
- Profile editing disabled when offline
- Disabled room menu items render at full width
- Missing media files handled gracefully (404 errors)
- Update check no longer auto-triggers when viewing settings