### PR TITLE
perf: fix Tier B/C render-perf storms (occupant panel, roster, search, contact picker)

### DIFF
--- a/apps/fluux/src/components/ContactSelector.memo.test.tsx
+++ b/apps/fluux/src/components/ContactSelector.memo.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useShallow } from 'zustand/react/shallow'
+import { ContactSelector } from './ContactSelector'
+import { chatStore } from '@fluux/sdk'
+import { useChatStore } from '@fluux/sdk/react'
+
+// useRoster runs once per ContactSelector render — its call count is a render counter.
+// vi.hoisted so the (hoisted) vi.mock factory below can reference it.
+const { useRosterMock } = vi.hoisted(() => ({ useRosterMock: vi.fn(() => ({ contacts: [] as unknown[] })) }))
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+vi.mock('./ui/TextInput', () => ({ TextInput: () => <input data-testid="ti" /> }))
+
+// Keep the REAL chatStore (so we can mutate it) and matchNameOrJid; only mock useRoster.
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return { ...actual, useRoster: useRosterMock }
+})
+// Keep the REAL useChatStore (so a regression that re-adds the subscription is caught);
+// only mock useConnectionStore.
+vi.mock('@fluux/sdk/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk/react')>()
+  return {
+    ...actual,
+    useConnectionStore: (selector: (s: { status: string }) => unknown) => selector({ status: 'online' }),
+  }
+})
+
+// Probe that DOES subscribe to the combined conversations array (the pattern ContactSelector
+// used to use). It proves the chatStore mutation below is "live" — i.e. it notifies
+// subscribers — so the test can't pass just because the mutation was a no-op.
+let probeRenders = 0
+function ConversationsProbe() {
+  useChatStore(useShallow((s: { conversations: Map<string, unknown> }) => Array.from(s.conversations.values())))
+  probeRenders++
+  return null
+}
+
+describe('ContactSelector subscription scope', () => {
+  it('does not re-render when an unrelated conversation changes', () => {
+    useRosterMock.mockClear()
+    probeRenders = 0
+
+    render(
+      <>
+        <ContactSelector selectedContacts={[]} onSelectionChange={() => {}} />
+        <ConversationsProbe />
+      </>
+    )
+    const rendersAfterMount = useRosterMock.mock.calls.length
+    const probeAfterMount = probeRenders
+    expect(rendersAfterMount).toBeGreaterThan(0)
+
+    // Mutate the REAL chatStore: a conversation gains activity.
+    act(() => {
+      chatStore.getState().addConversation({
+        id: 'c2-render-test@example.com',
+        name: 'C2 Test',
+        type: 'chat',
+        unreadCount: 0,
+      })
+    })
+
+    // The probe (subscribed) re-rendered → the mutation really notifies subscribers...
+    expect(probeRenders).toBeGreaterThan(probeAfterMount)
+    // ...but ContactSelector did NOT, because it reads recent-activity non-reactively.
+    expect(useRosterMock.mock.calls.length).toBe(rendersAfterMount)
+  })
+})

