### PR TITLE
fix(e2ee): drop rejected-signature bodiless signals instead of showing a ghost message

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -48,6 +48,7 @@ import { XMPPClient } from './XMPPClient'
 import { chatStore } from '../stores/chatStore'
 import {
   E2EEManager,
+  E2EEPluginError,
   InMemoryStorageBackend,
   type XMPPPrimitives,
 } from './e2ee'
@@ -565,6 +566,73 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // The placeholder must not linger.
       const ghost = messages.find((m) => m.id === 'retract-ghost')
       expect(ghost).toBeUndefined()
+    })
+
+    it('drops the placeholder for a deferred reaction whose signature is rejected on retry', async () => {
+      // A bodiless reaction stashed while the key was locked. On unlock the
+      // signature turns out to be invalid (forged) — we must not surface a
+      // ghost "[Message rejected]" bubble for a reaction the user can't see.
+      vi.spyOn(manager, 'decryptArchive').mockRejectedValue(
+        new E2EEPluginError('permanent', 'signature-failed', 'forged signature'),
+      )
+
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'reaction-ghost',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      const ghost = messages.find((m) => m.id === 'reaction-ghost')
+      expect(ghost).toBeUndefined()
+    })
+
+    it('marks a deferred *message* whose signature is rejected on retry as [Message rejected]', async () => {
+      // Regression guard: a real message placeholder (fallback body, not the
+      // "could not decrypt" marker) must still warn the user, not vanish.
+      vi.spyOn(manager, 'decryptArchive').mockRejectedValue(
+        new E2EEPluginError('permanent', 'signature-failed', 'forged signature'),
+      )
+
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'msg-pending',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[encrypted message]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      const msg = messages.find((m) => m.id === 'msg-pending')
+      expect(msg).toBeDefined()
+      expect(msg?.body).toBe('[Message rejected: invalid signature]')
+      expect(msg?.encryptedPayload).toBeUndefined()
     })
   })
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -113,7 +113,7 @@ import { MAM } from './modules/MAM'
 import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
 import { dataToElement } from './e2ee/stanzaAdapter'
-import { decryptStanzaInPlace } from './e2ee/stanzaDecrypt'
+import { decryptStanzaInPlace, COULD_NOT_DECRYPT_BODY, MESSAGE_REJECTED_BODY } from './e2ee/stanzaDecrypt'
 import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH, NS_REACTIONS, NS_RETRACT } from './namespaces'
 import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './defaultStoreBindings'
 import { logDebug, logInfo, logWarn } from './logger'
@@ -204,12 +204,16 @@ type RetryModification =
  * - `modification`: decrypt surfaced a bodiless signal (XEP-0444 reaction or XEP-0424 retraction) —
  *   apply it to its target and remove the placeholder; there is no message body to update.
  * - `unsupported`: protocol we have no plugin for — clear `encryptedPayload`, tag `unsupportedEncryption`, keep body.
+ * - `rejected`: signature is invalid (final, never retryable) — a real message placeholder is
+ *   replaced with a "[Message rejected]" body; a bodiless-signal placeholder (forged reaction/
+ *   retraction) is removed entirely so it never surfaces as a ghost bubble.
  * - `pending`: still cannot decrypt (key locked / plugin not ready) — leave `encryptedPayload`.
  */
 type RetryOutcome =
   | { kind: 'decrypted'; body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment }
   | { kind: 'modification'; modification: RetryModification }
   | { kind: 'unsupported'; info: { namespace: string; name: string } }
