### PR TITLE
fix(e2ee): normalize fingerprint case in peer-verification trust checks

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -90,6 +90,7 @@ import {
   publishVerificationsToServer,
   saveAppliedVerificationsVersion,
 } from './verificationSync'
+import { fingerprintsEqual } from './fingerprintCompare'
 import {
   clearKeyChangeAlert,
   getKeyChangeAlert,
@@ -2100,10 +2101,6 @@ function parseSecretKeyBackupItem(payload: XMLElementData): string | null {
   if (payload.name !== 'secretkey' || payload.attrs?.xmlns !== OX_NAMESPACE) return null
   const encoded = firstText(payload)
   return encoded ? base64DecodeOpenPgpBlock(encoded, 'PGP MESSAGE') : null
-}
-
-function fingerprintsEqual(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase()
 }
 
 function firstAttr(

--- a/apps/fluux/src/e2ee/fingerprintCompare.test.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { fingerprintsEqual, normalizeFingerprint } from './fingerprintCompare'
+
+describe('fingerprintCompare', () => {
+  it('treats UPPERCASE (Sequoia) and lowercase (openpgp.js) of the same key as equal', () => {
+    const upper = 'AABBCCDDEEFF00112233445566778899AABBCCDD'
+    const lower = 'aabbccddeeff00112233445566778899aabbccdd'
+    expect(fingerprintsEqual(upper, lower)).toBe(true)
+    expect(fingerprintsEqual(lower, upper)).toBe(true)
+  })
+
+  it('ignores whitespace separators', () => {
+    expect(fingerprintsEqual('AABB CCDD EEFF', 'aabbccddeeff')).toBe(true)
+  })
+
+  it('returns false for genuinely different fingerprints', () => {
+    expect(fingerprintsEqual('AABBCCDD', 'AABBCCDE')).toBe(false)
+  })
+
+  it('normalizeFingerprint lower-cases and strips whitespace', () => {
+    expect(normalizeFingerprint('AA BB\tCC\nDD')).toBe('aabbccdd')
+  })
+})

--- a/apps/fluux/src/e2ee/fingerprintCompare.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical fingerprint comparison for trust decisions.
+ *
+ * OpenPGP backends format fingerprints differently: Sequoia/Rust (the native
+ * Tauri client) emits UPPERCASE hex, openpgp.js (the web client) emits
+ * lowercase, and some sources add whitespace separators. A fingerprint
+ * verified on one backend and synced cross-device (verificationSync.ts) is
+ * stored verbatim, so a trust check that uses raw `===` would read a
+ * verification made on desktop as unverified on the web client.
+ *
+ * Every trust-decision site — the chip's `verified` derivation
+ * (useConversationEncryptionState) and `isPeerVerified` (which drives the
+ * inbound message SecurityContext) — must compare through this helper, the
+ * same normalization the sync layer already applies.
+ */
+
+/** Strip whitespace and lower-case so backend formatting can't affect equality. */
+export function normalizeFingerprint(fingerprint: string): string {
+  return fingerprint.replace(/\s+/g, '').toLowerCase()
+}
+
+/** Case- and whitespace-insensitive fingerprint equality. */
+export function fingerprintsEqual(a: string, b: string): boolean {
+  return normalizeFingerprint(a) === normalizeFingerprint(b)
+}

--- a/apps/fluux/src/e2ee/verificationSync.ts
+++ b/apps/fluux/src/e2ee/verificationSync.ts
@@ -35,6 +35,7 @@
 
 import type { PluginContext, XMLElementData } from '@fluux/sdk'
 import { buildScopedStorageKey } from '@fluux/sdk'
+import { fingerprintsEqual } from './fingerprintCompare'
 
 /** Encrypt `plaintext` to `recipientPublicArmored`. Returns armored ciphertext. */
 export type EncryptFn = (
@@ -59,11 +60,6 @@ export type DecryptFn = (
   signerFingerprint: string | null
   signaturePresent: boolean
 }>
-
-/** Case- and whitespace-insensitive fingerprint comparison. */
-function fingerprintsEqual(a: string, b: string): boolean {
-  return a.replace(/\s+/g, '').toLowerCase() === b.replace(/\s+/g, '').toLowerCase()
-}
 
 export const VERIFICATIONS_NODE = 'urn:xmpp:fluux:verifications:0'
 const VERIFICATIONS_XMLNS = VERIFICATIONS_NODE

--- a/apps/fluux/src/hooks/useConversationEncryptionState.test.tsx
+++ b/apps/fluux/src/hooks/useConversationEncryptionState.test.tsx
@@ -274,6 +274,29 @@ describe('useConversationEncryptionState', () => {
       })
     })
 
+    it("returns trust='verified' when the verified fingerprint differs only in case from the cached one (cross-backend sync)", () => {
+      // A native (Sequoia) device verified the peer and synced the
+      // fingerprint in UPPERCASE; this web (openpgp.js) device's plugin cache
+      // reports the same key lowercase. The lock must still be green.
+      store.useVerifiedPeerKeysStore
+        .getState()
+        .setVerified('adrien@example.com', 'AABBCCDDEEFF00112233445566778899AABBCCDD')
+      const plugin = makePlugin({
+        getPeerFingerprint: vi
+          .fn()
+          .mockReturnValue('aabbccddeeff00112233445566778899aabbccdd'),
+      })
+      wireMocks({ plugin })
+      const { result } = renderHook(() =>
+        useConversationEncryptionState('adrien@example.com', 'chat'),
+      )
+      expect(result.current).toEqual({
+        kind: 'encrypted',
+        fingerprint: 'aabbccddeeff00112233445566778899aabbccdd',
+        trust: 'verified',
+      })
+    })
+
     it("auto-demotes to 'unverified' when the cached fingerprint differs from the verified one", () => {
       // Pin to the OLD fingerprint, but the cache returns a NEW one —
       // simulates a key rotation that hasn't been re-confirmed. The

--- a/apps/fluux/src/hooks/useConversationEncryptionState.ts
+++ b/apps/fluux/src/hooks/useConversationEncryptionState.ts
@@ -6,6 +6,7 @@ import { useKeyChangeAlertsStore } from '@/stores/keyChangeAlertsStore'
 import { useConversationPlaintextOverrideStore } from '@/stores/conversationPlaintextOverrideStore'
 import { usePinnedPrimaryFingerprintsStore, isTofuNew } from '@/stores/pinnedPrimaryFingerprintsStore'
 import { useCertRejectionStore, type CertRejection } from '@/stores/certRejectionStore'
+import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
 import { useWebKeyLocked } from './useWebKeyLocked'
 
 /**
@@ -286,7 +287,10 @@ export function useConversationEncryptionState(
     if (webKeyLocked) {
       return { kind: 'keyLocked', fingerprint: base.fingerprint }
     }
-    const trust = verifiedFingerprint === base.fingerprint
+    // Normalized compare: the verified fingerprint may have been synced from
+    // another OpenPGP backend (Sequoia UPPERCASE ↔ openpgp.js lowercase), so
+    // raw `===` would spuriously read as unverified. See fingerprintCompare.ts.
+    const trust = verifiedFingerprint && fingerprintsEqual(verifiedFingerprint, base.fingerprint)
       ? 'verified'
       : (peerJid && isTofuNew(peerJid) ? 'tofu-new' : 'unverified')
     return { kind: 'encrypted', fingerprint: base.fingerprint, trust }

--- a/apps/fluux/src/stores/verifiedPeerKeysStore.test.ts
+++ b/apps/fluux/src/stores/verifiedPeerKeysStore.test.ts
@@ -27,6 +27,23 @@ describe('verifiedPeerKeysStore', () => {
     expect(isPeerVerified('bob@example.com', 'FP1')).toBe(false)
   })
 
+  it('isPeerVerified is case- and whitespace-insensitive (cross-backend sync: Sequoia UPPERCASE ↔ openpgp.js lowercase)', () => {
+    // The native (Sequoia/Rust) client formats fingerprints UPPERCASE and
+    // publishes them verbatim to the cross-device verification-sync node; the
+    // web (openpgp.js) client probes the same key and reports it lowercase.
+    // A trust decision must treat the two as the same key — otherwise a
+    // verification made on desktop reads as unverified on the web client.
+    const upper = 'AABBCCDDEEFF00112233445566778899AABBCCDD'
+    const lower = 'aabbccddeeff00112233445566778899aabbccdd'
+    useVerifiedPeerKeysStore.getState().setVerified('adrien@example.com', upper)
+    expect(isPeerVerified('adrien@example.com', lower)).toBe(true)
+    // Reverse direction too (verified lowercase, queried uppercase).
+    useVerifiedPeerKeysStore.getState().setVerified('bob@example.com', lower)
+    expect(isPeerVerified('bob@example.com', upper)).toBe(true)
+    // A genuinely different fingerprint still does NOT match.
+    expect(isPeerVerified('adrien@example.com', 'FFEE' + lower.slice(4))).toBe(false)
+  })
+
   it('clearVerified removes the entry', () => {
     useVerifiedPeerKeysStore.getState().setVerified('alice@example.com', 'FP1')
     expect(isPeerVerified('alice@example.com', 'FP1')).toBe(true)

--- a/apps/fluux/src/stores/verifiedPeerKeysStore.ts
+++ b/apps/fluux/src/stores/verifiedPeerKeysStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { buildScopedStorageKey } from '@fluux/sdk'
+import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
 
 /**
  * Per-peer fingerprint verifications the user has explicitly confirmed
@@ -118,9 +119,11 @@ export const useVerifiedPeerKeysStore = create<VerifiedPeerKeysState>((set) => (
  * `buildInboundSecurityContext`) to lift `tofu` → `verified`.
  */
 export function isPeerVerified(jid: string, fingerprint: string): boolean {
-  return (
-    useVerifiedPeerKeysStore.getState().verifiedFingerprintByJid[jid] === fingerprint
-  )
+  const stored = useVerifiedPeerKeysStore.getState().verifiedFingerprintByJid[jid]
+  // Normalized compare: a fingerprint verified on one OpenPGP backend
+  // (e.g. Sequoia, UPPERCASE) and synced to another (openpgp.js, lowercase)
+  // must still count as verified. See e2ee/fingerprintCompare.ts.
+  return stored !== undefined && fingerprintsEqual(stored, fingerprint)
 }
 
 /**


### PR DESCRIPTION
## Summary

A peer verified on the native Sequoia/Rust desktop client showed a **green** lock there but a **grey** one on the **web (openpgp.js)** client, for the same account and peer. Messaging worked on both.

**Root cause:** Sequoia's `cert.fingerprint().to_hex()` returns UPPERCASE hex; openpgp.js's `getFingerprint()` returns lowercase. The cross-device verification sync (`urn:xmpp:fluux:verifications:0`) stores and publishes the fingerprint verbatim, so the desktop's UPPERCASE entry synced fine — but the web client's trust checks compared it with raw `===` against its own lowercase cached fingerprint and never matched. Encryption was unaffected because those paths already used a normalizing compare.

**Fix:** new canonical `e2ee/fingerprintCompare.ts` helper (strip whitespace + lowercase), used at both trust-decision sites — the chip's `verified` derivation in `useConversationEncryptionState` and `isPeerVerified` (which also drives the inbound message `SecurityContext`). Also consolidates the two pre-existing duplicate `fingerprintsEqual` copies (`verificationSync.ts`, `OpenPGPPluginBase.ts`) onto the shared helper.

Regression tests assert that an UPPERCASE-stored fingerprint matches a lowercase cached one (and vice versa), covering the cross-backend sync path that the single-backend demo preview can't reproduce.