### PR TITLE
fix: FAST token reconnect skipped when server field was empty

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -129,7 +129,10 @@ function App() {
     const rememberMe = localStorage.getItem('xmpp-remember-me') === 'true'
     const savedJid = localStorage.getItem('xmpp-last-jid')
     const savedServer = localStorage.getItem('xmpp-last-server')
-    return !!(rememberMe && savedJid && savedServer && hasFastToken(savedJid))
+    // Fallback: derive server from JID domain when savedServer is empty
+    // (backward compat with older sessions that stored '' for the server field)
+    const effectiveServer = savedServer || (savedJid ? savedJid.split('@')[1] : null)
+    return !!(rememberMe && savedJid && effectiveServer && hasFastToken(savedJid))
   })
 
   // Track if we've ever been online this session

--- a/apps/fluux/src/components/LoginScreen.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.test.tsx
@@ -272,6 +272,64 @@ describe('LoginScreen', () => {
         })
     })
 
+    describe('server persistence on submit', () => {
+        it('should store resolved domain when server field is empty', async () => {
+            // Domain not in well-known list, so resolveServerForConnection falls back to bare domain
+            mockGetDomainFromJid.mockReturnValue('chat.example.com')
+            mockGetWebsocketUrlForDomain.mockReturnValue(null)
+
+            render(<LoginScreen />)
+
+            fireEvent.change(screen.getByLabelText('login.jidLabel'), { target: { value: 'alice@chat.example.com' } })
+            fireEvent.change(screen.getByLabelText('login.passwordLabel'), { target: { value: 'secret' } })
+            fireEvent.click(screen.getByRole('button', { name: 'login.connect' }))
+
+            await waitFor(() => {
+                expect(mockConnect).toHaveBeenCalled()
+            })
+
+            // Should store the domain (from resolveServerForConnection), not empty string
+            expect(localStorage.getItem('xmpp-last-server')).toBe('chat.example.com')
+        })
+
+        it('should store well-known WebSocket URL when available', async () => {
+            mockGetDomainFromJid.mockReturnValue('process-one.net')
+            mockGetWebsocketUrlForDomain.mockReturnValue('wss://chat.process-one.net/xmpp')
+
+            render(<LoginScreen />)
+
+            fireEvent.change(screen.getByLabelText('login.jidLabel'), { target: { value: 'alice@process-one.net' } })
+            fireEvent.change(screen.getByLabelText('login.passwordLabel'), { target: { value: 'secret' } })
+            fireEvent.click(screen.getByRole('button', { name: 'login.connect' }))
+
+            await waitFor(() => {
+                expect(mockConnect).toHaveBeenCalled()
+            })
+
+            expect(localStorage.getItem('xmpp-last-server')).toBe('wss://chat.process-one.net/xmpp')
+        })
+
+        it('should store explicit server input as-is', async () => {
+            mockGetDomainFromJid.mockReturnValue('example.com')
+            mockGetWebsocketUrlForDomain.mockReturnValue(null)
+
+            render(<LoginScreen />)
+
+            fireEvent.change(screen.getByLabelText('login.jidLabel'), { target: { value: 'alice@example.com' } })
+            fireEvent.change(screen.getByLabelText('login.passwordLabel'), { target: { value: 'secret' } })
+            // Show and fill server field
+            fireEvent.click(screen.getByText('login.serverLabel'))
+            fireEvent.change(screen.getByPlaceholderText('login.serverPlaceholder'), { target: { value: 'wss://custom.example.com/ws' } })
+            fireEvent.click(screen.getByRole('button', { name: 'login.connect' }))
+
+            await waitFor(() => {
+                expect(mockConnect).toHaveBeenCalled()
+            })
+
+            expect(localStorage.getItem('xmpp-last-server')).toBe('wss://custom.example.com/ws')
+        })
+    })
+
     describe('FAST token cleanup on auth error', () => {
         it('should delete FAST token on authentication error', () => {
             localStorage.setItem('xmpp-last-jid', 'user@example.com')

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -254,8 +254,10 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     const actualServer = resolveServerForConnection(jid, server)
 
     // Save JID and server for next time
+    // Store the resolved server (not the raw input) so FAST token auto-reconnect
+    // can use it even when the server field was left empty (hidden by default).
     localStorage.setItem(STORAGE_KEY_JID, jid)
-    localStorage.setItem(STORAGE_KEY_SERVER, server)
+    localStorage.setItem(STORAGE_KEY_SERVER, actualServer || server)
 
     // Save remember me preference
     localStorage.setItem(STORAGE_KEY_REMEMBER, rememberMe ? 'true' : 'false')

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -621,7 +621,10 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
     const rememberMe = localStorage.getItem('xmpp-remember-me') === 'true'
     const savedJid = localStorage.getItem('xmpp-last-jid')
     const savedServer = localStorage.getItem('xmpp-last-server')
-    if (rememberMe && savedJid && savedServer && hasFastToken(savedJid)) {
+    // Fallback: derive server from JID domain when savedServer is empty
+    // (backward compat with older sessions that stored '' for the server field)
+    const effectiveServer = savedServer || (savedJid ? savedJid.split('@')[1] : null)
+    if (rememberMe && savedJid && effectiveServer && hasFastToken(savedJid)) {
       const resource = getResource()
       console.log('[Auth] Attempting FAST token auto-connect (no password)')
 
@@ -630,10 +633,10 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         // after a fresh tab open faces the same wake-from-sleep network
         // flakiness as page-reload. Auth failures (bad/expired token) still
         // surface via the machine's AUTH_ERROR path and delete the token.
-        connect(savedJid, undefined, savedServer, undefined, resource, i18n.language, false, true, true).then(() => {
+        connect(savedJid, undefined, effectiveServer, undefined, resource, i18n.language, false, true, true).then(() => {
           // Save session for subsequent in-tab reconnects (no password needed —
           // FAST token in localStorage handles auth on future reconnects too)
-          saveSession(savedJid, '', savedServer)
+          saveSession(savedJid, '', effectiveServer)
         }).catch((err) => {
           console.log('[Auth] FAST token connect failed:', err?.message || err)
           deleteFastToken(savedJid)


### PR DESCRIPTION
## Summary

- LoginScreen stored the raw server input (`''`) to localStorage instead of the resolved server URL. Since the server field is hidden by default, most users never fill it, causing the FAST token auto-reconnect check to fail on PWA reopen (empty string is falsy).
- Store the resolved server (domain or WebSocket URL) in localStorage and add a domain-from-JID fallback in App.tsx and useSessionPersistence.ts for backward compatibility with existing sessions.
- Add 3 regression tests verifying server persistence on login submit.