### PR TITLE
fix(diagnostics): log webview errors readably in fluux.log instead of "{}"

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1182,11 +1182,37 @@ fn main() {
                         var origWarn = console.warn;
                         var origError = console.error;
                         var origDebug = console.debug;
+                        function serializeArg(a) {
+                            if (typeof a === 'string') return a;
+                            // Error objects keep message/stack on non-enumerable
+                            // properties, so JSON.stringify(err) === "{}". Surface
+                            // them explicitly or every logged error becomes "{}".
+                            if (a instanceof Error) {
+                                var head = (a.name || 'Error') + ': ' + (a.message || '');
+                                return a.stack ? head + '\n' + a.stack : head;
+                            }
+                            try {
+                                var s = JSON.stringify(a);
+                                if (s === undefined || s === '{}') {
+                                    // Error-like objects (DOMException, custom) or
+                                    // anything whose own enumerable props are empty.
+                                    if (a && (a.message || a.name || a.stack)) {
+                                        var parts = [];
+                                        if (a.name) parts.push(String(a.name));
+                                        if (a.message) parts.push(String(a.message));
+                                        if (a.stack) parts.push(String(a.stack));
+                                        return parts.join(': ');
+                                    }
+                                    return s === undefined ? String(a) : Object.prototype.toString.call(a);
+                                }
+                                return s;
+                            } catch (e) {
+                                try { return String(a); } catch (e2) { return '[unserializable]'; }
+                            }
+                        }
                         function forward(level, args) {
                             try {
-                                var msg = Array.prototype.slice.call(args).map(function(a) {
-                                    return typeof a === 'string' ? a : JSON.stringify(a);
-                                }).join(' ');
+                                var msg = Array.prototype.slice.call(args).map(serializeArg).join(' ');
                                 window.__TAURI_INTERNALS__.invoke('log_to_terminal', { level: level, message: msg });
                             } catch(e) {}
                         }
@@ -1196,11 +1222,25 @@ fn main() {
                         console.error = function() { origError.apply(console, arguments); forward('error', arguments); };
                         console.debug = function() { origDebug.apply(console, arguments); forward('debug', arguments); };
                         window.addEventListener('error', function(e) {
-                            if (e.target !== window && e.target.tagName) {
+                            // Resource load failures (img/video/script/link): e.target is the element.
+                            if (e.target && e.target !== window && e.target.tagName) {
                                 var src = e.target.src || e.target.href || '(unknown)';
                                 forward('error', ['Failed to load resource: ' + e.target.tagName.toLowerCase() + ' ' + src]);
+                                return;
+                            }
+                            // Uncaught JS exception: carries the real Error (message + stack)
+                            // and the source location. Without this, render-phase throws that
+                            // escape React reach the log as nothing at all.
+                            var where = (e.filename || '') + ':' + (e.lineno || 0) + ':' + (e.colno || 0);
+                            if (e.error) {
+                                forward('error', ['Uncaught exception at ' + where + ':', e.error]);
+                            } else {
+                                forward('error', ['Uncaught error at ' + where + ': ' + (e.message || '(unknown)')]);
                             }
                         }, true);
+                        window.addEventListener('unhandledrejection', function(e) {
+                            forward('error', ['Unhandled promise rejection:', e && e.reason]);
+                        });
                     })();
                 "#);
             }

--- a/apps/fluux/src/components/RenderLoopBoundary.test.tsx
+++ b/apps/fluux/src/components/RenderLoopBoundary.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RenderLoopBoundary } from './RenderLoopBoundary'
+
+/** Renders nothing but throws the given value during render. */
+function Thrower({ value }: { value: unknown }): null {
+  throw value
+}
+
+describe('RenderLoopBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('catches a non-Error throw without crashing the boundary itself', () => {
+    // React re-logs caught errors to console.error; silence to keep output pristine.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // A child throwing a plain object must NOT escape the boundary. If
+    // getDerivedStateFromError dereferences error.message on a non-Error,
+    // it throws, React tears down the whole tree, and the user gets a
+    // silent blank "freeze". The boundary must absorb it and show fallback.
+    expect(() =>
+      render(
+        <RenderLoopBoundary>
+          <Thrower value={{ shape: 'plain-object' }} />
+        </RenderLoopBoundary>,
+      ),
+    ).not.toThrow()
+
+    expect(screen.getByText('Something Went Wrong')).toBeInTheDocument()
+  })
+
+  it('still shows the render-loop UI for a render-loop Error', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <RenderLoopBoundary>
+        <Thrower value={new Error('Render loop detected in RoomView. 201 renders in 1000ms.')} />
+      </RenderLoopBoundary>,
+    )
+
+    expect(screen.getByText('Render Loop Detected')).toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/components/RenderLoopBoundary.tsx
+++ b/apps/fluux/src/components/RenderLoopBoundary.tsx
@@ -39,11 +39,16 @@ export class RenderLoopBoundary extends Component<Props, State> {
     }
   }
 
-  static getDerivedStateFromError(error: Error): Partial<State> {
-    const isRenderLoop = error.message.includes('Render loop detected')
+  static getDerivedStateFromError(error: unknown): Partial<State> {
+    // A child can throw a non-Error value (a string, a plain object, a DOM
+    // event). Reading `.message` on those would throw *inside* the boundary,
+    // which makes React tear down the whole tree — a silent blank "freeze"
+    // with no recovery UI. Normalize to an Error first.
+    const normalized = error instanceof Error ? error : new Error(String(error))
+    const isRenderLoop = normalized.message.includes('Render loop detected')
     return {
       hasError: true,
-      error,
+      error: normalized,
       renderStats: isRenderLoop ? getRenderStats() : null,
       selectorHistory: isRenderLoop ? getSelectorHistory() : null,
       copyStatus: 'idle',


### PR DESCRIPTION
## Summary

Every error forwarded from the webview to `fluux.log` showed up as `{}`, which made freeze/crash reports impossible to act on ("no useful errors in the logs"). The root cause: the Rust console-forwarder serialized each argument with `JSON.stringify`, and `JSON.stringify(new Error(...)) === "{}"` because `Error.message`/`.stack` are non-enumerable.

This makes webview errors readable so the next reproduction names the real error and component.