### PR TITLE
fix(proxy/auth): forward <open/> from= to unlock SASL2/FAST, add keychain fallback

### DIFF
--- a/apps/fluux/src-tauri/src/xmpp_proxy/framing.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/framing.rs
@@ -31,6 +31,7 @@ pub fn translate_ws_to_tcp<'a>(text: &'a str) -> Cow<'a, str> {
         };
 
         let mut to = String::new();
+        let mut from = String::new();
         let mut version = String::from("1.0");
         let mut lang = String::new();
 
@@ -40,6 +41,13 @@ pub fn translate_ws_to_tcp<'a>(text: &'a str) -> Cow<'a, str> {
                 let value = String::from_utf8_lossy(&attr.value);
                 match key.as_ref() {
                     "to" => to = value.to_string(),
+                    // Forward the `from` attribute: ejabberd gates SASL2 (XEP-0388)
+                    // stream features on the client's stream header carrying a
+                    // non-empty localpart `from=`. Without it, FAST (XEP-0484) auth
+                    // is never advertised and FAST token auto-connect fails with
+                    // "No credentials available". xmpp.js sets `from` on <open/>
+                    // when `username` is passed at connect time.
+                    "from" => from = value.to_string(),
                     "version" => version = value.to_string(),
                     "xml:lang" => lang = value.to_string(),
                     _ => {} // Skip xmlns and other attributes
@@ -51,6 +59,9 @@ pub fn translate_ws_to_tcp<'a>(text: &'a str) -> Cow<'a, str> {
         let mut stream_tag = String::from("<?xml version='1.0'?><stream:stream");
         if !to.is_empty() {
             stream_tag.push_str(&format!(" to='{}'", to));
+        }
+        if !from.is_empty() {
+            stream_tag.push_str(&format!(" from='{}'", from));
         }
         stream_tag.push_str(&format!(" version='{}'", version));
         if !lang.is_empty() {
@@ -420,6 +431,32 @@ mod tests {
         assert!(translated.contains("xml:lang='en'"));
         assert!(translated.contains("xmlns='jabber:client'"));
         assert!(translated.contains("xmlns:stream='http://etherx.jabber.org/streams'"));
+    }
+
+    #[test]
+    fn test_translate_open_forwards_from_attribute() {
+        // Regression: ejabberd gates SASL2 on the client's stream header carrying
+        // a non-empty localpart `from=`. The proxy MUST forward `from` from the
+        // <open/> frame to <stream:stream> or FAST auth is unreachable.
+        let open_tag = r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" to="example.com" from="user@example.com" version="1.0"/>"#;
+        let translated = translate_ws_to_tcp(open_tag);
+
+        assert!(translated.contains("<stream:stream"));
+        assert!(translated.contains("to='example.com'"));
+        assert!(translated.contains("from='user@example.com'"));
+        assert!(translated.contains("version='1.0'"));
+    }
+
+    #[test]
+    fn test_translate_open_without_from_attribute() {
+        // When <open/> has no `from`, the resulting <stream:stream> must not
+        // contain a stray `from=` attribute.
+        let open_tag = r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" to="example.com" version="1.0"/>"#;
+        let translated = translate_ws_to_tcp(open_tag);
+
+        assert!(translated.contains("<stream:stream"));
+        assert!(translated.contains("to='example.com'"));
+        assert!(!translated.contains(" from="));
     }
 
     #[test]

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -5,6 +5,7 @@ import { useRosterStore, useConnectionStore, useRoomStore } from '@fluux/sdk/rea
 import type { Contact, Room, RoomOccupant, ServerInfo, HttpUploadService, RoomMessage, ResourcePresence, JoinedRoomInfo } from '@fluux/sdk'
 import { getResource } from '@/utils/xmppResource'
 import { isTauri } from '@/utils/tauri'
+import { getCredentials, hasSavedCredentials } from '@/utils/keychain'
 
 const SESSION_KEY = 'xmpp-session'
 const ROSTER_KEY = 'xmpp-roster'
@@ -634,10 +635,9 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
     // When the user closed the tab, sessionStorage is lost but a FAST token
     // may persist in localStorage (valid for up to 14 days).
     // Only attempt this when the user previously opted in via "Remember Me".
-    // hasFastToken() only checks client-side token existence + expiry.
-    // Server-side FAST/SASL2 support is verified during negotiation by xmpp.js —
-    // if the server doesn't support SASL2/FAST, the token auth path is skipped,
-    // no password fallback is available, and we show the login screen.
+    // On Tauri, the OS keychain password is loaded as a fallback: if the
+    // server doesn't advertise SASL2/FAST during negotiation, xmpp.js will
+    // use the password over legacy SASL instead of throwing "no credentials".
     const rememberMe = localStorage.getItem('xmpp-remember-me') === 'true'
     const savedJid = localStorage.getItem('xmpp-last-jid')
     const savedServer = localStorage.getItem('xmpp-last-server')
@@ -646,22 +646,52 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
     const effectiveServer = savedServer || (savedJid ? savedJid.split('@')[1] : null)
     if (rememberMe && savedJid && effectiveServer && hasFastToken(savedJid)) {
       const resource = getResource()
-      console.log('[Auth] Attempting FAST token auto-connect (no password)')
 
-      const attemptFastConnect = () => {
+      const attemptFastConnect = async () => {
+        // On Tauri, load the keychain password as a fallback. xmpp.js will
+        // prefer the FAST token when the server advertises SASL2+FAST; the
+        // password is only used when FAST is unavailable. Web has no keychain
+        // — the FAST-only path remains unchanged.
+        let fallbackPassword: string | undefined
+        if (isTauri() && hasSavedCredentials()) {
+          try {
+            const creds = await getCredentials()
+            if (creds && getBareJid(creds.jid) === getBareJid(savedJid)) {
+              fallbackPassword = creds.password
+            }
+          } catch (err) {
+            console.log('[Auth] Keychain fallback unavailable:', err)
+          }
+        }
+
+        console.log(
+          fallbackPassword
+            ? '[Auth] Attempting FAST token auto-connect (keychain password as fallback)'
+            : '[Auth] Attempting FAST token auto-connect (no password)'
+        )
+
         // Auto-retry transient transport failures: FAST token auto-connect
         // after a fresh tab open faces the same wake-from-sleep network
         // flakiness as page-reload. Auth failures (bad/expired token) still
         // surface via the machine's AUTH_ERROR path and delete the token.
-        connect(savedJid, undefined, effectiveServer, undefined, resource, i18n.language, false, true, true).then(() => {
-          // Save session for subsequent in-tab reconnects (no password needed —
-          // FAST token in localStorage handles auth on future reconnects too)
-          saveSession(savedJid, '', effectiveServer)
-        }).catch((err) => {
-          console.log('[Auth] FAST token connect failed:', err?.message || err)
-          deleteFastToken(savedJid)
+        try {
+          await connect(savedJid, fallbackPassword, effectiveServer, undefined, resource, i18n.language, false, true, true)
+          // Save session for subsequent in-tab reconnects. Store the
+          // fallback password so reloads (Path A) don't have to re-hit
+          // the keychain; empty string preserves prior behavior when no
+          // password is available.
+          saveSession(savedJid, fallbackPassword ?? '', effectiveServer)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          console.log('[Auth] FAST token connect failed:', message)
+          // Only delete the token on an actual auth failure. Transport or
+          // "no credentials" errors (e.g. SASL2 not advertised) leave a valid
+          // token in place for a future attempt.
+          if (message.includes('not-authorized') || message.toLowerCase().includes('authentication')) {
+            deleteFastToken(savedJid)
+          }
           // Login screen shows (status reverts to error/disconnected)
-        })
+        }
       }
 
       // Check if another tab already holds this JID (web only)
@@ -671,14 +701,14 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
             console.log('[Auth] Another tab already connected, skipping FAST auto-connect')
             return
           }
-          attemptFastConnect()
+          void attemptFastConnect()
         }).catch(() => {
-          attemptFastConnect()
+          void attemptFastConnect()
         })
         return
       }
 
