### PR TITLE
fix(proxy): use JID domain for explicit endpoints; surface upstream stream errors

### DIFF
--- a/apps/fluux/src-tauri/src/xmpp_proxy/framing.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/framing.rs
@@ -82,6 +82,39 @@ pub fn translate_ws_to_tcp<'a>(text: &'a str) -> Cow<'a, str> {
     Cow::Borrowed(text)
 }
 
+/// Extract the `to` attribute from an RFC 7395 `<open/>` frame.
+///
+/// xmpp.js sends the XMPP service domain (the JID's domain) as the `to=` of its
+/// initial `<open/>`. The proxy reads it so explicit endpoints can use the JID
+/// domain for the STARTTLS `to=` and TLS SNI even when the connection host
+/// differs (e.g. `tcp://chat.process-one.net` for JID `me@process-one.net`).
+///
+/// Returns `None` when `text` is not an `<open/>` frame or carries no non-empty
+/// `to` attribute.
+pub fn extract_open_to(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if !(trimmed.starts_with("<open ") || trimmed.starts_with("<open>")) {
+        return None;
+    }
+
+    let mut reader = Reader::from_str(trimmed);
+    reader.config_mut().check_end_names = false;
+
+    let event = reader.read_event();
+    let attrs = match &event {
+        Ok(Event::Empty(e)) | Ok(Event::Start(e)) => e.attributes(),
+        _ => return None,
+    };
+
+    for attr in attrs.flatten() {
+        if attr.key.as_ref() == b"to" {
+            let value = String::from_utf8_lossy(&attr.value).to_string();
+            return if value.is_empty() { None } else { Some(value) };
+        }
+    }
+    None
+}
+
 /// Translate traditional XMPP stream framing to RFC 7395 WebSocket framing
 /// - `<stream:stream ...>` → `<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" .../>`
 /// - `</stream:stream>` → `<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>`
@@ -1042,5 +1075,37 @@ mod tests {
             None
         );
         assert_eq!(extract_stream_error_condition("</stream:stream>"), None);
+    }
+
+    // --- extract_open_to tests ---
+
+    #[test]
+    fn test_extract_open_to_double_quotes() {
+        let open = r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" to="process-one.net" version="1.0"/>"#;
+        assert_eq!(extract_open_to(open).as_deref(), Some("process-one.net"));
+    }
+
+    #[test]
+    fn test_extract_open_to_single_quotes_with_from() {
+        let open = r#"<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='process-one.net' from='me@process-one.net' version='1.0'/>"#;
+        assert_eq!(extract_open_to(open).as_deref(), Some("process-one.net"));
+    }
+
+    #[test]
+    fn test_extract_open_to_absent_returns_none() {
+        let open = r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" version="1.0"/>"#;
+        assert_eq!(extract_open_to(open), None);
+    }
+
+    #[test]
+    fn test_extract_open_to_empty_returns_none() {
+        let open = r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" to="" version="1.0"/>"#;
+        assert_eq!(extract_open_to(open), None);
+    }
+
+    #[test]
+    fn test_extract_open_to_non_open_returns_none() {
+        assert_eq!(extract_open_to(r#"<message to="a@b"/>"#), None);
+        assert_eq!(extract_open_to("</stream:stream>"), None);
     }
 }

--- a/apps/fluux/src-tauri/src/xmpp_proxy/mod.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/mod.rs
@@ -3,7 +3,8 @@ mod framing;
 
 use dns::{parse_server_input, resolve_xmpp_server, ConnectionMode, ParsedServer, XmppEndpoint};
 use framing::{
-    extract_stanza, extract_stream_error_condition, translate_tcp_to_ws, translate_ws_to_tcp,
+    extract_open_to, extract_stanza, extract_stream_error_condition, translate_tcp_to_ws,
+    translate_ws_to_tcp,
 };
 
 use futures_util::{SinkExt, StreamExt};
@@ -136,6 +137,55 @@ fn format_bridge_close_reason(end_reason_label: &str, stream_error: Option<&str>
         None => format!("Bridge closed: {end_reason_label}"),
     };
     clamp_close_reason(reason)
+}
+
+/// Extract the stream-error condition that an upstream-connect failure encodes.
+///
+/// `perform_starttls` formats a relayed upstream `<stream:error>` as
+/// "… stream-error: <condition>" (e.g. `host-unknown`). `connect_upstream_tls`
+/// aggregates endpoint failures into one string that preserves that substring,
+/// so the connection handler can recover the condition for the WebSocket close
+/// reason. Returns `None` for plain transport failures (timeouts, refused
+/// connections, TLS errors), which carry no stream-level condition.
+fn stream_error_condition_from_error(message: &str) -> Option<String> {
+    const MARKER: &str = "stream-error: ";
+    let start = message.find(MARKER)? + MARKER.len();
+    let rest = &message[start..];
+    // Conditions are XML element local names (e.g. `host-unknown`,
+    // `see-other-host`) — no whitespace — so the first whitespace ends it.
+    let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+    let condition = rest[..end].trim();
+    if condition.is_empty() {
+        None
+    } else {
+        Some(condition.to_string())
+    }
+}
+
+/// Send the RFC 7395 `<close/>` plus a WebSocket close frame carrying `reason`,
+/// so the client (xmpp.js) gets a deterministic disconnect with the real cause
+/// instead of an abrupt socket drop. Best-effort, bounded by a short timeout.
+///
+/// Used for pre-bridge upstream failures; the bridge teardown path has its own
+/// equivalent close handshake on the split sink.
+async fn send_close_with_reason(
+    ws: &mut tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+    reason: String,
+) {
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let _ = ws
+            .send(Message::Text(
+                r#"<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>"#.into(),
+            ))
+            .await;
+        let _ = ws
+            .send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Normal,
+                reason: reason.into(),
+            })))
+            .await;
+    })
+    .await;
 }
 
 /// Initialize rustls crypto provider (must be called once at startup)
