### PR TITLE
feat(login): validate JID shape locally before connecting

### DIFF
--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -12,6 +12,7 @@ import { getDomainFromJid, getWebsocketUrlForDomain } from '@/config/wellKnownSe
 import { useWindowDrag } from '@/hooks'
 import { isOpenpgpEnabled } from '@/stores/encryptionSettingsStore'
 import { getReconnectIntent } from '@/utils/reconnectIntent'
+import { validateBareJid } from '@/utils/jidValidation'
 
 const STORAGE_KEY_JID = 'xmpp-last-jid'
 const STORAGE_KEY_SERVER = 'xmpp-last-server'
@@ -100,6 +101,9 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
   }, [])
 
   const [jid, setJid] = useState('')
+  // Whether the JID field has been blurred at least once — only then do we show
+  // the malformed-shape hint, so the user isn't nagged mid-typing.
+  const [jidTouched, setJidTouched] = useState(false)
   const [password, setPassword] = useState('')
   const [server, setServer] = useState('')
   const [rememberMe, setRememberMe] = useState(false)
@@ -289,6 +293,11 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
   const isConnecting = status === 'connecting'
   const isLoading = isLoadingCredentials || isConnecting
 
+  // Local JID shape validation (UX_REVIEW §1.4) — gates Connect and shows
+  // inline help on a malformed shape, before any network round-trip.
+  const jidValidation = validateBareJid(jid)
+  const showJidError = jidTouched && !jidValidation.valid && jidValidation.reason === 'malformed'
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
@@ -379,14 +388,23 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
               autoComplete="username"
               value={jid}
               onChange={(e) => { setJid(e.target.value); setCredentialsModified(true) }}
+              onBlur={() => setJidTouched(true)}
               placeholder={t('login.jidPlaceholder')}
               required
               disabled={isLoading}
-              className="w-full px-3 py-2 bg-fluux-bg text-fluux-text rounded
-                         border border-fluux-border focus:border-fluux-brand
+              aria-invalid={showJidError}
+              aria-describedby={showJidError ? 'jid-error' : undefined}
+              className={`w-full px-3 py-2 bg-fluux-bg text-fluux-text rounded
+                         border focus:border-fluux-brand
                          focus-visible:ring-2 focus-visible:ring-fluux-brand/50
-                         placeholder:text-fluux-muted disabled:opacity-50"
+                         placeholder:text-fluux-muted disabled:opacity-50
+                         ${showJidError ? 'border-fluux-red' : 'border-fluux-border'}`}
             />
+            {showJidError && (
+              <p id="jid-error" className="text-xs text-fluux-red mt-1">
+                {t('login.jidInvalid')}
+              </p>
+            )}
           </div>
 
           {/* Password Field */}
@@ -513,7 +531,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
           {/* Submit Button */}
           <button
             type="submit"
-            disabled={isLoading || !jid || !password}
+            disabled={isLoading || !jidValidation.valid || !password}
             className="w-full py-2.5 bg-fluux-brand hover:bg-fluux-brand-hover
                        text-fluux-text-on-accent font-medium rounded transition-colors
                        disabled:opacity-50 disabled:cursor-not-allowed

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -22,6 +22,7 @@
         "subtitle": "اتصل بخادم XMPP الخاص بك",
         "jidLabel": "JID (معرّف Jabber)",
         "jidPlaceholder": "user@example.com",
+        "jidInvalid": "أدخل معرّف JID بالصيغة name@example.com",
         "passwordLabel": "كلمة المرور",
         "serverLabel": "الخادم (اختياري)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -22,6 +22,7 @@
         "subtitle": "Падключэнне да вашага XMPP сервера",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@domain.tld",
+        "jidInvalid": "Увядзіце JID у фармаце імя@example.com",
         "passwordLabel": "Пароль",
         "serverLabel": "Сервер (неабавязкова)",
         "serverPlaceholder": "wss://domain.tld/ws",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -22,6 +22,7 @@
         "subtitle": "Свържете се с вашия XMPP сървър",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "потребител@example.com",
+        "jidInvalid": "Въведете JID във формат име@example.com",
         "passwordLabel": "Парола",
         "serverLabel": "Сървър (незадължително)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -22,6 +22,7 @@
         "subtitle": "Connecta't al teu servidor XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "usuari@exemple.com",
