### PR TITLE
fix(app): pass saved rooms through connect call for SM resumption

### DIFF
--- a/apps/fluux/src/hooks/useSessionPersistence.test.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.test.ts
@@ -16,6 +16,7 @@ import {
   getSavedServerInfo,
   saveOwnResources,
   getSavedOwnResources,
+  toJoinedRoomInfos,
   type ViewStateData,
 } from './useSessionPersistence'
 import type { Contact, Room, RoomMessage, ServerInfo, HttpUploadService, ResourcePresence } from '@fluux/sdk'
@@ -684,8 +685,74 @@ describe('useSessionPersistence', () => {
       expect(getSession()).toBeNull()
     })
   })
-})
 
-// ============================================================================
-// Note: Hook behavior tests were removed as presence synchronization is now
-// handled by XState's native persistence in XMPPProvider
+  describe('toJoinedRoomInfos', () => {
+    const makeRoom = (overrides: Partial<Room> & { jid: string; nickname: string }): Room => ({
+      name: overrides.jid.split('@')[0],
+      joined: false,
+      occupants: new Map(),
+      typingUsers: new Set(),
+      messages: [],
+      unreadCount: 0,
+      mentionsCount: 0,
+      isBookmarked: false,
+      ...overrides,
+    })
+
+    it('should include only joined rooms', () => {
+      const rooms: Room[] = [
+        makeRoom({ jid: 'a@conf.example.com', nickname: 'me', joined: true }),
+        makeRoom({ jid: 'b@conf.example.com', nickname: 'me', joined: false, isBookmarked: true }),
+        makeRoom({ jid: 'c@conf.example.com', nickname: 'me', joined: true }),
+      ]
+
+      const result = toJoinedRoomInfos(rooms)
+
+      expect(result).toHaveLength(2)
+      expect(result.map(r => r.jid)).toEqual(['a@conf.example.com', 'c@conf.example.com'])
+    })
+
+    it('should preserve password and autojoin', () => {
+      const rooms: Room[] = [
+        makeRoom({ jid: 'secret@conf.example.com', nickname: 'me', joined: true, password: 'p4ss', autojoin: true }),
+      ]
+
+      const result = toJoinedRoomInfos(rooms)
+
+      expect(result[0]).toEqual({
+        jid: 'secret@conf.example.com',
+        nickname: 'me',
+        password: 'p4ss',
+        autojoin: true,
+      })
+    })
+
+    it('should return empty array when no rooms are joined', () => {
+      const rooms: Room[] = [
+        makeRoom({ jid: 'a@conf.example.com', nickname: 'me', joined: false }),
+      ]
+
+      expect(toJoinedRoomInfos(rooms)).toEqual([])
+    })
+
+    it('should return empty array for empty input', () => {
+      expect(toJoinedRoomInfos([])).toEqual([])
+    })
+
+    it('should round-trip through save/restore correctly', () => {
+      const rooms = new Map<string, Room>([
+        ['a@conf.example.com', makeRoom({ jid: 'a@conf.example.com', nickname: 'nick1', joined: true, autojoin: true })],
+        ['b@conf.example.com', makeRoom({ jid: 'b@conf.example.com', nickname: 'nick2', joined: false, isBookmarked: true })],
+        ['c@conf.example.com', makeRoom({ jid: 'c@conf.example.com', nickname: 'nick3', joined: true, password: 'pw' })],
+      ])
+
+      saveRooms(rooms, TEST_JID)
+      const restored = getSavedRooms(TEST_JID)!
+      const infos = toJoinedRoomInfos(restored)
+
+      expect(infos).toHaveLength(2)
+      expect(infos[0]).toEqual({ jid: 'a@conf.example.com', nickname: 'nick1', password: undefined, autojoin: true })
+      expect(infos[1]).toEqual({ jid: 'c@conf.example.com', nickname: 'nick3', password: 'pw', autojoin: undefined })
+    })
+  })
+})

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { connectionStore, rosterStore, roomStore, useXMPPContext, getBareJid, hasFastToken, deleteFastToken } from '@fluux/sdk'
 import { useRosterStore, useConnectionStore, useRoomStore } from '@fluux/sdk/react'
