### PR TITLE
perf(sdk): skip redundant MAM queries on SM resume and room preview

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -863,7 +863,7 @@ describe('XMPPClient', () => {
       expect(refreshSpy).toHaveBeenCalledWith(rooms)
     })
 
-    it('should run MAM catch-up on SM resumption when disconnect duration is unknown', async () => {
+    it('should skip MAM catch-up but fetch bookmarks on SM resumption when disconnect duration is unknown', async () => {
       const mockClientWithSM = createMockXmppClientWithSM('sm-id-catchup')
       mockClientFactory._setInstance(mockClientWithSM)
 
@@ -895,8 +895,8 @@ describe('XMPPClient', () => {
 
       await connectPromise
 
-      // Unknown disconnect duration → full refresh (safe default)
-      expect(catchUpSpy).toHaveBeenCalledWith({ concurrency: 2 })
+      // Unknown disconnect duration → SM replay covers messages, fetch bookmarks only
+      expect(catchUpSpy).not.toHaveBeenCalled()
       expect(bookmarksSpy).toHaveBeenCalled()
     })
 
@@ -946,7 +946,7 @@ describe('XMPPClient', () => {
       expect(newXmppClient.muc.refreshPresenceInRooms).toHaveBeenCalled()
     })
 
-    it('should run MAM catch-up on SM resumption for long disconnects', async () => {
+    it('should skip MAM catch-up but fetch bookmarks on SM resumption for long disconnects', async () => {
       const mockClientWithSM = createMockXmppClientWithSM('sm-id-long')
       mockClientFactory._setInstance(mockClientWithSM)
 
@@ -982,8 +982,8 @@ describe('XMPPClient', () => {
 
       await connectPromise
 
-      // Long disconnect (300s > 120s threshold) → full refresh
-      expect(catchUpSpy).toHaveBeenCalledWith({ concurrency: 2 })
+      // Long disconnect (300s > 120s threshold) → SM replay covers messages, fetch bookmarks only
+      expect(catchUpSpy).not.toHaveBeenCalled()
       expect(bookmarksSpy).toHaveBeenCalled()
     })
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1566,36 +1566,34 @@ export class XMPPClient {
       await this.muc.refreshPresenceInRooms(roomsToRefresh)
       if (this.isSessionSuperseded(gen, 'SM resumption aborted after room presence refresh')) return
 
-      // For short disconnects (< 2 min), SM replay already delivered all queued
-      // stanzas — skip the expensive room MAM catch-up and bookmark fetch.
-      // For longer or unknown-duration disconnects, run the full refresh as a
-      // safety net in case messages fell outside the SM queue window.
+      // SM replay already delivered all queued stanzas — room MAM catch-up
+      // is always skipped on successful SM resume, regardless of disconnect
+      // duration. If a room kicked the user during the disconnect, the kick
+      // notification is part of the SM replay; roomSideEffects excludes
+      // kicked rooms from fetchInitiated, so they get targeted MAM catch-up
+      // when they rejoin via the room:joined event.
+      //
+      // For long or unknown-duration disconnects, fetch bookmarks as a safety
+      // net (bookmarks are PEP items, not SM-queued stanzas, so they may have
+      // changed while disconnected).
       const SM_SHORT_DISCONNECT_MS = 120_000
       const isShortDisconnect = disconnectDurationMs != null
         && disconnectDurationMs < SM_SHORT_DISCONNECT_MS
 
       if (isShortDisconnect) {
         const sec = Math.round(disconnectDurationMs / 1000)
-        logInfo(`SM resumption: short disconnect (${sec}s) — skipping room MAM catch-up`)
+        logInfo(`SM resumption: short disconnect (${sec}s) — skipping bookmark fetch`)
         this.stores?.console.addEvent(
-          `SM resumption: short disconnect (${sec}s) — skipping room MAM catch-up and bookmark fetch`,
+          `SM resumption: short disconnect (${sec}s) — skipping bookmark fetch`,
           'sm'
         )
       } else {
         const sec = disconnectDurationMs != null ? Math.round(disconnectDurationMs / 1000) : 'unknown'
-        logInfo(`SM resumption: disconnect ${sec}s — running room MAM catch-up`)
+        logInfo(`SM resumption: disconnect ${sec}s — fetching bookmarks`)
         this.stores?.console.addEvent(
-          `SM resumption: disconnect ${sec}s — running room MAM catch-up and bookmark fetch`,
+          `SM resumption: disconnect ${sec}s — fetching bookmarks`,
           'sm'
         )
-
-        // Verify we haven't missed any room messages during the disconnect.
-        // SM replay covers stanzas the server queued, but if the disconnect was
-        // long enough for messages to fall outside the SM window, a forward MAM
-        // query from the newest cached message will catch them.
-        this.mam.catchUpAllRooms({ concurrency: 2 }).catch((err) => {
-          console.error('[XMPPClient] Room catch-up after SM resumption failed:', err)
-        })
 
         // Fetch bookmarks to restore room names and autojoin state.
         // Also join any newly bookmarked rooms not already joined.

--- a/packages/fluux-sdk/src/core/modules/MAM.preview.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.preview.test.ts
@@ -728,6 +728,71 @@ describe('MAM Preview Refresh', () => {
     })
   })
 
+  describe('fetchPreviewForRoom (cache-first)', () => {
+    it('should skip MAM query when IndexedDB cache has a preview', async () => {
+      await connectClient()
+
+      const cachedMessage = {
+        type: 'groupchat' as const,
+        id: 'cached-msg',
+        roomJid: 'room1@conference.example.com',
+        from: 'room1@conference.example.com/alice',
+        nick: 'alice',
+        body: 'Cached message',
+        timestamp: new Date(),
+        isOutgoing: false,
+      }
+
+      // Cache returns a message
+      vi.mocked(mockStores.room.loadPreviewFromCache).mockResolvedValue(cachedMessage as any)
+
+      // Track MAM queries
+      const mamQueryTargets: string[] = []
+      mockXmppClientInstance.iqCaller.request.mockImplementation(async (iq: any) => {
+        if (iq?.attrs?.to) mamQueryTargets.push(iq.attrs.to)
+        return createMockElement('iq', { type: 'result' }, [
+          { name: 'fin', attrs: { xmlns: 'urn:xmpp:mam:2', complete: 'true' }, children: [] },
+        ])
+      })
+
+      await xmppClient.mam.fetchPreviewForRoom('room1@conference.example.com')
+
+      // Should have tried the cache
+      expect(mockStores.room.loadPreviewFromCache).toHaveBeenCalledWith('room1@conference.example.com')
+      // Should NOT have made any MAM query
+      expect(mamQueryTargets).not.toContain('room1@conference.example.com')
+    })
+
+    it('should fall through to MAM query when cache is empty', async () => {
+      await connectClient()
+
+      // Cache returns null (no cached messages)
+      vi.mocked(mockStores.room.loadPreviewFromCache).mockResolvedValue(null)
+
+      // Mock room for nickname lookup
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({
+        jid: 'room1@conference.example.com',
+        nickname: 'me',
+      } as any)
+
+      // Track MAM queries
+      const mamQueryTargets: string[] = []
+      mockXmppClientInstance.iqCaller.request.mockImplementation(async (iq: any) => {
+        if (iq?.attrs?.to) mamQueryTargets.push(iq.attrs.to)
+        return createMockElement('iq', { type: 'result' }, [
+          { name: 'fin', attrs: { xmlns: 'urn:xmpp:mam:2', complete: 'true' }, children: [] },
+        ])
+      })
+
+      await xmppClient.mam.fetchPreviewForRoom('room1@conference.example.com')
+
+      // Should have tried the cache first
+      expect(mockStores.room.loadPreviewFromCache).toHaveBeenCalledWith('room1@conference.example.com')
+      // Should fall through to MAM query
+      expect(mamQueryTargets).toContain('room1@conference.example.com')
+    })
+  })
+
   describe('refreshArchivedConversationPreviews', () => {
     it('should do nothing when there are no archived conversations', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1166,6 +1166,11 @@ export class MAM extends BaseModule {
    */
   async fetchPreviewForRoom(roomJid: string): Promise<void> {
     try {
+      // Cache-first: try loading preview from IndexedDB before making a network query.
+      // Background catch-up (catchUpAllRooms) will correct the preview later if stale.
+      const cached = await this.deps.stores?.room.loadPreviewFromCache(roomJid)
+      if (cached) return
+
       const queryId = `preview_${generateUUID()}`
 
       // Room MAM doesn't need a 'with' filter


### PR DESCRIPTION
- **SM resume**: remove `catchUpAllRooms()` from `handleSmResumption()` — SM protocol guarantees delivery of all queued stanzas on successful resume, making room MAM catch-up redundant regardless of disconnect duration. Rooms kicked during disconnect still get targeted catch-up via `roomSideEffects` (excluded from `fetchInitiated`).
- **Room preview**: `fetchPreviewForRoom()` now tries IndexedDB cache before making a network query. If the cache has a displayable message, the `max=30` MAM query is skipped. Background catch-up and live messages correct the preview if stale.

On a typical reconnect with 7 rooms, this eliminates up to 7 × `max=30` preview queries + 7 × `max=100` catch-up queries.