### PR TITLE
perf(messages): skip off-screen rows with content-visibility

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 </div>
               </div>
               <div
+                class="message-row"
                 data-message-id="msg-1"
               >
                 <div
@@ -240,6 +241,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 </div>
               </div>
               <div
+                class="message-row"
                 data-message-id="msg-2"
               >
                 <div

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -302,6 +302,7 @@ export function MessageList<T extends BaseMessage>({
                 return (
                   <div
                     key={msg.id}
+                    className="message-row"
                     data-message-id={msg.id}
                     data-stanza-id={msg.stanzaId}
                     data-origin-id={msg.originId}

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -90,6 +90,7 @@ import {
   publishVerificationsToServer,
   saveAppliedVerificationsVersion,
 } from './verificationSync'
+import { fingerprintsEqual } from './fingerprintCompare'
 import {
   clearKeyChangeAlert,
   getKeyChangeAlert,
@@ -2100,10 +2101,6 @@ function parseSecretKeyBackupItem(payload: XMLElementData): string | null {
   if (payload.name !== 'secretkey' || payload.attrs?.xmlns !== OX_NAMESPACE) return null
   const encoded = firstText(payload)
   return encoded ? base64DecodeOpenPgpBlock(encoded, 'PGP MESSAGE') : null
-}
-
-function fingerprintsEqual(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase()
 }
 
 function firstAttr(

--- a/apps/fluux/src/e2ee/fingerprintCompare.test.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { fingerprintsEqual, normalizeFingerprint } from './fingerprintCompare'
+
+describe('fingerprintCompare', () => {
+  it('treats UPPERCASE (Sequoia) and lowercase (openpgp.js) of the same key as equal', () => {
+    const upper = 'AABBCCDDEEFF00112233445566778899AABBCCDD'
+    const lower = 'aabbccddeeff00112233445566778899aabbccdd'
+    expect(fingerprintsEqual(upper, lower)).toBe(true)
+    expect(fingerprintsEqual(lower, upper)).toBe(true)
+  })
+
+  it('ignores whitespace separators', () => {
+    expect(fingerprintsEqual('AABB CCDD EEFF', 'aabbccddeeff')).toBe(true)
+  })
+
+  it('returns false for genuinely different fingerprints', () => {
+    expect(fingerprintsEqual('AABBCCDD', 'AABBCCDE')).toBe(false)
+  })
+
+  it('normalizeFingerprint lower-cases and strips whitespace', () => {
+    expect(normalizeFingerprint('AA BB\tCC\nDD')).toBe('aabbccdd')
+  })
+})

--- a/apps/fluux/src/e2ee/fingerprintCompare.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical fingerprint comparison for trust decisions.
+ *
+ * OpenPGP backends format fingerprints differently: Sequoia/Rust (the native
+ * Tauri client) emits UPPERCASE hex, openpgp.js (the web client) emits
+ * lowercase, and some sources add whitespace separators. A fingerprint
+ * verified on one backend and synced cross-device (verificationSync.ts) is
+ * stored verbatim, so a trust check that uses raw `===` would read a
+ * verification made on desktop as unverified on the web client.
+ *
+ * Every trust-decision site — the chip's `verified` derivation
+ * (useConversationEncryptionState) and `isPeerVerified` (which drives the
+ * inbound message SecurityContext) — must compare through this helper, the
+ * same normalization the sync layer already applies.
+ */
+
+/** Strip whitespace and lower-case so backend formatting can't affect equality. */
+export function normalizeFingerprint(fingerprint: string): string {
+  return fingerprint.replace(/\s+/g, '').toLowerCase()
+}
+
+/** Case- and whitespace-insensitive fingerprint equality. */
+export function fingerprintsEqual(a: string, b: string): boolean {
+  return normalizeFingerprint(a) === normalizeFingerprint(b)
+}

--- a/apps/fluux/src/e2ee/verificationSync.ts
+++ b/apps/fluux/src/e2ee/verificationSync.ts
@@ -35,6 +35,7 @@
 
 import type { PluginContext, XMLElementData } from '@fluux/sdk'
 import { buildScopedStorageKey } from '@fluux/sdk'
+import { fingerprintsEqual } from './fingerprintCompare'
 
 /** Encrypt `plaintext` to `recipientPublicArmored`. Returns armored ciphertext. */
 export type EncryptFn = (
@@ -59,11 +60,6 @@ export type DecryptFn = (
   signerFingerprint: string | null
   signaturePresent: boolean
 }>
-
-/** Case- and whitespace-insensitive fingerprint comparison. */
-function fingerprintsEqual(a: string, b: string): boolean {
-  return a.replace(/\s+/g, '').toLowerCase() === b.replace(/\s+/g, '').toLowerCase()
-}
 
 export const VERIFICATIONS_NODE = 'urn:xmpp:fluux:verifications:0'
 const VERIFICATIONS_XMLNS = VERIFICATIONS_NODE

--- a/apps/fluux/src/hooks/useConversationEncryptionState.test.tsx
+++ b/apps/fluux/src/hooks/useConversationEncryptionState.test.tsx
@@ -274,6 +274,29 @@ describe('useConversationEncryptionState', () => {
       })
     })
 
+    it("returns trust='verified' when the verified fingerprint differs only in case from the cached one (cross-backend sync)", () => {
+      // A native (Sequoia) device verified the peer and synced the
+      // fingerprint in UPPERCASE; this web (openpgp.js) device's plugin cache
+      // reports the same key lowercase. The lock must still be green.
+      store.useVerifiedPeerKeysStore
+        .getState()
+        .setVerified('adrien@example.com', 'AABBCCDDEEFF00112233445566778899AABBCCDD')
+      const plugin = makePlugin({
+        getPeerFingerprint: vi
+          .fn()
+          .mockReturnValue('aabbccddeeff00112233445566778899aabbccdd'),
+      })
+      wireMocks({ plugin })
+      const { result } = renderHook(() =>
+        useConversationEncryptionState('adrien@example.com', 'chat'),
+      )
+      expect(result.current).toEqual({
+        kind: 'encrypted',
+        fingerprint: 'aabbccddeeff00112233445566778899aabbccdd',
+        trust: 'verified',
+      })
+    })
+
     it("auto-demotes to 'unverified' when the cached fingerprint differs from the verified one", () => {
       // Pin to the OLD fingerprint, but the cache returns a NEW one —
       // simulates a key rotation that hasn't been re-confirmed. The

--- a/apps/fluux/src/hooks/useConversationEncryptionState.ts
+++ b/apps/fluux/src/hooks/useConversationEncryptionState.ts
@@ -6,6 +6,7 @@ import { useKeyChangeAlertsStore } from '@/stores/keyChangeAlertsStore'
 import { useConversationPlaintextOverrideStore } from '@/stores/conversationPlaintextOverrideStore'
 import { usePinnedPrimaryFingerprintsStore, isTofuNew } from '@/stores/pinnedPrimaryFingerprintsStore'
 import { useCertRejectionStore, type CertRejection } from '@/stores/certRejectionStore'
+import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
 import { useWebKeyLocked } from './useWebKeyLocked'
 
 /**
@@ -286,7 +287,10 @@ export function useConversationEncryptionState(
     if (webKeyLocked) {
       return { kind: 'keyLocked', fingerprint: base.fingerprint }
     }
-    const trust = verifiedFingerprint === base.fingerprint
+    // Normalized compare: the verified fingerprint may have been synced from
+    // another OpenPGP backend (Sequoia UPPERCASE ↔ openpgp.js lowercase), so
+    // raw `===` would spuriously read as unverified. See fingerprintCompare.ts.
+    const trust = verifiedFingerprint && fingerprintsEqual(verifiedFingerprint, base.fingerprint)
       ? 'verified'
       : (peerJid && isTofuNew(peerJid) ? 'tofu-new' : 'unverified')
     return { kind: 'encrypted', fingerprint: base.fingerprint, trust }

--- a/apps/fluux/src/hooks/useMessageSelection.test.tsx
+++ b/apps/fluux/src/hooks/useMessageSelection.test.tsx
@@ -70,6 +70,56 @@ describe('useMessageSelection', () => {
     })
   })
 
+  // Message rows use `content-visibility: auto` (.message-row in index.css) to
+  // skip off-screen layout/paint. That also paint-clips on-screen rows, which
+  // would cut the selection toolbar. Pointer cases are handled by :hover /
+  // :focus-within, but keyboard selection scrolls the row in WITHOUT moving DOM
+  // focus to it, so the hook tags the selected row with `message-row-decontain`
+  // (the CSS rule lifts containment for it). Guard that tagging here.
+  describe('content-visibility decontain marker', () => {
+    beforeEach(() => {
+      // jsdom does not implement scrollIntoView, which the selection effect calls
+      Element.prototype.scrollIntoView = vi.fn()
+    })
+
+    it('marks only the selected row and clears the previous one', () => {
+      const ids = ['msg-0', 'msg-1', 'msg-2']
+      const els = ids.map((id) => {
+        const el = document.createElement('div')
+        el.className = 'message-row'
+        el.setAttribute('data-message-id', id)
+        document.body.appendChild(el)
+        return el
+      })
+
+      const messages = createMessages(3)
+      const { result } = renderHook(() =>
+        useMessageSelection(messages, mockScrollRef, mockIsAtBottomRef)
+      )
+
+      act(() => {
+        result.current.setSelectedMessageId('msg-1')
+      })
+      expect(els[1].classList.contains('message-row-decontain')).toBe(true)
+      expect(els[0].classList.contains('message-row-decontain')).toBe(false)
+
+      // Moving the selection re-tags and clears the previous marker
+      act(() => {
+        result.current.setSelectedMessageId('msg-2')
+      })
+      expect(els[1].classList.contains('message-row-decontain')).toBe(false)
+      expect(els[2].classList.contains('message-row-decontain')).toBe(true)
+
+      // Clearing selection removes the marker entirely
+      act(() => {
+        result.current.clearSelection()
+      })
+      expect(document.querySelectorAll('.message-row-decontain').length).toBe(0)
+
+      els.forEach((el) => el.remove())
+    })
+  })
+
   describe('toolbar debounce', () => {
     it('should hide toolbar immediately on selection change', () => {
       const messages = createMessages(5)

--- a/apps/fluux/src/hooks/useMessageSelection.ts
+++ b/apps/fluux/src/hooks/useMessageSelection.ts
@@ -86,12 +86,26 @@ export function useMessageSelection<T extends MessageLike>(
     }
   }, [selectedMessageId])
 
-  // Scroll selected message into view when keyboard navigating
+  // Scroll selected message into view when keyboard navigating.
+  //
+  // Also lift `content-visibility` containment on the selected row. Message rows
+  // use `content-visibility: auto` (see `.message-row` in index.css) to skip
+  // off-screen layout/paint, but that applies paint containment to ON-screen
+  // rows too, which would clip the selection toolbar that paints above the row.
+  // Pointer interaction is covered by the `:hover` / `:focus-within` rules, but
+  // keyboard selection scrolls the row into view WITHOUT moving DOM focus to it,
+  // so neither rule fires — mark it explicitly. At most one row carries the
+  // marker, so the cleanup query is O(1).
   useEffect(() => {
+    document
+      .querySelectorAll('.message-row-decontain')
+      .forEach((el) => el.classList.remove('message-row-decontain'))
+
     if (selectedMessageId) {
       const element = document.querySelector(`[data-message-id="${selectedMessageId}"]`) as HTMLElement
       if (element) {
         element.scrollIntoView({ block: 'nearest' })
+        element.classList.add('message-row-decontain')
       }
     }
   }, [selectedMessageId])

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -560,6 +560,37 @@ input[type="range"]::-moz-range-thumb {
   border-radius: 0.5rem;
 }
 
+/*
+ * Per-message render-cost containment.
+ *
+ * Busy rooms render their whole in-memory backlog (hundreds–thousands of
+ * messages) into the DOM with no virtualization. On WebKitGTK (Linux/Tauri)
+ * the message-list scroll-correction ResizeObserver then reflows that entire
+ * tree every frame, pinning ~50% of a core at idle (the per-room "constant CPU"
+ * report). `content-visibility: auto` lets the browser skip layout AND paint
+ * for off-screen rows, so a reflow only touches the visible handful regardless
+ * of backlog size. `contain-intrinsic-size: auto <h>` reserves an estimated
+ * height for skipped rows (the `auto` keyword makes the browser remember each
+ * row's real size once seen, so the scrollbar stays stable).
+ *
+ * CAVEAT: content-visibility:auto applies paint containment even to ON-screen
+ * rows, which would clip the floating hover toolbar (`-top-7 -end-2`) and the
+ * reaction-picker / more-menu dropdowns (`top-full` / `bottom-full`) that paint
+ * OUTSIDE the row box. Only one row is ever interacted with at a time, so we
+ * lift containment on the hovered/focused row, letting its overflow paint
+ * normally while every other row stays contained.
+ */
+.message-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 72px;
+}
+
+.message-row:hover,
+.message-row:focus-within,
+.message-row.message-row-decontain {
+  content-visibility: visible;
+}
+
 /* Persistent highlight for search context view */
 .message-highlight-persistent {
   background-color: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);

--- a/apps/fluux/src/stores/verifiedPeerKeysStore.test.ts
+++ b/apps/fluux/src/stores/verifiedPeerKeysStore.test.ts
@@ -27,6 +27,23 @@ describe('verifiedPeerKeysStore', () => {
     expect(isPeerVerified('bob@example.com', 'FP1')).toBe(false)
   })
 
+  it('isPeerVerified is case- and whitespace-insensitive (cross-backend sync: Sequoia UPPERCASE ↔ openpgp.js lowercase)', () => {
+    // The native (Sequoia/Rust) client formats fingerprints UPPERCASE and
+    // publishes them verbatim to the cross-device verification-sync node; the
+    // web (openpgp.js) client probes the same key and reports it lowercase.
+    // A trust decision must treat the two as the same key — otherwise a
+    // verification made on desktop reads as unverified on the web client.
+    const upper = 'AABBCCDDEEFF00112233445566778899AABBCCDD'
+    const lower = 'aabbccddeeff00112233445566778899aabbccdd'
+    useVerifiedPeerKeysStore.getState().setVerified('adrien@example.com', upper)
+    expect(isPeerVerified('adrien@example.com', lower)).toBe(true)
+    // Reverse direction too (verified lowercase, queried uppercase).
+    useVerifiedPeerKeysStore.getState().setVerified('bob@example.com', lower)
+    expect(isPeerVerified('bob@example.com', upper)).toBe(true)
+    // A genuinely different fingerprint still does NOT match.
+    expect(isPeerVerified('adrien@example.com', 'FFEE' + lower.slice(4))).toBe(false)
+  })
+
   it('clearVerified removes the entry', () => {
     useVerifiedPeerKeysStore.getState().setVerified('alice@example.com', 'FP1')
     expect(isPeerVerified('alice@example.com', 'FP1')).toBe(true)

--- a/apps/fluux/src/stores/verifiedPeerKeysStore.ts
+++ b/apps/fluux/src/stores/verifiedPeerKeysStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { buildScopedStorageKey } from '@fluux/sdk'
+import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
 
 /**
  * Per-peer fingerprint verifications the user has explicitly confirmed
@@ -118,9 +119,11 @@ export const useVerifiedPeerKeysStore = create<VerifiedPeerKeysState>((set) => (
  * `buildInboundSecurityContext`) to lift `tofu` → `verified`.
  */
 export function isPeerVerified(jid: string, fingerprint: string): boolean {
-  return (
-    useVerifiedPeerKeysStore.getState().verifiedFingerprintByJid[jid] === fingerprint
-  )
+  const stored = useVerifiedPeerKeysStore.getState().verifiedFingerprintByJid[jid]
+  // Normalized compare: a fingerprint verified on one OpenPGP backend
+  // (e.g. Sequoia, UPPERCASE) and synced to another (openpgp.js, lowercase)
+  // must still count as verified. See e2ee/fingerprintCompare.ts.
+  return stored !== undefined && fingerprintsEqual(stored, fingerprint)
 }
 
 /**


### PR DESCRIPTION
Busy rooms render the entire message backlog into the DOM with no virtualization. On WebKitGTK (Linux/Tauri) the message-list scroll-correction `ResizeObserver` reflows that whole tree every frame, pinning a CPU core at idle in large rooms.

Apply `content-visibility: auto` to message rows so the browser skips layout/paint for off-screen messages. Since that also paint-clips the floating hover toolbar and dropdowns, the hovered / focused / keyboard-selected row is decontained.

Covers both rooms and 1:1 chat (shared `MessageList` row). Note: the WebKitGTK CPU loop can't be reproduced on macOS (WKWebView), so the idle-CPU improvement needs verification on a Linux build.