### PR TITLE
fix(i18n): use verb form for whisper menu action across locales

### DIFF
--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Запрашэнне адхілена: {{error}}",
         "sendInvitations": "Адправіць {{count}} запрашэнне(няў)",
         "sendPrivateMessage": "Адправіць прыватнае паведамленне",
-        "whisper": "Шэпт",
+        "whisper": "Шапнуць",
         "whisperingTo": "Шэпчаце прыватна да {{nick}}",
         "whisperThread": "Прыватна з {{nick}}",
         "whisperCounterpartGone": "{{nick}} больш не ў пакоі — вы не можаце адказаць",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Покана отхвърлена: {{error}}",
         "sendInvitations": "Изпрати {{count}} покана(и)",
         "sendPrivateMessage": "Изпращане на лично съобщение",
-        "whisper": "Шепот",
+        "whisper": "Шепнене",
         "whisperingTo": "Шепнете лично на {{nick}}",
         "whisperThread": "Лично с {{nick}}",
         "whisperCounterpartGone": "{{nick}} вече не е в стаята — не можете да отговорите",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -315,7 +315,7 @@
         "inviteRejected": "Invitació rebutjada: {{error}}",
         "sendInvitations": "Envia {{count}} invitació/invitacions",
         "sendPrivateMessage": "Enviar missatge privat",
-        "whisper": "Xiuxiueig",
+        "whisper": "Xiuxiuejar",
         "whisperingTo": "Xiuxiuejant en privat a {{nick}}",
         "whisperThread": "Privat amb {{nick}}",
         "whisperCounterpartGone": "{{nick}} ja no és a la sala — no pots respondre",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -315,7 +315,7 @@
         "inviteRejected": "Pozvánka odmítnuta: {{error}}",
         "sendInvitations": "Odeslat {{count}} pozvánku(-ek)",
         "sendPrivateMessage": "Odeslat soukromou zprávu",
-        "whisper": "Šepot",
+        "whisper": "Šeptat",
         "whisperingTo": "Šeptáte soukromě {{nick}}",
         "whisperThread": "Soukromě s {{nick}}",
         "whisperCounterpartGone": "{{nick}} už není v místnosti — nemůžete odpovědět",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -314,7 +314,7 @@
         "inviteRejected": "Η πρόσκληση απορρίφθηκε: {{error}}",
         "sendInvitations": "Αποστολή {{count}} πρόσκλησης(-εων)",
         "sendPrivateMessage": "Αποστολή ιδιωτικού μηνύματος",
-        "whisper": "Ψίθυρος",
+        "whisper": "Ψιθύρισμα",
         "whisperingTo": "Ψιθυρίζετε ιδιωτικά στον {{nick}}",
         "whisperThread": "Ιδιωτικά με {{nick}}",
         "whisperCounterpartGone": "{{nick}} δεν είναι πλέον στο δωμάτιο — δεν μπορείτε να απαντήσετε",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -315,7 +315,7 @@
             "visitor": "Visitante"
         },
         "sendPrivateMessage": "Enviar mensaje privado",
-        "whisper": "Susurro",
+        "whisper": "Susurrar",
         "whisperingTo": "Susurrando en privado a {{nick}}",
         "whisperThread": "Privado con {{nick}}",
         "whisperCounterpartGone": "{{nick}} ya no está en la sala — no puedes responder",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -315,7 +315,7 @@
         "inviteRejected": "Kutse tagasi lükatud: {{error}}",
         "sendInvitations": "Saada {{count}} kutset",
         "sendPrivateMessage": "Saada privaatsõnum",
-        "whisper": "Sosistamine",
+        "whisper": "Sosista",
         "whisperingTo": "Sosistate privaatselt {{nick}}-le",
         "whisperThread": "Privaatne {{nick}}-ga",
         "whisperCounterpartGone": "{{nick}} pole enam toas — sa ei saa vastata",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Kutsu hylätty: {{error}}",
         "sendInvitations": "Lähetä {{count}} kutsu(a)",
         "sendPrivateMessage": "Lähetä yksityisviesti",
