### PR TITLE
feat(desktop): add WebSocket-to-TCP proxy for native XMPP connections

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -177,7 +177,7 @@ fn exit_app(app: tauri::AppHandle) {
 /// Start XMPP WebSocket-to-TCP proxy.
 /// The `server` parameter supports: `tls://host:port`, `tcp://host:port`, `host:port`, or bare `domain`.
 #[tauri::command]
-async fn start_xmpp_proxy(server: String) -> Result<String, String> {
+async fn start_xmpp_proxy(server: String) -> Result<xmpp_proxy::ProxyStartResult, String> {
     xmpp_proxy::start_proxy(server).await
 }
 

--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -57,7 +57,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "10.13",
-      "bundleVersion": "96b56b1",
+      "bundleVersion": "0ad0288",
       "entitlements": "Entitlements.plist",
       "signingIdentity": null
     },

--- a/apps/fluux/src/components/ProfileView.tsx
+++ b/apps/fluux/src/components/ProfileView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { X, Monitor, Smartphone, Globe, Pencil, Camera, Trash2, Key } from 'lucide-react'
+import { X, Monitor, Smartphone, Globe, Pencil, Camera, Trash2, Key, Network } from 'lucide-react'
 import { type ResourcePresence, getClientType, getLocalPart, useConnection, usePresence } from '@fluux/sdk'
 import { Avatar } from './Avatar'
 import { PRESENCE_COLORS } from '@/constants/ui'
@@ -16,7 +16,7 @@ interface ProfileViewProps {
 
 export function ProfileView({ onClose }: ProfileViewProps) {
   const { t } = useTranslation()
-  const { jid, isConnected, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
+  const { jid, isConnected, ownAvatar, ownNickname, ownResources, connectionMethod, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
   const { presenceStatus: presenceShow, statusMessage } = usePresence()
   const { titleBarClass, dragRegionProps } = useWindowDrag()
 
@@ -233,7 +233,18 @@ export function ProfileView({ onClose }: ProfileViewProps) {
           )}
 
           {/* JID */}
-          <p className="text-fluux-muted text-sm mb-3">{bareJid}</p>
+          <p className="text-fluux-muted text-sm mb-1">{bareJid}</p>
+
+          {/* Connection method */}
+          {connectionMethod && (
+            <div className="flex items-center gap-1.5 mb-3">
+              <Network className="w-3 h-3 text-fluux-muted" />
+              <span className="text-xs text-fluux-muted">
+                {t(`profile.connectionMethod_${connectionMethod}`)}
+              </span>
+            </div>
+          )}
+          {!connectionMethod && <div className="mb-2" />}
 
           {/* Presence status - always Active since you're using the app */}
           <div className="flex items-center gap-2 mb-2">

--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -153,6 +153,7 @@ export function XmppConsole() {
   // Use focused selectors instead of useConnection() to avoid re-renders when unrelated values change
   const status = useConnectionStore((s) => s.status)
   const serverInfo = useConnectionStore((s) => s.serverInfo)
+  const connectionMethod = useConnectionStore((s) => s.connectionMethod)
   const { sendRawXml } = useXMPP()
   const [inputXml, setInputXml] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -391,6 +392,7 @@ export function XmppConsole() {
       '================================================================================',
       `Fluux XMPP Console Log`,
       `Version: ${__APP_VERSION__} (${__GIT_COMMIT__})`,
+      `Connection: ${connectionMethod?.toUpperCase() ?? 'Unknown'}`,
       `Exported: ${exportDate}`,
       '================================================================================',
     ]

--- a/apps/fluux/src/components/settings-components/ProfileSettings.tsx
+++ b/apps/fluux/src/components/settings-components/ProfileSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Monitor, Smartphone, Globe, Pencil, Camera, Trash2, Key } from 'lucide-react'
+import { Monitor, Smartphone, Globe, Pencil, Camera, Trash2, Key, Network } from 'lucide-react'
 import { type ResourcePresence, getClientType, getLocalPart, useConnection, usePresence } from '@fluux/sdk'
 import { Avatar } from '../Avatar'
 import { PRESENCE_COLORS } from '@/constants/ui'
@@ -15,7 +15,7 @@ import { Tooltip } from '../Tooltip'
  */
 export function ProfileSettings() {
   const { t } = useTranslation()
-  const { jid, isConnected, ownAvatar, ownNickname, ownResources, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
+  const { jid, isConnected, ownAvatar, ownNickname, ownResources, connectionMethod, setOwnNickname, setOwnAvatar, clearOwnAvatar, clearOwnNickname, supportsPasswordChange } = useConnection()
   const { presenceStatus: presenceShow, statusMessage } = usePresence()
 
   const [isEditing, setIsEditing] = useState(false)
@@ -215,7 +215,18 @@ export function ProfileSettings() {
         )}
 
         {/* JID */}
-        <p className="text-fluux-muted text-sm mb-3">{bareJid}</p>
+        <p className="text-fluux-muted text-sm mb-1">{bareJid}</p>
+
+        {/* Connection method */}
+        {connectionMethod && (
+          <div className="flex items-center gap-1.5 mb-3">
+            <Network className="w-3 h-3 text-fluux-muted" />
+            <span className="text-xs text-fluux-muted">
+              {t(`profile.connectionMethod_${connectionMethod}`)}
+            </span>
+          </div>
+        )}
+        {!connectionMethod && <div className="mb-2" />}
 
         {/* Presence status - always Active since you're using the app */}
         <div className="flex items-center gap-2 mb-2">

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Passwort konnte nicht geändert werden",
     "passwordChangeNotSupported": "Passwortänderung wird von diesem Server nicht unterstützt",
     "priority": "Priorität",
-    "offlineNotice": "Profilbearbeitung ist offline nicht verfügbar"
+    "offlineNotice": "Profilbearbeitung ist offline nicht verfügbar",
+    "connection": "Verbindung",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "XMPP-Konsole",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Failed to change password",
     "passwordChangeNotSupported": "Password change is not supported by this server",
     "priority": "Priority",
-    "offlineNotice": "Profile editing is unavailable while offline"
+    "offlineNotice": "Profile editing is unavailable while offline",
+    "connection": "Connection",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "XMPP Console",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -424,7 +424,11 @@
     "failedToChangePassword": "Error al cambiar contrasena",
     "passwordChangeNotSupported": "El cambio de contrasena no es compatible con este servidor",
     "priority": "Prioridad",
-    "offlineNotice": "La edición del perfil no está disponible sin conexión"
+    "offlineNotice": "La edición del perfil no está disponible sin conexión",
+    "connection": "Conexión",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "Consola XMPP",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Échec du changement de mot de passe",
     "passwordChangeNotSupported": "Le changement de mot de passe n'est pas pris en charge par ce serveur",
     "priority": "Priorité",
-    "offlineNotice": "La modification du profil n'est pas disponible hors ligne"
+    "offlineNotice": "La modification du profil n'est pas disponible hors ligne",
+    "connection": "Connexion",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "Console XMPP",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Impossibile cambiare la password",
     "passwordChangeNotSupported": "Il cambio password non e supportato da questo server",
     "priority": "Priorita",
-    "offlineNotice": "La modifica del profilo non è disponibile offline"
+    "offlineNotice": "La modifica del profilo non è disponibile offline",
+    "connection": "Connessione",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "Console XMPP",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Wachtwoord wijzigen mislukt",
     "passwordChangeNotSupported": "Wachtwoord wijzigen wordt niet ondersteund door deze server",
     "priority": "Prioriteit",
-    "offlineNotice": "Profielbewerking is niet beschikbaar terwijl u offline bent"
+    "offlineNotice": "Profielbewerking is niet beschikbaar terwijl u offline bent",
+    "connection": "Verbinding",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "XMPP Console",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Nie udało się zmienić hasła",
     "passwordChangeNotSupported": "Zmiana hasła nie jest obsługiwana przez ten serwer",
     "priority": "Priorytet",
-    "offlineNotice": "Edycja profilu jest niedostępna w trybie offline"
+    "offlineNotice": "Edycja profilu jest niedostępna w trybie offline",
+    "connection": "Połączenie",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "Konsola XMPP",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -426,7 +426,11 @@
     "failedToChangePassword": "Falha ao alterar palavra-passe",
     "passwordChangeNotSupported": "A alteração de palavra-passe não é suportada por este servidor",
     "priority": "Prioridade",
-    "offlineNotice": "A edição do perfil não está disponível offline"
+    "offlineNotice": "A edição do perfil não está disponível offline",
+    "connection": "Conexão",
+    "connectionMethod_tls": "TLS",
+    "connectionMethod_starttls": "StartTLS",
+    "connectionMethod_websocket": "WebSocket"
   },
   "console": {
     "title": "Consola XMPP",

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -10,9 +10,14 @@ import './index.css'
 
 // Initialize global Tauri file drop listener immediately (before React renders)
 import './utils/tauriFileDrop'
+import { tauriProxyAdapter } from './utils/tauriProxyAdapter'
 
 // Check if running in Tauri
 const isTauri = '__TAURI_INTERNALS__' in window
+
+// Enable native TCP/TLS proxy in Tauri unless explicitly disabled
+const disableTcpProxy = localStorage.getItem('fluux:disable-tcp-proxy') === 'true'
+const proxyAdapter = isTauri && !disableTcpProxy ? tauriProxyAdapter : undefined
 
 // Register service worker only in browser (not Tauri)
 // Tauri uses a custom protocol that doesn't support service workers
@@ -52,7 +57,7 @@ document.addEventListener('keydown', (e) => {
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RenderLoopBoundary>
-      <XMPPProvider debug={import.meta.env.DEV}>
+      <XMPPProvider debug={import.meta.env.DEV} proxyAdapter={proxyAdapter}>
         <ThemeProvider>
           <BrowserRouter>
             <App />

--- a/apps/fluux/src/utils/tauriProxyAdapter.ts
+++ b/apps/fluux/src/utils/tauriProxyAdapter.ts
@@ -1,0 +1,27 @@
+import type { ProxyAdapter, ConnectionMethod } from '@fluux/sdk'
+
+/**
+ * Tauri proxy adapter for native TCP/TLS XMPP connections.
+ *
+ * Uses the Rust-side `start_xmpp_proxy` / `stop_xmpp_proxy` commands
+ * to bridge between a local WebSocket (used by xmpp.js) and a remote
+ * TCP/TLS connection to the XMPP server.
+ */
+export const tauriProxyAdapter: ProxyAdapter = {
+  async startProxy(server: string) {
+    const { invoke } = await import('@tauri-apps/api/core')
+    const result = await invoke<{ url: string; connection_method: string }>(
+      'start_xmpp_proxy',
+      { server },
+    )
+    return {
+      url: result.url,
+      connectionMethod: result.connection_method as ConnectionMethod,
+    }
+  },
+
+  async stopProxy() {
+    const { invoke } = await import('@tauri-apps/api/core')
+    await invoke('stop_xmpp_proxy')
+  },
+}

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -8,6 +8,7 @@ import type {
   SDKEvents,
   SDKEventHandler,
   StorageAdapter,
+  ProxyAdapter,
   PrivacyOptions,
 } from './types'
 import {
@@ -158,6 +159,7 @@ import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './
 export class XMPPClient {
   private currentJid: string | null = null
   private storageAdapter?: StorageAdapter
+  private proxyAdapter?: ProxyAdapter
   private privacyOptions?: PrivacyOptions
 
   /**
@@ -304,6 +306,7 @@ export class XMPPClient {
 
     // Store storage adapter for session persistence
     this.storageAdapter = config.storageAdapter
+    this.proxyAdapter = config.proxyAdapter
     // Store privacy options for avatar fetching behavior
     this.privacyOptions = config.privacyOptions
 
@@ -450,6 +453,7 @@ export class XMPPClient {
       emitSDK: <K extends keyof SDKEvents>(event: K, payload: SDKEvents[K]) => this.emitSDK(event, payload),
       getXmpp: () => this.getXmpp(),
       storageAdapter: this.storageAdapter,
+      proxyAdapter: this.proxyAdapter,
       registerMAMCollector: (queryId: string, collector: (stanza: Element) => void) => this.registerMAMCollector(queryId, collector),
       privacyOptions: this.privacyOptions,
     }

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -73,6 +73,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       setError: connectionStore.getState().setError,
       setReconnectState: connectionStore.getState().setReconnectState,
       setServerInfo: connectionStore.getState().setServerInfo,
+      setConnectionMethod: connectionStore.getState().setConnectionMethod,
       // Presence from external machine (or defaults for headless)
       getPresenceShow,
       getStatusMessage,

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -17,6 +17,7 @@ export type {
   StoreBindings,
   PresenceOptions,
   ConnectionStatus,
+  ConnectionMethod,
   Message,
   ConversationEntity,
   ConversationMetadata,

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -1,5 +1,5 @@
 import type { Element } from '@xmpp/client'
-import type { StoreBindings, XMPPClientEvents, SDKEvents, StorageAdapter, PrivacyOptions } from '../types'
+import type { StoreBindings, XMPPClientEvents, SDKEvents, StorageAdapter, ProxyAdapter, PrivacyOptions } from '../types'
 
 /**
  * Dependencies injected into each module by XMPPClient.
@@ -29,6 +29,11 @@ export interface ModuleDependencies {
    * Used by Connection module for SM state persistence.
    */
   storageAdapter?: StorageAdapter
+  /**
+   * Proxy adapter for WebSocket-to-TCP bridging.
+   * Used by Connection module for native TCP/TLS connections.
+   */
+  proxyAdapter?: ProxyAdapter
   /**
    * Register a MAM query collector.
    * The collector will be called for each incoming stanza while active.

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -563,6 +563,7 @@ export const createMockStores = (): MockStoreBindings => ({
     setPresenceState: vi.fn(),
     setAutoAway: vi.fn(),
     setServerInfo: vi.fn(),
+    setConnectionMethod: vi.fn(),
     getPresenceShow: vi.fn().mockReturnValue('online'),
     getStatusMessage: vi.fn().mockReturnValue(null),
     getIsAutoAway: vi.fn().mockReturnValue(false),

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Element } from '@xmpp/client'
-import type { ConnectionStatus } from './connection'
+import type { ConnectionStatus, ConnectionMethod } from './connection'
 import type { Message, Conversation } from './chat'
 import type { PresenceStatus, PresenceShow, Contact } from './roster'
 import type { Room, RoomOccupant, RoomMessage } from './room'
@@ -17,6 +17,7 @@ import type { RSMResponse, MAMQueryState } from './pagination'
 import type { MAMQueryDirection } from '../../stores/shared/mamState'
 import type { AdminCommand, AdminSession, EntityCounts } from './admin'
 import type { StorageAdapter } from './storage'
+import type { ProxyAdapter } from './proxy'
 
 // ============================================================================
 // Store Bindings (Internal)
@@ -41,6 +42,7 @@ export interface StoreBindings {
     setPresenceState: (show: PresenceStatus, message?: string | null) => void
     setAutoAway: (isAuto: boolean) => void
     setServerInfo: (info: ServerInfo | null) => void
+    setConnectionMethod: (method: ConnectionMethod | null) => void
     // Getters for presence preservation on reconnect
     getPresenceShow: () => PresenceStatus
     getStatusMessage: () => string | null
@@ -343,4 +345,21 @@ export interface XMPPClientConfig {
    * ```
    */
   storageAdapter?: StorageAdapter
+  /**
+   * Proxy adapter for WebSocket-to-TCP bridging.
+   *
+   * Desktop apps can provide a proxy adapter to enable native TCP/TLS
+   * connections to XMPP servers instead of WebSocket.
+   *
+   * When provided, the SDK will use this adapter to start/stop the proxy
+   * for each connection. When not provided, connections use WebSocket directly.
+   *
+   * @example
+   * ```tsx
+   * <XMPPProvider proxyAdapter={tauriProxyAdapter}>
+   *   <App />
+   * </XMPPProvider>
+   * ```
+   */
+  proxyAdapter?: ProxyAdapter
 }

--- a/packages/fluux-sdk/src/core/types/connection.ts
+++ b/packages/fluux-sdk/src/core/types/connection.ts
@@ -21,6 +21,19 @@
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'online' | 'reconnecting' | 'verifying' | 'error'
 
 /**
+ * The transport method used for the XMPP connection.
+ *
+ * @remarks
+ * - `tls`: Direct TLS connection via native TCP proxy (port 5223, Tauri desktop)
+ * - `starttls`: STARTTLS upgrade via native TCP proxy (port 5222, Tauri desktop)
+ * - `websocket`: WebSocket connection (web browser or explicit ws:// URL)
+ * - `null`: Not yet connected or unknown
+ *
+ * @category Connection
+ */
+export type ConnectionMethod = 'tls' | 'starttls' | 'websocket'
+
+/**
  * System state changes that the app can signal to the SDK.
  *
  * Used with `notifySystemState()` to inform the SDK about platform-specific

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -9,7 +9,7 @@
  */
 
 // Connection types
-export type { ConnectionStatus, ConnectOptions, SystemState } from './connection'
+export type { ConnectionStatus, ConnectionMethod, ConnectOptions, SystemState } from './connection'
 
 // Base message type (shared between chat and room messages)
 export type { BaseMessage } from './message-base'
@@ -126,6 +126,12 @@ export type {
   StoredCredentials,
   StorageAdapter,
 } from './storage'
+
+// Proxy types
+export type {
+  ProxyStartResult,
+  ProxyAdapter,
+} from './proxy'
 
 // SDK Events (for event-based decoupling)
 export type {

--- a/packages/fluux-sdk/src/core/types/proxy.ts
+++ b/packages/fluux-sdk/src/core/types/proxy.ts
@@ -1,0 +1,68 @@
+/**
+ * Proxy adapter interface for WebSocket-to-TCP bridging.
+ *
+ * Desktop apps can provide a proxy adapter to enable native TCP/TLS
+ * connections to XMPP servers. The proxy bridges between a local WebSocket
+ * (used by xmpp.js) and a remote TCP/TLS connection.
+ *
+ * @packageDocumentation
+ * @module Types/Proxy
+ */
+
+import type { ConnectionMethod } from './connection'
+
+/**
+ * Result of starting the proxy.
+ */
+export interface ProxyStartResult {
+  /** Local WebSocket URL to connect to (e.g., "ws://127.0.0.1:12345") */
+  url: string
+  /** Connection method used: 'tls' for direct TLS, 'starttls' for STARTTLS upgrade */
+  connectionMethod: ConnectionMethod
+}
+
+/**
+ * Adapter interface for WebSocket-to-TCP proxy implementations.
+ *
+ * The SDK uses this adapter to delegate native TCP/TLS connection handling
+ * to platform-specific implementations. When a proxy adapter is provided,
+ * the SDK will use it instead of connecting directly via WebSocket.
+ *
+ * @example Tauri desktop app
+ * ```typescript
+ * const tauriProxyAdapter: ProxyAdapter = {
+ *   async startProxy(server) {
+ *     const { invoke } = await import('@tauri-apps/api/core')
+ *     const result = await invoke('start_xmpp_proxy', { server })
+ *     return { url: result.url, connectionMethod: result.connection_method }
+ *   },
+ *   async stopProxy() {
+ *     const { invoke } = await import('@tauri-apps/api/core')
+ *     await invoke('stop_xmpp_proxy')
+ *   },
+ * }
+ * ```
+ *
+ * @category Core
+ */
+export interface ProxyAdapter {
+  /**
+   * Start the proxy for the given server.
+   *
+   * The server parameter supports multiple formats depending on the implementation:
+   * - `domain` — resolve via SRV records
+   * - `host:port` — connect directly
+   * - `tls://host:port` — direct TLS connection
+   * - `tcp://host:port` — STARTTLS connection
+   *
+   * @param server - Server specification
+   * @returns Local WebSocket URL and connection method
+   */
+  startProxy(server: string): Promise<ProxyStartResult>
+
+  /**
+   * Stop the running proxy.
+   * Should be graceful — no error if proxy is not running.
+   */
+  stopProxy(): Promise<void>
+}

--- a/packages/fluux-sdk/src/hooks/useConnection.ts
+++ b/packages/fluux-sdk/src/hooks/useConnection.ts
@@ -98,6 +98,7 @@ export function useConnection() {
   const reconnectAttempt = useConnectionStore((s) => s.reconnectAttempt)
   const reconnectIn = useConnectionStore((s) => s.reconnectIn)
   const serverInfo = useConnectionStore((s) => s.serverInfo)
+  const connectionMethod = useConnectionStore((s) => s.connectionMethod)
   // Own profile state
   const ownAvatar = useConnectionStore((s) => s.ownAvatar)
   const ownAvatarHash = useConnectionStore((s) => s.ownAvatarHash)
@@ -270,6 +271,7 @@ export function useConnection() {
       reconnectAttempt,
       reconnectIn,
       serverInfo,
+      connectionMethod,
       // Own profile state
       ownAvatar,
       ownAvatarHash,
@@ -294,6 +296,7 @@ export function useConnection() {
       reconnectAttempt,
       reconnectIn,
       serverInfo,
+      connectionMethod,
       ownAvatar,
       ownAvatarHash,
       ownNickname,

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -178,6 +178,7 @@ export type { StoreRefs, UnsubscribeBindings } from './bindings'
 export type {
   // Connection types
   ConnectionStatus,
+  ConnectionMethod,
   ConnectOptions,
 
   // Base message type (shared between chat and room messages)
@@ -473,6 +474,9 @@ export type { TauriCloseHandlerOptions } from './utils/tauriLifecycle'
 // Storage adapters for session persistence
 export { sessionStorageAdapter } from './utils/sessionStorageAdapter'
 export type { StorageAdapter, SessionState, StoredCredentials, JoinedRoomInfo } from './core/types'
+
+// Proxy adapter for WebSocket-to-TCP bridging (desktop apps)
+export type { ProxyAdapter, ProxyStartResult } from './core/types'
 
 // Emoji shortcode utilities (for clients that send :shortcodes: instead of Unicode)
 export { shortcodeToEmoji, convertShortcodes } from './core/emoji'

--- a/packages/fluux-sdk/src/provider/XMPPProvider.tsx
+++ b/packages/fluux-sdk/src/provider/XMPPProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useRef, useEffect, useMemo, type ReactNode }
 import { XMPPClient } from '../core/XMPPClient'
 import type { XMPPClientConfig } from '../core/types/client'
 import type { StorageAdapter } from '../core/types/storage'
+import type { ProxyAdapter } from '../core/types/proxy'
 import { setupTauriCloseHandlers } from '../utils/tauriLifecycle'
 import { sessionStorageAdapter } from '../utils/sessionStorageAdapter'
 import { setupDebugUtils } from '../utils/debugUtils'
@@ -48,6 +49,20 @@ export interface XMPPProviderProps {
    * ```
    */
   storageAdapter?: StorageAdapter
+  /**
+   * Proxy adapter for WebSocket-to-TCP bridging.
+   *
+   * Desktop apps can provide a proxy adapter to enable native TCP/TLS
+   * connections to XMPP servers instead of WebSocket.
+   *
+   * @example Desktop app with TCP proxy
+   * ```tsx
+   * <XMPPProvider proxyAdapter={tauriProxyAdapter}>
+   *   <App />
+   * </XMPPProvider>
+   * ```
+   */
+  proxyAdapter?: ProxyAdapter
 }
 
 /**
@@ -107,6 +122,7 @@ export function XMPPProvider({
   children,
   debug = false,
   storageAdapter = sessionStorageAdapter,
+  proxyAdapter,
 }: XMPPProviderProps) {
   const clientRef = useRef<XMPPClient | null>(null)
 
@@ -116,7 +132,7 @@ export function XMPPProvider({
   // - Presence sync (machine state -> XMPP presence)
   // - Storage adapter (session persistence)
   if (!clientRef.current) {
-    const config: XMPPClientConfig = { debug, storageAdapter }
+    const config: XMPPClientConfig = { debug, storageAdapter, proxyAdapter }
     clientRef.current = new XMPPClient(config)
   }
 

--- a/packages/fluux-sdk/src/stores/connectionStore.ts
+++ b/packages/fluux-sdk/src/stores/connectionStore.ts
@@ -1,5 +1,5 @@
 import { createStore } from 'zustand/vanilla'
-import type { ConnectionStatus, PresenceShow, ServerInfo, ResourcePresence, HttpUploadService } from '../core/types'
+import type { ConnectionStatus, ConnectionMethod, PresenceShow, ServerInfo, ResourcePresence, HttpUploadService } from '../core/types'
 
 // Re-export for convenience
 export type { ServerInfo, ServerIdentity, HttpUploadService } from '../core/types'
@@ -51,6 +51,7 @@ interface ConnectionState {
   reconnectAttempt: number
   reconnectIn: number | null
   serverInfo: ServerInfo | null
+  connectionMethod: ConnectionMethod | null
   // Own profile data
   ownAvatar: string | null  // Blob URL for display
   ownAvatarHash: string | null  // Hash for cache lookup
@@ -67,6 +68,7 @@ interface ConnectionState {
   setError: (error: string | null) => void
   setReconnectState: (attempt: number, reconnectIn: number | null) => void
   setServerInfo: (info: ServerInfo | null) => void
+  setConnectionMethod: (method: ConnectionMethod | null) => void
   // Own profile actions
   setOwnAvatar: (avatar: string | null, hash?: string | null) => void
   setOwnNickname: (nickname: string | null) => void
@@ -87,6 +89,7 @@ const initialState = {
   reconnectAttempt: 0,
   reconnectIn: null,
   serverInfo: null as ServerInfo | null,
+  connectionMethod: null as ConnectionMethod | null,
   ownAvatar: null as string | null,
   ownAvatarHash: null as string | null,
   ownNickname: null as string | null,
@@ -103,6 +106,7 @@ export const connectionStore = createStore<ConnectionState>((set) => ({
   setError: (error) => set({ error }),
   setReconnectState: (attempt, reconnectIn) => set({ reconnectAttempt: attempt, reconnectIn }),
   setServerInfo: (info) => set({ serverInfo: info }),
+  setConnectionMethod: (method) => set({ connectionMethod: method }),
 
   setOwnAvatar: (avatar, hash) => set({
     ownAvatar: avatar,


### PR DESCRIPTION
## Summary
- Add a Rust-based WebSocket-to-TCP proxy in the Tauri backend for native XMPP connections, bypassing the WebSocket requirement
- Introduce a `ProxyAdapter` type in the SDK to allow custom transport layers (e.g., Tauri proxy)
- Update connection module to support proxy adapters alongside standard WebSocket connections
- Add profile display of connection type (WebSocket vs TCP) in settings