### PR TITLE
refactor(sdk): move keepalive routing from app into SDK

### DIFF
--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -94,7 +94,6 @@ vi.mock('@fluux/sdk', () => ({
 import {
   usePlatformState,
   shouldHandleProxyClosedStatus,
-  handleXmppKeepalive,
   shouldReloadWebviewOnWake,
 } from './usePlatformState'
 
@@ -344,87 +343,6 @@ describe('usePlatformState', () => {
 
       // Should not call notifySystemState('awake') since heartbeat is inactive
       expect(mockClientNotifySystemState).not.toHaveBeenCalledWith('awake', expect.any(Number))
-    })
-  })
-
-  describe('handleXmppKeepalive', () => {
-    // The Rust side emits `xmpp-keepalive` every 30s on a native thread
-    // (immune to macOS JS timer throttling). It is the one reliable clock
-    // we have while the webview is backgrounded, so the handler must route
-    // it to nudgeReconnect() whenever the state machine is stuck in
-    // reconnecting — otherwise the JS setTimeout backoff can sit frozen
-    // for many minutes and the app looks "stuck on reconnect".
-    //
-    // Tested as a pure function (extracted from the listener) to avoid
-    // the Tauri event plumbing in unit tests. The listener → function
-    // wiring is a one-liner that's manually verified in Tauri dev mode.
-
-    let client: {
-      nudgeReconnect: ReturnType<typeof vi.fn<() => void>>
-      verifyConnectionHealth: ReturnType<typeof vi.fn<() => Promise<unknown>>>
-    }
-
-    beforeEach(() => {
-      client = {
-        nudgeReconnect: vi.fn<() => void>(),
-        verifyConnectionHealth: vi.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
-      }
-    })
-
-    it('calls nudgeReconnect (not verifyConnectionHealth) when status is reconnecting', () => {
-      handleXmppKeepalive('reconnecting', client)
-      expect(client.nudgeReconnect).toHaveBeenCalledTimes(1)
-      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
-    })
-
-    it('calls verifyConnectionHealth (not nudgeReconnect) when status is online', () => {
-      handleXmppKeepalive('online', client)
-      expect(client.verifyConnectionHealth).toHaveBeenCalledTimes(1)
-      expect(client.nudgeReconnect).not.toHaveBeenCalled()
-    })
-
-    it('is a no-op when status is disconnected', () => {
-      handleXmppKeepalive('disconnected', client)
-      expect(client.nudgeReconnect).not.toHaveBeenCalled()
-      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
-    })
-
-    it('is a no-op when status is connecting (initial connect is not our retry loop)', () => {
-      handleXmppKeepalive('connecting', client)
-      expect(client.nudgeReconnect).not.toHaveBeenCalled()
-      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
-    })
-
-    it('is a no-op when status is error (terminal state)', () => {
-      handleXmppKeepalive('error', client)
-      expect(client.nudgeReconnect).not.toHaveBeenCalled()
-      expect(client.verifyConnectionHealth).not.toHaveBeenCalled()
-    })
-
-    it('nudges every time it is called (no dedup, safe to tick repeatedly)', () => {
-      // Regression guard for the backgrounded-reconnect scenario: when the
-      // machine's own setTimeout is frozen, only the 30s native tick is
-      // advancing. Each tick must keep nudging — otherwise the loop stays
-      // stuck. State-machine-side guards (TRIGGER_RECONNECT ignored in
-      // reconnecting.attempting) prevent churn when an attempt is in flight.
-      handleXmppKeepalive('reconnecting', client)
-      handleXmppKeepalive('reconnecting', client)
-      handleXmppKeepalive('reconnecting', client)
-      expect(client.nudgeReconnect).toHaveBeenCalledTimes(3)
-    })
-
-    it('swallows verifyConnectionHealth rejections without throwing', async () => {
-      const failingClient = {
-        nudgeReconnect: vi.fn<() => void>(),
-        verifyConnectionHealth: vi.fn<() => Promise<unknown>>().mockRejectedValue(new Error('unreachable')),
-      }
-      // Must not throw synchronously.
-      expect(() => handleXmppKeepalive('online', failingClient)).not.toThrow()
-      // Let the microtask queue drain so the .catch runs. If the rejection
-      // weren't caught, Node would report an unhandled rejection.
-      await Promise.resolve()
-      await Promise.resolve()
-      expect(failingClient.verifyConnectionHealth).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -71,46 +71,6 @@ export function shouldReloadWebviewOnWake(
   return durationMs >= SLEEP_THRESHOLD_MS
 }
 
-/** Minimal client surface the keepalive handler needs, for unit testing. */
-export interface XmppKeepaliveClient {
-  nudgeReconnect: () => void
-  verifyConnectionHealth: () => Promise<unknown>
-}
-
-/**
- * Handle a tick from the Rust-native `xmpp-keepalive` event.
- *
- * The Rust side emits this every 30s on a native thread — it is the one
- * clock in the app that is immune to macOS JS timer throttling. Behaviour:
- *
- * - `online`: run a lightweight health check (`verifyConnectionHealth`)
- *   which silently sends an SM `<r/>` without changing status.
- * - `reconnecting`: nudge the state machine out of `reconnecting.waiting`
- *   whenever an attempt is pending. Without this, the machine's backoff
- *   `setTimeout` can sit frozen for many minutes while the OS throttles
- *   the JS runtime, leaving the app "stuck on reconnect" from the user's
- *   point of view even though the reconnect logic is healthy.
- *   `nudgeReconnect()` is a safe no-op when the machine is already in
- *   `reconnecting.attempting`, so firing this every 30s during a
- *   reconnect loop only accelerates progress — it cannot cause churn.
- * - anything else (`disconnected`, `connecting`, terminal): no-op.
- *
- * Extracted as a named export so it can be unit-tested without going
- * through the Tauri event dispatch plumbing.
- */
-export function handleXmppKeepalive(
-  status: string,
-  client: XmppKeepaliveClient
-): void {
-  if (status === 'reconnecting') {
-    client.nudgeReconnect()
-    return
-  }
-  if (status !== 'online') return
-  client.verifyConnectionHealth().catch((err) => {
-    console.debug('[PlatformState] Keepalive health check error:', err)
-  })
-}
 
 // ── Hook ───────────────────────────────────────────────────────────────────────
 
@@ -510,12 +470,10 @@ export function usePlatformState() {
     let cleanedUp = false
 
     void import('@tauri-apps/api/event').then(({ listen }) => {
-      // Rust-driven keepalive tick every 30s. See handleXmppKeepalive above
-      // for the routing logic (online → health check, reconnecting → nudge,
-      // else → no-op). Extracted to a named function so it can be
-      // unit-tested without going through the Tauri event dispatch.
+      // Rust-driven keepalive tick every 30s. The SDK routes the tick
+      // internally (nudge reconnect, health check, or no-op).
       void listen('xmpp-keepalive', () => {
-        handleXmppKeepalive(statusRef.current, client)
+        client.handleKeepaliveTick()
       }).then((fn) => {
         if (cleanedUp) { fn() } else { unlistenKeepalive = fn }
       })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -982,6 +982,17 @@ export class XMPPClient {
   }
 
   /**
+   * Handle a keepalive tick from an external clock (e.g., Rust native timer).
+   *
+   * The SDK routes the tick internally: nudges a stalled reconnect loop,
+   * runs a health check when connected, or no-ops otherwise. Apps should
+   * call this on every tick without inspecting connection status.
+   */
+  handleKeepaliveTick(): void {
+    this.connection.handleKeepaliveTick()
+  }
+
+  /**
    * Notify the SDK of a system state change.
    *
    * This is the recommended way for apps to signal platform-specific events

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3605,6 +3605,84 @@ describe('XMPPClient Connection', () => {
       expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
     })
 
+    describe('handleKeepaliveTick', () => {
+      it('runs health check when connected', async () => {
+        mockXmppClientInstance.send.mockImplementation(() => {
+          setTimeout(() => {
+            const ackNonza = createMockElement('a', { xmlns: 'urn:xmpp:sm:3', h: '5' })
+            mockXmppClientInstance._emit('nonza', ackNonza)
+          }, 50)
+          return Promise.resolve()
+        })
+
+        xmppClient.handleKeepaliveTick()
+
+        await vi.advanceTimersByTimeAsync(100)
+        expect(mockXmppClientInstance.send).toHaveBeenCalled()
+      })
+
+      it('nudges reconnect when in reconnecting.waiting', async () => {
+        // Disconnect → first reconnect attempt starts automatically
+        mockXmppClientInstance._emit('disconnect', { clean: false })
+        await vi.advanceTimersByTimeAsync(1000)
+
+        // Let the attempt fail (no 'online' event) via the 30s timeout
+        await vi.advanceTimersByTimeAsync(30_000)
+
+        // Machine should now be in reconnecting.waiting (backoff before next attempt)
+        const clientsBefore = mockClientFactory.mock.calls.length
+
+        xmppClient.handleKeepaliveTick()
+        await vi.advanceTimersByTimeAsync(0)
+
+        // nudge should have skipped the backoff and started a new attempt
+        expect(mockClientFactory.mock.calls.length).toBeGreaterThan(clientsBefore)
+      })
+
+      it('is safe to tick repeatedly (no dedup)', async () => {
+        mockXmppClientInstance.send.mockImplementation(() => {
+          setTimeout(() => {
+            const ackNonza = createMockElement('a', { xmlns: 'urn:xmpp:sm:3', h: '5' })
+            mockXmppClientInstance._emit('nonza', ackNonza)
+          }, 50)
+          return Promise.resolve()
+        })
+
+        xmppClient.handleKeepaliveTick()
+        xmppClient.handleKeepaliveTick()
+        xmppClient.handleKeepaliveTick()
+
+        await vi.advanceTimersByTimeAsync(100)
+        // Each tick triggers a health check — at least 3 SM <r/> requests sent
+        expect(mockXmppClientInstance.send.mock.calls.length).toBeGreaterThanOrEqual(3)
+      })
+
+      it('swallows health check rejections', async () => {
+        mockXmppClientInstance.send.mockRejectedValue(new Error('unreachable'))
+
+        xmppClient.handleKeepaliveTick()
+
+        await vi.advanceTimersByTimeAsync(100)
+        // No unhandled rejection — the catch inside handleKeepaliveTick absorbs it
+      })
+
+      it('is a no-op when disconnected', async () => {
+        await xmppClient.disconnect()
+        mockXmppClientInstance.send.mockClear()
+
+        xmppClient.handleKeepaliveTick()
+
+        expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
+      })
+
+      it('is a no-op during initial connecting state', async () => {
+        // Start a fresh client that hasn't connected yet
+        const freshClient = new XMPPClient(createMockStores())
+        freshClient.handleKeepaliveTick()
+        // No crash, no side effects — method returns silently
+      })
+    })
+
     it('should preserve rooms across multiple rapid disconnect/reconnect cycles', async () => {
       // Simulate 9 rooms joined (as seen in the real log)
       const nineRooms = Array.from({ length: 9 }, (_, i) => ({

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3677,7 +3677,7 @@ describe('XMPPClient Connection', () => {
 
       it('is a no-op during initial connecting state', async () => {
         // Start a fresh client that hasn't connected yet
-        const freshClient = new XMPPClient(createMockStores())
+        const freshClient = new XMPPClient()
         freshClient.handleKeepaliveTick()
         // No crash, no side effects — method returns silently
       })

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -893,6 +893,31 @@ export class Connection extends BaseModule {
   }
 
   /**
+   * Handle a keepalive tick from an external clock (e.g., Rust native timer).
+   *
+   * Routes the tick to the appropriate action based on the current connection
+   * state — the app does not need to inspect status and decide which method
+   * to call. Safe to invoke on every tick; no-ops when there is nothing to do.
+   *
+   * - `reconnecting`: nudge the state machine out of `reconnecting.waiting`
+   *   so a frozen JS setTimeout backoff doesn't stall recovery.
+   * - `connected` (online): run a lightweight health check (SM ack) without
+   *   changing status or triggering presence events.
+   * - anything else: no-op.
+   */
+  handleKeepaliveTick(): void {
+    if (this.isInReconnectingState()) {
+      this.nudgeReconnect()
+      return
+    }
+    if (!this.isInConnectedState()) return
+    this.verifyConnectionHealth().catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err)
+      logInfo(`Keepalive health check error: ${msg}`)
+    })
+  }
+
+  /**
    * Probe connection health via SM ack or ping fallback.
    *
    * Shared implementation for {@link verifyConnection} and


### PR DESCRIPTION
- Add `Connection.handleKeepaliveTick()` — a single SDK method that routes keepalive ticks internally (nudge stalled reconnect, health check when connected, or no-op).
- Replace the app-side `handleXmppKeepalive` function with a one-liner `client.handleKeepaliveTick()` call in the Tauri event listener.
- Remove the exported `handleXmppKeepalive`, `XmppKeepaliveClient` interface, and 7 associated app-side tests. Equivalent coverage (6 tests) now lives in `Connection.test.ts`.

## Why
The app's `handleXmppKeepalive` inspected connection status to decide whether to call `nudgeReconnect()` or `verifyConnectionHealth()`. The SDK then redundantly re-checked the same status inside each method. This is orchestration logic the SDK should own — the app shouldn't need to know the reconnecting-vs-online routing. The new `handleKeepaliveTick()` matches the `notifySystemState()` pattern: app provides the signal, SDK decides what to do.