### PR TITLE
fix(app): minor mobile related fixes

### DIFF
--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -47,7 +47,7 @@ document.addEventListener('keydown', enableFocusRings)
 document.addEventListener('keydown', (e) => {
   // Use e.code for reliable key detection regardless of Shift state
   // Also check e.key with lowercase for fallback compatibility
-  const isRKey = e.code === 'KeyR' || e.key.toLowerCase() === 'r'
+  const isRKey = e.code === 'KeyR' || e.key?.toLowerCase() === 'r'
   if ((e.metaKey || e.ctrlKey) && e.altKey && e.shiftKey && isRKey) {
     e.preventDefault()
     console.warn('[Emergency] Force reload triggered')

--- a/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
@@ -484,4 +484,73 @@ describe('Connection race conditions', () => {
       expect(snapshot.context.smResumeViable).toBe(false)
     })
   })
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Race 6: Reconnect attempt stalls mid-handshake → 30s timeout fires → retry
+  //
+  // Guards commit ed33cb1: post-wake auto-connect could stall after SASL and
+  // never emit 'online' or 'error', leaving the client wedged. The 30s
+  // RECONNECT_ATTEMPT_TIMEOUT_MS is the safety net. This test exercises the
+  // safety net end-to-end: stall → timeout → next backoff → success.
+  //
+  // Timeline:
+  //   T=0:     connected.healthy
+  //   T=0:     disconnect(clean:false) → reconnecting
+  //   T=1000:  attempting, clientA created, xmpp.start() resolves but no events
+  //   T=31000: RECONNECT_ATTEMPT_TIMEOUT_MS fires → clientA destroyed, waiting
+  //   T=33000: next backoff → attempting again, clientB created
+  //   T=33000+: clientB emits 'online' → connected.healthy
+  //   Assert:  final state is healthy, status is 'online', clientB is active
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Race 6: reconnect attempt stalls → timeout safety net → retry succeeds', () => {
+    it('should recover when an attempt hangs forever mid-handshake', async () => {
+      await connectAndGoOnline(xmppClient, mockXmppClientInstance)
+
+      // Enter reconnecting via unexpected disconnect
+      mockXmppClientInstance._emit('disconnect', { clean: false })
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Prime clientA for the first reconnect attempt. Crucially, clientA
+      // never emits 'online' or 'error' — it just hangs after start() resolves,
+      // simulating a post-SASL stall.
+      const clientA = createMockXmppClient()
+      mockClientFactory._setInstance(clientA)
+      mockClientFactory.mockClear()
+
+      // First reconnect attempt fires after 1s backoff
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(mockClientFactory).toHaveBeenCalledTimes(1)
+      expect(getMachineState(xmppClient)).toEqual({ reconnecting: 'attempting' })
+
+      // Prime clientB for the NEXT attempt that will happen after timeout +
+      // backoff. We install it now so mockClientFactory returns it next call.
+      const clientB = createMockXmppClient()
+      mockClientFactory._setInstance(clientB)
+      mockClientFactory.mockClear()
+
+      // Fast-forward past the 30s safety net — clientA's attempt is abandoned.
+      await vi.advanceTimersByTimeAsync(RECONNECT_ATTEMPT_TIMEOUT_MS)
+
+      // clientA must have been cleanly torn down — no stale handlers survive
+      // to interfere with clientB if a belated event arrives.
+      expect(clientA.removeAllListeners).toHaveBeenCalled()
+
+      // Advance enough to clear any next-attempt backoff (the second attempt
+      // uses exponential backoff, usually 2s). 5s comfortably covers both
+      // the backoff and attemptReconnect's internal network-settle delay.
+      await vi.advanceTimersByTimeAsync(5000)
+
+      // A fresh client must have been created for the retry.
+      expect(mockClientFactory).toHaveBeenCalledTimes(1)
+
+      // clientB completes the handshake normally.
+      clientB._emit('online')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(getStatus(mockStores)).toBe('online')
+      expect(hasActiveClient(xmppClient)).toBe(true)
+      expect(getMachineState(xmppClient)).toMatchObject({ connected: expect.anything() })
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3313,6 +3313,62 @@ describe('XMPPClient Connection', () => {
       expect(smState?.id).toBe('sm-resumed-session')
     })
 
+    // Regression: connecting with a hydrated smState must set sm.outbound BEFORE
+    // xmpp.js's ackQueue could run, so that `<resumed h=N/>` against an empty
+    // in-memory queue iterates zero times instead of crashing on item.stanza.
+    // See Connection.hydrateStreamManagement + xmpp.js stream-management#1119.
+    it('should hydrate sm.outbound before resume so ackQueue runs 0 iterations', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+        smState: { id: 'sm-resume-42', inbound: 9, outbound: 17 },
+      })
+
+      // Flush connect()'s async setup (server resolution + attemptConnection) so
+      // hydrateStreamManagement has run by the time we inspect the mock.
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Hydration is what sets sm.outbound = 17 — the server's expected h value
+      // on <resumed/>. xmpp.js would otherwise find outbound=0 on a fresh client
+      // and iterate 17 times over an empty queue, crashing on item.stanza.
+      expect(mockXmppClientInstance.streamManagement.id).toBe('sm-resume-42')
+      expect(mockXmppClientInstance.streamManagement.inbound).toBe(9)
+      expect(mockXmppClientInstance.streamManagement.outbound).toBe(17)
+
+      // Simulate xmpp.js's ackQueue against an empty outbound_q on resume:
+      // `for (let i = 0; i < +h - sm.outbound; i++) sm.outbound_q.shift().stanza`
+      // With hydration, h=17 and sm.outbound=17 → 0 iterations, no shift, no crash.
+      const smMock = mockXmppClientInstance.streamManagement as unknown as {
+        outbound: number
+      }
+      const serverH = 17
+      const simulateAckQueue = () => {
+        const emptyQ: Array<{ stanza: unknown }> = []
+        for (let i = 0; i < serverH - smMock.outbound; i++) {
+          const item = emptyQ.shift()
+          smMock.outbound++
+          void (item as { stanza: unknown }).stanza
+        }
+      }
+      expect(simulateAckQueue).not.toThrow()
+      expect(smMock.outbound).toBe(17)
+
+      // Finish the resume handshake and confirm the cache reflects it.
+      mockXmppClientInstance.streamManagement.enabled = true
+      const resumedNonza = createMockElement('resumed', {
+        xmlns: 'urn:xmpp:sm:3',
+        previd: 'sm-resume-42',
+        h: '17',
+      })
+      mockXmppClientInstance._emit('nonza', resumedNonza)
+      await connectPromise
+
+      const cached = xmppClient.getStreamManagementState()
+      expect(cached).toMatchObject({ id: 'sm-resume-42', inbound: 9, outbound: 17 })
+    })
+
     it('should preserve SM state through dead-socket → reconnect cycle', async () => {
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -14,7 +14,7 @@ import type {
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import { findMessageById } from '../utils/messageLookup'
 import { getBareJid } from '../core/jid'
-import { logWarn } from '../core/logger'
+import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import type { GetMessagesOptions } from '../utils/messageCache'
@@ -997,7 +997,7 @@ export const roomStore = createStore<RoomState>()(
       } else {
         // Message not in memory — update reactions directly in IndexedDB cache
         // so the correct state is restored when the message is loaded later
-        logWarn(`Reaction for message ${messageId} not in memory — updating in cache`)
+        logInfo(`Reaction for message ${messageId} not in memory — updating in cache`)
         void messageCache.updateRoomMessageReactions(messageId, reactorNick, emojis)
       }
 


### PR DESCRIPTION
## Summary

- **Mobile crash fix** ([apps/fluux/src/main.tsx:50](apps/fluux/src/main.tsx)) — the global emergency-reload shortcut handler called `e.key.toLowerCase()` unconditionally. Mobile virtual keyboards / IME composition can fire `keydown` events without a `key` property, throwing `Cannot read properties of undefined (reading 'toLowerCase')` from the document listener and crashing the bundle. Guarded with optional chaining.
- **Log-level downgrade** ([packages/fluux-sdk/src/stores/roomStore.ts:1000](packages/fluux-sdk/src/stores/roomStore.ts)) — the "reaction for message X not in memory — updating in cache" message is the *expected* path when MAM replays a reaction targeting a message older than the in-memory window. The SDK correctly persists the reaction to IndexedDB so it appears when the message is loaded later. Downgraded from `logWarn` to `logInfo` to remove console noise during room catch-up.