### PR TITLE
fix(e2ee): strip reply fallback quote on deferred decrypt retry

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -244,6 +244,118 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
     })
   })
 
+  describe('XEP-0461 reply fallback stripping on retry', () => {
+    // Regression guard for the duplicated-quote rendering bug: an encrypted
+    // reply's body carries the XEP-0461 compatibility quote ("> Author
+    // wrote:\n> …\n") and the OUTER stanza carries the XEP-0428 <fallback>
+    // range pointing at it. The stash holds the full original stanza so the
+    // retry can re-run fallback stripping; the old bare-element stash lost
+    // the <reply>/<fallback> context and clobbered the store body with the
+    // raw quote-prefixed plaintext (reply chip + quote rendered twice).
+    const REPLY_FALLBACK = '> Bob wrote:\n> original message\n'
+    const REPLY_PLAINTEXT = `${REPLY_FALLBACK}actual reply`
+    const FULL_STANZA_PAYLOAD =
+      `<message from="bob@example.com/web" to="me@example.com" type="chat" id="reply-1">` +
+      `<reply xmlns="urn:xmpp:reply:0" id="orig-1" to="me@example.com"/>` +
+      `<fallback xmlns="urn:xmpp:fallback:0" for="urn:xmpp:reply:0"><body start="0" end="${REPLY_FALLBACK.length}"/></fallback>` +
+      `<body>[encrypted]</body>` +
+      `<plain xmlns="urn:fluux:e2ee-dummy:0">${Buffer.from(REPLY_PLAINTEXT).toString('base64')}</plain>` +
+      `<encryption xmlns="urn:xmpp:eme:0" namespace="urn:fluux:e2ee-dummy:0"/>` +
+      `</message>`
+
+    beforeEach(() => {
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode(REPLY_PLAINTEXT),
+        senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+    })
+
+    it('strips the reply fallback quote from the decrypted body (deferred decrypt)', async () => {
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'msg-reply-deferred',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        replyTo: { id: 'orig-1', to: 'me@example.com' },
+        encryptedPayload: FULL_STANZA_PAYLOAD,
+      })
+
+      const count = await xmppClient.retryPendingDecrypts()
+
+      expect(count).toBe(1)
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      const msg = messages.find((m) => m.id === 'msg-reply-deferred')
+      expect(msg?.body).toBe('actual reply')
+      expect(msg?.encryptedPayload).toBeUndefined()
+    })
+
+    it('does not reintroduce the quote when re-verifying an already-decrypted reply', async () => {
+      // needsDeferredVerification case: the first pass decrypted and stripped
+      // the body correctly but could not verify the signature (peer key not
+      // cached). The retry must not clobber the body with the raw plaintext.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'msg-reply-reverify',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: 'actual reply',
+        timestamp: new Date(),
+        isOutgoing: false,
+        replyTo: { id: 'orig-1', to: 'me@example.com' },
+        securityContext: {
+          protocolId: 'dummy-plaintext',
+          trust: 'untrusted',
+          notes: ['Sender key not cached'],
+        },
+        encryptedPayload: FULL_STANZA_PAYLOAD,
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      const msg = messages.find((m) => m.id === 'msg-reply-reverify')
+      expect(msg?.body).toBe('actual reply')
+      expect(msg?.securityContext?.trust).toBe('verified')
+      expect(msg?.encryptedPayload).toBeUndefined()
+    })
+
+    it('still decrypts legacy bare-element payloads (no outer context available)', async () => {
+      // Stashes persisted before the full-stanza format hold only the
+      // encrypted child. They must keep decrypting; fallback stripping is
+      // impossible without the outer <fallback> range, so the raw body is
+      // accepted as-is.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'msg-reply-legacy',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: `<plain xmlns="urn:fluux:e2ee-dummy:0">${Buffer.from(REPLY_PLAINTEXT).toString('base64')}</plain>`,
+      })
+
+      const count = await xmppClient.retryPendingDecrypts()
+
+      expect(count).toBe(1)
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      const msg = messages.find((m) => m.id === 'msg-reply-legacy')
+      expect(msg?.body).toBe(REPLY_PLAINTEXT)
+      expect(msg?.encryptedPayload).toBeUndefined()
+    })
+  })
+
   describe('durable-cache deferred decryption', () => {
     // Regression guard for the web fresh-session reload bug: messages that
     // failed to decrypt while the key was locked are persisted to IndexedDB

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -41,7 +41,7 @@ import {
 } from '../stores'
 import { detectPlatform, getCachedPlatform } from './platform'
 import { isDeadSocketError } from './modules/connectionUtils'
-import { parseOobData } from './modules/messagingUtils'
+import { parseMessageContent } from './modules/messagingUtils'
 import {
   FRESH_SESSION_IQ_TIMEOUT_MS,
   FRESH_SESSION_SETUP_TIMEOUT_MS,
@@ -1604,8 +1604,8 @@ export class XMPPClient {
    * because decryption failed at receive time (no plugin registered, key
    * locked, etc.).
    *
-   * Iterates both chat and room stores, reconstructs a minimal stanza from
-   * the serialized XML, and re-runs {@link decryptStanzaInPlace}. On success
+   * Iterates both chat and room stores, reconstructs the stanza from the
+   * serialized XML, and re-runs {@link decryptStanzaInPlace}. On success
    * the message body + securityContext are updated in-place via
    * `store.updateMessage()`, and the `encryptedPayload` is cleared.
    *
@@ -1664,7 +1664,7 @@ export class XMPPClient {
         for (const msg of runtime.messages) {
           if (!msg.encryptedPayload) continue
           const outcome = await this.retryDecryptSingle(
-            manager, msg.encryptedPayload, msg.from, roomJid,
+            manager, msg.encryptedPayload, msg.from, roomJid, 'room',
           )
           if (outcome.kind === 'decrypted') {
             roomBindings.updateMessage(roomJid, msg.id, {
@@ -1724,7 +1724,9 @@ export class XMPPClient {
   }
 
   /**
-   * Attempt to decrypt a single serialized encrypted payload.
+   * Attempt to decrypt a single stashed payload — either a full original
+   * `<message>` stanza (current format, keeps outer reply/fallback context)
+   * or a bare encrypted element (legacy persisted stashes).
    * @returns `RetryOutcome` describing whether decryption succeeded, the
    *   protocol is unsupported, or the message should remain pending.
    * @internal
@@ -1734,20 +1736,28 @@ export class XMPPClient {
     encryptedPayloadXml: string,
     senderJid: string,
     peer: string,
+    messageContext: 'chat' | 'room' = 'chat',
   ): Promise<RetryOutcome> {
     try {
-      // Parse the serialized encrypted element back into an Element
       const ltx = await import('ltx')
-      const encryptedEl = ltx.parse(encryptedPayloadXml) as unknown as Element
+      const parsedPayload = ltx.parse(encryptedPayloadXml) as unknown as Element
 
-      // Build a minimal stanza wrapper for decryptStanzaInPlace.
+      // Current stashes hold the full original <message> stanza so outer
+      // cleartext context (XEP-0461 <reply>, XEP-0428 <fallback> ranges)
+      // survives until this retry. Stashes persisted before that format
+      // hold just the encrypted child and need a minimal wrapper.
+      const stanza =
+        parsedPayload.name === 'message'
+          ? parsedPayload
+          : (xml('message', { from: senderJid }, parsedPayload) as Element)
+      if (!stanza.attrs.from) stanza.attrs.from = senderJid
+
       // Detect self-outgoing (sent carbon or MAM self-replay): when the
       // sender's bare JID equals our own, the signcrypt envelope's <to/>
       // addresses the conversation peer — not us — so the plugin's
       // reflection check must be inverted via isSelfOutgoing.
       const ownBareJid = this.currentJid ? getBareJid(this.currentJid) : ''
       const isSelfOutgoing = ownBareJid !== '' && getBareJid(senderJid) === ownBareJid
-      const stanza = xml('message', { from: senderJid }, encryptedEl)
 
       const result = await decryptStanzaInPlace(
         stanza, manager, peer, 'archive',
@@ -1770,10 +1780,15 @@ export class XMPPClient {
       const body = stanza.getChildText('body')
       if (!body) return { kind: 'pending' }
 
-      // Extract attachment if present — parseOobData handles aesgcm:// URI
-      // parsing (XEP-0454 key/IV extraction), XEP-0446 file metadata, and
-      // XEP-0264 thumbnails, which the previous inline parser was missing.
-      const attachment = parseOobData(stanza)
+      // Re-run the shared content parse on the decrypted stanza: strips
+      // XEP-0428 fallback ranges (e.g. the XEP-0461 reply quote that the
+      // sender prefixed to the encrypted body) and extracts the attachment
+      // (aesgcm:// URI, XEP-0446 file metadata, XEP-0264 thumbnails).
+      // Legacy bare-element stashes carry no outer <fallback>, so their
+      // body passes through unchanged.
+      const parsed = parseMessageContent({ messageEl: stanza, body, messageContext })
+      const processedBody = parsed.processedBody
+      const attachment = parsed.attachment
       if (attachment) {
         logDebug(
           `E2EE deferred decrypt: attachment from ${getDomain(senderJid)} — ` +
@@ -1802,7 +1817,7 @@ export class XMPPClient {
 
       return {
         kind: 'decrypted',
-        body,
+        body: processedBody,
         ...(securityContext && { securityContext }),
         ...(attachment && { attachment }),
       }

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
@@ -343,6 +343,81 @@ describe('stanzaDecrypt encrypted payload stash on failure', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Full-stanza stash: outer cleartext context (XEP-0461 <reply> and XEP-0428
+// <fallback> ranges live OUTSIDE the encrypted element) must survive the
+// stash, otherwise retryPendingDecrypts cannot re-run fallback stripping and
+// overwrites the store body with the raw quote-prefixed plaintext.
+// ---------------------------------------------------------------------------
+
+function buildReplyStanza(): Element {
+  return xml(
+    'message',
+    { from: 'peer@example.com/resource', id: 'm-reply', type: 'chat' },
+    xml('reply', { xmlns: 'urn:xmpp:reply:0', id: 'orig-1', to: 'me@example.com' }),
+    xml(
+      'fallback',
+      { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+      xml('body', { start: '0', end: '32' }),
+    ),
+    xml('body', {}, '[Encrypted message]'),
+    xml('enc', { xmlns: TEST_NAMESPACE }),
+  ) as Element
+}
+
+describe('stanzaDecrypt full-stanza stash (outer reply/fallback context)', () => {
+  it('stashes the whole message stanza when plugin decrypt fails', async () => {
+    const manager = await makeManager(new FailingE2EEPlugin())
+    const stanza = buildReplyStanza()
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.encryptedPayloadXml).toMatch(/^<message/)
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:reply:0')
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:fallback:0')
+    expect(result.encryptedPayloadXml).toContain(TEST_NAMESPACE)
+  })
+
+  it('stashes the whole message stanza when decrypt succeeds but trust is untrusted', async () => {
+    const manager = await makeManager(new UntrustedE2EEPlugin())
+    const stanza = buildReplyStanza()
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.encryptedPayloadXml).toMatch(/^<message/)
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:reply:0')
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:fallback:0')
+    // The stash must hold the ENCRYPTED original (re-decryptable), not the
+    // in-place-decrypted stanza.
+    expect(result.encryptedPayloadXml).toContain(TEST_NAMESPACE)
+    expect(result.encryptedPayloadXml).not.toContain('decrypted body')
+  })
+
+  it('stashes the whole message stanza for an unclaimed EME-hinted stanza', async () => {
+    const manager = makeEmptyManager()
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/resource', id: 'm-eme', type: 'chat' },
+      xml('reply', { xmlns: 'urn:xmpp:reply:0', id: 'orig-1', to: 'me@example.com' }),
+      xml(
+        'fallback',
+        { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+        xml('body', { start: '0', end: '32' }),
+      ),
+      xml('body', {}, 'This message is encrypted'),
+      xml('encryption', { xmlns: 'urn:xmpp:eme:0', namespace: 'urn:xmpp:openpgp:0' }),
+      xml('openpgp', { xmlns: 'urn:xmpp:openpgp:0' }, 'ciphertext'),
+    ) as Element
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(false)
+    expect(result.encryptedPayloadXml).toMatch(/^<message/)
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:reply:0')
+    expect(result.encryptedPayloadXml).toContain('urn:xmpp:fallback:0')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Untrusted plugin: decrypt succeeds but reports untrusted trust (e.g. peer
 // key not cached, so signature could not be verified)
 // ---------------------------------------------------------------------------

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
@@ -78,12 +78,18 @@ export interface DecryptInPlaceResult {
    */
   authoredAt?: Date
   /**
-   * Serialized XML of the encrypted child element, present when:
+   * Serialized XML of the full original `<message>` stanza (captured before
+   * any mutation), present when:
    * - a plugin claimed the stanza but decrypt failed (e.g. key locked), or
+   * - decrypt succeeded but the signature could not be verified yet
+   *   (deferred re-verification), or
    * - an EME hint was present but no plugin is registered yet (deferred retry).
-   * Mutually exclusive with `unsupportedEncryption`. Callers should store this
-   * on the resulting {@link Message} so that
-   * {@link XMPPClient.retryPendingDecrypts} can re-attempt later.
+   * The whole stanza — not just the encrypted child — is kept so that outer
+   * cleartext context (XEP-0461 `<reply>`, XEP-0428 `<fallback>` ranges,
+   * XEP-0066 OOB) survives until the retry, which re-runs the normal parse.
+   * Stashes persisted before this format hold just the encrypted child;
+   * {@link XMPPClient.retryPendingDecrypts} handles both shapes.
+   * Mutually exclusive with `unsupportedEncryption`.
    */
   encryptedPayloadXml?: string
   /**
@@ -168,9 +174,12 @@ export async function decryptStanzaInPlace(
     return { attempted: false }
   }
 
-  // Serialize the encrypted element BEFORE any mutation — the element
-  // will be stripped below regardless of success/failure.
-  const encryptedChildXml = encryptedChild.toString()
+  // Serialize BEFORE any mutation — the encrypted element will be stripped
+  // below regardless of success/failure. The full stanza is what gets
+  // stashed for deferred retry: the encrypted child alone would lose outer
+  // cleartext context (XEP-0461 <reply>, XEP-0428 <fallback> ranges) that
+  // the retry needs to re-run fallback stripping on the decrypted body.
+  const originalStanzaXml = stanza.toString()
 
   let plaintext: string | null = null
   let securityContext: SecurityContext | null = null
@@ -246,7 +255,7 @@ export async function decryptStanzaInPlace(
     } else {
       // Decrypt failure (key locked, plugin missing, etc.): stash for
       // deferred retry and keep the sender's fallback body hint.
-      stashPayload(stanza, encryptedChildXml)
+      stashPayload(stanza, originalStanzaXml)
       if (!stanza.getChild('body')) {
         stanza.children.push(
           xml('body', {}, '[Encrypted message: could not decrypt]'),
@@ -306,7 +315,7 @@ export async function decryptStanzaInPlace(
   const needsDeferredVerification =
     failureReason === null && securityContext?.trust === 'untrusted'
   if (needsDeferredVerification) {
-    stashPayload(stanza, encryptedChildXml)
+    stashPayload(stanza, originalStanzaXml)
   }
 
   if (securityContext) {
@@ -322,7 +331,7 @@ export async function decryptStanzaInPlace(
     ...(securityContext && { securityContext }),
     ...(authoredAt && { authoredAt }),
     ...((failureReason !== null && securityContext?.trust !== 'rejected' || needsDeferredVerification) && {
-      encryptedPayloadXml: encryptedChildXml,
+      encryptedPayloadXml: originalStanzaXml,
     }),
   }
 }
@@ -376,7 +385,11 @@ export function deriveConversationContext(
 // Stanza stash helpers
 // ---------------------------------------------------------------------------
 
-/** Stash a serialized encrypted element on a stanza for deferred decrypt. */
+/**
+ * Stash the serialized original `<message>` stanza on a (mutated) stanza for
+ * deferred decrypt. See {@link DecryptInPlaceResult.encryptedPayloadXml} for
+ * why the whole stanza is kept rather than just the encrypted child.
+ */
 function stashPayload(stanza: Element, payloadXml: string): void {
   ;(stanza as unknown as { [ENCRYPTED_PAYLOAD_STASH]?: string })[
     ENCRYPTED_PAYLOAD_STASH
@@ -510,9 +523,11 @@ export function recordUnclaimedEME(
     return { kind: 'unsupported', info }
   }
 
-  // Not ready yet — stash the encrypted child for retryPendingDecrypts().
-  const payloadXml = target.child?.toString()
-  if (!payloadXml) return { kind: 'none' }
+  // Not ready yet — stash for retryPendingDecrypts(). The full stanza is
+  // kept (not just the encrypted child) so outer cleartext context like
+  // XEP-0461 <reply> / XEP-0428 <fallback> ranges survives until the retry.
+  if (!target.child) return { kind: 'none' }
+  const payloadXml = stanza.toString()
   stashPayload(stanza, payloadXml)
   logInfo(`E2EE: stashed encrypted payload (ns=${target.namespace}) for deferred decrypt`)
   return { kind: 'retry', encryptedPayloadXml: payloadXml }


### PR DESCRIPTION
## Summary

Fixes the duplicated-quote rendering on encrypted replies: the reply chip AND the "> Author wrote:" compatibility quote were both displayed after a deferred-decrypt retry.

**Root cause.** An encrypted reply carries the XEP-0461 compatibility quote inside the encrypted body, while the `<reply>` element and the XEP-0428 `<fallback>` range stay in cleartext on the outer stanza. When a message is stashed for deferred retry (key locked, signature not yet verifiable — e.g. peer key republished moments before sending), only the encrypted child element was serialized to `encryptedPayload`. `retryPendingDecrypts` then rebuilt a minimal stanza from that element alone, decrypted it, and overwrote the store body with the raw plaintext — quote included — with no `<fallback>` range left to strip it. The first-pass `replyTo` stayed on the message, so the quote rendered twice.

**Fix.**
- `decryptStanzaInPlace` and `recordUnclaimedEME` now stash the **full original `<message>` stanza** (serialized before any mutation — ciphertext only, no plaintext is persisted), so the outer reply/fallback context survives until the retry.
- `retryDecryptSingle` detects the stash shape (`<message>` root vs legacy bare element) and, after decrypting, re-runs the shared `parseMessageContent` — fallback ranges are stripped and attachments extracted exactly like the first pass. This also fixes the re-verification path (decrypt OK, signature pending) which previously clobbered an already-correct body.
- Legacy bare-element stashes persisted before this change still decrypt through the minimal-wrapper path (raw body, as before).

Regression guards: full-stanza stash shape pinned in `stanzaDecrypt.test.ts`; quote stripping, re-verification no-clobber, and legacy back-compat pinned in `XMPPClient.e2ee.test.ts`.