### PR TITLE
perf(muc): decouple composer + occupant panel from occupant/presence churn

### DIFF
--- a/.claude/skills/perf-stress-ui/SKILL.md
+++ b/.claude/skills/perf-stress-ui/SKILL.md
@@ -17,13 +17,53 @@ and `docs/superpowers/specs/2026-06-05-perf-stress-ui-harness-design.md`.
 - `mode:live` = reorders on every message (worst case).
 For custom sequences, drive `window.__demoClient.emitSDK('room:message', { roomJid, message })`.
 
+**Test EVERY churn source, not just messages.** A component can be decoupled from
+one and still storm on another (PR #451 killed the composer's *message* re-renders
+but it still re-renders ~1:1 on *occupant* churn — `addOccupant`/`removeOccupant`
+replace the occupants Map each event, so `useRoomOccupants` consumers + the
+unmemoized `OccupantPanel` storm). Drivers to replay individually:
+- messages → `emitSDK('room:message', { roomJid, message })`
+- presence storm (netsplit rejoin / busy room / show-flapping) →
+  `emitSDK('room:occupant-joined'|'room:occupant-left', …)` (one event per stanza;
+  `room:occupants-batch` is the single-render initial-join path — don't use it to
+  simulate a storm)
+- typing → `emitSDK('room:typing', { roomJid, nick, isTyping })`
+
+**Running from a git WORKTREE:** the worktree has no `node_modules`; the explicit-path
+alias `@xmpp/sasl-scram-sha-1 → ../../node_modules/...` in `apps/fluux/vite.config.ts`
+then fails (`[UNLOADABLE_DEPENDENCY]`, blank page). Fix: `ln -s <main-checkout>/node_modules <worktree>/node_modules`
+(remove it when done — `.gitignore`'s `node_modules/` has a trailing slash so it does
+NOT ignore a symlink, and it shows in `git status`). `@fluux/sdk` is aliased to
+`packages/fluux-sdk/src`, so you ARE testing the worktree's source.
+
 ## 2. Measure
