### PR TITLE
feat(perf): render-perf diagnostics — memory probe + EWMA sustained-rate detector

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -27,6 +27,7 @@ import { useExternalLinkHandler } from './hooks/useExternalLinkHandler'
 import { usePlatformState } from './hooks/usePlatformState'
 import { useAccountScopeRehydration } from './hooks/useAccountScopeRehydration'
 import { clearLocalData } from './utils/clearLocalData'
+import { startMemoryProbe } from './utils/memoryProbe'
 import { markConnectActive } from './utils/reconnectIntent'
 
 // Tauri detection
@@ -75,6 +76,10 @@ function App() {
   usePlatformState()
   useAccountScopeRehydration()
   const update = useAutoUpdate({ autoCheck: true })
+
+  // Opt-in memory/blob-pool probe (no-op unless localStorage['fluux:mem-probe']='1').
+  // Diagnostic for the SM-resume avatar blob-URL leak class — see utils/memoryProbe.ts.
+  useEffect(() => startMemoryProbe(), [])
 
   // Listen for --clear-storage CLI flag (Tauri only)
   // This clears all local data on startup when the flag is passed

--- a/apps/fluux/src/utils/memoryProbe.test.ts
+++ b/apps/fluux/src/utils/memoryProbe.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { isMemoryProbeEnabled, usedHeapMB, buildMemoryProbeLine, startMemoryProbe } from './memoryProbe'
+
+describe('memoryProbe', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('isMemoryProbeEnabled', () => {
+    it('is false by default', () => {
+      expect(isMemoryProbeEnabled()).toBe(false)
+    })
+    it('is true only when the flag is exactly "1"', () => {
+      localStorage.setItem('fluux:mem-probe', '1')
+      expect(isMemoryProbeEnabled()).toBe(true)
+    })
+    it('is false for any other flag value', () => {
+      localStorage.setItem('fluux:mem-probe', 'true')
+      expect(isMemoryProbeEnabled()).toBe(false)
+    })
+  })
+
+  describe('buildMemoryProbeLine', () => {
+    it('formats pool size, heap, and resume count', () => {
+      expect(buildMemoryProbeLine(42, 128, 7)).toBe(
+        '[MemProbe] avatarBlobPool=42 usedHeap=128MB smResumes=7'
+      )
+    })
+    it('renders heap as n/a when unavailable (WebKit has no performance.memory)', () => {
+      expect(buildMemoryProbeLine(42, null, 7)).toBe(
+        '[MemProbe] avatarBlobPool=42 usedHeap=n/a smResumes=7'
+      )
+    })
+  })
+
+  describe('usedHeapMB', () => {
+    const perf = performance as unknown as { memory?: { usedJSHeapSize: number } }
+    afterEach(() => {
+      delete perf.memory
+    })
+    it('returns null when performance.memory is unavailable', () => {
+      delete perf.memory
+      expect(usedHeapMB()).toBeNull()
+    })
+    it('returns megabytes when performance.memory is present', () => {
+      perf.memory = { usedJSHeapSize: 5 * 1048576 }
+      expect(usedHeapMB()).toBe(5)
+    })
+  })
+
+  describe('startMemoryProbe', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+    it('is a no-op when disabled (no sampling, stop is safe to call)', () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+      const stop = startMemoryProbe()
+      expect(info).not.toHaveBeenCalled()
+      expect(() => stop()).not.toThrow()
+      info.mockRestore()
+    })
+    it('samples immediately and every 30s when enabled, until stopped', () => {
+      localStorage.setItem('fluux:mem-probe', '1')
+      vi.useFakeTimers()
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+      const stop = startMemoryProbe()
+      expect(info).toHaveBeenCalledTimes(1) // immediate first sample
+
+      vi.advanceTimersByTime(30_000)
+      expect(info).toHaveBeenCalledTimes(2)
+
+      stop()
+      vi.advanceTimersByTime(90_000)
+      expect(info).toHaveBeenCalledTimes(2) // no further samples after stop
+
+      info.mockRestore()
+    })
+  })
+})

