### PR TITLE
feat(sdk): SASL2 user-agent + FAST token server-side invalidation

### DIFF
--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -108,7 +108,8 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
   const ownNickname = useConnectionStore((s) => s.ownNickname)
   // Get methods from client (not from store)
   const { client } = useXMPP()
-  const disconnect = () => client.disconnect()
+  const disconnect = (options?: { invalidateFastToken?: boolean }) =>
+    client.disconnect(options)
   const cancelReconnect = () => client.cancelReconnect()
   const isAdmin = useAdminStore((s) => s.isAdmin)
   // Use targeted store selectors instead of useChat()/useRoom() to avoid render loops.
@@ -515,9 +516,13 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
               </Tooltip>
             ) : (
               <UserMenu onLogout={async (shouldCleanLocalData) => {
-                // Always attempt disconnect first.
+                // Always attempt disconnect first. Request FAST token
+                // invalidation (XEP-0484 §6) so the server drops any
+                // stored token instead of leaving it usable until expiry.
                 const disconnectSettled = await Promise.race([
-                  disconnect().then(() => 'done' as const).catch(() => 'error' as const),
+                  disconnect({ invalidateFastToken: true })
+                    .then(() => 'done' as const)
+                    .catch(() => 'error' as const),
                   new Promise<'timeout'>((resolve) => {
                     setTimeout(() => resolve('timeout'), LOGOUT_DISCONNECT_TIMEOUT_MS)
                   }),

--- a/apps/fluux/src/utils/clearLocalData.ts
+++ b/apps/fluux/src/utils/clearLocalData.ts
@@ -11,6 +11,7 @@ import {
   getBareJid,
   deleteFastToken,
   clearSearchIndex,
+  clearUserAgentIdentity,
 } from '@fluux/sdk'
 import { clearSession, getSession } from '@/hooks/useSessionPersistence'
 import { deleteCredentials } from '@/utils/keychain'
@@ -80,6 +81,10 @@ export async function clearLocalData(options: ClearLocalDataOptions = {}): Promi
         }
       }
       fastTokenKeys.forEach((key) => localStorage.removeItem(key))
+      // Full wipe: also reset the SASL2 user-agent identity so the next
+      // login presents a fresh device to the server. On per-account logout
+      // we keep the id (same device, tokens are already scoped by JID).
+      clearUserAgentIdentity()
     } else if (scopedJid) {
       deleteFastToken(scopedJid)
     }

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -910,20 +910,30 @@ export class XMPPClient {
   /**
    * Disconnect from the XMPP server.
    *
+   * @param options.invalidateFastToken - When true and a FAST token
+   *   (XEP-0484) is stored for this account, request server-side
+   *   invalidation before tearing down the transport. Use this on
+   *   explicit user logout so the stored token can no longer be
+   *   replayed from another device.
+   *
    * @returns Promise that resolves when disconnected
    *
    * @example
    * ```typescript
+   * // Regular disconnect (preserves the FAST token)
    * await client.disconnect()
+   *
+   * // Explicit logout — also drops the server-side FAST token
+   * await client.disconnect({ invalidateFastToken: true })
    * ```
    */
-  async disconnect(): Promise<void> {
+  async disconnect(options: { invalidateFastToken?: boolean } = {}): Promise<void> {
     this.currentJid = null
     // Clear session-scoped tracking data
     this.xep0084AvatarChecked.clear()
     this.entityTime?.clearCache()
     this.lastActivity?.clearCache()
-    return this.connection.disconnect()
+    return this.connection.disconnect(options)
   }
 
   /**

--- a/packages/fluux-sdk/src/core/fastTokenInvalidation.test.ts
+++ b/packages/fluux-sdk/src/core/fastTokenInvalidation.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for FAST token invalidation (XEP-0484 §6).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── Mocks for @xmpp/client ──
+// A fresh mock xmpp.js client is produced per test. We emulate the FAST
+// module's `auth` method, which our code wraps to inject invalidate='true'
+// on the <fast/> element inside the outgoing <authenticate/>.
+interface MockFastAuthArgs {
+  authenticate: (innerArgs: unknown) => Promise<void>
+  streamFeatures: unknown[]
+  credentials: unknown
+}
+
+interface MockXmppInstance {
+  on: (event: string, handler: (...args: unknown[]) => void) => MockXmppInstance
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  fast: {
+    fetchToken: () => Promise<unknown>
+    saveToken: (t: unknown) => void
+    deleteToken: () => void
+    auth: (args: MockFastAuthArgs) => Promise<boolean>
+  }
+  _emit: (event: string, ...args: unknown[]) => void
+  _runAuth: () => Promise<void>
+  _capturedFastElement: { name: string; attrs: Record<string, string> } | null
+  _capturedInnerArgs: unknown
+  _startCalled: boolean
+  _stopCalled: boolean
+}
+
+const createMockInstance = (): MockXmppInstance => {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {}
+  // The fast element that will be emitted during auth. The real xmpp.js FAST
+  // module builds this via ltx's xml() inside its auth() method; we pre-build
+  // it here so the test can observe whether our patch set invalidate='true'.
+  const fastElement = { name: 'fast', attrs: { xmlns: 'urn:xmpp:fast:0' } }
+
+  const inst: MockXmppInstance = {
+    on: (event, handler) => {
+      handlers[event] = handlers[event] || []
+      handlers[event].push(handler)
+      return inst
+    },
+    start: vi.fn(async () => {
+      inst._startCalled = true
+    }),
+    stop: vi.fn(async () => {
+      inst._stopCalled = true
+    }),
+    fast: {
+      fetchToken: async () => null,
+      saveToken: () => {},
+      deleteToken: () => {},
+      // Emulate fast.auth: build streamFeatures with the <fast/> element,
+      // then call args.authenticate (which our patch wraps).
+      auth: async (args: MockFastAuthArgs) => {
+        const innerArgs = {
+          ...args,
+          streamFeatures: [...(args.streamFeatures ?? []), fastElement],
+        }
+        await args.authenticate(innerArgs)
+        return true
+      },
+    },
+    _emit: (event, ...args) => {
+      for (const h of handlers[event] ?? []) h(...args)
+    },
+    // Simulate sasl2 calling fast.auth with a no-op authenticate so the
+    // patch's inner wrapper runs and mutates the <fast/> attributes.
+    _runAuth: async () => {
+      await inst.fast.auth({
+        authenticate: async (innerArgs: unknown) => {
+          inst._capturedInnerArgs = innerArgs
+        },
+        streamFeatures: [],
+        credentials: {},
+      })
+    },
+    _capturedFastElement: fastElement,
+    _capturedInnerArgs: null,
+    _startCalled: false,
+    _stopCalled: false,
+  }
+  return inst
+}
+
+const { mockClientFactory, mockInstances } = vi.hoisted(() => {
+  const instances: MockXmppInstance[] = []
+  const factory = vi.fn()
+  return { mockClientFactory: factory, mockInstances: instances }
+})
+
+vi.mock('@xmpp/client', () => ({
+  client: mockClientFactory,
+}))
+
+vi.mock('@xmpp/debug', () => ({ default: vi.fn() }))
+
+// ── Mocks for fastTokenStorage ──
+const { mockFetchFastToken } = vi.hoisted(() => ({
+  mockFetchFastToken: vi.fn(),
+}))
+
+vi.mock('./fastTokenStorage', () => ({
+  fetchFastToken: mockFetchFastToken,
+  saveFastToken: vi.fn(),
+  deleteFastToken: vi.fn(),
+  hasFastToken: vi.fn(),
+}))
+
+// Quiet logger
+vi.mock('./logger', () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}))
+
+import { invalidateFastTokenOnServer } from './fastTokenInvalidation'
+
+const TOKEN = {
+  mechanism: 'HT-SHA-256-NONE',
+  token: 'opaque-token-abc',
+  expiry: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+}
+
+describe('invalidateFastTokenOnServer', () => {
+  beforeEach(() => {
+    mockClientFactory.mockReset()
+    mockFetchFastToken.mockReset()
+    mockInstances.length = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns {ok:false, no-token} when no stored token exists', async () => {
+    mockFetchFastToken.mockReturnValue(null)
+    const result = await invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    expect(result).toEqual({ ok: false, reason: 'no-token' })
+    expect(mockClientFactory).not.toHaveBeenCalled()
+  })
+
+  it('returns {ok:false, invalid-jid} when JID lacks a localpart', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const result = await invalidateFastTokenOnServer({
+      jid: 'example.com',
+      server: 'wss://example.com/ws',
+    })
+    expect(result).toEqual({ ok: false, reason: 'invalid-jid' })
+    expect(mockClientFactory).not.toHaveBeenCalled()
+  })
+
+  it('accepts a bare host for `server` and derives the WebSocket URL', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'example.com',
+    })
+    // Give microtasks a turn so the client handlers attach, then signal success
+    await Promise.resolve()
+    inst._emit('online')
+    const result = await p
+
+    expect(result.ok).toBe(true)
+    const arg = mockClientFactory.mock.calls[0][0] as { service: string }
+    expect(arg.service).toBe('wss://example.com/ws')
+  })
+
+  it('resolves {ok:true} when the xmpp.js client emits online', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    await Promise.resolve()
+    inst._emit('online')
+
+    const result = await p
+    expect(result).toEqual({ ok: true })
+    expect(inst._stopCalled).toBe(true)
+  })
+
+  it('sets invalidate="true" on the <fast/> element during auth', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    // Let the helper set up listeners and monkey-patch fast.auth
+    await Promise.resolve()
+    // Drive the fast.auth flow as sasl2 would
+    await inst._runAuth()
+    inst._emit('online')
+    await p
+
+    // Our patch should have mutated the <fast/> element
+    expect(inst._capturedFastElement?.attrs.invalidate).toBe('true')
+    // And the wrapped authenticate should have been invoked with the mutated features
+    const innerArgs = inst._capturedInnerArgs as { streamFeatures: unknown[] }
+    const fastEl = (innerArgs.streamFeatures as Array<{ name: string; attrs: Record<string, string> }>)
+      .find((el) => el.name === 'fast')
+    expect(fastEl?.attrs.invalidate).toBe('true')
+  })
+
+  it('overrides fetchToken to return the in-memory token', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    await Promise.resolve()
+    const fetched = await inst.fast.fetchToken()
+    inst._emit('online')
+    await p
+
+    expect(fetched).toEqual(TOKEN)
+  })
+
+  it('treats not-authorized as already-invalid (ok:true)', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    await Promise.resolve()
+    inst._emit('error', { condition: 'not-authorized', message: 'token rejected' })
+
+    const result = await p
+    expect(result.ok).toBe(true)
+    expect(result.reason).toBe('already-invalid')
+  })
+
+  it('resolves {ok:false} with the error message on unrelated errors', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    await Promise.resolve()
+    inst._emit('error', new Error('socket closed'))
+
+    const result = await p
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('socket closed')
+  })
+
+  it('times out with {ok:false, timeout} when no event fires', async () => {
+    vi.useFakeTimers()
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+      timeoutMs: 100,
+    })
+    await vi.advanceTimersByTimeAsync(150)
+
+    const result = await p
+    expect(result).toEqual({ ok: false, reason: 'timeout' })
+    expect(inst._stopCalled).toBe(true)
+  })
+
+  it('resolves {ok:false} when start() rejects', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    inst.start = vi.fn().mockRejectedValue(new Error('DNS failure'))
+    mockClientFactory.mockImplementation(() => inst)
+
+    const result = await invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('DNS failure')
+  })
+
+  it('does not resolve twice when multiple events fire', async () => {
+    mockFetchFastToken.mockReturnValue(TOKEN)
+    const inst = createMockInstance()
+    mockClientFactory.mockImplementation(() => inst)
+
+    const p = invalidateFastTokenOnServer({
+      jid: 'alice@example.com',
+      server: 'wss://example.com/ws',
+    })
+    await Promise.resolve()
+    inst._emit('online')
+    inst._emit('error', new Error('spurious later error'))
+
+    const result = await p
+    expect(result.ok).toBe(true)
+    // stop should only fire once from the online path
+    expect((inst.stop as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
+  })
+})

--- a/packages/fluux-sdk/src/core/fastTokenInvalidation.ts
+++ b/packages/fluux-sdk/src/core/fastTokenInvalidation.ts
@@ -1,0 +1,193 @@
+/**
+ * FAST Token Invalidation (XEP-0484 §6)
+ *
+ * Invalidation is strictly an authentication-time operation: the client
+ * must successfully authenticate with the token and include an
+ * `invalidate='true'` attribute on the `<fast/>` element inside the
+ * `<authenticate/>` stanza. Once the server confirms, it drops the token
+ * and MUST NOT issue a replacement.
+ *
+ * This module opens a short-lived SASL2 session for that purpose.
+ * xmpp.js's built-in FAST module is monkey-patched so the outgoing
+ * `<fast/>` carries `invalidate='true'` on this one auth exchange.
+ *
+ * @see https://xmpp.org/extensions/xep-0484.html#invalidation
+ */
+
+import { client } from '@xmpp/client'
+import { fetchFastToken, type FastToken } from './fastTokenStorage'
+import { getBareJid, getDomain, getLocalPart } from './jid'
+import { logInfo, logWarn } from './logger'
+import { FAST_TOKEN_INVALIDATION_TIMEOUT_MS } from './modules/connectionTimeouts'
+
+export interface InvalidateFastTokenOptions {
+  /** Full or bare JID of the account whose token should be invalidated */
+  jid: string
+  /** WebSocket URL (ws://, wss://) or host for the XMPP server */
+  server: string
+  /** Override the default invalidation timeout (ms) */
+  timeoutMs?: number
+}
+
+export interface InvalidateFastTokenResult {
+  ok: boolean
+  /** Short reason code for diagnostics (e.g., 'no-token', 'timeout') */
+  reason?: string
+}
+
+/**
+ * Attach a one-shot patch to xmpp.js's FAST module so the next auth
+ * exchange carries `invalidate='true'` on its `<fast/>` element.
+ *
+ * Wrapping the `authenticate` callback (rather than replacing `fast.auth`)
+ * keeps our change limited to the element mutation and leaves the rest
+ * of the xmpp.js FAST flow intact.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function patchFastForInvalidation(fastModule: any): void {
+  const originalAuth = fastModule.auth.bind(fastModule)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fastModule.auth = async (args: any) => {
+    const origAuthenticate = args.authenticate
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    args.authenticate = async (innerArgs: any) => {
+      if (Array.isArray(innerArgs?.streamFeatures)) {
+        for (const el of innerArgs.streamFeatures) {
+          if (el?.name === 'fast' && el?.attrs?.xmlns === 'urn:xmpp:fast:0') {
+            el.attrs.invalidate = 'true'
+          }
+        }
+      }
+      return origAuthenticate(innerArgs)
+    }
+    return originalAuth(args)
+  }
+}
+
+/**
+ * Open a short-lived SASL2 session to invalidate a stored FAST token on
+ * the server. Best-effort: returns a structured result rather than
+ * throwing, so the caller can proceed with logout regardless.
+ *
+ * The client-side storage entry is NOT deleted here — that remains the
+ * caller's responsibility, so this function can be re-tried safely.
+ */
+export async function invalidateFastTokenOnServer(
+  options: InvalidateFastTokenOptions
+): Promise<InvalidateFastTokenResult> {
+  const { jid, server, timeoutMs = FAST_TOKEN_INVALIDATION_TIMEOUT_MS } = options
+
+  const bareJid = getBareJid(jid)
+  const token: FastToken | null = fetchFastToken(bareJid)
+  if (!token) {
+    return { ok: false, reason: 'no-token' }
+  }
+
+  const domain = getDomain(jid)
+  const username = getLocalPart(jid)
+  if (!domain || !username) {
+    return { ok: false, reason: 'invalid-jid' }
+  }
+
+  const wsUrl = server.startsWith('ws') ? server : `wss://${server}/ws`
+
+  return new Promise<InvalidateFastTokenResult>((resolve) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let xmppClient: any = null
+    let settled = false
+    const settle = (result: InvalidateFastTokenResult) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (xmppClient) {
+        try {
+          void xmppClient.stop()
+        } catch {
+          /* ignore */
+        }
+      }
+      resolve(result)
+    }
+
+    const timer = setTimeout(() => {
+      logWarn(`FAST invalidation: timed out after ${timeoutMs}ms`)
+      settle({ ok: false, reason: 'timeout' })
+    }, timeoutMs)
+
+    try {
+      xmppClient = client({
+        service: wsUrl,
+        domain,
+        username,
+        credentials: async (
+          authenticate: (creds: Record<string, unknown>, mechanism: string) => Promise<void>,
+          mechanisms: string[],
+          fast: unknown | null
+        ) => {
+          if (!fast) {
+            throw new Error('FAST not advertised by server')
+          }
+          // We use the token path only; the fallback mechanism name just
+          // needs to parse — it won't actually be used because fast.auth
+          // will succeed (or fail and surface as an error).
+          const mechanism = mechanisms[0] ?? token.mechanism
+          await authenticate({ username, token }, mechanism)
+        },
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fastModule = (xmppClient as any).fast
+      if (!fastModule) {
+        settle({ ok: false, reason: 'no-fast-module' })
+        return
+      }
+
+      // Override token accessors so xmpp.js uses the token we have, and
+      // does not touch localStorage for this transient session.
+      fastModule.fetchToken = async () => token
+      fastModule.saveToken = () => {
+        /* server MUST NOT issue a new token on invalidation (XEP-0484 §6) */
+      }
+      fastModule.deleteToken = () => {
+        /* storage cleanup is handled by the caller */
+      }
+
+      patchFastForInvalidation(fastModule)
+
+      xmppClient.on('online', () => {
+        logInfo('FAST invalidation: SASL2 success — server dropped the token')
+        settle({ ok: true })
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      xmppClient.on('error', (err: any) => {
+        const msg = err?.message ?? String(err)
+        // A not-authorized / credentials-expired here means the server
+        // already considered the token invalid. Functionally the same
+        // outcome as a successful invalidation.
+        if (
+          err?.condition === 'not-authorized' ||
+          err?.condition === 'credentials-expired' ||
+          msg.includes('not-authorized') ||
+          msg.includes('credentials-expired')
+        ) {
+          logInfo(`FAST invalidation: token already invalid on server (${msg})`)
+          settle({ ok: true, reason: 'already-invalid' })
+          return
+        }
+        logWarn(`FAST invalidation: failed (${msg})`)
+        settle({ ok: false, reason: msg })
+      })
+
+      xmppClient.start().catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        logWarn(`FAST invalidation: start() rejected (${msg})`)
+        settle({ ok: false, reason: msg })
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      logWarn(`FAST invalidation: setup failed (${msg})`)
+      settle({ ok: false, reason: msg })
+    }
+  })
+}

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -74,6 +74,16 @@ vi.mock('../fastTokenStorage', () => ({
   hasFastToken: vi.fn(),
 }))
 
+// Mock the short-lived invalidation helper so we can assert it is (or isn't)
+// invoked without spinning up a real xmpp.js client.
+const { mockInvalidateFastTokenOnServer } = vi.hoisted(() => ({
+  mockInvalidateFastTokenOnServer: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('../fastTokenInvalidation', () => ({
+  invalidateFastTokenOnServer: mockInvalidateFastTokenOnServer,
+}))
+
 describe('XMPPClient Connection', () => {
   let xmppClient: XMPPClient
   let mockStores: MockStoreBindings
@@ -417,6 +427,67 @@ describe('XMPPClient Connection', () => {
       expect(mockXmppClientInstance.stop).toHaveBeenCalled()
       expect(mockStores.connection.setStatus).toHaveBeenCalledWith('disconnected')
       expect(mockStores.connection.setJid).toHaveBeenCalledWith(null)
+    })
+
+    it('does not request FAST token invalidation by default (XEP-0484)', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      mockInvalidateFastTokenOnServer.mockClear()
+      await xmppClient.disconnect()
+
+      expect(mockInvalidateFastTokenOnServer).not.toHaveBeenCalled()
+    })
+
+    it('requests server-side FAST token invalidation when invalidateFastToken:true', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      mockInvalidateFastTokenOnServer.mockClear()
+      mockInvalidateFastTokenOnServer.mockResolvedValue({ ok: true })
+
+      await xmppClient.disconnect({ invalidateFastToken: true })
+
+      expect(mockInvalidateFastTokenOnServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jid: 'user@example.com',
+          server: expect.stringContaining('example.com'),
+        })
+      )
+      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('disconnected')
+    })
+
+    it('continues disconnect cleanup when FAST token invalidation fails', async () => {
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      mockInvalidateFastTokenOnServer.mockClear()
+      mockInvalidateFastTokenOnServer.mockRejectedValueOnce(new Error('network down'))
+
+      await expect(
+        xmppClient.disconnect({ invalidateFastToken: true })
+      ).resolves.not.toThrow()
+
+      expect(mockXmppClientInstance.stop).toHaveBeenCalled()
+      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('disconnected')
     })
 
     it('should resolve disconnect even when client.stop never settles', async () => {
@@ -3469,7 +3540,8 @@ describe('XMPPClient Connection', () => {
       // Should authenticate with password, no token
       expect(mockAuthenticate).toHaveBeenCalledWith(
         expect.objectContaining({ username: 'user', password: 'secret' }),
-        expect.any(String)
+        expect.any(String),
+        expect.objectContaining({ name: 'user-agent', attrs: expect.objectContaining({ id: expect.any(String) }) })
       )
       // Auth method should be 'password'
       expect(mockStores.connection.setAuthMethod).toHaveBeenCalledWith('password')
@@ -3500,7 +3572,8 @@ describe('XMPPClient Connection', () => {
       // Should have token in credentials
       expect(mockAuthenticate).toHaveBeenCalledWith(
         expect.objectContaining({ token: mockToken }),
-        expect.any(String)
+        expect.any(String),
+        expect.objectContaining({ name: 'user-agent', attrs: expect.objectContaining({ id: expect.any(String) }) })
       )
       // Auth method should be 'fast-token'
       expect(mockStores.connection.setAuthMethod).toHaveBeenCalledWith('fast-token')
@@ -3557,7 +3630,8 @@ describe('XMPPClient Connection', () => {
       // Should succeed with token, no password
       expect(mockAuthenticate).toHaveBeenCalledWith(
         expect.objectContaining({ token: mockToken }),
-        expect.any(String)
+        expect.any(String),
+        expect.objectContaining({ name: 'user-agent', attrs: expect.objectContaining({ id: expect.any(String) }) })
       )
       expect(mockStores.connection.setAuthMethod).toHaveBeenCalledWith('fast-token')
     })

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -50,6 +50,8 @@ import {
 } from './serverResolution'
 import { SmPersistence } from './smPersistence'
 import { fetchFastToken, saveFastToken, deleteFastToken } from '../fastTokenStorage'
+import { invalidateFastTokenOnServer } from '../fastTokenInvalidation'
+import { buildUserAgentElement } from '../userAgent'
 import { ProxyManager } from './proxyManager'
 import { isConnectionTraceEnabled } from './connectionDiagnostics'
 
@@ -678,8 +680,13 @@ export class Connection extends BaseModule {
 
   /**
    * Disconnect from XMPP server.
+   *
+   * @param options.invalidateFastToken - When true and a FAST token
+   *   (XEP-0484) is stored for this account, open a short-lived SASL2
+   *   session to invalidate the token on the server before teardown.
+   *   Best-effort: failures do not block the rest of the disconnect.
    */
-  async disconnect(): Promise<void> {
+  async disconnect(options: { invalidateFastToken?: boolean } = {}): Promise<void> {
     const disconnectOp = ++this.disconnectOperationSeq
     const disconnectStart = Date.now()
     const logDisconnect = (message: string) => {
@@ -688,7 +695,7 @@ export class Connection extends BaseModule {
       this.logTrace(line)
     }
 
-    logDisconnect(`begin (state=${JSON.stringify(this.getMachineState())}, hasClient=${!!this.xmpp}, hasCredentials=${!!this.credentials})`)
+    logDisconnect(`begin (state=${JSON.stringify(this.getMachineState())}, hasClient=${!!this.xmpp}, hasCredentials=${!!this.credentials}, invalidateFastToken=${!!options.invalidateFastToken})`)
 
     // Signal machine: user-initiated disconnect
     this.sendMachineEvent({ type: 'DISCONNECT' }, 'disconnect:user')
@@ -701,6 +708,8 @@ export class Connection extends BaseModule {
     // Capture references needed for async cleanup before nulling them
     const clientToStop = this.xmpp
     const jidForSmCleanup = this.credentials?.jid
+    const serverForInvalidation = this.credentials?.server
+    const shouldInvalidateFastToken = !!options.invalidateFastToken
 
     if (clientToStop) {
       this.xmpp = null
@@ -722,6 +731,29 @@ export class Connection extends BaseModule {
     // ── Async cleanup phase ──
     // SM persistence, room message flush, and XMPP stream close.
     // Safe to run after UI has transitioned.
+
+    // Best-effort FAST token invalidation (XEP-0484 §6). Runs before the
+    // transport is torn down so the short-lived invalidation session can
+    // reach the server while we still have network path established.
+    if (shouldInvalidateFastToken && jidForSmCleanup && serverForInvalidation) {
+      const bareJid = getBareJid(jidForSmCleanup)
+      logDisconnect(`attempting FAST token invalidation for ${bareJid}`)
+      try {
+        const result = await invalidateFastTokenOnServer({
+          jid: bareJid,
+          server: serverForInvalidation,
+        })
+        if (result.ok) {
+          logDisconnect(`FAST token invalidated on server${result.reason ? ` (${result.reason})` : ''}`)
+          this.stores.console.addEvent('FAST token invalidated on server', 'connection')
+        } else {
+          logDisconnect(`FAST token invalidation skipped or failed (${result.reason ?? 'unknown'})`)
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logDisconnect(`FAST token invalidation threw (${message})`)
+      }
+    }
 
     this.smPersistence.clearCache()
     logDisconnect('SM in-memory cache cleared')
@@ -1405,10 +1437,13 @@ export class Connection extends BaseModule {
           'connection'
         )
         logInfo(`Auth: ${authMethod} (SASL: ${mechanism}, offered: ${mechanisms.join(', ')})`)
+        // XEP-0388 §2.2 / XEP-0484: FAST binds issued tokens to the user-agent
+        // id, so we MUST include <user-agent/> for the server to issue tokens.
+        const userAgent = buildUserAgentElement()
         const saslStart = Date.now()
         let saslTimeoutId: ReturnType<typeof setTimeout> | undefined
         await Promise.race([
-          Promise.resolve(authenticate(creds, mechanism)).then(() => {
+          Promise.resolve(authenticate(creds, mechanism, userAgent)).then(() => {
             clearTimeout(saslTimeoutId)
             logInfo(`SASL complete (${Date.now() - saslStart}ms)`)
           }),

--- a/packages/fluux-sdk/src/core/modules/connectionTimeouts.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionTimeouts.ts
@@ -101,3 +101,11 @@ export const SASL_AUTH_TIMEOUT_MS = 15_000
  * half-ready path, burning through backoff attempts with 15s timeouts each.
  */
 export const NETWORK_SETTLE_DELAY_MS = 2_000
+
+/**
+ * Budget for the best-effort FAST token invalidation roundtrip on logout
+ * (XEP-0484 §6). A short-lived SASL2 session is opened with `invalidate='true'`
+ * so the server drops the stored token; if the network is slow we give up
+ * and let client-side storage cleanup proceed.
+ */
+export const FAST_TOKEN_INVALIDATION_TIMEOUT_MS = 5_000

--- a/packages/fluux-sdk/src/core/userAgent.test.ts
+++ b/packages/fluux-sdk/src/core/userAgent.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  getOrCreateUserAgentId,
+  getUserAgentId,
+  clearUserAgentIdentity,
+  getUserAgentDeviceName,
+  setUserAgentDeviceName,
+  getEffectiveDeviceName,
+  buildUserAgentElement,
+} from './userAgent'
+
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const STORAGE_KEY_ID = 'fluux:user-agent-id'
+const STORAGE_KEY_DEVICE = 'fluux:user-agent-device'
+
+function installLocalStorageMock(): Record<string, string> {
+  const store: Record<string, string> = {}
+  const mock = {
+    getItem: vi.fn((k: string) => store[k] ?? null),
+    setItem: vi.fn((k: string, v: string) => { store[k] = v }),
+    removeItem: vi.fn((k: string) => { delete store[k] }),
+    clear: vi.fn(() => { for (const k of Object.keys(store)) delete store[k] }),
+    get length() { return Object.keys(store).length },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: mock,
+    writable: true,
+    configurable: true,
+  })
+  return store
+}
+
+function installThrowingLocalStorage(): void {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: () => { throw new Error('denied') },
+      setItem: () => { throw new Error('denied') },
+      removeItem: () => { throw new Error('denied') },
+      clear: () => {},
+      length: 0,
+      key: () => null,
+    },
+    writable: true,
+    configurable: true,
+  })
+}
+
+describe('userAgent', () => {
+  let store: Record<string, string>
+
+  beforeEach(() => {
+    store = installLocalStorageMock()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ----------------------------------------------------------------------
+  // getOrCreateUserAgentId
+  // ----------------------------------------------------------------------
+  describe('getOrCreateUserAgentId', () => {
+    it('creates a new UUIDv4 when none is stored', () => {
+      const id = getOrCreateUserAgentId()
+      expect(id).toMatch(UUID_V4_RE)
+      expect(store[STORAGE_KEY_ID]).toBe(id)
+    })
+
+    it('returns the same id across repeated calls (stable across sessions)', () => {
+      const id1 = getOrCreateUserAgentId()
+      const id2 = getOrCreateUserAgentId()
+      expect(id2).toBe(id1)
+    })
+
+    it('reuses a pre-existing id from localStorage', () => {
+      const existing = '11111111-2222-4333-8444-555555555555'
+      store[STORAGE_KEY_ID] = existing
+      expect(getOrCreateUserAgentId()).toBe(existing)
+    })
+
+    it('returns a valid UUID without throwing when localStorage throws', () => {
+      installThrowingLocalStorage()
+      const id = getOrCreateUserAgentId()
+      expect(id).toMatch(UUID_V4_RE)
+    })
+
+    it('returns different ids on each call when localStorage throws (not persisted)', () => {
+      installThrowingLocalStorage()
+      const id1 = getOrCreateUserAgentId()
+      const id2 = getOrCreateUserAgentId()
+      expect(id1).not.toBe(id2)
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // getUserAgentId (non-creating read)
+  // ----------------------------------------------------------------------
+  describe('getUserAgentId', () => {
+    it('returns null when no id is stored', () => {
+      expect(getUserAgentId()).toBeNull()
+    })
+
+    it('does NOT generate an id when none exists', () => {
+      getUserAgentId()
+      expect(store[STORAGE_KEY_ID]).toBeUndefined()
+    })
+
+    it('returns the stored id when present', () => {
+      store[STORAGE_KEY_ID] = '11111111-2222-4333-8444-555555555555'
+      expect(getUserAgentId()).toBe('11111111-2222-4333-8444-555555555555')
+    })
+
+    it('returns null when localStorage throws', () => {
+      installThrowingLocalStorage()
+      expect(getUserAgentId()).toBeNull()
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // clearUserAgentIdentity
+  // ----------------------------------------------------------------------
+  describe('clearUserAgentIdentity', () => {
+    it('removes the stored id', () => {
+      store[STORAGE_KEY_ID] = 'some-uuid'
+      clearUserAgentIdentity()
+      expect(store[STORAGE_KEY_ID]).toBeUndefined()
+    })
+
+    it('removes the stored device name', () => {
+      store[STORAGE_KEY_DEVICE] = "Mickaël's laptop"
+      clearUserAgentIdentity()
+      expect(store[STORAGE_KEY_DEVICE]).toBeUndefined()
+    })
+
+    it('is idempotent when nothing is stored', () => {
+      expect(() => clearUserAgentIdentity()).not.toThrow()
+    })
+
+    it('causes the next getOrCreateUserAgentId to produce a fresh id', () => {
+      const original = getOrCreateUserAgentId()
+      clearUserAgentIdentity()
+      const next = getOrCreateUserAgentId()
+      expect(next).toMatch(UUID_V4_RE)
+      expect(next).not.toBe(original)
+    })
+
+    it('does not throw when localStorage throws', () => {
+      installThrowingLocalStorage()
+      expect(() => clearUserAgentIdentity()).not.toThrow()
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // getUserAgentDeviceName
+  // ----------------------------------------------------------------------
+  describe('getUserAgentDeviceName', () => {
+    it('returns null when no override is set', () => {
+      expect(getUserAgentDeviceName()).toBeNull()
+    })
+
+    it('returns the stored value', () => {
+      store[STORAGE_KEY_DEVICE] = 'Work Laptop'
+      expect(getUserAgentDeviceName()).toBe('Work Laptop')
+    })
+
+    it('trims whitespace on read', () => {
+      store[STORAGE_KEY_DEVICE] = '  Work Laptop  '
+      expect(getUserAgentDeviceName()).toBe('Work Laptop')
+    })
+
+    it('returns null when the stored value is whitespace only', () => {
+      store[STORAGE_KEY_DEVICE] = '    '
+      expect(getUserAgentDeviceName()).toBeNull()
+    })
+
+    it('returns null when the stored value is an empty string', () => {
+      store[STORAGE_KEY_DEVICE] = ''
+      expect(getUserAgentDeviceName()).toBeNull()
+    })
+
+    it('returns null when localStorage throws', () => {
+      installThrowingLocalStorage()
+      expect(getUserAgentDeviceName()).toBeNull()
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // setUserAgentDeviceName
+  // ----------------------------------------------------------------------
+  describe('setUserAgentDeviceName', () => {
+    it('stores a non-empty name', () => {
+      setUserAgentDeviceName('Kitchen Tablet')
+      expect(store[STORAGE_KEY_DEVICE]).toBe('Kitchen Tablet')
+    })
+
+    it('trims whitespace before storing', () => {
+      setUserAgentDeviceName('  Kitchen Tablet  ')
+      expect(store[STORAGE_KEY_DEVICE]).toBe('Kitchen Tablet')
+    })
+
+    it('clears the override when given null', () => {
+      store[STORAGE_KEY_DEVICE] = 'Old Name'
+      setUserAgentDeviceName(null)
+      expect(store[STORAGE_KEY_DEVICE]).toBeUndefined()
+    })
+
+    it('clears the override when given an empty string', () => {
+      store[STORAGE_KEY_DEVICE] = 'Old Name'
+      setUserAgentDeviceName('')
+      expect(store[STORAGE_KEY_DEVICE]).toBeUndefined()
+    })
+
+    it('clears the override when given whitespace only', () => {
+      store[STORAGE_KEY_DEVICE] = 'Old Name'
+      setUserAgentDeviceName('   ')
+      expect(store[STORAGE_KEY_DEVICE]).toBeUndefined()
+    })
+
+    it('overwrites a previous override', () => {
+      setUserAgentDeviceName('First')
+      setUserAgentDeviceName('Second')
+      expect(store[STORAGE_KEY_DEVICE]).toBe('Second')
+    })
+
+    it('does not throw when localStorage throws', () => {
+      installThrowingLocalStorage()
+      expect(() => setUserAgentDeviceName('Anything')).not.toThrow()
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // getEffectiveDeviceName
+  // ----------------------------------------------------------------------
+  describe('getEffectiveDeviceName', () => {
+    it('returns the user override when set', () => {
+      setUserAgentDeviceName("Mickaël's MacBook")
+      expect(getEffectiveDeviceName()).toBe("Mickaël's MacBook")
+    })
+
+    it('falls back to a platform default when no override is set', () => {
+      expect(getEffectiveDeviceName()).toMatch(/^Fluux /)
+    })
+
+    it('falls back to platform default after clearing an override', () => {
+      setUserAgentDeviceName('Custom')
+      setUserAgentDeviceName(null)
+      expect(getEffectiveDeviceName()).toMatch(/^Fluux /)
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // buildUserAgentElement
+  // ----------------------------------------------------------------------
+  describe('buildUserAgentElement', () => {
+    it('has name "user-agent" with an id attribute matching UUIDv4', () => {
+      const el = buildUserAgentElement()
+      expect(el.name).toBe('user-agent')
+      expect(el.attrs.id).toMatch(UUID_V4_RE)
+    })
+
+    it('has <software>Fluux</software> and a <device> child', () => {
+      const el = buildUserAgentElement()
+      const software = el.getChild('software')
+      const device = el.getChild('device')
+      expect(software?.text()).toBe('Fluux')
+      expect(device?.text()).toBeTruthy()
+    })
+
+    it('reuses the persisted id across calls (FAST binding stability)', () => {
+      const a = buildUserAgentElement()
+      const b = buildUserAgentElement()
+      expect(b.attrs.id).toBe(a.attrs.id)
+    })
+
+    it('regenerates the id after clearUserAgentIdentity()', () => {
+      const before = buildUserAgentElement().attrs.id
+      clearUserAgentIdentity()
+      const after = buildUserAgentElement().attrs.id
+      expect(after).toMatch(UUID_V4_RE)
+      expect(after).not.toBe(before)
+    })
+
+    it('uses the user device-name override when one is set', () => {
+      setUserAgentDeviceName("Kim's Phone")
+      const el = buildUserAgentElement()
+      expect(el.getChild('device')?.text()).toBe("Kim's Phone")
+    })
+
+    it('uses the platform default when no override is set', () => {
+      const el = buildUserAgentElement()
+      expect(el.getChild('device')?.text()).toMatch(/^Fluux /)
+    })
+
+    it('serializes to XEP-0388 form', () => {
+      setUserAgentDeviceName('Work Laptop')
+      const xmlStr = buildUserAgentElement().toString()
+      expect(xmlStr).toContain('<user-agent id="')
+      expect(xmlStr).toContain('<software>Fluux</software>')
+      expect(xmlStr).toContain('<device>Work Laptop</device>')
+      expect(xmlStr).toContain('</user-agent>')
+    })
+  })
+
+  // ----------------------------------------------------------------------
+  // Interaction: setters, readers, and element-building together
+  // ----------------------------------------------------------------------
+  describe('full lifecycle', () => {
+    it('supports a set → read → clear → default cycle', () => {
+      expect(getUserAgentDeviceName()).toBeNull()
+
+      setUserAgentDeviceName('Home Desktop')
+      expect(getUserAgentDeviceName()).toBe('Home Desktop')
+      expect(getEffectiveDeviceName()).toBe('Home Desktop')
+
+      setUserAgentDeviceName(null)
+      expect(getUserAgentDeviceName()).toBeNull()
+      expect(getEffectiveDeviceName()).toMatch(/^Fluux /)
+    })
+
+    it('clearing identity also clears the device override', () => {
+      setUserAgentDeviceName('Custom')
+      getOrCreateUserAgentId()
+      clearUserAgentIdentity()
+      expect(getUserAgentId()).toBeNull()
+      expect(getUserAgentDeviceName()).toBeNull()
+    })
+
+    it('user-agent element reflects post-clear state', () => {
+      setUserAgentDeviceName('Old Device')
+      const idBefore = buildUserAgentElement().attrs.id
+      clearUserAgentIdentity()
+      const el = buildUserAgentElement()
+      expect(el.attrs.id).not.toBe(idBefore)
+      expect(el.getChild('device')?.text()).toMatch(/^Fluux /)
+    })
+  })
+})

--- a/packages/fluux-sdk/src/core/userAgent.ts
+++ b/packages/fluux-sdk/src/core/userAgent.ts
@@ -1,0 +1,136 @@
+/**
+ * SASL2 User Agent (XEP-0388 §2.2)
+ *
+ * Builds the `<user-agent/>` element included in `<authenticate/>`.
+ * The `id` attribute is a stable per-device UUIDv4 kept in localStorage;
+ * FAST (XEP-0484) binds issued tokens to this id, so it MUST be stable
+ * across sessions for token reuse to work.
+ *
+ * The `<device/>` label is human-readable and shown in other clients'
+ * connected-devices lists. It defaults to a platform-derived name
+ * ("Fluux Desktop" / "Fluux Web" / "Fluux Mobile") but the user can
+ * override it via `setUserAgentDeviceName()` (typically wired to a
+ * settings field).
+ *
+ * @see https://xmpp.org/extensions/xep-0388.html#initiation
+ */
+
+import { xml, Element } from '@xmpp/client'
+import { generateUUID } from '../utils/uuid'
+import { getCachedPlatform, type Platform } from './platform'
+
+const STORAGE_KEY_ID = 'fluux:user-agent-id'
+const STORAGE_KEY_DEVICE = 'fluux:user-agent-device'
+
+/**
+ * Get the persistent user-agent id for this installation,
+ * generating one on first use.
+ */
+export function getOrCreateUserAgentId(): string {
+  try {
+    const existing = localStorage.getItem(STORAGE_KEY_ID)
+    if (existing) return existing
+    const id = generateUUID()
+    localStorage.setItem(STORAGE_KEY_ID, id)
+    return id
+  } catch {
+    // localStorage unavailable (SSR, private mode with quota=0, etc.)
+    // Return a fresh UUID; token persistence won't work but auth will.
+    return generateUUID()
+  }
+}
+
+/**
+ * Read the current user-agent id without creating one.
+ * Returns null if no id has been generated yet.
+ */
+export function getUserAgentId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY_ID)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Clear the persisted user-agent id and device-name override.
+ *
+ * The next call to `buildUserAgentElement()` will generate a fresh id,
+ * which invalidates any FAST tokens the server has issued against the
+ * previous id. Use for "sign out of all devices" / full local-data wipes;
+ * do NOT call on a per-account logout where the user stays on the same
+ * browser and may reconnect.
+ */
+export function clearUserAgentIdentity(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY_ID)
+    localStorage.removeItem(STORAGE_KEY_DEVICE)
+  } catch {
+    // localStorage unavailable — nothing to clear.
+  }
+}
+
+function defaultDeviceName(platform: Platform | null): string {
+  switch (platform) {
+    case 'mobile':
+      return 'Fluux Mobile'
+    case 'desktop':
+      return 'Fluux Desktop'
+    case 'web':
+    default:
+      return 'Fluux Web'
+  }
+}
+
+/**
+ * Read a user-supplied device name override, or null if none is set.
+ * Callers should prefer `getEffectiveDeviceName()` unless they need to
+ * distinguish "user override" from "platform default".
+ */
+export function getUserAgentDeviceName(): string | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_DEVICE)
+    if (!raw) return null
+    const trimmed = raw.trim()
+    return trimmed.length > 0 ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Set or clear the user-supplied device name. Pass null/empty to
+ * revert to the platform default.
+ */
+export function setUserAgentDeviceName(name: string | null): void {
+  try {
+    if (name && name.trim().length > 0) {
+      localStorage.setItem(STORAGE_KEY_DEVICE, name.trim())
+    } else {
+      localStorage.removeItem(STORAGE_KEY_DEVICE)
+    }
+  } catch {
+    // localStorage unavailable — silently ignore; auth still works with default.
+  }
+}
+
+/**
+ * The device name that will be sent in `<device/>`: user override if set,
+ * otherwise the platform-derived default ("Fluux Desktop" / "Fluux Web" /
+ * "Fluux Mobile").
+ */
+export function getEffectiveDeviceName(): string {
+  return getUserAgentDeviceName() ?? defaultDeviceName(getCachedPlatform())
+}
+
+/**
+ * Build the SASL2 `<user-agent/>` element.
+ * Pass the returned element as the third argument of xmpp.js's
+ * `authenticate(credentials, mechanism, userAgent)` callback.
+ */
+export function buildUserAgentElement(): Element {
+  return xml('user-agent', { id: getOrCreateUserAgentId() }, [
+    xml('software', {}, 'Fluux'),
+    xml('device', {}, getEffectiveDeviceName()),
+  ])
+}

--- a/packages/fluux-sdk/src/hooks/useConnection.ts
+++ b/packages/fluux-sdk/src/hooks/useConnection.ts
@@ -141,9 +141,12 @@ export function useConnection() {
     return client.getStreamManagementState()
   }, [client])
 
-  const disconnect = useCallback(async () => {
-    await client.disconnect()
-  }, [client])
+  const disconnect = useCallback(
+    async (options: { invalidateFastToken?: boolean } = {}) => {
+      await client.disconnect(options)
+    },
+    [client]
+  )
 
   const cancelReconnect = useCallback(() => {
     client.cancelReconnect()

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -559,6 +559,17 @@ export type { DiscoveryResult } from './utils/websocketDiscovery'
 // FAST token utilities (XEP-0484)
 export { hasFastToken, deleteFastToken } from './core/fastTokenStorage'
 
+// SASL2 user-agent identity (XEP-0388 §2.2)
+// - id: stable per-device UUID, bound to by FAST tokens
+// - device name: user-visible label in other clients' session lists
+export {
+  getUserAgentId,
+  clearUserAgentIdentity,
+  getUserAgentDeviceName,
+  setUserAgentDeviceName,
+  getEffectiveDeviceName,
+} from './core/userAgent'
+
 // Storage adapters for session persistence
 export { sessionStorageAdapter } from './utils/sessionStorageAdapter'
 export type { StorageAdapter, SessionState, StoredCredentials, JoinedRoomInfo } from './core/types'


### PR DESCRIPTION
## Summary

Completes Fluux's SASL2 FAST (XEP-0484) lifecycle on both ends: token acquisition and server-side invalidation.

### Token acquisition (new)

Sends `<user-agent id="UUID"/>` in the SASL2 `<authenticate/>` stanza ([XEP-0388 §2.2](https://xmpp.org/extensions/xep-0388.html#initiation)). Without it, ejabberd advertises FAST but never returns a `<token/>` in `<success/>`, so token reuse never activates.

- New `core/userAgent.ts` with:
  - Stable per-device UUIDv4 in localStorage (bound to by FAST tokens)
  - User-settable `<device>` label (e.g., "Mickaël's MacBook") with platform-default fallback ("Fluux Desktop" / "Web" / "Mobile")
- `Connection.ts` passes the built element as the third argument of xmpp.js's `authenticate()`.
- Public exports — for settings UIs and logout flows: `getUserAgentId`, `setUserAgentDeviceName`, `getUserAgentDeviceName`, `getEffectiveDeviceName`, `clearUserAgentIdentity`.
- Full-wipe logout resets the identity; per-account logout preserves it (same device, tokens already scoped by JID).

### Server-side invalidation

On explicit user logout, opens a short-lived SASL2 session with the stored token and `invalidate='true'` on `<fast/>` ([XEP-0484 §6](https://xmpp.org/extensions/xep-0484.html#invalidation)). The server drops the token so it cannot be replayed until the 14-day expiry.

- New `{ invalidateFastToken?: boolean }` option on `client.disconnect()` / `useConnection().disconnect()`. Default `false` — backwards-compatible with programmatic disconnects (tab takeover, Tauri close) that preserve the token for auto-reconnect.
- Sidebar "Log out" handler passes `{ invalidateFastToken: true }`.
- Best-effort: runs with a 5s timeout before transport teardown; failures are logged but do not block disconnect.