### PR TITLE
feat: Dockerfile and docker-compose for web self-hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:latest as builder
+
+WORKDIR /home/app
+COPY ./fluux-messenger/package.json ./fluux-messenger/package-lock.json ./
+
+RUN npm install --frozen-lockfile
+
+COPY ./fluux-messenger/ /home/app
+RUN npm run build
+
+FROM nginx:alpine AS production
+
+# Copy the production build artifacts from the build stage
+COPY --from=builder /home/app/apps/fluux/dist /usr/share/nginx/html
+
+# Expose the default NGINX port
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  ejabberd:
+    image: ghcr.io/processone/ecs
+    container_name: ejabberd
+    volumes:
+      - ./conf/ejabberd.yml:/opt/ejabberd/conf/ejabberd.yml
+      - ./database:/opt/ejabberd/database
+      - ./logs:/opt/ejabberd/logs
+      - ./upload:/opt/ejabberd/upload
+  fluux-messenger:
+    build: .
+    container_name: fluux-messenger
+    working_dir: /home/app
+    restart: unless-stopped


### PR DESCRIPTION
Regarding issue #163 .

The Dockerfile builds an image with the react web app built and sent to a nginx-alpine to be exposed. It is used in a docker-compose.yml with a ejabberd/ecs server