### PR TITLE
fix(muc): reference origin-id for XEP-0308 corrections; harden author gate

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -1465,7 +1465,7 @@ describe('XMPPClient Message', () => {
     })
   })
 
-  describe('XEP-0461 reply id selection for reactions and corrections', () => {
+  describe('reference-id selection per XEP (reply / reaction / correction)', () => {
     it('should use client id for chat reaction reference (not stanzaId)', async () => {
       await connectClient()
 
@@ -1528,12 +1528,41 @@ describe('XMPPClient Message', () => {
       expect(replaceEl.attrs.id).toBe('client-msg-id')
     })
 
-    it('should prefer stanzaId for groupchat correction reference', async () => {
+    it('should reference origin-id for chat correction when the original has one', async () => {
       await connectClient()
 
+      vi.mocked(mockStores.chat.getMessage).mockReturnValue({
+        type: 'chat',
+        id: 'client-msg-id',
+        originId: 'origin-uuid',
+        stanzaId: 'server-stanza-id',
+        conversationId: 'alice@example.com',
+        from: 'me@example.com',
+        body: 'Original with typo',
+        timestamp: new Date(),
+        isOutgoing: true,
+      })
+
+      await xmppClient.chat.sendCorrection('alice@example.com', 'client-msg-id', 'Original without typo', 'chat')
+
+      const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
+      const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
+      // XEP-0308 references the sender-assigned id: origin-id when present.
+      expect(replaceEl.attrs.id).toBe('origin-uuid')
+      expect(replaceEl.attrs.id).not.toBe('server-stanza-id')
+    })
+
+    it('should reference origin-id (not stanzaId) for groupchat correction per XEP-0308', async () => {
+      await connectClient()
+
+      // XEP-0308 has NO group-chat carve-out (unlike XEP-0461 replies /
+      // XEP-0444 reactions / XEP-0424 retractions, which all switch to the MUC
+      // stanza-id). A correction references the id the original SENDER assigned
+      // — the origin-id — never the server/MUC stanza-id.
       mockStores.room.getMessage = vi.fn().mockReturnValue({
         type: 'groupchat',
         id: 'client-msg-id',
+        originId: 'origin-uuid',
         stanzaId: 'server-stanza-id',
         body: 'Original with typo',
         from: 'room@conference.example.com/me',
@@ -1544,7 +1573,31 @@ describe('XMPPClient Message', () => {
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
       expect(replaceEl).toBeDefined()
-      expect(replaceEl.attrs.id).toBe('server-stanza-id')
+      expect(replaceEl.attrs.id).toBe('origin-uuid')
+      expect(replaceEl.attrs.id).not.toBe('server-stanza-id')
+    })
+
+    it('should fall back to message id (never stanzaId) for groupchat correction without origin-id', async () => {
+      await connectClient()
+
+      // Regression guard for the real log scenario: ejabberd preserves the
+      // sender id and the store also holds a numeric stanza-id. The correction
+      // must reference the message id — using the stanza-id makes compliant
+      // clients (e.g. Conversations) render the edit as a brand-new message.
+      mockStores.room.getMessage = vi.fn().mockReturnValue({
+        type: 'groupchat',
+        id: 'client-msg-id',
+        stanzaId: '1780677708963770',
+        body: 'Original with typo',
+        from: 'room@conference.example.com/me',
+      })
+
+      await xmppClient.chat.sendCorrection('room@conference.example.com', 'client-msg-id', 'Original without typo', 'groupchat')
+
+      const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
+      const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
+      expect(replaceEl.attrs.id).toBe('client-msg-id')
+      expect(replaceEl.attrs.id).not.toBe('1780677708963770')
     })
   })
 
@@ -2095,13 +2148,14 @@ describe('XMPPClient Message', () => {
       })
     })
 
-    it('should prefer stanzaId for groupchat correction reference', async () => {
+    it('should reference origin-id (not stanzaId) for groupchat correction', async () => {
       await connectClient()
 
       mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: 'room@conference.example.com', nickname: 'me' })
       mockStores.room.getMessage = vi.fn().mockReturnValue({
         type: 'groupchat',
         id: 'client-msg-id',
+        originId: 'origin-uuid',
         stanzaId: 'server-stanza-id',
         body: 'Original',
         from: 'room@conference.example.com/me',
@@ -2111,7 +2165,9 @@ describe('XMPPClient Message', () => {
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
-      expect(replaceEl.attrs.id).toBe('server-stanza-id')
+      // XEP-0308 has no group-chat carve-out: reference the origin-id, not the MUC stanza-id.
+      expect(replaceEl.attrs.id).toBe('origin-uuid')
+      expect(replaceEl.attrs.id).not.toBe('server-stanza-id')
     })
   })
 
@@ -2252,6 +2308,86 @@ describe('XMPPClient Message', () => {
           isEdited: true,
         })
       })
+    })
+  })
+
+  describe('MUC author verification via occupant-id (XEP-0421)', () => {
+    const roomJid = 'room@conference.example.com'
+
+    function buildCorrection(senderNick: string, occupantId?: string, replaceId = 'original-msg-id') {
+      const children: any[] = [
+        { name: 'body', text: 'Corrected text' },
+        { name: 'replace', attrs: { xmlns: 'urn:xmpp:message-correct:0', id: replaceId } },
+      ]
+      if (occupantId) children.push({ name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: occupantId } })
+      return createMockElement('message', { from: `${roomJid}/${senderNick}`, to: 'user@example.com', type: 'groupchat', id: 'correction-stanza' }, children)
+    }
+
+    function buildRetraction(senderNick: string, occupantId?: string, retractId = 'server-stanza-id-999') {
+      const children: any[] = [
+        { name: 'retract', attrs: { xmlns: 'urn:xmpp:message-retract:1', id: retractId } },
+        { name: 'body', text: 'Fallback' },
+      ]
+      if (occupantId) children.push({ name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: occupantId } })
+      return createMockElement('message', { from: `${roomJid}/${senderNick}`, to: 'user@example.com', type: 'groupchat', id: 'retraction-stanza' }, children)
+    }
+
+    it('should reject a correction when occupant-id differs despite a matching nick (nickname takeover)', async () => {
+      await connectClient()
+      mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: roomJid, nickname: 'me' })
+      mockStores.room.getMessage = vi.fn().mockReturnValue({
+        type: 'groupchat', id: 'original-msg-id', from: `${roomJid}/Alice`,
+        occupantId: 'alice-occ', body: 'Original', nick: 'Alice',
+      })
+
+      // Mallory has taken the nick "Alice" but carries a different occupant-id
+      mockXmppClientInstance._emit('stanza', buildCorrection('Alice', 'mallory-occ'))
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
+    })
+
+    it('should apply a correction when the occupant-id matches', async () => {
+      await connectClient()
+      mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: roomJid, nickname: 'me' })
+      mockStores.room.getMessage = vi.fn().mockReturnValue({
+        type: 'groupchat', id: 'original-msg-id', from: `${roomJid}/Alice`,
+        occupantId: 'alice-occ', body: 'Original', nick: 'Alice',
+      })
+
+      mockXmppClientInstance._emit('stanza', buildCorrection('Alice', 'alice-occ'))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+        roomJid, messageId: 'original-msg-id', updates: expect.objectContaining({ isEdited: true }),
+      }))
+    })
+
+    it('should fall back to the full MUC JID when occupant-id is absent (legacy servers)', async () => {
+      await connectClient()
+      mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: roomJid, nickname: 'me' })
+      mockStores.room.getMessage = vi.fn().mockReturnValue({
+        type: 'groupchat', id: 'original-msg-id', from: `${roomJid}/Alice`,
+        body: 'Original', nick: 'Alice', // no occupantId stored
+      })
+
+      // No occupant-id on the stanza either → full-JID check applies
+      mockXmppClientInstance._emit('stanza', buildCorrection('Alice', undefined))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+        roomJid, messageId: 'original-msg-id', updates: expect.objectContaining({ isEdited: true }),
+      }))
+    })
+
+    it('should reject a retraction when occupant-id differs despite a matching nick (nickname takeover)', async () => {
+      await connectClient()
+      mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: roomJid, nickname: 'me' })
+      mockStores.room.getMessage = vi.fn().mockReturnValue({
+        type: 'groupchat', id: 'client-msg-id', stanzaId: 'server-stanza-id-999',
+        from: `${roomJid}/Alice`, occupantId: 'alice-occ', body: 'Original', nick: 'Alice',
+      })
+
+      mockXmppClientInstance._emit('stanza', buildRetraction('Alice', 'mallory-occ'))
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -331,7 +331,8 @@ export class Chat extends BaseModule {
         bareFrom,
         bareTo,
         type,
-        isSentCarbon
+        isSentCarbon,
+        stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
       )) return { handled: true }
     }
 
