### PR TITLE
fix(search): avoid nested <button> in search result rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ coverage/
 test-results/
 playwright-report/
 
+# Generated demo videos (large binaries) — root-anchored so scripts/video/ is NOT ignored
+/video/
+
 # Security
 *.pem
 *.key

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -335,7 +335,11 @@ function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav
   const highlighted = isActive || isSelected
 
   return (
-    <button
+    // Keyboard activation (Arrow + Enter) lives on the list container via
+    // useListKeyboardNav — see SearchView's getContainerProps / onSelect.
+    // The row is therefore a plain div (matching ConversationItem) so it can
+    // host the real "Go to message" button without nesting <button> in <button>.
+    <div
       {...itemAttribute}
       {...itemProps}
       onClick={onClick}
@@ -393,7 +397,7 @@ function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav
             </span>
             <button
               onClick={onGoToMessage}
-              className="p-0.5 rounded opacity-0 group-hover/result:opacity-100 transition-opacity hover:bg-fluux-hover-strong"
+              className="p-0.5 rounded opacity-0 group-hover/result:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-fluux-hover-strong"
               title="Go to message"
             >
               <ExternalLink className="size-3 text-fluux-muted" />
@@ -413,7 +417,7 @@ function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav
           <ContextLine key={`after-${i}`} body={msg.body} nick={msg.nick} from={msg.from} isRoom={result.isRoom} />
         ))}
       </div>
-    </button>
+    </div>
   )
 }
 

--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -33,6 +33,45 @@ The demo populates the UI with:
 - **1 group chat room** ("Team Chat") with 4 occupants, reactions, and replies
 - **Live animations** that start after page load: typing indicators, incoming messages, and emoji reactions
 
+## Recording a Demo Video
+
+A Playwright pipeline drives demo mode and records a promo-style walkthrough of the major features. It produces two variants from one shared storyboard:
+
+| Command                   | Produces                              | Length                 |
+|---------------------------|---------------------------------------|------------------------|
+| `npm run demo:video`      | both variants                         | —                      |
+| `npm run demo:video:reel` | `video/fluux-demo-reel.{webm,mp4}`    | ~90s highlight reel    |
+| `npm run demo:video:full` | `video/fluux-demo-full.{webm,mp4}`    | ~3–4 min full tour     |
+
+Output is written to the git-ignored `video/` directory at the repo root, as **1920×1080 WebM and MP4**.
+
+### Prerequisites
+
+```bash
+npm run build:sdk                 # demo consumes the built SDK
+npx playwright install chromium   # one-time, if not already installed
+# ffmpeg must be on PATH for the MP4 conversion (the WebM is always produced)
+```
+
+Playwright starts the dev server automatically (reusing one already running on `:5173`).
+
+### How it works
+
+The script opens `/demo.html?tutorial=false`, drives navigation deterministically (via the `HashRouter`), and layers on promo polish: a synthetic gliding cursor with click ripples, lower-third captions, and intro/outro title cards. "Live" moments — typing indicators, incoming messages, reactions — are fired on cue through `DemoClient.startAnimation()` while the camera is framed on the relevant conversation.
+
+### Editing the walkthrough
+
+| File                          | Purpose                                                                  |
+|-------------------------------|--------------------------------------------------------------------------|
+| `scripts/video/storyboard.ts` | Ordered scenes — add, reorder, or retag features here                    |
+| `scripts/video/helpers.ts`    | Cursor, captions, title cards, navigation, live beats, MP4 conversion    |
+| `scripts/video/record.ts`     | Entry point (the `reel` and `full` tests)                                |
+| `playwright.video.config.ts`  | 1080p canvas, video recording, timeout, dev-server reuse                 |
+
+Each scene is tagged `variant: 'reel'` (appears in both videos) or `variant: 'full'` (full tour only), so the reel is a strict subset of the full tour.
+
+> **Capture quality:** video is captured with Playwright's built-in `recordVideo` (variable frame rate) and re-encoded to a constant-30fps H.264 MP4 via ffmpeg. If motion looks choppy, the capture layer in `helpers.ts` can be swapped for deterministic frame capture (CDP screencast or interval screenshots) assembled by ffmpeg at a constant frame rate — without touching the storyboard.
+
 ## Architecture
 
 ### Entry Point

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "docs": "npm run ts-docs -w @fluux/sdk",
     "docs:watch": "npm run docs:watch -w @fluux/sdk",
     "screenshots": "npx playwright test --config playwright.config.ts",