@@ -499,24 +549,53 @@ async fn handle_connection(
         "Received initial client stanza"
     );
 
+    // The client's initial <open to='…'/> carries the JID's service domain.
+    // Use it as the STARTTLS `to=` / TLS SNI for explicit endpoints, where the
+    // connection host may legitimately differ from the XMPP domain
+    // (e.g. tcp://chat.process-one.net for JID me@process-one.net).
+    let client_domain = extract_open_to(&initial_ws_text);
+
     // Buffer client text frames received while upstream connect/STARTTLS is in progress.
     // They are flushed to TLS once the bridge starts.
     let mut pending_ws_texts = vec![initial_ws_text];
 
     let upstream_connect_started = Instant::now();
-    let connect_future = connect_upstream_tls(server_input);
+    let connect_future = connect_upstream_tls(server_input, client_domain.as_deref());
     tokio::pin!(connect_future);
 
     let tls_stream = loop {
         tokio::select! {
             result = &mut connect_future => {
-                let tls_stream = result?;
-                info!(
-                    conn_id,
-                    connect_ms = upstream_connect_started.elapsed().as_millis() as u64,
-                    "Upstream TLS connected"
-                );
-                break tls_stream;
+                match result {
+                    Ok(tls_stream) => {
+                        info!(
+                            conn_id,
+                            connect_ms = upstream_connect_started.elapsed().as_millis() as u64,
+                            "Upstream TLS connected"
+                        );
+                        break tls_stream;
+                    }
+                    Err(err) => {
+                        // Upstream connect/STARTTLS failed before the bridge could
+                        // start. Don't just drop the WebSocket — xmpp.js would report
+                        // a misleading "WebSocket ECONNERROR". Send a clean close
+                        // carrying the real cause: a relayed stream-error condition
+                        // (e.g. host-unknown) when the server reported one, else the
+                        // transport message.
+                        let condition = stream_error_condition_from_error(&err);
+                        let reason =
+                            format_bridge_close_reason("UpstreamConnectFailed", condition.as_deref());
+                        warn!(
+                            conn_id,
+                            error = %err,
+                            stream_error = ?condition,
+                            connect_ms = upstream_connect_started.elapsed().as_millis() as u64,
+                            "Upstream connection failed; closing WebSocket with reason"
+                        );
+                        send_close_with_reason(&mut ws, reason).await;
+                        return Ok(());
+                    }
+                }
             }
             msg = ws.next() => {
                 match msg {
@@ -685,11 +764,15 @@ async fn try_connect_endpoint(
 /// falling through to the next endpoint on TCP or TLS failure.
 async fn connect_upstream_tls(
     server_input: &str,
+    client_domain: Option<&str>,
 ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, String> {
     // Resolve DNS/SRV per connection (fresh resolution handles DNS changes after sleep)
     let resolve_started = Instant::now();
     let endpoints = match parse_server_input(server_input) {
         ParsedServer::Direct(host, port, mode, domain) => {
+            // Domain precedence: explicit `?domain=` override → client `<open to=>`
+            // (the JID's domain) → None (falls back to the connection host).
+            let domain = domain.or_else(|| client_domain.map(|d| d.to_string()));
             info!(host = %host, port, mode = ?mode, domain = ?domain, "Using explicit endpoint");
             vec![XmppEndpoint {
                 host,
@@ -842,6 +925,15 @@ async fn perform_starttls(
             if stanza.contains("<stream:features") || stanza.contains("<features") {
                 features_xml = stanza;
                 break;
+            }
+
+            // A <stream:error> (e.g. host-unknown, when the connection host serves
+            // a different vhost than the JID domain) terminates the stream. Surface
+            // the condition so the connection handler can tell the user *why*,
+            // instead of letting it look like a generic transport failure.
+            if let Some(condition) = extract_stream_error_condition(&stanza) {
+                warn!(condition = %condition, "STARTTLS: server returned stream error");
+                return Err(format!("STARTTLS: server stream-error: {condition}"));
             }
 
             // Unexpected stanza before features
@@ -1292,7 +1384,7 @@ pub async fn stop_proxy() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::SinkExt;
+    use futures_util::{SinkExt, StreamExt};
     use tokio::io::AsyncReadExt;
 
     // Note: DNS/parsing tests are in dns.rs, framing/stanza tests are in framing.rs.
@@ -1514,6 +1606,243 @@ mod tests {
             active_connections.load(Ordering::SeqCst),
             0,
             "connection guard should decrement active connection count on early exit"
+        );
+    }
+
+    /// Spin up a fake upstream TCP server + the proxy `handle_connection`, send
+    /// `client_open` from a WebSocket client, and return the first stream header
+    /// the proxy writes upstream (the STARTTLS `<stream:stream …>`).
+    ///
+    /// `domain_param`, when set, is appended as `?domain=…` to the `tcp://` server
+    /// input. The fake upstream stays silent after capturing the header, so the
+    /// proxy's STARTTLS eventually errors — but the header is already captured.
+    async fn capture_proxy_starttls_header(
+        client_open: &str,
+        domain_param: Option<&str>,
+    ) -> String {
+        let upstream = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake upstream");
+        let upstream_port = upstream.local_addr().expect("upstream addr").port();
+        let (hdr_tx, hdr_rx) = tokio::sync::oneshot::channel::<String>();
+
+        tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.expect("accept upstream");
+            let mut buf = [0u8; 4096];
+            let mut acc = Vec::new();
+            loop {
+                match tokio::time::timeout(std::time::Duration::from_secs(2), sock.read(&mut buf))
+                    .await
+                {
+                    Ok(Ok(n)) if n > 0 => {
+                        acc.extend_from_slice(&buf[..n]);
+                        let s = String::from_utf8_lossy(&acc);
+                        // Wait for the full <stream:stream …> open, skipping the
+                        // leading <?xml …?> declaration (its own '>' comes first).
+                        if let Some(idx) = s.find("<stream:stream") {
+                            if s[idx..].contains('>') {
+                                break;
+                            }
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            let _ = hdr_tx.send(String::from_utf8_lossy(&acc).to_string());
+            // Keep the socket open briefly so the proxy doesn't tear down first.
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(1), sock.read(&mut buf))
+                .await;
+        });
+
+        let server_input = match domain_param {
+            Some(d) => format!("tcp://127.0.0.1:{upstream_port}?domain={d}"),
+            None => format!("tcp://127.0.0.1:{upstream_port}"),
+        };
+
+        let ws_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ws listener");
+        let ws_addr = ws_listener.local_addr().expect("ws listener addr");
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        let active = Arc::new(AtomicUsize::new(0));
+        let active_for_handler = active.clone();
+
+        let handler = tokio::spawn(async move {
+            let (ws_stream, _) = ws_listener.accept().await.expect("accept ws");
+            let _ = handle_connection(
+                ws_stream,
+                &server_input,
+                shutdown_tx.subscribe(),
+                active_for_handler,
+                None,
+            )
+            .await;
+        });
+
+        let ws_url = format!("ws://{}", ws_addr);
+        let (mut ws_client, _) = tokio_tungstenite::connect_async(ws_url)
+            .await
+            .expect("connect ws client");
+        ws_client
+            .send(Message::Text(client_open.to_string().into()))
+            .await
+            .expect("send <open/>");
+
+        let header = tokio::time::timeout(std::time::Duration::from_secs(3), hdr_rx)
+            .await
+            .expect("should capture upstream stream header before timeout")
+            .expect("header channel should not drop");
+
+        drop(ws_client);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handler).await;
+        header
+    }
+
+    /// Regression guard (R1): when the connection host differs from the JID
+    /// domain, the STARTTLS stream header MUST carry the JID domain (taken from
+    /// the client's `<open to=>`), not the connection host. Host-based since #134.
+    #[tokio::test]
+    async fn test_explicit_starttls_uses_jid_domain_from_open_to() {
+        let client_open = "<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='process-one.net' from='me@process-one.net' version='1.0'/>";
+        let header = capture_proxy_starttls_header(client_open, None).await;
+        assert!(
+            header.contains("to='process-one.net'"),
+            "STARTTLS header must carry the JID domain from <open to=>, got: {header}"
+        );
+        assert!(
+            !header.contains("to='127.0.0.1'"),
+            "STARTTLS header must NOT use the connection host, got: {header}"
+        );
+    }
+
+    /// Precedence guard (R2): an explicit `?domain=` override wins over the
+    /// client's `<open to=>`.
+    #[tokio::test]
+    async fn test_explicit_starttls_domain_param_overrides_open_to() {
+        let client_open = "<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='process-one.net' version='1.0'/>";
+        let header = capture_proxy_starttls_header(client_open, Some("explicit.example")).await;
+        assert!(
+            header.contains("to='explicit.example'"),
+            "?domain= override must win over <open to=>, got: {header}"
+        );
+    }
+
+    /// Part 2: an upstream stream error (host-unknown) must be relayed to the
+    /// client in the WebSocket close reason, not swallowed as an abrupt socket
+    /// drop (which xmpp.js reports as the misleading "WebSocket ECONNERROR").
+    #[tokio::test]
+    async fn test_upstream_stream_error_surfaced_in_ws_close_reason() {
+        let upstream = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake upstream");
+        let upstream_port = upstream.local_addr().expect("upstream addr").port();
+
+        tokio::spawn(async move {
+            let (mut sock, _) = upstream.accept().await.expect("accept upstream");
+            let mut buf = [0u8; 4096];
+            // Read the proxy's <stream:stream> opening.
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(2), sock.read(&mut buf)).await;
+            // Reply with a stream header + host-unknown stream error, then close —
+            // exactly what ejabberd does for an unknown vhost.
+            let resp = "<?xml version='1.0'?><stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' from='process-one.net' id='x' version='1.0'><stream:error><host-unknown xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error></stream:stream>";
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.flush().await;
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(1), sock.read(&mut buf)).await;
+        });
+
+        let server_input = format!("tcp://127.0.0.1:{upstream_port}");
+        let ws_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ws listener");
+        let ws_addr = ws_listener.local_addr().expect("ws listener addr");
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        let active = Arc::new(AtomicUsize::new(0));
+        let active_for_handler = active.clone();
+
+        tokio::spawn(async move {
+            let (ws_stream, _) = ws_listener.accept().await.expect("accept ws");
+            let _ = handle_connection(
+                ws_stream,
+                &server_input,
+                shutdown_tx.subscribe(),
+                active_for_handler,
+                None,
+            )
+            .await;
+        });
+
+        let ws_url = format!("ws://{}", ws_addr);
+        let (mut ws_client, _) = tokio_tungstenite::connect_async(ws_url)
+            .await
+            .expect("connect ws client");
+        ws_client
+            .send(Message::Text(
+                "<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='process-one.net' version='1.0'/>"
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .expect("send <open/>");
+
+        let mut close_reason = String::new();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(msg) = ws_client.next().await {
+                match msg {
+                    Ok(Message::Close(Some(frame))) => {
+                        close_reason = frame.reason.to_string();
+                        break;
+                    }
+                    Ok(Message::Close(None)) => break,
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            close_reason.contains("host-unknown"),
+            "WebSocket close reason must carry the upstream stream-error condition, got: {close_reason:?}"
+        );
+    }
+
+    // --- stream_error_condition_from_error tests ---
+
+    #[test]
+    fn test_stream_error_condition_from_error_present() {
+        assert_eq!(
+            stream_error_condition_from_error("STARTTLS: server stream-error: host-unknown")
+                .as_deref(),
+            Some("host-unknown")
+        );
+    }
+
+    #[test]
+    fn test_stream_error_condition_from_error_in_aggregated_message() {
+        // connect_upstream_tls wraps each endpoint failure; the marker survives.
+        let aggregated = "All 1 endpoint(s) failed:\n  - chat.process-one.net:5222 (Tcp): STARTTLS: server stream-error: host-unknown";
+        assert_eq!(
+            stream_error_condition_from_error(aggregated).as_deref(),
+            Some("host-unknown")
+        );
+    }
+
+    #[test]
+    fn test_stream_error_condition_from_error_hyphenated_condition() {
+        assert_eq!(
+            stream_error_condition_from_error("STARTTLS: server stream-error: see-other-host")
+                .as_deref(),
+            Some("see-other-host")
+        );
+    }
+
+    #[test]
+    fn test_stream_error_condition_from_error_transport_failure_is_none() {
+        assert_eq!(
+            stream_error_condition_from_error("TCP connect timed out after 15s to host:5222"),
+            None
         );
     }
 }

--- a/docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md
+++ b/docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md
@@ -1,0 +1,173 @@
+# Proxy: JID-domain for explicit endpoints + surfacing upstream stream errors
+
+- **Date:** 2026-06-03
+- **Status:** Proposed (awaiting review)
+- **Area:** `apps/fluux/src-tauri/src/xmpp_proxy/`, `packages/fluux-sdk/src/core/modules/Connection.ts`, `apps/fluux/src` (LoginScreen + i18n)
+
+## Problem
+
+Connecting with an explicit STARTTLS/TLS server override fails. Reproduced with
+JID `mremond@process-one.net` and server `tcp://chat.process-one.net`. The login
+screen shows a misleading `WebSocket ECONNERROR ws://127.0.0.1:60342`.
+
+Evidence from `~/Library/Logs/com.processone.fluux/fluux.log.2026-06-03`
+(conn_id=2, the screenshot's port 60342):
+
+```
+Using explicit endpoint host=chat.process-one.net port=5222 mode=Tcp domain=None
+New WebSocket connection addr=127.0.0.1:60343          # loopback OK
+Connected (TCP), performing STARTTLS                    # TCP to server OK
+STARTTLS: Unexpected stanza before features stanza=<stream:error><host-unknown/></stream:error>
+Endpoint failed ... STARTTLS: Server closed connection before features
+-> webview: WebSocket ECONNERROR ws://127.0.0.1:60342
+```
+
+**Root cause (two independent defects):**
+
+1. **Wrong XMPP domain.** `parse_server_input("tcp://chat.process-one.net")`
+   yields `domain: None`, so `XmppEndpoint::tls_name()` falls back to the
+   *connection host* `chat.process-one.net`. `perform_starttls` then sends
+   `<stream:stream to='chat.process-one.net'>` and uses that host for TLS SNI.
+   The ejabberd server hosts the vhost `process-one.net`, so it returns
+   `<stream:error><host-unknown/></stream:error>` and closes. The connection
+   host is *not* the service domain — they legitimately differ.
+
+2. **The real error is swallowed.** The `host-unknown` failure happens during
+   STARTTLS, **before the WS↔TLS bridge starts**. `handle_connection` propagates
+   the error with `?` and the WebSocket is dropped **without a close frame**.
+   xmpp.js sees an abnormal 1006 close and reports the generic
+   `WebSocket ECONNERROR`. The existing `proxy-connection-closed` event and the
+   enriched `"Bridge closed: stream-error <condition>"` close reason are only
+   produced **inside** `bridge_websocket_tls` (post-bridge), so neither fires here.
+
+Not a transport problem: loopback and TCP both succeeded. (The morning `[::1]`
+loopback binds in the same log are unrelated and connected fine.)
+
+## Goals
+
+1. Explicit endpoints (`tcp://`, `tls://`, `host:port`) use the **JID's domain**
+   as the STARTTLS `to=` and TLS SNI, so connecting via a front host that serves
+   a different vhost works.
+2. When the upstream returns **any** stream error (`host-unknown`,
+   `see-other-host`, `not-authorized`, `conflict`, …), surface that condition as
+   a clear, localized message on the login screen instead of `ECONNERROR` — for
+   both pre-bridge and post-bridge failures.
+
+## Non-goals
+
+- No change to the SRV-resolution path (it already attaches the JID domain).
+- No new login form field; the existing `?domain=` override stays as the
+  power-user escape hatch and keeps precedence.
+- No redesign of reconnection / state machine.
+
+## Approved decisions
+
+- **Domain source:** read the JID domain from the **client's initial `<open to=>`**
+  stanza, which xmpp.js already sends in-band (the SDK configures the client with
+  `getDomain(jid)`; `from='user@domain'` is already forwarded). Pure Rust, no
+  SDK/adapter/UI plumbing.
+- **Error scope:** surface **any** upstream stream-error condition (generic
+  mapping with per-condition messages for the common cases).
+
+## Design
+
+### Part 1 — JID domain from the client `<open/>`
+
+Domain precedence for an explicit endpoint becomes:
+`?domain=` (explicit override) → client `<open to=>` → connection host (today's fallback).
+
+- **`framing.rs`:** factor the `<open>` attribute parsing currently inlined in
+  `translate_ws_to_tcp` into a shared helper and expose
+  `extract_open_to(text: &str) -> Option<String>` (returns a non-empty `to`).
+  This avoids duplicating the quick-xml parsing (per CLAUDE.md: no duplication).
+- **`mod.rs` `handle_connection`:** after `wait_for_initial_client_stanza`,
+  compute `client_domain = extract_open_to(&initial_ws_text)` and pass it to
+  `connect_upstream_tls`.
+- **`mod.rs` `connect_upstream_tls(server_input, client_domain: Option<&str>)`:**
+  for `ParsedServer::Direct(host, port, mode, parsed_domain)`, set the endpoint
+  domain to `parsed_domain.or(client_domain)`. `ParsedServer::Domain` (SRV) is
+  unchanged. `tls_name()` then yields the JID domain, used for both the STARTTLS
+  `to=` and TLS SNI/verification — making explicit endpoints behave exactly like
+  the SRV path (host = where to connect, domain = what to verify, RFC 6120 §13.7.2).
+
+### Part 2 — Surface upstream stream errors
+
+- **`perform_starttls`:** when an extracted stanza is a stream error
+  (`extract_stream_error_condition` returns `Some`), stop and return an error that
+  **carries the condition**, instead of the generic "Server closed connection
+  before features".
+- **Error type:** introduce a small `UpstreamConnectError { message: String,
+  stream_error: Option<String> }` returned by `perform_starttls` /
+  `try_connect_endpoint` / `connect_upstream_tls`, so the condition survives the
+  per-endpoint aggregation (record the first condition seen).
+- **`mod.rs` `handle_connection`:** on `connect_upstream_tls` error, **before
+  returning**, (a) send a clean RFC7395 `<close/>` + WebSocket close frame whose
+  reason is `format_bridge_close_reason(label, condition)` (e.g.
+  `"Bridge closed: stream-error host-unknown"`), and (b) emit the existing
+  `proxy-connection-closed` event with `{ conn_id, reason, stream_error }`. Factor
+  the close handshake currently inlined in `bridge_websocket_tls` into a shared
+  `send_ws_close_handshake(ws, reason)` helper used by both paths.
+  - Result: the webview gets a clean **1000** close with the enriched reason
+    (recognised by `Connection.ts:2086` `isExpectedBridgeClose`) instead of an
+    abrupt 1006 drop, and the Tauri event now fires for pre-bridge failures too.
+
+### Part 3 — Frontend surfacing (SDK stays i18n-free)
+
+- **`Connection.ts`:** in the `initialFailure` disconnect path (and the
+  connection-error path), when the close reason matches
+  `Bridge closed: stream-error <condition>`, extract `<condition>` and set
+  `connection.setError` to a stable token the app can recognize (keep the bare
+  condition, e.g. `stream-error:host-unknown`). Follows the existing
+  substring-token pattern (`isAuthError` already matches `not-authorized`).
+- **`LoginScreen.tsx`:** map a recognized stream-error condition to a localized
+  message via a small `streamErrorMessage(error, t)` helper; reveal the server
+  field (already done for non-auth errors). `host-unknown` gets a domain-specific
+  hint (front host serves a different vhost; use `?domain=` or check the server).
+- **i18n (`en.json` / `fr.json`):** add `login.streamError.*` keys for
+  `host-unknown`, `see-other-host`, `not-authorized`, `conflict`, `host-gone`,
+  `remote-connection-failed`, `policy-violation`, plus a generic
+  `stream-error: {{condition}}` fallback.
+
+## Affected units
+
+| Unit | Type | Responsibility |
+|------|------|----------------|
+| `framing::extract_open_to` | new, pure | Read `to=` from an `<open/>` frame |
+| `connect_upstream_tls` | changed | Accept `client_domain`, apply domain precedence |
+| `perform_starttls` | changed | Detect stream-error, return its condition |
+| `UpstreamConnectError` | new | Carry `(message, stream_error)` up the stack |
+| `send_ws_close_handshake` | new (extracted) | Send RFC7395+WS close with reason |
+| `handle_connection` | changed | Close cleanly + emit event on upstream failure |
+| `Connection.ts` close path | changed | Extract condition into `connection.error` |
+| `LoginScreen` + i18n | changed | Localized message; reveal server field |
+
+## Testing
+
+- **Rust / `framing.rs`:** `extract_open_to` with/without `to`, both quote
+  styles, non-`<open>` input.
+- **Rust / `mod.rs` (fake upstream harness, like the existing
+  `test_handle_connection_*`):**
+  - Part 1: client sends `<open to='process-one.net'/>` with `server_input =
+    tcp://127.0.0.1:<fake>`; assert the proxy's `<stream:stream>` carries
+    `to='process-one.net'` (host ≠ domain).
+  - Part 2: fake upstream replies `<stream:error><host-unknown/></stream:error>`;
+    assert the client receives a 1000 close whose reason contains
+    `stream-error host-unknown`.
+- **SDK / `Connection.test.ts`:** a `Bridge closed: stream-error host-unknown`
+  close reason ends up as a `host-unknown`-bearing `connection.error`.
+- **App:** `streamErrorMessage` maps known conditions; new i18n keys exist in
+  both locales.
+
+Existing suites for `dns.rs`, `framing.rs`, and the proxy harness must stay green.
+
+## Backward compatibility / risks
+
+- Domain precedence keeps `?domain=` first and leaves the SRV path untouched →
+  low risk.
+- Explicit endpoints now verify the TLS cert against the **JID domain** (correct
+  per RFC 6120), not the connection host. A user who relied on connecting to a
+  host whose certificate only matches the host name would now need the
+  `?domain=`/host certificate to cover the JID domain — this is the correct
+  behavior, and `?domain=` remains available. Note in release notes.
+- Pre-bridge failures now close with code 1000 (+`Bridge closed` reason) instead
+  of 1006; the SDK already treats that as an expected terminal bridge close.

--- a/docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md
+++ b/docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md
@@ -137,22 +137,30 @@ Domain precedence for an explicit endpoint becomes:
     (recognised by `Connection.ts:2086` `isExpectedBridgeClose`) instead of an
     abrupt 1006 drop, and the Tauri event now fires for pre-bridge failures too.
 
-### Part 3 — Frontend surfacing (SDK stays i18n-free)
+### Part 3 — Frontend surfacing (as built)
 
-- **`Connection.ts`:** in the `initialFailure` disconnect path (and the
-  connection-error path), when the close reason matches
-  `Bridge closed: stream-error <condition>`, extract `<condition>` and set
-  `connection.setError` to a stable token the app can recognize (keep the bare
-  condition, e.g. `stream-error:host-unknown`). Follows the existing
-  substring-token pattern (`isAuthError` already matches `not-authorized`).
-- **`LoginScreen.tsx`:** map a recognized stream-error condition to a localized
-  message via a small `streamErrorMessage(error, t)` helper; reveal the server
-  field (already done for non-auth errors). `host-unknown` gets a domain-specific
-  hint (front host serves a different vhost; use `?domain=` or check the server).
-- **i18n (`en.json` / `fr.json`):** add `login.streamError.*` keys for
-  `host-unknown`, `see-other-host`, `not-authorized`, `conflict`, `host-gone`,
-  `remote-connection-failed`, `policy-violation`, plus a generic
-  `stream-error: {{condition}}` fallback.
+- **`streamErrors.ts` (new SDK module):** two pure helpers —
+  `extractStreamErrorCondition(text)` (recovers the condition from the proxy's
+  `"… stream-error <condition>"` encoding, including inside a verbose
+  WebSocket-close message) and `humanizeStreamError(text)` (maps known conditions
+  — `host-unknown`, `see-other-host`, `not-authorized`, `conflict`, `host-gone`,
+  `remote-connection-failed`, `policy-violation`, … — to a clear, actionable
+  sentence that still shows the raw condition; generic fallback otherwise;
+  `null` when no condition is present).
+- **`Connection.ts`:** call `humanizeStreamError` in the two places the
+  user-facing connection error is built — the `connect()` catch (display string
+  for `CONNECTION_ERROR`/`emitSDK`) and the `initialFailure` disconnect branch
+  (which already folds the bridge close reason). When a condition is present the
+  humanized message replaces the transport noise; otherwise the existing message
+  is untouched. Machine routing stays keyed on the original message.
+- **`LoginScreen.tsx`:** no change — it already renders `connection.error`
+  verbatim, so the clearer message surfaces automatically (consistent with the
+  other English transport messages the SDK already emits, e.g. the local-proxy
+  firewall hint).
+- **Deferred:** full fr/en localization of connection errors. The app does not
+  localize connection errors today (they render raw), so localizing only stream
+  errors would be inconsistent. `extractStreamErrorCondition` is structured so a
+  later i18n pass can map the condition to `login.streamError.*` keys.
 
 ## Affected units
 

--- a/docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md
+++ b/docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md
@@ -43,6 +43,32 @@ Endpoint failed ... STARTTLS: Server closed connection before features
 Not a transport problem: loopback and TCP both succeeded. (The morning `[::1]`
 loopback binds in the same log are unrelated and connected fine.)
 
+## History / regression analysis
+
+It *feels* like a regression — the bare domain `process-one.net` connects fine
+(SRV resolves host `chat.process-one.net` + domain `process-one.net`, so STARTTLS
+sends `to='process-one.net'`), yet typing that **same host** as
+`tcp://chat.process-one.net` fails. The git history shows a long-standing latent
+gap rather than a single-commit break:
+
+- **`da3a38bc` (#134, "Add TCP connection support")** introduced `perform_starttls`
+  and called it with the **connection host** (`perform_starttls(tcp_stream,
+  &endpoint.host)`). Explicit STARTTLS endpoints have used the host as the `to=`/SNI
+  ever since.
+- **`8e624f54` ("…TLS SNI domain handling…")** added `XmppEndpoint.domain`,
+  `tls_name()`, and the `?domain=` override, wiring the JID domain for the **SRV
+  path** — but explicit endpoints kept `domain: None` (host fallback), and **no
+  frontend code ever produces `?domain=`**, so that override is dead.
+- **Direct TLS (`tls://`, port 5223) accidentally works:** the proxy sends no
+  pre-TLS header, so the client's own `<open to='process-one.net'/>` reaches the
+  server through the bridge with the correct domain. Only STARTTLS — which needs a
+  proxy-generated pre-TLS header — is wrong. The fix removes that asymmetry by
+  feeding the same client `<open to=>` into the STARTTLS header.
+
+Implication for tests: a regression guard must assert the **STARTTLS pre-TLS
+stream header carries the JID domain when the connection host differs** — the
+exact thing that has silently been host-based since #134.
+
 ## Goals
 
 1. Explicit endpoints (`tcp://`, `tls://`, `host:port`) use the **JID's domain**
@@ -143,16 +169,36 @@ Domain precedence for an explicit endpoint becomes:
 
 ## Testing
 
-- **Rust / `framing.rs`:** `extract_open_to` with/without `to`, both quote
-  styles, non-`<open>` input.
-- **Rust / `mod.rs` (fake upstream harness, like the existing
-  `test_handle_connection_*`):**
-  - Part 1: client sends `<open to='process-one.net'/>` with `server_input =
-    tcp://127.0.0.1:<fake>`; assert the proxy's `<stream:stream>` carries
-    `to='process-one.net'` (host ≠ domain).
-  - Part 2: fake upstream replies `<stream:error><host-unknown/></stream:error>`;
-    assert the client receives a 1000 close whose reason contains
-    `stream-error host-unknown`.
+The user explicitly asked for regression coverage. The guards below lock in the
+*correct* behavior so the host-based `to=` can never silently return.
+
+**Regression guards (must fail on today's code, pass after the fix):**
+
+- **R1 — STARTTLS uses JID domain when host differs (the core regression).**
+  Fake-upstream harness (like `test_handle_connection_*`): client sends
+  `<open to='process-one.net'/>`, `server_input = tcp://127.0.0.1:<fakeport>`
+  (host ≠ domain). Assert the proxy's pre-TLS `<stream:stream>` carries
+  `to='process-one.net'`, **not** the connection host. This is the exact case
+  that has been host-based since #134.
+- **R2 — `?domain=` keeps precedence.** `server_input =
+  tcp://127.0.0.1:<fakeport>?domain=explicit.example` with client
+  `<open to='process-one.net'/>` → header carries `to='explicit.example'`
+  (override wins over the client `<open to=>`).
+- **R3 — direct-TLS / STARTTLS consistency.** Document the path that already
+  works: `tls://`/5223 lets the client `<open to=>` reach the server unchanged;
+  after the fix STARTTLS matches it. (Covered structurally by R1.)
+
+**Unit tests:**
+
+- **`framing::extract_open_to`:** with/without `to`, single/double quotes,
+  non-`<open>` input, empty `to`.
+- **`dns::parse_server_input`:** explicit `tcp://host` / `tls://host` /
+  `host:port` still yield `domain: None` (documents that the host fallback is
+  intentional and that the client `<open to=>` is what now supplies the domain).
+- **Part 2 surfacing:** fake upstream replies
+  `<stream:error><host-unknown/></stream:error>`; assert the client receives a
+  1000 close whose reason contains `stream-error host-unknown` (today it drops
+  with no frame → 1006).
 - **SDK / `Connection.test.ts`:** a `Bridge closed: stream-error host-unknown`
   close reason ends up as a `host-unknown`-bearing `connection.error`.
 - **App:** `streamErrorMessage` maps known conditions; new i18n keys exist in

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -831,9 +831,13 @@ describe('XMPPClient Connection', () => {
       })
 
       const errorArg = vi.mocked(mockStores.connection.setError).mock.calls[0][0]
-      expect(errorArg).toBe(
-        'Connection failed: WebSocket closed (code: 1000, Bridge closed: stream-error host-unknown)'
-      )
+      // The relayed stream-error condition is surfaced as an actionable message
+      // (the connection host serves a different vhost than the JID domain),
+      // keeping the raw condition visible but dropping the transport noise.
+      expect(errorArg).not.toBeNull()
+      expect(errorArg).toContain('host-unknown')
+      expect(errorArg!.toLowerCase()).toContain('domain')
+      expect(errorArg).not.toContain('WebSocket closed')
     })
 
     it('should prefer discovered XEP-0156 WebSocket endpoint before proxy for domain server inputs', async () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -56,6 +56,7 @@ import { invalidateFastTokenOnServer } from '../fastTokenInvalidation'
 import { buildUserAgentElement } from '../userAgent'
 import { ProxyManager } from './proxyManager'
 import { isConnectionTraceEnabled } from './connectionDiagnostics'
+import { humanizeStreamError } from './streamErrors'
 
 // Dev-only error logging (checks Vite dev mode, excludes test mode)
 const isDev = (() => {
@@ -663,16 +664,21 @@ export class Connection extends BaseModule {
       }
       logError('Connection error:', error.message)
       logErr(`Connection error: ${error.message}`)
+      // If the failure carries a relayed upstream stream-error condition (e.g.
+      // host-unknown, when the connection host serves a different vhost than the
+      // JID domain), surface that actionable cause instead of the raw transport
+      // message. Machine routing stays keyed on the original message.
+      const displayError = humanizeStreamError(error.message) ?? error.message
       // Signal machine: initial connection failed. The machine's `connecting`
       // state routes CONNECTION_ERROR either to terminal.initialFailure
       // (default), to reconnecting.waiting (when SET_RETRY_INITIAL was set
       // to true by the caller), or — if a CONFLICT/AUTH_ERROR fired
       // synchronously from the stream-error handler — the machine is
       // already in a terminal state and CONNECTION_ERROR is ignored.
-      this.sendMachineEvent({ type: 'CONNECTION_ERROR', error: error.message }, 'connect:connection-error')
+      this.sendMachineEvent({ type: 'CONNECTION_ERROR', error: displayError }, 'connect:connection-error')
       this.stores.console.addEvent(`Connection error: ${error.message}`, 'error')
       // Emit SDK event for connection error
-      this.deps.emitSDK('connection:status', { status: 'error', error: error.message })
+      this.deps.emitSDK('connection:status', { status: 'error', error: displayError })
       this.emit('error', error)
       // Decide whether to throw based on the machine's POST-event state.
       // If the machine is in reconnecting.* the retry loop owns the outcome
@@ -2142,8 +2148,14 @@ export class Connection extends BaseModule {
             && (proxyServer.startsWith('ws://127.0.0.1:') || proxyServer.startsWith('ws://[::1]:'))
           const isAbnormalClose = rawReason && typeof rawReason === 'object' && 'code' in rawReason
             && (rawReason as { code: number }).code === 1006
+          // A relayed upstream <stream:error> (e.g. host-unknown) carried in the
+          // bridge close reason is the real, actionable cause — surface it ahead
+          // of the local-proxy/transport fallbacks.
+          const streamErrorMessage = reason ? humanizeStreamError(reason) : null
           let errorMsg: string
-          if (isProxyMode && isAbnormalClose) {
+          if (streamErrorMessage) {
+            errorMsg = streamErrorMessage
+          } else if (isProxyMode && isAbnormalClose) {
             errorMsg = 'Connection failed: Unable to reach local proxy. If a firewall prompt appeared, allow the connection and try again.'
           } else if (reason) {
             errorMsg = `Connection failed: ${reason}`

--- a/packages/fluux-sdk/src/core/modules/streamErrors.test.ts
+++ b/packages/fluux-sdk/src/core/modules/streamErrors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { extractStreamErrorCondition, humanizeStreamError } from './streamErrors'
+
+describe('extractStreamErrorCondition', () => {
+  it('extracts the condition from a bridge close reason (space-separated)', () => {
+    expect(
+      extractStreamErrorCondition('Bridge closed: stream-error host-unknown')
+    ).toBe('host-unknown')
+  })
+
+  it('extracts the condition from a colon-separated proxy error', () => {
+    expect(
+      extractStreamErrorCondition('STARTTLS: server stream-error: see-other-host')
+    ).toBe('see-other-host')
+  })
+
+  it('extracts the condition embedded in a verbose WebSocket-close message', () => {
+    expect(
+      extractStreamErrorCondition(
+        'Connection failed: WebSocket closed (code: 1000, Bridge closed: stream-error host-unknown)'
+      )
+    ).toBe('host-unknown')
+  })
+
+  it('is case-insensitive and normalizes to lower-case', () => {
+    expect(extractStreamErrorCondition('Stream-Error Host-Unknown')).toBe('host-unknown')
+  })
+
+  it('returns null for a transport error with no stream-error condition', () => {
+    expect(extractStreamErrorCondition('WebSocket ECONNERROR ws://127.0.0.1:60342')).toBeNull()
+  })
+})
+
+describe('humanizeStreamError', () => {
+  it('returns an actionable message for host-unknown that keeps the raw condition', () => {
+    const msg = humanizeStreamError('Bridge closed: stream-error host-unknown')
+    expect(msg).not.toBeNull()
+    expect(msg).toContain('host-unknown')
+    // Mentions the actionable cause (domain not served by this server).
+    expect(msg!.toLowerCase()).toContain('domain')
+  })
+
+  it('falls back to a generic message for an unknown condition', () => {
+    const msg = humanizeStreamError('Bridge closed: stream-error some-new-condition')
+    expect(msg).toContain('some-new-condition')
+  })
+
+  it('returns null when there is no stream-error condition (caller keeps its message)', () => {
+    expect(humanizeStreamError('WebSocket ECONNERROR ws://127.0.0.1:60342')).toBeNull()
+  })
+})

--- a/packages/fluux-sdk/src/core/modules/streamErrors.ts
+++ b/packages/fluux-sdk/src/core/modules/streamErrors.ts
@@ -1,0 +1,58 @@
+/**
+ * Helpers for surfacing XMPP stream-error conditions relayed by the Rust proxy
+ * bridge.
+ *
+ * When an upstream XMPP server closes the stream with a `<stream:error>` (RFC
+ * 6120 §4.9) — e.g. `host-unknown` when the connection host serves a different
+ * vhost than the JID domain — the Tauri proxy encodes the condition in the
+ * WebSocket close reason as `"… stream-error <condition>"`. Without translation
+ * the user only sees a generic transport failure (`WebSocket ECONNERROR`), which
+ * hides the real, actionable cause. These pure helpers recover the condition and
+ * turn it into a clear message.
+ */
+
+/**
+ * Clear, actionable wording for the stream-error conditions we expect to relay.
+ * Conditions not listed here fall back to a generic message that still includes
+ * the raw condition name.
+ */
+const STREAM_ERROR_MESSAGES: Record<string, string> = {
+  'host-unknown':
+    "This server does not serve your account's domain. Check the server address.",
+  'host-gone': "This server no longer serves your account's domain.",
+  'see-other-host': 'The server redirected the connection to a different host.',
+  'not-authorized': 'The server refused the connection (not authorized).',
+  'policy-violation': 'The connection was closed for a server policy violation.',
+  'remote-connection-failed': 'The server could not reach a required backend service.',
+  'system-shutdown': 'The server is shutting down or restarting.',
+  conflict: 'Another session replaced this connection.',
+}
+
+/**
+ * Extract an XMPP stream-error condition from a bridge close reason or
+ * connection error message.
+ *
+ * Recognizes the proxy's `"… stream-error <condition>"` and
+ * `"… stream-error: <condition>"` encodings, including when wrapped in a verbose
+ * WebSocket-close message. Returns the lower-cased condition (an XML element
+ * local name such as `host-unknown`), or `null` when the text carries no
+ * stream-error condition (e.g. a plain transport failure).
+ */
+export function extractStreamErrorCondition(text: string): string | null {
+  const match = text.match(/stream-error[:\s]+([a-z][a-z-]*)/i)
+  return match ? match[1].toLowerCase() : null
+}
+
+/**
+ * Turn a bridge close reason / connection error that encodes an upstream
+ * stream-error condition into a clear, actionable message.
+ *
+ * Returns `null` when the text carries no stream-error condition, so callers can
+ * keep their existing (transport-level) message unchanged.
+ */
+export function humanizeStreamError(text: string): string | null {
+  const condition = extractStreamErrorCondition(text)
+  if (!condition) return null
+  const detail = STREAM_ERROR_MESSAGES[condition]
+  return detail ? `${detail} (${condition})` : `The server closed the stream: ${condition}.`
+}


### PR DESCRIPTION
## Summary

Connecting via an explicit server override (e.g. `tcp://chat.process-one.net` for JID `me@process-one.net`) failed with a misleading `WebSocket ECONNERROR`. The proxy sent the **connection host** as the STARTTLS `to=` / TLS SNI instead of the JID's service domain, so ejabberd rejected the stream with `<host-unknown/>` — and the real cause never reached the UI.

Host-based since TCP support landed (#134); `8e624f54` added the `?domain=` override but wired the JID domain only for the SRV path, never for explicit endpoints (and no frontend ever produced `?domain=`).

## Changes

**Domain = JID's.** The proxy reads the JID domain from the client's initial `<open to=>` (already sent by xmpp.js) and uses it for the STARTTLS `to=` / TLS SNI on explicit endpoints. Precedence: explicit `?domain=` → client `<open to=>` → connection host. The SRV path is unchanged. Explicit endpoints now verify the TLS certificate against the JID domain (correct per RFC 6120 §13.7.2), matching the SRV path; the `?domain=` override remains for edge cases.

**Surface the real error.** On a pre-bridge STARTTLS failure the proxy sends a clean WebSocket close carrying the relayed `<stream:error>` condition (e.g. `host-unknown`) instead of dropping the socket. The SDK (`streamErrors.ts`, wired into `Connection.ts`) turns that into a clear, actionable login-screen message instead of `WebSocket ECONNERROR`.

## Coverage

Regression guards: explicit `tcp://<host>` with host ≠ JID domain emits `<stream:stream to='<jid-domain>'>` (fails on the old host-based code); `?domain=` keeps precedence over the client `<open to=>`; an upstream stream error reaches the WebSocket close reason. Plus unit tests for `extract_open_to`, the stream-error parser, and the SDK helpers — 12 new Rust + 9 SDK tests. Full Rust/SDK/app suites, typecheck and clippy are green.

Full fr/en localization of connection errors is deferred (the app renders connection errors raw today); the SDK exposes the condition so a later i18n pass can map it.

Design spec: `docs/superpowers/specs/2026-06-03-proxy-jid-domain-stream-errors-design.md`