### PR TITLE
fix: restore pointer cursor on interactive buttons

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Restore pointer cursor on interactive elements (Tailwind Preflight resets to default) */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+}
+
 /* Inter font - self-hosted for privacy (no Google Fonts connection) */
 @font-face {
   font-family: 'Inter';


### PR DESCRIPTION
Tailwind Preflight resets button cursor to default. This adds a base layer rule to restore cursor: pointer for non-disabled buttons, fixing the UX issue where top bar buttons didn't show the clickable cursor.