### PR TITLE
fix(muc): allow continuing a whispered conversation from its frame

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -533,6 +533,24 @@ describe('MessageBubble', () => {
 
       expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
     })
+
+    it('re-enters whisper mode when the thread header is clicked', () => {
+      const onReply = vi.fn()
+      render(<MessageBubble {...whisperProps({ onReply })} />)
+
+      const header = screen.getByText('rooms.whisperThread').closest('button')
+      expect(header).not.toBeNull()
+      fireEvent.click(header!)
+
+      expect(onReply).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders the thread header as plain text when the counterpart left the room', () => {
+      render(<MessageBubble {...whisperProps({ counterpartPresent: false })} />)
+
+      expect(screen.getByText('rooms.whisperThread')).toBeInTheDocument()
+      expect(screen.getByText('rooms.whisperThread').closest('button')).toBeNull()
+    })
   })
 })
 

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -502,6 +502,38 @@ describe('MessageBubble', () => {
       expect(messageDiv.getAttribute('data-message-body')).toBe('Test message content')
     })
   })
+
+  describe('Whisper threads (MUC private messages)', () => {
+    // A whisper can only be continued via "reply" (it re-enters whisper mode
+    // upstream), so unlike public messages the reply button must also be
+    // available on the LAST message of the conversation.
+    function whisperProps(overrides: Partial<MessageBubbleProps> = {}): MessageBubbleProps {
+      return createDefaultProps({
+        whisperThread: 'solo',
+        whisperWith: 'Adrien',
+        counterpartPresent: true,
+        ...overrides,
+      })
+    }
+
+    it('shows the reply button on the last message when it is a whisper', () => {
+      render(<MessageBubble {...whisperProps({ isLastMessage: true })} />)
+
+      expect(screen.getByRole('button', { name: 'chat.reply' })).toBeInTheDocument()
+    })
+
+    it('keeps the reply button hidden on the last message when it is public', () => {
+      render(<MessageBubble {...createDefaultProps({ isLastMessage: true })} />)
+
+      expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
+    })
+
+    it('hides the reply button on a whisper when the counterpart left the room', () => {
+      render(<MessageBubble {...whisperProps({ isLastMessage: true, counterpartPresent: false })} />)
+
+      expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
+    })
+  })
 })
 
 describe('buildReplyContext', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -428,7 +428,7 @@ export const MessageBubble = memo(function MessageBubble({
             onEdit={onEdit}
             onDelete={onDelete}
             myReactions={reactionsEnabled ? myReactions : []}
-            canReply={!isLastMessage && !counterpartGone}
+            canReply={(!isLastMessage || inThread) && !counterpartGone}
             canEdit={message.isOutgoing && isLastOutgoing}
             canDelete={message.isOutgoing || canModerate === true}
             isHidden={hideToolbar || false}

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -414,12 +414,24 @@ export const MessageBubble = memo(function MessageBubble({
 
       {/* Content */}
       <div className={`relative flex-1 min-w-0 ${isSelected ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''}`}>
-        {threadStart && (
+        {threadStart && (counterpartGone ? (
           <div className="flex items-center gap-1.5 pb-1 text-xs font-medium text-fluux-private">
             <Ear className="size-3.5 shrink-0" />
             <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
           </div>
-        )}
+        ) : (
+          // Clicking the header re-enters whisper mode (same flow as the
+          // toolbar reply button); read-only threads keep the plain label.
+          <button
+            type="button"
+            onClick={onReply}
+            title={t('rooms.sendPrivateMessage')}
+            className="flex max-w-full cursor-pointer items-center gap-1.5 -ms-1 mb-0.5 rounded px-1 py-0.5 text-xs font-medium text-fluux-private transition-colors hover:bg-fluux-private-hover"
+          >
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </button>
+        ))}
         {/* Floating hover toolbar - hidden when user is composing or message is retracted */}
         {!message.isRetracted && (
           <MessageToolbar

--- a/docs/superpowers/plans/2026-06-11-whisper-continue.md
+++ b/docs/superpowers/plans/2026-06-11-whisper-continue.md
@@ -1,0 +1,218 @@
+# Continue a Whispered Conversation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user continue a MUC whisper (private message) when it is the last message in the room — via the reply button and via a clickable "Private with {nick}" thread header.
+
+**Architecture:** Both changes live in `MessageBubble.tsx`. The existing `onReply` prop already routes private messages into whisper mode upstream (`RoomView.handleReplyToMessage` → `enterWhisperMode`), so no new wiring, no SDK change, no new i18n key. Spec: `docs/superpowers/specs/2026-06-11-whisper-continue-design.md`.
+
+**Tech Stack:** React + TypeScript, Tailwind, Vitest + @testing-library/react.
+
+**Branch:** `fix/whisper-continue-last-message` (already created, spec committed).
+
+---
+
+## Context for the implementer
+
+- `apps/fluux/src/components/conversation/MessageBubble.tsx` renders one message row. Relevant locals (lines ~361-365):
+  - `inThread = !!whisperThread` — message is part of a whisper thread.
+  - `threadStart` — first row of the thread; it renders the "Private with {nick}" header (lines ~417-422).
+  - `counterpartGone = inThread && counterpartPresent === false` — whisper counterpart left the room; thread is read-only.
+- The reply button lives in `MessageToolbar.tsx` and renders only when the `canReply` prop is true; its accessible name is `t('chat.reply')`.
+- `onReply: () => void` is already bound to the message by the parent; for private messages it enters whisper mode (with its own counterpart-gone guard + toast).
+- In tests, `react-i18next` is mocked so `t(key, params)` returns the raw key (e.g. `'rooms.whisperThread'`).
+- The memo comparator already invalidates on `whisperThread`, `counterpartPresent`, and `isLastMessage` (lines ~148-150, ~193); callback props are intentionally ignored. No memo change needed.
+- Run app tests from `apps/fluux` (NOT bare `vitest` from repo root — it mass-fails on `@/` aliases).
+
+---
+
+### Task 1: Show the reply button on the last message when it is a whisper
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/MessageBubble.tsx:431`
+- Test: `apps/fluux/src/components/conversation/MessageBubble.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new top-level `describe` block at the end of the `describe('MessageBubble', ...)` block in `MessageBubble.test.tsx` (after the `'Data Attributes'` block, before its closing `})`):
+
+```tsx
+  describe('Whisper threads (MUC private messages)', () => {
+    // A whisper can only be continued via "reply" (it re-enters whisper mode
+    // upstream), so unlike public messages the reply button must also be
+    // available on the LAST message of the conversation.
+    function whisperProps(overrides: Partial<MessageBubbleProps> = {}): MessageBubbleProps {
+      return createDefaultProps({
+        whisperThread: 'solo',
+        whisperWith: 'Adrien',
+        counterpartPresent: true,
+        ...overrides,
+      })
+    }
+
+    it('shows the reply button on the last message when it is a whisper', () => {
+      render(<MessageBubble {...whisperProps({ isLastMessage: true })} />)
+
+      expect(screen.getByRole('button', { name: 'chat.reply' })).toBeInTheDocument()
+    })
+
+    it('keeps the reply button hidden on the last message when it is public', () => {
+      render(<MessageBubble {...createDefaultProps({ isLastMessage: true })} />)
+
+      expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
+    })
+
+    it('hides the reply button on a whisper when the counterpart left the room', () => {
+      render(<MessageBubble {...whisperProps({ isLastMessage: true, counterpartPresent: false })} />)
+
+      expect(screen.queryByRole('button', { name: 'chat.reply' })).not.toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: Run the new tests to verify the right one fails**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: `'shows the reply button on the last message when it is a whisper'` FAILS (button absent); the two other new tests pass; all pre-existing tests pass.
+
+- [ ] **Step 3: Fix the `canReply` condition**
+
+In `MessageBubble.tsx` line 431, change:
+
+```tsx
+            canReply={!isLastMessage && !counterpartGone}
+```
+
+to:
+
+```tsx
+            canReply={(!isLastMessage || inThread) && !counterpartGone}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: ALL tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger && git add apps/fluux/src/components/conversation/MessageBubble.tsx apps/fluux/src/components/conversation/MessageBubble.test.tsx && git commit -m "fix(muc): allow replying to a whisper when it is the last message"
+```
+
+---
+
+### Task 2: Make the "Private with {nick}" thread header clickable
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/MessageBubble.tsx:417-422`
+- Test: `apps/fluux/src/components/conversation/MessageBubble.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `describe('Whisper threads (MUC private messages)', ...)` block from Task 1:
+
+```tsx
+    it('re-enters whisper mode when the thread header is clicked', () => {
+      const onReply = vi.fn()
+      render(<MessageBubble {...whisperProps({ onReply })} />)
+
+      const header = screen.getByText('rooms.whisperThread').closest('button')
+      expect(header).not.toBeNull()
+      fireEvent.click(header!)
+
+      expect(onReply).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders the thread header as plain text when the counterpart left the room', () => {
+      render(<MessageBubble {...whisperProps({ counterpartPresent: false })} />)
+
+      expect(screen.getByText('rooms.whisperThread')).toBeInTheDocument()
+      expect(screen.getByText('rooms.whisperThread').closest('button')).toBeNull()
+    })
+```
+
+- [ ] **Step 2: Run the tests to verify the right one fails**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: `'re-enters whisper mode when the thread header is clicked'` FAILS (`header` is null — the header is currently a `<div>`); the plain-text test passes; all other tests pass.
+
+- [ ] **Step 3: Implement the clickable header**
+
+In `MessageBubble.tsx`, replace the current header block (lines 417-422):
+
+```tsx
+        {threadStart && (
+          <div className="flex items-center gap-1.5 pb-1 text-xs font-medium text-fluux-private">
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </div>
+        )}
+```
+
+with a version that is a real button while the counterpart is present (clicking it re-enters whisper mode through the same `onReply` flow as the toolbar button) and stays a plain `<div>` once the counterpart left (the thread footer already explains why it is read-only):
+
+```tsx
+        {threadStart && (counterpartGone ? (
+          <div className="flex items-center gap-1.5 pb-1 text-xs font-medium text-fluux-private">
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onReply}
+            title={t('rooms.sendPrivateMessage')}
+            className="flex max-w-full cursor-pointer items-center gap-1.5 -ms-1 mb-0.5 rounded px-1 py-0.5 text-xs font-medium text-fluux-private transition-colors hover:bg-fluux-private-hover"
+          >
+            <Ear className="size-3.5 shrink-0" />
+            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+          </button>
+        ))}
+```
+
+Notes:
+- `Ear` is already imported; no new imports.
+- `title={t('rooms.sendPrivateMessage')}` reuses the existing occupant-menu key ("Send private message") as the tooltip — no new i18n key.
+- `-ms-1 px-1 py-0.5 rounded hover:bg-fluux-private-hover` gives the hover affordance without shifting the label (negative start margin compensates the padding); `mb-0.5` + `py-0.5` ≈ the old `pb-1` spacing.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/mremond/AIProjects/fluux-messenger/apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx`
+
+Expected: ALL tests pass.
+
+- [ ] **Step 5: Full verification (tests, typecheck, lint)**
+
+Run from the repo root:
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger && npm test && npm run typecheck && npm run lint
+```
+
+Expected: all three pass with no errors and no stderr noise.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger && git add apps/fluux/src/components/conversation/MessageBubble.tsx apps/fluux/src/components/conversation/MessageBubble.test.tsx && git commit -m "feat(muc): click the whisper thread header to continue the private conversation"
+```
+
+---
+
+### Task 3: Visual verification in demo mode
+
+**Files:** none (manual/browser verification).
+
+- [ ] **Step 1: Verify in the running app**
+
+Start the dev server (`npm run dev` from the repo root) and open `http://localhost:5173/demo.html?tutorial=false`. In a demo room containing a whisper thread (or after sending a whisper via an occupant's "Send private message"):
+
+- Hovering the last message when it is a whisper shows the reply button; clicking it switches the composer to whisper mode ("Whispering privately to {nick}").
+- Hovering "Private with {nick}" shows the hover background + pointer cursor; clicking it switches the composer to whisper mode.
+- A public last message still shows no reply button.
+
+If demo data needs re-seeding, clear `xmpp-chat-storage` and `fluux:activity-log` in localStorage.

--- a/docs/superpowers/specs/2026-06-11-whisper-continue-design.md
+++ b/docs/superpowers/specs/2026-06-11-whisper-continue-design.md
@@ -1,0 +1,61 @@
+# Continue a whispered conversation (MUC private messages)
+
+**Date:** 2026-06-11
+**Status:** Approved
+
+## Problem
+
+A whisper (MUC private message, XEP-0045 §7.5) can only be continued by clicking
+"Reply" on one of its messages, which re-enters whisper mode. But the reply
+button is hidden on the last message of the conversation
+(`canReply={!isLastMessage && !counterpartGone}` in `MessageBubble.tsx`) — a
+deliberate choice for public replies, where quoting the last message is
+redundant. When the whisper is the last message in the room, there is no way to
+continue the private conversation from the whisper frame; the user must go
+through the occupant panel.
+
+## Changes
+
+Both changes are in
+`apps/fluux/src/components/conversation/MessageBubble.tsx`. No SDK change, no
+composer/`whisperTarget` change, no new wiring in `RoomView.tsx`.
+
+### 1. Show the reply button on the last message when it is a whisper
+
+```tsx
+canReply={(!isLastMessage || inThread) && !counterpartGone}
+```
+
+The existing flow does the rest: `onReply` on a private message reaches
+`handleReplyToMessage` (`RoomView.tsx`), which enters whisper mode with the
+counterpart-gone guard and toast.
+
+### 2. Make the "Private with {nick}" thread header clickable
+
+The thread-start header (Ear icon + `rooms.whisperThread` label) becomes a real
+`<button type="button">` when the counterpart is present:
+
+- Click → `onReply(message)` — same flow as change 1.
+- Style: `hover:bg-fluux-private-hover`, rounded corner, `cursor-pointer`,
+  consistent with the composer whisper banner.
+- Accessibility/tooltip: reuse the existing i18n key
+  `rooms.sendPrivateMessage` ("Send private message") as `aria-label`/tooltip.
+  No new i18n key, so no translation pass over the 33 locales.
+- When the counterpart has left the room (`counterpartGone`), the header stays
+  a plain non-clickable `<div>` — the thread footer ("X is no longer in the
+  room") already explains why.
+
+## Testing
+
+Extend existing app tests around MessageBubble:
+
+- Reply button present on the last message when it is private; absent when the
+  last message is public; absent when the whisper counterpart has left.
+- Clicking the thread header calls `onReply` with the message.
+- The thread header is not a button when `counterpartGone`.
+
+## Out of scope
+
+- SDK changes.
+- Composer / `whisperTarget` behavior.
+- Reply button behavior on the last *public* message (unchanged).


### PR DESCRIPTION
## Summary

A whisper (MUC private message) could not be continued when it was the last message in the room: the reply button — the only way to re-enter whisper mode from the message list — is deliberately hidden on the last message (quoting the last public message is redundant, but for whispers "reply" doesn't quote, it re-enters whisper mode).

- Show the reply button on the last message when it is part of a whisper thread (still hidden when the counterpart left the room).
- Make the "Private with {nick}" thread header a clickable button that re-enters whisper mode through the same `onReply` flow, with hover affordance and the existing `rooms.sendPrivateMessage` key as tooltip (no new i18n key). It stays plain text when the counterpart left.

Spec and plan in `docs/superpowers/`.