--- a/apps/fluux/src/utils/memoryProbe.ts
+++ b/apps/fluux/src/utils/memoryProbe.ts
@@ -1,0 +1,60 @@
+import { getBlobUrlPoolSize, getAvatarResumeCount } from '@fluux/sdk'
+
+/**
+ * Opt-in memory / blob-pool probe.
+ *
+ * The avatar blob-URL leak class (orphaned `blob:` URLs on every SM resumption)
+ * is invisible to React, to the render-loop detector, and to the resize monitor —
+ * it only shows up as growing native WebKit memory. This probe makes it visible:
+ * once enabled, it logs one `[MemProbe]` line every 30s (forwarded to fluux.log in
+ * Tauri), so a tester can watch the avatar blob-pool size against the SM-resume
+ * count. A flat pool size across many resumes confirms the leak class is gone.
+ *
+ * Off by default — enable with `localStorage['fluux:mem-probe'] = '1'`.
+ */
+const PROBE_INTERVAL_MS = 30_000
+const FLAG_KEY = 'fluux:mem-probe'
+const BYTES_PER_MB = 1024 * 1024
+
+export function isMemoryProbeEnabled(): boolean {
+  try {
+    return localStorage.getItem(FLAG_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Used JS heap in whole MB, or null when the engine doesn't expose it.
+ * `performance.memory` is Chromium-only — undefined on WebKit / WebKitGTK (the
+ * Tauri webview on macOS/Linux), where the blob-pool size is the load-bearing signal.
+ */
+export function usedHeapMB(): number | null {
+  const mem = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory
+  return mem ? Math.round(mem.usedJSHeapSize / BYTES_PER_MB) : null
+}
+
+export function buildMemoryProbeLine(
+  poolSize: number,
+  heapMB: number | null,
+  resumeCount: number
+): string {
+  const heap = heapMB == null ? 'n/a' : `${heapMB}MB`
+  return `[MemProbe] avatarBlobPool=${poolSize} usedHeap=${heap} smResumes=${resumeCount}`
+}
+
+function sample(): void {
+  console.info(buildMemoryProbeLine(getBlobUrlPoolSize(), usedHeapMB(), getAvatarResumeCount()))
+}
+
+/**
+ * Start the probe. No-op (returns a no-op stop fn) unless the flag is set, so it is
+ * safe to mount unconditionally. Logs one sample immediately, then every 30s.
+ * @returns a stop function that cancels the interval.
+ */
+export function startMemoryProbe(): () => void {
+  if (!isMemoryProbeEnabled()) return () => {}
+  sample()
+  const id = setInterval(sample, PROBE_INTERVAL_MS)
+  return () => clearInterval(id)
+}

--- a/apps/fluux/src/utils/renderLoopDetector.test.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // test-setup.ts globally mocks this module to no-ops for component tests.
 // Here we exercise the REAL implementation via importActual.
-const { detectRenderLoop, notifyUserInput, resetRenderLoopDetector } =
+const { detectRenderLoop, notifyUserInput, resetRenderLoopDetector, __setClock } =
   await vi.importActual<typeof import('./renderLoopDetector')>('./renderLoopDetector')
 
 const WARNING_RE = /has rendered 30 times/
@@ -36,5 +36,58 @@ describe('renderLoopDetector — interaction grace', () => {
     expect(() => {
       for (let i = 0; i < 250; i++) detectRenderLoop('LoopComp')
     }).toThrow(/Render loop detected/)
+  })
+})
+
+const SUSTAINED_RE = /Sustained render rate/
+
+describe('renderLoopDetector — EWMA sustained-rate', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetRenderLoopDetector()
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    resetRenderLoopDetector() // also restores the real clock
+    vi.restoreAllMocks()
+  })
+
+  const sustainedWarnCount = () =>
+    warn.mock.calls.filter((c: unknown[]) => SUSTAINED_RE.test(String(c[0]))).length
+
+  // Drive `name` at `rate` renders/sec for `durationMs`, with an injected clock.
+  const drive = (name: string, rate: number, durationMs: number) => {
+    const stepMs = 1000 / rate
+    let t = 5_000_000 // far above any real timestamp, so grace windows never apply
+    __setClock(() => t)
+    for (let elapsed = 0; elapsed <= durationMs; elapsed += stepMs) {
+      detectRenderLoop(name)
+      t += stepMs
+    }
+  }
+
+  it('warns when a component sustains a >40/sec render rate for >3s (sub-threshold storm)', () => {
+    drive('StormComp', 100, 5000) // 100/sec for 5s — well under the 200/window throw
+    expect(sustainedWarnCount()).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does NOT warn for a slow, steady render rate (10/sec)', () => {
+    drive('CalmComp', 10, 6000)
+    expect(sustainedWarnCount()).toBe(0)
+  })
+
+  it('warns at most once per cooldown despite a continuous storm', () => {
+    // 100/sec for 15s: with a 10s cooldown, the sustained warn must fire at most twice,
+    // proving it does not spam once per render.
+    drive('StormComp2', 100, 15000)
+    const n = sustainedWarnCount()
+    expect(n).toBeGreaterThanOrEqual(1)
+    expect(n).toBeLessThanOrEqual(2)
+  })
+
+  it('never throws for a sustained sub-threshold rate (it is WARN-only)', () => {
+    expect(() => drive('NoThrowComp', 150, 6000)).not.toThrow()
   })
 })

