### PR TITLE
fix(e2ee): calm TOFU encryption icon in chat header

### DIFF
--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -318,12 +318,16 @@ function EncryptionIcon({
   // encrypted — shield/lock icon + popover with verify + disable options.
   const verified = state.kind === 'encrypted' && state.trust === 'verified'
   const tofuNew = state.kind === 'encrypted' && state.trust === 'tofu-new'
-  const Icon = verified ? ShieldCheck : tofuNew ? ShieldAlert : Lock
+  // `tofu-new` (freshly TOFU-pinned, unchanged, not yet OOB-verified) renders
+  // the same neutral gray Lock as `unverified` — homogeneous with the Settings
+  // → Encryption screen and the Security tab. `tofuNew` survives only to pick a
+  // gentler tooltip below. The yellow ShieldAlert is now reserved exclusively
+  // for the genuine `blocked` (key-changed) alert, so the two states no longer
+  // share an alarming icon.
+  const Icon = verified ? ShieldCheck : Lock
   const colorClass = verified
     ? 'text-green-500'
-    : tofuNew
-      ? 'text-yellow-500'
-      : 'text-fluux-muted hover:text-fluux-text'
+    : 'text-fluux-muted hover:text-fluux-text'
   const hasActions = onVerifyClick || onDisableClick
 
   if (!hasActions) {


### PR DESCRIPTION
## Summary

The chat-header encryption icon for the `tofu-new` trust state — a key auto-pinned on first use (TOFU), unchanged, and not yet verified out-of-band — used a yellow `ShieldAlert` (shield + "!"). This was alarmist for a perfectly benign state, and it was the *same* icon and color as the `blocked` state (peer key actually changed), so a normal new contact looked identical to a real security alert.

It now renders as a **neutral gray `Lock`** (`text-fluux-muted`), identical to the `unverified` state and homogeneous with the Settings → Encryption screen and the contact Security tab. The yellow `ShieldAlert` is now reserved exclusively for the genuine `blocked` (key-changed) alert, removing the collision. The distinct "new contact - verify fingerprint" tooltip is preserved.