+        "jidInvalid": "Introduïu un JID com ara nom@exemple.com",
         "passwordLabel": "Mot de pas",
         "serverLabel": "Servidor (Opcional)",
         "serverPlaceholder": "wss://xat.exemple.com/ws",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -22,6 +22,7 @@
         "subtitle": "Připojte se k vašemu XMPP serveru",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@example.com",
+        "jidInvalid": "Zadejte JID ve tvaru jmeno@example.com",
         "passwordLabel": "Heslo",
         "serverLabel": "Server (volitelné)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -22,6 +22,7 @@
         "subtitle": "Opret forbindelse til din XMPP-server",
         "jidLabel": "JID (Jabber-ID)",
         "jidPlaceholder": "bruger@eksempel.dk",
+        "jidInvalid": "Indtast et JID som navn@example.com",
         "passwordLabel": "Adgangskode",
         "serverLabel": "Server (valgfrit)",
         "serverPlaceholder": "wss://chat.eksempel.dk/ws",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -22,6 +22,7 @@
         "subtitle": "Mit Ihrem XMPP-Server verbinden",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "benutzer@beispiel.de",
+        "jidInvalid": "Gib eine JID wie name@example.com ein",
         "passwordLabel": "Passwort",
         "serverLabel": "Server (optional)",
         "serverPlaceholder": "wss://chat.beispiel.de/ws",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -22,6 +22,7 @@
         "subtitle": "Συνδεθείτε στον XMPP διακομιστή σας",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@example.com",
+        "jidInvalid": "Εισαγάγετε ένα JID όπως name@example.com",
         "passwordLabel": "Κωδικός πρόσβασης",
         "serverLabel": "Διακομιστής (Προαιρετικό)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -22,6 +22,7 @@
         "subtitle": "Connect to your XMPP server",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@example.com",
+        "jidInvalid": "Enter a JID like name@example.com",
         "passwordLabel": "Password",
         "serverLabel": "Server (Optional)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -22,6 +22,7 @@
         "subtitle": "Conectar a tu servidor XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "usuario@ejemplo.com",
+        "jidInvalid": "Introduce un JID como nombre@ejemplo.com",
         "passwordLabel": "Contrasena",
         "serverLabel": "Servidor (Opcional)",
         "serverPlaceholder": "wss://chat.ejemplo.com/ws",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -22,6 +22,7 @@
         "subtitle": "Ühenda oma XMPP serveriga",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "kasutaja@naide.ee",
+        "jidInvalid": "Sisestage JID kujul nimi@example.com",
         "passwordLabel": "Parool",
         "serverLabel": "Server (valikuline)",
         "serverPlaceholder": "wss://chat.naide.ee/ws",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -22,6 +22,7 @@
         "subtitle": "Yhdistä XMPP-palvelimeen",
         "jidLabel": "JID (Jabber-tunnus)",
         "jidPlaceholder": "käyttäjä@esimerkki.fi",
+        "jidInvalid": "Anna JID muodossa nimi@example.com",
         "passwordLabel": "Salasana",
         "serverLabel": "Palvelin (valinnainen)",
         "serverPlaceholder": "wss://chat.esimerkki.fi/ws",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -22,6 +22,7 @@
         "subtitle": "Connectez-vous à votre serveur XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "utilisateur@exemple.com",
+        "jidInvalid": "Saisissez un JID au format nom@exemple.com",
         "passwordLabel": "Mot de passe",
         "serverLabel": "Serveur (Optionnel)",
         "serverPlaceholder": "wss://chat.exemple.com/ws",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -22,6 +22,7 @@
         "subtitle": "Ceangail le do fhreastalaí XMPP",
         "jidLabel": "JID (Aitheantas Jabber)",
         "jidPlaceholder": "úsáideoir@sampla.ie",
+        "jidInvalid": "Cuir isteach JID ar nós ainm@example.com",
         "passwordLabel": "Pasfhocal",
         "serverLabel": "Freastalaí (Roghnach)",
         "serverPlaceholder": "wss://chat.sampla.ie/ws",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -22,6 +22,7 @@
         "subtitle": "התחברות לשרת XMPP",
         "jidLabel": "JID (מזהה Jabber)",
         "jidPlaceholder": "user@example.com",
