### PR TITLE
fix(sdk): prevent duplicate avatar fetches for unchanged hashes

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -534,6 +534,11 @@ export class XMPPClient {
       // Emitted by PubSub module for real events or Roster for vcard-temp:x:update
       this.on('avatarMetadataUpdate', (jid, hash) => {
         if (hash) {
+          // Skip if contact already has this avatar hash with a loaded avatar
+          const contact = this.stores?.roster.getContact(jid)
+          if (contact?.avatarHash === hash && contact?.avatar) {
+            return
+          }
           this.profile.fetchAvatarData(jid, hash).catch(() => {})
         } else {
           // Avatar was removed

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -242,13 +242,17 @@ export class MUC extends BaseModule {
         buffer.push(occupant)
         this.pendingOccupants.set(roomJid, buffer)
       } else {
-        // Room already joined - add occupant immediately (e.g., late joiner)
+        // Room already joined - add occupant immediately (e.g., late joiner or presence update)
         // SDK event only - binding calls store.addOccupant
         this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
 
         // XEP-0398: Trigger avatar fetch if occupant has avatar hash
+        // Only emit if hash changed from what we already have
         if (avatarHash) {
-          this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
+          const existing = room?.occupants.get(nick)
+          if (existing?.avatarHash !== avatarHash || !existing?.avatar) {
+            this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add IndexedDB cache check in `fetchAvatarData()` before making network requests, and persist fetched avatars to IndexedDB after successful fetch
- Add hash deduplication at multiple layers: Roster presence handler, MUC occupant presence handler, and XMPPClient event handlers skip re-fetching when the avatar hash hasn't changed
- Add room avatar presence dedup to avoid re-fetching room avatars on repeated presence updates

Fixes an issue where every presence update (including status-only changes like available/away) triggered a full avatar fetch cycle, even when the avatar hash was unchanged and already cached.