### PR TITLE
feat(diagnostics): freeze-triage probes for fluux.log

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -1974,5 +1974,43 @@ describe('MessageList scroll behavior', () => {
       expect(MockResizeObserver.instances.length).toBe(liveAfterMount)
       expect(contentWrapperIsObserved()).toBe(true)
     })
+
+    // Field diagnostic for the WebKitGTK freeze class: a SLOW correction (the
+    // scrollHeight read reflows the whole backlog) must produce a rate-limited
+    // contextual warning so fluux.log shows duration + backlog size.
+    it('warns with context when a scroll correction is slow', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      // Every performance.now() call advances 50ms -> any measured correction
+      // "takes" 50ms, above the 32ms threshold.
+      let fakeNow = 0
+      const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => {
+        fakeNow += 50
+        return fakeNow
+      })
+
+      try {
+        render(renderList(createTestMessages(5)))
+        const scroller = document.querySelector('[data-message-list]')!
+        const wrapper = Array.from(scroller.children).find(
+          (c) => c instanceof HTMLDivElement
+        ) as Element
+        const observer = MockResizeObserver.observing(wrapper)
+        expect(observer).toBeDefined()
+
+        act(() => {
+          observer!.triggerResize(800)
+        })
+
+        const slowWarnings = warnSpy.mock.calls
+          .map((c) => String(c[0]))
+          .filter((m) => m.includes('[SlowScrollCorrection]'))
+        expect(slowWarnings.length).toBe(1)
+        expect(slowWarnings[0]).toContain('conversation=conv-1')
+        expect(slowWarnings[0]).toContain('rows=')
+      } finally {
+        nowSpy.mockRestore()
+        warnSpy.mockRestore()
+      }
+    })
   })
 })