--- a/apps/fluux/src/components/ContactSelector.test.tsx
+++ b/apps/fluux/src/components/ContactSelector.test.tsx
@@ -23,6 +23,12 @@ vi.mock('@fluux/sdk', () => ({
   useRoster: () => ({
     contacts: mockContacts,
   }),
+  // Recent-activity ordering is now read non-reactively from the vanilla chatStore.
+  chatStore: {
+    getState: () => ({
+      conversations: new Map(mockConversations.map((c) => [c.id, c])),
+    }),
+  },
   // JID utilities moved from app to SDK
   matchNameOrJid: (name: string, jid: string, query: string) => {
     const lowerQuery = query.toLowerCase()

--- a/apps/fluux/src/components/ContactSelector.tsx
+++ b/apps/fluux/src/components/ContactSelector.tsx
@@ -1,9 +1,8 @@
 import { useState, useRef, useEffect, useLayoutEffect } from 'react'
-import { useShallow } from 'zustand/react/shallow'
 import { TextInput } from './ui/TextInput'
 import { useTranslation } from 'react-i18next'
-import { useRoster, matchNameOrJid } from '@fluux/sdk'
-import { useChatStore, useConnectionStore } from '@fluux/sdk/react'
+import { useRoster, matchNameOrJid, chatStore } from '@fluux/sdk'
+import { useConnectionStore } from '@fluux/sdk/react'
 import { X } from 'lucide-react'
 import { APP_OFFLINE_PRESENCE_COLOR, PRESENCE_COLORS } from '@/constants/ui'
 
@@ -73,9 +72,6 @@ export function ContactSelector({
   const { contacts } = useRoster()
   const connectionStatus = useConnectionStore((s) => s.status)
   const forceOffline = connectionStatus !== 'online'
-  // Focused selector — useChat() would also pull in typing/draft Maps, MAM
-  // state, active conversation, etc., which this selector doesn't need.
-  const conversations = useChatStore(useShallow((s) => Array.from(s.conversations.values())))
   const [search, setSearch] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(0)
   const [flipUp, setFlipUp] = useState(false)
@@ -83,15 +79,17 @@ export function ContactSelector({
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Build a map of JID -> last activity timestamp for sorting
+  // Recent-activity ordering is a one-shot nicety for the dropdown. Read it
+  // non-reactively (getState, not a subscription) so the picker does NOT re-render
+  // on every conversation change while open — the combined conversations map churns
+  // on every new message / typing / meta update.
   const recentActivityMap = (() => {
     const map = new Map<string, number>()
-    conversations.forEach(conv => {
+    for (const conv of chatStore.getState().conversations.values()) {
       if (conv.lastMessage?.timestamp) {
-        const time = conv.lastMessage.timestamp.getTime()
-        map.set(conv.id, time)
+        map.set(conv.id, conv.lastMessage.timestamp.getTime())
       }
-    })
+    }
     return map
   })()
 

--- a/apps/fluux/src/components/OccupantGrouping.test.ts
+++ b/apps/fluux/src/components/OccupantGrouping.test.ts
@@ -1,58 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { getBareJid, getBestPresenceShow, type RoomOccupant, type PresenceShow } from '@fluux/sdk'
-
-// Type for grouped occupants (copied from RoomView.tsx for testing)
-interface GroupedOccupant {
-  bareJid?: string
-  connections: RoomOccupant[]
-  primaryNick: string
-  bestPresence?: PresenceShow
-}
-
-// Helper function copied from RoomView.tsx for testing
-function groupOccupantsByBareJid(occupants: RoomOccupant[]): GroupedOccupant[] {
-  const byBareJid = new Map<string, RoomOccupant[]>()
-  const noJid: RoomOccupant[] = []
-
-  for (const occupant of occupants) {
-    if (occupant.jid) {
-      const bareJid = getBareJid(occupant.jid)
-      const existing = byBareJid.get(bareJid)
-      if (existing) {
-        existing.push(occupant)
-      } else {
-        byBareJid.set(bareJid, [occupant])
-      }
-    } else {
-      noJid.push(occupant)
-    }
-  }
-
-  const result: GroupedOccupant[] = []
-
-  for (const [bareJid, connections] of byBareJid) {
-    connections.sort((a, b) => a.nick.localeCompare(b.nick))
-    result.push({
-      bareJid,
-      connections,
-      primaryNick: connections[0].nick,
-      bestPresence: getBestPresenceShow(connections.map(c => c.show)),
-    })
-  }
-
-  for (const occupant of noJid) {
-    result.push({
-      bareJid: undefined,
-      connections: [occupant],
-      primaryNick: occupant.nick,
-      bestPresence: occupant.show,
-    })
-  }
-
-  result.sort((a, b) => a.primaryNick.localeCompare(b.primaryNick))
-
-  return result
-}
+import type { RoomOccupant } from '@fluux/sdk'
+import { groupOccupantsByBareJid } from '@/utils/occupantGrouping'
 
 // Helper to create test occupants
 function createOccupant(nick: string, opts: Partial<RoomOccupant> = {}): RoomOccupant {

--- a/apps/fluux/src/components/OccupantPanel.memo.test.tsx
+++ b/apps/fluux/src/components/OccupantPanel.memo.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/react'
 import { OccupantPanel } from './OccupantPanel'
+import { groupOccupantsByRole } from '@/utils/occupantGrouping'
 import type { Room, RoomOccupant } from '@fluux/sdk'
 
 // Count occupant-row renders: each online occupant row renders exactly one Avatar.
@@ -54,6 +55,14 @@ vi.mock('@/utils/presence', () => ({
   getTranslatedShowText: (show: string | undefined) => show || 'online',
 }))
 
+// Wrap the real grouping helper in a spy so we can assert it is memoized (not
+// recomputed on every panel render). importOriginal keeps the real implementation
+// so the rows still render correctly.
+vi.mock('@/utils/occupantGrouping', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/occupantGrouping')>()
+  return { ...actual, groupOccupantsByRole: vi.fn(actual.groupOccupantsByRole) }
+})
+
 const createOccupant = (overrides: Partial<RoomOccupant> = {}): RoomOccupant => ({
   nick: 'User', role: 'participant', affiliation: 'none', ...overrides,
 })
@@ -95,5 +104,31 @@ describe('OccupantPanel per-row memoization', () => {
     // Only bob's row should re-render — one row's worth, NOT all three.
     expect(delta).toBeGreaterThan(0)
     expect(delta).toBeLessThanOrEqual(perRowCost)
+  })
+
+  it('memoizes grouping — does not re-group when the panel re-renders with unchanged occupants', () => {
+    const groupSpy = vi.mocked(groupOccupantsByRole)
+    groupSpy.mockClear()
+
+    const alice = createOccupant({ nick: 'alice', jid: 'alice@example.com' })
+    const bob = createOccupant({ nick: 'bob', jid: 'bob@example.com' })
+    const occupants = new Map([['alice', alice], ['bob', bob]])
+    const contactsByJid = new Map()
+    const onClose = () => {}
+
+    const room1 = createRoom(occupants)
+    const { rerender } = render(
+      <OccupantPanel room={room1} contactsByJid={contactsByJid} onClose={onClose} />
+    )
+    const callsAfterMount = groupSpy.mock.calls.length
+    expect(callsAfterMount).toBeGreaterThan(0)
+
+    // A parent re-render that does NOT change occupants (message activity, menu or
+    // connection-state change): NEW room object, SAME occupants Map ref. The old IIFE
+    // re-grouped here on every render; the useMemo must skip it.
+    const room2 = { ...room1 }
+    rerender(<OccupantPanel room={room2} contactsByJid={contactsByJid} onClose={onClose} />)
+
+    expect(groupSpy.mock.calls.length).toBe(callsAfterMount)
   })
 })

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -9,10 +9,10 @@
  * - Shows contact avatars for known roster contacts
  * - Right-click context menu: private message, copy JID, ignore, user info
  */
-import { useState, useRef, memo } from 'react'
+import { useState, useRef, useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { Room, RoomOccupant, Contact, PresenceShow, RoomAffiliation, RoomRole } from '@fluux/sdk'
-import { getPresenceFromShow, getBareJid, getBestPresenceShow, generateConsistentColorHexSync, canKick, canBan, getAvailableAffiliations, getAvailableRoles } from '@fluux/sdk'
+import type { Room, RoomOccupant, Contact, RoomAffiliation, RoomRole } from '@fluux/sdk'
+import { getPresenceFromShow, getBareJid, generateConsistentColorHexSync, canKick, canBan, getAvailableAffiliations, getAvailableRoles } from '@fluux/sdk'
 import { useRoomActions } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore } from '@fluux/sdk/react'
 import { ignoreStore, type IgnoredUser } from '@fluux/sdk/stores'
@@ -23,17 +23,10 @@ import { useContextMenu, useWindowDrag } from '@/hooks'
 import { useToastStore } from '@/stores/toastStore'
 import { getTranslatedShowText } from '@/utils/presence'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
+import { groupOccupantsByRole, type GroupedOccupant } from '@/utils/occupantGrouping'
 import { OccupantModerationModal } from './OccupantModerationModal'
 import { UserInfoPopover } from './conversation/UserInfoPopover'
 import { Shield, Crown, UserCheck, X, ArrowLeft, MessageCircle, EyeOff, User, Settings, Ear } from 'lucide-react'
-
-// Type for grouped occupants (multiple connections from same bare JID)
-interface GroupedOccupant {
-  bareJid?: string
-  connections: RoomOccupant[]
-  primaryNick: string // Main display nick
-  bestPresence?: PresenceShow // Best presence show state (online > chat > away > xa > dnd)
-}
 
 export interface OccupantPanelProps {
   room: Room
@@ -424,58 +417,14 @@ export function OccupantPanel({
     }
   }
 
-  // Sort occupants by role priority: moderator > participant > visitor
-  const sortedOccupants = (() => {
-    const occupants = Array.from(room.occupants.values())
+  // Sort + group occupants by role (and by bare JID within each role). Memoized on the
+  // occupants Map ref so a parent re-render (message activity, menu / connection state)
+  // does NOT redo the O(n log n) work when the occupants are unchanged.
+  const groupedOccupants = useMemo(() => groupOccupantsByRole(room.occupants), [room.occupants])
 
-    const rolePriority: Record<string, number> = {
-      moderator: 0,
-      participant: 1,
-      visitor: 2,
-      none: 3,
-    }
-
-    return occupants.sort((a, b) => {
-      // First by role
-      const roleDiff = (rolePriority[a.role] ?? 3) - (rolePriority[b.role] ?? 3)
-      if (roleDiff !== 0) return roleDiff
-      // Then alphabetically by nick
-      return a.nick.localeCompare(b.nick)
-    })
-  })()
-
-  // Group occupants by role, then by bare JID within each role
-  const groupedOccupants = (() => {
-    const groups: { role: string; occupants: GroupedOccupant[] }[] = []
-    let currentRole: string | null = null
-    let currentRoleOccupants: RoomOccupant[] = []
-
-    // First, group by role
-    for (const occupant of sortedOccupants) {
-      if (occupant.role !== currentRole) {
-        if (currentRoleOccupants.length > 0 && currentRole) {
-          // Process the current role group
-          const groupedByJid = groupOccupantsByBareJid(currentRoleOccupants)
-          groups.push({ role: currentRole, occupants: groupedByJid })
-        }
-        currentRole = occupant.role
-        currentRoleOccupants = [occupant]
-      } else {
-        currentRoleOccupants.push(occupant)
-      }
-    }
-
-    // Don't forget the last role group
-    if (currentRoleOccupants.length > 0 && currentRole) {
-      const groupedByJid = groupOccupantsByBareJid(currentRoleOccupants)
-      groups.push({ role: currentRole, occupants: groupedByJid })
-    }
-
-    return groups
-  })()
-
-  // Compute offline members: affiliated members not currently online as occupants
-  const offlineMembers = (() => {
+  // Affiliated members not currently online as occupants. Memoized on occupants +
+  // member list so it is not recomputed on unrelated re-renders.
+  const offlineMembers = useMemo(() => {
     if (!room.affiliatedMembers || room.affiliatedMembers.length === 0) return []
 
     // Collect all online JIDs and nicks from occupants
@@ -496,10 +445,10 @@ export function OccupantPanel({
       const nameB = b.nick || b.jid
       return nameA.localeCompare(nameB)
     })
-  })()
+  }, [room.affiliatedMembers, room.occupants])
 
-  // Compute ignored users not already visible as online occupants or offline members
-  const hiddenIgnoredUsers = (() => {
+  // Ignored users not already visible as online occupants or offline members.
+  const hiddenIgnoredUsers = useMemo(() => {
     if (ignoredForRoom.length === 0) return []
 
     // Collect all identifiers visible in the occupant list
@@ -516,7 +465,7 @@ export function OccupantPanel({
     }
 
     return ignoredForRoom.filter(u => !visibleIdentifiers.has(u.identifier))
-  })()
+  }, [ignoredForRoom, room.occupants, offlineMembers])
 
   const getRoleLabel = (role: string) => {
     switch (role) {
@@ -699,7 +648,7 @@ export function OccupantPanel({
           </div>
         )}
 
-        {sortedOccupants.length === 0 && offlineMembers.length === 0 && (
+        {room.occupants.size === 0 && offlineMembers.length === 0 && (
           <div className="px-4 py-8 text-center text-fluux-muted text-sm">
             {t('rooms.noMembersInRoom')}
           </div>
@@ -861,57 +810,4 @@ function getHatColors(hat: { uri: string; hue?: number }) {
     backgroundColor: bgColor,
     color: textColor,
   }
-}
-
-/**
- * Group occupants by bare JID within a role.
- * Occupants with the same bare JID are grouped together.
- * Occupants without a JID are each in their own group.
- */
-function groupOccupantsByBareJid(occupants: RoomOccupant[]): GroupedOccupant[] {
-  const byBareJid = new Map<string, RoomOccupant[]>()
-  const noJid: RoomOccupant[] = []
-
-  for (const occupant of occupants) {
-    if (occupant.jid) {
-      const bareJid = getBareJid(occupant.jid)
-      const existing = byBareJid.get(bareJid)
-      if (existing) {
-        existing.push(occupant)
-      } else {
-        byBareJid.set(bareJid, [occupant])
-      }
-    } else {
-      noJid.push(occupant)
-    }
-  }
-
-  const result: GroupedOccupant[] = []
-
-  // Add grouped occupants (those with JIDs)
-  for (const [bareJid, connections] of byBareJid) {
-    // Sort connections by nick for consistency
-    connections.sort((a, b) => a.nick.localeCompare(b.nick))
-    result.push({
-      bareJid,
-      connections,
-      primaryNick: connections[0].nick,
-      bestPresence: getBestPresenceShow(connections.map(c => c.show)),
-    })
-  }
-
-  // Add occupants without JIDs as individual groups
-  for (const occupant of noJid) {
-    result.push({
-      bareJid: undefined,
-      connections: [occupant],
-      primaryNick: occupant.nick,
-      bestPresence: occupant.show,
-    })
-  }
-
-  // Sort all by primary nick
-  result.sort((a, b) => a.primaryNick.localeCompare(b.primaryNick))
-
-  return result
 }

--- a/apps/fluux/src/components/RoomMembersModal.test.tsx
+++ b/apps/fluux/src/components/RoomMembersModal.test.tsx
@@ -21,6 +21,8 @@ vi.mock('@fluux/sdk', () => ({
   useRoster: () => ({
     contacts: mockContacts,
   }),
+  // ContactSelector reads recent-activity non-reactively from the vanilla chatStore.
+  chatStore: { getState: () => ({ conversations: new Map() }) },
   getAvailableAffiliations: (selfAff: RoomAffiliation, _targetAff: RoomAffiliation) => {
     if (selfAff === 'owner') return ['owner', 'admin', 'member', 'none', 'outcast']
     return []

--- a/apps/fluux/src/components/sidebar-components/ContactList.memo.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.memo.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ContactList } from './ContactList'
+import type { Contact } from '@fluux/sdk'
+
+// Each contact row renders exactly one Avatar — count them to detect over-rendering.
+const avatarRenders = { count: 0 }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+// Stable hover handlers — mirrors the REAL useListKeyboardNav, which caches per-item
+// handlers by id so their identity is stable across renders (so React.memo can bail).
+const stableEnter = vi.fn()
+const stableMove = vi.fn()
+vi.mock('@/hooks', () => ({
+  useContextMenu: () => ({
+    isOpen: false, position: { x: 0, y: 0 }, close: vi.fn(), menuRef: { current: null },
+    handleContextMenu: vi.fn(), handleTouchStart: vi.fn(), handleTouchEnd: vi.fn(),
+  }),
+  useTypeToFocus: () => {},
+  useListKeyboardNav: () => ({
+    selectedIndex: -1,
+    isKeyboardNav: false,
+    getItemProps: () => ({ 'data-selected': false, onMouseEnter: stableEnter, onMouseMove: stableMove }),
+    getContainerProps: () => ({}),
+  }),
+}))
+
+vi.mock('./types', () => ({
+  useSidebarZone: () => ({ current: null }),
+  ContactTooltipContent: () => null,
+}))
+
+vi.mock('../Avatar', () => ({
+  Avatar: ({ name }: { name: string }) => {
+    avatarRenders.count++
+    return <div data-testid="avatar">{name}</div>
+  },
+}))
+
+vi.mock('../Tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../RenameContactModal', () => ({ RenameContactModal: () => null }))
+
+vi.mock('../ui/TextInput', () => ({
+  TextInput: () => <input data-testid="search" />,
+}))
+
+vi.mock('@/utils/statusText', () => ({ getTranslatedStatusText: () => '' }))
+
+vi.mock('@/utils/renderLoopDetector', () => ({ detectRenderLoop: () => {} }))
+
+const removeContact = vi.fn()
+const renameContact = vi.fn(async () => {})
+let mockContacts: Contact[] = []
+
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    useRoster: () => ({ sortedContacts: mockContacts, removeContact, renameContact }),
+    useAdminPermissions: () => ({ isAdmin: false, hasUserCommands: false, canManageUser: () => false }),
+  }
+})
+
+vi.mock('@fluux/sdk/react', () => ({
+  useConnectionStore: (selector: (s: { status: string }) => unknown) => selector({ status: 'online' }),
+}))
+
+const makeContact = (jid: string, over: Partial<Contact> = {}): Contact => ({
+  jid,
+  name: jid.split('@')[0],
+  presence: 'online',
+  subscription: 'both',
+  ...over,
+}) as Contact
+
+describe('ContactList row memoization', () => {
+  beforeEach(() => { avatarRenders.count = 0 })
+
+  it('re-renders only the changed contact row when a single contact updates', () => {
+    const alice = makeContact('alice@example.com')
+    const bob = makeContact('bob@example.com')
+    const carol = makeContact('carol@example.com')
+    mockContacts = [alice, bob, carol]
+
+    // Stable props that must NOT break the row memo across the re-render.
+    const onSelectContact = () => {}
+    const { rerender } = render(<ContactList onSelectContact={onSelectContact} />)
+
+    expect(avatarRenders.count).toBeGreaterThan(0)
+    const perRowCost = avatarRenders.count / 3 // avatars per row at mount (3 online contacts)
+    const afterMount = avatarRenders.count
+
+    // Mirror rosterStore.updatePresence: a NEW contacts array where only bob's object is
+    // replaced (alice & carol keep their refs); bob stays "online-ish" (away ≠ offline) so
+    // group membership is unchanged — only his row's data differs.
+    const bobAway = makeContact('bob@example.com', { presence: 'away' })
+    mockContacts = [alice, bobAway, carol]
+    rerender(<ContactList onSelectContact={onSelectContact} />)
+
+    const delta = avatarRenders.count - afterMount
+    // Only bob's row should re-render — one row's worth, NOT all three.
+    expect(delta).toBeGreaterThan(0)
+    expect(delta).toBeLessThanOrEqual(perRowCost)
+  })
+})

--- a/apps/fluux/src/components/sidebar-components/ContactList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.tsx
@@ -56,21 +56,39 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
   // Map from jid to flat index for quick lookup
   const jidToIndex = new Map(flatContactList.map((c, i) => [c.jid, i]))
 
-  // Handle contact selection - single click opens profile and updates highlight
-  const handleSelectContact = (contact: Contact) => {
-    onSelectContact?.(contact)
+  // Reference-STABLE row callbacks for the memoized ContactItem. Their identity must stay
+  // fixed across re-renders or the memo no-ops and the WHOLE roster re-renders row by row
+  // on every presence stanza (rosterStore replaces the contacts Map each time). Same
+  // lazy-init + "latest" ref pattern as RoomsList (compiler-proof; useCallback is stripped).
+  const latestRef = useRef({ onSelectContact, onStartChat, removeContact, renameContact, onManageUser })
+  latestRef.current = { onSelectContact, onStartChat, removeContact, renameContact, onManageUser }
+  const rowHandlersRef = useRef<{
+    onSelect: (contact: Contact) => void
+    onStartChat: (contact: Contact) => void
+    onRemove: (jid: string) => void
+    onRename: (jid: string, name: string) => Promise<void>
+    onManageUser: (jid: string) => void
+  } | null>(null)
+  if (!rowHandlersRef.current) {
+    rowHandlersRef.current = {
+      onSelect: (contact) => latestRef.current.onSelectContact?.(contact),
+      onStartChat: (contact) => latestRef.current.onStartChat?.(contact),
+      onRemove: (jid) => latestRef.current.removeContact(jid),
+      onRename: (jid, name) => latestRef.current.renameContact(jid, name),
+      onManageUser: (jid) => latestRef.current.onManageUser?.(jid),
+    }
   }
-
-  // Handle starting a chat - double click
-  const handleStartChat = (contact: Contact) => {
-    onStartChat?.(contact)
-  }
+  const rowHandlers = rowHandlersRef.current
+  // Manage handler is exposed only when the capability exists (parent passed onManageUser);
+  // ContactItem keys its "Manage" menu item off this being defined. `onManageUser` is a
+  // stable prop so this derived value stays referentially stable across renders.
+  const onManageUserStable = onManageUser ? rowHandlers.onManageUser : undefined
 
   // Keyboard navigation using the hook
   // Plain arrows: just highlight, Alt+arrows: navigate AND open contact profile
   const { selectedIndex, isKeyboardNav, getItemProps, getContainerProps } = useListKeyboardNav({
     items: flatContactList,
-    onSelect: handleSelectContact,
+    onSelect: rowHandlers.onSelect,
     listRef,
     searchInputRef,
     getItemId: (contact) => contact.jid,
@@ -126,11 +144,11 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
                 selectedJid={selectedJid}
                 isKeyboardNav={isKeyboardNav}
                 jidToIndex={jidToIndex}
-                onSelect={handleSelectContact}
-                onStartChat={handleStartChat}
-                onRemove={removeContact}
-                onRename={renameContact}
-                onManageUser={onManageUser}
+                onSelect={rowHandlers.onSelect}
+                onStartChat={rowHandlers.onStartChat}
+                onRemove={rowHandlers.onRemove}
+                onRename={rowHandlers.onRename}
+                onManageUser={onManageUserStable}
                 getItemProps={getItemProps}
                 forceOffline={forceOffline}
               />
@@ -143,11 +161,11 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
                 selectedJid={selectedJid}
                 isKeyboardNav={isKeyboardNav}
                 jidToIndex={jidToIndex}
-                onSelect={handleSelectContact}
-                onStartChat={handleStartChat}
-                onRemove={removeContact}
-                onRename={renameContact}
-                onManageUser={onManageUser}
+                onSelect={rowHandlers.onSelect}
+                onStartChat={rowHandlers.onStartChat}
+                onRemove={rowHandlers.onRemove}
+                onRename={rowHandlers.onRename}
+                onManageUser={onManageUserStable}
                 getItemProps={getItemProps}
                 forceOffline={forceOffline}
               />
@@ -160,11 +178,11 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
                 selectedJid={selectedJid}
                 isKeyboardNav={isKeyboardNav}
                 jidToIndex={jidToIndex}
-                onSelect={handleSelectContact}
-                onStartChat={handleStartChat}
-                onRemove={removeContact}
-                onRename={renameContact}
-                onManageUser={onManageUser}
+                onSelect={rowHandlers.onSelect}
+                onStartChat={rowHandlers.onStartChat}
+                onRemove={rowHandlers.onRemove}
+                onRename={rowHandlers.onRename}
+                onManageUser={onManageUserStable}
                 getItemProps={getItemProps}
                 forceOffline={forceOffline}
               />
@@ -227,11 +245,11 @@ function ContactGroup({
               isActive={contact.jid === activeJid}
               isSelected={contact.jid === selectedJid}
               isKeyboardNav={isKeyboardNav}
-              onSelect={() => onSelect(contact)}
-              onStartChat={() => onStartChat(contact)}
-              onRemove={() => onRemove(contact.jid)}
-              onRename={(name) => onRename(contact.jid, name)}
-              onManageUser={onManageUser ? () => onManageUser(contact.jid) : undefined}
+              onSelect={onSelect}
+              onStartChat={onStartChat}
+              onRemove={onRemove}
+              onRename={onRename}
+              onManageUser={onManageUser}
               onMouseEnter={itemProps.onMouseEnter}
               onMouseMove={itemProps.onMouseMove}
               forceOffline={forceOffline}
@@ -248,11 +266,11 @@ interface ContactItemProps {
   isActive?: boolean
   isSelected?: boolean
   isKeyboardNav?: boolean
-  onSelect: () => void
-  onStartChat: () => void
-  onRemove: () => void
-  onRename: (name: string) => Promise<void>
-  onManageUser?: () => void
+  onSelect: (contact: Contact) => void
+  onStartChat: (contact: Contact) => void
+  onRemove: (jid: string) => void
+  onRename: (jid: string, name: string) => Promise<void>
+  onManageUser?: (jid: string) => void
   onMouseEnter?: (e: React.MouseEvent) => void
   onMouseMove?: (e: React.MouseEvent) => void
   forceOffline: boolean
@@ -287,17 +305,17 @@ const ContactItem = memo(function ContactItem({
   // Handle single-click to select contact (shows profile view)
   const handleClick = () => {
     if (menu.isOpen) return
-    onSelect()
+    onSelect(contact)
   }
 
   const handleStartChat = () => {
     menu.close()
-    onStartChat()
+    onStartChat(contact)
   }
 
   const handleRemove = () => {
     menu.close()
-    onRemove()
+    onRemove(contact.jid)
   }
 
   const handleRename = () => {
@@ -307,7 +325,7 @@ const ContactItem = memo(function ContactItem({
 
   const handleManage = () => {
     menu.close()
-    onManageUser?.()
+    onManageUser?.(contact.jid)
   }
 
   return (
@@ -322,7 +340,7 @@ const ContactItem = memo(function ContactItem({
         <div
           data-contact-jid={contact.jid}
           onClick={handleClick}
-          onDoubleClick={onStartChat}
+          onDoubleClick={() => onStartChat(contact)}
           onContextMenu={menu.handleContextMenu}
           onTouchStart={menu.handleTouchStart}
           onTouchEnd={menu.handleTouchEnd}
@@ -413,7 +431,7 @@ const ContactItem = memo(function ContactItem({
       {showRenameModal && (
         <RenameContactModal
           contact={contact}
-          onRename={onRename}
+          onRename={(name) => onRename(contact.jid, name)}
           onClose={() => setShowRenameModal(false)}
         />
       )}

--- a/apps/fluux/src/components/sidebar-components/SearchView.memo.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.memo.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { SearchView } from './SearchView'
+import type { SearchResult } from '@fluux/sdk'
+
+// Each non-room result row renders exactly one Avatar — count them to detect over-rendering.
+const avatarRenders = { count: 0 }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+// Stable hover handlers — mirrors the real useListKeyboardNav (cached per item id).
+const stableEnter = vi.fn()
+const stableMove = vi.fn()
+vi.mock('@/hooks', () => ({
+  useListKeyboardNav: () => ({
+    selectedIndex: -1,
+    isKeyboardNav: false,
+    getItemProps: () => ({ 'data-selected': false, onMouseEnter: stableEnter, onMouseMove: stableMove }),
+    getItemAttribute: (index: number) => ({ 'data-search-result-id': String(index) }),
+    getContainerProps: () => ({}),
+  }),
+}))
+
+vi.mock('@/hooks/useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({ navigateToConversation: vi.fn(), navigateToRoom: vi.fn() }),
+}))
+
+vi.mock('../Avatar', () => ({
+  Avatar: ({ name }: { name: string }) => {
+    avatarRenders.count++
+    return <div data-testid="avatar">{name}</div>
+  },
+}))
+
+vi.mock('../ui/TextInput', () => ({ TextInput: () => <input data-testid="search" /> }))
+vi.mock('@/utils/dateFormat', () => ({ formatConversationTime: () => '12:00' }))
+vi.mock('@/utils/renderLoopDetector', () => ({ detectRenderLoop: () => {} }))
+vi.mock('./types', () => ({ useSidebarZone: () => ({ current: null }) }))
+vi.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { timeFormat: string }) => unknown) => selector({ timeFormat: '24h' }),
+}))
+
+let mockSearch: ReturnType<typeof baseSearch>
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  const emptyStore = {
+    getState: () => ({
+      rooms: { get: () => undefined },
+      contacts: { get: () => undefined },
+      conversationEntities: { get: () => undefined },
+    }),
+  }
+  return {
+    ...actual,
+    useSearch: () => mockSearch,
+    chatStore: emptyStore,
+    roomStore: emptyStore,
+    rosterStore: emptyStore,
+    getLocalPart: (jid: string) => jid.split('@')[0],
+  }
+})
+
+const makeResult = (indexId: string, conversationId: string): SearchResult => ({
+  indexId,
+  conversationId,
+  conversationName: conversationId.split('@')[0],
+  messageId: `m-${indexId}`,
+  isRoom: false,
+  timestamp: 1700000000000,
+  source: 'local',
+  matchSnippet: { text: 'hello world', matchStart: 0, matchEnd: 5 },
+}) as unknown as SearchResult
+
+function baseSearch(results: SearchResult[], previewResult: SearchResult | null) {
+  return {
+    query: 'hello', results, isSearching: false, error: null,
+    search: vi.fn(), clearSearch: vi.fn(), previewResult, setPreviewResult: vi.fn(),
+    isSearchingMAM: false, mamResults: [] as SearchResult[], hasMoreMAMResults: false, mamError: null,
+    searchScope: null, searchMAM: vi.fn(), loadMoreMAMResults: vi.fn(), setSearchScope: vi.fn(),
+    resultContext: new Map(), searchFilter: 'all', setSearchFilter: vi.fn(),
+    inPrefixSuggestions: [], isInPrefixActive: false, selectInPrefixSuggestion: vi.fn(),
+  }
+}
+
+describe('SearchView result-row memoization', () => {
+  beforeEach(() => { avatarRenders.count = 0 })
+
+  it('re-renders only the affected result row when the preview selection changes', () => {
+    const r1 = makeResult('1', 'alice@example.com')
+    const r2 = makeResult('2', 'bob@example.com')
+    const r3 = makeResult('3', 'carol@example.com')
+    mockSearch = baseSearch([r1, r2, r3], null)
+
+    const { rerender } = render(<SearchView />)
+    expect(avatarRenders.count).toBeGreaterThan(0)
+    const perRowCost = avatarRenders.count / 3 // avatars per row at mount (3 results)
+    const afterMount = avatarRenders.count
+
+    // Select r2 for preview: SAME results array/refs, only previewResult changes (isActive
+    // flips for r2 only). The non-memoized row re-rendered all three; the memo must bail
+    // on r1 and r3.
+    mockSearch = baseSearch([r1, r2, r3], r2)
+    rerender(<SearchView />)
+
+    const delta = avatarRenders.count - afterMount
+    expect(delta).toBeGreaterThan(0)
+    expect(delta).toBeLessThanOrEqual(perRowCost)
+  })
+})

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState } from 'react'
+import { useRef, useEffect, useCallback, useState, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearch, chatStore, roomStore, rosterStore, getLocalPart } from '@fluux/sdk'
 import type { SearchResult, SearchResultContext, SearchFilterType } from '@fluux/sdk'
@@ -42,18 +42,36 @@ export function SearchView() {
     inputRef.current?.focus()
   }, [])
 
-  const handleSelect = useCallback(
-    (result: SearchResult) => {
-      setPreviewResult(result)
-    },
-    [setPreviewResult]
-  )
+  // Reference-stable row callbacks for the memoized SearchResultItem (lazy-init + latest
+  // ref; compiler-proof — useCallback is stripped for JSX-only callbacks, which would
+  // break the row memo on every keystroke / selection change).
+  const latestRef = useRef({ setPreviewResult, navigateToRoom, navigateToConversation })
+  latestRef.current = { setPreviewResult, navigateToRoom, navigateToConversation }
+  const rowHandlersRef = useRef<{
+    onSelect: (result: SearchResult) => void
+    onGoToMessage: (e: React.MouseEvent, result: SearchResult) => void
+  } | null>(null)
+  if (!rowHandlersRef.current) {
+    rowHandlersRef.current = {
+      onSelect: (result) => latestRef.current.setPreviewResult(result),
+      onGoToMessage: (e, result) => {
+        e.stopPropagation()
+        latestRef.current.setPreviewResult(null)
+        if (result.isRoom) {
+          latestRef.current.navigateToRoom(result.conversationId, result.messageId)
+        } else {
+          latestRef.current.navigateToConversation(result.conversationId, result.messageId)
+        }
+      },
+    }
+  }
+  const rowHandlers = rowHandlersRef.current
 
   const allResults = [...results, ...mamResults]
 
   const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav({
     items: allResults,
-    onSelect: handleSelect,
+    onSelect: rowHandlers.onSelect,
     listRef,
     searchInputRef: inputRef,
     getItemId: (result) => result.indexId,
@@ -61,19 +79,6 @@ export function SearchView() {
     zoneRef,
     activateOnAltNav: true,
   })
-
-  const handleGoToMessage = useCallback(
-    (e: React.MouseEvent, result: SearchResult) => {
-      e.stopPropagation()
-      setPreviewResult(null)
-      if (result.isRoom) {
-        navigateToRoom(result.conversationId, result.messageId)
-      } else {
-        navigateToConversation(result.conversationId, result.messageId)
-      }
-    },
-    [navigateToConversation, navigateToRoom, setPreviewResult]
-  )
 
   // Reset highlight when suggestions change
   useEffect(() => {
@@ -222,13 +227,12 @@ export function SearchView() {
                 isActive={previewResult?.indexId === result.indexId}
                 isSelected={selectedIndex === index}
                 isKeyboardNav={isKeyboardNav}
-                onClick={() => handleSelect(result)}
-                onGoToMessage={(e) => handleGoToMessage(e, result)}
-                itemProps={getItemProps(index)}
-                itemAttribute={getItemAttribute(index)}
+                onSelect={rowHandlers.onSelect}
+                onGoToMessage={rowHandlers.onGoToMessage}
+                {...getItemProps(index)}
+                {...getItemAttribute(index)}
                 currentLang={currentLang}
                 timeFormat={timeFormat}
-                t={t}
               />
             ))}
           </div>
@@ -275,13 +279,12 @@ export function SearchView() {
                   isActive={previewResult?.indexId === result.indexId}
                   isSelected={selectedIndex === globalIndex}
                   isKeyboardNav={isKeyboardNav}
-                  onClick={() => handleSelect(result)}
-                  onGoToMessage={(e) => handleGoToMessage(e, result)}
-                  itemProps={getItemProps(globalIndex)}
-                  itemAttribute={getItemAttribute(globalIndex)}
+                  onSelect={rowHandlers.onSelect}
+                  onGoToMessage={rowHandlers.onGoToMessage}
+                  {...getItemProps(globalIndex)}
+                  {...getItemAttribute(globalIndex)}
                   currentLang={currentLang}
                   timeFormat={timeFormat}
-                  t={t}
                 />
               )
             })}
@@ -322,16 +325,20 @@ interface SearchResultItemProps {
   isActive: boolean
   isSelected: boolean
   isKeyboardNav: boolean
-  onClick: () => void
-  onGoToMessage: (e: React.MouseEvent) => void
-  itemProps: ReturnType<ReturnType<typeof useListKeyboardNav>['getItemProps']>
-  itemAttribute: Record<string, string>
+  onSelect: (result: SearchResult) => void
+  onGoToMessage: (e: React.MouseEvent, result: SearchResult) => void
+  onMouseEnter?: (e: React.MouseEvent) => void
+  onMouseMove?: (e: React.MouseEvent) => void
+  'data-selected'?: boolean
+  'data-search-result-id'?: string
   currentLang: string
   timeFormat: TimeFormat
-  t: (key: string) => string
 }
 
-function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav, onClick, onGoToMessage, itemProps, itemAttribute, currentLang, timeFormat, t }: SearchResultItemProps) {
+const SearchResultItem = memo(function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav, onSelect, onGoToMessage, onMouseEnter, onMouseMove, currentLang, timeFormat, ...rest }: SearchResultItemProps) {
+  // Self-source t (like ContactItem/RoomItem/OccupantRow) — a t passed as a prop is a
+  // fresh function each parent render and would break this row's memo.
+  const { t } = useTranslation()
   const timestamp = new Date(result.timestamp)
 
   const highlighted = isActive || isSelected
@@ -341,10 +348,14 @@ function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav
     // useListKeyboardNav — see SearchView's getContainerProps / onSelect.
     // The row is therefore a plain div (matching ConversationItem) so it can
     // host the real "Go to message" button without nesting <button> in <button>.
+    // itemProps/itemAttribute are spread at the call site so the row receives flat,
+    // reference-stable props (onMouseEnter/onMouseMove cached by id) — the memo bails
+    // unless THIS row's data actually changes.
     <div
-      {...itemAttribute}
-      {...itemProps}
-      onClick={onClick}
+      {...rest}
+      onMouseEnter={onMouseEnter}
+      onMouseMove={onMouseMove}
+      onClick={() => onSelect(result)}
       className={`w-full px-2 py-1.5 rounded flex items-start gap-2.5 text-start cursor-pointer
                  transition-colors group/result ${
                    highlighted
@@ -398,7 +409,7 @@ function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav
               {formatConversationTime(timestamp, t, currentLang, timeFormat)}
             </span>
             <button
-              onClick={onGoToMessage}
+              onClick={(e) => onGoToMessage(e, result)}
               className="p-0.5 rounded opacity-0 group-hover/result:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-fluux-hover-strong"
               title="Go to message"
             >
@@ -421,7 +432,7 @@ function SearchResultItem({ result, context, isActive, isSelected, isKeyboardNav
       </div>
     </div>
   )
-}
+})
 
 function ContextLine({
   body,

--- a/apps/fluux/src/utils/occupantGrouping.ts
+++ b/apps/fluux/src/utils/occupantGrouping.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure occupant-grouping helpers for the MUC occupant panel.
+ *
+ * Extracted from OccupantPanel so the (O(n log n)) sort + grouping can be memoized
+ * on the occupants Map reference — and unit-tested / spied in isolation. The panel
+ * re-renders whenever its parent passes a new `room` (message activity, menu state,
+ * connection status), so running this on every render is wasted work when the
+ * occupants themselves did not change.
+ */
+import { getBareJid, getBestPresenceShow } from '@fluux/sdk'
+import type { RoomOccupant, PresenceShow } from '@fluux/sdk'
+
+/** A bare-JID group of one or more occupant connections (same person, multiple devices). */
+export interface GroupedOccupant {
+  bareJid?: string
+  connections: RoomOccupant[]
+  primaryNick: string // Main display nick
+  bestPresence?: PresenceShow // Best presence show state (online > chat > away > xa > dnd)
+}
+
+/** Occupants of a single MUC role (moderator / participant / visitor), grouped by bare JID. */
+export interface OccupantRoleGroup {
+  role: string
+  occupants: GroupedOccupant[]
+}
+
+// Role display order: lower number sorts higher in the list.
+const ROLE_PRIORITY: Record<string, number> = {
+  moderator: 0,
+  participant: 1,
+  visitor: 2,
+  none: 3,
+}
+
+/**
+ * Group occupants by bare JID within a role. Occupants sharing a bare JID are merged
+ * into one group (multi-device); occupants without a JID each get their own group.
+ * Result is sorted by primary nick.
+ */
+export function groupOccupantsByBareJid(occupants: RoomOccupant[]): GroupedOccupant[] {
+  const byBareJid = new Map<string, RoomOccupant[]>()
+  const noJid: RoomOccupant[] = []
+
+  for (const occupant of occupants) {
+    if (occupant.jid) {
+      const bareJid = getBareJid(occupant.jid)
+      const existing = byBareJid.get(bareJid)
+      if (existing) {
+        existing.push(occupant)
+      } else {
+        byBareJid.set(bareJid, [occupant])
+      }
+    } else {
+      noJid.push(occupant)
+    }
+  }
+
+  const result: GroupedOccupant[] = []
+
+  // Grouped occupants (those with JIDs)
+  for (const [bareJid, connections] of byBareJid) {
+    connections.sort((a, b) => a.nick.localeCompare(b.nick))
+    result.push({
+      bareJid,
+      connections,
+      primaryNick: connections[0].nick,
+      bestPresence: getBestPresenceShow(connections.map(c => c.show)),
+    })
+  }
+
+  // Occupants without JIDs as individual groups
+  for (const occupant of noJid) {
+    result.push({
+      bareJid: undefined,
+      connections: [occupant],
+      primaryNick: occupant.nick,
+      bestPresence: occupant.show,
+    })
+  }
+
+  // Sort all by primary nick
+  result.sort((a, b) => a.primaryNick.localeCompare(b.primaryNick))
+
+  return result
+}
+
+/**
+ * Sort occupants by role priority then nick, and group them by role (and by bare JID
+ * within each role). Pure — callers should memoize on the occupants Map reference so
+ * this is skipped when a parent re-render does not change the occupants.
+ */
+export function groupOccupantsByRole(occupants: Map<string, RoomOccupant>): OccupantRoleGroup[] {
+  const sorted = Array.from(occupants.values()).sort((a, b) => {
+    const roleDiff = (ROLE_PRIORITY[a.role] ?? 3) - (ROLE_PRIORITY[b.role] ?? 3)
+    if (roleDiff !== 0) return roleDiff
+    return a.nick.localeCompare(b.nick)
+  })
+
+  const groups: OccupantRoleGroup[] = []
+  let currentRole: string | null = null
+  let currentRoleOccupants: RoomOccupant[] = []
+
+  for (const occupant of sorted) {
+    if (occupant.role !== currentRole) {
+      if (currentRoleOccupants.length > 0 && currentRole) {
+        groups.push({ role: currentRole, occupants: groupOccupantsByBareJid(currentRoleOccupants) })
+      }
+      currentRole = occupant.role
+      currentRoleOccupants = [occupant]
+    } else {
+      currentRoleOccupants.push(occupant)
+    }
+  }
+
+  // Last role group
+  if (currentRoleOccupants.length > 0 && currentRole) {
+    groups.push({ role: currentRole, occupants: groupOccupantsByBareJid(currentRoleOccupants) })
+  }
+
+  return groups
+}


### PR DESCRIPTION
## Summary

Follow-up to #465 — measures and fixes the Tier B/C render-perf candidates surfaced in that audit. Each fix ships with a deterministic render-count regression guard (the "measure" step, kept as a test). App-layer only; no SDK changes.

### Tier B

**OccupantPanel — memoize occupant grouping.** The panel re-grouped all occupants (O(n log n) sort + bare-JID grouping) on every render via an IIFE, and it re-renders ~1:1 with its parent (room message activity, menu / connection state). Extracted the grouping into a pure, tested module (`utils/occupantGrouping.ts`) and memoized it on the occupants Map ref; also memoized the offline-member and hidden-ignored derivations. The pre-existing `OccupantGrouping.test.ts` now imports the real helper instead of a copied implementation. Guard: grouping runs once across an occupant-unchanged re-render (was 2, now 1).

**ContactList — stop the whole roster re-rendering on each presence stanza.** `ContactGroup` passed inline closures to the memoized `ContactItem`, so the memo no-opped and every row re-rendered whenever rosterStore replaced the contacts Map (every presence stanza). Applied the RoomsList ref-stable handler pattern (lazy-init + latest ref). Guard: a single contact's presence change re-renders only that row (was 3, now 1).

### Tier C

**SearchView — memoize result rows.** `SearchResultItem` was non-memoized and fed inline `onClick`/`onGoToMessage` closures plus whole `itemProps`/`itemAttribute` objects, so every result row re-rendered on any SearchView render (each keystroke, preview selection, keyboard navigation). Memoized it, passed reference-stable handlers, spread `getItemProps`/`getItemAttribute` at the call site, and self-source `t` via `useTranslation` (a prop `t` is a fresh function each parent render and would defeat the memo). Guard: changing the preview selection re-renders only the affected row (was 3, now 1).

**ContactSelector — read recent-activity non-reactively.** The picker subscribed to the whole combined conversations array just to build a recent-activity sort map for its dropdown, so it re-rendered on every conversation change while open. Now reads it via `chatStore.getState()` (non-reactive), matching SearchView / ConversationList. Guard (self-validating): a probe that subscribes re-renders on the mutation, proving it is live, while ContactSelector does not.

Verification: full suite green (2922 passed, 19 skipped), typecheck and lint clean.
