### PR TITLE
Instrument render-perf blind spots; decouple useChat from typing/draft churn

### DIFF
--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import { useChat, useRoom, useRoster, matchNameOrJid, getLocalPart, searchStore } from '@fluux/sdk'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
+import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { useChatStore, useConnectionStore } from '@fluux/sdk/react'
 import type { PresenceStatus } from '@fluux/sdk'
 import type { SidebarView } from './Sidebar'
@@ -168,6 +169,7 @@ function CommandPaletteContent({
   onAddContact,
   onStartConversation,
 }: CommandPaletteProps) {
+  detectRenderLoop('CommandPalette')
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -22,6 +22,7 @@ import { MenuButton, MenuDivider } from './sidebar-components/SidebarListMenu'
 import { useContextMenu, useWindowDrag } from '@/hooks'
 import { useToastStore } from '@/stores/toastStore'
 import { getTranslatedShowText } from '@/utils/presence'
+import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { OccupantModerationModal } from './OccupantModerationModal'
 import { UserInfoPopover } from './conversation/UserInfoPopover'
 import { Shield, Crown, UserCheck, X, ArrowLeft, MessageCircle, EyeOff, User, Settings, Ear } from 'lucide-react'
@@ -291,6 +292,7 @@ export function OccupantPanel({
   onShowProfile,
   fullScreen = false,
 }: OccupantPanelProps) {
+  detectRenderLoop('OccupantPanel')
   const { t } = useTranslation()
   const connectionStatus = useConnectionStore((s) => s.status)
   const forceOffline = connectionStatus !== 'online'

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1556,6 +1556,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
   sendWhisper,
   ref,
 }: RoomMessageInputProps & { ref?: React.Ref<MessageComposerHandle> }) {
+  detectRenderLoop('RoomMessageInput')
   const { t } = useTranslation()
   // Narrow, reference-stable subscriptions: the composer re-renders on entity
   // changes (name/nickname) and occupant COUNT changes (join/leave), but NOT on

--- a/apps/fluux/src/components/sidebar-components/ContactList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.tsx
@@ -8,6 +8,7 @@ import { RenameContactModal } from '../RenameContactModal'
 import { Tooltip } from '../Tooltip'
 import { useSidebarZone, ContactTooltipContent } from './types'
 import { getTranslatedStatusText } from '@/utils/statusText'
+import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { MessageCircle, Trash2, Pencil, Wrench } from 'lucide-react'
 import { TextInput } from '../ui/TextInput'
 
@@ -19,6 +20,7 @@ interface ContactListProps {
 }
 
 export function ContactList({ onStartChat, onSelectContact, onManageUser, activeContactJid }: ContactListProps) {
+  detectRenderLoop('ContactList')
   const { t } = useTranslation()
   const { sortedContacts, removeContact, renameContact } = useRoster()
   const connectionStatus = useConnectionStore((s) => s.status)

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -6,6 +6,7 @@ import { Avatar } from '../Avatar'
 import { useNavigateToTarget } from '@/hooks/useNavigateToTarget'
 import { useListKeyboardNav } from '@/hooks'
 import { formatConversationTime } from '@/utils/dateFormat'
+import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { useSettingsStore, type TimeFormat } from '@/stores/settingsStore'
 import { useSidebarZone } from './types'
 import { Search, X, Loader2, ExternalLink, Cloud, Users, MessageSquare, Hash } from 'lucide-react'
@@ -19,6 +20,7 @@ function getConversationName(conversationId: string): string {
 }
 
 export function SearchView() {
+  detectRenderLoop('SearchView')
   const { t, i18n } = useTranslation()
   const {
     query, results, isSearching, error, search, clearSearch, previewResult, setPreviewResult,

--- a/packages/fluux-sdk/src/hooks/useChat.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChat.renderStability.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useChat } from './useChat'
 import { useChatActive } from './useChatActive'
@@ -128,5 +128,70 @@ describe('useChat render stability', () => {
     // Should be bounded — linear at worst
     expect(totalRenders).toBeLessThanOrEqual(50)
     expect(result.current.conversations.length).toBe(50)
+  })
+
+  // Typing / draft churn must NOT re-render list consumers of useChat().
+  // useChat() must not subscribe to the whole typingStates / drafts Maps — those
+  // are replaced on every keystroke in ANY conversation, which would storm the
+  // sidebar conversation list during background activity. Per-conversation typing
+  // and drafts are read inside the memoized ConversationItem via narrow selectors
+  // (useChatStore((s) => s.typingStates.get(id))), not at the list level.
+  describe('typing/draft churn isolation (regression guard for #1)', () => {
+    // setTyping schedules an auto-clear setTimeout; fake timers keep it from
+    // firing after teardown (which would surface as stderr).
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.clearAllTimers(); vi.useRealTimers() })
+
+    function setupActiveConversation() {
+      const convs = generateConversations(5)
+      act(() => {
+        convs.forEach(c => chatStore.getState().addConversation(c))
+        chatStore.getState().setActiveConversation(convs[0].id)
+      })
+      return convs
+    }
+
+    it('does NOT re-render a useChat() consumer when a non-active conversation starts typing', () => {
+      const convs = setupActiveConversation()
+
+      const { result } = renderHook(
+        () => {
+          const renderCount = useRenderCount()
+          useChat()
+          return { renderCount }
+        },
+        { wrapper }
+      )
+
+      const before = result.current.renderCount
+
+      act(() => {
+        chatStore.getState().setTyping(convs[1].id, 'someone@example.com', true)
+      })
+
+      // A typing change in a background conversation must not touch the list.
+      expect(result.current.renderCount).toBe(before)
+    })
+
+    it('does NOT re-render a useChat() consumer when a draft changes', () => {
+      const convs = setupActiveConversation()
+
+      const { result } = renderHook(
+        () => {
+          const renderCount = useRenderCount()
+          useChat()
+          return { renderCount }
+        },
+        { wrapper }
+      )
+
+      const before = result.current.renderCount
+
+      act(() => {
+        chatStore.getState().setDraft(convs[1].id, 'a background draft')
+      })
+
+      expect(result.current.renderCount).toBe(before)
+    })
   })
 })

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -135,11 +135,13 @@ export function useChat() {
     return Array.from(typingSet)
   }))
 
