### PR TITLE
feat: decorative quotation marks for blockquotes

### DIFF
--- a/apps/fluux/src/demo/conversations/james.ts
+++ b/apps/fluux/src/demo/conversations/james.ts
@@ -89,6 +89,16 @@ export const JAMES_MESSAGES: Message[] = [
     },
   },
   {
+    type: 'chat', id: 'demo-james-7d', from: conv,
+    body: 'From the XEP-0198 spec:\n\n> When a session is resumed, the server MUST replay any stanzas\n> that were not handled by the client before the disconnect.\n\nSo we should be safe with our current approach.',
+    timestamp: hoursAgo(2.1), isOutgoing: false, conversationId: conv,
+  },
+  {
+    type: 'chat', id: 'demo-james-7e', from: SELF_JID,
+    body: 'Right, and building on that:\n\n>> When a session is resumed, the server MUST replay any stanzas\n> This means our queue should be empty after resume\n\nExactly what I observed in testing.',
+    timestamp: hoursAgo(2.05), isOutgoing: true, conversationId: conv,
+  },
+  {
     type: 'chat', id: 'demo-james-8', from: conv, body: 'By the way, I found a bug in the error handling — when the server returns a 503, we retry immediately instead of backing off',
     timestamp: hoursAgo(2), isOutgoing: false, conversationId: conv,
   },

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -420,6 +420,44 @@ html, body {
   -webkit-overflow-scrolling: touch;
 }
 
