### PR TITLE
fix(ui): never render a message row with an undefined React key

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.keys.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.keys.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression guard: MessageList must render with ZERO React
+ * `Each child in a list should have a unique "key" prop` warnings — even when
+ * a message arrives without an `id`.
+ *
+ * `BaseMessage.id` is typed `string`, but demo echoes and persisted state can
+ * violate that invariant (a stanza with no id attribute). `key={undefined}` is
+ * treated by React as a MISSING key, so the reconciler warned on every
+ * re-render ("Check the render method of `div`. It was passed a child from
+ * MessageList."). The row key must therefore fall back to another stable
+ * identifier, and the id-based dedup must not swallow id-less messages
+ * (two distinct messages with `id: undefined` are not duplicates).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import type { BaseMessage } from '@fluux/sdk'
+import { scrollStateManager } from '@/utils/scrollStateManager'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+}))
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const KEY_WARNING = /unique "key" prop/
+
+function message(overrides: Partial<BaseMessage>): BaseMessage {
+  return {
+    id: 'msg-default',
+    from: 'user@example.com',
+    body: 'hello',
+    timestamp: new Date(2024, 0, 1, 12, 0),
+    isOutgoing: false,
+    type: 'chat' as const,
+    ...overrides,
+  }
+}
+
+describe('MessageList — row keys resilient to id-less messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    scrollStateManager.reset()
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renders messages with undefined id without key warnings and without dropping them', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const messages: BaseMessage[] = [
+      message({ id: 'msg-1', body: 'first', timestamp: new Date(2024, 0, 1, 12, 0) }),
+      // Two DISTINCT id-less messages: both must render, with stable keys.
+      message({
+        id: undefined as unknown as string,
+        body: 'no id, has stanza id',
+        stanzaId: 'stanza-abc',
+        timestamp: new Date(2024, 0, 1, 12, 1),
+      }),
+      message({
+        id: undefined as unknown as string,
+        body: 'no id at all',
+        timestamp: new Date(2024, 0, 1, 12, 2),
+      }),
+      message({ id: 'msg-2', body: 'last', timestamp: new Date(2024, 0, 1, 12, 3) }),
+    ]
+
+    const { container } = render(
+      <MessageList
+        messages={messages}
+        conversationId="conv-keys"
+        clearFirstNewMessageId={vi.fn()}
+        renderMessage={(msg) => <div>{msg.body}</div>}
+      />
+    )
+
+    const keyWarnings = errorSpy.mock.calls.filter((args) =>
+      args.some((a) => typeof a === 'string' && KEY_WARNING.test(a)),
+    )
+    expect(keyWarnings).toEqual([])
+
+    // Dedup must not treat distinct id-less messages as duplicates of each other.
+    expect(container.querySelectorAll('.message-row')).toHaveLength(4)
+    expect(container.textContent).toContain('no id, has stanza id')
+    expect(container.textContent).toContain('no id at all')
+  })
+
+  it('still deduplicates messages sharing a real id', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const messages: BaseMessage[] = [
+      message({ id: 'dup', body: 'kept' }),
+      message({ id: 'dup', body: 'dropped', timestamp: new Date(2024, 0, 1, 12, 1) }),
+    ]
+
+    const { container } = render(
+      <MessageList
+        messages={messages}
+        conversationId="conv-dedup"
+        clearFirstNewMessageId={vi.fn()}
+        renderMessage={(msg) => <div>{msg.body}</div>}
+      />
+    )
+
+    expect(container.querySelectorAll('.message-row')).toHaveLength(1)
+    const keyWarnings = errorSpy.mock.calls.filter((args) =>
+      args.some((a) => typeof a === 'string' && KEY_WARNING.test(a)),
+    )
+    expect(keyWarnings).toEqual([])
+  })
+})

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -126,10 +126,15 @@ export function MessageList<T extends BaseMessage>({
   // MESSAGE PROCESSING
   // --------------------------------------------------------------------------
 
-  // Deduplicate messages by ID (safety net for any race conditions in store)
+  // Deduplicate messages by ID (safety net for any race conditions in store).
+  // Only real ids participate: `id` is typed string but demo echoes / persisted
+  // state can miss it, and two distinct id-less messages are not duplicates.
   const deduplicatedMessages = (() => {
     const seen = new Set<string>()
     return messages.filter((msg) => {
+      if (!msg.id) {
+        return true
+      }
       if (seen.has(msg.id)) {
         return false
       }
@@ -299,9 +304,14 @@ export function MessageList<T extends BaseMessage>({
                     : group.messages[idx - 1].timestamp.getTime() <= forwardGapTimestamp)
                 )
 
+                // `key={undefined}` counts as a MISSING key for React (it warns
+                // and falls back to positional reconciliation), so an id-less
+                // message needs another stable identifier.
+                const rowKey = msg.id || msg.stanzaId || msg.originId || `${group.date}-pos-${idx}`
+
                 return (
                   <div
-                    key={msg.id}
+                    key={rowKey}
                     className="message-row"
                     data-message-id={msg.id}
                     data-stanza-id={msg.stanzaId}

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -34,6 +34,7 @@ import type { Room, RoomMessage, RoomOccupant } from '../core/types/room'
 import type { DemoData, DemoAnimationStep } from './types'
 import { buildStressEvents, type StressScenario } from './stress'
 import { parsePollElement, parsePollClosedElement } from '../core/poll'
+import { generateUUID } from '../utils/uuid'
 import type { PollData, PollClosedData } from '../core/types/message-base'
 
 type AnimationState = 'idle' | 'playing' | 'paused' | 'stopped'
@@ -508,7 +509,9 @@ export class DemoClient extends XMPPClient {
 
     const nick = room.nickname
     const body = stanza.getChildText('body') ?? ''
-    const id = stanza.attrs.id as string
+    // A stanza without an id attribute must not echo an id-less message —
+    // `RoomMessage.id` is a string invariant the UI relies on (row keys, dedup).
+    const id = (stanza.attrs.id as string | undefined) || generateUUID()
 
     // Parse reply info from the stanza (XEP-0461)
     const replyEl = stanza.getChild('reply')


### PR DESCRIPTION
Demo mode logged a recurring React warning: `Each child in a list should have a unique "key" prop. … It was passed a child from MessageList.`

The cause is not a missing `key` prop — `MessageList` keys every row with `msg.id`. But a message can reach the store without an id (`BaseMessage.id` is typed `string`, yet the demo groupchat echo built it straight from a missing stanza `id` attribute, and persisted state can carry the same violation). `key={undefined}` counts as a missing key for React, which warns on every re-render and falls back to positional reconciliation.

- **MessageList**: row key falls back `id → stanzaId → originId → position`; the id-based dedup no longer treats distinct id-less messages as duplicates of each other (it silently dropped all but the first)
- **DemoClient**: the groupchat echo generates a UUID when the outgoing stanza has no id, restoring the invariant the real ingestion paths already guarantee via `generateStableMessageId`
- **MessageList.keys.test.tsx**: renders id-less messages and asserts zero key warnings and no dropped rows (failed with the exact reported warning before the fix)

Verified in live demo mode: injecting id-less room messages renders them with a clean console.