### PR TITLE
fix(app): scale images up to fill lightbox viewport

### DIFF
--- a/apps/fluux/src/components/ImageLightbox.tsx
+++ b/apps/fluux/src/components/ImageLightbox.tsx
@@ -63,7 +63,7 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, onClose }: Imag
       <img
         src={src}
         alt={alt || 'Image'}
-        className="max-w-[90vw] max-h-[85vh] object-contain rounded-lg select-none"
+        className="w-[90vw] h-[85vh] object-contain rounded-lg select-none"
         draggable={false}
       />
 


### PR DESCRIPTION
The image lightbox (`ImageLightbox.tsx`) used `max-w-[90vw] max-h-[85vh]` which only capped image size. Smaller images rendered at their natural dimensions instead of filling the overlay, so clicking an image often produced a surprisingly small preview.

Switching to fixed `w-[90vw] h-[85vh]` with `object-contain` makes the `<img>` element span the lightbox, and `object-contain` scales the image content up (or down) to fit while preserving aspect ratio.

Verified in-browser with a 500×300 test image on a 1280×800 viewport:
- Before: rendered at 500×300 (natural size)
- After: rendered at ~1133×680 (scaled to fit 90vw × 85vh, aspect ratio preserved)