+/* Blockquote with decorative quotation marks — distinguishes quotes from reply indicators */
+.blockquote-decorated {
+  position: relative;
+  padding-left: 1.25rem;
+  padding-right: 0.5rem;
+  margin-block: 0.125rem;
+}
+.blockquote-decorated::before {
+  content: '\201C';
+  position: absolute;
+  left: 0;
+  top: -0.15rem;
+  font-size: 1.75rem;
+  line-height: 1;
+  color: var(--fluux-brand);
+  opacity: 0.6;
+  font-family: Georgia, 'Times New Roman', serif;
+}
+.blockquote-decorated::after {
+  content: '\201D';
+  font-size: 1.75rem;
+  line-height: 0;
+  color: var(--fluux-brand);
+  opacity: 0.6;
+  font-family: Georgia, 'Times New Roman', serif;
+  vertical-align: -0.4rem;
+  margin-left: 0.1rem;
+}
+/* Nested blockquote level — indented with a thin left border, no extra quote marks */
+.blockquote-nested {
+  position: relative;
+  padding-left: 0.625rem;
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+  border-left: 2px solid var(--fluux-brand);
+  opacity: 0.85;
+}
+
 /* Remove default focus outline */
 *:focus {
   outline: none;

--- a/apps/fluux/src/utils/messageStyles.test.tsx
+++ b/apps/fluux/src/utils/messageStyles.test.tsx
@@ -218,6 +218,34 @@ describe('renderStyledMessage', () => {
       const container = renderText('x > y means greater than')
       expect(container.querySelector('blockquote')).toBeFalsy()
     })
+
+    it('renders nested blockquote with >> syntax', () => {
+      const container = renderText('>> Deep quote\n> Shallow quote')
+      const outer = container.querySelector('blockquote.blockquote-decorated')
+      expect(outer).toBeTruthy()
+      const nested = outer?.querySelector('blockquote.blockquote-nested')
+      expect(nested).toBeTruthy()
+      expect(nested?.textContent).toContain('Deep quote')
+      expect(outer?.textContent).toContain('Shallow quote')
+    })
+
+    it('renders mixed depth quotes with proper nesting', () => {
+      const container = renderText('> Top level\n>> Nested level\n> Back to top')
+      const outer = container.querySelector('blockquote.blockquote-decorated')
+      expect(outer).toBeTruthy()
+      expect(outer?.textContent).toContain('Top level')
+      expect(outer?.textContent).toContain('Nested level')
+      expect(outer?.textContent).toContain('Back to top')
+      const nested = outer?.querySelector('blockquote.blockquote-nested')
+      expect(nested).toBeTruthy()
+      expect(nested?.textContent).toBe('Nested level')
+    })
+
+    it('uses blockquote-decorated class on outer quote', () => {
+      const container = renderText('> Simple quote')
+      const quote = container.querySelector('blockquote')
+      expect(quote?.classList.contains('blockquote-decorated')).toBe(true)
+    })
   })
 
   describe('unordered lists (-, +, *)', () => {

--- a/apps/fluux/src/utils/messageStyles.tsx
+++ b/apps/fluux/src/utils/messageStyles.tsx
@@ -648,28 +648,59 @@ function renderTextBlock(
 ): React.ReactNode[] {
   const lines = text.split('\n')
   const result: React.ReactNode[] = []
-  let quoteBuffer: { depth: number; lines: string[]; lineOffsets: number[] } | null = null
+  let quoteBuffer: { depth: number; content: string; offset: number }[] | null = null
   let ulBuffer: { lines: string[]; lineOffsets: number[] } | null = null
   let olBuffer: { items: { number: number; content: string; offset: number }[] } | null = null
   let index = startIndex
   let currentOffset = textOffset
 
+  const renderQuoteBlock = (
+    entries: { depth: number; content: string; offset: number }[],
+    currentDepth: number,
+    baseIdx: number
+  ): React.ReactNode => {
+    const children: React.ReactNode[] = []
+    let i = 0
+
+    while (i < entries.length) {
+      const entry = entries[i]
+      if (entry.depth <= currentDepth) {
+        // Render this line at the current depth
+        // Add <br/> between consecutive same-depth lines
+        if (children.length > 0 && i > 0 && entries[i - 1].depth <= currentDepth) {
+          children.push(<br key={`br-${baseIdx + i}`} />)
+        }
+        children.push(
+          <React.Fragment key={`line-${baseIdx + i}`}>
+            {renderInline(entry.content, baseIdx + i, mentionRanges, entry.offset, isDarkMode, disableMentionFallback)}
+          </React.Fragment>
+        )
+        i++
+      } else {
+        // Collect consecutive deeper lines and render as nested blockquote
+        const nestedStart = i
+        while (i < entries.length && entries[i].depth > currentDepth) {
+          i++
+        }
+        children.push(renderQuoteBlock(entries.slice(nestedStart, i), currentDepth + 1, baseIdx + nestedStart))
+      }
+    }
+
+    const isOutermost = currentDepth === 1
+    return (
+      <blockquote
+        key={`quote-${baseIdx}`}
+        className={isOutermost ? 'blockquote-decorated text-fluux-muted italic' : 'blockquote-nested text-fluux-muted italic'}
+      >
+        {children}
+      </blockquote>
+    )
+  }
+
   const flushQuote = () => {
-    if (quoteBuffer && quoteBuffer.lines.length > 0) {
-      result.push(
-        <blockquote
-          key={`quote-${index++}`}
-          className="border-l-4 border-fluux-brand pl-3 my-1 text-fluux-muted italic"
-        >
-          {quoteBuffer.lines.map((line, i) => (
-            <React.Fragment key={i}>
-              {renderInline(line, index + i, mentionRanges, quoteBuffer!.lineOffsets[i], isDarkMode, disableMentionFallback)}
-              {i < quoteBuffer!.lines.length - 1 && <br />}
-            </React.Fragment>
-          ))}
-        </blockquote>
-      )
-      index += quoteBuffer.lines.length
+    if (quoteBuffer && quoteBuffer.length > 0) {
+      result.push(renderQuoteBlock(quoteBuffer, 1, index))
+      index += quoteBuffer.length
       quoteBuffer = null
     }
   }
@@ -733,11 +764,10 @@ function renderTextBlock(
       flushOrderedList()
 
       if (!quoteBuffer) {
-        quoteBuffer = { depth: 1, lines: [], lineOffsets: [] }
+        quoteBuffer = []
       }
       const prefixLength = line.length - quoteCheck.content.length
-      quoteBuffer.lines.push(quoteCheck.content)
-      quoteBuffer.lineOffsets.push(lineOffset + prefixLength)
+      quoteBuffer.push({ depth: quoteCheck.depth, content: quoteCheck.content, offset: lineOffset + prefixLength })
       currentOffset += line.length + 1
       continue
     }


### PR DESCRIPTION
## Summary
- Replace solid left border on blockquotes with decorative curly quotation marks to visually distinguish quotes from reply indicators
- Support nested quotes (`>>` syntax) rendered as indented blocks with a thin brand-colored left border
- Reduce vertical spacing around blockquotes for tighter integration with surrounding text