### PR TITLE
fix(sdk): run discovery calls before serial session setup chain

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -1823,4 +1823,92 @@ describe('XMPPClient', () => {
       )
     })
   })
+
+  describe('fresh session discovery resilience', () => {
+    // Regression test for issue #308: fire-and-forget discovery calls must run
+    // even when earlier serial IQ calls (roster, bookmarks, etc.) fail or the
+    // overall session setup timeout fires.
+
+    it('should call discoverHttpUploadService even when fetchRoster throws', async () => {
+      // Set up a JID so discovery has a domain to query
+      ;(xmppClient as any).currentJid = 'user@example.com'
+
+      const discoverSpy = vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+      const fetchServerInfoSpy = vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
+      const fetchProfileSpy = vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
+
+      // Make fetchRoster throw (simulating slow server + IQ timeout)
+      vi.spyOn(xmppClient.roster, 'fetchRoster').mockRejectedValue(new Error('IQ timeout'))
+
+      // Call runFreshSessionSetup directly (private method)
+      try {
+        await (xmppClient as any).runFreshSessionSetup(undefined, 1, 15000)
+      } catch {
+        // Expected: fetchRoster throws and propagates
+      }
+
+      // Discovery should have been called regardless of fetchRoster failure
+      expect(discoverSpy).toHaveBeenCalled()
+      expect(fetchServerInfoSpy).toHaveBeenCalled()
+      expect(fetchProfileSpy).toHaveBeenCalled()
+    })
+
+    it('should call discoverHttpUploadService even when fetchBookmarks throws', async () => {
+      ;(xmppClient as any).currentJid = 'user@example.com'
+
+      const discoverSpy = vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockResolvedValue()
+
+      // Let fetchRoster succeed but fetchBookmarks fail
+      vi.spyOn(xmppClient.roster, 'fetchRoster').mockResolvedValue()
+      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockRejectedValue(new Error('IQ timeout'))
+      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockResolvedValue()
+      vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockResolvedValue()
+
+      try {
+        await (xmppClient as any).runFreshSessionSetup(undefined, 1, 15000)
+      } catch {
+        // Expected
+      }
+
+      expect(discoverSpy).toHaveBeenCalled()
+    })
+
+    it('should call discoverHttpUploadService before any await in the setup chain', async () => {
+      ;(xmppClient as any).currentJid = 'user@example.com'
+
+      const callOrder: string[] = []
+
+      vi.spyOn(xmppClient.discovery, 'discoverHttpUploadService').mockImplementation(async () => {
+        callOrder.push('discoverHttpUploadService')
+      })
+      vi.spyOn(xmppClient.discovery, 'fetchServerInfo').mockImplementation(async () => {
+        callOrder.push('fetchServerInfo')
+      })
+      vi.spyOn(xmppClient.profile, 'fetchOwnProfile').mockImplementation(async () => {
+        callOrder.push('fetchOwnProfile')
+      })
+      vi.spyOn(xmppClient.roster, 'fetchRoster').mockImplementation(async () => {
+        callOrder.push('fetchRoster')
+      })
+      vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
+      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [] })
+
+      // Mock conversation sync
+      const convSync = (xmppClient as any).conversationSync
+      if (convSync) {
+        vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
+      }
+
+      await (xmppClient as any).runFreshSessionSetup(undefined, 1, 15000)
+
+      // Discovery calls should be initiated before fetchRoster starts
+      // (they're fire-and-forget so they start synchronously before the first await)
+      const discoverIdx = callOrder.indexOf('discoverHttpUploadService')
+      const rosterIdx = callOrder.indexOf('fetchRoster')
+      expect(discoverIdx).not.toBe(-1)
+      expect(rosterIdx).not.toBe(-1)
+      expect(discoverIdx).toBeLessThan(rosterIdx)
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -1892,7 +1892,7 @@ describe('XMPPClient', () => {
         callOrder.push('fetchRoster')
       })
       vi.spyOn(xmppClient.roster, 'sendInitialPresence').mockResolvedValue()
-      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [] })
+      vi.spyOn(xmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Mock conversation sync
       const convSync = (xmppClient as any).conversationSync

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1649,6 +1649,24 @@ export class XMPPClient {
     this.stores?.roster.resetAllPresence()
     this.stores?.connection.clearOwnResources()
 
+    // Fire-and-forget discovery calls — start immediately, independent of the serial
+    // session setup chain. These must not be blocked by slow IQ responses (roster,
+    // bookmarks, conversation sync) or the overall session setup timeout.
+    this.discovery.fetchServerInfo().then(() => {
+      const serverInfo = this.stores?.connection.getServerInfo?.()
+      const hasWebPush = serverInfo?.features.includes(NS_P1_PUSH_WEBPUSH)
+      const pushEnabled = this.stores?.connection.getWebPushEnabled?.() ?? true
+      console.log('[WebPush] Server disco: p1:push:webpush feature =', hasWebPush,
+        '| pushEnabled =', pushEnabled, '| All features:', serverInfo?.features)
+      if (hasWebPush && pushEnabled) {
+        this.webPush.queryServices().catch((err) => {
+          console.warn('[WebPush] queryServices failed:', err)
+        })
+      }
+    }).catch(() => {})
+    this.discovery.discoverHttpUploadService().catch(() => {})
+    this.profile.fetchOwnProfile().catch(() => {})
+
     // Fetch roster before sending presence
     await this.roster.fetchRoster(iqTimeout)
     if (this.isSessionSuperseded(gen, 'Fresh session aborted after fetchRoster')) return
@@ -1715,23 +1733,6 @@ export class XMPPClient {
       }
     }
 
-    // Server discovery is non-blocking to avoid stalling the reconnection flow.
-    // The backgroundSync serverInfo subscriber will detect when MAM becomes available.
-    // Web Push service discovery is chained after server info to check for p1:push:webpush feature.
-    this.discovery.fetchServerInfo().then(() => {
-      const serverInfo = this.stores?.connection.getServerInfo?.()
-      const hasWebPush = serverInfo?.features.includes(NS_P1_PUSH_WEBPUSH)
-      const pushEnabled = this.stores?.connection.getWebPushEnabled?.() ?? true
-      console.log('[WebPush] Server disco: p1:push:webpush feature =', hasWebPush,
-        '| pushEnabled =', pushEnabled, '| All features:', serverInfo?.features)
-      if (hasWebPush && pushEnabled) {
-        this.webPush.queryServices().catch((err) => {
-          console.warn('[WebPush] queryServices failed:', err)
-        })
-      }
-    }).catch(() => {})
-    this.discovery.discoverHttpUploadService().catch(() => {})
-    this.profile.fetchOwnProfile().catch(() => {})
   }
 
   /**


### PR DESCRIPTION
## Summary

- Move fire-and-forget discovery calls (`fetchServerInfo`, `discoverHttpUploadService`, `fetchOwnProfile`) to the top of `runFreshSessionSetup`, before any awaited IQ calls
- Add regression tests verifying discovery runs even when `fetchRoster` or `fetchBookmarks` throw

Fixes #308 — file uploads broke in v0.15 for users on slower servers (e.g., Openfire) because the 30s session setup timeout could fire before discovery calls at the bottom of the function were reached.