--- a/apps/fluux/src/utils/renderLoopDetector.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.ts
@@ -24,6 +24,13 @@ interface ComponentState {
   hasTriggered: boolean
   hasWarned: boolean
   renderHistory: RenderEntry[]  // Last N renders for debugging
+  // Sustained-rate (EWMA) tracking — orthogonal to the per-window counter, which
+  // resets every TIME_WINDOW_MS and is therefore blind to a sustained sub-threshold
+  // storm (e.g. 30-199 renders/sec held for many seconds).
+  emaRate: number          // exponentially-weighted moving average of renders/sec
+  lastRenderTs: number     // timestamp of the previous render (0 = none yet)
+  sustainedSince: number   // when emaRate first crossed the sustained threshold (0 = not sustained)
+  lastSustainedWarn: number // last sustained-rate warning timestamp (cooldown)
 }
 
 const componentStates = new Map<string, ComponentState>()
@@ -49,6 +56,11 @@ const WAKE_GRACE_PERIOD_MS = 3000   // Suppress warnings for this long after wak
 const SYNC_GRACE_PERIOD_MS = 15000  // Raise error threshold after fresh connection (covers full MAM + roster + room catch-up)
 const SYNC_GRACE_THRESHOLD = 500    // Error threshold during sync grace period
 const INTERACTION_GRACE_MS = 1500   // Suppress warnings for this long after a keystroke (covers inter-key gaps; rolling)
+// Sustained-rate (EWMA) detector — catches the storm class the per-window counter misses.
+const SUSTAINED_RATE_PER_SEC = 40   // Warn above this many renders/sec...
+const SUSTAINED_DURATION_MS = 3000  // ...when held for at least this long...
+const SUSTAINED_COOLDOWN_MS = 10000 // ...at most once per this cooldown (so it never spams).
+const EWMA_TAU_MS = 1500            // EWMA time constant (smooths instantaneous spikes)
 
 // Track if we're in a grace period (e.g., after wake from sleep)
 let wakeGraceUntil = 0
@@ -59,10 +71,23 @@ let syncGraceUntil = 0
 // or OS key-repeat pushes past the warning threshold without any actual loop).
 let interactionGraceUntil = 0
 
