### PR TITLE
fix(scroll): coalesce composer-resize correction into rAF; mute benign RO notice

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1324,6 +1324,15 @@ fn main() {
                         console.error = function() { origError.apply(console, arguments); forward('error', arguments); };
                         console.debug = function() { origDebug.apply(console, arguments); forward('debug', arguments); };
                         window.addEventListener('error', function(e) {
+                            // Benign, self-correcting browser notice — NOT an app error. WebKitGTK
+                            // emits 'ResizeObserver loop completed with undelivered notifications'
+                            // routinely with content-visibility rows plus a scroll-correction
+                            // ResizeObserver. Forwarding it as 'Uncaught error' is alarming log
+                            // noise; a genuine runaway loop is surfaced separately by the
+                            // rate-limited '[ScrollResizeLoop]' diagnostic. Swallow it here.
+                            if (e.message && e.message.indexOf('ResizeObserver loop') !== -1) {
+                                return;
+                            }
                             // Resource load failures (img/video/script/link): e.target is the element.
                             if (e.target && e.target !== window && e.target.tagName) {
                                 var src = e.target.src || e.target.href || '(unknown)';

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -282,6 +282,66 @@ describe('MessageList scroll behavior', () => {
   })
 
   describe('container resize scroll', () => {
+    it('defers the scroll correction to rAF instead of writing scrollTop inside the ResizeObserver callback', () => {
+      // Regression guard: writing scrollTop synchronously inside a ResizeObserver
+      // callback is the literal trigger for WebKitGTK's "ResizeObserver loop
+      // completed with undelivered notifications". The correction must be
+      // coalesced into a requestAnimationFrame so it runs OUTSIDE the observer's
+      // delivery cycle (parity with the content observer hardened in #439).
+      const messages = createTestMessages(5)
+      const scrollSpy = vi.fn()
+
+      // Queue rAF callbacks rather than running them immediately, so we can
+      // observe whether the scroll write happens synchronously or is deferred.
+      const rafQueue: FrameRequestCallback[] = []
+      window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+        rafQueue.push(cb)
+        return rafQueue.length
+      }
+      const flushRaf = () => act(() => { rafQueue.splice(0).forEach((cb) => cb(0)) })
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
+      expect(container).toBeTruthy()
+
+      let scrollTopValue = 500 // at bottom (scrollHeight 1000 - clientHeight 500)
+      Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+      Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+      Object.defineProperty(container, 'scrollTop', {
+        get: () => scrollTopValue,
+        set: (v) => { scrollTopValue = v; scrollSpy(v) },
+        configurable: true,
+      })
+
+      // Drain any rAF scheduled during mount, then establish the baseline height.
+      // Select the container observer by its observed target — the content
+      // observer (created on the same commit since #508) also exists, so
+      // instances[0] is no longer reliably the container one.
+      flushRaf()
+      const observer = MockResizeObserver.observing(container)!
+      expect(observer).toBeTruthy()
+      act(() => { observer.triggerResize(500) })
+      flushRaf()
+      scrollSpy.mockClear()
+
+      // Container shrinks while at bottom: the correction must NOT be applied
+      // synchronously inside the observer callback...
+      act(() => { observer.triggerResize(400) })
+      expect(scrollSpy).not.toHaveBeenCalled()
+
+      // ...only after the rAF flushes.
+      flushRaf()
+      expect(scrollSpy).toHaveBeenCalledWith(1000)
+    })
+
     it('should scroll to bottom when container height decreases and user is at bottom', async () => {
       const messages = createTestMessages(5)
       const scrollSpy = vi.fn()

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1224,9 +1224,23 @@ export function useMessageListScroll({
     if (!scroller) return
 
     let lastHeight: number | null = null
+    let pendingHeight: number | null = null
+    let scheduled = false
+    let rafId: number | null = null
+    let monitor: ReturnType<typeof createResizeLoopMonitor> | null = null
 
-    const observer = new ResizeObserver((entries) => {
-      const newHeight = entries[0].contentRect.height
+    // The measure + scroll-correction. Runs inside a rAF so the scrollTop write
+    // never happens synchronously inside the ResizeObserver delivery cycle —
+    // that synchronous write is the literal trigger for WebKitGTK's
+    // "ResizeObserver loop completed with undelivered notifications". Parity with
+    // the content observer's rAF coalescing (see setContentRef above).
+    const runCorrection = () => {
+      scheduled = false
+      rafId = null
+      const newHeight = pendingHeight
+      pendingHeight = null
+      if (newHeight === null) return
+
       if (lastHeight === null) { lastHeight = newHeight; return }
 
       const shrunk = lastHeight - newHeight
@@ -1236,10 +1250,33 @@ export function useMessageListScroll({
       }
 
       lastHeight = newHeight
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      // Diagnostic only: surface a runaway fire rate (the composer-resize
+      // observer is a second candidate for the WebKitGTK feedback loop).
+      // Log-rate-limited; never disconnects.
+      if (!monitor) monitor = createResizeLoopMonitor()
+      const warning = monitor.record(performance.now())
+      if (warning) console.warn(warning)
+
+      // Track the latest height and coalesce the correction into one rAF per
+      // frame, no matter how many times the observer fires this frame. The
+      // `scheduled` flag (rather than `rafId === null`) is what guards against
+      // double-scheduling: it stays correct even when rAF runs the callback
+      // synchronously and reentrantly.
+      pendingHeight = entries[0].contentRect.height
+      if (!scheduled) {
+        scheduled = true
+        rafId = requestAnimationFrame(runCorrection)
+      }
     })
 
     observer.observe(scroller)
-    return () => observer.disconnect()
+    return () => {
+      observer.disconnect()
+      if (rafId !== null) cancelAnimationFrame(rafId)
+    }
   }, [conversationId])
 
   // ==========================================================================


### PR DESCRIPTION
Two small WebKitGTK half-freeze hardenings, surfaced by field logs showing `ResizeObserver loop completed with undelivered notifications` before a freeze.

**A — Container ResizeObserver no longer writes `scrollTop` synchronously inside its callback.** The composer-resize observer was the one RO in the message list still doing a synchronous scroll write inside the delivery cycle — the literal trigger for the "undelivered notifications" loop. It now coalesces measure + correction into a single `requestAnimationFrame` (parity with the content observer's existing hardening), and routes fires through `resizeLoopMonitor` so a runaway on this observer also shows up as `[ScrollResizeLoop]` in `fluux.log`. Rescheduling guards on a dedicated `scheduled` flag rather than `rafId === null`, which stays correct under reentrant/synchronous rAF.

**B — The benign `ResizeObserver loop` browser notice is no longer forwarded as an "Uncaught error."** With `content-visibility` rows it fires routinely; logging it as an uncaught error was alarming noise. A genuine runaway is still surfaced by the rate-limited `[ScrollResizeLoop]` diagnostic.

Complementary to #497 (content-visibility) and #508 (observer mount-order); intended for the 0.16.1 hardening set.

Tests: new regression test asserts the correction is deferred to rAF instead of written inside the observer callback; full `conversation/` suite (350) green, typecheck clean, lint 0 errors.