### PR TITLE
fix(avatar): re-point own avatar after blob URL refresh

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -959,6 +959,28 @@ describe('XMPPClient Own Avatar', () => {
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:occupant-avatar', expect.objectContaining({ nick: 'Bob' }))
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:occupant-avatar', expect.objectContaining({ nick: 'Carol' }))
     })
+
+    it('should re-point the current user\'s own avatar via connection:own-avatar', async () => {
+      emitSDKSpy.mockClear()
+
+      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-self', 'blob:fresh-self']]))
+      // The own avatar is stored in the hash store as a 'contact' under the
+      // user's own bare JID (Profile.fetchOwnAvatar → saveAvatarHash(..., 'contact')).
+      vi.mocked(getAllAvatarHashes).mockResolvedValue([
+        { jid: 'user@example.com', hash: 'hash-self', type: 'contact' },
+      ])
+      // The user is not in their own roster, so getContact misses.
+      mockStores.roster.getContact.mockReturnValue(undefined)
+
+      await xmppClient.profile.refreshAllAvatarBlobUrls()
+
+      // Must re-point the own avatar through the connection store, not the roster.
+      expect(emitSDKSpy).toHaveBeenCalledWith('connection:own-avatar', {
+        avatar: 'blob:fresh-self', hash: 'hash-self',
+      })
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:avatar', expect.objectContaining({ jid: 'user@example.com' }))
+    })
   })
 
   describe('Negative Avatar Cache', () => {

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -1010,12 +1010,24 @@ export class Profile extends BaseModule {
       const freshUrls = await refreshAllBlobUrls()
       if (freshUrls.size === 0) return
 
+      const currentJid = this.deps.getCurrentJid()
+      const ownBareJid = currentJid ? getBareJid(currentJid) : null
+
       const hashMappings = await getAllAvatarHashes()
       for (const mapping of hashMappings) {
         const url = freshUrls.get(mapping.hash)
         if (!url) continue
 
         if (mapping.type === 'contact') {
+          // The current user's own avatar is stored as a 'contact' under their
+          // own bare JID, but the user isn't in their own roster (so getContact
+          // misses) and it needs the connection:own-avatar event, not
+          // roster:avatar. Without this the own avatar's blob URL — revoked by
+          // refreshAllBlobUrls — is never re-pointed and renders as a fallback.
+          if (ownBareJid && mapping.jid === ownBareJid) {
+            this.deps.emitSDK('connection:own-avatar', { avatar: url, hash: mapping.hash })
+            continue
+          }
           const contact = this.deps.stores?.roster.getContact(mapping.jid)
           if (contact) {
             this.deps.emitSDK('roster:avatar', { jid: mapping.jid, avatar: url, avatarHash: mapping.hash })


### PR DESCRIPTION
`refreshAllAvatarBlobUrls()` re-pointed contacts, rooms and MUC occupants after blob-URL revocation, but never the current user's own avatar — it's stored as a `contact` under the user's own JID and gets skipped (the user isn't in their own roster), and would emit the wrong event anyway.

Latent until #476 started revoking stale blob URLs instead of leaking them: the own avatar's revoked URL is now never re-pointed, so it renders as a fallback initial after a long SM resumption or sleep-wake.

Routes the own JID to the `connection:own-avatar` event inside the refresh loop.