### PR TITLE
chore(renovate): improve dependency update config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,16 @@
     "devel"
   ],
   "labels": ["dependencies"],
-  "postUpdateOptions": ["npmInstallTwice"],
-  "ignoreDeps": ["@xmpp/client", "@xmpp/debug"],
   "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
     {
       "groupName": "Rust crates",
       "groupSlug": "rust",
       "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["minor", "patch", "major"]
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "groupName": "GitHub Actions (CI)",
@@ -48,12 +50,18 @@
       ]
     },
     {
-      "groupName": "ESLint & TypeScript",
-      "groupSlug": "lint",
+      "groupName": "ESLint",
+      "groupSlug": "eslint",
       "matchPackageNames": [
         "/eslint/",
-        "/typescript-eslint/",
-        "/typescript/"
+        "/typescript-eslint/"
+      ]
+    },
+    {
+      "groupName": "XMPP",
+      "groupSlug": "xmpp",
+      "matchPackageNames": [
+        "/^@xmpp//"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Enable automerge for minor/patch updates (CI must pass)
- Remove `npmInstallTwice` workaround
- Unignore `@xmpp/client` and `@xmpp/debug`, group them as XMPP
- Separate ESLint from TypeScript into distinct groups
- Exclude major updates from Rust crates group (majors get individual PRs)