### PR TITLE
fix(e2ee): deferred decryption for messages arriving before key unlock

### DIFF
--- a/apps/fluux/src/components/UnlockEncryptionDialog.tsx
+++ b/apps/fluux/src/components/UnlockEncryptionDialog.tsx
@@ -80,6 +80,10 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
         throw new Error(t('settings.encryption.backupPluginUnavailable'))
       }
       await plugin.unlock(passphrase)
+      // Trigger deferred decryption of messages that arrived while the
+      // key was locked (e.g. MAM catch-up messages fetched before the
+      // user entered the passphrase).
+      client.notifyE2EEKeyUnlocked()
       onClose(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))

--- a/apps/fluux/src/e2ee/generateWebVectors.manual.test.ts
+++ b/apps/fluux/src/e2ee/generateWebVectors.manual.test.ts
@@ -5,8 +5,11 @@
  * This test writes fixture files that the Rust test
  * `consume_web_golden_vectors` reads and decrypts with Sequoia-PGP.
  *
- * Run with:
- *   npx vitest run src/e2ee/generateWebVectors.test.ts
+ * Excluded from `npm test` (`.manual.test.ts`) because it regenerates
+ * fixture files with fresh keys on every run. Run explicitly when you
+ * need to update the vectors:
+ *
+ *   npx vitest run src/e2ee/generateWebVectors.manual.test.ts
  *
  * Then run the Rust consumer:
  *   cd apps/fluux/src-tauri && cargo test consume_web_golden_vectors -- --ignored --nocapture

--- a/apps/fluux/vitest.config.ts
+++ b/apps/fluux/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     silent: true,
     setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    exclude: ['src/**/*.manual.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -11,6 +11,8 @@ import type {
   StorageAdapter,
   ProxyAdapter,
   PrivacyOptions,
+  FileAttachment,
+  MessageSecurityContext,
 } from './types'
 import {
   presenceMachine,
@@ -109,9 +111,10 @@ import { MAM } from './modules/MAM'
 import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
 import { dataToElement } from './e2ee/stanzaAdapter'
+import { decryptStanzaInPlace } from './e2ee/stanzaDecrypt'
 import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH } from './namespaces'
 import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './defaultStoreBindings'
-import { logInfo } from './logger'
+import { logInfo, logWarn } from './logger'
 import { SDK_VERSION } from '../version'
 import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
 
