### PR TITLE
chore(renovate): target main and ignore broken majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,22 @@
     "schedule:daily",
     "group:allNonMajor"
   ],
-  "baseBranchPatterns": [
-    "devel"
-  ],
   "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Disable known-broken major bumps that need manual migration work",
+      "matchPackageNames": [
+        "zod-validation-error",
+        "typescript",
+        "keyring",
+        "tailwindcss"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "groupName": "Rust crates",


### PR DESCRIPTION
## Summary

Follow-up to #403. Switches Renovate from `devel` base branch to `main` and silences four major bumps known to require manual migration work to prepare auto bumps for small version changes.

## Changes

- Remove `baseBranchPatterns: ["devel"]` so Renovate uses the default branch (`main`).
- Add a `packageRule` disabling major bumps for:
  - `zod-validation-error` - v5 breaks `eslint-plugin-react-hooks` which still requires a `zod-validation-error/v4` subpath import.
  - `typescript` - v6 has peerDep conflicts (`npm ci` fails on the bumped lockfile).
  - `keyring` - v4 is an architecture change (features renamed, API rewrite), needs a code migration.
  - `tailwindcss` - v4 is a substantial config migration, best done in a dedicated window.
