### PR TITLE
fix(e2ee): tolerate signer clock skew + live trust/lock color

### DIFF
--- a/apps/fluux/src-tauri/src/openpgp.rs
+++ b/apps/fluux/src-tauri/src/openpgp.rs
@@ -1559,6 +1559,91 @@ mod tests {
         );
     }
 
+    /// Test-only: encrypt to `recipient_public_armored` and sign with
+    /// `sender_secret_armored`, stamping the signature creation time at
+    /// `signed_at`. Lets us simulate a sender whose machine clock is ahead of
+    /// the verifier's. Mirrors `encrypt_and_sign` but for a single recipient
+    /// and with an explicit signature time.
+    fn sign_encrypt_at(
+        recipient_public_armored: &str,
+        sender_secret_armored: &str,
+        plaintext: &str,
+        signed_at: SystemTime,
+    ) -> Result<String> {
+        let policy = StandardPolicy::new();
+        let recipient = Cert::from_bytes(recipient_public_armored.as_bytes())?;
+        let sender = Cert::from_bytes(sender_secret_armored.as_bytes())?;
+        let recipients: Vec<Recipient> = recipient
+            .keys()
+            .with_policy(&policy, None)
+            .supported()
+            .alive()
+            .revoked(false)
+            .for_transport_encryption()
+            .map(Recipient::from)
+            .collect();
+        let signer_keypair = sender
+            .keys()
+            .with_policy(&policy, None)
+            .supported()
+            .alive()
+            .revoked(false)
+            .for_signing()
+            .secret()
+            .next()
+            .expect("sender has a signing key")
+            .key()
+            .clone()
+            .into_keypair()?;
+        let mut sink: Vec<u8> = Vec::new();
+        {
+            let message = Message::new(&mut sink);
+            let message = Armorer::new(message).build()?;
+            let message = Encryptor::for_recipients(message, recipients).build()?;
+            let message = Signer::new(message, signer_keypair)?
+                .creation_time(signed_at)
+                .build()?;
+            let mut message = LiteralWriter::new(message).build()?;
+            message.write_all(plaintext.as_bytes())?;
+            message.finalize()?;
+        }
+        String::from_utf8(sink).context("armored ciphertext is not UTF-8")
+    }
+
+    #[test]
+    fn verifies_signature_from_a_clock_slightly_ahead() {
+        // Regression for "[Message rejected: invalid signature]": a sender whose
+        // machine clock runs a few minutes ahead stamps the signature in the
+        // verifier's future. The verifier must tolerate a small clock-skew
+        // window, otherwise a freshly-signed message is rejected.
+        let (_state, alice, bob) = setup_two_accounts();
+        let ten_min_ahead = SystemTime::now() + Duration::from_secs(600);
+        let ct =
+            sign_encrypt_at(&bob.public_armored, &alice.secret_armored, "hello", ten_min_ahead)
+                .unwrap();
+        let out = decrypt_and_verify(&bob.secret_armored, &ct, Some(&alice.public_armored)).unwrap();
+        assert_eq!(out.plaintext, "hello");
+        assert!(
+            out.signature_verified,
+            "a signature within the clock-skew tolerance must verify"
+        );
+    }
+
+    #[test]
+    fn rejects_signature_dated_far_beyond_skew_tolerance() {
+        // Guard: the tolerance stays bounded — a grossly future-dated signature
+        // is still not trusted.
+        let (_state, alice, bob) = setup_two_accounts();
+        let far_future = SystemTime::now() + Duration::from_secs(30 * 24 * 3600);
+        let ct = sign_encrypt_at(&bob.public_armored, &alice.secret_armored, "x", far_future)
+            .unwrap();
+        let out = decrypt_and_verify(&bob.secret_armored, &ct, Some(&alice.public_armored)).unwrap();
+        assert!(
+            !out.signature_verified,
+            "a grossly future-dated signature must still be rejected"
+        );
+    }
+
     #[test]
     fn decrypt_verified_reports_signature_present() {
         // Positive-path companion to the key-not-cached case: a verified

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MessageBubble, buildReplyContext, type MessageBubbleProps } from './MessageBubble'
 import type { BaseMessage } from '@fluux/sdk'
