### PR TITLE
fix(e2ee): apply deferred-decrypted reactions and retractions instead of dropping them

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -511,5 +511,60 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       const ghost = messages.find((m) => m.id === 'reaction-ghost')
       expect(ghost).toBeUndefined()
     })
+
+    it('applies a deferred-decrypted retraction to its target and drops the placeholder', async () => {
+      // Retractions are the sibling of reactions: sendRetraction keeps an outer
+      // fallback body, but the <retract> element itself is bodiless inside the
+      // payload, so a deferred decrypt surfaces it with no <body> — the same
+      // code path that dropped reactions.
+      const retractEnvelope =
+        `<payload xmlns="jabber:client">` +
+        `<retract xmlns="urn:xmpp:message-retract:1" id="spam-msg"/>` +
+        `</payload>`
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode(retractEnvelope),
+        senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      // The message Bob later retracted — still visible until the retract applies.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'spam-msg',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: 'oops wrong chat',
+        timestamp: new Date(),
+        isOutgoing: false,
+      })
+      // Bob's retraction, stashed as a placeholder while the key was locked.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'retract-ghost',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      // The target must now be marked retracted (only its author may retract it).
+      const target = messages.find((m) => m.id === 'spam-msg')
+      expect(target?.isRetracted).toBe(true)
+      // The placeholder must not linger.
+      const ghost = messages.find((m) => m.id === 'retract-ghost')
+      expect(ghost).toBeUndefined()
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -442,4 +442,74 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(count).toBe(1)
     })
   })