--- a/apps/fluux/src/components/conversation/slowCorrectionMonitor.test.ts
+++ b/apps/fluux/src/components/conversation/slowCorrectionMonitor.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
+
+describe('slowCorrectionMonitor', () => {
+  it('stays silent for corrections under the threshold', () => {
+    const monitor = createSlowCorrectionMonitor({ thresholdMs: 32, cooldownMs: 5000 })
+    expect(monitor.record(0, 1000)).toBe(false)
+    expect(monitor.record(31, 2000)).toBe(false)
+  })
+
+  it('reports a correction at or above the threshold', () => {
+    const monitor = createSlowCorrectionMonitor({ thresholdMs: 32, cooldownMs: 5000 })
+    expect(monitor.record(32, 1000)).toBe(true)
+  })
+
+  it('rate-limits reports within the cooldown window', () => {
+    const monitor = createSlowCorrectionMonitor({ thresholdMs: 32, cooldownMs: 5000 })
+    expect(monitor.record(100, 1000)).toBe(true)
+    expect(monitor.record(100, 2000)).toBe(false) // within cooldown
+    expect(monitor.record(100, 6001)).toBe(true) // cooldown elapsed
+  })
+
+  it('uses defaults when no options given', () => {
+    const monitor = createSlowCorrectionMonitor()
+    expect(monitor.record(31, 0)).toBe(false)
+    expect(monitor.record(33, 0)).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/slowCorrectionMonitor.ts
+++ b/apps/fluux/src/components/conversation/slowCorrectionMonitor.ts
@@ -1,0 +1,55 @@
+/**
+ * Diagnostic-only monitor for SLOW message-list scroll corrections.
+ *
+ * Complements `resizeLoopMonitor` (which counts fire FREQUENCY): on WebKitGTK
+ * with a large non-virtualized backlog, each correction's scrollHeight read
+ * forces a reflow of the whole message tree, so the observer fires only a few
+ * times per second — far under the frequency threshold — while each fire blows
+ * the frame budget. That failure mode is invisible to a rate counter; this one
+ * measures DURATION instead.
+ *
+ * Like resizeLoopMonitor it never throttles or disconnects anything: it only
+ * tells the caller "this correction was slow enough to log" (rate-limited so a
+ * sustained slowdown produces one line per cooldown, not one per frame). The
+ * caller assembles the log context (row count, scrollHeight, conversation)
+ * lazily — those reads are not free, so they must happen only on the warn path.
+ *
+ * Pure fixed-window logic, timestamps passed in, unit-testable.
+ */
+export interface SlowCorrectionMonitor {
+  /**
+   * Record one correction that took `durationMs`, finishing at `now` (ms,
+   * monotonic e.g. performance.now()). Returns true when the caller should
+   * log a diagnostic line (duration ≥ threshold and cooldown elapsed).
+   */
+  record(durationMs: number, now: number): boolean
+}
+
+export interface SlowCorrectionMonitorOptions {
+  /** Corrections taking at least this long are reportable. */
+  thresholdMs?: number
+  /** Minimum gap between two reports, so a sustained slowdown logs once. */
+  cooldownMs?: number
+}
+
+// ~2 frames at 60fps: one slow frame happens (GC, decode); two is a pattern.
+const DEFAULT_THRESHOLD_MS = 32
+const DEFAULT_COOLDOWN_MS = 5000
+
+export function createSlowCorrectionMonitor(
+  opts: SlowCorrectionMonitorOptions = {}
+): SlowCorrectionMonitor {
+  const thresholdMs = opts.thresholdMs ?? DEFAULT_THRESHOLD_MS
+  const cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS
+
+  let lastReportAt = Number.NEGATIVE_INFINITY
+
+  return {
+    record(durationMs: number, now: number): boolean {
+      if (durationMs < thresholdMs) return false
+      if (now - lastReportAt < cooldownMs) return false
+      lastReportAt = now
+      return true
+    },
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -18,6 +18,7 @@
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import { scrollStateManager } from '@/utils/scrollStateManager'
 import { createResizeLoopMonitor } from './resizeLoopMonitor'
+import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
 
 // ============================================================================
 // DEBUG
@@ -113,6 +114,8 @@ export function useMessageListScroll({
   const correctionRafRef = useRef<number | null>(null)
   // Diagnostic-only monitor for runaway ResizeObserver fire rates (WebKitGTK).
   const resizeMonitorRef = useRef<ReturnType<typeof createResizeLoopMonitor> | null>(null)
+  // Diagnostic-only monitor for SLOW corrections (reflow cost, not fire rate).
+  const slowCorrectionMonitorRef = useRef<ReturnType<typeof createSlowCorrectionMonitor> | null>(null)
 
   // Track scroll position - always create internal ref to follow rules of hooks
   const internalIsAtBottomRef = useRef(true)
@@ -200,9 +203,9 @@ export function useMessageListScroll({
   //    values they need are read through latestRef (updated each render via
   //    effect), never closed over.
 
-  const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef })
+  const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef, conversationId })
   useEffect(() => {
-    latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef }
+    latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef, conversationId }
   })
 
   const stableSettersRef = useRef<{
@@ -250,6 +253,33 @@ export function useMessageListScroll({
         const currentScroller = scrollerRef.current
         if (!currentScroller) return
 
+        // Time the whole correction (including the skip paths — the
+        // scrollHeight read below is the reflow that costs, whatever branch
+        // follows). The frequency monitor in the observer callback cannot see
+        // this failure mode: slow corrections fire only a few times a second.
+        const correctionStart = performance.now()
+        try {
+          runCorrectionBody(currentScroller)
+        } finally {
+          const correctionEnd = performance.now()
+          if (!slowCorrectionMonitorRef.current) {
+            slowCorrectionMonitorRef.current = createSlowCorrectionMonitor()
+          }
+          if (slowCorrectionMonitorRef.current.record(correctionEnd - correctionStart, correctionEnd)) {
+            // Context reads are warn-path only (rate-limited): querySelectorAll
+            // over the backlog is not free.
+            const rows = currentScroller.querySelectorAll('.message-row').length
+            console.warn(
+              `[SlowScrollCorrection] scroll correction took ${Math.round(correctionEnd - correctionStart)}ms ` +
+              `(rows=${rows}, scrollHeight=${currentScroller.scrollHeight}, ` +
+              `conversation=${latestRef.current.conversationId}) — ` +
+              `reflow cost scales with the rendered backlog.`
+            )
+          }
+        }
+      }
+
+      const runCorrectionBody = (currentScroller: HTMLDivElement) => {
         const newHeight = currentScroller.scrollHeight
         const currentScrollTop = currentScroller.scrollTop
 

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -12,6 +12,8 @@ import './index.css'
 import './utils/tauriFileDrop'
 import { tauriProxyAdapter } from './utils/tauriProxyAdapter'
 import { installBeforeInputGuard } from './utils/tauriInputFix'
+import { logStartupCapabilities } from './utils/startupDiagnostics'
+import { startStallSentinel } from './utils/stallSentinel'
 
 // Check if running in Tauri
 const isTauri = '__TAURI_INTERNALS__' in window
@@ -57,6 +59,11 @@ document.addEventListener('keydown', (e) => {
 
 // Block control characters Tauri's macOS webview inserts on arrow-key boundary hits
 installBeforeInputGuard()
+
+// Freeze-triage diagnostics (log-only, forwarded to fluux.log in Tauri):
+// engine capability line + main-thread stall sentinel.
+logStartupCapabilities()
+startStallSentinel()
 
 // Auto-recover from dynamic import failures. Two failure modes share the
 // same recovery path:

--- a/apps/fluux/src/utils/stallSentinel.test.ts
+++ b/apps/fluux/src/utils/stallSentinel.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { createStallSentinel } from './stallSentinel'
+
+const OPTS = { intervalMs: 500, stallThresholdMs: 1000, cooldownMs: 5000 }
+
+describe('stallSentinel', () => {
+  it('returns null on the first tick (baseline only)', () => {
+    const sentinel = createStallSentinel(OPTS)
+    expect(sentinel.tick(1000, false)).toBeNull()
+  })
+
+  it('returns null for on-time ticks', () => {
+    const sentinel = createStallSentinel(OPTS)
+    sentinel.tick(1000, false)
+    expect(sentinel.tick(1500, false)).toBeNull()
+    expect(sentinel.tick(2010, false)).toBeNull() // small timer jitter is fine
+  })
+
+  it('reports a stall when the gap exceeds interval + threshold', () => {
+    const sentinel = createStallSentinel(OPTS)
+    sentinel.tick(1000, false)
+    const message = sentinel.tick(4000, false) // gap 3000ms, ~2500ms blocked
+    expect(message).toContain('[MainThreadStall]')
+    expect(message).toContain('~2500ms')
+  })
+
+  it('rate-limits stall reports within the cooldown window', () => {
+    const sentinel = createStallSentinel(OPTS)
+    sentinel.tick(1000, false)
+    expect(sentinel.tick(4000, false)).not.toBeNull()
+    expect(sentinel.tick(7000, false)).toBeNull() // stall again, but within cooldown
+    expect(sentinel.tick(12000, false)).not.toBeNull() // cooldown elapsed
+  })
+
+  it('ignores gaps while the document is hidden (background throttling)', () => {
+    const sentinel = createStallSentinel(OPTS)
+    sentinel.tick(1000, false)
+    expect(sentinel.tick(60000, true)).toBeNull() // hidden: no stall, reset baseline
+    // First visible tick after hiding only re-baselines — a huge gap is not a stall
+    expect(sentinel.tick(120000, false)).toBeNull()
+    // ...but a real stall after re-baselining is still caught
+    expect(sentinel.tick(125000, false)).not.toBeNull()
+  })
+})

--- a/apps/fluux/src/utils/stallSentinel.ts
+++ b/apps/fluux/src/utils/stallSentinel.ts
@@ -1,0 +1,103 @@
+/**
+ * Main-thread stall sentinel.
+ *
+ * A heartbeat interval compares the expected tick gap against the wall clock.
+ * When the main thread is blocked (long reflow, sync loop, render storm), the
+ * timer fires late — the overshoot IS the blocked duration. This catches ANY
+ * freeze class, including ones with no React render and no observer involved,
+ * and turns "the app half-froze" reports into quantified events in fluux.log:
+ * how long, how often, and on which route.
+ *
+ * Background throttling guard: browsers clamp timers in hidden windows, which
+ * looks exactly like a stall. Ticks while hidden are ignored, and the first
+ * visible tick only re-baselines.
+ *
+ * Pure tick logic (timestamps and visibility passed in) for unit testing;
+ * `startStallSentinel` wires it to setInterval + document.hidden.
+ */
+export interface StallSentinel {
+  /**
+   * Record one heartbeat at `now` (ms, monotonic). Returns a log line when a
+   * stall is detected (rate-limited), null otherwise.
+   */
+  tick(now: number, hidden: boolean): string | null
+}
+
+export interface StallSentinelOptions {
+  /** Heartbeat period. */
+  intervalMs?: number
+  /** Overshoot beyond the period that counts as a stall. */
+  stallThresholdMs?: number
+  /** Minimum gap between two reports. */
+  cooldownMs?: number
+  /** Returns extra context appended to the log line (e.g. active route). */
+  getContext?: () => string
+}
+
+const DEFAULT_INTERVAL_MS = 500
+const DEFAULT_STALL_THRESHOLD_MS = 1000
+const DEFAULT_COOLDOWN_MS = 5000
+
+export function createStallSentinel(opts: StallSentinelOptions = {}): StallSentinel {
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS
+  const stallThresholdMs = opts.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS
+  const cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS
+  const getContext = opts.getContext
+
+  let lastTickAt: number | null = null
+  let needsRebaseline = false
+  let lastReportAt = Number.NEGATIVE_INFINITY
+
+  return {
+    tick(now: number, hidden: boolean): string | null {
+      if (hidden) {
+        // Timer clamping in hidden windows mimics a stall — don't evaluate,
+        // and make the next visible tick re-baseline instead of comparing
+        // against a pre-hide timestamp.
+        lastTickAt = now
+        needsRebaseline = true
+        return null
+      }
+
+      if (lastTickAt === null || needsRebaseline) {
+        lastTickAt = now
+        needsRebaseline = false
+        return null
+      }
+
+      const gap = now - lastTickAt
+      lastTickAt = now
+
+      const blockedMs = gap - intervalMs
+      if (blockedMs < stallThresholdMs) return null
+      if (now - lastReportAt < cooldownMs) return null
+      lastReportAt = now
+
+      const context = getContext ? ` (${getContext()})` : ''
+      return (
+        `[MainThreadStall] main thread blocked ~${Math.round(blockedMs)}ms` +
+        `${context} — heartbeat expected every ${intervalMs}ms, fired after ${Math.round(gap)}ms`
+      )
+    },
+  }
+}
+
+/**
+ * Start the sentinel on a real interval. Returns a stop function.
+ * Log-only: one rate-limited console.warn per detected stall (the Tauri
+ * console forwarder ships it to fluux.log).
+ */
+export function startStallSentinel(opts: StallSentinelOptions = {}): () => void {
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS
+  const sentinel = createStallSentinel({
+    getContext: () => `route: ${window.location.hash || '/'}`,
+    ...opts,
+  })
+
+  const id = setInterval(() => {
+    const warning = sentinel.tick(performance.now(), document.hidden)
+    if (warning) console.warn(warning)
+  }, intervalMs)
+
+  return () => clearInterval(id)
+}

--- a/apps/fluux/src/utils/startupDiagnostics.test.ts
+++ b/apps/fluux/src/utils/startupDiagnostics.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { formatStartupCapabilities } from './startupDiagnostics'
+
+describe('formatStartupCapabilities', () => {
+  it('reports content-visibility support', () => {
+    const line = formatStartupCapabilities(() => true, 'TestUA/1.0')
+    expect(line).toContain('[StartupDiagnostics]')
+    expect(line).toContain('content-visibility=supported')
+    expect(line).toContain('TestUA/1.0')
+  })
+
+  it('reports missing content-visibility support', () => {
+    const line = formatStartupCapabilities(
+      (prop) => prop !== 'content-visibility',
+      'OldWebKit/2.40'
+    )
+    expect(line).toContain('content-visibility=UNSUPPORTED')
+  })
+
+  it('survives a CSS.supports that throws (very old engines)', () => {
+    const line = formatStartupCapabilities(() => {
+      throw new Error('no CSS.supports')
+    }, 'Ancient/0.1')
+    expect(line).toContain('content-visibility=unknown')
+  })
+})

--- a/apps/fluux/src/utils/startupDiagnostics.ts
+++ b/apps/fluux/src/utils/startupDiagnostics.ts
@@ -1,0 +1,35 @@
+/**
+ * One-shot startup diagnostics line for fluux.log.
+ *
+ * Records engine capabilities that silently change how fixes behave in the
+ * field. Motivating case: the message-list perf fix relies on
+ * `content-visibility: auto` — engines that predate it (WebKitGTK < 2.46)
+ * ignore the property and the fix is a no-op. Without this line, a "still
+ * freezing on 0.16.1" report is ambiguous; with it, the first grep answers
+ * whether the fix could even apply.
+ */
+export function formatStartupCapabilities(
+  supports: (property: string, value: string) => boolean,
+  userAgent: string
+): string {
+  let contentVisibility: string
+  try {
+    contentVisibility = supports('content-visibility', 'auto') ? 'supported' : 'UNSUPPORTED'
+  } catch {
+    contentVisibility = 'unknown'
+  }
+
+  return (
+    `[StartupDiagnostics] content-visibility=${contentVisibility} ua=${userAgent}`
+  )
+}
+
+/** Log the capabilities line once (console.info → forwarded to fluux.log). */
+export function logStartupCapabilities(): void {
+  console.info(
+    formatStartupCapabilities(
+      (property, value) => CSS.supports(property, value),
+      navigator.userAgent
+    )
+  )
+}


### PR DESCRIPTION
## Summary

Three log-only probes so the next WebKitGTK half-freeze report is measurable from `fluux.log` alone:

1. **`[SlowScrollCorrection]`** — times each message-list scroll correction; rate-limited warn above 32ms with row count, `scrollHeight` and conversation. The existing `[ScrollResizeLoop]` monitor counts fire *frequency* and physically cannot trip when each fire is *slow* (a few/s, each blowing the frame budget) — the failure mode the 0.16.0 field evidence points at. After #497 ships, this same line gives before/after proof.
2. **`[StartupDiagnostics]`** — one boot line: `content-visibility` support + UA. If the tester's WebKitGTK predates support (~2.46), #497 is a silent no-op and we'd be chasing ghosts.
3. **`[MainThreadStall]`** — heartbeat sentinel quantifying any main-thread block ≥1s with duration and active route, whatever the cause. Hidden-window ticks are ignored (background timer clamping mimics a stall).

All three follow the `resizeLoopMonitor` pattern: pure-function cores + unit tests (13 new), O(1) hot paths, rate-limited, warn-path-only context reads. Verified in demo: modules produce the intended lines with real route/UA; the hidden-guard correctly suppressed a deliberate 1.5s busy-loop in an occluded window.
