### PR TITLE
perf(rooms): stop presence churn re-rendering the room message list + occupant panel

### DIFF
--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -20,7 +20,7 @@ import { ToastContainer } from './ToastContainer'
 import {
   // Vanilla stores for imperative .getState() access
   chatStore, roomStore, consoleStore, adminStore, rosterStore, searchStore, activityLogStore,
-  useRosterActions,
+  useRosterActions, useContactIdentities,
   type Contact, type Conversation, type AdminCategory
 } from '@fluux/sdk'
 // React hook wrappers for reactive subscriptions
@@ -846,16 +846,11 @@ function FullScreenOccupantPanel({ onClose, onStartChat, onShowProfile }: {
     const jid = s.activeRoomJid
     return jid ? s.rooms.get(jid) : undefined
   })
-  const contacts = useRosterStore((s) => s.contacts)
   const ownAvatar = useConnectionStore((s) => s.ownAvatar)
-
-  const contactsByJid = (() => {
-    const map = new Map<string, Contact>()
-    for (const contact of contacts.values()) {
-      map.set(contact.jid, contact)
-    }
-    return map
-  })()
+  // Presence-immune identity map (name/avatar) — same fix as RoomView: using
+  // useContactIdentities instead of the full roster keeps occupant rows from
+  // re-rendering on every presence stanza.
+  const contactsByJid = useContactIdentities()
 
   if (!activeRoom) return null
 

--- a/apps/fluux/src/components/OccupantPanel.memo.test.tsx
+++ b/apps/fluux/src/components/OccupantPanel.memo.test.tsx
@@ -131,4 +131,26 @@ describe('OccupantPanel per-row memoization', () => {
 
     expect(groupSpy.mock.calls.length).toBe(callsAfterMount)
   })
+
+  // ---- Presence-churn guard (the RoomView / FullScreenOccupantPanel fix) ----
+
+  it('re-renders ALL rows when contactsByJid identity changes (the pre-fix presence storm)', () => {
+    const alice = createOccupant({ nick: 'alice', jid: 'alice@example.com' })
+    const bob = createOccupant({ nick: 'bob', jid: 'bob@example.com' })
+    const onClose = () => {}
+    const room = createRoom(new Map([['alice', alice], ['bob', bob]]))
+
+    // A NEW contactsByJid Map each render is what the OLD useRoster sourcing produced on
+    // every presence stanza. OccupantRow's comparator depends on contactsByJid identity.
+    const { rerender } = render(<OccupantPanel room={room} contactsByJid={new Map()} onClose={onClose} />)
+    const afterMount = avatarRenders.count
+    const perRow = afterMount / 2
+    rerender(<OccupantPanel room={room} contactsByJid={new Map()} onClose={onClose} />)
+
+    // Both rows re-render because contactsByJid is a fresh reference. The RoomView /
+    // FullScreenOccupantPanel fix sources contactsByJid from useContactIdentities, which
+    // returns a STABLE ref across presence churn (proven in the SDK
+    // useRoster.renderStability test) — so in the app these rows bail on presence stanzas.
+    expect(avatarRenders.count - afterMount).toBeGreaterThanOrEqual(perRow * 2)
+  })
 })

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -11,7 +11,7 @@
  */
 import { useState, useRef, useMemo, memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { Room, RoomOccupant, Contact, RoomAffiliation, RoomRole } from '@fluux/sdk'
+import type { Room, RoomOccupant, ContactIdentity, RoomAffiliation, RoomRole } from '@fluux/sdk'
 import { getPresenceFromShow, getBareJid, generateConsistentColorHexSync, canKick, canBan, getAvailableAffiliations, getAvailableRoles } from '@fluux/sdk'
 import { useRoomActions } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore } from '@fluux/sdk/react'
