### PR TITLE
fix(avatar): refresh MUC occupant blob URLs after wake/SM-resume

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { XMPPClient } from '../XMPPClient'
+import type { Room, RoomOccupant } from '../types/room'
 import {
   createMockXmppClient,
   createMockStores,
@@ -921,6 +922,42 @@ describe('XMPPClient Own Avatar', () => {
       await xmppClient.profile.refreshAllAvatarBlobUrls()
 
       expect(emitSDKSpy).not.toHaveBeenCalled()
+    })
+
+    it('should refresh stale blob URLs for MUC occupants', async () => {
+      emitSDKSpy.mockClear()
+
+      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-o1', 'blob:fresh-occupant1']]))
+      // Occupant avatars are NOT in the contact/room hash store, so this stays empty.
+      vi.mocked(getAllAvatarHashes).mockResolvedValue([])
+
+      // A joined room whose occupant's avatar blob URL went stale after wake.
+      // refreshAllBlobUrls revoked the old blobs; occupants must be re-pointed.
+      const occupants = new Map<string, RoomOccupant>([
+        ['Alice', { nick: 'Alice', affiliation: 'none', role: 'participant', avatar: 'blob:stale-occupant', avatarHash: 'hash-o1' }],
+        ['Bob', { nick: 'Bob', affiliation: 'none', role: 'participant' }], // no avatarHash → must be skipped
+        ['Carol', { nick: 'Carol', affiliation: 'none', role: 'participant', avatar: 'blob:stale', avatarHash: 'hash-unknown' }], // hash not refreshed → skipped
+      ])
+      mockStores.room.joinedRooms.mockReturnValue([
+        {
+          jid: 'room@conf.example.com', name: 'Room', nickname: '',
+          joined: true, isBookmarked: false, occupants,
+          messages: [], unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>(),
+        } as Room,
+      ])
+
+      await xmppClient.profile.refreshAllAvatarBlobUrls()
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
+        roomJid: 'room@conf.example.com',
+        nick: 'Alice',
+        avatar: 'blob:fresh-occupant1',
+        avatarHash: 'hash-o1',
+      })
+      // Occupants without a hash, or whose hash wasn't refreshed, must not emit.
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:occupant-avatar', expect.objectContaining({ nick: 'Bob' }))
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:occupant-avatar', expect.objectContaining({ nick: 'Carol' }))
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -1030,6 +1030,28 @@ export class Profile extends BaseModule {
           }
         }
       }
+
+      // MUC occupant avatars live in each room's occupant map (keyed by nick),
+      // not in the contact/room hash store, so the loop above never touches
+      // them. After blob invalidation (WebKit reclaiming memory on sleep, or
+      // revokeAllBlobUrls on disconnect) their URLs are dead and were never
+      // re-pointed — the cause of broken occupant avatars ("img blob:" load
+      // failures) when reading public groups. Re-point each occupant whose
+      // cached avatar hash has a fresh URL.
+      const joinedRooms = this.deps.stores?.room?.joinedRooms?.() ?? []
+      for (const room of joinedRooms) {
+        for (const occupant of room.occupants.values()) {
+          if (!occupant.avatarHash) continue
+          const url = freshUrls.get(occupant.avatarHash)
+          if (!url) continue
+          this.deps.emitSDK('room:occupant-avatar', {
+            roomJid: room.jid,
+            nick: occupant.nick,
+            avatar: url,
+            avatarHash: occupant.avatarHash,
+          })
+        }
+      }
     } catch (error) {
       console.warn('Failed to refresh avatar blob URLs:', error)
     }


### PR DESCRIPTION
## Summary

Occupant avatars in public groups (MUC) showed broken `img blob: … Failed to load resource` errors after the app woke from sleep, resumed a stream, or reconnected.

`Profile.refreshAllAvatarBlobUrls` re-creates fresh avatar blob URLs after events that invalidate them (WebKit reclaiming memory on sleep, `revokeAllBlobUrls` on disconnect), but only re-pointed **contact** and **room** avatars. **MUC occupant** avatars (`nickToAvatarCache`, keyed by nick) were never refreshed, so they kept pointing at dead blob URLs and fell back to initials until a fresh vCard fetch.

The fix iterates `joinedRooms()` and emits the existing `room:occupant-avatar` event for every occupant whose cached avatar hash has a fresh URL, mirroring the contact/room refresh path already in place. No new public APIs.

Covered by a new unit test in `Profile.avatar.test.ts` (occupants with no hash, or a hash that wasn't refreshed, are correctly skipped).