-        "whisper": "Kuiskaus",
+        "whisper": "Kuiskaa",
         "whisperingTo": "Kuiskaat yksityisesti {{nick}}:lle",
         "whisperThread": "Yksityinen {{nick}}:n kanssa",
         "whisperCounterpartGone": "{{nick}} ei ole enää huoneessa — et voi vastata",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -314,7 +314,7 @@
         "sendInvitations": "Envoyer {{count}} invitation(s)",
         "outcast": "Banni",
         "sendPrivateMessage": "Envoyer un message privé",
-        "whisper": "Chuchotement",
+        "whisper": "Chuchoter",
         "whisperingTo": "Vous chuchotez en privé à {{nick}}",
         "whisperThread": "Privé avec {{nick}}",
         "whisperCounterpartGone": "{{nick}} n'est plus dans le salon — vous ne pouvez pas répondre",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Cuireadh diúltaithe: {{error}}",
         "sendInvitations": "Seol {{count}} cuireadh",
         "sendPrivateMessage": "Seol teachtaireacht phríobháideach",
-        "whisper": "Cogar",
+        "whisper": "Cogair",
         "whisperingTo": "Ag cogarnach go príobháideach chuig {{nick}}",
         "whisperThread": "Príobháideach le {{nick}}",
         "whisperCounterpartGone": "Níl {{nick}} sa seomra a thuilleadh — ní féidir leat freagra a thabhairt",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -313,7 +313,7 @@
         "inviteRejected": "ההזמנה נדחתה: {{error}}",
         "sendInvitations": "שלח {{count}} הזמנות",
         "sendPrivateMessage": "שלח הודעה פרטית",
-        "whisper": "לחישה",
+        "whisper": "לחש",
         "whisperingTo": "לוחש בפרטיות ל-{{nick}}",
         "whisperThread": "פרטי עם {{nick}}",
         "whisperCounterpartGone": "{{nick}} כבר לא נמצא בחדר — אי אפשר להשיב",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Pozivnica odbijena: {{error}}",
         "sendInvitations": "Pošalji {{count}} pozivnica(e)",
         "sendPrivateMessage": "Pošalji privatnu poruku",
-        "whisper": "Šaputanje",
+        "whisper": "Šapni",
         "whisperingTo": "Šaputate privatno {{nick}}-u",
         "whisperThread": "Privatno s {{nick}}",
         "whisperCounterpartGone": "{{nick}} više nije u sobi — ne možete odgovoriti",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -315,7 +315,7 @@
         "sendInvitations": "Invia {{count}} invito/i",
         "outcast": "Bandito",
         "sendPrivateMessage": "Invia messaggio privato",
-        "whisper": "Sussurro",
+        "whisper": "Sussurra",
         "whisperingTo": "Stai sussurrando in privato a {{nick}}",
         "whisperThread": "Privato con {{nick}}",
         "whisperCounterpartGone": "{{nick}} non è più nella stanza — non puoi rispondere",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Pakvietimas atmestas: {{error}}",
         "sendInvitations": "Siųsti {{count}} pakvietimą(us)",
         "sendPrivateMessage": "Siųsti privačią žinutę",
-        "whisper": "Šnabždesys",
+        "whisper": "Šnabždėti",
         "whisperingTo": "Šnabždate privačiai {{nick}}",
         "whisperThread": "Privačiai su {{nick}}",
         "whisperCounterpartGone": "{{nick}} nebėra kambaryje — negalite atsakyti",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -314,7 +314,7 @@
         "inviteRejected": "Uzaicinājums noraidīts: {{error}}",
         "sendInvitations": "Nosūtīt {{count}} uzaicinājumu(-s)",
         "sendPrivateMessage": "Sūtīt privātu ziņojumu",
-        "whisper": "Čuksts",
+        "whisper": "Čukstēt",
         "whisperingTo": "Čukstat privāti {{nick}}",
         "whisperThread": "Privāti ar {{nick}}",
         "whisperCounterpartGone": "{{nick}} vairs nav istabā — jūs nevarat atbildēt",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -315,7 +315,7 @@
         "inviteRejected": "Stedina rrifjutata: {{error}}",
         "sendInvitations": "Ibgħat {{count}} stedina/i",
         "sendPrivateMessage": "Ibgħat messaġġ privat",