-import type { Contact, Room, RoomOccupant, ServerInfo, HttpUploadService, RoomMessage, ResourcePresence } from '@fluux/sdk'
+import type { Contact, Room, RoomOccupant, ServerInfo, HttpUploadService, RoomMessage, ResourcePresence, JoinedRoomInfo } from '@fluux/sdk'
 import { getResource } from '@/utils/xmppResource'
 import { isTauri } from '@/utils/tauri'
 
@@ -446,6 +446,17 @@ export function getSession(jid?: string | null): SessionData | null {
 }
 
 /**
+ * Convert saved Room objects to the JoinedRoomInfo format expected by
+ * ConnectOptions.previouslyJoinedRooms. Only includes rooms that were
+ * actually joined (not just bookmarked).
+ */
+export function toJoinedRoomInfos(rooms: Room[]): JoinedRoomInfo[] {
+  return rooms
+    .filter((r) => r.joined)
+    .map((r) => ({ jid: r.jid, nickname: r.nickname, password: r.password, autojoin: r.autojoin }))
+}
+
+/**
  * Hook to auto-reconnect on page reload if session exists.
  * Uses sessionStorage which persists across reload but clears when tab closes.
  * Supports XEP-0198 Stream Management for faster session resumption.
@@ -479,12 +490,13 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
     lang?: string,
     disableSmKeepalive?: boolean,
     rememberSession?: boolean,
-    autoRetryOnTransientFailure?: boolean
+    autoRetryOnTransientFailure?: boolean,
+    previouslyJoinedRooms?: JoinedRoomInfo[]
   ) => {
     connectionStore.getState().setStatus('connecting')
     connectionStore.getState().setError(null)
     try {
-      await client.connect({ jid, password, server, resource, smState, lang, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure })
+      await client.connect({ jid, password, server, resource, smState, lang, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure, previouslyJoinedRooms })
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Connection failed'
       connectionStore.getState().setStatus('error')
@@ -524,8 +536,10 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
 
       // Restore rooms (bookmarks, join status, occupants)
       const savedRooms = getSavedRooms(session.jid)
+      let joinedRoomInfos: JoinedRoomInfo[] | undefined
       if (savedRooms && savedRooms.length > 0) {
         savedRooms.forEach((room) => addRoom(room))
+        joinedRoomInfos = toJoinedRoomInfos(savedRooms)
       }
 
       // Restore server discovery info
@@ -591,14 +605,14 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
             isResumptionRef.current = false
             return
           }
-          connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry).catch((err) => {
+          connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry, joinedRoomInfos).catch((err) => {
             console.log('[Auth] Reconnection failed:', err?.message || err)
             clearSession()
             isResumptionRef.current = false
           })
         }).catch(() => {
           // Claim check failed, try connecting anyway
-          connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry).catch((err) => {
+          connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry, joinedRoomInfos).catch((err) => {
             console.log('[Auth] Reconnection failed:', err?.message || err)
             clearSession()
             isResumptionRef.current = false
@@ -607,7 +621,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         return
       }
 
-      connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry).catch((err) => {
+      connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry, joinedRoomInfos).catch((err) => {
         console.log('[Auth] Reconnection failed:', err?.message || err)
         // If auto-reconnect fails, clear session
         clearSession()


### PR DESCRIPTION
- After a webview reload + SM resumption, the room list was empty because `handleSmResumption()` found no rooms from either SM persistence or the store
- Pass rooms restored from sessionStorage directly as `previouslyJoinedRooms` in the `connect()` call, so they flow through `Connection.connect()` to `handleSmResumption()` as a first-class parameter
- Extracted `toJoinedRoomInfos()` helper to convert `Room[]` to `JoinedRoomInfo[]` format, with tests validating filtering, field mapping, and save/restore round-trip