### PR TITLE
fix(composer): grey the send-button encryption badge when the button is disabled

### DIFF
--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -843,13 +843,13 @@ export function MessageComposer({
           <button
             type="submit"
             disabled={(!text.trim() && !pendingAttachment) || sending || disabled || sendDisabled}
-            className="p-3 text-fluux-brand hover:text-fluux-brand-hover
+            className="group/send p-3 text-fluux-brand hover:text-fluux-brand-hover
                        disabled:text-fluux-muted disabled:cursor-not-allowed transition-colors relative"
           >
             <Send className="rtl-mirror size-5" />
             {encryptionState?.kind === 'encrypted' ? (
               encryptionState.trust === 'verified'
-                ? <ShieldCheck className="absolute bottom-2 end-2 size-2.5 text-green-500" />
+                ? <ShieldCheck className="absolute bottom-2 end-2 size-2.5 text-green-500 group-disabled/send:text-fluux-muted" />
                 : <Lock className="absolute bottom-2 end-2 size-2.5 text-fluux-muted" />
             ) : sendBadge}
           </button>


### PR DESCRIPTION
## Summary

The verified-encryption `ShieldCheck` badge on the send button was hard-coded to `text-green-500`, so it stayed green even when the send button was disabled and greyed out (e.g. an empty composer). The green badge clashed with the muted `Send` icon.

The badge now follows the button: green when the button is active, and the same muted grey (`fluux-muted`) as the disabled `Send` icon when the button is disabled.

## Change

`apps/fluux/src/components/MessageComposer.tsx` — added a named `group/send` to the send `<button>` and `group-disabled/send:text-fluux-muted` to the `ShieldCheck` badge. A named group is used so it can't bind to an ancestor `group`. Pure CSS (Tailwind variant) — no change to the composer's render behaviour. The unverified `Lock` badge was already `fluux-muted`, so it needed no change.

Verified against the live stylesheet: disabled-button badge resolves to `rgb(74, 77, 84)` (identical to the disabled `Send` icon), enabled-button badge stays `rgb(34, 197, 94)` (green-500).