### PR TITLE
fix(reconnect): keep wake listeners alive during spinner + widen xmpp.js handshake timeout

### DIFF
--- a/apps/fluux/src/App.reconnect.test.tsx
+++ b/apps/fluux/src/App.reconnect.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import App from './App'
+
+const {
+  mockUseConnection,
+  mockUsePlatformState,
+  mockGetSession,
+} = vi.hoisted(() => ({
+  mockUseConnection: vi.fn(),
+  mockUsePlatformState: vi.fn(),
+  mockGetSession: vi.fn(),
+}))
+
+vi.mock('@fluux/sdk', () => ({
+  useConnection: () => mockUseConnection(),
+  useXMPPContext: () => ({
+    client: {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    },
+  }),
+  hasFastToken: vi.fn(() => false),
+}))
+
+vi.mock('./hooks/useSessionPersistence', () => ({
+  useSessionPersistence: vi.fn(),
+  getSession: () => mockGetSession(),
+}))
+
+vi.mock('./hooks/usePlatformState', () => ({
+  usePlatformState: () => mockUsePlatformState(),
+}))
+
+vi.mock('./hooks', () => ({
+  useAutoUpdate: vi.fn(() => ({
+    available: false,
+    downloadAndInstall: vi.fn(),
+    relaunchApp: vi.fn(),
+    dismissUpdate: vi.fn(),
+  })),
+}))
+
+vi.mock('./hooks/useFullscreen', () => ({
+  useFullscreen: vi.fn(() => false),
+}))
+
+vi.mock('./hooks/useTauriCloseHandler', () => ({
+  useTauriCloseHandler: vi.fn(),
+}))
+
+vi.mock('./hooks/useTauriTrayRestore', () => ({
+  useTauriTrayRestore: vi.fn(),
+}))
+
+vi.mock('./hooks/useIgnoreSync', () => ({
+  useIgnoreSync: vi.fn(),
+}))
+
+vi.mock('./hooks/useExternalLinkHandler', () => ({
+  useExternalLinkHandler: vi.fn(),
+}))
+
+vi.mock('./hooks/useTabCoordination', () => ({
+  useTabCoordination: vi.fn(() => ({
+    blocked: false,
+    takenOver: false,
+    claimConnection: vi.fn(),
+    takeOver: vi.fn(),
+  })),
+}))
+
+vi.mock('./components/ChatLayout', () => ({
+  ChatLayout: () => <div data-testid="chat-layout">ChatLayout</div>,
+}))
+
+vi.mock('./components/LoginScreen', () => ({
+  LoginScreen: () => <div data-testid="login-screen">LoginScreen</div>,
+}))
+
+vi.mock('./components/TabBlockedScreen', () => ({
+  TabBlockedScreen: () => <div data-testid="tab-blocked-screen">TabBlockedScreen</div>,
+}))
+
+vi.mock('./components/UpdateModal', () => ({
+  UpdateModal: () => <div data-testid="update-modal">UpdateModal</div>,
+}))
+
+describe('App reconnect recovery hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseConnection.mockReturnValue({ status: 'connecting' })
+    mockGetSession.mockReturnValue({
+      jid: 'user@example.com',
+      password: 'secret',
+      server: 'example.com',
+    })
+  })
+
+  it('keeps platform-state listeners mounted during the initial auto-reconnect spinner', () => {
+    render(
+      <MemoryRouter initialEntries={['/messages']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Reconnecting...')).toBeInTheDocument()
+    expect(mockUsePlatformState).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/fluux/src/App.routes.test.tsx
+++ b/apps/fluux/src/App.routes.test.tsx
@@ -42,6 +42,10 @@ vi.mock('./hooks/useFullscreen', () => ({
   useFullscreen: vi.fn(() => false),
 }))
 
+vi.mock('./hooks/usePlatformState', () => ({
+  usePlatformState: vi.fn(),
+}))
+
 // Mock Tauri close handler (no-op in tests)
 vi.mock('./hooks/useTauriCloseHandler', () => ({
   useTauriCloseHandler: vi.fn(),

--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -14,6 +14,7 @@ import { useTauriTrayRestore } from './hooks/useTauriTrayRestore'
 import { useAutoUpdate } from './hooks'
 import { useIgnoreSync } from './hooks/useIgnoreSync'
 import { useExternalLinkHandler } from './hooks/useExternalLinkHandler'
+import { usePlatformState } from './hooks/usePlatformState'
 import { clearLocalData } from './utils/clearLocalData'
 
 // Tauri detection
@@ -55,6 +56,9 @@ function App() {
   useTauriTrayRestore()
   useIgnoreSync()
   useExternalLinkHandler()
+  // Must stay mounted even during the full-screen auto-reconnect spinner:
+  // native keepalive / wake listeners are what unstick reconnect after long sleep.
+  usePlatformState()
   const update = useAutoUpdate({ autoCheck: true })
 
   // Listen for --clear-storage CLI flag (Tauri only)

--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -325,10 +325,6 @@ vi.mock('@/hooks/useEventsDesktopNotifications', () => ({
   useEventsDesktopNotifications: () => {},
 }))
 
-vi.mock('@/hooks/usePlatformState', () => ({
-  usePlatformState: () => {},
-}))
-
 vi.mock('@/utils/renderLoopDetector', () => ({
   detectRenderLoop: () => {},
 }))

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -31,7 +31,6 @@ import { useWebPush } from '@/hooks/useWebPush'
 import { useSoundNotification } from '@/hooks/useSoundNotification'
 import { useEventsSoundNotification } from '@/hooks/useEventsSoundNotification'
 import { useEventsDesktopNotifications } from '@/hooks/useEventsDesktopNotifications'
-import { usePlatformState } from '@/hooks/usePlatformState'
 import { useSDKErrorToasts } from '@/hooks/useSDKErrorToasts'
 import { useFocusZones, useViewNavigation, isMobileWeb, isSmallScreen, useWindowVisibility, useRouteSync, type FocusZoneRefs } from '@/hooks'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
@@ -81,9 +80,6 @@ function GlobalEffects() {
 
   // Register for web push notifications (browser only, skipped in Tauri)
   useWebPush()
-
-  // Platform state detection: wake/sleep, idle/activity, visibility
-  usePlatformState()
 
   // Track window visibility for new message markers
   useWindowVisibility()

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -5,7 +5,11 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { XMPPClient } from '../XMPPClient'
-import { DIRECT_WEBSOCKET_PRECHECK_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS } from './connectionTimeouts'
+import {
+  DIRECT_WEBSOCKET_PRECHECK_TIMEOUT_MS,
+  RECONNECT_ATTEMPT_TIMEOUT_MS,
+  XMPP_STREAM_OPEN_TIMEOUT_MS,
+} from './connectionTimeouts'
 import {
   createMockXmppClient,
   createMockStores,
@@ -113,6 +117,7 @@ describe('XMPPClient Connection', () => {
         expect.objectContaining({
           service: 'wss://example.com/ws',
           domain: 'example.com',
+          timeout: XMPP_STREAM_OPEN_TIMEOUT_MS,
           credentials: expect.any(Function),
         })
       )

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -39,6 +39,7 @@ import {
   SASL_AUTH_TIMEOUT_MS,
   VERIFY_CONNECTION_TIMEOUT_MS,
   WAKE_VERIFY_TIMEOUT_MS,
+  XMPP_STREAM_OPEN_TIMEOUT_MS,
 } from './connectionTimeouts'
 import {
   shouldSkipDiscovery,
@@ -1310,6 +1311,7 @@ export class Connection extends BaseModule {
       domain,
       resource,
       lang,
+      timeout: XMPP_STREAM_OPEN_TIMEOUT_MS,
       credentials: async (
         authenticate: (creds: Record<string, unknown>, mechanism: string, userAgent?: unknown) => Promise<void>,
         mechanisms: string[],

--- a/packages/fluux-sdk/src/core/modules/connectionTimeouts.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionTimeouts.ts
@@ -12,6 +12,15 @@
 export const DISCONNECT_CLEANUP_TIMEOUT_MS = 2_000
 
 /**
+ * Timeout waiting for the server's initial stream-open reply.
+ *
+ * xmpp.js defaults this to 2s, which is too aggressive on wake/network-change
+ * recovery when the desktop proxy path may need fresh SRV lookup, TCP connect,
+ * TLS handshake, and only then the server's `<open/>` response.
+ */
+export const XMPP_STREAM_OPEN_TIMEOUT_MS = 15_000
+
+/**
  * Timeout for graceful client stop (stream close + socket close).
  * Used as a safety bound when xmpp.js stop() hangs on dead transports.
  */

--- a/packages/fluux-sdk/src/xmpp.d.ts
+++ b/packages/fluux-sdk/src/xmpp.d.ts
@@ -44,6 +44,14 @@ declare module '@xmpp/client' {
     password?: string
     resource?: string
     lang?: string  // Sets xml:lang attribute on the stream
+    /**
+     * Timeout (ms) for low-level stream operations: waiting for the server's
+     * `<stream:open>` reply, stream close, and raw `sendReceive` exchanges.
+     * xmpp.js defaults to 2000ms; we override to give the desktop proxy path
+     * room to do DNS + TCP + TLS on cold networks after wake. IQ requests
+     * have their own independent 30s default in `@xmpp/iq/caller`.
+     */
+    timeout?: number
     /** Custom SASL credentials handler. When provided, username/password are ignored. */
     credentials?: (
       authenticate: (creds: Record<string, unknown>, mechanism: string, userAgent?: unknown) => Promise<void>,


### PR DESCRIPTION
- Move `usePlatformState()` from `ChatLayout → GlobalEffects` up to `App` so Tauri native wake, `xmpp-keepalive`, heartbeat, visibility, and window-focus nudges stay registered during the full-screen "Reconnecting..." spinner (which unmounts ChatLayout on page reload).
- Introduce `XMPP_STREAM_OPEN_TIMEOUT_MS = 15_000` and pass it to the xmpp.js `client()` factory, overriding the upstream 2s default for the wait on the server's `<stream:open>` reply — 2s is too tight for the desktop proxy fallback (DNS SRV + TCP + TLS + server) on cold networks after wake.