### PR TITLE
fix: prevent sleep/wake freeze and restore rooms after reconnect

### DIFF
--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -68,7 +68,7 @@
     ],
     "macOS": {
       "minimumSystemVersion": "10.13",
-      "bundleVersion": "54a0d8a",
+      "bundleVersion": "9307919",
       "entitlements": "Entitlements.plist",
       "signingIdentity": null
     },

--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -245,15 +245,29 @@ describe('usePlatformState', () => {
       expect(mockClientNotifySystemState).not.toHaveBeenCalledWith('visible')
     })
 
-    it('should register focus listener during connecting status', () => {
-      // When status is 'connecting' (reconnect attempt in progress), the
-      // effect should still be active — not torn down. This ensures the
-      // focus handler is ready if status transitions to reconnecting.
+    it('should register focus listener during reconnecting status', () => {
+      // When status is 'reconnecting' (retry loop in progress, including the
+      // attempting substate which now also maps to 'reconnecting'), the
+      // effect must stay active so window focus can nudge a stalled retry.
+      const addSpy = vi.spyOn(window, 'addEventListener')
+      mockConnectionStatus.current = 'reconnecting'
+      renderHook(() => usePlatformState())
+
+      expect(addSpy).toHaveBeenCalledWith('focus', expect.any(Function))
+      addSpy.mockRestore()
+    })
+
+    it('should NOT register focus listener during connecting status', () => {
+      // 'connecting' is reserved for the initial connection attempt (machine
+      // state 'connecting'), not reconnects. No wake-nudge needed there.
       const addSpy = vi.spyOn(window, 'addEventListener')
       mockConnectionStatus.current = 'connecting'
       renderHook(() => usePlatformState())
 
-      expect(addSpy).toHaveBeenCalledWith('focus', expect.any(Function))
+      const focusCalls = addSpy.mock.calls.filter(
+        ([event]) => (event as string) === 'focus'
+      )
+      expect(focusCalls).toHaveLength(0)
       addSpy.mockRestore()
     })
 
@@ -270,31 +284,32 @@ describe('usePlatformState', () => {
     })
   })
 
