### PR TITLE
fix: prevent reconnection loop after system sleep/wake

### DIFF
--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -167,6 +167,10 @@ export function setupBackgroundSyncSideEffects(
           if (nonQuickChatRooms.length > 0) {
             logInfo(`Background sync: member discovery for ${nonQuickChatRooms.length} rooms`)
             for (const room of nonQuickChatRooms) {
+              if (!client.isConnected()) {
+                logInfo('Background sync: aborting member discovery — disconnected')
+                break
+              }
               await client.muc.queryRoomMembers(room.jid)
             }
           }

--- a/packages/fluux-sdk/src/core/connectionMachine.test.ts
+++ b/packages/fluux-sdk/src/core/connectionMachine.test.ts
@@ -372,7 +372,7 @@ describe('connectionMachine', () => {
       actor.stop()
     })
 
-    it('should reset backoff counter on WAKE while waiting', () => {
+    it('should preserve backoff counter on WAKE while waiting', () => {
       // Build up backoff: attempt 1 → fail → attempt 2 → fail → attempt 3
       actor.send({ type: 'TRIGGER_RECONNECT' })
       actor.send({ type: 'CONNECTION_ERROR', error: 'fail' })
@@ -383,14 +383,14 @@ describe('connectionMachine', () => {
       expect(actor.getSnapshot().context.reconnectAttempt).toBe(3)
       expect(actor.getSnapshot().context.nextRetryDelayMs).toBe(4000)
 
-      // WAKE should reset backoff so next failure starts at attempt 1
+      // WAKE should skip to attempting but preserve the attempt counter
       actor.send({ type: 'WAKE', sleepDurationMs: 5000 })
-      expect(actor.getSnapshot().context.reconnectAttempt).toBe(0)
+      expect(actor.getSnapshot().context.reconnectAttempt).toBe(3)
 
-      // Failure after WAKE-reset should use attempt 1 delay (1s)
+      // Failure after WAKE should continue backoff from attempt 3 → 4
       actor.send({ type: 'CONNECTION_ERROR', error: 'fail' })
-      expect(actor.getSnapshot().context.reconnectAttempt).toBe(1)
-      expect(actor.getSnapshot().context.nextRetryDelayMs).toBe(INITIAL_RECONNECT_DELAY)
+      expect(actor.getSnapshot().context.reconnectAttempt).toBe(4)
+      expect(actor.getSnapshot().context.nextRetryDelayMs).toBe(8000)
       actor.stop()
     })
 
@@ -405,11 +405,9 @@ describe('connectionMachine', () => {
       actor.send({ type: 'TRIGGER_RECONNECT' })
       expect(actor.getSnapshot().value).toEqual({ reconnecting: 'attempting' })
       actor.send({ type: 'WAKE', sleepDurationMs: 5000 })
-      // WAKE transitions to waiting (with nextRetryDelayMs=0, so the after
-      // timer fires immediately back to attempting for a fresh attempt)
-      // Counter is reset so backoff starts fresh
-      expect(actor.getSnapshot().context.reconnectAttempt).toBe(0)
-      expect(actor.getSnapshot().context.nextRetryDelayMs).toBe(0)
+      // WAKE transitions to waiting and increments attempt (stale attempt = failure)
+      expect(actor.getSnapshot().context.reconnectAttempt).toBe(4)
+      expect(actor.getSnapshot().context.nextRetryDelayMs).toBe(8000)
       actor.stop()
     })
 
@@ -418,10 +416,10 @@ describe('connectionMachine', () => {
       expect(actor.getSnapshot().value).toEqual({ reconnecting: 'attempting' })
       expect(actor.getSnapshot().context.smResumeViable).toBe(true)
 
-      // WAKE with sleep exceeding SM timeout
+      // WAKE with sleep exceeding SM timeout — increments attempt (stale = failure)
       actor.send({ type: 'WAKE', sleepDurationMs: SM_SESSION_TIMEOUT_MS + 1000 })
       expect(actor.getSnapshot().context.smResumeViable).toBe(false)
-      expect(actor.getSnapshot().context.reconnectAttempt).toBe(0)
+      expect(actor.getSnapshot().context.reconnectAttempt).toBe(2)
       actor.stop()
     })
 
@@ -440,10 +438,10 @@ describe('connectionMachine', () => {
     it('should mark SM resume not viable on WAKE with long sleep while waiting', () => {
       expect(actor.getSnapshot().context.smResumeViable).toBe(true)
 
-      // WAKE with sleep exceeding SM timeout while waiting
+      // WAKE with sleep exceeding SM timeout while waiting — preserves attempt counter
       actor.send({ type: 'WAKE', sleepDurationMs: SM_SESSION_TIMEOUT_MS + 1000 })
       expect(actor.getSnapshot().context.smResumeViable).toBe(false)
-      expect(actor.getSnapshot().context.reconnectAttempt).toBe(0)
+      expect(actor.getSnapshot().context.reconnectAttempt).toBe(1)
       actor.stop()
     })
 

--- a/packages/fluux-sdk/src/core/connectionMachine.ts
+++ b/packages/fluux-sdk/src/core/connectionMachine.ts
@@ -561,19 +561,19 @@ export const connectionMachine = setup({
               target: 'attempting',
               actions: 'clearTargetTime',
             },
-            // Wake while waiting — skip to immediate attempt and reset backoff.
-            // Sleep/wake failures (network not ready) shouldn't accumulate backoff.
+            // Wake while waiting — skip remaining wait and try immediately,
+            // but preserve the attempt counter so backoff keeps growing on failure.
             // Check SM timeout so a long sleep during reconnection correctly
             // marks SM resume as not viable for the next attempt.
             WAKE: [
               {
                 guard: 'sleepExceedsSMTimeout',
                 target: 'attempting',
-                actions: ['clearTargetTime', 'resetAttemptCounter', 'markSmResumeNotViable'],
+                actions: ['clearTargetTime', 'markSmResumeNotViable'],
               },
               {
                 target: 'attempting',
-                actions: ['clearTargetTime', 'resetAttemptCounter'],
+                actions: ['clearTargetTime'],
               },
             ],
             VISIBLE: {
@@ -602,19 +602,18 @@ export const connectionMachine = setup({
               target: 'waiting',
               actions: 'incrementAttempt',
             },
-            // Wake during active attempt — abort stale attempt by transitioning
-            // to waiting. After sleep, the in-flight client has a dead socket and
-            // stale JS timers that may not fire reliably. Transitioning to waiting
-            // (with nextRetryDelayMs=0) triggers an immediate fresh attempt.
+            // Wake during active attempt — the in-flight client has a dead socket
+            // and stale JS timers. Treat it as a failed attempt so backoff grows,
+            // then retry from waiting.
             WAKE: [
               {
                 guard: 'sleepExceedsSMTimeout',
                 target: 'waiting',
-                actions: ['resetAttemptCounter', 'markSmResumeNotViable'],
+                actions: ['incrementAttempt', 'markSmResumeNotViable'],
               },
               {
                 target: 'waiting',
-                actions: 'resetAttemptCounter',
+                actions: 'incrementAttempt',
               },
             ],
             // Already attempting — ignore to prevent parallel attempts


### PR DESCRIPTION
## Summary

- WAKE events were resetting the reconnect attempt counter to zero, preventing exponential backoff from escalating. With macOS sending multiple wake notifications, this created an infinite 0-1s retry loop that kept the app stuck on "Connexion..."
- Removed `resetAttemptCounter` from WAKE handlers in `reconnecting.waiting` and replaced it with `incrementAttempt` in `reconnecting.attempting`, so backoff grows correctly (1s, 2s, 4s, 8s...)
- Added `isConnected()` guard to background sync member discovery loop to abort early on disconnect