### PR TITLE
fix(app): skip webview reload when app was hidden but machine stayed awake

### DIFF
--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -95,6 +95,7 @@ import {
   usePlatformState,
   shouldHandleProxyClosedStatus,
   shouldReloadWebviewOnWake,
+  shouldReloadOnVisibilityWake,
 } from './usePlatformState'
 
 describe('usePlatformState', () => {
@@ -384,6 +385,40 @@ describe('usePlatformState', () => {
     it('returns false for unknown duration (cannot tell if it was real sleep)', () => {
       expect(shouldReloadWebviewOnWake(undefined, true)).toBe(false)
       expect(shouldReloadWebviewOnWake(undefined, false)).toBe(false)
+    })
+  })
+
+  describe('shouldReloadOnVisibilityWake', () => {
+    // The visibility handler cannot distinguish "machine slept" from
+    // "app was hidden while machine stayed awake." The heartbeat gap
+    // disambiguates: a small gap means JS was running (machine awake),
+    // a large gap means JS was frozen by the OS (real sleep).
+
+    const THRESHOLD = 180_000 // SLEEP_THRESHOLD_MS
+
+    it('returns true when both hidden duration AND heartbeat gap exceed threshold (real sleep)', () => {
+      expect(shouldReloadOnVisibilityWake(THRESHOLD, THRESHOLD, true)).toBe(true)
+      expect(shouldReloadOnVisibilityWake(5 * 60_000, 5 * 60_000, true)).toBe(true)
+      expect(shouldReloadOnVisibilityWake(60 * 60_000, 60 * 60_000, true)).toBe(true)
+    })
+
+    it('returns false when hidden long but heartbeat was recent (app just hidden, machine awake)', () => {
+      // This is the bug scenario: user switched to another app for 7+ minutes,
+      // machine stayed awake, heartbeat kept firing every ~10s.
+      expect(shouldReloadOnVisibilityWake(7 * 60_000, 10_000, true)).toBe(false)
+      expect(shouldReloadOnVisibilityWake(THRESHOLD, 30_000, true)).toBe(false)
+      expect(shouldReloadOnVisibilityWake(10 * 60_000, THRESHOLD - 1, true)).toBe(false)
+    })
+
+    it('returns false when hidden duration is below threshold', () => {
+      expect(shouldReloadOnVisibilityWake(THRESHOLD - 1, THRESHOLD, true)).toBe(false)
+      expect(shouldReloadOnVisibilityWake(60_000, 60_000, true)).toBe(false)
+      expect(shouldReloadOnVisibilityWake(0, 0, true)).toBe(false)
+    })
+
+    it('returns false on web even with real sleep (no WKWebView rendering bug)', () => {
+      expect(shouldReloadOnVisibilityWake(THRESHOLD, THRESHOLD, false)).toBe(false)
+      expect(shouldReloadOnVisibilityWake(60 * 60_000, 60 * 60_000, false)).toBe(false)
     })
   })
 })

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -71,6 +71,29 @@ export function shouldReloadWebviewOnWake(
   return durationMs >= SLEEP_THRESHOLD_MS
 }
 
+/**
+ * Decide whether a visibility-triggered wake should reload the webview.
+ *
+ * Unlike OS wake events (which are authoritative), the visibilitychange
+ * API cannot distinguish "machine slept for 10 minutes" from "user was
+ * in another app for 10 minutes while the machine stayed awake."
+ *
+ * We cross-check the JS heartbeat timer (Effect 3): if it was firing
+ * normally, the gap between `now` and `lastHeartbeatRef` will be small
+ * (≈ HEARTBEAT_INTERVAL_MS). A large gap (≥ SLEEP_THRESHOLD_MS) means
+ * the OS froze JS execution — i.e. real sleep — and the rendering
+ * context may be lost.
+ */
+export function shouldReloadOnVisibilityWake(
+  hiddenDurationMs: number,
+  heartbeatGapMs: number,
+  isTauriMode: boolean
+): boolean {
+  if (!shouldReloadWebviewOnWake(hiddenDurationMs, isTauriMode)) return false
+  if (heartbeatGapMs < SLEEP_THRESHOLD_MS) return false
+  return true
+}
+
 
 // ── Hook ───────────────────────────────────────────────────────────────────────
 
@@ -419,15 +442,24 @@ export function usePlatformState() {
 
       if (!shouldHandleWake('visibility')) return
 
+      const heartbeatGap = now - lastHeartbeatRef.current
       console.log(`[PlatformState] Page visible after ${Math.round(hiddenDuration / 1000)}s`)
 
       // If the hide was long enough to count as a real sleep on Tauri,
       // reload the webview (same rendering-context hazard as OS sleep).
-      if (maybeReloadOnLongWake(hiddenDuration, 'visibility')) return
+      // Cross-check the JS heartbeat: if it was firing normally (gap
+      // below threshold), the machine was awake and the app was merely
+      // hidden — no rendering context loss, no reload needed.
+      if (shouldReloadOnVisibilityWake(hiddenDuration, heartbeatGap, isTauri())) {
+        const secs = Math.round(hiddenDuration / 1000)
+        console.log(`[PlatformState] Wake from sleep (visibility, ${secs}s), reloading webview to restore rendering`)
+        logEvent(`Wake from sleep (visibility, ${secs}s), reloading webview`)
+        window.location.reload()
+        return
+      }
 
-      // Sub-threshold (or web mode): just nudge a stalled reconnect via
-      // notifySystemState('visible'). Lighter "tab came back" path — no
-      // state-machine WAKE, no verify.
+      // Sub-threshold, machine was awake, or web mode: just nudge a
+      // stalled reconnect via notifySystemState('visible').
       try {
         await client.notifySystemState('visible')
       } catch (err) {


### PR DESCRIPTION
- The visibility handler treated any hide > 3 minutes as a potential sleep and force-reloaded the webview, causing unnecessary reconnects when the user simply switched to another app while the machine stayed awake
- Added `shouldReloadOnVisibilityWake()` which cross-checks the JS heartbeat gap: if the heartbeat was firing normally (gap < threshold), the machine was awake and no reload is needed
- OS wake events (`system-did-wake`, heartbeat gap detection) remain unchanged — those are authoritative signals