### PR TITLE
fix(e2ee): verify own-key signature before merging synced verifications

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -995,6 +995,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     this._syncingFromRemoteCount++
     const ctx = this.ctx
     const ownPublicArmored = this.ownBundle.publicArmored
+    const ownFingerprint = this.ownBundle.fingerprint
     try {
       const remote = await fetchVerificationsFromServer(
         ctx,
@@ -1002,6 +1003,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
           this.decryptWithOwnKey(ctx.account.jid, ciphertext, senderKey),
         ctx.account.jid,
         ownPublicArmored,
+        ownFingerprint,
       )
       if (!remote) return
       const local = useVerifiedPeerKeysStore.getState().verifiedFingerprintByJid

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -3411,13 +3411,16 @@ describe('SequoiaPgpPlugin', () => {
 
     // Build a PEP item that looks exactly like one publishVerificationsToServer
     // would produce: base64(OPENPGP-STUB ciphertext) inside verifications-data.
+    // `signerFp` defaults to `ownFp` (a legitimate self-signed item); pass a
+    // different value to simulate a server-forged node signed by a foreign key.
     function buildVerificationsPepItem(
       ownFp: string,
       verifications: Record<string, string>,
+      signerFp: string = ownFp,
     ): PEPItem {
       const json = JSON.stringify({ v: 1, ts: 1000, verifications })
       const encoded = btoa(unescape(encodeURIComponent(json)))
-      const armored = `OPENPGP-STUB:${ownFp}:${ownFp}:${encoded}`
+      const armored = `OPENPGP-STUB:${ownFp}:${signerFp}:${encoded}`
       const b64Armored = btoa(unescape(encodeURIComponent(armored)))
       return {
         id: 'current',
@@ -3452,6 +3455,31 @@ describe('SequoiaPgpPlugin', () => {
 
       const { isPeerVerified: isVerified } = await import('@/stores/verifiedPeerKeysStore')
       expect(isVerified('alice@example.com', 'ALICE_FP')).toBe(true)
+    })
+
+    it('ignores a server-forged verifications node signed by a foreign key', async () => {
+      const { ctx, peerPublish } = makeContext('me@example.com')
+      const fp = 'FP_FORGE_TEST'
+      fake.accounts.set('me@example.com', {
+        fingerprint: fp,
+        publicArmored: makeOpenPgpArmor(
+          'PGP PUBLIC KEY BLOCK',
+          `Fingerprint: ${fp}\nUID: xmpp:me@example.com\nKind: public\nRotation: 0\n`,
+        ),
+        keychainBacked: true,
+      })
+      // A malicious server can encrypt an arbitrary map to our public key, but
+      // it cannot sign as us — so the embedded signer fingerprint is foreign.
+      peerPublish(
+        'me@example.com',
+        VERIFICATIONS_NODE,
+        buildVerificationsPepItem(fp, { 'mallory@example.com': 'MALLORY_FP' }, 'ATTACKER_FP'),
+      )
+      await plugin.init(ctx)
+      await new Promise((r) => setTimeout(r, 0))
+
+      const { isPeerVerified: isVerified } = await import('@/stores/verifiedPeerKeysStore')
+      expect(isVerified('mallory@example.com', 'MALLORY_FP')).toBe(false)
     })
 
     it('publishes the verifications PEP node after a local verification is added', async () => {

--- a/apps/fluux/src/e2ee/verificationSync.test.ts
+++ b/apps/fluux/src/e2ee/verificationSync.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PluginContext } from '@fluux/sdk'
+
+import {
+  fetchVerificationsFromServer,
+  VERIFICATIONS_NODE,
+  type DecryptFn,
+} from './verificationSync'
+
+const OWN_FP = 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555'
+const OWN_PUBLIC = 'OWN-PUBLIC-ARMOR'
+const OWN_JID = 'me@example.com'
+
+const VALID_PAYLOAD = JSON.stringify({
+  v: 1,
+  ts: 1000,
+  verifications: { 'bob@example.com': 'BOB_FP' },
+})
+
+/** Minimal PluginContext whose queryPEP serves a single verifications item. */
+function makeCtx(dataChild = 'AAAA'): PluginContext {
+  return {
+    xmpp: {
+      queryPEP: async () => [
+        {
+          id: 'current',
+          payload: {
+            name: 'verifications-data',
+            attrs: { xmlns: VERIFICATIONS_NODE },
+            children: [{ name: 'data', attrs: {}, children: [dataChild] }],
+          },
+        },
+      ],
+    },
+  } as unknown as PluginContext
+}
+
+/** A decrypt fn that returns fixed plaintext + caller-controlled signature metadata. */
+function decryptReturning(meta: {
+  plaintext?: string
+  signatureVerified: boolean
+  signerFingerprint: string | null
+  signaturePresent: boolean
+}): DecryptFn {
+  return async () => ({
+    plaintext: meta.plaintext ?? VALID_PAYLOAD,
+    signatureVerified: meta.signatureVerified,
+    signerFingerprint: meta.signerFingerprint,
+    signaturePresent: meta.signaturePresent,
+  })
+}
+
+describe('fetchVerificationsFromServer — signature enforcement', () => {
+  it('returns the map for a payload validly signed by our own primary key', async () => {
+    const result = await fetchVerificationsFromServer(
+      makeCtx(),
+      decryptReturning({
+        signatureVerified: true,
+        signerFingerprint: OWN_FP,
+        signaturePresent: true,
+      }),
+      OWN_JID,
+      OWN_PUBLIC,
+      OWN_FP,
+    )
+    expect(result).toEqual({ 'bob@example.com': 'BOB_FP' })
+  })
+
+  it('rejects an unsigned payload (server-forged ciphertext to our public key)', async () => {
+    const result = await fetchVerificationsFromServer(
+      makeCtx(),
+      decryptReturning({
+        signatureVerified: false,
+        signerFingerprint: null,
+        signaturePresent: false,
+      }),
+      OWN_JID,
+      OWN_PUBLIC,
+      OWN_FP,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('rejects a payload whose signature is present but does not verify', async () => {
+    const result = await fetchVerificationsFromServer(
+      makeCtx(),
+      decryptReturning({
+        signatureVerified: false,
+        signerFingerprint: OWN_FP,
+        signaturePresent: true,
+      }),
+      OWN_JID,
+      OWN_PUBLIC,
+      OWN_FP,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('rejects a payload validly signed by a key other than our own primary key', async () => {
+    const result = await fetchVerificationsFromServer(
+      makeCtx(),
+      decryptReturning({
+        signatureVerified: true,
+        signerFingerprint: 'DEADBEEF0000111122223333444455556666AAAA',
+        signaturePresent: true,
+      }),
+      OWN_JID,
+      OWN_PUBLIC,
+      OWN_FP,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('rejects a verified signature with no signer fingerprint (defensive)', async () => {
+    const result = await fetchVerificationsFromServer(
+      makeCtx(),
+      decryptReturning({
+        signatureVerified: true,
+        signerFingerprint: null,
+        signaturePresent: true,
+      }),
+      OWN_JID,
+      OWN_PUBLIC,
+      OWN_FP,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('matches the signer fingerprint case-insensitively', async () => {
+    const result = await fetchVerificationsFromServer(
+      makeCtx(),
+      decryptReturning({
+        signatureVerified: true,
+        signerFingerprint: OWN_FP.toLowerCase(),
+        signaturePresent: true,
+      }),
+      OWN_JID,
+      OWN_PUBLIC,
+      OWN_FP.toUpperCase(),
+    )
+    expect(result).toEqual({ 'bob@example.com': 'BOB_FP' })
+  })
+})

--- a/apps/fluux/src/e2ee/verificationSync.ts
+++ b/apps/fluux/src/e2ee/verificationSync.ts
@@ -2,9 +2,14 @@
  * Cross-device synchronisation of peer verification records.
  *
  * Publishes the local `verifiedPeerKeysStore` map to a private PEP node
- * (`urn:xmpp:fluux:verifications:0`, `accessModel='whitelist'`) encrypted
+ * (`urn:xmpp:fluux:verifications:0`, `accessModel='whitelist'`) sign+encrypted
  * to the user's own OpenPGP key. Other devices of the same account receive
  * a PEP headline, fetch the node, decrypt it, and merge the entries.
+ *
+ * Trust hinges on the signature, not the access model: the fetch path discards
+ * any payload not signed by the account's own primary key, so a tampering
+ * server cannot inject forged "verified" entries by encrypting to the user's
+ * (public) key.
  *
  * Crypto is abstracted behind {@link EncryptFn}/{@link DecryptFn} so this
  * module works with both the Sequoia/Tauri backend and the openpgp.js web
@@ -23,11 +28,28 @@ export type EncryptFn = (
   recipientPublicArmored: string,
 ) => Promise<string>
 
-/** Decrypt `ciphertext` (encrypted to us). Returns `{ plaintext }`. */
+/**
+ * Decrypt `ciphertext` (encrypted to us) and report on its signature.
+ *
+ * The signature metadata is mandatory: cross-device sync only trusts a
+ * payload that carries a valid signature from the account's own key, so the
+ * caller must surface whatever the crypto backend reports. Mirrors the
+ * backend `DecryptOutput` shape.
+ */
 export type DecryptFn = (
   ciphertext: string,
   senderPublicArmored: string,
-) => Promise<{ plaintext: string }>
+) => Promise<{
+  plaintext: string
+  signatureVerified: boolean
+  signerFingerprint: string | null
+  signaturePresent: boolean
+}>
+
+/** Case- and whitespace-insensitive fingerprint comparison. */
+function fingerprintsEqual(a: string, b: string): boolean {
+  return a.replace(/\s+/g, '').toLowerCase() === b.replace(/\s+/g, '').toLowerCase()
+}
 
 export const VERIFICATIONS_NODE = 'urn:xmpp:fluux:verifications:0'
 const VERIFICATIONS_XMLNS = VERIFICATIONS_NODE
@@ -109,13 +131,23 @@ export async function publishVerificationsToServer(
 
 /**
  * Fetch the private PEP node, decrypt it, and return the verification map.
- * Returns `null` when the node is absent or decryption fails.
+ *
+ * Downgrade protection: the decrypted payload is only trusted when it carries
+ * a signature that verifies against the account's *own primary key*
+ * (`ownFingerprint`). A malicious server can encrypt an arbitrary map to the
+ * user's public key (it is, after all, public), but it cannot forge a
+ * signature from the user's secret key — so any unsigned, wrong-signed, or
+ * foreign-signed payload is discarded.
+ *
+ * Returns `null` when the node is absent, decryption fails, or the signature
+ * check does not pass.
  */
 export async function fetchVerificationsFromServer(
   ctx: PluginContext,
   decryptFn: DecryptFn,
   ownJid: string,
   ownPublicArmored: string,
+  ownFingerprint: string,
 ): Promise<Record<string, string> | null> {
   let items: { id: string; payload: XMLElementData }[]
   try {
@@ -130,10 +162,21 @@ export async function fetchVerificationsFromServer(
 
   const armored = b64Decode(base64Ciphertext)
 
-  let decrypted: { plaintext: string }
+  let decrypted: Awaited<ReturnType<DecryptFn>>
   try {
     decrypted = await decryptFn(armored, ownPublicArmored)
   } catch {
+    return null
+  }
+
+  // Downgrade protection: only a payload signed by our own primary key is
+  // trusted. Reject unsigned, unverified, or foreign-signed maps — these can
+  // only originate from a tampering server, not from one of our devices.
+  if (
+    !decrypted.signatureVerified ||
+    !decrypted.signerFingerprint ||
+    !fingerprintsEqual(decrypted.signerFingerprint, ownFingerprint)
+  ) {
     return null
   }
 


### PR DESCRIPTION
This change threads the signature metadata through `DecryptFn` and gates the merge: `fetchVerificationsFromServer` now requires a valid signature from the account's **own primary key** before returning the map. Unsigned, present-but-unverified, and foreign-signed payloads are all discarded. The publish side already sign+encrypts, so legitimate cross-device sync is unaffected.