### PR TITLE
fix(app): use ServiceWorker.showNotification() on web

### DIFF
--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -9,6 +9,7 @@ import { useNotificationPermission, isTauri } from './useNotificationPermission'
 import { getNotificationAvatarUrl } from '@/utils/notificationAvatar'
 import { formatMessagePreview } from '@fluux/sdk'
 import { notificationDebug } from '@/utils/notificationDebug'
+import { showWebNotification } from '@/utils/webNotification'
 
 /**
  * Hook to show desktop notifications for new messages and room mentions.
@@ -97,21 +98,16 @@ export function useDesktopNotifications(): void {
         extra: { navType: 'conversation', navTarget: conv.id },
       })
     } else {
-      if (typeof Notification === 'undefined') return
-
-      const notification = new Notification(title, {
-        body,
-        icon: avatarUrl || './icon-512.png',
-        tag: conv.id, // Prevents duplicate notifications for same conversation
-      })
-
-      notification.onclick = () => {
-        window.focus()
-        navigateToConversation(conv.id)
-        notification.close()
-      }
-
-      setTimeout(() => notification.close(), 5000)
+      await showWebNotification(
+        title,
+        {
+          body,
+          icon: avatarUrl || './icon-512.png',
+          tag: conv.id,
+          onClick: () => navigateToConversation(conv.id),
+        },
+        { from: conv.id, type: 'conversation' },
+      )
     }
   }
 
@@ -148,21 +144,16 @@ export function useDesktopNotifications(): void {
         extra: { navType: 'room', navTarget: room.jid },
       })
     } else {
-      if (typeof Notification === 'undefined') return
-
-      const notification = new Notification(title, {
-        body,
-        icon: avatarUrl || './icon-512.png',
-        tag: `room-${room.jid}`,
-      })
-
-      notification.onclick = () => {
-        window.focus()
-        navigateToRoom(room.jid)
-        notification.close()
-      }
-
-      setTimeout(() => notification.close(), 5000)
+      await showWebNotification(
+        title,
+        {
+          body,
+          icon: avatarUrl || './icon-512.png',
+          tag: `room-${room.jid}`,
+          onClick: () => navigateToRoom(room.jid),
+        },
+        { from: room.jid, type: 'room' },
+      )
     }
   }
 

--- a/apps/fluux/src/utils/webNotification.ts
+++ b/apps/fluux/src/utils/webNotification.ts
@@ -1,0 +1,65 @@
+/**
+ * Web notification helper.
+ *
+ * Mobile browsers (notably Android Chrome) disallow `new Notification(...)` and
+ * throw `TypeError: Failed to construct 'Notification': Illegal constructor`.
+ * Only `ServiceWorkerRegistration.showNotification()` is permitted there.
+ *
+ * This helper prefers the service worker path when available so the same code
+ * works on mobile and desktop. Clicks are routed by sw.ts via `data.from` /
+ * `data.type`, which it converts into hash-route deep links.
+ */
+
+export interface WebNotificationNav {
+  /** Target JID (conversation id or room jid). Consumed by sw.ts click handler. */
+  from?: string
+  /** 'room' for MUC, otherwise treated as a 1:1 conversation. */
+  type?: 'room' | 'conversation'
+}
+
+export interface WebNotificationOptions {
+  body: string
+  icon?: string
+  tag?: string
+  /** Click fallback when the in-page Notification constructor is used. */
+  onClick?: () => void
+}
+
+const canUseServiceWorker = (): boolean =>
+  typeof navigator !== 'undefined' && 'serviceWorker' in navigator
+
+export async function showWebNotification(
+  title: string,
+  options: WebNotificationOptions,
+  nav: WebNotificationNav = {},
+): Promise<void> {
+  const { onClick, ...notificationOptions } = options
+  const payload: NotificationOptions = {
+    ...notificationOptions,
+    data: nav,
+  }
+
+  if (canUseServiceWorker()) {
+    try {
+      const registration = await navigator.serviceWorker.ready
+      await registration.showNotification(title, payload)
+      return
+    } catch {
+      // Fall through to constructor path below.
+    }
+  }
+
+  if (typeof Notification === 'undefined') return
+
+  try {
+    const notification = new Notification(title, notificationOptions)
+    notification.onclick = () => {
+      window.focus()
+      onClick?.()
+      notification.close()
+    }
+    setTimeout(() => notification.close(), 5000)
+  } catch {
+    // Mobile browsers throw here — SW path above handles them.
+  }
+}


### PR DESCRIPTION
## Summary

- Mobile browsers (notably Android Chrome) reject `new Notification(...)` with `TypeError: Failed to construct 'Notification': Illegal constructor`; only `ServiceWorkerRegistration.showNotification()` is permitted there.
- New helper `apps/fluux/src/utils/webNotification.ts` prefers the SW path when available and falls back to the `Notification` constructor only when no SW is registered.