### PR TITLE
feat(muc): presence-gate the whisper composer mid-compose (XEP-0045 §7.5)

### DIFF
--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -146,6 +146,12 @@ interface MessageComposerProps {
   onEditLastMessage?: () => void
   /** Encryption state for the current conversation (badge on send button) */
   encryptionState?: ConversationEncryptionState
+  /**
+   * Small badge overlaid on the Send button (bottom-end corner), mirroring the
+   * encryption padlock. Used to signal a non-default send mode — e.g. a whisper
+   * (private message). Hidden when an encryption badge is shown (encryption wins).
+   */
+  sendBadge?: ReactNode
 }
 
 export function MessageComposer({
@@ -178,6 +184,7 @@ export function MessageComposer({
   sendDisabled = false,
   onEditLastMessage,
   encryptionState,
+  sendBadge,
   ref,
 }: MessageComposerProps & { ref?: Ref<MessageComposerHandle> }) {
   detectRenderLoop('MessageComposer')
@@ -835,11 +842,11 @@ export function MessageComposer({
                        disabled:text-fluux-muted disabled:cursor-not-allowed transition-colors relative"
           >
             <Send className="rtl-mirror size-5" />
-            {encryptionState?.kind === 'encrypted' && (
+            {encryptionState?.kind === 'encrypted' ? (
               encryptionState.trust === 'verified'
                 ? <ShieldCheck className="absolute bottom-2 end-2 size-2.5 text-green-500" />
                 : <Lock className="absolute bottom-2 end-2 size-2.5 text-fluux-muted" />
-            )}
+            ) : sendBadge}
           </button>
         </Tooltip>
       </div>

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -135,6 +135,13 @@ interface MessageComposerProps {
   onRemovePendingAttachment?: () => void
   /** Whether sending is disabled (e.g., when offline) */
   disabled?: boolean
+  /**
+   * Disable only the Send action (button + Enter) while keeping the textarea
+   * editable. Unlike {@link disabled}, the typed text is preserved and can still
+   * be edited — used when a whisper counterpart has left the room, so the private
+   * draft is held but must not be sent (XEP-0045 §7.5).
+   */
+  sendDisabled?: boolean
   /** Callback when Up arrow is pressed in empty field (to edit last message) */
   onEditLastMessage?: () => void
   /** Encryption state for the current conversation (badge on send button) */
@@ -168,6 +175,7 @@ export function MessageComposer({
   pendingAttachment,
   onRemovePendingAttachment,
   disabled = false,
+  sendDisabled = false,
   onEditLastMessage,
   encryptionState,
   ref,
@@ -424,8 +432,9 @@ export function MessageComposer({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      // Don't submit if disabled (e.g., offline)
-      if (disabled) return
+      // Don't submit if disabled (e.g., offline) or send-gated (e.g., whisper
+      // counterpart left the room — keep the draft, just refuse to send).
+      if (disabled || sendDisabled) return
       void handleSubmit(e)
     } else if (e.key === 'Escape') {
       // Cancel edit mode on Escape
@@ -821,7 +830,7 @@ export function MessageComposer({
         >
           <button
             type="submit"
-            disabled={(!text.trim() && !pendingAttachment) || sending || disabled}
+            disabled={(!text.trim() && !pendingAttachment) || sending || disabled || sendDisabled}
             className="p-3 text-fluux-brand hover:text-fluux-brand-hover
                        disabled:text-fluux-muted disabled:cursor-not-allowed transition-colors relative"
           >

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -5,7 +5,7 @@ import { useRoomActive, useRoster, getBareJid, generateConsistentColorHexSync, g
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, isSmallScreen } from '@/hooks'
-import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, buildReplyContext, PollBanner, type WhisperThreadPosition } from './conversation'
+import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, whisperTargetPresent, decideWhisperSend, buildReplyContext, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar, getConsistentTextColor } from './Avatar'
@@ -176,8 +176,10 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   const [nickMenuTarget, setNickMenuTarget] = useState<string | null>(null) // nick string
   const [nickModerationTarget, setNickModerationTarget] = useState<string | null>(null)
 
-  // Whisper mode: when set, the composer targets a specific nick privately
-  const [whisperTarget, setWhisperTarget] = useState<string | null>(null)
+  // Whisper mode: when set, the composer targets a specific occupant privately.
+  // Carries the counterpart's occupant-id (captured at entry) so presence checks
+  // bind to the person, not just the nick (XEP-0045 §7.5, XEP-0421).
+  const [whisperTarget, setWhisperTarget] = useState<WhisperTarget | null>(null)
 
   // setAffiliation and setRole are now from useRoomActive() to avoid subscribing
   // to list-level selectors that cause render loops when other rooms update
@@ -263,6 +265,12 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   const pendingAttachmentRef = useRef(pendingAttachment)
   pendingAttachmentRef.current = pendingAttachment
 
+  // Track the active room in a ref so enterWhisperMode can resolve the
+  // counterpart's occupant-id at call time without depending on activeRoom
+  // (which changes on every occupant update and would destabilize the callback).
+  const activeRoomRef = useRef(activeRoom)
+  activeRoomRef.current = activeRoom
+
   // Stable callback that clears any staged compose state before entering whisper
   // mode. Whispers are text-only so a staged reply, edit, or pending attachment
   // must be discarded to avoid showing conflicting UI (banner + attachment preview).
@@ -273,7 +281,9 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
       URL.revokeObjectURL(pendingAttachmentRef.current.previewUrl)
     }
     setPendingAttachment(null)
-    setWhisperTarget(nick)
+    // Capture the counterpart's occupant-id now so the send/disable gates can
+    // bind to this exact person even if they later change nick or leave.
+    setWhisperTarget(resolveWhisperTarget(nick, activeRoomRef.current?.occupants ?? new Map()))
   }, [])
 
   // Replying to a whisper stays private: re-enter whisper mode with that counterpart
@@ -1440,7 +1450,7 @@ interface RoomMessageInputProps {
   processLinkPreview?: (messageId: string, body: string, to: string, type: 'chat' | 'groupchat') => Promise<void>
   isConnected: boolean
   onMessageIdSent?: (messageId: string) => void
-  whisperTarget?: string | null
+  whisperTarget?: WhisperTarget | null
   onClearWhisper?: () => void
   sendWhisper: (roomJid: string, nick: string, body: string) => Promise<string>
 }
@@ -1478,7 +1488,13 @@ function RoomMessageInput({
 }: RoomMessageInputProps & { ref?: React.Ref<MessageComposerHandle> }) {
   const { t } = useTranslation()
   const { setDraft, getDraft, clearDraft, clearFirstNewMessageId } = useRoomActive()
+  const addToast = useToastStore((s) => s.addToast)
   const [showPollCreator, setShowPollCreator] = useState(false)
+
+  // Reactive whisper-counterpart presence. `room.occupants` updates when someone
+  // leaves/joins, so this re-evaluates on every occupant change — driving the
+  // "gone" banner and the disabled Send button while preserving the typed draft.
+  const whisperCounterpartGone = !!whisperTarget && !whisperTargetPresent(whisperTarget, room.occupants)
 
   // Mention state
   const [cursorPosition, setCursorPosition] = useState(0)
@@ -1502,6 +1518,16 @@ function RoomMessageInput({
     composerRef,
     onDraftRestored: handleDraftRestored,
   })
+
+  // Exit whisper mode AND discard the typed text. The composer draft is keyed only
+  // by room JID, so a private whisper draft would otherwise survive into the public
+  // composer and could be sent to the whole room. Discarding upholds the invariant:
+  // private text is never converted into a public message (XEP-0045 §7.5).
+  const handleClearWhisper = () => {
+    setText('')
+    clearDraft(room.jid)
+    onClearWhisper?.()
+  }
 
   // Type-to-focus: auto-focus composer when user starts typing anywhere
   useTypeToFocus(composerRef)
@@ -1590,9 +1616,19 @@ function RoomMessageInput({
   const handleSend = async (sendText: string): Promise<boolean> => {
     // Whisper mode (XEP-0045 §7.5): text-only, ephemeral, no reply/attachment.
     if (whisperTarget) {
-      const body = sendText.trim()
-      if (!body) return false
-      const messageId = await sendWhisper(room.jid, whisperTarget, body)
+      // Hard backstop: re-check presence against the LIVE occupant list (not the
+      // closed-over prop) so we cover the gap between the counterpart leaving and
+      // React re-rendering the disabled Send button. Never deliver private text
+      // once they've left or the nick has been recycled by someone else.
+      const liveOccupants = roomStore.getState().getRoom(room.jid)?.occupants ?? room.occupants
+      const decision = decideWhisperSend(whisperTarget, sendText, liveOccupants)
+      if (!decision.ok) {
+        if (decision.reason === 'counterpart-gone') {
+          addToast('info', t('rooms.whisperCounterpartGone', { nick: decision.nick }))
+        }
+        return false
+      }
+      const messageId = await sendWhisper(room.jid, decision.nick, decision.body)
       onMessageIdSent?.(messageId)
       clearDraft(room.jid)
       onMessageSent?.()
@@ -1852,7 +1888,7 @@ function RoomMessageInput({
       onKeyDownCapture={(e) => {
         if (whisperTarget && e.key === 'Escape') {
           e.stopPropagation()
-          onClearWhisper?.()
+          handleClearWhisper()
         }
       }}
     >
@@ -1865,16 +1901,26 @@ function RoomMessageInput({
         />
       )}
       {whisperTarget && (
-        <div className="flex items-center justify-between gap-2 px-3 py-1.5 mb-1 rounded bg-fluux-private-soft text-sm text-fluux-private">
+        <div className={`flex items-center justify-between gap-2 px-3 py-1.5 mb-1 rounded text-sm ${
+          whisperCounterpartGone
+            ? 'bg-fluux-muted/10 text-fluux-muted'
+            : 'bg-fluux-private-soft text-fluux-private'
+        }`}>
           <span className="inline-flex items-center gap-1.5 min-w-0">
-            <Ear className="size-4 shrink-0" />
-            <span className="truncate">{t('rooms.whisperingTo', { nick: whisperTarget })}</span>
+            {whisperCounterpartGone
+              ? <AlertCircle className="size-4 shrink-0" />
+              : <Ear className="size-4 shrink-0" />}
+            <span className="truncate">
+              {whisperCounterpartGone
+                ? t('rooms.whisperCounterpartGone', { nick: whisperTarget.nick })
+                : t('rooms.whisperingTo', { nick: whisperTarget.nick })}
+            </span>
           </span>
           <button
             type="button"
-            onClick={() => onClearWhisper?.()}
+            onClick={handleClearWhisper}
             aria-label={t('common.cancel')}
-            className="shrink-0 rounded p-0.5 hover:bg-fluux-private-hover"
+            className={`shrink-0 rounded p-0.5 ${whisperCounterpartGone ? 'hover:bg-fluux-muted/20' : 'hover:bg-fluux-private-hover'}`}
           >
             <X className="size-4" />
           </button>
@@ -1883,7 +1929,7 @@ function RoomMessageInput({
       <MessageComposer
         ref={composerRef}
         textareaRef={textareaRef}
-        placeholder={whisperTarget ? t('rooms.whisperPlaceholder', { nick: whisperTarget }) : t('chat.messageRoom', { name: room.name })}
+        placeholder={whisperTarget ? t('rooms.whisperPlaceholder', { nick: whisperTarget.nick }) : t('chat.messageRoom', { name: room.name })}
         replyingTo={replyInfo}
         onCancelReply={onCancelReply}
         editingMessage={editInfo}
@@ -1908,6 +1954,7 @@ function RoomMessageInput({
         pendingAttachment={pendingAttachment}
         onRemovePendingAttachment={onRemovePendingAttachment}
         disabled={!isConnected}
+        sendDisabled={whisperCounterpartGone}
         onEditLastMessage={onEditLastMessage}
       />
     </div>

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1955,6 +1955,9 @@ function RoomMessageInput({
         onRemovePendingAttachment={onRemovePendingAttachment}
         disabled={!isConnected}
         sendDisabled={whisperCounterpartGone}
+        sendBadge={whisperTarget
+          ? <Ear className={`absolute bottom-2 end-2 size-2.5 ${whisperCounterpartGone ? 'text-fluux-muted' : 'text-fluux-private'}`} />
+          : undefined}
         onEditLastMessage={onEditLastMessage}
       />
     </div>

--- a/apps/fluux/src/components/conversation/index.ts
+++ b/apps/fluux/src/components/conversation/index.ts
@@ -24,6 +24,9 @@ export type { MessageBubbleProps } from './MessageBubble'
 export { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage } from './messageGrouping'
 export type { MessageGroup, WhisperThreadPosition } from './messageGrouping'
 
+export { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend } from './whisperTarget'
+export type { WhisperTarget, WhisperSendDecision } from './whisperTarget'
+
 export { MessageList } from './MessageList'
 export type { MessageListProps } from './MessageList'
 

--- a/apps/fluux/src/components/conversation/whisperTarget.test.ts
+++ b/apps/fluux/src/components/conversation/whisperTarget.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Whisper-target tests (XEP-0045 §7.5 mid-compose guard, "approach B").
+ *
+ * The composer captures the counterpart's stable occupant-id (XEP-0421) the
+ * moment whisper mode is entered. Every later presence check — the reactive
+ * Send-disable, the "gone" banner, and the send-time backstop — matches on that
+ * occupant-id (nick fallback when absent). This guarantees the typed private
+ * text can never be delivered to a *different* person who later took the nick,
+ * nor sent at all once the counterpart has left.
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend } from './whisperTarget'
+
+const occ = (nick: string, occupantId?: string) => ({ nick, occupantId })
+const occupantsOf = (...list: { nick: string; occupantId?: string }[]) =>
+  new Map(list.map((o) => [o.nick, o] as const))
+
+describe('resolveWhisperTarget', () => {
+  it('captures the counterpart occupant-id from the live occupant list', () => {
+    const target = resolveWhisperTarget('bob', occupantsOf(occ('bob', 'occ-1')))
+    expect(target).toEqual({ nick: 'bob', occupantId: 'occ-1' })
+  })
+
+  it('falls back to a nick-only target when the occupant has no occupant-id', () => {
+    const target = resolveWhisperTarget('bob', occupantsOf(occ('bob')))
+    expect(target.nick).toBe('bob')
+    expect(target.occupantId).toBeUndefined()
+  })
+
+  it('returns a nick-only target when the nick is not a current occupant', () => {
+    const target = resolveWhisperTarget('ghost', occupantsOf(occ('bob', 'occ-1')))
+    expect(target.nick).toBe('ghost')
+    expect(target.occupantId).toBeUndefined()
+  })
+})
+
+describe('whisperTargetPresent', () => {
+  it('is present when an occupant still holds the captured occupant-id', () => {
+    const target = { nick: 'bob', occupantId: 'occ-1' }
+    expect(whisperTargetPresent(target, occupantsOf(occ('bob', 'occ-1')))).toBe(true)
+  })
+
+  it('tracks the person across a nick change (same occupant-id, new nick)', () => {
+    const target = { nick: 'bob', occupantId: 'occ-1' }
+    expect(whisperTargetPresent(target, occupantsOf(occ('bobby', 'occ-1')))).toBe(true)
+  })
+
+  it('is absent when the nick is recycled by a different person (occupant-id differs)', () => {
+    const target = { nick: 'bob', occupantId: 'occ-1' }
+    expect(whisperTargetPresent(target, occupantsOf(occ('bob', 'occ-2')))).toBe(false)
+  })
+
+  it('is absent once the captured occupant has left', () => {
+    const target = { nick: 'bob', occupantId: 'occ-1' }
+    expect(whisperTargetPresent(target, occupantsOf())).toBe(false)
+  })
+
+  it('falls back to nick presence when no occupant-id was captured', () => {
+    const target = { nick: 'bob' }
+    expect(whisperTargetPresent(target, occupantsOf(occ('bob')))).toBe(true)
+    expect(whisperTargetPresent(target, occupantsOf(occ('carol')))).toBe(false)
+  })
+})
+
+describe('decideWhisperSend (send-time guard)', () => {
+  const presentOccupants = occupantsOf(occ('bob', 'occ-1'))
+
+  it('allows the send and returns the trimmed body when the counterpart is present', () => {
+    const decision = decideWhisperSend({ nick: 'bob', occupantId: 'occ-1' }, '  psst hello  ', presentOccupants)
+    expect(decision).toEqual({ ok: true, nick: 'bob', body: 'psst hello' })
+  })
+
+  it('refuses empty/whitespace-only text without a toast reason', () => {
+    const decision = decideWhisperSend({ nick: 'bob', occupantId: 'occ-1' }, '   ', presentOccupants)
+    expect(decision).toEqual({ ok: false, reason: 'empty', nick: 'bob' })
+  })
+
+  it('refuses when the counterpart has left the room', () => {
+    const decision = decideWhisperSend({ nick: 'bob', occupantId: 'occ-1' }, 'secret', occupantsOf())
+    expect(decision).toEqual({ ok: false, reason: 'counterpart-gone', nick: 'bob' })
+  })
+
+  it('refuses when the nick is now held by a different person (never mis-address private text)', () => {
+    // The invariant: bob (occ-1) left, someone else joined as "bob" (occ-2).
+    const decision = decideWhisperSend({ nick: 'bob', occupantId: 'occ-1' }, 'secret', occupantsOf(occ('bob', 'occ-2')))
+    expect(decision).toEqual({ ok: false, reason: 'counterpart-gone', nick: 'bob' })
+  })
+
+  it('refuses present-but-empty before checking presence (empty wins)', () => {
+    const decision = decideWhisperSend({ nick: 'bob', occupantId: 'occ-1' }, '', occupantsOf())
+    expect(decision).toEqual({ ok: false, reason: 'empty', nick: 'bob' })
+  })
+})

--- a/apps/fluux/src/components/conversation/whisperTarget.ts
+++ b/apps/fluux/src/components/conversation/whisperTarget.ts
@@ -1,0 +1,70 @@
+import { whisperCounterpartPresent } from './messageGrouping'
+
+/**
+ * Composer whisper target (XEP-0045 §7.5). Holds the counterpart's nick plus the
+ * stable occupant-id (XEP-0421) captured the moment whisper mode is entered.
+ * The occupant-id lets presence checks re-bind to the same *person* — surviving
+ * nick changes and refusing a nick that a different occupant later recycled —
+ * so the typed private text can never be mis-addressed. Absent in rooms without
+ * occupant-id support, where checks fall back to the nick.
+ */
+export interface WhisperTarget {
+  nick: string
+  occupantId?: string
+}
+
+/**
+ * Capture a {@link WhisperTarget} for `nick` from the live occupant list,
+ * resolving the occupant-id once at entry time. Existing whisper-entry call
+ * sites pass only a nick; the occupant-id is filled in here.
+ */
+export function resolveWhisperTarget(
+  nick: string,
+  occupants: ReadonlyMap<string, { occupantId?: string }>,
+): WhisperTarget {
+  return { nick, occupantId: occupants.get(nick)?.occupantId }
+}
+
+/**
+ * Whether the whisper counterpart is still in the room — occupant-id aware with
+ * a nick fallback. Shares {@link whisperCounterpartPresent} so the reply-gate,
+ * the composer Send-disable, and the send-time backstop all agree.
+ */
+export function whisperTargetPresent(
+  target: WhisperTarget,
+  occupants: ReadonlyMap<string, { occupantId?: string }>,
+): boolean {
+  return whisperCounterpartPresent(
+    { whisperWith: target.nick, whisperWithOccupantId: target.occupantId },
+    occupants,
+  )
+}
+
+/**
+ * Outcome of the send-time whisper guard. `empty` is a silent no-op (nothing
+ * typed); `counterpart-gone` should surface a toast and preserve the draft.
+ */
+export type WhisperSendDecision =
+  | { ok: true; nick: string; body: string }
+  | { ok: false; reason: 'empty' | 'counterpart-gone'; nick: string }
+
+/**
+ * Decide whether a whisper may be sent right now. Pure backstop for the RoomView
+ * send handler: trims the text, refuses empty input, and — critically — refuses
+ * if the captured counterpart is no longer present (left, or the nick is now held
+ * by a different occupant-id). Callers should evaluate this against the *live*
+ * occupant list so it covers the gap between the counterpart leaving and React
+ * re-rendering the disabled Send button.
+ */
+export function decideWhisperSend(
+  target: WhisperTarget,
+  rawText: string,
+  occupants: ReadonlyMap<string, { occupantId?: string }>,
+): WhisperSendDecision {
+  const body = rawText.trim()
+  if (!body) return { ok: false, reason: 'empty', nick: target.nick }
+  if (!whisperTargetPresent(target, occupants)) {
+    return { ok: false, reason: 'counterpart-gone', nick: target.nick }
+  }
+  return { ok: true, nick: target.nick, body }
+}


### PR DESCRIPTION
Follow-up to #443. Closes the whisper "counterpart leaves mid-compose" gap so the typed private text can never be sent publicly or to the wrong occupant.

Whisper mode now binds to the counterpart's stable occupant-id (XEP-0421), captured the moment whisper mode is entered:

- **Reactive composer state** — when the counterpart is no longer present, the Send button is disabled and a muted "{nick} is no longer in the room" banner replaces the "whispering to" label. The typed draft is preserved, and Send re-enables if the same person (same occupant-id) rejoins.
- **Send-time backstop** — the send handler re-checks presence against the *live* occupant list (covering the gap between the occupant leaving and React re-rendering the disabled button) and refuses with a toast, matching by occupant-id so a recycled nick is never mis-addressed.
- **Discard on clear** — clearing whisper mode (Esc / dismiss) now discards the composer text, so a private draft is never converted into a public message. Previously the private text was left behind in the now-public composer.

Presence logic is extracted to `conversation/whisperTarget.ts` (`resolveWhisperTarget`, `whisperTargetPresent`, `decideWhisperSend`) with unit tests, reusing the existing `whisperCounterpartPresent` helper and the `rooms.whisperCounterpartGone` i18n key (no new translations).
