### PR TITLE
feat: add clipboard image paste support with Cmd+V

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1019,13 +1019,14 @@ const RoomMessageInput = React.forwardRef<MessageComposerHandle, RoomMessageInpu
   ) : null
 
   // Custom input renderer with mention highlighting
-  const renderMentionInput = useCallback(({ inputRef, mergedRef, value, onChange, onKeyDown: baseKeyDown, onSelect, placeholder }: {
+  const renderMentionInput = useCallback(({ inputRef, mergedRef, value, onChange, onKeyDown: baseKeyDown, onSelect, onPaste, placeholder }: {
     inputRef: React.RefObject<HTMLTextAreaElement>
     mergedRef: (node: HTMLTextAreaElement | null) => void
     value: string
     onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
     onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
     onSelect?: (e: React.SyntheticEvent<HTMLTextAreaElement>) => void
+    onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
     placeholder: string
   }) => {
     // Enhanced keydown handler for mentions
@@ -1130,6 +1131,7 @@ const RoomMessageInput = React.forwardRef<MessageComposerHandle, RoomMessageInpu
           onChange={onChange}
           onSelect={onSelect}
           onKeyDown={handleKeyDown}
+          onPaste={onPaste}
           onScroll={(e) => {
             // Sync overlay scroll when textarea scrolls
             const overlay = e.currentTarget.previousElementSibling as HTMLElement


### PR DESCRIPTION
## Summary

- Add ability to paste images directly from clipboard using Cmd+V (macOS) or Ctrl+V (Windows/Linux)
- Images are staged as pending attachments before sending, maintaining the privacy-first design
- Works in both ChatView (1:1 chats) and RoomView (group chats with mention support)

## Changes

- **MessageComposer.tsx**: Add `handlePaste` callback and wire it to the textarea
- **RoomView.tsx**: Forward `onPaste` prop to the custom mention input renderer
- **MessageComposer.test.tsx**: Add 7 new tests covering clipboard paste functionality