### PR TITLE
Fix room sorting after connection

### DIFF
--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "10.13",
-      "bundleVersion": "e0f24f9",
+      "bundleVersion": "673aeec",
       "entitlements": "Entitlements.plist",
       "signingIdentity": null
     },


### PR DESCRIPTION
fix(store): remove `lastInteractedAt` updates on room join