+        "jidInvalid": "הזינו JID בתבנית name@example.com",
         "passwordLabel": "סיסמה",
         "serverLabel": "שרת (אופציונלי)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -22,6 +22,7 @@
         "subtitle": "Povežite se s vašim XMPP poslužiteljem",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "korisnik@primjer.hr",
+        "jidInvalid": "Unesite JID u obliku ime@example.com",
         "passwordLabel": "Lozinka",
         "serverLabel": "Poslužitelj (opcionalno)",
         "serverPlaceholder": "wss://chat.primjer.hr/ws",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -22,6 +22,7 @@
         "subtitle": "Csatlakozás az XMPP szerverhez",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "felhasználó@példa.hu",
+        "jidInvalid": "Adjon meg egy JID-t, például nev@example.com",
         "passwordLabel": "Jelszó",
         "serverLabel": "Szerver (nem kötelező)",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -22,6 +22,7 @@
         "subtitle": "Tengstu við XMPP þjóninn þinn",
         "jidLabel": "JID (Jabber auðkenni)",
         "jidPlaceholder": "notandi@dæmi.is",
+        "jidInvalid": "Sláðu inn JID á borð við nafn@example.com",
         "passwordLabel": "Lykilorð",
         "serverLabel": "Þjónn (valfrjálst)",
         "serverPlaceholder": "wss://chat.dæmi.is/ws",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -22,6 +22,7 @@
         "subtitle": "Connettiti al tuo server XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "utente@esempio.it",
+        "jidInvalid": "Inserisci un JID come nome@esempio.com",
         "passwordLabel": "Password",
         "serverLabel": "Server (opzionale)",
         "serverPlaceholder": "wss://chat.esempio.it/ws",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -22,6 +22,7 @@
         "subtitle": "Prisijunkite prie savo XMPP serverio",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "vartotojas@pavyzdys.lt",
+        "jidInvalid": "Įveskite JID formatu vardas@example.com",
         "passwordLabel": "Slaptažodis",
         "serverLabel": "Serveris (neprivaloma)",
         "serverPlaceholder": "wss://chat.pavyzdys.lt/ws",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -22,6 +22,7 @@
         "subtitle": "Savienojieties ar savu XMPP serveri",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "lietotajs@piemers.com",
+        "jidInvalid": "Ievadiet JID formātā vards@example.com",
         "passwordLabel": "Parole",
         "serverLabel": "Serveris (Neobligāts)",
         "serverPlaceholder": "wss://chat.piemers.com/ws",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -22,6 +22,7 @@
         "subtitle": "Ikkonnettja mas-server XMPP tiegħek",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "utent@eżempju.com",
+        "jidInvalid": "Daħħal JID bħal isem@example.com",
         "passwordLabel": "Password",
         "serverLabel": "Server (Mhux obbligatorju)",
         "serverPlaceholder": "wss://chat.eżempju.com/ws",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -22,6 +22,7 @@
         "subtitle": "Koble til XMPP-serveren din",
         "jidLabel": "JID (Jabber-ID)",
         "jidPlaceholder": "bruker@eksempel.no",
+        "jidInvalid": "Skriv inn en JID som navn@example.com",
         "passwordLabel": "Passord",
         "serverLabel": "Server (valgfritt)",
         "serverPlaceholder": "wss://chat.eksempel.no/ws",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -22,6 +22,7 @@
         "subtitle": "Verbind met je XMPP-server",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "gebruiker@voorbeeld.nl",
+        "jidInvalid": "Voer een JID in zoals naam@example.com",
         "passwordLabel": "Wachtwoord",
         "serverLabel": "Server (Optioneel)",
         "serverPlaceholder": "wss://chat.voorbeeld.nl/ws",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -22,6 +22,7 @@
         "subtitle": "Połącz się ze swoim serwerem XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "użytkownik@przykład.pl",
+        "jidInvalid": "Wprowadź JID w formacie nazwa@example.com",
         "passwordLabel": "Hasło",
         "serverLabel": "Serwer (opcjonalnie)",
         "serverPlaceholder": "wss://czat.przykład.pl/ws",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -22,6 +22,7 @@
         "subtitle": "Ligar ao seu servidor XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "utilizador@exemplo.com",
