### PR TITLE
feat(muc): persist whispers locally + presence-gated reply (XEP-0045 §7.5)

### DIFF
--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -40,7 +40,7 @@ export interface OccupantPanelProps {
   ownAvatar?: string | null
   onClose: () => void
   onStartChat?: (jid: string) => void
-  /** Start an ephemeral private "whisper" (XEP-0045 §7.5) with an occupant by nick */
+  /** Start a private "whisper" (XEP-0045 §7.5) with an occupant by nick */
   onWhisper?: (nick: string) => void
   onShowProfile?: (jid: string) => void
   /** When true, renders as full-screen view with back arrow instead of inline sidebar */
@@ -627,7 +627,7 @@ export function OccupantPanel({
               label={t('rooms.sendPrivateMessage')}
             />
           )}
-          {/* Whisper (ephemeral in-room private message) */}
+          {/* Whisper (in-room private message) */}
           {onWhisper && (
             <MenuButton
               onClick={() => { onWhisper(menuTarget.primaryNick); menu.close() }}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -5,7 +5,7 @@ import { useRoomActive, useRoster, getBareJid, generateConsistentColorHexSync, g
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, isSmallScreen } from '@/hooks'
-import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, buildReplyContext, PollBanner, type WhisperThreadPosition } from './conversation'
+import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, buildReplyContext, PollBanner, type WhisperThreadPosition } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar, getConsistentTextColor } from './Avatar'
@@ -280,11 +280,17 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // instead of staging a public reply (which would leak the private text into the room).
   const handleReplyToMessage = useCallback((message: RoomMessage) => {
     if (message.isPrivate && message.whisperWith) {
-      enterWhisperMode(message.whisperWith)
+      // Only continue a private thread if the counterpart is still in the room —
+      // replying to a recycled or absent nick would leak the private text.
+      if (activeRoom && whisperCounterpartPresent(message, activeRoom.occupants)) {
+        enterWhisperMode(message.whisperWith)
+      } else {
+        addToast('info', t('rooms.whisperCounterpartGone', { nick: message.whisperWith }))
+      }
     } else {
       setReplyingTo(message)
     }
-  }, [enterWhisperMode])
+  }, [enterWhisperMode, activeRoom, addToast, t])
 
   // Clear reply/edit/whisper/pending attachment state when room changes
   // Note: scroll position is managed by MessageList component
@@ -1291,6 +1297,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
         knownNicks={knownNicks}
         whisperWith={message.whisperWith}
         whisperThread={whisperThread}
