### PR TITLE
fix(e2ee): recover from transient clock-skew signature failures

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -210,6 +210,14 @@ export interface DecryptOutput {
   signatureVerified: boolean
   signerFingerprint: string | null
   signaturePresent: boolean
+  /**
+   * Set when signature verification failed specifically because the
+   * signature's creation time is ahead of the verifier's clock (beyond the
+   * skew tolerance) — i.e. a *transient* clock-skew failure that may verify
+   * once clocks converge, NOT a genuine bad signature. Lets the decrypt path
+   * mark the message retryable rather than permanently rejected.
+   */
+  signatureNotYetValid?: boolean
 }
 
 export interface CertValidation {
@@ -1706,6 +1714,17 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     }
     // Case A: sender key available but signature did not verify.
     if (senderPublicArmored && !output.signatureVerified) {
+      // A clock-skew "not yet valid" failure is transient — the signature may
+      // verify once clocks converge. Throw a distinct transient code so the
+      // decrypt pipeline stashes it for retry (retryPendingDecrypts) instead
+      // of issuing a permanent, sticky rejection. Any other failure is genuine.
+      if (output.signatureNotYetValid) {
+        throw new E2EEPluginError(
+          'transient',
+          'signature-not-yet-valid',
+          `${this.pluginName()}: signcrypt signature creation time is ahead of our clock beyond tolerance — will retry`,
+        )
+      }
       throw new E2EEPluginError(
         'permanent',
         'signature-failed',

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -618,6 +618,81 @@ describe('WebOpenPGPPlugin', () => {
       expect(decrypted.signaturePresent).toBe(true)
       expect(decrypted.signatureVerified).toBe(false)
     })
+
+    it('flags a beyond-tolerance future signature as not-yet-valid (transient, retryable)', async () => {
+      // A signature dated past the skew window fails to verify, but the cause
+      // is a clock difference, not a bad key — so it must be marked transient
+      // so the upper layer can retry it rather than reject it permanently.
+      const plugin = new TestableWebOpenPGPPlugin()
+      const { ctx } = makeCtx('alice@example.com')
+      setSessionPassphrase('hunter2-strong-passphrase')
+      await plugin.init(ctx)
+      const ownBundle = await plugin.callEnsureKeyMaterial('alice@example.com')
+
+      const { generateKey, createMessage, encrypt, readKey } = await import('openpgp')
+      const { privateKey: senderPriv } = await generateKey({
+        type: 'ecc',
+        curve: 'curve25519Legacy',
+        userIDs: [{ name: 'xmpp:bob@example.com' }],
+        format: 'object',
+      })
+      const twoHoursAhead = new Date(Date.now() + 2 * 60 * 60 * 1000)
+      const ciphertext = await encrypt({
+        message: await createMessage({ text: 'too far in the future' }),
+        encryptionKeys: await readKey({ armoredKey: ownBundle.publicArmored }),
+        signingKeys: senderPriv,
+        date: twoHoursAhead,
+        format: 'armored',
+      })
+
+      const decrypted = await plugin.callDecryptWithOwnKey(
+        'bob@example.com',
+        ciphertext,
+        senderPriv.toPublic().armor(),
+      )
+
+      expect(decrypted.signatureVerified).toBe(false)
+      expect(decrypted.signatureNotYetValid).toBe(true)
+    })
+
+    it('does NOT flag a genuine key mismatch as not-yet-valid (permanent)', async () => {
+      // Signature made by one key, verified against a different key → a real
+      // failure that must stay permanent (not retried, not self-healing).
+      const plugin = new TestableWebOpenPGPPlugin()
+      const { ctx } = makeCtx('alice@example.com')
+      setSessionPassphrase('hunter2-strong-passphrase')
+      await plugin.init(ctx)
+      const ownBundle = await plugin.callEnsureKeyMaterial('alice@example.com')
+
+      const { generateKey, createMessage, encrypt, readKey } = await import('openpgp')
+      const { privateKey: actualSigner } = await generateKey({
+        type: 'ecc',
+        curve: 'curve25519Legacy',
+        userIDs: [{ name: 'xmpp:bob@example.com' }],
+        format: 'object',
+      })
+      const { privateKey: wrongKey } = await generateKey({
+        type: 'ecc',
+        curve: 'curve25519Legacy',
+        userIDs: [{ name: 'xmpp:mallory@example.com' }],
+        format: 'object',
+      })
+      const ciphertext = await encrypt({
+        message: await createMessage({ text: 'signed by the wrong key' }),
+        encryptionKeys: await readKey({ armoredKey: ownBundle.publicArmored }),
+        signingKeys: actualSigner,
+        format: 'armored',
+      })
+
+      const decrypted = await plugin.callDecryptWithOwnKey(
+        'bob@example.com',
+        ciphertext,
+        wrongKey.toPublic().armor(), // verify against a different key
+      )
+
+      expect(decrypted.signatureVerified).toBe(false)
+      expect(decrypted.signatureNotYetValid).toBeFalsy()
+    })
   })
 
   describe('validateCert', () => {
@@ -1862,6 +1937,44 @@ describe('WebOpenPGPPlugin', () => {
       await expect(bob.plugin.decrypt(bobHandle, claim)).rejects.toMatchObject({
         code: 'envelope-stale',
       })
+    })
+
+    it('throws a transient (retryable) error for a clock-skew signature failure, not a permanent rejection', async () => {
+      // When the sender key is present but the signature fails *because its
+      // creation time is ahead of our clock* (beyond tolerance), the failure
+      // is transient — decrypt() must throw `signature-not-yet-valid`
+      // (transient) so the pipeline stashes it for retry, NOT
+      // `signature-failed` (permanent) which renders a sticky red rejection.
+      const { alice, bob } = await buildCrossPublishedPair()
+      await alice.plugin.probePeer('bob@example.com')
+      const handle = await alice.plugin.openConversation({ kind: 'direct', peer: 'bob@example.com' })
+      const payload = await alice.plugin.encrypt(handle, encodeBody('clock skew message'))
+
+      clearSessionPassphrase()
+      setSessionPassphrase('bob-strong-pp')
+      await bob.plugin.probePeer('alice@example.com') // alice's key cached → Case A path
+      const bobHandle = await bob.plugin.openConversation({ kind: 'direct', peer: 'alice@example.com' })
+      const claim = bob.plugin.tryClaimInbound(payload.stanzaElement)!
+
+      // Keep the real decryption (valid envelope) but report a not-yet-valid
+      // signature, exactly as the crypto layer would under clock skew.
+      const target = bob.testable as unknown as {
+        decryptWithOwnKey: (...a: unknown[]) => Promise<Record<string, unknown>>
+      }
+      const real = target.decryptWithOwnKey.bind(target)
+      const spy = vi
+        .spyOn(target, 'decryptWithOwnKey')
+        .mockImplementation(async (...args) => ({
+          ...(await real(...args)),
+          signatureVerified: false,
+          signatureNotYetValid: true,
+          signerFingerprint: null,
+        }))
+
+      await expect(
+        bob.plugin.decrypt(bobHandle, claim, { messageId: 'm-skew' }),
+      ).rejects.toMatchObject({ kind: 'transient', code: 'signature-not-yet-valid' })
+      spy.mockRestore()
     })
 
     describe('pending signature verification buffer', () => {

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -231,6 +231,7 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
 
     let signatureVerified = false
     let signerFingerprint: string | null = null
+    let signatureNotYetValid = false
     const signaturePresent = signatures.length > 0
 
     if (signaturePresent && senderPublicArmored) {
@@ -243,6 +244,12 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
         signerFingerprint = verificationKeys[0].getFingerprint()
       } catch (err) {
         signatureVerified = false
+        const reason = err instanceof Error ? err.message : String(err)
+        // A failure caused purely by the signature being dated ahead of our
+        // clock (beyond the skew tolerance) is transient — clocks may
+        // converge. Flag it so the decrypt path retries instead of issuing a
+        // permanent rejection. Any other reason (bad key, tamper) is genuine.
+        signatureNotYetValid = /creation time is in the future|not yet valid/i.test(reason)
         // DIAGNOSTIC: surface why openpgp.js rejected the signature — the
         // message names the cause (time-window vs EdDSA/MPI vs key lookup).
         // The signature creation time is pulled separately so this log can
@@ -257,9 +264,7 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
         this.requireCtx().logger.warn(
           `WebOpenPGPPlugin: signature verify failed (signer ${
             verificationKeys[0]?.getFingerprint?.() ?? '?'
-          }, sigCreated ${sigCreated}, now ${new Date().toISOString()}): ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          }, sigCreated ${sigCreated}, now ${new Date().toISOString()}): ${reason}`,
         )
       }
     }
@@ -269,6 +274,7 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
       signatureVerified,
       signerFingerprint,
       signaturePresent,
+      ...(signatureNotYetValid && { signatureNotYetValid }),
     }
   }
 

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
@@ -20,6 +20,7 @@ import {
 } from './stanzaDecrypt'
 import { E2EEManager, InMemoryStorageBackend, type XMPPPrimitives } from './index'
 import { serialize as serializePayloadEnvelope } from './payloadEnvelope'
+import { E2EEPluginError } from './errors'
 import type {
   ConversationHandle,
   ConversationTarget,
@@ -225,6 +226,18 @@ class FailingE2EEPlugin extends FakeE2EEPlugin {
   }
 }
 
+// Claims the encrypted child but throws a caller-supplied E2EEPluginError —
+// lets us exercise the rejection-vs-retry routing per error code/kind.
+class ThrowingSignaturePlugin extends FakeE2EEPlugin {
+  constructor(private readonly error: E2EEPluginError) {
+    super(undefined)
+  }
+
+  override async decrypt(): Promise<DecryptResult> {
+    throw this.error
+  }
+}
+
 class NonClaimingOpenPgpPlugin extends FakeE2EEPlugin {
   readonly descriptor: E2EEProtocolDescriptor = {
     ...descriptor,
@@ -297,6 +310,35 @@ describe('stanzaDecrypt encrypted payload stash on failure', () => {
     expect(readStashedEncryptedPayload(stanza)).toBe(result.encryptedPayloadXml)
     // Security context should reflect untrusted
     expect(result.securityContext?.trust).toBe('untrusted')
+  })
+
+  it('routes a transient signature failure (clock skew) to retry, not rejection', async () => {
+    // Guard for the sticky-rejection recovery: a transient
+    // `signature-not-yet-valid` error must be stashed for retryPendingDecrypts,
+    // NOT rendered as a permanent rejection. Only `signature-failed` /
+    // `signature-missing` map to a rejection — anything else is retryable.
+    const manager = await makeManager(
+      new ThrowingSignaturePlugin(
+        new E2EEPluginError('transient', 'signature-not-yet-valid', 'clock skew'),
+      ),
+    )
+    const stanza = buildStanza()
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+    expect(result.securityContext?.trust).not.toBe('rejected')
+    expect(result.encryptedPayloadXml).toBeDefined()
+    expect(readStashedEncryptedPayload(stanza)).toBe(result.encryptedPayloadXml)
+  })
+
+  it('routes a permanent signature failure to a final rejection (no retry)', async () => {
+    const manager = await makeManager(
+      new ThrowingSignaturePlugin(
+        new E2EEPluginError('permanent', 'signature-failed', 'bad signature'),
+      ),
+    )
+    const stanza = buildStanza()
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+    expect(result.securityContext?.trust).toBe('rejected')
+    expect(result.encryptedPayloadXml).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Follow-up to #484. A signature that fails verification *only* because its creation time is ahead of the verifier's clock (beyond the skew tolerance) is transient — it can verify once clocks converge. Today such a failure is a permanent, sticky rejection.

The web verifier now surfaces that case (`DecryptOutput.signatureNotYetValid`) and `decrypt()` throws a distinct transient `signature-not-yet-valid` error, so the decrypt pipeline stashes it for `retryPendingDecrypts` on the next reconnect instead of rejecting permanently. Genuine signature mismatches still throw `signature-failed` and stay rejected — so we never re-decrypt a truly bad signature on every reconnect.

Note: messages rejected *before* this change carry no retry payload and still need a MAM re-pull to recover.