### PR TITLE
feat(perf): reusable UI stress/perf harness + perf-stress-ui skill

### DIFF
--- a/.claude/skills/perf-stress-ui/SKILL.md
+++ b/.claude/skills/perf-stress-ui/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: perf-stress-ui
+description: Use when investigating a UI render-performance problem or render loop in the Fluux app (sidebar/list re-render storms, "why is X re-rendering", verifying a render-perf fix). Reproduces load deterministically in demo mode, measures with react-scan + renderLoopDetector, and diagnoses the memo-breaking prop.
+---
+
+# Perf / Stress UI debugging (Fluux)
+
+## When to use
+A sidebar/list re-renders too much, a render loop is suspected, or you're
+verifying a render-perf change. See `memory/project_render_perf_react_compiler.md`
+and `docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md`.
+
+## 1. Reproduce (demo mode — no server)
+`npm run dev`, then open:
+`http://localhost:5173/demo.html?tutorial=false&stress=rooms:15,messages:150,mode:backfill&perf=1`
+- `mode:backfill` = historical timestamps, no reorder (real "join N rooms" case).
+- `mode:live` = reorders on every message (worst case).
+For custom sequences, drive `window.__demoClient.emitSDK('room:message', { roomJid, message })`.
+
+## 2. Measure
+- `await window.__perf.measure('label', () => window.__demoClient.runStressScenario({ kind:'room-join', rooms:15, messagesPerRoom:150, mode:'live' }))`
+  → per-component render table.
+- `window.__det = await import('/src/utils/renderLoopDetector.ts')` →
+  `__det.getRenderStats()`, `__det.getSelectorHistory()`.
+- CAVEAT: React StrictMode doubles dev renders — divide by 2 for logical counts.
+- Sanity baseline: a no-op parent re-render should produce 0 child renders.
+
+## 3. Diagnose — find the memo-breaking prop, then its source
+react-scan reports React-Compiler-memoized components as `forget:true`,
+`changes:[]`, `unnecessary:null` (it cannot attribute the cause). To find which
+prop breaks `memo`, temporarily wrap the child:
+```tsx
+memo(Component, (prev, next) => {
+  for (const k of new Set([...Object.keys(prev), ...Object.keys(next)]))
+    if (!Object.is((prev as any)[k], (next as any)[k]))
+      ((window as any).__memoDiff ??= {})[k] = (((window as any).__memoDiff||{})[k]||0)+1
+  return /* shallow-equal? */ ...
+})
+```
+Then trace the offending prop to its SOURCE hook. Two traps that recur here:
+- **React Compiler strips `useCallback`** and only memoizes callbacks used as a
+  hook dependency; JSX-only callbacks are fresh closures each render (PR #450).
+- **A prop's source hook returns an unstable ref** (e.g. `useFileUpload`), so
+  `React.memo` no-ops even though the JSX looks fine (PR #451).
+Also distinguish reorder (activity-sorted list order changed — legitimate list
+re-render) vs content churn (only one row's data changed).
+
+## 4. Fix patterns
+- Stable callbacks: lazy-init `useRef` + a "latest" ref (NOT `useCallback`).
+- Subscribe to an ordered id/JID list via `useShallow` (e.g. `roomSidebarJids()`),
+  and have each row self-subscribe by id (`getRoom(jid)` — stable per row).
+- Use focused hooks over ones that recombine entity/meta/runtime each render.
+
+## 5. Verify
+- No-op parent re-render → 0 child renders (memo bails).
+- Worst-case burst → ~1 render per message (not × rows).
+- Add a render-count regression guard (see
+  `packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md`).

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,9 @@ server/
 .output.txt
 
 # AI Tools
-.claude/
+.claude/*
+# ...but track shared, project-level skills (the rest of .claude/ stays local)
+!.claude/skills/
 .copilot/
 .gemini/
 .aider/

--- a/apps/fluux/package.json
+++ b/apps/fluux/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "fake-indexeddb": "^6.2.5",
     "postcss": "^8.4.32",
+    "react-scan": "^0.5.7",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.53.0",

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -23,6 +23,7 @@ import { RenderLoopBoundary, RenderLoopWarningBanner } from './components/Render
 import { DemoTutorialProvider } from './demo/tutorial/DemoTutorialProvider'
 import { buildDemoData, buildDemoAnimation } from './demo/demoData'
 import { getDiscoverableRooms } from './demo/rooms'
+import { parseStressParam } from './demo/perfHarness'
 import App from './App'
 import i18n from './i18n'
 import './index.css'
@@ -51,6 +52,12 @@ const demoAnimation = buildDemoAnimation()
 const demoClient = new DemoClient()
 demoClient.populateDemo(demoData)
 demoClient.setDiscoverableRooms(getDiscoverableRooms())
+
+const stressScenario = parseStressParam(params)
+if (stressScenario) {
+  // Defer so the first paint happens before the load starts.
+  setTimeout(() => demoClient.runStressScenario(stressScenario), 500)
+}
 
 // Seed E2EE state so the encryption badge is visible on Ava's conversation.
 // URL param ?e2ee=conflict starts with no local key to trigger IdentityChoiceDialog.

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -23,7 +23,7 @@ import { RenderLoopBoundary, RenderLoopWarningBanner } from './components/Render
 import { DemoTutorialProvider } from './demo/tutorial/DemoTutorialProvider'
 import { buildDemoData, buildDemoAnimation } from './demo/demoData'
 import { getDiscoverableRooms } from './demo/rooms'
-import { parseStressParam } from './demo/perfHarness'
+import { parseStressParam, installPerfHarness } from './demo/perfHarness'
 import App from './App'
 import i18n from './i18n'
 import './index.css'
@@ -57,6 +57,10 @@ const stressScenario = parseStressParam(params)
 if (stressScenario) {
   // Defer so the first paint happens before the load starts.
   setTimeout(() => demoClient.runStressScenario(stressScenario), 500)
+}
+
+if (params.get('perf') === '1') {
+  void installPerfHarness()
 }
 
 // Seed E2EE state so the encryption badge is visible on Ava's conversation.

--- a/apps/fluux/src/demo/perfHarness.test.ts
+++ b/apps/fluux/src/demo/perfHarness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseStressParam } from './perfHarness'
+import { parseStressParam, aggregateRenders } from './perfHarness'
 
 describe('parseStressParam', () => {
   it('returns null when absent', () => {
@@ -12,5 +12,14 @@ describe('parseStressParam', () => {
   it('ignores unknown keys and clamps invalid numbers', () => {
     const s = parseStressParam(new URLSearchParams('stress=rooms:abc,foo:bar,messages:10'))
     expect(s).toEqual({ kind: 'room-join', messagesPerRoom: 10 })
+  })
+})
+
+describe('aggregateRenders', () => {
+  it('sums render counts per component name', () => {
+    const counts = {}
+    aggregateRenders(counts, [{ componentName: 'RoomItem', count: 1 }, { componentName: 'Tooltip', count: 2 }])
+    aggregateRenders(counts, [{ componentName: 'RoomItem', count: 1 }])
+    expect(counts).toEqual({ RoomItem: 2, Tooltip: 2 })
   })
 })

--- a/apps/fluux/src/demo/perfHarness.test.ts
+++ b/apps/fluux/src/demo/perfHarness.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { parseStressParam } from './perfHarness'
+
+describe('parseStressParam', () => {
+  it('returns null when absent', () => {
+    expect(parseStressParam(new URLSearchParams(''))).toBeNull()
+  })
+  it('parses key:value,key:value into a room-join scenario', () => {
+    const s = parseStressParam(new URLSearchParams('stress=rooms:15,messages:150,occupants:80,mode:backfill'))
+    expect(s).toEqual({ kind: 'room-join', rooms: 15, messagesPerRoom: 150, occupants: 80, mode: 'backfill' })
+  })
+  it('ignores unknown keys and clamps invalid numbers', () => {
+    const s = parseStressParam(new URLSearchParams('stress=rooms:abc,foo:bar,messages:10'))
+    expect(s).toEqual({ kind: 'room-join', messagesPerRoom: 10 })
+  })
+})

--- a/apps/fluux/src/demo/perfHarness.ts
+++ b/apps/fluux/src/demo/perfHarness.ts
@@ -1,0 +1,20 @@
+import type { StressScenario } from '@fluux/sdk'
+
+/** Parse `?stress=rooms:15,messages:150,occupants:80,mode:backfill` into a scenario. */
+export function parseStressParam(params: URLSearchParams): StressScenario | null {
+  const raw = params.get('stress')
+  if (raw === null) return null
+  const scenario: StressScenario = { kind: 'room-join' }
+  for (const part of raw.split(',')) {
+    const [key, value] = part.split(':')
+    if (!key || value === undefined) continue
+    const n = Number(value)
+    switch (key.trim()) {
+      case 'rooms': if (Number.isFinite(n)) scenario.rooms = n; break
+      case 'messages': if (Number.isFinite(n)) scenario.messagesPerRoom = n; break
+      case 'occupants': if (Number.isFinite(n)) scenario.occupants = n; break
+      case 'mode': if (value === 'backfill' || value === 'live') scenario.mode = value; break
+    }
+  }
+  return scenario
+}

--- a/apps/fluux/src/demo/perfHarness.ts
+++ b/apps/fluux/src/demo/perfHarness.ts
@@ -18,3 +18,48 @@ export function parseStressParam(params: URLSearchParams): StressScenario | null
   }
   return scenario
 }
+
+type RenderRecord = { componentName?: string | null; count?: number }
+
+/** Fold a batch of react-scan render records into a per-component count map. */
+export function aggregateRenders(counts: Record<string, number>, renders: RenderRecord[]): Record<string, number> {
+  for (const r of renders ?? []) {
+    const name = r.componentName || '?'
+    counts[name] = (counts[name] ?? 0) + (r.count ?? 1)
+  }
+  return counts
+}
+
+/**
+ * DEV/DEMO ONLY. Loads react-scan (devDependency) on demand and exposes a small
+ * measurement API on window.__perf. Never called in production (gated by ?perf
+ * in demo.tsx; react-scan is a devDependency and demo assets are stripped from
+ * prod builds).
+ */
+export async function installPerfHarness(): Promise<void> {
+  let counts: Record<string, number> = {}
+  try {
+    const reactScan = (window as unknown as { reactScan?: (o: unknown) => void }).reactScan
+      ?? (await import('react-scan')).scan
+    reactScan({ enabled: true, log: false, onRender: (_f: unknown, renders: RenderRecord[]) => aggregateRenders(counts, renders) })
+  } catch (e) {
+    console.warn('[perf] react-scan unavailable:', e)
+  }
+  const det = await import('../utils/renderLoopDetector').catch(() => null)
+  ;(window as unknown as Record<string, unknown>).__perf = {
+    reset: () => { counts = {} },
+    counts: () => ({ ...counts }),
+    async measure(label: string, fn: () => unknown | Promise<unknown>) {
+      counts = {}
+      const t0 = performance.now()
+      await fn()
+      await new Promise(r => setTimeout(r, 50))
+      const top = Object.entries(counts).sort((a, b) => b[1] - a[1])
+      const report = { label, durationMs: Math.round(performance.now() - t0), renders: top, note: 'StrictMode doubles dev renders; divide by 2 for logical counts' }
+      console.table(top)
+      return report
+    },
+    detector: det,
+  }
+  console.info('[perf] window.__perf ready — try await __perf.measure("burst", () => __demoClient.runStressScenario({ kind: "room-join", rooms: 15, messagesPerRoom: 150, mode: "live" }))')
+}

--- a/docs/superpowers/plans/2026-06-05-perf-stress-ui-harness.md
+++ b/docs/superpowers/plans/2026-06-05-perf-stress-ui-harness.md
@@ -1,0 +1,624 @@
+# Perf / Stress UI Harness + Claude Skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the render-perf debugging recipe from PR #450/#451 durable — a deterministic in-repo stress harness, an opt-in measurement layer, and a Claude skill that drives them.
+
+**Architecture:** A pure event generator + a `DemoClient.runStressScenario` scheduler (SDK); demo-mode `?stress=`/`?perf=1` wiring with a `window.__perf` measurement layer backed by an opt-in react-scan devDependency + the existing `renderLoopDetector` (app, dev/demo-only); standardized render-count regression guards; and a `.claude/skills/perf-stress-ui` skill.
+
+**Tech Stack:** TypeScript, Vitest, Zustand, React 19 + React Compiler, react-scan (devDependency), Vite.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md`
+
+**Branch note:** This plan is for `feat/perf-stress-ui-harness` (off `main`). Task 5 (render-count guards) builds on tests introduced in PR #450; if #450 is not yet merged, rebase this branch onto it first, or skip Task 5's references to those specific files.
+
+---
+
+## File Structure
+
+- `packages/fluux-sdk/src/demo/stress.ts` — pure `buildStressEvents()` generator + `StressScenario` type. **Create.**
+- `packages/fluux-sdk/src/demo/stress.test.ts` — unit tests for the generator. **Create.**
+- `packages/fluux-sdk/src/demo/DemoClient.ts` — add `runStressScenario()` method. **Modify.**
+- `packages/fluux-sdk/src/demo/DemoClient.stress.test.ts` — scheduler test. **Create.**
+- `packages/fluux-sdk/src/index.ts` — export `StressScenario`. **Modify.**
+- `apps/fluux/src/demo/perfHarness.ts` — `parseStressParam()`, `aggregateRenders()`, `installPerfHarness()`. **Create.**
+- `apps/fluux/src/demo/perfHarness.test.ts` — tests for the pure helpers. **Create.**
+- `apps/fluux/src/demo.tsx` — parse `?stress` / `?perf`. **Modify.**
+- `apps/fluux/package.json` — add `react-scan` devDependency. **Modify.**
+- `.claude/skills/perf-stress-ui/SKILL.md` — the skill. **Create.**
+
+---
+
+## Task 1: SDK stress event generator (pure)
+
+**Files:**
+- Create: `packages/fluux-sdk/src/demo/stress.ts`
+- Test: `packages/fluux-sdk/src/demo/stress.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/fluux-sdk/src/demo/stress.test.ts
+import { describe, it, expect } from 'vitest'
+import { buildStressEvents } from './stress'
+
+const ctx = { selfJid: 'you@fluux.chat', selfNick: 'you', conferenceService: 'conference.fluux.chat' }
+
+describe('buildStressEvents (room-join)', () => {
+  it('emits added/joined/self-occupant/occupants-batch then N messages per room', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 2, occupants: 3, messagesPerRoom: 4 }, ctx)
+    const room0 = ev.filter(e => (e.payload as any).roomJid === 'stress-0@conference.fluux.chat' || (e.payload as any).room?.jid === 'stress-0@conference.fluux.chat')
+    const types = room0.map(e => e.type)
+    expect(types.slice(0, 4)).toEqual(['room:added', 'room:joined', 'room:self-occupant', 'room:occupants-batch'])
+    expect(room0.filter(e => e.type === 'room:message')).toHaveLength(4)
+    // total = rooms * (4 setup + messagesPerRoom)
+    expect(ev).toHaveLength(2 * (4 + 4))
+  })
+
+  it('backfill mode keeps a stable, non-increasing order (later rooms older)', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 3, messagesPerRoom: 2, mode: 'backfill' }, ctx)
+    const tsOf = (i: number) => (ev.find(e => e.type === 'room:message' && (e.payload as any).roomJid === `stress-${i}@conference.fluux.chat`)!.payload as any).message.timestamp.getTime()
+    expect(tsOf(0)).toBeGreaterThan(tsOf(1))
+    expect(tsOf(1)).toBeGreaterThan(tsOf(2))
+  })
+
+  it('live mode assigns strictly increasing message timestamps (reorders)', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 2, messagesPerRoom: 3, mode: 'live' }, ctx)
+    const stamps = ev.filter(e => e.type === 'room:message').map(e => (e.payload as any).message.timestamp.getTime())
+    const sorted = [...stamps].sort((a, b) => a - b)
+    expect(stamps).toEqual(sorted)
+    expect(new Set(stamps).size).toBe(stamps.length) // all distinct
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run --root packages/fluux-sdk src/demo/stress.test.ts`
+Expected: FAIL — `buildStressEvents` is not exported / not a function.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// packages/fluux-sdk/src/demo/stress.ts
+import type { Room, RoomMessage, RoomOccupant } from '../core/types/room'
+
+export interface StressScenario {
+  kind: 'room-join'
+  rooms?: number
+  occupants?: number
+  messagesPerRoom?: number
+  mode?: 'backfill' | 'live'
+  roomStepMs?: number
+  msgStepMs?: number
+}
+
+export interface StressEvent {
+  delayMs: number
+  type: 'room:added' | 'room:joined' | 'room:self-occupant' | 'room:occupants-batch' | 'room:message'
+  payload: unknown
+}
+
+export interface StressContext {
+  selfJid: string
+  selfNick: string
+  conferenceService: string
+}
+
+// Fixed epoch base so backfill ordering is deterministic and never "now".
+const BASE_TS = 1577836800000 // 2020-01-01T00:00:00Z
+
+export function buildStressEvents(scenario: StressScenario, ctx: StressContext): StressEvent[] {
+  const rooms = scenario.rooms ?? 15
+  const occupants = scenario.occupants ?? 60
+  const messagesPerRoom = scenario.messagesPerRoom ?? 30
+  const mode = scenario.mode ?? 'backfill'
+  const roomStepMs = scenario.roomStepMs ?? 50
+  const msgStepMs = scenario.msgStepMs ?? 10
+  const domain = ctx.selfJid.split('@')[1] ?? 'fluux.chat'
+
+  const events: StressEvent[] = []
+  let globalMsg = 0
+  for (let i = 0; i < rooms; i++) {
+    const base = i * roomStepMs
+    const roomJid = `stress-${i}@${ctx.conferenceService}`
+    const room: Room = {
+      jid: roomJid, name: `Stress ${i}`, nickname: ctx.selfNick, joined: true,
+      isBookmarked: false, autojoin: false, supportsMAM: true, supportsReactions: true,
+      unreadCount: 0, mentionsCount: 0, typingUsers: new Set(), occupants: new Map(), messages: [],
+    }
+    const selfOcc: RoomOccupant = { nick: ctx.selfNick, jid: ctx.selfJid, affiliation: 'owner', role: 'moderator' }
+    events.push({ delayMs: base, type: 'room:added', payload: { room } })
+    events.push({ delayMs: base, type: 'room:joined', payload: { roomJid, joined: true } })
+    events.push({ delayMs: base, type: 'room:self-occupant', payload: { roomJid, occupant: selfOcc } })
+    const occList: RoomOccupant[] = [selfOcc]
+    for (let k = 0; k < occupants; k++) {
+      occList.push({ nick: `U${i}_${k}`, jid: `u${i}_${k}@${domain}`, affiliation: 'member', role: 'participant' })
+    }
+    events.push({ delayMs: base, type: 'room:occupants-batch', payload: { roomJid, occupants: occList } })
+    for (let m = 0; m < messagesPerRoom; m++) {
+      // backfill: fixed, distinct-per-room, older for later rooms -> no reorder.
+      // live: globally increasing -> each message becomes newest -> reorders.
+      const ts = mode === 'backfill' ? BASE_TS - i * 60000 : BASE_TS + globalMsg + 1
+      const nick = `U${i}_${m % Math.max(occupants, 1)}`
+      const message: RoomMessage = {
+        type: 'groupchat', id: `stress-${i}-${m}`, from: `${roomJid}/${nick}`, nick,
+        body: `stress message ${m}`, timestamp: new Date(ts), isOutgoing: false, roomJid,
+      }
+      events.push({ delayMs: base + 20 + m * msgStepMs, type: 'room:message', payload: { roomJid, message } })
+      globalMsg++
+    }
+  }
+  return events
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run --root packages/fluux-sdk src/demo/stress.test.ts`
+Expected: PASS (3 tests). Output pristine.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/src/demo/stress.ts packages/fluux-sdk/src/demo/stress.test.ts
+git commit -m "feat(demo): pure stress-event generator for room-join load"
+```
+
+---
+
+## Task 2: DemoClient.runStressScenario scheduler
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/demo/DemoClient.ts`
+- Modify: `packages/fluux-sdk/src/index.ts` (export `StressScenario`)
+- Test: `packages/fluux-sdk/src/demo/DemoClient.stress.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { DemoClient } from './DemoClient'
+
+describe('DemoClient.runStressScenario', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('emits the generated events over time and stop() cancels the rest', () => {
+    const client = new DemoClient()
+    // populateDemo sets selfJid/conferenceService; emulate minimally:
+    ;(client as unknown as { selfJid: string }).selfJid = 'you@fluux.chat'
+    ;(client as unknown as { conferenceService: string }).conferenceService = 'conference.fluux.chat'
+    const emit = vi.spyOn(client as unknown as { emitSDK: (...a: unknown[]) => void }, 'emitSDK').mockImplementation(() => {})
+
+    const handle = client.runStressScenario({ kind: 'room-join', rooms: 1, occupants: 1, messagesPerRoom: 3, msgStepMs: 10, roomStepMs: 0 })
+    vi.advanceTimersByTime(25) // setup events (delay 0) + first message (delay 20)
+    const afterFirst = emit.mock.calls.length
+    expect(afterFirst).toBeGreaterThanOrEqual(5) // 4 setup + >=1 message
+
+    handle.stop()
+    vi.advanceTimersByTime(1000)
+    expect(emit.mock.calls.length).toBe(afterFirst) // no further emits after stop
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run --root packages/fluux-sdk src/demo/DemoClient.stress.test.ts`
+Expected: FAIL — `runStressScenario` is not a function.
+
+- [ ] **Step 3: Add the method to DemoClient**
+
+Add the import near the other type imports in `DemoClient.ts`:
+
+```ts
+import { buildStressEvents, type StressScenario } from './stress'
+```
+
+Add this public method to the `DemoClient` class (e.g. right after `setDiscoverableRooms`):
+
+```ts
+  /**
+   * DEV/DEMO ONLY. Replays a synthetic load (e.g. joining many large rooms) by
+   * scheduling SDK events over timers, to reproduce render-performance issues
+   * deterministically. Returns a handle whose stop() cancels pending events.
+   */
+  runStressScenario(scenario: StressScenario): { stop: () => void } {
+    const selfNick = this.selfJid.split('@')[0] || 'you'
+    const events = buildStressEvents(scenario, {
+      selfJid: this.selfJid,
+      selfNick,
+      conferenceService: this.conferenceService,
+    })
+    let timers: ReturnType<typeof setTimeout>[] = [
+      ...events.map(ev =>
+        setTimeout(() => {
+          // Same cast style as dispatchStep(): payloads are generated to match the event.
+          this.emitSDK(ev.type as Parameters<typeof this.emitSDK>[0], ev.payload as never)
+        }, ev.delayMs),
+      ),
+    ]
+    return {
+      stop: () => {
+        for (const t of timers) clearTimeout(t)
+        timers = []
+      },
+    }
+  }
+```
+
+- [ ] **Step 4: Export the type**
+
+In `packages/fluux-sdk/src/index.ts`, add `StressScenario` to the demo type export line (next to `DemoRoomData`):
+
+```ts
+export type { DemoData, DemoSelf, DemoPresence, DemoOwnResource, DemoRoomData, DemoAnimationStep } from './demo/types'
+export type { StressScenario } from './demo/stress'
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `npx vitest run --root packages/fluux-sdk src/demo/DemoClient.stress.test.ts`
+Expected: PASS.
+Run: `npm run build:sdk && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/demo/DemoClient.ts packages/fluux-sdk/src/demo/DemoClient.stress.test.ts packages/fluux-sdk/src/index.ts
+git commit -m "feat(demo): DemoClient.runStressScenario scheduler"
+```
+
+---
+
+## Task 3: App `?stress` param parsing + wiring
+
+**Files:**
+- Create: `apps/fluux/src/demo/perfHarness.ts`
+- Create: `apps/fluux/src/demo/perfHarness.test.ts`
+- Modify: `apps/fluux/src/demo.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/fluux/src/demo/perfHarness.test.ts
+import { describe, it, expect } from 'vitest'
+import { parseStressParam } from './perfHarness'
+
+describe('parseStressParam', () => {
+  it('returns null when absent', () => {
+    expect(parseStressParam(new URLSearchParams(''))).toBeNull()
+  })
+  it('parses key:value,key:value into a room-join scenario', () => {
+    const s = parseStressParam(new URLSearchParams('stress=rooms:15,messages:150,occupants:80,mode:backfill'))
+    expect(s).toEqual({ kind: 'room-join', rooms: 15, messagesPerRoom: 150, occupants: 80, mode: 'backfill' })
+  })
+  it('ignores unknown keys and clamps invalid numbers', () => {
+    const s = parseStressParam(new URLSearchParams('stress=rooms:abc,foo:bar,messages:10'))
+    expect(s).toEqual({ kind: 'room-join', messagesPerRoom: 10 })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run --root apps/fluux src/demo/perfHarness.test.ts`
+Expected: FAIL — `parseStressParam` not exported.
+
+- [ ] **Step 3: Implement `parseStressParam` (and a stub `installPerfHarness` for Task 4)**
+
+```ts
+// apps/fluux/src/demo/perfHarness.ts
+import type { StressScenario } from '@fluux/sdk'
+
+/** Parse `?stress=rooms:15,messages:150,occupants:80,mode:backfill` into a scenario. */
+export function parseStressParam(params: URLSearchParams): StressScenario | null {
+  const raw = params.get('stress')
+  if (raw === null) return null
+  const scenario: StressScenario = { kind: 'room-join' }
+  for (const part of raw.split(',')) {
+    const [key, value] = part.split(':')
+    if (!key || value === undefined) continue
+    const n = Number(value)
+    switch (key.trim()) {
+      case 'rooms': if (Number.isFinite(n)) scenario.rooms = n; break
+      case 'messages': if (Number.isFinite(n)) scenario.messagesPerRoom = n; break
+      case 'occupants': if (Number.isFinite(n)) scenario.occupants = n; break
+      case 'mode': if (value === 'backfill' || value === 'live') scenario.mode = value; break
+    }
+  }
+  return scenario
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run --root apps/fluux src/demo/perfHarness.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire into `demo.tsx`**
+
+In `apps/fluux/src/demo.tsx`, after `demoClient.setDiscoverableRooms(...)`, add:
+
+```ts
+import { parseStressParam } from './demo/perfHarness'
+// ...
+const stressScenario = parseStressParam(params)
+if (stressScenario) {
+  // Defer so the first paint happens before the load starts.
+  setTimeout(() => demoClient.runStressScenario(stressScenario), 500)
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/demo/perfHarness.ts apps/fluux/src/demo/perfHarness.test.ts apps/fluux/src/demo.tsx
+git commit -m "feat(demo): ?stress= param runs a stress scenario in demo mode"
+```
+
+---
+
+## Task 4: `?perf` measurement layer (react-scan + detector)
+
+**Files:**
+- Modify: `apps/fluux/package.json` (devDependency)
+- Modify: `apps/fluux/src/demo/perfHarness.ts` (add `aggregateRenders`, `installPerfHarness`)
+- Modify: `apps/fluux/src/demo/perfHarness.test.ts` (test `aggregateRenders`)
+- Modify: `apps/fluux/src/demo.tsx` (call `installPerfHarness` on `?perf=1`)
+
+- [ ] **Step 1: Add react-scan as a devDependency**
+
+Run: `npm install -D react-scan -w @xmpp/fluux`
+Verify it lands under `devDependencies` (not `dependencies`) in `apps/fluux/package.json`.
+
+- [ ] **Step 2: Write the failing test for the pure aggregator**
+
+```ts
+// add to apps/fluux/src/demo/perfHarness.test.ts
+import { aggregateRenders } from './perfHarness'
+
+describe('aggregateRenders', () => {
+  it('sums render counts per component name', () => {
+    const counts = {}
+    aggregateRenders(counts, [{ componentName: 'RoomItem', count: 1 }, { componentName: 'Tooltip', count: 2 }])
+    aggregateRenders(counts, [{ componentName: 'RoomItem', count: 1 }])
+    expect(counts).toEqual({ RoomItem: 2, Tooltip: 2 })
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run --root apps/fluux src/demo/perfHarness.test.ts`
+Expected: FAIL — `aggregateRenders` not exported.
+
+- [ ] **Step 4: Implement `aggregateRenders` + `installPerfHarness`**
+
+Append to `apps/fluux/src/demo/perfHarness.ts`:
+
+```ts
+type RenderRecord = { componentName?: string; count?: number }
+
+/** Fold a batch of react-scan render records into a per-component count map. */
+export function aggregateRenders(counts: Record<string, number>, renders: RenderRecord[]): Record<string, number> {
+  for (const r of renders ?? []) {
+    const name = r.componentName || '?'
+    counts[name] = (counts[name] ?? 0) + (r.count ?? 1)
+  }
+  return counts
+}
+
+/**
+ * DEV/DEMO ONLY. Loads react-scan (devDependency) on demand and exposes a small
+ * measurement API on window.__perf. Never called in production (gated by ?perf
+ * in demo.tsx; react-scan is a devDependency and demo assets are stripped from
+ * prod builds).
+ */
+export async function installPerfHarness(): Promise<void> {
+  let counts: Record<string, number> = {}
+  try {
+    const reactScan = (window as unknown as { reactScan?: (o: unknown) => void }).reactScan
+      ?? (await import('react-scan')).scan
+    reactScan({ enabled: true, log: false, onRender: (_f: unknown, renders: RenderRecord[]) => aggregateRenders(counts, renders) })
+  } catch (e) {
+    console.warn('[perf] react-scan unavailable:', e)
+  }
+  const det = await import('../utils/renderLoopDetector').catch(() => null) // getRenderStats / getSelectorHistory
+  ;(window as unknown as Record<string, unknown>).__perf = {
+    reset: () => { counts = {} },
+    counts: () => ({ ...counts }),
+    async measure(label: string, fn: () => unknown | Promise<unknown>) {
+      counts = {}
+      const t0 = performance.now()
+      await fn()
+      await new Promise(r => setTimeout(r, 50))
+      const top = Object.entries(counts).sort((a, b) => b[1] - a[1])
+      const report = { label, durationMs: Math.round(performance.now() - t0), renders: top, note: 'StrictMode doubles dev renders; divide by 2 for logical counts' }
+      console.table(top)
+      return report
+    },
+    detector: det, // getRenderStats / getSelectorHistory live here when needed
+  }
+  console.info('[perf] window.__perf ready — try await __perf.measure("burst", () => __demoClient.runStressScenario({ kind: "room-join", rooms: 15, messagesPerRoom: 150, mode: "live" }))')
+}
+```
+
+Note: `(await import('react-scan')).scan` — confirm the export name against the installed react-scan version during implementation; adjust if it differs (the global build also sets `window.reactScan`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run --root apps/fluux src/demo/perfHarness.test.ts`
+Expected: PASS. (`installPerfHarness` is not unit-tested — it is browser/react-scan glue verified manually in Step 7.)
+
+- [ ] **Step 6: Wire `?perf` into `demo.tsx`**
+
+```ts
+import { parseStressParam, installPerfHarness } from './demo/perfHarness'
+// ...
+if (params.get('perf') === '1') {
+  void installPerfHarness()
+}
+```
+
+- [ ] **Step 7: Manual verification**
+
+Run: `npm run dev`, open `http://localhost:5173/demo.html?perf=1`, switch to the Salons view, then in the console:
+`await window.__perf.measure('burst', () => window.__demoClient.runStressScenario({ kind: 'room-join', rooms: 15, messagesPerRoom: 150, mode: 'live' }))`
+Expected: a per-component render table where `RoomItem` ≈ messages count (÷2 for StrictMode), not messages × rooms.
+
+- [ ] **Step 8: Typecheck + commit**
+
+Run: `npm run typecheck && npm run lint`
+Expected: 0 errors.
+
+```bash
+git add apps/fluux/package.json package-lock.json apps/fluux/src/demo/perfHarness.ts apps/fluux/src/demo/perfHarness.test.ts apps/fluux/src/demo.tsx
+git commit -m "feat(demo): ?perf=1 measurement layer (react-scan + window.__perf)"
+```
+
+---
+
+## Task 5: Document the render-count regression-guard pattern
+
+**Files:**
+- Create: `packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md`
+- (Optional stretch) Create: `apps/fluux/src/components/sidebar-components/RoomsList.renderCount.test.tsx`
+
+**Depends on PR #450** (which adds `roomStore.sidebarJids.test.ts`, `roomStore.perRoomStability.test.ts`, and the `useListKeyboardNav` reorder test). Rebase onto #450 first if not merged.
+
+- [ ] **Step 1: Write the guide doc** (no test — documentation)
+
+```md
+# Render-count regression guards
+
+When fixing a render-perf issue, add a guard so it can't silently regress.
+
+## Store/hook level (preferred — real store, no app mock)
+Use the SDK render-stability helpers (`renderStability.helpers.tsx`): seed the
+store, capture a baseline, dispatch a background update, assert the subscription
+result is unchanged (`toEqual`) or the hook's render count did not increase.
+
+Examples in this repo:
+- `roomStore.sidebarJids.test.ts` — selector returns the same JIDs after a
+  non-reordering message (so `useShallow` bails).
+- `roomStore.perRoomStability.test.ts` — `getRoom(B)` keeps its ref after a
+  message to room A (so a per-row subscription only fires for the changed row).
+- `useListKeyboardNav.test.tsx` — `getItemProps` hover handlers stay
+  identity-stable across renders AND reorders.
+
+## Component level (stretch)
+To assert a background message re-renders only its row, render the component
+against the REAL store (override the global `@fluux/sdk` app mock in that test
+file with `vi.unmock` / `importActual`) and count renders with a module-level
+counter or React Profiler. Account for StrictMode double-rendering.
+```
+
+- [ ] **Step 2: (Stretch) component-level guard** — only if the app-mock override lands cleanly; otherwise skip and note it in the commit. Render `RoomsList` with the real `roomStore`, seed 5 joined rooms, wrap a render counter, dispatch a background `addMessage`, assert only one extra `RoomItem` render (×2 StrictMode). If it fights the mock for more than ~15 min, skip — the store-level guards already cover the invariant.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md
+git commit -m "docs(test): render-count regression guard pattern"
+```
+
+---
+
+## Task 6: Claude skill `perf-stress-ui`
+
+**Files:**
+- Create: `.claude/skills/perf-stress-ui/SKILL.md`
+
+- [ ] **Step 1: Write the skill** (no automated test — verified by triggering)
+
+```md
+---
+name: perf-stress-ui
+description: Use when investigating a UI render-performance problem or render loop in the Fluux app (sidebar/list re-render storms, "why is X re-rendering", verifying a render-perf fix). Reproduces load deterministically in demo mode, measures with react-scan + renderLoopDetector, and diagnoses the memo-breaking prop.
+---
+
+# Perf / Stress UI debugging (Fluux)
+
+## When to use
+A sidebar/list re-renders too much, a render loop is suspected, or you're
+verifying a render-perf change. See `memory/project_render_perf_react_compiler.md`
+and `docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md`.
+
+## 1. Reproduce (demo mode — no server)
+`npm run dev`, then open:
+`http://localhost:5173/demo.html?tutorial=false&stress=rooms:15,messages:150,mode:backfill&perf=1`
+- `mode:backfill` = historical timestamps, no reorder (real "join N rooms" case).
+- `mode:live` = reorders on every message (worst case).
+For custom sequences, drive `window.__demoClient.emitSDK('room:message', { roomJid, message })`.
+
+## 2. Measure
+- `await window.__perf.measure('label', () => window.__demoClient.runStressScenario({ kind:'room-join', rooms:15, messagesPerRoom:150, mode:'live' }))`
+  → per-component render table.
+- `window.__det = await import('/src/utils/renderLoopDetector.ts')` →
+  `__det.getRenderStats()`, `__det.getSelectorHistory()`.
+- CAVEAT: React StrictMode doubles dev renders — divide by 2 for logical counts.
+- Sanity baseline: a no-op parent re-render should produce 0 child renders.
+
+## 3. Diagnose — find the memo-breaking prop, then its source
+react-scan reports React-Compiler-memoized components as `forget:true`,
+`changes:[]`, `unnecessary:null` (it cannot attribute the cause). To find which
+prop breaks `memo`, temporarily wrap the child:
+\```tsx
+memo(Component, (prev, next) => {
+  for (const k of new Set([...Object.keys(prev), ...Object.keys(next)]))
+    if (!Object.is((prev as any)[k], (next as any)[k]))
+      ((window as any).__memoDiff ??= {})[k] = (((window as any).__memoDiff||{})[k]||0)+1
+  return /* shallow-equal? */ ...
+})
+\```
+Then trace the offending prop to its SOURCE hook. Two traps that recur here:
+- **React Compiler strips `useCallback`** and only memoizes callbacks used as a
+  hook dependency; JSX-only callbacks are fresh closures each render (PR #450).
+- **A prop's source hook returns an unstable ref** (e.g. `useFileUpload`), so
+  `React.memo` no-ops even though the JSX looks fine (PR #451).
+Also distinguish reorder (activity-sorted list order changed — legitimate list
+re-render) vs content churn (only one row's data changed).
+
+## 4. Fix patterns
+- Stable callbacks: lazy-init `useRef` + a "latest" ref (NOT `useCallback`).
+- Subscribe to an ordered id/JID list via `useShallow` (e.g. `roomSidebarJids()`),
+  and have each row self-subscribe by id (`getRoom(jid)` — stable per row).
+- Use focused hooks over ones that recombine entity/meta/runtime each render.
+
+## 5. Verify
+- No-op parent re-render → 0 child renders (memo bails).
+- Worst-case burst → ~1 render per message (not × rows).
+- Add a render-count regression guard (see
+  `packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md`).
+```
+
+- [ ] **Step 2: Verify the skill loads**
+
+Run: `/doctor` or confirm the skill appears in the available-skills list in a new session. Sanity-check the description triggers on "investigate a render loop in fluux".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/perf-stress-ui/SKILL.md
+git commit -m "feat(skill): perf-stress-ui — reproduce/measure/diagnose render perf"
+```
+
+---
+
+## Final verification
+
+- [ ] `npm run build:sdk && npm run typecheck` → no errors
+- [ ] `npm test` (or per-workspace `npx vitest run`) → all green, no stderr
+- [ ] `npm run lint` → 0 errors
+- [ ] Manual: `/demo.html?stress=rooms:15,messages:150,mode:live&perf=1` → `__perf` shows ~1 RoomItem render/message
+- [ ] Push branch + open PR against `main` (no test plan / no footer per repo convention)
+
+## Self-review notes (author)
+
+- **Spec coverage:** scenarios (T1–2), `?stress`/`?perf` + `window.__perf` (T3–4), react-scan opt-in devDep (T4), regression guards (T5), skill (T6) — all covered.
+- **Known integration seams to confirm during impl:** react-scan's programmatic export name/signature (Task 4 Step 4 note); the `emitSDK` cast in Task 2 mirrors the existing `dispatchStep` pattern.
+- **Branch dependency:** Task 5 references PR #450's test files; rebase if unmerged.

--- a/docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md
+++ b/docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md
@@ -1,0 +1,131 @@
+# Perf / Stress UI Harness + Claude Skill — Design
+
+- **Date:** 2026-06-05
+- **Status:** Approved (design); pending implementation plan
+- **Related:** PR #450 (sidebar render cascade), PR #451 (MUC composer render decoupling), `memory/project_render_perf_react_compiler.md`
+
+## Context
+
+Render-performance regressions keep recurring in the sidebar/list UIs (PR #450 and PR #451 both hit the same class: a memoized child re-rendering because a prop — or a prop's *source hook* — has an unstable identity, often because the **React Compiler** leaves JSX-only `useCallback`s as fresh closures). Each was diagnosed ad-hoc with a throwaway harness: replay server events via `window.__demoClient.emitSDK`, count renders with react-scan's `onRender`, read `renderLoopDetector` stats, and bisect the offending prop with a temporary `memo` comparator.
+
+That recipe is reusable but is re-derived every time. This project makes it durable in two layers:
+
+1. **A dev/CI harness in the repo** — reproducible stress scenarios + an opt-in measurement layer + automated render-count regression tests.
+2. **A Claude skill** that drives the harness and codifies the diagnose → fix → verify workflow.
+
+## Goals
+
+- Reproduce a "join 10–15 large rooms" style load **deterministically**, in the real demo UI, in one command.
+- Make render measurement a one-liner for a human or for Claude (`window.__perf.measure(...)`).
+- Catch regressions automatically in CI via render-count assertions.
+- Give Claude a repeatable, documented workflow (including the React-Compiler and unstable-source-hook traps).
+- Keep all of this **strictly dev/demo-only** — react-scan and the harness must never reach a production bundle.
+
+## Non-goals
+
+- A standalone interactive `/perf.html` playground (rejected: too much surface; YAGNI).
+- A broad library of scenarios up front — start with the room-join scenario; the structure must allow more later (typing storm, large message list, roster churn).
+- Real-server load testing — the harness replays SDK events through `DemoClient`, which is faithful for component-render behaviour and deterministic.
+
+## Architecture
+
+Four components, layered:
+
+```
+SDK:  DemoClient.runStressScenario(opts)         ← deterministic event replay
+App:  demo.tsx wiring (?stress=…, ?perf=1)       ← triggers scenario + measurement
+      perfHarness.ts (window.__perf)             ← react-scan (opt-in) + detector helpers
+Test: render-count regression guards             ← CI safety net
+Skill: .claude/skills/perf-stress-ui/            ← drives the above; diagnose/fix/verify recipe
+```
+
+### 1. Stress scenarios — SDK (`packages/fluux-sdk/src/demo/stress.ts`)
+
+A new `DemoClient.runStressScenario(opts): { stop(): void }` method (a method, so it can use the protected `emitSDK`). It replays the real fresh-join event sequence over timers:
+`room:added → room:joined → room:self-occupant → room:occupants-batch → room:message×N`.
+
+```ts
+type StressScenario = {
+  kind: 'room-join'              // only kind for now; union extensible later
+  rooms: number                 // default 15
+  occupants: number             // default 60
+  messagesPerRoom: number       // default 30
+  mode: 'backfill' | 'live'     // default 'backfill'
+  roomStepMs?: number           // stagger between room joins (default 50)
+  msgStepMs?: number            // stagger between messages (default 10)
+}
+```
+
+- **`backfill`** — fixed historical timestamps, distinct-but-stable per room → **no reordering** (models MAM backfill on join; the real reported scenario).
+- **`live`** — `new Date()` per message → reorders the activity-sorted list on every message (worst case).
+- Returns `{ stop() }` to cancel pending timers. Idempotent stop.
+
+Unit-tested at the SDK level (the existing render-stability helpers already provide `createRoom` etc.).
+
+### 2. Demo wiring + measurement — App (`apps/fluux/src/demo/`)
+
+In `demo.tsx` (dev-only entry), parse two URL params:
+
+- **`?stress=rooms:15,messages:150,occupants:80,mode:backfill`** → after the normal seed, call `demoClient.runStressScenario(parsed)`.
+- **`?perf=1`** → dynamically `import('react-scan')` (a **devDependency**), enable it, and install `window.__perf`.
+
+`apps/fluux/src/demo/perfHarness.ts` exposes `window.__perf`:
+
+- `measure(label, fn): Promise<Report>` — reset counters, run `fn` (e.g. a scenario), return per-component render counts (react-scan `onRender` tally) + `renderLoopDetector.getRenderStats()` + duration. Notes StrictMode doubling in the report.
+- `counts()` — current per-component render tally.
+- `detector()` — handle to `getRenderStats` / `getSelectorHistory` / `resetRenderLoopDetector` (imported live).
+- `findMemoBreaker` — documented helper/recipe for the temporary `memo` custom-comparator trick (kept as documentation + a copy-paste snippet, since wiring it requires editing the component under test).
+
+**Production safety:** all of this lives behind `demo.tsx` + `import.meta.env.DEV` + the `?perf` flag, and react-scan is a `devDependency` imported dynamically — it can never enter the production app bundle. (`vite.config.ts` already strips demo assets from prod builds.)
+
+### 3. Perf regression tests (CI guard)
+
+Standardize the render-count guard pattern already started in PR #450 (`roomStore.sidebarJids.test.ts`, `roomStore.perRoomStability.test.ts`, the `useListKeyboardNav` reorder test). Add a short documented helper/section so new guards are easy to write, and keep them at the **store/hook level** (real store, no app-mock fight). 
+
+**Stretch (optional):** a component-level guard — render `RoomsList` against the real store and assert a background message re-renders only its row. Requires bypassing the global `@fluux/sdk` app mock for that test file; include only if it lands cleanly.
+
+### 4. Claude skill (`.claude/skills/perf-stress-ui/SKILL.md`)
+
+Codifies the workflow so Claude can do this on demand without re-deriving it:
+
+- **Trigger / description:** investigating UI perf or a render loop in fluux; "why is X re-rendering"; before/after a render-perf change.
+- **Reproduce:** `npm run dev` → open `/demo.html?stress=…&perf=1`; or drive `window.__demoClient.emitSDK(...)` for custom event sequences.
+- **Measure:** `window.__perf.measure(...)`, react-scan overlay/console, `renderLoopDetector` stats. Caveat: React **StrictMode doubles** dev renders.
+- **Diagnose:** find the memo-breaking prop (temporary custom `memo` comparator), then **trace it to its source hook** — the React-Compiler `useCallback`-strip trap (PR #450) and the unstable-prop-source-hook trap, e.g. `useFileUpload` (PR #451). Distinguish reorder vs content churn.
+- **Fix patterns:** ref-stable handlers (lazy-init + "latest" ref, *not* `useCallback`), per-jid/-id subscription + `useShallow` on id lists, focused hooks over recombined entity/meta.
+- **Verify:** no-op parent re-render → **0** child renders; worst-case burst → **~1 render/message**.
+- References this harness and `memory/project_render_perf_react_compiler.md`.
+
+## Data flow
+
+`?stress` → `demoClient.runStressScenario` → `emitSDK` events → store bindings → Zustand stores → React re-renders → react-scan `onRender` + `renderLoopDetector` count them → `window.__perf` report.
+
+## Error handling / guards
+
+- `runStressScenario` validates/clamps params; `stop()` cancels all timers and is safe to call twice.
+- `?perf` import failure (react-scan missing) → log a clear console message, no crash.
+- Everything gated to dev/demo; no prod footprint.
+
+## File layout
+
+```
+packages/fluux-sdk/src/demo/stress.ts            (+ DemoClient method + export)
+packages/fluux-sdk/src/demo/stress.test.ts
+apps/fluux/src/demo/perfHarness.ts
+apps/fluux/src/demo.tsx                            (parse ?stress / ?perf)
+apps/fluux/package.json                            (react-scan devDependency)
+.claude/skills/perf-stress-ui/SKILL.md
+docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md   (this file)
+```
+
+## Testing
+
+- SDK: unit test `runStressScenario` (emits the expected event sequence; `backfill` preserves order, `live` reorders; `stop()` cancels).
+- The existing render-count guards remain; document the pattern.
+- Manual: `/demo.html?stress=rooms:15,messages:150&perf=1` → `window.__perf` shows ~1 RoomItem render/message.
+
+## Out of scope / future
+
+- Additional scenarios (typing storm, large message list, roster churn) — add as new `StressScenario.kind`s when needed.
+- Standalone perf playground UI.
+- CI performance budgets / automated perf dashboards.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "fake-indexeddb": "^6.2.5",
         "postcss": "^8.4.32",
+        "react-scan": "^0.5.7",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.53.0",
@@ -1877,6 +1878,23 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "4.0.0-beta.70",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.70.tgz",
+      "integrity": "sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "effect": "^4.0.0-beta.70"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -2631,6 +2649,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -2702,6 +2727,90 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -2759,6 +2868,474 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.132.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
@@ -2767,6 +3344,648 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.20.0.tgz",
+      "integrity": "sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.20.0.tgz",
+      "integrity": "sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.20.0.tgz",
+      "integrity": "sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.20.0.tgz",
+      "integrity": "sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.20.0.tgz",
+      "integrity": "sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.20.0.tgz",
+      "integrity": "sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.20.0.tgz",
+      "integrity": "sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz",
+      "integrity": "sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz",
+      "integrity": "sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz",
+      "integrity": "sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz",
+      "integrity": "sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz",
+      "integrity": "sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz",
+      "integrity": "sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz",
+      "integrity": "sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz",
+      "integrity": "sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz",
+      "integrity": "sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.20.0.tgz",
+      "integrity": "sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.20.0.tgz",
+      "integrity": "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.20.0.tgz",
+      "integrity": "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.68.0.tgz",
+      "integrity": "sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.68.0.tgz",
+      "integrity": "sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.68.0.tgz",
+      "integrity": "sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.68.0.tgz",
+      "integrity": "sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.68.0.tgz",
+      "integrity": "sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.68.0.tgz",
+      "integrity": "sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.68.0.tgz",
+      "integrity": "sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.68.0.tgz",
+      "integrity": "sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.68.0.tgz",
+      "integrity": "sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.68.0.tgz",
+      "integrity": "sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.68.0.tgz",
+      "integrity": "sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.68.0.tgz",
+      "integrity": "sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.68.0.tgz",
+      "integrity": "sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.68.0.tgz",
+      "integrity": "sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.68.0.tgz",
+      "integrity": "sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.68.0.tgz",
+      "integrity": "sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.68.0.tgz",
+      "integrity": "sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.68.0.tgz",
+      "integrity": "sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.68.0.tgz",
+      "integrity": "sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -2781,6 +4000,83 @@
       "bin": {
         "playwright": "cli.js"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.1.tgz",
+      "integrity": "sha512-xVqN8mJjbSN5IB/8Ubmd9NN+Ew6zJswoRxrjZbH3YsgkMshFeO6d8zxEFpHRTq9GJZx7cnPs2CnCpFqtGXGNsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
+      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@react-grab/cli": {
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@react-grab/cli/-/cli-0.1.44.tgz",
+      "integrity": "sha512-gMDYY2rw6OWajCcDlXSIgs2LC432YJXSb3Lm5yM187uhRgBYddoEVULi36h+IolX3r7jSb3ew7vn9FfI8NSo0A==",
+      "dev": true,
+      "dependencies": {
+        "agent-install": "^0.0.5",
+        "commander": "^14.0.3",
+        "ignore": "^7.0.5",
+        "ora": "^9.4.0",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "prompts": "^2.4.2",
+        "tinyexec": "^1.1.2"
+      },
+      "bin": {
+        "react-grab": "bin/cli.js"
+      }
+    },
+    "node_modules/@react-grab/cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@react-grab/cli/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@react-grab/cli/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -3556,6 +4852,113 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/server-utils": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.56.0.tgz",
+      "integrity": "sha512-6kuZI/vAjyVKMm1cTzc2pdUmVR4Px4etMG6wnCPyFnwEaGbUKQnTynUBFpTuo/q6Js6QBQvhLNoAnO4YsOfW4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.56.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
+      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.56.0.tgz",
+      "integrity": "sha512-qvgtXHkcR4CH3fh0VEVyw4Ysc6MMiAnm727NdTTm0yU5e53erCeo2521+yfJkqmRTGiOSgwA7B5Bs+ot9j0vFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry-internal/server-utils": "10.56.0",
+        "@sentry/core": "10.56.0",
+        "@sentry/node-core": "10.56.0",
+        "@sentry/opentelemetry": "10.56.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.56.0.tgz",
+      "integrity": "sha512-61lD2Wjtv5Lw2F3lJarcD0ORjR4GlVxrEd6w6Of/uF3DH73dD6K3n/3wXEeCIRfV/kgiCFIrCIq76nz0LVgE5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.56.0",
+        "@sentry/opentelemetry": "10.56.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.56.0.tgz",
+      "integrity": "sha512-PtMudApHMHvttjos3b7JZ2gJ+nstHAOYE3vKPYB5o0WQO95ldiaYnpLKMCRIGZWF3Dk7ynrqqnBpn8LZLt+Mrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.56.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "4.1.0",
@@ -5087,6 +6490,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -5095,6 +6508,34 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-install": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.5.tgz",
+      "integrity": "sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "commander": "^14.0.0",
+        "jsonc-parser": "^3.3.1",
+        "picocolors": "^1.1.1",
+        "prompts": "^2.4.2",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "agent-install": "bin/agent-install.mjs"
+      }
+    },
+    "node_modules/agent-install/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ajv": {
@@ -5113,6 +6554,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -5292,6 +6775,17 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -5462,6 +6956,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bippy": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/bippy/-/bippy-0.5.41.tgz",
+      "integrity": "sha512-jCP2pXXLhXqPrAN+iSEFZmLI4uUM4fjSqajh0K+TmM062VehfDT3ZJNkrTGyN701Z5XMejs9qAudSqkMGhSMKg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0.1"
       }
     },
     "node_modules/brace-expansion": {
@@ -5683,6 +7187,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
@@ -5741,6 +7258,42 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -5769,6 +7322,67 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/conf": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
+      "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^10.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.7.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/conf/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/confbox": {
@@ -5976,6 +7590,22 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6063,6 +7693,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/deslop-js": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/deslop-js/-/deslop-js-0.0.19.tgz",
+      "integrity": "sha512-gLEwJ26XSRNN5r7x/AI8Zi0Fs6uJe/junYM+jQaaVRjfagUUAerPD90fZlwjRnK0Lpb9jRzqaM9BvmHXUHkGxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0",
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.2.5",
+        "oxc-parser": "^0.132.0",
+        "oxc-resolver": "^11.19.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/deslop-js/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -6108,6 +7767,38 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dot-prop": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
+      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6121,6 +7812,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.70",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.70.tgz",
+      "integrity": "sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/ejs": {
@@ -6163,6 +7873,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -6618,6 +8341,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6779,6 +8525,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -6967,6 +8720,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -7395,6 +9161,22 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7421,6 +9203,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -7644,6 +9436,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -7841,6 +9646,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -8091,6 +9909,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8110,6 +9935,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -8144,11 +9976,28 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/koa-compose": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
       "license": "MIT"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -8515,6 +10364,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8824,6 +10690,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8873,10 +10752,57 @@
         "ufo": "^1.6.3"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz",
+      "integrity": "sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8917,6 +10843,22 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.46",
@@ -9013,6 +10955,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -9057,6 +11015,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -9073,6 +11054,140 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.20.0.tgz",
+      "integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.20.0",
+        "@oxc-resolver/binding-android-arm64": "11.20.0",
+        "@oxc-resolver/binding-darwin-arm64": "11.20.0",
+        "@oxc-resolver/binding-darwin-x64": "11.20.0",
+        "@oxc-resolver/binding-freebsd-x64": "11.20.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.20.0",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.20.0",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-x64-musl": "11.20.0",
+        "@oxc-resolver/binding-openharmony-arm64": "11.20.0",
+        "@oxc-resolver/binding-wasm32-wasi": "11.20.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.20.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.20.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.68.0.tgz",
+      "integrity": "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.68.0",
+        "@oxlint/binding-android-arm64": "1.68.0",
+        "@oxlint/binding-darwin-arm64": "1.68.0",
+        "@oxlint/binding-darwin-x64": "1.68.0",
+        "@oxlint/binding-freebsd-x64": "1.68.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.68.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.68.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.68.0",
+        "@oxlint/binding-linux-arm64-musl": "1.68.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.68.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.68.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.68.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.68.0",
+        "@oxlint/binding-linux-x64-gnu": "1.68.0",
+        "@oxlint/binding-linux-x64-musl": "1.68.0",
+        "@oxlint/binding-openharmony-arm64": "1.68.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.68.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.68.0",
+        "@oxlint/binding-win32-x64-msvc": "1.68.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.22.1",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/oxlint-plugin-react-doctor/-/oxlint-plugin-react-doctor-0.4.0.tgz",
+      "integrity": "sha512-iC+iV296B41pghbPEmR1oklwjTo8v9LlTVG1LTHed3ZkeuljH3Kq+SKeHB1YXvLuq9MARr+n4WDmN5r7bHtJfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.59.3",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "oxc-parser": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/p-limit": {
@@ -9113,6 +11228,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -9458,6 +11580,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9497,6 +11630,20 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -9526,6 +11673,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9557,6 +11721,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-doctor": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-doctor/-/react-doctor-0.4.0.tgz",
+      "integrity": "sha512-BWum4WfKZ9Sdv4zTlzRoog4fYEIBEWZXHnq8GaCL42XMLmoldATdix/i3xZSHD3+SqpMrUVGcuzerOL9R9P+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@effect/platform-node-shared": "4.0.0-beta.70",
+        "@sentry/node": "^10.54.0",
+        "agent-install": "0.0.5",
+        "conf": "^15.1.0",
+        "confbox": "^0.2.4",
+        "deslop-js": "^0.0.19",
+        "effect": "4.0.0-beta.70",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "jiti": "^2.7.0",
+        "magicast": "^0.5.3",
+        "oxlint": "^1.66.0",
+        "oxlint-plugin-react-doctor": "0.4.0",
+        "prompts": "^2.4.2",
+        "typescript": ">=5.0.4 <7",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "react-doctor": "bin/react-doctor.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/react-doctor/node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-doctor/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
@@ -9567,6 +11781,28 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-grab": {
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/react-grab/-/react-grab-0.1.44.tgz",
+      "integrity": "sha512-bDEwBdI90ljq2lhUtPqmWis/HwYB/CvfT0m5i+P9F83Pt0Ot8o9XL8v00s9jcWzdQUlsFDzmq2FO2CHUe8JY8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-grab/cli": "0.1.44",
+        "bippy": "^0.5.41"
+      },
+      "bin": {
+        "react-grab": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-i18next": {
@@ -9640,6 +11876,52 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-scan": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/react-scan/-/react-scan-0.5.7.tgz",
+      "integrity": "sha512-KRlq734yN6q/f2CZmZi9CWHuiqSzoLhPFLtcJOL6XM4lR54myyFcY81pG9QOwj+eBC1hIHm5n+Ntbtqiilu8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@preact/signals": "^2.9.0",
+        "@rollup/pluginutils": "^5.3.0",
+        "bippy": "^0.5.39",
+        "commander": "^14.0.0",
+        "picocolors": "^1.1.1",
+        "preact": "^10.29.1",
+        "prompts": "^2.4.2",
+        "react-doctor": "latest",
+        "react-grab": "latest"
+      },
+      "bin": {
+        "react-scan": "bin/cli.js"
+      },
+      "optionalDependencies": {
+        "unplugin": "^3.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-scan/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/read-cache": {
@@ -9843,6 +12125,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -9873,6 +12169,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -10334,6 +12647,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/smob": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
@@ -10409,6 +12729,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -10442,6 +12775,23 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -10560,6 +12910,35 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -10582,6 +12961,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -10638,6 +13034,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -10827,6 +13236,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tough-cookie": {
@@ -11166,6 +13585,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -11337,6 +13769,22 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -11418,6 +13866,20 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -11680,6 +14142,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -11702,6 +14219,14 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
@@ -11727,6 +14252,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -12258,6 +14790,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
@@ -1,0 +1,25 @@
+// packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { DemoClient } from './DemoClient'
+
+describe('DemoClient.runStressScenario', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('emits the generated events over time and stop() cancels the rest', () => {
+    const client = new DemoClient()
+    // populateDemo sets selfJid/conferenceService; emulate minimally:
+    ;(client as unknown as { selfJid: string }).selfJid = 'you@fluux.chat'
+    ;(client as unknown as { conferenceService: string }).conferenceService = 'conference.fluux.chat'
+    const emit = vi.spyOn(client as unknown as { emitSDK: (...a: unknown[]) => void }, 'emitSDK').mockImplementation(() => {})
+
+    const handle = client.runStressScenario({ kind: 'room-join', rooms: 1, occupants: 1, messagesPerRoom: 3, msgStepMs: 10, roomStepMs: 0 })
+    vi.advanceTimersByTime(25) // setup events (delay 0) + first message (delay 20)
+    const afterFirst = emit.mock.calls.length
+    expect(afterFirst).toBeGreaterThanOrEqual(5) // 4 setup + >=1 message
+
+    handle.stop()
+    vi.advanceTimersByTime(1000)
+    expect(emit.mock.calls.length).toBe(afterFirst) // no further emits after stop
+  })
+})

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -32,6 +32,7 @@ import type { ActivityEventInput } from '../core/types/activity'
 import type { Contact } from '../core/types/roster'
 import type { Room, RoomMessage, RoomOccupant } from '../core/types/room'
 import type { DemoData, DemoAnimationStep } from './types'
+import { buildStressEvents, type StressScenario } from './stress'
 import { parsePollElement, parsePollClosedElement } from '../core/poll'
 import type { PollData, PollClosedData } from '../core/types/message-base'
 
@@ -109,6 +110,34 @@ export class DemoClient extends XMPPClient {
       if (!this.knownRooms.has(room.jid)) {
         this.knownRooms.set(room.jid, { name: room.name, occupantCount: room.occupantCount })
       }
+    }
+  }
+
+  /**
+   * DEV/DEMO ONLY. Replays a synthetic load (e.g. joining many large rooms) by
+   * scheduling SDK events over timers, to reproduce render-performance issues
+   * deterministically. Returns a handle whose stop() cancels pending events.
+   */
+  runStressScenario(scenario: StressScenario): { stop: () => void } {
+    const selfNick = this.selfJid.split('@')[0] || 'you'
+    const events = buildStressEvents(scenario, {
+      selfJid: this.selfJid,
+      selfNick,
+      conferenceService: this.conferenceService,
+    })
+    let timers: ReturnType<typeof setTimeout>[] = [
+      ...events.map(ev =>
+        setTimeout(() => {
+          // Same cast style as dispatchStep(): payloads are generated to match the event.
+          this.emitSDK(ev.type as Parameters<typeof this.emitSDK>[0], ev.payload as never)
+        }, ev.delayMs),
+      ),
+    ]
+    return {
+      stop: () => {
+        for (const t of timers) clearTimeout(t)
+        timers = []
+      },
     }
   }
 

--- a/packages/fluux-sdk/src/demo/stress.test.ts
+++ b/packages/fluux-sdk/src/demo/stress.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { buildStressEvents } from './stress'
+
+const ctx = { selfJid: 'you@fluux.chat', selfNick: 'you', conferenceService: 'conference.fluux.chat' }
+
+describe('buildStressEvents (room-join)', () => {
+  it('emits added/joined/self-occupant/occupants-batch then N messages per room', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 2, occupants: 3, messagesPerRoom: 4 }, ctx)
+    const room0 = ev.filter(e =>
+      e.type === 'room:added'
+        ? e.payload.room.jid === 'stress-0@conference.fluux.chat'
+        : e.payload.roomJid === 'stress-0@conference.fluux.chat'
+    )
+    const types = room0.map(e => e.type)
+    expect(types.slice(0, 4)).toEqual(['room:added', 'room:joined', 'room:self-occupant', 'room:occupants-batch'])
+    expect(room0.filter(e => e.type === 'room:message')).toHaveLength(4)
+    // total = rooms * (4 setup + messagesPerRoom)
+    expect(ev).toHaveLength(2 * (4 + 4))
+  })
+
+  it('backfill mode keeps a stable, non-increasing order (later rooms older)', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 3, messagesPerRoom: 2, mode: 'backfill' }, ctx)
+    const tsOf = (i: number) => {
+      const e = ev.find(e => e.type === 'room:message' && e.payload.roomJid === `stress-${i}@conference.fluux.chat`)!
+      return e.type === 'room:message' ? e.payload.message.timestamp.getTime() : 0
+    }
+    expect(tsOf(0)).toBeGreaterThan(tsOf(1))
+    expect(tsOf(1)).toBeGreaterThan(tsOf(2))
+  })
+
+  it('live mode assigns strictly increasing message timestamps (reorders)', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 2, messagesPerRoom: 3, mode: 'live' }, ctx)
+    const stamps = ev
+      .filter(e => e.type === 'room:message')
+      .map(e => e.type === 'room:message' ? e.payload.message.timestamp.getTime() : 0)
+    const sorted = [...stamps].sort((a, b) => a - b)
+    expect(stamps).toEqual(sorted)
+    expect(new Set(stamps).size).toBe(stamps.length) // all distinct
+  })
+
+  it('includes the self occupant first in the occupants batch', () => {
+    const ev = buildStressEvents({ kind: 'room-join', rooms: 1, occupants: 2, messagesPerRoom: 0 }, ctx)
+    const batch = ev.find(e => e.type === 'room:occupants-batch')!
+    if (batch.type !== 'room:occupants-batch') throw new Error('expected batch')
+    expect(batch.payload.occupants[0].jid).toBe(ctx.selfJid)
+  })
+})

--- a/packages/fluux-sdk/src/demo/stress.ts
+++ b/packages/fluux-sdk/src/demo/stress.ts
@@ -1,0 +1,75 @@
+import type { Room, RoomMessage, RoomOccupant } from '../core/types/room'
+
+export interface StressScenario {
+  kind: 'room-join'
+  rooms?: number
+  occupants?: number
+  messagesPerRoom?: number
+  mode?: 'backfill' | 'live'
+  roomStepMs?: number
+  msgStepMs?: number
+}
+
+export type StressEvent =
+  | { delayMs: number; type: 'room:added';           payload: { room: Room } }
+  | { delayMs: number; type: 'room:joined';          payload: { roomJid: string; joined: boolean } }
+  | { delayMs: number; type: 'room:self-occupant';   payload: { roomJid: string; occupant: RoomOccupant } }
+  | { delayMs: number; type: 'room:occupants-batch'; payload: { roomJid: string; occupants: RoomOccupant[] } }
+  | { delayMs: number; type: 'room:message';         payload: { roomJid: string; message: RoomMessage } }
+
+export interface StressContext {
+  selfJid: string
+  selfNick: string
+  conferenceService: string
+}
+
+// Fixed epoch base so backfill ordering is deterministic and never "now".
+const BASE_TS = 1577836800000 // 2020-01-01T00:00:00Z
+// Each room is placed one minute earlier so rooms never share timestamps.
+const MS_PER_MINUTE = 60_000
+
+export function buildStressEvents(scenario: StressScenario, ctx: StressContext): StressEvent[] {
+  const rooms = scenario.rooms ?? 15
+  const occupants = scenario.occupants ?? 60
+  // Guard against 0 so message nick math is valid.
+  const occ = Math.max(1, occupants)
+  const messagesPerRoom = scenario.messagesPerRoom ?? 30
+  const mode = scenario.mode ?? 'backfill'
+  const roomStepMs = scenario.roomStepMs ?? 50
+  const msgStepMs = scenario.msgStepMs ?? 10
+  const domain = ctx.selfJid.split('@')[1] ?? 'fluux.chat'
+
+  const events: StressEvent[] = []
+  let globalMsg = 0
+  for (let i = 0; i < rooms; i++) {
+    const base = i * roomStepMs
+    const roomJid = `stress-${i}@${ctx.conferenceService}`
+    const room: Room = {
+      jid: roomJid, name: `Stress ${i}`, nickname: ctx.selfNick, joined: true,
+      isBookmarked: false, autojoin: false, supportsMAM: true, supportsReactions: true,
+      unreadCount: 0, mentionsCount: 0, typingUsers: new Set(), occupants: new Map(), messages: [],
+    }
+    const selfOcc: RoomOccupant = { nick: ctx.selfNick, jid: ctx.selfJid, affiliation: 'owner', role: 'moderator' }
+    events.push({ delayMs: base, type: 'room:added', payload: { room } })
+    events.push({ delayMs: base, type: 'room:joined', payload: { roomJid, joined: true } })
+    events.push({ delayMs: base, type: 'room:self-occupant', payload: { roomJid, occupant: selfOcc } })
+    const occList: RoomOccupant[] = [selfOcc]
+    for (let k = 0; k < occ; k++) {
+      occList.push({ nick: `U${i}_${k}`, jid: `u${i}_${k}@${domain}`, affiliation: 'member', role: 'participant' })
+    }
+    events.push({ delayMs: base, type: 'room:occupants-batch', payload: { roomJid, occupants: occList } })
+    for (let m = 0; m < messagesPerRoom; m++) {
+      // backfill: fixed, distinct-per-room, older for later rooms -> no reorder.
+      // live: globally increasing -> each message becomes newest -> reorders.
+      const ts = mode === 'backfill' ? BASE_TS - i * MS_PER_MINUTE : BASE_TS + globalMsg + 1
+      const nick = `U${i}_${m % occ}`
+      const message: RoomMessage = {
+        type: 'groupchat', id: `stress-${i}-${m}`, from: `${roomJid}/${nick}`, nick,
+        body: `stress message ${m}`, timestamp: new Date(ts), isOutgoing: false, roomJid,
+      }
+      events.push({ delayMs: base + 20 + m * msgStepMs, type: 'room:message', payload: { roomJid, message } })
+      globalMsg++
+    }
+  }
+  return events
+}

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -716,4 +716,5 @@ export {
 
 export { DemoClient } from './demo/DemoClient'
 export type { DemoData, DemoSelf, DemoPresence, DemoOwnResource, DemoRoomData, DemoAnimationStep } from './demo/types'
+export type { StressScenario } from './demo/stress'
 export { minutesAgo, hoursAgo, daysAgo } from './demo/timeHelpers'

--- a/packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md
+++ b/packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md
@@ -1,0 +1,22 @@
+# Render-count regression guards
+
+When fixing a render-perf issue, add a guard so it can't silently regress.
+
+## Store/hook level (preferred — real store, no app mock)
+Use the SDK render-stability helpers (`renderStability.helpers.tsx`): seed the
+store, capture a baseline, dispatch a background update, assert the subscription
+result is unchanged (`toEqual`) or the hook's render count did not increase.
+
+Examples in this repo:
+- `roomStore.sidebarJids.test.ts` — selector returns the same JIDs after a
+  non-reordering message (so `useShallow` bails).
+- `roomStore.perRoomStability.test.ts` — `getRoom(B)` keeps its ref after a
+  message to room A (so a per-row subscription only fires for the changed row).
+- `useListKeyboardNav.test.tsx` — `getItemProps` hover handlers stay
+  identity-stable across renders AND reorders.
+
+## Component level (stretch)
+To assert a background message re-renders only its row, render the component
+against the REAL store (override the global `@fluux/sdk` app mock in that test
+file with `vi.unmock` / `importActual`) and count renders with a module-level
+counter or React Profiler. Account for StrictMode double-rendering.


### PR DESCRIPTION
## Summary

A durable, reusable version of the render-performance debugging recipe used to fix #450 (and #451): reproduce realistic load deterministically, measure renders, and a Claude skill that drives the whole loop. Two layers — a dev/CI harness, and a skill on top of it.

## What's included

- **SDK** — `DemoClient.runStressScenario(scenario)` + a pure `buildStressEvents` generator that replays a "join N large rooms" load over timers. `backfill` mode (fixed timestamps, no reorder = the real MAM-backfill case) and `live` mode (reorders every message = worst case).
- **Demo mode wiring** — `?stress=rooms:15,messages:150,mode:backfill` runs a scenario after seed; `?perf=1` loads the **opt-in react-scan devDependency** and exposes `window.__perf` (per-component render counts + `renderLoopDetector` access). Strictly dev/demo-only — react-scan never reaches a production bundle.
- **Render-count guard doc** — `packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md` standardizing the regression-guard pattern (store/hook-level guards from #450).
- **Claude skill** — `.claude/skills/perf-stress-ui/` codifying reproduce → measure → diagnose → fix → verify, including the two traps that keep recurring here: the React-Compiler `useCallback`-strip and the unstable prop-source hook. A targeted `.gitignore` exception now tracks `.claude/skills/` while the rest of `.claude/` stays local.

## Design docs

- Spec: `docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md`
- Plan: `docs/superpowers/plans/2026-06-05-perf-stress-ui-harness.md`

## Verification

typecheck clean; SDK 3904 + app 2891 tests pass; lint 0 errors. Manual: `/demo.html?stress=rooms:15,messages:150,mode:live&perf=1` → `window.__perf` shows ~1 RoomItem render per message (no cascade).