-        "whisper": "Sussurru",
+        "whisper": "Fesfes",
         "whisperingTo": "Qiegħed tsussurra b'mod privat lil {{nick}}",
         "whisperThread": "Privat ma' {{nick}}",
         "whisperCounterpartGone": "{{nick}} m'għadux fil-kamra — ma tistax twieġeb",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -315,7 +315,7 @@
         "sendInvitations": "Wyślij {{count}} zaproszeń",
         "outcast": "Zbanowany",
         "sendPrivateMessage": "Wyślij prywatną wiadomość",
-        "whisper": "Szept",
+        "whisper": "Szepnij",
         "whisperingTo": "Szepczesz prywatnie do {{nick}}",
         "whisperThread": "Prywatnie z {{nick}}",
         "whisperCounterpartGone": "{{nick}} nie jest już w pokoju — nie możesz odpowiedzieć",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -315,7 +315,7 @@
         "sendInvitations": "Enviar {{count}} convite(s)",
         "outcast": "Banido",
         "sendPrivateMessage": "Enviar mensagem privada",
-        "whisper": "Sussurro",
+        "whisper": "Sussurrar",
         "whisperingTo": "Sussurrando em privado para {{nick}}",
         "whisperThread": "Privado com {{nick}}",
         "whisperCounterpartGone": "{{nick}} já não está na sala — não podes responder",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -315,7 +315,7 @@
         "inviteRejected": "Invitație respinsă: {{error}}",
         "sendInvitations": "Trimite {{count}} invitație(i)",
         "sendPrivateMessage": "Trimite mesaj privat",
-        "whisper": "Șoaptă",
+        "whisper": "Șoptește",
         "whisperingTo": "Îi șoptești în privat lui {{nick}}",
         "whisperThread": "Privat cu {{nick}}",
         "whisperCounterpartGone": "{{nick}} nu mai este în cameră — nu poți răspunde",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Приглашение отклонено: {{error}}",
         "sendInvitations": "Отправить {{count}} приглашение(я/ий)",
         "sendPrivateMessage": "Отправить личное сообщение",
-        "whisper": "Шёпот",
+        "whisper": "Шепнуть",
         "whisperingTo": "Шепчете лично {{nick}}",
         "whisperThread": "Лично с {{nick}}",
         "whisperCounterpartGone": "{{nick}} больше не в комнате — вы не можете ответить",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -314,7 +314,7 @@
         "inviteRejected": "Pozvánka odmietnutá: {{error}}",
         "sendInvitations": "Odoslať {{count}} pozvánku(y)",
         "sendPrivateMessage": "Odoslať súkromnú správu",
-        "whisper": "Šepot",
+        "whisper": "Šepkať",
         "whisperingTo": "Šepkáte súkromne {{nick}}",
         "whisperThread": "Súkromne s {{nick}}",
         "whisperCounterpartGone": "{{nick}} už nie je v miestnosti — nemôžete odpovedať",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -315,7 +315,7 @@
         "inviteRejected": "Povabilo zavrnjeno: {{error}}",
         "sendInvitations": "Pošlji {{count}} povabilo(a)",
         "sendPrivateMessage": "Pošlji zasebno sporočilo",
-        "whisper": "Šepetanje",
+        "whisper": "Šepni",
         "whisperingTo": "Šepetate zasebno {{nick}}",
         "whisperThread": "Zasebno z {{nick}}",
         "whisperCounterpartGone": "{{nick}} ni več v sobi — ne morete odgovoriti",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Inbjudan avvisad: {{error}}",
         "sendInvitations": "Skicka {{count}} inbjudan(ar)",
         "sendPrivateMessage": "Skicka privat meddelande",
-        "whisper": "Viskning",
+        "whisper": "Viska",
         "whisperingTo": "Viskar privat till {{nick}}",
         "whisperThread": "Privat med {{nick}}",
         "whisperCounterpartGone": "{{nick}} är inte längre i rummet — du kan inte svara",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -313,7 +313,7 @@
         "inviteRejected": "Запрошення відхилено: {{error}}",
         "sendInvitations": "Надіслати {{count}} запрошення(ь)",
         "sendPrivateMessage": "Надіслати приватне повідомлення",