-  // Get all typing states (Map of conversationId -> Set of JIDs typing)
-  const typingStates = useChatStore(useShallow((s) => s.typingStates))
-
-  // Get all drafts (Map of conversationId -> draft text)
-  const drafts = useChatStore(useShallow((s) => s.drafts))
+  // NOTE: useChat() deliberately does NOT subscribe to the whole typingStates /
+  // drafts Maps. Those are replaced on every keystroke in ANY conversation, so a
+  // list-level subscription would storm every useChat() consumer (the sidebar
+  // conversation list, command palette) during background activity. Per-conversation
+  // typing and drafts are read inside the memoized ConversationItem via narrow
+  // selectors: useChatStore((s) => s.typingStates.get(id)). The active
+  // conversation's typing indicator is covered by activeTypingUsers above.
 
   // Easter egg animation state
   const activeAnimation = useChatStore((s) => s.activeAnimation)
@@ -444,8 +446,6 @@ export function useChat() {
       activeConversation,
       activeMessages,
       activeTypingUsers,
-      typingStates,
-      drafts,
       activeAnimation,
       // XEP-0313: MAM state
       supportsMAM,
@@ -462,8 +462,6 @@ export function useChat() {
       activeConversation,
       activeMessages,
       activeTypingUsers,
-      typingStates,
-      drafts,
       activeAnimation,
       supportsMAM,
       activeMAMState,


### PR DESCRIPTION
## Summary

Two related render-performance changes for the sidebar and list surfaces.

### Instrument render-perf blind spots
Adds `detectRenderLoop()` to five churn-prone components the render-loop detector did not previously track — `OccupantPanel`, `ContactList`, `CommandPalette`, `SearchView` and `RoomMessageInput` — so they appear in `getRenderStats()` and the react-scan / `renderLoopDetector` harness. The detector previously instrumented only 8 components, which left occupant, presence and typing floods unmeasurable on these surfaces.

### Decouple useChat() from typing/draft churn
`useChat()` subscribed to the whole `typingStates` and `drafts` Maps, which are replaced on every keystroke in any conversation. That re-rendered every `useChat()` consumer — the sidebar `ConversationList` and the command palette — on typing or draft activity in unrelated conversations, despite a `ConversationList` comment claiming these were not subscribed at the list level.

Nothing actually consumed those whole Maps from `useChat`: per-conversation typing and drafts are already read inside the memoized `ConversationItem` via narrow selectors (`useChatStore((s) => s.typingStates.get(id))`). This removes the two whole-Map subscriptions and their return fields, keeping the narrow `activeTypingUsers` for the active conversation's indicator.

A regression guard in `useChat.renderStability.test.tsx` asserts a `useChat()` consumer gets zero extra renders when a background conversation's typing state or draft changes.