+        counterpartPresent={message.isPrivate ? whisperCounterpartPresent(message, room.occupants) : true}
         onNickContextMenu={!message.isOutgoing ? handleNickContextMenu : undefined}
         onNickTouchStart={!message.isOutgoing ? handleNickTouchStart : undefined}
         onNickTouchEnd={!message.isOutgoing ? onNickTouchEnd : undefined}

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -6,7 +6,7 @@
  */
 import { useState, useMemo, memo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { CornerUpRight, AlertCircle, RefreshCw, Lock, ShieldAlert, Ear } from 'lucide-react'
+import { CornerUpRight, AlertCircle, RefreshCw, Lock, ShieldAlert, Ear, UserX } from 'lucide-react'
 import { formatMessagePreview, formatXMPPError, type BaseMessage, type MentionReference, type Contact, type ContactIdentity, type RoomRole, type RoomAffiliation } from '@fluux/sdk'
 import { Avatar } from '../Avatar'
 import { AvatarLightbox } from '../AvatarLightbox'
@@ -64,6 +64,12 @@ export interface MessageBubbleProps {
   whisperWith?: string
   /** Position within a whisper thread — drives the bounded "private with X" container. */
   whisperThread?: WhisperThreadPosition | null
+  /**
+   * Whether the whisper counterpart is currently in the room. When false, the
+   * thread's last row shows a "no longer in the room" note and reply is disabled.
+   * Undefined = treated as present (e.g. non-whisper messages).
+   */
+  counterpartPresent?: boolean
 
   // Nick header extras (for room moderator badge, hats)
   nickExtras?: ReactNode
@@ -139,6 +145,7 @@ function arePropsEqual(prev: MessageBubbleProps, next: MessageBubbleProps): bool
   if (prev.message.body !== next.message.body) return false
   if (prev.whisperWith !== next.whisperWith) return false
   if (prev.whisperThread !== next.whisperThread) return false
+  if (prev.counterpartPresent !== next.counterpartPresent) return false
   if (prev.message.isEdited !== next.message.isEdited) return false
   if (prev.message.isRetracted !== next.message.isRetracted) return false
   if (prev.message.isOutgoing !== next.message.isOutgoing) return false
@@ -258,6 +265,7 @@ export const MessageBubble = memo(function MessageBubble({
   senderOccupantJid,
   whisperWith,
   whisperThread,
+  counterpartPresent,
   nickExtras,
   myReactions,
   onReaction,
@@ -334,6 +342,8 @@ export const MessageBubble = memo(function MessageBubble({
   const inThread = !!whisperThread
   const threadStart = whisperThread === 'start' || whisperThread === 'solo'
   const threadEnd = whisperThread === 'end' || whisperThread === 'solo'
+  // Counterpart left the room: the thread becomes read-only (can't reply privately).
+  const counterpartGone = inThread && counterpartPresent === false
   const outerRowClass = inThread
     ? `group flex gap-4 -mx-4 px-4 transition-colors ${threadStart ? 'pt-3' : ''} ${threadEnd ? 'pb-1.5' : ''}`
     : `group flex gap-4 ${hoverClass} -mx-4 px-4 py-0.5 transition-colors ${showAvatar ? 'pt-4' : ''}`
@@ -399,7 +409,7 @@ export const MessageBubble = memo(function MessageBubble({
             onEdit={onEdit}
             onDelete={onDelete}
             myReactions={reactionsEnabled ? myReactions : []}
-            canReply={!isLastMessage}
+            canReply={!isLastMessage && !counterpartGone}
             canEdit={message.isOutgoing && isLastOutgoing}
             canDelete={message.isOutgoing || canModerate === true}
             isHidden={hideToolbar || false}
@@ -591,6 +601,14 @@ export const MessageBubble = memo(function MessageBubble({
                 {t('chat.errorDetails', { error: formatXMPPError(message.deliveryError) })}
               </div>
             )}
+          </div>
+        )}
+
+        {/* Whisper thread footer: counterpart is no longer in the room — reply disabled */}
+        {threadEnd && counterpartGone && (
+          <div className="flex items-center gap-1.5 pt-1.5 text-xs text-fluux-muted">
+            <UserX className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperCounterpartGone', { nick: whisperWith })}</span>
           </div>
         )}
       </div>

--- a/apps/fluux/src/components/conversation/index.ts
+++ b/apps/fluux/src/components/conversation/index.ts
@@ -21,7 +21,7 @@ export { HistoryGapMarker } from './HistoryGapMarker'
 export { MessageBubble, buildReplyContext } from './MessageBubble'
 export type { MessageBubbleProps } from './MessageBubble'
 
-export { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, scrollToMessage, isActionMessage } from './messageGrouping'
+export { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage } from './messageGrouping'
 export type { MessageGroup, WhisperThreadPosition } from './messageGrouping'
 
 export { MessageList } from './MessageList'

--- a/apps/fluux/src/components/conversation/messageGrouping.test.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, scrollToMessage, isActionMessage } from './messageGrouping'
+import { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage } from './messageGrouping'
 
 // Mock CSS.escape since it's not available in JSDOM
 // This implementation matches the browser's CSS.escape behavior
@@ -331,6 +331,58 @@ describe('whisperThreadPosition', () => {
     const msgs = [w('1', 'emma', 'emma'), w('2', 'emma', 'you')]
     expect(whisperThreadPosition(msgs, 0)).toBe('start')
     expect(whisperThreadPosition(msgs, 1)).toBe('end')
+  })
+
+  // Thread identity prefers the stable occupant-id (XEP-0421): a recycled nick
+  // must not merge two different people's whisper runs.
+  const wo = (id: string, whisperWith: string, whisperWithOccupantId: string, from = 'alice') => ({
+    id, timestamp: new Date('2024-01-15T10:00:00'), from, isPrivate: true, whisperWith, whisperWithOccupantId,
+  })
+
+  it('splits same-nick whispers that have different occupant-ids (recycled nick)', () => {
+    const msgs = [wo('1', 'bob', 'occ-1'), wo('2', 'bob', 'occ-2')]
+    expect(whisperThreadPosition(msgs, 0)).toBe('solo')
+    expect(whisperThreadPosition(msgs, 1)).toBe('solo')
+  })
+
+  it('keeps same-occupant-id whispers in one thread', () => {
+    const msgs = [wo('1', 'bob', 'occ-1'), wo('2', 'bob', 'occ-1')]
+    expect(whisperThreadPosition(msgs, 0)).toBe('start')
+    expect(whisperThreadPosition(msgs, 1)).toBe('end')
+  })
+
+  it('falls back to nick when either side lacks an occupant-id', () => {
+    const legacy = { id: '1', timestamp: new Date('2024-01-15T10:00:00'), from: 'alice', isPrivate: true, whisperWith: 'bob' }
+    const withId = wo('2', 'bob', 'occ-1')
+    expect(whisperThreadPosition([legacy, withId], 0)).toBe('start')
+    expect(whisperThreadPosition([legacy, withId], 1)).toBe('end')
+  })
+})
+
+describe('whisperCounterpartPresent', () => {
+  const occ = (nick: string, occupantId?: string) => ({ nick, occupantId })
+  const occupantsOf = (...list: { nick: string; occupantId?: string }[]) =>
+    new Map(list.map((o) => [o.nick, o] as const))
+
+  it('is present when an occupant matches the counterpart occupant-id', () => {
+    const msg = { whisperWith: 'bob', whisperWithOccupantId: 'occ-1' }
+    expect(whisperCounterpartPresent(msg, occupantsOf(occ('bob', 'occ-1')))).toBe(true)
+  })
+
+  it('is absent when the nick matches but the occupant-id differs (recycled nick)', () => {
+    const msg = { whisperWith: 'bob', whisperWithOccupantId: 'occ-1' }
+    expect(whisperCounterpartPresent(msg, occupantsOf(occ('bob', 'occ-2')))).toBe(false)
+  })
+
+  it('falls back to nick presence when the message has no occupant-id', () => {
+    const msg = { whisperWith: 'bob' }
+    expect(whisperCounterpartPresent(msg, occupantsOf(occ('bob')))).toBe(true)
+    expect(whisperCounterpartPresent(msg, occupantsOf(occ('carol')))).toBe(false)
+  })
+
+  it('is absent when the counterpart is no longer in the room', () => {
+    const msg = { whisperWith: 'bob', whisperWithOccupantId: 'occ-1' }
+    expect(whisperCounterpartPresent(msg, occupantsOf())).toBe(false)
   })
 })
 

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -30,6 +30,8 @@ interface GroupableMessage {
   isPrivate?: boolean
   /** Nick of the whisper counterpart (recipient if outgoing, sender if incoming). */
   whisperWith?: string
+  /** XEP-0421 occupant-id of the whisper counterpart, when known. */
+  whisperWithOccupantId?: string
 }
 
 /**
@@ -47,6 +49,22 @@ function sameSecurityContext(
 }
 
 /**
+ * Whether two whispers share the same counterpart. Prefers the stable XEP-0421
+ * occupant-id when both carry it (so a recycled nick can't merge two different
+ * people's runs); falls back to the nick when either side lacks an id (legacy /
+ * persisted whispers, or rooms without occupant-id support).
+ */
+function sameWhisperCounterpart(
+  a: GroupableMessage | undefined,
+  b: GroupableMessage | undefined,
+): boolean {
+  if (a?.whisperWithOccupantId && b?.whisperWithOccupantId) {
+    return a.whisperWithOccupantId === b.whisperWithOccupantId
+  }
+  return a?.whisperWith === b?.whisperWith
+}
+
+/**
  * Two messages share a group only if their whisper context matches: both public,
  * or both whispers with the same counterpart. A public↔whisper transition (or a
  * whisper-to-A↔whisper-to-B switch) forces a group break so the whisper badge
@@ -56,7 +74,7 @@ function sameSecurityContext(
 function sameWhisperContext(a: GroupableMessage, b: GroupableMessage): boolean {
   if (!a.isPrivate && !b.isPrivate) return true
   if (!a.isPrivate || !b.isPrivate) return false
-  return a.whisperWith === b.whisperWith
+  return sameWhisperCounterpart(a, b)
 }
 
 /**
@@ -149,7 +167,7 @@ function sameWhisperThread(
   a: GroupableMessage | undefined,
   b: GroupableMessage | undefined,
 ): boolean {
-  return !!a?.isPrivate && !!b?.isPrivate && a.whisperWith === b.whisperWith
+  return !!a?.isPrivate && !!b?.isPrivate && sameWhisperCounterpart(a, b)
 }
 
 /**
@@ -172,6 +190,25 @@ export function whisperThreadPosition<T extends GroupableMessage>(
   if (isStart) return 'start'
   if (isEnd) return 'end'
   return 'middle'
+}
+
+/**
+ * Whether the counterpart of a whisper is currently in the room — used to gate
+ * replying (you can only continue a private thread with someone who is present).
+ * Matches on the stable occupant-id when the message carries one (so a recycled
+ * nick held by someone else reads as "not present"); otherwise falls back to nick.
+ */
+export function whisperCounterpartPresent(
+  msg: { whisperWith?: string; whisperWithOccupantId?: string },
+  occupants: ReadonlyMap<string, { occupantId?: string }>,
+): boolean {
+  if (msg.whisperWithOccupantId) {
+    for (const occ of occupants.values()) {
+      if (occ.occupantId === msg.whisperWithOccupantId) return true
+    }
+    return false
+  }
+  return !!msg.whisperWith && occupants.has(msg.whisperWith)
 }
 
 /**

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -316,6 +316,7 @@
         "whisper": "همس",
         "whisperingTo": "تهمس بشكل خاص إلى {{nick}}",
         "whisperThread": "خاص مع {{nick}}",
+        "whisperCounterpartGone": "{{nick}} لم يعد موجودًا في الغرفة — لا يمكنك الرد",
         "whisperPlaceholder": "اهمس إلى {{nick}}…",
         "ignoreUser": "تجاهل في هذه الغرفة",
         "stopIgnoring": "إلغاء التجاهل",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -316,6 +316,7 @@
         "whisper": "Шэпт",
         "whisperingTo": "Шэпчаце прыватна да {{nick}}",
         "whisperThread": "Прыватна з {{nick}}",
+        "whisperCounterpartGone": "{{nick}} больш не ў пакоі — вы не можаце адказаць",
         "whisperPlaceholder": "Шапніце {{nick}}…",
         "ignoreUser": "Ігнараваць у гэтым пакоі",
         "stopIgnoring": "Спыніць ігнараванне",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -316,6 +316,7 @@
         "whisper": "Шепот",
         "whisperingTo": "Шепнете лично на {{nick}}",
         "whisperThread": "Лично с {{nick}}",
+        "whisperCounterpartGone": "{{nick}} вече не е в стаята — не можете да отговорите",
         "whisperPlaceholder": "Шепнете на {{nick}}…",
         "ignoreUser": "Игнориране в тази стая",
         "stopIgnoring": "Спиране на игнорирането",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -318,6 +318,7 @@
         "whisper": "Xiuxiueig",
         "whisperingTo": "Xiuxiuejant en privat a {{nick}}",
         "whisperThread": "Privat amb {{nick}}",
+        "whisperCounterpartGone": "{{nick}} ja no és a la sala — no pots respondre",
         "whisperPlaceholder": "Xiuxiueja a {{nick}}…",
         "ignoreUser": "Ignorar en aquesta sala",
         "stopIgnoring": "Deixar d'ignorar",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -318,6 +318,7 @@
         "whisper": "Šepot",
         "whisperingTo": "Šeptáte soukromě {{nick}}",
         "whisperThread": "Soukromě s {{nick}}",
+        "whisperCounterpartGone": "{{nick}} už není v místnosti — nemůžete odpovědět",
         "whisperPlaceholder": "Šeptat {{nick}}…",
         "ignoreUser": "Ignorovat v této místnosti",
         "stopIgnoring": "Přestat ignorovat",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -316,6 +316,7 @@
         "whisper": "Hvisk",
         "whisperingTo": "Hvisker privat til {{nick}}",
         "whisperThread": "Privat med {{nick}}",
+        "whisperCounterpartGone": "{{nick}} er ikke længere i rummet — du kan ikke svare",
         "whisperPlaceholder": "Hvisk til {{nick}}…",
         "ignoreUser": "Ignorér i dette rum",
         "stopIgnoring": "Stop med at ignorere",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -318,6 +318,7 @@
         "whisper": "Flüstern",
         "whisperingTo": "Flüstert privat an {{nick}}",
         "whisperThread": "Privat mit {{nick}}",
+        "whisperCounterpartGone": "{{nick}} ist nicht mehr im Raum — du kannst nicht antworten",
         "whisperPlaceholder": "Flüstern an {{nick}}…",
         "ignoreUser": "In diesem Raum ignorieren",
         "stopIgnoring": "Nicht mehr ignorieren",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -317,6 +317,7 @@
         "whisper": "Ψίθυρος",
         "whisperingTo": "Ψιθυρίζετε ιδιωτικά στον {{nick}}",
         "whisperThread": "Ιδιωτικά με {{nick}}",
+        "whisperCounterpartGone": "{{nick}} δεν είναι πλέον στο δωμάτιο — δεν μπορείτε να απαντήσετε",
         "whisperPlaceholder": "Ψιθύρισε στον {{nick}}…",
         "ignoreUser": "Αγνόηση σε αυτό το δωμάτιο",
         "stopIgnoring": "Διακοπή αγνόησης",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -316,6 +316,7 @@
         "whisper": "Whisper",
         "whisperingTo": "Whispering privately to {{nick}}",
         "whisperThread": "Private with {{nick}}",
+        "whisperCounterpartGone": "{{nick}} is no longer in the room — you can't reply",
         "whisperPlaceholder": "Whisper to {{nick}}…",
         "ignoreUser": "Ignore in this room",
         "stopIgnoring": "Stop ignoring",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -318,6 +318,7 @@
         "whisper": "Susurro",
         "whisperingTo": "Susurrando en privado a {{nick}}",
         "whisperThread": "Privado con {{nick}}",
+        "whisperCounterpartGone": "{{nick}} ya no está en la sala — no puedes responder",
         "whisperPlaceholder": "Susurrar a {{nick}}…",
         "ignoreUser": "Ignorar en esta sala",
         "stopIgnoring": "Dejar de ignorar",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -318,6 +318,7 @@
         "whisper": "Sosistamine",
         "whisperingTo": "Sosistate privaatselt {{nick}}-le",
         "whisperThread": "Privaatne {{nick}}-ga",
+        "whisperCounterpartGone": "{{nick}} pole enam toas — sa ei saa vastata",
         "whisperPlaceholder": "Sosista {{nick}}-le…",
         "ignoreUser": "Ignoreeri selles ruumis",
         "stopIgnoring": "Lõpeta ignoreerimine",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -316,6 +316,7 @@
         "whisper": "Kuiskaus",
         "whisperingTo": "Kuiskaat yksityisesti {{nick}}:lle",
         "whisperThread": "Yksityinen {{nick}}:n kanssa",
+        "whisperCounterpartGone": "{{nick}} ei ole enää huoneessa — et voi vastata",
         "whisperPlaceholder": "Kuiskaa {{nick}}:lle…",
         "ignoreUser": "Ohita tässä huoneessa",
         "stopIgnoring": "Lopeta ohittaminen",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -317,6 +317,7 @@
         "whisper": "Chuchotement",
         "whisperingTo": "Vous chuchotez en privé à {{nick}}",
         "whisperThread": "Privé avec {{nick}}",
+        "whisperCounterpartGone": "{{nick}} n'est plus dans le salon — vous ne pouvez pas répondre",
         "whisperPlaceholder": "Chuchoter à {{nick}}…",
         "ignoreUser": "Ignorer dans ce salon",
         "stopIgnoring": "Ne plus ignorer",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -316,6 +316,7 @@
         "whisper": "Cogar",
         "whisperingTo": "Ag cogarnach go príobháideach chuig {{nick}}",
         "whisperThread": "Príobháideach le {{nick}}",
+        "whisperCounterpartGone": "Níl {{nick}} sa seomra a thuilleadh — ní féidir leat freagra a thabhairt",
         "whisperPlaceholder": "Cogar chuig {{nick}}…",
         "ignoreUser": "Déan neamhaird sa seomra seo",
         "stopIgnoring": "Stop ag déanamh neamhaird",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -316,6 +316,7 @@
         "whisper": "לחישה",
         "whisperingTo": "לוחש בפרטיות ל-{{nick}}",
         "whisperThread": "פרטי עם {{nick}}",
+        "whisperCounterpartGone": "{{nick}} כבר לא נמצא בחדר — אי אפשר להשיב",
         "whisperPlaceholder": "לחש ל-{{nick}}…",
         "ignoreUser": "התעלם בחדר זה",
         "stopIgnoring": "הפסק להתעלם",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -316,6 +316,7 @@
         "whisper": "Šaputanje",
         "whisperingTo": "Šaputate privatno {{nick}}-u",
         "whisperThread": "Privatno s {{nick}}",
+        "whisperCounterpartGone": "{{nick}} više nije u sobi — ne možete odgovoriti",
         "whisperPlaceholder": "Šapni {{nick}}…",
         "ignoreUser": "Ignoriraj u ovoj sobi",
         "stopIgnoring": "Prestani ignorirati",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -316,6 +316,7 @@
         "whisper": "Suttogás",
         "whisperingTo": "Privát suttogás {{nick}} felé",
         "whisperThread": "Privát: {{nick}}",
+        "whisperCounterpartGone": "{{nick}} már nincs a szobában — nem válaszolhatsz",
         "whisperPlaceholder": "Suttogás {{nick}} felé…",
         "ignoreUser": "Mellőzés ebben a szobában",
         "stopIgnoring": "Mellőzés befejezése",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -316,6 +316,7 @@
         "whisper": "Hvísla",
         "whisperingTo": "Hvíslað í einrúmi til {{nick}}",
         "whisperThread": "Einka með {{nick}}",
+        "whisperCounterpartGone": "{{nick}} er ekki lengur í herberginu — þú getur ekki svarað",
         "whisperPlaceholder": "Hvísla til {{nick}}…",
         "ignoreUser": "Hunsa í þessu herbergi",
         "stopIgnoring": "Hætta að hunsa",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -318,6 +318,7 @@
         "whisper": "Sussurro",
         "whisperingTo": "Stai sussurrando in privato a {{nick}}",
         "whisperThread": "Privato con {{nick}}",
+        "whisperCounterpartGone": "{{nick}} non è più nella stanza — non puoi rispondere",
         "whisperPlaceholder": "Sussurra a {{nick}}…",
         "ignoreUser": "Ignora in questa stanza",
         "stopIgnoring": "Smetti di ignorare",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -316,6 +316,7 @@
         "whisper": "Šnabždesys",
         "whisperingTo": "Šnabždate privačiai {{nick}}",
         "whisperThread": "Privačiai su {{nick}}",
+        "whisperCounterpartGone": "{{nick}} nebėra kambaryje — negalite atsakyti",
         "whisperPlaceholder": "Šnabždėti {{nick}}…",
         "ignoreUser": "Ignoruoti šiame kambaryje",
         "stopIgnoring": "Nustoti ignoruoti",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -317,6 +317,7 @@
         "whisper": "Čuksts",
         "whisperingTo": "Čukstat privāti {{nick}}",
         "whisperThread": "Privāti ar {{nick}}",
+        "whisperCounterpartGone": "{{nick}} vairs nav istabā — jūs nevarat atbildēt",
         "whisperPlaceholder": "Čukstēt {{nick}}…",
         "ignoreUser": "Ignorēt šajā istabā",
         "stopIgnoring": "Pārtraukt ignorēšanu",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -318,6 +318,7 @@
         "whisper": "Sussurru",
         "whisperingTo": "Qiegħed tsussurra b'mod privat lil {{nick}}",
         "whisperThread": "Privat ma' {{nick}}",
+        "whisperCounterpartGone": "{{nick}} m'għadux fil-kamra — ma tistax twieġeb",
         "whisperPlaceholder": "Sussurra lil {{nick}}…",
         "ignoreUser": "Injora f'din il-kamra",
         "stopIgnoring": "Ieqaf tinjora",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -316,6 +316,7 @@
         "whisper": "Hvisk",
         "whisperingTo": "Hvisker privat til {{nick}}",
         "whisperThread": "Privat med {{nick}}",
+        "whisperCounterpartGone": "{{nick}} er ikke lenger i rommet — du kan ikke svare",
         "whisperPlaceholder": "Hvisk til {{nick}}…",
         "ignoreUser": "Ignorer i dette rommet",
         "stopIgnoring": "Slutt å ignorere",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -316,6 +316,7 @@
         "whisper": "Fluisteren",
         "whisperingTo": "Fluistert privé naar {{nick}}",
         "whisperThread": "Privé met {{nick}}",
+        "whisperCounterpartGone": "{{nick}} is niet meer in de ruimte — je kunt niet antwoorden",
         "whisperPlaceholder": "Fluister naar {{nick}}…",
         "ignoreUser": "Negeren in deze kamer",
         "stopIgnoring": "Stoppen met negeren",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -318,6 +318,7 @@
         "whisper": "Szept",
         "whisperingTo": "Szepczesz prywatnie do {{nick}}",
         "whisperThread": "Prywatnie z {{nick}}",
+        "whisperCounterpartGone": "{{nick}} nie jest już w pokoju — nie możesz odpowiedzieć",
         "whisperPlaceholder": "Szepnij do {{nick}}…",
         "ignoreUser": "Ignoruj w tym pokoju",
         "stopIgnoring": "Przestań ignorować",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -318,6 +318,7 @@
         "whisper": "Sussurro",
         "whisperingTo": "Sussurrando em privado para {{nick}}",
         "whisperThread": "Privado com {{nick}}",
+        "whisperCounterpartGone": "{{nick}} já não está na sala — não podes responder",
         "whisperPlaceholder": "Sussurrar para {{nick}}…",
         "ignoreUser": "Ignorar nesta sala",
         "stopIgnoring": "Parar de ignorar",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -318,6 +318,7 @@
         "whisper": "Șoaptă",
         "whisperingTo": "Îi șoptești în privat lui {{nick}}",
         "whisperThread": "Privat cu {{nick}}",
+        "whisperCounterpartGone": "{{nick}} nu mai este în cameră — nu poți răspunde",
         "whisperPlaceholder": "Șoptește către {{nick}}…",
         "ignoreUser": "Ignoră în această cameră",
         "stopIgnoring": "Oprește ignorarea",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -316,6 +316,7 @@
         "whisper": "Шёпот",
         "whisperingTo": "Шепчете лично {{nick}}",
         "whisperThread": "Лично с {{nick}}",
+        "whisperCounterpartGone": "{{nick}} больше не в комнате — вы не можете ответить",
         "whisperPlaceholder": "Шепнуть {{nick}}…",
         "ignoreUser": "Игнорировать в этой комнате",
         "stopIgnoring": "Прекратить игнорирование",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -317,6 +317,7 @@
         "whisper": "Šepot",
         "whisperingTo": "Šepkáte súkromne {{nick}}",
         "whisperThread": "Súkromne s {{nick}}",
+        "whisperCounterpartGone": "{{nick}} už nie je v miestnosti — nemôžete odpovedať",
         "whisperPlaceholder": "Šepkať {{nick}}…",
         "ignoreUser": "Ignorovať v tejto miestnosti",
         "stopIgnoring": "Prestať ignorovať",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -318,6 +318,7 @@
         "whisper": "Šepetanje",
         "whisperingTo": "Šepetate zasebno {{nick}}",
         "whisperThread": "Zasebno z {{nick}}",
+        "whisperCounterpartGone": "{{nick}} ni več v sobi — ne morete odgovoriti",
         "whisperPlaceholder": "Šepetaj {{nick}}…",
         "ignoreUser": "Prezri v tej sobi",
         "stopIgnoring": "Prenehaj prezirati",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -316,6 +316,7 @@
         "whisper": "Viskning",
         "whisperingTo": "Viskar privat till {{nick}}",
         "whisperThread": "Privat med {{nick}}",
+        "whisperCounterpartGone": "{{nick}} är inte längre i rummet — du kan inte svara",
         "whisperPlaceholder": "Viska till {{nick}}…",
         "ignoreUser": "Ignorera i detta rum",
         "stopIgnoring": "Sluta ignorera",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -316,6 +316,7 @@
         "whisper": "Шепіт",
         "whisperingTo": "Шепочете приватно до {{nick}}",
         "whisperThread": "Приватно з {{nick}}",
+        "whisperCounterpartGone": "{{nick}} більше не в кімнаті — ви не можете відповісти",
         "whisperPlaceholder": "Шепнути до {{nick}}…",
         "ignoreUser": "Ігнорувати в цій кімнаті",
         "stopIgnoring": "Припинити ігнорування",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -316,6 +316,7 @@
         "whisper": "私语",
         "whisperingTo": "正在私语给 {{nick}}",
         "whisperThread": "与 {{nick}} 私聊",
+        "whisperCounterpartGone": "{{nick}} 已不在房间中 — 无法回复",
         "whisperPlaceholder": "私语给 {{nick}}…",
         "ignoreUser": "在此房间中忽略",
         "stopIgnoring": "停止忽略",

--- a/packages/fluux-sdk/src/bindings/storeBindings.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.test.ts
@@ -245,7 +245,7 @@ describe('createStoreBindings', () => {
       )
     })
 
-    it('room:whisper adds an ephemeral (noStore) message to the room store', () => {
+    it('room:whisper forwards a locally-durable private message to the room store', () => {
       const message: RoomMessage = {
         type: 'groupchat',
         id: 'w-1',
@@ -257,7 +257,7 @@ describe('createStoreBindings', () => {
         isOutgoing: false,
         isPrivate: true,
         whisperWith: 'bob',
-        noStore: true,
+        whisperWithOccupantId: 'occ-bob',
       }
       mockClient.emit('room:whisper', {
         roomJid: 'room@conf.example.com',
@@ -268,9 +268,12 @@ describe('createStoreBindings', () => {
 
       expect(mockStores.room.addMessage).toHaveBeenCalledWith(
         'room@conf.example.com',
-        expect.objectContaining({ id: 'w-1', isPrivate: true, noStore: true }),
+        expect.objectContaining({ id: 'w-1', isPrivate: true, whisperWith: 'bob', whisperWithOccupantId: 'occ-bob' }),
         expect.objectContaining({ incrementUnread: true, incrementMentions: true }),
       )
+      // The whisper carries no local-skip flag — addMessage will persist it.
+      const forwarded = (mockStores.room.addMessage as any).mock.calls[0][1]
+      expect(forwarded.noLocalStore).toBeUndefined()
     })
 
     it('should handle room:message-updated', () => {

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -307,7 +307,7 @@ export function createStoreBindings(
     const doNotNotify =
       isMessageFromIgnoredUser(ignoredUsers, message, nickToJidCache) ||
       isReplyToIgnoredUser(ignoredUsers, message.replyTo, nickToJidCache)
-    // Whisper is already noStore — addMessage appends to runtime only.
+    // Whispers are locally durable: addMessage persists + indexes them like any message.
     stores.room.addMessage(roomJid, message, {
       incrementUnread: !!incrementUnread && !doNotNotify,
       incrementMentions: !!incrementMentions && !doNotNotify,

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -882,8 +882,9 @@ export class Chat extends BaseModule {
    * XEP-0045 §7.5: send a private message ("whisper") to a single room
    * occupant. Unlike {@link sendMessage}, this preserves the `/nick`
    * resource (sendMessage strips it for type='chat') and emits `room:whisper`
-   * instead of `chat:message` so the message is treated as an ephemeral room
-   * private message rather than a 1:1 conversation.
+   * instead of `chat:message` so the message is tracked as a private room
+   * message rather than a 1:1 conversation. The XEP-0334 `<no-store>` hint
+   * keeps it off the server archive; it is still persisted locally.
    *
    * @param roomJid bare room JID, e.g. 'room@conference.example.com'
    * @param nick    target occupant's nickname
@@ -906,6 +907,9 @@ export class Chat extends BaseModule {
     const room = this.deps.stores?.room.getRoom(roomJid)
     if (!room) logWarn(`sendWhisper: room ${roomJid} not found in store — sender nick will be empty`)
     const ourNick = room?.nickname || ''
+    // Counterpart's stable occupant-id (XEP-0421), resolved from the live occupant
+    // list, so a persisted thread can be re-bound to the same person later.
+    const targetOccupantId = room?.occupants.get(nick)?.occupantId
     const whisper: RoomMessage = {
       type: 'groupchat',
       id,
@@ -918,7 +922,7 @@ export class Chat extends BaseModule {
       isOutgoing: true,
       isPrivate: true,
       whisperWith: nick,
-      noStore: true,
+      ...(targetOccupantId && { whisperWithOccupantId: targetOccupantId }),
     }
     this.deps.emitSDK('room:whisper', {
       roomJid,
@@ -2058,9 +2062,9 @@ export class Chat extends BaseModule {
 
   /**
    * XEP-0045 §7.5: build a RoomMessage for an incoming/sent private message.
-   * Mirrors the core of processRoomMessage but marks the message private and
-   * ephemeral (noStore), and skips public-only concerns (polls, public
-   * mention scanning). Emits `room:whisper`.
+   * Mirrors the core of processRoomMessage but marks the message private
+   * (persisted locally, kept off the server archive), and skips public-only
+   * concerns (polls, public mention scanning). Emits `room:whisper`.
    */
   private processRoomWhisper(
     stanza: Element,
@@ -2087,6 +2091,11 @@ export class Chat extends BaseModule {
     // whisperWith is always the remote occupant: the sender for incoming, or
     // (rare sent-carbon case) the recipient derived from the `to` resource.
     const whisperWith = isOutgoing ? (getResource(stanza.attrs.to) || nick) : nick
+    // Counterpart's stable occupant-id (XEP-0421): the sender's id for an incoming
+    // whisper, or the recipient's (looked up by nick) for a sent-carbon echo.
+    const whisperWithOccupantId = isOutgoing
+      ? room.occupants.get(whisperWith)?.occupantId
+      : occupantId
 
     const message: RoomMessage = {
       type: 'groupchat',
@@ -2100,7 +2109,7 @@ export class Chat extends BaseModule {
       isOutgoing,
       isPrivate: true,
       whisperWith,
-      noStore: true,
+      ...(whisperWithOccupantId && { whisperWithOccupantId }),
       ...(parsed.isDelayed && { isDelayed: true }),
       ...(parsed.noStyling && { noStyling: true }),
       ...(parsed.replyTo && { replyTo: parsed.replyTo }),

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -92,7 +92,13 @@ describe('MUC Whispers', () => {
 
     it('emits room:whisper (not chat:message) for the outgoing whisper', async () => {
       await connectClient()
-      const room = createMockRoom('room@conference.example.com', { joined: true, nickname: 'me' })
+      const room = createMockRoom('room@conference.example.com', {
+        joined: true,
+        nickname: 'me',
+        occupants: new Map([
+          ['bob', { nick: 'bob', affiliation: 'member', role: 'participant', occupantId: 'occ-bob' }],
+        ]),
+      })
       vi.mocked(mockStores.room.getRoom).mockReturnValue(room)
 
       await xmppClient.chat.sendWhisper('room@conference.example.com', 'bob', 'psst hello')
@@ -103,12 +109,19 @@ describe('MUC Whispers', () => {
           isPrivate: true,
           isOutgoing: true,
           whisperWith: 'bob',
-          noStore: true,
           body: 'psst hello',
           originId: expect.any(String),
         }),
       }))
       expect(emitSDKSpy).not.toHaveBeenCalledWith('chat:message', expect.anything())
+
+      // Whispers are locally durable now: not flagged noLocalStore, and they carry
+      // the counterpart's occupant-id (resolved from the occupants map) so a recycled
+      // nick can't be mis-addressed when replying later.
+      const whisperCall = emitSDKSpy.mock.calls.find((c: any) => c[0] === 'room:whisper')
+      const whisperMsg = (whisperCall?.[1] as any)?.message
+      expect(whisperMsg.noLocalStore).toBeUndefined()
+      expect(whisperMsg.whisperWithOccupantId).toBe('occ-bob')
     })
   })
 
@@ -123,7 +136,10 @@ describe('MUC Whispers', () => {
         to: 'user@example.com',
         type: 'chat',
         id: 'w-1',
-      }, [{ name: 'body', text: 'between us' }])
+      }, [
+        { name: 'body', text: 'between us' },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+      ])
 
       mockXmppClientInstance._emit('stanza', stanza)
 
@@ -134,12 +150,17 @@ describe('MUC Whispers', () => {
           isOutgoing: false,
           nick: 'bob',
           whisperWith: 'bob',
-          noStore: true,
           body: 'between us',
         }),
         incrementUnread: true,
         incrementMentions: true,
       }))
+
+      // Incoming whisper is locally durable and carries the sender's occupant-id.
+      const whisperCall = emitSDKSpy.mock.calls.find((c: any) => c[0] === 'room:whisper')
+      const whisperMsg = (whisperCall?.[1] as any)?.message
+      expect(whisperMsg.noLocalStore).toBeUndefined()
+      expect(whisperMsg.whisperWithOccupantId).toBe('occ-bob')
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message', expect.anything())
       expect(emitSDKSpy).not.toHaveBeenCalledWith('chat:message', expect.anything())
     })
@@ -209,10 +230,14 @@ describe('MUC Whispers', () => {
         message: expect.objectContaining({
           isPrivate: true,
           isOutgoing: true,
-          noStore: true,
         }),
       }))
       expect(emitSDKSpy).not.toHaveBeenCalledWith('chat:message', expect.anything())