+
+  describe('deferred-decrypt of bodiless modifications', () => {
+    // Regression guard for the production bug (lost encrypted reaction):
+    //
+    // An encrypted XEP-0444 reaction has NO <body> — the whole <reactions>
+    // element rides inside the OpenPGP payload. When such a stanza is replayed
+    // from MAM (or received live) while the key is still locked, the decrypt is
+    // deferred: stanzaDecrypt injects an "[Encrypted message: could not decrypt]"
+    // placeholder body so the bodiless stanza survives parseArchiveMessage's
+    // `if (!body) return null` gate, and the encrypted payload is stashed for
+    // retry. The stanza is therefore persisted as a placeholder "message".
+    //
+    // On unlock, retryPendingDecrypts re-decrypts it. The decrypt SUCCEEDS, but
+    // the deferred-retry path was body-only: a decrypted payload that surfaces
+    // a <reactions> (no <body>) was reported as `pending`, so the reaction was
+    // never applied to its target and the placeholder lingered. The user saw no
+    // reaction and re-did it by hand.
+    it('applies a deferred-decrypted reaction to its target and drops the placeholder', async () => {
+      // Decrypt yields a payload envelope carrying <reactions>, not a <body>.
+      const reactionEnvelope =
+        `<payload xmlns="jabber:client">` +
+        `<reactions xmlns="urn:xmpp:reactions:0" id="xcom-msg"><reaction>👍</reaction></reactions>` +
+        `</payload>`
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode(reactionEnvelope),
+        senderDevice: { jid: 'me@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      // The message the reaction targets — a normal text message already stored.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'xcom-msg',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: 'https://x.com/claudeai/status/2064394146916229443',
+        timestamp: new Date(),
+        isOutgoing: false,
+      })
+      // Our own reaction, stashed as a placeholder while the key was locked
+      // (self-outgoing MAM replay: from === own bare JID).
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'reaction-ghost',
+        conversationId: 'bob@example.com',
+        from: 'me@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: true,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      // The 👍 must land on the target message.
+      const target = messages.find((m) => m.id === 'xcom-msg')
+      expect(target?.reactions).toEqual({ '👍': ['me@example.com'] })
+      // The placeholder must not linger as a ghost "could not decrypt" bubble.
+      const ghost = messages.find((m) => m.id === 'reaction-ghost')
+      expect(ghost).toBeUndefined()
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -114,7 +114,8 @@ import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
 import { dataToElement } from './e2ee/stanzaAdapter'
 import { decryptStanzaInPlace } from './e2ee/stanzaDecrypt'
-import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH, NS_REACTIONS } from './namespaces'
+import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH, NS_REACTIONS, NS_RETRACT } from './namespaces'
+import { applyRetraction } from './modules/messagingUtils'
 import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './defaultStoreBindings'
 import { logDebug, logInfo, logWarn } from './logger'
 import { SDK_VERSION } from '../version'
@@ -194,13 +195,15 @@ import { bumpAvatarResumeCount } from '../utils/avatarCache'
  * The placeholder "message" it was provisionally stored under must be replaced
  * by applying the signal to its target.
  */
-type RetryModification = { type: 'reactions'; targetId: string; emojis: string[] }
+type RetryModification =
+  | { type: 'reactions'; targetId: string; emojis: string[] }
+  | { type: 'retract'; targetId: string }
 
 /**
  * Result of a single deferred-decrypt attempt.
  * - `decrypted`: plaintext recovered — update body/security/attachment, clear `encryptedPayload`.
- * - `modification`: decrypt surfaced a bodiless signal (XEP-0444 reaction) — apply it to its
- *   target and remove the placeholder; there is no message body to update.
+ * - `modification`: decrypt surfaced a bodiless signal (XEP-0444 reaction or XEP-0424 retraction) —
+ *   apply it to its target and remove the placeholder; there is no message body to update.
  * - `unsupported`: protocol we have no plugin for — clear `encryptedPayload`, tag `unsupportedEncryption`, keep body.
  * - `pending`: still cannot decrypt (key locked / plugin not ready) — leave `encryptedPayload`.
  */
@@ -1723,16 +1726,12 @@ export class XMPPClient {
         } else if (outcome.kind === 'modification') {
           // Conversation isn't loaded in memory. Apply best-effort to the
           // in-memory target (no-op if absent) and drop the durable placeholder
-          // so it can't resurrect as a "[could not decrypt]" bubble. The
-          // store binding's removeMessage only touches in-memory state, so
-          // delete from the durable cache explicitly. For never-opened
-          // conversations the reaction is reconciled on the next MAM
-          // catch-up, when the now-unlocked key decrypts it inline.
-          if (outcome.modification.type === 'reactions') {
-            chatBindings.updateReactions(
-              conversationId, outcome.modification.targetId, getBareJid(msg.from), outcome.modification.emojis,
-            )
-          }
+          // so it can't resurrect as a "[could not decrypt]" bubble. The store
+          // binding's removeMessage only touches in-memory state, so delete
+          // from the durable cache explicitly. For never-opened conversations
+          // the signal is reconciled on the next MAM catch-up, when the
+          // now-unlocked key decrypts it inline.
+          this.applyDeferredChatModification(conversationId, msg, outcome.modification, chatBindings)
           await cacheDeleteMessage(msg.id)
           decryptedCount++
         } else if (outcome.kind === 'unsupported') {
@@ -1754,11 +1753,12 @@ export class XMPPClient {
   }
 
   /**
-   * Apply a bodiless signal (XEP-0444 reaction) recovered from a deferred
-   * decrypt to its target message, then remove the "[could not decrypt]"
-   * placeholder it was provisionally stored under. The reactor is the sender
-   * of the placeholder stanza — our own bare JID for a self-outgoing MAM
-   * replay, the peer's for an inbound one.
+   * Apply a bodiless signal (XEP-0444 reaction or XEP-0424 retraction)
+   * recovered from a deferred decrypt to its target message, then remove the
+   * "[could not decrypt]" placeholder it was provisionally stored under. The
+   * sender of the placeholder stanza is the actor — our own bare JID for a
+   * self-outgoing MAM replay, the peer's for an inbound one. A retraction is
+   * only honoured when that actor authored the target (mirrors the live path).
    */
   private applyDeferredChatModification(
     conversationId: string,
@@ -1766,10 +1766,13 @@ export class XMPPClient {
     modification: RetryModification,
     chatBindings: StoreBindings['chat'],
   ): void {
+    const actorJid = getBareJid(placeholder.from)
     if (modification.type === 'reactions') {
-      chatBindings.updateReactions(
-        conversationId, modification.targetId, getBareJid(placeholder.from), modification.emojis,
-      )
+      chatBindings.updateReactions(conversationId, modification.targetId, actorJid, modification.emojis)
+    } else {
+      const target = chatBindings.getMessage(conversationId, modification.targetId)
+      const updates = applyRetraction(!!target && target.from === actorJid)
+      if (updates) chatBindings.updateMessage(conversationId, modification.targetId, updates)
     }
     chatBindings.removeMessage(conversationId, placeholder.id)
   }
@@ -1827,13 +1830,13 @@ export class XMPPClient {
         return { kind: 'pending' }
       }
 
-      // Bodiless signal stanzas (XEP-0444 reactions) carry no <body> — the
-      // whole element rode inside the encrypted payload and now sits at the
-      // stanza root after decryptStanzaInPlace unwrapped it. These were stored
-      // under a "[could not decrypt]" placeholder while the key was locked;
-      // returning 'pending' here (the historical body-only behaviour) silently
-      // dropped them. Surface them as a modification so the caller applies the
-      // reaction to its target and removes the placeholder.
+      // Bodiless signal stanzas (XEP-0444 reactions, XEP-0424 retractions)
+      // carry no <body> — the whole element rode inside the encrypted payload
+      // and now sits at the stanza root after decryptStanzaInPlace unwrapped
+      // it. These were stored under a "[could not decrypt]" placeholder while
+      // the key was locked; returning 'pending' here (the historical body-only
+      // behaviour) silently dropped them. Surface them as a modification so the
+      // caller applies the signal to its target and removes the placeholder.
       const reactionsEl = stanza.getChild('reactions', NS_REACTIONS)
       if (reactionsEl?.attrs.id) {
         const emojis = reactionsEl
@@ -1844,6 +1847,10 @@ export class XMPPClient {
           kind: 'modification',
           modification: { type: 'reactions', targetId: reactionsEl.attrs.id, emojis },
         }
+      }
+      const retractEl = stanza.getChild('retract', NS_RETRACT)
+      if (retractEl?.attrs.id) {
+        return { kind: 'modification', modification: { type: 'retract', targetId: retractEl.attrs.id } }
       }
 
       // Extract the decrypted body

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -114,12 +114,12 @@ import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
 import { dataToElement } from './e2ee/stanzaAdapter'
 import { decryptStanzaInPlace } from './e2ee/stanzaDecrypt'
-import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH } from './namespaces'
+import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH, NS_REACTIONS } from './namespaces'
 import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './defaultStoreBindings'
 import { logDebug, logInfo, logWarn } from './logger'
 import { SDK_VERSION } from '../version'
 import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
-import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage } from '../utils/messageCache'
+import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, deleteMessage as cacheDeleteMessage } from '../utils/messageCache'
 import { bumpAvatarResumeCount } from '../utils/avatarCache'
 
 /**
@@ -188,13 +188,25 @@ import { bumpAvatarResumeCount } from '../utils/avatarCache'
  */
 
 /**
+ * A bodiless signal stanza recovered from a deferred decrypt. The whole
+ * element rode inside the encrypted payload (so the server never saw it), and
+ * it has no `<body>` — it targets ANOTHER message rather than carrying content.
+ * The placeholder "message" it was provisionally stored under must be replaced
+ * by applying the signal to its target.
+ */
+type RetryModification = { type: 'reactions'; targetId: string; emojis: string[] }
+
+/**
  * Result of a single deferred-decrypt attempt.
  * - `decrypted`: plaintext recovered — update body/security/attachment, clear `encryptedPayload`.
+ * - `modification`: decrypt surfaced a bodiless signal (XEP-0444 reaction) — apply it to its
+ *   target and remove the placeholder; there is no message body to update.
  * - `unsupported`: protocol we have no plugin for — clear `encryptedPayload`, tag `unsupportedEncryption`, keep body.
  * - `pending`: still cannot decrypt (key locked / plugin not ready) — leave `encryptedPayload`.
  */
 type RetryOutcome =
   | { kind: 'decrypted'; body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment }
