### PR TITLE
fix(app): auto-reload on dynamic import failure

### DIFF
--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -58,6 +58,24 @@ document.addEventListener('keydown', (e) => {
 // Block control characters Tauri's macOS webview inserts on arrow-key boundary hits
 installBeforeInputGuard()
 
+// Auto-recover from dynamic import failures. Vite's production build uses
+// content-hashed chunk filenames, so a tab that was open before a deploy may
+// hold stale URLs that now 404 — and a hosted SPA typically rewrites 404s to
+// index.html, which Safari rejects as "not a valid JavaScript MIME type".
+// React.lazy has no retry logic, so the error bubbles to RenderLoopBoundary.
+// Vite dispatches 'vite:preloadError' from its runtime when import() fails;
+// reloading the page transparently recovers. Safeguard: at most one reload
+// per 60s so a persistent failure surfaces instead of looping forever.
+window.addEventListener('vite:preloadError', (event) => {
+  const KEY = 'fluux:preload-error-reload-at'
+  const last = Number(sessionStorage.getItem(KEY) || '0')
+  if (Date.now() - last < 60_000) return
+  sessionStorage.setItem(KEY, String(Date.now()))
+  event.preventDefault()
+  console.warn('[Fluux] Dynamic import failed, reloading to recover:', event)
+  window.location.reload()
+})
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RenderLoopBoundary>


### PR DESCRIPTION
## Summary
Add a `vite:preloadError` listener in `main.tsx` that transparently reloads the page on dynamic import failure, throttled to one reload per 60s via `sessionStorage`.

## Why
On Safari (hosted production build), users were hitting the `RenderLoopBoundary` "Something Went Wrong" screen after login, with the technical detail `'text/html' is not a valid JavaScript MIME type`. A tab open before a deploy holds stale content-hashed chunk URLs for lazy-loaded views (`SettingsView`, `AdminView`, etc. preloaded in `ChatLayout`); the 404 gets rewritten to `index.html` by the hosted SPA fallback, and Safari strictly enforces ES module MIME types. Chrome is more forgiving; Tauri is unaffected.

`React.lazy` has no retry logic, so the error bubbles to the top-level error boundary. The listener intercepts `vite:preloadError` before that happens and reloads the page — users never see the error screen. This is the canonical Vite pattern for the gap ([Vite docs](https://vitejs.dev/guide/build.html#load-error-handling)).

The 60s `sessionStorage` throttle prevents reload loops if a persistent failure somehow remains after reload — the error will then surface normally so the user can report it.