-    "ux:audit": "npx playwright test --config playwright.ux.config.ts"
+    "ux:audit": "npx playwright test --config playwright.ux.config.ts",
+    "demo:video": "npx playwright test --config playwright.video.config.ts",
+    "demo:video:reel": "npx playwright test --config playwright.video.config.ts --grep reel",
+    "demo:video:full": "npx playwright test --config playwright.video.config.ts --grep full"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/playwright.video.config.ts
+++ b/playwright.video.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test'
+
+/**
+ * Playwright config for the demo *video* pipeline (scripts/video/record.ts).
+ *
+ * Separate from playwright.config.ts (screenshots) so the two never collide:
+ * here we WANT motion (no reducedMotion), a 1080p canvas, and a long timeout
+ * for the multi-minute walkthrough. Video is recorded per-context inside the
+ * test (see record.ts) rather than via `use.video`, so we control the output
+ * path and the MP4 conversion.
+ */
+export default defineConfig({
+  testDir: './scripts/video',
+  testMatch: 'record.ts',
+  // Full tour can run several minutes + ffmpeg conversion afterwards.
+  timeout: 360_000,
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  use: {
+    baseURL: 'http://localhost:5173',
+    viewport: { width: 1920, height: 1080 },
+    // Backstop: never let a missing element hang the whole multi-minute run.
+    actionTimeout: 20_000,
+    navigationTimeout: 30_000,
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+})

--- a/scripts/video/helpers.ts
+++ b/scripts/video/helpers.ts
@@ -1,0 +1,431 @@
+/**
+ * Reusable helpers for the Fluux demo video recorder.
+ *
+ * Playwright drives the real demo (`/demo.html`) deterministically; these
+ * helpers add the "promo" polish (a synthetic gliding cursor, click ripples,
+ * caption + title cards) and the deterministic "live beats" (typing /
+ * incoming messages fired through the demo client on cue).
+ *
+ * Nothing here is Fluux-specific beyond the selectors/JIDs — the same
+ * patterns power scripts/screenshots.ts.
+ */
+
+import { type Page, type Locator } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+// ── Constants ──────────────────────────────────────────────────────
+
+export const BASE_URL = 'http://localhost:5173'
+export const DEMO_URL = `${BASE_URL}/demo.html?tutorial=false`
+export const VIDEO_SIZE = { width: 1920, height: 1080 }
+
+/** Demo JIDs (stable in demo seed data — see apps/fluux/src/demo/). */
+export const DOMAIN = 'fluux.chat'
+export const SELF_JID = `you@${DOMAIN}`
+export const ROOM_JID = `team@conference.${DOMAIN}`
+
+// ── Readiness ──────────────────────────────────────────────────────
+
+/**
+ * Open the demo page and paint a dark background immediately, so the brief
+ * Vite/React load shows dark (matching the title card) instead of white.
+ */
+export async function openDemo(page: Page): Promise<void> {
+  // Paint the root dark at document-start, before any app code runs, so the
+  // multi-second dev module load shows dark (matching the title card) rather
+  // than a white flash.
+  await page.addInitScript(() => {
+    try { document.documentElement.style.background = '#0b0c18' } catch { /* no DOM yet */ }
+  })
+  await page.goto(DEMO_URL, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(() => {
+    document.documentElement.style.background = '#0b0c18'
+    document.body.style.background = '#0b0c18'
+  })
+  // Cosmetic only — keep transitions intact for smooth motion.
+  await page.addStyleTag({
+    content: `
+      *::-webkit-scrollbar { display: none !important; }
+      * { scrollbar-width: none !important; }
+      * { caret-color: transparent !important; }
+    `,
+  })
+}
+
+/**
+ * Wait until the demo app is fully interactive, then stop the auto-started
+ * 5-minute global timeline so we can drive our own deterministic beats.
+ * Call this AFTER covering the screen with the intro card so the load
+ * happens off-camera.
+ */
+export async function waitForAppReady(page: Page): Promise<void> {
+  await page.waitForSelector('[data-nav="messages"]', { timeout: 20_000 })
+  await page.getByText('Emma Wilson').first().waitFor({ timeout: 15_000 })
+  await page.waitForLoadState('networkidle')
+  await page.evaluate(() => {
+    const client = (window as any).__demoClient
+    if (client?.stopAnimation) client.stopAnimation()
+  })
+  await page.waitForTimeout(300)
+}
+
+// ── Polish layers (cursor, ripples, captions, title cards) ─────────
+
+/**
+ * Inject the synthetic cursor, click-ripple, caption (lower third) and
+ * full-screen title-card overlays. All layers are `pointer-events: none`
+ * so real Playwright mouse/keyboard events still drive the React app.
+ */
+export async function installPolishLayers(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (document.getElementById('vid-cursor')) return
+    const NS = 'http://www.w3.org/2000/svg'
+
+    const style = document.createElement('style')
+    style.textContent = `
+      #vid-cursor, #vid-caption, #vid-title { position: fixed; pointer-events: none; }
+      #vid-cursor {
+        z-index: 2147483647; left: 0; top: 0; width: 28px; height: 28px;
+        margin: -2px 0 0 -2px; filter: drop-shadow(0 2px 3px rgba(0,0,0,.45));
+        transition: opacity .25s ease;
+      }
+      .vid-ripple {
+        position: fixed; z-index: 2147483646; pointer-events: none;
+        width: 14px; height: 14px; margin: -7px 0 0 -7px; border-radius: 50%;
+        background: rgba(88,101,242,.55); border: 2px solid rgba(88,101,242,.9);
+        animation: vidRipple .55s ease-out forwards;
+      }
+      @keyframes vidRipple {
+        from { transform: scale(1); opacity: .9; }
+        to   { transform: scale(3.6); opacity: 0; }
+      }
+      #vid-caption {
+        z-index: 2147483640; bottom: 8%; left: 50%;
+        transform: translate(-50%, 14px); opacity: 0;
+        transition: opacity .45s ease, transform .45s ease;
+        max-width: 78%; padding: 16px 26px; border-radius: 16px; text-align: center;
+        background: rgba(15,17,21,.74); backdrop-filter: blur(10px);
+        box-shadow: 0 10px 40px rgba(0,0,0,.35);
+        font-family: Inter, system-ui, -apple-system, sans-serif; color: #fff;
+      }
+      #vid-caption.show { opacity: 1; transform: translate(-50%, 0); }
+      #vid-caption .t { font-size: 32px; font-weight: 700; line-height: 1.15; }
+      #vid-caption .s { font-size: 19px; font-weight: 400; opacity: .82; margin-top: 6px; }
+      #vid-title {
+        z-index: 2147483645; inset: 0; opacity: 0; transition: opacity .6s ease;
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+        gap: 18px; text-align: center;
+        background: radial-gradient(120% 120% at 50% 30%, #2b2f63 0%, #14152b 55%, #0b0c18 100%);
+        font-family: Inter, system-ui, -apple-system, sans-serif; color: #fff;
+      }
+      #vid-title.show { opacity: 1; }
+      #vid-title img { width: 104px; height: 104px; border-radius: 24px; box-shadow: 0 12px 48px rgba(0,0,0,.5); }
+      #vid-title .tt { font-size: 68px; font-weight: 800; letter-spacing: -1px; }
+      #vid-title .ts { font-size: 26px; font-weight: 500; color: rgba(255,255,255,.82); }
+    `
+    document.head.appendChild(style)
+
+    // Synthetic cursor (macOS-style arrow)
+    const cursor = document.createElementNS(NS, 'svg')
+    cursor.setAttribute('id', 'vid-cursor')
+    cursor.setAttribute('viewBox', '0 0 28 28')
+    cursor.innerHTML =
+      '<path d="M5 3 L5 22 L10 17 L13.5 24 L16.5 22.6 L13 16 L20 16 Z" ' +
+      'fill="#fff" stroke="#1a1b1e" stroke-width="1.3" stroke-linejoin="round"/>'
+    document.body.appendChild(cursor)
+
+    // Caption (lower third)
+    const cap = document.createElement('div')
+    cap.id = 'vid-caption'
+    cap.innerHTML = '<div class="t"></div><div class="s"></div>'
+    document.body.appendChild(cap)
+
+    // Full-screen title card
+    const title = document.createElement('div')
+    title.id = 'vid-title'
+    title.innerHTML = '<img src="/logo.png" alt=""><div class="tt"></div><div class="ts"></div>'
+    document.body.appendChild(title)
+
+    // Track real mouse events dispatched by Playwright.
+    window.addEventListener('mousemove', (e) => {
+      cursor.style.left = `${e.clientX}px`
+      cursor.style.top = `${e.clientY}px`
+    }, true)
+    window.addEventListener('mousedown', (e) => {
+      const r = document.createElement('span')
+      r.className = 'vid-ripple'
+      r.style.left = `${e.clientX}px`
+      r.style.top = `${e.clientY}px`
+      document.body.appendChild(r)
+      r.addEventListener('animationend', () => r.remove())
+    }, true)
+  })
+  // Park the cursor off to the side initially.
+  await page.mouse.move(VIDEO_SIZE.width * 0.5, VIDEO_SIZE.height * 0.5)
+}
+
+/** Show the lower-third caption (fades in, stays until hideCaption). */
+export async function showCaption(page: Page, title: string, subtitle = ''): Promise<void> {
+  await page.evaluate(({ title, subtitle }) => {
+    const el = document.getElementById('vid-caption')
+    if (!el) return
+    ;(el.querySelector('.t') as HTMLElement).textContent = title
+    ;(el.querySelector('.s') as HTMLElement).textContent = subtitle
+    el.classList.add('show')
+  }, { title, subtitle })
+  await page.waitForTimeout(500)
+}
+
+/** Hide the lower-third caption. */
+export async function hideCaption(page: Page): Promise<void> {
+  await page.evaluate(() => document.getElementById('vid-caption')?.classList.remove('show'))
+  await page.waitForTimeout(450)
+}
+
+/** Instantly cover the screen with the branded card (no fade-in) — used to
+ *  hide the app's initial load behind the intro card. */
+export async function coverWithTitle(page: Page, title: string, subtitle: string): Promise<void> {
+  await page.evaluate(({ title, subtitle }) => {
+    const el = document.getElementById('vid-title')
+    if (!el) return
+    ;(el.querySelector('.tt') as HTMLElement).textContent = title
+    ;(el.querySelector('.ts') as HTMLElement).textContent = subtitle
+    const prev = el.style.transition
+    el.style.transition = 'none'
+    el.classList.add('show')
+    // Force reflow, then restore the transition for a smooth fade-out later.
+    void el.offsetHeight
+    el.style.transition = prev
+  }, { title, subtitle })
+}
+
+/** Fade the branded card out, revealing the app. */
+export async function hideTitleCard(page: Page): Promise<void> {
+  await page.evaluate(() => document.getElementById('vid-title')?.classList.remove('show'))
+  await page.waitForTimeout(700)
+}
+
+/** Show a full-screen branded title/outro card, hold, then fade out. */
+export async function titleCard(page: Page, title: string, subtitle: string, holdMs = 2600): Promise<void> {
+  await page.evaluate(({ title, subtitle }) => {
+    const el = document.getElementById('vid-title')
+    if (!el) return
+    ;(el.querySelector('.tt') as HTMLElement).textContent = title
+    ;(el.querySelector('.ts') as HTMLElement).textContent = subtitle
+    el.classList.add('show')
+  }, { title, subtitle })
+  await page.waitForTimeout(holdMs)
+  await page.evaluate(() => document.getElementById('vid-title')?.classList.remove('show'))
+  await page.waitForTimeout(650)
+}
+
+// ── Pacing + pointer movement ──────────────────────────────────────
+
+export async function dwell(page: Page, ms: number): Promise<void> {
+  await page.waitForTimeout(ms)
+}
+
+function asLocator(page: Page, target: Locator | string): Locator {
+  return typeof target === 'string' ? page.locator(target) : target
+}
+
+/** Glide the cursor to a locator's centre (stepped move = visible motion). */
+export async function glideTo(page: Page, target: Locator | string): Promise<{ x: number; y: number }> {
+  const loc = asLocator(page, target)
+  await loc.scrollIntoViewIfNeeded({ timeout: 15_000 })
+  const box = await loc.boundingBox()
+  if (!box) throw new Error(`glideTo: target has no bounding box: ${String(target)}`)
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+  await page.mouse.move(x, y, { steps: 28 })
+  return { x, y }
+}
+
+/**
+ * Glide the cursor to a target, then perform a robust `locator.click()`.
+ * The glide supplies the visible motion; the real click uses Playwright
+ * actionability (auto-wait, retries) so navigation reliably fires. The click
+ * still dispatches a mousedown, so the ripple animation plays.
+ */
+export async function glideClick(page: Page, target: Locator | string, afterMs = 700): Promise<void> {
+  const loc = asLocator(page, target)
+  await glideTo(page, loc)
+  await page.waitForTimeout(240)
+  await loc.click({ timeout: 15_000 })
+  await page.waitForTimeout(afterMs)
+}
+
+// ── Navigation ─────────────────────────────────────────────────────
+
+/** Maps an icon-rail view to its router path (most are 1:1). */
+const VIEW_PATHS: Record<string, string> = {
+  messages: '/messages',
+  rooms: '/rooms',
+  directory: '/contacts',
+  archive: '/archive',
+  events: '/events',
+  search: '/search',
+  admin: '/admin',
+  settings: '/settings',
+}
+
+/**
+ * Switch the top-level view. The cursor glides to the nav icon and clicks it
+ * (visible ripple), but the actual route change goes through the HashRouter —
+ * the icon-rail click alone does NOT reliably switch views from every
+ * sub-route (verified: a native click on [data-nav="messages"] from inside a
+ * room is a no-op), whereas a hash change always works and is deterministic.
+ */
+export async function navigateTo(page: Page, view: string): Promise<void> {
+  const navBtn = page.locator(`[data-nav="${view}"]`)
+  try {
+    await glideTo(page, navBtn)
+    await page.waitForTimeout(220)
+    await navBtn.click({ timeout: 5_000 }) // ripple + works for the cases it can
+  } catch {
+    /* visual nicety only — navigation below is authoritative */
+  }
+  const path = VIEW_PATHS[view] ?? `/${view}`
+  await page.evaluate((p) => { window.location.hash = `#${p}` }, path)
+  await page.waitForTimeout(850)
+}
+
+export async function selectItem(page: Page, name: string): Promise<void> {
+  await glideClick(page, page.getByText(name, { exact: true }).first(), 1000)
+}
+
+export async function setTheme(page: Page, themeId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const store = (window as any).__themeStore
+    if (store) store.getState().setActiveTheme(id)
+  }, themeId)
+  await page.waitForTimeout(700)
+}
+
+export async function setColorScheme(page: Page, scheme: 'dark' | 'light'): Promise<void> {
+  await page.emulateMedia({ colorScheme: scheme })
+  await page.waitForTimeout(700)
+}
+
+export async function setLanguage(page: Page, langCode: string): Promise<void> {
+  await page.evaluate((code) => {
+    const i18n = (window as any).__i18n
+    if (i18n) void i18n.changeLanguage(code)
+  }, langCode)
+  await page.waitForTimeout(900)
+}
+
+/** Scroll a message/element containing `text` into view (best-effort). */
+export async function scrollToText(page: Page, text: string): Promise<void> {
+  const el = page.getByText(text, { exact: false }).first()
+  if (await el.isVisible().catch(() => false)) {
+    await el.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(700)
+  }
+}
+
+// ── Live beats (deterministic, fired through the demo client) ──────
+
+/**
+ * Play a typing → incoming-message beat in the currently open 1:1 chat.
+ * Returns the injected message id (so a reaction can target it).
+ */
+export async function beatIncomingChat(
+  page: Page,
+  opts: { conversationId: string; from: string; body: string; typingMs?: number },
+): Promise<string> {
+  const typingMs = opts.typingMs ?? 1900
+  const id = await page.evaluate(({ conversationId, from, body, typingMs }) => {
+    const client = (window as any).__demoClient
+    client.stopAnimation()
+    const id = `demo-vid-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    client.startAnimation([
+      { delayMs: 0, action: 'typing', data: { conversationId, jid: from, isTyping: true } },
+      { delayMs: typingMs, action: 'stop-typing', data: { conversationId, jid: from, isTyping: false } },
+      {
+        delayMs: typingMs + 120,
+        action: 'message',
+        data: {
+          message: {
+            type: 'chat', id, from, body,
+            timestamp: new Date(), isOutgoing: false, conversationId,
+          },
+        },
+      },
+    ])
+    return id
+  }, { conversationId: opts.conversationId, from: opts.from, body: opts.body, typingMs })
+  await page.waitForTimeout(typingMs + 700)
+  return id
+}
+
+/** Add an emoji reaction to a message in a 1:1 chat. */
+export async function beatChatReaction(
+  page: Page,
+  opts: { conversationId: string; messageId: string; reactorJid: string; emojis: string[] },
+): Promise<void> {
+  await page.evaluate((o) => {
+    const client = (window as any).__demoClient
+    client.stopAnimation()
+    client.startAnimation([{ delayMs: 0, action: 'chat-reaction', data: o }])
+  }, opts)
+  await page.waitForTimeout(800)
+}
+
+/** Play a typing → message beat from a participant in a room. */
+export async function beatRoomMessage(
+  page: Page,
+  opts: { roomJid: string; nick: string; body: string; typingMs?: number },
+): Promise<void> {
+  const typingMs = opts.typingMs ?? 1700
+  await page.evaluate(({ roomJid, nick, body, typingMs }) => {
+    const client = (window as any).__demoClient
+    client.stopAnimation()
+    const id = `demo-vid-room-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+    client.startAnimation([
+      { delayMs: 0, action: 'room-typing', data: { roomJid, nick, isTyping: true } },
+      { delayMs: typingMs, action: 'room-typing', data: { roomJid, nick, isTyping: false } },
+      {
+        delayMs: typingMs + 120,
+        action: 'room-message',
+        data: {
+          roomJid,
+          message: {
+            type: 'groupchat', id, from: `${roomJid}/${nick}`, nick, body,
+            timestamp: new Date(), isOutgoing: false, roomJid,
+          },
+          incrementUnread: true,
+        },
+      },
+    ])
+  }, { roomJid: opts.roomJid, nick: opts.nick, body: opts.body, typingMs })
+  await page.waitForTimeout(typingMs + 700)
+}
+
+// ── Output ─────────────────────────────────────────────────────────
+
+/**
+ * Convert a WebM (Playwright recordVideo) to an H.264 MP4 at a constant
+ * 30fps. No-op with a warning if ffmpeg is unavailable.
+ */
+export function convertToMp4(webmPath: string, mp4Path: string): void {
+  try {
+    execFileSync('ffmpeg', [
+      '-y', '-i', webmPath,
+      '-r', '30',
+      '-c:v', 'libx264',
+      '-pix_fmt', 'yuv420p',
+      '-crf', '18',
+      '-movflags', '+faststart',
+      '-an',
+      mp4Path,
+    ], { stdio: 'ignore' })
+    if (!existsSync(mp4Path)) throw new Error('ffmpeg produced no output')
+    // eslint-disable-next-line no-console
+    console.log(`  ✓ MP4: ${mp4Path}`)
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`  ⚠ ffmpeg conversion skipped (${(err as Error).message}). WebM kept: ${webmPath}`)
+  }
+}

