### PR TITLE
fix(activity-log): navigate to contact profile on subscription events

### DIFF
--- a/apps/fluux/src/components/sidebar-components/ActivityLogView.tsx
+++ b/apps/fluux/src/components/sidebar-components/ActivityLogView.tsx
@@ -94,7 +94,7 @@ export function ActivityLogView() {
     setPreviewEvent,
   } = useActivityLog()
   const { pendingCount } = useEvents()
-  const { navigateToConversation, navigateToRoom } = useNavigateToTarget()
+  const { navigateToConversation, navigateToContact, navigateToRoom } = useNavigateToTarget()
   // Read room existence imperatively — subscribing via selector would return
   // a new closure on every store update, causing an infinite render loop.
   const hasRoom = useCallback((jid: string) => roomStore.getState().rooms.has(jid), [])
@@ -109,7 +109,9 @@ export function ActivityLogView() {
     const target = getNavigationTarget(event)
     if (!target) return
 
-    if (target.type === 'room') {
+    if (target.type === 'contact') {
+      navigateToContact(target.jid)
+    } else if (target.type === 'room') {
       navigateToRoom(target.jid, target.messageId)
     } else if (target.type === 'conversation') {
       navigateToConversation(target.jid, target.messageId)
@@ -121,7 +123,7 @@ export function ActivityLogView() {
         navigateToConversation(target.jid, target.messageId)
       }
     }
-  }, [navigateToConversation, navigateToRoom, hasRoom, setPreviewEvent])
+  }, [navigateToConversation, navigateToContact, navigateToRoom, hasRoom, setPreviewEvent])
 
   const groupedEvents = useMemo(() => groupEventsByDate(events), [events])
 

--- a/apps/fluux/src/components/sidebar-components/activityNavigation.test.ts
+++ b/apps/fluux/src/components/sidebar-components/activityNavigation.test.ts
@@ -15,18 +15,18 @@ function createEvent(payload: ActivityEvent['payload'], overrides: Partial<Activ
 }
 
 describe('getNavigationTarget', () => {
-  it('should return conversation target for subscription-request', () => {
+  it('should return contact target for subscription-request', () => {
     const event = createEvent({ type: 'subscription-request', from: 'alice@example.com' })
     const target = getNavigationTarget(event)
 
-    expect(target).toEqual({ type: 'conversation', jid: 'alice@example.com' })
+    expect(target).toEqual({ type: 'contact', jid: 'alice@example.com' })
   })
 
-  it('should return conversation target for subscription-accepted', () => {
+  it('should return contact target for subscription-accepted', () => {
     const event = createEvent({ type: 'subscription-accepted', from: 'bob@example.com/res' })
     const target = getNavigationTarget(event)
 
-    expect(target).toEqual({ type: 'conversation', jid: 'bob@example.com' })
+    expect(target).toEqual({ type: 'contact', jid: 'bob@example.com' })
   })
 
   it('should return null for subscription-denied', () => {
@@ -114,6 +114,6 @@ describe('getNavigationTarget', () => {
     const event = createEvent({ type: 'subscription-request', from: 'alice@example.com/mobile' })
     const target = getNavigationTarget(event)
 
-    expect(target).toEqual({ type: 'conversation', jid: 'alice@example.com' })
+    expect(target).toEqual({ type: 'contact', jid: 'alice@example.com' })
   })
 })

--- a/apps/fluux/src/components/sidebar-components/activityNavigation.ts
+++ b/apps/fluux/src/components/sidebar-components/activityNavigation.ts
@@ -2,7 +2,7 @@ import type { ActivityEvent } from '@fluux/sdk'
 import { getBareJid } from '@fluux/sdk'
 
 export interface NavigationTarget {
-  type: 'conversation' | 'room' | 'auto'
+  type: 'conversation' | 'room' | 'contact' | 'auto'
   jid: string
   messageId?: string
 }
@@ -20,7 +20,7 @@ export function getNavigationTarget(event: ActivityEvent): NavigationTarget | nu
       return { type: 'auto', jid: p.conversationId, messageId: p.messageId }
     case 'subscription-request':
     case 'subscription-accepted':
-      return { type: 'conversation', jid: getBareJid(p.from) }
+      return { type: 'contact', jid: getBareJid(p.from) }
     case 'muc-invitation':
       return { type: 'room', jid: p.roomJid }
     case 'stranger-message':

--- a/apps/fluux/src/hooks/useNavigateToTarget.test.tsx
+++ b/apps/fluux/src/hooks/useNavigateToTarget.test.tsx
@@ -169,6 +169,34 @@ describe('useNavigateToTarget', () => {
     })
   })
 
+  describe('navigateToContact', () => {
+    it('should navigate to contacts URL with encoded JID', () => {
+      const { result } = renderHook(() => useNavigateToTarget(), {
+        wrapper: createWrapper('/events'),
+      })
+
+      act(() => {
+        result.current.navigateToContact('alice@example.com')
+      })
+
+      expect(currentLocation.current.pathname).toBe('/contacts/alice%40example.com')
+    })
+
+    it('should clear active conversation and room', () => {
+      const { result } = renderHook(() => useNavigateToTarget(), {
+        wrapper: createWrapper('/messages'),
+      })
+
+      act(() => {
+        result.current.navigateToContact('bob@example.com')
+      })
+
+      expect(mockState.setActiveConversation).toHaveBeenCalledWith(null)
+      expect(mockState.setActiveRoom).toHaveBeenCalledWith(null)
+      expect(currentLocation.current.pathname).toBe('/contacts/bob%40example.com')
+    })
+  })
+
   describe('navigateToConversation with messageId', () => {
     it('should set targetMessageId in chat store when messageId is provided', () => {
       const { result } = renderHook(() => useNavigateToTarget(), {

--- a/apps/fluux/src/hooks/useNavigateToTarget.ts
+++ b/apps/fluux/src/hooks/useNavigateToTarget.ts
@@ -80,6 +80,18 @@ export function useNavigateToTarget() {
   }
 
   /**
+   * Navigate to a contact's profile.
+   * Uses URL-based navigation (/contacts/:jid) and clears active conversation/room.
+   * Clears all active notifications.
+   */
+  const navigateToContact = (jid: string) => {
+    void setActiveConversationRef.current(null)
+    void setActiveRoomRef.current(null)
+    void navigateRef.current(`/contacts/${encodeURIComponent(jid)}`)
+    void clearAllNotifications()
+  }
+
+  /**
    * Navigate to a MUC room.
    * Uses URL-based navigation (/rooms/:jid) and sets active room.
    * Optionally scrolls to a specific message.
@@ -96,5 +108,5 @@ export function useNavigateToTarget() {
     void clearAllNotifications()
   }
 
-  return { navigateToConversation, navigateToRoom }
+  return { navigateToConversation, navigateToContact, navigateToRoom }
 }


### PR DESCRIPTION
## Summary

- Clicking subscription-accepted or subscription-request events in the activity log now opens the contact's profile view instead of the conversation/messages view
- Added `'contact'` navigation target type in `activityNavigation.ts`
- Added `navigateToContact` function to `useNavigateToTarget` hook (clears active conversation/room, navigates to `/contacts/:jid`)
- Updated existing tests and added new tests for `navigateToContact`