-- `await window.__perf.measure('label', () => window.__demoClient.runStressScenario({ kind:'room-join', rooms:15, messagesPerRoom:150, mode:'live' }))`
-  → per-component render table.
-- `window.__det = await import('/src/utils/renderLoopDetector.ts')` →
-  `__det.getRenderStats()`, `__det.getSelectorHistory()`.
+- **Preferred:** `await window.__perf.measure('label', () => window.__demoClient.runStressScenario({ kind:'room-join', rooms:15, messagesPerRoom:150, mode:'live' }))`
+  → per-component render table (react-scan).
+- **If `?perf=1` / react-scan HANGS the renderer on load** (seen: react-scan +
+  React-Compiler + StrictMode over the full demo tree — every eval/screenshot times
+  out): skip it and use the always-on detector instead. `window.__det = await import('/src/utils/renderLoopDetector.ts')`
+  (same singleton Vite serves) → `__det.getRenderStats()`. Instrumented components:
+  App, ChatLayout, Sidebar, RoomsList, ConversationList, RoomView, MessageList,
+  MessageComposer (NOT RoomMessageInput / OccupantPanel — add a counter for those).
+- **Detector `getRenderStats()` count uses a RESETTING 1000ms window** — it zeroes
+  when a component renders past the window, so it CANNOT capture cumulative magnitude
+  for floods that span/​spill past ~1s (you read a tiny post-reset remnant; saw a
+  60-event storm report "2"). For reliable magnitude, splice a never-resetting counter
+  `;(globalThis).__rc = (globalThis).__rc||{}; (globalThis).__rc.X = ((globalThis).__rc.X||0)+1`
+  after each `detectRenderLoop()` call (and into un-instrumented components), reset
+  `window.__rc = {}` before each run. `startSyncGracePeriod()` raises the throw
+  threshold 200→500 + silences warnings so a legit heavy flood doesn't trip the
+  RenderLoopBoundary mid-measurement.
+- **Live preview evals choke** ("Promise was collected" / 30s timeout) on awaits ≳1s
+  and while the renderer is saturated mid-flood. So: FIRE the flood fire-and-forget in
+  one eval, `sleep` in Bash, READ counters in a separate eval (the `__rc` counter is
+  cumulative so read timing doesn't matter). Read the live store via
+  `import('/@fs/<abs>/packages/fluux-sdk/src/index.ts')` — same instance; verify
+  `roomStore.getState().activeRoomJid` matches the open room.
 - CAVEAT: React StrictMode doubles dev renders — divide by 2 for logical counts.
-- Sanity baseline: a no-op parent re-render should produce 0 child renders.
+- Sanity baseline: a no-op parent re-render should produce 0 child renders (the
+  per-event diagnostic — fire ONE event, read which counters tick — is the cleanest
+  signal and sidesteps batching/coalescing).
 
 ## 3. Diagnose — find the memo-breaking prop, then its source
 react-scan reports React-Compiler-memoized components as `forget:true`,

--- a/apps/fluux/src/components/OccupantPanel.memo.test.tsx
+++ b/apps/fluux/src/components/OccupantPanel.memo.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { OccupantPanel } from './OccupantPanel'
+import type { Room, RoomOccupant } from '@fluux/sdk'
+
+// Count occupant-row renders: each online occupant row renders exactly one Avatar.
+const avatarRenders = { count: 0 }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useWindowDrag: () => ({ titleBarClass: '', dragRegionProps: {} }),
+  useContextMenu: () => ({
+    isOpen: false, position: { x: 0, y: 0 }, open: vi.fn(), close: vi.fn(),
+    menuRef: { current: null }, triggerHandlers: {},
+    handleContextMenu: vi.fn(), handleTouchStart: vi.fn(), handleTouchEnd: vi.fn(),
+  }),
+}))
+
+vi.mock('./Avatar', () => ({
+  Avatar: ({ name }: { name: string }) => {
+    avatarRenders.count++
+    return <div data-testid="avatar">{name}</div>
+  },
+}))
+
+vi.mock('./conversation/UserInfoPopover', () => ({
+  UserInfoPopover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@fluux/sdk', async () => {
+  const actual = await vi.importActual('@fluux/sdk')
+  return {
+    ...actual,
+    getPresenceFromShow: (show: string | undefined) => show || 'online',
+    getBareJid: (jid: string) => jid.split('/')[0],
+    getBestPresenceShow: (shows: (string | undefined)[]) => shows[0],
+    generateConsistentColorHexSync: () => '#abc123',
+    useBlocking: () => ({ blockedJids: [], isBlocked: () => false, blockJid: vi.fn(), unblockJid: vi.fn(), unblockAll: vi.fn(), fetchBlocklist: vi.fn() }),
+    useRoomActions: () => ({ setAffiliation: vi.fn(), setRole: vi.fn(), queryAffiliationList: vi.fn() }),
+  }
+})
+
+vi.mock('@fluux/sdk/stores', () => ({
+  ignoreStore: {
+    getState: () => ({ ignoredUsers: {}, isIgnored: () => false, getIgnoredForRoom: () => [] }),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+}))
+
+vi.mock('@/utils/presence', () => ({
+  getTranslatedShowText: (show: string | undefined) => show || 'online',
+}))
+
+const createOccupant = (overrides: Partial<RoomOccupant> = {}): RoomOccupant => ({
+  nick: 'User', role: 'participant', affiliation: 'none', ...overrides,
+})
+
+const createRoom = (occupants: Map<string, RoomOccupant>): Room => ({
+  jid: 'room@conference.example.com', name: 'Test Room', nickname: 'Me',
+  occupants, messages: [], joined: true, unreadCount: 0, mentionsCount: 0,
+  typingUsers: new Set(), isBookmarked: false,
+})
+
+describe('OccupantPanel per-row memoization', () => {
+  beforeEach(() => { avatarRenders.count = 0 })
+
+  it('re-renders only the changed occupant row when a single occupant updates', () => {
+    const alice = createOccupant({ nick: 'alice', jid: 'alice@example.com' })
+    const bob = createOccupant({ nick: 'bob', jid: 'bob@example.com' })
+    const carol = createOccupant({ nick: 'carol', jid: 'carol@example.com' })
+
+    // Stable refs that must NOT change across the re-render.
+    const contactsByJid = new Map()
+    const onClose = () => {}
+
+    const room1 = createRoom(new Map([['alice', alice], ['bob', bob], ['carol', carol]]))
+    const { rerender } = render(
+      <OccupantPanel room={room1} contactsByJid={contactsByJid} onClose={onClose} />
+    )
+
+    const perRowCost = avatarRenders.count / 3 // avatars rendered per row at mount (handles StrictMode)
+    expect(avatarRenders.count).toBeGreaterThan(0)
+    const afterMount = avatarRenders.count
+
+    // Mirror roomStore.addOccupant: a NEW occupants Map where only bob's object is
+    // replaced; alice & carol keep their refs (this is what the store actually does).
+    const bobAway = { ...bob, show: 'away' as const }
+    const room2 = createRoom(new Map([['alice', alice], ['bob', bobAway], ['carol', carol]]))
+    rerender(<OccupantPanel room={room2} contactsByJid={contactsByJid} onClose={onClose} />)
+
+    const delta = avatarRenders.count - afterMount
+    // Only bob's row should re-render — one row's worth, NOT all three.
+    expect(delta).toBeGreaterThan(0)
+    expect(delta).toBeLessThanOrEqual(perRowCost)
+  })
+})

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -9,7 +9,7 @@
  * - Shows contact avatars for known roster contacts
  * - Right-click context menu: private message, copy JID, ignore, user info
  */
-import { useState } from 'react'
+import { useState, useRef, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Room, RoomOccupant, Contact, PresenceShow, RoomAffiliation, RoomRole } from '@fluux/sdk'
 import { getPresenceFromShow, getBareJid, getBestPresenceShow, generateConsistentColorHexSync, canKick, canBan, getAvailableAffiliations, getAvailableRoles } from '@fluux/sdk'
@@ -50,6 +50,237 @@ export interface OccupantPanelProps {
 // Stable empty array for useIgnoreStore selector to prevent infinite re-render loops
 const EMPTY_IGNORED_ARRAY: IgnoredUser[] = []
 
+// Affiliation badge — pure mapping from affiliation to a small icon. Module-level so
+// the memoized OccupantRow can use it without recreating a closure per render.
+function getAffiliationBadge(affiliation: string) {
+  switch (affiliation) {
+    case 'owner':
+      return (
+        <span className="flex items-center gap-0.5 text-amber-600 dark:text-amber-400">
+          <Crown className="size-3" />
+        </span>
+      )
+    case 'admin':
+      return (
+        <span className="flex items-center gap-0.5 text-fluux-brand">
+          <Shield className="size-3" />
+        </span>
+      )
+    case 'member':
+      return (
+        <span className="flex items-center gap-0.5 text-fluux-green">
+          <UserCheck className="size-3" />
+        </span>
+      )
+    default:
+      return null
+  }
+}
+
+interface OccupantRowProps {
+  group: GroupedOccupant
+  roomJid: string
+  roomNickname: string
+  ownAvatar?: string | null
+  forceOffline: boolean
+  contactsByJid: Map<string, Contact>
+  ignored: boolean
+  onContextMenu: (group: GroupedOccupant, e: React.MouseEvent) => void
+  onTouchStart: (group: GroupedOccupant, e: React.TouchEvent) => void
+  onTouchEnd: (e: React.TouchEvent) => void
+  onTouchMove: (e: React.TouchEvent) => void
+}
+
+/**
+ * One occupant row (a bare-JID group of connections), memoized so a presence/occupant
+ * event re-renders ONLY the changed row, not the whole list. `roomStore.addOccupant`
+ * replaces the occupants Map but keeps unchanged occupants' object refs, so the
+ * connection-by-reference comparison below bails for every row except the one whose
+ * occupant object actually changed. All other props are kept reference-stable by the
+ * parent (callbacks via a lazy ref; `contactsByJid` from a memoized map).
+ */
+function occupantRowPropsEqual(prev: OccupantRowProps, next: OccupantRowProps): boolean {
+  const pc = prev.group.connections
+  const nc = next.group.connections
+  if (pc.length !== nc.length) return false
+  for (let i = 0; i < pc.length; i++) {
+    if (pc[i] !== nc[i]) return false // occupant object ref changed → this row changed
+  }
+  return (
+    prev.roomJid === next.roomJid &&
+    prev.roomNickname === next.roomNickname &&
+    prev.ownAvatar === next.ownAvatar &&
+    prev.forceOffline === next.forceOffline &&
+    prev.contactsByJid === next.contactsByJid &&
+    prev.ignored === next.ignored &&
+    prev.onContextMenu === next.onContextMenu &&
+    prev.onTouchStart === next.onTouchStart &&
+    prev.onTouchEnd === next.onTouchEnd &&
+    prev.onTouchMove === next.onTouchMove
+  )
+}
+
+const OccupantRow = memo(function OccupantRow({
+  group,
+  roomJid,
+  roomNickname,
+  ownAvatar,
+  forceOffline,
+  contactsByJid,
+  ignored,
+  onContextMenu,
+  onTouchStart,
+  onTouchEnd,
+  onTouchMove,
+}: OccupantRowProps) {
+  const { t } = useTranslation()
+  const primaryOccupant = group.connections[0]
+  const hasMultipleConnections = group.connections.length > 1
+  const isMe = group.connections.some(conn => conn.nick === roomNickname)
+
+  // Get occupant avatar from XEP-0398 or fall back to contact avatar
+  const occupantAvatar = group.connections.find(c => c.avatar)?.avatar
+  const contact = group.bareJid ? contactsByJid.get(group.bareJid) : undefined
+  const contactAvatar = contact?.avatar
+  const displayAvatar = occupantAvatar || contactAvatar
+
+  // Build tooltip showing all nicks if multiple connections
+  const tooltip = hasMultipleConnections
+    ? `${group.connections.map(c => c.nick).join(', ')} (${group.connections.length} ${t('rooms.connections')})`
+    : getOccupantTooltip(primaryOccupant, t, forceOffline)
+
+  // Collect all unique hats from all connections
+  const allHats = new Map<string, { uri: string; title: string; hue?: number }>()
+  for (const conn of group.connections) {
+    conn.hats?.forEach(hat => {
+      if (!allHats.has(hat.uri)) {
+        allHats.set(hat.uri, hat)
+      }
+    })
+  }
+
+  // Get highest affiliation from all connections
+  const affiliationPriority: Record<string, number> = { owner: 0, admin: 1, member: 2, outcast: 3, none: 4 }
+  const bestAffiliation = group.connections.reduce((best, conn) => {
+    const bestPriority = affiliationPriority[best] ?? 5
+    const connPriority = affiliationPriority[conn.affiliation] ?? 5
+    return connPriority < bestPriority ? conn.affiliation : best
+  }, 'none' as string)
+
+  return (
+    <Tooltip
+      content={tooltip || ''}
+      position="left"
+      disabled={!tooltip}
+      className="block"
+    >
+      <div
+        onContextMenu={(e) => onContextMenu(group, e)}
+        onTouchStart={(e) => onTouchStart(group, e)}
+        onTouchEnd={onTouchEnd}
+        onTouchMove={onTouchMove}
+        className={`px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-hover/50 cursor-default
+                   ${isMe ? 'bg-fluux-brand/10' : ''}
+                   ${ignored ? 'opacity-40' : ''}`}
+      >
+        {/* Avatar with best presence (XEP-0398 occupant avatar or roster contact avatar) */}
+        <Avatar
+          identifier={group.primaryNick}
+          name={group.primaryNick}
+          avatarUrl={isMe ? (ownAvatar || undefined) : displayAvatar}
+          size="sm"
+          presence={getPresenceFromShow(group.bestPresence)}
+          presenceBorderColor="border-fluux-sidebar"
+          fallbackColor={isMe ? 'var(--fluux-bg-accent)' : undefined}
+          forceOffline={forceOffline}
+        />
+
+        {/* Nick and badges */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {isMe ? (
+              <span className="truncate text-sm font-semibold text-fluux-text">
+                {group.primaryNick}
+                <span className="text-fluux-muted font-normal"> {t('rooms.you')}</span>
+              </span>
+            ) : (
+              <UserInfoPopover
+                contact={group.bareJid ? contactsByJid.get(group.bareJid) : undefined}
+                jid={group.bareJid}
+                occupantJid={`${roomJid}/${group.primaryNick}`}
+                role={primaryOccupant.role}
+                affiliation={bestAffiliation as RoomAffiliation}
+              >
+                <span className="truncate text-sm text-fluux-text">
+                  {group.primaryNick}
+                </span>
+              </UserInfoPopover>
+            )}
+            {/* Connection count badge */}
+            {hasMultipleConnections && (
+              <span className="flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-medium rounded-full bg-fluux-muted/20 text-fluux-muted">
+                ×{group.connections.length}
+              </span>
+            )}
+            {getAffiliationBadge(bestAffiliation)}
+            {/* Ignored indicator */}
+            {ignored && (
+              <EyeOff className="size-3 text-fluux-muted" />
+            )}
+            {/* XEP-0317 Hats from all connections (max 3 inline, overflow in tooltip) */}
+            {(() => {
+              const hats = Array.from(allHats.values())
+              const MAX_INLINE = 3
+              const visible = hats.slice(0, MAX_INLINE)
+              const overflow = hats.slice(MAX_INLINE, MAX_INLINE + 9)
+              return (
+                <>
+                  {visible.map((hat) => (
+                    <span
+                      key={hat.uri}
+                      className="px-1.5 py-0.5 text-[10px] font-medium rounded"
+                      style={getHatColors(hat)}
+                    >
+                      {hat.title}
+                    </span>
+                  ))}
+                  {overflow.length > 0 && (
+                    <Tooltip
+                      content={
+                        <div className="flex flex-col gap-1">
+                          {overflow.map((hat) => (
+                            <span
+                              key={hat.uri}
+                              className="px-1.5 py-0.5 text-[10px] font-medium rounded inline-block"
+                              style={getHatColors(hat)}
+                            >
+                              {hat.title}
+                            </span>
+                          ))}
+                        </div>
+                      }
+                      position="top"
+                      delay={300}
+                    >
+                      <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-fluux-muted/20 text-fluux-muted cursor-default">
+                        +{overflow.length}
+                      </span>
+                    </Tooltip>
+                  )}
+                </>
+              )
+            })()}
+          </div>
+          {/* Show bare JID if available */}
+          {group.bareJid && (
+            <p className="text-xs text-fluux-muted truncate">{group.bareJid}</p>
+          )}
+        </div>
+      </div>
+    </Tooltip>
+  )
+}, occupantRowPropsEqual)
+
 export function OccupantPanel({
   room,
   contactsByJid,
@@ -70,18 +301,41 @@ export function OccupantPanel({
   const menu = useContextMenu()
   const [menuTarget, setMenuTarget] = useState<GroupedOccupant | null>(null)
 
-  const handleOccupantContextMenu = (e: React.MouseEvent, group: GroupedOccupant) => {
-    // Don't show menu for self
-    if (group.connections.some(conn => conn.nick === room.nickname)) return
-    setMenuTarget(group)
-    menu.handleContextMenu(e)
+  // Reference-STABLE row callbacks for the memoized OccupantRow. They must not be
+  // recreated each render or the memo would no-op (it compares them by reference).
+  // Lazy-init + a "latest" ref keeps the function identities fixed while still reading
+  // the current menu/nickname (the compiler-proof pattern, NOT useCallback).
+  const rowCtxRef = useRef({ menu, setMenuTarget, roomNickname: room.nickname })
+  rowCtxRef.current = { menu, setMenuTarget, roomNickname: room.nickname }
+  const rowHandlersRef = useRef<{
+    onContextMenu: (group: GroupedOccupant, e: React.MouseEvent) => void
+    onTouchStart: (group: GroupedOccupant, e: React.TouchEvent) => void
+    onTouchEnd: (e: React.TouchEvent) => void
+    onTouchMove: (e: React.TouchEvent) => void
+  } | null>(null)
+  if (!rowHandlersRef.current) {
+    rowHandlersRef.current = {
+      onContextMenu: (group, e) => {
+        const { menu, setMenuTarget, roomNickname } = rowCtxRef.current
+        if (group.connections.some(conn => conn.nick === roomNickname)) return // no menu for self
+        setMenuTarget(group)
+        menu.handleContextMenu(e)
+      },
+      onTouchStart: (group, e) => {
+        const { menu, setMenuTarget, roomNickname } = rowCtxRef.current
+        if (group.connections.some(conn => conn.nick === roomNickname)) return
+        setMenuTarget(group)
+        menu.handleTouchStart(e)
+      },
+      onTouchEnd: () => rowCtxRef.current.menu.handleTouchEnd(),
+      onTouchMove: () => rowCtxRef.current.menu.handleTouchEnd(),
+    }
   }
+  const rowHandlers = rowHandlersRef.current
 
-  const handleOccupantTouchStart = (e: React.TouchEvent, group: GroupedOccupant) => {
-    if (group.connections.some(conn => conn.nick === room.nickname)) return
-    setMenuTarget(group)
-    menu.handleTouchStart(e)
-  }
+  // Non-memoized rows (e.g. hidden-ignored synthetic rows) delegate to the same logic.
+  const handleOccupantContextMenu = (e: React.MouseEvent, group: GroupedOccupant) => rowHandlers.onContextMenu(group, e)
+  const handleOccupantTouchStart = (e: React.TouchEvent, group: GroupedOccupant) => rowHandlers.onTouchStart(group, e)
 
   /** Get the best stable identifier for an occupant group */
   const getOccupantIdentifier = (group: GroupedOccupant): string => {
@@ -279,32 +533,6 @@ export function OccupantPanel({
     }
   }
 
-  // Affiliation badges - tooltips removed, info now in unified row tooltip
-  const getAffiliationBadge = (affiliation: string) => {
-    switch (affiliation) {
-      case 'owner':
-        return (
-          <span className="flex items-center gap-0.5 text-amber-600 dark:text-amber-400">
-            <Crown className="size-3" />
-          </span>
-        )
-      case 'admin':
-        return (
-          <span className="flex items-center gap-0.5 text-fluux-brand">
-            <Shield className="size-3" />
-          </span>
-        )
-      case 'member':
-        return (
-          <span className="flex items-center gap-0.5 text-fluux-green">
-            <UserCheck className="size-3" />
-          </span>
-        )
-      default:
-        return null
-    }
-  }
-
   return (
     <div className={`${fullScreen ? 'w-full h-full' : 'w-64 border-s border-fluux-bg'} flex flex-col bg-fluux-sidebar`}>
       {/* Panel header */}
@@ -345,160 +573,24 @@ export function OccupantPanel({
               <span className="text-fluux-muted/60">— {occupants.length}</span>
             </div>
 
-            {/* Grouped occupants in this role */}
-            {occupants.map((group) => {
-              const primaryOccupant = group.connections[0]
-              const hasMultipleConnections = group.connections.length > 1
-              const isMe = group.connections.some(conn => conn.nick === room.nickname)
-
-              // Get occupant avatar from XEP-0398 or fall back to contact avatar
-              // Check all connections for an avatar (any of them may have it)
-              const occupantAvatar = group.connections.find(c => c.avatar)?.avatar
-              // Get contact avatar if occupant's real JID is known and they're in our roster
-              const contact = group.bareJid ? contactsByJid.get(group.bareJid) : undefined
-              const contactAvatar = contact?.avatar
-              // Prefer occupant's direct avatar (XEP-0398) over contact avatar
-              const displayAvatar = occupantAvatar || contactAvatar
-
-              // Build tooltip showing all nicks if multiple connections
-              const tooltip = hasMultipleConnections
-                ? `${group.connections.map(c => c.nick).join(', ')} (${group.connections.length} ${t('rooms.connections')})`
-                : getOccupantTooltip(primaryOccupant, t, forceOffline)
-
-              // Collect all unique hats from all connections
-              const allHats = new Map<string, { uri: string; title: string; hue?: number }>()
-              for (const conn of group.connections) {
-                conn.hats?.forEach(hat => {
-                  if (!allHats.has(hat.uri)) {
-                    allHats.set(hat.uri, hat)
-                  }
-                })
-              }
-
-              // Get highest affiliation from all connections
-              const affiliationPriority: Record<string, number> = { owner: 0, admin: 1, member: 2, outcast: 3, none: 4 }
-              const bestAffiliation = group.connections.reduce((best, conn) => {
-                const bestPriority = affiliationPriority[best] ?? 5
-                const connPriority = affiliationPriority[conn.affiliation] ?? 5
-                return connPriority < bestPriority ? conn.affiliation : best
-              }, 'none' as string)
-
-              const ignored = isOccupantIgnored(group)
-
-              return (
-                <Tooltip
-                  key={group.bareJid || group.primaryNick}
-                  content={tooltip || ''}
-                  position="left"
-                  disabled={!tooltip}
-                  className="block"
-                >
-                  <div
-                    onContextMenu={(e) => handleOccupantContextMenu(e, group)}
-                    onTouchStart={(e) => handleOccupantTouchStart(e, group)}
-                    onTouchEnd={menu.handleTouchEnd}
-                    onTouchMove={menu.handleTouchEnd}
-                    className={`px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-hover/50 cursor-default
-                               ${isMe ? 'bg-fluux-brand/10' : ''}
-                               ${ignored ? 'opacity-40' : ''}`}
-                  >
-                    {/* Avatar with best presence (XEP-0398 occupant avatar or roster contact avatar) */}
-                    <Avatar
-                      identifier={group.primaryNick}
-                      name={group.primaryNick}
-                      avatarUrl={isMe ? (ownAvatar || undefined) : displayAvatar}
-                      size="sm"
-                      presence={getPresenceFromShow(group.bestPresence)}
-                      presenceBorderColor="border-fluux-sidebar"
-                      fallbackColor={isMe ? 'var(--fluux-bg-accent)' : undefined}
-                      forceOffline={forceOffline}
-                    />
-
-                    {/* Nick and badges */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5 flex-wrap">
-                        {isMe ? (
-                          <span className="truncate text-sm font-semibold text-fluux-text">
-                            {group.primaryNick}
-                            <span className="text-fluux-muted font-normal"> {t('rooms.you')}</span>
-                          </span>
-                        ) : (
-                          <UserInfoPopover
-                            contact={group.bareJid ? contactsByJid.get(group.bareJid) : undefined}
-                            jid={group.bareJid}
-                            occupantJid={`${room.jid}/${group.primaryNick}`}
-                            role={primaryOccupant.role}
-                            affiliation={bestAffiliation as RoomAffiliation}
-                          >
-                            <span className="truncate text-sm text-fluux-text">
-                              {group.primaryNick}
-                            </span>
-                          </UserInfoPopover>
-                        )}
-                        {/* Connection count badge */}
-                        {hasMultipleConnections && (
-                          <span className="flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-medium rounded-full bg-fluux-muted/20 text-fluux-muted">
-                            ×{group.connections.length}
-                          </span>
-                        )}
-                        {getAffiliationBadge(bestAffiliation)}
-                        {/* Ignored indicator */}
-                        {ignored && (
-                          <EyeOff className="size-3 text-fluux-muted" />
-                        )}
-                        {/* XEP-0317 Hats from all connections (max 3 inline, overflow in tooltip) */}
-                        {(() => {
-                          const hats = Array.from(allHats.values())
-                          const MAX_INLINE = 3
-                          const visible = hats.slice(0, MAX_INLINE)
-                          const overflow = hats.slice(MAX_INLINE, MAX_INLINE + 9)
-                          return (
-                            <>
-                              {visible.map((hat) => (
-                                <span
-                                  key={hat.uri}
-                                  className="px-1.5 py-0.5 text-[10px] font-medium rounded"
-                                  style={getHatColors(hat)}
-                                >
-                                  {hat.title}
-                                </span>
-                              ))}
-                              {overflow.length > 0 && (
-                                <Tooltip
-                                  content={
-                                    <div className="flex flex-col gap-1">
-                                      {overflow.map((hat) => (
-                                        <span
-                                          key={hat.uri}
-                                          className="px-1.5 py-0.5 text-[10px] font-medium rounded inline-block"
-                                          style={getHatColors(hat)}
-                                        >
-                                          {hat.title}
-                                        </span>
-                                      ))}
-                                    </div>
-                                  }
-                                  position="top"
-                                  delay={300}
-                                >
-                                  <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-fluux-muted/20 text-fluux-muted cursor-default">
-                                    +{overflow.length}
-                                  </span>
-                                </Tooltip>
-                              )}
-                            </>
-                          )
-                        })()}
-                      </div>
-                      {/* Show bare JID if available */}
-                      {group.bareJid && (
-                        <p className="text-xs text-fluux-muted truncate">{group.bareJid}</p>
-                      )}
-                    </div>
-                  </div>
-                </Tooltip>
-              )
-            })}
+            {/* Grouped occupants in this role — each row is a memoized OccupantRow so a
+                presence/occupant event re-renders ONLY the changed row, not the whole list. */}
+            {occupants.map((group) => (
+              <OccupantRow
+                key={group.bareJid || group.primaryNick}
+                group={group}
+                roomJid={room.jid}
+                roomNickname={room.nickname}
+                ownAvatar={ownAvatar}
+                forceOffline={forceOffline}
+                contactsByJid={contactsByJid}
+                ignored={isOccupantIgnored(group)}
+                onContextMenu={rowHandlers.onContextMenu}
+                onTouchStart={rowHandlers.onTouchStart}
+                onTouchEnd={rowHandlers.onTouchEnd}
+                onTouchMove={rowHandlers.onTouchMove}
+              />
+            ))}
           </div>
         ))}
 

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -123,6 +123,7 @@ vi.mock('@fluux/sdk', () => ({
   // Focused room subscriptions used by the memoized RoomMessageInput composer.
   useRoomEntity: () => mockActiveRoom ? { name: mockActiveRoom.name, nickname: mockActiveRoom.nickname } : undefined,
   useRoomOccupants: () => mockActiveRoom?.occupants ?? new Map(),
+  useRoomOccupantCount: () => mockActiveRoom?.occupants?.size ?? 0,
   useRoster: () => ({
     contacts: mockContacts,
   }),

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useRoomActive, useRoomEntity, useRoomOccupants, useRoster, getBareJid, generateConsistentColorHexSync, getPresenceFromShow, createMessageLookup, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, canModerate, getAvailableAffiliations, getAvailableRoles, getMyReactions, type RoomMessage, type Room, type MentionReference, type ChatStateNotification, type Contact, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
+import { useRoomActive, useRoomEntity, useRoomOccupantCount, useRoster, getBareJid, generateConsistentColorHexSync, getPresenceFromShow, createMessageLookup, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, canModerate, getAvailableAffiliations, getAvailableRoles, getMyReactions, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type Contact, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, isSmallScreen } from '@/hooks'
@@ -66,6 +66,8 @@ const MAX_ROOM_SIZE_FOR_TYPING = 30
 
 // Stable empty array for useIgnoreStore selector to prevent infinite re-render loops
 const EMPTY_IGNORED_ARRAY: import('@fluux/sdk/stores').IgnoredUser[] = []
+// Stable empty fallback for the composer's NON-reactive occupants read.
+const EMPTY_OCCUPANTS: Map<string, RoomOccupant> = new Map()
 
 export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = false, onShowOccupantsChange, onStartChat, onShowProfile, findOnPageRef, onSearchInConversation }: RoomViewProps) {
   detectRenderLoop('RoomView')
@@ -1502,11 +1504,22 @@ export const RoomMessageInput = memo(function RoomMessageInput({
 }: RoomMessageInputProps & { ref?: React.Ref<MessageComposerHandle> }) {
   const { t } = useTranslation()
   // Narrow, reference-stable subscriptions: the composer re-renders on entity
-  // changes (name/nickname) and occupant changes, but NOT on message churn.
+  // changes (name/nickname) and occupant COUNT changes (join/leave), but NOT on
+  // message churn nor on occupant metadata churn (show/avatar/presence flapping).
   const entity = useRoomEntity(roomJid)
   const roomName = entity?.name ?? roomJid
   const roomNickname = entity?.nickname ?? ''
-  const occupants = useRoomOccupants(roomJid)
+  // Subscribe ONLY to the occupant COUNT (a primitive). The occupants Map ref is
+  // replaced on every occupant event (join/leave/show/avatar update), so subscribing
+  // to the Map re-rendered the composer ~1:1 with presence churn (netsplit rejoin,
+  // busy room, show-flapping). The count changes only on join/leave. The occupant
+  // DATA — needed for mention candidates and the typing threshold — is read
+  // NON-reactively from the store on each render (like messageNicks below): the
+  // composer already re-renders on every keystroke while composing a mention, so the
+  // candidate list stays fresh without a Map subscription, and the nick set only
+  // changes on join/leave (a count change, which DOES re-render).
+  const occupantCount = useRoomOccupantCount(roomJid)
+  const occupants = roomStore.getState().getRoom(roomJid)?.occupants ?? EMPTY_OCCUPANTS
   // Draft actions are stable function refs — read non-reactively from the store.
   const { setDraft, getDraft, clearDraft, clearFirstNewMessageId } = roomStore.getState()
   const addToast = useToastStore((s) => s.addToast)
@@ -1554,8 +1567,8 @@ export const RoomMessageInput = memo(function RoomMessageInput({
   // Type-to-focus: auto-focus composer when user starts typing anywhere
   useTypeToFocus(composerRef)
 
-  // Check if room is small enough to send typing notifications
-  const shouldSendTypingNotifications = occupants.size < MAX_ROOM_SIZE_FOR_TYPING
+  // Check if room is small enough to send typing notifications (reactive on count).
+  const shouldSendTypingNotifications = occupantCount < MAX_ROOM_SIZE_FOR_TYPING
 
   // Collect mention-candidate nicks (occupants + history authors + affiliated
   // members). Read NON-reactively from the store on each render: this must NOT

--- a/packages/fluux-sdk/src/hooks/index.ts
+++ b/packages/fluux-sdk/src/hooks/index.ts
@@ -34,6 +34,7 @@ export {
   useRoomRuntime,
   useRoomMessages,
   useRoomOccupants,
+  useRoomOccupantCount,
   useAllRoomSidebarItems,
   useRoomSidebarItems,
   useRoomTotalMentionsCount,

--- a/packages/fluux-sdk/src/hooks/useMetadataSubscriptions.ts
+++ b/packages/fluux-sdk/src/hooks/useMetadataSubscriptions.ts
@@ -255,6 +255,23 @@ export function useRoomOccupants(roomJid: string): Map<string, RoomOccupant> {
   return useRoomStore(roomSelectors.runtimeOccupantsFor(roomJid)) ?? EMPTY_OCCUPANT_MAP
 }
 
+/**
+ * Subscribe to the room occupant COUNT (a primitive) instead of the occupants Map.
+ *
+ * The occupants Map ref is replaced on every occupant event (join / leave / show /
+ * avatar update), so `useRoomOccupants` consumers re-render on all of them. Use this
+ * when you only need the size: it re-renders only when the count actually changes
+ * (join / leave), bailing on metadata-only churn (e.g. presence flapping in a busy
+ * room). Read the occupant data non-reactively (`roomStore.getState()`) if you also
+ * need it for a computation that is already recomputed each render.
+ *
+ * @param roomJid - The room JID to subscribe to
+ * @returns The number of occupants currently in the room
+ */
+export function useRoomOccupantCount(roomJid: string): number {
+  return useRoomStore(roomSelectors.runtimeOccupantCountFor(roomJid))
+}
+
 /** Room sidebar item type - shared between hooks */
 export interface RoomSidebarItem {
   jid: string

--- a/packages/fluux-sdk/src/hooks/useRoomOccupantCount.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoomOccupantCount.renderStability.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useRoomOccupantCount } from './useMetadataSubscriptions'
+import { roomStore } from '../stores'
+import { wrapper, useRenderCount, createRoom } from './renderStability.helpers'
+
+const ROOM = 'roomA@conference.example.com'
+
+describe('useRoomOccupantCount render stability', () => {
+  beforeEach(() => {
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      mamQueryStates: new Map(),
+      activeAnimation: null,
+      drafts: new Map(),
+    })
+  })
+
+  it('does NOT re-render when an occupant\'s metadata changes but the count is unchanged', () => {
+    act(() => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      roomStore.getState().setActiveRoom(ROOM)
+      roomStore.getState().addOccupant(ROOM, { nick: 'alice', affiliation: 'member', role: 'participant' })
+    })
+
+    const { result } = renderHook(
+      () => ({ renderCount: useRenderCount(), count: useRoomOccupantCount(ROOM) }),
+      { wrapper }
+    )
+
+    const rendersAfterMount = result.current.renderCount
+    expect(result.current.count).toBe(1)
+
+    // 20 metadata-only updates to the SAME occupant (presence/show flapping) — count stays 1.
+    act(() => {
+      for (let i = 0; i < 20; i++) {
+        roomStore.getState().addOccupant(ROOM, {
+          nick: 'alice',
+          affiliation: 'member',
+          role: 'participant',
+          show: i % 2 ? 'away' : undefined,
+        })
+      }
+    })
+
+    expect(result.current.count).toBe(1)
+    expect(result.current.renderCount).toBe(rendersAfterMount) // count subscription bailed on every update
+  })
+
+  it('re-renders when the occupant count changes (join / leave)', () => {
+    act(() => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      roomStore.getState().setActiveRoom(ROOM)
+      roomStore.getState().addOccupant(ROOM, { nick: 'alice', affiliation: 'member', role: 'participant' })
+    })
+
+    const { result } = renderHook(
+      () => ({ renderCount: useRenderCount(), count: useRoomOccupantCount(ROOM) }),
+      { wrapper }
+    )
+
+    const rendersAfterMount = result.current.renderCount
+
+    act(() => {
+      roomStore.getState().addOccupant(ROOM, { nick: 'bob', affiliation: 'member', role: 'participant' })
+    })
+    expect(result.current.count).toBe(2)
+    expect(result.current.renderCount).toBeGreaterThan(rendersAfterMount)
+
+    const rendersAfterJoin = result.current.renderCount
+    act(() => {
+      roomStore.getState().removeOccupant(ROOM, 'bob')
+    })
+    expect(result.current.count).toBe(1)
+    expect(result.current.renderCount).toBeGreaterThan(rendersAfterJoin)
+  })
+
+  it('does NOT re-render when a BACKGROUND room receives presence churn', () => {
+    const BG = 'roomB@conference.example.com'
+    act(() => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      roomStore.getState().addRoom(createRoom(BG, { joined: true }))
+      roomStore.getState().setActiveRoom(ROOM)
+      roomStore.getState().addOccupant(ROOM, { nick: 'alice', affiliation: 'member', role: 'participant' })
+    })
+
+    // Subscribe to the ACTIVE room's count.
+    const { result } = renderHook(
+      () => ({ renderCount: useRenderCount(), count: useRoomOccupantCount(ROOM) }),
+      { wrapper }
+    )
+    const rendersAfterMount = result.current.renderCount
+
+    // Storm the BACKGROUND room with individual joins/leaves + metadata flapping.
+    act(() => {
+      for (let i = 0; i < 30; i++) {
+        roomStore.getState().addOccupant(BG, { nick: `U${i}`, jid: `u${i}@x`, affiliation: 'member', role: 'participant' })
+      }
+      for (let i = 0; i < 30; i++) {
+        roomStore.getState().addOccupant(BG, { nick: `U${i}`, jid: `u${i}@x`, affiliation: 'member', role: 'participant', show: 'away' })
+      }
+      for (let i = 0; i < 10; i++) {
+        roomStore.getState().removeOccupant(BG, `U${i}`)
+      }
+    })
+
+    // The displayed (active) room's count subscription is fully isolated.
+    expect(result.current.count).toBe(1)
+    expect(result.current.renderCount).toBe(rendersAfterMount)
+  })
+})

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -132,6 +132,7 @@ export {
   useRoomRuntime,
   useRoomMessages,
   useRoomOccupants,
+  useRoomOccupantCount,
   useAllRoomSidebarItems,
   useRoomSidebarItems,
   useRoomTotalMentionsCount,

--- a/packages/fluux-sdk/src/stores/roomSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.test.ts
@@ -682,4 +682,25 @@ describe('roomSelectors', () => {
       expect(result.get('alice')).toEqual(occupant)
     })
   })
+
+  describe('runtimeOccupantCountFor', () => {
+    it('should return the occupant count from runtime', () => {
+      const runtime: RoomRuntime = {
+        occupants: new Map([
+          ['alice', { nick: 'alice', affiliation: 'member', role: 'participant' }],
+          ['bob', { nick: 'bob', affiliation: 'member', role: 'participant' }],
+        ]),
+        messages: [],
+      }
+      const roomRuntime = new Map([['room@conference.example.com', runtime]])
+      const state = createMockState({ roomRuntime })
+
+      expect(roomSelectors.runtimeOccupantCountFor('room@conference.example.com')(state)).toBe(2)
+    })
+
+    it('should return 0 for an unknown room', () => {
+      const state = createMockState({ roomRuntime: new Map() })
+      expect(roomSelectors.runtimeOccupantCountFor('missing@conference.example.com')(state)).toBe(0)
+    })
+  })
 })

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -550,4 +550,16 @@ export const roomSelectors = {
   runtimeOccupantsFor: (roomJid: string) => (state: RoomState): Map<string, RoomOccupant> => {
     return state.roomRuntime.get(roomJid)?.occupants ?? EMPTY_OCCUPANT_MAP
   },
+
+  /**
+   * Get the occupant COUNT for a room (a primitive) using the runtime map.
+   *
+   * Prefer this over `runtimeOccupantsFor` when a consumer only needs the size:
+   * the occupants Map ref is replaced on every occupant event (join/leave/show/
+   * avatar update), so subscribing to the Map re-renders on all of them; the count
+   * only changes on join/leave, so a count subscription bails on metadata churn.
+   */
+  runtimeOccupantCountFor: (roomJid: string) => (state: RoomState): number => {
+    return state.roomRuntime.get(roomJid)?.occupants.size ?? 0
+  },
 }


### PR DESCRIPTION
## Summary

Follow-up to #451. That PR stopped the MUC composer re-rendering on **message** churn, but it still re-rendered ~1:1 on **occupant/presence** churn: `roomStore.addOccupant`/`removeOccupant` replace the occupants `Map` on every event, so `useRoomOccupants` consumers (the composer) and the unmemoized `OccupantPanel` re-rendered on every join / leave / show / avatar update. A presence storm — a netsplit rejoin, a busy room filling up, or presence-flapping in a large room — could re-saturate the WebKitGTK main thread the same way #451 set out to fix.

## Changes

**SDK**
- Add `roomSelectors.runtimeOccupantCountFor` + `useRoomOccupantCount(roomJid)` — a primitive (count) subscription that bails on metadata-only occupant updates and only fires on join/leave.

**Composer (`RoomMessageInput`)**
- Subscribe to the occupant **count** for the typing threshold; read occupant **data non-reactively** for mention candidates. The composer already re-renders on every keystroke while composing a mention, and the candidate nick set only changes on join/leave (a count change), so the list stays fresh without a `Map` subscription.

**OccupantPanel**
- Extract a memoized `OccupantRow` whose comparator compares `group.connections` by **reference**. `addOccupant` keeps unchanged occupants' object refs, so only the changed occupant's row re-renders. Row callbacks are stabilized with a lazy ref (React Compiler strips `useCallback`).

## Result (measured in demo mode)

| Scenario | Before | After |
| --- | --- | --- |
| 50-event presence-flapping storm — composer | ~47 renders | **0** |
| 50-event presence-flapping storm — occupant rows | whole list ×50 | **1 row / event** |
| Background-room presence storm — open conversation | — | **0 renders** |

Joins/leaves still re-render the composer once each (correct — the count changed, and joins are bounded by room size).

Also includes a skill-doc commit capturing the harness gotchas hit while validating (worktree `node_modules` symlink, react-scan fallback, testing every churn source).
