### PR TITLE
fix(e2ee): prevent encrypted-message leak via plaintext reply fallback

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1013,11 +1013,15 @@ export const MessageInput = memo(function MessageInput({
 
   // Show a banner notice when the reply will be sent in cleartext but the
   // quoted message arrived encrypted — the SDK strips the quote in that case.
-  // `keyLocked` is excluded: the send is blocked until unlock, then encrypts.
+  // Excluded kinds are those where the reply will NOT go out as cleartext:
+  // `encrypted` encrypts; `keyLocked` blocks until unlock then encrypts;
+  // `blocked` throws on encrypt (never sent); `checking` is an in-flight probe.
   const replyQuoteHidden =
     !!replyingTo &&
     encryptionState.kind !== 'encrypted' &&
     encryptionState.kind !== 'keyLocked' &&
+    encryptionState.kind !== 'blocked' &&
+    encryptionState.kind !== 'checking' &&
     isEncryptedSource(replyingTo)
 
   // Convert Message to EditInfo for the composer

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -965,7 +965,7 @@ export const MessageInput = memo(function MessageInput({
   onCancelReply: () => void
   editingMessage: Message | null
   onCancelEdit: () => void
-  sendMessage: (to: string, body: string, type?: 'chat' | 'groupchat', replyTo?: { id: string; to?: string; fallback?: { author: string; body: string } }, attachment?: import('@fluux/sdk').FileAttachment) => Promise<string>
+  sendMessage: (to: string, body: string, type?: 'chat' | 'groupchat', replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } }, attachment?: import('@fluux/sdk').FileAttachment) => Promise<string>
   sendCorrection: (conversationId: string, messageId: string, newBody: string, attachment?: import('@fluux/sdk').FileAttachment) => Promise<void>
   retractMessage: (conversationId: string, messageId: string) => Promise<void>
   sendChatState: (to: string, state: import('@fluux/sdk').ChatStateNotification, type?: 'chat' | 'groupchat') => Promise<void>

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -20,6 +20,7 @@ import { ChristmasAnimation } from './ChristmasAnimation'
 import { ChatHeader } from './ChatHeader'
 import { MessageComposer, type ReplyInfo, type EditInfo, type MessageComposerHandle, type PendingAttachment } from './MessageComposer'
 import { findLastEditableMessage, findLastEditableMessageId } from '@/utils/messageUtils'
+import { isEncryptedSource } from '@/utils/replyEncryption'
 import { useExpandedMessagesStore } from '@/stores/expandedMessagesStore'
 import { ConfirmDialog } from './ConfirmDialog'
 
@@ -1051,13 +1052,13 @@ export const MessageInput = memo(function MessageInput({
 
     // Include reply info if replying to a message (with XEP-0428 fallback for compatibility)
     // SDK resolves stanzaId vs id for the protocol reference (XEP-0461)
-    let replyTo: { id: string; to: string; fallback?: { author: string; body: string } } | undefined
+    let replyTo: { id: string; to: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } } | undefined
     if (replyingTo) {
       const authorName = contactsByJid.get(replyingTo.from.split('/')[0])?.name || replyingTo.from.split('@')[0]
       replyTo = {
         id: replyingTo.id,
         to: replyingTo.from,
-        fallback: { author: authorName, body: replyingTo.body }
+        fallback: { author: authorName, body: replyingTo.body, fromEncrypted: isEncryptedSource(replyingTo) }
       }
     }
 

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1011,6 +1011,15 @@ export const MessageInput = memo(function MessageInput({
       }
     : null
 
+  // Show a banner notice when the reply will be sent in cleartext but the
+  // quoted message arrived encrypted — the SDK strips the quote in that case.
+  // `keyLocked` is excluded: the send is blocked until unlock, then encrypts.
+  const replyQuoteHidden =
+    !!replyingTo &&
+    encryptionState.kind !== 'encrypted' &&
+    encryptionState.kind !== 'keyLocked' &&
+    isEncryptedSource(replyingTo)
+
   // Convert Message to EditInfo for the composer
   const editInfo: EditInfo | null = editingMessage
     ? {
@@ -1119,6 +1128,7 @@ export const MessageInput = memo(function MessageInput({
         placeholder={t('chat.messageTo', { name: conversationName })}
         replyingTo={replyInfo}
         onCancelReply={onCancelReply}
+        replyQuoteHidden={replyQuoteHidden}
         editingMessage={editInfo}
         onCancelEdit={onCancelEdit}
         onSendCorrection={handleCorrection}

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -83,6 +83,8 @@ interface MessageComposerProps {
   replyingTo?: ReplyInfo | null
   /** Callback when reply is cancelled */
   onCancelReply?: () => void
+  /** When true, the reply quote is hidden because the source message was encrypted and this reply is plaintext */
+  replyQuoteHidden?: boolean
   /** Edit info if editing a message */
   editingMessage?: EditInfo | null
   /** Callback when edit is cancelled */
@@ -160,6 +162,7 @@ export function MessageComposer({
   placeholder,
   replyingTo,
   onCancelReply,
+  replyQuoteHidden,
   editingMessage,
   onCancelEdit,
   onSendCorrection,
@@ -681,9 +684,16 @@ export function MessageComposer({
             <p className="text-xs font-medium text-fluux-brand">
               Replying to {replyingTo.senderName}
             </p>
-            <p className="text-xs text-fluux-muted truncate">
-              {replyingTo.body}
-            </p>
+            {replyQuoteHidden ? (
+              <p className="text-xs text-fluux-muted italic truncate flex items-center gap-1">
+                <Lock className="size-3 flex-shrink-0" />
+                {t('chat.replyQuoteHiddenEncrypted')}
+              </p>
+            ) : (
+              <p className="text-xs text-fluux-muted truncate">
+                {replyingTo.body}
+              </p>
+            )}
           </div>
           <button
             type="button"

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -686,7 +686,7 @@ export function MessageComposer({
             </p>
             {replyQuoteHidden ? (
               <p className="text-xs text-fluux-muted italic truncate flex items-center gap-1">
-                <Lock className="size-3 flex-shrink-0" />
+                <Lock aria-hidden="true" className="size-3 flex-shrink-0" />
                 {t('chat.replyQuoteHiddenEncrypted')}
               </p>
             ) : (

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -428,6 +428,7 @@
         "attachment": "مرفق",
         "removeAttachment": "إزالة المرفق",
         "reply": "رد",
+        "replyQuoteHiddenEncrypted": "تم إخفاء الاقتباس — كانت الرسالة الأصلية مُشفَّرة",
         "forwardMessage": "إعادة توجيه الرسالة (قريبًا)",
         "moreReactions": "المزيد من التفاعلات",
         "reactionOthers": "{{count}} آخرين",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -428,6 +428,7 @@
         "attachment": "Прыкладанне",
         "removeAttachment": "Выдаліць прыкладанне",
         "reply": "Адказаць",
+        "replyQuoteHiddenEncrypted": "Цытата схаваная — арыгінал быў зашыфраваны",
         "forwardMessage": "Пераслаць паведамленне (хутка)",
         "moreReactions": "Больш рэакцый",
         "reactionOthers": "{{count}} іншых",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -428,6 +428,7 @@
         "attachment": "Прикачен файл",
         "removeAttachment": "Премахни прикачен файл",
         "reply": "Отговор",
+        "replyQuoteHiddenEncrypted": "Цитатът е скрит — оригиналът беше шифрован",
         "forwardMessage": "Препрати съобщение (очаквайте скоро)",
         "moreReactions": "Още реакции",
         "reactionOthers": "{{count}} други",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -430,6 +430,7 @@
         "attachment": "Adjunt",
         "removeAttachment": "Elimina l'adjunt",
         "reply": "Respon",
+        "replyQuoteHiddenEncrypted": "Cita amagada — l'original estava xifrat",
         "forwardMessage": "Reenvia el missatge (properament)",
         "moreReactions": "Més reaccions",
         "reactionOthers": "{{count}} altres",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -430,6 +430,7 @@
         "attachment": "Příloha",
         "removeAttachment": "Odebrat přílohu",
         "reply": "Odpovědět",
+        "replyQuoteHiddenEncrypted": "Citace skryta — originál byl šifrovaný",
         "forwardMessage": "Přeposlat zprávu (již brzy)",
         "moreReactions": "Více reakcí",
         "reactionOthers": "{{count}} dalších",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -428,6 +428,7 @@
         "attachment": "Vedhæftning",
         "removeAttachment": "Fjern vedhæftning",
         "reply": "Svar",
+        "replyQuoteHiddenEncrypted": "Citat skjult — originalen var krypteret",
         "forwardMessage": "Videresend besked (kommer snart)",
         "moreReactions": "Flere reaktioner",
         "reactionOthers": "{{count}} andre",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -430,6 +430,7 @@
         "attachment": "Anhang",
         "removeAttachment": "Anhang entfernen",
         "reply": "Antworten",
+        "replyQuoteHiddenEncrypted": "Zitat ausgeblendet – Original war verschlüsselt",
         "forwardMessage": "Nachricht weiterleiten (bald verfügbar)",
         "moreReactions": "Mehr Reaktionen",
         "reactionOthers": "{{count}} andere",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -429,6 +429,7 @@
         "attachment": "Συνημμένο",
         "removeAttachment": "Αφαίρεση συνημμένου",
         "reply": "Απάντηση",
+        "replyQuoteHiddenEncrypted": "Το απόσπασμα αποκρύφθηκε — το αρχικό ήταν κρυπτογραφημένο",
         "forwardMessage": "Προώθηση μηνύματος (σύντομα διαθέσιμο)",
         "moreReactions": "Περισσότερες αντιδράσεις",
         "reactionOthers": "{{count}} ακόμη",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -428,6 +428,7 @@
         "attachment": "Attachment",
         "removeAttachment": "Remove attachment",
         "reply": "Reply",
+        "replyQuoteHiddenEncrypted": "Quote hidden — original was encrypted",
         "forwardMessage": "Forward message (coming soon)",
         "moreReactions": "More reactions",
         "reactionOthers": "{{count}} others",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -430,6 +430,7 @@
         "attachment": "Adjunto",
         "removeAttachment": "Eliminar adjunto",
         "reply": "Responder",
+        "replyQuoteHiddenEncrypted": "Cita oculta: el original estaba cifrado",
         "forwardMessage": "Reenviar mensaje (proximamente)",
         "moreReactions": "Mas reacciones",
         "reactionOthers": "{{count}} otros",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -430,6 +430,7 @@
         "attachment": "Manus",
         "removeAttachment": "Eemalda manus",
         "reply": "Vasta",
+        "replyQuoteHiddenEncrypted": "Tsitaat peidetud — originaal oli krüpteeritud",
         "forwardMessage": "Edasta sõnum (tulemas)",
         "moreReactions": "Rohkem reaktsioone",
         "reactionOthers": "{{count}} muud",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -428,6 +428,7 @@
         "attachment": "Liite",
         "removeAttachment": "Poista liite",
         "reply": "Vastaa",
+        "replyQuoteHiddenEncrypted": "Lainaus piilotettu — alkuperäinen oli salattu",
         "forwardMessage": "Välitä viesti (tulossa pian)",
         "moreReactions": "Lisää reaktioita",
         "reactionOthers": "{{count}} muuta",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -429,6 +429,7 @@
         "attachment": "Pièce jointe",
         "removeAttachment": "Supprimer la pièce jointe",
         "reply": "Répondre",
+        "replyQuoteHiddenEncrypted": "Citation masquée — le message d'origine était chiffré",
         "forwardMessage": "Transférer le message (bientôt disponible)",
         "moreReactions": "Plus de réactions",
         "reactionOthers": "{{count}} autres",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -428,6 +428,7 @@
         "attachment": "Ceangaltán",
         "removeAttachment": "Bain ceangaltán",
         "reply": "Freagair",
+        "replyQuoteHiddenEncrypted": "Athfhriotal i bhfolach — bhí an bunteachtaireacht criptithe",
         "forwardMessage": "Seol ar aghaidh (ag teacht go luath)",
         "moreReactions": "Níos mó frithghníomhartha",
         "reactionOthers": "{{count}} eile",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -428,6 +428,7 @@
         "attachment": "קובץ מצורף",
         "removeAttachment": "הסרת קובץ מצורף",
         "reply": "תגובה",
+        "replyQuoteHiddenEncrypted": "הציטוט הוסתר — המקור היה מוצפן",
         "forwardMessage": "העברת הודעה (בקרוב)",
         "moreReactions": "תגובות נוספות",
         "reactionOthers": "{{count}} אחרים",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -428,6 +428,7 @@
         "attachment": "Privitak",
         "removeAttachment": "Ukloni privitak",
         "reply": "Odgovori",
+        "replyQuoteHiddenEncrypted": "Citat skriven — izvornik je bio šifriran",
         "forwardMessage": "Proslijedi poruku (uskoro dolazi)",
         "moreReactions": "Više reakcija",
         "reactionOthers": "{{count}} drugih",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -428,6 +428,7 @@
         "attachment": "Melléklet",
         "removeAttachment": "Melléklet eltávolítása",
         "reply": "Válasz",
+        "replyQuoteHiddenEncrypted": "Idézet elrejtve — az eredeti titkosított volt",
         "forwardMessage": "Üzenet továbbítása (hamarosan)",
         "moreReactions": "További reakciók",
         "reactionOthers": "{{count}} másik",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -428,6 +428,7 @@
         "attachment": "Viðhengi",
         "removeAttachment": "Fjarlægja viðhengi",
         "reply": "Svara",
+        "replyQuoteHiddenEncrypted": "Tilvitnun falin — upprunalega skeytið var dulkóðað",
         "forwardMessage": "Áframsenda skilaboð (væntanlegt)",
         "moreReactions": "Fleiri viðbrögð",
         "reactionOthers": "{{count}} aðrir",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -430,6 +430,7 @@
         "attachment": "Allegato",
         "removeAttachment": "Rimuovi allegato",
         "reply": "Rispondi",
+        "replyQuoteHiddenEncrypted": "Citazione nascosta — l'originale era cifrato",
         "forwardMessage": "Inoltra messaggio (in arrivo)",
         "moreReactions": "Altre reazioni",
         "reactionOthers": "{{count}} altri",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -428,6 +428,7 @@
         "attachment": "Priedas",
         "removeAttachment": "Pašalinti priedą",
         "reply": "Atsakyti",
+        "replyQuoteHiddenEncrypted": "Citata paslėpta — originalas buvo užšifruotas",
         "forwardMessage": "Persiųsti žinutę (greitai)",
         "moreReactions": "Daugiau reakcijų",
         "reactionOthers": "{{count}} kitų",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -429,6 +429,7 @@
         "attachment": "Pielikums",
         "removeAttachment": "Noņemt pielikumu",
         "reply": "Atbildēt",
+        "replyQuoteHiddenEncrypted": "Citāts paslēpts — oriģināls bija šifrēts",
         "forwardMessage": "Pārsūtīt ziņojumu (drīzumā)",
         "moreReactions": "Vairāk reakciju",
         "reactionOthers": "{{count}} citi",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -430,6 +430,7 @@
         "attachment": "Mehmuż",
         "removeAttachment": "Neħħi attachment",
         "reply": "Wieġeb",
+        "replyQuoteHiddenEncrypted": "Kwotazzjoni moħbija — l-oriġinal kien ikkriptat",
         "forwardMessage": "Ibgħat 'il quddiem (dalwaqt)",
         "moreReactions": "Aktar reazzjonijiet",
         "reactionOthers": "{{count}} oħrajn",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -428,6 +428,7 @@
         "attachment": "Vedlegg",
         "removeAttachment": "Fjern vedlegg",
         "reply": "Svar",
+        "replyQuoteHiddenEncrypted": "Sitat skjult — originalen var kryptert",
         "forwardMessage": "Videresend melding (kommer snart)",
         "moreReactions": "Flere reaksjoner",
         "reactionOthers": "{{count}} andre",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -428,6 +428,7 @@
         "attachment": "Bijlage",
         "removeAttachment": "Bijlage verwijderen",
         "reply": "Beantwoorden",
+        "replyQuoteHiddenEncrypted": "Citaat verborgen — origineel was versleuteld",
         "forwardMessage": "Bericht doorsturen (binnenkort)",
         "moreReactions": "Meer reacties",
         "reactionOthers": "{{count}} anderen",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -430,6 +430,7 @@
         "attachment": "Załącznik",
         "removeAttachment": "Usuń załącznik",
         "reply": "Odpowiedz",
+        "replyQuoteHiddenEncrypted": "Cytat ukryty — oryginał był zaszyfrowany",
         "forwardMessage": "Przekaż wiadomość (wkrótce)",
         "moreReactions": "Więcej reakcji",
         "reactionOthers": "{{count}} innych",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -430,6 +430,7 @@
         "attachment": "Anexo",
         "removeAttachment": "Remover anexo",
         "reply": "Responder",
+        "replyQuoteHiddenEncrypted": "Citação oculta — o original estava cifrado",
         "forwardMessage": "Encaminhar mensagem (brevemente)",
         "moreReactions": "Mais reações",
         "reactionOthers": "{{count}} outros",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -430,6 +430,7 @@
         "attachment": "Atașament",
         "removeAttachment": "Elimină atașamentul",
         "reply": "Răspunde",
+        "replyQuoteHiddenEncrypted": "Citat ascuns — originalul era criptat",
         "forwardMessage": "Redirecționează mesajul (în curând)",
         "moreReactions": "Mai multe reacții",
         "reactionOthers": "{{count}} alții",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -428,6 +428,7 @@
         "attachment": "Вложение",
         "removeAttachment": "Удалить вложение",
         "reply": "Ответить",
+        "replyQuoteHiddenEncrypted": "Цитата скрыта — оригинал был зашифрован",
         "forwardMessage": "Переслать сообщение (скоро)",
         "moreReactions": "Другие реакции",
         "reactionOthers": "{{count}} других",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -429,6 +429,7 @@
         "attachment": "Príloha",
         "removeAttachment": "Odstrániť prílohu",
         "reply": "Odpovedať",
+        "replyQuoteHiddenEncrypted": "Citácia skrytá — originál bol šifrovaný",
         "forwardMessage": "Preposlať správu (už čoskoro)",
         "moreReactions": "Viac reakcií",
         "reactionOthers": "{{count}} ďalších",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -430,6 +430,7 @@
         "attachment": "Priloga",
         "removeAttachment": "Odstrani prilogo",
         "reply": "Odgovori",
+        "replyQuoteHiddenEncrypted": "Citat skrit — izvirnik je bil šifriran",
         "forwardMessage": "Posreduj sporočilo (kmalu)",
         "moreReactions": "Več odzivov",
         "reactionOthers": "{{count}} drugih",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -428,6 +428,7 @@
         "attachment": "Bilaga",
         "removeAttachment": "Ta bort bilaga",
         "reply": "Svara",
+        "replyQuoteHiddenEncrypted": "Citat dolt — originalet var krypterat",
         "forwardMessage": "Vidarebefordra meddelande (kommer snart)",
         "moreReactions": "Fler reaktioner",
         "reactionOthers": "{{count}} andra",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -428,6 +428,7 @@
         "attachment": "Вкладення",
         "removeAttachment": "Видалити вкладення",
         "reply": "Відповісти",
+        "replyQuoteHiddenEncrypted": "Цитату приховано — оригінал був зашифрований",
         "forwardMessage": "Переслати повідомлення (незабаром)",
         "moreReactions": "Більше реакцій",
         "reactionOthers": "{{count}} інших",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -428,6 +428,7 @@
         "attachment": "附件",
         "removeAttachment": "移除附件",
         "reply": "回复",
+        "replyQuoteHiddenEncrypted": "引用已隐藏 — 原始消息已加密",
         "forwardMessage": "转发消息（即将推出）",
         "moreReactions": "更多回应",
         "reactionOthers": "{{count}} 人",

--- a/apps/fluux/src/utils/replyEncryption.test.ts
+++ b/apps/fluux/src/utils/replyEncryption.test.ts
@@ -13,4 +13,8 @@ describe('isEncryptedSource', () => {
   it('is false for a plaintext message (neither field present)', () => {
     expect(isEncryptedSource({})).toBe(false)
   })
+
+  it('is true when the message used an unsupported encryption protocol', () => {
+    expect(isEncryptedSource({ unsupportedEncryption: { namespace: 'eu.siacs.conversations.axolotl', name: 'OMEMO' } })).toBe(true)
+  })
 })

--- a/apps/fluux/src/utils/replyEncryption.test.ts
+++ b/apps/fluux/src/utils/replyEncryption.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { isEncryptedSource } from './replyEncryption'
+
+describe('isEncryptedSource', () => {
+  it('is true when the message was decrypted (securityContext present)', () => {
+    expect(isEncryptedSource({ securityContext: { protocolId: 'openpgp', trust: 'verified' } })).toBe(true)
+  })
+
+  it('is true when the message is still pending decrypt (encryptedPayload present)', () => {
+    expect(isEncryptedSource({ encryptedPayload: '<message/>' })).toBe(true)
+  })
+
+  it('is false for a plaintext message (neither field present)', () => {
+    expect(isEncryptedSource({})).toBe(false)
+  })
+})

--- a/apps/fluux/src/utils/replyEncryption.ts
+++ b/apps/fluux/src/utils/replyEncryption.ts
@@ -2,12 +2,13 @@ import type { Message } from '@fluux/sdk'
 
 /**
  * A message arrived end-to-end encrypted if it was successfully decrypted
- * (`securityContext` set) or is still awaiting a deferred decrypt
- * (`encryptedPayload` set). Used to decide whether quoting it in a cleartext
- * reply would leak the original — see Chat.sendMessage's strip guard.
+ * (`securityContext` set), is still awaiting a deferred decrypt
+ * (`encryptedPayload` set), or used an encryption protocol this client cannot
+ * decrypt (`unsupportedEncryption` set). Used to decide whether quoting it in a
+ * cleartext reply would leak the original — see Chat.sendMessage's strip guard.
  */
 export function isEncryptedSource(
-  message: Pick<Message, 'securityContext' | 'encryptedPayload'>,
+  message: Pick<Message, 'securityContext' | 'encryptedPayload' | 'unsupportedEncryption'>,
 ): boolean {
-  return !!(message.securityContext || message.encryptedPayload)
+  return !!(message.securityContext || message.encryptedPayload || message.unsupportedEncryption)
 }

--- a/apps/fluux/src/utils/replyEncryption.ts
+++ b/apps/fluux/src/utils/replyEncryption.ts
@@ -1,0 +1,13 @@
+import type { Message } from '@fluux/sdk'
+
+/**
+ * A message arrived end-to-end encrypted if it was successfully decrypted
+ * (`securityContext` set) or is still awaiting a deferred decrypt
+ * (`encryptedPayload` set). Used to decide whether quoting it in a cleartext
+ * reply would leak the original — see Chat.sendMessage's strip guard.
+ */
+export function isEncryptedSource(
+  message: Pick<Message, 'securityContext' | 'encryptedPayload'>,
+): boolean {
+  return !!(message.securityContext || message.encryptedPayload)
+}

--- a/docs/superpowers/plans/2026-06-10-plaintext-reply-encrypted-quote-leak.md
+++ b/docs/superpowers/plans/2026-06-10-plaintext-reply-encrypted-quote-leak.md
@@ -1,0 +1,539 @@
+# Plaintext-Reply Encrypted-Quote Leak Protection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the decrypted body of an encrypted message from leaking in cleartext when the user replies to it without encryption — strip the quote from the wire, keep reply threading, and tell the user in the composer.
+
+**Architecture:** The SDK is the security boundary. `Chat.sendMessage` already builds the XEP-0461 reply quote into the outgoing body *before* the encryption step. When the send ends up encrypted, the quote rides safely inside the `<payload/>`. When it ends up cleartext, a new post-encryption guard strips the quote block from the outer `<body>` and drops the `<fallback for="urn:xmpp:reply:0">` marker (keeping the `<reply/>` reference). The app passes a `fromEncrypted` flag (derived from the source message's `securityContext`/`encryptedPayload`) so the SDK knows the quote is sensitive, and renders a one-line notice in the reply banner.
+
+**Tech Stack:** TypeScript, `@xmpp/client` (ltx `xml()` element builder), Vitest, React, react-i18next (33 locales).
+
+**Spec:** [docs/superpowers/specs/2026-06-10-plaintext-reply-encrypted-quote-leak-design.md](../specs/2026-06-10-plaintext-reply-encrypted-quote-leak-design.md)
+
+---
+
+## File Structure
+
+- **`packages/fluux-sdk/src/core/modules/Chat.ts`** (modify) — extend the `replyTo.fallback` param type with `fromEncrypted?`, add a private `stripEncryptedReplyQuoteFromCleartext()` helper, and call it after the E2EE step in `sendMessage`.
+- **`packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts`** (modify) — three integration tests covering the strip, the no-strip-when-encrypted regression, and the no-strip-when-source-was-cleartext regression.
+- **`apps/fluux/src/utils/replyEncryption.ts`** (create) — pure predicate `isEncryptedSource(message)` reused for both the wire flag and the UI notice (DRY).
+- **`apps/fluux/src/utils/replyEncryption.test.ts`** (create) — unit tests for the predicate.
+- **`apps/fluux/src/components/ChatView.tsx`** (modify) — set `fromEncrypted` on the reply fallback passed to `sendMessage`; compute `replyQuoteHidden` and pass it to the composer.
+- **`apps/fluux/src/components/MessageComposer.tsx`** (modify) — add optional `replyQuoteHidden` prop; render the notice instead of the quote body in the reply banner.
+- **`apps/fluux/src/i18n/locales/*.json`** (modify, 33 files) — add `chat.replyQuoteHiddenEncrypted`.
+
+---
+
+## Task 1: SDK — strip the quote from a cleartext reply to an encrypted message
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/modules/Chat.ts` (signature ~`:700`, helper near `:646`, call-site after `:830`)
+- Test: `packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `Chat.e2ee.test.ts`, inside the top-level `describe('Chat E2EE wiring', () => { ... })` (e.g. right after the existing `describe('outbound encryption', ...)` block). It reuses the file's existing `chat`, `captured`, `makeDeps`, `stubXmppPrimitives`, `stubMAM`, `E2EEManager`, `InMemoryStorageBackend`, and `Chat` from the top of the file.
+
+```typescript
+  describe('reply-quote leak protection (cleartext reply to an encrypted message)', () => {
+    const encryptedReply = {
+      id: 'orig',
+      to: 'bob@example.com',
+      fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true },
+    }
+
+    it('strips the quote from the outer body when the reply is sent in CLEARTEXT', async () => {
+      // Fresh manager with no plugins → the send goes out unencrypted.
+      const emptyManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      const { deps } = makeDeps({
+        jid: 'me@example.com',
+        manager: emptyManager,
+        captureStanza: (el) => captured.push(el),
+      })
+      const plainChat = new Chat(deps, stubMAM())
+
+      await plainChat.sendMessage('bob@example.com', 'sure thing', 'chat', encryptedReply)
+
+      const sent = captured[0]
+      const body = sent.getChild('body')?.text() ?? ''
+      // The decrypted quote must NOT appear in the cleartext body.
+      expect(body).not.toContain('4471')
+      expect(body).not.toContain('> Bob wrote:')
+      expect(body).toBe('sure thing')
+
+      // The reply fallback marker is dropped (its [0, end) region no longer exists)…
+      const replyFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
+      expect(replyFallback).toBeUndefined()
+
+      // …but the reply reference itself survives so threading / jump-to still works.
+      const reply = sent.getChild('reply', 'urn:xmpp:reply:0')
+      expect(reply).toBeDefined()
+      expect(reply?.attrs.id).toBe('orig')
+    })
+
+    it('keeps the quote INSIDE the encrypted payload when the reply is encrypted', async () => {
+      // `chat` uses the DummyPlaintextPlugin (registered in beforeEach) → encrypts.
+      await chat.sendMessage('bob@example.com', 'sure thing', 'chat', encryptedReply)
+
+      const sent = captured[0]
+      // Outer body is the generic fallback, never the quote.
+      expect(sent.getChild('body')?.text()).toBe('[dummy-plaintext payload]')
+      expect(sent.getChild('body')?.text()).not.toContain('4471')
+
+      // The reply fallback marker is preserved on the encrypted path.
+      const replyFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
+      expect(replyFallback).toBeDefined()
+
+      // The quote still reaches the recipient — it is inside the encrypted payload.
+      const enc = sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')
+      expect(enc).toBeDefined()
+      const decoded = Buffer.from(enc!.text(), 'base64').toString('utf8')
+      expect(decoded).toContain('4471')
+    })
+
+    it('does NOT strip a cleartext reply to a cleartext message (no regression)', async () => {
+      const emptyManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      const { deps } = makeDeps({
+        jid: 'me@example.com',
+        manager: emptyManager,
+        captureStanza: (el) => captured.push(el),
+      })
+      const plainChat = new Chat(deps, stubMAM())
+
+      await plainChat.sendMessage('bob@example.com', 'sure thing', 'chat', {
+        id: 'orig',
+        to: 'bob@example.com',
+        fallback: { author: 'Bob', body: 'hello there' }, // fromEncrypted omitted → false
+      })
+
+      const sent = captured[0]
+      const body = sent.getChild('body')?.text() ?? ''
+      // The quote is preserved exactly as today.
+      expect(body).toContain('> Bob wrote:')
+      expect(body).toContain('hello there')
+      const replyFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
+      expect(replyFallback).toBeDefined()
+    })
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.e2ee.test.ts -t "reply-quote leak protection"`
+Expected: the first test FAILS — the cleartext body still contains `4471` / `> Bob wrote:` and the reply fallback is still present (no strip implemented yet). The other two should already pass (they describe current behavior), confirming the tests are wired correctly.
+
+- [ ] **Step 3: Extend the `replyTo` parameter type**
+
+In `Chat.ts`, in the `sendMessage` signature (around line 700), add `fromEncrypted?: boolean` to the fallback shape:
+
+```typescript
+  async sendMessage(
+    to: string,
+    body: string,
+    type: 'chat' | 'groupchat' = 'chat',
+    replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } },
+    references?: MentionReference[],
+    attachment?: FileAttachment
+  ): Promise<string> {
+```
+
+- [ ] **Step 4: Add the private strip helper**
+
+In `Chat.ts`, add this method just above the `E2EE_PROTECTED_CHILD_KEYS` declaration (around line 644, right after `applyE2EEToOutboundChat` ends at line 625). It mutates `children` in place.
+
+```typescript
+  /**
+   * Privacy guard (E2EE): a XEP-0461 reply quote is built from the *displayed*
+   * body of the message being replied to. If that source message arrived
+   * encrypted, its body is decrypted plaintext, and the outgoing `<body/>`
+   * now carries that plaintext as a `> … wrote:` quote.
+   *
+   * On the ENCRYPTED send path the quote rode safely inside the `<payload/>`
+   * (the outer body was replaced with a generic fallback by
+   * {@link applyE2EEToOutboundChat}). On the CLEARTEXT path it would leak the
+   * original message on the wire, in server MAM, and via carbons. This strips
+   * the quote block out of the outer body and removes the reply fallback
+   * marker, while keeping the `<reply/>` reference so threading still works.
+   *
+   * `fallbackEnd` is the length of the leading quote block in `fullBody`
+   * (`[0, fallbackEnd)`). OOB fallback offsets, if present, shift left by the
+   * same amount so a supporting client still hides the correct URL region.
+   */
+  private stripEncryptedReplyQuoteFromCleartext(
+    children: Element[],
+    ctx: {
+      fullBody: string
+      fallbackEnd: number
+      hasAttachment: boolean
+      oobFallbackStart: number
+      oobFallbackEnd: number
+    },
+  ): void {
+    const { fullBody, fallbackEnd, hasAttachment, oobFallbackStart, oobFallbackEnd } = ctx
+    if (fallbackEnd <= 0) return
+
+    const strippedBody = fullBody.slice(fallbackEnd)
+    const bodyIdx = children.findIndex(
+      (c): c is Element => typeof c !== 'string' && (c as Element).name === 'body',
+    )
+    if (bodyIdx >= 0) children[bodyIdx] = xml('body', {}, strippedBody)
+
+    const replyFallbackIdx = children.findIndex(
+      (c) =>
+        typeof c !== 'string' &&
+        (c as Element).name === 'fallback' &&
+        (c as Element).attrs?.for === NS_REPLY,
+    )
+    if (replyFallbackIdx >= 0) children.splice(replyFallbackIdx, 1)
+
+    if (hasAttachment) {
+      const oobFallbackIdx = children.findIndex(
+        (c) =>
+          typeof c !== 'string' &&
+          (c as Element).name === 'fallback' &&
+          (c as Element).attrs?.for === NS_OOB,
+      )
+      if (oobFallbackIdx >= 0) {
+        children[oobFallbackIdx] = xml(
+          'fallback',
+          { xmlns: NS_FALLBACK, for: NS_OOB },
+          xml('body', {
+            start: String(oobFallbackStart - fallbackEnd),
+            end: String(oobFallbackEnd - fallbackEnd),
+          }),
+        )
+      }
+    }
+  }
+```
+
+- [ ] **Step 5: Call the helper after the E2EE step in `sendMessage`**
+
+In `Chat.ts`, immediately after the `applyE2EEToOutboundChat` assignment block (after line 830, before the attachment-encryption guard at line 832), insert:
+
+```typescript
+    // Never let a quote decrypted from an encrypted message ride in a
+    // cleartext body. Only relevant for 1:1 chat (MUC has no E2EE) and only
+    // when the send actually went out unencrypted (no security context).
+    if (type === 'chat' && !outgoingSecurityContext && replyTo?.fallback?.fromEncrypted) {
+      this.stripEncryptedReplyQuoteFromCleartext(children, {
+        fullBody,
+        fallbackEnd,
+        hasAttachment: !!attachment,
+        oobFallbackStart,
+        oobFallbackEnd,
+      })
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.e2ee.test.ts`
+Expected: PASS — all tests in the file, including the new `reply-quote leak protection` block.
+
+- [ ] **Step 7: Typecheck the SDK and rebuild it**
+
+Run: `cd packages/fluux-sdk && npx tsc --noEmit && cd ../.. && npm run build:sdk`
+Expected: no type errors; SDK build succeeds. (Rebuild is required so the app picks up the new `fromEncrypted` field on the `sendMessage` type — see the project memory note "After changing SDK types, rebuild SDK before app typecheck".)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/modules/Chat.ts packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+git commit -m "fix(e2ee): strip reply quote from cleartext reply to an encrypted message"
+```
+
+---
+
+## Task 2: App — derive `fromEncrypted` with a reusable predicate
+
+**Files:**
+- Create: `apps/fluux/src/utils/replyEncryption.ts`
+- Test: `apps/fluux/src/utils/replyEncryption.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/utils/replyEncryption.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { isEncryptedSource } from './replyEncryption'
+
+describe('isEncryptedSource', () => {
+  it('is true when the message was decrypted (securityContext present)', () => {
+    expect(isEncryptedSource({ securityContext: { protocolId: 'openpgp', trust: 'verified' } })).toBe(true)
+  })
+
+  it('is true when the message is still pending decrypt (encryptedPayload present)', () => {
+    expect(isEncryptedSource({ encryptedPayload: '<message/>' })).toBe(true)
+  })
+
+  it('is false for a plaintext message (neither field present)', () => {
+    expect(isEncryptedSource({})).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/utils/replyEncryption.test.ts`
+Expected: FAIL — `Failed to resolve import "./replyEncryption"` (module not created yet).
+
+- [ ] **Step 3: Create the predicate**
+
+Create `apps/fluux/src/utils/replyEncryption.ts`:
+
+```typescript
+import type { Message } from '@fluux/sdk'
+
+/**
+ * A message arrived end-to-end encrypted if it was successfully decrypted
+ * (`securityContext` set) or is still awaiting a deferred decrypt
+ * (`encryptedPayload` set). Used to decide whether quoting it in a cleartext
+ * reply would leak the original — see Chat.sendMessage's strip guard.
+ */
+export function isEncryptedSource(
+  message: Pick<Message, 'securityContext' | 'encryptedPayload'>,
+): boolean {
+  return !!(message.securityContext || message.encryptedPayload)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/utils/replyEncryption.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire `fromEncrypted` into the reply sent by `ChatView`**
+
+In `apps/fluux/src/components/ChatView.tsx`, add the import near the other util imports (top of file):
+
+```typescript
+import { isEncryptedSource } from '@/utils/replyEncryption'
+```
+
+Then update the `replyTo` construction (currently lines 1057–1061) to set `fromEncrypted`:
+
+```typescript
+      replyTo = {
+        id: replyingTo.id,
+        to: replyingTo.from,
+        fallback: { author: authorName, body: replyingTo.body, fromEncrypted: isEncryptedSource(replyingTo) }
+      }
+```
+
+- [ ] **Step 6: Typecheck the app**
+
+Run: `npm run typecheck`
+Expected: no errors. (If it complains that `fromEncrypted` is not assignable, the SDK was not rebuilt — re-run `npm run build:sdk`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/utils/replyEncryption.ts apps/fluux/src/utils/replyEncryption.test.ts apps/fluux/src/components/ChatView.tsx
+git commit -m "feat(e2ee): mark replies to encrypted messages so the SDK strips the cleartext quote"
+```
+
+---
+
+## Task 3: i18n — add the reply-banner notice string to all 33 locales
+
+**Files:**
+- Modify: `apps/fluux/src/i18n/locales/*.json` (33 files)
+
+- [ ] **Step 1: Add the key to every locale**
+
+In each locale file, add a `replyQuoteHiddenEncrypted` entry to the `chat` object (place it next to the existing `"reply"` key). Use the translation for that locale from the table below. Example for `en.json` — find the line `"reply": "Reply",` inside `"chat": {` and add the new line after it:
+
+```json
+        "reply": "Reply",
+        "replyQuoteHiddenEncrypted": "Quote hidden — original was encrypted",
+```
+
+Translation table (value per locale file):
+
+| File | Value |
+|------|-------|
+| `en.json` | `Quote hidden — original was encrypted` |
+| `ar.json` | `تم إخفاء الاقتباس — كانت الرسالة الأصلية مُشفَّرة` |
+| `be.json` | `Цытата схаваная — арыгінал быў зашыфраваны` |
+| `bg.json` | `Цитатът е скрит — оригиналът беше шифрован` |
+| `ca.json` | `Cita amagada — l'original estava xifrat` |
+| `cs.json` | `Citace skryta — originál byl šifrovaný` |
+| `da.json` | `Citat skjult — originalen var krypteret` |
+| `de.json` | `Zitat ausgeblendet – Original war verschlüsselt` |
+| `el.json` | `Το απόσπασμα αποκρύφθηκε — το αρχικό ήταν κρυπτογραφημένο` |
+| `es.json` | `Cita oculta: el original estaba cifrado` |
+| `et.json` | `Tsitaat peidetud — originaal oli krüpteeritud` |
+| `fi.json` | `Lainaus piilotettu — alkuperäinen oli salattu` |
+| `fr.json` | `Citation masquée — le message d'origine était chiffré` |
+| `ga.json` | `Athfhriotal i bhfolach — bhí an bunteachtaireacht criptithe` |
+| `he.json` | `הציטוט הוסתר — המקור היה מוצפן` |
+| `hr.json` | `Citat skriven — izvornik je bio šifriran` |
+| `hu.json` | `Idézet elrejtve — az eredeti titkosított volt` |
+| `is.json` | `Tilvitnun falin — upprunalega skeytið var dulkóðað` |
+| `it.json` | `Citazione nascosta — l'originale era cifrato` |
+| `lt.json` | `Citata paslėpta — originalas buvo užšifruotas` |
+| `lv.json` | `Citāts paslēpts — oriģināls bija šifrēts` |
+| `mt.json` | `Kwotazzjoni moħbija — l-oriġinal kien ikkriptat` |
+| `nb.json` | `Sitat skjult — originalen var kryptert` |
+| `nl.json` | `Citaat verborgen — origineel was versleuteld` |
+| `pl.json` | `Cytat ukryty — oryginał był zaszyfrowany` |
+| `pt.json` | `Citação oculta — o original estava cifrado` |
+| `ro.json` | `Citat ascuns — originalul era criptat` |
+| `ru.json` | `Цитата скрыта — оригинал был зашифрован` |
+| `sk.json` | `Citácia skrytá — originál bol šifrovaný` |
+| `sl.json` | `Citat skrit — izvirnik je bil šifriran` |
+| `sv.json` | `Citat dolt — originalet var krypterat` |
+| `uk.json` | `Цитату приховано — оригінал був зашифрований` |
+| `zh-CN.json` | `引用已隐藏 — 原始消息已加密` |
+
+- [ ] **Step 2: Verify the JSON is valid and the key is present in every file**
+
+Run: `cd apps/fluux/src/i18n/locales && for f in *.json; do node -e "JSON.parse(require('fs').readFileSync('$f','utf8')).chat.replyQuoteHiddenEncrypted || (console.error('MISSING in $f'), process.exit(1))" || exit 1; done && echo "all 33 OK"`
+Expected: prints `all 33 OK` with no `MISSING`/parse errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/fluux/src/i18n/locales
+git commit -m "i18n(chat): add reply-quote-hidden notice for encrypted-source replies"
+```
+
+---
+
+## Task 4: App — render the notice in the reply banner
+
+**Files:**
+- Modify: `apps/fluux/src/components/MessageComposer.tsx` (props ~`:84`, banner ~`:677`)
+- Modify: `apps/fluux/src/components/ChatView.tsx` (compute + pass `replyQuoteHidden`, near `:1004` and `:1119`)
+
+- [ ] **Step 1: Add the `replyQuoteHidden` prop to `MessageComposer`**
+
+In `MessageComposer.tsx`, in the props interface, add the prop right after the existing `onCancelReply` declaration (around line 86):
+
+```typescript
+  /** Callback when reply is cancelled */
+  onCancelReply?: () => void
+  /** When true, the reply quote is hidden because the source message was encrypted and this reply is plaintext */
+  replyQuoteHidden?: boolean
+```
+
+- [ ] **Step 2: Destructure the new prop**
+
+In `MessageComposer.tsx`, find where props are destructured in the component body (the list that includes `replyingTo,` around line 161) and add `replyQuoteHidden,` to it:
+
+```typescript
+  replyingTo,
+  onCancelReply,
+  replyQuoteHidden,
+```
+
+- [ ] **Step 3: Render the notice instead of the quote body**
+
+In `MessageComposer.tsx`, replace the quote-body paragraph in the reply preview (currently lines 684–686):
+
+```tsx
+            <p className="text-xs text-fluux-muted truncate">
+              {replyingTo.body}
+            </p>
+```
+
+with a conditional that shows the notice when the quote is hidden:
+
+```tsx
+            {replyQuoteHidden ? (
+              <p className="text-xs text-fluux-muted italic truncate flex items-center gap-1">
+                <Lock className="size-3 flex-shrink-0" />
+                {t('chat.replyQuoteHiddenEncrypted')}
+              </p>
+            ) : (
+              <p className="text-xs text-fluux-muted truncate">
+                {replyingTo.body}
+              </p>
+            )}
+```
+
+(`Lock` and `t` are already imported/available in `MessageComposer.tsx`.)
+
+- [ ] **Step 4: Compute and pass `replyQuoteHidden` from `ChatView`**
+
+In `ChatView.tsx`, just after the `replyInfo` definition (after line 1011), add:
+
+```typescript
+  // Show a banner notice when the reply will be sent in cleartext but the
+  // quoted message arrived encrypted — the SDK strips the quote in that case.
+  // `keyLocked` is excluded: the send is blocked until unlock, then encrypts.
+  const replyQuoteHidden =
+    !!replyingTo &&
+    encryptionState.kind !== 'encrypted' &&
+    encryptionState.kind !== 'keyLocked' &&
+    isEncryptedSource(replyingTo)
+```
+
+Then pass it to the composer where `replyingTo={replyInfo}` is set (line 1119):
+
+```tsx
+        replyingTo={replyInfo}
+        onCancelReply={onCancelReply}
+        replyQuoteHidden={replyQuoteHidden}
+```
+
+(`isEncryptedSource` was imported in Task 2, Step 5.)
+
+- [ ] **Step 5: Typecheck and run the affected app tests**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+Run: `cd apps/fluux && npx vitest run src/components/MessageInput.memo.test.tsx src/components/RoomMessageInput.memo.test.tsx`
+Expected: PASS — the new prop is optional, so existing composer tests are unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/components/MessageComposer.tsx apps/fluux/src/components/ChatView.tsx
+git commit -m "feat(e2ee): show 'quote hidden' notice when replying in cleartext to an encrypted message"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full SDK + app test suites**
+
+Run: `cd packages/fluux-sdk && npx vitest run` then `cd ../../apps/fluux && npx vitest run`
+Expected: all pass, no stderr. (Per project memory, do not run bare `vitest` from the repo root — it mass-fails app tests on `@/` aliases. Run each workspace separately.)
+
+- [ ] **Step 2: Typecheck + lint the whole repo**
+
+Run: `npm run typecheck && npm run lint`
+Expected: clean.
+
+- [ ] **Step 3: Manual smoke (optional, demo mode)**
+
+If verifying in the browser: `npm run dev`, open the demo, open an encrypted conversation, disable encryption for it, reply to one of the earlier (encrypted) messages, and confirm the composer shows "Quote hidden — original was encrypted" and the sent message contains no quoted text. (Demo mode has no real E2EE; this primarily exercises the UI notice path. The wire-strip behavior is covered by the SDK tests in Task 1.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** SDK strip on cleartext path (Task 1) ✓; app supplies `fromEncrypted` from `securityContext`/`encryptedPayload` (Task 2) ✓; banner notice (Tasks 3–4) ✓; reply reference preserved / fallback dropped (Task 1 tests) ✓; encrypted path unchanged (Task 1 regression test) ✓; 1:1-only gating via `type === 'chat'` (Task 1, Step 5) ✓; i18n across 33 locales (Task 3) ✓.
+- **Type consistency:** `fromEncrypted` is the same name in the SDK param (Task 1), the app call-site (Task 2), and conceptually in `isEncryptedSource`. `replyQuoteHidden` is the same prop name in `MessageComposer` (Task 4 Steps 1–3) and the `ChatView` call-site (Task 4 Step 4). Helper name `stripEncryptedReplyQuoteFromCleartext` is used identically in declaration and call-site.
+- **Edge case (reply + unencrypted attachment + plaintext):** handled — the body is `fullBody.slice(fallbackEnd)` (preserves the URL tail) and the OOB fallback offsets shift left by `fallbackEnd`. An *encrypted* attachment can never reach this branch (the `attachment?.encryption && !outgoingSecurityContext` guard at Chat.ts:835 throws first).

--- a/docs/superpowers/specs/2026-06-10-plaintext-reply-encrypted-quote-leak-design.md
+++ b/docs/superpowers/specs/2026-06-10-plaintext-reply-encrypted-quote-leak-design.md
@@ -1,0 +1,106 @@
+# Design: Prevent encrypted-message leak via plaintext reply fallback
+
+**Date:** 2026-06-10
+**Status:** Approved (design)
+
+## Problem
+
+When a user replies to a message that arrived **encrypted** (OpenPGP E2EE), and the
+reply itself is sent **without encryption**, the decrypted plaintext of the original
+message leaks in the clear.
+
+The reply fallback quote (XEP-0461 / XEP-0428) is built from the *displayed* body of
+the message being replied to. For an encrypted message that body is the
+already-decrypted plaintext:
+
+- `apps/fluux/src/components/ChatView.tsx:1054` builds
+  `replyTo.fallback = { author, body: replyingTo.body }`. `replyingTo.body` is the
+  decrypted plaintext; the message's `securityContext` marker is never consulted.
+- `packages/fluux-sdk/src/core/modules/Chat.ts:709` prepends the quote to the outgoing
+  body: `fullBody = "> {author} wrote:\n> {quoted}\n" + body`.
+- `applyE2EEToOutboundChat()` then runs:
+  - **Encrypted reply (safe):** the whole `fullBody` — quote included — goes inside the
+    OpenPGP `<payload>`, and the outer cleartext `<body>` is replaced with
+    `[encrypted message]`. No leak.
+  - **Plaintext reply (the leak):** when the conversation is not encrypting
+    (`encryptionState` is `plaintextForced`, `disabled`, `unsupported`, …),
+    `applyE2EEToOutboundChat` does nothing and `fullBody` *is* the cleartext `<body>`
+    on the wire — quote included.
+
+The leaked quote is not just transient on-wire exposure: it is persisted in server-side
+**MAM**, synced via **carbons** to the user's other devices, and stored in the
+recipient's cleartext history — exactly the exposure E2EE was meant to prevent.
+
+**Most reliable trigger:** encrypted history exists with a contact, the user disables
+encryption for that conversation (or the master toggle is off), then replies to one of
+the earlier encrypted messages.
+
+Scope note: 1:1 chat only today — `applyE2EEToOutboundChat` is gated on `type === 'chat'`
+and MUC rooms have no E2EE yet.
+
+## Hard constraint
+
+A cleartext outgoing `<body>` must **never** embed content decrypted from an encrypted
+message. "Send anyway with the quote" is never an option; the quote is always stripped
+from the wire in the leak case.
+
+## Approach (chosen: SDK-enforced strip, app supplies signal + notice)
+
+The SDK is the security boundary (per CLAUDE.md: the SDK owns "all XMPP protocol logic").
+The guard lives in the SDK so every consumer — the Fluux app, bots, demo — is protected,
+not just one UI path. The app supplies the provenance signal it already has at the reply
+site and renders the user-facing notice.
+
+Considered and rejected:
+- **App strips before `sendMessage`** — puts leak-prevention in UI code; SDK consumers
+  reusing the reply API get no protection.
+- **SDK fully self-enforcing via message-cache lookup of `replyTo.id`** — most robust but
+  the source message isn't always resolvable (scrolled-out / evicted) and it couples send
+  to cache state. Good hardening follow-up, overkill for v1.
+
+### Trigger condition
+
+Outgoing message is **not** encrypted **and** the replied-to message is an encrypted
+message — i.e. it carries `securityContext` (decrypted) or still-pending `encryptedPayload`.
+
+### SDK — `Chat.sendMessage` (`packages/fluux-sdk/src/core/modules/Chat.ts:696`)
+
+- Extend the `replyTo.fallback` parameter with `fromEncrypted?: boolean`.
+- After `applyE2EEToOutboundChat` returns: if `outgoingSecurityContext` is `undefined`
+  (the send went out plaintext) **and** `replyTo.fallback.fromEncrypted` is true:
+  - set the `<body>` child to just the user's `body` (drop the `> … wrote:` quote block);
+  - skip pushing the `<fallback for="urn:xmpp:reply:0">` element;
+  - keep the `<reply id="…">` reference element so threading / jump-to still works on the
+    recipient side.
+- Encrypted path: unchanged — the quote rides inside the `<payload>` and the outer body
+  becomes `[encrypted message]`.
+
+### App — `ChatView.tsx` (`apps/fluux/src/components/ChatView.tsx:1054`)
+
+- Set `fromEncrypted: !!(replyingTo.securityContext || replyingTo.encryptedPayload)` on the
+  fallback passed to `sendMessage`.
+- In the composer's reply banner (reply preview), when
+  `encryptionState.kind !== 'encrypted'` and the source message is encrypted, render a
+  subtle inline notice before sending: **"Quote hidden — original was encrypted."**
+
+## Testing (TDD)
+
+**SDK (`Chat` reply tests / `Chat.e2ee.test.ts`):**
+- Plaintext reply with `fromEncrypted: true` → outgoing `<body>` has no `>` quote and no
+  `<fallback>` element; `<reply>` reference is present.
+- Encrypted reply with `fromEncrypted: true` → quote inside the `<payload>`, outer body
+  `[encrypted message]` (regression guard for the existing safe path).
+- Plaintext reply with `fromEncrypted: false` (cleartext reply to a cleartext message) →
+  quote present exactly as today (no regression).
+
+**App (`ChatView` tests):**
+- `fromEncrypted` derived correctly from `replyingTo.securityContext` / `encryptedPayload`.
+- Reply-banner notice shows only on the mismatch (plaintext send + encrypted source).
+
+## Scope / YAGNI
+
+- Replies only. Link previews are already gated on encryption
+  (`apps/fluux/src/components/ChatView.tsx:1096`); there is no forward feature; copy is
+  OS-level.
+- MUC is naturally unaffected (MUC messages aren't encrypted yet).
+- Cache-lookup self-enforcement (Approach C) deferred as a possible hardening follow-up.

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -1754,6 +1754,101 @@ describe('Chat E2EE wiring', () => {
     })
   })
 
+  describe('reply-quote leak protection (cleartext reply to an encrypted message)', () => {
+    const encryptedReply = {
+      id: 'orig',
+      to: 'bob@example.com',
+      fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true },
+    }
+
+    it('strips the quote from the outer body when the reply is sent in CLEARTEXT', async () => {
+      // Fresh manager with no plugins → the send goes out unencrypted.
+      const emptyManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      const { deps } = makeDeps({
+        jid: 'me@example.com',
+        manager: emptyManager,
+        captureStanza: (el) => captured.push(el),
+      })
+      const plainChat = new Chat(deps, stubMAM())
+
+      await plainChat.sendMessage('bob@example.com', 'sure thing', 'chat', encryptedReply)
+
+      const sent = captured[0]
+      const body = sent.getChild('body')?.text() ?? ''
+      // The decrypted quote must NOT appear in the cleartext body.
+      expect(body).not.toContain('4471')
+      expect(body).not.toContain('> Bob wrote:')
+      expect(body).toBe('sure thing')
+
+      // The reply fallback marker is dropped (its [0, end) region no longer exists)…
+      const replyFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
+      expect(replyFallback).toBeUndefined()
+
+      // …but the reply reference itself survives so threading / jump-to still works.
+      const reply = sent.getChild('reply', 'urn:xmpp:reply:0')
+      expect(reply).toBeDefined()
+      expect(reply?.attrs.id).toBe('orig')
+    })
+
+    it('keeps the quote INSIDE the encrypted payload when the reply is encrypted', async () => {
+      // `chat` uses the DummyPlaintextPlugin (registered in beforeEach) → encrypts.
+      await chat.sendMessage('bob@example.com', 'sure thing', 'chat', encryptedReply)
+
+      const sent = captured[0]
+      // Outer body is the generic fallback, never the quote.
+      expect(sent.getChild('body')?.text()).toBe('[dummy-plaintext payload]')
+      expect(sent.getChild('body')?.text()).not.toContain('4471')
+
+      // The reply fallback marker is preserved on the encrypted path.
+      const replyFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
+      expect(replyFallback).toBeDefined()
+
+      // The quote still reaches the recipient — it is inside the encrypted payload.
+      const enc = sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')
+      expect(enc).toBeDefined()
+      const decoded = Buffer.from(enc!.text(), 'base64').toString('utf8')
+      expect(decoded).toContain('4471')
+    })
+
+    it('does NOT strip a cleartext reply to a cleartext message (no regression)', async () => {
+      const emptyManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      const { deps } = makeDeps({
+        jid: 'me@example.com',
+        manager: emptyManager,
+        captureStanza: (el) => captured.push(el),
+      })
+      const plainChat = new Chat(deps, stubMAM())
+
+      await plainChat.sendMessage('bob@example.com', 'sure thing', 'chat', {
+        id: 'orig',
+        to: 'bob@example.com',
+        fallback: { author: 'Bob', body: 'hello there' }, // fromEncrypted omitted → false
+      })
+
+      const sent = captured[0]
+      const body = sent.getChild('body')?.text() ?? ''
+      // The quote is preserved exactly as today.
+      expect(body).toContain('> Bob wrote:')
+      expect(body).toContain('hello there')
+      const replyFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
+      expect(replyFallback).toBeDefined()
+    })
+  })
+
   describe('outbound encryption — sendEasterEgg', () => {
     it('moves the easter-egg element inside the encrypted payload and keeps no-store', async () => {
       await chat.sendEasterEgg('bob@example.com', 'chat', 'confetti')

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -1847,6 +1847,54 @@ describe('Chat E2EE wiring', () => {
         .find((el) => el.attrs?.for === 'urn:xmpp:reply:0')
       expect(replyFallback).toBeDefined()
     })
+
+    it('shifts OOB fallback offsets when a cleartext reply to an encrypted message carries an attachment', async () => {
+      const emptyManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      const { deps } = makeDeps({
+        jid: 'me@example.com',
+        manager: emptyManager,
+        captureStanza: (el) => captured.push(el),
+      })
+      const plainChat = new Chat(deps, stubMAM())
+
+      const attachmentUrl = 'https://upload.example.com/file.bin'
+      await plainChat.sendMessage(
+        'bob@example.com',
+        'sure thing',
+        'chat',
+        { id: 'orig', to: 'bob@example.com', fallback: { author: 'Bob', body: 'the code is 4471', fromEncrypted: true } },
+        undefined,
+        { url: attachmentUrl, name: 'file.bin', mediaType: 'application/octet-stream' }, // unencrypted attachment → cleartext send
+      )
+
+      const sent = captured[0]
+      const body = sent.getChild('body')?.text() ?? ''
+      // Quote stripped, but caption and URL preserved.
+      expect(body).not.toContain('4471')
+      expect(body).not.toContain('> Bob wrote:')
+      expect(body).toContain('sure thing')
+      expect(body).toContain(attachmentUrl)
+
+      // Reply fallback dropped, reply reference kept.
+      expect(
+        sent.getChildren('fallback', 'urn:xmpp:fallback:0').find((el) => el.attrs?.for === 'urn:xmpp:reply:0'),
+      ).toBeUndefined()
+      expect(sent.getChild('reply', 'urn:xmpp:reply:0')).toBeDefined()
+
+      // OOB fallback offsets must still point exactly at the URL region of the
+      // (now quote-stripped) body — proves the offset shift is correct.
+      const oobFallback = sent
+        .getChildren('fallback', 'urn:xmpp:fallback:0')
+        .find((el) => el.attrs?.for === 'jabber:x:oob')
+      expect(oobFallback).toBeDefined()
+      const start = Number(oobFallback!.getChild('body')?.attrs.start)
+      const end = Number(oobFallback!.getChild('body')?.attrs.end)
+      expect(body.slice(start, end)).toBe(attachmentUrl)
+    })
   })
 
   describe('outbound encryption — sendEasterEgg', () => {

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -625,6 +625,70 @@ export class Chat extends BaseModule {
   }
 
   /**
+   * Privacy guard (E2EE): a XEP-0461 reply quote is built from the *displayed*
+   * body of the message being replied to. If that source message arrived
+   * encrypted, its body is decrypted plaintext, and the outgoing `<body/>`
+   * now carries that plaintext as a `> … wrote:` quote.
+   *
+   * On the ENCRYPTED send path the quote rode safely inside the `<payload/>`
+   * (the outer body was replaced with a generic fallback by
+   * {@link applyE2EEToOutboundChat}). On the CLEARTEXT path it would leak the
+   * original message on the wire, in server MAM, and via carbons. This strips
+   * the quote block out of the outer body and removes the reply fallback
+   * marker, while keeping the `<reply/>` reference so threading still works.
+   *
+   * `fallbackEnd` is the length of the leading quote block in `fullBody`
+   * (`[0, fallbackEnd)`). OOB fallback offsets, if present, shift left by the
+   * same amount so a supporting client still hides the correct URL region.
+   */
+  private stripEncryptedReplyQuoteFromCleartext(
+    children: Element[],
+    ctx: {
+      fullBody: string
+      fallbackEnd: number
+      hasAttachment: boolean
+      oobFallbackStart: number
+      oobFallbackEnd: number
+    },
+  ): void {
+    const { fullBody, fallbackEnd, hasAttachment, oobFallbackStart, oobFallbackEnd } = ctx
+    if (fallbackEnd <= 0) return
+
+    const strippedBody = fullBody.slice(fallbackEnd)
+    const bodyIdx = children.findIndex(
+      (c): c is Element => typeof c !== 'string' && (c as Element).name === 'body',
+    )
+    if (bodyIdx >= 0) children[bodyIdx] = xml('body', {}, strippedBody)
+
+    const replyFallbackIdx = children.findIndex(
+      (c) =>
+        typeof c !== 'string' &&
+        (c as Element).name === 'fallback' &&
+        (c as Element).attrs?.for === NS_REPLY,
+    )
+    if (replyFallbackIdx >= 0) children.splice(replyFallbackIdx, 1)
+
+    if (hasAttachment) {
+      const oobFallbackIdx = children.findIndex(
+        (c) =>
+          typeof c !== 'string' &&
+          (c as Element).name === 'fallback' &&
+          (c as Element).attrs?.for === NS_OOB,
+      )
+      if (oobFallbackIdx >= 0) {
+        children[oobFallbackIdx] = xml(
+          'fallback',
+          { xmlns: NS_FALLBACK, for: NS_OOB },
+          xml('body', {
+            start: String(oobFallbackStart - fallbackEnd),
+            end: String(oobFallbackEnd - fallbackEnd),
+          }),
+        )
+      }
+    }
+  }
+
+  /**
    * Keys of stanza extension children that should ride inside the OpenPGP
    * `<payload/>` when E2EE is on, per the XEP-0420 §9-aligned policy
    * documented in docs/ENCRYPTION.md. Each key is `"<name>|<xmlns>"` so
@@ -697,7 +761,7 @@ export class Chat extends BaseModule {
     to: string,
     body: string,
     type: 'chat' | 'groupchat' = 'chat',
-    replyTo?: { id: string; to?: string; fallback?: { author: string; body: string } },
+    replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } },
     references?: MentionReference[],
     attachment?: FileAttachment
   ): Promise<string> {
@@ -828,6 +892,19 @@ export class Chat extends BaseModule {
             Chat.E2EE_PROTECTED_CHILD_KEYS,
           )
         : undefined
+
+    // Never let a quote decrypted from an encrypted message ride in a
+    // cleartext body. Only relevant for 1:1 chat (MUC has no E2EE) and only
+    // when the send actually went out unencrypted (no security context).
+    if (type === 'chat' && !outgoingSecurityContext && replyTo?.fallback?.fromEncrypted) {
+      this.stripEncryptedReplyQuoteFromCleartext(children, {
+        fullBody,
+        fallbackEnd,
+        hasAttachment: !!attachment,
+        oobFallbackStart,
+        oobFallbackEnd,
+      })
+    }
 
     // Guard: an encrypted attachment's aesgcm:// OOB URL carries the AES
     // key. If stanza-level E2EE didn't move that element into the payload,


### PR DESCRIPTION
## Summary

Replying **without encryption** to a message that arrived **encrypted** leaked the original's decrypted body in the cleartext XEP-0461 reply quote — and thus on the wire, in server MAM, and via carbons.

- **SDK** (`Chat.sendMessage`): when a reply goes out in cleartext and the quoted source was encrypted (caller passes `fromEncrypted`), strip the quote from the outer `<body>` and drop the `<fallback for="urn:xmpp:reply:0">` marker, keeping the `<reply>` reference so threading still works. The encrypted-reply path is unchanged — the quote rides inside the encrypted payload as before.
- **App**: flags replies whose source arrived encrypted (`securityContext` / `encryptedPayload` / `unsupportedEncryption`) and shows a "Quote hidden — original was encrypted" notice in the composer when the reply will be sent in cleartext (i18n across all 33 locales).

The SDK is the enforcement boundary, so any consumer (app, bots, demo) is protected; the UI notice is advisory.