### PR TITLE
fix(messaging): stop sending correction/reaction fallbacks, keep rendering them

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -1344,10 +1344,9 @@ describe('Chat E2EE wiring', () => {
       expect(sent.getChild('encryption', 'urn:xmpp:eme:0')).toBeDefined()
       expect(sent.getChild('replace', 'urn:xmpp:message-correct:0')).toBeDefined()
 
-      // The <fallback for="NS_CORRECTION"> with body indices must be removed:
-      // its start/end positions referenced the plaintext body, not the E2EE
-      // fallback string, so keeping it causes recipients to truncate the
-      // displayed fallback (e.g. "[OpenPGP-encrypted message]" → "rypted message]").
+      // No XEP-0428 fallback is attached to a correction (neither the old
+      // "[Corrected] " prefix nor a <fallback for="NS_CORRECTION">), so the
+      // encrypted stanza carries no fallback elements.
       const fallbacks = sent.children.filter(
         (c): c is Element =>
           typeof c !== 'string' && c.name === 'fallback' && c.attrs?.xmlns === 'urn:xmpp:fallback:0',
@@ -1418,7 +1417,7 @@ describe('Chat E2EE wiring', () => {
       expect(captured).toHaveLength(0)
     })
 
-    it('strips both correction and OOB fallback when encrypting a correction with attachment', async () => {
+    it('strips the OOB fallback when encrypting a correction with attachment', async () => {
       await chat.sendCorrection('bob@example.com', 'orig-id', 'new caption', 'chat', {
         url: 'https://upload.example.com/photo.bin',
         name: 'photo.jpg',
@@ -1449,7 +1448,7 @@ describe('Chat E2EE wiring', () => {
       expect(captured).toHaveLength(1)
       const sent = captured[0]
       const body = sent.getChild('body')
-      expect(body?.text()).toBe('[Corrected] fixed text')
+      expect(body?.text()).toBe('fixed text')
       expect(sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')).toBeUndefined()
     })
   })
@@ -1457,9 +1456,9 @@ describe('Chat E2EE wiring', () => {
   describe('outbound encryption — sendReaction', () => {
     /**
      * Build a deps object with a `chat.getMessage` stub that hands out a
-     * fixed "original" message — the reactions reply-fallback would quote
-     * its `body` in cleartext if it ran. We use this fixture to prove the
-     * suppression actually fires when E2EE is reachable.
+     * fixed "original" message. Reactions no longer quote that body, so the
+     * `originalBody` is only here to prove — via these tests — that no
+     * cleartext copy of it ever reaches the wire.
      */
     function makeDepsWithOriginal(options: {
       manager: E2EEManager
@@ -1541,7 +1540,7 @@ describe('Chat E2EE wiring', () => {
       expect(evt!.payload.emojis).toEqual(['👍'])
     })
 
-    it('strict mode throws when reacting to an E2EE-unreachable peer with a quoted original', async () => {
+    it('strict mode throws when reacting to an E2EE-unreachable peer', async () => {
       const strictManager = new E2EEManager({
         storage: new InMemoryStorageBackend(),
         xmpp: stubXmppPrimitives(async () => {}),
@@ -1560,11 +1559,11 @@ describe('Chat E2EE wiring', () => {
       expect(built.capturedStanzas).toHaveLength(0)
     })
 
-    it('keeps the legacy reply-quote fallback when no E2EE manager is wired', async () => {
-      // Regression guard: removing the leak for E2EE peers must not
-      // change behavior for accounts that never opted into E2EE, where
-      // the cleartext fallback is the actual interop story for legacy
-      // clients that don't speak <reactions/>.
+    it('sends a clean bodiless reaction even when no E2EE manager is wired', async () => {
+      // We no longer attach a reply-quote fallback to reactions — modern
+      // clients render <reactions/> natively, and the fallback surfaced
+      // reactions as quoted replies in other clients. This holds with or
+      // without E2EE; an unencrypted account simply sends the bare reaction.
       const emptyManager = new E2EEManager({
         storage: new InMemoryStorageBackend(),
         xmpp: stubXmppPrimitives(async () => {}),
@@ -1579,9 +1578,12 @@ describe('Chat E2EE wiring', () => {
       await plainChat.sendReaction('bob@example.com', 'orig-id', ['🎉'])
 
       const sent = built.capturedStanzas[0]
-      const body = sent.getChild('body')
-      expect(body?.text()).toContain('legacy chat — already plaintext anyway')
-      expect(sent.getChild('reply', 'urn:xmpp:reply:0')).toBeDefined()
+      expect(sent.getChild('reactions', 'urn:xmpp:reactions:0')).toBeDefined()
+      expect(sent.getChild('body')).toBeUndefined()
+      expect(sent.getChild('reply', 'urn:xmpp:reply:0')).toBeUndefined()
+      expect(sent.getChildren('fallback', 'urn:xmpp:fallback:0')).toHaveLength(0)
+      // Bodiless reaction still gets a store hint for MAM archival.
+      expect(sent.getChild('store', 'urn:xmpp:hints')).toBeDefined()
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -1136,7 +1136,7 @@ describe('XMPPClient Message', () => {
   })
 
   describe('sendReaction (XEP-0444)', () => {
-    it('should send reaction with fallback body when original message found', async () => {
+    it('should send a clean bodiless reaction stanza (no reply-quote fallback)', async () => {
       await connectClient()
 
       mockStores.chat.getMessage = vi.fn().mockReturnValue({
@@ -1155,14 +1155,7 @@ describe('XMPPClient Message', () => {
       expect(sentStanza.attrs.to).toBe('alice@example.com')
       expect(sentStanza.attrs.type).toBe('chat')
 
-      // Should have body with quoted original + emojis
-      const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
-      expect(bodyEl).toBeDefined()
-      expect(bodyEl.children[0]).toContain('alice@example.com wrote:')
-      expect(bodyEl.children[0]).toContain('> Hello world')
-      expect(bodyEl.children[0]).toContain('👍❤️')
-
-      // Should have reactions element
+      // Reactions element with the emoji
       const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
       expect(reactionsEl).toBeDefined()
       expect(reactionsEl.attrs.xmlns).toBe('urn:xmpp:reactions:0')
@@ -1172,34 +1165,13 @@ describe('XMPPClient Message', () => {
       expect(reactionEls[0].children[0]).toBe('👍')
       expect(reactionEls[1].children[0]).toBe('❤️')
 
-      // Should have reply element
-      const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
-      expect(replyEl).toBeDefined()
-      expect(replyEl.attrs.xmlns).toBe('urn:xmpp:reply:0')
-      expect(replyEl.attrs.id).toBe('msg-123')
-      expect(replyEl.attrs.to).toBe('alice@example.com')
+      // No body, no <reply>, no <fallback> — we don't surface reactions as
+      // quoted replies and don't force fallback processing on other clients.
+      expect(sentStanza.children.find((c: any) => c.name === 'body')).toBeUndefined()
+      expect(sentStanza.children.find((c: any) => c.name === 'reply')).toBeUndefined()
+      expect(sentStanza.children.filter((c: any) => c.name === 'fallback').length).toBe(0)
 
-      // Should have reply fallback (with range)
-      const fallbackEls = sentStanza.children.filter((c: any) => c.name === 'fallback')
-      expect(fallbackEls.length).toBe(2)
-      const replyFallback = fallbackEls.find((c: any) => c.attrs.for === 'urn:xmpp:reply:0')
-      expect(replyFallback).toBeDefined()
-      expect(replyFallback.attrs.xmlns).toBe('urn:xmpp:fallback:0')
-      const replyFallbackBody = replyFallback.children[0]
-      expect(replyFallbackBody.attrs.start).toBe('0')
-      expect(parseInt(replyFallbackBody.attrs.end, 10)).toBeGreaterThan(0)
-
-      // Should have reactions fallback (entire body, no range)
-      const reactionsFallback = fallbackEls.find((c: any) => c.attrs.for === 'urn:xmpp:reactions:0')
-      expect(reactionsFallback).toBeDefined()
-      expect(reactionsFallback.attrs.xmlns).toBe('urn:xmpp:fallback:0')
-      const reactionsFallbackBody = reactionsFallback.children[0]
-      expect(reactionsFallbackBody.name).toBe('body')
-      // No start/end means entire body
-      expect(reactionsFallbackBody.attrs.start).toBeUndefined()
-      expect(reactionsFallbackBody.attrs.end).toBeUndefined()
-
-      // Should have store hint
+      // Store hint so the bodiless reaction is still archived in MAM
       const storeEl = sentStanza.children.find((c: any) => c.name === 'store')
       expect(storeEl).toBeDefined()
       expect(storeEl.attrs.xmlns).toBe('urn:xmpp:hints')
@@ -1323,7 +1295,7 @@ describe('XMPPClient Message', () => {
       expect(reactionsEl.attrs.id).toBe('unknown-msg-id')
     })
 
-    it('should include fallback for groupchat reactions with original message', async () => {
+    it('should send a clean bodiless reaction stanza for groupchat (no reply-quote fallback)', async () => {
       await connectClient()
 
       mockStores.room.getRoom = vi.fn().mockReturnValue({ jid: 'room@conference.example.com', nickname: 'me' })
@@ -1339,20 +1311,19 @@ describe('XMPPClient Message', () => {
 
       const sentStanza = mockXmppClientInstance.send.mock.calls[0][0]
 
-      // Should have body, reactions, reply, both fallbacks, and store hint
-      const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
-      expect(bodyEl).toBeDefined()
+      // Reactions element references the server stanza-id for MUC
+      const reactionsEl = sentStanza.children.find((c: any) => c.name === 'reactions')
+      expect(reactionsEl).toBeDefined()
+      expect(reactionsEl.attrs.id).toBe('server-stanza-id')
 
-      const replyEl = sentStanza.children.find((c: any) => c.name === 'reply')
-      expect(replyEl).toBeDefined()
-      expect(replyEl.attrs.to).toBe('room@conference.example.com/alice')
+      // No body, no <reply>, no <fallback>
+      expect(sentStanza.children.find((c: any) => c.name === 'body')).toBeUndefined()
+      expect(sentStanza.children.find((c: any) => c.name === 'reply')).toBeUndefined()
+      expect(sentStanza.children.filter((c: any) => c.name === 'fallback').length).toBe(0)
 
-      const fallbackEls = sentStanza.children.filter((c: any) => c.name === 'fallback')
-      expect(fallbackEls.length).toBe(2)
-
-      // Reactions fallback should indicate entire body is fallback
-      const reactionsFallback = fallbackEls.find((c: any) => c.attrs.for === 'urn:xmpp:reactions:0')
-      expect(reactionsFallback).toBeDefined()
+      // Store hint so the bodiless reaction is still archived in MAM
+      const storeEl = sentStanza.children.find((c: any) => c.name === 'store')
+      expect(storeEl).toBeDefined()
     })
   })
 
@@ -1874,10 +1845,10 @@ describe('XMPPClient Message', () => {
       expect(sentStanza.attrs.type).toBe('chat')
       expect(sentStanza.attrs.to).toBe('contact@example.com') // bare JID for chat
 
-      // Check body with [Corrected] prefix
+      // Body is the corrected text verbatim — no "[Corrected] " prefix
       const bodyEl = sentStanza.children.find((c: any) => c.name === 'body')
       expect(bodyEl).toBeDefined()
-      expect(bodyEl.children[0]).toBe('[Corrected] Fixed message')
+      expect(bodyEl.children[0]).toBe('Fixed message')
 
       // Check replace element
       const replaceEl = sentStanza.children.find((c: any) => c.name === 'replace')
@@ -1885,11 +1856,12 @@ describe('XMPPClient Message', () => {
       expect(replaceEl.attrs.xmlns).toBe('urn:xmpp:message-correct:0')
       expect(replaceEl.attrs.id).toBe('original-msg-123')
 
-      // Check fallback for correction prefix
+      // No correction fallback indication is sent — compliant clients replace
+      // the original from <replace> alone.
       const fallbackEl = sentStanza.children.find(
         (c: any) => c.name === 'fallback' && c.attrs.for === 'urn:xmpp:message-correct:0'
       )
-      expect(fallbackEl).toBeDefined()
+      expect(fallbackEl).toBeUndefined()
     })
 
     it('should include OOB element when correction includes attachment', async () => {
@@ -2033,13 +2005,12 @@ describe('XMPPClient Message', () => {
       )
       const bodyRangeEl = oobFallbackEl?.children.find((c: any) => c.name === 'body')
 
-      // Body should be: "[Corrected] user text\nURL"
-      const correctionPrefix = '[Corrected] '
-      const expectedBody = correctionPrefix + userText + '\n' + url
+      // Body should be: "user text\nURL" — no "[Corrected] " prefix
+      const expectedBody = userText + '\n' + url
       expect(bodyEl.children[0]).toBe(expectedBody)
 
-      // OOB fallback should mark ONLY the URL portion (after correction prefix and user text)
-      const expectedStart = correctionPrefix.length + userText.length + 1 // +1 for newline
+      // OOB fallback should mark ONLY the URL portion (after the user text)
+      const expectedStart = userText.length + 1 // +1 for newline
       expect(bodyRangeEl.attrs.start).toBe(String(expectedStart))
       expect(bodyRangeEl.attrs.end).toBe(String(expectedBody.length))
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -584,22 +584,6 @@ export class Chat extends BaseModule {
             children.unshift(xml('body', {}, fallbackBody))
           }
         }
-        // Remove <fallback for="NS_CORRECTION">: its body indices referenced the
-        // plaintext "[Corrected] …" prefix which no longer exists in the E2EE
-        // fallback body.  Keeping it causes recipients to truncate the displayed
-        // fallback (e.g. "[OpenPGP-encrypted message]" → "rypted message]").
-        for (let i = children.length - 1; i >= 0; i--) {
-          const c = children[i]
-          if (typeof c === 'string') continue
-          const el = c as Element
-          if (
-            el.name === 'fallback' &&
-            el.attrs?.xmlns === NS_FALLBACK &&
-            el.attrs?.for === NS_CORRECTION
-          ) {
-            children.splice(i, 1)
-          }
-        }
         children.push(dataToElement(result.payload.stanzaElement))
         children.push(
           xml('encryption', {
@@ -1088,66 +1072,29 @@ export class Chat extends BaseModule {
     const referenceId = this.getMessageReferenceId(to, messageId, type)
 
     const reactionElements = emojis.map(emoji => xml('reaction', {}, emoji))
-    const children: Element[] = []
 
-    // Look up original message to build fallback body for legacy clients
-    const originalMsg = type === 'groupchat'
-      ? this.deps.stores?.room.getMessage(to, messageId)
-      : this.deps.stores?.chat.getMessage(to, messageId)
+    // XEP-0444: send a bodiless <reactions> stanza. We intentionally do NOT
+    // attach a reply-quote body, a <reply> element, or <fallback> markers —
+    // compliant clients render <reactions> natively, and the legacy reply-quote
+    // fallback surfaced reactions as quoted replies in other clients. Incoming
+    // reply-quoted reactions are still rendered on the receive side. For 1:1
+    // chats the reply-quote also leaked the decrypted original body in
+    // cleartext; dropping it removes that exposure too.
+    const children: Element[] = [
+      xml('reactions', { xmlns: NS_REACTIONS, id: referenceId }, ...reactionElements),
+    ]
 
-    // The reply-quote fallback embeds the *decrypted* original body in
-    // cleartext for legacy reactions-blind clients. For 1:1 chats with
-    // E2EE active that branch would publish the original plaintext to
-    // the server — far worse than the reaction itself leaking. Skip the
-    // entire fallback block whenever encryption is available; an E2EE-
-    // capable peer is by definition modern enough to handle <reactions>
-    // natively. In strict mode we additionally refuse to send the
-    // reply-quote fallback even when the peer is currently unreachable
-    // over E2EE — better to throw than silently downgrade.
     const manager = this.deps.getE2EEManager?.()
-    let suppressReplyFallback = false
     let peerCanEncrypt = false
     if (type === 'chat' && manager) {
       peerCanEncrypt = await manager
         .canEncryptTo({ kind: 'direct', peer: recipient })
         .catch(() => false)
-      if (peerCanEncrypt) {
-        suppressReplyFallback = true
-      } else if (manager.getSendPolicy() === 'strict') {
+      // Strict mode refuses to put even a bodiless reaction on the wire in
+      // cleartext when the peer should be reachable over E2EE.
+      if (!peerCanEncrypt && manager.getSendPolicy() === 'strict') {
         throw new E2EEEncryptionRequiredError({ kind: 'direct', peer: recipient })
       }
-    }
-
-    if (originalMsg?.body && emojis.length > 0 && !suppressReplyFallback) {
-      // Build full stanza with fallback for backward compatibility:
-      // - Reactions-capable clients: handle <reactions>, ignore body (reactions fallback)
-      // - Reply-capable clients (no reactions): show quoted reply with emoji body
-      // - Legacy clients: show full body as-is
-      const emojiStr = emojis.join('')
-      const senderJid = originalMsg.from
-      const quotedLines = originalMsg.body.split('\n').map((line: string) => `> ${line}`).join('\n')
-      const replyFallback = `> ${senderJid} wrote:\n${quotedLines}\n\n`
-      const fullBody = replyFallback + emojiStr
-
-      children.push(xml('body', {}, fullBody))
-      children.push(xml('reactions', { xmlns: NS_REACTIONS, id: referenceId }, ...reactionElements))
-      children.push(xml('reply', { xmlns: NS_REPLY, id: referenceId, to: senderJid }))
-      children.push(
-        xml('fallback', { xmlns: NS_FALLBACK, for: NS_REPLY },
-          xml('body', { start: '0', end: String(replyFallback.length) })
-        )
-      )
-      children.push(
-        xml('fallback', { xmlns: NS_FALLBACK, for: NS_REACTIONS },
-          xml('body', {})
-        )
-      )
-      children.push(xml('store', { xmlns: NS_HINTS }))
-    } else {
-      // No original message, removing reactions, or suppressing the
-      // cleartext reply-quote because the peer can be encrypted to —
-      // simple stanza without fallback body.
-      children.push(xml('reactions', { xmlns: NS_REACTIONS, id: referenceId }, ...reactionElements))
     }
 
     const reactionStanzaId = generateUUID()
@@ -1155,13 +1102,17 @@ export class Chat extends BaseModule {
 
     // Encrypt the reactions element (and the id it references) for 1:1 chats
     // whenever the peer is E2EE-reachable. A mid-flight plugin failure throws
-    // here, blocking a silent plaintext downgrade.
+    // here, blocking a silent plaintext downgrade. The E2EE path adds its own
+    // <store> hint; the plaintext path adds one below so the bodiless reaction
+    // is still archived in MAM.
     if (type === 'chat' && peerCanEncrypt) {
       await this.applyE2EEToOutboundChat(recipient, '', children, Chat.E2EE_REACTION_KEYS, {
         encryptBody: false,
         outerBody: 'remove',
         storeHint: 'store',
       })
+    } else {
+      children.push(xml('store', { xmlns: NS_HINTS }))
     }
 
     const message = xml('message', { to: recipient, type, id: reactionStanzaId }, ...children)
@@ -1219,9 +1170,6 @@ export class Chat extends BaseModule {
       : this.deps.stores?.chat.getMessage(to, originalMessageId)
     const referenceId = original?.originId ?? originalMessageId
 
-    const correctionPrefix = '[Corrected] '
-    const correctionFallbackEnd = correctionPrefix.length
-
     // Build the body text, preserving user text when there's an attachment
     let bodyText = newBody
     let oobFallbackStart = 0
@@ -1230,23 +1178,24 @@ export class Chat extends BaseModule {
       if (newBody.length === 0 || newBody === attachment.url) {
         // No user text, or user explicitly typed the URL - use URL as body
         bodyText = attachment.url
-        oobFallbackStart = correctionFallbackEnd
+        oobFallbackStart = 0
       } else {
         // User has text - append URL after a newline
-        oobFallbackStart = correctionFallbackEnd + newBody.length + 1 // +1 for newline
+        oobFallbackStart = newBody.length + 1 // +1 for newline
         bodyText = newBody + '\n' + attachment.url
       }
-      oobFallbackEnd = correctionFallbackEnd + bodyText.length
+      oobFallbackEnd = bodyText.length
     }
 
-    const fallbackBody = correctionPrefix + bodyText
-
+    // XEP-0308: send the corrected body verbatim alongside a <replace> marker.
+    // We intentionally do NOT add a "[Corrected] " body prefix or a
+    // <fallback for="urn:xmpp:message-correct:0"> indication — compliant
+    // clients replace the original from <replace> alone, and the prefix
+    // confused clients that don't strip the fallback. We still strip an
+    // incoming "[Corrected] " prefix on the receive side (see fallbackRegistry).
     const children = [
-      xml('body', {}, fallbackBody),
+      xml('body', {}, bodyText),
       xml('replace', { xmlns: NS_CORRECTION, id: referenceId }),
-      xml('fallback', { xmlns: NS_FALLBACK, for: NS_CORRECTION },
-        xml('body', { start: '0', end: String(correctionFallbackEnd) })
-      )
     ]
 
     if (attachment) {
@@ -1285,9 +1234,8 @@ export class Chat extends BaseModule {
 
     // Encrypt the corrected body for 1:1 chats. Without this an edit on
     // an encrypted conversation would push the plaintext correction to
-    // the server. The cleartext "[Corrected] " prefix only mattered to
-    // legacy clients that don't know <replace>; E2EE peers handle the
-    // edit natively. MUC encryption is a later phase.
+    // the server. E2EE peers handle <replace> natively. MUC encryption
+    // is a later phase.
     const correctionSecurityContext = type === 'chat'
       ? await this.applyE2EEToOutboundChat(
           recipient,


### PR DESCRIPTION
## Summary

Stops Fluux from sending the non-standard XEP-0428 fallbacks on outgoing message **corrections** and **reactions**, which were confusing third-party clients. We still process incoming fallbacks, so messages from clients that send them keep rendering correctly — we just no longer force other clients to support our fallbacks.

- **Corrections (XEP-0308):** no longer prepend a `[Corrected] ` body prefix or attach `<fallback for="urn:xmpp:message-correct:0">`. The corrected body is sent verbatim with `<replace>` — compliant clients replace the original from `<replace>` alone.
- **Reactions (XEP-0444):** now sent as a clean bodiless `<reactions>` stanza — dropped the reply-quote body, the `<reply>` element, and both fallback markers. Previously a reaction surfaced as a quoted reply in other clients.

Receive-side fallback processing (`fallbackUtils`, `fallbackRegistry`, incoming handlers) is unchanged, so corrections and reply-quoted reactions from other clients still render. Bodiless reactions now carry a `<store>` hint so they remain archived in MAM.