### PR TITLE
perf(sidebar): stop per-message render cascade in room & conversation lists

### DIFF
--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -75,13 +75,23 @@ export function ConversationList() {
   // Create maps for quick lookup
   const contactMap = new Map(contacts.map(c => [c.jid, c]))
 
-  const handleConversationClick = (convId: string) => {
-    // Push if going from list to first item, replace if switching between items
-    const hasActive = !!chatStore.getState().activeConversationId
-    void setActiveRoom(null)
-    void setActiveConversation(convId)
-    navigateToMessages(convId, { replace: hasActive })
+  // Identity-stable click handler. useCallback is unreliable here: the React
+  // Compiler leaves JSX-only callbacks as fresh closures, which breaks
+  // ConversationItem's React.memo and re-renders the whole list on every update.
+  // A lazy-init ref + "latest" ref keeps the handler stable for the list's life.
+  const latestNavRef = useRef({ setActiveRoom, setActiveConversation, navigateToMessages })
+  latestNavRef.current = { setActiveRoom, setActiveConversation, navigateToMessages }
+  const clickRef = useRef<((convId: string) => void) | null>(null)
+  if (!clickRef.current) {
+    clickRef.current = (convId: string) => {
+      const L = latestNavRef.current
+      const hasActive = !!chatStore.getState().activeConversationId
+      void L.setActiveRoom(null)
+      void L.setActiveConversation(convId)
+      L.navigateToMessages(convId, { replace: hasActive })
+    }
   }
+  const handleConversationClick = clickRef.current
 
   // Keyboard navigation
   // Alt+Arrow navigation is owned by the global handler in useKeyboardShortcuts
@@ -118,7 +128,7 @@ export function ConversationList() {
             isActive={conv.id === activeConversationId}
             isSelected={index === selectedIndex}
             isKeyboardNav={isKeyboardNav}
-            onClick={() => handleConversationClick(conv.id)}
+            onClick={handleConversationClick}
             {...getItemAttribute(index)}
             {...getItemProps(index)}
           />
@@ -162,12 +172,20 @@ export function ArchiveList() {
 
   const contactMap = new Map(contacts.map(c => [c.jid, c]))
 
-  const handleConversationClick = (convId: string) => {
-    const hasActive = !!chatStore.getState().activeConversationId
-    void setActiveRoom(null)
-    void setActiveConversation(convId)
-    navigateToArchive(convId, { replace: hasActive })
+  // Identity-stable click handler (see ConversationList for rationale).
+  const latestNavRef = useRef({ setActiveRoom, setActiveConversation, navigateToArchive })
+  latestNavRef.current = { setActiveRoom, setActiveConversation, navigateToArchive }
+  const clickRef = useRef<((convId: string) => void) | null>(null)
+  if (!clickRef.current) {
+    clickRef.current = (convId: string) => {
+      const L = latestNavRef.current
+      const hasActive = !!chatStore.getState().activeConversationId
+      void L.setActiveRoom(null)
+      void L.setActiveConversation(convId)
+      L.navigateToArchive(convId, { replace: hasActive })
+    }
   }
+  const handleConversationClick = clickRef.current
 
   const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav({
     items: archivedConversations,
@@ -201,7 +219,7 @@ export function ArchiveList() {
             isActive={conv.id === activeConversationId}
             isSelected={index === selectedIndex}
             isKeyboardNav={isKeyboardNav}
-            onClick={() => handleConversationClick(conv.id)}
+            onClick={handleConversationClick}
             {...getItemAttribute(index)}
             {...getItemProps(index)}
           />
@@ -228,7 +246,7 @@ interface ConversationItemProps {
   isActive: boolean
   isSelected?: boolean
   isKeyboardNav?: boolean
-  onClick: () => void
+  onClick: (conversationId: string) => void
   onMouseEnter?: (e: React.MouseEvent) => void
   onMouseMove?: (e: React.MouseEvent) => void
   'data-conv-id'?: string
@@ -266,7 +284,7 @@ export const ConversationItem = memo(function ConversationItem({
 
   const handleClick = () => {
     if (isOpen || longPressTriggered.current) return
-    onClick()
+    onClick(conversation.id)
   }
 
   return (

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -2,11 +2,11 @@ import React, { useState, useRef, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 import { useContextMenu, useListKeyboardNav, useRouteSync } from '@/hooks'
+import { detectRenderLoop, trackSelectorChange } from '@/utils/renderLoopDetector'
 import {
   useRoomActions,
   roomStore,
   generateConsistentColorHexSync,
-  type Room,
 } from '@fluux/sdk'
 import { useChatStore, useRoomStore } from '@fluux/sdk/react'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
@@ -29,94 +29,135 @@ import {
   Plus,
 } from 'lucide-react'
 
+type SidebarSection = 'quick' | 'joined' | 'bookmarked'
+
+/** Decode a "<section> <jid>" entry from roomSidebarJids(). */
+function decodeSidebarEntry(entry: string): { section: SidebarSection; jid: string } {
+  const sep = entry.indexOf(' ')
+  return { section: entry.slice(0, sep) as SidebarSection, jid: entry.slice(sep + 1) }
+}
+
 export function RoomsList() {
+  detectRenderLoop('RoomsList')
   const { t } = useTranslation()
-  // Focused subscriptions — avoid useRoom() which subscribes to ~15 values
-  // (activeRoom, activeMessages, totalUnreadCount, etc.) that this list-level
-  // component doesn't need. RoomsList is always mounted in the Sidebar, so each
-  // unrelated subscription would re-render the whole list during sync.
-  // drafts is intentionally NOT subscribed here — each RoomItem subscribes to
-  // its own draft entry to avoid full-list re-renders on per-room keystrokes.
-  const rooms = useRoomStore(useShallow((s) => s.allRooms()))
+
+  // Subscribe ONLY to the sidebar-ordered, section-encoded list of room JIDs.
+  // This re-renders the list only on membership / order / section changes — NOT on
+  // per-room message, unread, or last-message-preview churn (which is the storm a
+  // multi-room join produces). Each RoomItem subscribes to its own room by JID, so
+  // a message to one room re-renders just that row. drafts/typing are likewise per-row.
+  const sidebarEntries = useRoomStore(useShallow((s) => s.roomSidebarJids()))
   const activeRoomJid = useRoomStore((s) => s.activeRoomJid)
   const { joinRoom, leaveRoom, setBookmark, removeBookmark, setActiveRoom } = useRoomActions()
   const setActiveConversation = useChatStore((s) => s.setActiveConversation)
   const { navigateToRooms } = useRouteSync()
-  const [editingRoom, setEditingRoom] = useState<Room | null>(null)
+  const [editingRoomJid, setEditingRoomJid] = useState<string | null>(null)
   const [showCreateRoom, setShowCreateRoom] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
   const zoneRef = useSidebarZone()
 
-  // Separate quick chats, joined/joining rooms, and bookmarked-only rooms
-  const quickChats = rooms.filter(r => r.isQuickChat)
-  // Include rooms that are joined OR currently joining (so they move to Joined section immediately)
-  const joinedRooms = rooms.filter(r => (r.joined || r.isJoining) && !r.isQuickChat)
-  const bookmarkedNotJoined = rooms
-    .filter(r => !r.joined && !r.isJoining && r.isBookmarked && !r.isQuickChat)
-    .sort((a, b) => (a.name || a.jid).toLowerCase().localeCompare((b.name || b.jid).toLowerCase()))
+  // Diagnostic: track the subscription value per render (dev-only).
+  trackSelectorChange('RoomsList', 'sidebarEntries', sidebarEntries)
+  trackSelectorChange('RoomsList', 'activeRoomJid', activeRoomJid)
 
-  // Full list of rooms for plain arrow navigation (all rooms)
-  const flatRooms = [...quickChats, ...joinedRooms, ...bookmarkedNotJoined]
-
-  // Map from jid to flat index for quick lookup
-  const jidToIndex = new Map(flatRooms.map((r, i) => [r.jid, i]))
-
-  const handleRoomClick = (roomJid: string, isJoined: boolean) => {
-    // Allow single-click to select any room (joined or bookmarked)
-    // Non-joined rooms will show cached history with a "join to participate" prompt
-    void isJoined // Unused now, but kept for API consistency
-    // Push if going from list to first item, replace if switching between rooms
-    const hasActive = !!roomStore.getState().activeRoomJid
-    // Clear any active 1:1 conversation
-    void setActiveConversation(null)
-    // Set this room as active
-    void setActiveRoom(roomJid)
-    navigateToRooms(roomJid, { replace: hasActive })
+  // Decode into sections (display order is already correct in sidebarEntries).
+  const quickChatJids: string[] = []
+  const joinedJids: string[] = []
+  const bookmarkedJids: string[] = []
+  const flatJids: string[] = []
+  for (const entry of sidebarEntries) {
+    const { section, jid } = decodeSidebarEntry(entry)
+    flatJids.push(jid)
+    if (section === 'quick') quickChatJids.push(jid)
+    else if (section === 'joined') joinedJids.push(jid)
+    else bookmarkedJids.push(jid)
   }
+  const jidToIndex = new Map(flatJids.map((jid, i) => [jid, i]))
 
-  const handleRoomDoubleClick = async (roomJid: string, isJoined: boolean, nickname: string) => {
-    const hasActive = !!roomStore.getState().activeRoomJid
-    if (isJoined) {
-      // If already joined, just select it
-      void setActiveConversation(null)
-      void setActiveRoom(roomJid)
-    } else {
-      // Join the bookmarked room and switch to it
-      await joinRoom(roomJid, nickname)
-      void setActiveConversation(null)
-      void setActiveRoom(roomJid)
+  // Stable per-row callbacks (taking a JID) so the memoized RoomItem rows keep
+  // identity-stable props and only re-render when their own room changes.
+  //
+  // NOTE: useCallback is intentionally NOT used here. With the React Compiler
+  // enabled, callbacks that are only consumed by JSX (not by a hook dependency)
+  // are left as fresh closures each render; the parent's JSX memoization is
+  // supposed to cover them, but it is invalidated whenever activeRoomJid /
+  // selectedIndex change — which re-creates the closures and breaks RoomItem's
+  // React.memo, re-rendering every row. Building the handlers once in a ref and
+  // routing through a "latest" ref keeps their identity stable for the lifetime
+  // of the list while always invoking the current actions.
+  const latestRef = useRef({ setActiveConversation, setActiveRoom, joinRoom, leaveRoom, removeBookmark, setBookmark, navigateToRooms, setEditingRoomJid })
+  latestRef.current = { setActiveConversation, setActiveRoom, joinRoom, leaveRoom, removeBookmark, setBookmark, navigateToRooms, setEditingRoomJid }
+
+  const handlersRef = useRef<{
+    onSelect: (roomJid: string) => void
+    onActivate: (roomJid: string) => void
+    onJoin: (roomJid: string) => void
+    onLeave: (roomJid: string) => void
+    onEditBookmark: (roomJid: string) => void
+    onRemoveBookmark: (roomJid: string) => void
+    onToggleAutojoin: (roomJid: string) => void
+  } | null>(null)
+  if (!handlersRef.current) {
+    handlersRef.current = {
+      onSelect: (roomJid) => {
+        const L = latestRef.current
+        const hasActive = !!roomStore.getState().activeRoomJid
+        void L.setActiveConversation(null)
+        void L.setActiveRoom(roomJid)
+        L.navigateToRooms(roomJid, { replace: hasActive })
+      },
+      onActivate: async (roomJid) => {
+        const L = latestRef.current
+        const room = roomStore.getState().getRoom(roomJid)
+        const hasActive = !!roomStore.getState().activeRoomJid
+        if (room?.joined) {
+          void L.setActiveConversation(null)
+          void L.setActiveRoom(roomJid)
+        } else {
+          await L.joinRoom(roomJid, room?.nickname ?? '')
+          void L.setActiveConversation(null)
+          void L.setActiveRoom(roomJid)
+        }
+        L.navigateToRooms(roomJid, { replace: hasActive })
+      },
+      onJoin: (roomJid) => {
+        const L = latestRef.current
+        const room = roomStore.getState().getRoom(roomJid)
+        void L.joinRoom(roomJid, room?.nickname ?? '')
+      },
+      onLeave: (roomJid) => {
+        const L = latestRef.current
+        if (roomStore.getState().activeRoomJid === roomJid) void L.setActiveRoom(null)
+        void L.leaveRoom(roomJid)
+      },
+      onEditBookmark: (roomJid) => latestRef.current.setEditingRoomJid(roomJid),
+      onRemoveBookmark: (roomJid) => { void latestRef.current.removeBookmark(roomJid) },
+      onToggleAutojoin: (roomJid) => {
+        const room = roomStore.getState().getRoom(roomJid)
+        if (!room) return
+        void latestRef.current.setBookmark(roomJid, {
+          name: room.name,
+          nick: room.nickname,
+          autojoin: !room.autojoin,
+        })
+      },
     }
-    navigateToRooms(roomJid, { replace: hasActive })
   }
+  const handlers = handlersRef.current
 
-  // Keyboard navigation - select room on Enter (same as single-click)
-  const handleRoomSelect = (room: Room) => {
-    // Select the room (joined or bookmarked) to show its content
-    // Non-joined rooms will show cached history with join prompt
-    const hasActive = !!roomStore.getState().activeRoomJid
-    void setActiveConversation(null)
-    void setActiveRoom(room.jid)
-    navigateToRooms(room.jid, { replace: hasActive })
-  }
-
-  // Keyboard navigation:
-  // - Plain arrows: highlight rooms (all rooms including bookmarked) — does not activate
-  // - Enter: select highlighted room
-  // - Alt+arrows: handled by the global shortcut (useKeyboardShortcuts.goToNextItem)
-  //   which navigates joined rooms only. The list reacts via `activeItemId` so
-  //   the active room is scrolled into view.
+  // Keyboard navigation over the flat JID list. Enter selects the highlighted room.
   const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav({
-    items: flatRooms,
-    onSelect: handleRoomSelect,
+    items: flatJids,
+    onSelect: handlers.onSelect,
     listRef,
-    getItemId: (room) => room.jid,
+    getItemId: (jid) => jid,
     itemAttribute: 'data-room-jid',
     zoneRef,
     enableBounce: true,
     activeItemId: activeRoomJid,
   })
 
-  if (rooms.length === 0) {
+  if (sidebarEntries.length === 0) {
     return (
       <>
         <div className="px-3 py-4 text-fluux-muted text-sm text-center">
@@ -140,116 +181,66 @@ export function RoomsList() {
     )
   }
 
+  const editingRoom = editingRoomJid ? roomStore.getState().getRoom(editingRoomJid) : null
+
+  const renderRoom = (jid: string, isQuickChat: boolean) => {
+    const flatIndex = jidToIndex.get(jid) ?? -1
+    return (
+      <RoomItem
+        key={jid}
+        roomJid={jid}
+        isActive={jid === activeRoomJid}
+        isSelected={flatIndex === selectedIndex}
+        isKeyboardNav={isKeyboardNav}
+        isQuickChat={isQuickChat}
+        onSelect={handlers.onSelect}
+        onActivate={handlers.onActivate}
+        onJoin={handlers.onJoin}
+        onLeave={handlers.onLeave}
+        onEditBookmark={handlers.onEditBookmark}
+        onRemoveBookmark={handlers.onRemoveBookmark}
+        onToggleAutojoin={handlers.onToggleAutojoin}
+        {...getItemAttribute(flatIndex)}
+        {...getItemProps(flatIndex)}
+      />
+    )
+  }
+
   return (
     <div ref={listRef} className="px-2 py-2" {...getContainerProps()}>
       {/* Quick Chats - only show if any exist */}
-      {quickChats.length > 0 && (
+      {quickChatJids.length > 0 && (
         <div className="mb-4">
           <h3 className="text-xs font-semibold text-fluux-muted uppercase px-2 mb-2 flex items-center gap-1">
             <Zap className="size-3 text-amber-500" />
-            {t('rooms.quickChatSection')} — {quickChats.length}
+            {t('rooms.quickChatSection')} — {quickChatJids.length}
           </h3>
           <div className="space-y-0.5">
-            {quickChats.map((room) => {
-              const flatIndex = jidToIndex.get(room.jid) ?? -1
-              return (
-                <RoomItem
-                  key={room.jid}
-                  room={room}
-                  isActive={room.jid === activeRoomJid}
-                  isSelected={flatIndex === selectedIndex}
-                  isKeyboardNav={isKeyboardNav}
-                  onClick={() => handleRoomClick(room.jid, true)}
-                  onDoubleClick={() => handleRoomDoubleClick(room.jid, true, room.nickname)}
-                  onJoin={() => joinRoom(room.jid, room.nickname)}
-                  onLeave={() => {
-                    if (activeRoomJid === room.jid) void setActiveRoom(null)
-                    void leaveRoom(room.jid)
-                  }}
-                  onEditBookmark={() => {}} // Quick chats don't have bookmark editing
-                  onRemoveBookmark={() => {}} // Quick chats aren't bookmarked
-                  onToggleAutojoin={() => {}} // Quick chats don't have autojoin
-                  isQuickChat
-                  {...getItemAttribute(flatIndex)}
-                  {...getItemProps(flatIndex)}
-                />
-              )
-            })}
+            {quickChatJids.map((jid) => renderRoom(jid, true))}
           </div>
         </div>
       )}
 
       {/* Joined rooms */}
-      {joinedRooms.length > 0 && (
+      {joinedJids.length > 0 && (
         <>
           <h3 className="text-xs font-semibold text-fluux-muted uppercase px-2 mb-2">
-              {t('rooms.joined')} — {joinedRooms.length}
+              {t('rooms.joined')} — {joinedJids.length}
           </h3>
           <div className="space-y-0.5">
-            {joinedRooms.map((room) => {
-              const flatIndex = jidToIndex.get(room.jid) ?? -1
-              return (
-                <RoomItem
-                  key={room.jid}
-                  room={room}
-                  isActive={room.jid === activeRoomJid}
-                  isSelected={flatIndex === selectedIndex}
-                  isKeyboardNav={isKeyboardNav}
-                  onClick={() => handleRoomClick(room.jid, true)}
-                  onDoubleClick={() => handleRoomDoubleClick(room.jid, true, room.nickname)}
-                  onJoin={() => joinRoom(room.jid, room.nickname)}
-                  onLeave={() => {
-                    if (activeRoomJid === room.jid) void setActiveRoom(null)
-                    void leaveRoom(room.jid)
-                  }}
-                  onEditBookmark={() => setEditingRoom(room)}
-                  onRemoveBookmark={() => removeBookmark(room.jid)}
-                  onToggleAutojoin={() => setBookmark(room.jid, {
-                    name: room.name,
-                    nick: room.nickname,
-                    autojoin: !room.autojoin,
-                  })}
-                  {...getItemAttribute(flatIndex)}
-                  {...getItemProps(flatIndex)}
-                />
-              )
-            })}
+            {joinedJids.map((jid) => renderRoom(jid, false))}
           </div>
         </>
       )}
 
       {/* Bookmarked but not joined */}
-      {bookmarkedNotJoined.length > 0 && (
+      {bookmarkedJids.length > 0 && (
         <>
           <h3 className="text-xs font-semibold text-fluux-muted uppercase px-2 mb-2 mt-4">
-            {t('rooms.bookmarked')} — {bookmarkedNotJoined.length}
+            {t('rooms.bookmarked')} — {bookmarkedJids.length}
           </h3>
           <div className="space-y-0.5">
-          {bookmarkedNotJoined.map((room) => {
-            const flatIndex = jidToIndex.get(room.jid) ?? -1
-            return (
-              <RoomItem
-                key={room.jid}
-                room={room}
-                isActive={room.jid === activeRoomJid}
-                isSelected={flatIndex === selectedIndex}
-                isKeyboardNav={isKeyboardNav}
-                onClick={() => handleRoomClick(room.jid, false)}
-                onDoubleClick={() => handleRoomDoubleClick(room.jid, false, room.nickname)}
-                onJoin={() => joinRoom(room.jid, room.nickname)}
-                onLeave={() => leaveRoom(room.jid)}
-                onEditBookmark={() => setEditingRoom(room)}
-                onRemoveBookmark={() => removeBookmark(room.jid)}
-                onToggleAutojoin={() => setBookmark(room.jid, {
-                  name: room.name,
-                  nick: room.nickname,
-                  autojoin: !room.autojoin,
-                })}
-                {...getItemAttribute(flatIndex)}
-                {...getItemProps(flatIndex)}
-              />
-            )
-          })}
+            {bookmarkedJids.map((jid) => renderRoom(jid, false))}
           </div>
         </>
       )}
@@ -260,9 +251,9 @@ export function RoomsList() {
           room={editingRoom}
           onSave={async (options) => {
             await setBookmark(editingRoom.jid, options)
-            setEditingRoom(null)
+            setEditingRoomJid(null)
           }}
-          onClose={() => setEditingRoom(null)}
+          onClose={() => setEditingRoomJid(null)}
         />
       )}
 
@@ -275,17 +266,17 @@ export function RoomsList() {
 }
 
 interface RoomItemProps {
-  room: Room
+  roomJid: string
   isActive: boolean
   isSelected?: boolean
   isKeyboardNav?: boolean
-  onClick: () => void
-  onDoubleClick: () => void
-  onJoin: () => void
-  onLeave: () => void
-  onEditBookmark: () => void
-  onRemoveBookmark: () => void
-  onToggleAutojoin: () => void
+  onSelect: (roomJid: string) => void
+  onActivate: (roomJid: string) => void
+  onJoin: (roomJid: string) => void
+  onLeave: (roomJid: string) => void
+  onEditBookmark: (roomJid: string) => void
+  onRemoveBookmark: (roomJid: string) => void
+  onToggleAutojoin: (roomJid: string) => void
   onMouseEnter?: (e: React.MouseEvent) => void
   onMouseMove?: (e: React.MouseEvent) => void
   isQuickChat?: boolean
@@ -294,12 +285,12 @@ interface RoomItemProps {
 }
 
 const RoomItem = memo(function RoomItem({
-  room,
+  roomJid,
   isActive,
   isSelected,
   isKeyboardNav,
-  onClick,
-  onDoubleClick,
+  onSelect,
+  onActivate,
   onJoin,
   onLeave,
   onEditBookmark,
@@ -315,9 +306,13 @@ const RoomItem = memo(function RoomItem({
   const menu = useContextMenu()
   const currentLang = i18n.language.split('-')[0]
   const timeFormat = useSettingsStore((s) => s.timeFormat)
-  // Per-item subscription: only this row re-renders when ITS draft changes,
-  // not the whole list when any room's draft changes.
-  const draft = useRoomStore((s) => s.drafts.get(room.jid))
+  // Per-row subscriptions: this row re-renders only when ITS room (messages,
+  // unread, last message, presence) or draft changes — not when any other room
+  // updates during a multi-room join / MAM sync.
+  const room = useRoomStore((s) => s.getRoom(roomJid))
+  const draft = useRoomStore((s) => s.drafts.get(roomJid))
+
+  if (!room) return null
 
   // Get last message for preview (uses pre-computed lastMessage from metadata for better performance)
   const lastMessage = room.lastMessage ?? null
@@ -326,14 +321,14 @@ const RoomItem = memo(function RoomItem({
     if (menu.isOpen || menu.longPressTriggered.current) return
     // Don't allow click during joining - room is not ready yet
     if (room.isJoining) return
-    onClick()
+    onSelect(roomJid)
   }
 
   const handleDoubleClick = () => {
     if (menu.isOpen) return
     // Don't allow double-click during joining
     if (room.isJoining) return
-    onDoubleClick()
+    onActivate(roomJid)
   }
 
   // Determine tooltip based on state
@@ -475,7 +470,7 @@ const RoomItem = memo(function RoomItem({
           {/* Join (only for non-joined rooms) */}
           {!room.joined && (
             <button
-              onClick={() => { menu.close(); onJoin() }}
+              onClick={() => { menu.close(); onJoin(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
             >
               <LogIn className="size-4" />
@@ -486,7 +481,7 @@ const RoomItem = memo(function RoomItem({
           {/* Edit bookmark (only for bookmarked rooms) */}
           {room.isBookmarked && (
             <button
-              onClick={() => { menu.close(); onEditBookmark() }}
+              onClick={() => { menu.close(); onEditBookmark(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
             >
               <Pencil className="size-4" />
@@ -497,7 +492,7 @@ const RoomItem = memo(function RoomItem({
           {/* Toggle autojoin (only for bookmarked rooms) */}
           {room.isBookmarked && (
             <button
-              onClick={() => { menu.close(); onToggleAutojoin() }}
+              onClick={() => { menu.close(); onToggleAutojoin(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
             >
               {room.autojoin ? (
@@ -522,7 +517,7 @@ const RoomItem = memo(function RoomItem({
           {/* Leave room (only for joined rooms) */}
           {room.joined && (
             <button
-              onClick={() => { menu.close(); onLeave() }}
+              onClick={() => { menu.close(); onLeave(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-red hover:bg-fluux-red hover:text-white transition-colors"
             >
               <LogOut className="size-4" />
@@ -533,7 +528,7 @@ const RoomItem = memo(function RoomItem({
           {/* Remove bookmark (only for bookmarked rooms) */}
           {room.isBookmarked && (
             <button
-              onClick={() => { menu.close(); onRemoveBookmark() }}
+              onClick={() => { menu.close(); onRemoveBookmark(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-red hover:bg-fluux-red hover:text-white transition-colors"
             >
               <BookmarkX className="size-4" />

--- a/apps/fluux/src/hooks/useListKeyboardNav.test.tsx
+++ b/apps/fluux/src/hooks/useListKeyboardNav.test.tsx
@@ -68,6 +68,64 @@ describe('useListKeyboardNav', () => {
     })
   })
 
+  describe('getItemProps reference stability', () => {
+    it('returns stable onMouseEnter/onMouseMove refs for the same index across renders', () => {
+      const { result, rerender } = renderHook(createWrapper(mockItems, mockOnSelect))
+
+      const firstEnter = result.current.getItemProps(1).onMouseEnter
+      const firstMove = result.current.getItemProps(1).onMouseMove
+
+      // Simulate a parent/list re-render (e.g. an incoming message updating the store).
+      rerender()
+
+      const secondEnter = result.current.getItemProps(1).onMouseEnter
+      const secondMove = result.current.getItemProps(1).onMouseMove
+
+      // Unstable handler identities defeat React.memo on every list item, so the
+      // entire list re-renders whenever any single item changes.
+      expect(secondEnter).toBe(firstEnter)
+      expect(secondMove).toBe(firstMove)
+    })
+
+    it('returns a stable handler ref for the same item after the list reorders', () => {
+      const itemsA: TestItem[] = [
+        { id: '1', name: 'Alice' },
+        { id: '2', name: 'Bob' },
+        { id: '3', name: 'Charlie' },
+      ]
+      const itemsReordered: TestItem[] = [
+        { id: '3', name: 'Charlie' },
+        { id: '1', name: 'Alice' },
+        { id: '2', name: 'Bob' },
+      ]
+      const { result, rerender } = renderHook(
+        ({ items }: { items: TestItem[] }) => {
+          const listRef = useRef<HTMLDivElement>(null)
+          return useListKeyboardNav({
+            items,
+            onSelect: mockOnSelect,
+            listRef,
+            getItemId: (item) => item.id,
+            itemAttribute: 'data-item-id',
+          })
+        },
+        { initialProps: { items: itemsA } }
+      )
+
+      // Handler for item '1', which starts at index 0.
+      const handlerBefore = result.current.getItemProps(0).onMouseEnter
+
+      // Reorder so item '1' moves to index 1 (as the activity-sorted sidebar does
+      // on every incoming message).
+      rerender({ items: itemsReordered })
+      const handlerAfter = result.current.getItemProps(1).onMouseEnter
+
+      // The hover handler must stay identity-stable PER ITEM across a reorder,
+      // otherwise every row whose index shifts re-renders, defeating React.memo.
+      expect(handlerAfter).toBe(handlerBefore)
+    })
+  })
+
   describe('Arrow key navigation', () => {
     it('selects first item on ArrowDown when no selection', () => {
       const { result } = renderHook(createWrapper(mockItems, mockOnSelect))

--- a/apps/fluux/src/hooks/useListKeyboardNav.ts
+++ b/apps/fluux/src/hooks/useListKeyboardNav.ts
@@ -333,11 +333,25 @@ export function useListKeyboardNav<T>({
     element?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
   }, [selectedIndex, items, listRef, getItemId, itemAttribute])
 
-  // Helper to get props for each item
-  const getItemProps = (index: number) => ({
-      'data-selected': index === selectedIndex,
+  // Per-item hover handlers are cached (keyed by item id) so their identities stay
+  // stable across renders AND reorders. Passing fresh onMouseEnter/onMouseMove would defeat
+  // React.memo on every list item, re-rendering the whole list whenever any single
+  // item changes (e.g. the rapid store updates during a multi-room join / MAM sync).
+  // Mutable state read inside the handlers (isKeyboardNav) is accessed via a ref so
+  // the cached closures never go stale.
+  const isKeyboardNavRef = useRef(isKeyboardNav)
+  isKeyboardNavRef.current = isKeyboardNav
+  const itemHandlersRef = useRef<Map<string, {
+    onMouseEnter: (e: React.MouseEvent) => void
+    onMouseMove: (e: React.MouseEvent) => void
+  }>>(new Map())
+
+  const getItemHandlers = (itemId: string) => {
+    const cached = itemHandlersRef.current.get(itemId)
+    if (cached) return cached
+    const handlers = {
       onMouseEnter: (e: React.MouseEvent) => {
-        if (isKeyboardNav) return
+        if (isKeyboardNavRef.current) return
         // Ignore scroll-induced enters: when the list scrolls (keyboard auto-scroll or mouse wheel),
         // items pass under a stationary cursor, triggering onMouseEnter. We detect this by checking
         // whether the mouse actually moved to new coordinates.
@@ -346,6 +360,11 @@ export function useListKeyboardNav<T>({
         const y = e.clientY
         if (prev && prev.x === x && prev.y === y) return
         lastMousePosRef.current = { x, y }
+        // Resolve the item's CURRENT index at call time. Handlers are keyed by id,
+        // so a row keeps one stable handler even when the activity-sorted list
+        // reorders (its index changes, but its handler identity does not).
+        const index = itemIdToIndexRef.current.get(itemId)
+        if (index === undefined) return
         selectionSourceRef.current = 'mouse'
         setSelectedIndex(index)
       },
@@ -358,11 +377,29 @@ export function useListKeyboardNav<T>({
         const y = e.clientY
         if (prev && prev.x === x && prev.y === y) return
         lastMousePosRef.current = { x, y }
-        if (isKeyboardNav) {
+        if (isKeyboardNavRef.current) {
           setIsKeyboardNav(false)
         }
       },
-    })
+    }
+    itemHandlersRef.current.set(itemId, handlers)
+    return handlers
+  }
+
+  // Helper to get props for each item. data-selected is per-render (a primitive,
+  // so it only differs for the items whose selection actually changed), while the
+  // hover handlers are stable references keyed by item id — so a row keeps the same
+  // handler identity across re-renders AND reorders, letting React.memo bail.
+  const getItemProps = (index: number) => {
+    const item = items[index]
+    const itemId = item ? getItemId(item) : `__index__${index}`
+    const handlers = getItemHandlers(itemId)
+    return {
+      'data-selected': index === selectedIndex,
+      onMouseEnter: handlers.onMouseEnter,
+      onMouseMove: handlers.onMouseMove,
+    }
+  }
 
   // Helper to get the data attribute for scroll targeting
   const getItemAttribute = (index: number): Record<string, string> => {

--- a/packages/fluux-sdk/src/stores/roomStore.perRoomStability.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.perRoomStability.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { roomStore } from './roomStore'
+import { createRoom, createRoomMessage } from '../hooks/renderStability.helpers'
+
+// Diagnostic: which per-room reads stay referentially stable for an UNRELATED room
+// (B) after a message arrives in another room (A)? Whatever is stable is what a
+// per-row sidebar component must subscribe to so only the changed row re-renders.
+describe('per-room ref stability after unrelated message', () => {
+  beforeEach(() => {
+    roomStore.setState({
+      rooms: new Map(), roomEntities: new Map(), roomMeta: new Map(), roomRuntime: new Map(),
+      activeRoomJid: null, mamQueryStates: new Map(), activeAnimation: null, drafts: new Map(),
+    })
+  })
+
+  it('entity / meta / combined refs for room B after a message to room A', () => {
+    roomStore.getState().addRoom(createRoom('a@x', { joined: true }))
+    roomStore.getState().addRoom(createRoom('b@x', { joined: true }))
+
+    const beforeRoom = roomStore.getState().getRoom('b@x')
+    const beforeEntity = roomStore.getState().roomEntities.get('b@x')
+    const beforeMeta = roomStore.getState().roomMeta.get('b@x')
+
+    roomStore.getState().addMessage('a@x', createRoomMessage('a@x', 'bob', 'hi'))
+
+    expect(roomStore.getState().roomEntities.get('b@x')).toBe(beforeEntity)
+    expect(roomStore.getState().roomMeta.get('b@x')).toBe(beforeMeta)
+    expect(roomStore.getState().getRoom('b@x')).toBe(beforeRoom)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.sidebarJids.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.sidebarJids.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { roomStore } from './roomStore'
+import { createRoom, createRoomMessage } from '../hooks/renderStability.helpers'
+
+/**
+ * roomSidebarJids() is the subscription target for the sidebar room list.
+ *
+ * It returns the sidebar-ordered room JIDs (section-encoded as "<section> <jid>"),
+ * NOT the room objects. Subscribing to JIDs (via useShallow) means the list
+ * component only re-renders when membership / order / section changes — not on
+ * every message, unread, or last-message-preview update. Each row subscribes to
+ * its own room.
+ */
+const SEP = ' '
+
+function resetRoomStore() {
+  roomStore.setState({
+    rooms: new Map(),
+    roomEntities: new Map(),
+    roomMeta: new Map(),
+    roomRuntime: new Map(),
+    activeRoomJid: null,
+    mamQueryStates: new Map(),
+    activeAnimation: null,
+    drafts: new Map(),
+  })
+}
+
+describe('roomStore.roomSidebarJids', () => {
+  beforeEach(resetRoomStore)
+
+  it('returns joined room JIDs encoded with their section', () => {
+    roomStore.getState().addRoom(createRoom('team@conf.example.com', { joined: true }))
+
+    expect(roomStore.getState().roomSidebarJids()).toEqual([`joined${SEP}team@conf.example.com`])
+  })
+
+  it('does NOT change when a joined room receives a message (no reorder)', () => {
+    roomStore.getState().addRoom(createRoom('team@conf.example.com', { joined: true }))
+    const before = roomStore.getState().roomSidebarJids()
+
+    roomStore.getState().addMessage(
+      'team@conf.example.com',
+      createRoomMessage('team@conf.example.com', 'bob', 'hello there'),
+    )
+    const after = roomStore.getState().roomSidebarJids()
+
+    // Same JIDs in the same order → useShallow bails → RoomsList does not re-render.
+    expect(after).toEqual([`joined${SEP}team@conf.example.com`])
+    expect(after).toEqual(before)
+  })
+
+  it('changes when a new room is added (membership change)', () => {
+    roomStore.getState().addRoom(createRoom('team@conf.example.com', { joined: true }))
+    const before = roomStore.getState().roomSidebarJids()
+
+    roomStore.getState().addRoom(createRoom('design@conf.example.com', { joined: true }))
+
+    expect(roomStore.getState().roomSidebarJids()).not.toEqual(before)
+    expect(roomStore.getState().roomSidebarJids()).toHaveLength(2)
+  })
+
+  it('separates sections: bookmarked-not-joined sorted by name, after joined', () => {
+    roomStore.getState().addRoom(createRoom('zeta@conf.example.com', { joined: true }))
+    roomStore.getState().addRoom(createRoom('beta@conf.example.com', { joined: false, isBookmarked: true, name: 'Beta' }))
+    roomStore.getState().addRoom(createRoom('alpha@conf.example.com', { joined: false, isBookmarked: true, name: 'Alpha' }))
+
+    const jids = roomStore.getState().roomSidebarJids()
+    // joined first, then bookmarked-not-joined alphabetically by name (Alpha, Beta)
+    expect(jids).toEqual([
+      `joined${SEP}zeta@conf.example.com`,
+      `bookmarked${SEP}alpha@conf.example.com`,
+      `bookmarked${SEP}beta@conf.example.com`,
+    ])
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -142,6 +142,7 @@ function saveDismissedPollsToStorage(dismissedPolls: Map<string, Set<string>>, j
  * constants instead of creating new [] instances each time.
  */
 const EMPTY_ROOM_ARRAY: Room[] = []
+const EMPTY_SIDEBAR_JIDS: string[] = []
 
 // Selector memoization caches.
 // Store selectors (joinedRooms, allRooms, etc.) are called on every Zustand subscription check.
@@ -314,6 +315,13 @@ export interface RoomState {
   joinedRooms: () => Room[]
   bookmarkedRooms: () => Room[]
   allRooms: () => Room[] // All rooms (bookmarked or joined)
+  /**
+   * Sidebar-ordered, section-encoded room JIDs ("<section> <jid>", where section
+   * is quick | joined | bookmarked). Subscribe via useShallow so the sidebar list
+   * re-renders only when membership / order / section changes — NOT on every
+   * message or unread update. Each row subscribes to its own room by JID.
+   */
+  roomSidebarJids: () => string[]
   quickChatRooms: () => Room[] // All quick chat rooms
   activeRoom: () => Room | undefined
   activeMessages: () => RoomMessage[]
@@ -1898,6 +1906,33 @@ export const roomStore = createStore<RoomState>()(
     })
     _cachedAllRooms = result
     return result
+  },
+
+  roomSidebarJids: () => {
+    const all = get().allRooms() // activity-sorted; bookmarked || joined
+    if (all.length === 0) return EMPTY_SIDEBAR_JIDS
+    // Partition into the sidebar's three sections. Section + JID are encoded into a
+    // single string (space-separated; JIDs and section codes never contain spaces)
+    // so the result is a flat string[] that compares cleanly under useShallow — the
+    // list re-renders only when membership, order, or section actually changes, not
+    // when a room's messages / unread / last-message-preview change.
+    const quick: string[] = []
+    const joined: string[] = []
+    const bookmarkedNotJoined: Room[] = []
+    for (const r of all) {
+      if (r.isQuickChat) quick.push(`quick ${r.jid}`)
+      else if (r.joined || r.isJoining) joined.push(`joined ${r.jid}`)
+      else if (r.isBookmarked) bookmarkedNotJoined.push(r)
+    }
+    // Bookmarked-but-not-joined rooms are listed alphabetically by name.
+    bookmarkedNotJoined.sort((a, b) =>
+      (a.name || a.jid).toLowerCase().localeCompare((b.name || b.jid).toLowerCase())
+    )
+    return [
+      ...quick,
+      ...joined,
+      ...bookmarkedNotJoined.map(r => `bookmarked ${r.jid}`),
+    ]
   },
 
   quickChatRooms: () => {


### PR DESCRIPTION
## Summary

Joining 10-15 large rooms caused a sidebar render storm — roughly 70 wasted component renders per incoming message, enough to trip the render-loop detector.

Three compounding causes:
- `RoomsList` subscribed to `allRooms()` (full `Room` objects), so it re-rendered on every message in any room.
- The React Compiler (`babel-plugin-react-compiler`) strips hand-written `useCallback` and only memoizes callbacks used as hook dependencies. The per-row handlers (`onJoin`, `onLeave`, …) are JSX-only, so they were recreated every render, breaking `RoomItem`'s `React.memo` and re-rendering every row whenever the list re-rendered.
- `useListKeyboardNav` cached hover handlers by index, so a row's handler changed identity whenever the activity-sorted list reordered.

## Changes
- **`roomStore.roomSidebarJids()`** — new selector returning section-ordered room JIDs; `RoomsList` subscribes via `useShallow` and re-renders only on membership/order changes. Each `RoomItem` self-subscribes by jid (`getRoom` keeps a stable ref for unrelated rooms), so only the changed row re-renders.
- **`useListKeyboardNav`** — hover handlers cached by item id (stable across renders and reorders).
- **Compiler-proof stable callbacks** — per-row handlers built once via a lazy-init `useRef` + a "latest" ref (not `useCallback`, which the compiler strips); the same cascade-killer is applied to `ConversationList`/`ArchiveList`.
- **`detectRenderLoop('RoomsList')`** — the only sidebar list that was missing the guardrail.

## Impact
- No-op list re-render → 0 row re-renders (memo now bails).
- Worst case (240 messages, 45 rooms, reorder on every message): `RoomItem` renders ~2400 → ~250 (one per message).
- MAM-backfill case (no reorder): `RoomsList` 256 → 24, `RoomItem` 3584 → 528, `Tooltip` 6832 → 1044.

## Note on scope
`RoomsList` gets the full per-jid subscription. `ConversationList`/`ArchiveList` get the stable-callback cascade-killer (rows are isolated, but the list still re-renders per DM message); a per-jid subscription for conversations is a possible follow-up.