### PR TITLE
fix(e2ee): stop revoked verifications from resurfacing on sync

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -85,8 +85,10 @@ import {
 import {
   VERIFICATIONS_NODE,
   fetchVerificationsFromServer,
-  mergeVerifications,
+  loadAppliedVerificationsVersion,
+  planVerificationUpdate,
   publishVerificationsToServer,
+  saveAppliedVerificationsVersion,
 } from './verificationSync'
 import {
   clearKeyChangeAlert,
@@ -1005,11 +1007,11 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       )
       if (!remote) return
       const local = useVerifiedPeerKeysStore.getState().verifiedFingerprintByJid
-      const { hasNewEntries, merged } = mergeVerifications(remote, local)
-      if (!hasNewEntries) return
-      for (const [jid, fp] of Object.entries(merged)) {
-        if (!local[jid]) setPeerVerified(jid, fp)
-      }
+      const plan = planVerificationUpdate(remote, local, loadAppliedVerificationsVersion())
+      if (!plan.apply) return
+      for (const { jid, fingerprint } of plan.toSet) setPeerVerified(jid, fingerprint)
+      for (const jid of plan.toClear) clearPeerVerified(jid)
+      saveAppliedVerificationsVersion(plan.version)
     } catch {
       // Non-blocking — local store is always the source of truth.
     } finally {
@@ -1026,13 +1028,19 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       if (!this.ownBundle || !this.ctx) return
       const ctx = this.ctx
       const ownPublicArmored = this.ownBundle.publicArmored
+      // Reserve the next version above the highest we've applied/published.
+      // Real versions start at 1; 0 is reserved for legacy (v1) snapshots.
+      const nextVersion = Math.max(loadAppliedVerificationsVersion(), 0) + 1
       void publishVerificationsToServer(
         ctx,
         (plaintext, recipientKey) =>
           this.encryptToRecipient(ctx.account.jid, recipientKey, plaintext),
         ownPublicArmored,
         verifications,
-      ).catch(() => {})
+        nextVersion,
+      )
+        .then(() => saveAppliedVerificationsVersion(nextVersion))
+        .catch(() => {})
     }, 500)
   }
 

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -3414,8 +3414,12 @@ describe('SequoiaPgpPlugin', () => {
     function buildVerificationsPepItem(
       ownFp: string,
       verifications: Record<string, string>,
+      version?: number,
     ): PEPItem {
-      const json = JSON.stringify({ v: 1, ts: 1000, verifications })
+      const json =
+        version === undefined
+          ? JSON.stringify({ v: 1, ts: 1000, verifications })
+          : JSON.stringify({ v: 2, ts: 1000, version, verifications })
       const encoded = btoa(unescape(encodeURIComponent(json)))
       const armored = `OPENPGP-STUB:${ownFp}:${ownFp}:${encoded}`
       const b64Armored = btoa(unescape(encodeURIComponent(armored)))
@@ -3427,6 +3431,23 @@ describe('SequoiaPgpPlugin', () => {
           children: [{ name: 'data', attrs: {}, children: [b64Armored] }],
         },
       }
+    }
+
+    // Reverse the plugin's publish encoding: data child holds
+    // base64(makeOpenPgpArmor('OPENPGP-STUB:<recipient>:<sender>:<base64-json>')).
+    function decodePublishedVerifications(item: PEPItem): {
+      version?: number
+      verifications: Record<string, string>
+    } {
+      const dataChild = item.payload.children.find(
+        (c): c is XMLElementData => typeof c !== 'string' && c.name === 'data',
+      )
+      const dataText = dataChild?.children[0]
+      if (typeof dataText !== 'string') throw new Error('no data child in published item')
+      const armored = decodeURIComponent(escape(atob(dataText)))
+      const stub = readOpenPgpArmorPayloadForTest(armored)
+      const payloadB64 = stub.slice('OPENPGP-STUB:'.length).split(':')[2]
+      return JSON.parse(decodeURIComponent(escape(atob(payloadB64))))
     }
 
     it('seeds the local verified-peers store from the server node on init', async () => {
@@ -3562,6 +3583,130 @@ describe('SequoiaPgpPlugin', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+
+    it('publishes an empty snapshot when the last verification is revoked, and it does not resurrect on resync', async () => {
+      vi.useFakeTimers()
+      try {
+        let verificationsCb: ((item: PEPItem) => void) | null = null
+        const { ctx, published } = makeContext('me@example.com')
+        ctx.xmpp.subscribePEP = (_jid, node, cb) => {
+          if (node === VERIFICATIONS_NODE) verificationsCb = cb
+          return { unsubscribe: () => {} }
+        }
+        const fp = 'FP_REVOKE_TEST'
+        fake.accounts.set('me@example.com', {
+          fingerprint: fp,
+          publicArmored: makeOpenPgpArmor(
+            'PGP PUBLIC KEY BLOCK',
+            `Fingerprint: ${fp}\nUID: xmpp:me@example.com\nKind: public\nRotation: 0\n`,
+          ),
+          keychainBacked: true,
+        })
+        await plugin.init(ctx)
+
+        const store = await import('@/stores/verifiedPeerKeysStore')
+        store.setPeerVerified('alice@example.com', 'ALICE_FP')
+        await vi.advanceTimersByTimeAsync(600)
+        store.clearPeerVerified('alice@example.com')
+        await vi.advanceTimersByTimeAsync(600)
+
+        // The empty map is published (not skipped), overwriting the server node.
+        const verNodes = published.filter((p) => p.node === VERIFICATIONS_NODE)
+        const lastPayload = decodePublishedVerifications(verNodes[verNodes.length - 1].item)
+        expect(lastPayload.verifications).toEqual({})
+
+        // The server now serves that empty snapshot; a resync must not resurrect alice.
+        verificationsCb!({ id: 'current', payload: { name: '', attrs: {}, children: [] } })
+        for (let i = 0; i < 10; i++) await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(600)
+        expect(store.isPeerVerified('alice@example.com', 'ALICE_FP')).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('ignores a replayed older snapshot from the server (no trust rollback)', async () => {
+      let verificationsCb: ((item: PEPItem) => void) | null = null
+      let currentItem: PEPItem | null = null
+      const { ctx } = makeContext('me@example.com')
+      ctx.xmpp.subscribePEP = (_jid, node, cb) => {
+        if (node === VERIFICATIONS_NODE) verificationsCb = cb
+        return { unsubscribe: () => {} }
+      }
+      ctx.xmpp.queryPEP = async (_jid, node) =>
+        node === VERIFICATIONS_NODE && currentItem ? [currentItem] : []
+      const fp = 'FP_REPLAY_TEST'
+      fake.accounts.set('me@example.com', {
+        fingerprint: fp,
+        publicArmored: makeOpenPgpArmor(
+          'PGP PUBLIC KEY BLOCK',
+          `Fingerprint: ${fp}\nUID: xmpp:me@example.com\nKind: public\nRotation: 0\n`,
+        ),
+        keychainBacked: true,
+      })
+      await plugin.init(ctx)
+      const store = await import('@/stores/verifiedPeerKeysStore')
+
+      // A newer snapshot (version 5): bob is verified, alice already revoked elsewhere.
+      currentItem = buildVerificationsPepItem(fp, { 'bob@example.com': 'BOB_FP' }, 5)
+      verificationsCb!({ id: 'current', payload: { name: '', attrs: {}, children: [] } })
+      await new Promise((r) => setTimeout(r, 0))
+      expect(store.isPeerVerified('bob@example.com', 'BOB_FP')).toBe(true)
+      expect(store.isPeerVerified('alice@example.com', 'ALICE_FP')).toBe(false)
+
+      // The server replays an OLDER snapshot (version 1) that still trusts alice.
+      currentItem = buildVerificationsPepItem(
+        fp,
+        { 'alice@example.com': 'ALICE_FP', 'bob@example.com': 'BOB_FP' },
+        1,
+      )
+      verificationsCb!({ id: 'current', payload: { name: '', attrs: {}, children: [] } })
+      await new Promise((r) => setTimeout(r, 0))
+
+      // Rollback rejected: alice is NOT resurrected, bob is untouched.
+      expect(store.isPeerVerified('alice@example.com', 'ALICE_FP')).toBe(false)
+      expect(store.isPeerVerified('bob@example.com', 'BOB_FP')).toBe(true)
+    })
+
+    it('clears a locally-verified peer that a newer remote snapshot drops', async () => {
+      let verificationsCb: ((item: PEPItem) => void) | null = null
+      let currentItem: PEPItem | null = null
+      const { ctx } = makeContext('me@example.com')
+      ctx.xmpp.subscribePEP = (_jid, node, cb) => {
+        if (node === VERIFICATIONS_NODE) verificationsCb = cb
+        return { unsubscribe: () => {} }
+      }
+      ctx.xmpp.queryPEP = async (_jid, node) =>
+        node === VERIFICATIONS_NODE && currentItem ? [currentItem] : []
+      const fp = 'FP_DROP_TEST'
+      fake.accounts.set('me@example.com', {
+        fingerprint: fp,
+        publicArmored: makeOpenPgpArmor(
+          'PGP PUBLIC KEY BLOCK',
+          `Fingerprint: ${fp}\nUID: xmpp:me@example.com\nKind: public\nRotation: 0\n`,
+        ),
+        keychainBacked: true,
+      })
+
+      const store = await import('@/stores/verifiedPeerKeysStore')
+      // Seed local state BEFORE init so the store subscription (attached during
+      // init) does not schedule a publish from these writes.
+      store.useVerifiedPeerKeysStore.setState({
+        verifiedFingerprintByJid: {
+          'alice@example.com': 'ALICE_FP',
+          'bob@example.com': 'BOB_FP',
+        },
+      })
+      await plugin.init(ctx)
+
+      // Another device published a newer snapshot (version 5) that dropped alice.
+      currentItem = buildVerificationsPepItem(fp, { 'bob@example.com': 'BOB_FP' }, 5)
+      verificationsCb!({ id: 'current', payload: { name: '', attrs: {}, children: [] } })
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(store.isPeerVerified('alice@example.com', 'ALICE_FP')).toBe(false)
+      expect(store.isPeerVerified('bob@example.com', 'BOB_FP')).toBe(true)
     })
   })
 })

--- a/apps/fluux/src/e2ee/verificationSync.test.ts
+++ b/apps/fluux/src/e2ee/verificationSync.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import type { PluginContext, XMLElementData } from '@fluux/sdk'
+import {
+  VERIFICATIONS_NODE,
+  publishVerificationsToServer,
+  fetchVerificationsFromServer,
+  planVerificationUpdate,
+} from './verificationSync'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function b64(input: string): string {
+  return btoa(unescape(encodeURIComponent(input)))
+}
+function unb64(encoded: string): string {
+  return decodeURIComponent(escape(atob(encoded)))
+}
+
+/** A passthrough crypto pair: the "ciphertext" is the plaintext verbatim. */
+const passthroughEncrypt = async (plaintext: string) => plaintext
+const passthroughDecrypt = async (ciphertext: string) => ({ plaintext: ciphertext })
+
+/** Minimal ctx exposing only the PEP primitives the module touches. */
+function makeCtx(): {
+  ctx: PluginContext
+  published: Array<{ node: string; item: { id: string; payload: XMLElementData }; options?: unknown }>
+  setNode: (item: { id: string; payload: XMLElementData } | null) => void
+} {
+  const published: Array<{ node: string; item: { id: string; payload: XMLElementData }; options?: unknown }> = []
+  let node: { id: string; payload: XMLElementData } | null = null
+  const ctx = {
+    xmpp: {
+      publishPEP: async (n: string, item: { id: string; payload: XMLElementData }, options?: unknown) => {
+        published.push({ node: n, item, options })
+        node = item
+      },
+      queryPEP: async () => (node ? [node] : []),
+    },
+  } as unknown as PluginContext
+  return { ctx, published, setNode: (item) => (node = item) }
+}
+
+/** Build a PEP item exactly as the module would, from a payload JSON string. */
+function itemFromJson(json: string): { id: string; payload: XMLElementData } {
+  return {
+    id: 'current',
+    payload: {
+      name: 'verifications-data',
+      attrs: { xmlns: VERIFICATIONS_NODE },
+      children: [{ name: 'data', attrs: {}, children: [b64(json)] }],
+    },
+  }
+}
+
+function decodePublishedPayload(item: { payload: XMLElementData }): Record<string, unknown> {
+  const dataChild = item.payload.children.find(
+    (c): c is XMLElementData => typeof c !== 'string' && c.name === 'data',
+  )
+  const text = dataChild?.children[0]
+  if (typeof text !== 'string') throw new Error('no data child')
+  return JSON.parse(unb64(text)) as Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// publishVerificationsToServer
+// ---------------------------------------------------------------------------
+
+describe('publishVerificationsToServer', () => {
+  it('publishes even when the verifications map is empty (revocation of the last entry)', async () => {
+    const { ctx, published } = makeCtx()
+    await publishVerificationsToServer(ctx, passthroughEncrypt, 'OWNPUB', {}, 1)
+    expect(published).toHaveLength(1)
+    expect(published[0].node).toBe(VERIFICATIONS_NODE)
+    expect(decodePublishedPayload(published[0].item).verifications).toEqual({})
+  })
+
+  it('embeds v:2 and the supplied monotonic version in the payload', async () => {
+    const { ctx, published } = makeCtx()
+    await publishVerificationsToServer(
+      ctx,
+      passthroughEncrypt,
+      'OWNPUB',
+      { 'alice@example.com': 'ALICE_FP' },
+      7,
+    )
+    const payload = decodePublishedPayload(published[0].item)
+    expect(payload.v).toBe(2)
+    expect(payload.version).toBe(7)
+    expect(payload.verifications).toEqual({ 'alice@example.com': 'ALICE_FP' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetchVerificationsFromServer
+// ---------------------------------------------------------------------------
+
+describe('fetchVerificationsFromServer', () => {
+  it('returns the verifications and version from a v2 payload', async () => {
+    const { ctx, setNode } = makeCtx()
+    setNode(itemFromJson(JSON.stringify({ v: 2, ts: 1000, version: 5, verifications: { 'a@x': 'A' } })))
+    const result = await fetchVerificationsFromServer(ctx, passthroughDecrypt, 'me@x', 'OWNPUB')
+    expect(result).toEqual({ verifications: { 'a@x': 'A' }, version: 5 })
+  })
+
+  it('defaults version to 0 for a legacy v1 payload (no version field)', async () => {
+    const { ctx, setNode } = makeCtx()
+    setNode(itemFromJson(JSON.stringify({ v: 1, ts: 1000, verifications: { 'a@x': 'A' } })))
+    const result = await fetchVerificationsFromServer(ctx, passthroughDecrypt, 'me@x', 'OWNPUB')
+    expect(result).toEqual({ verifications: { 'a@x': 'A' }, version: 0 })
+  })
+
+  it('returns null when the node is absent', async () => {
+    const { ctx } = makeCtx()
+    const result = await fetchVerificationsFromServer(ctx, passthroughDecrypt, 'me@x', 'OWNPUB')
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planVerificationUpdate — the security-critical convergence logic
+// ---------------------------------------------------------------------------
+
+describe('planVerificationUpdate', () => {
+  it('ignores a snapshot whose version is not newer than the last applied (replay/rollback defense)', () => {
+    const plan = planVerificationUpdate(
+      { verifications: { 'alice@x': 'A' }, version: 3 },
+      { 'alice@x': 'A' },
+      3,
+    )
+    expect(plan.apply).toBe(false)
+    expect(plan.toSet).toEqual([])
+    expect(plan.toClear).toEqual([])
+    expect(plan.version).toBe(3)
+
+    const older = planVerificationUpdate(
+      { verifications: { 'alice@x': 'A', 'bob@x': 'B' }, version: 2 },
+      { 'bob@x': 'B' },
+      3,
+    )
+    expect(older.apply).toBe(false)
+    expect(older.toClear).toEqual([])
+  })
+
+  it('clears a locally-verified peer absent from a newer remote snapshot (revocation propagates)', () => {
+    const plan = planVerificationUpdate(
+      { verifications: { 'bob@x': 'B' }, version: 4 },
+      { 'alice@x': 'A', 'bob@x': 'B' },
+      3,
+    )
+    expect(plan.apply).toBe(true)
+    expect(plan.toClear).toEqual(['alice@x'])
+    expect(plan.toSet).toEqual([])
+    expect(plan.version).toBe(4)
+  })
+
+  it('clears everything when a newer snapshot is empty (last revocation propagates)', () => {
+    const plan = planVerificationUpdate(
+      { verifications: {}, version: 1 },
+      { 'alice@x': 'A' },
+      0,
+    )
+    expect(plan.apply).toBe(true)
+    expect(plan.toClear).toEqual(['alice@x'])
+    expect(plan.toSet).toEqual([])
+  })
+
+  it('sets new and changed fingerprints from a newer snapshot', () => {
+    const plan = planVerificationUpdate(
+      { verifications: { 'alice@x': 'A2', 'carol@x': 'C' }, version: 1 },
+      { 'alice@x': 'A1' },
+      0,
+    )
+    expect(plan.apply).toBe(true)
+    expect(plan.toSet).toEqual(
+      expect.arrayContaining([
+        { jid: 'alice@x', fingerprint: 'A2' },
+        { jid: 'carol@x', fingerprint: 'C' },
+      ]),
+    )
+    expect(plan.toSet).toHaveLength(2)
+    expect(plan.toClear).toEqual([])
+  })
+
+  it('applies a legacy (version 0) snapshot on a fresh device (lastApplied -1)', () => {
+    const plan = planVerificationUpdate(
+      { verifications: { 'alice@x': 'A' }, version: 0 },
+      {},
+      -1,
+    )
+    expect(plan.apply).toBe(true)
+    expect(plan.toSet).toEqual([{ jid: 'alice@x', fingerprint: 'A' }])
+    expect(plan.version).toBe(0)
+  })
+})

--- a/apps/fluux/src/e2ee/verificationSync.ts
+++ b/apps/fluux/src/e2ee/verificationSync.ts
@@ -4,15 +4,32 @@
  * Publishes the local `verifiedPeerKeysStore` map to a private PEP node
  * (`urn:xmpp:fluux:verifications:0`, `accessModel='whitelist'`) encrypted
  * to the user's own OpenPGP key. Other devices of the same account receive
- * a PEP headline, fetch the node, decrypt it, and merge the entries.
+ * a PEP headline, fetch the node, decrypt it, and reconcile their store.
  *
  * Crypto is abstracted behind {@link EncryptFn}/{@link DecryptFn} so this
  * module works with both the Sequoia/Tauri backend and the openpgp.js web
  * backend without modification.
  *
- * Merge strategy: **union**. Remote entries absent from local are added;
- * no deletions are propagated across devices (revocations remain
- * device-local for this phase).
+ * Sync strategy: **versioned snapshot, last-writer-wins**. Each publish
+ * carries a monotonically increasing `version`. A device applies a remote
+ * snapshot only when its `version` is strictly newer than the highest it
+ * has already applied ({@link loadAppliedVerificationsVersion}); the
+ * snapshot then *replaces* local state — additions, fingerprint changes,
+ * AND removals all propagate. Two consequences matter for security:
+ *
+ *  - Revocations propagate. A device that revokes its last verification
+ *    publishes an empty (but signed + versioned) snapshot rather than
+ *    skipping the publish, so the entry cannot resurface on resync.
+ *  - Server rollback is rejected. The published payload is signed by the
+ *    account's own primary key, but a signature proves authorship, not
+ *    freshness — a malicious server can replay an older genuine snapshot.
+ *    The monotonic `version` gate makes a replayed (older-or-equal) node a
+ *    no-op, closing the trust-rollback path.
+ *
+ * The trade-off is that two concurrent verifications made offline on
+ * different devices collapse to the later publisher's snapshot (the other
+ * verification is lost and must be re-done) — a fail-safe direction
+ * (under-trust → re-verify), never resurrection of a revoked key.
  */
 
 import type { PluginContext, XMLElementData } from '@fluux/sdk'
@@ -32,10 +49,26 @@ export type DecryptFn = (
 export const VERIFICATIONS_NODE = 'urn:xmpp:fluux:verifications:0'
 const VERIFICATIONS_XMLNS = VERIFICATIONS_NODE
 
+/** localStorage key holding the highest snapshot version applied/published. */
+const VERSION_STORAGE_KEY = 'fluux-e2ee-verifications-version'
+
 interface VerificationPayload {
-  v: 1
+  v: 2
   ts: number
+  version: number
   verifications: Record<string, string>
+}
+
+/** Outcome of reconciling a fetched snapshot against local state. */
+export interface VerificationUpdatePlan {
+  /** Whether the snapshot is newer and should be applied. */
+  apply: boolean
+  /** Entries to write locally (new peers or changed fingerprints). */
+  toSet: Array<{ jid: string; fingerprint: string }>
+  /** JIDs to drop locally (absent from the newer snapshot). */
+  toClear: string[]
+  /** Version now in effect (the remote's when applied, else the prior one). */
+  version: number
 }
 
 // ---------------------------------------------------------------------------
@@ -80,23 +113,59 @@ function b64Decode(encoded: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Applied-version persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Highest snapshot version this device has applied (from a remote fetch) or
+ * published. `-1` means "nothing applied yet", so a legacy v1 node (which
+ * decodes to version `0`) is still picked up exactly once on first sync.
+ */
+export function loadAppliedVerificationsVersion(): number {
+  try {
+    const raw = localStorage.getItem(VERSION_STORAGE_KEY)
+    if (raw === null) return -1
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) ? n : -1
+  } catch {
+    return -1
+  }
+}
+
+export function saveAppliedVerificationsVersion(version: number): void {
+  try {
+    localStorage.setItem(VERSION_STORAGE_KEY, String(version))
+  } catch {
+    // Best-effort, mirroring verifiedPeerKeysStore: a failed persist still
+    // leaves in-memory state consistent for the rest of the session.
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
  * Encrypt `verifications` to own key and publish to the private PEP node.
- * Skips the publish if the map is empty to avoid creating a node with no
- * useful data.
+ *
+ * Always publishes — including an empty map — so a revocation of the last
+ * verification overwrites the server node instead of leaving a stale one
+ * behind. `version` must be strictly greater than any previously published
+ * version for the monotonic replay gate on the receiving side to work.
  */
 export async function publishVerificationsToServer(
   ctx: PluginContext,
   encryptFn: EncryptFn,
   ownPublicArmored: string,
   verifications: Record<string, string>,
+  version: number,
 ): Promise<void> {
-  if (Object.keys(verifications).length === 0) return
-
-  const json = JSON.stringify({ v: 1, ts: Date.now(), verifications } satisfies VerificationPayload)
+  const json = JSON.stringify({
+    v: 2,
+    ts: Date.now(),
+    version,
+    verifications,
+  } satisfies VerificationPayload)
 
   const armored = await encryptFn(json, ownPublicArmored)
 
@@ -108,15 +177,17 @@ export async function publishVerificationsToServer(
 }
 
 /**
- * Fetch the private PEP node, decrypt it, and return the verification map.
- * Returns `null` when the node is absent or decryption fails.
+ * Fetch the private PEP node, decrypt it, and return the verification map
+ * together with its `version`. A legacy v1 payload (no `version` field)
+ * decodes to version `0`. Returns `null` when the node is absent, fails to
+ * decrypt, or is malformed.
  */
 export async function fetchVerificationsFromServer(
   ctx: PluginContext,
   decryptFn: DecryptFn,
   ownJid: string,
   ownPublicArmored: string,
-): Promise<Record<string, string> | null> {
+): Promise<{ verifications: Record<string, string>; version: number } | null> {
   let items: { id: string; payload: XMLElementData }[]
   try {
     items = await ctx.xmpp.queryPEP(ownJid, VERIFICATIONS_NODE)
@@ -139,43 +210,54 @@ export async function fetchVerificationsFromServer(
 
   try {
     const payload = JSON.parse(decrypted.plaintext) as unknown
-    if (
-      !payload ||
-      typeof payload !== 'object' ||
-      (payload as Record<string, unknown>).v !== 1 ||
-      typeof (payload as Record<string, unknown>).verifications !== 'object'
-    )
-      return null
-    const raw = (payload as VerificationPayload).verifications
+    if (!payload || typeof payload !== 'object') return null
+    const obj = payload as Record<string, unknown>
+    if (obj.v !== 1 && obj.v !== 2) return null
+    if (typeof obj.verifications !== 'object' || obj.verifications === null) return null
+
+    const version =
+      obj.v === 2 && typeof obj.version === 'number' && Number.isFinite(obj.version)
+        ? obj.version
+        : 0
+
     // Defensive: only keep string→string entries.
     const out: Record<string, string> = {}
-    for (const [k, v] of Object.entries(raw)) {
-      if (typeof k === 'string' && typeof v === 'string' && v.length > 0) out[k] = v
+    for (const [k, val] of Object.entries(obj.verifications as Record<string, unknown>)) {
+      if (typeof k === 'string' && typeof val === 'string' && val.length > 0) out[k] = val
     }
-    return out
+    return { verifications: out, version }
   } catch {
     return null
   }
 }
 
 /**
- * Union-merge `remote` into `local`.
+ * Reconcile a fetched `remote` snapshot against `local` state.
  *
- * Entries present in `remote` but absent from `local` are added.
- * Entries already in `local` are kept as-is (local device wins on conflict).
- * Returns the merged map and whether any new entries were introduced.
+ * The snapshot is applied only when it is strictly newer than
+ * `lastAppliedVersion` (replay/rollback defense). When applied, the remote
+ * snapshot is authoritative: entries whose fingerprint differs are set,
+ * and local JIDs absent from the snapshot are cleared — so revocations and
+ * fingerprint changes converge across devices.
  */
-export function mergeVerifications(
-  remote: Record<string, string>,
+export function planVerificationUpdate(
+  remote: { verifications: Record<string, string>; version: number },
   local: Record<string, string>,
-): { merged: Record<string, string>; hasNewEntries: boolean } {
-  let hasNewEntries = false
-  const merged = { ...local }
-  for (const [jid, fp] of Object.entries(remote)) {
-    if (!merged[jid]) {
-      merged[jid] = fp
-      hasNewEntries = true
-    }
+  lastAppliedVersion: number,
+): VerificationUpdatePlan {
+  if (remote.version <= lastAppliedVersion) {
+    return { apply: false, toSet: [], toClear: [], version: lastAppliedVersion }
   }
-  return { merged, hasNewEntries }
+
+  const toSet: Array<{ jid: string; fingerprint: string }> = []
+  for (const [jid, fingerprint] of Object.entries(remote.verifications)) {
+    if (local[jid] !== fingerprint) toSet.push({ jid, fingerprint })
+  }
+
+  const toClear: string[] = []
+  for (const jid of Object.keys(local)) {
+    if (!(jid in remote.verifications)) toClear.push(jid)
+  }
+
+  return { apply: true, toSet, toClear, version: remote.version }
 }


### PR DESCRIPTION
## Summary

Cross-device verification sync could let a revoked verification come back. `publishVerificationsToServer` skipped publishing when the map was empty (leaving a stale node on the server), and the merge was an additive union — so a removal on one device was re-added from another device's stale copy, or replayed by the server from an older signed snapshot.

This replaces the union merge with a **versioned, last-writer-wins snapshot**:

- Every publish carries a monotonic `version`, and the empty map is now always published, so revoking the last verification overwrites the server node instead of leaving the old one.
- A fetched snapshot is applied only when its `version` is strictly newer than the highest already applied (persisted locally), then *replaces* local state — additions, fingerprint changes, and removals all converge across devices.
- The monotonic gate also rejects a server replaying an older but genuinely signed snapshot, closing the trust-rollback path (a signature proves authorship, not freshness).

The merge decision now lives in a pure `planVerificationUpdate`; the plugin applies it (set + clear) under the existing remote-sync guard. Legacy (`v1`) snapshots decode to version `0` and are still picked up once.