### PR TITLE
fix(sdk): write live room messages to IndexedDB directly

### DIFF
--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -41,7 +41,6 @@ vi.mock('../utils/messageCache', () => ({
   getOldestRoomMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
   getRoomMessageCount: vi.fn().mockResolvedValue(0),
-  flushPendingRoomMessages: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { setupBackgroundSyncSideEffects } from './backgroundSync'

--- a/packages/fluux-sdk/src/core/chatNetworkScenarios.test.ts
+++ b/packages/fluux-sdk/src/core/chatNetworkScenarios.test.ts
@@ -40,7 +40,6 @@ vi.mock('../utils/messageCache', () => ({
   getOldestRoomMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
   getRoomMessageCount: vi.fn().mockResolvedValue(0),
-  flushPendingRoomMessages: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { chatStore } from '../stores/chatStore'

--- a/packages/fluux-sdk/src/core/chatSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.test.ts
@@ -38,7 +38,6 @@ vi.mock('../utils/messageCache', () => ({
   getOldestRoomMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
   getRoomMessageCount: vi.fn().mockResolvedValue(0),
-  flushPendingRoomMessages: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { setupChatSideEffects } from './chatSideEffects'

--- a/packages/fluux-sdk/src/core/conversationSyncSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/conversationSyncSideEffects.test.ts
@@ -41,7 +41,6 @@ vi.mock('../utils/messageCache', () => ({
   getOldestRoomMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
   getRoomMessageCount: vi.fn().mockResolvedValue(0),
-  flushPendingRoomMessages: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { setupConversationSyncSideEffects } from './conversationSyncSideEffects'

--- a/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
@@ -54,21 +54,9 @@ const { mockDiscoverWebSocket } = vi.hoisted(() => ({
   mockDiscoverWebSocket: vi.fn(),
 }))
 
-const { mockFlushPendingRoomMessages } = vi.hoisted(() => ({
-  mockFlushPendingRoomMessages: vi.fn(),
-}))
-
 vi.mock('../../utils/websocketDiscovery', () => ({
   discoverWebSocket: mockDiscoverWebSocket,
 }))
-
-vi.mock('../../utils/messageCache', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/messageCache')>('../../utils/messageCache')
-  return {
-    ...actual,
-    flushPendingRoomMessages: mockFlushPendingRoomMessages,
-  }
-})
 
 vi.mock('../fastTokenStorage', () => ({
   fetchFastToken: vi.fn().mockReturnValue(null),
@@ -124,8 +112,6 @@ describe('Connection race conditions', () => {
 
     mockDiscoverWebSocket.mockClear()
     mockDiscoverWebSocket.mockResolvedValue(null)
-    mockFlushPendingRoomMessages.mockClear()
-    mockFlushPendingRoomMessages.mockResolvedValue(undefined)
 
     mockStores = createMockStores()
     xmppClient = new XMPPClient({ debug: false })

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -51,23 +51,10 @@ const { mockDiscoverWebSocket } = vi.hoisted(() => ({
   mockDiscoverWebSocket: vi.fn(),
 }))
 
-const { mockFlushPendingRoomMessages } = vi.hoisted(() => ({
-  mockFlushPendingRoomMessages: vi.fn(),
-}))
-
 // Mock websocketDiscovery to prevent real network calls
 vi.mock('../../utils/websocketDiscovery', () => ({
   discoverWebSocket: mockDiscoverWebSocket,
 }))
-
-// Mock message cache flushing so disconnect tests can control stall behavior
-vi.mock('../../utils/messageCache', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/messageCache')>('../../utils/messageCache')
-  return {
-    ...actual,
-    flushPendingRoomMessages: mockFlushPendingRoomMessages,
-  }
-})
 
 // Mock fastTokenStorage for FAST tests
 const { mockFetchFastToken, mockSaveFastToken, mockDeleteFastToken } = vi.hoisted(() => ({
@@ -97,8 +84,6 @@ describe('XMPPClient Connection', () => {
     // Reset WebSocket discovery mock to return null (discovery failed -> use fallback URL)
     mockDiscoverWebSocket.mockClear()
     mockDiscoverWebSocket.mockResolvedValue(null)
-    mockFlushPendingRoomMessages.mockClear()
-    mockFlushPendingRoomMessages.mockResolvedValue(undefined)
 
     mockStores = createMockStores()
     xmppClient = new XMPPClient({ debug: false })
@@ -377,36 +362,6 @@ describe('XMPPClient Connection', () => {
       expect(mockXmppClientInstance.stop).toHaveBeenCalled()
       expect(mockStores.connection.setStatus).toHaveBeenCalledWith('disconnected')
       expect(mockStores.connection.setJid).toHaveBeenCalledWith(null)
-    })
-
-    it('should not hang disconnect when room message flush stalls', async () => {
-      // First connect
-      const connectPromise = xmppClient.connect({
-        jid: 'user@example.com',
-        password: 'secret',
-        server: 'example.com',
-        skipDiscovery: true,
-      })
-      mockXmppClientInstance._emit('online')
-      await connectPromise
-
-      // Simulate IndexedDB/WebKit stall in flushPendingRoomMessages()
-      mockFlushPendingRoomMessages.mockImplementation(
-        () => new Promise<void>(() => {})
-      )
-
-      const disconnectPromise = xmppClient.disconnect()
-
-      // Fast-forward cleanup timeout (2s) so disconnect can proceed to stop()
-      await vi.advanceTimersByTimeAsync(2000)
-      await disconnectPromise
-
-      expect(mockXmppClientInstance.stop).toHaveBeenCalled()
-      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('disconnected')
-      expect(mockStores.console.addEvent).toHaveBeenCalledWith(
-        'Disconnect cleanup warning: room message flush timed out',
-        'error'
-      )
     })
 
     it('should resolve disconnect even when client.stop never settles', async () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -6,7 +6,6 @@ import type { ConnectOptions, ConnectionMethod } from '../types'
 import { getBareJid, getDomain, getLocalPart, getResource } from '../jid'
 import { getClientIdentity, CLIENT_FEATURES } from '../caps'
 import { NS_DISCO_INFO, NS_PING, NS_TIME } from '../namespaces'
-import { flushPendingRoomMessages } from '../../utils/messageCache'
 import { logInfo, logWarn, logError as logErr } from '../logger'
 import {
   type SmPatchState,
@@ -732,31 +731,8 @@ export class Connection extends BaseModule {
       }
     }
 
-    logDisconnect('flushing pending room message cache')
-    try {
-      let timedOut = false
-      await Promise.race([
-        flushPendingRoomMessages(),
-        new Promise<void>((resolve) => {
-          setTimeout(() => {
-            timedOut = true
-            resolve()
-          }, DISCONNECT_CLEANUP_TIMEOUT_MS)
-        }),
-      ])
-      if (timedOut) {
-        logWarn(`Disconnect cleanup: room message flush timed out after ${DISCONNECT_CLEANUP_TIMEOUT_MS}ms`)
-        this.stores.console.addEvent('Disconnect cleanup warning: room message flush timed out', 'error')
-        logDisconnect('room message flush timed out')
-      } else {
-        logDisconnect('room message flush complete')
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      logWarn(`Disconnect cleanup: failed to flush room message buffer: ${message}`)
-      this.stores.console.addEvent(`Disconnect cleanup warning: failed to flush message cache (${message})`, 'error')
-      logDisconnect(`room message flush failed (${message})`)
-    }
+    // Room messages are written to IDB directly on arrival; no buffer to
+    // flush on disconnect.
 
     if (clientToStop) {
       logDisconnect('stopping xmpp client (non-blocking)')

--- a/packages/fluux-sdk/src/core/networkScenarios.test.ts
+++ b/packages/fluux-sdk/src/core/networkScenarios.test.ts
@@ -40,7 +40,6 @@ vi.mock('../utils/messageCache', () => ({
   getOldestRoomMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
   getRoomMessageCount: vi.fn().mockResolvedValue(0),
-  flushPendingRoomMessages: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { roomStore } from '../stores/roomStore'

--- a/packages/fluux-sdk/src/core/roomSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.test.ts
@@ -39,7 +39,6 @@ vi.mock('../utils/messageCache', () => ({
   getOldestRoomMessageTimestamp: vi.fn().mockResolvedValue(null),
   getMessageCount: vi.fn().mockResolvedValue(0),
   getRoomMessageCount: vi.fn().mockResolvedValue(0),
-  flushPendingRoomMessages: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { setupRoomSideEffects } from './roomSideEffects'

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -599,7 +599,6 @@ export {
   deleteRoomMessage,
   deleteRoomMessages,
   getOldestRoomMessageTimestamp,
-  flushPendingRoomMessages,
   // Utility
   clearAllMessages,
   isMessageCacheAvailable,

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -359,7 +359,6 @@ describe('messageCache', () => {
         const message = createMockRoomMessage(roomJid, { id: 'room-1' })
 
         await messageCache.saveRoomMessage(message)
-        await messageCache.flushPendingRoomMessages() // Flush buffer to persist
 
         const retrieved = await messageCache.getRoomMessage('room-1')
         expect(retrieved).not.toBeNull()
@@ -373,7 +372,6 @@ describe('messageCache', () => {
         })
 
         await messageCache.saveRoomMessage(message)
-        await messageCache.flushPendingRoomMessages() // Flush buffer to persist
 
         const byStanzaId = await messageCache.getRoomMessageByStanzaId('room-stanza-123')
         expect(byStanzaId).not.toBeNull()
@@ -431,7 +429,6 @@ describe('messageCache', () => {
       it('should update an existing room message', async () => {
         const message = createMockRoomMessage(roomJid, { id: 'room-update', body: 'Original' })
         await messageCache.saveRoomMessage(message)
-        await messageCache.flushPendingRoomMessages() // Flush buffer before update
 
         await messageCache.updateRoomMessage('room-update', {
           body: 'Updated',
@@ -448,7 +445,6 @@ describe('messageCache', () => {
       it('should delete a room message', async () => {
         const message = createMockRoomMessage(roomJid, { id: 'room-delete' })
         await messageCache.saveRoomMessage(message)
-        await messageCache.flushPendingRoomMessages() // Flush buffer before delete
 
         await messageCache.deleteRoomMessage('room-delete')
 
@@ -470,7 +466,6 @@ describe('messageCache', () => {
         await messageCache.saveRoomMessage(
           createMockRoomMessage(otherRoom, { id: 'other-room' })
         )
-        await messageCache.flushPendingRoomMessages() // Flush buffer before delete
 
         await messageCache.deleteRoomMessages(roomJid)
 
@@ -535,7 +530,6 @@ describe('messageCache', () => {
       await messageCache.saveRoomMessage(
         createMockRoomMessage('room2@conference.example.com', { id: 'rtotal-2' })
       )
-      await messageCache.flushPendingRoomMessages()
 
       const count = await messageCache.getTotalRoomMessageCount()
       expect(count).toBe(2)
@@ -545,23 +539,15 @@ describe('messageCache', () => {
       const count = await messageCache.getTotalRoomMessageCount()
       expect(count).toBe(0)
     })
-
-    it('should flush buffered room messages before counting', async () => {
-      // Save without explicit flush — getTotalRoomMessageCount should flush internally
-      await messageCache.saveRoomMessage(
-        createMockRoomMessage('room@conference.example.com', { id: 'buffered-1' })
-      )
-
-      const count = await messageCache.getTotalRoomMessageCount()
-      expect(count).toBe(1)
-    })
   })
 
   describe('iterateAllRoomMessages', () => {
-    it('should flush buffered room messages before iterating', async () => {
-      // Save room messages without explicit flush
+    it('should iterate a saved room message without any flush dance', async () => {
+      // Direct-write semantics: a single save is visible immediately,
+      // no buffer to drain. This is the guarantee that fixes the
+      // reload-loses-notified-message race.
       await messageCache.saveRoomMessage(
-        createMockRoomMessage('room@conference.example.com', { id: 'iter-buf-1', body: 'Buffered message' })
+        createMockRoomMessage('room@conference.example.com', { id: 'iter-direct-1', body: 'Direct write' })
       )
 
       const collected: RoomMessage[] = []
@@ -570,7 +556,7 @@ describe('messageCache', () => {
       })
 
       expect(collected.length).toBe(1)
-      expect(collected[0].body).toBe('Buffered message')
+      expect(collected[0].body).toBe('Direct write')
     })
   })
 
@@ -586,7 +572,6 @@ describe('messageCache', () => {
       await messageCache.saveRoomMessage(
         createMockRoomMessage(roomJid, { id: 'clear-room' })
       )
-      await messageCache.flushPendingRoomMessages() // Flush buffer before clear
 
       await messageCache.clearAllMessages()
 

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -416,7 +416,6 @@ export async function getTotalMessageCount(): Promise<number> {
  */
 export async function getTotalRoomMessageCount(): Promise<number> {
   try {
-    await flushPendingRoomMessages()
     const db = await getDB(getStorageScopeJid())
     return await db.count(ROOM_MESSAGES_STORE)
   } catch {
@@ -500,81 +499,16 @@ export async function deleteConversationMessages(conversationId: string): Promis
 // =============================================================================
 
 /**
- * Write buffer for room messages.
- * Collects messages and flushes them in batches for better performance
- * and reliability during rapid-fire history message delivery (e.g., room join).
- */
-const roomMessageBuffer: RoomMessage[] = []
-let roomMessageFlushTimer: ReturnType<typeof setTimeout> | null = null
-let roomMessageBufferScope: string | null = null
-const ROOM_MESSAGE_FLUSH_DELAY = 100 // ms - flush after 100ms of inactivity
-
-/**
- * Flush the room message buffer to IndexedDB.
- */
-async function flushRoomMessageBuffer(scopeJid: string | null): Promise<void> {
-  if (roomMessageBuffer.length === 0) return
-
-  // Take all messages from buffer
-  const messagesToSave = roomMessageBuffer.splice(0, roomMessageBuffer.length)
-
-  try {
-    const db = await getDB(scopeJid)
-    const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
-    const store = tx.objectStore(ROOM_MESSAGES_STORE)
-
-    await Promise.all(messagesToSave.map((msg) => store.put(serializeRoomMessage(msg))))
-    await tx.done
-  } catch (error) {
-    if (isIndexedDBAvailable()) {
-      console.warn('Failed to flush room message buffer:', error)
-    }
-  }
-}
-
-/**
  * Save a room message to IndexedDB.
- * Uses a write buffer to batch rapid writes for better performance.
+ *
+ * Writes directly to the store — no batching. A live message must reach IDB
+ * before the next `window.location.reload()` (e.g. long-sleep detection),
+ * otherwise the message is lost from the cache and the subsequent MAM
+ * catch-up cursor may skip past it. Batched writes for history replay
+ * should use {@link saveRoomMessages} instead.
  */
 export async function saveRoomMessage(message: RoomMessage): Promise<void> {
-  const currentScope = getStorageScopeJid()
-
-  // Ensure queued messages are flushed to the account-specific DB they belong to.
-  if (roomMessageBuffer.length > 0 && roomMessageBufferScope !== currentScope) {
-    await flushPendingRoomMessages()
-  }
-
-  roomMessageBufferScope = currentScope
-
-  // Add to buffer
-  roomMessageBuffer.push(message)
-
-  // Clear existing timer
-  if (roomMessageFlushTimer) {
-    clearTimeout(roomMessageFlushTimer)
-  }
-
-  // Set new timer to flush after delay
-  roomMessageFlushTimer = setTimeout(() => {
-    roomMessageFlushTimer = null
-    const flushScope = roomMessageBufferScope
-    roomMessageBufferScope = null
-    void flushRoomMessageBuffer(flushScope)
-  }, ROOM_MESSAGE_FLUSH_DELAY)
-}
-
-/**
- * Force flush any pending room messages immediately.
- * Call this before disconnect or when ensuring data persistence.
- */
-export async function flushPendingRoomMessages(): Promise<void> {
-  if (roomMessageFlushTimer) {
-    clearTimeout(roomMessageFlushTimer)
-    roomMessageFlushTimer = null
-  }
-  const flushScope = roomMessageBufferScope
-  roomMessageBufferScope = null
-  await flushRoomMessageBuffer(flushScope)
+  await saveRoomMessages([message])
 }
 
 /**
@@ -856,7 +790,6 @@ export async function deleteRoomMessages(roomJid: string): Promise<void> {
  */
 export async function clearAllMessages(): Promise<void> {
   try {
-    await flushPendingRoomMessages()
     const db = await getDB(getStorageScopeJid())
     const tx = db.transaction([MESSAGES_STORE, ROOM_MESSAGES_STORE], 'readwrite')
     await Promise.all([tx.objectStore(MESSAGES_STORE).clear(), tx.objectStore(ROOM_MESSAGES_STORE).clear()])
@@ -960,8 +893,6 @@ export async function iterateAllRoomMessages(
   batchSize: number,
   onBatch: (messages: RoomMessage[]) => Promise<void>
 ): Promise<void> {
-  // Flush any buffered room messages to IDB before reading
-  await flushPendingRoomMessages()
   const db = await getDB(getStorageScopeJid())
   const allRaw = await db.getAll(ROOM_MESSAGES_STORE)
 
@@ -987,12 +918,6 @@ export function isMessageCacheAvailable(): boolean {
  * @internal
  */
 export function _resetDBForTesting(): void {
-  if (roomMessageFlushTimer) {
-    clearTimeout(roomMessageFlushTimer)
-    roomMessageFlushTimer = null
-  }
-  roomMessageBuffer.length = 0
-  roomMessageBufferScope = null
   dbPromise = null
   dbNameForPromise = null
 }

--- a/packages/fluux-sdk/src/utils/searchIndex.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.test.ts
@@ -20,7 +20,7 @@ import {
   parseSearchQuery,
   _resetDBForTesting,
 } from './searchIndex'
-import { _resetDBForTesting as _resetMessageCacheDB, flushPendingRoomMessages } from './messageCache'
+import { _resetDBForTesting as _resetMessageCacheDB } from './messageCache'
 
 // =============================================================================
 // Test helpers
@@ -612,7 +612,6 @@ describe('searchIndex', () => {
         stanzaId: 'stanza-old-1',
         body: 'Historical room discussion',
       }))
-      await flushPendingRoomMessages()
 
       await backfillFromMessageCache()
 
@@ -654,7 +653,6 @@ describe('searchIndex', () => {
         stanzaId: 'stanza-mixed',
         body: 'Searchable content in room',
       }))
-      await flushPendingRoomMessages()
 
       await backfillFromMessageCache()
 
@@ -715,7 +713,6 @@ describe('searchIndex', () => {
       await messageCache.saveRoomMessage(createRoomMessage('room@conference.example.com', {
         id: 'count-3', stanzaId: 'stanza-count-3', body: 'Third message',
       }))
-      await flushPendingRoomMessages()
 
       const count = await rebuildSearchIndex()
       expect(count).toBe(3)
@@ -784,7 +781,6 @@ describe('searchIndex', () => {
           timestamp: new Date(Date.now() - i * 1000),
         }))
       }
-      await flushPendingRoomMessages()
 
       const count = await rebuildSearchIndex()
 
@@ -803,7 +799,6 @@ describe('searchIndex', () => {
       await messageCache.saveRoomMessage(createRoomMessage('room@conference.example.com', {
         id: 'prog-3', stanzaId: 'stanza-prog-3', body: 'Third progress message',
       }))
-      await flushPendingRoomMessages()
 
       const progressUpdates: Array<{ indexed: number; total: number }> = []
       await rebuildSearchIndex((p) => progressUpdates.push({ ...p }))


### PR DESCRIPTION
Live room messages went through a 100 ms batching buffer before reaching IndexedDB. When `window.location.reload()` fired (e.g. the long-sleep detection path in `usePlatformState`), the `setTimeout` was killed with the JS context and buffered writes were lost, and could lead to message loss.
This is now fixed.