### PR TITLE
fix: recover Tauri reconnect stalls via native keepalive + proxy fallback

### DIFF
--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -12,6 +12,8 @@ const {
   mockPresenceConnect,
   mockPresenceDisconnect,
   mockClientNotifySystemState,
+  mockClientNudgeReconnect,
+  mockClientVerifyConnectionHealth,
   mockConnectionStatus,
   tauriListeners,
   mockListen,
@@ -24,6 +26,8 @@ const {
     mockPresenceConnect: vi.fn(),
     mockPresenceDisconnect: vi.fn(),
     mockClientNotifySystemState: vi.fn().mockResolvedValue(undefined),
+    mockClientNudgeReconnect: vi.fn(),
+    mockClientVerifyConnectionHealth: vi.fn().mockResolvedValue(undefined),
     mockConnectionStatus: { current: 'online' },
     tauriListeners: listeners,
     mockListen: vi.fn((event: string, handler: (event?: { payload?: unknown }) => unknown) => {
@@ -61,6 +65,8 @@ vi.mock('@fluux/sdk', () => ({
   useXMPP: () => ({
     client: {
       notifySystemState: mockClientNotifySystemState,
+      nudgeReconnect: mockClientNudgeReconnect,
+      verifyConnectionHealth: mockClientVerifyConnectionHealth,
     },
   }),
   useSystemState: () => ({
@@ -85,7 +91,7 @@ vi.mock('@fluux/sdk', () => ({
 }))
 
 // Import after mocks are set up
-import { usePlatformState, shouldHandleProxyClosedStatus } from './usePlatformState'
+import { usePlatformState, shouldHandleProxyClosedStatus, handleXmppKeepalive } from './usePlatformState'
 
 describe('usePlatformState', () => {
   beforeEach(() => {
@@ -333,6 +339,87 @@ describe('usePlatformState', () => {
 
       // Should not call notifySystemState('awake') since heartbeat is inactive
       expect(mockClientNotifySystemState).not.toHaveBeenCalledWith('awake', expect.any(Number))
+    })
+  })
+
+  describe('handleXmppKeepalive', () => {
+    // The Rust side emits `xmpp-keepalive` every 30s on a native thread
+    // (immune to macOS JS timer throttling). It is the one reliable clock
+    // we have while the webview is backgrounded, so the handler must route
+    // it to nudgeReconnect() whenever the state machine is stuck in
+    // reconnecting — otherwise the JS setTimeout backoff can sit frozen
+    // for many minutes and the app looks "stuck on reconnect".
+    //
+    // Tested as a pure function (extracted from the listener) to avoid
+    // the Tauri event plumbing in unit tests. The listener → function
+    // wiring is a one-liner that's manually verified in Tauri dev mode.
+
+    let client: {
+      nudgeReconnect: ReturnType<typeof vi.fn<() => void>>
+      verifyConnectionHealth: ReturnType<typeof vi.fn<() => Promise<unknown>>>
+    }
+
+    beforeEach(() => {
+      client = {
+        nudgeReconnect: vi.fn<() => void>(),
+        verifyConnectionHealth: vi.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+      }
+    })
+
+    it('calls nudgeReconnect (not verifyConnectionHealth) when status is reconnecting', () => {
+      handleXmppKeepalive('reconnecting', client)
+      expect(client.nudgeReconnect).toHaveBeenCalledTimes(1)
+      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
+    })
+
+    it('calls verifyConnectionHealth (not nudgeReconnect) when status is online', () => {
+      handleXmppKeepalive('online', client)
+      expect(client.verifyConnectionHealth).toHaveBeenCalledTimes(1)
+      expect(client.nudgeReconnect).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when status is disconnected', () => {
+      handleXmppKeepalive('disconnected', client)
+      expect(client.nudgeReconnect).not.toHaveBeenCalled()
+      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when status is connecting (initial connect is not our retry loop)', () => {
+      handleXmppKeepalive('connecting', client)
+      expect(client.nudgeReconnect).not.toHaveBeenCalled()
+      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when status is error (terminal state)', () => {
+      handleXmppKeepalive('error', client)
+      expect(client.nudgeReconnect).not.toHaveBeenCalled()
+      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
+    })
+
+    it('nudges every time it is called (no dedup, safe to tick repeatedly)', () => {
+      // Regression guard for the backgrounded-reconnect scenario: when the
+      // machine's own setTimeout is frozen, only the 30s native tick is
+      // advancing. Each tick must keep nudging — otherwise the loop stays
+      // stuck. State-machine-side guards (TRIGGER_RECONNECT ignored in
+      // reconnecting.attempting) prevent churn when an attempt is in flight.
+      handleXmppKeepalive('reconnecting', client)
+      handleXmppKeepalive('reconnecting', client)
+      handleXmppKeepalive('reconnecting', client)
+      expect(client.nudgeReconnect).toHaveBeenCalledTimes(3)
+    })
+
+    it('swallows verifyConnectionHealth rejections without throwing', async () => {
+      const failingClient = {
+        nudgeReconnect: vi.fn<() => void>(),
+        verifyConnectionHealth: vi.fn<() => Promise<unknown>>().mockRejectedValue(new Error('unreachable')),
+      }
+      // Must not throw synchronously.
+      expect(() => handleXmppKeepalive('online', failingClient)).not.toThrow()
+      // Let the microtask queue drain so the .catch runs. If the rejection
+      // weren't caught, Node would report an unhandled rejection.
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(failingClient.verifyConnectionHealth).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -91,7 +91,12 @@ vi.mock('@fluux/sdk', () => ({
 }))
 
 // Import after mocks are set up
-import { usePlatformState, shouldHandleProxyClosedStatus, handleXmppKeepalive } from './usePlatformState'
+import {
+  usePlatformState,
+  shouldHandleProxyClosedStatus,
+  handleXmppKeepalive,
+  shouldReloadWebviewOnWake,
+} from './usePlatformState'
 
 describe('usePlatformState', () => {
   beforeEach(() => {
@@ -433,6 +438,34 @@ describe('usePlatformState', () => {
       expect(shouldHandleProxyClosedStatus('reconnecting')).toBe(false)
       expect(shouldHandleProxyClosedStatus('disconnected')).toBe(false)
       expect(shouldHandleProxyClosedStatus('error')).toBe(false)
+    })
+  })
+
+  describe('shouldReloadWebviewOnWake', () => {
+    // Gates the Tauri webview reload on wake-from-sleep. The 3-minute
+    // threshold comes from SLEEP_THRESHOLD_MS — the project-wide
+    // "real sleep vs timer throttling" line.
+
+    it('returns true for a 3+ minute wake in Tauri', () => {
+      expect(shouldReloadWebviewOnWake(180_000, true)).toBe(true)
+      expect(shouldReloadWebviewOnWake(5 * 60 * 1000, true)).toBe(true)
+      expect(shouldReloadWebviewOnWake(60 * 60 * 1000, true)).toBe(true)
+    })
+
+    it('returns false for a sub-threshold wake in Tauri (brief hide / timer throttling)', () => {
+      expect(shouldReloadWebviewOnWake(0, true)).toBe(false)
+      expect(shouldReloadWebviewOnWake(30_000, true)).toBe(false)
+      expect(shouldReloadWebviewOnWake(179_999, true)).toBe(false)
+    })
+
+    it('returns false on web even for a long wake (web browsers do not have the WRY rendering-context bug)', () => {
+      expect(shouldReloadWebviewOnWake(180_000, false)).toBe(false)
+      expect(shouldReloadWebviewOnWake(60 * 60 * 1000, false)).toBe(false)
+    })
+
+    it('returns false for unknown duration (cannot tell if it was real sleep)', () => {
+      expect(shouldReloadWebviewOnWake(undefined, true)).toBe(false)
+      expect(shouldReloadWebviewOnWake(undefined, false)).toBe(false)
     })
   })
 })

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -208,6 +208,28 @@ export function usePlatformState() {
   )
 
   /**
+   * Unified 'awake' wake handler shared by the Tauri native wake events
+   * and the JS heartbeat fallback. Kept separate from the visibility
+   * handler because visibility uses the lighter 'visible' nudge semantic.
+   */
+  const handleWakeFromSleep = useCallback(
+    (durationMs: number | undefined, source: string): void => {
+      const secs = durationMs !== undefined ? Math.round(durationMs / 1000) : undefined
+      const message = secs !== undefined
+        ? `System woke from sleep (${source}, ~${secs}s)`
+        : `System woke from sleep (${source})`
+      console.log(`[PlatformState] ${message}`)
+      logEvent(message)
+      if (maybeReloadOnLongWake(durationMs, source)) return
+      client.notifySystemState('awake', durationMs).catch((err) => {
+        console.error('[PlatformState] Error handling wake:', err)
+      })
+      lastActivityRef.current = Date.now()
+    },
+    [client, logEvent, maybeReloadOnLongWake]
+  )
+
+  /**
    * Handle user activity — signals SDK, throttled to avoid flooding.
    */
   const handleActivity = useCallback(async () => {
@@ -334,32 +356,23 @@ export function usePlatformState() {
       // Immediate wake notification
       void listen('system-did-wake', () => {
         if (cancelled) return
-        console.log('[PlatformState] Tauri system-did-wake event received')
         if (!shouldHandleWake('system-did-wake')) return
         const sleepDuration = sleepStartRef.current ? Date.now() - sleepStartRef.current : undefined
         sleepStartRef.current = null
-        console.log(`[PlatformState] System woke from sleep (OS notification${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s` : ''})`)
-        logEvent(`System woke from sleep (OS notification${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s` : ''})`)
-        if (maybeReloadOnLongWake(sleepDuration, 'system-did-wake')) return
-        client.notifySystemState('awake', sleepDuration).catch(() => {})
-        lastActivityRef.current = Date.now()
+        handleWakeFromSleep(sleepDuration, 'system-did-wake')
       }).then(fn => {
         if (cancelled) { fn() } else { unlistenWake = fn }
       })
 
-      // Deferred wake notification (app was in background during wake)
+      // Deferred wake notification (app was in background during wake;
+      // Tauri delivers the event with a delay measured in seconds).
       void listen<number>('system-did-wake-deferred', (event) => {
         if (cancelled) return
         const delaySecs = event.payload || 0
-        console.log(`[PlatformState] Tauri system-did-wake-deferred event received (delay=${delaySecs}s)`)
         if (!shouldHandleWake('system-did-wake-deferred')) return
         const sleepDuration = sleepStartRef.current ? Date.now() - sleepStartRef.current : undefined
         sleepStartRef.current = null
-        console.log(`[PlatformState] System woke from sleep (deferred ${delaySecs}s${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s sleep` : ''})`)
-        logEvent(`System woke from sleep (deferred ${delaySecs}s - app was in background${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s sleep` : ''})`)
-        if (maybeReloadOnLongWake(sleepDuration, 'system-did-wake-deferred')) return
-        client.notifySystemState('awake', sleepDuration).catch(() => {})
-        lastActivityRef.current = Date.now()
+        handleWakeFromSleep(sleepDuration, `system-did-wake-deferred +${delaySecs}s`)
       }).then(fn => {
         if (cancelled) { fn() } else { unlistenWakeDeferred = fn }
       })
@@ -367,8 +380,8 @@ export function usePlatformState() {
       // Sleep notification
       void listen('system-will-sleep', () => {
         if (cancelled) return
-        console.log('[PlatformState] Tauri system-will-sleep event received')
         sleepStartRef.current = Date.now()
+        console.log('[PlatformState] Tauri system-will-sleep event received')
         logEvent('System going to sleep')
         client.notifySystemState('sleeping').catch(() => {})
       }).then(fn => {
@@ -382,7 +395,7 @@ export function usePlatformState() {
       unlistenWakeDeferred?.()
       unlistenSleep?.()
     }
-  }, [client, shouldHandleWake, logEvent, maybeReloadOnLongWake])
+  }, [client, shouldHandleWake, logEvent, handleWakeFromSleep])
 
   // ── Effect 3: Time-gap wake detection (JS heartbeat) ──────────────────────
   // Also runs during 'reconnecting' status so we still update the heartbeat
@@ -405,11 +418,7 @@ export function usePlatformState() {
       if (statusRef.current === 'reconnecting') return
       if (!shouldHandleWake('time-gap')) return
 
-      console.log(`[PlatformState] Detected wake from sleep (${Math.round(gap / 1000)}s gap)`)
-      if (maybeReloadOnLongWake(gap, 'heartbeat')) return
-      client.notifySystemState('awake', gap).catch((err) => {
-        console.error('[PlatformState] Error handling wake:', err)
-      })
+      handleWakeFromSleep(gap, 'heartbeat')
     }
 
     const interval = setInterval(checkForWake, HEARTBEAT_INTERVAL_MS)
@@ -417,7 +426,7 @@ export function usePlatformState() {
     return () => {
       clearInterval(interval)
     }
-  }, [status, client, shouldHandleWake, maybeReloadOnLongWake])
+  }, [status, shouldHandleWake, handleWakeFromSleep])
 
   // ── Effect 4: Page visibility and window focus ──────────────────────────────
   // Runs during 'reconnecting' so window focus can still nudge a stalled

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -44,6 +44,47 @@ export function shouldHandleProxyClosedStatus(status: string): boolean {
   return status === 'online'
 }
 
+/** Minimal client surface the keepalive handler needs, for unit testing. */
+export interface XmppKeepaliveClient {
+  nudgeReconnect: () => void
+  verifyConnectionHealth: () => Promise<unknown>
+}
+
+/**
+ * Handle a tick from the Rust-native `xmpp-keepalive` event.
+ *
+ * The Rust side emits this every 30s on a native thread — it is the one
+ * clock in the app that is immune to macOS JS timer throttling. Behaviour:
+ *
+ * - `online`: run a lightweight health check (`verifyConnectionHealth`)
+ *   which silently sends an SM `<r/>` without changing status.
+ * - `reconnecting`: nudge the state machine out of `reconnecting.waiting`
+ *   whenever an attempt is pending. Without this, the machine's backoff
+ *   `setTimeout` can sit frozen for many minutes while the OS throttles
+ *   the JS runtime, leaving the app "stuck on reconnect" from the user's
+ *   point of view even though the reconnect logic is healthy.
+ *   `nudgeReconnect()` is a safe no-op when the machine is already in
+ *   `reconnecting.attempting`, so firing this every 30s during a
+ *   reconnect loop only accelerates progress — it cannot cause churn.
+ * - anything else (`disconnected`, `connecting`, terminal): no-op.
+ *
+ * Extracted as a named export so it can be unit-tested without going
+ * through the Tauri event dispatch plumbing.
+ */
+export function handleXmppKeepalive(
+  status: string,
+  client: XmppKeepaliveClient
+): void {
+  if (status === 'reconnecting') {
+    client.nudgeReconnect()
+    return
+  }
+  if (status !== 'online') return
+  client.verifyConnectionHealth().catch((err) => {
+    console.debug('[PlatformState] Keepalive health check error:', err)
+  })
+}
+
 // ── Hook ───────────────────────────────────────────────────────────────────────
 
 /**
@@ -430,14 +471,12 @@ export function usePlatformState() {
     let cleanedUp = false
 
     void import('@tauri-apps/api/event').then(({ listen }) => {
-      // Keepalive: lightweight connection health check every 30s (Rust-driven, immune to JS throttling).
-      // Uses verifyConnectionHealth() which silently sends SM <r/> without changing status.
+      // Rust-driven keepalive tick every 30s. See handleXmppKeepalive above
+      // for the routing logic (online → health check, reconnecting → nudge,
+      // else → no-op). Extracted to a named function so it can be
+      // unit-tested without going through the Tauri event dispatch.
       void listen('xmpp-keepalive', () => {
-        if (statusRef.current !== 'online') return
-        client.verifyConnectionHealth()
-          .catch((err) => {
-            console.debug('[PlatformState] Keepalive health check error:', err)
-          })
+        handleXmppKeepalive(statusRef.current, client)
       }).then((fn) => {
         if (cleanedUp) { fn() } else { unlistenKeepalive = fn }
       })

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -13,28 +13,28 @@ const ACTIVITY_THROTTLE_MS = 5000
 /** Heartbeat interval for time-gap sleep detection (ms). */
 const HEARTBEAT_INTERVAL_MS = 10_000
 
-/** Minimum time gap to consider as system sleep (ms).
+/** Minimum time gap to consider a real sleep/wake cycle (ms).
+ *
  * Set to 3 minutes because macOS routinely throttles WebKit JS timers when
  * the app is on another virtual desktop or behind other windows, producing
- * gaps of 60–120s that are NOT real sleep.  The Tauri system-did-wake event
- * handles real OS-level sleep/wake with zero delay; this heartbeat-based
- * detection is only a fallback for web mode. */
+ * gaps of 60–120s that are NOT real sleep.
+ *
+ * This same threshold also gates the Tauri webview reload on wake: any
+ * confirmed sleep/wake ≥ 3 minutes is long enough for WKWebView to have
+ * lost its rendering context (wry#184), so we force-reload the page and
+ * let useSessionPersistence auto-reconnect from the stored session.
+ * Short hides (lock screen under 3 min, alt-tab for a moment) don't
+ * trigger a reload — those keep working through the normal reconnect
+ * path. */
 const SLEEP_THRESHOLD_MS = 180_000
 
 /** Minimum time the page must be hidden before signaling SDK (ms).
- * Matches SLEEP_THRESHOLD_MS — switching virtual desktops or apps for
- * a couple of minutes is normal macOS workflow, not worth reconnecting for. */
-const MIN_HIDDEN_TIME_MS = 180_000
+ * Matches SLEEP_THRESHOLD_MS — same "real sleep vs timer throttling"
+ * definition. */
+const MIN_HIDDEN_TIME_MS = SLEEP_THRESHOLD_MS
 
 /** Debounce window to prevent duplicate wake handling (ms). */
 const WAKE_DEBOUNCE_MS = 2000
-
-/** Sleep duration above which we force-reload the webview on wake (ms).
- * After very long sleep (overnight), the WRY/WKWebView on macOS can lose
- * its rendering context — the app window shows but the content is blank.
- * Reloading resets the webview pipeline; useSessionPersistence will
- * auto-reconnect from the stored session. */
-const LONG_SLEEP_RELOAD_MS = 60 * 60 * 1000 // 1 hour
 
 /**
  * Proxy-close events should only trigger wake/reconnect while the app was
@@ -42,6 +42,33 @@ const LONG_SLEEP_RELOAD_MS = 60 * 60 * 1000 // 1 hour
  */
 export function shouldHandleProxyClosedStatus(status: string): boolean {
   return status === 'online'
+}
+
+/**
+ * Decide whether a wake from sleep should reload the Tauri webview.
+ *
+ * Background: after a confirmed sleep/wake cycle the WRY/WKWebView on
+ * macOS can lose its rendering context — the app window shows but the
+ * content is blank (wry#184). The only reliable recovery is a full
+ * `window.location.reload()`, which rebuilds the rendering pipeline;
+ * `useSessionPersistence` then auto-reconnects from the stored session.
+ *
+ * Gating rules:
+ * - Only in Tauri (the web browser path doesn't have this bug).
+ * - Only when duration is ≥ SLEEP_THRESHOLD_MS, which is the project-wide
+ *   threshold for "real sleep" vs "timer throttling / brief hide".
+ * - Unknown duration → no reload (we can't tell if it was real sleep).
+ *
+ * Extracted as a pure function so it can be unit-tested without touching
+ * `window.location.reload()` in jsdom.
+ */
+export function shouldReloadWebviewOnWake(
+  durationMs: number | undefined,
+  isTauriMode: boolean
+): boolean {
+  if (!isTauriMode) return false
+  if (durationMs === undefined) return false
+  return durationMs >= SLEEP_THRESHOLD_MS
 }
 
 /** Minimal client surface the keepalive handler needs, for unit testing. */
@@ -157,13 +184,28 @@ export function usePlatformState() {
   }, [])
 
   /**
-   * Dispatch CSS resize workaround for WebKit layout corruption after wake.
+   * Decide whether to reload the Tauri webview on a wake event and do it.
+   *
+   * Returns true if a reload was triggered — caller should bail out of
+   * any follow-up work, the page is going away.
+   *
+   * This is the single place in the hook that calls window.location.reload().
+   * Splitting the reload decision from the "what to do instead" path keeps
+   * each wake source in control of its own non-reload semantics (Tauri OS
+   * wake + heartbeat want to signal 'awake' for state-machine verify;
+   * visibility-change wants to signal 'visible' for reconnect nudge).
    */
-  const dispatchResizeWorkaround = useCallback(() => {
-    requestAnimationFrame(() => {
-      window.dispatchEvent(new Event('resize'))
-    })
-  }, [])
+  const maybeReloadOnLongWake = useCallback(
+    (durationMs: number | undefined, source: string): boolean => {
+      if (!shouldReloadWebviewOnWake(durationMs, isTauri())) return false
+      const secs = Math.round((durationMs ?? 0) / 1000)
+      console.log(`[PlatformState] Wake from sleep (${source}, ${secs}s), reloading webview to restore rendering`)
+      logEvent(`Wake from sleep (${source}, ${secs}s), reloading webview`)
+      window.location.reload()
+      return true
+    },
+    [logEvent]
+  )
 
   /**
    * Handle user activity — signals SDK, throttled to avoid flooding.
@@ -298,14 +340,9 @@ export function usePlatformState() {
         sleepStartRef.current = null
         console.log(`[PlatformState] System woke from sleep (OS notification${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s` : ''})`)
         logEvent(`System woke from sleep (OS notification${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s` : ''})`)
-        if (sleepDuration && sleepDuration >= LONG_SLEEP_RELOAD_MS) {
-          console.log(`[PlatformState] Long sleep detected (${Math.round(sleepDuration / 1000)}s), reloading webview to restore rendering`)
-          window.location.reload()
-          return
-        }
+        if (maybeReloadOnLongWake(sleepDuration, 'system-did-wake')) return
         client.notifySystemState('awake', sleepDuration).catch(() => {})
         lastActivityRef.current = Date.now()
-        dispatchResizeWorkaround()
       }).then(fn => {
         if (cancelled) { fn() } else { unlistenWake = fn }
       })
@@ -320,14 +357,9 @@ export function usePlatformState() {
         sleepStartRef.current = null
         console.log(`[PlatformState] System woke from sleep (deferred ${delaySecs}s${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s sleep` : ''})`)
         logEvent(`System woke from sleep (deferred ${delaySecs}s - app was in background${sleepDuration ? `, ~${Math.round(sleepDuration / 1000)}s sleep` : ''})`)
-        if (sleepDuration && sleepDuration >= LONG_SLEEP_RELOAD_MS) {
-          console.log(`[PlatformState] Long sleep detected (${Math.round(sleepDuration / 1000)}s), reloading webview to restore rendering`)
-          window.location.reload()
-          return
-        }
+        if (maybeReloadOnLongWake(sleepDuration, 'system-did-wake-deferred')) return
         client.notifySystemState('awake', sleepDuration).catch(() => {})
         lastActivityRef.current = Date.now()
-        dispatchResizeWorkaround()
       }).then(fn => {
         if (cancelled) { fn() } else { unlistenWakeDeferred = fn }
       })
@@ -350,7 +382,7 @@ export function usePlatformState() {
       unlistenWakeDeferred?.()
       unlistenSleep?.()
     }
-  }, [client, shouldHandleWake, logEvent, dispatchResizeWorkaround])
+  }, [client, shouldHandleWake, logEvent, maybeReloadOnLongWake])
 
   // ── Effect 3: Time-gap wake detection (JS heartbeat) ──────────────────────
   // Also runs during 'reconnecting' status so we still update the heartbeat
@@ -360,33 +392,24 @@ export function usePlatformState() {
   useEffect(() => {
     if (status !== 'online' && status !== 'reconnecting') return
 
-    const checkForWake = async () => {
+    const checkForWake = () => {
       const now = Date.now()
       const gap = now - lastHeartbeatRef.current
       lastHeartbeatRef.current = now
 
       if (gap < SLEEP_THRESHOLD_MS) return
-      // Machine is already handling the reconnect with its own backoff.
-      // Re-entering handleAwake() here would cause overlapping cleanup +
-      // attemptReconnect sequences and a render storm.
+      // Machine is already handling the reconnect with its own backoff +
+      // the Rust keepalive nudge. Re-entering handleAwake() here would
+      // cause overlapping cleanup + attemptReconnect sequences and a
+      // render storm.
       if (statusRef.current === 'reconnecting') return
       if (!shouldHandleWake('time-gap')) return
 
-      const gapSeconds = Math.round(gap / 1000)
-      console.log(`[PlatformState] Detected wake from sleep (${gapSeconds}s gap)`)
-
-      if (isTauri() && gap >= LONG_SLEEP_RELOAD_MS) {
-        console.log(`[PlatformState] Long sleep detected (${gapSeconds}s), reloading webview to restore rendering`)
-        window.location.reload()
-        return
-      }
-
-      try {
-        await client.notifySystemState('awake', gap)
-        dispatchResizeWorkaround()
-      } catch (err) {
+      console.log(`[PlatformState] Detected wake from sleep (${Math.round(gap / 1000)}s gap)`)
+      if (maybeReloadOnLongWake(gap, 'heartbeat')) return
+      client.notifySystemState('awake', gap).catch((err) => {
         console.error('[PlatformState] Error handling wake:', err)
-      }
+      })
     }
 
     const interval = setInterval(checkForWake, HEARTBEAT_INTERVAL_MS)
@@ -394,7 +417,7 @@ export function usePlatformState() {
     return () => {
       clearInterval(interval)
     }
-  }, [status, client, shouldHandleWake, dispatchResizeWorkaround])
+  }, [status, client, shouldHandleWake, maybeReloadOnLongWake])
 
   // ── Effect 4: Page visibility and window focus ──────────────────────────────
   // Runs during 'reconnecting' so window focus can still nudge a stalled
@@ -428,9 +451,16 @@ export function usePlatformState() {
       if (!shouldHandleWake('visibility')) return
 
       console.log(`[PlatformState] Page visible after ${Math.round(hiddenDuration / 1000)}s`)
+
+      // If the hide was long enough to count as a real sleep on Tauri,
+      // reload the webview (same rendering-context hazard as OS sleep).
+      if (maybeReloadOnLongWake(hiddenDuration, 'visibility')) return
+
+      // Sub-threshold (or web mode): just nudge a stalled reconnect via
+      // notifySystemState('visible'). Lighter "tab came back" path — no
+      // state-machine WAKE, no verify.
       try {
         await client.notifySystemState('visible')
-        dispatchResizeWorkaround()
       } catch (err) {
         console.error('[PlatformState] Error handling visibility change:', err)
       }
@@ -459,7 +489,7 @@ export function usePlatformState() {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       window.removeEventListener('focus', handleWindowFocus)
     }
-  }, [status, client, shouldHandleWake, dispatchResizeWorkaround])
+  }, [status, client, shouldHandleWake, maybeReloadOnLongWake])
 
   // ── Effect 5: Tauri native events (keepalive + proxy watchdog) ────────────
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -938,14 +938,17 @@ export class XMPPClient {
   }
 
   /**
-   * Immediately trigger a reconnection attempt.
+   * Nudge the reconnect loop forward if it is currently stuck waiting.
    *
    * @remarks
-   * Useful when you want to reconnect without waiting for the
-   * automatic reconnection timer.
+   * Only does work when the state machine is in `reconnecting.waiting`: it
+   * skips the remaining backoff delay and transitions to `attempting`.
+   * When the machine is in `reconnecting.attempting` the signal is ignored,
+   * and outside of reconnecting states this method early-returns. Safe to
+   * call repeatedly as a heartbeat (e.g., from a native-thread keepalive).
    */
-  triggerReconnect(): void {
-    this.connection.triggerReconnect()
+  nudgeReconnect(): void {
+    this.connection.nudgeReconnect()
   }
 
   /**
@@ -957,7 +960,7 @@ export class XMPPClient {
    * ```typescript
    * const isAlive = await client.verifyConnection()
    * if (!isAlive) {
-   *   client.triggerReconnect()
+   *   client.nudgeReconnect()
    * }
    * ```
    */

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -930,6 +930,135 @@ describe('XMPPClient Connection', () => {
       proxyClient.cancelReconnect()
     })
 
+    it('should fall back to proxy when direct WebSocket reconnect fails on a Tauri install', async () => {
+      // Regression for "stuck on reconnect" where a Tauri client that won
+      // initial connect on direct WebSocket would retry the same doomed URL
+      // forever, never touching the available Rust proxy. After this fix
+      // the first reconnect failure flips the client onto the proxy.
+      //
+      // Uses a server ('chat.example.com') that is intentionally different
+      // from the JID domain ('example.com'). If the fallback code fell back
+      // to getDomain(jid) instead of reading the recorded originalServer,
+      // startProxy would be called with 'example.com' — asserting the
+      // expected 'chat.example.com' proves that setOriginalServer() was
+      // wired on the initial direct-WS path.
+      mockDiscoverWebSocket.mockResolvedValue('wss://chat.example.com/xmpp')
+
+      const mockProxyAdapter = {
+        startProxy: vi.fn().mockResolvedValue({ url: 'ws://127.0.0.1:12345' }),
+        stopProxy: vi.fn().mockResolvedValue(undefined),
+      }
+      const proxyClient = new XMPPClient({ debug: false, proxyAdapter: mockProxyAdapter })
+      proxyClient.bindStores(mockStores)
+
+      // Initial connect wins via direct WebSocket (XEP-0156 discovery).
+      const connectPromise = proxyClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'chat.example.com',
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      // Direct-WS initial path should NOT have started the proxy yet.
+      expect(mockProxyAdapter.startProxy).not.toHaveBeenCalled()
+      expect(mockClientFactory).toHaveBeenLastCalledWith(
+        expect.objectContaining({ service: 'wss://chat.example.com/xmpp' })
+      )
+      expect(mockStores.connection.setConnectionMethod).toHaveBeenLastCalledWith('websocket')
+
+      // Trigger unexpected disconnect — machine → reconnecting.
+      vi.mocked(mockStores.console.addEvent).mockClear()
+      vi.mocked(mockStores.connection.setConnectionMethod).mockClear()
+      mockXmppClientInstance._emit('disconnect', { clean: false })
+      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('reconnecting')
+
+      // First reconnect attempt retries the direct-WS URL and fails; the
+      // fallback catch block then calls ensureProxy() and retries on the
+      // proxy URL, which succeeds.
+      const failedDirectClient = createMockXmppClient()
+      failedDirectClient.start.mockRejectedValue(new Error('direct websocket still dead'))
+      const proxyReconnectClient = createMockXmppClient()
+      mockClientFactory
+        .mockImplementationOnce(() => failedDirectClient)
+        .mockImplementationOnce(() => proxyReconnectClient)
+
+      // Advance past the 1s backoff timer so the waiting substate fires.
+      await vi.advanceTimersByTimeAsync(1000)
+      // Let the catch block run ensureProxy() and schedule the retry.
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Resolve the proxy retry.
+      proxyReconnectClient._emit('online')
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Proxy was started exactly once — during the fallback.
+      expect(mockProxyAdapter.startProxy).toHaveBeenCalledTimes(1)
+      // And it was started with the ORIGINAL user-provided server
+      // (proof that setOriginalServer ran on the initial direct-WS path).
+      expect(mockProxyAdapter.startProxy).toHaveBeenCalledWith('chat.example.com')
+
+      // The second reconnect attempt used the proxy URL.
+      expect(mockClientFactory).toHaveBeenLastCalledWith(
+        expect.objectContaining({ service: 'ws://127.0.0.1:12345' })
+      )
+      expect(mockStores.connection.setConnectionMethod).toHaveBeenCalledWith('proxy')
+
+      // Operator-visible fallback log was emitted.
+      expect(mockStores.console.addEvent).toHaveBeenCalledWith(
+        expect.stringContaining('falling back to proxy'),
+        'connection'
+      )
+
+      proxyClient.cancelReconnect()
+    })
+
+    it('should NOT fall back to proxy on direct-WS reconnect failure when there is no proxy adapter (web mode)', async () => {
+      // Regression guard: the new fallback gate requires proxyManager.hasProxy.
+      // Without a proxy adapter, a failed direct-WS reconnect should propagate
+      // the error to the state machine (which retries with backoff) without
+      // any proxy calls. The default xmppClient from beforeEach has no
+      // proxyAdapter, which simulates web mode.
+      mockDiscoverWebSocket.mockResolvedValue('wss://chat.example.com/xmpp')
+
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'chat.example.com',
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      // Trigger disconnect; reconnect attempt should fail and simply
+      // propagate to CONNECTION_ERROR → reconnecting.waiting.
+      mockXmppClientInstance._emit('disconnect', { clean: false })
+      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('reconnecting')
+
+      const failedReconnect = createMockXmppClient()
+      failedReconnect.start.mockRejectedValue(new Error('direct websocket failed'))
+      mockClientFactory._setInstance(failedReconnect)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // The reconnect attempt's error must have surfaced on the error store
+      // (proving we did not swallow it via a fallback attempt).
+      const errorCalls = vi.mocked(mockStores.connection.setError).mock.calls.map(c => c[0])
+      expect(
+        errorCalls.some(err => typeof err === 'string' && err.includes('direct websocket failed'))
+      ).toBe(true)
+
+      // And no "falling back to proxy" log was emitted.
+      const consoleCalls = vi.mocked(mockStores.console.addEvent).mock.calls.map(c => c[0])
+      expect(
+        consoleCalls.some(msg => typeof msg === 'string' && msg.includes('falling back to proxy'))
+      ).toBe(false)
+
+      xmppClient.cancelReconnect()
+    })
+
     it('should auto-reconnect when connection drops after successful connection', async () => {
       // First, connect successfully
       const connectPromise = xmppClient.connect({

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -985,7 +985,7 @@ describe('XMPPClient Connection', () => {
       )
       expect(mockStores.connection.setStatus).toHaveBeenCalledWith('reconnecting')
       expect(mockStores.console.addEvent).toHaveBeenCalledWith(
-        expect.stringContaining('Dead-socket recovery: triggering immediate reconnect'),
+        expect.stringContaining('Dead-socket recovery: nudging reconnect immediately'),
         'connection'
       )
 
@@ -2936,28 +2936,29 @@ describe('XMPPClient Connection', () => {
       await vi.advanceTimersByTimeAsync(1000)
       expect(mockClientFactory).toHaveBeenCalledTimes(1)
 
-      // Now call triggerReconnect() while the first attempt is still in progress
-      // (simulates app becoming visible while reconnecting)
+      // Now call nudgeReconnect() while the first attempt is still in progress
+      // (simulates app becoming visible while reconnecting). The machine ignores
+      // TRIGGER_RECONNECT in `reconnecting.attempting`, so this must be a no-op.
       mockClientFactory.mockClear()
-      xmppClient.triggerReconnect()
+      xmppClient.nudgeReconnect()
 
       // No second reconnect attempt should start while machine stays in attempting.
       expect(mockClientFactory).not.toHaveBeenCalled()
     })
 
-    it('should allow repeated reconnect triggers after "still online" short-circuit', async () => {
+    it('should allow repeated reconnect nudges after "still online" short-circuit', async () => {
       // Force the defensive online short-circuit path in attemptReconnect()
       ;(mockXmppClientInstance as any).status = 'online'
 
       // First immediate reconnect short-circuits
       xmppClient.connectionActor.send({ type: 'SOCKET_DIED' })
-      xmppClient.triggerReconnect()
+      xmppClient.nudgeReconnect()
       await vi.advanceTimersByTimeAsync(0)
 
-      // A second trigger should still run through attempting, not get stuck.
+      // A second nudge should still run through attempting, not get stuck.
       vi.mocked(mockStores.console.addEvent).mockClear()
       xmppClient.connectionActor.send({ type: 'SOCKET_DIED' })
-      xmppClient.triggerReconnect()
+      xmppClient.nudgeReconnect()
       await vi.advanceTimersByTimeAsync(0)
 
       expect(mockStores.console.addEvent).toHaveBeenCalled()
@@ -3011,12 +3012,14 @@ describe('XMPPClient Connection', () => {
       expect(mockStores.connection.setStatus).toHaveBeenCalledWith('reconnecting')
 
       // Prepare mock for reconnect BEFORE calling notifySystemState,
-      // because triggerReconnect() fires attemptReconnect() synchronously
+      // because the WAKE event fires attemptReconnect() synchronously via
+      // the state-machine subscription.
       const reconnectClient = createMockXmppClient()
       mockClientFactory._setInstance(reconnectClient)
 
-      // Now the wake event fires with a long sleep duration (8 hours)
-      // Since we're already in reconnecting state, this should triggerReconnect
+      // Now the wake event fires with a long sleep duration (8 hours).
+      // Since we're already in reconnecting state, handleAwake sends WAKE
+      // to the machine, which transitions waiting → attempting.
       const eightHoursMs = 8 * 60 * 60 * 1000
       await xmppClient.notifySystemState('awake', eightHoursMs)
 
@@ -3030,7 +3033,7 @@ describe('XMPPClient Connection', () => {
       // After wake, attemptReconnect adds a 2s network settle delay (NETWORK_SETTLE_DELAY_MS).
       await vi.advanceTimersByTimeAsync(3000)
 
-      // The triggerReconnect should have started attemptReconnect
+      // The WAKE event should have started attemptReconnect
       expect(mockClientFactory).toHaveBeenCalledTimes(1)
 
       // Simulate successful reconnection on the new client

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3886,6 +3886,40 @@ describe('XMPPClient Connection', () => {
       expect(result).toBe(false)
     })
 
+    it('waitForNetworkReady short-circuits to true when a proxy adapter is in use', async () => {
+      // Regression: on Tauri desktop the XMPP socket is owned by the Rust
+      // proxy at the OS level, not by the webview. `navigator.onLine` is
+      // the browser's own network perception and can lie after WKWebView
+      // sleep/wake — stay true when the network is dead, or go false while
+      // the Rust proxy could have connected fine. We must NOT block on
+      // that signal when a proxy adapter is available; the proxy-fallback
+      // path in attemptReconnect is the real recovery mechanism on desktop.
+      const mockProxyAdapter = {
+        startProxy: vi.fn().mockResolvedValue({ url: 'ws://127.0.0.1:12345' }),
+        stopProxy: vi.fn().mockResolvedValue(undefined),
+      }
+      const proxyClient = new XMPPClient({ debug: false, proxyAdapter: mockProxyAdapter })
+      proxyClient.bindStores(mockStores)
+
+      // Force navigator.onLine false — a non-proxy client would block here
+      // for up to `timeoutMs` waiting for the 'online' event.
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true })
+
+      const connectionModule = (proxyClient.connection as any)
+      const result = await connectionModule.waitForNetworkReady(5000)
+      expect(result).toBe(true)
+
+      // Confirm we did NOT emit the "waiting for network" diagnostic —
+      // the short-circuit must bail before touching the console store
+      // or registering event listeners.
+      const consoleCalls = vi.mocked(mockStores.console.addEvent).mock.calls.map(c => c[0])
+      expect(
+        consoleCalls.some(msg => typeof msg === 'string' && msg.includes('Waiting for network'))
+      ).toBe(false)
+
+      proxyClient.cancelReconnect()
+    })
+
     it('attemptReconnect skips WebSocket creation when network is not available', async () => {
       // Connect first
       const connectPromise = xmppClient.connect({

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -554,6 +554,17 @@ export class Connection extends BaseModule {
             'connection'
           )
 
+          // Record the original server target in ProxyManager before the
+          // direct-WS attempt. credentials.server will soon hold the resolved
+          // wss:// URL, which is useless for starting the Rust proxy later —
+          // the proxy needs the original XMPP host/domain. If a later
+          // reconnect fails on direct WS and falls back to proxy, the
+          // ProxyManager reads this to bring the proxy up against the right
+          // target. Safe idempotent call; harmless if direct WS then fails
+          // and we fall through to the ensureProxy() path below, which also
+          // updates the same field.
+          this.proxyManager.setOriginalServer(server || domain)
+
           try {
             const timeoutSentinel = Symbol('direct-ws-precheck-timeout')
             const result = await Promise.race([
@@ -2134,31 +2145,67 @@ export class Connection extends BaseModule {
         await connectWithOptions(reconnectOptions)
       } catch (reconnectError) {
         const errorMsg = reconnectError instanceof Error ? reconnectError.message : String(reconnectError)
-        // Only when reconnecting through a cached local proxy endpoint and that
-        // endpoint fails do we refresh/restart the proxy and retry once.
+
+        // Two recovery paths on reconnect failure:
+        //
+        //  (1) `shouldRefreshProxy` — we were already on the Rust proxy and the
+        //      cached endpoint died (e.g., proxy watchdog closed the socket).
+        //      Restart the proxy against the same target and retry once.
+        //
+        //  (2) `shouldFallBackToProxy` — we were on a direct WebSocket endpoint
+        //      and it failed. Switch to the Rust proxy for the retry and for
+        //      the rest of the session. On Tauri the webview's WebSocket can
+        //      lose its context after background/sleep; the proxy owns its own
+        //      OS-level TCP connection and is far more resilient, so a single
+        //      direct-WS failure should flip us onto the proxy permanently
+        //      rather than retrying the same doomed URL forever.
         const shouldRefreshProxy = reconnectUsesCachedProxy && !this.isInTerminalState()
-        if (!shouldRefreshProxy) {
+        const shouldFallBackToProxy =
+          !reconnectUsesCachedProxy &&
+          this.proxyManager.hasProxy &&
+          !this.isLocalProxyServer(reconnectOptions.server) &&
+          !this.isInTerminalState()
+
+        if (!shouldRefreshProxy && !shouldFallBackToProxy) {
           throw reconnectError
         }
 
         const reconnectDomain = getDomain(reconnectOptions.jid)
         const proxyServer = this.proxyManager.getOriginalServer() || reconnectDomain
-        this.stores.console.addEvent(
-          `Reconnect: cached proxy endpoint failed (${errorMsg}), refreshing endpoint`,
-          'connection'
-        )
+
+        if (shouldRefreshProxy) {
+          this.stores.console.addEvent(
+            `Reconnect: cached proxy endpoint failed (${errorMsg}), refreshing endpoint`,
+            'connection'
+          )
+        } else {
+          this.stores.console.addEvent(
+            `Reconnect: direct WebSocket failed (${errorMsg}), falling back to proxy (${proxyServer})`,
+            'connection'
+          )
+          logInfo(`attemptReconnect: direct WebSocket failed, falling back to proxy for ${proxyServer}`)
+        }
+
         this.cleanupClient()
-        const proxyRefreshStart = Date.now()
-        const refreshed = await this.proxyManager.restartProxy(proxyServer, reconnectDomain)
-        const proxyRefreshMs = Date.now() - proxyRefreshStart
+        const proxyStart = Date.now()
+        const refreshed = shouldRefreshProxy
+          ? await this.proxyManager.restartProxy(proxyServer, reconnectDomain)
+          : await this.proxyManager.ensureProxy(proxyServer, reconnectDomain)
+        const proxyMs = Date.now() - proxyStart
         reconnectOptions = { ...reconnectOptions, server: refreshed.server }
         this.credentials = reconnectOptions
         this.stores.connection.setConnectionMethod(refreshed.connectionMethod)
         this.stores.console.addEvent(
-          `Reconnect: proxy refreshed in ${proxyRefreshMs}ms -> ${refreshed.server}`,
+          shouldRefreshProxy
+            ? `Reconnect: proxy refreshed in ${proxyMs}ms -> ${refreshed.server}`
+            : `Reconnect: proxy started in ${proxyMs}ms -> ${refreshed.server}`,
           'connection'
         )
-        logInfo(`attemptReconnect: proxy refreshed (${refreshed.server}) in ${proxyRefreshMs}ms`)
+        logInfo(
+          shouldRefreshProxy
+            ? `attemptReconnect: proxy refreshed (${refreshed.server}) in ${proxyMs}ms`
+            : `attemptReconnect: fell back to proxy (${refreshed.server}) in ${proxyMs}ms`
+        )
 
         await connectWithOptions(reconnectOptions)
       }

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -1253,8 +1253,25 @@ export class Connection extends BaseModule {
    * After wake-from-sleep, the OS network stack may need several seconds
    * to reinitialize. This prevents wasting reconnect attempts on a
    * network that isn't ready yet.
+   *
+   * Short-circuits to `true` when a proxy adapter is in use (typically
+   * Tauri desktop): the XMPP socket is owned by the native Rust proxy,
+   * not by the webview, so `navigator.onLine` reflects the webview's
+   * browser-level network perception rather than actual reachability.
+   * On WKWebView in particular, `navigator.onLine` is known to lie
+   * after sleep/wake — can stay `true` when the real network is dead,
+   * or report `false` spuriously while the Rust proxy could have
+   * connected fine. The proxy-fallback path in attemptReconnect() is
+   * the correct recovery mechanism on desktop; blocking on the
+   * unreliable browser signal first just adds latency.
    */
   private waitForNetworkReady(timeoutMs: number = NETWORK_READY_TIMEOUT_MS): Promise<boolean> {
+    // Proxy mode: trust the Rust side; `navigator.onLine` is not a
+    // meaningful signal for an OS-level TCP socket.
+    if (this.proxyManager.hasProxy) {
+      return Promise.resolve(true)
+    }
+
     // Fast path: already online
     if (typeof navigator !== 'undefined' && navigator.onLine) {
       return Promise.resolve(true)

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -114,7 +114,7 @@ const isAuthStreamError = (message: string): boolean =>
  *
  * // Manual reconnection control
  * client.connection.cancelReconnect()
- * client.connection.triggerReconnect()
+ * client.connection.nudgeReconnect()
  *
  * // Check connection health after sleep
  * const isAlive = await client.verifyConnection()
@@ -804,15 +804,22 @@ export class Connection extends BaseModule {
   }
 
   /**
-   * Immediately trigger a reconnection attempt.
+   * Nudge the reconnect loop forward if it is currently stuck waiting.
    *
-   * Use this when the app becomes visible while in a reconnecting state,
-   * since background timers may have been suspended by the browser/OS.
-   * This cancels any pending scheduled reconnection attempts immediately.
+   * Only does work when the state machine is in `reconnecting.waiting`: it
+   * skips the remaining backoff delay and transitions to `attempting`. When
+   * the machine is in `reconnecting.attempting` (an attempt is already in
+   * flight) the signal is ignored, and outside of reconnecting states this
+   * method early-returns. Safe to call repeatedly as a heartbeat.
+   *
+   * Use this when you have an external signal that the reconnect loop may
+   * have stalled — e.g., the app became visible while in a reconnecting
+   * state and background timers may have been suspended by the OS, or a
+   * native-thread keepalive is nudging a JS-throttled backoff timer.
    */
-  triggerReconnect(): void {
+  nudgeReconnect(): void {
     if (!this.isInReconnectingState() || !this.credentials) {
-      const message = `triggerReconnect skipped (reconnecting=${this.isInReconnectingState()}, hasCredentials=${!!this.credentials}, state=${JSON.stringify(this.getMachineState())})`
+      const message = `nudgeReconnect skipped (reconnecting=${this.isInReconnectingState()}, hasCredentials=${!!this.credentials}, state=${JSON.stringify(this.getMachineState())})`
       this.stores.console.addEvent(message, 'connection')
       logInfo(message)
       return
@@ -820,7 +827,9 @@ export class Connection extends BaseModule {
 
     // Signal machine: skip waiting, go directly to attempting.
     // The state-machine subscription starts the reconnect attempt.
-    this.sendMachineEvent({ type: 'TRIGGER_RECONNECT' }, 'triggerReconnect')
+    // In `attempting` state the machine ignores TRIGGER_RECONNECT, so this
+    // is a safe no-op even while an attempt is in flight.
+    this.sendMachineEvent({ type: 'TRIGGER_RECONNECT' }, 'nudgeReconnect')
   }
 
   /**
@@ -1051,7 +1060,7 @@ export class Connection extends BaseModule {
     }
 
     // Signal to setupConnectionHandlers' error handler that recovery is already
-    // in progress. Must be set BEFORE cleanupClient/triggerReconnect so the
+    // in progress. Must be set BEFORE cleanupClient/nudgeReconnect so the
     // EventEmitter snapshot handler sees it and skips its own onError/reject.
     this.deadSocketRecoveryInProgress = true
 
@@ -1082,10 +1091,10 @@ export class Connection extends BaseModule {
 
     if (immediateReconnect) {
       this.stores.console.addEvent(
-        `Dead-socket recovery: triggering immediate reconnect (state=${JSON.stringify(this.getMachineState())})`,
+        `Dead-socket recovery: nudging reconnect immediately (state=${JSON.stringify(this.getMachineState())})`,
         'connection'
       )
-      this.triggerReconnect()
+      this.nudgeReconnect()
     }
 
     // Reconnect scheduling is handled by the state machine (`reconnecting.waiting`).
@@ -1131,9 +1140,9 @@ export class Connection extends BaseModule {
 
       case 'visible':
         if (this.isInReconnectingState()) {
-          logInfo('System state: visible, triggering immediate reconnect')
-          this.stores.console.addEvent('System state: visible, triggering immediate reconnect', 'connection')
-          this.triggerReconnect()
+          logInfo('System state: visible, nudging reconnect')
+          this.stores.console.addEvent('System state: visible, nudging reconnect', 'connection')
+          this.nudgeReconnect()
         }
         break
 


### PR DESCRIPTION
## Summary

Addresses the "stuck on reconnect" blank screen reported on Tauri desktop after sleep/wake. The `xmpp-debug.log` traced the worst case to a 17-minute gap between reconnect attempts — not sleep itself, but a `setTimeout(attempt, 4000)` sitting frozen while macOS throttled the webview JS runtime.

Five commits, each independently revertable:

- **`refactor(sdk): rename triggerReconnect() to nudgeReconnect()`** — pure rename. The old name overpromised: in `reconnecting.attempting` the state machine ignores the event, so the honest semantics are "poke the loop if it's waiting, otherwise no-op."

- **`fix: recover stalled Tauri reconnect via native keepalive + proxy fallback`** — the core fix:
  - **Keepalive nudge**: the Rust `xmpp-keepalive` event (30 s, native thread, immune to macOS JS timer throttling) now calls `client.nudgeReconnect()` when the state machine is reconnecting. Gives the retry loop a heartbeat that keeps advancing even when JS `setTimeout` is frozen. Fixes the 17-minute stall directly.
  - **Proxy fallback on direct-WS failure**: `attemptReconnect`'s catch block used to only recover if we were already on the Rust proxy. A Tauri client that won initial connect on direct WebSocket would retry the same URL forever. Now a failed direct-WS reconnect flips the client onto the proxy for the rest of the session — the proxy owns its own OS-level TCP socket and is far more resilient to WKWebView sleep quirks. Wires up the previously-dead `proxyManager.setOriginalServer()` so the proxy knows the right target.

- **`refactor(app): consolidate Tauri sleep/wake webview-reload workaround`** — cleanup of the accumulated workaround stack: deletes `LONG_SLEEP_RELOAD_MS` (1 h threshold was too high — user's 15–35 min sleeps never triggered it), deletes `dispatchResizeWorkaround` (no field evidence it helped), routes all wake sources through a single `maybeReloadOnLongWake` helper gated by the existing `SLEEP_THRESHOLD_MS` (3 min), Tauri-only. Extracts `shouldReloadWebviewOnWake` as a pure testable function.

- **`fix(sdk): skip navigator.onLine gate in proxy mode`** — `waitForNetworkReady()` was blocking up to 15 s on every reconnect attempt whenever `navigator.onLine` reported false. In Tauri the XMPP socket is owned by the Rust proxy; the webview's `navigator.onLine` is the browser's own network perception, and WKWebView is known to lie after sleep/wake. Short-circuits to `true` when a proxy adapter is present. Web path unchanged.

- **`refactor(app): consolidate Tauri wake handlers through handleWakeFromSleep`** — the three Tauri wake sources (system-did-wake, system-did-wake-deferred, JS heartbeat) each had their own copy of the same log → reload-check → notify boilerplate with subtly different log formats. Extracts one `handleWakeFromSleep` helper so future changes land in one place.

## Regression coverage

- Connection proxy fallback (direct-WS reconnect failure + `setOriginalServer` wiring): end-to-end test using a server that differs from the JID domain, so the assertion that `startProxy` was called with the original target proves the wiring.
- Web-mode guard: no `proxyAdapter` → no fallback attempt.
- `waitForNetworkReady` proxy short-circuit: returns `true` even when `navigator.onLine` is false, no diagnostic log leaked.
- `handleXmppKeepalive` routing for every status value, plus repeated-tick non-dedup.
- `shouldReloadWebviewOnWake` threshold + Tauri gate for all 4 combinations.

Total: **3472 SDK tests, 2430 app tests, 0 failures**. Typecheck and lint clean on touched files.

## Not in scope

- State machine (`verifying`, `smResumeViable`, `retryInitialFailure`) — all still load-bearing, left alone.
- `handleDeadSocket` / `deadSocketRecoveryInProgress` — working per the log, minimal guard, left alone.
- `__wry_was_online` LoginScreen reload — different WRY bug (post-signout native event delivery), orthogonal.