### PR TITLE
Fix status label truncation in sidebar user panel

### DIFF
--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -472,12 +472,12 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
 
         {/* User Panel - avatar spans both rows */}
         <div className="px-2 py-2 bg-fluux-sidebar border-t border-fluux-bg">
-          <div className="flex items-center gap-3 min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
             {/* Large avatar - clickable for profile settings */}
             <Tooltip content={t('sidebar.viewProfile')} position="top">
               <div
                 onClick={() => { modalActions.close('presenceMenu'); navigateToSettings('profile') }}
-                className="flex-shrink-0 rounded-full hover:ring-2 hover:ring-fluux-muted/30 transition-all cursor-pointer"
+                className="flex-shrink-0 me-1 rounded-full hover:ring-2 hover:ring-fluux-muted/30 transition-all cursor-pointer"
               >
                 <Avatar
                   identifier={jid || ''}

--- a/apps/fluux/src/components/sidebar-components/UserMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/UserMenu.tsx
@@ -55,7 +55,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
 
   return (
     <>
-      <div className="relative" ref={menuRef}>
+      <div className="relative flex-shrink-0" ref={menuRef}>
         <Tooltip content={t('common.options')} position="top" disabled={isOpen}>
           <button
             onClick={() => setIsOpen(!isOpen)}


### PR DESCRIPTION
## Summary

- Reduce `gap-3` → `gap-2` between flex children in the sidebar user panel, recovering 4px for the status text
- Add `me-1` on the avatar wrapper to preserve the original avatar-to-text spacing
- Add `flex-shrink-0` on the UserMenu wrapper to prevent accidental shrinking