### PR TITLE
chore(flatpak): Upgrade runtime

### DIFF
--- a/packaging/flatpak/com.processone.fluux.yaml
+++ b/packaging/flatpak/com.processone.fluux.yaml
@@ -1,6 +1,6 @@
 app-id: com.processone.fluux
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 command: fluux-messenger
 appstream-compose: false


### PR DESCRIPTION
The GNOME 47 runtime is no longer supported as of October 15, 2025.

This should also solve an issue a user encountered on NVIDIA + X11; "Failed to create GBM buffer of size 1000x700: Invalid argument".