### PR TITLE
fix(app): probe runtime before reloading on dynamic import failure

### DIFF
--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -58,21 +58,46 @@ document.addEventListener('keydown', (e) => {
 // Block control characters Tauri's macOS webview inserts on arrow-key boundary hits
 installBeforeInputGuard()
 
-// Auto-recover from dynamic import failures. Vite's production build uses
-// content-hashed chunk filenames, so a tab that was open before a deploy may
-// hold stale URLs that now 404 — and a hosted SPA typically rewrites 404s to
-// index.html, which Safari rejects as "not a valid JavaScript MIME type".
-// React.lazy has no retry logic, so the error bubbles to RenderLoopBoundary.
-// Vite dispatches 'vite:preloadError' from its runtime when import() fails;
-// reloading the page transparently recovers. Safeguard: at most one reload
-// per 60s so a persistent failure surfaces instead of looping forever.
-window.addEventListener('vite:preloadError', (event) => {
+// Auto-recover from dynamic import failures. Two failure modes share the
+// same recovery path:
+//  - Web: Vite's production build uses content-hashed chunk filenames, so a
+//    tab open across a deploy may hold URLs that 404. Reloading picks up
+//    fresh hashes.
+//  - Tauri: chunks are served through the `tauri://localhost` custom
+//    protocol (WKURLSchemeHandler on macOS). After wake-from-sleep or a
+//    programmatic webview reload, the scheme handler can be transiently
+//    unreachable — reloading straight away just hits the same failure.
+//
+// Vite dispatches 'vite:preloadError' when a preload link or import()
+// fetch fails. The already-rejected import can't be resumed in place, so
+// we still reload — but we probe the document URL with bounded backoff
+// first, so the reload lands when the runtime is actually healthy again.
+// Safeguard: at most one reload per 60s so a persistent failure surfaces
+// instead of looping forever.
+let preloadReloadPending = false
+window.addEventListener('vite:preloadError', async (event) => {
   const KEY = 'fluux:preload-error-reload-at'
   const last = Number(sessionStorage.getItem(KEY) || '0')
   if (Date.now() - last < 60_000) return
-  sessionStorage.setItem(KEY, String(Date.now()))
+  if (preloadReloadPending) return
+  preloadReloadPending = true
+
   event.preventDefault()
-  console.warn('[Fluux] Dynamic import failed, reloading to recover:', event)
+  console.warn('[Fluux] Dynamic import failed, probing before reload:', event)
+
+  const PROBE_DELAYS_MS = [150, 400, 800, 1500]
+  const probeUrl = new URL(window.location.pathname, window.location.origin).href
+  for (const delay of PROBE_DELAYS_MS) {
+    await new Promise((r) => setTimeout(r, delay))
+    try {
+      const res = await fetch(probeUrl, { cache: 'reload' })
+      if (res.ok) break
+    } catch {
+      // keep probing until the delay budget is exhausted
+    }
+  }
+
+  sessionStorage.setItem(KEY, String(Date.now()))
   window.location.reload()
 })
 


### PR DESCRIPTION
- After wake-from-sleep, Tauri reloads the webview, but the `tauri://localhost` scheme handler can be transiently unavailable — the first preload requests on the new page fail, triggering the existing `vite:preloadError` handler to reload again immediately. A user's log showed exactly this double-reload cascade after a 928s sleep on a 5G tether.
- Before reloading, probe the document URL with `fetch({ cache: 'reload' })` on a bounded backoff (150/400/800/1500 ms, ~2.85s total). Exit early on the first successful response.
- Debounce concurrent preload errors with a `preloadReloadPending` flag so simultaneous chunk failures don't queue multiple probes/reloads.
- 60s rate-limit is preserved (without `preventDefault`) so persistent failures still surface rather than looping forever.
- Comment updated to cover both the web stale-chunk case and the Tauri scheme-handler stall case.