### PR TITLE
fix(ui): use the same sender color for reply quotes as the main message

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -8,8 +8,8 @@ import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, 
 import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
-import { Avatar, getConsistentTextColor } from './Avatar'
-import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar } from './conversation/roomSenderResolution'
+import { Avatar } from './Avatar'
+import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor } from './conversation/roomSenderResolution'
 import { format } from 'date-fns'
 import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, Users, MessageCircle, EyeOff, User, Settings, Ear, X } from 'lucide-react'
 import { ChristmasAnimation } from './ChristmasAnimation'
@@ -962,6 +962,7 @@ export const RoomMessageList = memo(function RoomMessageList({
     // nothing object-shaped is passed that could bust the row memo on presence churn).
     let replyAvatarUrl: string | undefined
     let replyAvatarIdentifier: string | undefined
+    let replyBareJid: string | undefined
     if (msg.replyTo) {
       // Reply-target nick from the XEP-0461 `to` JID (room@server/nick). The reply BODY
       // is resolved reactively in the row via useReferencedMessage; only the preview
@@ -971,6 +972,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       const ra = resolveReplyAvatar(replyNick, room, contactsByJid, room.nickname, ownAvatar)
       replyAvatarUrl = ra.avatarUrl
       replyAvatarIdentifier = ra.avatarIdentifier
+      replyBareJid = ra.senderBareJid
     }
 
     return (
@@ -994,6 +996,7 @@ export const RoomMessageList = memo(function RoomMessageList({
         counterpartPresent={sender.counterpartPresent}
         replyAvatarUrl={replyAvatarUrl}
         replyAvatarIdentifier={replyAvatarIdentifier}
+        replyBareJid={replyBareJid}
         knownNicks={knownNicks}
         contactsByJid={contactsByJid}
         ownAvatar={ownAvatar}
@@ -1083,6 +1086,9 @@ interface RoomMessageBubbleWrapperProps {
   // Reply-preview avatar as primitives; the wrapper builds replyContext from these.
   replyAvatarUrl: string | undefined
   replyAvatarIdentifier: string | undefined
+  // Reply sender's bare JID, for the contact-color lookup (keeps the quote's
+  // color identical to the sender's main-message color).
+  replyBareJid: string | undefined
   knownNicks: ReadonlySet<string>
   contactsByJid: Map<string, ContactIdentity>
   ownAvatar?: string | null
@@ -1148,6 +1154,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   counterpartPresent,
   replyAvatarUrl,
   replyAvatarIdentifier,
+  replyBareJid,
   knownNicks,
   contactsByJid,
   ownAvatar,
@@ -1209,9 +1216,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   // Get sender color: accent for own messages, contact's pre-calculated color, or fallback to nick-based generation
   const senderColor = message.isOutgoing
     ? 'var(--fluux-text-accent)'
-    : contact
-      ? (isDarkMode ? contact.colorDark : contact.colorLight) || getConsistentTextColor(resolvedSenderName, isDarkMode)
-      : getConsistentTextColor(resolvedSenderName, isDarkMode)
+    : resolveSenderColor(resolvedSenderName, contact, isDarkMode ?? true)
 
   // Get my current reactions to this message (room — uses nick)
   const myReactions = getMyReactions(message.reactions, myNick, undefined, true)
@@ -1255,7 +1260,11 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
       // Own messages: use accent color
       if (originalMsg?.isOutgoing) return 'var(--fluux-text-accent)'
       const nick = originalMsg?.nick || (fallbackId ? fallbackId.split('/').pop() : undefined)
-      return nick ? getConsistentTextColor(nick, dark) : 'var(--fluux-brand)'
+      if (!nick) return 'var(--fluux-brand)'
+      // Same contact-color preference as the main senderColor above, so the
+      // quote never disagrees with the sender's main-message color.
+      const replyContact = replyBareJid ? contactsByJid.get(replyBareJid) : undefined
+      return resolveSenderColor(nick, replyContact, dark ?? true)
     },
     // Reply-target avatar resolved to primitives in the list layer (resolveReplyAvatar)
     // and passed in — so this callback reads no `room` and the row memo stays bail-able.

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent, act, within } from '@testing-library/react'
 import { MessageBubble, buildReplyContext, type MessageBubbleProps } from './MessageBubble'
 import type { BaseMessage } from '@fluux/sdk'
 import { setPeerVerified, clearPeerVerified } from '@/stores/verifiedPeerKeysStore'
@@ -203,6 +203,48 @@ describe('MessageBubble', () => {
       // When avatarUrl is not provided, no avatar img should be rendered in reply context
       const avatarImg = screen.queryByRole('img', { name: 'Bob' })
       expect(avatarImg).not.toBeInTheDocument()
+    })
+
+    // Regression: the quote's letter avatar auto-generated its color from the
+    // identifier (nick hash) while the main message avatar followed senderColor
+    // (contact color) — same sender, two different hues. The quote avatar must
+    // follow replyContext.senderColor like the quote's border and nick text do.
+    it('uses replyContext.senderColor as the quote letter avatar background', () => {
+      const props = createDefaultProps({
+        replyContext: {
+          senderName: 'Bob',
+          senderColor: 'rgb(0, 255, 0)',
+          body: 'Original message',
+          messageId: 'original-msg-1',
+          avatarIdentifier: 'bob@example.com',
+        },
+      })
+      render(<MessageBubble {...props} />)
+
+      const quote = screen.getByText('Original message').closest('button')!
+      const letter = within(quote).getByText('B')
+      expect(letter.parentElement).toHaveStyle({ backgroundColor: 'rgb(0, 255, 0)' })
+    })
+
+    it('re-renders the quote when only replyContext.senderColor changes', () => {
+      // Contact colors can arrive after the first render (roster load) — a
+      // senderColor-only change must invalidate the memo or the quote keeps
+      // the stale nick-hash color forever.
+      const base = {
+        senderName: 'Bob',
+        senderColor: 'rgb(0, 255, 0)',
+        body: 'Original message',
+        messageId: 'original-msg-1',
+        avatarIdentifier: 'bob@example.com',
+      }
+      const props = createDefaultProps({ replyContext: base })
+      const { rerender } = render(<MessageBubble {...props} />)
+
+      rerender(<MessageBubble {...props} replyContext={{ ...base, senderColor: 'rgb(255, 0, 255)' }} />)
+
+      const quote = screen.getByText('Original message').closest('button')!
+      expect(within(quote).getByText('B').parentElement).toHaveStyle({ backgroundColor: 'rgb(255, 0, 255)' })
+      expect(within(quote).getByText('Bob')).toHaveStyle({ color: 'rgb(255, 0, 255)' })
     })
 
     it('does not render reply context for retracted messages', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -212,6 +212,7 @@ function arePropsEqual(prev: MessageBubbleProps, next: MessageBubbleProps): bool
     if (prev.replyContext.messageId !== next.replyContext.messageId) return false
     if (prev.replyContext.body !== next.replyContext.body) return false
     if (prev.replyContext.senderName !== next.replyContext.senderName) return false
+    if (prev.replyContext.senderColor !== next.replyContext.senderColor) return false
     if (prev.replyContext.avatarUrl !== next.replyContext.avatarUrl) return false
     if (prev.replyContext.avatarIdentifier !== next.replyContext.avatarIdentifier) return false
   }
@@ -510,6 +511,7 @@ export const MessageBubble = memo(function MessageBubble({
                 identifier={replyContext.avatarIdentifier}
                 name={replyContext.senderName}
                 avatarUrl={replyContext.avatarUrl}
+                fallbackColor={replyContext.senderColor}
                 size="xs"
               />
               <CornerUpRight className="rtl-mirror size-3 text-fluux-muted" />

--- a/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar } from './roomSenderResolution'
+import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor } from './roomSenderResolution'
+import { getConsistentTextColor } from '../Avatar'
 import type { RoomOccupant, Room, RoomMessage } from '@fluux/sdk'
 
 const occ = (nick: string, extra: Partial<RoomOccupant> = {}): RoomOccupant =>
@@ -133,5 +134,35 @@ describe('resolveReplyAvatar', () => {
     // getBareJid strips resource; 'alice@x' has no slash so getBareJid returns 'alice@x' unchanged
     const contacts = new Map([['alice@x', { jid: 'alice@x', name: 'Alice', avatar: 'blob:contact' } as any]])
     expect(resolveReplyAvatar('alice', r, contacts, 'me', undefined).avatarUrl).toBe('blob:contact')
+  })
+  // The reply sender's bare JID is needed by the row to look up the contact's
+  // pre-calculated XEP-0392 color, so the quote matches the main message color.
+  it('returns the reply sender bare JID from the occupant full JID', () => {
+    const r = room({
+      occupants: new Map([['alice', { nick: 'alice', jid: 'alice@x/res' } as any]]),
+    })
+    expect(resolveReplyAvatar('alice', r, new Map(), 'me', undefined).senderBareJid).toBe('alice@x')
+  })
+  it('falls back to nickToJidCache for the bare JID when the occupant left', () => {
+    const r = room({ nickToJidCache: new Map([['alice', 'alice@x']]) })
+    expect(resolveReplyAvatar('alice', r, new Map(), 'me', undefined).senderBareJid).toBe('alice@x')
+  })
+})
+
+describe('resolveSenderColor', () => {
+  // Regression: the reply quote colored stepforward green (nick hash) while the
+  // main message was purple (contact color hashed from the bare JID). Both paths
+  // must prefer the contact's pre-calculated color and share this helper.
+  const contact = { jid: 'alice@x', colorLight: '#7b4500', colorDark: '#ffa54c' } as any
+  it('prefers the contact pre-calculated color for the active theme', () => {
+    expect(resolveSenderColor('alice', contact, true)).toBe('#ffa54c')
+    expect(resolveSenderColor('alice', contact, false)).toBe('#7b4500')
+  })
+  it('falls back to the nick-hash color when there is no contact', () => {
+    expect(resolveSenderColor('alice', undefined, true)).toBe(getConsistentTextColor('alice', true))
+    expect(resolveSenderColor('alice', undefined, false)).toBe(getConsistentTextColor('alice', false))
+  })
+  it('falls back to the nick-hash color when the contact has no pre-calculated colors', () => {
+    expect(resolveSenderColor('alice', { jid: 'alice@x' } as any, false)).toBe(getConsistentTextColor('alice', false))
   })
 })

--- a/apps/fluux/src/components/conversation/roomSenderResolution.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.ts
@@ -1,5 +1,6 @@
 import { getBareJid, getPresenceFromShow, canModerate, canBan } from '@fluux/sdk'
 import { whisperCounterpartPresent } from './'
+import { getConsistentTextColor } from '../Avatar'
 import type { Room, RoomMessage, RoomRole, RoomAffiliation, ContactIdentity, RoomOccupant } from '@fluux/sdk'
 
 export interface ResolvedRoomSender {
@@ -71,9 +72,9 @@ export function resolveReplyAvatar(
   contactsByJid: ReadonlyMap<string, ContactIdentity>,
   myNick: string | undefined,
   ownAvatar: string | null | undefined,
-): { avatarUrl: string | undefined; avatarIdentifier: string } {
+): { avatarUrl: string | undefined; avatarIdentifier: string; senderBareJid: string | undefined } {
   if (nick === myNick && nick) {
-    return { avatarUrl: ownAvatar || undefined, avatarIdentifier: nick }
+    return { avatarUrl: ownAvatar || undefined, avatarIdentifier: nick, senderBareJid: undefined }
   }
   const occupantForReply = nick ? room.occupants.get(nick) : undefined
   const senderBareJid = occupantForReply?.jid
@@ -84,7 +85,23 @@ export function resolveReplyAvatar(
   return {
     avatarUrl: occupantForReply?.avatar || cachedReplyAvatar || contactAvatar,
     avatarIdentifier: nick || 'unknown',
+    senderBareJid,
   }
+}
+
+/**
+ * Sender color for a room message: the roster contact's pre-calculated
+ * XEP-0392 color (hashed from the bare JID) when known, otherwise the
+ * nick-hash color. Shared by the main message and the reply quote so the
+ * same sender always gets the same color in both places.
+ */
+export function resolveSenderColor(
+  identifier: string,
+  contact: Pick<ContactIdentity, 'colorLight' | 'colorDark'> | undefined,
+  isDarkMode: boolean,
+): string {
+  const contactColor = contact ? (isDarkMode ? contact.colorDark : contact.colorLight) : undefined
+  return contactColor || getConsistentTextColor(identifier, isDarkMode)
 }
 
 export function selectSelfOccupant(


### PR DESCRIPTION
Fixes the inconsistent avatar color reported in room reply quotes: the same sender showed a purple avatar on their messages but a green one in quotes of their messages.

Root cause: the quote's letter avatar auto-generated its color from the nick hash, while the main message follows `senderColor`, which prefers the roster contact's pre-calculated XEP-0392 color (hashed from the bare JID). Different hash input, different hue.

- The quote letter avatar now follows `replyContext.senderColor`, like the quote border and nick text already did (covers 1:1 and rooms).
- The room reply color callback now prefers the contact color through a new shared `resolveSenderColor` helper; `resolveReplyAvatar` exposes the reply sender's bare JID for that lookup.
- The `MessageBubble` memo comparator now compares `replyContext.senderColor`, so contact colors arriving after roster load repaint the quote.

Regression tests added for the helper, the bare-JID resolution, the quote avatar background, and the memo invalidation. Verified live in demo mode: quote color now equals the quoted sender's main message color (contact color, not nick hash).