+        "jidInvalid": "Insira um JID como nome@exemplo.com",
         "passwordLabel": "Palavra-passe",
         "serverLabel": "Servidor (Opcional)",
         "serverPlaceholder": "wss://chat.exemplo.com/ws",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -22,6 +22,7 @@
         "subtitle": "Conectează-te la serverul tău XMPP",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "utilizator@exemplu.com",
+        "jidInvalid": "Introduceți un JID precum nume@example.com",
         "passwordLabel": "Parolă",
         "serverLabel": "Server (Opțional)",
         "serverPlaceholder": "wss://chat.exemplu.com/ws",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -22,6 +22,7 @@
         "subtitle": "Подключитесь к вашему XMPP-серверу",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@domain.tld",
+        "jidInvalid": "Введите JID в формате имя@example.com",
         "passwordLabel": "Пароль",
         "serverLabel": "Сервер (Опционально)",
         "serverPlaceholder": "wss://domain.tld/ws",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -22,6 +22,7 @@
         "subtitle": "Pripojte sa k vášmu XMPP serveru",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "používateľ@príklad.sk",
+        "jidInvalid": "Zadajte JID v tvare meno@example.com",
         "passwordLabel": "Heslo",
         "serverLabel": "Server (voliteľné)",
         "serverPlaceholder": "wss://chat.príklad.sk/ws",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -22,6 +22,7 @@
         "subtitle": "Povežite se s svojim XMPP strežnikom",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "uporabnik@primer.si",
+        "jidInvalid": "Vnesite JID v obliki ime@example.com",
         "passwordLabel": "Geslo",
         "serverLabel": "Strežnik (neobvezno)",
         "serverPlaceholder": "wss://chat.primer.si/ws",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -22,6 +22,7 @@
         "subtitle": "Anslut till din XMPP-server",
         "jidLabel": "JID (Jabber-ID)",
         "jidPlaceholder": "användare@exempel.se",
+        "jidInvalid": "Ange ett JID som namn@example.com",
         "passwordLabel": "Lösenord",
         "serverLabel": "Server (valfritt)",
         "serverPlaceholder": "wss://chat.exempel.se/ws",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -22,6 +22,7 @@
         "subtitle": "Підключення до вашого XMPP сервера",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@domain.tld",
+        "jidInvalid": "Введіть JID у форматі імʼя@example.com",
         "passwordLabel": "Пароль",
         "serverLabel": "Сервер (необов'язково)",
         "serverPlaceholder": "wss://domain.tld/ws",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -22,6 +22,7 @@
         "subtitle": "连接到您的 XMPP 服务器",
         "jidLabel": "JID (Jabber ID)",
         "jidPlaceholder": "user@example.com",
+        "jidInvalid": "请输入 JID，格式如 name@example.com",
         "passwordLabel": "密码",
         "serverLabel": "服务器（可选）",
         "serverPlaceholder": "wss://chat.example.com/ws",