+// Injectable clock — defaults to Date.now. The sustained-rate detector needs
+// multi-second timing, which is impractical to exercise with real time, so tests
+// drive it via __setClock. Production always uses Date.now.
+let nowFn: () => number = Date.now
+
+/** Test seam: override the detector's clock. Reset by resetRenderLoopDetector(). @internal */
+export function __setClock(fn: () => number): void {
+  nowFn = fn
+}
+
 function getComponentState(componentName: string): ComponentState {
   let state = componentStates.get(componentName)
   if (!state) {
-    state = { renderCount: 0, windowStart: Date.now(), hasTriggered: false, hasWarned: false, renderHistory: [] }
+    state = {
+      renderCount: 0, windowStart: nowFn(), hasTriggered: false, hasWarned: false, renderHistory: [],
+      emaRate: 0, lastRenderTs: 0, sustainedSince: 0, lastSustainedWarn: 0,
+    }
     componentStates.set(componentName, state)
   }
   return state
@@ -110,7 +135,7 @@ export function detectRenderLoop(componentName: string): void {
   // Don't check during cooldown period
   if (state.hasTriggered) return
 
-  const now = Date.now()
+  const now = nowFn()
 
   // Reset window if enough time has passed
   if (now - state.windowStart > TIME_WINDOW_MS) {
@@ -136,6 +161,46 @@ export function detectRenderLoop(componentName: string): void {
   // Skip warning during a grace period (expected high render frequency): after
   // sleep/wake, or while the user is actively typing into a controlled input.
   const inGracePeriod = now < wakeGraceUntil || now < interactionGraceUntil
+
+  // Sustained-rate (EWMA) detection — orthogonal to the per-window counter above,
+  // which resets every TIME_WINDOW_MS and so cannot see a sustained sub-threshold
+  // storm (the class behind the "half-freeze"). Track a decaying renders/sec average
+  // and warn — once per cooldown, outside any grace period — when it holds above the
+  // threshold for SUSTAINED_DURATION_MS. WARN-only: never throws.
+  if (state.lastRenderTs !== 0) {
+    const dt = now - state.lastRenderTs
+    if (dt > 0) {
+      const inst = 1000 / dt
+      const alpha = 1 - Math.exp(-dt / EWMA_TAU_MS)
+      state.emaRate += alpha * (inst - state.emaRate)
+    }
+  }
+  state.lastRenderTs = now
+
+  if (state.emaRate >= SUSTAINED_RATE_PER_SEC) {
+    if (state.sustainedSince === 0) state.sustainedSince = now
+    const heldFor = now - state.sustainedSince
+    if (!inGracePeriod && heldFor >= SUSTAINED_DURATION_MS && now - state.lastSustainedWarn > SUSTAINED_COOLDOWN_MS) {
+      state.lastSustainedWarn = now
+      console.warn(
+        `[RenderLoopDetector] Sustained render rate: ${componentName} averaging ` +
+        `${state.emaRate.toFixed(0)}/sec for ${(heldFor / 1000).toFixed(1)}s ` +
+        `(sub-threshold storm — likely a broken memo or a churning store map).`
+      )
+      if (typeof window !== 'undefined') {
+        try {
+          window.dispatchEvent(new CustomEvent('fluux:render-loop-sustained', {
+            detail: { componentName, rate: Math.round(state.emaRate), heldMs: heldFor },
+          }))
+        } catch {
+          // CustomEvent not available — ignore
+        }
+      }
+    }
+  } else {
+    state.sustainedSince = 0
+  }
+
   if (state.renderCount === WARNING_THRESHOLD && !state.hasWarned && !inGracePeriod) {
     state.hasWarned = true
     console.warn(
@@ -202,7 +267,7 @@ export function detectRenderLoop(componentName: string): void {
     setTimeout(() => {
       state.hasTriggered = false
       state.renderCount = 0
-      state.windowStart = Date.now()
+      state.windowStart = nowFn()
       state.hasWarned = false
       state.renderHistory = []
     }, COOLDOWN_MS)
@@ -248,7 +313,7 @@ export function trackSelectorChange(componentName: string, selectorName: string,
     selectorName,
     value: describedValue,
     extra,
-    timestamp: Date.now(),
+    timestamp: nowFn(),
   })
 
   // Keep history bounded
@@ -277,7 +342,7 @@ export function clearSelectorHistory(): void {
  */
 export function logRenderSummary(): void {
   console.group('[RenderLoopDetector] Render Summary')
-  const now = Date.now()
+  const now = nowFn()
   for (const [name, state] of componentStates) {
     const age = now - state.windowStart
     if (state.renderCount > 0) {
@@ -296,6 +361,7 @@ export function resetRenderLoopDetector(): void {
   wakeGraceUntil = 0
   syncGraceUntil = 0
   interactionGraceUntil = 0
+  nowFn = Date.now
 }
 
 /**
@@ -306,7 +372,7 @@ export function resetRenderLoopDetector(): void {
  * typing still trips the hard break.
  */
 export function notifyUserInput(): void {
-  interactionGraceUntil = Date.now() + INTERACTION_GRACE_MS
+  interactionGraceUntil = nowFn() + INTERACTION_GRACE_MS
 }
 
 /**
@@ -315,7 +381,7 @@ export function notifyUserInput(): void {
  * The error threshold is NOT suppressed - only warnings.
  */
 export function startWakeGracePeriod(): void {
-  wakeGraceUntil = Date.now() + WAKE_GRACE_PERIOD_MS
+  wakeGraceUntil = nowFn() + WAKE_GRACE_PERIOD_MS
 }
 
 /**
@@ -325,7 +391,7 @@ export function startWakeGracePeriod(): void {
  * cause rapid component re-renders.
  */
 export function startSyncGracePeriod(): void {
-  syncGraceUntil = Date.now() + SYNC_GRACE_PERIOD_MS
+  syncGraceUntil = nowFn() + SYNC_GRACE_PERIOD_MS
   // Also suppress warnings during sync
   wakeGraceUntil = Math.max(wakeGraceUntil, syncGraceUntil)
 }
@@ -335,7 +401,7 @@ export function startSyncGracePeriod(): void {
  */
 export function getRenderStats(): Record<string, { count: number; windowMs: number; triggered: boolean }> {
   const stats: Record<string, { count: number; windowMs: number; triggered: boolean }> = {}
-  const now = Date.now()
+  const now = nowFn()
   for (const [name, state] of componentStates) {
     stats[name] = {
       count: state.renderCount,

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -120,6 +120,7 @@ import { logDebug, logInfo, logWarn } from './logger'
 import { SDK_VERSION } from '../version'
 import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
 import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage } from '../utils/messageCache'
+import { bumpAvatarResumeCount } from '../utils/avatarCache'
 
 /**
  * Core XMPP client with namespace-based module API.
@@ -2053,6 +2054,7 @@ export class XMPPClient {
     // the URLs are still live there, so refreshing would re-read every avatar from
     // IndexedDB and re-create its blob URL on every reconnection for no benefit.
     if (!isShortDisconnect) {
+      bumpAvatarResumeCount() // diagnostic: count refresh-triggering resumes (memory probe)
       this.profile.refreshAllAvatarBlobUrls().catch(() => {})
     }
 

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -710,6 +710,9 @@ export type { GetMessagesOptions } from './utils/messageCache'
 export {
   clearAllAvatarData,
   revokeAllBlobUrls,
+  getBlobUrlPoolSize,
+  bumpAvatarResumeCount,
+  getAvatarResumeCount,
 } from './utils/avatarCache'
 
 // =============================================================================

--- a/packages/fluux-sdk/src/utils/avatarCache.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.test.ts
@@ -9,6 +9,9 @@ import {
   revokeAllBlobUrls,
   refreshAllBlobUrls,
   clearAllAvatarData,
+  getBlobUrlPoolSize,
+  bumpAvatarResumeCount,
+  getAvatarResumeCount,
   _resetBlobUrlPoolForTesting,
   _resetDBForTesting,
 } from './avatarCache'
@@ -209,6 +212,25 @@ describe('avatarCache blob URL pool', () => {
       // Pool is cleared, IndexedDB is cleared — should get null
       const url = await getCachedAvatar('hash-abc')
       expect(url).toBeNull()
+    })
+  })
+
+  describe('diagnostics', () => {
+    it('getBlobUrlPoolSize reflects the number of live pooled blob URLs', async () => {
+      expect(getBlobUrlPoolSize()).toBe(0)
+      await cacheAvatar('hash-1', btoa('a'), 'image/png')
+      await cacheAvatar('hash-2', btoa('b'), 'image/png')
+      expect(getBlobUrlPoolSize()).toBe(2)
+
+      revokeAllBlobUrls()
+      expect(getBlobUrlPoolSize()).toBe(0)
+    })
+
+    it('bumpAvatarResumeCount increments the resume counter monotonically', () => {
+      const before = getAvatarResumeCount()
+      bumpAvatarResumeCount()
+      bumpAvatarResumeCount()
+      expect(getAvatarResumeCount()).toBe(before + 2)
     })
   })
 })

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -657,6 +657,28 @@ export function _resetBlobUrlPoolForTesting(): void {
 }
 
 /**
+ * Diagnostic counter of SM resumptions that triggered an avatar blob-URL refresh.
+ * Lets the opt-in memory probe correlate blob-pool growth against resume count —
+ * a flat pool size across many resumes confirms the SM-resume leak class is gone.
+ */
+let avatarResumeCount = 0
+
+/** Current number of live avatar blob URLs. Diagnostic only. */
+export function getBlobUrlPoolSize(): number {
+  return blobUrlPool.size
+}
+
+/** Record one SM resumption that triggered a blob-URL refresh. Diagnostic only. */
+export function bumpAvatarResumeCount(): void {
+  avatarResumeCount++
+}
+
+/** Number of SM resumptions seen this session. Diagnostic only. */
+export function getAvatarResumeCount(): number {
+  return avatarResumeCount
+}
+
+/**
  * Reset the PEP-forbidden domains set.
  * For test isolation only.
  * @internal


### PR DESCRIPTION
## Summary

Two diagnostics for the "half-freeze" class, now that both root causes are fixed (#476 avatar blob-URL leak, #474 MUC presence-churn render storm). Neither changes runtime behaviour by default — they make the *next* regression measurable instead of an invisible multi-minute freeze.

### 1. Opt-in memory / blob-pool probe
The avatar blob-URL leak was invisible to React, to the render-loop detector, and to the resize monitor — it only showed as growing native WebKit memory. This probe makes it visible: once enabled, it logs one `[MemProbe]` line every 30s (avatar blob-pool size, used JS heap where available, SM-resume count), forwarded to `fluux.log` in Tauri. A flat pool size across many SM resumes confirms the leak class is gone.

- New SDK getters `getBlobUrlPoolSize` / `getAvatarResumeCount` / `bumpAvatarResumeCount` (the latter wired at the gated refresh site in `handleSmResumption`).
- New `apps/fluux/src/utils/memoryProbe.ts`, mounted once in `App`. **Off by default** — enable with `localStorage['fluux:mem-probe'] = '1'`.
- `performance.memory` is Chromium-only, so the blob-pool size is the load-bearing signal on WebKit/WebKitGTK (heap shows `n/a` there).

### 2. EWMA sustained-rate detector
The render-loop detector's per-component counter resets every 1000ms, so it is structurally blind to a *sustained* sub-threshold storm (30–199 renders/sec held for seconds) — exactly the class behind the freeze. This adds an orthogonal EWMA of renders/sec that **WARNs** (once per 10s cooldown, outside grace periods) when a component sustains >40/sec for >3s, and dispatches a `fluux:render-loop-sustained` event. WARN-only — it never throws. It also introduces an injectable clock seam (`__setClock`) so the multi-second behaviour is deterministically unit-tested.

This is a standing regression tripwire: it would have surfaced the MUC presence-churn storm, and it generalises to any future memo break or churning store map.