### PR TITLE
refactor(demo): fill the video frame with a denser capture

### DIFF
--- a/playwright.video.config.ts
+++ b/playwright.video.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
   workers: 1,
   use: {
     baseURL: 'http://localhost:5173',
-    viewport: { width: 1920, height: 1080 },
+    // The recording context (record.ts) sets its own denser viewport + 2×
+    // device scale; this is just the fixture default.
+    viewport: { width: 1280, height: 720 },
     // Backstop: never let a missing element hang the whole multi-minute run.
     actionTimeout: 20_000,
     navigationTimeout: 30_000,

--- a/scripts/video/helpers.ts
+++ b/scripts/video/helpers.ts
@@ -18,6 +18,14 @@ import { existsSync } from 'node:fs'
 
 export const BASE_URL = 'http://localhost:5173'
 export const DEMO_URL = `${BASE_URL}/demo.html?tutorial=false`
+/**
+ * CSS viewport the app lays out in. Deliberately denser than the 1080p output
+ * (same width as the marketing screenshots) so the UI fills the frame instead
+ * of leaving wide empty gutters — the app is captured at 2× and scaled to the
+ * output size below, keeping the result crisp.
+ */
+export const RENDER_SIZE = { width: 1280, height: 720 }
+/** Output video dimensions. */
 export const VIDEO_SIZE = { width: 1920, height: 1080 }
 
 /** Demo JIDs (stable in demo seed data — see apps/fluux/src/demo/). */
@@ -161,8 +169,8 @@ export async function installPolishLayers(page: Page): Promise<void> {
       r.addEventListener('animationend', () => r.remove())
     }, true)
   })
-  // Park the cursor off to the side initially.
-  await page.mouse.move(VIDEO_SIZE.width * 0.5, VIDEO_SIZE.height * 0.5)
+  // Park the cursor in the middle of the (CSS) viewport initially.
+  await page.mouse.move(RENDER_SIZE.width * 0.5, RENDER_SIZE.height * 0.5)
 }
 
 /** Show the lower-third caption (fades in, stays until hideCaption). */
@@ -413,6 +421,8 @@ export function convertToMp4(webmPath: string, mp4Path: string): void {
   try {
     execFileSync('ffmpeg', [
       '-y', '-i', webmPath,
+      // Upscale the dense native capture to the 1080p output (lanczos = sharp).
+      '-vf', `scale=${VIDEO_SIZE.width}:${VIDEO_SIZE.height}:flags=lanczos`,
       '-r', '30',
       '-c:v', 'libx264',
       '-pix_fmt', 'yuv420p',

--- a/scripts/video/record.ts
+++ b/scripts/video/record.ts
@@ -23,7 +23,7 @@
 import { test, type Browser } from '@playwright/test'
 import { mkdirSync } from 'node:fs'
 import {
-  VIDEO_SIZE, BASE_URL, DEMO_URL,
+  RENDER_SIZE, BASE_URL, DEMO_URL,
   openDemo, waitForAppReady, installPolishLayers,
   coverWithTitle, hideTitleCard, titleCard, convertToMp4,
 } from './helpers'
@@ -45,11 +45,13 @@ async function record(browser: Browser, variant: Variant): Promise<void> {
   await warm.close()
 
   const context = await browser.newContext({
-    viewport: VIDEO_SIZE,
-    deviceScaleFactor: 1,
+    // Lay out + capture natively at the denser RENDER_SIZE so the UI fills the
+    // frame (and cursor coordinates stay native); convertToMp4 upscales the
+    // result to VIDEO_SIZE (1080p) with a high-quality lanczos filter.
+    viewport: RENDER_SIZE,
     colorScheme: 'dark',
     baseURL: BASE_URL,
-    recordVideo: { dir: RAW_DIR, size: VIDEO_SIZE },
+    recordVideo: { dir: RAW_DIR, size: RENDER_SIZE },
   })
   const page = await context.newPage()
   const video = page.video()


### PR DESCRIPTION
## Summary

Follow-up to #446. At 1920×1080 the demo video left wide empty gutters — the chat column has a max-width, and the settings/admin panels are sparse — so a lot of the frame was empty.

This renders and captures the walkthrough at **1280×720** (the same density as the marketing screenshots, which fill nicely), so the UI fills the frame and the result is more harmonious. The capture is then upscaled to a **1920×1080** MP4 with a lanczos filter for a crisp result.

Native cursor coordinates are preserved — no device-scale or CSS-zoom tricks that would misalign the synthetic cursor's clicks.

Regenerate with `npm run demo:video` (or `:reel` / `:full`).