### PR TITLE
fix(e2ee): recover deferred-decrypted message corrections from MAM

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -567,4 +567,61 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(ghost).toBeUndefined()
     })
   })
+
+  describe('deferred-decrypt of an encrypted correction', () => {
+    // End-to-end counterpart to the MAM-side fix: a message corrected while
+    // the key was locked is stored with the sender's hint body, isEdited=true,
+    // and — crucially — the CORRECTION stanza's ciphertext as encryptedPayload
+    // (stamped by applyModifications / emitUnresolved*). retryPendingDecrypts
+    // must surface the corrected plaintext, not leave it frozen on the hint,
+    // while preserving the edit markers it must not own.
+    const CORRECTED_TEXT = 'corrected after unlock'
+    const CORRECTION_STANZA =
+      `<message from="bob@example.com/web" to="me@example.com" type="chat" id="corr-1">` +
+      `<replace xmlns="urn:xmpp:message-correct:0" id="orig-1"/>` +
+      `<body>[OpenPGP-encrypted message]</body>` +
+      `<plain xmlns="urn:fluux:e2ee-dummy:0">${Buffer.from(CORRECTED_TEXT).toString('base64')}</plain>` +
+      `<encryption xmlns="urn:xmpp:eme:0" namespace="urn:fluux:e2ee-dummy:0"/>` +
+      `</message>`
+
+    it('recovers the corrected text and keeps the edit markers', async () => {
+      // Decrypt now succeeds with a verified signature (key unlocked / peer
+      // key cached), so the retry is not deferred again for re-verification.
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode(CORRECTED_TEXT),
+        senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      // The target message as it sits after a deferred correction was applied:
+      // edited, hint body, carrying the correction's ciphertext for retry.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'orig-1',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[OpenPGP-encrypted message]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        isEdited: true,
+        originalBody: 'the original text',
+        encryptedPayload: CORRECTION_STANZA,
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const msg = (chatStore.getState().messages.get('bob@example.com') ?? []).find((m) => m.id === 'orig-1')
+      expect(msg?.body).toBe(CORRECTED_TEXT)
+      // The retry owns the body, not the edit state: those must survive.
+      expect(msg?.isEdited).toBe(true)
+      expect(msg?.originalBody).toBe('the original text')
+      expect(msg?.encryptedPayload).toBeUndefined()
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -79,6 +79,9 @@ interface TestHarness {
    *  feed archive entries through the collector before the query returns. */
   resolveNextIQ: (fin: Element) => void
   iqPending: () => Promise<void>
+  /** Every emitSDK(event, payload) call, in order — lets tests assert on
+   *  modifications emitted against messages not present in the queried page. */
+  emitted: { event: string; payload: Record<string, unknown> }[]
 }
 
 function makeHarness(options: {
@@ -86,6 +89,7 @@ function makeHarness(options: {
   manager: E2EEManager
 }): TestHarness {
   const collectors = new Map<string, (stanza: Element) => void>()
+  const emitted: { event: string; payload: Record<string, unknown> }[] = []
   let pendingResolve: ((value: Element) => void) | null = null
   let pendingReady: (() => void) | null = null
   const readyPromise = new Promise<void>((r) => {
@@ -102,7 +106,9 @@ function makeHarness(options: {
       }),
     getCurrentJid: () => options.jid,
     emit: () => {},
-    emitSDK: () => {},
+    emitSDK: ((event: string, payload: Record<string, unknown>) => {
+      emitted.push({ event, payload })
+    }) as ModuleDependencies['emitSDK'],
     getXmpp: () => null,
     getE2EEManager: () => options.manager,
     registerMAMCollector: (queryId, collector) => {
@@ -115,6 +121,7 @@ function makeHarness(options: {
   return {
     mam,
     collectors,
+    emitted,
     iqPending: () => readyPromise,
     resolveNextIQ: (fin: Element) => {
       if (!pendingResolve) throw new Error('No pending sendIQ')
@@ -131,6 +138,7 @@ function makeHarness(options: {
  */
 function makeHarnessNoManager(jid: string): TestHarness {
   const collectors = new Map<string, (stanza: Element) => void>()
+  const emitted: { event: string; payload: Record<string, unknown> }[] = []
   let pendingResolve: ((value: Element) => void) | null = null
   let pendingReady: (() => void) | null = null
   const readyPromise = new Promise<void>((r) => {
@@ -147,7 +155,9 @@ function makeHarnessNoManager(jid: string): TestHarness {
       }),
     getCurrentJid: () => jid,
     emit: () => {},
-    emitSDK: () => {},
+    emitSDK: ((event: string, payload: Record<string, unknown>) => {
+      emitted.push({ event, payload })
+    }) as ModuleDependencies['emitSDK'],
     getXmpp: () => null,
     getE2EEManager: () => null,
     registerMAMCollector: (queryId, collector) => {
@@ -160,6 +170,7 @@ function makeHarnessNoManager(jid: string): TestHarness {
   return {
     mam,
     collectors,
+    emitted,
     iqPending: () => readyPromise,
     resolveNextIQ: (fin: Element) => {
       if (!pendingResolve) throw new Error('No pending sendIQ')
@@ -493,6 +504,150 @@ describe('MAM E2EE wiring', () => {
       expect(msg.body).toBe('just a plain message')
       expect(msg.encryptedPayload).toBeUndefined()
       expect(msg.unsupportedEncryption).toBeUndefined()
+    })
+  })
+
+  describe('deferred-decrypt of encrypted corrections (XEP-0308)', () => {
+    // Regression guard for the production bug (lost encrypted correction):
+    //
+    // A correction whose <replace> rides in CLEARTEXT but whose new body is
+    // encrypted arrives via MAM before the OpenPGP plugin is registered (or
+    // while the key is locked). decrypt is deferred, so collectModification
+    // captures the sender's hint body and applyModifications stamps it onto
+    // the target. Historically the correction stanza's stashed ciphertext was
+    // dropped, so retryPendingDecrypts — which only re-decrypts a stored
+    // message's OWN encryptedPayload — had nothing to recover: the corrected
+    // bubble stayed frozen on "[OpenPGP-encrypted message]" forever.
+    //
+    // The fix: the applied correction must carry the CORRECTION stanza's
+    // encryptedPayload onto the target (overwriting the original's), so the
+    // deferred retry decrypts the corrected text — not the stale original.
+    it("propagates the correction's encrypted payload onto the target so retry recovers the corrected text", async () => {
+      // Decrypt is unavailable at archive time (key locked / plugin late).
+      vi.spyOn(manager, 'decryptArchive').mockRejectedValue(new Error('key locked'))
+
+      const ORIGINAL_CT = Buffer.from('the original secret').toString('base64')
+      const CORRECTED_CT = Buffer.from('the corrected secret').toString('base64')
+
+      // Original encrypted message, archived first.
+      const original = xml(
+        'message',
+        { from: PEER + '/res', to: ME, type: 'chat', id: 'orig-1' },
+        xml('origin-id', { xmlns: 'urn:xmpp:sid:0', id: 'orig-1' }),
+        xml('body', {}, '[OpenPGP-encrypted message]'),
+        xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, ORIGINAL_CT),
+      )
+      // XEP-0308 correction of orig-1 — cleartext <replace>, encrypted body.
+      const correction = xml(
+        'message',
+        { from: PEER + '/res', to: ME, type: 'chat', id: 'corr-1' },
+        xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: 'orig-1' }),
+        xml('origin-id', { xmlns: 'urn:xmpp:sid:0', id: 'corr-1' }),
+        xml('body', {}, '[OpenPGP-encrypted message]'),
+        xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, CORRECTED_CT),
+      )
+
+      const resultPromise = harness.mam.queryArchive({ with: PEER, max: 10 })
+      await harness.iqPending()
+      const [queryId, collector] = [...harness.collectors.entries()][0]
+      for (const [archiveId, forwardedMessage] of [
+        ['arch-orig', original],
+        ['arch-corr', correction],
+      ] as const) {
+        const entry = buildMAMResult({ archiveId, forwardedMessage })
+        entry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+        collector(entry)
+      }
+      harness.resolveNextIQ(
+        xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+      )
+      const result = await resultPromise
+
+      // The correction is consumed (not its own message); only the target remains.
+      expect(result.messages).toHaveLength(1)
+      const target = result.messages[0]
+      expect(target.id).toBe('orig-1')
+      // Correction was applied: hint body + edited marker.
+      expect(target.isEdited).toBe(true)
+      expect(target.body).toBe('[OpenPGP-encrypted message]')
+      // The retained ciphertext must be the CORRECTION's, so the deferred
+      // retry decrypts the corrected text — never the stale original.
+      expect(target.encryptedPayload).toBeDefined()
+      expect(target.encryptedPayload).toContain(CORRECTED_CT)
+      expect(target.encryptedPayload).not.toContain(ORIGINAL_CT)
+    })
+
+    it('carries the correction payload on the emitted 1:1 update when the target is not in the page', async () => {
+      // The exact production scenario: the corrected message was synced in an
+      // earlier page (or lives only in the durable cache), so the correction
+      // resolves to nothing in this batch and rides out on the
+      // emitUnresolvedChatModifications update instead of applyModifications.
+      vi.spyOn(manager, 'decryptArchive').mockRejectedValue(new Error('key locked'))
+      const ORPHAN_CT = Buffer.from('the corrected secret').toString('base64')
+
+      const correction = xml(
+        'message',
+        { from: PEER + '/res', to: ME, type: 'chat', id: 'orphan-corr-1' },
+        xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: 'cached-orig-1' }),
+        xml('body', {}, '[OpenPGP-encrypted message]'),
+        xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, ORPHAN_CT),
+      )
+
+      const resultPromise = harness.mam.queryArchive({ with: PEER, max: 10 })
+      await harness.iqPending()
+      const [queryId, collector] = [...harness.collectors.entries()][0]
+      const entry = buildMAMResult({ archiveId: 'arch-orphan', forwardedMessage: correction })
+      entry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+      collector(entry)
+      harness.resolveNextIQ(
+        xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+      )
+      await resultPromise
+
+      const update = harness.emitted.find(
+        (e) => e.event === 'chat:message-updated' && e.payload.messageId === 'cached-orig-1',
+      )
+      expect(update).toBeDefined()
+      const updates = update!.payload.updates as Record<string, unknown>
+      expect(updates.isEdited).toBe(true)
+      expect(updates.encryptedPayload).toContain(ORPHAN_CT)
+    })
+
+    it('carries the correction payload on the emitted MUC update when the target is not in the page', async () => {
+      // Room counterpart, unresolved path: the correction's target was synced
+      // in an earlier page, so applyModifications can't find it and the fix
+      // must ride out on the emitUnresolvedRoomModifications update instead.
+      vi.spyOn(manager, 'decryptArchive').mockRejectedValue(new Error('key locked'))
+      const ROOM = 'room@conference.example.com'
+      const ROOM_CT = Buffer.from('room corrected secret').toString('base64')
+
+      const correction = xml(
+        'message',
+        { from: ROOM + '/Bob', type: 'groupchat', id: 'rcorr-1' },
+        xml('replace', { xmlns: 'urn:xmpp:message-correct:0', id: 'room-orig-1' }),
+        xml('occupant-id', { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' }),
+        xml('body', {}, '[OpenPGP-encrypted message]'),
+        xml('plain', { xmlns: 'urn:fluux:e2ee-dummy:0' }, ROOM_CT),
+      )
+
+      const resultPromise = harness.mam.queryRoomArchive({ roomJid: ROOM, max: 10 })
+      await harness.iqPending()
+      const [queryId, collector] = [...harness.collectors.entries()][0]
+      const entry = buildMAMResult({ archiveId: 'rarch-corr', forwardedMessage: correction })
+      entry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+      collector(entry)
+      harness.resolveNextIQ(
+        xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+      )
+      await resultPromise
+
+      const update = harness.emitted.find(
+        (e) => e.event === 'room:message-updated' && e.payload.messageId === 'room-orig-1',
+      )
+      expect(update).toBeDefined()
+      const updates = update!.payload.updates as Record<string, unknown>
+      expect(updates.isEdited).toBe(true)
+      expect(updates.encryptedPayload).toContain(ROOM_CT)
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1458,6 +1458,10 @@ export class MAM extends BaseModule {
         if (correctionData.attachment) {
           target.attachment = correctionData.attachment
         }
+        // Carry the correction's ciphertext onto the target (or clear a stale
+        // original one) so a deferred retry recovers the corrected text, not
+        // the original. See CorrectionResult.encryptedPayload.
+        target.encryptedPayload = correctionData.encryptedPayload
         // Track the correction's stanza-id so replies referencing it can resolve
         if (correction.correctionStanzaId) {
           target.correctionStanzaIds = [...(target.correctionStanzaIds ?? []), correction.correctionStanzaId]
@@ -1558,6 +1562,9 @@ export class MAM extends BaseModule {
           originalBody: correctionData.originalBody,
           ...(correctionData.attachment ? { attachment: correctionData.attachment } : {}),
           ...(correctionStanzaIds ? { correctionStanzaIds } : {}),
+          // Stamp/clear the correction's ciphertext so a deferred retry
+          // recovers the corrected text, not the stale original.
+          encryptedPayload: correctionData.encryptedPayload,
         },
       })
     }
@@ -1619,6 +1626,9 @@ export class MAM extends BaseModule {
           originalBody: correctionData.originalBody,
           ...(correctionData.attachment ? { attachment: correctionData.attachment } : {}),
           ...(correctionStanzaIds ? { correctionStanzaIds } : {}),
+          // Stamp/clear the correction's ciphertext so a deferred retry
+          // recovers the corrected text, not the stale original.
+          encryptedPayload: correctionData.encryptedPayload,
         },
       })
     }

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.ts
@@ -11,6 +11,7 @@
 
 import { Element, xml } from '@xmpp/client'
 import { getBareJid } from '../jid'
+import { readStashedEncryptedPayload } from '../e2ee/stanzaDecrypt'
 import {
   NS_DELAY,
   NS_REPLY,
@@ -426,6 +427,17 @@ export interface CorrectionResult {
   attachment?: FileAttachment
   /** Accumulated stanza-IDs from correction stanzas (for reply lookup) */
   correctionStanzaIds?: string[]
+  /**
+   * Serialized encrypted payload of the CORRECTION stanza when its new body
+   * could not be decrypted at apply time (plugin not yet registered / key
+   * locked). Callers must stamp this onto the target message — overwriting any
+   * payload left by the original — so {@link XMPPClient.retryPendingDecrypts}
+   * recovers the corrected text, not the stale original. `undefined` when the
+   * correction was decrypted inline (or is cleartext): callers should then
+   * clear the target's `encryptedPayload`, so a previously-stashed original
+   * isn't re-decrypted on top of the applied correction.
+   */
+  encryptedPayload?: string
 }
 
 /**
@@ -448,5 +460,9 @@ export function applyCorrection(
     isEdited: true,
     originalBody,
     ...(parsed.attachment && { attachment: parsed.attachment }),
+    // Always present (string when the correction is still encrypted, undefined
+    // otherwise) so callers can unconditionally stamp/clear the target's
+    // encryptedPayload — see CorrectionResult.encryptedPayload.
+    encryptedPayload: readStashedEncryptedPayload(messageEl),
   }
 }


### PR DESCRIPTION
## Summary

When a XEP-0308 correction of an **encrypted** message is resynced from MAM **before** the OpenPGP plugin is registered (or while the key is locked), the corrected bubble stayed frozen on the sender's `[OpenPGP-encrypted message]` hint forever — even after the key became available. Reported from a real resync where the originating device differed from the resyncing one.

## Fix

`applyCorrection` now reads the correction stanza's stashed payload and returns it in `CorrectionResult.encryptedPayload`. All apply sites stamp it onto the target message:

- `applyModifications` (resolved MAM, generic 1:1 + MUC)
- `emitUnresolvedChatModifications` / `emitUnresolvedRoomModifications` (target synced in an earlier page → rides out on the `*:message-updated` event)
- live `handleIncomingCorrection` (already spreads `correctionData`)

It is always set — a string while the correction is still encrypted, `undefined` to **clear** a stale original payload so retry doesn't re-decrypt the original on top of the applied correction. The existing `retryPendingDecrypts` then recovers the corrected text on the next pass and re-runs `parseMessageContent`, while `isEdited` / `originalBody` survive.