### PR TITLE
perf: skip PEP avatar requests for domains that block PubSub access

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -59,6 +59,10 @@ vi.mock('../../utils/avatarCache', () => ({
   hasNoAvatar: vi.fn().mockResolvedValue(false),
   markNoAvatar: vi.fn().mockResolvedValue(undefined),
   clearNoAvatar: vi.fn().mockResolvedValue(undefined),
+  // PEP-forbidden domain cache functions
+  isPepForbiddenDomain: vi.fn().mockReturnValue(false),
+  markPepForbiddenDomain: vi.fn().mockResolvedValue(undefined),
+  loadPepForbiddenDomains: vi.fn().mockResolvedValue(undefined),
 }))
 
 describe('XMPPClient Own Avatar', () => {

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -4,7 +4,7 @@ import { BaseModule } from './BaseModule'
 import { getBareJid, getLocalPart, getDomain } from '../jid'
 import type { VCardInfo } from '../types/roster'
 import { generateUUID } from '../../utils/uuid'
-import { getCachedAvatar, getAvatarHash, cacheAvatar, saveAvatarHash, getAllAvatarHashes, hasNoAvatar, markNoAvatar, clearNoAvatar, refreshAllBlobUrls } from '../../utils/avatarCache'
+import { getCachedAvatar, getAvatarHash, cacheAvatar, saveAvatarHash, getAllAvatarHashes, hasNoAvatar, markNoAvatar, clearNoAvatar, refreshAllBlobUrls, isPepForbiddenDomain, markPepForbiddenDomain, loadPepForbiddenDomains } from '../../utils/avatarCache'
 import {
   NS_PUBSUB,
   NS_NICK,
@@ -66,6 +66,13 @@ export class Profile extends BaseModule {
       return
     }
 
+    // Skip PEP for domains known to block PubSub avatar access
+    const domain = getDomain(bareJid)
+    if (isPepForbiddenDomain(domain)) {
+      await this.fetchVCardAvatar(bareJid)
+      return
+    }
+
     try {
       // Try XEP-0084 (PEP) first
       const iq = xml('iq', { type: 'get', to: bareJid, id: `avatar_${generateUUID()}` },
@@ -89,7 +96,12 @@ export class Profile extends BaseModule {
         // Fallback to VCard
         await this.fetchVCardAvatar(bareJid)
       }
-    } catch {
+    } catch (err: any) {
+      // Learn from forbidden/service-unavailable: cache the domain to skip PEP next time
+      const condition = err?.condition as string | undefined
+      if (condition === 'forbidden' || condition === 'service-unavailable') {
+        markPepForbiddenDomain(domain).catch(() => {})
+      }
       await this.fetchVCardAvatar(bareJid)
     }
   }
@@ -109,6 +121,13 @@ export class Profile extends BaseModule {
 
     // Check negative cache first - skip if we recently confirmed no avatar
     if (await hasNoAvatar(bareJid)) {
+      return null
+    }
+
+    // Skip PEP for domains known to block PubSub avatar access
+    const domain = getDomain(bareJid)
+    if (isPepForbiddenDomain(domain)) {
+      await this.fetchVCardAvatar(bareJid)
       return null
     }
 
@@ -147,7 +166,12 @@ export class Profile extends BaseModule {
         this.deps.emit('avatarMetadataUpdate', bareJid, hash)
         return hash
       }
-    } catch {
+    } catch (err: any) {
+      // Learn from forbidden/service-unavailable: cache the domain to skip PEP next time
+      const condition = err?.condition as string | undefined
+      if (condition === 'forbidden' || condition === 'service-unavailable') {
+        markPepForbiddenDomain(domain).catch(() => {})
+      }
       // Contact may not support XEP-0084 or PEP, try vCard-temp (XEP-0054) as fallback
       await this.fetchVCardAvatar(bareJid)
     }
@@ -271,47 +295,49 @@ export class Profile extends BaseModule {
     // If we have a real JID, try to fetch from their PEP or vCard
     if (realJid) {
       const bareJid = getBareJid(realJid)
+      const domain = getDomain(bareJid)
 
       // The presence advertises an avatar hash, which is a positive signal
       // that the user now has an avatar. Clear any stale negative cache entry
       // (they may have been marked as "no avatar" from a previous session).
       await clearNoAvatar(bareJid)
 
-      let gotForbidden = false
-
-      try {
-        // Try XEP-0084 (PEP) first
-        const iq = xml('iq', { type: 'get', to: bareJid, id: `avatar_${generateUUID()}` },
-          xml('pubsub', { xmlns: NS_PUBSUB },
-            xml('items', { node: NS_AVATAR_DATA },
-              xml('item', { id: avatarHash })
+      // Skip PEP for domains known to block PubSub avatar access
+      if (!isPepForbiddenDomain(domain)) {
+        try {
+          // Try XEP-0084 (PEP) first
+          const iq = xml('iq', { type: 'get', to: bareJid, id: `avatar_${generateUUID()}` },
+            xml('pubsub', { xmlns: NS_PUBSUB },
+              xml('items', { node: NS_AVATAR_DATA },
+                xml('item', { id: avatarHash })
+              )
             )
           )
-        )
-        const result = await this.deps.sendIQ(iq)
-        const data = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')?.getChild('data', NS_AVATAR_DATA)?.text()
+          const result = await this.deps.sendIQ(iq)
+          const data = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')?.getChild('data', NS_AVATAR_DATA)?.text()
 
-        if (data) {
-          const mimeType = 'image/png'
-          const blobUrl = await cacheAvatar(avatarHash, data, mimeType)
-          await clearNoAvatar(bareJid)
-          // Persist JID→hash mapping so we can restore from cache on next session
-          await saveAvatarHash(bareJid, avatarHash, 'contact')
-          this.deps.emitSDK('room:occupant-avatar', {
-            roomJid,
-            nick,
-            avatar: blobUrl,
-            avatarHash,
-          })
-          return
+          if (data) {
+            const mimeType = 'image/png'
+            const blobUrl = await cacheAvatar(avatarHash, data, mimeType)
+            await clearNoAvatar(bareJid)
+            // Persist JID→hash mapping so we can restore from cache on next session
+            await saveAvatarHash(bareJid, avatarHash, 'contact')
+            this.deps.emitSDK('room:occupant-avatar', {
+              roomJid,
+              nick,
+              avatar: blobUrl,
+              avatarHash,
+            })
+            return
+          }
+        } catch (err: any) {
+          // Learn from forbidden/service-unavailable: cache the domain to skip PEP next time
+          const condition = err?.condition as string | undefined
+          if (condition === 'forbidden' || condition === 'service-unavailable') {
+            markPepForbiddenDomain(domain).catch(() => {})
+          }
+          // Fall through to vCard fetch
         }
-      } catch (err) {
-        // Check if this is a forbidden error
-        const errorMsg = err instanceof Error ? err.message : String(err)
-        if (errorMsg.includes('forbidden')) {
-          gotForbidden = true
-        }
-        // Fall through to vCard fetch
       }
 
       // Try vCard-temp (XEP-0054)
@@ -341,13 +367,9 @@ export class Profile extends BaseModule {
           // vCard exists but no photo - mark as no avatar
           await markNoAvatar(bareJid, 'contact')
         }
-      } catch (err) {
-        // Check if this is a forbidden error
-        const errorMsg = err instanceof Error ? err.message : String(err)
-        if (errorMsg.includes('forbidden') || gotForbidden) {
-          // Cache forbidden errors to avoid repeated queries
-          await markNoAvatar(bareJid, 'contact')
-        }
+      } catch {
+        // vCard fetch failed - mark as no avatar
+        await markNoAvatar(bareJid, 'contact')
       }
       return
     }
@@ -921,6 +943,9 @@ export class Profile extends BaseModule {
    * This is called after roster load to populate avatars for offline contacts.
    */
   async restoreAllContactAvatarHashes(): Promise<void> {
+    // Load PEP-forbidden domains before avatar fetches begin
+    await loadPepForbiddenDomains().catch(() => {})
+
     try {
       const mappings = await getAllAvatarHashes('contact')
       for (const mapping of mappings) {

--- a/packages/fluux-sdk/src/utils/avatarCache.pepForbidden.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.pepForbidden.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isPepForbiddenDomain,
+  markPepForbiddenDomain,
+  clearAllPepForbiddenDomains,
+  _resetPepForbiddenDomainsForTesting,
+} from './avatarCache'
+
+describe('PEP-forbidden domain cache', () => {
+  beforeEach(() => {
+    _resetPepForbiddenDomainsForTesting()
+  })
+
+  it('should return false for unknown domains', () => {
+    expect(isPepForbiddenDomain('example.com')).toBe(false)
+  })
+
+  it('should return true after marking a domain', async () => {
+    await markPepForbiddenDomain('disroot.org')
+    expect(isPepForbiddenDomain('disroot.org')).toBe(true)
+  })
+
+  it('should not affect other domains', async () => {
+    await markPepForbiddenDomain('disroot.org')
+    expect(isPepForbiddenDomain('jabber.org')).toBe(false)
+  })
+
+  it('should handle multiple domains', async () => {
+    await markPepForbiddenDomain('disroot.org')
+    await markPepForbiddenDomain('yax.im')
+    await markPepForbiddenDomain('monocles.de')
+
+    expect(isPepForbiddenDomain('disroot.org')).toBe(true)
+    expect(isPepForbiddenDomain('yax.im')).toBe(true)
+    expect(isPepForbiddenDomain('monocles.de')).toBe(true)
+    expect(isPepForbiddenDomain('process-one.net')).toBe(false)
+  })
+
+  it('should clear all domains', async () => {
+    await markPepForbiddenDomain('disroot.org')
+    await markPepForbiddenDomain('yax.im')
+
+    await clearAllPepForbiddenDomains()
+
+    expect(isPepForbiddenDomain('disroot.org')).toBe(false)
+    expect(isPepForbiddenDomain('yax.im')).toBe(false)
+  })
+
+  it('should be idempotent when marking the same domain twice', async () => {
+    await markPepForbiddenDomain('disroot.org')
+    await markPepForbiddenDomain('disroot.org')
+    expect(isPepForbiddenDomain('disroot.org')).toBe(true)
+  })
+})

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -5,16 +5,24 @@
  */
 
 const DB_NAME = 'fluux-avatar-cache'
-const DB_VERSION = 3
+const DB_VERSION = 4
 const STORE_NAME = 'avatars'
 const HASH_STORE_NAME = 'avatar-hashes'
 const NO_AVATAR_STORE_NAME = 'no-avatar-jids'
+const PEP_FORBIDDEN_STORE_NAME = 'pep-forbidden-domains'
 
 /**
  * Default TTL for "no avatar" cache entries (24 hours in milliseconds)
  * After this time, we'll re-check if the JID has an avatar
  */
 const NO_AVATAR_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Default TTL for PEP-forbidden domain cache entries (7 days in milliseconds).
+ * Domains that return 'forbidden' or 'service-unavailable' for PEP avatar
+ * requests are cached so we skip PEP and go directly to vCard-temp.
+ */
+const PEP_FORBIDDEN_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
 interface CachedAvatar {
   hash: string // SHA-1 hash (primary key)
@@ -41,6 +49,15 @@ interface NoAvatarEntry {
   type: AvatarEntityType // 'contact' or 'room'
 }
 
+/**
+ * Entry tracking a domain whose server blocks PEP avatar access.
+ * Used to skip PEP requests and go directly to vCard-temp.
+ */
+interface PepForbiddenDomainEntry {
+  domain: string // Domain (primary key)
+  timestamp: number // When this was recorded
+}
+
 let dbPromise: Promise<IDBDatabase> | null = null
 
 /**
@@ -49,6 +66,13 @@ let dbPromise: Promise<IDBDatabase> | null = null
  * proper cleanup via URL.revokeObjectURL().
  */
 const blobUrlPool = new Map<string, string>()
+
+/**
+ * In-memory set of domains known to block PEP avatar access.
+ * Populated from IndexedDB on load, updated on new forbidden responses.
+ * Enables synchronous checks to skip PEP requests entirely.
+ */
+const pepForbiddenDomains = new Set<string>()
 
 /**
  * Check if IndexedDB is available in the current environment
@@ -98,6 +122,10 @@ function getDB(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains(NO_AVATAR_STORE_NAME)) {
         const noAvatarStore = db.createObjectStore(NO_AVATAR_STORE_NAME, { keyPath: 'jid' })
         noAvatarStore.createIndex('type', 'type', { unique: false })
+      }
+      // PEP-forbidden domains store (v4) - domain-level negative cache
+      if (!db.objectStoreNames.contains(PEP_FORBIDDEN_STORE_NAME)) {
+        db.createObjectStore(PEP_FORBIDDEN_STORE_NAME, { keyPath: 'domain' })
       }
     }
   })
@@ -533,6 +561,102 @@ export async function clearAllNoAvatarEntries(): Promise<void> {
   }
 }
 
+// =============================================================================
+// PEP-Forbidden Domain Cache Functions
+// =============================================================================
+
+/**
+ * Check if a domain is known to block PEP avatar access (synchronous).
+ * Returns true if the domain previously returned 'forbidden' or
+ * 'service-unavailable' for PEP avatar requests.
+ */
+export function isPepForbiddenDomain(domain: string): boolean {
+  return pepForbiddenDomains.has(domain)
+}
+
+/**
+ * Mark a domain as blocking PEP avatar access.
+ * Adds to in-memory Set and persists to IndexedDB.
+ */
+export async function markPepForbiddenDomain(domain: string): Promise<void> {
+  pepForbiddenDomains.add(domain)
+
+  try {
+    const db = await getDB()
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(PEP_FORBIDDEN_STORE_NAME, 'readwrite')
+      const store = transaction.objectStore(PEP_FORBIDDEN_STORE_NAME)
+      const entry: PepForbiddenDomainEntry = {
+        domain,
+        timestamp: Date.now(),
+      }
+      const request = store.put(entry)
+
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve()
+    })
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to persist PEP-forbidden domain:', error)
+    }
+  }
+}
+
+/**
+ * Load PEP-forbidden domains from IndexedDB into the in-memory Set.
+ * Expired entries (older than TTL) are removed during load.
+ * Call once at startup before avatar fetches begin.
+ */
+export async function loadPepForbiddenDomains(ttlMs: number = PEP_FORBIDDEN_TTL_MS): Promise<void> {
+  try {
+    const db = await getDB()
+    const transaction = db.transaction(PEP_FORBIDDEN_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(PEP_FORBIDDEN_STORE_NAME)
+    const entries: PepForbiddenDomainEntry[] = await new Promise((resolve, reject) => {
+      const request = store.getAll()
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result as PepForbiddenDomainEntry[])
+    })
+
+    const cutoff = Date.now() - ttlMs
+    for (const entry of entries) {
+      if (entry.timestamp < cutoff) {
+        // Expired — remove from IndexedDB
+        store.delete(entry.domain)
+      } else {
+        pepForbiddenDomains.add(entry.domain)
+      }
+    }
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to load PEP-forbidden domains:', error)
+    }
+  }
+}
+
+/**
+ * Clear all PEP-forbidden domain entries (in-memory and IndexedDB).
+ */
+export async function clearAllPepForbiddenDomains(): Promise<void> {
+  pepForbiddenDomains.clear()
+
+  try {
+    const db = await getDB()
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(PEP_FORBIDDEN_STORE_NAME, 'readwrite')
+      const store = transaction.objectStore(PEP_FORBIDDEN_STORE_NAME)
+      const request = store.clear()
+
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve()
+    })
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to clear PEP-forbidden domains:', error)
+    }
+  }
+}
+
 /**
  * Revoke all tracked avatar blob URLs.
  * Call on disconnect or when clearing all avatar data.
@@ -584,6 +708,15 @@ export function _resetBlobUrlPoolForTesting(): void {
 }
 
 /**
+ * Reset the PEP-forbidden domains set.
+ * For test isolation only.
+ * @internal
+ */
+export function _resetPepForbiddenDomainsForTesting(): void {
+  pepForbiddenDomains.clear()
+}
+
+/**
  * Reset the database instance.
  * For test isolation only.
  * @internal
@@ -601,6 +734,7 @@ export async function clearAllAvatarData(): Promise<void> {
     clearAllAvatars(),
     clearAllAvatarHashes(),
     clearAllNoAvatarEntries(),
+    clearAllPepForbiddenDomains(),
   ])
 }
 


### PR DESCRIPTION
- Add a domain-level PEP-forbidden cache that learns from `forbidden`/`service-unavailable` errors on PEP avatar data requests
- Domains are cached in-memory (Set) for fast synchronous lookup, backed by IndexedDB for cross-session persistence with a 7-day TTL
- `fetchAvatarData`, `fetchContactAvatarMetadata`, and `fetchOccupantAvatar` all skip PEP and go directly to vCard-temp for cached domains
- Eliminates wasted PEP IQ round-trips per login