### PR TITLE
fix(sdk): suppress spurious FAST token deletion log on first login

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -1472,7 +1472,12 @@ export class Connection extends BaseModule {
           }
         : () => { /* rememberSession disabled — do not persist FAST token */ }
       fastModule.deleteToken = () => {
-        logInfo('FAST token invalidated/deleted')
+        // xmpp.js calls deleteToken() whenever it takes the "invalid token" path,
+        // including when no token existed (isTokenValid(undefined) === false).
+        // Only log when a token was actually present to avoid spurious noise on first login.
+        if (fetchFastToken(bareJid) !== null) {
+          logInfo('FAST token invalidated/deleted')
+        }
         deleteFastToken(bareJid)
       }
     }


### PR DESCRIPTION
## Summary

- xmpp.js's `fast.auth()` routes to `onInvalidToken()` whenever `isTokenValid()` returns false — including when no token ever existed. That path always calls `deleteToken()`, so our hook was logging `FAST token invalidated/deleted` on every fresh login even though nothing was deleted.
- Gate the log on actual token presence in localStorage. The `deleteFastToken` call stays unconditional since `localStorage.removeItem` is idempotent.
- Surfaced by a mobile first-login log where the sequence `FAST token not available, falling back to password` → `FAST token invalidated/deleted` → `FAST token saved` appeared despite no prior token existing.