--- a/scripts/video/record.ts
+++ b/scripts/video/record.ts
@@ -1,0 +1,93 @@
+/**
+ * Demo video recorder for Fluux Messenger.
+ *
+ * Drives the demo (`/demo.html`) with Playwright and records a promo video of
+ * the major features. Produces two variants:
+ *   - reel: short highlight (~90s)
+ *   - full: comprehensive tour (~3–4 min)
+ *
+ * Usage:
+ *   npm run demo:video         # both variants
+ *   npm run demo:video:reel    # reel only
+ *   npm run demo:video:full    # full only
+ *
+ * Output (gitignored):
+ *   video/fluux-demo-reel.webm  + .mp4
+ *   video/fluux-demo-full.webm  + .mp4
+ *
+ * Capture strategy A: Playwright recordVideo (WebM) → ffmpeg → MP4. If motion
+ * looks choppy, swap the capture layer for deterministic CDP frames at a
+ * constant fps without touching the storyboard.
+ */
+
+import { test, type Browser } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import {
+  VIDEO_SIZE, BASE_URL, DEMO_URL,
+  openDemo, waitForAppReady, installPolishLayers,
+  coverWithTitle, hideTitleCard, titleCard, convertToMp4,
+} from './helpers'
+import { scenesFor, type Variant } from './storyboard'
+
+const OUTPUT_DIR = 'video'
+const RAW_DIR = `${OUTPUT_DIR}/.raw`
+
+async function record(browser: Browser, variant: Variant): Promise<void> {
+  mkdirSync(RAW_DIR, { recursive: true })
+
+  // Pre-warm the dev server (off-camera): the first cold load of the large
+  // demo bundle takes several seconds to compile in Vite dev, which would show
+  // as a white flash at the very start of the recording. Warming it first lets
+  // the recorded navigation reach the app almost immediately.
+  const warm = await browser.newContext()
+  const warmPage = await warm.newPage()
+  await warmPage.goto(DEMO_URL, { waitUntil: 'networkidle', timeout: 60_000 }).catch(() => {})
+  await warm.close()
+
+  const context = await browser.newContext({
+    viewport: VIDEO_SIZE,
+    deviceScaleFactor: 1,
+    colorScheme: 'dark',
+    baseURL: BASE_URL,
+    recordVideo: { dir: RAW_DIR, size: VIDEO_SIZE },
+  })
+  const page = await context.newPage()
+  const video = page.video()
+
+  try {
+    // Open the page and immediately cover it with the intro card so the
+    // app's load happens off-camera (no white flash, no pre-roll glimpse).
+    await openDemo(page)
+    await installPolishLayers(page)
+    await coverWithTitle(page, 'Fluux Messenger', 'A modern XMPP client')
+    await waitForAppReady(page)
+    await page.waitForTimeout(1600) // hold the intro card
+    await hideTitleCard(page)
+
+    for (const scene of scenesFor(variant)) {
+      // eslint-disable-next-line no-console
+      console.log(`  ▶ ${variant}: ${scene.id}`)
+      await scene.run(page)
+    }
+
+    await titleCard(page, 'Fluux Messenger', 'Open. Secure. Yours.', 2800)
+  } finally {
+    await context.close() // finalises the WebM
+  }
+
+  if (video) {
+    const webm = `${OUTPUT_DIR}/fluux-demo-${variant}.webm`
+    await video.saveAs(webm)
+    // eslint-disable-next-line no-console
+    console.log(`  ✓ WebM: ${webm}`)
+    convertToMp4(webm, `${OUTPUT_DIR}/fluux-demo-${variant}.mp4`)
+  }
+}
+
+test('reel — Fluux demo video', async ({ browser }) => {
+  await record(browser, 'reel')
+})
+
+test('full — Fluux demo video', async ({ browser }) => {
+  await record(browser, 'full')
+})

