### PR TITLE
fix(scroll): tame WebKitGTK ResizeObserver scroll-correction freeze

### DIFF
--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -265,20 +265,27 @@ export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoa
   }
 
   return (
-    <div className="pt-2 max-w-md rounded-lg overflow-hidden bg-black" style={containerStyle}>
-      <video
-        src={proxiedVideoUrl}
-        controls
-        preload="metadata"
-        poster={proxiedPosterUrl || undefined}
-        className="w-full h-full"
-        tabIndex={-1}
-        onLoadedMetadata={onLoad}
-        onError={() => {
-          failedUrlCache.add(attachment.url)
-          setLoadError(true)
-        }}
-      />
+    <div className="pt-2 max-w-md rounded-lg overflow-hidden bg-black">
+      {/* Height-locked video region: the box height is fixed by aspect-ratio and
+          the <video> is absolutely positioned to fill it, so native controls
+          render as an overlay and can never change the box height. On WebKitGTK
+          that height oscillation is what drives the message-list ResizeObserver
+          scroll-correction feedback loop. */}
+      <div className="relative w-full" style={containerStyle}>
+        <video
+          src={proxiedVideoUrl}
+          controls
+          preload="metadata"
+          poster={proxiedPosterUrl || undefined}
+          className="absolute inset-0 h-full w-full object-contain"
+          tabIndex={-1}
+          onLoadedMetadata={onLoad}
+          onError={() => {
+            failedUrlCache.add(attachment.url)
+            setLoadError(true)
+          }}
+        />
+      </div>
       {/* Video info bar */}
       {attachment.name && (
         <div className="flex items-center gap-2 px-3 py-2 bg-fluux-bg/60 border-t border-fluux-border">

--- a/apps/fluux/src/components/conversation/resizeLoopMonitor.test.ts
+++ b/apps/fluux/src/components/conversation/resizeLoopMonitor.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { createResizeLoopMonitor } from './resizeLoopMonitor'
+
+/**
+ * Pure, deterministic tests — timestamps are passed in explicitly so there is
+ * no dependency on Date.now()/performance.now().
+ */
+describe('createResizeLoopMonitor', () => {
+  it('stays silent while the fire rate is at or under the threshold', () => {
+    const m = createResizeLoopMonitor({ threshold: 5, windowMs: 1000, cooldownMs: 5000 })
+    let last: string | null = 'x'
+    for (let i = 0; i < 5; i++) last = m.record(i * 100) // 5 fires across 400ms
+    expect(last).toBeNull()
+  })
+
+  it('warns once when fires exceed the threshold inside the window', () => {
+    const m = createResizeLoopMonitor({ threshold: 5, windowMs: 1000, cooldownMs: 5000 })
+    const out: (string | null)[] = []
+    for (let i = 0; i < 9; i++) out.push(m.record(i * 40)) // 9 fires in 320ms
+    const warnings = out.filter((r): r is string => r !== null)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatch(/resize/i)
+  })
+
+  it('rate-limits to one warning per cooldown during a sustained runaway', () => {
+    const m = createResizeLoopMonitor({ threshold: 3, windowMs: 1000, cooldownMs: 5000 })
+    const out: (string | null)[] = []
+    for (let i = 0; i < 40; i++) out.push(m.record(i * 50)) // 40 fires over 1950ms
+    const warnings = out.filter((r): r is string => r !== null)
+    expect(warnings).toHaveLength(1) // cooldown (5000ms) outlasts the 1950ms span
+  })
+
+  it('does not warn for normal bursts spread across separate windows', () => {
+    const m = createResizeLoopMonitor({ threshold: 10, windowMs: 1000, cooldownMs: 5000 })
+    let last: string | null = 'x'
+    for (let s = 0; s < 6; s++) {
+      for (let k = 0; k < 3; k++) last = m.record(s * 1000 + k * 120) // 3 fires/sec
+    }
+    expect(last).toBeNull()
+  })
+})

--- a/apps/fluux/src/components/conversation/resizeLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/resizeLoopMonitor.ts
@@ -1,0 +1,74 @@
+/**
+ * Diagnostic-only monitor for a runaway ResizeObserver → scroll-correction
+ * loop.
+ *
+ * Background: on WebKitGTK (Linux/Tauri) a `<video controls>` (or other
+ * oscillating content) can change height continuously, firing the message
+ * list's content ResizeObserver hundreds of times per second. That is a pure
+ * main-thread loop with NO React render, so `renderLoopDetector` (React-only)
+ * never sees it — the app just "freezes while reading", with nothing in the
+ * logs.
+ *
+ * This monitor makes that failure mode VISIBLE. It does NOT break the loop
+ * (no `disconnect()`); the rAF-coalescing of the correction already bounds the
+ * expensive work to once per frame. It only emits a single, rate-limited log
+ * line so the loop class finally shows up in `fluux.log`.
+ *
+ * Implemented as a pure, O(1)-per-fire fixed-window counter (no allocation on
+ * the hot path — important, since it runs precisely when something is already
+ * firing thousands of times per second). Timestamps are passed in so the logic
+ * is deterministic and unit-testable.
+ */
+export interface ResizeLoopMonitor {
+  /**
+   * Record one observer fire at `now` (ms, monotonic e.g. performance.now()).
+   * Returns a warning string to log once per cooldown when a runaway is
+   * detected, or null otherwise.
+   */
+  record(now: number): string | null
+}
+
+export interface ResizeLoopMonitorOptions {
+  /** Fires within `windowMs` above this count are considered a runaway. */
+  threshold?: number
+  /** Sliding-ish window length in ms. */
+  windowMs?: number
+  /** Minimum gap between two warnings, so a sustained loop logs once. */
+  cooldownMs?: number
+}
+
+export function createResizeLoopMonitor(opts: ResizeLoopMonitorOptions = {}): ResizeLoopMonitor {
+  // Defaults: >60 fires in 1s = sustained faster-than-one-per-frame churn,
+  // which never happens during normal scrolling but is the signature of the
+  // WebKitGTK feedback loop. Warn at most every 5s.
+  const threshold = opts.threshold ?? 60
+  const windowMs = opts.windowMs ?? 1000
+  const cooldownMs = opts.cooldownMs ?? 5000
+
+  let windowStart = 0
+  let count = 0
+  let started = false
+  let lastWarnAt = Number.NEGATIVE_INFINITY
+
+  return {
+    record(now: number): string | null {
+      if (!started || now - windowStart > windowMs) {
+        windowStart = now
+        count = 0
+        started = true
+      }
+      count++
+
+      if (count > threshold && now - lastWarnAt >= cooldownMs) {
+        lastWarnAt = now
+        const elapsed = Math.max(1, Math.round(now - windowStart))
+        return (
+          `[ScrollResizeLoop] message-list ResizeObserver fired ${count} times in ${elapsed}ms ` +
+          `(threshold ${threshold}/${windowMs}ms) — likely a WebKitGTK scroll-correction feedback loop. ` +
+          `Scroll correction is rAF-coalesced; this log is a diagnostic only.`
+        )
+      }
+      return null
+    },
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -17,6 +17,7 @@
 
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import { scrollStateManager } from '@/utils/scrollStateManager'
+import { createResizeLoopMonitor } from './resizeLoopMonitor'
 
 // ============================================================================
 // DEBUG
@@ -108,6 +109,10 @@ export function useMessageListScroll({
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const contentObserverRef = useRef<ResizeObserver | null>(null)
+  // Pending rAF id for the coalesced scroll correction (content ResizeObserver).
+  const correctionRafRef = useRef<number | null>(null)
+  // Diagnostic-only monitor for runaway ResizeObserver fire rates (WebKitGTK).
+  const resizeMonitorRef = useRef<ReturnType<typeof createResizeLoopMonitor> | null>(null)
 
   // Track scroll position - always create internal ref to follow rules of hooks
   const internalIsAtBottomRef = useRef(true)
@@ -196,6 +201,10 @@ export function useMessageListScroll({
       contentObserverRef.current.disconnect()
       contentObserverRef.current = null
     }
+    if (correctionRafRef.current !== null) {
+      cancelAnimationFrame(correctionRafRef.current)
+      correctionRafRef.current = null
+    }
 
     contentRef.current = element
 
@@ -217,7 +226,10 @@ export function useMessageListScroll({
       // Set up content ResizeObserver
       let lastHeight = scroller.scrollHeight
 
-      const observer = new ResizeObserver(() => {
+      // The actual measure + scroll-correction. Run at most once per frame via
+      // the rAF-coalescing in the observer callback below.
+      const runCorrection = () => {
+        correctionRafRef.current = null
         const currentScroller = scrollerRef.current
         if (!currentScroller) return
 
@@ -265,6 +277,24 @@ export function useMessageListScroll({
         }
 
         lastHeight = newHeight
+      }
+
+      const observer = new ResizeObserver(() => {
+        // Diagnostic only: surface a runaway fire rate. WebKitGTK can oscillate
+        // a <video controls> height continuously, firing this hundreds of times
+        // a second — a pure main-thread loop the React render-loop detector
+        // can't see. Log-rate-limited; never disconnects.
+        if (!resizeMonitorRef.current) resizeMonitorRef.current = createResizeLoopMonitor()
+        const warning = resizeMonitorRef.current.record(performance.now())
+        if (warning) console.warn(warning)
+
+        // Coalesce the measure + correction into a single rAF no matter how many
+        // times the observer fires this frame. This breaks the read-scrollHeight
+        // -> write-scrollTop -> reflow -> re-fire feedback and caps the expensive
+        // work to once per frame.
+        if (correctionRafRef.current === null) {
+          correctionRafRef.current = requestAnimationFrame(runCorrection)
+        }
       })
 
       observer.observe(element)
@@ -846,6 +876,10 @@ export function useMessageListScroll({
       }
       if (contentObserverRef.current) {
         contentObserverRef.current.disconnect()
+      }
+      if (correctionRafRef.current !== null) {
+        cancelAnimationFrame(correctionRafRef.current)
+        correctionRafRef.current = null
       }
     }
   }, [])


### PR DESCRIPTION
## Summary

A strong suspect for the recurring Debian (WebKitGTK) "freeze while reading" — including the variants that left **nothing in the logs**.

The message-list content `ResizeObserver` read `scrollHeight` and wrote `scrollTop` **synchronously on every fire**. On WebKitGTK a `<video controls>` oscillating its height fires the observer continuously, turning that read→write→reflow into a main-thread feedback loop that freezes the UI. It runs with **no React render**, so `renderLoopDetector` (React-only) can't see it and the loop never reaches `fluux.log`.

### Changes
1. **rAF-coalesce the scroll correction** (`useMessageListScroll.ts`): the observer now records the fire and schedules a single `requestAnimationFrame` for the measure + `scrollTop` write, instead of working synchronously. Caps the cost to once per frame regardless of fire rate and breaks the read→write→reflow coupling. The pending rAF is cancelled in both teardown paths.
2. **Height-lock the video box** (`FileAttachments.tsx`): the `<video>` is now `absolute inset-0` inside an aspect-ratio region, so native controls render as an overlay and can no longer change the box height — removing the oscillation at its source. (A `.webm` was present in the user's frozen session.)
3. **Log-only resize-loop monitor** (`resizeLoopMonitor.ts`): a pure, O(1)-per-fire counter that logs once per cooldown when the observer runs away, making this loop class visible in `fluux.log` for the first time. Diagnostic only — it never disconnects the observer.