### PR TITLE
perf(app): scope typing/draft subscriptions per conversation item

### DIFF
--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -13,7 +13,7 @@ import {
   type Contact,
   type Room,
 } from '@fluux/sdk'
-import { useConnectionStore } from '@fluux/sdk/react'
+import { useChatStore, useConnectionStore } from '@fluux/sdk/react'
 import { Avatar, TypingIndicator } from '../Avatar'
 import { Tooltip } from '../Tooltip'
 import { useSidebarZone, ContactTooltipContent } from './types'
@@ -45,8 +45,6 @@ export function ConversationList() {
     setActiveConversation,
     deleteConversation,
     archiveConversation,
-    typingStates,
-    drafts,
   } = useChat()
   const { setActiveRoom, getRoom } = useRoom()
   const { contacts } = useRoster()
@@ -55,10 +53,11 @@ export function ConversationList() {
   const zoneRef = useSidebarZone()
 
   // Diagnostic: track every selector-derived value per render. Dev-only.
+  // Note: typingStates / drafts are NOT subscribed at the list level — each
+  // ConversationItem subscribes to its own entry to avoid re-rendering the
+  // full list on every typing / draft change during background sync.
   trackSelectorChange('ConversationList', 'conversations', conversations)
   trackSelectorChange('ConversationList', 'activeConversationId', activeConversationId)
-  trackSelectorChange('ConversationList', 'typingStates', typingStates)
-  trackSelectorChange('ConversationList', 'drafts', drafts)
   trackSelectorChange('ConversationList', 'contacts', contacts)
 
   // Create maps for quick lookup
@@ -95,27 +94,20 @@ export function ConversationList() {
   return (
     <SidebarListMenuProvider<Conversation>>
       <div ref={listRef} className="px-2 space-y-0.5" {...getContainerProps()}>
-        {conversations.map((conv, index) => {
-          const typingSet = typingStates.get(conv.id)
-          const isTyping = typingSet && typingSet.size > 0
-          const draft = drafts.get(conv.id)
-          return (
-            <ConversationItem
-              key={conv.id}
-              conversation={conv}
-              contact={conv.type === 'chat' ? contactMap.get(conv.id) : undefined}
-              room={conv.type === 'groupchat' ? getRoom(conv.id) : undefined}
-              isActive={conv.id === activeConversationId}
-              isSelected={index === selectedIndex}
-              isKeyboardNav={isKeyboardNav}
-              isTyping={isTyping}
-              draft={draft}
-              onClick={() => handleConversationClick(conv.id)}
-              {...getItemAttribute(index)}
-              {...getItemProps(index)}
-            />
-          )
-        })}
+        {conversations.map((conv, index) => (
+          <ConversationItem
+            key={conv.id}
+            conversation={conv}
+            contact={conv.type === 'chat' ? contactMap.get(conv.id) : undefined}
+            room={conv.type === 'groupchat' ? getRoom(conv.id) : undefined}
+            isActive={conv.id === activeConversationId}
+            isSelected={index === selectedIndex}
+            isKeyboardNav={isKeyboardNav}
+            onClick={() => handleConversationClick(conv.id)}
+            {...getItemAttribute(index)}
+            {...getItemProps(index)}
+          />
+        ))}
       </div>
       <ConversationContextMenu
         isArchived={false}
@@ -137,8 +129,6 @@ export function ArchiveList() {
     setActiveConversation,
     deleteConversation,
     unarchiveConversation,
-    typingStates,
-    drafts,
   } = useChat()
   const { setActiveRoom, getRoom } = useRoom()
   const { contacts } = useRoster()
@@ -178,27 +168,20 @@ export function ArchiveList() {
   return (
     <SidebarListMenuProvider<Conversation>>
       <div ref={listRef} className="px-2 space-y-0.5" {...getContainerProps()}>
-        {archivedConversations.map((conv, index) => {
-          const typingSet = typingStates.get(conv.id)
-          const isTyping = typingSet && typingSet.size > 0
-          const draft = drafts.get(conv.id)
-          return (
-            <ConversationItem
-              key={conv.id}
-              conversation={conv}
-              contact={conv.type === 'chat' ? contactMap.get(conv.id) : undefined}
-              room={conv.type === 'groupchat' ? getRoom(conv.id) : undefined}
-              isActive={conv.id === activeConversationId}
-              isSelected={index === selectedIndex}
-              isKeyboardNav={isKeyboardNav}
-              isTyping={isTyping}
-              draft={draft}
-              onClick={() => handleConversationClick(conv.id)}
-              {...getItemAttribute(index)}
-              {...getItemProps(index)}
-            />
-          )
-        })}
+        {archivedConversations.map((conv, index) => (
+          <ConversationItem
+            key={conv.id}
+            conversation={conv}
+            contact={conv.type === 'chat' ? contactMap.get(conv.id) : undefined}
+            room={conv.type === 'groupchat' ? getRoom(conv.id) : undefined}
+            isActive={conv.id === activeConversationId}
+            isSelected={index === selectedIndex}
+            isKeyboardNav={isKeyboardNav}
+            onClick={() => handleConversationClick(conv.id)}
+            {...getItemAttribute(index)}
+            {...getItemProps(index)}
+          />
+        ))}
       </div>
       <ConversationContextMenu
         isArchived={true}
@@ -221,8 +204,6 @@ interface ConversationItemProps {
   isActive: boolean
   isSelected?: boolean
   isKeyboardNav?: boolean
-  isTyping?: boolean
-  draft?: string
   onClick: () => void
   onMouseEnter?: (e: React.MouseEvent) => void
   onMouseMove?: (e: React.MouseEvent) => void
@@ -237,8 +218,6 @@ export const ConversationItem = memo(function ConversationItem({
   isActive,
   isSelected,
   isKeyboardNav,
-  isTyping,
-  draft,
   onClick,
   onMouseEnter,
   onMouseMove,
@@ -251,6 +230,11 @@ export const ConversationItem = memo(function ConversationItem({
   const { getItemMenuProps, isOpen, longPressTriggered } = useSidebarListMenu<Conversation>()
   const currentLang = i18n.language.split('-')[0]
   const timeFormat = useSettingsStore((s) => s.timeFormat)
+
+  // Per-item subscriptions: each item only re-renders when ITS typing/draft
+  // changes, not when any conversation's state changes.
+  const isTyping = useChatStore((s) => (s.typingStates.get(conversation.id)?.size ?? 0) > 0)
+  const draft = useChatStore((s) => s.drafts.get(conversation.id))
 
   const isGroupChat = conversation.type === 'groupchat'
   const menuProps = getItemMenuProps(conversation)

--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -233,7 +233,8 @@ export const ConversationItem = memo(function ConversationItem({
 
   // Per-item subscriptions: each item only re-renders when ITS typing/draft
   // changes, not when any conversation's state changes.
-  const isTyping = useChatStore((s) => (s.typingStates.get(conversation.id)?.size ?? 0) > 0)
+  const typingCount = useChatStore((s) => s.typingStates.get(conversation.id)?.size ?? 0)
+  const isTyping = typingCount > 0
   const draft = useChatStore((s) => s.drafts.get(conversation.id))
 
   const isGroupChat = conversation.type === 'groupchat'

--- a/apps/fluux/src/utils/renderLoopDetector.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.ts
@@ -46,7 +46,7 @@ const TIME_WINDOW_MS = 1000         // Time window in milliseconds
 const COOLDOWN_MS = 5000            // Cooldown before resetting after trigger
 const MAX_RENDER_HISTORY = 20       // Keep last N renders per component for debugging
 const WAKE_GRACE_PERIOD_MS = 3000   // Suppress warnings for this long after wake
-const SYNC_GRACE_PERIOD_MS = 5000   // Raise error threshold after fresh connection
+const SYNC_GRACE_PERIOD_MS = 15000  // Raise error threshold after fresh connection (covers full MAM + roster + room catch-up)
 const SYNC_GRACE_THRESHOLD = 500    // Error threshold during sync grace period
 
 // Track if we're in a grace period (e.g., after wake from sleep)


### PR DESCRIPTION
## Summary

`ConversationList` subscribed to the full `typingStates` and `drafts` maps at the list level. Any store update to either map (including background MAM sync on a fresh session, which rewrites these maps as messages land) re-rendered the entire list, not just the items whose state actually changed.

This PR moves those subscriptions into the memoized `ConversationItem` so each item only re-renders when its own typing or draft state changes:

- `ConversationList` / `ArchiveList` no longer destructure `typingStates` / `drafts` from `useChat()` and no longer compute `isTyping` / `draft` per item in the parent render.
- `ConversationItem` picks up its own state via `useChatStore((s) => s.typingStates.get(conversation.id))` and `useChatStore((s) => s.drafts.get(conversation.id))`.
- Drops `isTyping` / `draft` from `ConversationItemProps` (no longer passed down).

Also bumps `renderLoopDetector.SYNC_GRACE_PERIOD_MS` from 5s to 15s. A fresh-session sync (MAM catch-up + roster discovery + the 10s room catch-up delay + room MAM + member discovery) can run ~13s on an active account and was tripping the render-loop error threshold during the grace window.