@@ -374,6 +377,14 @@ export class XMPPClient {
    * @internal
    */
   private isSmResumedSession = false
+
+  /**
+   * Guard flag for {@link retryPendingDecrypts}. Prevents concurrent
+   * retry loops when multiple triggers (plugin-registered, key-unlocked)
+   * fire close together.
+   * @internal
+   */
+  private isRetryingDecrypts = false
 
   /**
    * Monotonically increasing session generation counter.
@@ -1563,6 +1574,153 @@ export class XMPPClient {
   }
 
   /**
+   * Signal that the E2EE private key has been unlocked (e.g. web passphrase
+   * entered). Triggers an automatic retry of all pending decryptions.
+   */
+  notifyE2EEKeyUnlocked(): void {
+    this.emitSDK('e2ee:key-unlocked', undefined)
+    void this.retryPendingDecrypts()
+  }
+
+  /**
+   * Re-decrypt all stored messages that carry an {@link encryptedPayload}
+   * because decryption failed at receive time (no plugin registered, key
+   * locked, etc.).
+   *
+   * Iterates both chat and room stores, reconstructs a minimal stanza from
+   * the serialized XML, and re-runs {@link decryptStanzaInPlace}. On success
+   * the message body + securityContext are updated in-place via
+   * `store.updateMessage()`, and the `encryptedPayload` is cleared.
+   *
+   * Protected by a flag to prevent concurrent retry loops when multiple
+   * triggers fire close together.
+   *
+   * @returns the number of messages successfully decrypted
+   */
+  async retryPendingDecrypts(): Promise<number> {
+    if (this.isRetryingDecrypts) return 0
+    const manager = this.e2ee
+    if (!manager || !manager.hasPlugins()) return 0
+    if (!this.stores) return 0
+
+    this.isRetryingDecrypts = true
+    let decryptedCount = 0
+
+    try {
+      const chatBindings = this.stores.chat
+      const roomBindings = this.stores.room
+
+      // --- 1:1 chat messages ---
+      // Read state from the imported Zustand stores (getState), mutate
+      // through StoreBindings so the abstract API contract is honoured.
+      const chatMessages = chatStore.getState().messages
+      for (const [conversationId, messages] of chatMessages) {
+        for (const msg of messages) {
+          if (!msg.encryptedPayload) continue
+          const result = await this.retryDecryptSingle(
+            manager, msg.encryptedPayload, msg.from, conversationId,
+          )
+          if (result) {
+            chatBindings.updateMessage(conversationId, msg.id, {
+              body: result.body,
+              ...(result.securityContext && { securityContext: result.securityContext }),
+              ...(result.attachment && { attachment: result.attachment }),
+              encryptedPayload: undefined,
+            })
+            decryptedCount++
+          }
+        }
+      }
+
+      // --- Room messages ---
+      const roomRuntimes = roomStore.getState().roomRuntime
+      for (const [roomJid, runtime] of roomRuntimes) {
+        for (const msg of runtime.messages) {
+          if (!msg.encryptedPayload) continue
+          const result = await this.retryDecryptSingle(
+            manager, msg.encryptedPayload, msg.from, roomJid,
+          )
+          if (result) {
+            roomBindings.updateMessage(roomJid, msg.id, {
+              body: result.body,
+              ...(result.securityContext && { securityContext: result.securityContext }),
+              ...(result.attachment && { attachment: result.attachment }),
+              encryptedPayload: undefined,
+            })
+            decryptedCount++
+          }
+        }
+      }
+
+      if (decryptedCount > 0) {
+        logInfo(`E2EE deferred decrypt: successfully decrypted ${decryptedCount} message(s)`)
+      }
+    } finally {
+      this.isRetryingDecrypts = false
+    }
+
+    return decryptedCount
+  }
+
+  /**
+   * Attempt to decrypt a single serialized encrypted payload.
+   * @returns Decrypted content or `null` if decryption still fails.
+   * @internal
+   */
+  private async retryDecryptSingle(
+    manager: E2EEManager,
+    encryptedPayloadXml: string,
+    senderJid: string,
+    peer: string,
+  ): Promise<{ body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment } | null> {
+    try {
+      // Parse the serialized encrypted element back into an Element
+      const ltx = await import('ltx')
+      const encryptedEl = ltx.parse(encryptedPayloadXml) as unknown as Element
+
+      // Build a minimal stanza wrapper for decryptStanzaInPlace
+      const stanza = xml('message', { from: senderJid }, encryptedEl)
+
+      const result = await decryptStanzaInPlace(stanza, manager, peer, 'archive')
+      if (!result.attempted || result.encryptedPayloadXml) {
+        // Still can't decrypt
+        return null
+      }
+
+      // Extract the decrypted body
+      const body = stanza.getChildText('body')
+      if (!body) return null
+
+      // Extract attachment if present (XEP-0066 OOB)
+      const oobEl = stanza.getChild('x', 'jabber:x:oob')
+      let attachment: FileAttachment | undefined
+      if (oobEl) {
+        const url = oobEl.getChildText('url')
+        if (url) {
+          attachment = { url }
+          const desc = oobEl.getChildText('desc')
+          if (desc) attachment.name = desc
+        }
+      }
+
+      // Map SecurityContext to MessageSecurityContext
+      let securityContext: MessageSecurityContext | undefined
+      if (result.securityContext) {
+        securityContext = {
+          protocolId: result.securityContext.protocolId,
+          trust: result.securityContext.trust,
+          ...(result.securityContext.notes && { notes: result.securityContext.notes }),
+        }
+      }
+
+      return { body, securityContext, attachment }
+    } catch (err) {
+      logWarn(`E2EE deferred decrypt failed for message from ${senderJid}: ${err instanceof Error ? err.message : String(err)}`)
+      return null
+    }
+  }
+
+  /**
    * Build the E2EEManager if it doesn't yet exist, or if the previous
    * manager was bound to a different JID. On a plain reconnect/SM-resume
    * for the same identity this is a no-op and existing plugins stay
@@ -1598,6 +1756,12 @@ export class XMPPClient {
         messageId,
         securityContext,
       })
+    })
+    // When a plugin registers, emit a SDK event so backgroundSync (and other
+    // listeners) can trigger deferred decryption of messages that arrived
+    // before the plugin was available.
+    this.e2ee.onPluginRegistered((pluginId) => {
+      this.emitSDK('e2ee:plugin-registered', { pluginId })
     })
   }
 

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -731,3 +731,38 @@ describe('E2EE capability warm-up on fresh session', () => {
     expect(canEncryptTo).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Deferred E2EE decryption triggers
+// ---------------------------------------------------------------------------
+describe('deferred E2EE decryption triggers', () => {
+  let mockClient: ReturnType<typeof createMockClient>
+  let cleanup: () => void
+
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    connectionStore.getState().reset()
+    mockClient = createMockClient()
+    localStorageMock.clear()
+  })
+
+  afterEach(() => {
+    cleanup?.()
+  })
+
+  it('calls retryPendingDecrypts when e2ee:plugin-registered fires', () => {
+    cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+    mockClient._emitSDK('e2ee:plugin-registered', { pluginId: 'openpgp' })
+
+    expect(mockClient.retryPendingDecrypts).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls retryPendingDecrypts when e2ee:key-unlocked fires', () => {
+    cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+    mockClient._emitSDK('e2ee:key-unlocked', undefined)
+
+    expect(mockClient.retryPendingDecrypts).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -287,11 +287,30 @@ export function setupBackgroundSyncSideEffects(
     }
   )
 
+  // --- Deferred E2EE decryption triggers ---
+  // When an E2EE plugin registers (e.g. OpenPGP plugin loaded after
+  // background sync already fetched MAM messages), re-decrypt any messages
+  // that have a stashed encrypted payload.
+  const unsubscribePluginRegistered = client.subscribe('e2ee:plugin-registered', ({ pluginId }) => {
+    logInfo(`Background sync: E2EE plugin "${pluginId}" registered — retrying pending decrypts`)
+    void client.retryPendingDecrypts()
+  })
+
+  // When the user unlocks the E2EE private key (e.g. web passphrase entered
+  // after initial connect), re-decrypt messages that failed because the key
+  // was locked at receive time.
+  const unsubscribeKeyUnlocked = client.subscribe('e2ee:key-unlocked', () => {
+    logInfo('Background sync: E2EE key unlocked — retrying pending decrypts')
+    void client.retryPendingDecrypts()
+  })
+
   return () => {
     unsubscribeOnline()
     unsubscribeResumed()
     unsubscribeConnection()
     unsubscribeServerInfo()
+    unsubscribePluginRegistered()
+    unsubscribeKeyUnlocked()
     if (roomCatchUpTimer) {
       clearTimeout(roomCatchUpTimer)
       roomCatchUpTimer = undefined

--- a/packages/fluux-sdk/src/core/e2ee/E2EEManager.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/E2EEManager.test.ts
@@ -796,3 +796,27 @@ describe('E2EEManager — assertPlaintextPermitted', () => {
     await expect(mgr.assertPlaintextPermitted(groupTarget)).resolves.toBeUndefined()
   })
 })
+
+describe('E2EEManager — deferred decrypt support', () => {
+  it('hasPlugins returns false when no plugins are registered', () => {
+    const mgr = makeManager()
+    expect(mgr.hasPlugins()).toBe(false)
+  })
+
+  it('hasPlugins returns true after registering a plugin', async () => {
+    const mgr = makeManager()
+    await mgr.register(new FakePlugin(weakDescriptor, 'urn:test:weak'))
+    expect(mgr.hasPlugins()).toBe(true)
+  })
+
+  it('onPluginRegistered fires callback with the plugin id', async () => {
+    const mgr = makeManager()
+    const cb = vi.fn()
+    mgr.onPluginRegistered(cb)
+
+    await mgr.register(new FakePlugin(weakDescriptor, 'urn:test:weak'))
+
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledWith('openpgp')
+  })
+})

--- a/packages/fluux-sdk/src/core/e2ee/E2EEManager.ts
+++ b/packages/fluux-sdk/src/core/e2ee/E2EEManager.ts
@@ -85,6 +85,7 @@ export class E2EEManager {
   private sendPolicy: E2EESendPolicy = 'opportunistic'
   private readonly securityContextListeners = new Set<SecurityContextUpdateListener>()
   private readonly forcedPlaintextConversations = new Set<string>()
+  private pluginRegisteredCallback: ((pluginId: string) => void) | null = null
 
   constructor(options: E2EEManagerOptions) {
     this.storage = options.storage
@@ -135,6 +136,7 @@ export class E2EEManager {
     await plugin.init(ctx)
     this.plugins.set(id, plugin)
     this.logger.info(`E2EE plugin registered: ${id}`)
+    this.pluginRegisteredCallback?.(id)
   }
 
   /** Shut down and remove a plugin. Safe to call with an unknown id. */
@@ -156,6 +158,16 @@ export class E2EEManager {
   /** Get a specific plugin by id, or `null`. */
   getPlugin(id: string): E2EEPlugin | null {
     return this.plugins.get(id) ?? null
+  }
+
+  /** True when at least one plugin is registered. */
+  hasPlugins(): boolean {
+    return this.plugins.size > 0
+  }
+
+  /** Set a callback invoked whenever a plugin is registered. */
+  onPluginRegistered(cb: (pluginId: string) => void): void {
+    this.pluginRegisteredCallback = cb
   }
 
   /** Force all outbound sends to this target to skip encryption entirely. Inbound decryption is unaffected. */

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
@@ -12,6 +12,8 @@ import {
   decryptStanzaInPlace,
   readStashedAuthoredAt,
   readStashedSecurityContext,
+  readStashedEncryptedPayload,
+  stanzaHasEMEHint,
 } from './stanzaDecrypt'
 import { E2EEManager, InMemoryStorageBackend, type XMPPPrimitives } from './index'
 import { serialize as serializePayloadEnvelope } from './payloadEnvelope'
@@ -188,5 +190,141 @@ describe('stanzaDecrypt authoredAt stash', () => {
 
     expect(first.authoredAt?.toISOString()).toBe(authored.toISOString())
     expect(second.authoredAt?.toISOString()).toBe(authored.toISOString())
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Failing plugin: claims the encrypted child but throws on decrypt
+// ---------------------------------------------------------------------------
+
+class FailingE2EEPlugin extends FakeE2EEPlugin {
+  constructor() {
+    super(undefined)
+  }
+
+  override async decrypt(): Promise<DecryptResult> {
+    throw new Error('key locked')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a manager with no plugins registered
+// ---------------------------------------------------------------------------
+
+function makeEmptyManager(): E2EEManager {
+  return new E2EEManager({
+    storage: new InMemoryStorageBackend(),
+    xmpp: stubXmppPrimitives(),
+    account: { jid: 'me@example.com' },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Deferred decryption: encrypted payload stash on failure
+// ---------------------------------------------------------------------------
+
+describe('stanzaDecrypt encrypted payload stash on failure', () => {
+  it('stashes serialized encrypted XML when plugin decrypt fails', async () => {
+    const manager = await makeManager(new FailingE2EEPlugin())
+    const stanza = buildStanza()
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(true)
+    expect(result.encryptedPayloadXml).toBeDefined()
+    expect(result.encryptedPayloadXml).toContain(TEST_NAMESPACE)
+    expect(readStashedEncryptedPayload(stanza)).toBe(result.encryptedPayloadXml)
+  })
+
+  it('does not stash payload on successful decrypt', async () => {
+    const manager = await makeManager(new FakeE2EEPlugin(undefined))
+    const stanza = buildStanza()
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(true)
+    expect(result.encryptedPayloadXml).toBeUndefined()
+    expect(readStashedEncryptedPayload(stanza)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Deferred decryption: EME-based stash without plugin
+// ---------------------------------------------------------------------------
+
+describe('stanzaDecrypt EME-based stash without plugin', () => {
+  it('stashes encrypted child via EME when no plugin claims', async () => {
+    const manager = makeEmptyManager()
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/resource', id: 'm2', type: 'chat' },
+      xml('body', {}, 'This message is encrypted'),
+      xml('encryption', { xmlns: 'urn:xmpp:eme:0', namespace: 'urn:xmpp:openpgp:0' }),
+      xml('openpgp', { xmlns: 'urn:xmpp:openpgp:0' }, 'ciphertext'),
+    ) as Element
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(false)
+    expect(result.encryptedPayloadXml).toBeDefined()
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:openpgp:0')
+    expect(readStashedEncryptedPayload(stanza)).toBe(result.encryptedPayloadXml)
+  })
+
+  it('does not stash when there is no EME hint and no plugin claims', async () => {
+    const manager = makeEmptyManager()
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/resource', id: 'm3', type: 'chat' },
+      xml('body', {}, 'Hello, plain text'),
+    ) as Element
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(false)
+    expect(result.encryptedPayloadXml).toBeUndefined()
+    expect(readStashedEncryptedPayload(stanza)).toBeUndefined()
+  })
+
+  it('does not stash when EME namespace attr is missing', async () => {
+    const manager = makeEmptyManager()
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/resource', id: 'm4', type: 'chat' },
+      xml('body', {}, 'Encrypted without namespace hint'),
+      xml('encryption', { xmlns: 'urn:xmpp:eme:0' }),
+    ) as Element
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(false)
+    expect(result.encryptedPayloadXml).toBeUndefined()
+    expect(readStashedEncryptedPayload(stanza)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stanzaHasEMEHint
+// ---------------------------------------------------------------------------
+
+describe('stanzaHasEMEHint', () => {
+  it('returns true when EME element is present', () => {
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/resource', id: 'm5', type: 'chat' },
+      xml('encryption', { xmlns: 'urn:xmpp:eme:0', namespace: 'urn:xmpp:openpgp:0' }),
+    ) as Element
+
+    expect(stanzaHasEMEHint(stanza)).toBe(true)
+  })
+
+  it('returns false when no EME element', () => {
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/resource', id: 'm6', type: 'chat' },
+      xml('body', {}, 'plain text message'),
+    ) as Element
+
+    expect(stanzaHasEMEHint(stanza)).toBe(false)
   })
 })

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
@@ -23,11 +23,13 @@ import { elementToData } from './stanzaAdapter'
 import { parse as parsePayloadEnvelope } from './payloadEnvelope'
 import type { E2EEManager, SecurityContext } from './index'
 import type { InboundSource } from './types'
-import { logWarn } from '../logger'
+import { logWarn, logInfo } from '../logger'
+import { NS_EME } from '../namespaces'
 
 const DECRYPTED_MARKER = '__e2eeDecrypted'
 const SECURITY_CONTEXT_STASH = '__securityContext'
 const AUTHORED_AT_STASH = '__authoredAt'
+const ENCRYPTED_PAYLOAD_STASH = '__encryptedPayload'
 
 /**
  * Result of {@link decryptStanzaInPlace}. `attempted` is true whenever a
@@ -45,6 +47,14 @@ export interface DecryptInPlaceResult {
    * should prefer this over the stanza's `<delay/>` or arrival time.
    */
   authoredAt?: Date
+  /**
+   * Serialized XML of the encrypted child element, present only when
+   * decryption was attempted but failed (key locked, unsupported protocol)
+   * or when an EME hint was detected but no plugin claimed the stanza.
+   * Callers should store this on the resulting {@link Message} so that
+   * {@link XMPPClient.retryPendingDecrypts} can re-attempt later.
+   */
+  encryptedPayloadXml?: string
 }
 
 /**
@@ -100,8 +110,18 @@ export async function decryptStanzaInPlace(
     }
   }
   if (!claim || !encryptedChild) {
-    return { attempted: false }
+    // No plugin claimed — check if this is still an encrypted message via
+    // XEP-0380 EME (Explicit Message Encryption). This happens when no
+    // plugin is registered yet (race at startup) or the message uses a
+    // protocol this client doesn't support. Stash the encrypted element
+    // so retryPendingDecrypts() can re-attempt when a plugin is available.
+    const payloadXml = stashEncryptedPayloadViaEME(stanza)
+    return { attempted: false, ...(payloadXml && { encryptedPayloadXml: payloadXml }) }
   }
+
+  // Serialize the encrypted element BEFORE any mutation — the element
+  // will be stripped below regardless of success/failure.
+  const encryptedChildXml = encryptedChild.toString()
 
   let plaintext: string | null = null
   let securityContext: SecurityContext | null = null
@@ -136,6 +156,9 @@ export async function decryptStanzaInPlace(
 
   if (failureReason !== null) {
     logWarn(`E2EE decrypt failed for message from ${senderPeer}: ${failureReason}`)
+    // Stash the serialized encrypted element for deferred decryption.
+    // retryPendingDecrypts() will re-attempt when the key is unlocked.
+    stashPayload(stanza, encryptedChildXml)
     // XEP-0373: a well-behaved sender inserted a fallback <body> for
     // clients that cannot decrypt. Leave it alone. Synthesize a minimal
     // placeholder only when none was provided, so the message still
@@ -196,7 +219,44 @@ export async function decryptStanzaInPlace(
     attempted: true,
     ...(securityContext && { securityContext }),
     ...(authoredAt && { authoredAt }),
+    ...(failureReason !== null && { encryptedPayloadXml: encryptedChildXml }),
   }
+}
+
+// ---------------------------------------------------------------------------
+// Stanza stash helpers
+// ---------------------------------------------------------------------------
+
+/** Stash a serialized encrypted element on a stanza for deferred decrypt. */
+function stashPayload(stanza: Element, payloadXml: string): void {
+  ;(stanza as unknown as { [ENCRYPTED_PAYLOAD_STASH]?: string })[
+    ENCRYPTED_PAYLOAD_STASH
+  ] = payloadXml
+}
+
+/**
+ * EME-based fallback: when no plugin claimed the stanza, look for an
+ * XEP-0380 `<encryption>` hint. If found, locate the encrypted child by
+ * matching its namespace to the EME `namespace` attribute, serialize it,
+ * and stash it on the stanza. Returns the serialized XML or `undefined`.
+ */
+function stashEncryptedPayloadViaEME(stanza: Element): string | undefined {
+  const emeEl = stanza.getChild('encryption', NS_EME)
+  if (!emeEl) return undefined
+  const emeNamespace = emeEl.attrs.namespace
+  if (!emeNamespace) return undefined
+
+  for (const child of stanza.children) {
+    if (typeof child === 'string') continue
+    const childEl = child as Element
+    if (childEl.attrs.xmlns === emeNamespace) {
+      const payloadXml = childEl.toString()
+      stashPayload(stanza, payloadXml)
+      logInfo(`E2EE: stashed encrypted payload via EME (ns=${emeNamespace}) for deferred decrypt`)
+      return payloadXml
+    }
+  }
+  return undefined
 }
 
 /**
@@ -223,6 +283,17 @@ export function readStashedAuthoredAt(stanza: Element): Date | undefined {
 }
 
 /**
+ * Read back the serialized encrypted payload that was stashed on a stanza
+ * because decryption failed or no plugin was available. Returns `undefined`
+ * for cleartext messages or successfully-decrypted messages.
+ */
+export function readStashedEncryptedPayload(stanza: Element): string | undefined {
+  return (stanza as unknown as { [ENCRYPTED_PAYLOAD_STASH]?: string })[
+    ENCRYPTED_PAYLOAD_STASH
+  ]
+}
+
+/**
  * Fast synchronous probe: does any child of this stanza look like something
  * a registered E2EE plugin would claim? Used by the live path to decide
  * whether to short-circuit normal processing in favour of the async
@@ -240,4 +311,15 @@ export function stanzaHasE2EEClaim(
     if (manager.claimInbound(elementToData(child as Element))) return true
   }
   return false
+}
+
+/**
+ * Fast synchronous check: does this stanza carry an XEP-0380 EME hint
+ * indicating it's encrypted, regardless of whether any plugin is registered?
+ * Used by the live path when no E2EE manager or plugin is available to
+ * detect messages that should carry an {@link encryptedPayload} for deferred
+ * decryption.
+ */
+export function stanzaHasEMEHint(stanza: Element): boolean {
+  return !!stanza.getChild('encryption', NS_EME)
 }

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -749,6 +749,78 @@ describe('Chat E2EE wiring', () => {
     })
   })
 
+  describe('deferred decrypt — EME without plugin', () => {
+    /**
+     * Helper: build deps with no E2EE manager at all (getE2EEManager returns null).
+     */
+    function makeDepsNoManager(jid: string) {
+      const emitted: unknown[] = []
+      const sdkEmitted: unknown[] = []
+      const deps: ModuleDependencies = {
+        stores: null,
+        sendStanza: async () => {},
+        sendIQ: async () => xml('iq', {}) as Element,
+        getCurrentJid: () => jid,
+        emit: (event, ...args) => {
+          emitted.push({ event, args })
+        },
+        emitSDK: (event, payload) => {
+          sdkEmitted.push({ event, payload })
+        },
+        getXmpp: () => null,
+        getE2EEManager: () => null,
+      }
+      return { deps, emitted, sdkEmitted }
+    }
+
+    it('sets encryptedPayload when EME hint is present but no plugin claims', async () => {
+      const built = makeDepsNoManager('me@example.com')
+      const noManagerChat = new Chat(built.deps, stubMAM())
+
+      const inbound = xml(
+        'message',
+        { from: 'bob@example.com/r', to: 'me@example.com', type: 'chat', id: 'm-deferred-1' },
+        xml('body', {}, '[OpenPGP-encrypted message]'),
+        xml('openpgp', { xmlns: 'urn:xmpp:openpgp:0' }, 'base64ciphertext'),
+        xml('encryption', { xmlns: 'urn:xmpp:eme:0', namespace: 'urn:xmpp:openpgp:0', name: 'OpenPGP' }),
+      )
+
+      noManagerChat.handle(inbound)
+      await new Promise((r) => setTimeout(r, 0))
+
+      const chatMessageEvent = built.sdkEmitted.find(
+        (e) => (e as { event: string }).event === 'chat:message',
+      ) as { payload: { message: { body: string; encryptedPayload?: string } } } | undefined
+
+      expect(chatMessageEvent).toBeDefined()
+      expect(chatMessageEvent!.payload.message.encryptedPayload).toBeDefined()
+      expect(chatMessageEvent!.payload.message.encryptedPayload).toContain('urn:xmpp:openpgp:0')
+      expect(chatMessageEvent!.payload.message.body).toBe('[OpenPGP-encrypted message]')
+    })
+
+    it('does not set encryptedPayload on a plain message without EME', async () => {
+      const built = makeDepsNoManager('me@example.com')
+      const noManagerChat = new Chat(built.deps, stubMAM())
+
+      const inbound = xml(
+        'message',
+        { from: 'bob@example.com/r', to: 'me@example.com', type: 'chat', id: 'm-deferred-2' },
+        xml('body', {}, 'Hello'),
+      )
+
+      noManagerChat.handle(inbound)
+      await new Promise((r) => setTimeout(r, 0))
+
+      const chatMessageEvent = built.sdkEmitted.find(
+        (e) => (e as { event: string }).event === 'chat:message',
+      ) as { payload: { message: { body: string; encryptedPayload?: string } } } | undefined
+
+      expect(chatMessageEvent).toBeDefined()
+      expect(chatMessageEvent!.payload.message.encryptedPayload).toBeUndefined()
+      expect(chatMessageEvent!.payload.message.body).toBe('Hello')
+    })
+  })
+
   // -------------------------------------------------------------------
   // Regression: every chat-like outbound primitive must route through the
   // E2EE wrap. A leak in any of these paths (resend a failed encrypted

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -36,8 +36,10 @@ import { E2EEEncryptionRequiredError } from '../e2ee'
 import {
   decryptStanzaInPlace,
   readStashedAuthoredAt,
+  readStashedEncryptedPayload,
   readStashedSecurityContext,
   stanzaHasE2EEClaim,
+  stanzaHasEMEHint,
 } from '../e2ee/stanzaDecrypt'
 import { serialize as serializePayloadEnvelope } from '../e2ee/payloadEnvelope'
 import { build as buildAesgcmUri } from './AesgcmUri'
@@ -171,6 +173,15 @@ export class Chat extends BaseModule {
     // the encrypted stanza.
     if (this.tryHandleEncrypted(stanza, isCarbonCopy, isSentCarbon)) {
       return { handled: true }
+    }
+
+    // Deferred decrypt: when tryHandleEncrypted returned false (no plugin
+    // registered or no manager), detect encrypted messages via EME hint and
+    // stash the encrypted payload for later retry. decryptStanzaInPlace
+    // handles the case where a manager exists but no plugin claims; this
+    // covers the case where no manager exists at all.
+    if (!readStashedEncryptedPayload(stanza) && stanzaHasEMEHint(stanza)) {
+      this.stashEncryptedPayloadForDeferredDecrypt(stanza)
     }
 
     const from = stanza.attrs.from
@@ -356,6 +367,30 @@ export class Chat extends BaseModule {
     const bareFrom = from ? getBareJid(from) : ''
     await decryptStanzaInPlace(stanza, manager, bareFrom, 'live')
     this.handleMessageInternal(stanza, isCarbonCopy, isSentCarbon)
+  }
+
+  /**
+   * Stash the encrypted child element on a stanza for deferred decryption
+   * when no E2EE manager or plugin is available. Uses the XEP-0380 EME hint
+   * to locate the encrypted child by namespace.
+   */
+  private stashEncryptedPayloadForDeferredDecrypt(stanza: Element): void {
+    const emeEl = stanza.getChild('encryption', NS_EME)
+    if (!emeEl) return
+    const emeNamespace = emeEl.attrs.namespace
+    if (!emeNamespace) return
+    for (const child of stanza.children) {
+      if (typeof child === 'string') continue
+      const childEl = child as Element
+      if (childEl.attrs.xmlns === emeNamespace) {
+        // Stash the serialized element for later retry — reuse the same
+        // stanza-level stash that decryptStanzaInPlace uses so downstream
+        // readers (processChatMessage) see it via readStashedEncryptedPayload.
+        const STASH = '__encryptedPayload'
+        ;(stanza as unknown as Record<string, string>)[STASH] = childEl.toString()
+        return
+      }
+    }
   }
 
   /**
@@ -1659,6 +1694,7 @@ export class Chat extends BaseModule {
     const messageId = replaceTargetId || stanza.attrs.id || generateStableMessageId(bareFrom, parsed.timestamp, body)
 
     const securityContext = this.readMessageSecurityContext(stanza)
+    const encryptedPayload = readStashedEncryptedPayload(stanza)
     const message: Message = {
       type: 'chat',
       id: messageId,
@@ -1675,6 +1711,7 @@ export class Chat extends BaseModule {
       ...(parsed.attachment && { attachment: parsed.attachment }),
       ...(isCorrection && { isEdited: true }),
       ...(securityContext && { securityContext }),
+      ...(encryptedPayload && { encryptedPayload }),
     }
 
     if (!isOutgoing && this.deps.stores) {
@@ -1725,6 +1762,7 @@ export class Chat extends BaseModule {
     const occupantId = stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
 
     const securityContext = this.readMessageSecurityContext(stanza)
+    const encryptedPayload = readStashedEncryptedPayload(stanza)
     const message: RoomMessage = {
       type: 'groupchat',
       id: messageId,
@@ -1743,6 +1781,7 @@ export class Chat extends BaseModule {
       ...(isCorrection && { isEdited: true }),
       ...(occupantId && { occupantId }),
       ...(securityContext && { securityContext }),
+      ...(encryptedPayload && { encryptedPayload }),
     }
 
     // Poll detection: check for <poll> or <poll-closed> elements

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -75,6 +75,7 @@ import { logInfo, logError as logErr } from '../logger'
 import {
   decryptStanzaInPlace,
   readStashedAuthoredAt,
+  readStashedEncryptedPayload,
   readStashedSecurityContext,
 } from '../e2ee/stanzaDecrypt'
 import type { MessageSecurityContext } from '../types'
@@ -233,14 +234,14 @@ export class MAM extends BaseModule {
           const response = await this.deps.sendIQ(iq)
           const { complete, rsm } = this.parseMAMResponse(response)
 
-          // Drain the buffer: run modification detection + opportunistic
-          // E2EE decrypt, then parse into Message objects.
+          // Drain the buffer: E2EE decrypt first (so modification bodies are
+          // plaintext, not fallback hints), then modification detection, then parse.
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
             const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
+            await this.decryptArchiveEntryIfNeeded(messageEl, conversationId)
             if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp)) {
               continue
             }
-            await this.decryptArchiveEntryIfNeeded(messageEl, conversationId)
             const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
             if (msg) collectedMessages.push(msg)
           }
@@ -377,13 +378,13 @@ export class MAM extends BaseModule {
           const response = await this.deps.sendIQ(iq)
           const { complete, rsm } = this.parseMAMResponse(response)
 
-          // Drain buffer: modification detection + opportunistic E2EE decrypt, then parse.
+          // Drain buffer: E2EE decrypt first, then modification detection, then parse.
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
             const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
+            await this.decryptArchiveEntryIfNeeded(messageEl, roomJid)
             if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp)) {
               continue
             }
-            await this.decryptArchiveEntryIfNeeded(messageEl, roomJid)
             const msg = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
             if (msg) collectedMessages.push(msg)
           }
@@ -503,14 +504,14 @@ export class MAM extends BaseModule {
       const ownBareJid = currentJid ? getBareJid(currentJid) : ''
       for (const { forwarded, messageEl, archiveId } of rawEntries) {
         const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
-        if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp)) {
-          continue
-        }
         // Derive conversationId from the message's from/to
         const from = getBareJid(messageEl.attrs.from || '')
         const to = getBareJid(messageEl.attrs.to || '')
         const conversationId = from === ownBareJid ? to : from
         await this.decryptArchiveEntryIfNeeded(messageEl, conversationId)
+        if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp)) {
+          continue
+        }
         const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
         if (msg) collectedMessages.push(msg)
       }
@@ -569,10 +570,10 @@ export class MAM extends BaseModule {
 
       for (const { forwarded, messageEl, archiveId } of rawEntries) {
         const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
+        await this.decryptArchiveEntryIfNeeded(messageEl, roomJid)
         if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp)) {
           continue
         }
-        await this.decryptArchiveEntryIfNeeded(messageEl, roomJid)
         const msg = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
         if (msg) collectedMessages.push(msg)
       }
@@ -1729,6 +1730,7 @@ export class MAM extends BaseModule {
     const messageId = messageEl.attrs.id || generateStableMessageId(from, parsed.timestamp, body || '')
 
     const securityContext = this.archiveSecurityContext(messageEl)
+    const encryptedPayload = readStashedEncryptedPayload(messageEl)
 
     return {
       type: 'chat',
@@ -1745,6 +1747,7 @@ export class MAM extends BaseModule {
       ...(parsed.replyTo && { replyTo: parsed.replyTo }),
       ...(parsed.attachment && { attachment: parsed.attachment }),
       ...(securityContext && { securityContext }),
+      ...(encryptedPayload && { encryptedPayload }),
     }
   }
 
@@ -1794,6 +1797,9 @@ export class MAM extends BaseModule {
     // XEP-0421: Anonymous Unique Occupant Identifiers
     const occupantId = messageEl.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
 
+    const roomSecurityContext = this.archiveSecurityContext(messageEl)
+    const roomEncryptedPayload = readStashedEncryptedPayload(messageEl)
+
     const message: RoomMessage = {
       type: 'groupchat',
       id: messageId,
@@ -1810,6 +1816,8 @@ export class MAM extends BaseModule {
       ...(parsed.replyTo && { replyTo: parsed.replyTo }),
       ...(parsed.attachment && { attachment: parsed.attachment }),
       ...(occupantId && { occupantId }),
+      ...(roomSecurityContext && { securityContext: roomSecurityContext }),
+      ...(roomEncryptedPayload && { encryptedPayload: roomEncryptedPayload }),
     }
 
     // Poll detection: parse <poll> or <poll-closed> elements from archived messages

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -55,6 +55,7 @@ export function createMockClient() {
       discoverMAMSearchCapability: vi.fn().mockResolvedValue(undefined),
     },
     isConnected: vi.fn().mockReturnValue(true),
+    retryPendingDecrypts: vi.fn().mockResolvedValue(0),
     e2ee: null as any,
     on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       if (!handlers.has(event)) handlers.set(event, new Set())

--- a/packages/fluux-sdk/src/core/types/message-base.ts
+++ b/packages/fluux-sdk/src/core/types/message-base.ts
@@ -184,6 +184,21 @@ export interface BaseMessage {
    * state, protocol badge).
    */
   securityContext?: MessageSecurityContext
+  /**
+   * Serialized encrypted stanza element XML for deferred decryption.
+   *
+   * Present when an E2EE-tagged message could not be decrypted at receive
+   * time — either because no plugin was registered yet (race at startup)
+   * or because the private key was locked (web passphrase not entered).
+   *
+   * {@link XMPPClient.retryPendingDecrypts} iterates messages carrying this
+   * field, reconstructs a minimal stanza, and re-attempts decryption.  On
+   * success the field is cleared and `body` / `securityContext` are updated.
+   *
+   * Persisted in IndexedDB so deferred decrypt survives page navigations
+   * within the same session.
+   */
+  encryptedPayload?: string
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -191,6 +191,20 @@ export interface ChatEvents {
     messageId: string
     securityContext: import('./message-base').MessageSecurityContext
   }
+
+  /**
+   * Fired when an E2EE plugin is successfully registered on the manager.
+   * Used by background sync to trigger deferred decryption of messages
+   * that arrived before the plugin was available.
+   */
+  'e2ee:plugin-registered': { pluginId: string }
+
+  /**
+   * Fired when the E2EE private key is unlocked (e.g. web passphrase
+   * entered). Triggers deferred decryption of messages that failed because
+   * the key was locked at receive time.
+   */
+  'e2ee:key-unlocked': undefined
 }
 
 // ============================================================================


### PR DESCRIPTION
- **Deferred decrypt**: when an E2EE message cannot be decrypted at receive time (plugin not registered yet, or web passphrase not entered), the encrypted XML is stored on the message and automatically re-decrypted when conditions are met — no MAM re-fetch needed
- **MAM corrections fix**: `decryptArchiveEntryIfNeeded()` is now called *before* `collectModification()` in all 4 MAM drain loops, so encrypted corrections are decrypted before being consumed as modifications
- **New SDK events**: `e2ee:plugin-registered` and `e2ee:key-unlocked` allow background sync to trigger deferred decryption automatically