### PR TITLE
Redact peer JIDs and attachment filename in XMPPClient diagnostic logs

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1776,7 +1776,7 @@ export class XMPPClient {
         logDebug(
           `E2EE deferred decrypt: attachment from ${getDomain(senderJid)} — ` +
           `url=${attachment.url.slice(0, 40)}… mediaType=${attachment.mediaType ?? 'none'} ` +
-          `encrypted=${!!attachment.encryption} name=${attachment.name ?? 'none'}`,
+          `encrypted=${!!attachment.encryption} name=${attachment.name ? '<redacted>' : 'none'}`,
         )
       }
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -46,7 +46,7 @@ import {
   FRESH_SESSION_IQ_TIMEOUT_MS,
   FRESH_SESSION_SETUP_TIMEOUT_MS,
 } from './modules/connectionTimeouts'
-import { getBareJid, getLocalPart } from './jid'
+import { getBareJid, getLocalPart, getDomain } from './jid'
 import { getStorageScopeJid, setStorageScopeJid } from '../utils/storageScope'
 
 /**
@@ -1774,7 +1774,7 @@ export class XMPPClient {
       const attachment = parseOobData(stanza)
       if (attachment) {
         logDebug(
-          `E2EE deferred decrypt: attachment from ${senderJid} — ` +
+          `E2EE deferred decrypt: attachment from ${getDomain(senderJid)} — ` +
           `url=${attachment.url.slice(0, 40)}… mediaType=${attachment.mediaType ?? 'none'} ` +
           `encrypted=${!!attachment.encryption} name=${attachment.name ?? 'none'}`,
         )
@@ -1805,7 +1805,7 @@ export class XMPPClient {
         ...(attachment && { attachment }),
       }
     } catch (err) {
-      logWarn(`E2EE deferred decrypt failed for message from ${senderJid}: ${err instanceof Error ? err.message : String(err)}`)
+      logWarn(`E2EE deferred decrypt failed for message from ${getDomain(senderJid)}: ${err instanceof Error ? err.message : String(err)}`)
       return { kind: 'pending' }
     }
   }
@@ -1874,7 +1874,7 @@ export class XMPPClient {
       }
     }
     if (updated > 0) {
-      logInfo(`E2EE peer key change: updated ${updated} message(s) for ${peer}`)
+      logInfo(`E2EE peer key change: updated ${updated} message(s) for ${getDomain(peer)}`)
     }
   }
 


### PR DESCRIPTION
## Summary

Four diagnostic log calls in `XMPPClient.ts` leaked identifying data into the persistent `[Fluux]` file log (shipped in user bug reports), violating the SDK logger doctrine (`packages/fluux-sdk/src/core/logger.ts`: "Never pass message bodies or JID local parts… use `getDomain(jid)` for 1:1 conversation identifiers").

Peer JIDs (local part + domain) → redacted to domain-only via `getDomain(...)`:
- `E2EE deferred decrypt: attachment from <jid>` (logDebug)
- `E2EE deferred decrypt failed for message from <jid>` (logWarn)
- `E2EE peer key change: updated N message(s) for <jid>` (logInfo)

Attachment filename → obfuscated (the same `logDebug` already logs `mediaType`/`encrypted`, so the filename adds no diagnostic value beyond presence):
- `name=<actual filename>` → `name=<redacted>` when present, `name=none` when absent

An audit of every `logInfo/logWarn/logDebug/logError` and `console.addEvent` call in the file confirmed these are the only leaks; all other calls interpolate enums, counts, SM state, or version strings. `getDomain` returns the service domain for MUC occupant JIDs too, so it is safe regardless of conversation kind.

This is an independent fix for pre-existing leaks; the branch is merged up to date with `main` (which now contains the related "E2EE events in the XMPP log" work, #458).