### PR TITLE
perf(messages): stop message rows re-rendering on every new message

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, memo, type RefObject } from 'react'
+import React, { useState, useRef, useEffect, useCallback, useMemo, useImperativeHandle, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { useChatActive, useContactIdentities, createMessageLookup, getBareJid, getLocalPart, getMyReactions, useXMPPContext, type Message, type ContactIdentity } from '@fluux/sdk'
@@ -41,7 +41,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, activeMessages, activeTypingUsers, sendReaction, sendCorrection, retractMessage, retryMessage, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, targetMessageId, clearTargetMessageId } = useChatActive()
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -82,13 +82,20 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     ? () => onSearchInConversation(activeConversation.id)
     : undefined
 
+  // Latest messages in a ref so the stable callbacks below don't close over
+  // `activeMessages` (which changes on every incoming message). This keeps the
+  // props passed to the memoized MessageInput referentially stable, so the
+  // composer no longer re-renders once per message (RenderLoopDetector warning).
+  const activeMessagesRef = useRef(activeMessages)
+  activeMessagesRef.current = activeMessages
+
   // Handler to edit the last outgoing message (triggered by Up arrow in empty composer)
-  const handleEditLastMessage = () => {
-    const msg = findLastEditableMessage(activeMessages)
+  const handleEditLastMessage = useCallback(() => {
+    const msg = findLastEditableMessage(activeMessagesRef.current)
     if (msg) {
       setEditingMessage(msg)
     }
-  }
+  }, [])
 
   // Composing state - hides message toolbars when user is typing
   const [isComposing, setIsComposing] = useState(false)
@@ -96,15 +103,21 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   // Track which message has reaction picker open (hides other toolbars)
   const [activeReactionPickerMessageId, setActiveReactionPickerMessageId] = useState<string | null>(null)
 
-  // Callbacks for child components
-  const handleCancelReply = () => setReplyingTo(null)
-  const handleCancelEdit = () => setEditingMessage(null)
-  const handleReactionPickerChange = (messageId: string, isOpen: boolean) => {
+  // Callbacks for child components (stable identities for the memoized MessageInput)
+  const handleCancelReply = useCallback(() => setReplyingTo(null), [])
+  const handleCancelEdit = useCallback(() => setEditingMessage(null), [])
+  // Stable identity so it does not break the memo bailout of every message row.
+  const handleReactionPickerChange = useCallback((messageId: string, isOpen: boolean) => {
     setActiveReactionPickerMessageId(isOpen ? messageId : null)
-  }
+  }, [])
 
-  // Upload state object
-  const uploadStateObj = { isUploading, progress, error: uploadError, clearError: clearUploadError }
+  // Upload state object — memoized so it stays referentially stable between
+  // renders when no upload is in progress, preventing the memoized MessageInput
+  // from re-rendering on every ChatView render.
+  const uploadStateObj = useMemo(
+    () => ({ isUploading, progress, error: uploadError, clearError: clearUploadError }),
+    [isUploading, progress, uploadError, clearUploadError],
+  )
 
   // Composer handle ref for type-to-focus (separate from focus zone ref)
   const composerHandleRef = useRef<MessageComposerHandle>(null)
@@ -129,14 +142,21 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const isAtBottomRef = useRef(true)
 
   // Scroll to bottom (used after sending a message)
-  const scrollToBottom = () => {
+  const scrollToBottom = useCallback(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTo({
         top: scrollRef.current.scrollHeight,
         behavior: 'smooth',
       })
     }
-  }
+  }, [])
+
+  // Stable handler for the send-animation: clears the highlight after 400 ms.
+  const handleMessageIdSent = useCallback((id: string) => {
+    if (lastSentTimerRef.current) clearTimeout(lastSentTimerRef.current)
+    setLastSentMessageId(id)
+    lastSentTimerRef.current = setTimeout(() => setLastSentMessageId(null), 400)
+  }, [])
 
   // Note: Media load scroll handling is now managed by useMessageListScroll hook
   // via the handleMediaLoad callback passed through renderMessage. This provides
@@ -144,11 +164,11 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
 
   // Scroll to bottom when composer resizes (typing long message)
   // Only scrolls if user was already at bottom to avoid disrupting scroll position
