### PR TITLE
Wake and reconnect resilience: stale timer, DarkWake, reload cooldown, settle scaling

### DIFF
--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "fluux"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "block2",
  "ctor 0.8.0",

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -667,10 +667,46 @@ mod macos {
     use objc2_foundation::{
         NSNotification, NSNotificationCenter, NSNotificationName, NSProcessInfo, NSString,
     };
+    use serde::Serialize;
     use std::ptr::NonNull;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use tauri::WebviewWindow;
+
+    // CoreGraphics FFI: detects whether the main display is actually awake.
+    //
+    // macOS wakes the system periodically for background tasks (DarkWake /
+    // PowerNap — e.g. Mail fetch, Time Machine) without turning the display
+    // on. From the app's point of view these look identical to a real wake:
+    // `NSWorkspaceDidWakeNotification` fires, timers resume, the network
+    // briefly comes up. Without a way to distinguish the two, the client
+    // performs a full reconnect + MAM catch-up + webview reload dozens of
+    // times per night, burning battery and churning state that no one sees.
+    //
+    // `CGDisplayIsAsleep(CGMainDisplayID())` returns non-zero during dark
+    // wake and zero during user-driven wake. We pipe this into the wake
+    // event payload so the webview can skip handling when no user is
+    // present to benefit from the work.
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGMainDisplayID() -> u32;
+        fn CGDisplayIsAsleep(display: u32) -> i32;
+    }
+
+    fn is_display_active() -> bool {
+        // SAFETY: CGMainDisplayID / CGDisplayIsAsleep are pure Core Graphics
+        // queries with no preconditions; safe to call from any thread.
+        unsafe {
+            let display = CGMainDisplayID();
+            CGDisplayIsAsleep(display) == 0
+        }
+    }
+
+    #[derive(Serialize, Clone)]
+    struct WakeEventPayload {
+        #[serde(rename = "displayActive")]
+        display_active: bool,
+    }
 
     // Store the window reference for the observer callback
     static WINDOW: std::sync::OnceLock<Arc<Mutex<Option<WebviewWindow>>>> =
@@ -802,9 +838,19 @@ mod macos {
                         .unwrap_or(0);
                     PENDING_WAKE_TIME.store(now, Ordering::SeqCst);
 
+                    // Probe the display state before emitting so the webview
+                    // can distinguish DarkWake/PowerNap (display asleep, no
+                    // user present) from a user-driven wake. The probe runs
+                    // on the notification-center dispatch thread; it's a
+                    // read-only CG call and doesn't block.
+                    let display_active = is_display_active();
+
                     // Also emit immediately - if app is in foreground, JS will handle it
                     // and the pending wake will be cleared when activation fires
-                    let _ = wake_handle.emit("system-did-wake", ());
+                    let _ = wake_handle.emit(
+                        "system-did-wake",
+                        WakeEventPayload { display_active },
+                    );
                 }),
             );
         }

--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -97,6 +97,11 @@ import {
   shouldHandleDisplayWake,
   shouldReloadWebviewOnWake,
   shouldReloadOnVisibilityWake,
+  readReloadMarker,
+  writeReloadMarker,
+  clearReloadMarker,
+  isWithinReloadCooldown,
+  RELOAD_MARKER_STORAGE_KEY,
 } from './usePlatformState'
 
 describe('usePlatformState', () => {
@@ -358,6 +363,92 @@ describe('usePlatformState', () => {
       expect(shouldHandleProxyClosedStatus('reconnecting')).toBe(false)
       expect(shouldHandleProxyClosedStatus('disconnected')).toBe(false)
       expect(shouldHandleProxyClosedStatus('error')).toBe(false)
+    })
+  })
+
+  describe('post-reload cooldown', () => {
+    beforeEach(() => {
+      localStorage.removeItem(RELOAD_MARKER_STORAGE_KEY)
+    })
+
+    describe('readReloadMarker / writeReloadMarker / clearReloadMarker', () => {
+      it('returns 0 when no marker has been written', () => {
+        expect(readReloadMarker()).toBe(0)
+      })
+
+      it('round-trips a written timestamp', () => {
+        writeReloadMarker(1_700_000_000_000)
+        expect(readReloadMarker()).toBe(1_700_000_000_000)
+      })
+
+      it('returns 0 when the stored value is not a finite number', () => {
+        localStorage.setItem(RELOAD_MARKER_STORAGE_KEY, 'garbage')
+        expect(readReloadMarker()).toBe(0)
+      })
+
+      it('clearReloadMarker removes the stored value', () => {
+        writeReloadMarker(1_700_000_000_000)
+        clearReloadMarker()
+        expect(readReloadMarker()).toBe(0)
+      })
+    })
+
+    describe('isWithinReloadCooldown', () => {
+      const COOLDOWN = 60_000
+
+      it('returns false when no marker has been set', () => {
+        expect(isWithinReloadCooldown(0, 1_000_000, COOLDOWN)).toBe(false)
+      })
+
+      it('returns true for a marker set moments ago', () => {
+        expect(isWithinReloadCooldown(1_000_000, 1_000_050, COOLDOWN)).toBe(true)
+      })
+
+      it('returns true for a marker near but within the cooldown boundary', () => {
+        expect(isWithinReloadCooldown(1_000_000, 1_059_999, COOLDOWN)).toBe(true)
+      })
+
+      it('returns false once the cooldown has elapsed', () => {
+        expect(isWithinReloadCooldown(1_000_000, 1_060_000, COOLDOWN)).toBe(false)
+        expect(isWithinReloadCooldown(1_000_000, 2_000_000, COOLDOWN)).toBe(false)
+      })
+
+      it('returns false when the clock has moved backward since the marker was set', () => {
+        // NTP adjustment edge case — don't gate on a negative elapsed window.
+        expect(isWithinReloadCooldown(1_000_000, 999_000, COOLDOWN)).toBe(false)
+      })
+    })
+
+    it('suppresses window-focus wakes while within the post-reload cooldown', async () => {
+      // Simulate the state the new React instance sees right after
+      // window.location.reload() was called by a previous instance:
+      // a recent marker in localStorage. The window-focus handler is a
+      // clean test vehicle because it calls shouldHandleWake with no
+      // time-gap guard in front of it, so we can observe the cooldown
+      // decision directly.
+      writeReloadMarker(Date.now() - 1_000)
+      mockConnectionStatus.current = 'reconnecting'
+      renderHook(() => usePlatformState())
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'))
+        await Promise.resolve()
+      })
+
+      expect(mockClientNotifySystemState).not.toHaveBeenCalledWith('visible')
+    })
+
+    it('handles wake signals normally once the cooldown has elapsed', async () => {
+      writeReloadMarker(Date.now() - 120_000) // 2 min ago, well past the 60s cooldown
+      mockConnectionStatus.current = 'reconnecting'
+      renderHook(() => usePlatformState())
+
+      await act(async () => {
+        window.dispatchEvent(new Event('focus'))
+        await Promise.resolve()
+      })
+
+      expect(mockClientNotifySystemState).toHaveBeenCalledWith('visible')
     })
   })
 