-      attemptFastConnect()
+      void attemptFastConnect()
     }
   }, [status, connect, setContacts, i18n.language, addRoom, restoreOwnAvatarFromCache, setHttpUploadService, setOwnNickname, setServerInfo, updateOwnResource, claimConnection])
 


### PR DESCRIPTION
## Summary

Two related fixes that restore FAST (XEP-0484) auto-connect on Tauri when the app bridges through the local SRV/proxy path.

### 1. `fix(proxy)` — forward `<open/>`'s `from=` to `<stream:stream>`

The Rust proxy parsed the RFC 7395 `<open/>` frame but only kept `to`, `version`, and `xml:lang` when rebuilding the traditional `<stream:stream>` header. ejabberd gates SASL2 (XEP-0388) stream features on the client header carrying a non-empty-localpart `from=` (see `xmpp_stream_in.erl:send_features/1`). Without it, SASL2 is never advertised, FAST has no chance to negotiate, and FAST-only auto-connect throws `No credentials available`.

xmpp.js already emits `from="user@domain"` on `<open/>` (via the `username` parameter added in #348). The proxy now forwards it. Two regression tests pin the behavior.

### 2. `fix(app)` — keychain password as a FAST auto-connect fallback (Tauri)

FAST auto-connect previously passed `password=undefined`. If SASL2/FAST wasn't advertised (legacy server, proxy issue, etc.), the credentials callback had literally nothing to submit — even though the OS keychain held a valid password the whole time.

On Tauri, the keychain password is now loaded upfront and passed as a fallback. xmpp.js still prefers the FAST token when the server advertises SASL2+FAST; the password is only used when FAST is unavailable. Web paths are unchanged (no keychain available).

Failure handling was also tightened: the FAST token is only deleted on genuine auth failures (`not-authorized` / `authentication`). Transport or "no credentials" errors leave the token in place, so a transient proxy hiccup no longer forces a full password re-prompt next time.

### Verification

- `cargo test xmpp_proxy::framing` — **50/50 pass** (includes 2 new regression tests)
- `npm run typecheck` — clean
- App test suite — **2473/2473 pass**