### PR TITLE
fix(ui): use consistent border color for attachments across themes

### DIFF
--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -71,7 +71,7 @@ export function ImageAttachment({ attachment, onLoad }: AttachmentProps) {
   if (isLoading) {
     return (
       <div
-        className="pt-2 rounded-lg bg-fluux-hover/60 border border-fluux-muted/10 flex items-center justify-center"
+        className="pt-2 rounded-lg bg-fluux-hover/60 border border-fluux-border flex items-center justify-center"
         style={{ aspectRatio, maxWidth: `${maxWidthPx}px`, maxHeight: '300px', minHeight: '100px' }}
       >
         <Loader2 className="w-6 h-6 text-fluux-muted animate-spin" />
@@ -83,7 +83,7 @@ export function ImageAttachment({ attachment, onLoad }: AttachmentProps) {
   if (error || !proxiedImageSrc || loadError) {
     return (
       <div
-        className="pt-2 rounded-lg bg-fluux-hover/60 border border-fluux-muted/10 flex flex-col items-center justify-center text-fluux-muted text-sm gap-2"
+        className="pt-2 rounded-lg bg-fluux-hover/60 border border-fluux-border flex flex-col items-center justify-center text-fluux-muted text-sm gap-2"
         style={{ aspectRatio, maxWidth: `${maxWidthPx}px`, maxHeight: '300px', minHeight: '100px' }}
       >
         <ImageOff className="w-8 h-8" />
@@ -97,7 +97,7 @@ export function ImageAttachment({ attachment, onLoad }: AttachmentProps) {
       href={attachment.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block pt-2 rounded-lg overflow-hidden hover:opacity-90 transition-opacity"
+      className="block pt-2 rounded-lg overflow-hidden border border-fluux-border hover:opacity-90 transition-opacity"
       style={{ maxWidth: `${maxWidthPx}px` }}
       tabIndex={-1}
     >
@@ -157,7 +157,7 @@ export function VideoAttachment({ attachment, onLoad }: AttachmentProps) {
   // Show error/fallback if fetch failed or video failed to load (404, etc.)
   if (error || !proxiedVideoUrl || loadError) {
     return (
-      <div className="pt-2 max-w-md rounded-lg overflow-hidden bg-fluux-hover/60 border border-fluux-muted/10">
+      <div className="pt-2 max-w-md rounded-lg overflow-hidden bg-fluux-hover/60 border border-fluux-border">
         <div className="flex flex-col items-center justify-center text-fluux-muted text-sm py-8 gap-2">
           <FileX className="w-8 h-8" />
           <span>{t('chat.videoUnavailable')}</span>
@@ -190,7 +190,7 @@ export function VideoAttachment({ attachment, onLoad }: AttachmentProps) {
       </video>
       {/* Video info bar */}
       {attachment.name && (
-        <div className="flex items-center gap-2 px-3 py-2 bg-fluux-hover/80">
+        <div className="flex items-center gap-2 px-3 py-2 bg-fluux-bg/60 border-t border-fluux-border">
           <Film className="w-4 h-4 text-fluux-muted flex-shrink-0" />
           <span className="text-sm text-fluux-text truncate">{attachment.name}</span>
           {attachment.duration !== undefined && (
@@ -238,7 +238,7 @@ export function AudioAttachment({ attachment }: AttachmentProps) {
 
   return (
     <div className="pt-2 max-w-sm">
-      <div className={`flex items-center gap-3 p-3 rounded-t-lg border border-b-0 border-fluux-muted/10 ${hasError ? 'bg-fluux-hover/40' : 'bg-fluux-hover/60'}`}>
+      <div className={`flex items-center gap-3 p-3 rounded-t-lg border border-b-0 border-fluux-border ${hasError ? 'bg-fluux-hover/40' : 'bg-fluux-hover/60'}`}>
         <div className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${hasError ? 'bg-fluux-muted/30' : 'bg-fluux-brand'}`}>
           {isLoading ? (
             <Loader2 className="w-5 h-5 text-white animate-spin" />
@@ -275,7 +275,7 @@ export function AudioAttachment({ attachment }: AttachmentProps) {
         )}
       </div>
       {hasError ? (
-        <div className="w-full rounded-b-lg bg-fluux-bg/40 border border-t-0 border-fluux-muted/10 h-10" />
+        <div className="w-full rounded-b-lg bg-fluux-bg/40 border border-t-0 border-fluux-border h-10" />
       ) : (
         <audio
           controls
@@ -307,7 +307,7 @@ export function FileAttachmentCard({ attachment }: AttachmentProps) {
       href={attachment.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-3 p-3 mt-2 max-w-sm rounded-lg bg-fluux-bg/60 border border-fluux-muted/10 hover:border-fluux-muted/20 hover:bg-fluux-hover/60 transition-colors group/file"
+      className="flex items-center gap-3 p-3 mt-2 max-w-sm rounded-lg bg-fluux-bg/60 border border-fluux-border hover:bg-fluux-hover/60 transition-colors group/file"
       tabIndex={-1}
     >
       {/* File type icon */}

--- a/apps/fluux/src/components/LinkPreviewCard.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.tsx
@@ -28,7 +28,7 @@ export function LinkPreviewCard({ preview, onLoad }: LinkPreviewCardProps) {
       href={preview.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block mt-2 max-w-md border border-fluux-muted/10 hover:border-fluux-muted/20 rounded-lg overflow-hidden bg-fluux-bg/60 hover:bg-fluux-hover/60 transition-colors"
+      className="block mt-2 max-w-md border border-fluux-border rounded-lg overflow-hidden bg-fluux-bg/60 hover:bg-fluux-hover/60 transition-colors"
     >
       {/* Image preview - hidden entirely on error */}
       {preview.image && !imageError && (

--- a/apps/fluux/src/components/MessageAttachments.tsx
+++ b/apps/fluux/src/components/MessageAttachments.tsx
@@ -20,6 +20,10 @@ interface MessageAttachmentsProps {
   attachment: FileAttachment | undefined
   /** Called when media (images) finish loading - useful for scroll adjustment */
   onMediaLoad?: () => void
+  /** Whether the parent message is selected (for gradient adaptation) */
+  isSelected?: boolean
+  /** Whether the parent message is hovered (for gradient adaptation) */
+  isHovered?: boolean
 }
 
 /**
@@ -27,7 +31,7 @@ interface MessageAttachmentsProps {
  * Each attachment component internally checks if it should render
  * based on the attachment's media type.
  */
-export function MessageAttachments({ attachment, onMediaLoad }: MessageAttachmentsProps) {
+export function MessageAttachments({ attachment, onMediaLoad, isSelected, isHovered }: MessageAttachmentsProps) {
   if (!attachment) return null
 
   const canPreview = canPreviewAsText(attachment.mediaType, attachment.name)
@@ -44,7 +48,7 @@ export function MessageAttachments({ attachment, onMediaLoad }: MessageAttachmen
       <AudioAttachment attachment={attachment} />
 
       {/* Text file preview (code, markdown, json, etc.) */}
-      {canPreview && <TextFilePreview attachment={attachment} />}
+      {canPreview && <TextFilePreview attachment={attachment} isSelected={isSelected} isHovered={isHovered} />}
 
       {/* Document/file attachment card (PDF, Word, etc.) */}
       {shouldShowFileCard(attachment, canPreview) && (

--- a/apps/fluux/src/components/TextFilePreview.tsx
+++ b/apps/fluux/src/components/TextFilePreview.tsx
@@ -6,13 +6,17 @@ import type { FileAttachment } from '@fluux/sdk'
 
 interface TextFilePreviewProps {
   attachment: FileAttachment
+  /** Whether the parent message is selected (for gradient adaptation) */
+  isSelected?: boolean
+  /** Whether the parent message is hovered (for gradient adaptation) */
+  isHovered?: boolean
 }
 
 /**
  * Renders an inline text file preview with the file content displayed
  * in a code block, plus a download card below.
  */
-export function TextFilePreview({ attachment }: TextFilePreviewProps) {
+export function TextFilePreview({ attachment, isSelected = false, isHovered = false }: TextFilePreviewProps) {
   const { t } = useTranslation()
   const canPreview = canPreviewAsText(attachment.mediaType, attachment.name)
   const { content, isLoading, error, isTruncated } = useTextPreview(
@@ -26,7 +30,7 @@ export function TextFilePreview({ attachment }: TextFilePreviewProps) {
   return (
     <div className="mt-2 max-w-md">
       {/* Text content preview */}
-      <div className="rounded-t-lg bg-fluux-bg/60 border border-fluux-muted/10 border-b-0 overflow-hidden">
+      <div className="rounded-t-lg bg-fluux-bg/60 border border-fluux-border border-b-0 overflow-hidden">
         {isLoading ? (
           <div className="flex items-center justify-center p-4 text-fluux-muted">
             <Loader2 className="w-4 h-4 animate-spin mr-2" />
@@ -42,7 +46,15 @@ export function TextFilePreview({ attachment }: TextFilePreviewProps) {
               {content}
             </pre>
             {isTruncated && (
-              <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-fluux-bg/60 to-transparent pointer-events-none" />
+              <div
+                className="absolute bottom-0 left-0 right-0 h-8 pointer-events-none"
+                style={{
+                  // Adapt gradient to parent message highlight state (selected > hovered > default)
+                  background: `linear-gradient(to top, var(${
+                    isSelected ? '--fluux-selection' : isHovered ? '--fluux-hover' : '--fluux-bg'
+                  }) 60%, transparent)`,
+                }}
+              />
             )}
           </div>
         ) : null}
@@ -53,7 +65,7 @@ export function TextFilePreview({ attachment }: TextFilePreviewProps) {
         href={attachment.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-3 p-3 rounded-b-lg bg-fluux-hover/60 hover:bg-fluux-bg/60 border border-fluux-muted/10 transition-colors group/file"
+        className="flex items-center gap-3 p-3 rounded-b-lg bg-fluux-hover/60 hover:bg-fluux-bg/60 border border-fluux-border transition-colors group/file"
       >
         <div className="w-8 h-8 rounded-lg bg-fluux-muted/20 flex items-center justify-center flex-shrink-0">
           <FileText className="w-4 h-4 text-fluux-muted" />

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -341,7 +341,7 @@ export const MessageBubble = memo(function MessageBubble({
           />
 
           {/* File attachments (image, video, audio, text preview, document card) - hidden for retracted */}
-          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={onMediaLoad} />}
+          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={onMediaLoad} isSelected={isSelected} isHovered={isHovered} />}
 
           {/* Link preview - hidden for retracted */}
           {!message.isRetracted && message.linkPreview && <LinkPreviewCard preview={message.linkPreview} onLoad={onMediaLoad} />}


### PR DESCRIPTION
- Change from border-fluux-muted/10 to border-fluux-border for all attachment components (images, videos, audio, files, link previews)
- Add border to successfully loaded images (previously had none)
- TextFilePreview truncation gradient now adapts to hover/selection state
- Pass isSelected/isHovered props through MessageAttachments

The fluux-border CSS variable uses black with opacity which provides consistent subtle borders across both dark and light themes:
- Dark mode: rgba(0,0,0,0.1)
- Light mode: rgba(0,0,0,0.15)