### PR TITLE
fix(deps): bump fast-uri and @babel/plugin-transform-modules-systemjs for security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6691,9 +6691,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bumps `fast-uri` 3.1.0 -> 3.1.2 (GHSA-q3j6-qgpj-74h6 path traversal, GHSA-v39h-62p7-jpjc host confusion)
- Bumps `@babel/plugin-transform-modules-systemjs` 7.29.0 -> 7.29.4 (GHSA-fv7c-fp4j-7gwp arbitrary code generation)

Both are transitive dev dependencies, so only `package-lock.json` changes.

The remaining Dependabot alerts on the Rust side (rustls-webpki, aws-lc-sys, tar, rand, hickory-*) are not included here: a `cargo update` currently fails on devel because `keyring = "4"` in Cargo.toml is unsatisfiable against the features requested (apple-native, windows-native, etc.). That needs to be resolved first in a separate PR before any Rust lockfile bumps can land.