+  | { kind: 'rejected'; securityContext?: MessageSecurityContext }
   | { kind: 'pending' }
 
 export class XMPPClient {
@@ -1666,6 +1670,8 @@ export class XMPPClient {
           } else if (outcome.kind === 'modification') {
             this.applyDeferredChatModification(conversationId, msg, outcome.modification, chatBindings)
             decryptedCount++
+          } else if (outcome.kind === 'rejected') {
+            this.resolveRejectedChatPlaceholder(conversationId, msg, outcome.securityContext, chatBindings)
           } else if (outcome.kind === 'unsupported') {
             chatBindings.updateMessage(conversationId, msg.id, {
               encryptedPayload: undefined,
@@ -1691,6 +1697,14 @@ export class XMPPClient {
               encryptedPayload: undefined,
             })
             decryptedCount++
+          } else if (outcome.kind === 'rejected') {
+            // MUC carries no encrypted bodiless signals, so a rejected room
+            // message always has real content — warn the user and clear the stash.
+            roomBindings.updateMessage(roomJid, msg.id, {
+              body: MESSAGE_REJECTED_BODY,
+              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+              encryptedPayload: undefined,
+            })
           } else if (outcome.kind === 'unsupported') {
             roomBindings.updateMessage(roomJid, msg.id, {
               encryptedPayload: undefined,
@@ -1733,6 +1747,17 @@ export class XMPPClient {
           this.applyDeferredChatModification(conversationId, msg, outcome.modification, chatBindings)
           await cacheDeleteMessage(msg.id)
           decryptedCount++
+        } else if (outcome.kind === 'rejected') {
+          if (msg.body === COULD_NOT_DECRYPT_BODY) {
+            // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
+            await cacheDeleteMessage(msg.id)
+          } else {
+            await cacheUpdateMessage(msg.id, {
+              body: MESSAGE_REJECTED_BODY,
+              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+              encryptedPayload: undefined,
+            })
+          }
         } else if (outcome.kind === 'unsupported') {
           await cacheUpdateMessage(msg.id, {
             encryptedPayload: undefined,
@@ -1774,6 +1799,32 @@ export class XMPPClient {
       if (updates) chatBindings.updateMessage(conversationId, modification.targetId, updates)
     }
     chatBindings.removeMessage(conversationId, placeholder.id)
+  }
+
+  /**
+   * Resolve a chat placeholder whose deferred decrypt was finally rejected
+   * (invalid signature — final, never retried again). A bodiless-signal
+   * placeholder still carries the {@link COULD_NOT_DECRYPT_BODY} marker that
+   * stanzaDecrypt stamps onto reactions/retractions; it is removed entirely so
+   * a forged signal never surfaces as a ghost bubble. A real message
+   * placeholder (any other body) is replaced with a "[Message rejected]" body
+   * so the user is warned the message could not be trusted.
+   */
+  private resolveRejectedChatPlaceholder(
+    conversationId: string,
+    placeholder: { id: string; body: string },
+    securityContext: MessageSecurityContext | undefined,
+    chatBindings: StoreBindings['chat'],
+  ): void {
+    if (placeholder.body === COULD_NOT_DECRYPT_BODY) {
+      chatBindings.removeMessage(conversationId, placeholder.id)
+    } else {
+      chatBindings.updateMessage(conversationId, placeholder.id, {
+        body: MESSAGE_REJECTED_BODY,
+        ...(securityContext && { securityContext }),
+        encryptedPayload: undefined,
+      })
+    }
   }
 
   /**
@@ -1829,6 +1880,21 @@ export class XMPPClient {
         return { kind: 'pending' }
       }
 
+      // A rejected signature is final — never retryable. decryptStanzaInPlace
+      // threw before unwrapping the payload, so no <reactions>/<retract>/<body>
+      // was surfaced; the caller decides whether to show a "[Message rejected]"
+      // bubble (real message placeholder) or drop it (bodiless-signal placeholder).
+      if (result.securityContext?.trust === 'rejected') {
+        return {
+          kind: 'rejected',
+          securityContext: {
+            protocolId: result.securityContext.protocolId,
+            trust: result.securityContext.trust,
+            ...(result.securityContext.notes && { notes: result.securityContext.notes }),
+          },
+        }
+      }
+
       // Bodiless signal stanzas (XEP-0444 reactions, XEP-0424 retractions)
       // carry no <body> — the whole element rode inside the encrypted payload
       // and now sits at the stanza root after decryptStanzaInPlace unwrapped
@@ -1880,14 +1946,6 @@ export class XMPPClient {
           protocolId: result.securityContext.protocolId,
           trust: result.securityContext.trust,
           ...(result.securityContext.notes && { notes: result.securityContext.notes }),
-        }
-      }
-
-      if (securityContext?.trust === 'rejected') {
-        return {
-          kind: 'decrypted',
-          body: '[Message rejected: invalid signature]',
-          securityContext,
         }
       }
 

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
@@ -36,6 +36,18 @@ import {
   NS_EASTER_EGG,
 } from '../namespaces'
 
+/**
+ * Client-side placeholder body stamped onto a stanza whose decrypt was
+ * deferred (key locked / plugin not ready). It doubles as the carrier that
+ * keeps the stanza persisted so {@link retryPendingDecrypts} can re-attempt
+ * later — `retryPendingDecrypts` matches on this exact string to tell a
+ * deferred bodiless-signal placeholder apart from a real message.
+ */
+export const COULD_NOT_DECRYPT_BODY = '[Encrypted message: could not decrypt]'
+
+/** Client-side placeholder body for a message whose signature was rejected. */
+export const MESSAGE_REJECTED_BODY = '[Message rejected: invalid signature]'
+
 // Elements permitted inside a decrypted payload envelope. Anything not
 // in this set is dropped to prevent a malicious sender from injecting
 // stanza children (e.g. <delay/>, <origin-id/>) that downstream parsers
@@ -235,30 +247,40 @@ export async function decryptStanzaInPlace(
 
   if (failureReason !== null) {
     const isRejection = securityContext?.trust === 'rejected'
+    const existingBody = stanza.getChild('body')
+    const isBodilessSignal = isRejection && !existingBody
     manager
       .getDiagnosticLogger()
       .warn(
-        `decrypt failed from ${getDomain(senderPeer)} (${isRejection ? 'rejected: invalid signature' : 'retryable'}): ${failureReason}`,
+        `decrypt failed from ${getDomain(senderPeer)} (${
+          isBodilessSignal
+            ? 'rejected: invalid signature — bodiless signal dropped'
+            : isRejection
+              ? 'rejected: invalid signature'
+              : 'retryable'
+        }): ${failureReason}`,
       )
     if (isRejection) {
-      // Signature rejection: suppress any sender-supplied body hint and
-      // replace with a client-side placeholder. Do NOT stash for deferred
-      // retry — the rejection is final.
-      const existingBody = stanza.getChild('body')
+      // Signature rejection: the rejection is final, so do NOT stash for
+      // deferred retry.
       if (existingBody) {
-        existingBody.children = ['[Message rejected: invalid signature]']
-      } else {
-        stanza.children.push(
-          xml('body', {}, '[Message rejected: invalid signature]'),
-        )
+        // A real message carries a fallback <body> — replace it with a
+        // client-side placeholder so the user is warned the message could
+        // not be trusted.
+        existingBody.children = [MESSAGE_REJECTED_BODY]
       }
+      // Otherwise this is a bodiless signal stanza (XEP-0444 reaction,
+      // XEP-0424 retraction, fastening): there is no content to show and a
+      // forged signature can't be trusted, so drop it entirely. Synthesizing
+      // a placeholder body would surface a forged reaction as a ghost text
+      // message. The warn above records the drop in the E2EE events log.
     } else {
       // Decrypt failure (key locked, plugin missing, etc.): stash for
       // deferred retry and keep the sender's fallback body hint.
       stashPayload(stanza, originalStanzaXml)
       if (!stanza.getChild('body')) {
         stanza.children.push(
-          xml('body', {}, '[Encrypted message: could not decrypt]'),
+          xml('body', {}, COULD_NOT_DECRYPT_BODY),
         )
       }
       securityContext = {

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -94,6 +94,20 @@ class FakeOpenPGPPlugin implements E2EEPlugin {
   async getDeviceTrust(_peer: BareJID, _deviceId: string): Promise<TrustState> { return 'verified' }
 }
 
+/**
+ * Dummy plugin variant whose decrypt always rejects the signature. Used to
+ * exercise the rejected-signature inbound path: decryptStanzaInPlace maps a
+ * thrown `signature-failed` error to `trust: 'rejected'`.
+ */
+class RejectingDummyPlugin extends DummyPlaintextPlugin {
+  override async decrypt(
+    _handle: ConversationHandle,
+    _payload: EncryptedPayload,
+  ): Promise<DecryptResult> {
+    throw new E2EEPluginError('permanent', 'signature-failed', 'forged signature')
+  }
+}
+
 function stubXmppPrimitives(sendStanza: (el: Element) => Promise<void>): XMPPPrimitives {
   return {
     sendStanza: async (data) => {
@@ -1584,6 +1598,63 @@ describe('Chat E2EE wiring', () => {
       expect(sent.getChildren('fallback', 'urn:xmpp:fallback:0')).toHaveLength(0)
       // Bodiless reaction still gets a store hint for MAM archival.
       expect(sent.getChild('store', 'urn:xmpp:hints')).toBeDefined()
+    })
+  })
+
+  describe('inbound encrypted reaction — rejected signature', () => {
+    /** Replay an outgoing encrypted stanza as if it arrived from Bob. */
+    function asInbound(outgoing: Element, id: string): Element {
+      return xml(
+        'message',
+        { from: 'bob@example.com/r', to: 'me@example.com', type: 'chat', id },
+        ...outgoing.children.filter((c) => typeof c === 'string' || c.name !== 'active'),
+      )
+    }
+
+    async function rejectingChat(): Promise<{ chat: Chat; sdkEmitted: unknown[] }> {
+      const rejectingManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      await rejectingManager.register(new RejectingDummyPlugin())
+      const built = makeDeps({
+        jid: 'me@example.com',
+        manager: rejectingManager,
+        captureStanza: () => {},
+      })
+      return { chat: new Chat(built.deps, stubMAM()), sdkEmitted: built.sdkEmitted }
+    }
+
+    it('drops a forged (rejected-signature) bodiless reaction instead of showing a ghost message', async () => {
+      // Build the on-wire encrypted reaction with the working dummy plugin.
+      await chat.sendReaction('bob@example.com', 'orig-id', ['👍'])
+      const inbound = asInbound(captured[0], 'm-react-rejected')
+
+      const { chat: rxChat, sdkEmitted: rxEmitted } = await rejectingChat()
+      rxChat.handle(inbound)
+      await new Promise((r) => setTimeout(r, 0))
+
+      // A forged reaction must NOT be applied and must NOT surface as a bubble.
+      expect(rxEmitted.find((e) => (e as { event: string }).event === 'chat:reactions')).toBeUndefined()
+      expect(rxEmitted.find((e) => (e as { event: string }).event === 'chat:message')).toBeUndefined()
+    })
+
+    it('still surfaces a rejected-signature *message* (which has a body) as [Message rejected]', async () => {
+      // Regression guard: a real message carries a fallback <body>, so a rejected
+      // signature must still warn the user — only bodiless signals are dropped.
+      await chat.sendMessage('bob@example.com', 'hello bob')
+      const inbound = asInbound(captured[0], 'm-msg-rejected')
+
+      const { chat: rxChat, sdkEmitted: rxEmitted } = await rejectingChat()
+      rxChat.handle(inbound)
+      await new Promise((r) => setTimeout(r, 0))
+
+      const msgEvt = rxEmitted.find((e) => (e as { event: string }).event === 'chat:message') as
+        | { payload: { message: { body: string } } }
+        | undefined
+      expect(msgEvt).toBeDefined()
+      expect(msgEvt!.payload.message.body).toBe('[Message rejected: invalid signature]')
     })
   })
 


### PR DESCRIPTION
## Summary

A 1:1 encrypted XEP-0444 reaction (and XEP-0424 retraction / fastening) has no `<body>` — the whole signal rides inside the encrypted payload. When such a stanza failed decryption with a **rejected** signature (a genuinely invalid/forged signature, distinct from the clock-skew case [#485](https://github.com/processone/fluux-messenger/pull/485) made retryable), `decryptStanzaInPlace` synthesized a `[Message rejected: invalid signature]` placeholder body. Because the stanza is bodiless and no `<reactions>` element survives, that placeholder made it indistinguishable from a real message — so a forged reaction surfaced as a **ghost text bubble** in the conversation.

This is the inverse residual of [#488](https://github.com/processone/fluux-messenger/pull/488): #488 fixed the *recoverable* case (a deferred reaction is applied and its placeholder removed on unlock); the *rejected* case still produced a permanent ghost because a rejection is never stashed nor retried.

A forged reaction should be dropped (you can't trust it and there's nothing to show), not displayed as a fake message.