+import { setPeerVerified, clearPeerVerified } from '@/stores/verifiedPeerKeysStore'
 
 // Mock i18next
 vi.mock('react-i18next', () => ({
@@ -307,6 +308,62 @@ describe('MessageBubble', () => {
       expect(
         container.querySelector('[aria-label="Encrypted with openpgp, trust untrusted"]'),
       ).toBeNull()
+    })
+
+    it('upgrades a tofu lock to verified once the peer is verified out-of-band', () => {
+      // Frozen-color regression: verifying a peer must recolor their already-
+      // decrypted `tofu` messages to `verified` live — the stored
+      // securityContext.trust does NOT change, so the bubble must derive the
+      // displayed trust from the live verification store.
+      const peer = 'verifytest@example.com'
+      clearPeerVerified(peer)
+      const props = createDefaultProps({
+        message: createTestMessage({
+          from: peer,
+          securityContext: { protocolId: 'openpgp', trust: 'tofu' },
+        }),
+      })
+      const { container } = render(<MessageBubble {...props} />)
+      expect(
+        container.querySelector('[aria-label="Encrypted with openpgp, trust tofu"]'),
+      ).not.toBeNull()
+
+      // User confirms the peer's fingerprint out-of-band — a store update only,
+      // no prop/securityContext change on the message.
+      act(() => {
+        setPeerVerified(peer, 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555')
+      })
+
+      expect(
+        container.querySelector('[aria-label="Encrypted with openpgp, trust verified"]'),
+      ).not.toBeNull()
+      expect(
+        container.querySelector('[aria-label="Encrypted with openpgp, trust tofu"]'),
+      ).toBeNull()
+      clearPeerVerified(peer)
+    })
+
+    it('downgrades a verified lock back to tofu when verification is cleared', () => {
+      const peer = 'verifytest2@example.com'
+      setPeerVerified(peer, 'FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000')
+      const props = createDefaultProps({
+        message: createTestMessage({
+          from: peer,
+          securityContext: { protocolId: 'openpgp', trust: 'verified' },
+        }),
+      })
+      const { container } = render(<MessageBubble {...props} />)
+      expect(
+        container.querySelector('[aria-label="Encrypted with openpgp, trust verified"]'),
+      ).not.toBeNull()
+
+      act(() => {
+        clearPeerVerified(peer)
+      })
+
+      expect(
+        container.querySelector('[aria-label="Encrypted with openpgp, trust tofu"]'),
+      ).not.toBeNull()
     })
 
     it('re-renders the tooltip when only the security notes change', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -7,7 +7,8 @@
 import { useState, useMemo, memo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CornerUpRight, AlertCircle, RefreshCw, Lock, ShieldAlert, Ear, UserX } from 'lucide-react'
-import { formatMessagePreview, formatXMPPError, type BaseMessage, type MentionReference, type Contact, type ContactIdentity, type RoomRole, type RoomAffiliation } from '@fluux/sdk'
+import { formatMessagePreview, formatXMPPError, getBareJid, type BaseMessage, type MentionReference, type Contact, type ContactIdentity, type RoomRole, type RoomAffiliation } from '@fluux/sdk'
+import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
 import { Avatar } from '../Avatar'
 import { AvatarLightbox } from '../AvatarLightbox'
 import { MessageToolbar } from './MessageToolbar'
@@ -298,6 +299,23 @@ export const MessageBubble = memo(function MessageBubble({
   const [showAvatarLightbox, setShowAvatarLightbox] = useState(false)
   const [showErrorDetails, setShowErrorDetails] = useState(false)
 
+  // Trust color must track verification LIVE, not freeze at decrypt time.
+  // The plugin bakes `verified`/`tofu` onto the message when it's decrypted;
+  // if the user verifies the peer later, the stored value never updates. So
+  // derive the displayed trust here from the live verification store, keyed on
+  // the conversation peer. The store only changes on explicit verify/un-verify
+  // (never during sync/typing), so this per-peer subscription is cheap.
+  const peerVerified = useVerifiedPeerKeysStore(
+    (s) => !!s.verifiedFingerprintByJid[getBareJid(message.from)],
+  )
+  const displayTrust =
+    message.securityContext &&
+    (message.securityContext.trust === 'tofu' || message.securityContext.trust === 'verified')
+      ? peerVerified
+        ? 'verified'
+        : 'tofu'
+      : message.securityContext?.trust
+
   // Whether reactions are enabled for this message (room has stable occupant identity)
   const reactionsEnabled = onReaction !== undefined
 
@@ -446,20 +464,20 @@ export const MessageBubble = memo(function MessageBubble({
               {formatTime(message.timestamp)}
             </span>
             {message.securityContext && (
-              <Tooltip content={formatSecurityTooltip(t, message.securityContext)} position="top" triggerMode="click">
+              <Tooltip content={formatSecurityTooltip(t, { ...message.securityContext, trust: displayTrust ?? message.securityContext.trust })} position="top" triggerMode="click">
                 <span
                   className={`flex items-center ${
-                    message.securityContext.trust === 'verified'
+                    displayTrust === 'verified'
                       ? 'text-green-500'
-                      : message.securityContext.trust === 'rejected'
+                      : displayTrust === 'rejected'
                       ? 'text-red-500'
-                      : message.securityContext.trust === 'untrusted'
+                      : displayTrust === 'untrusted'
                       ? 'text-yellow-500'
                       : 'text-fluux-muted'
                   }`}
-                  aria-label={`Encrypted with ${message.securityContext.protocolId}, trust ${message.securityContext.trust}`}
+                  aria-label={`Encrypted with ${message.securityContext.protocolId}, trust ${displayTrust}`}
                 >
-                  {message.securityContext.trust === 'rejected'
+                  {displayTrust === 'rejected'
                     ? <ShieldAlert className="size-3" />
                     : <Lock className="size-3" />}
                 </span>

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -539,6 +539,87 @@ describe('WebOpenPGPPlugin', () => {
     })
   })
 
+  describe('clock skew tolerance', () => {
+    it('verifies a signature created slightly in the future (signer clock ahead)', async () => {
+      // Regression for the "[Message rejected: invalid signature]" reports:
+      // openpgp.js rejects a signature whose creation time is after the
+      // verifier's clock ("Signature creation time is in the future") with
+      // zero tolerance. When the sender's machine clock is a little ahead,
+      // a freshly-signed message fails to verify. The verifier must allow a
+      // small clock-skew window.
+      const plugin = new TestableWebOpenPGPPlugin()
+      const { ctx } = makeCtx('alice@example.com')
+      setSessionPassphrase('hunter2-strong-passphrase')
+      await plugin.init(ctx)
+      const ownBundle = await plugin.callEnsureKeyMaterial('alice@example.com')
+
+      // A peer signs a message addressed to us, but their clock is 2 minutes
+      // ahead of ours.
+      const { generateKey, createMessage, encrypt, readKey } = await import('openpgp')
+      const { privateKey: senderPriv } = await generateKey({
+        type: 'ecc',
+        curve: 'curve25519Legacy',
+        userIDs: [{ name: 'xmpp:bob@example.com' }],
+        format: 'object',
+      })
+      const twoMinutesAhead = new Date(Date.now() + 2 * 60 * 1000)
+      const ciphertext = await encrypt({
+        message: await createMessage({ text: 'hello from a fast clock' }),
+        encryptionKeys: await readKey({ armoredKey: ownBundle.publicArmored }),
+        signingKeys: senderPriv,
+        date: twoMinutesAhead,
+        format: 'armored',
+      })
+
+      const decrypted = await plugin.callDecryptWithOwnKey(
+        'bob@example.com',
+        ciphertext,
+        senderPriv.toPublic().armor(),
+      )
+
+      expect(decrypted.plaintext).toBe('hello from a fast clock')
+      expect(decrypted.signaturePresent).toBe(true)
+      expect(decrypted.signatureVerified).toBe(true)
+    })
+
+    it('still rejects a signature dated far beyond the skew tolerance', async () => {
+      // Guard: the skew tolerance must stay bounded — a signature created
+      // grossly in the future (well past the tolerance window) is still not
+      // trusted. This distinguishes "allow modest skew" from "disable the
+      // creation-time check entirely".
+      const plugin = new TestableWebOpenPGPPlugin()
+      const { ctx } = makeCtx('alice@example.com')
+      setSessionPassphrase('hunter2-strong-passphrase')
+      await plugin.init(ctx)
+      const ownBundle = await plugin.callEnsureKeyMaterial('alice@example.com')
+
+      const { generateKey, createMessage, encrypt, readKey } = await import('openpgp')
+      const { privateKey: senderPriv } = await generateKey({
+        type: 'ecc',
+        curve: 'curve25519Legacy',
+        userIDs: [{ name: 'xmpp:bob@example.com' }],
+        format: 'object',
+      })
+      const thirtyDaysAhead = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+      const ciphertext = await encrypt({
+        message: await createMessage({ text: 'far-future forgery attempt' }),
+        encryptionKeys: await readKey({ armoredKey: ownBundle.publicArmored }),
+        signingKeys: senderPriv,
+        date: thirtyDaysAhead,
+        format: 'armored',
+      })
+
+      const decrypted = await plugin.callDecryptWithOwnKey(
+        'bob@example.com',
+        ciphertext,
+        senderPriv.toPublic().armor(),
+      )
+
+      expect(decrypted.signaturePresent).toBe(true)
+      expect(decrypted.signatureVerified).toBe(false)
+    })
+  })
+
   describe('validateCert', () => {
     it('returns the fingerprint and a positive subkey count for a generated key', async () => {
       const plugin = new TestableWebOpenPGPPlugin()

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -39,6 +39,24 @@ import { detectArmorKind } from './armorDetect'
 const PRIVATE_KEY_STORAGE_KEY = 'private-key'
 
 /**
+ * Clock-skew tolerance applied when verifying a signature's *creation time*.
+ *
+ * openpgp.js rejects any signature whose creation time is after the
+ * verification date ("Signature creation time is in the future") with zero
+ * tolerance. When a sender's machine clock runs even slightly ahead of the
+ * verifier's, a freshly-signed message is rejected as "invalid signature" —
+ * intermittently, depending on the instantaneous skew. We verify against
+ * `now + this window` so modest clock skew doesn't cause spurious rejections.
+ *
+ * This only widens the *future* bound of the signature timestamp; message
+ * freshness/replay is enforced separately by the signcrypt `<time>` envelope
+ * check ({@link SIGNCRYPT_CLOCK_SKEW_MS}). Accepting a slightly-future
+ * signature carries no authenticity risk — forging one still requires the
+ * signing key.
+ */
+const SIGNATURE_CLOCK_SKEW_TOLERANCE_MS = 60 * 60 * 1000 // 1 hour
+
+/**
  * A local-key failure that the server backup might fix: the stored blob
  * won't decrypt with this passphrase, or there's no local blob but the
  * server advertises an identity. Both are worth a backup-recovery attempt.
@@ -204,6 +222,10 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
     const { data: plaintext, signatures } = await decrypt({
       message,
       decryptionKeys: this.ownPrivateKey!,
+      // Verify against now + skew tolerance so a sender whose clock runs
+      // slightly ahead doesn't trip openpgp.js's zero-tolerance "creation
+      // time is in the future" rejection. See SIGNATURE_CLOCK_SKEW_TOLERANCE_MS.
+      date: new Date(Date.now() + SIGNATURE_CLOCK_SKEW_TOLERANCE_MS),
       ...(verificationKeys.length > 0 && { verificationKeys }),
     })
 
@@ -219,8 +241,26 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
         // match Sequoia's behavior. keyID.toHex() only gives the 8-byte
         // key ID (16 chars), which would never match the cached peer FP.
         signerFingerprint = verificationKeys[0].getFingerprint()
-      } catch {
+      } catch (err) {
         signatureVerified = false
+        // DIAGNOSTIC: surface why openpgp.js rejected the signature — the
+        // message names the cause (time-window vs EdDSA/MPI vs key lookup).
+        // The signature creation time is pulled separately so this log can
+        // never throw out of the catch even if `.signature` rejected too.
+        let sigCreated = '?'
+        try {
+          const sig = await signatures[0].signature
+          sigCreated = sig?.packets?.[0]?.created?.toISOString() ?? '?'
+        } catch {
+          /* signature packet unavailable — leave as '?' */
+        }
+        this.requireCtx().logger.warn(
+          `WebOpenPGPPlugin: signature verify failed (signer ${
+            verificationKeys[0]?.getFingerprint?.() ?? '?'
+          }, sigCreated ${sigCreated}, now ${new Date().toISOString()}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        )
       }
     }
 


### PR DESCRIPTION
Two related E2EE fixes behind the intermittent `[Message rejected: invalid signature]` reports.

**Clock-skew signature rejection.** openpgp.js rejects a signature whose creation time is ahead of the verifier's clock ("Signature creation time is in the future") with zero tolerance — so when a sender's machine clock runs slightly ahead, a freshly-signed message is rejected on web receivers, intermittently. Web verify now uses a 1h clock-skew tolerance (replay/freshness is still guarded by the signcrypt `<time>` envelope check), and the previously-swallowed openpgp.js verify error is logged. Sequoia already tolerates modest skew (accepts +10min, rejects +30d), so the desktop path is unchanged — added characterization tests for that asymmetry.

**Frozen lock color.** Trust (verified/tofu) was baked onto each message at decrypt time, so verifying a peer afterwards never recolored already-decrypted messages. `MessageBubble` now derives the displayed trust live from the verified-peer store (per-peer selector on a low-churn store — no render-perf regression), flipping tofu↔verified for color, icon, aria-label and tooltip.

Note: rejections are still sticky, so messages rejected before this fix won't self-heal until re-decrypted (follow-up).