### PR TITLE
fix(scroll): create the content ResizeObserver on same-commit mounts

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -47,13 +47,28 @@ function createTestMessages(count: number, withReactions = false): BaseMessage[]
 class MockResizeObserver {
   callback: ResizeObserverCallback
   static instances: MockResizeObserver[] = []
+  // Total constructions (never decremented) — `instances` only tracks live
+  // observers, so it cannot detect a disconnect+recreate churn cycle.
+  static constructed = 0
 
   constructor(callback: ResizeObserverCallback) {
     this.callback = callback
     MockResizeObserver.instances.push(this)
+    MockResizeObserver.constructed++
   }
 
-  observe() {}
+  targets: Element[] = []
+
+  observe(target: Element) {
+    this.targets.push(target)
+  }
+
+  // Find the live observer watching a given element (don't rely on creation
+  // order — the content observer now exists alongside the container one).
+  static observing(target: Element | null): MockResizeObserver | undefined {
+    if (!target) return undefined
+    return MockResizeObserver.instances.find((inst) => inst.targets.includes(target))
+  }
   unobserve() {}
   disconnect() {
     const index = MockResizeObserver.instances.indexOf(this)
@@ -76,6 +91,7 @@ describe('MessageList scroll behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     MockResizeObserver.instances = []
+    MockResizeObserver.constructed = 0
 
     // Reset scrollStateManager to prevent state leakage between tests
     scrollStateManager.reset()
@@ -295,7 +311,7 @@ describe('MessageList scroll behavior', () => {
         })
 
         // First trigger an initial resize to establish baseline height
-        const observer = MockResizeObserver.instances[0]
+        const observer = MockResizeObserver.observing(container)
         if (observer) {
           act(() => {
             observer.triggerResize(500) // Establish baseline
@@ -350,7 +366,7 @@ describe('MessageList scroll behavior', () => {
         })
 
         // First trigger an initial resize to establish baseline height
-        const observer = MockResizeObserver.instances[0]
+        const observer = MockResizeObserver.observing(container)
         if (observer) {
           act(() => {
             observer.triggerResize(500) // Establish baseline
@@ -399,7 +415,7 @@ describe('MessageList scroll behavior', () => {
           configurable: true,
         })
 
-        const observer = MockResizeObserver.instances[0]
+        const observer = MockResizeObserver.observing(container)
         if (observer) {
           // First establish baseline height
           act(() => {
@@ -465,7 +481,7 @@ describe('MessageList scroll behavior', () => {
 
         scrollSpy.mockClear()
 
-        const observer = MockResizeObserver.instances[0]
+        const observer = MockResizeObserver.observing(container)
         if (observer) {
           // Rapid resize events (composer expanding as user types)
           act(() => {
@@ -1908,6 +1924,55 @@ describe('MessageList scroll behavior', () => {
         const scrollCalls = scrollSpy.mock.calls.flat()
         expect(scrollCalls).toContain(200)
       }
+    })
+  })
+
+  describe('content ResizeObserver lifecycle', () => {
+    const renderList = (messages: BaseMessage[]) => (
+      <MessageList
+        messages={messages}
+        conversationId="conv-1"
+        clearFirstNewMessageId={vi.fn()}
+        typingUsers={[]}
+        renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+      />
+    )
+
+    // Is some LIVE observer watching the content wrapper (the direct child of
+    // the scroll container)?
+    const contentWrapperIsObserved = () => {
+      const scroller = document.querySelector('[data-message-list]')
+      return MockResizeObserver.instances.some((inst) =>
+        inst.targets.some((t) => t.parentElement === scroller)
+      )
+    }
+
+    // React attaches refs child-first within a commit. When MessageList mounts
+    // WITH messages already present (same-commit mount of scroller + content
+    // wrapper), the content ref callback runs before the scroller ref is set —
+    // it must not silently skip observer setup (lost scroll correction).
+    it('creates the content observer when mounted with messages already present', () => {
+      render(renderList(createTestMessages(5)))
+      expect(contentWrapperIsObserved()).toBe(true)
+    })
+
+    // Regression guard: the wrapper ref must be identity-stable so React does
+    // not detach/reattach it per render — that would tear down and recreate
+    // the observer on EVERY render (a full-reflow amplifier in busy rooms on
+    // a large non-virtualized backlog).
+    it('does not recreate observers when a new message re-renders the list', () => {
+      const { rerender } = render(renderList(createTestMessages(5)))
+      const constructedAfterMount = MockResizeObserver.constructed
+      const liveAfterMount = MockResizeObserver.instances.length
+      expect(contentWrapperIsObserved()).toBe(true)
+
+      // Simulate two incoming messages (the busy-MUC case: one render each)
+      rerender(renderList(createTestMessages(6)))
+      rerender(renderList(createTestMessages(7)))
+
+      expect(MockResizeObserver.constructed).toBe(constructedAfterMount)
+      expect(MockResizeObserver.instances.length).toBe(liveAfterMount)
+      expect(contentWrapperIsObserved()).toBe(true)
     })
   })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -177,40 +177,57 @@ export function useMessageListScroll({
     el.scrollHeight - el.scrollTop - el.clientHeight
 
   // ==========================================================================
-  // REF SETTER (connects external ref if provided)
-  // ==========================================================================
-
-  const setScrollContainerRef = (el: HTMLDivElement | null) => {
-    scrollerRef.current = el
-    if (externalScrollerRef) {
-      (externalScrollerRef as React.MutableRefObject<HTMLElement | null>).current = el
-    }
-  }
-
-  // ==========================================================================
-  // CALLBACK REF: Content wrapper (replaces useEffect + useRef pattern)
+  // CALLBACK REFS: scroll container + content wrapper
   // ==========================================================================
   //
-  // Using a callback ref ensures the ResizeObserver is connected as soon as
-  // the content wrapper mounts, even if it mounts after initial render
-  // (e.g., MUC rooms that show a loading state before revealing messages).
+  // Using a callback ref for the content wrapper ensures the ResizeObserver is
+  // connected as soon as the wrapper mounts, even if it mounts after initial
+  // render (e.g., MUC rooms that show a loading state before revealing
+  // messages).
+  //
+  // Two constraints shape the implementation:
+  //
+  // 1. ATTACH ORDER: React attaches refs child-first within a commit. When the
+  //    list mounts WITH messages already present, the content-wrapper ref runs
+  //    before the scroller ref is set. Observer setup is therefore late-bound:
+  //    both setters call trySetupContentObserver(), and whichever attaches
+  //    last completes the setup.
+  //
+  // 2. IDENTITY STABILITY: both setters are created once (lazy useRef), NOT
+  //    re-created per render. An unstable callback ref makes React detach
+  //    (null) + reattach it on EVERY render, tearing down and recreating the
+  //    observer each time — a forced-reflow amplifier in busy rooms. Per-render
+  //    values they need are read through latestRef (updated each render via
+  //    effect), never closed over.
 
-  const setContentRef = (element: HTMLDivElement | null) => {
-    // Cleanup previous observer
-    if (contentObserverRef.current) {
-      contentObserverRef.current.disconnect()
-      contentObserverRef.current = null
+  const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef })
+  useEffect(() => {
+    latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef }
+  })
+
+  const stableSettersRef = useRef<{
+    setScrollContainerRef: (el: HTMLDivElement | null) => void
+    setContentRef: (el: HTMLDivElement | null) => void
+  } | null>(null)
+
+  if (stableSettersRef.current === null) {
+    const teardownContentObserver = () => {
+      if (contentObserverRef.current) {
+        contentObserverRef.current.disconnect()
+        contentObserverRef.current = null
+      }
+      if (correctionRafRef.current !== null) {
+        cancelAnimationFrame(correctionRafRef.current)
+        correctionRafRef.current = null
+      }
     }
-    if (correctionRafRef.current !== null) {
-      cancelAnimationFrame(correctionRafRef.current)
-      correctionRafRef.current = null
-    }
 
-    contentRef.current = element
-
-    if (element) {
+    const trySetupContentObserver = () => {
       const scroller = scrollerRef.current
-      if (!scroller) return
+      const element = contentRef.current
+      if (!scroller || !element || contentObserverRef.current) return
+
+      const { staticMode, isAtBottomRef } = latestRef.current
 
       // On mount: if we should be at bottom, scroll there immediately
       if (isAtBottomRef.current && !staticMode) {
@@ -258,6 +275,8 @@ export function useMessageListScroll({
           return
         }
 
+        const { staticMode, isAtBottomRef } = latestRef.current
+
         // Content grew and we were at bottom -> stay at bottom
         if (newHeight > lastHeight && isAtBottomRef.current && !staticMode) {
           debugLog('RESIZE SCROLL TO BOTTOM', {
@@ -300,7 +319,26 @@ export function useMessageListScroll({
       observer.observe(element)
       contentObserverRef.current = observer
     }
+
+    stableSettersRef.current = {
+      setScrollContainerRef: (el: HTMLDivElement | null) => {
+        scrollerRef.current = el
+        const externalScrollerRef = latestRef.current.externalScrollerRef
+        if (externalScrollerRef) {
+          (externalScrollerRef as React.MutableRefObject<HTMLElement | null>).current = el
+        }
+        if (el) trySetupContentObserver()
+      },
+      setContentRef: (element: HTMLDivElement | null) => {
+        if (element === contentRef.current) return
+        teardownContentObserver()
+        contentRef.current = element
+        if (element) trySetupContentObserver()
+      },
+    }
   }
+
+  const { setScrollContainerRef, setContentRef } = stableSettersRef.current
 
   // ==========================================================================
   // SCROLL ACTIONS
@@ -1149,7 +1187,6 @@ export function useMessageListScroll({
 
   // ==========================================================================
   // EFFECT: Container resize (composer grows/shrinks)
-  // NOTE: This effect MUST come before content resize so tests can find it at instances[0]
   // ==========================================================================
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Found while auditing the message-list scroll logic for the WebKitGTK half-freeze (it is **not** the freeze cause — that remains the non-virtualized backlog amplifier fixed by #497, this is a latent bug the audit surfaced).

React attaches callback refs **child-first** within a commit. When `MessageList` mounts with messages already present (returning to a room whose backlog is in the store, view switches), the content-wrapper ref ran before the scroller ref was set, hit the `if (!scroller) return` guard, and the content ResizeObserver was **never created** — scroll correction silently missing for the whole view session, partially masked by the `messageCount` effect.

Fix:
- **Late-bound setup**: both ref setters call `trySetupContentObserver()`; whichever attaches last completes setup.
- **Identity-stable setters** (lazy `useRef` + latest-ref): observer lifecycle no longer depends on the React Compiler stabilizing function identity (vitest runs without the compiler, which is how the vacuous-pass slipped through), and React no longer detaches/reattaches the refs on re-render.
- Tests select observers by observed target instead of creation order (`instances[0]` only worked because the content observer was missing); new guards for same-commit mount + re-render observer stability.

Verified live in demo: observer present after room remount, survives a 10-message burst with zero recreations, auto-scroll intact. Full app suite (3074 tests), typecheck, lint green.