-        "whisper": "Шепіт",
+        "whisper": "Шепнути",
         "whisperingTo": "Шепочете приватно до {{nick}}",
         "whisperThread": "Приватно з {{nick}}",
         "whisperCounterpartGone": "{{nick}} більше не в кімнаті — ви не можете відповісти",

--- a/docs/superpowers/plans/2026-06-11-whisper-continue.md
+++ b/docs/superpowers/plans/2026-06-11-whisper-continue.md
@@ -1,0 +1,218 @@
+# Continue a Whispered Conversation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user continue a MUC whisper (private message) when it is the last message in the room — via the reply button and via a clickable "Private with {nick}" thread header.
+
+**Architecture:** Both changes live in `MessageBubble.tsx`. The existing `onReply` prop already routes private messages into whisper mode upstream (`RoomView.handleReplyToMessage` → `enterWhisperMode`), so no new wiring, no SDK change, no new i18n key. Spec: `docs/superpowers/specs/2026-06-11-whisper-continue-design.md`.
+
+**Tech Stack:** React + TypeScript, Tailwind, Vitest + @testing-library/react.
+
+**Branch:** `fix/whisper-continue-last-message` (already created, spec committed).
+
+---
+
+## Context for the implementer
+
+- `apps/fluux/src/components/conversation/MessageBubble.tsx` renders one message row. Relevant locals (lines ~361-365):
+  - `inThread = !!whisperThread` — message is part of a whisper thread.
+  - `threadStart` — first row of the thread; it renders the "Private with {nick}" header (lines ~417-422).
+  - `counterpartGone = inThread && counterpartPresent === false` — whisper counterpart left the room; thread is read-only.
+- The reply button lives in `MessageToolbar.tsx` and renders only when the `canReply` prop is true; its accessible name is `t('chat.reply')`.
+- `onReply: () => void` is already bound to the message by the parent; for private messages it enters whisper mode (with its own counterpart-gone guard + toast).
+- In tests, `react-i18next` is mocked so `t(key, params)` returns the raw key (e.g. `'rooms.whisperThread'`).
+- The memo comparator already invalidates on `whisperThread`, `counterpartPresent`, and `isLastMessage` (lines ~148-150, ~193); callback props are intentionally ignored. No memo change needed.
+- Run app tests from `apps/fluux` (NOT bare `vitest` from repo root — it mass-fails on `@/` aliases).
+
+---
+
+### Task 1: Show the reply button on the last message when it is a whisper
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/MessageBubble.tsx:431`
+- Test: `apps/fluux/src/components/conversation/MessageBubble.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new top-level `describe` block at the end of the `describe('MessageBubble', ...)` block in `MessageBubble.test.tsx` (after the `'Data Attributes'` block, before its closing `})`):
+
+```tsx
+  describe('Whisper threads (MUC private messages)', () => {
+    // A whisper can only be continued via "reply" (it re-enters whisper mode
+    // upstream), so unlike public messages the reply button must also be
+    // available on the LAST message of the conversation.
+    function whisperProps(overrides: Partial<MessageBubbleProps> = {}): MessageBubbleProps {
+      return createDefaultProps({
+        whisperThread: 'solo',
+        whisperWith: 'Adrien',
+        counterpartPresent: true,
+        ...overrides,
+      })
+    }
+
+    it('shows the reply button on the last message when it is a whisper', () => {
+      render(<MessageBubble {...whisperProps({ isLastMessage: true })} />)
+
+      expect(screen.getByRole('button', { name: 'chat.reply' })).toBeInTheDocument()
+    })
+
+    it('keeps the reply button hidden on the last message when it is public', () => {
+      render(<MessageBubble {...createDefaultProps({ isLastMessage: true })} />)
+
+      expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
+    })
+
+    it('hides the reply button on a whisper when the counterpart left the room', () => {
+      render(<MessageBubble {...whisperProps({ isLastMessage: true, counterpartPresent: false })} />)
+
+      expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: Run the new tests to verify the right one fails**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: `'shows the reply button on the last message when it is a whisper'` FAILS (button absent); the two other new tests pass; all pre-existing tests pass.
+
+- [ ] **Step 3: Fix the `canReply` condition**
+
+In `MessageBubble.tsx` line 431, change:
+
+```tsx
+            canReply={!isLastMessage && !counterpartGone}
+```
+
+to:
+
+```tsx
+            canReply={(!isLastMessage || inThread) && !counterpartGone}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: ALL tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger && git add apps/fluux/src/components/conversation/MessageBubble.tsx apps/fluux/src/components/conversation/MessageBubble.test.tsx && git commit -m "fix(muc): allow replying to a whisper when it is the last message"
+```
+
+---
+
+### Task 2: Make the "Private with {nick}" thread header clickable
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/MessageBubble.tsx:417-422`
+- Test: `apps/fluux/src/components/conversation/MessageBubble.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `describe('Whisper threads (MUC private messages)', ...)` block from Task 1:
+
+```tsx
+    it('re-enters whisper mode when the thread header is clicked', () => {
+      const onReply = vi.fn()
+      render(<MessageBubble {...whisperProps({ onReply })} />)
+
+      const header = screen.getByText('rooms.whisperThread').closest('button')
+      expect(header).not.toBeNull()
+      fireEvent.click(header!)
+
+      expect(onReply).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders the thread header as plain text when the counterpart left the room', () => {
+      render(<MessageBubble {...whisperProps({ counterpartPresent: false })} />)
+
+      expect(screen.getByText('rooms.whisperThread')).toBeInTheDocument()
+      expect(screen.getByText('rooms.whisperThread').closest('button')).toBeNull()
+    })
+```
+
+- [ ] **Step 2: Run the tests to verify the right one fails**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: `'re-enters whisper mode when the thread header is clicked'` FAILS (`header` is null — the header is currently a `<div>`); the plain-text test passes; all other tests pass.
+
+- [ ] **Step 3: Implement the clickable header**
+
+In `MessageBubble.tsx`, replace the current header block (lines 417-422):
+
+```tsx
+        {threadStart && (
+          <div className="flex items-center gap-1.5 pb-1 text-xs font-medium text-fluux-private">
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </div>
+        )}
+```
+
+with a version that is a real button while the counterpart is present (clicking it re-enters whisper mode through the same `onReply` flow as the toolbar button) and stays a plain `<div>` once the counterpart left (the thread footer already explains why it is read-only):
+
+```tsx
+        {threadStart && (counterpartGone ? (
+          <div className="flex items-center gap-1.5 pb-1 text-xs font-medium text-fluux-private">
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onReply}
+            title={t('rooms.sendPrivateMessage')}
+            className="flex max-w-full cursor-pointer items-center gap-1.5 -ms-1 mb-0.5 rounded px-1 py-0.5 text-xs font-medium text-fluux-private transition-colors hover:bg-fluux-private-hover"
+          >
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </button>
+        ))}
+```
+
+Notes:
+- `Ear` is already imported; no new imports.
+- `title={t('rooms.sendPrivateMessage')}` reuses the existing occupant-menu key ("Send private message") as the tooltip — no new i18n key.
+- `-ms-1 px-1 py-0.5 rounded hover:bg-fluux-private-hover` gives the hover affordance without shifting the label (negative start margin compensates the padding); `mb-0.5` + `py-0.5` ≈ the old `pb-1` spacing.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: ALL tests pass.
+
+- [ ] **Step 5: Full verification (tests, typecheck, lint)**
+
+Run from the repo root:
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger && npm test && npm run typecheck && npm run lint
+```
+
+Expected: all three pass with no errors and no stderr noise.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger && git add apps/fluux/src/components/conversation/MessageBubble.tsx apps/fluux/src/components/conversation/MessageBubble.test.tsx && git commit -m "feat(muc): click the whisper thread header to continue the private conversation"
+```
+
+---
+
+### Task 3: Visual verification in demo mode
+
+**Files:** none (manual/browser verification).
+
+- [ ] **Step 1: Verify in the running app**
+
+Start the dev server (`npm run dev` from the repo root) and open `http://localhost:5173/demo.html?tutorial=false`. In a demo room containing a whisper thread (or after sending a whisper via an occupant's "Send private message"):
+
+- Hovering the last message when it is a whisper shows the reply button; clicking it switches the composer to whisper mode ("Whispering privately to {nick}").
+- Hovering "Private with {nick}" shows the hover background + pointer cursor; clicking it switches the composer to whisper mode.
+- A public last message still shows no reply button.
+
+If demo data needs re-seeding, clear `xmpp-chat-storage` and `fluux:activity-log` in localStorage.