--- a/apps/fluux/src/hooks/usePlatformState.test.tsx
+++ b/apps/fluux/src/hooks/usePlatformState.test.tsx
@@ -94,6 +94,7 @@ vi.mock('@fluux/sdk', () => ({
 import {
   usePlatformState,
   shouldHandleProxyClosedStatus,
+  shouldHandleDisplayWake,
   shouldReloadWebviewOnWake,
   shouldReloadOnVisibilityWake,
 } from './usePlatformState'
@@ -357,6 +358,24 @@ describe('usePlatformState', () => {
       expect(shouldHandleProxyClosedStatus('reconnecting')).toBe(false)
       expect(shouldHandleProxyClosedStatus('disconnected')).toBe(false)
       expect(shouldHandleProxyClosedStatus('error')).toBe(false)
+    })
+  })
+
+  describe('shouldHandleDisplayWake', () => {
+    it('returns true when no payload is attached (Linux/Windows or older build)', () => {
+      expect(shouldHandleDisplayWake(undefined)).toBe(true)
+    })
+
+    it('returns true when the display is active on macOS (user-driven wake)', () => {
+      expect(shouldHandleDisplayWake({ displayActive: true })).toBe(true)
+    })
+
+    it('returns false when the display is asleep on macOS (DarkWake / PowerNap)', () => {
+      expect(shouldHandleDisplayWake({ displayActive: false })).toBe(false)
+    })
+
+    it('returns true when displayActive is missing but payload exists (fail-open)', () => {
+      expect(shouldHandleDisplayWake({})).toBe(true)
     })
   })
 

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -45,6 +45,35 @@ export function shouldHandleProxyClosedStatus(status: string): boolean {
 }
 
 /**
+ * Payload for macOS `system-did-wake`. On other platforms the event carries
+ * no payload; the field will be undefined and the wake is always handled.
+ */
+export interface SystemWakePayload {
+  /** False on macOS DarkWake/PowerNap (display off); true or undefined otherwise. */
+  displayActive?: boolean
+}
+
+/**
+ * Decide whether to act on a wake event or drop it as a DarkWake.
+ *
+ * macOS wakes the system periodically so background daemons (Mail, iCloud,
+ * Time Machine) can sync — the display stays off and the user isn't
+ * present. The Rust side probes `CGDisplayIsAsleep` and sets
+ * `displayActive=false` on those. We want to let the existing SM session
+ * ride through instead of triggering a full reconnect + MAM catch-up
+ * + webview reload that no one will see.
+ *
+ * When the payload is missing the field entirely (Linux/Windows, or an
+ * older build) we default to handling the wake — losing a real wake is
+ * much worse than doing unnecessary work on a dark one.
+ */
+export function shouldHandleDisplayWake(payload: SystemWakePayload | undefined): boolean {
+  if (!payload) return true
+  if (payload.displayActive === false) return false
+  return true
+}
+
+/**
  * Decide whether a wake from sleep should reload the Tauri webview.
  *
  * Background: after a confirmed sleep/wake cycle the WRY/WKWebView on
@@ -337,8 +366,17 @@ export function usePlatformState() {
 
     void import('@tauri-apps/api/event').then(({ listen }) => {
       // Immediate wake notification
-      void listen('system-did-wake', () => {
+      void listen<SystemWakePayload | undefined>('system-did-wake', (event) => {
         if (cancelled) return
+        // DarkWake filter: when macOS wakes for background sync and the
+        // display is still asleep, there's no user to receive the work.
+        // Skip *before* the debounce so that if a real wake arrives
+        // moments later, it still gets processed.
+        if (!shouldHandleDisplayWake(event.payload)) {
+          console.log('[PlatformState] Ignoring system-did-wake (display asleep / DarkWake)')
+          logEvent('Ignored wake (display asleep / DarkWake)')
+          return
+        }
         if (!shouldHandleWake('system-did-wake')) return
         const sleepDuration = sleepStartRef.current ? Date.now() - sleepStartRef.current : undefined
         sleepStartRef.current = null

--- a/apps/fluux/src/hooks/usePlatformState.ts
+++ b/apps/fluux/src/hooks/usePlatformState.ts
@@ -36,6 +36,74 @@ const MIN_HIDDEN_TIME_MS = SLEEP_THRESHOLD_MS
 /** Debounce window to prevent duplicate wake handling (ms). */
 const WAKE_DEBOUNCE_MS = 2000
 
+/** How long after a wake-triggered reload we treat additional wake
+ * signals as redundant (ms).
+ *
+ * When a wake is big enough to require `window.location.reload()`, the
+ * fresh webview takes real time to boot — 5-50s observed, dominated by
+ * network re-establishment after sleep. During that window the OS
+ * replays queued wake signals to the new React instance (the heartbeat
+ * tick re-detects the same sleep gap, `system-did-wake` fires once the
+ * JS engine resumes listening, visibility changes as the window is
+ * reparented). Each of those signals would otherwise be treated as a
+ * fresh wake and kick another reconnect or reload cycle.
+ *
+ * 60s covers the slowest reloads we've observed without being long
+ * enough to swallow a genuinely new wake after the system briefly
+ * slept again. */
+const POST_RELOAD_COOLDOWN_MS = 60_000
+
+/** localStorage key for the timestamp we last initiated
+ * window.location.reload() from a wake handler. Read by the post-reload
+ * instance on mount to recognize it was spawned by a wake the previous
+ * instance already handled. */
+export const RELOAD_MARKER_STORAGE_KEY = 'fluux.platformState.reloadInitiatedAt'
+
+export function readReloadMarker(): number {
+  try {
+    if (typeof localStorage === 'undefined') return 0
+    const raw = localStorage.getItem(RELOAD_MARKER_STORAGE_KEY)
+    const parsed = raw ? Number(raw) : 0
+    return Number.isFinite(parsed) ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+export function writeReloadMarker(ts: number): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(RELOAD_MARKER_STORAGE_KEY, String(ts))
+  } catch {
+    // Persistence is best-effort; if it fails we lose the cooldown
+    // but the in-memory debounce still catches ms-level duplicates.
+  }
+}
+
+export function clearReloadMarker(): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.removeItem(RELOAD_MARKER_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Decide whether a wake signal arrived inside the post-reload cooldown
+ * and should be treated as a redundant echo of the wake that triggered
+ * the reload.
+ */
+export function isWithinReloadCooldown(
+  markerAt: number,
+  nowMs: number,
+  cooldownMs: number
+): boolean {
+  if (markerAt <= 0) return false
+  const elapsed = nowMs - markerAt
+  return elapsed >= 0 && elapsed < cooldownMs
+}
+
 /**
  * Proxy-close events should only trigger wake/reconnect while the app was
  * previously connected. Reconnect loops already manage backoff internally.
@@ -181,11 +249,29 @@ export function usePlatformState() {
   }, [])
 
   /**
-   * Check if a wake event should be processed (debounce).
-   * Returns true and updates lastWakeTime if the event should be handled.
+   * Check if a wake event should be processed.
+   *
+   * Two gates:
+   *  1. Post-reload cooldown (localStorage-backed, survives reload).
+   *     After a wake big enough to trigger window.location.reload(),
+   *     the new instance ignores all wake signals for
+   *     POST_RELOAD_COOLDOWN_MS — they're echoes of the wake the old
+   *     instance already handled.
+   *  2. Short in-memory debounce. Collapses simultaneous signals from
+   *     independent sources (heartbeat + system-did-wake firing within
+   *     the same event loop tick).
    */
   const shouldHandleWake = useCallback((source: string): boolean => {
     const now = Date.now()
+
+    if (isWithinReloadCooldown(readReloadMarker(), now, POST_RELOAD_COOLDOWN_MS)) {
+      consoleStore.getState().addEvent(
+        `[${source}] Wake ignored: post-reload cooldown`,
+        'presence'
+      )
+      return false
+    }
+
     if (now - lastWakeTimeRef.current < WAKE_DEBOUNCE_MS) {
       return false
     }
@@ -213,6 +299,11 @@ export function usePlatformState() {
       const secs = Math.round((durationMs ?? 0) / 1000)
       console.log(`[PlatformState] Wake from sleep (${source}, ${secs}s), reloading webview to restore rendering`)
       logEvent(`Wake from sleep (${source}, ${secs}s), reloading webview`)
+      // Persist the reload time BEFORE navigating away so the instance
+      // that mounts after the reload sees it and ignores residual wake
+      // signals (queued system-did-wake, first heartbeat tick, etc.)
+      // for the duration of the cooldown window.
+      writeReloadMarker(Date.now())
       window.location.reload()
       return true
     },

--- a/packages/fluux-sdk/src/core/logger.ts
+++ b/packages/fluux-sdk/src/core/logger.ts
@@ -15,6 +15,10 @@
 
 const PREFIX = '[Fluux]'
 
+export function logDebug(message: string): void {
+  console.debug(PREFIX, message)
+}
+
 export function logInfo(message: string): void {
   console.info(PREFIX, message)
 }

--- a/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.races.test.ts
@@ -486,6 +486,50 @@ describe('Connection race conditions', () => {
   })
 
   // ─────────────────────────────────────────────────────────────────────────
+  // Race 7: Reconnect timer slept through (no wake event delivered)
+  //
+  // macOS suspends JS timers while the system sleeps. If the app is in the
+  // middle of a reconnect attempt when sleep begins, the 30s RECONNECT_ATTEMPT
+  // timer freezes. On wake, the Tauri `system-did-wake` event may be dropped
+  // (observed in prod logs) so `handleAwake` never runs — only the stale
+  // setTimeout fires, many minutes late. Without an explicit wake, the
+  // follow-up proxy fallback connects on a half-ready network and SASL
+  // times out, turning a 30s stale timer into a multi-minute outage.
+  //
+  // The fix records an implicit wake (via lastWakeTimestamp) when the timer
+  // fires with >1.5x drift, so the next attempt applies the settle delay.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Race 7: stale timer synthesizes a wake when no explicit event fired', () => {
+    it('updates lastWakeTimestamp when the reconnect timer fires far past its scheduled time', async () => {
+      await connectAndGoOnline(xmppClient, mockXmppClientInstance)
+      mockXmppClientInstance._emit('disconnect', { clean: false })
+      await vi.advanceTimersByTimeAsync(0)
+
+      const clientA = createMockXmppClient()
+      mockClientFactory._setInstance(clientA)
+      mockClientFactory.mockClear()
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(getMachineState(xmppClient)).toEqual({ reconnecting: 'attempting' })
+
+      // Baseline: no wake has been recorded yet.
+      expect((xmppClient.connection as any).lastWakeTimestamp).toBe(0)
+
+      // Simulate the system sleeping while the 30s reconnect timer is pending:
+      // jump the wall-clock forward so when the timer finally fires the
+      // callback observes huge `Date.now() - attemptStart` drift.
+      const sleepDurationMs = 1_000_000
+      vi.setSystemTime(Date.now() + sleepDurationMs)
+      await vi.advanceTimersByTimeAsync(RECONNECT_ATTEMPT_TIMEOUT_MS)
+
+      // The stale-timer branch must synthesize a wake timestamp — without it
+      // the subsequent proxy fallback skips the settle delay.
+      const wakeTs = (xmppClient.connection as any).lastWakeTimestamp
+      expect(wakeTs).toBeGreaterThan(0)
+    })
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────
   // Race 6: Reconnect attempt stalls mid-handshake → 30s timeout fires → retry
   //
   // Guards commit ed33cb1: post-wake auto-connect could stall after SASL and

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3068,7 +3068,8 @@ describe('XMPPClient Connection', () => {
 
       // The reconnect timer should be running (not stuck in verification loop)
       // Verify by advancing timer and confirming a reconnect attempt is made.
-      // After wake, attemptReconnect adds a 2s network settle delay (NETWORK_SETTLE_DELAY_MS).
+      // After wake, attemptReconnect adds a network settle delay from
+      // computeNetworkSettleMs (2s default when no sleep duration is known).
       const reconnectClient = createMockXmppClient()
       mockClientFactory._setInstance(reconnectClient)
       await vi.advanceTimersByTimeAsync(3000)
@@ -3240,7 +3241,8 @@ describe('XMPPClient Connection', () => {
       )
 
       // Allow the async attemptReconnect to progress (cleanupClient, createXmppClient, start).
-      // After wake, attemptReconnect adds a 2s network settle delay (NETWORK_SETTLE_DELAY_MS).
+      // After wake, attemptReconnect adds a network settle delay from
+      // computeNetworkSettleMs (2s default when no sleep duration is known).
       await vi.advanceTimersByTimeAsync(3000)
 
       // The WAKE event should have started attemptReconnect

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -28,6 +28,8 @@ import {
   withTimeout,
   forceDestroyClient,
   isDeadSocketError,
+  computePostWakeSettleMs,
+  didTimerSleepThrough,
 } from './connectionUtils'
 import {
   DIRECT_WEBSOCKET_PRECHECK_TIMEOUT_MS,
@@ -1291,6 +1293,30 @@ export class Connection extends BaseModule {
   }
 
   /**
+   * Pause long enough for the OS network stack to settle after a wake.
+   *
+   * Centralizes the post-wake delay logic so every point that starts a
+   * fresh connection attempt (initial attemptReconnect, the proxy
+   * fallback inside attemptReconnect, synthesized wakes from late-firing
+   * timers) observes the same quiet window. No-op when no wake has been
+   * recorded or the settle window has already passed.
+   */
+  private async awaitPostWakeSettle(source: string): Promise<void> {
+    const settleMs = computePostWakeSettleMs(
+      this.lastWakeTimestamp,
+      Date.now(),
+      NETWORK_SETTLE_DELAY_MS
+    )
+    if (settleMs <= 0) return
+    logInfo(`${source}: waiting ${settleMs}ms for network to settle after wake`)
+    this.stores.console.addEvent(
+      `Waiting ${Math.round(settleMs / 1000)}s for network to settle after wake`,
+      'connection'
+    )
+    await new Promise((resolve) => setTimeout(resolve, settleMs))
+  }
+
+  /**
    * Wait for the browser to report network availability.
    * Returns true if online, false if timed out while offline.
    *
@@ -1723,10 +1749,17 @@ export class Connection extends BaseModule {
       // are initialized.
       const timeoutId = setTimeout(() => {
         const elapsed = Date.now() - attemptStart
-        if (elapsed > RECONNECT_ATTEMPT_TIMEOUT_MS * 1.5) {
+        if (didTimerSleepThrough(elapsed, RECONNECT_ATTEMPT_TIMEOUT_MS)) {
           logInfo(
             `${timeoutLabel} timeout fired late (${Math.round(elapsed / 1000)}s elapsed, expected ${RECONNECT_ATTEMPT_TIMEOUT_MS / 1000}s) — system likely slept through it`
           )
+          // No wake event reached the webview during sleep (e.g. Tauri
+          // system-did-wake was dropped while the JS engine was suspended).
+          // Use the drift as implicit evidence of a wake so the subsequent
+          // proxy-fallback retry applies the post-wake settle delay; without
+          // it, that retry connects on a half-ready network and SASL times
+          // out, turning a 30s stale timer into a multi-minute outage.
+          this.lastWakeTimestamp = Date.now()
         }
 
         // Prevent any late events from this client from resolving the attempt.
@@ -2163,15 +2196,7 @@ export class Connection extends BaseModule {
     // session tickets expired). WebSocket TCP handshake may succeed but SASL
     // exchanges hang on the half-ready path, causing repeated 15s timeouts.
     // A short settle delay lets the OS finish re-establishing connectivity.
-    const msSinceWake = Date.now() - this.lastWakeTimestamp
-    if (this.lastWakeTimestamp > 0 && msSinceWake < NETWORK_SETTLE_DELAY_MS + 1_000) {
-      const settleMs = Math.max(0, NETWORK_SETTLE_DELAY_MS - msSinceWake)
-      if (settleMs > 0) {
-        logInfo(`attemptReconnect: waiting ${settleMs}ms for network to settle after wake`)
-        this.stores.console.addEvent(`Waiting ${Math.round(settleMs / 1000)}s for network to settle after wake`, 'connection')
-        await new Promise((resolve) => setTimeout(resolve, settleMs))
-      }
-    }
+    await this.awaitPostWakeSettle('attemptReconnect')
 
     // Track which client this attempt creates, so the outer catch block can
     // detect if a WAKE event replaced it with a newer attempt's client.
@@ -2331,6 +2356,11 @@ export class Connection extends BaseModule {
             ? `attemptReconnect: proxy refreshed (${refreshed.server}) in ${proxyMs}ms`
             : `attemptReconnect: fell back to proxy (${refreshed.server}) in ${proxyMs}ms`
         )
+
+        // The first connect attempt may have failed because its timer slept
+        // through, which sets lastWakeTimestamp. Re-apply the settle window
+        // before the proxy retry so SASL doesn't run on a half-ready network.
+        await this.awaitPostWakeSettle('attemptReconnect:proxy-fallback')
 
         await connectWithOptions(reconnectOptions)
       }

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -28,6 +28,7 @@ import {
   withTimeout,
   forceDestroyClient,
   isDeadSocketError,
+  computeNetworkSettleMs,
   computePostWakeSettleMs,
   didTimerSleepThrough,
 } from './connectionUtils'
@@ -36,7 +37,6 @@ import {
   CLIENT_STOP_TIMEOUT_MS,
   DISCONNECT_CLEANUP_TIMEOUT_MS,
   NETWORK_READY_TIMEOUT_MS,
-  NETWORK_SETTLE_DELAY_MS,
   RECONNECT_ATTEMPT_TIMEOUT_MS,
   SASL_AUTH_TIMEOUT_MS,
   VERIFY_CONNECTION_TIMEOUT_MS,
@@ -183,6 +183,11 @@ export class Connection extends BaseModule {
   // short settle delay — navigator.onLine goes true before the network path is
   // fully functional (DNS, TLS, Wi-Fi re-association), causing SASL timeouts.
   private lastWakeTimestamp = 0
+
+  // Sleep duration that produced `lastWakeTimestamp`, used to scale the settle
+  // delay by how long we were gone (undefined = source didn't report duration,
+  // fall back to the policy default). See computeNetworkSettleMs for the bands.
+  private lastSleepDurationMs: number | undefined = undefined
 
   // Timestamp when the connection was lost (set in handleDeadSocket).
   // Used to compute disconnect duration and pass it to XMPPClient so SM
@@ -1242,6 +1247,7 @@ export class Connection extends BaseModule {
     logInfo(`System state: awake${sleepSec != null ? ` (sleep: ${sleepSec}s)` : ''}`)
 
     this.lastWakeTimestamp = Date.now()
+    this.lastSleepDurationMs = sleepDurationMs
 
     if (this.isInConnectedState()) {
       // Send WAKE to the machine — if sleep exceeds SM timeout, the guard
@@ -1298,19 +1304,25 @@ export class Connection extends BaseModule {
    * Centralizes the post-wake delay logic so every point that starts a
    * fresh connection attempt (initial attemptReconnect, the proxy
    * fallback inside attemptReconnect, synthesized wakes from late-firing
-   * timers) observes the same quiet window. No-op when no wake has been
-   * recorded or the settle window has already passed.
+   * timers) observes the same quiet window. The settle budget is scaled
+   * to the length of sleep we just came out of — short sleeps skip the
+   * delay entirely, long sleeps get a longer window to let Wi-Fi /
+   * DHCP / DNS recover before SASL runs.
    */
   private async awaitPostWakeSettle(source: string): Promise<void> {
+    const budgetMs = computeNetworkSettleMs(this.lastSleepDurationMs)
     const settleMs = computePostWakeSettleMs(
       this.lastWakeTimestamp,
       Date.now(),
-      NETWORK_SETTLE_DELAY_MS
+      budgetMs
     )
     if (settleMs <= 0) return
-    logInfo(`${source}: waiting ${settleMs}ms for network to settle after wake`)
+    const sleepSec = this.lastSleepDurationMs != null
+      ? `${Math.round(this.lastSleepDurationMs / 1000)}s`
+      : 'unknown'
+    logInfo(`${source}: waiting ${settleMs}ms for network to settle after wake (sleep: ${sleepSec}, budget: ${budgetMs}ms)`)
     this.stores.console.addEvent(
-      `Waiting ${Math.round(settleMs / 1000)}s for network to settle after wake`,
+      `Waiting ${Math.round(settleMs / 1000)}s for network to settle after wake (sleep ${sleepSec})`,
       'connection'
     )
     await new Promise((resolve) => setTimeout(resolve, settleMs))
@@ -1760,6 +1772,11 @@ export class Connection extends BaseModule {
           // it, that retry connects on a half-ready network and SASL times
           // out, turning a 30s stale timer into a multi-minute outage.
           this.lastWakeTimestamp = Date.now()
+          // Approximate the sleep duration from the timer drift so the
+          // settle budget scales correctly: a timer that should have
+          // fired after RECONNECT_ATTEMPT_TIMEOUT_MS but fired `elapsed`
+          // later was frozen for ~`elapsed - RECONNECT_ATTEMPT_TIMEOUT_MS`.
+          this.lastSleepDurationMs = Math.max(0, elapsed - RECONNECT_ATTEMPT_TIMEOUT_MS)
         }
 
         // Prevent any late events from this client from resolving the attempt.

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -6,7 +6,7 @@ import type { ConnectOptions, ConnectionMethod } from '../types'
 import { getBareJid, getDomain, getLocalPart, getResource } from '../jid'
 import { getClientIdentity, CLIENT_FEATURES } from '../caps'
 import { NS_DISCO_INFO, NS_PING, NS_TIME } from '../namespaces'
-import { logInfo, logWarn, logError as logErr } from '../logger'
+import { logDebug, logInfo, logWarn, logError as logErr } from '../logger'
 import {
   type SmPatchState,
   createSmPatchState,
@@ -856,9 +856,13 @@ export class Connection extends BaseModule {
    */
   nudgeReconnect(): void {
     if (!this.isInReconnectingState() || !this.credentials) {
+      // Benign: callers (keepalive, visibility, WS error handler) invoke
+      // this liberally and it no-ops whenever the machine is not in a
+      // reconnecting substate. Log at debug so normal logs stay quiet;
+      // the in-app console event remains visible for diagnostics.
       const message = `nudgeReconnect skipped (reconnecting=${this.isInReconnectingState()}, hasCredentials=${!!this.credentials}, state=${JSON.stringify(this.getMachineState())})`
       this.stores.console.addEvent(message, 'connection')
-      logInfo(message)
+      logDebug(message)
       return
     }
 

--- a/packages/fluux-sdk/src/core/modules/connectionTimeouts.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionTimeouts.ts
@@ -93,14 +93,9 @@ export const NETWORK_READY_TIMEOUT_MS = 15_000
  */
 export const SASL_AUTH_TIMEOUT_MS = 15_000
 
-/**
- * Delay before the first reconnect attempt after wake-from-sleep.
- * Even when navigator.onLine is true, the OS network stack (DNS, TLS session
- * cache, Wi-Fi re-association) may need a moment to become fully functional.
- * Without this, WebSocket TCP connects but SASL exchanges hang on a
- * half-ready path, burning through backoff attempts with 15s timeouts each.
- */
-export const NETWORK_SETTLE_DELAY_MS = 2_000
+// NETWORK_SETTLE_DELAY_MS was removed — the settle budget is now computed
+// per-wake by computeNetworkSettleMs(sleepDurationMs) in connectionUtils,
+// scaling with how long we were gone. See that function for the bands.
 
 /**
  * Budget for the best-effort FAST token invalidation roundtrip on logout

--- a/packages/fluux-sdk/src/core/modules/connectionUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionUtils.test.ts
@@ -3,6 +3,7 @@ import {
   withTimeout,
   forceDestroyClient,
   isDeadSocketError,
+  computeNetworkSettleMs,
   computePostWakeSettleMs,
   didTimerSleepThrough,
   CLIENT_STOP_TIMEOUT_MS,
@@ -129,6 +130,38 @@ describe('connectionUtils', () => {
 
     it('returns 0 once past the upper slack bound', () => {
       expect(computePostWakeSettleMs(100_000, 103_000, 2_000)).toBe(0)
+    })
+  })
+
+  describe('computeNetworkSettleMs', () => {
+    it('returns the default 2000ms when no sleep duration is known', () => {
+      // Undefined comes through for wake sources that don't report a
+      // duration (e.g. a heartbeat without a prior system-will-sleep).
+      expect(computeNetworkSettleMs(undefined)).toBe(2_000)
+    })
+
+    it('returns 0 for sub-threshold sleeps that are really just throttling', () => {
+      expect(computeNetworkSettleMs(0)).toBe(0)
+      expect(computeNetworkSettleMs(5_000)).toBe(0)
+      expect(computeNetworkSettleMs(29_999)).toBe(0)
+    })
+
+    it('returns 500ms for short sleeps (30s–3min)', () => {
+      expect(computeNetworkSettleMs(30_000)).toBe(500)
+      expect(computeNetworkSettleMs(120_000)).toBe(500)
+      expect(computeNetworkSettleMs(179_999)).toBe(500)
+    })
+
+    it('returns 1500ms for medium sleeps (3min–15min)', () => {
+      expect(computeNetworkSettleMs(180_000)).toBe(1_500)
+      expect(computeNetworkSettleMs(600_000)).toBe(1_500)
+      expect(computeNetworkSettleMs(899_999)).toBe(1_500)
+    })
+
+    it('returns 3000ms for long sleeps (>= 15min, capped)', () => {
+      expect(computeNetworkSettleMs(900_000)).toBe(3_000)
+      expect(computeNetworkSettleMs(3_600_000)).toBe(3_000)
+      expect(computeNetworkSettleMs(8 * 60 * 60 * 1000)).toBe(3_000)
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/connectionUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionUtils.test.ts
@@ -3,6 +3,8 @@ import {
   withTimeout,
   forceDestroyClient,
   isDeadSocketError,
+  computePostWakeSettleMs,
+  didTimerSleepThrough,
   CLIENT_STOP_TIMEOUT_MS,
   RECONNECT_ATTEMPT_TIMEOUT_MS,
 } from './connectionUtils'
@@ -105,6 +107,40 @@ describe('connectionUtils', () => {
       }
       expect(() => forceDestroyClient(client)).not.toThrow()
       expect(endFn).toHaveBeenCalled()
+    })
+  })
+
+  describe('computePostWakeSettleMs', () => {
+    it('returns 0 when no wake has been recorded', () => {
+      expect(computePostWakeSettleMs(0, 100_000, 2_000)).toBe(0)
+    })
+
+    it('returns 0 when the wake happened long before the settle window', () => {
+      expect(computePostWakeSettleMs(1_000, 100_000, 2_000)).toBe(0)
+    })
+
+    it('returns the remaining delay when wake is mid-window', () => {
+      expect(computePostWakeSettleMs(100_000, 100_500, 2_000)).toBe(1_500)
+    })
+
+    it('returns the full delay when the wake just happened', () => {
+      expect(computePostWakeSettleMs(100_000, 100_000, 2_000)).toBe(2_000)
+    })
+
+    it('returns 0 once past the upper slack bound', () => {
+      expect(computePostWakeSettleMs(100_000, 103_000, 2_000)).toBe(0)
+    })
+  })
+
+  describe('didTimerSleepThrough', () => {
+    it('returns false when the timer fires near the scheduled delay', () => {
+      expect(didTimerSleepThrough(30_000, 30_000)).toBe(false)
+      expect(didTimerSleepThrough(40_000, 30_000)).toBe(false)
+    })
+
+    it('returns true when elapsed clearly exceeds 1.5x the scheduled delay', () => {
+      expect(didTimerSleepThrough(46_000, 30_000)).toBe(true)
+      expect(didTimerSleepThrough(1_059_000, 30_000)).toBe(true)
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/connectionUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionUtils.ts
@@ -104,6 +104,30 @@ export function didTimerSleepThrough(
 }
 
 /**
+ * Budget for how long to let the OS network stack settle after a wake,
+ * scaled to the length of sleep we just came out of.
+ *
+ * Short sleeps (lid flicks, brief throttling) keep the network path
+ * mostly warm and don't need a delay at all — blocking would only add
+ * perceived latency. Long sleeps typically require Wi-Fi re-association,
+ * DHCP renewal, and a fresh TLS session, so SASL fires into a half-open
+ * socket if we don't give the stack a moment. The upper bound caps at
+ * 3s because past that the bottleneck is the TCP/TLS handshake itself,
+ * not the pre-connect settle.
+ *
+ * `undefined` falls through to the middle-of-the-road default so a wake
+ * from an untagged source (e.g. a heartbeat with no duration hint) is
+ * still protected.
+ */
+export function computeNetworkSettleMs(sleepDurationMs: number | undefined): number {
+  if (sleepDurationMs === undefined) return 2_000
+  if (sleepDurationMs < 30_000) return 0
+  if (sleepDurationMs < 180_000) return 500
+  if (sleepDurationMs < 900_000) return 1_500
+  return 3_000
+}
+
+/**
  * Check if an error indicates a dead WebSocket connection.
  * This can happen after system sleep when the socket dies silently.
  */

--- a/packages/fluux-sdk/src/core/modules/connectionUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/connectionUtils.ts
@@ -66,6 +66,44 @@ export function forceDestroyClient(client: any): void {
 }
 
 /**
+ * Compute how long to wait for the network stack to settle after a wake-from-sleep.
+ *
+ * Returns 0 when no wait is needed: either no wake has been recorded, the
+ * wake was long enough ago that the settle window has already passed, or
+ * the remaining delay rounds to zero.
+ *
+ * The `+ 1_000` slack on the upper bound keeps the window open slightly
+ * past `settleDelayMs` so clocks reading a few hundred ms after the wake
+ * still apply the delay.
+ */
+export function computePostWakeSettleMs(
+  lastWakeTimestamp: number,
+  nowMs: number,
+  settleDelayMs: number
+): number {
+  if (lastWakeTimestamp <= 0) return 0
+  const msSinceWake = nowMs - lastWakeTimestamp
+  if (msSinceWake >= settleDelayMs + 1_000) return 0
+  return Math.max(0, settleDelayMs - msSinceWake)
+}
+
+/**
+ * Decide whether a connection-attempt timer firing `elapsedMs` after it was
+ * scheduled should be treated as evidence that the system slept through it.
+ *
+ * `setTimeout` freezes while macOS sleeps; when the app wakes, the timer
+ * fires immediately regardless of how long the sleep lasted. An elapsed
+ * time well past the scheduled timeout is a strong signal that we just
+ * came out of sleep, even when no explicit wake event was delivered.
+ */
+export function didTimerSleepThrough(
+  elapsedMs: number,
+  timeoutMs: number
+): boolean {
+  return elapsedMs > timeoutMs * 1.5
+}
+
+/**
  * Check if an error indicates a dead WebSocket connection.
  * This can happen after system sleep when the socket dies silently.
  */


### PR DESCRIPTION
## Summary

Five-part pass on wake/sleep reconnect behavior, driven by analysis of a 15-hour `xmpp-debug.log` showing a ~57-minute outage after an overnight wake and ~40 spurious reconnect cycles per night.

- **Stale reconnect timer** ([840e5a2](https://github.com/processone/fluux-messenger/commit/840e5a2)) — detect macOS `setTimeout` drift as an implicit wake so the proxy-fallback retry applies the post-wake settle delay instead of SASL-timing-out into a multi-minute outage.
- **Skip DarkWake / PowerNap reconnects** ([59564b6](https://github.com/processone/fluux-messenger/commit/59564b6)) — Rust probes `CGDisplayIsAsleep`; webview drops the wake if display is off. Eliminates ~40 overnight reconnect cycles.
- **Post-reload cooldown** ([8341900](https://github.com/processone/fluux-messenger/commit/8341900)) — persist a reload marker in `localStorage`; the new React instance ignores residual wake signals for 60s after the reload that spawned it. Kills the paired "reloading webview" / duplicate auth-on-reload pattern.
- **Settle delay scales with sleep duration** ([59b07f2](https://github.com/processone/fluux-messenger/commit/59b07f2)) — replace the fixed 2s `NETWORK_SETTLE_DELAY_MS` with a four-band policy: 0 / 500 / 1500 / 3000 ms depending on how long we were gone. Unknown duration falls back to 2000ms. Also feeds into the slept-through-timer path by synthesizing duration from drift.
- **Demote `nudgeReconnect skipped` log to debug** ([0382421](https://github.com/processone/fluux-messenger/commit/0382421)) — it's a defensive no-op by design; `console.info` noise on every visibility/keepalive call is unhelpful. In-app console event stays.