@@ -1207,8 +1208,16 @@ export class Chat extends BaseModule {
   async sendCorrection(to: string, originalMessageId: string, newBody: string, type: 'chat' | 'groupchat' = 'chat', attachment?: FileAttachment): Promise<void> {
     const recipient = type === 'chat' ? getBareJid(to) : to
 
-    // For MUC, prefer stanzaId (server-assigned, stable) for the correction reference
-    const referenceId = this.getMessageReferenceId(to, originalMessageId, type)
+    // XEP-0308 (Last Message Correction) has NO group-chat carve-out — unlike
+    // XEP-0461 replies, XEP-0444 reactions and XEP-0424 retractions, which all
+    // switch to the server/MUC stanza-id. A correction MUST reference the id the
+    // ORIGINAL SENDER assigned: the origin-id (XEP-0359) when present, otherwise
+    // the message id. Referencing the stanza-id breaks correction matching on
+    // compliant clients (they render the edit as a brand-new message).
+    const original = type === 'groupchat'
+      ? this.deps.stores?.room.getMessage(to, originalMessageId)
+      : this.deps.stores?.chat.getMessage(to, originalMessageId)
+    const referenceId = original?.originId ?? originalMessageId
 
     const correctionPrefix = '[Corrected] '
     const correctionFallbackEnd = correctionPrefix.length
@@ -1293,17 +1302,13 @@ export class Chat extends BaseModule {
 
     await this.deps.sendStanza(xml('message', { to: recipient, type, id: correctionStanzaId }, ...children))
 
-    // SDK events only - bindings call store methods
-    if (type === 'groupchat') {
-      const original = this.deps.stores?.room.getMessage(to, originalMessageId)
-      if (original) {
-        const updates = { body: newBody, isEdited: true, originalBody: original.originalBody ?? original.body, attachment }
+    // SDK events only - bindings call store methods. Reuses the original
+    // message fetched above for the correction reference.
+    if (original) {
+      const updates = { body: newBody, isEdited: true, originalBody: original.originalBody ?? original.body, attachment }
+      if (type === 'groupchat') {
         this.deps.emitSDK('room:message-updated', { roomJid: to, messageId: originalMessageId, updates })
-      }
-    } else {
-      const original = this.deps.stores?.chat.getMessage(to, originalMessageId)
-      if (original) {
-        const updates = { body: newBody, isEdited: true, originalBody: original.originalBody ?? original.body, attachment }
+      } else {
         this.deps.emitSDK('chat:message-updated', { conversationId: to, messageId: originalMessageId, updates })
       }
     }
@@ -1722,6 +1727,21 @@ export class Chat extends BaseModule {
     }
   }
 
+  /**
+   * XEP-0421: in a MUC the occupant-id is the stable, unforgeable author
+   * identity — the full room JID is nick-based and a nick can be reassigned to
+   * a different occupant once the author leaves. Prefer occupant-id when BOTH
+   * the stored message and the incoming stanza carry one; otherwise fall back to
+   * the full MUC JID (older servers / no XEP-0421 support). XEP-0424 mandates
+   * this occupant-id check for retractions; we apply the same gate to corrections.
+   */
+  private isSameMucAuthor(original: RoomMessage, from: string, senderOccupantId: string | undefined): boolean {
+    if (original.occupantId && senderOccupantId) {
+      return original.occupantId === senderOccupantId
+    }
+    return original.from === from
+  }
+
   private handleIncomingCorrection(stanza: Element, originalId: string, from: string, bareFrom: string, bareTo: string | undefined, body: string, type: string, isSentCarbon: boolean): boolean {
     const myBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
     const isOutgoing = isSentCarbon || bareFrom === myBareJid
@@ -1735,7 +1755,8 @@ export class Chat extends BaseModule {
     // SDK events only - bindings call store methods
     if (type === 'groupchat') {
       const original = this.deps.stores?.room.getMessage(conversationId, originalId)
-      if (original && original.from === from) {
+      const senderOccupantId = stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
+      if (original && this.isSameMucAuthor(original, from, senderOccupantId)) {
         const correctionData = applyCorrection(stanza, body, original.originalBody ?? original.body)
         if (correctionStanzaId) {
           correctionData.correctionStanzaIds = [...(original.correctionStanzaIds ?? []), correctionStanzaId]
@@ -1757,7 +1778,7 @@ export class Chat extends BaseModule {
     return false
   }
 
-  private handleIncomingRetraction(originalId: string, from: string, bareFrom: string, bareTo: string | undefined, type: string, isSentCarbon: boolean): boolean {
+  private handleIncomingRetraction(originalId: string, from: string, bareFrom: string, bareTo: string | undefined, type: string, isSentCarbon: boolean, senderOccupantId?: string): boolean {
     const myBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
     const isOutgoing = isSentCarbon || bareFrom === myBareJid
     const conversationId = isOutgoing ? bareTo : bareFrom
@@ -1766,7 +1787,7 @@ export class Chat extends BaseModule {
     // SDK events only - bindings call store methods
     if (type === 'groupchat') {
       const original = this.deps.stores?.room.getMessage(conversationId, originalId)
-      const retractionData = applyRetraction(!!original && original.from === from)
+      const retractionData = applyRetraction(!!original && this.isSameMucAuthor(original, from, senderOccupantId))
       if (retractionData) {
         this.deps.emitSDK('room:message-updated', { roomJid: conversationId, messageId: originalId, updates: retractionData })
         return true

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1029,6 +1029,22 @@ describe('chatStore', () => {
       expect(messages?.[0].reactions).toEqual({ '👍': ['bob@example.com'] })
     })
 
+    it('should find message by origin-id when a reaction references the sender id', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      const msg: Message = {
+        ...createMessage('alice@example.com', 'Hello!'),
+        id: 'rewritten-id',
+        originId: 'sender-origin-uuid',
+      }
+      chatStore.getState().addMessage(msg)
+
+      // XEP-0444: a 1:1 reaction references the origin-id when present.
+      chatStore.getState().updateReactions('alice@example.com', 'sender-origin-uuid', 'bob@example.com', ['👍'])
+
+      const messages = chatStore.getState().messages.get('alice@example.com')
+      expect(messages?.[0].reactions).toEqual({ '👍': ['bob@example.com'] })
+    })
+
     it('should add multiple reactions from same user', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com'))
       const msg = createMessage('alice@example.com', 'Hello!')
@@ -2205,6 +2221,30 @@ describe('chatStore', () => {
 
       const updated = store.getMessage('alice@example.com', 'msg-123')
       expect(updated?.body).toBe('Edited message')
+      expect(updated?.isEdited).toBe(true)
+    })
+
+    it('should find message by origin-id when a correction references it (XEP-0308)', () => {
+      const store = chatStore.getState()
+      store.addConversation(createConversation('alice@example.com'))
+
+      const message: Message = {
+        type: 'chat',
+        id: 'rewritten-id',
+        originId: 'sender-origin-uuid',
+        conversationId: 'alice@example.com',
+        from: 'alice@example.com',
+        body: 'Original',
+        timestamp: new Date(),
+        isOutgoing: false,
+      }
+      store.addMessage(message)
+
+      // Correction references the sender-assigned origin-id, not the stored id.
+      store.updateMessage('alice@example.com', 'sender-origin-uuid', { body: 'Fixed', isEdited: true })
+
+      const updated = store.getMessage('alice@example.com', 'rewritten-id')
+      expect(updated?.body).toBe('Fixed')
       expect(updated?.isEdited).toBe(true)
     })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2,7 +2,7 @@ import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState, RSMResponse } from '../core'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
-import { findMessageById } from '../utils/messageLookup'
+import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
@@ -920,8 +920,9 @@ export const chatStore = createStore<ChatState>()(
           const convMessages = state.messages.get(conversationId)
           if (!convMessages) return state
 
-          // Find message by id or stanzaId (reactions may reference either)
-          const messageIndex = convMessages.findIndex((m) => m.id === messageId || m.stanzaId === messageId)
+          // Resolve by id/stanzaId first, origin-id only as fallback (reactions
+          // may reference any tier; origin-id must not shadow a real id).
+          const messageIndex = findMessageIndexById(convMessages, messageId)
           if (messageIndex === -1) return state
 
           const message = convMessages[messageIndex]
@@ -966,8 +967,9 @@ export const chatStore = createStore<ChatState>()(
           const convMessages = state.messages.get(conversationId)
           if (!convMessages) return state
 
-          // Find message by id or stanzaId (corrections may reference either)
-          const messageIndex = convMessages.findIndex((m) => m.id === messageId || m.stanzaId === messageId)
+          // Resolve by id/stanzaId first, origin-id only as fallback. XEP-0308
+          // corrections reference the origin-id; retractions/MAM may use stanzaId.
+          const messageIndex = findMessageIndexById(convMessages, messageId)
           if (messageIndex === -1) return state
 
           const newMessages = new Map(state.messages)

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1801,6 +1801,19 @@ describe('roomStore', () => {
       expect(room?.messages[0].reactions).toEqual({ '👍': ['bob'] })
     })
 
+    it('should find message by originId when a reaction references the sender id', () => {
+      const messages = [createMessage('muc-rewritten-id', 'test@conference.example.com', 'alice', 'Hello')]
+      messages[0].originId = 'sender-origin-uuid'
+      messages[0].stanzaId = 'server-stanza-id-789'
+      roomStore.getState().addRoom(createRoom('test@conference.example.com', { messages }))
+
+      // Reaction references the sender-assigned origin-id (e.g. a corrected message)
+      roomStore.getState().updateReactions('test@conference.example.com', 'sender-origin-uuid', 'bob', ['👍'])
+
+      const room = roomStore.getState().rooms.get('test@conference.example.com')
+      expect(room?.messages[0].reactions).toEqual({ '👍': ['bob'] })
+    })
+
     it('should replace reactions when referenced by stanzaId', () => {
       const messages = [createMessage('msg1', 'test@conference.example.com', 'alice', 'Hello')]
       messages[0].stanzaId = 'server-stanza-id-456'
@@ -3095,6 +3108,50 @@ describe('roomStore', () => {
       expect(updated?.isRetracted).toBe(true)
       // Verify IndexedDB update uses actual message id, not the stanza-id
       expect(messageCache.updateRoomMessage).toHaveBeenCalledWith('client-id-1', { isRetracted: true })
+    })
+
+    it('should update message found by originId when a correction references the origin-id', () => {
+      const roomJid = 'room@conference.example.com'
+      const msg: RoomMessage = {
+        ...createMessage('muc-rewritten-id', roomJid, 'alice', 'Hello'),
+        originId: 'sender-origin-uuid',
+        stanzaId: 'server-stanza-id-123',
+      }
+      const room = createRoom(roomJid, { messages: [msg], joined: true })
+      roomStore.getState().addRoom(room)
+
+      // XEP-0308 corrections reference the sender-assigned origin-id. If a MUC
+      // rewrote the message id, matching on id/stanzaId alone would miss it.
+      roomStore.getState().updateMessage(roomJid, 'sender-origin-uuid', { isEdited: true, body: 'Hello (fixed)' })
+
+      const updated = roomStore.getState().rooms.get(roomJid)?.messages[0]
+      expect(updated?.isEdited).toBe(true)
+      expect(updated?.body).toBe('Hello (fixed)')
+      // IndexedDB update still keyed by the actual stored message id.
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith('muc-rewritten-id', { isEdited: true, body: 'Hello (fixed)' })
+    })
+
+    it('should not touch an origin-id carrier when another message owns the id (no over-match)', () => {
+      const roomJid = 'room@conference.example.com'
+      const carrier: RoomMessage = {
+        ...createMessage('other-id', roomJid, 'alice', 'carrier body'),
+        originId: 'shared-value',
+      }
+      const owner = createMessage('shared-value', roomJid, 'alice', 'owner body')
+      const room = createRoom(roomJid, { messages: [carrier, owner], joined: true })
+      roomStore.getState().addRoom(room)
+
+      // Reference resolves to the message that OWNS it as id — not the carrier
+      // that merely holds it as a (spoofable) origin-id.
+      roomStore.getState().updateMessage(roomJid, 'shared-value', { isEdited: true, body: 'edited' })
+
+      const msgs = roomStore.getState().rooms.get(roomJid)?.messages
+      const updatedOwner = msgs?.find((m) => m.id === 'shared-value')
+      const untouchedCarrier = msgs?.find((m) => m.id === 'other-id')
+      expect(updatedOwner?.body).toBe('edited')
+      expect(updatedOwner?.isEdited).toBe(true)
+      expect(untouchedCarrier?.body).toBe('carrier body')
+      expect(untouchedCarrier?.isEdited).toBeUndefined()
     })
 
     it('should update roomRuntime messages in sync', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -12,7 +12,7 @@ import type {
   RSMResponse,
 } from '../core/types'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
-import { findMessageById } from '../utils/messageLookup'
+import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
 import { getBareJid } from '../core/jid'
 import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
@@ -964,10 +964,11 @@ export const roomStore = createStore<RoomState>()(
       const existing = newRooms.get(roomJid)
       if (!existing) return state
 
+      // Resolve to a single target: id/stanzaId win, origin-id is fallback only.
+      const targetIdx = findMessageIndexById(existing.messages, messageId)
       let updatedMessage: RoomMessage | undefined
-      const newMessages = existing.messages.map((msg) => {
-        // Match by id or stanzaId (reactions may reference either)
-        if (msg.id !== messageId && msg.stanzaId !== messageId) return msg
+      const newMessages = targetIdx === -1 ? existing.messages : existing.messages.map((msg, i) => {
+        if (i !== targetIdx) return msg
 
         // Build new reactions map
         const newReactions: Record<string, string[]> = {}
@@ -1028,10 +1029,13 @@ export const roomStore = createStore<RoomState>()(
       const existing = newRooms.get(roomJid)
       if (!existing) return state
 
+      // Resolve to a single target: id/stanzaId win, origin-id is fallback only.
+      // Retractions (XEP-0424) reference the MUC stanza-id; corrections (XEP-0308)
+      // reference the sender-assigned origin-id (a MUC may rewrite the message id).
+      const targetIdx = findMessageIndexById(existing.messages, messageId)
       let updatedMessage: RoomMessage | undefined
-      const newMessages = existing.messages.map((msg) => {
-        // Match by id or stanzaId (retractions/corrections reference stanza-id in MUC)
-        if (msg.id !== messageId && msg.stanzaId !== messageId) return msg
+      const newMessages = targetIdx === -1 ? existing.messages : existing.messages.map((msg, i) => {
+        if (i !== targetIdx) return msg
         updatedMessage = { ...msg, ...updates }
         return updatedMessage
       })

--- a/packages/fluux-sdk/src/utils/messageLookup.test.ts
+++ b/packages/fluux-sdk/src/utils/messageLookup.test.ts
@@ -122,6 +122,35 @@ describe('createMessageLookup', () => {
     expect(found?.nick).toBe('debacle')
   })
 
+  it('should index messages by origin-id when present (XEP-0359)', () => {
+    // After XEP-0308, an inbound correction references the sender-assigned
+    // origin-id. If a MUC rewrote the message id, the original is only
+    // resolvable via origin-id.
+    const messages = [
+      { id: 'muc-rewritten-id', originId: 'sender-origin-uuid', stanzaId: 'mam-id', body: 'Hello' },
+    ]
+
+    const lookup = createMessageLookup(messages)
+
+    expect(lookup.get('muc-rewritten-id')).toEqual(messages[0])
+    expect(lookup.get('mam-id')).toEqual(messages[0])
+    expect(lookup.get('sender-origin-uuid')).toEqual(messages[0])
+  })
+
+  it('should not let an origin-id shadow another message\'s real id (no over-match)', () => {
+    // origin-id is sender-controlled (XEP-0359) and only a fallback tier: a
+    // message owning the value as its real id must win over a different message
+    // that merely carries it as origin-id, regardless of array order.
+    const messages = [
+      { id: 'real-id-owner', body: 'owner (listed first)' },
+      { id: 'other', originId: 'real-id-owner', body: 'origin-id carrier' },
+    ]
+
+    const lookup = createMessageLookup(messages)
+
+    expect(lookup.get('real-id-owner')?.body).toBe('owner (listed first)')
+  })
+
   it('should handle messages without correctionStanzaIds', () => {
     const messages = [
       { id: 'msg-1', stanzaId: 'stanza-1', body: 'No corrections' },
@@ -190,6 +219,27 @@ describe('findMessageById', () => {
 
     const found = findMessageById(messages, 'correction-stanza-1')
     expect(found).toEqual(messages[0])
+  })
+
+  it('should find message by origin-id (XEP-0308 correction reference)', () => {
+    const messages = [
+      { id: 'muc-rewritten-id', originId: 'sender-origin-uuid', stanzaId: 'mam-id', body: 'Hello' },
+    ]
+
+    const found = findMessageById(messages, 'sender-origin-uuid')
+    expect(found).toEqual(messages[0])
+  })
+
+  it('should prefer a strong-tier (id/stanzaId) match over an origin-id match', () => {
+    // Guards against over-matching: an earlier message carrying the value as a
+    // (spoofable) origin-id must not shadow the later message that owns it as id.
+    const messages = [
+      { id: 'other', originId: 'shared-value', body: 'origin-id carrier (first)' },
+      { id: 'shared-value', body: 'real id owner' },
+    ]
+
+    const found = findMessageById(messages, 'shared-value')
+    expect(found?.body).toBe('real id owner')
   })
 
   it('should return undefined when correction stanza-id does not match', () => {

--- a/packages/fluux-sdk/src/utils/messageLookup.ts
+++ b/packages/fluux-sdk/src/utils/messageLookup.ts
@@ -1,20 +1,24 @@
 /**
  * Creates a lookup map for messages indexed by both client ID and stanza-ID.
  *
- * This is needed because replies and corrections may reference messages by either:
+ * This is needed because replies and corrections may reference messages by any of:
  * - Client-generated message ID (e.g., "148a9d4f-68ee-4c5c-abca-685bc7981c2b")
+ * - Sender-assigned origin-ID (XEP-0359) — the reference XEP-0308 corrections use
  * - Server-assigned stanza-ID from MAM (e.g., "1766999538188692")
  * - Server-assigned stanza-ID from a correction stanza (XEP-0308 + XEP-0359)
  *
- * XEP-0461 (Message Replies) and XEP-0308 (Last Message Correction) allow
- * the `id` attribute to reference either, so we index by both to ensure
- * lookups succeed. For corrected messages, we also index by the correction's
- * stanza-ID since other clients may reference the corrected archive entry.
+ * XEP-0461 (Message Replies) and XEP-0308 (Last Message Correction) reference
+ * different identity tiers — replies/reactions use the MUC stanza-id, corrections
+ * use the sender-assigned origin-id — so we index by all of them to ensure lookups
+ * succeed regardless of which one the remote referenced. For corrected messages we
+ * also index by the correction's stanza-ID since other clients may reference the
+ * corrected archive entry.
  */
 
 interface MessageWithIds {
   id: string
   stanzaId?: string
+  originId?: string
   correctionStanzaIds?: string[]
 }
 
@@ -25,6 +29,7 @@ interface MessageWithIds {
  */
 export function createMessageLookup<T extends MessageWithIds>(messages: T[]): Map<string, T> {
   const map = new Map<string, T>()
+  // Pass 1 — strong identity tiers: server/client ids and correction archive ids.
   for (const message of messages) {
     map.set(message.id, message)
     if (message.stanzaId) {
@@ -37,24 +42,55 @@ export function createMessageLookup<T extends MessageWithIds>(messages: T[]): Ma
       }
     }
   }
+  // Pass 2 — origin-id (XEP-0359) is sender-controlled and spoofable, so it is a
+  // fallback only: never let it shadow a strong-tier id already indexed above.
+  for (const message of messages) {
+    if (message.originId && !map.has(message.originId)) {
+      map.set(message.originId, message)
+    }
+  }
   return map
 }
 
 /**
- * Find a message by ID, checking id, stanzaId, and correctionStanzaIds fields.
- * Useful for corrections and replies that may reference either ID format.
+ * Resolve a reference id to a message index, with strong-tier priority.
+ *
+ * Strong tiers (client id, server/MUC stanza-id, correction archive ids) are
+ * checked first across ALL messages; the sender-controlled, spoofable origin-id
+ * (XEP-0359) is consulted only as a fallback. This guarantees an origin-id can
+ * never shadow a real id/stanza-id match on a different message — avoiding
+ * over-matching while still resolving corrections that reference the origin-id.
+ *
+ * @returns The index of the matching message, or -1 if none match.
+ */
+export function findMessageIndexById<T extends MessageWithIds>(
+  messages: T[],
+  messageId: string
+): number {
+  let idx = messages.findIndex((m) =>
+    m.id === messageId ||
+    m.stanzaId === messageId ||
+    m.correctionStanzaIds?.includes(messageId)
+  )
+  if (idx === -1) {
+    idx = messages.findIndex((m) => m.originId === messageId)
+  }
+  return idx
+}
+
+/**
+ * Find a message by ID, checking id, stanzaId, originId, and correctionStanzaIds.
+ * Useful for corrections and replies that may reference any ID tier. Strong tiers
+ * take priority over the spoofable origin-id (see {@link findMessageIndexById}).
  *
  * @param messages Array of messages to search
- * @param messageId The ID to search for (could be client id, stanza-id, or correction stanza-id)
+ * @param messageId The ID to search for (client id, stanza-id, origin-id, or correction stanza-id)
  * @returns The matching message or undefined
  */
 export function findMessageById<T extends MessageWithIds>(
   messages: T[],
   messageId: string
 ): T | undefined {
-  return messages.find((m) =>
-    m.id === messageId ||
-    m.stanzaId === messageId ||
-    m.correctionStanzaIds?.includes(messageId)
-  )
+  const idx = findMessageIndexById(messages, messageId)
+  return idx === -1 ? undefined : messages[idx]
 }


### PR DESCRIPTION
## Summary

A message correction sent by Fluux in a MUC referenced the **server-assigned stanza-id** instead of the **sender-assigned origin-id**.

## Changes

**Send (XEP-0308)** — `sendCorrection` references `originId ?? originalMessageId` in chat and groupchat. `getMessageReferenceId` is unchanged and still used for reply/reaction/retraction (stanza-id in MUC is correct there). `sendRetraction` is intentionally untouched.

**Receive (inbound + MAM)** — `findMessageById`/`createMessageLookup` and the `roomStore`/`chatStore` `updateMessage`+`updateReactions` matchers now also resolve by origin-id, so an inbound correction referencing the origin-id matches even when a MUC rewrote the message id (otherwise it fell through to a duplicate "[corrected]" message).

**Over-match guard** — origin-id is sender-controlled/spoofable (XEP-0359), so it is a strict fallback tier. New shared `findMessageIndexById` checks id/stanzaId/correctionStanzaIds first across all messages, consults origin-id only if nothing stronger matched, and the matchers update a single resolved target (the old `.map` mutated every match). An origin-id can never shadow a real id/stanza-id.

**Author gate (XEP-0421 / XEP-0424)** — incoming correction/retraction were gated only on the nick-based full MUC JID. `isSameMucAuthor` prefers occupant-id when both the stored message and the incoming stanza carry one (rejecting nickname-takeover), falling back to the full JID for legacy servers. XEP-0424 mandates this occupant-id check for retractions.