### PR TITLE
fix(muc): fix + harden frozen-derived-value row regressions (reply-scroll, poll-close)

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -5,7 +5,7 @@ import { useRoomActive, useRoomEntity, useRoomOccupantCount, useContactIdentitie
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, isSmallScreen } from '@/hooks'
-import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, buildReplyContext, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
+import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar, getConsistentTextColor } from './Avatar'
@@ -272,6 +272,14 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // getter so a new Map (every appended message) does not break the memo bailout
   // of every RoomMessageBubbleWrapper. Ref updated in an effect (not during
   // render) to avoid making the React Compiler bail on RoomView.
+  //
+  // GUARD (regression class): a value DERIVED from this stable getter AT RENDER TIME
+  // inside a memoized row freezes — the row only re-renders when its own props change,
+  // so it won't pick up later lookup contents (e.g. a reply whose target hadn't loaded
+  // yet). Either (a) make the consumer tolerate a stale/unresolved result — as
+  // scrollToMessage does by also matching data-stanza-id / data-origin-id — or
+  // (b) pass a reactive per-message prop instead of reading the getter at render (see
+  // canClosePoll / isPollClosed). Never gate UI solely on a render-time read here.
   const messagesById = useMemo(() => createMessageLookup(activeMessages), [activeMessages])
   const messagesByIdRef = useRef(messagesById)
   useEffect(() => { messagesByIdRef.current = messagesById }, [messagesById])