--- a/apps/fluux/src/utils/jidValidation.test.ts
+++ b/apps/fluux/src/utils/jidValidation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { validateBareJid } from './jidValidation'
+
+// Local shape validation for the login JID field (UX_REVIEW §1.4): catch a
+// typo'd JID before a network round-trip. Permissive on domain (XMPP allows a
+// single-label host like `localhost`), strict on the local@domain skeleton and
+// on characters RFC 7622 forbids in the localpart.
+
+describe('validateBareJid', () => {
+  it('treats empty / whitespace-only input as empty (not an error to surface)', () => {
+    expect(validateBareJid('')).toEqual({ valid: false, reason: 'empty' })
+    expect(validateBareJid('   ')).toEqual({ valid: false, reason: 'empty' })
+  })
+
+  it('accepts a well-formed bare JID', () => {
+    expect(validateBareJid('alice@example.com')).toEqual({ valid: true })
+  })
+
+  it('accepts a single-label domain (e.g. localhost)', () => {
+    expect(validateBareJid('alice@localhost')).toEqual({ valid: true })
+  })
+
+  it('accepts a full JID with a resource', () => {
+    expect(validateBareJid('alice@example.com/phone')).toEqual({ valid: true })
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(validateBareJid('  alice@example.com  ')).toEqual({ valid: true })
+  })
+
+  it('rejects a missing @', () => {
+    expect(validateBareJid('alice.example.com')).toEqual({ valid: false, reason: 'malformed' })
+  })
+
+  it('rejects an empty localpart', () => {
+    expect(validateBareJid('@example.com')).toEqual({ valid: false, reason: 'malformed' })
+  })
+
+  it('rejects an empty domain', () => {
+    expect(validateBareJid('alice@')).toEqual({ valid: false, reason: 'malformed' })
+    expect(validateBareJid('alice@/phone')).toEqual({ valid: false, reason: 'malformed' })
+  })
+
+  it('rejects more than one @', () => {
+    expect(validateBareJid('a@b@example.com')).toEqual({ valid: false, reason: 'malformed' })
+  })
+
+  it('rejects internal whitespace', () => {
+    expect(validateBareJid('al ice@example.com')).toEqual({ valid: false, reason: 'malformed' })
+  })
+
+  it.each(['"', '&', "'", ':', '<', '>'])(
+    'rejects the RFC 7622 forbidden localpart character %s',
+    (ch) => {
+      expect(validateBareJid(`al${ch}ice@example.com`)).toEqual({ valid: false, reason: 'malformed' })
+    }
+  )
+})

--- a/apps/fluux/src/utils/jidValidation.ts
+++ b/apps/fluux/src/utils/jidValidation.ts
@@ -1,0 +1,37 @@
+/**
+ * Local, network-free validation of the login JID field (UX_REVIEW §1.4).
+ *
+ * Catches a typo'd JID before a connection round-trip. Deliberately permissive
+ * on the domain (XMPP allows a single-label host such as `localhost`) and on an
+ * optional resource, but strict on the `local@domain` skeleton and on the
+ * characters RFC 7622 forbids in the localpart.
+ *
+ * `reason: 'empty'` lets the UI gate the Connect button without nagging the user
+ * about a field they simply haven't filled yet; `reason: 'malformed'` is the
+ * case worth surfacing inline help for.
+ */
+export type JidValidation = { valid: true } | { valid: false; reason: 'empty' | 'malformed' }
+
+// RFC 7622 §3.3.1 — characters disallowed in a localpart (resource separator
+// '/' and the '@' delimiter are checked structurally below).
+const FORBIDDEN_LOCALPART_CHARS = /["&'<>:]/
+
+export function validateBareJid(input: string): JidValidation {
+  const jid = input.trim()
+  if (jid.length === 0) return { valid: false, reason: 'empty' }
+
+  if (/\s/.test(jid)) return { valid: false, reason: 'malformed' }
+
+  const atParts = jid.split('@')
+  if (atParts.length !== 2) return { valid: false, reason: 'malformed' }
+
+  const [localpart, domainAndResource] = atParts
+  if (localpart.length === 0) return { valid: false, reason: 'malformed' }
+  if (FORBIDDEN_LOCALPART_CHARS.test(localpart)) return { valid: false, reason: 'malformed' }
+
+  // Domain is everything up to an optional '/resource'; it must be non-empty.
+  const domain = domainAndResource.split('/')[0]
+  if (domain.length === 0) return { valid: false, reason: 'malformed' }
+
+  return { valid: true }
+}


### PR DESCRIPTION
## Summary

Catches a typo'd JID before a network round-trip (UX_REVIEW §1.4) — the last small polish on the login screen ahead of the real onboarding work (registration, which belongs to the invitation-flow spec).

- New pure `validateBareJid()` (`utils/jidValidation.ts`) checks the `local@domain` skeleton and the RFC 7622 forbidden localpart characters, while staying permissive on single-label domains (`localhost`) and an optional `/resource`. Returns `{ valid: false, reason: 'empty' | 'malformed' }` so the UI can gate without nagging an unfilled field.
- The Connect button is gated on a valid shape (was gated on non-empty only).
- A malformed JID shows an inline hint with a red border and `aria-invalid` / `aria-describedby`, but only **after the field has been blurred** — no nagging mid-typing. The hint and styling clear live as the user fixes the value.
- New `login.jidInvalid` string translated in all 33 locales.