-  const handleInputResize = () => {
+  const handleInputResize = useCallback(() => {
     if (scrollRef.current && isAtBottomRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }
+  }, [])
 
   // Keyboard navigation for message selection
   const {
@@ -170,9 +190,20 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   // Format copied messages with sender headers
   useMessageCopy(scrollRef)
 
-  // Create a lookup map for messages by ID (for reply context)
-  // Index by both client id and stanza-id since replies may reference either
-  const messagesById = createMessageLookup(activeMessages)
+  // Lookup map for messages by ID (for reply context), indexed by both client id
+  // and stanza-id since replies may reference either. Exposed to rows as a STABLE
+  // getter: a fresh Map would change identity every render and break the memo
+  // bailout of every ChatMessageBubble when a new message is appended.
+  //
+  // The ref is updated in an effect (NOT during render): a render-phase ref write
+  // that calls createMessageLookup makes the React Compiler bail on ChatView and
+  // stop memoizing the <MessageInput> element (composer re-renders per message).
+  // The one-render lag is irrelevant — reply targets are older messages already
+  // present in the previous render's map.
+  const messagesById = useMemo(() => createMessageLookup(activeMessages), [activeMessages])
+  const messagesByIdRef = useRef(messagesById)
+  useEffect(() => { messagesByIdRef.current = messagesById }, [messagesById])
+  const getMessageById = useCallback((id: string) => messagesByIdRef.current.get(id), [])
 
   // Track pendingAttachment in a ref for cleanup (not a trigger)
   const pendingAttachmentRef = useRef(pendingAttachment)
@@ -198,7 +229,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
 
   // File drop handler - stages file for preview only (no upload yet - privacy protection)
   // Upload happens when user clicks Send, not on drop (prevents accidental data leaks)
-  const handleFileDrop = (file: File) => {
+  const handleFileDrop = useCallback((file: File) => {
     if (!activeConversation || !isSupported) return
     // Create preview URL for images/videos
     const previewUrl = file.type.startsWith('image/') || file.type.startsWith('video/')
@@ -207,15 +238,15 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     setPendingAttachment({ file, previewUrl })
     // Focus composer so user can add a message
     setTimeout(() => composerHandleRef.current?.focus(), 0)
-  }
+  }, [activeConversation, isSupported])
 
   // Clear pending attachment and revoke preview URL
-  const handleRemovePendingAttachment = () => {
-    if (pendingAttachment?.previewUrl) {
-      URL.revokeObjectURL(pendingAttachment.previewUrl)
+  const handleRemovePendingAttachment = useCallback(() => {
+    if (pendingAttachmentRef.current?.previewUrl) {
+      URL.revokeObjectURL(pendingAttachmentRef.current.previewUrl)
     }
     setPendingAttachment(null)
-  }
+  }, [])
 
   // Drag-and-drop for file upload (handles both HTML5 and Tauri native)
   const { isDragging, dragHandlers } = useDragAndDrop({
@@ -223,12 +254,13 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     isUploadSupported: isSupported,
   })
 
-  // Handle reply button click - set reply state and focus composer
-  const handleReply = (message: Message) => {
+  // Handle reply button click - set reply state and focus composer.
+  // Stable identity so it does not break the memo bailout of every message row.
+  const handleReply = useCallback((message: Message) => {
     setReplyingTo(message)
     // Focus composer so user can start typing immediately
     setTimeout(() => composerHandleRef.current?.focus(), 0)
-  }
+  }, [])
 
   const conversationId = activeConversation?.id
   const handleClearFirstNewMessageId = () => {
@@ -397,7 +429,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
         <ChatMessageList
           messages={activeMessages}
           contactsByJid={contactsByJid}
-          messagesById={messagesById}
+          getMessageById={getMessageById}
           typingUsers={activeTypingUsers}
           scrollerRef={scrollRef}
           isAtBottomRef={isAtBottomRef}
@@ -444,19 +476,23 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
         conversationName={activeConversation.name}
         type={activeConversation.type}
         onMessageSent={scrollToBottom}
-        onMessageIdSent={(id) => {
-          if (lastSentTimerRef.current) clearTimeout(lastSentTimerRef.current)
-          setLastSentMessageId(id)
-          lastSentTimerRef.current = setTimeout(() => setLastSentMessageId(null), 400)
-        }}
+        onMessageIdSent={handleMessageIdSent}
         onInputResize={handleInputResize}
         replyingTo={replyingTo}
         onCancelReply={handleCancelReply}
         editingMessage={editingMessage}
         onCancelEdit={handleCancelEdit}
         onEditLastMessage={handleEditLastMessage}
+        sendMessage={sendMessage}
         sendCorrection={sendCorrection}
         retractMessage={retractMessage}
+        sendChatState={sendChatState}
+        isArchived={isArchived}
+        unarchiveConversation={unarchiveConversation}
+        setDraft={setDraft}
+        getDraft={getDraft}
+        clearDraft={clearDraft}
+        clearFirstNewMessageId={clearFirstNewMessageId}
         contactsByJid={contactsByJid}
         onComposingChange={setIsComposing}
         sendEasterEgg={sendEasterEgg}
@@ -480,10 +516,10 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   )
 }
 
-const ChatMessageList = memo(function ChatMessageList({
+export const ChatMessageList = memo(function ChatMessageList({
   messages,
   contactsByJid,
-  messagesById,
+  getMessageById,
   typingUsers,
   scrollerRef,
   isAtBottomRef,
@@ -521,7 +557,7 @@ const ChatMessageList = memo(function ChatMessageList({
 }: {
   messages: Message[]
   contactsByJid: Map<string, ContactIdentity>
-  messagesById: Map<string, Message>
+  getMessageById: (id: string) => Message | undefined
   typingUsers: string[]
   scrollerRef: React.RefObject<HTMLElement | null>
   isAtBottomRef: React.MutableRefObject<boolean>
@@ -565,18 +601,19 @@ const ChatMessageList = memo(function ChatMessageList({
   const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null)
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Handle mouse enter on a message - set it as hovered immediately
-  const handleMessageHover = (messageId: string) => {
+  // Handle mouse enter on a message - set it as hovered immediately.
+  // Stable identity (refs/stable setter) so it does not break row memo bailout.
+  const handleMessageHover = useCallback((messageId: string) => {
     // Clear any pending timeout to clear hover
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
       hoverTimeoutRef.current = null
     }
     setHoveredMessageId(messageId)
-  }
+  }, [])
 
-  // Handle mouse leave from a message - delay clearing to allow moving to toolbar
-  const handleMessageLeave = () => {
+  // Handle mouse leave from a message - delay clearing to allow moving to toolbar.
+  const handleMessageLeave = useCallback(() => {
     // Clear any existing timeout
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
@@ -586,7 +623,7 @@ const ChatMessageList = memo(function ChatMessageList({
       setHoveredMessageId(null)
       hoverTimeoutRef.current = null
     }, 100) // Small delay to allow mouse to reach toolbar
-  }
+  }, [])
 
   // Clear hover when conversation changes
   useEffect(() => {
@@ -621,13 +658,13 @@ const ChatMessageList = memo(function ChatMessageList({
       sendReaction={sendReaction}
       myBareJid={myBareJid}
       contactsByJid={contactsByJid}
-      messagesById={messagesById}
+      getMessageById={getMessageById}
       onReply={onReply}
       onEdit={onEdit}
       isLastOutgoing={msg.id === lastOutgoingMessageId}
       isLastMessage={msg.id === lastMessageId}
       hideToolbar={isComposing || (activeReactionPickerMessageId !== null && activeReactionPickerMessageId !== msg.id)}
-      onReactionPickerChange={(isOpen) => onReactionPickerChange(msg.id, isOpen)}
+      onReactionPickerChange={onReactionPickerChange}
       retractMessage={retractMessage}
       retryMessage={retryMessage}
       isSelected={msg.id === selectedMessageId}
@@ -636,7 +673,7 @@ const ChatMessageList = memo(function ChatMessageList({
       isDarkMode={isDarkMode}
       onMediaLoad={onMediaLoad}
       isHovered={hoveredMessageId === msg.id}
-      onMouseEnter={() => handleMessageHover(msg.id)}
+      onMouseEnter={handleMessageHover}
       onMouseLeave={handleMessageLeave}
       formatTime={formatTime}
       timeFormat={effectiveTimeFormat}
@@ -687,13 +724,15 @@ interface ChatMessageBubbleProps {
   sendReaction: (to: string, messageId: string, emojis: string[], type: 'chat' | 'groupchat') => Promise<void>
   myBareJid?: string
   contactsByJid: Map<string, ContactIdentity>
-  messagesById: Map<string, Message>
+  getMessageById: (id: string) => Message | undefined
   onReply: (message: Message) => void
   onEdit: (message: Message) => void
   isLastOutgoing: boolean
   isLastMessage: boolean
   hideToolbar?: boolean
-  onReactionPickerChange?: (isOpen: boolean) => void
+  // Receives the row's own id so the row can be passed a STABLE handler (the id
+  // is bound inside the row, not via a per-render closure in the parent).
+  onReactionPickerChange?: (messageId: string, isOpen: boolean) => void
   retractMessage: (conversationId: string, messageId: string) => Promise<void>
   retryMessage: (conversationId: string, messageId: string) => Promise<void>
   isSelected?: boolean
@@ -701,9 +740,10 @@ interface ChatMessageBubbleProps {
   showToolbarForSelection?: boolean
   isDarkMode?: boolean
   onMediaLoad?: () => void
-  // Hover state for stable toolbar interaction
+  // Hover state for stable toolbar interaction.
+  // onMouseEnter receives the row's own id so the parent can pass a stable handler.
   isHovered?: boolean
-  onMouseEnter?: () => void
+  onMouseEnter?: (messageId: string) => void
   onMouseLeave?: () => void
   // Time formatting function (respects user's 12h/24h preference)
   formatTime: (date: Date) => string
@@ -726,7 +766,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   sendReaction,
   myBareJid,
   contactsByJid,
-  messagesById,
+  getMessageById,
   onReply,
   onEdit,
   isLastOutgoing,
@@ -781,7 +821,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   // Build reply context using shared helper
   const replyContext = buildReplyContext(
     message,
-    messagesById,
+    getMessageById,
     (originalMsg, fallbackId) => {
       // Own messages: use ownNickname or JID username
       if (originalMsg?.isOutgoing) {
@@ -844,7 +884,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
         isLastMessage={isLastMessage}
         isDarkMode={isDarkMode}
         isHovered={isHovered}
-        onMouseEnter={onMouseEnter}
+        onMouseEnter={() => onMouseEnter?.(message.id)}
         onMouseLeave={onMouseLeave}
         senderName={senderName}
         senderColor={senderColor}
@@ -862,7 +902,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
         onRetry={message.deliveryError ? () => { void retryMessage(conversationId, message.id) } : undefined}
         onMediaLoad={onMediaLoad}
         replyContext={replyContext}
-        onReactionPickerChange={onReactionPickerChange}
+        onReactionPickerChange={(isOpen) => onReactionPickerChange?.(message.id, isOpen)}
         formatTime={formatTime}
         timeFormat={timeFormat}
         highlightTerms={highlightTerms}
@@ -885,7 +925,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   )
 })
 
-function MessageInput({
+export const MessageInput = memo(function MessageInput({
   composerRef,
   textareaRef,
   conversationId,
@@ -897,8 +937,16 @@ function MessageInput({
   onCancelReply,
   editingMessage,
   onCancelEdit,
+  sendMessage,
   sendCorrection,
   retractMessage,
+  sendChatState,
+  isArchived,
+  unarchiveConversation,
+  setDraft,
+  getDraft,
+  clearDraft,
+  clearFirstNewMessageId,
   contactsByJid,
   onComposingChange,
   sendEasterEgg,
@@ -927,8 +975,16 @@ function MessageInput({
   onCancelReply: () => void
   editingMessage: Message | null
   onCancelEdit: () => void
+  sendMessage: (to: string, body: string, type?: 'chat' | 'groupchat', replyTo?: { id: string; to?: string; fallback?: { author: string; body: string } }, attachment?: import('@fluux/sdk').FileAttachment) => Promise<string>
   sendCorrection: (conversationId: string, messageId: string, newBody: string, attachment?: import('@fluux/sdk').FileAttachment) => Promise<void>
   retractMessage: (conversationId: string, messageId: string) => Promise<void>
+  sendChatState: (to: string, state: import('@fluux/sdk').ChatStateNotification, type?: 'chat' | 'groupchat') => Promise<void>
+  isArchived: (id: string) => boolean
+  unarchiveConversation: (id: string) => void
+  setDraft: (conversationId: string, text: string) => void
+  getDraft: (conversationId: string) => string
+  clearDraft: (conversationId: string) => void
+  clearFirstNewMessageId: (conversationId: string) => void
   contactsByJid: Map<string, ContactIdentity>
   onComposingChange?: (isComposing: boolean) => void
   sendEasterEgg: (to: string, type: 'chat' | 'groupchat', animation: string) => Promise<void>
@@ -945,7 +1001,6 @@ function MessageInput({
   encryptionState: ConversationEncryptionState
 }) {
   const { t } = useTranslation()
-  const { sendMessage, sendChatState, isArchived, unarchiveConversation, setDraft, getDraft, clearDraft, clearFirstNewMessageId } = useChatActive()
   const openWebUnlockDialog = useWebUnlockDialogStore((s) => s.openWebUnlockDialog)
 
   // Draft persistence - saves on conversation change, restores on load
@@ -1097,5 +1152,5 @@ function MessageInput({
       />
     </>
   )
-}
+})
 

--- a/apps/fluux/src/components/MessageInput.memo.test.tsx
+++ b/apps/fluux/src/components/MessageInput.memo.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useState, type ComponentProps } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// Count MessageComposer renders via a spy module mock.
+const composerRenders = { count: 0 }
+vi.mock('./MessageComposer', () => ({
+  MessageComposer: () => { composerRenders.count++; return <div data-testid="composer" /> },
+  MESSAGE_INPUT_BASE_CLASSES: '',
+  MESSAGE_INPUT_TEXT_CLASSES: '',
+  MESSAGE_INPUT_OVERLAY_CLASSES: '',
+}))
+
+import { MessageInput } from './ChatView'
+
+// Stable props defined once so only the parent's own state changes between renders.
+// This proves MessageInput stays decoupled from ChatView's per-message re-renders:
+// the 1:1 composer used to re-render once per incoming message (RenderLoopDetector
+// warning) because ChatView fed it fresh closures every render.
+const STABLE: ComponentProps<typeof MessageInput> = {
+  composerRef: { current: null },
+  conversationId: 'alice@example.com',
+  conversationName: 'Alice',
+  type: 'chat',
+  onMessageSent: vi.fn(),
+  onMessageIdSent: vi.fn(),
+  onInputResize: vi.fn(),
+  replyingTo: null,
+  onCancelReply: vi.fn(),
+  editingMessage: null,
+  onCancelEdit: vi.fn(),
+  onEditLastMessage: vi.fn(),
+  sendMessage: vi.fn(async () => 'id'),
+  sendCorrection: vi.fn(async () => {}),
+  retractMessage: vi.fn(async () => {}),
+  sendChatState: vi.fn(async () => {}),
+  isArchived: vi.fn(() => false),
+  unarchiveConversation: vi.fn(),
+  setDraft: vi.fn(),
+  getDraft: vi.fn(() => ''),
+  clearDraft: vi.fn(),
+  clearFirstNewMessageId: vi.fn(),
+  contactsByJid: new Map(),
+  onComposingChange: vi.fn(),
+  sendEasterEgg: vi.fn(async () => {}),
+  isConnected: true,
+  uploadState: { isUploading: false, progress: 0, error: null, clearError: vi.fn() },
+  isUploadSupported: false,
+  onFileSelect: vi.fn(),
+  uploadFile: vi.fn(async () => null),
+  pendingAttachment: null,
+  onRemovePendingAttachment: vi.fn(),
+  processLinkPreview: vi.fn(async () => {}),
+  onSwitchToMessages: vi.fn(),
+  encryptionState: { kind: 'disabled' } as ComponentProps<typeof MessageInput>['encryptionState'],
+}
+
+function Harness() {
+  const [, setTick] = useState(0)
+  return (
+    <>
+      <button onClick={() => setTick((t) => t + 1)}>tick</button>
+      <MessageInput {...STABLE} />
+    </>
+  )
+}
+
+describe('MessageInput memoization (1:1 composer decoupling)', () => {
+  beforeEach(() => { composerRenders.count = 0 })
+
+  it('does not re-render MessageComposer when the parent re-renders with identical props', () => {
+    render(<Harness />)
+    const afterMount = composerRenders.count
+    fireEvent.click(screen.getByText('tick'))
+    fireEvent.click(screen.getByText('tick'))
+    expect(composerRenders.count).toBe(afterMount) // memo bailout — composer decoupled
+  })
+})

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -88,14 +88,16 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     ? () => onSearchInConversation(activeRoom.jid)
     : undefined
 
-  // Create a map of contacts by JID for quick lookup (used to show avatars for known contacts)
-  const contactsByJid = (() => {
+  // Create a map of contacts by JID for quick lookup (used to show avatars for known
+  // contacts). Memoized so it keeps a stable identity across renders — a fresh Map
+  // every render breaks the memo bailout of every RoomMessageBubbleWrapper.
+  const contactsByJid = useMemo(() => {
     const map = new Map<string, Contact>()
     for (const contact of contacts) {
       map.set(contact.jid, contact)
     }
     return map
-  })()
+  }, [contacts])
 
   // Filter out messages from ignored users and replies quoting them (client-side ignore)
   // IMPORTANT: Use stable empty array reference to prevent infinite re-renders.
@@ -169,9 +171,10 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
 
   const handleCancelReply = useCallback(() => setReplyingTo(null), [])
   const handleCancelEdit = useCallback(() => setEditingMessage(null), [])
-  const handleReactionPickerChange = (messageId: string, isOpen: boolean) => {
+  // Stable identity so it does not break the memo bailout of every message row.
+  const handleReactionPickerChange = useCallback((messageId: string, isOpen: boolean) => {
     setActiveReactionPickerMessageId(isOpen ? messageId : null)
-  }
+  }, [])
   const handleCloseOccupants = () => setShowOccupants(false)
 
   // Nick context menu state (right-click / long-press on nick in messages)
@@ -188,21 +191,28 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // to list-level selectors that cause render loops when other rooms update
   const addToast = useToastStore((s) => s.addToast)
 
-  const handleNickContextMenu = (nick: string, e: React.MouseEvent) => {
-    if (!activeRoom || nick === activeRoom.nickname) return
+  // Stable identities (read the room from the store at call time instead of closing
+  // over the recombined `activeRoom`) so they do not break the memo bailout of every
+  // message row. The nickMenu.* handlers are stabilized inside useContextMenu, so
+  // destructuring them gives exhaustive-deps stable references to depend on.
+  const { handleContextMenu: openNickMenu, handleTouchStart: startNickLongPress, handleTouchEnd: cancelNickLongPress } = nickMenu
+  const handleNickContextMenu = useCallback((nick: string, e: React.MouseEvent) => {
+    const room = roomStore.getState().activeRoom()
+    if (!room || nick === room.nickname) return
     setNickMenuTarget(nick)
-    nickMenu.handleContextMenu(e)
-  }
+    openNickMenu(e)
+  }, [openNickMenu])
 
-  const handleNickTouchStart = (nick: string, e: React.TouchEvent) => {
-    if (!activeRoom || nick === activeRoom.nickname) return
+  const handleNickTouchStart = useCallback((nick: string, e: React.TouchEvent) => {
+    const room = roomStore.getState().activeRoom()
+    if (!room || nick === room.nickname) return
     setNickMenuTarget(nick)
-    nickMenu.handleTouchStart(e)
-  }
+    startNickLongPress(e)
+  }, [startNickLongPress])
 
-  const handleNickTouchEnd = () => {
-    nickMenu.handleTouchEnd()
-  }
+  const handleNickTouchEnd = useCallback(() => {
+    cancelNickLongPress()
+  }, [cancelNickLongPress])
 
   const uploadStateObj = useMemo(
     () => ({ isUploading, progress, error: uploadError, clearError: clearUploadError }),
@@ -263,9 +273,15 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // Format copied messages with sender headers
   useMessageCopy(scrollRef)
 
-  // Create a lookup map for messages by ID (for reply context)
-  // Index by both client id and stanza-id since replies may reference either
+  // Lookup map for messages by ID (for reply context), indexed by both client id
+  // and stanza-id since replies may reference either. Exposed to rows as a STABLE
+  // getter so a new Map (every appended message) does not break the memo bailout
+  // of every RoomMessageBubbleWrapper. Ref updated in an effect (not during
+  // render) to avoid making the React Compiler bail on RoomView.
   const messagesById = useMemo(() => createMessageLookup(activeMessages), [activeMessages])
+  const messagesByIdRef = useRef(messagesById)
+  useEffect(() => { messagesByIdRef.current = messagesById }, [messagesById])
+  const getMessageById = useCallback((id: string) => messagesByIdRef.current.get(id), [])
 
   // Track pendingAttachment in a ref for cleanup (not a trigger)
   const pendingAttachmentRef = useRef(pendingAttachment)
@@ -276,6 +292,33 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // (which changes on every occupant update and would destabilize the callback).
   const activeRoomRef = useRef(activeRoom)
   activeRoomRef.current = activeRoom
+
+  // Referentially-stable room for the message rows. `activeRoom` is recombined
+  // (entity/meta/runtime) on every render, so passing it directly re-renders every
+  // RoomMessageBubbleWrapper on each new message. The rows only read these fields,
+  // none of which change on a plain message append — so keep the previous reference
+  // until one of them actually changes (occupant/cache/nick churn). Implemented with
+  // a ref + field comparison rather than useMemo-with-partial-deps so it stays clean
+  // for both react-hooks/exhaustive-deps and the React Compiler.
+  const stableRoomRef = useRef(activeRoom)
+  {
+    const prev = stableRoomRef.current
+    if (!activeRoom) {
+      stableRoomRef.current = undefined
+    } else if (
+      !prev ||
+      prev.jid !== activeRoom.jid ||
+      prev.nickname !== activeRoom.nickname ||
+      prev.joined !== activeRoom.joined ||
+      prev.supportsReactions !== activeRoom.supportsReactions ||
+      prev.occupants !== activeRoom.occupants ||
+      prev.nickToJidCache !== activeRoom.nickToJidCache ||
+      prev.nickToAvatarCache !== activeRoom.nickToAvatarCache
+    ) {
+      stableRoomRef.current = activeRoom
+    }
+  }
+  const stableRoom = stableRoomRef.current
 
   // Stable callback that clears any staged compose state before entering whisper
   // mode. Whispers are text-only so a staged reply, edit, or pending attachment
@@ -298,7 +341,10 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     if (message.isPrivate && message.whisperWith) {
       // Only continue a private thread if the counterpart is still in the room —
       // replying to a recycled or absent nick would leak the private text.
-      if (activeRoom && whisperCounterpartPresent(message, activeRoom.occupants)) {
+      // Read the room from a ref (not the recombined activeRoom) so this callback
+      // keeps a stable identity and does not break the message-row memo bailout.
+      const room = activeRoomRef.current
+      if (room && whisperCounterpartPresent(message, room.occupants)) {
         enterWhisperMode(message.whisperWith)
       } else {
         addToast('info', t('rooms.whisperCounterpartGone', { nick: message.whisperWith }))
@@ -306,7 +352,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     } else {
       setReplyingTo(message)
     }
-  }, [enterWhisperMode, activeRoom, addToast, t])
+  }, [enterWhisperMode, addToast, t])
 
   // Clear reply/edit/whisper/pending attachment state when room changes
   // Note: scroll position is managed by MessageList component
@@ -461,10 +507,10 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
           )}
           <RoomMessageList
             messages={displayMessages}
-            messagesById={messagesById}
+            getMessageById={getMessageById}
             scrollerRef={scrollRef}
             isAtBottomRef={isAtBottomRef}
-            room={activeRoom}
+            room={stableRoom ?? activeRoom}
             contactsByJid={contactsByJid}
             ownAvatar={ownAvatar}
             sendReaction={sendReaction}
@@ -711,9 +757,9 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   )
 }
 
-const RoomMessageList = memo(function RoomMessageList({
+export const RoomMessageList = memo(function RoomMessageList({
   messages,
-  messagesById,
+  getMessageById,
   scrollerRef,
   isAtBottomRef,
   room,
@@ -758,7 +804,7 @@ const RoomMessageList = memo(function RoomMessageList({
   isCatchingUp,
 }: {
   messages: RoomMessage[]
-  messagesById: Map<string, RoomMessage>
+  getMessageById: (id: string) => RoomMessage | undefined
   scrollerRef: React.RefObject<HTMLElement | null>
   isAtBottomRef: React.MutableRefObject<boolean>
   room: Room
@@ -810,18 +856,19 @@ const RoomMessageList = memo(function RoomMessageList({
   const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null)
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Handle mouse enter on a message - set it as hovered immediately
-  const handleMessageHover = (messageId: string) => {
+  // Handle mouse enter on a message - set it as hovered immediately.
+  // Stable identity (refs/stable setter) so it does not break row memo bailout.
+  const handleMessageHover = useCallback((messageId: string) => {
     // Clear any pending timeout to clear hover
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
       hoverTimeoutRef.current = null
     }
     setHoveredMessageId(messageId)
-  }
+  }, [])
 
-  // Handle mouse leave from a message - delay clearing to allow moving to toolbar
-  const handleMessageLeave = () => {
+  // Handle mouse leave from a message - delay clearing to allow moving to toolbar.
+  const handleMessageLeave = useCallback(() => {
     // Clear any existing timeout
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current)
@@ -831,7 +878,7 @@ const RoomMessageList = memo(function RoomMessageList({
       setHoveredMessageId(null)
       hoverTimeoutRef.current = null
     }, 100) // Small delay to allow mouse to reach toolbar
-  }
+  }, [])
 
   // Clear hover when room changes
   useEffect(() => {
@@ -848,7 +895,9 @@ const RoomMessageList = memo(function RoomMessageList({
   }, [])
 
   // Set of original poll message IDs that have been closed (a poll-closed message references them).
-  // Used to disable the "Close poll" button on already-closed polls.
+  // Used to disable the "Close poll" button on already-closed polls. Exposed to rows
+  // as a STABLE getter — a fresh Set every render (messages change on every append)
+  // would break the memo bailout of every RoomMessageBubbleWrapper.
   const closedPollIds = useMemo(() => {
     const ids = new Set<string>()
     for (const msg of messages) {
@@ -858,6 +907,9 @@ const RoomMessageList = memo(function RoomMessageList({
     }
     return ids
   }, [messages])
+  const closedPollIdsRef = useRef(closedPollIds)
+  useEffect(() => { closedPollIdsRef.current = closedPollIds }, [closedPollIds])
+  const isPollClosed = useCallback((pollMessageId: string) => closedPollIdsRef.current.has(pollMessageId), [])
 
   // Set of known occupant nicknames for IRC-style mention highlighting
   const knownNicks = useMemo(() => {
@@ -910,7 +962,7 @@ const RoomMessageList = memo(function RoomMessageList({
       message={msg}
       showAvatar={shouldShowAvatar(groupMessages, idx)}
       whisperThread={whisperThreadPosition(groupMessages, idx)}
-      messagesById={messagesById}
+      getMessageById={getMessageById}
       room={room}
       knownNicks={knownNicks}
       contactsByJid={contactsByJid}
@@ -919,13 +971,13 @@ const RoomMessageList = memo(function RoomMessageList({
       votePoll={votePoll}
       closePoll={closePoll}
 
-      closedPollIds={closedPollIds}
+      isPollClosed={isPollClosed}
       onReply={onReply}
       onEdit={onEdit}
       isLastOutgoing={msg.id === lastOutgoingMessageId}
       isLastMessage={msg.id === lastMessageId}
       hideToolbar={isComposing || (activeReactionPickerMessageId !== null && activeReactionPickerMessageId !== msg.id)}
-      onReactionPickerChange={(isOpen) => onReactionPickerChange(msg.id, isOpen)}
+      onReactionPickerChange={onReactionPickerChange}
       retractMessage={retractMessage}
       moderateMessage={moderateMessage}
       isSelected={msg.id === selectedMessageId}
@@ -934,7 +986,7 @@ const RoomMessageList = memo(function RoomMessageList({
       isDarkMode={isDarkMode}
       onMediaLoad={onMediaLoad}
       isHovered={hoveredMessageId === msg.id}
-      onMouseEnter={() => handleMessageHover(msg.id)}
+      onMouseEnter={handleMessageHover}
       onMouseLeave={handleMessageLeave}
       formatTime={formatTime}
       timeFormat={effectiveTimeFormat}
@@ -979,7 +1031,7 @@ interface RoomMessageBubbleWrapperProps {
   message: RoomMessage
   showAvatar: boolean
   whisperThread: WhisperThreadPosition | null
-  messagesById: Map<string, RoomMessage>
+  getMessageById: (id: string) => RoomMessage | undefined
   room: Room
   knownNicks: ReadonlySet<string>
   contactsByJid: Map<string, Contact>
@@ -992,7 +1044,8 @@ interface RoomMessageBubbleWrapperProps {
   isLastOutgoing: boolean
   isLastMessage: boolean
   hideToolbar?: boolean
-  onReactionPickerChange?: (isOpen: boolean) => void
+  // Receives the row's own id so the parent can pass a STABLE handler (id bound here).
+  onReactionPickerChange?: (messageId: string, isOpen: boolean) => void
   retractMessage: (roomJid: string, messageId: string) => Promise<void>
   moderateMessage: (roomJid: string, stanzaId: string, reason?: string) => Promise<void>
   isSelected?: boolean
@@ -1000,9 +1053,10 @@ interface RoomMessageBubbleWrapperProps {
   showToolbarForSelection?: boolean
   isDarkMode?: boolean
   onMediaLoad?: () => void
-  // Hover state for stable toolbar interaction
+  // Hover state for stable toolbar interaction.
+  // onMouseEnter receives the row's own id so the parent can pass a stable handler.
   isHovered?: boolean
-  onMouseEnter?: () => void
+  onMouseEnter?: (messageId: string) => void
   onMouseLeave?: () => void
   // Time formatting function (respects user's 12h/24h preference)
   formatTime: (date: Date) => string
@@ -1014,8 +1068,8 @@ interface RoomMessageBubbleWrapperProps {
   onNickTouchEnd?: () => void
   // Affiliation action (passed from parent to avoid useRoom() subscription)
   setAffiliation: (roomJid: string, userJid: string, affiliation: RoomAffiliation, reason?: string) => Promise<void>
-  // Set of poll message IDs that have been closed (to disable close button)
-  closedPollIds: Set<string>
+  // Stable getter: is this poll message closed? (to disable close button)
+  isPollClosed: (pollMessageId: string) => boolean
   // Highlight terms for find-on-page
   highlightTerms?: string[]
   // Whether this message is the current find-on-page match
@@ -1026,7 +1080,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   message,
   showAvatar,
   whisperThread,
-  messagesById,
+  getMessageById,
   room,
   knownNicks,
   contactsByJid,
@@ -1056,7 +1110,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   onNickTouchStart,
   onNickTouchEnd,
   setAffiliation,
-  closedPollIds,
+  isPollClosed,
   highlightTerms,
   isCurrentMatch,
 }: RoomMessageBubbleWrapperProps) {
@@ -1161,7 +1215,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   // Build reply context using shared helper
   const replyContext = buildReplyContext(
     message,
-    messagesById,
+    getMessageById,
     (originalMsg, fallbackId) => {
       if (originalMsg) return originalMsg.nick
       // For rooms, fallbackId is the full JID like room@server/nick - extract nick
@@ -1289,7 +1343,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
         isLastMessage={isLastMessage}
         isDarkMode={isDarkMode}
         isHovered={isHovered}
-        onMouseEnter={onMouseEnter}
+        onMouseEnter={() => onMouseEnter?.(message.id)}
         onMouseLeave={onMouseLeave}
         senderName={resolvedSenderName}
         senderColor={senderColor}
@@ -1327,9 +1381,9 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
         onNickContextMenu={!message.isOutgoing ? handleNickContextMenu : undefined}
         onNickTouchStart={!message.isOutgoing ? handleNickTouchStart : undefined}
         onNickTouchEnd={!message.isOutgoing ? onNickTouchEnd : undefined}
-        onReactionPickerChange={onReactionPickerChange}
+        onReactionPickerChange={(isOpen) => onReactionPickerChange?.(message.id, isOpen)}
         onPollVote={handlePollVote}
-        onClosePoll={message.isOutgoing && message.poll && !closedPollIds.has(message.id) && !message.pollClosedAt ? () => closePoll(room.jid, message.id) : undefined}
+        onClosePoll={message.isOutgoing && message.poll && !isPollClosed(message.id) && !message.pollClosedAt ? () => closePoll(room.jid, message.id) : undefined}
 
         formatTime={formatTime}
         timeFormat={timeFormat}

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -437,7 +437,7 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
     // Build reply context
     const replyContext = buildReplyContext(
       msg,
-      messagesById,
+      (id) => messagesById.get(id),
       (originalMsg, fallbackId) => {
         if (originalMsg?.isOutgoing) return ownNickname || originalMsg.from.split('@')[0]
         if (isRoom && originalMsg?.type === 'groupchat') return (originalMsg as RoomMessage).nick

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -454,7 +454,7 @@ describe('buildReplyContext', () => {
 
     const result = buildReplyContext(
       message,
-      messagesById,
+      (id) => messagesById.get(id),
       () => 'Unknown',
       () => 'rgb(0, 0, 0)',
       () => ({ avatarUrl: undefined, avatarIdentifier: 'unknown' })
@@ -479,7 +479,7 @@ describe('buildReplyContext', () => {
 
     const result = buildReplyContext(
       replyMessage,
-      messagesById,
+      (id) => messagesById.get(id),
       (msg) => msg ? 'Bob' : 'Unknown',
       () => 'rgb(100, 100, 100)',
       (msg) => ({ avatarUrl: msg ? 'http://example.com/bob.jpg' : undefined, avatarIdentifier: 'bob@example.com' })
@@ -508,7 +508,7 @@ describe('buildReplyContext', () => {
 
     const result = buildReplyContext(
       replyMessage,
-      messagesById,
+      (id) => messagesById.get(id),
       (msg, fallbackId) => msg ? 'Found' : (fallbackId ? 'Charlie' : 'Unknown'),
       () => 'rgb(50, 50, 50)',
       (_msg, fallbackId) => ({ avatarUrl: undefined, avatarIdentifier: fallbackId || 'unknown' })
@@ -551,7 +551,7 @@ describe('buildReplyContext', () => {
 
     const result = buildReplyContext(
       replyMessage,
-      messagesById,
+      (id) => messagesById.get(id),
       (msg) => msg ? 'Bob' : 'Unknown',
       () => 'rgb(100, 100, 100)',
       () => ({ avatarUrl: 'http://example.com/bob.jpg', avatarIdentifier: 'bob@example.com' })

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -649,7 +649,7 @@ function formatSecurityTooltip(
  */
 export function buildReplyContext<T extends BaseMessage>(
   message: T,
-  messagesById: Map<string, T>,
+  getMessageById: (id: string) => T | undefined,
   getSenderName: (msg: T | undefined, fallbackId: string | undefined) => string,
   getSenderColor: (msg: T | undefined, fallbackId: string | undefined, isDarkMode?: boolean) => string,
   getAvatarInfo: (msg: T | undefined, fallbackId: string | undefined) => { avatarUrl?: string; avatarIdentifier: string },
@@ -657,7 +657,7 @@ export function buildReplyContext<T extends BaseMessage>(
 ): MessageBubbleProps['replyContext'] {
   if (!message.replyTo) return undefined
 
-  const originalMessage = messagesById.get(message.replyTo.id)
+  const originalMessage = getMessageById(message.replyTo.id)
   const fallbackId = message.replyTo.to
   const senderName = getSenderName(originalMessage, fallbackId)
   const senderColor = getSenderColor(originalMessage, fallbackId, isDarkMode)

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -489,7 +489,11 @@ export function useMessageListScroll({
   //
   // This prevents jitter from multiple images loading in sequence.
 
-  const handleMediaLoad = () => {
+  // Stable identity (deps are all refs/constants) so it can be passed to every
+  // memoized message row without breaking their `memo` bailout. React Compiler
+  // does NOT memoize this (it's returned from a hook and used only in parent
+  // JSX), so the manual useCallback is required — see RENDER_PERF_TESTS.md.
+  const handleMediaLoad = useCallback(() => {
     const scroller = scrollerRef.current
     if (!scroller) return
 
@@ -540,7 +544,7 @@ export function useMessageListScroll({
       mediaLoadSnapshotRef.current = null
       mediaLoadDebounceRef.current = null
     }, MEDIA_LOAD_DEBOUNCE_MS)
-  }
+  }, [isAtBottomRef])
 
   // ==========================================================================
   // SCROLL EVENT HANDLER

--- a/apps/fluux/src/components/messageRowMemo.test.tsx
+++ b/apps/fluux/src/components/messageRowMemo.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Render-count regression guard for the message-row memo fix.
+ *
+ * Bug (both views): every existing message row re-rendered on every new message
+ * because the row's `memo` was broken by unstable per-row props — a fresh
+ * `messagesById` Map, inline `onReactionPickerChange`/`onMouseEnter` closures in
+ * `renderMessage`, a recombined `room` object, an unmemoized `contactsByJid`, a
+ * fresh `closedPollIds` Set, and unstable reply/nick callbacks. react-scan
+ * measured ChatMessageBubble at 2720 and RoomMessageBubbleWrapper at 4984 renders
+ * for a 40-message flood (≈ Σ list-length).
+ *
+ * Guard: when the list re-renders with a NEW `messages` array (same items, as
+ * happens on every append), the existing rows must NOT re-render — their `memo`
+ * must bail because every per-row prop is referentially stable. We count renders
+ * of the inner MessageBubble, keyed by message id.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Count inner MessageBubble renders by message id. Both ChatMessageBubble and
+// RoomMessageBubbleWrapper render <MessageBubble message={message} .../>, so the
+// id is available on the mock's props.
+const bubbleRenders: Record<string, number> = {}
+vi.mock('./conversation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./conversation')>()
+  return {
+    ...actual,
+    MessageBubble: ({ message }: { message: { id: string } }) => {
+      bubbleRenders[message.id] = (bubbleRenders[message.id] ?? 0) + 1
+      return null
+    },
+  }
+})
+
+import { ChatMessageList } from './ChatView'
+import { RoomMessageList } from './RoomView'
+import type { Message, RoomMessage, Room } from '@fluux/sdk'
+
+beforeEach(() => {
+  for (const k of Object.keys(bubbleRenders)) delete bubbleRenders[k]
+})
+
+function chatMessages(n: number): Message[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `c${i}`,
+    from: 'alice@example.com',
+    body: `message ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i),
+    isOutgoing: false,
+    type: 'chat',
+  })) as unknown as Message[]
+}
+
+function roomMessages(n: number): RoomMessage[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `r${i}`,
+    stanzaId: `s${i}`,
+    from: 'team@conf.example.com/Alice',
+    nick: 'Alice',
+    body: `message ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i),
+    isOutgoing: false,
+    type: 'groupchat',
+  })) as unknown as RoomMessage[]
+}
+
+const stubRoom = {
+  jid: 'team@conf.example.com',
+  name: 'team',
+  nickname: 'Me',
+  joined: true,
+  isJoining: false,
+  supportsReactions: true,
+  occupants: new Map(),
+  nickToJidCache: new Map(),
+  nickToAvatarCache: new Map(),
+} as unknown as Room
+
+// Stable props shared across both renders — only the `messages` array reference
+// changes, exactly like a real message append.
+const CHAT_PROPS = {
+  contactsByJid: new Map(),
+  getMessageById: () => undefined,
+  typingUsers: [] as string[],
+  scrollerRef: { current: null },
+  isAtBottomRef: { current: true },
+  conversationId: 'alice@example.com',
+  conversationType: 'chat' as const,
+  sendReaction: vi.fn(),
+  myBareJid: 'me@example.com',
+  ownAvatar: null,
+  ownNickname: null,
+  onReply: vi.fn(),
+  onEdit: vi.fn(),
+  lastOutgoingMessageId: null,
+  lastMessageId: 'c4',
+  isComposing: false,
+  activeReactionPickerMessageId: null,
+  onReactionPickerChange: vi.fn(),
+  retractMessage: vi.fn(),
+  retryMessage: vi.fn(),
+  selectedMessageId: null,
+  hasKeyboardSelection: false,
+  showToolbarForSelection: false,
+  firstNewMessageId: undefined,
+  targetMessageId: null,
+  clearTargetMessageId: vi.fn(),
+  clearFirstNewMessageId: vi.fn(),
+  onMessageSeen: vi.fn(),
+  isDarkMode: false,
+  onScrollToTop: vi.fn(),
+  isLoadingOlder: false,
+  isHistoryComplete: false,
+  isInitialLoading: false,
+  highlightTerms: undefined,
+  currentMatchId: undefined,
+  lastSentMessageId: null,
+}
+
+const ROOM_PROPS = {
+  getMessageById: () => undefined,
+  scrollerRef: { current: null },
+  isAtBottomRef: { current: true },
+  room: stubRoom,
+  contactsByJid: new Map(),
+  ownAvatar: null,
+  sendReaction: vi.fn(),
+  votePoll: vi.fn(),
+  closePoll: vi.fn(),
+  onReply: vi.fn(),
+  onEdit: vi.fn(),
+  lastOutgoingMessageId: null,
+  lastMessageId: 'r4',
+  typingUsers: [] as string[],
+  isComposing: false,
+  activeReactionPickerMessageId: null,
+  onReactionPickerChange: vi.fn(),
+  retractMessage: vi.fn(),
+  moderateMessage: vi.fn(),
+  selectedMessageId: null,
+  hasKeyboardSelection: false,
+  showToolbarForSelection: false,
+  firstNewMessageId: undefined,
+  targetMessageId: null,
+  clearTargetMessageId: vi.fn(),
+  clearFirstNewMessageId: vi.fn(),
+  onMessageSeen: vi.fn(),
+  isJoined: true,
+  isDarkMode: false,
+  onMediaLoad: vi.fn(),
+  onScrollToTop: vi.fn(),
+  isLoadingOlder: false,
+  isHistoryComplete: false,
+  onNickContextMenu: vi.fn(),
+  onNickTouchStart: vi.fn(),
+  onNickTouchEnd: vi.fn(),
+  setAffiliation: vi.fn(),
+  highlightTerms: undefined,
+  currentMatchId: undefined,
+  lastSentMessageId: null,
+  forwardGapTimestamp: undefined,
+  onCatchUpHistory: vi.fn(),
+  isCatchingUp: false,
+}
+
+describe('message-row memo bailout (render-perf regression guard)', () => {
+  it('ChatMessageList: appending a message does not re-render existing rows', () => {
+    const msgs = chatMessages(5)
+    const { rerender } = render(<ChatMessageList messages={msgs} {...CHAT_PROPS} />)
+    const initial = { ...bubbleRenders }
+    expect(Object.keys(initial).sort()).toEqual(['c0', 'c1', 'c2', 'c3', 'c4'])
+
+    // New array reference (same items) — the exact shape of a message append.
+    rerender(<ChatMessageList messages={[...msgs]} {...CHAT_PROPS} />)
+    for (const id of Object.keys(initial)) {
+      expect(bubbleRenders[id]).toBe(initial[id])
+    }
+  })
+
+  it('RoomMessageList: appending a message does not re-render existing rows', () => {
+    const msgs = roomMessages(5)
+    const { rerender } = render(<RoomMessageList messages={msgs} {...ROOM_PROPS} />)
+    const initial = { ...bubbleRenders }
+    expect(Object.keys(initial).sort()).toEqual(['r0', 'r1', 'r2', 'r3', 'r4'])
+
+    rerender(<RoomMessageList messages={[...msgs]} {...ROOM_PROPS} />)
+    for (const id of Object.keys(initial)) {
+      expect(bubbleRenders[id]).toBe(initial[id])
+    }
+  })
+})

--- a/apps/fluux/src/hooks/useContextMenu.ts
+++ b/apps/fluux/src/hooks/useContextMenu.ts
@@ -127,16 +127,17 @@ export function useContextMenu(options: UseContextMenuOptions = {}): ContextMenu
     }
   }, [isOpen, position.x, position.y])
 
-  // Right-click handler (desktop)
-  const handleContextMenu = (e: React.MouseEvent) => {
+  // Right-click handler (desktop). Stable identity (refs + stable setters) so
+  // consumers can depend on it without re-creating their own callbacks each render.
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     clickPosition.current = { x: e.clientX, y: e.clientY }
     setPosition({ x: e.clientX, y: e.clientY })
     setIsOpen(true)
-  }
+  }, [])
 
   // Long-press start (mobile)
-  const handleTouchStart = (e: React.TouchEvent) => {
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
     longPressTriggered.current = false
     const touch = e.touches[0]
     longPressTimeout.current = setTimeout(() => {
@@ -145,15 +146,15 @@ export function useContextMenu(options: UseContextMenuOptions = {}): ContextMenu
       setPosition({ x: touch.clientX, y: touch.clientY })
       setIsOpen(true)
     }, longPressDuration)
-  }
+  }, [longPressDuration])
 
   // Cancel long-press on move or end
-  const handleTouchEnd = () => {
+  const handleTouchEnd = useCallback(() => {
     if (longPressTimeout.current) {
       clearTimeout(longPressTimeout.current)
       longPressTimeout.current = null
     }
-  }
+  }, [])
 
   return {
     isOpen,

--- a/apps/fluux/src/hooks/useTimeFormat.ts
+++ b/apps/fluux/src/hooks/useTimeFormat.ts
@@ -4,6 +4,7 @@
  * Provides a formatTime function that respects the user's time format setting
  * (12-hour, 24-hour, or system default) and the current language.
  */
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { formatTime as formatTimeUtil, getEffectiveTimeFormat } from '@/utils/dateFormat'
@@ -21,9 +22,13 @@ export function useTimeFormat() {
   const { i18n } = useTranslation()
   const timeFormat = useSettingsStore((s) => s.timeFormat)
 
-  const formatTime = (date: Date): string => {
-    return formatTimeUtil(date, i18n.language, timeFormat)
-  }
+  // Stable identity (only changes with language / format preference) so it can be
+  // passed to memoized message rows without breaking their `memo` bailout — without
+  // relying on the React Compiler to memoize the closure.
+  const formatTime = useCallback(
+    (date: Date): string => formatTimeUtil(date, i18n.language, timeFormat),
+    [i18n.language, timeFormat],
+  )
 
   // Resolve 'auto' to actual '12h' or '24h' for layout calculations
   const effectiveTimeFormat = getEffectiveTimeFormat(timeFormat)


### PR DESCRIPTION
Existing message rows re-rendered on every incoming message in both the 1:1 and MUC message lists, because each row's `React.memo` was broken by unstable per-row props. The cost scales with history length and caused jank during message bursts. This is the real issue behind the reported `MessageComposer` render-loop warning — the composer itself does not storm on message arrival (its memo holds).

After the fix, only the new row (and the previous last row's `isLastMessage` transition) re-render when a message arrives.

## What changed

`memo` only bails when every prop is referentially equal, so each unstable per-row prop is stabilized:

- `messagesById` Map → stable `getMessageById` getter (`buildReplyContext` now takes a getter, not a Map)
- MUC `closedPollIds` Set → `isPollClosed` getter
- per-row `onReactionPickerChange` / `onMouseEnter` inline closures → stable handlers; the row binds its own id internally
- `onReply` / nick handlers no longer close over the recombined `activeRoom` (read from the store at call time); `useContextMenu` handlers memoized
- recombined `room` object → ref + field-comparison `stableRoom`; the `contactsByJid` IIFE → `useMemo`
- `handleMediaLoad` (`useMessageListScroll`) and `formatTime` (`useTimeFormat`) → `useCallback`, so the row bailout no longer depends on the React Compiler

The 1:1 composer (`MessageInput`) is also `memo`-wrapped and decoupled.

## Regression guards

- `messageRowMemo.test.tsx` — appending a message (new array, same items) must not re-render existing rows in either list
- `MessageInput.memo.test.tsx` — the 1:1 composer stays decoupled from ChatView's per-message re-renders