@@ -889,9 +897,12 @@ export const RoomMessageList = memo(function RoomMessageList({
   }, [])
 
   // Set of original poll message IDs that have been closed (a poll-closed message references them).
-  // Used to disable the "Close poll" button on already-closed polls. Exposed to rows
-  // as a STABLE getter — a fresh Set every render (messages change on every append)
-  // would break the memo bailout of every RoomMessageBubbleWrapper.
+  // Used to disable the "Close poll" button on already-closed polls. Each row receives a
+  // per-message boolean derived from this set (see renderMessage), NOT the Set itself nor a
+  // stable getter: a fresh Set or a stable-ref getter read during render would either break the
+  // memo bailout of every row on each append, or freeze the closed-state inside the memoized row
+  // (a row only re-renders when its own props change). A per-message boolean flips only for the
+  // poll that closed, so it stays reactive without re-rendering unrelated rows.
   const closedPollIds = useMemo(() => {
     const ids = new Set<string>()
     for (const msg of messages) {
@@ -901,9 +912,6 @@ export const RoomMessageList = memo(function RoomMessageList({
     }
     return ids
   }, [messages])
-  const closedPollIdsRef = useRef(closedPollIds)
-  useEffect(() => { closedPollIdsRef.current = closedPollIds }, [closedPollIds])
-  const isPollClosed = useCallback((pollMessageId: string) => closedPollIdsRef.current.has(pollMessageId), [])
 
   // Set of known occupant nicknames for IRC-style mention highlighting
   const knownNicks = useMemo(() => {
@@ -965,7 +973,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       votePoll={votePoll}
       closePoll={closePoll}
 
-      isPollClosed={isPollClosed}
+      isPollClosed={closedPollIds.has(msg.id)}
       onReply={onReply}
       onEdit={onEdit}
       isLastOutgoing={msg.id === lastOutgoingMessageId}
@@ -1062,8 +1070,10 @@ interface RoomMessageBubbleWrapperProps {
   onNickTouchEnd?: () => void
   // Affiliation action (passed from parent to avoid useRoom() subscription)
   setAffiliation: (roomJid: string, userJid: string, affiliation: RoomAffiliation, reason?: string) => Promise<void>
-  // Stable getter: is this poll message closed? (to disable close button)
-  isPollClosed: (pollMessageId: string) => boolean
+  // Per-message boolean: is this poll already closed? (to hide the close action).
+  // A reactive prop, NOT a stable getter — so the memoized row updates when its own
+  // poll closes instead of freezing a render-time lookup.
+  isPollClosed: boolean
   // Highlight terms for find-on-page
   highlightTerms?: string[]
   // Whether this message is the current find-on-page match
@@ -1377,7 +1387,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
         onNickTouchEnd={!message.isOutgoing ? onNickTouchEnd : undefined}
         onReactionPickerChange={(isOpen) => onReactionPickerChange?.(message.id, isOpen)}
         onPollVote={handlePollVote}
-        onClosePoll={message.isOutgoing && message.poll && !isPollClosed(message.id) && !message.pollClosedAt ? () => closePoll(room.jid, message.id) : undefined}
+        onClosePoll={canClosePoll(message, isPollClosed) ? () => closePoll(room.jid, message.id) : undefined}
 
         formatTime={formatTime}
         timeFormat={timeFormat}

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -303,6 +303,8 @@ export function MessageList<T extends BaseMessage>({
                   <div
                     key={msg.id}
                     data-message-id={msg.id}
+                    data-stanza-id={msg.stanzaId}
+                    data-origin-id={msg.originId}
                     style={msg.id === lastSentMessageId ? { animation: 'message-send 300ms ease-out' } : undefined}
                   >
                     {showGapMarker && <HistoryGapMarker onLoadMore={onCatchUpHistory} isLoading={isCatchingUp ?? false} />}

--- a/apps/fluux/src/components/conversation/index.ts
+++ b/apps/fluux/src/components/conversation/index.ts
@@ -21,7 +21,7 @@ export { HistoryGapMarker } from './HistoryGapMarker'
 export { MessageBubble, buildReplyContext } from './MessageBubble'
 export type { MessageBubbleProps } from './MessageBubble'
 
-export { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage } from './messageGrouping'
+export { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage, canClosePoll } from './messageGrouping'
 export type { MessageGroup, WhisperThreadPosition } from './messageGrouping'
 
 export { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend } from './whisperTarget'

--- a/apps/fluux/src/components/conversation/messageGrouping.test.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.test.ts
@@ -481,6 +481,53 @@ describe('scrollToMessage', () => {
     expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="abc\\+def\\/ghi\\=jkl"]')
     expect(mockElement.scrollIntoView).toHaveBeenCalled()
   })
+
+  it('should resolve a message by its stanza-id when the local id does not match', () => {
+    // Regression: MUC replies (XEP-0461) reference the room-assigned stanza-id, but
+    // DOM rows are keyed by local message id. When the reply context froze the raw
+    // stanza-id (target not in the lookup at render time), scrollToMessage must fall
+    // through to data-stanza-id to find the row instead of giving up.
+    querySelectorSpy.mockImplementation((sel: string) =>
+      sel === '[data-stanza-id="2026-06-08-b9469e60caa58b7f"]'
+        ? (mockElement as unknown as Element)
+        : null
+    )
+
+    scrollToMessage('2026-06-08-b9469e60caa58b7f')
+
+    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="2026-06-08-b9469e60caa58b7f"]')
+    expect(querySelectorSpy).toHaveBeenCalledWith('[data-stanza-id="2026-06-08-b9469e60caa58b7f"]')
+    expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+    })
+    expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
+  })
+
+  it('should resolve a message by its origin-id when neither local id nor stanza-id match', () => {
+    // XEP-0308 corrections reference the sender-assigned origin-id.
+    querySelectorSpy.mockImplementation((sel: string) =>
+      sel === '[data-origin-id="origin-xyz"]' ? (mockElement as unknown as Element) : null
+    )
+
+    scrollToMessage('origin-xyz')
+
+    expect(querySelectorSpy).toHaveBeenCalledWith('[data-origin-id="origin-xyz"]')
+    expect(mockElement.scrollIntoView).toHaveBeenCalled()
+  })
+
+  it('should prefer the local-id match over stanza-id / origin-id', () => {
+    // The strong local-id tier wins so a sender-controlled origin-id can never shadow
+    // a real id match on a different row.
+    querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
+
+    scrollToMessage('local-1')
+
+    // First lookup is by data-message-id; since it matches, the fallbacks are skipped.
+    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="local-1"]')
+    expect(querySelectorSpy).not.toHaveBeenCalledWith('[data-stanza-id="local-1"]')
+    expect(mockElement.scrollIntoView).toHaveBeenCalled()
+  })
 })
 
 describe('isActionMessage', () => {

--- a/apps/fluux/src/components/conversation/messageGrouping.test.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage } from './messageGrouping'
+import { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage, canClosePoll } from './messageGrouping'
 
 // Mock CSS.escape since it's not available in JSDOM
 // This implementation matches the browser's CSS.escape behavior
@@ -557,5 +557,32 @@ describe('isActionMessage', () => {
     expect(isActionMessage(undefined)).toBe(false)
     // @ts-expect-error - testing null handling
     expect(isActionMessage(null)).toBe(false)
+  })
+})
+
+describe('canClosePoll', () => {
+  const ownPoll = { isOutgoing: true, poll: { title: 'Lunch?' } }
+
+  it('offers close for your own open poll', () => {
+    expect(canClosePoll(ownPoll, false)).toBe(true)
+  })
+
+  it('hides close once the poll is closed (reactive boolean — the regression guard)', () => {
+    // This is the value that must stay reactive: passing `true` here (because a
+    // poll-closed message arrived) MUST flip the decision. The row receives this as
+    // a plain boolean prop, never reads it from a frozen stable getter at render.
+    expect(canClosePoll(ownPoll, true)).toBe(false)
+  })
+
+  it('hides close when the poll message itself is marked closed', () => {
+    expect(canClosePoll({ ...ownPoll, pollClosedAt: new Date() }, false)).toBe(false)
+  })
+
+  it('never offers close on someone else’s poll', () => {
+    expect(canClosePoll({ isOutgoing: false, poll: { title: 'Lunch?' } }, false)).toBe(false)
+  })
+
+  it('never offers close on a non-poll message', () => {
+    expect(canClosePoll({ isOutgoing: true }, false)).toBe(false)
   })
 })

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -222,8 +222,22 @@ export function scrollToMessage(messageId: string): void {
   // Some clients use base64-encoded IDs that contain these characters
   const escapedId = CSS.escape(messageId)
 
+  // A reply/reaction/correction references its target by whichever id tier the
+  // sender chose: XEP-0461 replies in a MUC reference the room-assigned stanza-id,
+  // XEP-0308 corrections reference the sender's origin-id. The DOM keys each row by
+  // the local message id but also exposes data-stanza-id / data-origin-id, so resolve
+  // against every tier — the reference passed here may not have been mapped back to a
+  // local id (e.g. the target wasn't in the lookup when the reply row last rendered).
+  function findElement(): Element | null {
+    return (
+      document.querySelector(`[data-message-id="${escapedId}"]`) ??
+      document.querySelector(`[data-stanza-id="${escapedId}"]`) ??
+      document.querySelector(`[data-origin-id="${escapedId}"]`)
+    )
+  }
+
   function tryScroll(retriesLeft: number) {
-    const element = document.querySelector(`[data-message-id="${escapedId}"]`)
+    const element = findElement()
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'center' })
       element.classList.add('message-highlight')

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -9,6 +9,25 @@ export function isActionMessage(body: string | undefined): boolean {
 }
 
 /**
+ * Whether the "close poll" action should be offered for a message.
+ *
+ * GUARD (regression class): `isClosed` MUST be a plain reactive value — derived
+ * per-message and passed to the row as a prop — NOT read at render time from a
+ * stable getter/ref inside a memoized row. A memoized row only re-renders when its
+ * own props change, so reading a stable getter during render freezes the result:
+ * the row would keep offering "close" on an already-closed poll until it remounts.
+ * This is the same failure mode that froze the reply-scroll target (see
+ * `scrollToMessage` and RoomView's `getMessageById` note). Keeping this a typed
+ * `boolean` parameter makes the freeze unrepresentable for this decision.
+ */
+export function canClosePoll(
+  message: { isOutgoing?: boolean; poll?: unknown; pollClosedAt?: Date },
+  isClosed: boolean,
+): boolean {
+  return Boolean(message.isOutgoing && message.poll && !isClosed && !message.pollClosedAt)
+}
+
+/**
  * Security context subset used for grouping. Matches the SDK's
  * `MessageSecurityContext` shape — duplicated here to keep this module
  * free of SDK imports so it stays cheap to unit-test.


### PR DESCRIPTION
Two fixes for the same regression class introduced by the render-perf optimization rounds: **a value derived at render inside a memoized message row from a deliberately-stable getter/ref freezes**, because the row only re-renders when its own props change.

### 1. Reply-scroll target (the reported bug)
Clicking a MUC reply's quoted snippet didn't scroll to the original message. A reply references its target by the room-assigned stanza-id (XEP-0461), but `buildReplyContext` resolves stanza-id → local id at render inside the memoized row via the stable `getMessageById`. When the quoted message isn't in the lookup at that render (MAM can add a reply before the older message it quotes), the resolved id froze as the raw stanza-id and the row never recomputed — so `scrollToMessage` searched `[data-message-id="<stanza-id>"]`, which never exists. Not store drift: `rooms` and `roomRuntime` stay in sync.

**Fix:** make each row addressable by every id tier a reference can carry — render `data-stanza-id`/`data-origin-id` alongside `data-message-id`, and resolve in `scrollToMessage` by `data-message-id` → `data-stanza-id` → `data-origin-id`. Fixes rooms, 1:1 chat, and search uniformly.

### 2. Poll-close gating (same class, found while auditing)
`isPollClosed` was a stable getter read at render to gate the "close poll" action — the same freeze edge. A poll closed via a poll-closed message (not the poll's own `pollClosedAt`) could keep offering "close" until the row remounted.

**Fix:** replace it with a reactive per-message boolean prop (flips only for the closed poll, so other rows keep their memo bailout; the `boolean` type makes the freeze unrepresentable). Extracted the gate into a documented, unit-tested `canClosePoll(message, isClosed)` predicate.

### Guard
Documented the regression class at the canonical stable getter (`getMessageById`): deriving at render from a stable getter freezes inside a memoized row — either make the consumer tolerate staleness (as `scrollToMessage` now does) or pass a reactive per-item prop (as `isPollClosed` now does). Also audited the other perf rounds (#462/#465/#467/#468); the occupant/avatar/presence concerns are safe because the store replaces those Maps immutably and `stableRoom` propagates the reference change.