+  | { kind: 'modification'; modification: RetryModification }
   | { kind: 'unsupported'; info: { namespace: string; name: string } }
   | { kind: 'pending' }
 
@@ -1649,6 +1661,9 @@ export class XMPPClient {
               encryptedPayload: undefined,
             })
             decryptedCount++
+          } else if (outcome.kind === 'modification') {
+            this.applyDeferredChatModification(conversationId, msg, outcome.modification, chatBindings)
+            decryptedCount++
           } else if (outcome.kind === 'unsupported') {
             chatBindings.updateMessage(conversationId, msg.id, {
               encryptedPayload: undefined,
@@ -1705,6 +1720,21 @@ export class XMPPClient {
             encryptedPayload: undefined,
           })
           decryptedCount++
+        } else if (outcome.kind === 'modification') {
+          // Conversation isn't loaded in memory. Apply best-effort to the
+          // in-memory target (no-op if absent) and drop the durable placeholder
+          // so it can't resurrect as a "[could not decrypt]" bubble. The
+          // store binding's removeMessage only touches in-memory state, so
+          // delete from the durable cache explicitly. For never-opened
+          // conversations the reaction is reconciled on the next MAM
+          // catch-up, when the now-unlocked key decrypts it inline.
+          if (outcome.modification.type === 'reactions') {
+            chatBindings.updateReactions(
+              conversationId, outcome.modification.targetId, getBareJid(msg.from), outcome.modification.emojis,
+            )
+          }
+          await cacheDeleteMessage(msg.id)
+          decryptedCount++
         } else if (outcome.kind === 'unsupported') {
           await cacheUpdateMessage(msg.id, {
             encryptedPayload: undefined,
@@ -1721,6 +1751,27 @@ export class XMPPClient {
     }
 
     return decryptedCount
+  }
+
+  /**
+   * Apply a bodiless signal (XEP-0444 reaction) recovered from a deferred
+   * decrypt to its target message, then remove the "[could not decrypt]"
+   * placeholder it was provisionally stored under. The reactor is the sender
+   * of the placeholder stanza — our own bare JID for a self-outgoing MAM
+   * replay, the peer's for an inbound one.
+   */
+  private applyDeferredChatModification(
+    conversationId: string,
+    placeholder: { id: string; from: string },
+    modification: RetryModification,
+    chatBindings: StoreBindings['chat'],
+  ): void {
+    if (modification.type === 'reactions') {
+      chatBindings.updateReactions(
+        conversationId, modification.targetId, getBareJid(placeholder.from), modification.emojis,
+      )
+    }
+    chatBindings.removeMessage(conversationId, placeholder.id)
   }
 
   /**
@@ -1774,6 +1825,25 @@ export class XMPPClient {
       if (!result.attempted || result.encryptedPayloadXml) {
         // Still can't decrypt
         return { kind: 'pending' }
+      }
+
+      // Bodiless signal stanzas (XEP-0444 reactions) carry no <body> — the
+      // whole element rode inside the encrypted payload and now sits at the
+      // stanza root after decryptStanzaInPlace unwrapped it. These were stored
+      // under a "[could not decrypt]" placeholder while the key was locked;
+      // returning 'pending' here (the historical body-only behaviour) silently
+      // dropped them. Surface them as a modification so the caller applies the
+      // reaction to its target and removes the placeholder.
+      const reactionsEl = stanza.getChild('reactions', NS_REACTIONS)
+      if (reactionsEl?.attrs.id) {
+        const emojis = reactionsEl
+          .getChildren('reaction')
+          .map((r) => r.getText())
+          .filter(Boolean)
+        return {
+          kind: 'modification',
+          modification: { type: 'reactions', targetId: reactionsEl.attrs.id, emojis },
+        }
       }
 
       // Extract the decrypted body

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -114,6 +114,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       setTyping: chatStore.getState().setTyping,
       updateReactions: chatStore.getState().updateReactions,
       updateMessage: chatStore.getState().updateMessage,
+      removeMessage: chatStore.getState().removeMessage,
       getMessage: chatStore.getState().getMessage,
       triggerAnimation: chatStore.getState().triggerAnimation,
       // XEP-0313: MAM support

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -646,6 +646,7 @@ export const createMockStores = (): MockStoreBindings => ({
     setTyping: vi.fn(),
     updateReactions: vi.fn(),
     updateMessage: vi.fn(),
+    removeMessage: vi.fn(),
     getMessage: vi.fn().mockReturnValue(undefined),
     triggerAnimation: vi.fn(),
     // XEP-0313: MAM support

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -83,6 +83,7 @@ export interface StoreBindings {
     setTyping: (conversationId: string, jid: string, isTyping: boolean) => void
     updateReactions: (conversationId: string, messageId: string, reactorJid: string, emojis: string[]) => void
     updateMessage: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+    removeMessage: (conversationId: string, messageId: string) => void
     getMessage: (conversationId: string, messageId: string) => Message | undefined
     triggerAnimation?: (conversationId: string, animation: string) => void
     // XEP-0313: MAM support

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -130,6 +130,14 @@ interface ChatState {
   clearAllTyping: () => void
   updateReactions: (conversationId: string, messageId: string, reactorJid: string, emojis: string[]) => void
   updateMessage: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+  /**
+   * Hard-remove a message from the conversation, the search index, and the
+   * durable cache. Used when a stanza that was provisionally stored as a
+   * message turns out not to be one — e.g. a deferred-decrypted bodiless
+   * signal (XEP-0444 reaction) whose "[could not decrypt]" placeholder must
+   * disappear once the real reaction is applied to its target.
+   */
+  removeMessage: (conversationId: string, messageId: string) => void
   getMessage: (conversationId: string, messageId: string) => Message | undefined
   triggerAnimation: (conversationId: string, animation: string) => void
   clearAnimation: () => void
@@ -1018,6 +1026,28 @@ export const chatStore = createStore<ChatState>()(
         const convMessages = get().messages.get(conversationId)
         if (!convMessages) return undefined
         return findMessageById(convMessages, messageId)
+      },
+
+      removeMessage: (conversationId, messageId) => {
+        set((state) => {
+          const convMessages = state.messages.get(conversationId)
+          if (!convMessages) return state
+
+          const messageIndex = findMessageIndexById(convMessages, messageId)
+          if (messageIndex === -1) return state
+
+          const removed = convMessages[messageIndex]
+          const updatedConvMessages = convMessages.filter((_, i) => i !== messageIndex)
+          const newMessages = new Map(state.messages)
+          newMessages.set(conversationId, updatedConvMessages)
+
+          // Mirror updateMessage: keep the search index and durable cache in
+          // sync, using the message's real id (not the lookup id).
+          void searchIndex.removeMessage(removed)
+          void messageCache.deleteMessage(removed.id)
+
+          return { messages: newMessages }
+        })
       },
 
       triggerAnimation: (conversationId, animation) => {


### PR DESCRIPTION
An encrypted XEP-0444 reaction (and XEP-0424 retraction) has no `<body>` — the whole signal element rides inside the OpenPGP payload. When such a stanza is replayed from MAM (or received live) while the E2EE key is still locked, decrypt is deferred: a `[could not decrypt]` placeholder body is injected so the bodiless stanza survives `parseArchiveMessage`, and the payload is stashed for retry.

On unlock, `retryPendingDecrypts` re-decrypted it successfully — but the retry path was **body-only**: a decrypted payload that surfaced `<reactions>`/`<retract>` (no `<body>`) was reported as `pending`, so the signal was never applied to its target and the placeholder lingered as a ghost. The reaction/retraction was silently lost (the user saw no reaction and re-did it by hand). It only happened when the key was locked at MAM/ingest time — if already unlocked, the immediate path applied it correctly.

**Fix:** `retryDecryptSingle` now detects a surfaced `<reactions>`/`<retract>` before the body guard and returns a `modification` outcome; `retryPendingDecrypts` applies it (reactions via `updateReactions`; retractions via `applyRetraction`, author-authorized to mirror the live path) and removes the placeholder. New `chatStore.removeMessage` + binding (no hard-delete existed before — retractions only tombstone). The durable-cache path applies best-effort and deletes the placeholder; never-opened conversations reconcile on the next MAM catch-up. Corrections are unaffected — they carry the new body and round-trip the existing body path.

Regression tests in `XMPPClient.e2ee.test.ts` ("deferred-decrypt of bodiless modifications") cover both reaction and retraction: locked-key deferred decrypt → unlock → signal applied to target, placeholder gone.