--- a/scripts/video/storyboard.ts
+++ b/scripts/video/storyboard.ts
@@ -1,0 +1,255 @@
+/**
+ * Ordered storyboard for the Fluux demo video.
+ *
+ * Each scene declares the minimum `variant` it belongs to:
+ *   - 'reel' scenes appear in BOTH the short reel and the full tour
+ *   - 'full' scenes appear ONLY in the full tour
+ *
+ * The array is in full-tour order; filtering to 'reel' keeps a sensible
+ * subset flow. Scenes drive navigation deterministically and fire "live
+ * beats" so the app feels real-time on camera.
+ */
+
+import { type Page } from '@playwright/test'
+import {
+  DOMAIN, ROOM_JID,
+  showCaption, hideCaption, dwell, navigateTo, selectItem, glideClick,
+  setTheme, setColorScheme, setLanguage, scrollToText,
+  beatIncomingChat, beatChatReaction, beatRoomMessage,
+} from './helpers'
+
+export type Variant = 'reel' | 'full'
+
+export interface Scene {
+  id: string
+  variant: Variant
+  run: (page: Page) => Promise<void>
+}
+
+export const storyboard: Scene[] = [
+  // 1 — Direct messaging + reactions/replies (reel)
+  {
+    id: 'messaging',
+    variant: 'reel',
+    run: async (page) => {
+      await navigateTo(page, 'messages')
+      await selectItem(page, 'Emma Wilson')
+      await showCaption(page, 'Fast, modern messaging', 'Reactions, replies & rich text — built in')
+      await dwell(page, 2200)
+      const msgId = await beatIncomingChat(page, {
+        conversationId: `emma@${DOMAIN}`,
+        from: `emma@${DOMAIN}`,
+        body: 'Perfect — see you at 4! 🎉',
+      })
+      await dwell(page, 900)
+      await beatChatReaction(page, {
+        conversationId: `emma@${DOMAIN}`,
+        messageId: msgId,
+        reactorJid: `you@${DOMAIN}`,
+        emojis: ['👍'],
+      })
+      await dwell(page, 1500)
+      await hideCaption(page)
+    },
+  },
+
+  // 2 — Command palette (reel)
+  {
+    id: 'command-palette',
+    variant: 'reel',
+    run: async (page) => {
+      await showCaption(page, 'Jump anywhere', 'Command palette — ⌘K')
+      await page.keyboard.press('Meta+k')
+      await dwell(page, 900)
+      await page.keyboard.type('team', { delay: 130 })
+      await dwell(page, 2000)
+      await page.keyboard.press('Escape')
+      await dwell(page, 600)
+      await hideCaption(page)
+    },
+  },
+
+  // 3 — Group rooms + members + live room message (reel)
+  {
+    id: 'rooms',
+    variant: 'reel',
+    run: async (page) => {
+      await navigateTo(page, 'rooms')
+      await selectItem(page, 'Team Chat')
+      await showCaption(page, 'Group chat & rooms', 'MUC rooms with presence, roles & members')
+      const membersBtn = page.locator('button[aria-label="Show members"]')
+      if (await membersBtn.isVisible().catch(() => false)) {
+        await dwell(page, 600)
+        await membersBtn.click()
+        await dwell(page, 1200)
+      }
+      await beatRoomMessage(page, { roomJid: ROOM_JID, nick: 'James', body: 'Pushed the fix — CI is green ✅' })
+      await dwell(page, 1600)
+      await hideCaption(page)
+    },
+  },
+
+  // 4 — Polls & code blocks (full only)
+  {
+    id: 'poll-code',
+    variant: 'full',
+    run: async (page) => {
+      await navigateTo(page, 'rooms')
+      await selectItem(page, 'Team Chat')
+      await showCaption(page, 'Polls & code sharing', 'Syntax-highlighted code and built-in polls')
+      const poll = page.locator('[class*="poll" i]').first()
+      if (await poll.isVisible().catch(() => false)) {
+        await poll.scrollIntoViewIfNeeded()
+        await dwell(page, 2000)
+      }
+      const code = page.locator('pre code').first()
+      if (await code.isVisible().catch(() => false)) {
+        await code.scrollIntoViewIfNeeded()
+        await dwell(page, 2000)
+      }
+      await hideCaption(page)
+    },
+  },
+
+  // 5 — Whispers (full only)
+  {
+    id: 'whisper',
+    variant: 'full',
+    run: async (page) => {
+      await navigateTo(page, 'rooms')
+      await selectItem(page, 'Team Chat')
+      await showCaption(page, 'Private whispers', 'One-to-one messages inside a room (XEP-0045)')
+      await scrollToText(page, 'Private with Emma')
+      await dwell(page, 2200)
+      await hideCaption(page)
+    },
+  },
+
+  // 6 — End-to-end encryption badges (reel)
+  {
+    id: 'encryption',
+    variant: 'reel',
+    run: async (page) => {
+      await navigateTo(page, 'messages')
+      await selectItem(page, 'Ava Martinez')
+      await showCaption(page, 'End-to-end encryption', 'OpenPGP with verified / TOFU trust states')
+      await dwell(page, 3200)
+      await hideCaption(page)
+    },
+  },
+
+  // 7 — Encryption settings (full only)
+  {
+    id: 'encryption-settings',
+    variant: 'full',
+    run: async (page) => {
+      await navigateTo(page, 'settings')
+      await glideClickText(page, 'Encryption')
+      await page.locator('code').filter({ hasText: 'BAF0' }).first()
+        .waitFor({ timeout: 6_000 }).catch(() => {})
+      await showCaption(page, 'Your keys, your control', 'Fingerprint, backup, export & key rotation')
+      await dwell(page, 3000)
+      await hideCaption(page)
+    },
+  },
+
+  // 8 — Themes & dark/light (reel)
+  {
+    id: 'themes',
+    variant: 'reel',
+    run: async (page) => {
+      await navigateTo(page, 'messages')
+      await selectItem(page, 'Emma Wilson')
+      await showCaption(page, 'Make it yours', 'Light & dark, plus curated themes')
+      await setColorScheme(page, 'light')
+      await dwell(page, 1500)
+      await setTheme(page, 'nord')
+      await dwell(page, 1400)
+      await setTheme(page, 'dracula')
+      await dwell(page, 1400)
+      // Reset to the default ('fluux') dark look for any following scenes.
+      await setTheme(page, 'fluux')
+      await setColorScheme(page, 'dark')
+      await dwell(page, 900)
+      await hideCaption(page)
+    },
+  },
+
+  // 9 — Global search (full only)
+  {
+    id: 'search',
+    variant: 'full',
+    run: async (page) => {
+      await navigateTo(page, 'search')
+      await showCaption(page, 'Search everything', 'Full-text search across conversations & rooms')
+      const input = page.locator('input[type="text"]').first()
+      await input.click()
+      await page.keyboard.type('design', { delay: 120 })
+      await dwell(page, 1600)
+      const firstResult = page.locator('[data-search-result-id]').first()
+      if (await firstResult.isVisible().catch(() => false)) {
+        await firstResult.click()
+        await dwell(page, 1800)
+      }
+      await hideCaption(page)
+    },
+  },
+
+  // 10 — i18n / RTL (full only)
+  {
+    id: 'i18n',
+    variant: 'full',
+    run: async (page) => {
+      await navigateTo(page, 'messages')
+      await selectItem(page, 'Emma Wilson')
+      await showCaption(page, '33 languages · full RTL', 'Right-to-left layouts, fully mirrored')
+      await setLanguage(page, 'ar')
+      await dwell(page, 3000)
+      await setLanguage(page, 'en')
+      await dwell(page, 800)
+      await hideCaption(page)
+    },
+  },
+
+  // 11 — Admin console (full only)
+  {
+    id: 'admin',
+    variant: 'full',
+    run: async (page) => {
+      await navigateTo(page, 'admin')
+      await glideClickText(page, 'Users')
+      // In demo mode fetchUsers() has no server — reseed the list (as in screenshots.ts).
+      await page.evaluate(() => {
+        const adminStore = (window as any).__adminStore
+        if (!adminStore) return
+        adminStore.getState().setUserList({
+          items: [
+            { jid: 'emma@fluux.chat', username: 'emma', isOnline: true },
+            { jid: 'james@fluux.chat', username: 'james', isOnline: true },
+            { jid: 'sophia@fluux.chat', username: 'sophia', isOnline: true },
+            { jid: 'olivia@fluux.chat', username: 'olivia', isOnline: true },
+            { jid: 'mia@fluux.chat', username: 'mia', isOnline: false },
+            { jid: 'liam@fluux.chat', username: 'liam', isOnline: true },
+            { jid: 'ava@fluux.chat', username: 'ava', isOnline: true },
+            { jid: 'alex@fluux.chat', username: 'alex', isOnline: false },
+          ],
+          isLoading: false, error: null, searchQuery: '', hasFetched: true,
+          pagination: { count: 8 },
+        })
+      })
+      await showCaption(page, 'Built-in admin console', 'Manage users, rooms & the server (ejabberd / XEP-0133)')
+      await dwell(page, 3000)
+      await hideCaption(page)
+    },
+  },
+]
+
+/** Glide-click a settings/admin category by its visible label. */
+async function glideClickText(page: Page, label: string): Promise<void> {
+  await glideClick(page, page.getByText(label, { exact: true }).first(), 900)
+}
+
+/** Scenes for a given variant, in storyboard order. */
+export function scenesFor(variant: Variant): Scene[] {
+  return variant === 'full' ? storyboard : storyboard.filter((s) => s.variant === 'reel')
+}


### PR DESCRIPTION
The global search results list rendered each result row as a `<button>` with the "Go to message" action nested as another `<button>` inside it. A button nested inside a button is invalid HTML — it breaks hydration and accessibility and triggers React's `<button> cannot contain a nested <button>` DOM-nesting warning (visible in the dev console when typing a query in the Search view).