--- a/docs/superpowers/specs/2026-06-11-whisper-continue-design.md
+++ b/docs/superpowers/specs/2026-06-11-whisper-continue-design.md
@@ -1,0 +1,61 @@
+# Continue a whispered conversation (MUC private messages)
+
+**Date:** 2026-06-11
+**Status:** Approved
+
+## Problem
+
+A whisper (MUC private message, XEP-0045 §7.5) can only be continued by clicking
+"Reply" on one of its messages, which re-enters whisper mode. But the reply
+button is hidden on the last message of the conversation
+(`canReply={!isLastMessage && !counterpartGone}` in `MessageBubble.tsx`) — a
+deliberate choice for public replies, where quoting the last message is
+redundant. When the whisper is the last message in the room, there is no way to
+continue the private conversation from the whisper frame; the user must go
+through the occupant panel.
+
+## Changes
+
+Both changes are in
+`apps/fluux/src/components/conversation/MessageBubble.tsx`. No SDK change, no
+composer/`whisperTarget` change, no new wiring in `RoomView.tsx`.
+
+### 1. Show the reply button on the last message when it is a whisper
+
+```tsx
+canReply={(!isLastMessage || inThread) && !counterpartGone}
+```
+
+The existing flow does the rest: `onReply` on a private message reaches
+`handleReplyToMessage` (`RoomView.tsx`), which enters whisper mode with the
+counterpart-gone guard and toast.
+
+### 2. Make the "Private with {nick}" thread header clickable
+
+The thread-start header (Ear icon + `rooms.whisperThread` label) becomes a real
+`<button type="button">` when the counterpart is present:
+
+- Click → `onReply(message)` — same flow as change 1.
+- Style: `hover:bg-fluux-private-hover`, rounded corner, `cursor-pointer`,
+  consistent with the composer whisper banner.
+- Accessibility/tooltip: reuse the existing i18n key
+  `rooms.sendPrivateMessage` ("Send private message") as `aria-label`/tooltip.
+  No new i18n key, so no translation pass over the 33 locales.
+- When the counterpart has left the room (`counterpartGone`), the header stays
+  a plain non-clickable `<div>` — the thread footer ("X is no longer in the
+  room") already explains why.
+
+## Testing
+
+Extend existing app tests around MessageBubble:
+
+- Reply button present on the last message when it is private; absent when the
+  last message is public; absent when the whisper counterpart has left.
+- Clicking the thread header calls `onReply` with the message.
+- The thread header is not a button when `counterpartGone`.
+
+## Out of scope
+
+- SDK changes.
+- Composer / `whisperTarget` behavior.
+- Reply button behavior on the last *public* message (unchanged).


### PR DESCRIPTION
The occupant context-menu label `rooms.whisper` was translated as a noun in 24 locales (fr « Chuchotement », es « Susurro », it « Sussurro », …) while the sibling menu items (« Envoyer un message privé », « Ignorer dans ce salon », « Gérer ») are action verbs.

Each locale is now aligned with its own menu convention — infinitive (fr « Chuchoter », es « Susurrar », ru « Шепнуть ») or imperative (it « Sussurra », fi « Kuiskaa », ro « Șoptește ») depending on what the neighbouring keys use. Locales whose menus follow a nominal convention (ar, hu, zh-CN) or were already verbs (de, nl, da, nb, is) are untouched.