### PR TITLE
fix(muc): preserve occupant avatar across presence updates

### DIFF
--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1737,6 +1737,68 @@ describe('roomStore', () => {
       expect(room?.occupants.size).toBe(1)
       expect(room?.occupants.get('alice')?.nick).toBe('alice')
     })
+
+    it('preserves a fetched avatar across a presence update (unchanged hash)', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+
+      // Occupant joins, carrying only the XEP-0153 avatar hash from presence.
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'zoidberg',
+        affiliation: 'member',
+        role: 'participant',
+        avatarHash: 'hash123',
+      })
+
+      // Async XEP-0398 fetch resolves the blob URL onto the occupant + cache.
+      roomStore.getState().updateOccupantAvatar('test@conference.example.com', 'zoidberg', 'blob:zoidberg', 'hash123')
+      expect(roomStore.getState().rooms.get('test@conference.example.com')?.occupants.get('zoidberg')?.avatar).toBe('blob:zoidberg')
+
+      // A later presence update (e.g. status change) carries only the hash, never the blob.
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'zoidberg',
+        affiliation: 'member',
+        role: 'participant',
+        show: 'away',
+        avatarHash: 'hash123',
+      })
+
+      // The occupant must keep its resolved avatar — otherwise the members list drops to a letter.
+      const occ = roomStore.getState().rooms.get('test@conference.example.com')?.occupants.get('zoidberg')
+      expect(occ?.avatar).toBe('blob:zoidberg')
+      expect(occ?.show).toBe('away')
+    })
+
+    it('preserves a fetched avatar across a presence update with no hash', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'zoidberg', affiliation: 'member', role: 'participant', avatarHash: 'hash123',
+      })
+      roomStore.getState().updateOccupantAvatar('test@conference.example.com', 'zoidberg', 'blob:zoidberg', 'hash123')
+
+      // Presence update with no vcard-temp:x:update at all (avatarHash undefined).
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'zoidberg', affiliation: 'member', role: 'participant', show: 'dnd',
+      })
+
+      expect(roomStore.getState().rooms.get('test@conference.example.com')?.occupants.get('zoidberg')?.avatar).toBe('blob:zoidberg')
+    })
+
+    it('drops the avatar when the presence hash changes (a fresh one will be fetched)', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'zoidberg', affiliation: 'member', role: 'participant', avatarHash: 'hash123',
+      })
+      roomStore.getState().updateOccupantAvatar('test@conference.example.com', 'zoidberg', 'blob:zoidberg', 'hash123')
+
+      // Presence carries a NEW hash → the old blob is stale and must not be kept.
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'zoidberg', affiliation: 'member', role: 'participant', avatarHash: 'hash999',
+      })
+
+      const occ = roomStore.getState().rooms.get('test@conference.example.com')?.occupants.get('zoidberg')
+      expect(occ?.avatar).toBeUndefined()
+      expect(occ?.avatarHash).toBe('hash999')
+    })
   })
 
   describe('removeOccupant', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -35,6 +35,27 @@ import { buildScopedStorageKey } from '../utils/storageScope'
 const MAX_MESSAGES_PER_ROOM = 1000
 
 /**
+ * Carry a previously-resolved avatar across a presence update.
+ *
+ * Presence stanzas only carry the XEP-0153 avatar *hash*; the resolved blob URL
+ * arrives asynchronously and is written via `updateOccupantAvatar`. Without this,
+ * every plain presence refresh (status/role change) would overwrite the occupant
+ * with the freshly-parsed, blob-less object — silently dropping the avatar. Message
+ * rows survive via `nickToAvatarCache`, but the members panel reads `occupant.avatar`
+ * directly, so the avatar would vanish there until the hash next changes.
+ *
+ * Keep the existing blob when the incoming presence has no blob and its hash is
+ * unchanged or absent. Drop it only when the hash actually changed, so the async
+ * XEP-0398 fetch repopulates a fresh one.
+ */
+function preserveOccupantAvatar(existing: RoomOccupant | undefined, incoming: RoomOccupant): RoomOccupant {
+  if (!existing?.avatar || incoming.avatar) return incoming
+  const hashUnchanged = !incoming.avatarHash || incoming.avatarHash === existing.avatarHash
+  if (!hashUnchanged) return incoming
+  return { ...incoming, avatar: existing.avatar, avatarHash: incoming.avatarHash ?? existing.avatarHash }
+}
+
+/**
  * localStorage key for persisting room drafts.
  * Room drafts are stored separately from the main room state because
  * room data is restored from server bookmarks on reconnect, but drafts
@@ -621,20 +642,22 @@ export const roomStore = createStore<RoomState>()(
       if (!existing) return state
 
       const newOccupants = new Map(existing.occupants)
-      newOccupants.set(occupant.nick, occupant)
+      // Presence carries only the avatar hash — keep an already-fetched blob alive.
+      const merged = preserveOccupantAvatar(existing.occupants.get(occupant.nick), occupant)
+      newOccupants.set(merged.nick, merged)
 
       // Update nick→jid cache for non-anonymous rooms (when real JID is visible)
       let nickToJidCache = existing.nickToJidCache
-      if (occupant.jid) {
+      if (merged.jid) {
         nickToJidCache = new Map(nickToJidCache || [])
-        nickToJidCache.set(occupant.nick, getBareJid(occupant.jid))
+        nickToJidCache.set(merged.nick, getBareJid(merged.jid))
       }
 
       // Update nick→avatar cache if occupant has avatar
       let nickToAvatarCache = existing.nickToAvatarCache
-      if (occupant.avatar) {
+      if (merged.avatar) {
         nickToAvatarCache = new Map(nickToAvatarCache || [])
-        nickToAvatarCache.set(occupant.nick, occupant.avatar)
+        nickToAvatarCache.set(merged.nick, merged.avatar)
       }
 
       newRooms.set(roomJid, { ...existing, occupants: newOccupants, nickToJidCache, nickToAvatarCache })
@@ -664,22 +687,24 @@ export const roomStore = createStore<RoomState>()(
 
       // Add all occupants in a single update
       for (const occupant of occupants) {
-        newOccupants.set(occupant.nick, occupant)
+        // Presence carries only the avatar hash — keep an already-fetched blob alive.
+        const merged = preserveOccupantAvatar(newOccupants.get(occupant.nick), occupant)
+        newOccupants.set(merged.nick, merged)
 
         // Update nick→jid cache for non-anonymous rooms
-        if (occupant.jid) {
+        if (merged.jid) {
           if (!nickToJidCache || nickToJidCache === existing.nickToJidCache) {
             nickToJidCache = new Map(nickToJidCache || [])
           }
-          nickToJidCache.set(occupant.nick, getBareJid(occupant.jid))
+          nickToJidCache.set(merged.nick, getBareJid(merged.jid))
         }
 
         // Update nick→avatar cache
-        if (occupant.avatar) {
+        if (merged.avatar) {
           if (!nickToAvatarCache || nickToAvatarCache === existing.nickToAvatarCache) {
             nickToAvatarCache = new Map(nickToAvatarCache || [])
           }
-          nickToAvatarCache.set(occupant.nick, occupant.avatar)
+          nickToAvatarCache.set(merged.nick, merged.avatar)
         }
       }
 


### PR DESCRIPTION
## Summary

A MUC occupant's avatar showed in message bubbles but rendered as a letter placeholder in the **members panel** (user report from `stepforward`). Reconnecting temporarily restored it.

Root cause: presence stanzas carry only the XEP-0153 avatar *hash*, never the resolved blob URL (fetched async via `updateOccupantAvatar`). `addOccupant` overwrote the occupant wholesale on every presence refresh (status/role change), dropping `occupant.avatar`. Message rows survived via `nickToAvatarCache`, but `OccupantPanel` reads `occupant.avatar` directly — so the avatar silently vanished there until the hash next changed.

This is a latent bug since the first public release, **not** a regression from the recent occupant-panel/content-visibility perf work (`addOccupant`'s resolution is unchanged by those PRs).

## Fix

`preserveOccupantAvatar` in `roomStore`: keep an already-fetched blob when the incoming presence has no blob and its hash is unchanged or absent; drop it only when the hash actually changes (the async XEP-0398 fetch then repopulates). Applied in `addOccupant` and `batchAddOccupants`. Keeps `occupant.avatar` correct for all consumers and avoids needless re-fetches.