### PR TITLE
fix(xmpp console): by default don't show Stream Management (SM) packets

### DIFF
--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -176,7 +176,7 @@ export function XmppConsole() {
   const [searchQuery, setSearchQuery] = useState('')
   const [showServerInfo, setShowServerInfo] = useState(false)
   const [enabledTypes, setEnabledTypes] = useState<Set<FilterType>>(
-    new Set(['message', 'iq', 'sm', 'event'])
+    new Set(['message', 'iq', 'event'])
   )
   const [directionFilter, setDirectionFilter] = useState<DirectionFilter>('all')
   const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null)


### PR DESCRIPTION
The SM packets flood the log when debugging but most of time it's not interesting while debugging. They are disabled by default in Gajim and Psi