### PR TITLE
fix(composer): suppress render-loop warning during fast typing

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -327,6 +327,7 @@ vi.mock('@/hooks/useEventsDesktopNotifications', () => ({
 
 vi.mock('@/utils/renderLoopDetector', () => ({
   detectRenderLoop: () => {},
+  notifyUserInput: () => {},
 }))
 
 // Note: useRouteSync is not mocked - we use the real implementation with MemoryRouter

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback, Suspense, lazy, type ReactNode, type RefObject, type Ref, useImperativeHandle } from 'react'
 import { useTranslation } from 'react-i18next'
-import { detectRenderLoop } from '@/utils/renderLoopDetector'
+import { detectRenderLoop, notifyUserInput } from '@/utils/renderLoopDetector'
 import { Send, Smile, Paperclip, Reply, X, Pencil, Loader2, Image, FileText, Trash2, BarChart3, Plus, Lock, ShieldCheck } from 'lucide-react'
 import { useClickOutside, useSlashCommands } from '@/hooks'
 import { Tooltip } from './Tooltip'
@@ -323,6 +323,11 @@ export function MessageComposer({
   // Control character filtering (Tauri macOS arrow-key bug) is handled by
   // the TextArea component — see ui/TextInput.tsx
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    // A keystroke legitimately re-renders this controlled input (text + caret)
+    // ~1-2× — fast typing / key-repeat would otherwise trip the render-loop
+    // *warning*. Arm the interaction grace so warnings stay quiet while typing;
+    // the hard loop-break threshold is unaffected.
+    notifyUserInput()
     setText(e.target.value)
 
     // Update toolbar visibility based on typing activity

--- a/apps/fluux/src/test-setup.ts
+++ b/apps/fluux/src/test-setup.ts
@@ -16,6 +16,7 @@ vi.mock('@/utils/renderLoopDetector', () => ({
   resetRenderLoopDetector: vi.fn(),
   startWakeGracePeriod: vi.fn(),
   startSyncGracePeriod: vi.fn(),
+  notifyUserInput: vi.fn(),
   getRenderStats: vi.fn(() => ({})),
 }))
 

--- a/apps/fluux/src/utils/renderLoopDetector.test.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// test-setup.ts globally mocks this module to no-ops for component tests.
+// Here we exercise the REAL implementation via importActual.
+const { detectRenderLoop, notifyUserInput, resetRenderLoopDetector } =
+  await vi.importActual<typeof import('./renderLoopDetector')>('./renderLoopDetector')
+
+const WARNING_RE = /has rendered 30 times/
+
+describe('renderLoopDetector — interaction grace', () => {
+  beforeEach(() => {
+    resetRenderLoopDetector()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('warns once a component crosses the warning threshold (no interaction)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (let i = 0; i < 30; i++) detectRenderLoop('NoGraceComp')
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(WARNING_RE))
+  })
+
+  it('suppresses the warning while the user is actively typing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    notifyUserInput() // a keystroke just happened — arms the interaction grace
+    for (let i = 0; i < 30; i++) detectRenderLoop('TypingComp')
+    expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(WARNING_RE))
+  })
+
+  it('still breaks a genuine render loop even during interaction grace', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    notifyUserInput() // grace silences the warning, but must NOT disable the hard break
+    expect(() => {
+      for (let i = 0; i < 250; i++) detectRenderLoop('LoopComp')
+    }).toThrow(/Render loop detected/)
+  })
+})

--- a/apps/fluux/src/utils/renderLoopDetector.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.ts
@@ -48,11 +48,16 @@ const MAX_RENDER_HISTORY = 20       // Keep last N renders per component for deb
 const WAKE_GRACE_PERIOD_MS = 3000   // Suppress warnings for this long after wake
 const SYNC_GRACE_PERIOD_MS = 15000  // Raise error threshold after fresh connection (covers full MAM + roster + room catch-up)
 const SYNC_GRACE_THRESHOLD = 500    // Error threshold during sync grace period
+const INTERACTION_GRACE_MS = 1500   // Suppress warnings for this long after a keystroke (covers inter-key gaps; rolling)
 
 // Track if we're in a grace period (e.g., after wake from sleep)
 let wakeGraceUntil = 0
 // Track sync grace period (raised error threshold during initial connection sync)
 let syncGraceUntil = 0
+// Track interaction grace period (suppress warnings during active typing — a
+// controlled input legitimately re-renders ~1-2× per keystroke, which fast typing
+// or OS key-repeat pushes past the warning threshold without any actual loop).
+let interactionGraceUntil = 0
 
 function getComponentState(componentName: string): ComponentState {
   let state = componentStates.get(componentName)
@@ -128,8 +133,9 @@ export function detectRenderLoop(componentName: string): void {
   }
 
   // Warning threshold - log but don't throw
-  // Skip warning during wake grace period (expected high render frequency after sleep)
-  const inGracePeriod = now < wakeGraceUntil
+  // Skip warning during a grace period (expected high render frequency): after
+  // sleep/wake, or while the user is actively typing into a controlled input.
+  const inGracePeriod = now < wakeGraceUntil || now < interactionGraceUntil
   if (state.renderCount === WARNING_THRESHOLD && !state.hasWarned && !inGracePeriod) {
     state.hasWarned = true
     console.warn(
@@ -289,6 +295,18 @@ export function resetRenderLoopDetector(): void {
   componentStates.clear()
   wakeGraceUntil = 0
   syncGraceUntil = 0
+  interactionGraceUntil = 0
+}
+
+/**
+ * Signal that a user-input event just occurred (e.g. a keystroke in the message
+ * composer). Suppresses render-loop *warnings* for a short rolling window so that
+ * legitimate per-keystroke re-renders of a controlled input don't read as a loop.
+ * The error/throw threshold is NOT affected — a genuine loop triggered while
+ * typing still trips the hard break.
+ */
+export function notifyUserInput(): void {
+  interactionGraceUntil = Date.now() + INTERACTION_GRACE_MS
 }
 
 /**


### PR DESCRIPTION
Typing fast into a message composer — or holding a key, triggering OS key-repeat — logged a stream of `[RenderLoopDetector] Warning: RoomMessageInput/MessageComposer has rendered 30 times in 1000ms` warnings. This is a false positive, not a render loop.