### PR TITLE
fix: ToC links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@
 
 ## Table of Contents
 
-- [Screenshots](#-screenshots)
-- [Features](#-features)
-- [Quick Start](#-quick-start)
-- [Technology Stack](#-technology-stack)
-- [Support & Community](#-support-and-community)
-- [Frequently Asked Questions](#-frequently-asked-questions)
-- [Contributing](#-contributing)
-- [License](#-license)
-- [Star History](#-star-history)
+- [Screenshots](#screenshots)
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [Technology Stack](#technology-stack)
+- [Support & Community](#support-and-community)
+- [Frequently Asked Questions](#frequently-asked-questions)
+- [Contributing](#contributing)
+- [License](#license)
+- [Star History](#star-history)
 
 ## Screenshots
 


### PR DESCRIPTION
Removes leading "-" in Table of Contents links so links jump to appropriate place on the page.