### PR TITLE
fix(e2ee): try expired subkeys when decrypting historical messages

### DIFF
--- a/apps/fluux/src-tauri/src/openpgp.rs
+++ b/apps/fluux/src-tauri/src/openpgp.rs
@@ -1335,6 +1335,7 @@ impl DecryptionHelper for DecryptHelper<'_> {
         sym_algo: Option<SymmetricAlgorithm>,
         decrypt: &mut dyn FnMut(Option<SymmetricAlgorithm>, &SessionKey) -> bool,
     ) -> openpgp::Result<Option<Cert>> {
+        // First pass: try currently-valid encryption subkeys (common case).
         for ka in self
             .secret
             .keys()
@@ -1353,6 +1354,27 @@ impl DecryptionHelper for DecryptHelper<'_> {
                 }
             }
         }
+
+        // Second pass: try ALL secret subkeys regardless of policy/expiry.
+        // Historical MAM messages carry PKESK packets targeted at the
+        // encryption subkey that was current at send time. After subkey
+        // rotation the retired subkey is expired but its secret material
+        // is still in the local cert — we must try it. Also covers
+        // cross-implementation edge cases where the sender's library
+        // targeted a subkey that our policy filter doesn't surface.
+        for key in self.secret.keys().secret() {
+            let mut pair = key.key().clone().into_keypair()?;
+            for pkesk in pkesks {
+                if pkesk
+                    .decrypt(&mut pair, sym_algo)
+                    .map(|(algo, sk)| decrypt(algo, &sk))
+                    .unwrap_or(false)
+                {
+                    return Ok(Some(self.secret.clone()));
+                }
+            }
+        }
+
         Ok(None)
     }
 }
@@ -2045,6 +2067,39 @@ mod tests {
             out.signature_verified,
             "bob's signature must verify on replay regardless of alice's rotation"
         );
+    }
+
+    #[test]
+    fn ciphertext_encrypted_to_expired_subkey_still_decrypts() {
+        // The rotation expires the old subkey with a 1-second validity
+        // window. After that window closes, the policy-filtered first
+        // pass in DecryptionHelper won't find the old subkey. The
+        // second pass (all secret keys, no policy) must still succeed.
+        let (state, _alice, bob) = setup_two_accounts();
+
+        let pre_rotation_ciphertext = state
+            .encrypt("bob@example.com", &_alice.public_armored, "historical message")
+            .unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _rotated = runtime
+            .block_on(state.rotate_encryption_subkey("alice@example.com".into()))
+            .unwrap();
+
+        // Wait for the 1-second validity window to close.
+        std::thread::sleep(std::time::Duration::from_secs(2));
+
+        let out = state
+            .decrypt(
+                "alice@example.com",
+                &pre_rotation_ciphertext,
+                Some(&bob.public_armored),
+            )
+            .unwrap();
+        assert_eq!(out.plaintext, "historical message");
     }
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12274,16 +12274,16 @@
       }
     },
     "node_modules/zod-validation-error": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
-      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "zod": "^3.24.4"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {


### PR DESCRIPTION
## Summary

- The Sequoia `DecryptionHelper` only tried encryption subkeys passing the current-time policy filter. After a subkey rotation, the retired subkey is expired and Sequoia skipped it — making MAM-replayed messages encrypted to the old subkey permanently undecryptable.
- Adds a second pass that iterates over ALL secret subkeys regardless of policy/expiry. The first pass (policy-filtered) still runs for the common case; the fallback only fires when no current subkey matched.
- The existing test `ciphertext_encrypted_to_old_subkey_still_decrypts_after_rotation` did not catch this because it ran within the 1-second validity window of the expired binding. A new test sleeps past that window to exercise the fallback path.