### PR TITLE
fix: adjust context menu position to stay within viewport bounds

### DIFF
--- a/apps/fluux/src/hooks/useContextMenu.ts
+++ b/apps/fluux/src/hooks/useContextMenu.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useLayoutEffect } from 'react'
 import { useClickOutside } from './useClickOutside'
 
 export interface ContextMenuState {
@@ -6,7 +6,7 @@ export interface ContextMenuState {
   isOpen: boolean
   /** Position where the menu should be rendered */
   position: { x: number; y: number }
-  /** Ref to attach to the menu element (for click-outside detection) */
+  /** Ref to attach to the menu element (for click-outside detection and positioning) */
   menuRef: React.RefObject<HTMLDivElement>
   /** Whether a long press was triggered (use to prevent click after long press) */
   longPressTriggered: React.RefObject<boolean>
@@ -75,6 +75,8 @@ export function useContextMenu(options: UseContextMenuOptions = {}): ContextMenu
   const menuRef = useRef<HTMLDivElement>(null)
   const longPressTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const longPressTriggered = useRef(false)
+  // Store the click position separately from the adjusted position
+  const clickPosition = useRef({ x: 0, y: 0 })
 
   // Close menu
   const close = useCallback(() => setIsOpen(false), [])
@@ -82,9 +84,45 @@ export function useContextMenu(options: UseContextMenuOptions = {}): ContextMenu
   // Click outside to close
   useClickOutside(menuRef, close, isOpen)
 
+  // Adjust position after menu renders to keep it within viewport
+  useLayoutEffect(() => {
+    if (!isOpen || !menuRef.current) return
+
+    const menu = menuRef.current
+    const rect = menu.getBoundingClientRect()
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+    const padding = 8 // Keep some distance from viewport edges
+
+    let { x, y } = clickPosition.current
+
+    // Adjust horizontal position if menu would overflow right edge
+    if (x + rect.width > viewportWidth - padding) {
+      x = Math.max(padding, viewportWidth - rect.width - padding)
+    }
+
+    // Adjust vertical position if menu would overflow bottom edge
+    if (y + rect.height > viewportHeight - padding) {
+      // Try positioning above the click point
+      const aboveY = clickPosition.current.y - rect.height
+      if (aboveY >= padding) {
+        y = aboveY
+      } else {
+        // If it doesn't fit above either, position at the bottom of viewport
+        y = Math.max(padding, viewportHeight - rect.height - padding)
+      }
+    }
+
+    // Only update if position changed to avoid infinite loops
+    if (x !== position.x || y !== position.y) {
+      setPosition({ x, y })
+    }
+  }, [isOpen, position.x, position.y])
+
   // Right-click handler (desktop)
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
+    clickPosition.current = { x: e.clientX, y: e.clientY }
     setPosition({ x: e.clientX, y: e.clientY })
     setIsOpen(true)
   }, [])
@@ -95,6 +133,7 @@ export function useContextMenu(options: UseContextMenuOptions = {}): ContextMenu
     const touch = e.touches[0]
     longPressTimeout.current = setTimeout(() => {
       longPressTriggered.current = true
+      clickPosition.current = { x: touch.clientX, y: touch.clientY }
       setPosition({ x: touch.clientX, y: touch.clientY })
       setIsOpen(true)
     }, longPressDuration)


### PR DESCRIPTION
## Summary

- Fix context menus going off-screen when right-clicking items at the bottom of sidebar lists
- Add viewport boundary detection to `useContextMenu` hook
- Menu position is adjusted if it would overflow the viewport (with 8px padding)

Affects all sidebar context menus: conversations, contacts, and rooms.