+
+      // Sent-carbon whisper is also locally durable.
+      const whisperCall = emitSDKSpy.mock.calls.find((c: any) => c[0] === 'room:whisper')
+      const whisperMsg = (whisperCall?.[1] as any)?.message
+      expect(whisperMsg.noLocalStore).toBeUndefined()
     })
 
     it('still routes type=chat from a non-joined JID to chat:message (no regression)', async () => {

--- a/packages/fluux-sdk/src/core/types/message-base.ts
+++ b/packages/fluux-sdk/src/core/types/message-base.ts
@@ -145,11 +145,16 @@ export interface BaseMessage {
   /** XEP-0422 + OGP: Link preview metadata for URLs in message */
   linkPreview?: LinkPreview
   /**
-   * XEP-0334: Message Processing Hint - do not store this message.
-   * When true, the message should not be persisted to local cache or server archives.
-   * Automatically set for messages in Quick Chat (transient) rooms.
+   * Local persistence opt-out. When true, this message is kept in the in-memory
+   * store only — it is NOT written to the local IndexedDB cache or the search
+   * index. Automatically set for messages in Quick Chat (transient) rooms.
+   *
+   * Independent of server archival: the XEP-0334 `<no-store>` wire hint that
+   * asks the server not to archive is added at the send site, not derived from
+   * this field. A message can be kept off the server archive yet still persisted
+   * locally (e.g. MUC whispers), or vice versa.
    */
-  noStore?: boolean
+  noLocalStore?: boolean
   /**
    * Delivery error received from the server for this message.
    * Set when the server returns a `<message type="error">` stanza,

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -142,6 +142,13 @@ export interface RoomMessage extends Omit<BaseMessage, 'type'> {
    * if incoming. Always identifies the *remote* occupant.
    */
   whisperWith?: string
+  /**
+   * XEP-0421 occupant-id of the whisper counterpart (the remote occupant named
+   * in {@link whisperWith}). Lets a persisted whisper thread re-bind to the same
+   * person across rejoins/nick changes, and gates replying so a recycled nick
+   * can't be mis-addressed. Absent in rooms without occupant-id support.
+   */
+  whisperWithOccupantId?: string
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -277,9 +277,8 @@ export interface RoomEvents {
 
   /**
    * Private message ("whisper") received or sent in a room (XEP-0045 §7.5).
-   * Separate from `room:message` so bindings can mark it ephemeral and the
-   * UI can badge it. The carried message has `isPrivate: true` and
-   * `noStore: true`.
+   * Separate from `room:message` so the UI can badge it as private. The carried
+   * message has `isPrivate: true` and `whisperWith` set to the counterpart nick.
    */
   'room:whisper': {
     roomJid: string

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -469,7 +469,7 @@ describe('chatStore', () => {
       expect(conv?.unreadCount).toBe(1) // Only incremented once
     })
 
-    it('should save message to IndexedDB when noStore is false', () => {
+    it('should save message to IndexedDB when noLocalStore is false', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com'))
       const msg = createMessage('alice@example.com', 'Hello!')
 
@@ -478,18 +478,18 @@ describe('chatStore', () => {
       expect(messageCache.saveMessage).toHaveBeenCalledWith(msg)
     })
 
-    it('should not save message to IndexedDB when noStore is true (XEP-0334)', () => {
+    it('should not save message to IndexedDB when noLocalStore is true (XEP-0334)', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com'))
-      const msg = { ...createMessage('alice@example.com', 'Ephemeral message'), noStore: true }
+      const msg = { ...createMessage('alice@example.com', 'Ephemeral message'), noLocalStore: true }
 
       chatStore.getState().addMessage(msg)
 
       expect(messageCache.saveMessage).not.toHaveBeenCalled()
     })
 
-    it('should still add noStore message to in-memory store', () => {
+    it('should still add noLocalStore message to in-memory store', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com'))
-      const msg = { ...createMessage('alice@example.com', 'Ephemeral'), noStore: true }
+      const msg = { ...createMessage('alice@example.com', 'Ephemeral'), noLocalStore: true }
 
       chatStore.getState().addMessage(msg)
 
@@ -498,9 +498,9 @@ describe('chatStore', () => {
       expect(messages?.[0].body).toBe('Ephemeral')
     })
 
-    it('should still increment unreadCount for noStore messages', () => {
+    it('should still increment unreadCount for noLocalStore messages', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com'))
-      const msg = { ...createMessage('alice@example.com', 'Ephemeral', false), noStore: true }
+      const msg = { ...createMessage('alice@example.com', 'Ephemeral', false), noLocalStore: true }
 
       chatStore.getState().addMessage(msg)
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -625,8 +625,8 @@ export const chatStore = createStore<ChatState>()(
             return state // Don't add duplicate message
           }
 
-          // XEP-0334: Save to IndexedDB only if message doesn't have noStore hint
-          if (!msg.noStore) {
+          // Save to IndexedDB + search index only if the message is locally persistable
+          if (!msg.noLocalStore) {
             void messageCache.saveMessage(msg)
             searchIndex.indexMessage(msg).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
           }
@@ -1098,8 +1098,8 @@ export const chatStore = createStore<ChatState>()(
             return { mamQueryStates: newStates }
           }
 
-          // XEP-0334: Save only messages without noStore hint to IndexedDB
-          const persistableMessages = newMessages.filter(msg => !msg.noStore)
+          // Persist only locally-persistable messages to IndexedDB
+          const persistableMessages = newMessages.filter(msg => !msg.noLocalStore)
           if (persistableMessages.length > 0) {
             void messageCache.saveMessages(persistableMessages)
             searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1266,7 +1266,7 @@ describe('roomStore', () => {
       expect(room?.lastReadAt).toEqual(msgTimestamp) // Updated to message time
     })
 
-    it('should save message to IndexedDB when noStore is false', () => {
+    it('should save message to IndexedDB when noLocalStore is false', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com'))
       const message = createMessage('msg1', 'test@conference.example.com', 'alice', 'Hello!')
 
@@ -1275,16 +1275,16 @@ describe('roomStore', () => {
       expect(messageCache.saveRoomMessage).toHaveBeenCalled()
     })
 
-    it('should not save message to IndexedDB when noStore is true (XEP-0334)', () => {
+    it('should not save message to IndexedDB when noLocalStore is true (XEP-0334)', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com'))
-      const message = { ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Ephemeral'), noStore: true }
+      const message = { ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Ephemeral'), noLocalStore: true }
 
       roomStore.getState().addMessage('test@conference.example.com', message)
 
       expect(messageCache.saveRoomMessage).not.toHaveBeenCalled()
     })
 
-    it('should set noStore=true on messages for Quick Chat rooms', () => {
+    it('should set noLocalStore=true on messages for Quick Chat rooms', () => {
       roomStore.getState().addRoom(createRoom('quickchat@conference.example.com', { isQuickChat: true }))
       const message = createMessage('msg1', 'quickchat@conference.example.com', 'alice', 'Quick chat message')
 
@@ -1293,15 +1293,15 @@ describe('roomStore', () => {
       // Message should not be saved to IndexedDB
       expect(messageCache.saveRoomMessage).not.toHaveBeenCalled()
 
-      // But message should still be in memory with noStore flag
+      // But message should still be in memory with noLocalStore flag
       const room = roomStore.getState().rooms.get('quickchat@conference.example.com')
       expect(room?.messages.length).toBe(1)
-      expect(room?.messages[0].noStore).toBe(true)
+      expect(room?.messages[0].noLocalStore).toBe(true)
     })
 
-    it('should still add noStore message to in-memory store', () => {
+    it('should still add noLocalStore message to in-memory store', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com'))
-      const message = { ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Ephemeral'), noStore: true }
+      const message = { ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Ephemeral'), noLocalStore: true }
 
       roomStore.getState().addMessage('test@conference.example.com', message)
 
@@ -1310,9 +1310,9 @@ describe('roomStore', () => {
       expect(room?.messages[0].body).toBe('Ephemeral')
     })
 
-    it('should still increment unreadCount for noStore messages', () => {
+    it('should still increment unreadCount for noLocalStore messages', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com'))
-      const message = { ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Ephemeral'), noStore: true }
+      const message = { ...createMessage('msg1', 'test@conference.example.com', 'alice', 'Ephemeral'), noLocalStore: true }
 
       roomStore.getState().addMessage('test@conference.example.com', message)
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -850,13 +850,13 @@ export const roomStore = createStore<RoomState>()(
     // Get room to check if it's a Quick Chat (transient history)
     const room = get().rooms.get(roomJid)
 
-    // XEP-0334: Set noStore hint for Quick Chat room messages
+    // Quick Chat rooms are transient: keep their messages in memory only
     const messageToAdd = room?.isQuickChat
-      ? { ...message, noStore: true }
+      ? { ...message, noLocalStore: true }
       : message
 
-    // Save to IndexedDB only if message doesn't have noStore hint
-    if (!messageToAdd.noStore) {
+    // Save to IndexedDB only if the message is locally persistable
+    if (!messageToAdd.noLocalStore) {
       void messageCache.saveRoomMessage(messageToAdd)
       searchIndex.indexMessage(messageToAdd).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
     }
@@ -1775,8 +1775,8 @@ export const roomStore = createStore<RoomState>()(
         return { mamQueryStates: newStates }
       }
 
-      // XEP-0334: Save only messages without noStore hint to IndexedDB
-      const persistableMessages = newFromMAM.filter(msg => !msg.noStore)
+      // Persist only locally-persistable messages to IndexedDB
+      const persistableMessages = newFromMAM.filter(msg => !msg.noLocalStore)
       if (persistableMessages.length > 0) {
         void messageCache.saveRoomMessages(persistableMessages)
         searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))

--- a/packages/fluux-sdk/src/utils/searchIndex.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.test.ts
@@ -367,10 +367,10 @@ describe('searchIndex', () => {
       expect(results).toHaveLength(0)
     })
 
-    it('should skip noStore messages', async () => {
+    it('should skip noLocalStore messages', async () => {
       await indexMessage(createChatMessage('alice@example.com', {
         body: 'Ephemeral message',
-        noStore: true,
+        noLocalStore: true,
       }))
 
       const results = await search('ephemeral')
@@ -489,7 +489,7 @@ describe('searchIndex', () => {
         createChatMessage('alice@example.com', { body: 'Valid message' }),
         createChatMessage('alice@example.com', { body: '', }), // empty body
         createChatMessage('alice@example.com', { body: 'Retracted', isRetracted: true }),
-        createChatMessage('alice@example.com', { body: 'No store', noStore: true }),
+        createChatMessage('alice@example.com', { body: 'No store', noLocalStore: true }),
       ]
 
       await indexMessages(messages)

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -271,12 +271,12 @@ export async function initSearchIndex(scopeJid: string): Promise<void> {
 
 /**
  * Index a single message into the search index.
- * Skips messages with no body, retracted messages, and noStore messages.
+ * Skips messages with no body, retracted messages, and noLocalStore messages.
  * Silently returns if IndexedDB is not available.
  */
 export async function indexMessage(message: Message | RoomMessage): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  if (!message.body || message.isRetracted || message.noStore) return
+  if (!message.body || message.isRetracted || message.noLocalStore) return
 
   const indexId = getIndexId(message)
   const tokens = uniqueTokens(message.body)
@@ -340,7 +340,7 @@ const INDEX_BATCH_SIZE = 50
  */
 export async function indexMessages(messages: (Message | RoomMessage)[]): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  const indexable = messages.filter((m) => m.body && !m.isRetracted && !m.noStore)
+  const indexable = messages.filter((m) => m.body && !m.isRetracted && !m.noLocalStore)
   if (indexable.length === 0) return
 
   // Process in small batches to keep each IDB transaction short-lived


### PR DESCRIPTION
## Summary

In-room private messages ("whispers", XEP-0045 §7.5) were ephemeral end-to-end: kept only in memory, so reopening a room lost the whole private thread. This makes whispers **persist locally** while staying **off the server archive**, and gates replying on the counterpart still being in the room.

## Storage model

The message field `noStore` only ever governed local persistence (IndexedDB cache + search index) — it was never read to build the wire stanza. The name implied a coupling that didn't exist, so it's renamed to **`noLocalStore`**. The XEP-0334 `<no-store>` hint is still emitted at the send site, so whispers remain **unarchived on the server**; they are now simply kept locally like any other message.

- Whispers stop setting the local-skip flag → they persist, get indexed, and reload through the existing room cache path on reopen.
- Quick-Chat rooms keep their transient behaviour (`noLocalStore`) unchanged.

## Thread identity & presence

- New `whisperWithOccupantId` field (the counterpart's XEP-0421 occupant-id), captured on send (from the occupant list) and on receive (from the stanza).
- Whisper-thread grouping keys by occupant-id with nick fallback, so a **recycled nick** can't merge two different people's private runs.
- Reply-in-private is gated on the counterpart being present. When they've left, the thread shows a subtle "no longer in the room" note and reply is disabled — preventing a private reply from leaking to whoever now holds that nick.

## i18n

New key `rooms.whisperCounterpartGone`, translated across all 33 locales.

## Behaviour change

Reverses the previous "ephemeral whisper" decision intentionally: whispers are now durable on the device (cleared with the rest of local history) but never sent to the server's MAM archive.
