### PR TITLE
fix(tooltip): prevent stuck tooltips on rapid hover

### DIFF
--- a/apps/fluux/src/components/Tooltip.tsx
+++ b/apps/fluux/src/components/Tooltip.tsx
@@ -64,6 +64,10 @@ export function Tooltip({
 
   const showTooltip = () => {
     if (effectiveDisabled) return
+    // Clear any existing timeout to prevent orphaned timeouts from firing
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
     timeoutRef.current = setTimeout(() => {
       setIsVisible(true)
     }, delay)


### PR DESCRIPTION
Clear existing timeout in showTooltip() before starting a new one. This prevents orphaned timeouts from firing after mouse has left.