### PR TITLE
fix(ui): persist room members sidebar state across view switches

### DIFF
--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -157,6 +157,9 @@ function ChatLayoutContent() {
     selectedContactJid ? s.contacts.get(selectedContactJid) ?? null : null
   )
 
+  // Room occupants panel state (persisted across view switches)
+  const [showRoomOccupants, setShowRoomOccupants] = useState(false)
+
   // Phase 3: Use consolidated navigation hook for per-tab memory and modal management
   const {
     sidebarView,
@@ -216,6 +219,11 @@ function ChatLayoutContent() {
         setSelectedContactJid(savedViewState.selectedContactJid)
       }
 
+      // Restore room occupants panel state
+      if (savedViewState.showRoomOccupants !== undefined) {
+        setShowRoomOccupants(savedViewState.showRoomOccupants)
+      }
+
       // Navigate to the saved sidebar view (including settings)
       switch (savedViewState.sidebarView) {
         case 'messages':
@@ -252,9 +260,10 @@ function ChatLayoutContent() {
       activeConversationId: activeConversationId ?? null,
       activeRoomJid: activeRoomJid ?? null,
       selectedContactJid: selectedContactJid,
+      showRoomOccupants,
     }
     saveViewState(viewState)
-  }, [status, sidebarView, activeConversationId, activeRoomJid, selectedContactJid])
+  }, [status, sidebarView, activeConversationId, activeRoomJid, selectedContactJid, showRoomOccupants])
 
   // Clear selected contact when conversation or room becomes active
   useEffect(() => {
@@ -547,7 +556,7 @@ function ChatLayoutContent() {
           {sidebarView === 'settings' ? (
             <SettingsView onBack={handleSettingsBack} />
           ) : activeRoomJid ? (
-            <RoomView onBack={handleRoomBack} mainContentRef={focusZoneRefs.mainContent} composerRef={focusZoneRefs.composer} />
+            <RoomView onBack={handleRoomBack} mainContentRef={focusZoneRefs.mainContent} composerRef={focusZoneRefs.composer} showOccupants={showRoomOccupants} onShowOccupantsChange={setShowRoomOccupants} />
           ) : activeConversationId ? (
             <ChatView onBack={handleChatBack} onSwitchToMessages={(conversationId) => navigateToMessages(conversationId)} mainContentRef={focusZoneRefs.mainContent} composerRef={focusZoneRefs.composer} />
           ) : selectedContact ? (

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -37,12 +37,15 @@ interface RoomViewProps {
   // Focus zone refs for Tab cycling
   mainContentRef?: RefObject<HTMLElement>
   composerRef?: RefObject<HTMLElement>
+  // Occupant panel state (lifted to parent for persistence across view switches)
+  showOccupants?: boolean
+  onShowOccupantsChange?: (show: boolean) => void
 }
 
 // Max room size for sending typing indicators (to avoid noise in large rooms)
 const MAX_ROOM_SIZE_FOR_TYPING = 30
 
-export function RoomView({ onBack, mainContentRef, composerRef }: RoomViewProps) {
+export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = false, onShowOccupantsChange }: RoomViewProps) {
   const { t } = useTranslation()
   const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, sendChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, activeMAMState } = useRoom()
   const { contacts } = useRoster()
@@ -97,8 +100,10 @@ export function RoomView({ onBack, mainContentRef, composerRef }: RoomViewProps)
   // Track which message has reaction picker open (hides other toolbars)
   const [activeReactionPickerMessageId, setActiveReactionPickerMessageId] = useState<string | null>(null)
 
-  // Occupant panel state
-  const [showOccupants, setShowOccupants] = useState(false)
+  // Occupant panel state setter (calls parent callback if provided)
+  const setShowOccupants = useCallback((show: boolean) => {
+    onShowOccupantsChange?.(show)
+  }, [onShowOccupantsChange])
 
   // Memoized callbacks to prevent render loops (new function refs cause child re-renders)
   const handleCancelReply = useCallback(() => setReplyingTo(null), [])
@@ -106,7 +111,7 @@ export function RoomView({ onBack, mainContentRef, composerRef }: RoomViewProps)
   const handleReactionPickerChange = useCallback((messageId: string, isOpen: boolean) => {
     setActiveReactionPickerMessageId(isOpen ? messageId : null)
   }, [])
-  const handleCloseOccupants = useCallback(() => setShowOccupants(false), [])
+  const handleCloseOccupants = useCallback(() => setShowOccupants(false), [setShowOccupants])
 
   // Memoized upload state to prevent new object reference on every render
   const uploadStateObj = useMemo(() => ({ isUploading, progress }), [isUploading, progress])

--- a/apps/fluux/src/hooks/useSessionPersistence.test.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.test.ts
@@ -130,6 +130,26 @@ describe('useSessionPersistence', () => {
         expect(restored?.sidebarView).toBe(view)
       })
     })
+
+    it('should persist showRoomOccupants state', () => {
+      const viewState: ViewStateData = {
+        sidebarView: 'rooms',
+        activeConversationId: null,
+        activeRoomJid: 'room@conference.example.com',
+        selectedContactJid: null,
+        showRoomOccupants: true,
+      }
+
+      saveViewState(viewState)
+      const restored = getSavedViewState()
+      expect(restored?.showRoomOccupants).toBe(true)
+
+      // Also test with false
+      viewState.showRoomOccupants = false
+      saveViewState(viewState)
+      const restoredFalse = getSavedViewState()
+      expect(restoredFalse?.showRoomOccupants).toBe(false)
+    })
   })
 
   describe('Roster serialization', () => {

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -34,6 +34,7 @@ export interface ViewStateData {
   activeConversationId: string | null
   activeRoomJid: string | null
   selectedContactJid: string | null
+  showRoomOccupants?: boolean  // Whether members sidebar is expanded in room view
 }
 
 /**


### PR DESCRIPTION
When expanding the members sidebar in a room, it persisted when switching between rooms but was lost when navigating to Messages and back to Rooms.

Root cause: showOccupants was local state in RoomView, lost on unmount.

Fix: Lift state to ChatLayout and persist via ViewStateData in sessionStorage. This ensures the members panel state survives view switches and page reloads.