### PR TITLE
fix(ui): prevent blockquote quote marks from being clipped

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -432,6 +432,8 @@ html, body {
   position: relative;
   padding-left: 1.25rem;
   padding-right: 0.5rem;
+  padding-top: 0.2rem;
+  padding-bottom: 0.5rem;
   margin-block: 0.125rem;
 }
 .blockquote-decorated::before {


### PR DESCRIPTION
## Summary

- The decorative `"` / `"` marks on `.blockquote-decorated` blockquotes were visually truncated
- Root cause: `::before` uses `top: -0.15rem` and `::after` uses `vertical-align: -0.4rem`, both extending the 1.75rem glyphs outside the element's bounding box
- Any ancestor with `overflow: hidden` (message bubble, collapsible wrapper) would clip the overflowing edges
- Fix: add `padding-top: 0.2rem` and `padding-bottom: 0.5rem` to `.blockquote-decorated` so the box fully contains both pseudo-elements