@@ -30,7 +30,7 @@ import { Shield, Crown, UserCheck, X, ArrowLeft, MessageCircle, EyeOff, User, Se
 
 export interface OccupantPanelProps {
   room: Room
-  contactsByJid: Map<string, Contact>
+  contactsByJid: Map<string, ContactIdentity>
   ownAvatar?: string | null
   onClose: () => void
   onStartChat?: (jid: string) => void
@@ -77,7 +77,7 @@ interface OccupantRowProps {
   roomNickname: string
   ownAvatar?: string | null
   forceOffline: boolean
-  contactsByJid: Map<string, Contact>
+  contactsByJid: Map<string, ContactIdentity>
   ignored: boolean
   onContextMenu: (group: GroupedOccupant, e: React.MouseEvent) => void
   onTouchStart: (group: GroupedOccupant, e: React.TouchEvent) => void

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -127,6 +127,13 @@ vi.mock('@fluux/sdk', () => ({
   useRoster: () => ({
     contacts: mockContacts,
   }),
+  // RoomView reads contact avatars via useContactIdentities (presence-immune); map the
+  // test contacts to identity entries so avatar assertions still hold.
+  useContactIdentities: () => {
+    const map = new Map<string, { jid: string; name: string; avatar?: string }>()
+    for (const c of mockContacts) map.set(c.jid, { jid: c.jid, name: c.name, avatar: c.avatar })
+    return map
+  },
   useConnection: () => ({
     jid: 'me@example.com/resource',
     ownAvatar: null,

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useRoomActive, useRoomEntity, useRoomOccupantCount, useRoster, getBareJid, generateConsistentColorHexSync, getPresenceFromShow, createMessageLookup, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, canModerate, getAvailableAffiliations, getAvailableRoles, getMyReactions, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type Contact, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
+import { useRoomActive, useRoomEntity, useRoomOccupantCount, useContactIdentities, getBareJid, generateConsistentColorHexSync, getPresenceFromShow, createMessageLookup, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, canModerate, getAvailableAffiliations, getAvailableRoles, getMyReactions, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, isSmallScreen } from '@/hooks'
@@ -73,7 +73,6 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   detectRenderLoop('RoomView')
   const { t } = useTranslation()
   const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId } = useRoomActive()
-  const { contacts } = useRoster()
   // NOTE: Use focused selectors instead of useConnection() hook to avoid
   // re-renders when unrelated connection state changes (error, reconnectAttempt, etc.)
   const ownAvatar = useConnectionStore((s) => s.ownAvatar)
@@ -88,16 +87,11 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
     ? () => onSearchInConversation(activeRoom.jid)
     : undefined
 
-  // Create a map of contacts by JID for quick lookup (used to show avatars for known
-  // contacts). Memoized so it keeps a stable identity across renders — a fresh Map
-  // every render breaks the memo bailout of every RoomMessageBubbleWrapper.
-  const contactsByJid = useMemo(() => {
-    const map = new Map<string, Contact>()
-    for (const contact of contacts) {
-      map.set(contact.jid, contact)
-    }
-    return map
-  }, [contacts])
+  // Contact identity (name/avatar) lookup for occupant + message-row avatars. Sourced from
+  // useContactIdentities (NOT useRoster) so it stays referentially stable across presence
+  // churn — a fresh map every render breaks the memo bailout of every RoomMessageBubbleWrapper
+  // and OccupantRow, and presence-only updates don't change a contact's identity.
+  const contactsByJid = useContactIdentities()
 
   // Filter out messages from ignored users and replies quoting them (client-side ignore)
   // IMPORTANT: Use stable empty array reference to prevent infinite re-renders.
@@ -808,7 +802,7 @@ export const RoomMessageList = memo(function RoomMessageList({
   scrollerRef: React.RefObject<HTMLElement | null>
   isAtBottomRef: React.MutableRefObject<boolean>
   room: Room
-  contactsByJid: Map<string, Contact>
+  contactsByJid: Map<string, ContactIdentity>
   ownAvatar?: string | null
   sendReaction: (roomJid: string, messageId: string, emojis: string[]) => Promise<void>
   votePoll: (roomJid: string, messageId: string, optionEmoji: string, currentMyReactions: string[], poll: PollData, isClosed?: boolean) => Promise<void>
@@ -1034,7 +1028,7 @@ interface RoomMessageBubbleWrapperProps {
   getMessageById: (id: string) => RoomMessage | undefined
   room: Room
   knownNicks: ReadonlySet<string>
-  contactsByJid: Map<string, Contact>
+  contactsByJid: Map<string, ContactIdentity>
   ownAvatar?: string | null
   sendReaction: (roomJid: string, messageId: string, emojis: string[]) => Promise<void>
   votePoll: (roomJid: string, messageId: string, optionEmoji: string, currentMyReactions: string[], poll: PollData, isClosed?: boolean) => Promise<void>

--- a/packages/fluux-sdk/src/hooks/useRoster.renderStability.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoster.renderStability.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useRoster } from './useRoster'
+import { useContactIdentities } from './useContactIdentities'
 import { rosterStore } from '../stores'
 import {
   wrapper,
@@ -157,5 +158,48 @@ describe('useRoster render stability', () => {
     // setContacts is a single setState call — should be 1 render
     expect(totalRenders).toBeLessThanOrEqual(2)
     expect(result.current.contacts.length).toBe(500)
+  })
+
+  // Source proof for the RoomView fix: useRoster() subscribes to contacts/sortedContacts/
+  // onlineContacts, so it re-renders on every presence stanza. useContactIdentities()
+  // returns a stable ref unless an identity field (name/avatar/color) changes — so it is
+  // immune to presence-only churn. RoomView builds its contactsByJid avatar-lookup map, and
+  // that map is a memo-breaking prop on every message row (RoomView.tsx comment) and
+  // OccupantRow (comparator) — so sourcing it from useContactIdentities stops presence
+  // churn from re-rendering those rows.
+  it('useContactIdentities() is immune to presence churn, unlike useRoster()', () => {
+    const contacts = generateContacts(10)
+    act(() => {
+      rosterStore.getState().setContacts(contacts)
+    })
+
+    const rosterHook = renderHook(() => {
+      const renderCount = useRenderCount()
+      useRoster()
+      return renderCount
+    }, { wrapper })
+    const identHook = renderHook(() => {
+      const renderCount = useRenderCount()
+      useContactIdentities()
+      return renderCount
+    }, { wrapper })
+
+    const rosterBefore = rosterHook.result.current
+    const identBefore = identHook.result.current
+
+    // Presence-only burst: 10 contacts come online (identity fields unchanged), each in its
+    // own act() so renders are not coalesced.
+    for (let i = 0; i < 10; i++) {
+      act(() => {
+        rosterStore.getState().updatePresence(
+          `${contacts[i].jid}/resource`, 'chat', 0, undefined, undefined, undefined
+        )
+      })
+    }
+
+    // useRoster re-renders on each presence update...
+    expect(rosterHook.result.current - rosterBefore).toBeGreaterThan(0)
+    // ...useContactIdentities does NOT (name/avatar/color unchanged).
+    expect(identHook.result.current - identBefore).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

RoomView and ChatLayout's full-screen occupant panel built their `contactsByJid` avatar-lookup map from `useRoster().contacts`, which the roster store replaces on **every presence stanza**. That map is a known memo-breaking prop on every `RoomMessageBubbleWrapper` (the RoomView comment spells this out) and every `OccupantRow` (its comparator checks `contactsByJid` identity). So with a room open, **every roster presence stanza re-rendered the whole message list + occupant panel, row by row** — a storm the message-row perf work never caught because it was validated against *message* floods (where `contactsByJid` stays stable), not presence floods (a login/reconnect burst with a room open).

### Fix
Source `contactsByJid` from the existing presence-immune `useContactIdentities()` instead. It returns a stable reference unless a contact's identity field (name/avatar/color) changes, so presence-only updates no longer churn the map and the rows bail. `contactsByJid`'s element type changes `Contact → ContactIdentity`; every consumer reads only `avatar`/`name`/`color` (and `UserInfoPopover` already accepts `Contact | ContactIdentity`), verified by typecheck.

**Whisper is unaffected:** the composer reads whisper-counterpart presence from room occupants (`room.occupants` / `useWhisperCounterpartPresent`), not the roster — so narrowing roster avatars can't break it.