### PR TITLE
fix(deps): apply zod-validation-error override to unbreak ESLint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12274,16 +12274,16 @@
       }
     },
     "node_modules/zod-validation-error": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
-      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "zod": "^3.24.4"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {


### PR DESCRIPTION
## Summary

`npm run lint` crashes in the `@xmpp/fluux` workspace with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4' is not defined
by "exports" in node_modules/zod-validation-error/package.json
```

**Root cause:** `eslint-plugin-react-hooks@7.1.1` (pulled in by a recent dependency bump) hard-imports `zod-validation-error/v4` — a subpath that only exists in `zod-validation-error` v4. The plugin's *declared* range (`^3.5.0 || ^4.0.0`) is too permissive, so npm kept the already-resolved `3.5.4`, which exports only `.`.

The root `package.json` already pins `zod-validation-error: 4.0.2` via `overrides` (added during the React 19 migration in e3dfe4cf), but the lockfile was never regenerated to honor it — so `3.5.4` stayed resolved and the import crashed.

**Fix:** pin the single `zod-validation-error` lockfile entry to `4.0.2`. Its peer requirement `zod: ^3.25.0 || ^4.0.0` is satisfied by the project's `zod@3.25.76`, and `4.0.2` exposes the `./v4` subpath react-hooks needs. The change is deliberately scoped to that one entry — no other dependency resolutions move (avoids bundling incidental within-range bumps into this fix).