-  describe('heartbeat during connecting status', () => {
-    it('should keep heartbeat running during connecting status', async () => {
+  describe('heartbeat during reconnecting status', () => {
+    it('should NOT re-fire notifySystemState("awake") while already reconnecting', async () => {
+      // Regression: previously, during a reconnect attempt the heartbeat
+      // would observe macOS JS throttling as a >180s time gap and re-enter
+      // handleAwake(), cascading into overlapping cleanupClient +
+      // attemptReconnect sequences and freezing the webview. The state
+      // machine owns the retry loop — the heartbeat must not re-kick it.
       const startTime = Date.now()
-      // Start with connecting status (reconnect attempt in progress)
-      mockConnectionStatus.current = 'connecting'
+      mockConnectionStatus.current = 'reconnecting'
       renderHook(() => usePlatformState())
 
-      // Let the first heartbeat tick fire (10s) to establish baseline
       await act(async () => {
         vi.advanceTimersByTime(10_000)
         await Promise.resolve()
       })
       vi.clearAllMocks()
 
-      // Simulate macOS sleep: jump system time forward by 200s, then fire the
-      // next interval tick. This creates a gap of 200s between the last heartbeat
-      // check and now, exceeding the 180s SLEEP_THRESHOLD_MS.
+      // Simulate a 200s JS-throttling gap (exceeds SLEEP_THRESHOLD_MS = 180s).
       vi.setSystemTime(new Date(startTime + 10_000 + 200_000))
       await act(async () => {
         vi.advanceTimersByTime(10_000)
         await Promise.resolve()
       })
 
-      // Should detect the time gap and call notifySystemState('awake')
-      expect(mockClientNotifySystemState).toHaveBeenCalledWith('awake', expect.any(Number))
+      // Must NOT have re-entered handleAwake via a heartbeat-driven wake.
+      expect(mockClientNotifySystemState).not.toHaveBeenCalledWith('awake', expect.any(Number))
     })
 
     it('should NOT run heartbeat when status is disconnected', async () => {

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -312,13 +312,12 @@ export function usePlatformState() {
   }, [client, shouldHandleWake, logEvent, dispatchResizeWorkaround])
 
   // ── Effect 3: Time-gap wake detection (JS heartbeat) ──────────────────────
-  // Also runs during 'connecting' status: when a reconnect attempt is in
-  // progress (reconnecting.attempting → status 'connecting'), macOS may freeze
-  // JS. Without 'connecting', the heartbeat would be torn down and couldn't
-  // detect sleep gaps that occur mid-reconnect.
+  // Also runs during 'reconnecting' status so we still update the heartbeat
+  // reference while the machine is retrying. We do NOT re-kick a wake while
+  // already reconnecting — the state machine owns that retry loop.
 
   useEffect(() => {
-    if (status !== 'online' && status !== 'reconnecting' && status !== 'connecting') return
+    if (status !== 'online' && status !== 'reconnecting') return
 
     const checkForWake = async () => {
       const now = Date.now()
@@ -326,6 +325,10 @@ export function usePlatformState() {
       lastHeartbeatRef.current = now
 
       if (gap < SLEEP_THRESHOLD_MS) return
+      // Machine is already handling the reconnect with its own backoff.
+      // Re-entering handleAwake() here would cause overlapping cleanup +
+      // attemptReconnect sequences and a render storm.
+      if (statusRef.current === 'reconnecting') return
       if (!shouldHandleWake('time-gap')) return
 
       const gapSeconds = Math.round(gap / 1000)
@@ -353,13 +356,11 @@ export function usePlatformState() {
   }, [status, client, shouldHandleWake, dispatchResizeWorkaround])
 
   // ── Effect 4: Page visibility and window focus ──────────────────────────────
-  // Also runs during 'connecting' status: when reconnecting.attempting starts,
-  // status becomes 'connecting' and macOS may freeze JS. Without 'connecting'
-  // here, the focus listener would be torn down and couldn't trigger reconnect
-  // when the user returns to the app.
+  // Runs during 'reconnecting' so window focus can still nudge a stalled
+  // reconnect attempt to retry immediately when the user returns to the app.
 
   useEffect(() => {
-    if (status !== 'online' && status !== 'reconnecting' && status !== 'connecting') return
+    if (status !== 'online' && status !== 'reconnecting') return
 
     const handleVisibilityChange = async () => {
       if (document.hidden) {

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -987,6 +987,83 @@ describe('XMPPClient', () => {
       expect(bookmarksSpy).toHaveBeenCalled()
     })
 
+    it('should fall back to live room store when previouslyJoinedRooms is empty', async () => {
+      const mockClientWithSM = createMockXmppClientWithSM('sm-id-fallback')
+      mockClientFactory._setInstance(mockClientWithSM)
+
+      const stores = createMockStores()
+      // Simulate rooms restored by app persistence layer (addRoom before connect)
+      const storeRooms = [
+        createMockRoom('room1@conference.example.com', { nickname: 'testuser', joined: true }),
+        createMockRoom('room2@conference.example.com', { nickname: 'testuser', joined: true }),
+      ]
+      stores.room.joinedRooms.mockReturnValue(storeRooms)
+
+      const newXmppClient = new XMPPClient({ debug: false })
+      newXmppClient.bindStores(stores)
+
+      const refreshSpy = vi.spyOn(newXmppClient.muc, 'refreshPresenceInRooms').mockResolvedValue()
+
+      // Connect WITHOUT previouslyJoinedRooms (simulates empty SM persistence)
+      const connectPromise = newXmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        smState: { id: 'sm-id-fallback', inbound: 5 },
+        skipDiscovery: true,
+      })
+
+      const resumedNonza = createMockElement('resumed', {
+        xmlns: 'urn:xmpp:sm:3',
+        previd: 'sm-id-fallback',
+        h: '5',
+      })
+      mockClientWithSM._emit('nonza', resumedNonza)
+
+      await connectPromise
+
+      // Should use rooms from the live store as fallback
+      expect(refreshSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ jid: 'room1@conference.example.com', nickname: 'testuser' }),
+          expect.objectContaining({ jid: 'room2@conference.example.com', nickname: 'testuser' }),
+        ])
+      )
+    })
+
+    it('should not refresh rooms when both previouslyJoinedRooms and store are empty', async () => {
+      const mockClientWithSM = createMockXmppClientWithSM('sm-id-empty')
+      mockClientFactory._setInstance(mockClientWithSM)
+
+      const stores = createMockStores()
+      // joinedRooms returns empty (default mock behavior)
+
+      const newXmppClient = new XMPPClient({ debug: false })
+      newXmppClient.bindStores(stores)
+
+      const refreshSpy = vi.spyOn(newXmppClient.muc, 'refreshPresenceInRooms').mockResolvedValue()
+
+      const connectPromise = newXmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        smState: { id: 'sm-id-empty', inbound: 5 },
+        skipDiscovery: true,
+      })
+
+      const resumedNonza = createMockElement('resumed', {
+        xmlns: 'urn:xmpp:sm:3',
+        previd: 'sm-id-empty',
+        h: '5',
+      })
+      mockClientWithSM._emit('nonza', resumedNonza)
+
+      await connectPromise
+
+      // No rooms anywhere → should not attempt refresh
+      expect(refreshSpy).not.toHaveBeenCalled()
+    })
+
     it('should detect new session when SM resume fails (online event fires)', async () => {
       // SM resume failed - server emits 'online' instead of 'resumed'
       const mockClientWithSM = createMockXmppClientWithSM(null)

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1501,10 +1501,27 @@ export class XMPPClient {
     // SM resumption preserves our MUC membership, so we don't need a full
     // rejoin (no disco#info, no history request). We just resend directed
     // presence to confirm we're still in each room.
-    if (previouslyJoinedRooms && previouslyJoinedRooms.length > 0) {
-      logInfo(`SM resumption: refreshing presence in ${previouslyJoinedRooms.length} room(s)`)
+    //
+    // Fallback: if SM persistence had no rooms (e.g. SM was enabled before
+    // rooms joined during a fresh session), read from the live room store
+    // which may have been restored by the app persistence layer.
+    let roomsToRefresh = previouslyJoinedRooms
+    if (!roomsToRefresh || roomsToRefresh.length === 0) {
+      const storeRooms = this.stores?.room.joinedRooms() ?? []
+      if (storeRooms.length > 0) {
+        logInfo(`SM resumption: using ${storeRooms.length} room(s) from store (SM persistence was empty)`)
+        roomsToRefresh = storeRooms.map(r => ({
+          jid: r.jid,
+          nickname: r.nickname,
+          password: r.password,
+          autojoin: r.autojoin,
+        }))
+      }
+    }
+    if (roomsToRefresh && roomsToRefresh.length > 0) {
+      logInfo(`SM resumption: refreshing presence in ${roomsToRefresh.length} room(s)`)
       this.stores?.console.addEvent(
-        `Refreshing presence in ${previouslyJoinedRooms.length} room(s) after SM resumption`,
+        `Refreshing presence in ${roomsToRefresh.length} room(s) after SM resumption`,
         'sm'
       )
 
@@ -1512,7 +1529,7 @@ export class XMPPClient {
       // The room store is ephemeral (not persisted), so after page reload it's empty.
       // Without entries, self-presence responses (status 110) are silently dropped
       // by setRoomJoined() which requires the room to already exist.
-      for (const room of previouslyJoinedRooms) {
+      for (const room of roomsToRefresh) {
         if (!this.stores?.room.getRoom(room.jid)) {
           this.emitSDK('room:added', {
             room: {
@@ -1532,7 +1549,7 @@ export class XMPPClient {
         }
       }
 
-      await this.muc.refreshPresenceInRooms(previouslyJoinedRooms)
+      await this.muc.refreshPresenceInRooms(roomsToRefresh)
       if (this.isSessionSuperseded(gen, 'SM resumption aborted after room presence refresh')) return
 
       // For short disconnects (< 2 min), SM replay already delivered all queued
@@ -1567,7 +1584,7 @@ export class XMPPClient {
         })
 
         // Fetch bookmarks to restore room names and autojoin state.
-        // Also join any newly bookmarked rooms not in previouslyJoinedRooms.
+        // Also join any newly bookmarked rooms not already joined.
         this.muc.fetchBookmarks(FRESH_SESSION_IQ_TIMEOUT_MS).then(({ roomsToAutojoin }) => {
           if (this.isSessionStale(gen)) return
           for (const room of roomsToAutojoin) {

--- a/packages/fluux-sdk/src/core/connectionMachine.test.ts
+++ b/packages/fluux-sdk/src/core/connectionMachine.test.ts
@@ -1101,8 +1101,23 @@ describe('connectionMachine', () => {
         expect(getConnectionStatusFromState({ reconnecting: 'waiting' })).toBe('reconnecting')
       })
 
-      it('should map reconnecting.attempting to connecting', () => {
-        expect(getConnectionStatusFromState({ reconnecting: 'attempting' })).toBe('connecting')
+      it('should map reconnecting.attempting to reconnecting (stable status across waiting↔attempting loop)', () => {
+        // Regression: this previously returned 'connecting', which caused the
+        // UI footer to show "Connexion..." during reconnects and forced the
+        // wake-detection effects in usePlatformState to include 'connecting'
+        // in their run conditions — allowing the heartbeat to re-enter
+        // handleAwake() mid-reconnect and cascade into a webview freeze.
+        expect(getConnectionStatusFromState({ reconnecting: 'attempting' })).toBe('reconnecting')
+      })
+
+      it('should keep the same status across the waiting↔attempting loop', () => {
+        // Both reconnecting substates must map to the same status so that
+        // status-driven React effects do not tear down/rebuild intervals
+        // on every machine transition during a reconnect backoff cycle.
+        const waiting = getConnectionStatusFromState({ reconnecting: 'waiting' })
+        const attempting = getConnectionStatusFromState({ reconnecting: 'attempting' })
+        expect(waiting).toBe(attempting)
+        expect(waiting).toBe('reconnecting')
       })
 
       it('should map all terminal states to error', () => {

--- a/packages/fluux-sdk/src/core/connectionMachine.ts
+++ b/packages/fluux-sdk/src/core/connectionMachine.ts
@@ -713,7 +713,11 @@ export function getConnectionStatusFromState(stateValue: ConnectionStateValue): 
       case 'waiting':
         return 'reconnecting'
       case 'attempting':
-        return 'connecting'
+        // Stays 'reconnecting' (not 'connecting') so the UI label and all
+        // status-driven effects see a stable value across the whole
+        // waiting↔attempting loop. This prevents wake-detection effects from
+        // re-entering handleAwake() mid-reconnect.
+        return 'reconnecting'
     }
   }
 

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -2601,6 +2601,87 @@ describe('XMPPClient Connection', () => {
       // Should verify (isVerifying flag set)
       expect(mockStores.connection.setIsVerifying).toHaveBeenCalledWith(true)
     })
+
+    it('should coalesce concurrent "awake" notifications into a single handler run', async () => {
+      // Regression: overlapping wake signals (Tauri system-did-wake, deferred
+      // wake, JS heartbeat time-gap, visibility/focus) arriving during the
+      // async verifyConnection() window previously produced overlapping
+      // cleanupClient + attemptReconnect sequences, saturating the React
+      // render loop and hanging the webview. handleAwake() now single-flights.
+      mockXmppClientInstance.streamManagement = {
+        id: 'sm-123',
+        inbound: 5,
+        outbound: 0,
+        enabled: true,
+        on: vi.fn(),
+      }
+
+      // Block SM verification so the first handler stays in-flight.
+      mockXmppClientInstance.send.mockImplementation(() => {
+        setTimeout(() => {
+          const ackNonza = createMockElement('a', { xmlns: 'urn:xmpp:sm:3', h: '5' })
+          mockXmppClientInstance._emit('nonza', ackNonza)
+        }, 50)
+        return Promise.resolve()
+      })
+
+      mockStores.console.addEvent.mockClear()
+
+      // Fire 3 overlapping wake signals — they must coalesce.
+      const p1 = xmppClient.notifySystemState('awake')
+      const p2 = xmppClient.notifySystemState('awake')
+      const p3 = xmppClient.notifySystemState('awake')
+
+      await vi.runAllTimersAsync()
+      await Promise.all([p1, p2, p3])
+
+      // Only ONE verification should have been logged, not three.
+      const verifyingEvents = mockStores.console.addEvent.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('verifying connection')
+      )
+      expect(verifyingEvents).toHaveLength(1)
+
+      // Coalesce log line must be present at least twice (for p2 and p3).
+      // (It is only logged through logInfo, not the console store — assert via
+      // the single verifying-connection call above, which is the observable
+      // side effect of single-flighting.)
+    })
+
+    it('should allow a new handleAwake run after the previous one completes', async () => {
+      // The in-flight guard must clear on completion so subsequent real wake
+      // events (a later sleep→wake cycle) are handled normally.
+      mockXmppClientInstance.streamManagement = {
+        id: 'sm-123',
+        inbound: 5,
+        outbound: 0,
+        enabled: true,
+        on: vi.fn(),
+      }
+      mockXmppClientInstance.send.mockImplementation(() => {
+        setTimeout(() => {
+          const ackNonza = createMockElement('a', { xmlns: 'urn:xmpp:sm:3', h: '5' })
+          mockXmppClientInstance._emit('nonza', ackNonza)
+        }, 10)
+        return Promise.resolve()
+      })
+
+      // First wake — completes normally.
+      const first = xmppClient.notifySystemState('awake')
+      await vi.runAllTimersAsync()
+      await first
+
+      mockStores.console.addEvent.mockClear()
+
+      // Second wake — must not be swallowed by a stale in-flight promise.
+      const second = xmppClient.notifySystemState('awake')
+      await vi.runAllTimersAsync()
+      await second
+
+      const verifyingEvents = mockStores.console.addEvent.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('verifying connection')
+      )
+      expect(verifyingEvents).toHaveLength(1)
+    })
   })
 
   // ── Wake-from-sleep reconnection regression tests ─────────────────────────

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -154,6 +154,14 @@ export class Connection extends BaseModule {
   // promise and sending CONNECTION_ERROR that would disrupt the new reconnect.
   private deadSocketRecoveryInProgress = false
 
+  // Single-flight guard for handleAwake(). Overlapping wake signals (Tauri
+  // system-did-wake, system-did-wake-deferred, JS heartbeat, visibility) can
+  // arrive concurrently; each would otherwise spawn its own cleanupClient +
+  // attemptReconnect sequence and race with verifyConnection(). Coalescing them
+  // into a single in-flight promise prevents the render storm that causes the
+  // webview to hang after wake.
+  private handleAwakeInFlight: Promise<void> | null = null
+
   // Timestamp of last wake-from-sleep event. Used by attemptReconnect to add a
   // short settle delay — navigator.onLine goes true before the network path is
   // fully functional (DNS, TLS, Wi-Fi re-association), causing SASL timeouts.
@@ -1148,8 +1156,22 @@ export class Connection extends BaseModule {
    * - Connected + long sleep (> SM timeout): transition to reconnecting, clean up dead client.
    * - Connected + short sleep: verify connection health (SM ack or ping).
    * - Already reconnecting: send WAKE to reset backoff and retry immediately.
+   *
+   * Single-flight: concurrent callers share the in-flight promise so only one
+   * cleanup/verify/reconnect sequence runs at a time.
    */
-  private async handleAwake(sleepDurationMs?: number): Promise<void> {
+  private handleAwake(sleepDurationMs?: number): Promise<void> {
+    if (this.handleAwakeInFlight) {
+      logInfo('handleAwake: already in flight, coalescing')
+      return this.handleAwakeInFlight
+    }
+    this.handleAwakeInFlight = this.handleAwakeImpl(sleepDurationMs).finally(() => {
+      this.handleAwakeInFlight = null
+    })
+    return this.handleAwakeInFlight
+  }
+
+  private async handleAwakeImpl(sleepDurationMs?: number): Promise<void> {
     const sleepSec = sleepDurationMs != null ? Math.round(sleepDurationMs / 1000) : null
     logInfo(`System state: awake${sleepSec != null ? ` (sleep: ${sleepSec}s)` : ''}`)
 

--- a/packages/fluux-sdk/src/core/modules/smPersistence.test.ts
+++ b/packages/fluux-sdk/src/core/modules/smPersistence.test.ts
@@ -190,6 +190,82 @@ describe('SmPersistence', () => {
 
       await expect(sm.persist('user@example.com', 'res1')).resolves.toBeUndefined()
     })
+
+    it('should preserve existing rooms when current joinedRooms is empty', async () => {
+      const existingRooms = [
+        { jid: 'room1@conf.example.com', nickname: 'me' },
+        { jid: 'room2@conf.example.com', nickname: 'me' },
+      ]
+      // Pre-populate storage with rooms from a previous session
+      mockStorage.store.set('user@example.com', {
+        smId: 'old-sm',
+        smInbound: 10,
+        resource: 'res1',
+        timestamp: Date.now() - 5000,
+        joinedRooms: existingRooms,
+      })
+
+      // Current store returns no rooms (e.g. SM enabled before rooms joined)
+      const sm = new SmPersistence(createDeps({
+        storageAdapter: mockStorage.adapter,
+        getJoinedRooms: () => [],
+      }))
+      sm.updateCache('new-sm', 0)
+
+      await sm.persist('user@example.com', 'res1')
+
+      // Should update SM state but preserve the existing rooms
+      expect(mockStorage.adapter.setSessionState).toHaveBeenCalledWith('user@example.com', {
+        smId: 'new-sm',
+        smInbound: 0,
+        resource: 'res1',
+        timestamp: expect.any(Number),
+        joinedRooms: existingRooms,
+      })
+    })
+
+    it('should overwrite rooms when current joinedRooms is non-empty', async () => {
+      const existingRooms = [
+        { jid: 'room1@conf.example.com', nickname: 'me' },
+        { jid: 'room2@conf.example.com', nickname: 'me' },
+      ]
+      mockStorage.store.set('user@example.com', {
+        smId: 'old-sm',
+        smInbound: 10,
+        resource: 'res1',
+        timestamp: Date.now() - 5000,
+        joinedRooms: existingRooms,
+      })
+
+      const currentRooms = [{ jid: 'room3@conf.example.com', nickname: 'me' }]
+      const sm = new SmPersistence(createDeps({
+        storageAdapter: mockStorage.adapter,
+        getJoinedRooms: () => currentRooms,
+      }))
+      sm.updateCache('new-sm', 0)
+
+      await sm.persist('user@example.com', 'res1')
+
+      // Should use current rooms, not preserved ones
+      expect(mockStorage.adapter.setSessionState).toHaveBeenCalledWith('user@example.com', expect.objectContaining({
+        joinedRooms: currentRooms,
+      }))
+    })
+
+    it('should save empty rooms when no existing state in storage', async () => {
+      // No pre-existing state in storage
+      const sm = new SmPersistence(createDeps({
+        storageAdapter: mockStorage.adapter,
+        getJoinedRooms: () => [],
+      }))
+      sm.updateCache('new-sm', 0)
+
+      await sm.persist('user@example.com', 'res1')
+
+      expect(mockStorage.adapter.setSessionState).toHaveBeenCalledWith('user@example.com', expect.objectContaining({
+        joinedRooms: [],
+      }))
+    })
   })
 
   describe('persistNow', () => {

--- a/packages/fluux-sdk/src/core/modules/smPersistence.ts
+++ b/packages/fluux-sdk/src/core/modules/smPersistence.ts
@@ -105,12 +105,24 @@ export class SmPersistence {
     }
     try {
       const joinedRooms = this.deps.getJoinedRooms()
+
+      // If current joinedRooms is empty, preserve previously persisted rooms.
+      // This avoids overwriting valid room data during SM negotiation when
+      // rooms haven't joined yet (e.g. SM enabled fires before bookmark join).
+      let roomsToSave = joinedRooms
+      if (joinedRooms.length === 0) {
+        const existing = await this.deps.storageAdapter.getSessionState(jid)
+        if (existing?.joinedRooms && existing.joinedRooms.length > 0) {
+          roomsToSave = existing.joinedRooms
+        }
+      }
+
       await this.deps.storageAdapter.setSessionState(jid, {
         smId: this.cache.id,
         smInbound: this.cache.inbound,
         resource: resource || '',
         timestamp: Date.now(),
-        joinedRooms,
+        joinedRooms: roomsToSave,
       })
     } catch {
       // Storage errors are non-fatal


### PR DESCRIPTION
## Summary

- **Prevent sleep/wake freeze and grey-screen cascade**: Guard against reconnect attempts while the system is asleep or the page is hidden, and coalesce rapid wake events to avoid a cascade of stale reconnections that freeze the UI.
- **Restore rooms after SM resumption when persistence was empty**: Fix a race where SM `persist()` was called before rooms had joined (during SM negotiation), overwriting the persisted room list with an empty array. On next app restart, rooms were not restored despite successful SM session resumption. Now `persist()` preserves existing rooms when the current store is empty, and `handleSmResumption()` falls back to the live room store.