### PR TITLE
fix(app): display upload errors and allow HTTP upload URLs

### DIFF
--- a/apps/fluux/src-tauri/capabilities/default.json
+++ b/apps/fluux/src-tauri/capabilities/default.json
@@ -54,7 +54,9 @@
       "identifier": "http:default",
       "allow": [
         { "url": "https://*" },
-        { "url": "https://*:*/**" }
+        { "url": "https://*:*/**" },
+        { "url": "http://*" },
+        { "url": "http://*:*/**" }
       ]
     },
     "http:allow-fetch-read-body",

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -43,7 +43,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, m
   const ownNickname = useConnectionStore((s) => s.ownNickname)
   const status = useConnectionStore((s) => s.status)
   const isConnected = status === 'online'
-  const { uploadFile, isUploading, progress, isSupported } = useFileUpload()
+  const { uploadFile, isUploading, progress, isSupported, error: uploadError, clearError: clearUploadError } = useFileUpload()
   const { processMessageForLinkPreview } = useLinkPreview()
   const { resolvedMode } = useMode()
   const myBareJid = jid?.split('/')[0]
@@ -95,7 +95,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, m
   }
 
   // Upload state object
-  const uploadStateObj = { isUploading, progress }
+  const uploadStateObj = { isUploading, progress, error: uploadError, clearError: clearUploadError }
 
   // Composer handle ref for type-to-focus (separate from focus zone ref)
   const composerHandleRef = useRef<MessageComposerHandle>(null)
@@ -830,7 +830,7 @@ function MessageInput({
   sendEasterEgg: (to: string, type: 'chat' | 'groupchat', animation: string) => Promise<void>
   isConnected: boolean
   onEditLastMessage?: () => void
-  uploadState?: { isUploading: boolean; progress: number }
+  uploadState?: { isUploading: boolean; progress: number; error: string | null; clearError: () => void }
   isUploadSupported?: boolean
   onFileSelect?: (file: File) => void
   uploadFile?: (file: File) => Promise<import('@fluux/sdk').FileAttachment | null>

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -58,6 +58,8 @@ export interface MessageComposerHandle {
 interface UploadState {
   isUploading: boolean
   progress: number
+  error: string | null
+  clearError: () => void
 }
 
 /** Pending attachment staged for sending (not yet sent) */
@@ -673,7 +675,22 @@ export function MessageComposer({
         </div>
       )}
 
-      <div className={`bg-fluux-hover ${(replyingTo || editingMessage || pendingAttachment) ? 'rounded-b-lg' : 'rounded-lg'} flex items-center`}>
+      {/* Upload error banner */}
+      {uploadState?.error && (
+        <div className={`bg-fluux-red/10 ${(replyingTo || editingMessage || pendingAttachment) ? '' : 'rounded-t-lg'} px-3 py-2 flex items-center gap-2`}>
+          <p className="text-xs text-fluux-red flex-1">{uploadState.error}</p>
+          <button
+            type="button"
+            onClick={uploadState.clearError}
+            className="p-0.5 text-fluux-red/60 hover:text-fluux-red transition-colors flex-shrink-0"
+            aria-label={t('sidebar.dismiss')}
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      )}
+
+      <div className={`bg-fluux-hover ${(replyingTo || editingMessage || pendingAttachment || uploadState?.error) ? 'rounded-b-lg' : 'rounded-lg'} flex items-center`}>
         {/* Hidden file input */}
         <input
           ref={fileInputRef}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -77,7 +77,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   const ownAvatar = useConnectionStore((s) => s.ownAvatar)
   const status = useConnectionStore((s) => s.status)
   const isConnected = status === 'online'
-  const { uploadFile, isUploading, progress, isSupported } = useFileUpload()
+  const { uploadFile, isUploading, progress, isSupported, error: uploadError, clearError: clearUploadError } = useFileUpload()
   const { processMessageForLinkPreview } = useLinkPreview()
   const { resolvedMode } = useMode()
 
@@ -195,7 +195,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     nickMenu.handleTouchEnd()
   }
 
-  const uploadStateObj = { isUploading, progress }
+  const uploadStateObj = { isUploading, progress, error: uploadError, clearError: clearUploadError }
 
   // Scroll ref for programmatic scrolling and keyboard navigation
   const scrollRef = useRef<HTMLElement>(null)
@@ -1376,7 +1376,7 @@ interface RoomMessageInputProps {
   onCancelEdit: () => void
   onEditLastMessage?: () => void
   onComposingChange?: (isComposing: boolean) => void
-  uploadState?: { isUploading: boolean; progress: number }
+  uploadState?: { isUploading: boolean; progress: number; error: string | null; clearError: () => void }
   isUploadSupported?: boolean
   onFileSelect?: (file: File) => void
   uploadFile?: (file: File) => Promise<FileAttachment | null>


### PR DESCRIPTION
## Summary

- Display upload errors as a dismissible banner above the message composer. Previously errors from `useFileUpload()` were silently swallowed — the upload would fail and the user would see no feedback (just the spinner reverting).
- Add `http://` URL patterns to Tauri HTTP capability scope. Openfire and other servers may serve XEP-0363 upload URLs over plain HTTP (e.g., port 7070), which was blocked by the HTTPS-only scope causing instant silent upload failures.

Follows up on #314 and addresses user feedback on #308.