### PR TITLE
Stop logout from immediately reconnecting

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -27,6 +27,7 @@ import { useExternalLinkHandler } from './hooks/useExternalLinkHandler'
 import { usePlatformState } from './hooks/usePlatformState'
 import { useAccountScopeRehydration } from './hooks/useAccountScopeRehydration'
 import { clearLocalData } from './utils/clearLocalData'
+import { markConnectActive } from './utils/reconnectIntent'
 
 // Tauri detection
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
@@ -185,6 +186,12 @@ function App() {
     if (status === 'online') {
       setIsAutoReconnecting(false)
       setHasBeenOnline(true)
+      // Re-arm auto-reconnect: reaching 'online' means the user is connected on
+      // purpose (manual login, keychain auto-connect, or a reload reconnect), so
+      // future reloads should reconnect. This is the single chokepoint that
+      // clears a prior logout's intent — it can only run on a transition INTO
+      // 'online', never during logout (disconnect() flips status first).
+      markConnectActive()
       // Mark that we've been online this session. LoginScreen reads this flag
       // to detect post-disconnect transitions and trigger a webview reload
       // (workaround for WRY losing native event delivery on macOS).

--- a/apps/fluux/src/components/LoginScreen.reconnectIntent.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.reconnectIntent.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { LoginScreen } from './LoginScreen'
+import { markLoggedOut, markConnectActive } from '@/utils/reconnectIntent'
+
+const mockConnect = vi.fn().mockResolvedValue(undefined)
+
+// Tauri + saved keychain credentials => the keychain auto-connect effect arms.
+vi.mock('@fluux/sdk', () => ({
+  useConnectionStatus: () => ({ status: 'offline', error: null }),
+  useConnectionActions: () => ({ connect: mockConnect }),
+  deleteFastToken: vi.fn(),
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({ useWindowDrag: () => ({ dragRegionProps: {} }) }))
+vi.mock('@/hooks/useSessionPersistence', () => ({ saveSession: vi.fn() }))
+vi.mock('@/utils/xmppResource', () => ({ getResource: () => 'test-resource' }))
+vi.mock('@/utils/tauri', () => ({ isTauri: () => true }))
+vi.mock('@/utils/keychain', () => ({
+  hasSavedCredentials: () => true,
+  getCredentials: vi.fn().mockResolvedValue({
+    jid: 'user@example.com',
+    password: 'secret',
+    server: 'wss://example.com/ws',
+  }),
+  saveCredentials: vi.fn(),
+  deleteCredentials: vi.fn(),
+}))
+vi.mock('@/config/wellKnownServers', () => ({
+  getDomainFromJid: () => null,
+  getWebsocketUrlForDomain: () => null,
+}))
+vi.mock('@/stores/encryptionSettingsStore', () => ({ isOpenpgpEnabled: () => false }))
+
+describe('LoginScreen — keychain auto-connect respects reconnect intent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    mockConnect.mockClear()
+  })
+
+  // Positive control: proves the keychain auto-connect path actually fires here,
+  // so the "not called" assertion below is meaningful.
+  it('auto-connects from the keychain when intent is active', async () => {
+    markConnectActive()
+
+    render(<LoginScreen />)
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalled())
+  })
+
+  // ★ After an explicit logout, the keychain must not silently log the user back
+  // in — even if keychain credential deletion lost its race and creds remain.
+  it('does NOT auto-connect from the keychain after logout (intent = logged-out)', async () => {
+    markLoggedOut()
+
+    render(<LoginScreen />)
+
+    // Give the credential-load + auto-connect effects time to run.
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(mockConnect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -11,6 +11,7 @@ import { isTauri } from '@/utils/tauri'
 import { getDomainFromJid, getWebsocketUrlForDomain } from '@/config/wellKnownServers'
 import { useWindowDrag } from '@/hooks'
 import { isOpenpgpEnabled } from '@/stores/encryptionSettingsStore'
+import { getReconnectIntent } from '@/utils/reconnectIntent'
 
 const STORAGE_KEY_JID = 'xmpp-last-jid'
 const STORAGE_KEY_SERVER = 'xmpp-last-server'
@@ -253,6 +254,11 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     if (!loadedFromKeychain) return
     if (!jid || !password) return
     if (status === 'connecting' || status === 'online') return
+    // Respect a deliberate logout: never silently re-authenticate from the
+    // keychain after the user logged out, even if credential deletion lost its
+    // race and the keychain entry survived. Mirrors the gate in
+    // useSessionPersistence — the reconnect intent is the single source of truth.
+    if (getReconnectIntent() === 'logged-out') return
 
     // Mark as auto-connected to prevent loops
     hasAutoConnected.current = true

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import { useClickOutside, useWindowDrag, useRouteSync } from '@/hooks'
 import { useModals } from '@/contexts'
 import {
   useXMPP,
-  connectionStore,
   type Contact,
   type AdminCategory,
 } from '@fluux/sdk'
@@ -37,9 +36,7 @@ import {
   UserPlus,
   RefreshCw,
 } from 'lucide-react'
-import { clearSession } from '@/hooks/useSessionPersistence'
-import { deleteCredentials } from '@/utils/keychain'
-import { clearLocalData, clearAutoReconnectCredentials } from '@/utils/clearLocalData'
+import { performLogout } from '@/utils/performLogout'
 
 // Import extracted sidebar components
 import {
@@ -64,9 +61,6 @@ import {
 
 // Re-export SidebarView for external use
 export type { SidebarView }
-
-const LOGOUT_DISCONNECT_TIMEOUT_MS = 2500
-const LOGOUT_KEYCHAIN_TIMEOUT_MS = 2500
 
 interface SidebarProps {
   onSelectContact?: (contact: Contact) => void
@@ -519,58 +513,9 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
                 </button>
               </Tooltip>
             ) : (
-              <UserMenu onLogout={async (shouldCleanLocalData) => {
-                // Always attempt disconnect first. Request FAST token
-                // invalidation (XEP-0484 §6) so the server drops any
-                // stored token instead of leaving it usable until expiry.
-                const disconnectSettled = await Promise.race([
-                  disconnect({ invalidateFastToken: true })
-                    .then(() => 'done' as const)
-                    .catch(() => 'error' as const),
-                  new Promise<'timeout'>((resolve) => {
-                    setTimeout(() => resolve('timeout'), LOGOUT_DISCONNECT_TIMEOUT_MS)
-                  }),
-                ])
-                if (disconnectSettled === 'timeout') {
-                  console.warn(
-                    `[Fluux] Logout: disconnect timed out after ${LOGOUT_DISCONNECT_TIMEOUT_MS}ms, continuing cleanup`
-                  )
-                }
-
-                // Clear persisted session immediately so the UI can leave ChatLayout
-                // even if OS keychain or storage cleanup stalls on this platform.
-                clearSession()
-
-                if (shouldCleanLocalData) {
-                  // clearLocalData() clears session at the end of cleanup.
-                  await clearLocalData().catch(() => {})
-                } else {
-                  // Drop the FAST token synchronously so the post-logout webview
-                  // reload (LoginScreen's WRY workaround) can't trip the
-                  // auto-reconnect path. The SDK's disconnect() also clears it,
-                  // but only after an async server round-trip that the reload
-                  // can outrace. (clearLocalData handles this in the clean path.)
-                  clearAutoReconnectCredentials(jid)
-
-                  // Clear connection store state so the next login starts fresh.
-                  // (App's route to LoginScreen is driven by the 'disconnected'
-                  // status from disconnect() above — see the gate in App.tsx —
-                  // not by this reset. clearLocalData resets stores in the clean path.)
-                  connectionStore.getState().reset()
-
-                  const keychainSettled = await Promise.race([
-                    deleteCredentials().then(() => 'done' as const).catch(() => 'error' as const),
-                    new Promise<'timeout'>((resolve) => {
-                      setTimeout(() => resolve('timeout'), LOGOUT_KEYCHAIN_TIMEOUT_MS)
-                    }),
-                  ])
-                  if (keychainSettled === 'timeout') {
-                    console.warn(
-                      `[Fluux] Logout: keychain cleanup timed out after ${LOGOUT_KEYCHAIN_TIMEOUT_MS}ms`
-                    )
-                  }
-                }
-              }} />
+              <UserMenu onLogout={(shouldCleanLocalData) =>
+                performLogout({ disconnect, jid, shouldCleanLocalData })
+              } />
             )}
           </div>
         </div>

--- a/apps/fluux/src/hooks/useSessionPersistence.reconnectIntent.test.tsx
+++ b/apps/fluux/src/hooks/useSessionPersistence.reconnectIntent.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useSessionPersistence, saveSession } from './useSessionPersistence'
+import { markLoggedOut, markConnectActive } from '@/utils/reconnectIntent'
+
+// Spy client. The auto-reconnect engine calls `client.connect(...)` through its
+// internal connect wrapper; this spy lets us assert whether a reconnect was
+// attempted.
+const mockConnect = vi.fn().mockResolvedValue(undefined)
+
+// Override the SDK mock from test-setup for this file only:
+//  - `useXMPPContext` returns our spy client (the real one needs a provider)
+//  - `connectionStore.getState()` exposes the setters the connect wrapper calls
+//  - real `hasFastToken` / `getBareJid` / `deleteFastToken` are preserved so the
+//    FAST-token Path B reads our seeded token exactly like production
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    useXMPPContext: () => ({ client: { connect: mockConnect } }),
+    connectionStore: {
+      getState: () => ({ setStatus: vi.fn(), setError: vi.fn() }),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+  }
+})
+
+const JID = 'user@example.com'
+const SERVER = 'example.com'
+
+function seedFastTokenSession(): void {
+  // "Remember Me" + last account + a valid FAST token => Path B auto-connect arms.
+  localStorage.setItem('xmpp-remember-me', 'true')
+  localStorage.setItem('xmpp-last-jid', JID)
+  localStorage.setItem('xmpp-last-server', SERVER)
+  const expiry = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+  localStorage.setItem(
+    `fluux:fast-token:${JID}`,
+    JSON.stringify({ mechanism: 'HT-SHA-256-NONE', token: 'tok', expiry })
+  )
+}
+
+async function flush(): Promise<void> {
+  // Let the effect's async attemptFastConnect() microtasks settle.
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useSessionPersistence — reconnect intent gate', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    mockConnect.mockClear()
+  })
+
+  // Positive control: proves the harness actually arms Path B, so a "not called"
+  // assertion below is meaningful (the gate, not broken wiring).
+  it('auto-connects via FAST token when intent is active (default)', async () => {
+    seedFastTokenSession()
+    markConnectActive()
+
+    renderHook(() => useSessionPersistence())
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1))
+  })
+
+  // ★ The core regression guard.
+  it('does NOT auto-connect via FAST token after logout (intent = logged-out)', async () => {
+    seedFastTokenSession()
+    markLoggedOut()
+
+    renderHook(() => useSessionPersistence())
+    await flush()
+
+    expect(mockConnect).not.toHaveBeenCalled()
+  })
+
+  // ★ Path A (in-tab reload): a sessionStorage session must also be gated.
+  it('does NOT auto-connect via a stored sessionStorage session after logout', async () => {
+    saveSession(JID, 'secret', SERVER)
+    markLoggedOut()
+
+    renderHook(() => useSessionPersistence())
+    await flush()
+
+    expect(mockConnect).not.toHaveBeenCalled()
+  })
+
+  // ★ The exact reload scenario: the in-memory once-per-startup guard is reset
+  // by the webview reload AND the FAST token deletion lost its race (token still
+  // present). The persisted intent must still block the reconnect.
+  it('does NOT auto-connect after logout even across a simulated reload with the FAST token still present', async () => {
+    seedFastTokenSession()
+    markLoggedOut()
+
+    // First mount (pre-reload), then unmount to simulate the WRY reload tearing
+    // down the JS context, then a fresh mount with a brand-new ref.
+    const { unmount } = renderHook(() => useSessionPersistence())
+    await flush()
+    unmount()
+
+    renderHook(() => useSessionPersistence())
+    await flush()
+
+    expect(mockConnect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -6,6 +6,7 @@ import type { Contact, Room, RoomOccupant, ServerInfo, HttpUploadService, RoomMe
 import { getResource } from '@/utils/xmppResource'
 import { isTauri } from '@/utils/tauri'
 import { getCredentials, hasSavedCredentials } from '@/utils/keychain'
+import { getReconnectIntent } from '@/utils/reconnectIntent'
 
 const SESSION_KEY = 'xmpp-session'
 const ROSTER_KEY = 'xmpp-roster'
@@ -522,6 +523,15 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
     // disconnect can accidentally trigger an "auto-reconnect on reload".
     if (autoReconnectCheckedRef.current || status !== 'disconnected') return
     autoReconnectCheckedRef.current = true
+
+    // Single source of truth: if the user deliberately logged out, never
+    // auto-reconnect — no matter which credential (sessionStorage session or
+    // FAST token) happened to survive cleanup, and regardless of the webview
+    // reload that resets the in-memory guard above. The intent is persisted in
+    // localStorage so it survives that reload; logout sets it synchronously
+    // before any cleanup runs. This replaces the previous "delete the credential
+    // fast enough to beat the reload" race with a guard that runs first.
+    if (getReconnectIntent() === 'logged-out') return
 
     const session = getSession()
     if (session) {

--- a/apps/fluux/src/utils/performLogout.test.ts
+++ b/apps/fluux/src/utils/performLogout.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { hasFastToken } from '@fluux/sdk'
+import { performLogout } from './performLogout'
+import { getReconnectIntent } from './reconnectIntent'
+import { saveSession, getSession } from '@/hooks/useSessionPersistence'
+
+// Keep real reconnectIntent / clearAutoReconnectCredentials / clearSession (the
+// behaviours under test). Only stub the heavy/native edges.
+const mockReset = vi.fn()
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    connectionStore: { getState: () => ({ reset: mockReset }), subscribe: vi.fn(() => vi.fn()) },
+  }
+})
+vi.mock('@/utils/keychain', () => ({
+  deleteCredentials: vi.fn().mockResolvedValue(undefined),
+}))
+
+const JID = 'user@example.com'
+const SERVER = 'example.com'
+
+function seedFastToken(): void {
+  const expiry = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+  localStorage.setItem(
+    `fluux:fast-token:${JID}`,
+    JSON.stringify({ mechanism: 'HT-SHA-256-NONE', token: 'tok', expiry })
+  )
+}
+
+describe('performLogout', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    mockReset.mockClear()
+  })
+
+  // ★ The ordering invariant: the intent must flip BEFORE any await, so a
+  // disconnect that hangs (or a webview reload mid-logout) can't leave the app
+  // in a reconnectable state.
+  it('marks logged-out synchronously, before awaiting disconnect', () => {
+    vi.useFakeTimers()
+    try {
+      const neverResolves = () => new Promise<void>(() => {})
+
+      // Intentionally not awaited: assert the synchronous prefix already ran.
+      void performLogout({ disconnect: neverResolves, jid: JID, shouldCleanLocalData: false })
+
+      expect(getReconnectIntent()).toBe('logged-out')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('requests FAST-token invalidation on disconnect', async () => {
+    const disconnect = vi.fn().mockResolvedValue(undefined)
+
+    await performLogout({ disconnect, jid: JID, shouldCleanLocalData: false })
+
+    expect(disconnect).toHaveBeenCalledWith({ invalidateFastToken: true })
+  })
+
+  // Post-condition (keep-data logout): every local re-auth vector is gone AND
+  // the intent is logged-out. "One credential survived" becomes a test failure.
+  it('clears all local credential vectors and sets logged-out intent (keep-data path)', async () => {
+    seedFastToken()
+    saveSession(JID, 'secret', SERVER)
+    expect(hasFastToken(JID)).toBe(true)
+    expect(getSession()).not.toBeNull()
+
+    await performLogout({
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      jid: JID,
+      shouldCleanLocalData: false,
+    })
+
+    expect(hasFastToken(JID)).toBe(false)
+    expect(getSession()).toBeNull()
+    expect(getReconnectIntent()).toBe('logged-out')
+    expect(mockReset).toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/utils/performLogout.ts
+++ b/apps/fluux/src/utils/performLogout.ts
@@ -1,0 +1,82 @@
+import { connectionStore } from '@fluux/sdk'
+import { clearSession } from '@/hooks/useSessionPersistence'
+import { deleteCredentials } from '@/utils/keychain'
+import { clearLocalData, clearAutoReconnectCredentials } from '@/utils/clearLocalData'
+import { markLoggedOut } from '@/utils/reconnectIntent'
+
+const LOGOUT_DISCONNECT_TIMEOUT_MS = 2500
+const LOGOUT_KEYCHAIN_TIMEOUT_MS = 2500
+
+export interface PerformLogoutDeps {
+  /** Disconnect the live client. Resolves once the server round-trip settles. */
+  disconnect: (options?: { invalidateFastToken?: boolean }) => Promise<void>
+  /** Bare/full JID of the account being logged out (for FAST-token cleanup). */
+  jid: string | null
+  /** When true, wipe all local account data; otherwise keep messages/cache. */
+  shouldCleanLocalData: boolean
+}
+
+/**
+ * Single, idempotent logout operation.
+ *
+ * The first thing it does — synchronously, before any await, cleanup, or the
+ * post-logout webview reload — is record the logout intent. The auto-reconnect
+ * engines (`useSessionPersistence`, LoginScreen's keychain auto-connect) refuse
+ * to reconnect while that intent is set, so logout sticks even if a credential
+ * survives cleanup or a reload races the deletions. The credential deletions
+ * below are now defense-in-depth rather than the load-bearing prevention.
+ *
+ * Every step is bounded by a timeout so a stalled keychain or socket can never
+ * trap the user in ChatLayout: the reactive `disconnected` status (set by
+ * `disconnect()`) routes to LoginScreen regardless of cleanup progress.
+ */
+export async function performLogout({ disconnect, jid, shouldCleanLocalData }: PerformLogoutDeps): Promise<void> {
+  // 1. Record logout intent FIRST — see module docstring. Must precede any await.
+  markLoggedOut()
+
+  // 2. Always attempt disconnect first. Request FAST token invalidation
+  //    (XEP-0484 §6) so the server drops any stored token instead of leaving
+  //    it usable until expiry.
+  const disconnectSettled = await Promise.race([
+    disconnect({ invalidateFastToken: true })
+      .then(() => 'done' as const)
+      .catch(() => 'error' as const),
+    new Promise<'timeout'>((resolve) => {
+      setTimeout(() => resolve('timeout'), LOGOUT_DISCONNECT_TIMEOUT_MS)
+    }),
+  ])
+  if (disconnectSettled === 'timeout') {
+    console.warn(
+      `[Fluux] Logout: disconnect timed out after ${LOGOUT_DISCONNECT_TIMEOUT_MS}ms, continuing cleanup`
+    )
+  }
+
+  // 3. Clear persisted session immediately so the UI can leave ChatLayout even
+  //    if OS keychain or storage cleanup stalls on this platform.
+  clearSession()
+
+  if (shouldCleanLocalData) {
+    // clearLocalData() clears session at the end of cleanup.
+    await clearLocalData().catch(() => {})
+    return
+  }
+
+  // 4. Keep-data path: drop the FAST token synchronously (defense-in-depth
+  //    alongside the intent flag) and reset connection store state so the next
+  //    login starts fresh. (App's route to LoginScreen is driven by the
+  //    'disconnected' status from disconnect() above, not by this reset.)
+  clearAutoReconnectCredentials(jid)
+  connectionStore.getState().reset()
+
+  const keychainSettled = await Promise.race([
+    deleteCredentials().then(() => 'done' as const).catch(() => 'error' as const),
+    new Promise<'timeout'>((resolve) => {
+      setTimeout(() => resolve('timeout'), LOGOUT_KEYCHAIN_TIMEOUT_MS)
+    }),
+  ])
+  if (keychainSettled === 'timeout') {
+    console.warn(
+      `[Fluux] Logout: keychain cleanup timed out after ${LOGOUT_KEYCHAIN_TIMEOUT_MS}ms`
+    )
+  }
+}

--- a/apps/fluux/src/utils/reconnectIntent.test.ts
+++ b/apps/fluux/src/utils/reconnectIntent.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getReconnectIntent,
+  markLoggedOut,
+  markConnectActive,
+  RECONNECT_INTENT_KEY,
+} from './reconnectIntent'
+
+describe('reconnectIntent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults to "active" when nothing is stored (backward compat with existing sessions)', () => {
+    expect(getReconnectIntent()).toBe('active')
+  })
+
+  it('markLoggedOut() makes the intent "logged-out"', () => {
+    markLoggedOut()
+    expect(getReconnectIntent()).toBe('logged-out')
+  })
+
+  it('markConnectActive() re-arms the intent to "active"', () => {
+    markLoggedOut()
+    expect(getReconnectIntent()).toBe('logged-out')
+
+    markConnectActive()
+    expect(getReconnectIntent()).toBe('active')
+  })
+
+  it('persists "logged-out" across a simulated reload (value lives in localStorage)', () => {
+    markLoggedOut()
+    // A reload destroys in-memory state but not localStorage. Re-reading the
+    // intent (as the post-reload auto-reconnect engine does) still sees it.
+    expect(localStorage.getItem(RECONNECT_INTENT_KEY)).toBe('logged-out')
+    expect(getReconnectIntent()).toBe('logged-out')
+  })
+
+  it('treats an unknown/garbage stored value as "active" (fail-open, never strands a remembered user)', () => {
+    localStorage.setItem(RECONNECT_INTENT_KEY, 'something-else')
+    expect(getReconnectIntent()).toBe('active')
+  })
+})

--- a/apps/fluux/src/utils/reconnectIntent.ts
+++ b/apps/fluux/src/utils/reconnectIntent.ts
@@ -1,0 +1,60 @@
+/**
+ * Single source of truth for "should the app auto-reconnect?".
+ *
+ * The recurring "click logout → immediately logged back in" regression came
+ * from there being NO stored answer to this question. Auto-reconnect was
+ * re-derived on every startup from a fragile mix of surviving credentials
+ * (sessionStorage session, FAST token) plus an in-memory once-per-startup ref
+ * that the Tauri/WRY post-logout `window.location.reload()` silently resets.
+ * Every prior fix tried to delete a credential fast enough to beat that reload
+ * — i.e. to win a race. This module replaces the race with a persisted intent.
+ *
+ * `markLoggedOut()` is called synchronously at the very start of logout, before
+ * any disconnect/cleanup side effect or reload. The auto-reconnect engines
+ * (`useSessionPersistence`, LoginScreen's keychain auto-connect) refuse to
+ * connect while the intent is `logged-out`, regardless of which credential
+ * happened to survive cleanup. `markConnectActive()` re-arms it whenever a
+ * connection actually reaches `online`.
+ *
+ * The flag lives in localStorage so it survives the JS-context teardown that a
+ * webview reload causes (an in-memory guard cannot). It is deliberately NOT
+ * removed by `clearLocalData()` / `clearSession()`: a missing flag defaults to
+ * `active` (so remembered users still reconnect), so it must persist as the
+ * explicit `logged-out` marker once set.
+ */
+
+export type ReconnectIntent = 'active' | 'logged-out'
+
+export const RECONNECT_INTENT_KEY = 'fluux:reconnect-intent'
+
+/**
+ * Returns the stored connection intent.
+ *
+ * Defaults to `'active'` when absent (backward compatibility: existing installs
+ * with a valid session keep auto-reconnecting) and for any unrecognised value
+ * (fail-open — never strand a remembered user on the login screen). The only
+ * value that suppresses auto-reconnect is the explicit `'logged-out'` marker.
+ */
+export function getReconnectIntent(): ReconnectIntent {
+  return localStorage.getItem(RECONNECT_INTENT_KEY) === 'logged-out'
+    ? 'logged-out'
+    : 'active'
+}
+
+/**
+ * Record that the user deliberately logged out. Call this FIRST in the logout
+ * handler — synchronously, before any await or reload — so the auto-reconnect
+ * engines see it even if cleanup stalls or the webview reloads mid-logout.
+ */
+export function markLoggedOut(): void {
+  localStorage.setItem(RECONNECT_INTENT_KEY, 'logged-out')
+}
+
+/**
+ * Record that the user is connected on purpose, re-arming auto-reconnect for
+ * future reloads. Call this when a connection reaches `online`, regardless of
+ * how it got there (manual login, keychain auto-connect, reload reconnect).
+ */
+export function markConnectActive(): void {
+  localStorage.setItem(RECONNECT_INTENT_KEY, 'active')
+}

--- a/packages/fluux-sdk/src/core/connectionMachine.test.ts
+++ b/packages/fluux-sdk/src/core/connectionMachine.test.ts
@@ -892,6 +892,43 @@ describe('connectionMachine', () => {
       actor.stop()
     })
 
+    // Contract: a deliberately-disconnected machine (post-logout) must NOT
+    // re-enter the reconnect loop on its own. SOCKET_DIED (emitted as the
+    // post-logout socket tears down) and TRIGGER_RECONNECT are ignored by the
+    // disconnected state — pin that by assertion so a future handler added here
+    // can't silently re-enable auto-reconnect after logout. Only CONNECT (a
+    // user-initiated login) may leave 'disconnected'.
+    it('should ignore SOCKET_DIED in disconnected (post-logout socket teardown)', () => {
+      const actor = createActor(connectionMachine).start()
+      actor.send({ type: 'CONNECT' })
+      actor.send({ type: 'CONNECTION_SUCCESS' })
+      actor.send({ type: 'DISCONNECT' })
+      actor.send({ type: 'SOCKET_DIED' })
+      expect(actor.getSnapshot().value).toBe('disconnected')
+      actor.stop()
+    })
+
+    it('should ignore TRIGGER_RECONNECT in disconnected', () => {
+      const actor = createActor(connectionMachine).start()
+      actor.send({ type: 'CONNECT' })
+      actor.send({ type: 'CONNECTION_SUCCESS' })
+      actor.send({ type: 'DISCONNECT' })
+      actor.send({ type: 'TRIGGER_RECONNECT' })
+      expect(actor.getSnapshot().value).toBe('disconnected')
+      actor.stop()
+    })
+
+    it('should only leave disconnected on CONNECT', () => {
+      const actor = createActor(connectionMachine).start()
+      actor.send({ type: 'CONNECT' })
+      actor.send({ type: 'CONNECTION_SUCCESS' })
+      actor.send({ type: 'DISCONNECT' })
+      expect(actor.getSnapshot().value).toBe('disconnected')
+      actor.send({ type: 'CONNECT' })
+      expect(actor.getSnapshot().value).toBe('connecting')
+      actor.stop()
+    })
+
     it('should ignore TRIGGER_RECONNECT in terminal', () => {
       const actor = createActor(connectionMachine).start()
       actor.send({ type: 'CONNECT' })


### PR DESCRIPTION
Clicking logout could immediately log the user back in.

The cause: there was no stored answer to "should we auto-reconnect?". It was re-derived on every startup from surviving credentials plus an in-memory guard that the post-logout webview reload resets — so previous fixes only tried to delete the credential fast enough to beat the reload, and the bug kept coming back.

This replaces that race with a persisted reconnect-intent flag as the single source of truth:

- New `reconnectIntent.ts` (`getReconnectIntent` / `markLoggedOut` / `markConnectActive`), stored in localStorage so it survives the reload; defaults to active for backward compatibility.
- The `useSessionPersistence` auto-reconnect (sessionStorage and FAST-token paths) and the `LoginScreen` keychain auto-connect now refuse to connect while the intent is logged-out.
- The intent is re-armed at the single App "online" chokepoint.
- Logout is extracted into `performLogout()`, which sets logged-out synchronously before any await; the existing credential deletions remain as defense-in-depth.

Tests cover the intent module, the gated reconnect paths (including across a simulated reload with the credential still present), the logout sequence, and the connection machine's disconnected contract.