### PR TITLE
fix(e2ee): keep decrypted message cache across locked-key web reloads

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -23,6 +23,7 @@ vi.mock('../utils/messageCache', () => ({
   saveMessage: vi.fn().mockResolvedValue(undefined),
   saveMessages: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue([]),
+  getMessagesWithEncryptedPayload: vi.fn().mockResolvedValue([]),
   getMessage: vi.fn().mockResolvedValue(null),
   getMessageByStanzaId: vi.fn().mockResolvedValue(null),
   updateMessage: vi.fn().mockResolvedValue(undefined),
@@ -52,6 +53,7 @@ import {
 } from './e2ee'
 import { DummyPlaintextPlugin } from './e2ee/DummyPlaintextPlugin'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import * as messageCache from '../utils/messageCache'
 
 function stubXmppPrimitives(): XMPPPrimitives {
   return {
@@ -239,6 +241,93 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       const msg = messages.find((m) => m.id === 'msg-body-check')
       expect(msg?.body).toBe('hello')
       expect(msg?.encryptedPayload).toBeUndefined()
+    })
+  })
+
+  describe('durable-cache deferred decryption', () => {
+    // Regression guard for the web fresh-session reload bug: messages that
+    // failed to decrypt while the key was locked are persisted to IndexedDB
+    // (encryptedPayload stashed) but for conversations the user has NOT opened
+    // they are never loaded into the in-memory store. The original
+    // retryPendingDecrypts only scanned the in-memory store, so those stayed
+    // permanently "could not be decrypted" even after unlock.
+    it('decrypts and repairs a message that exists only in the durable cache', async () => {
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode('hello'),
+        senderDevice: { jid: 'me@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      // In-memory store is empty for this conversation; the message lives ONLY
+      // in IndexedDB (mocked), as after a fresh-session reload of an unopened
+      // conversation.
+      vi.mocked(messageCache.getMessagesWithEncryptedPayload).mockResolvedValue([
+        {
+          type: 'chat',
+          id: 'durable-1',
+          conversationId: 'carol@example.com',
+          from: 'carol@example.com',
+          body: '[dummy-plaintext payload]',
+          timestamp: new Date(),
+          isOutgoing: false,
+          encryptedPayload: DUMMY_PAYLOAD_XML,
+        },
+      ])
+
+      const count = await xmppClient.retryPendingDecrypts()
+
+      expect(count).toBe(1)
+      // Written back to the DURABLE cache with plaintext + cleared stash.
+      expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        'durable-1',
+        expect.objectContaining({ body: 'hello', encryptedPayload: undefined })
+      )
+    })
+
+    it('does not double-process a message present in both memory and the durable cache', async () => {
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode('hello'),
+        senderDevice: { jid: 'me@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      chatStore.getState().addConversation({
+        id: 'dave@example.com',
+        name: 'Dave',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'dup-1',
+        conversationId: 'dave@example.com',
+        from: 'dave@example.com',
+        body: '[dummy-plaintext payload]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+      // Same message also surfaced by the durable scan.
+      vi.mocked(messageCache.getMessagesWithEncryptedPayload).mockResolvedValue([
+        {
+          type: 'chat',
+          id: 'dup-1',
+          conversationId: 'dave@example.com',
+          from: 'dave@example.com',
+          body: '[dummy-plaintext payload]',
+          timestamp: new Date(),
+          isOutgoing: false,
+          encryptedPayload: DUMMY_PAYLOAD_XML,
+        },
+      ])
+
+      const decryptSpy = vi.spyOn(manager, 'decryptArchive')
+      const count = await xmppClient.retryPendingDecrypts()
+
+      // Decrypted exactly once — the durable pass skips the already-handled id.
+      expect(decryptSpy).toHaveBeenCalledTimes(1)
+      expect(count).toBe(1)
     })
   })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -118,6 +118,7 @@ import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './
 import { logDebug, logInfo, logWarn } from './logger'
 import { SDK_VERSION } from '../version'
 import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
+import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage } from '../utils/messageCache'
 
 /**
  * Core XMPP client with namespace-based module API.
@@ -1619,6 +1620,9 @@ export class XMPPClient {
 
     this.isRetryingDecrypts = true
     let decryptedCount = 0
+    // Chat messages handled by the in-memory pass below, so the durable-cache
+    // pass can skip them (keyed by conversationId + message id).
+    const handledChatKeys = new Set<string>()
 
     try {
       const chatBindings = this.stores.chat
@@ -1631,6 +1635,7 @@ export class XMPPClient {
       for (const [conversationId, messages] of chatMessages) {
         for (const msg of messages) {
           if (!msg.encryptedPayload) continue
+          handledChatKeys.add(`${conversationId} ${msg.id}`)
           const outcome = await this.retryDecryptSingle(
             manager, msg.encryptedPayload, msg.from, conversationId,
           )
@@ -1673,6 +1678,36 @@ export class XMPPClient {
               unsupportedEncryption: outcome.info,
             })
           }
+        }
+      }
+
+      // --- Durable cache (web fresh-session reload) ---
+      // Conversations the user has not opened are absent from the in-memory
+      // store, so the loops above miss their stashed messages — they would
+      // stay permanently "could not be decrypted" even after unlock. Repair
+      // them straight in IndexedDB. The sparse `encryptedPayload` index makes
+      // this O(pending), not a full-archive scan, and near-free when nothing
+      // is pending (the steady state).
+      for (const msg of await getMessagesWithEncryptedPayload()) {
+        const conversationId = msg.conversationId
+        if (!msg.encryptedPayload || !conversationId) continue
+        if (handledChatKeys.has(`${conversationId} ${msg.id}`)) continue
+        const outcome = await this.retryDecryptSingle(
+          manager, msg.encryptedPayload, msg.from, conversationId,
+        )
+        if (outcome.kind === 'decrypted') {
+          await cacheUpdateMessage(msg.id, {
+            body: outcome.body,
+            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+            ...(outcome.attachment && { attachment: outcome.attachment }),
+            encryptedPayload: undefined,
+          })
+          decryptedCount++
+        } else if (outcome.kind === 'unsupported') {
+          await cacheUpdateMessage(msg.id, {
+            encryptedPayload: undefined,
+            unsupportedEncryption: outcome.info,
+          })
         }
       }
 

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -583,6 +583,189 @@ describe('messageCache', () => {
     })
   })
 
+  describe('non-destructive E2EE save (never degrade decrypted cache)', () => {
+    const conversationId = 'peer@example.com'
+
+    it('does not let an undecryptable re-ingest overwrite an already-decrypted message', async () => {
+      setStorageScopeJid('me@example.com')
+
+      // Session 1: the message was decrypted live and persisted as plaintext.
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'm1',
+          body: 'Bonjour en clair',
+          // no encryptedPayload — fully decrypted
+        })
+      )
+
+      // Reload → fresh-session MAM catch-up re-ingests the SAME message (same
+      // id) while the OpenPGP key is still locked: it arrives undecryptable,
+      // carrying the encrypted placeholder. This must NOT clobber the plaintext.
+      await messageCache.saveMessages([
+        createMockMessage(conversationId, {
+          id: 'm1',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">CIPHER</openpgp>',
+        }),
+      ])
+
+      const stored = await messageCache.getMessage('m1')
+      expect(stored?.body).toBe('Bonjour en clair')
+      expect(stored?.encryptedPayload).toBeUndefined()
+    })
+
+    it('still lets a decrypted message upgrade a previously-undecryptable one', async () => {
+      setStorageScopeJid('me@example.com')
+
+      // Received while locked → stored undecryptable.
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'm2',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">CIPHER</openpgp>',
+        })
+      )
+
+      // Deferred decrypt succeeds → plaintext, no stash. Upgrade must apply.
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'm2',
+          body: 'Coucou déchiffré',
+        })
+      )
+
+      const stored = await messageCache.getMessage('m2')
+      expect(stored?.body).toBe('Coucou déchiffré')
+      expect(stored?.encryptedPayload).toBeUndefined()
+    })
+
+    it('refreshes an undecryptable message with another undecryptable version', async () => {
+      setStorageScopeJid('me@example.com')
+
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'm3',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">OLD</openpgp>',
+        })
+      )
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'm3',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">NEW</openpgp>',
+        })
+      )
+
+      const stored = await messageCache.getMessage('m3')
+      expect(stored?.encryptedPayload).toContain('NEW')
+    })
+
+    it('does not let an unsupported-encryption fallback overwrite an already-decrypted message', async () => {
+      setStorageScopeJid('me@example.com')
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, { id: 'u1', body: 'Texte clair' })
+      )
+      // Peer toggled their encryption off → re-ingest arrives as a fallback
+      // with no ciphertext to retry. Must not clobber the decrypted plaintext.
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'u1',
+          body: '[Encrypted message]',
+          unsupportedEncryption: { namespace: 'urn:xmpp:openpgp:0', name: 'OpenPGP' },
+        })
+      )
+
+      const stored = await messageCache.getMessage('u1')
+      expect(stored?.body).toBe('Texte clair')
+      expect(stored?.unsupportedEncryption).toBeUndefined()
+    })
+
+    it('does not let an unsupported fallback overwrite a retriable encryptedPayload message', async () => {
+      setStorageScopeJid('me@example.com')
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'u2',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">CIPHER</openpgp>',
+        })
+      )
+      // A fallback (no ciphertext) must not destroy the retriable ciphertext.
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'u2',
+          body: '[Encrypted message]',
+          unsupportedEncryption: { namespace: 'eu.siacs.conversations.axolotl', name: 'OMEMO' },
+        })
+      )
+
+      const stored = await messageCache.getMessage('u2')
+      expect(stored?.encryptedPayload).toContain('CIPHER')
+      expect(stored?.unsupportedEncryption).toBeUndefined()
+    })
+
+    it('lets a retriable encryptedPayload replace an unsupported fallback (upgrade)', async () => {
+      setStorageScopeJid('me@example.com')
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'u3',
+          body: '[Encrypted message]',
+          unsupportedEncryption: { namespace: 'eu.siacs.conversations.axolotl', name: 'OMEMO' },
+        })
+      )
+      // Plugin now available → ciphertext arrives and SHOULD take over so the
+      // deferred retry can decrypt it.
+      await messageCache.saveMessage(
+        createMockMessage(conversationId, {
+          id: 'u3',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">C3</openpgp>',
+        })
+      )
+
+      const stored = await messageCache.getMessage('u3')
+      expect(stored?.encryptedPayload).toContain('C3')
+      expect(stored?.unsupportedEncryption).toBeUndefined()
+    })
+  })
+
+  describe('getMessagesWithEncryptedPayload', () => {
+    it('returns only messages that still carry an encryptedPayload, across conversations', async () => {
+      setStorageScopeJid('me@example.com')
+      await messageCache.saveMessage(
+        createMockMessage('a@example.com', { id: 'plain', body: 'clair' })
+      )
+      await messageCache.saveMessage(
+        createMockMessage('a@example.com', {
+          id: 'enc1',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">ONE</openpgp>',
+        })
+      )
+      await messageCache.saveMessage(
+        createMockMessage('b@example.com', {
+          id: 'enc2',
+          body: '[OpenPGP-encrypted message]',
+          encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">TWO</openpgp>',
+        })
+      )
+
+      const pending = await messageCache.getMessagesWithEncryptedPayload()
+      const ids = pending.map((m) => m.id).sort()
+      expect(ids).toEqual(['enc1', 'enc2'])
+      // Each must keep the data the deferred retry needs.
+      expect(pending.every((m) => !!m.encryptedPayload && !!m.conversationId)).toBe(true)
+    })
+
+    it('returns an empty array when nothing is pending', async () => {
+      setStorageScopeJid('me@example.com')
+      await messageCache.saveMessage(
+        createMockMessage('a@example.com', { id: 'plain', body: 'clair' })
+      )
+      expect(await messageCache.getMessagesWithEncryptedPayload()).toEqual([])
+    })
+  })
+
   describe('Error handling', () => {
     it('should handle getMessages on empty database gracefully', async () => {
       const messages = await messageCache.getMessages('nonexistent@example.com')

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -12,7 +12,9 @@ import type { Message, RoomMessage } from '../core/types'
 import { getStorageScopeJid } from './storageScope'
 
 const DB_NAME = 'fluux-message-cache'
-const DB_VERSION = 2
+// v3: add a SPARSE index on `encryptedPayload` so deferred decryption can list
+// only the messages still awaiting a key — without scanning the whole archive.
+const DB_VERSION = 3
 const MESSAGES_STORE = 'messages'
 const ROOM_MESSAGES_STORE = 'room-messages'
 
@@ -79,6 +81,8 @@ interface MessageCacheSchema extends DBSchema {
       stanzaId: string
       timestamp: number
       conv_timestamp: [string, number]
+      // Sparse: only messages awaiting deferred decryption are indexed here.
+      encryptedPayload: string
     }
   }
   [ROOM_MESSAGES_STORE]: {
@@ -135,8 +139,8 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
 
   dbNameForPromise = targetDbName
   dbPromise = openDB<MessageCacheSchema>(targetDbName, DB_VERSION, {
-    upgrade(db, oldVersion) {
-      // Chat messages store (unchanged)
+    upgrade(db, oldVersion, _newVersion, transaction) {
+      // Chat messages store
       if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
         const msgStore = db.createObjectStore(MESSAGES_STORE, { keyPath: 'id' })
         msgStore.createIndex('conversationId', 'conversationId', { unique: false })
@@ -145,6 +149,14 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
         msgStore.createIndex('conv_timestamp', ['conversationId', 'timestamp'], {
           unique: false,
         })
+        // Sparse index — records without `encryptedPayload` are excluded.
+        msgStore.createIndex('encryptedPayload', 'encryptedPayload', { unique: false })
+      } else if (oldVersion < 3) {
+        // v3 migration for existing DBs: add the sparse encryptedPayload index.
+        const msgStore = transaction.objectStore(MESSAGES_STORE)
+        if (!msgStore.indexNames.contains('encryptedPayload')) {
+          msgStore.createIndex('encryptedPayload', 'encryptedPayload', { unique: false })
+        }
       }
 
       // Room messages store
@@ -226,14 +238,69 @@ function deserializeRoomMessage(stored: StoredRoomMessage): RoomMessage {
 // Chat Message Operations
 // =============================================================================
 
+/** Minimal structural view of the idb chat-message object store. */
+type ChatMessageStore = {
+  get(key: string): Promise<StoredMessage | undefined>
+  put(value: StoredMessage): Promise<unknown>
+}
+
+/**
+ * Recoverability rank of a stored or incoming chat message:
+ *   2 = fully decrypted (real plaintext body)
+ *   1 = ciphertext stashed (`encryptedPayload`) — still retriable after unlock
+ *   0 = unsupported-encryption fallback — no ciphertext, cannot be recovered
+ */
+function decryptionRank(msg: {
+  encryptedPayload?: string
+  unsupportedEncryption?: unknown
+}): number {
+  if (msg.encryptedPayload) return 1
+  if (msg.unsupportedEncryption) return 0
+  return 2
+}
+
+/**
+ * Put a chat message without ever DEGRADING a higher-quality cache entry.
+ *
+ * E2EE re-ingestion hazards: a web page reload that yields a *fresh* session
+ * runs the background MAM catch-up while the OpenPGP key may still be locked,
+ * and a peer toggling their encryption makes history re-arrive as an
+ * unsupported fallback. Either way the re-fetched copy is less recoverable
+ * than what we already stored, and a blind `put` would overwrite our decrypted
+ * plaintext (or our retriable ciphertext) with a placeholder — leaving the
+ * message permanently showing "could not be decrypted" / "not supported".
+ *
+ * Guard: skip the write when the incoming message is strictly less recoverable
+ * than the stored one (see {@link decryptionRank}). Equal-or-better writes
+ * upsert normally — decrypted updates, ciphertext refreshes, and the upgrade
+ * of a fallback once the real ciphertext arrives.
+ */
+async function putChatMessageGuarded(
+  store: ChatMessageStore,
+  message: Message
+): Promise<void> {
+  const incomingRank = decryptionRank(message)
+  if (incomingRank < 2) {
+    const existing = await store.get(message.id)
+    if (existing && decryptionRank(existing) > incomingRank) {
+      // Existing entry is more recoverable — don't degrade it.
+      return
+    }
+  }
+  await store.put(serializeMessage(message))
+}
+
 /**
  * Save a chat message to IndexedDB.
- * Upserts - will overwrite if message with same ID exists.
+ * Upserts - will overwrite if message with same ID exists, EXCEPT it never
+ * degrades an already-decrypted entry (see {@link putChatMessageGuarded}).
  */
 export async function saveMessage(message: Message): Promise<void> {
   try {
     const db = await getDB(getStorageScopeJid())
-    await db.put(MESSAGES_STORE, serializeMessage(message))
+    const tx = db.transaction(MESSAGES_STORE, 'readwrite')
+    await putChatMessageGuarded(tx.store, message)
+    await tx.done
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to save message:', error)
@@ -243,6 +310,7 @@ export async function saveMessage(message: Message): Promise<void> {
 
 /**
  * Save multiple chat messages to IndexedDB in a single transaction.
+ * Never degrades an already-decrypted entry (see {@link putChatMessageGuarded}).
  */
 export async function saveMessages(messages: Message[]): Promise<void> {
   if (messages.length === 0) return
@@ -252,12 +320,41 @@ export async function saveMessages(messages: Message[]): Promise<void> {
     const tx = db.transaction(MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(MESSAGES_STORE)
 
-    await Promise.all(messages.map((msg) => store.put(serializeMessage(msg))))
+    for (const msg of messages) {
+      await putChatMessageGuarded(store, msg)
+    }
     await tx.done
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to save messages:', error)
     }
+  }
+}
+
+/**
+ * Return every cached chat message that still carries an `encryptedPayload` —
+ * i.e. that was ingested while no plugin could decrypt it (typically a locked
+ * E2EE key after a fresh-session page reload).
+ *
+ * Deferred decryption uses this to repair the DURABLE cache after the key is
+ * unlocked, not just the messages currently loaded in the in-memory store:
+ * conversations the user has not opened are otherwise left permanently showing
+ * "could not be decrypted". Scoped to the active account.
+ */
+export async function getMessagesWithEncryptedPayload(): Promise<Message[]> {
+  try {
+    const db = await getDB(getStorageScopeJid())
+    // Sparse index: this reads ONLY the messages still carrying an
+    // encryptedPayload — not the whole archive — so it stays cheap to call on
+    // every plugin-register / key-unlock, and is near-free when none are
+    // pending (the steady state).
+    const pending = await db.getAllFromIndex(MESSAGES_STORE, 'encryptedPayload')
+    return pending.map(deserializeMessage)
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to read pending-decrypt messages:', error)
+    }
+    return []
   }
 }
 


### PR DESCRIPTION
On web, a reload that falls back to a fresh session re-runs the MAM catch-up while the OpenPGP key is still locked. The undecryptable re-fetched copies overwrote already-decrypted IndexedDB entries, and the deferred retry only scanned the in-memory store — so messages stayed permanently "could not be decrypted" (notably one's own messages composed on another device).

- **messageCache**: `saveMessage`/`saveMessages` never degrade a higher-quality cache entry — ranked decrypted > retriable ciphertext > unsupported fallback. Also fixes the reverse (real ciphertext can now upgrade an old fallback).
- **Sparse `encryptedPayload` index (DB v3)**: deferred decryption lists only pending messages instead of scanning the whole archive (near-free when none are pending).
- **retryPendingDecrypts**: now also repairs the durable IndexedDB cache, not just the in-memory store, so conversations the user has not opened recover after unlock. Deduped against the in-memory pass.
