### PR TITLE
fix(ui): reserve the image attachment box in its error state

### DIFF
--- a/apps/fluux/src/components/FileAttachments.test.tsx
+++ b/apps/fluux/src/components/FileAttachments.test.tsx
@@ -91,6 +91,24 @@ describe('FileAttachments', () => {
       const { container } = render(<ImageAttachment attachment={pdfAttachment} />)
       expect(container.firstChild).toBeNull()
     })
+
+    it('reserves the aspect-ratio box in the error state to avoid a layout shift', () => {
+      // When an image fails to load — or its blob URL is invalidated AFTER it was
+      // displayed (sleep/wake, WebKit blob reclaim) — the error fallback must keep
+      // the same reserved box the loading/loaded image used. Collapsing to a
+      // compact card shifts every row below it; a burst of such invalidations
+      // feeds the message-list ResizeObserver scroll-correction loop on WebKitGTK.
+      mockUseProxiedUrl.mockReturnValue({
+        url: null,
+        isLoading: false,
+        error: new Error('Failed to fetch'),
+      })
+
+      const { container } = render(<ImageAttachment attachment={imageAttachment} />)
+
+      const reserved = container.querySelector('[style*="aspect-ratio"]')
+      expect(reserved).toBeTruthy()
+    })
   })
 
   describe('VideoAttachment', () => {

--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -97,32 +97,37 @@ export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoa
     )
   }
 
-  // Show error state if fetch failed or image failed to load (404, etc.)
+  // Show error state if fetch failed or image failed to load (404, etc.).
+  // Reserve the SAME aspect-ratio box the loading/loaded image uses: an image
+  // whose blob URL is invalidated after it was displayed (sleep/wake, WebKit
+  // blob reclaim) must not collapse to a compact card, or every row below it
+  // shifts — and a burst of such invalidations feeds the message-list
+  // ResizeObserver scroll-correction loop on WebKitGTK.
   if (error || !proxiedImageSrc || loadError) {
     return (
-      <div className="pt-2 max-w-sm">
-        <a
-          href={attachment.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-3 p-3 rounded-lg bg-fluux-bg/60 border border-fluux-border hover:bg-fluux-hover/60 transition-colors group/file"
-          tabIndex={-1}
+      <a
+        href={attachment.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block pt-2 group/file"
+        style={{ maxWidth: `${maxWidthPx}px` }}
+        tabIndex={-1}
+      >
+        <div
+          className="flex flex-col items-center justify-center gap-2 px-3 rounded-lg bg-fluux-bg/60 border border-fluux-border hover:bg-fluux-hover/60 transition-colors text-fluux-muted"
+          style={{ aspectRatio, maxHeight: '300px', minHeight: '100px' }}
         >
-          <div className="size-10 rounded-lg flex items-center justify-center flex-shrink-0 bg-fluux-muted/20 text-fluux-muted">
-            <ImageOff className="size-5" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-fluux-muted truncate">
-              {attachment.name || t('chat.imageUnavailable')}
-            </p>
-            <p className="text-xs text-fluux-muted">
-              {t('chat.imageUnavailable')}
-              {attachment.size ? ` • ${formatBytes(attachment.size)}` : ''}
-            </p>
-          </div>
-          <Download className="size-4 text-fluux-muted opacity-0 group-hover/file:opacity-100 transition-opacity flex-shrink-0" />
-        </a>
-      </div>
+          <ImageOff className="size-6 flex-shrink-0" />
+          <p className="text-sm font-medium truncate max-w-full">
+            {attachment.name || t('chat.imageUnavailable')}
+          </p>
+          <p className="text-xs">
+            {t('chat.imageUnavailable')}
+            {attachment.size ? ` • ${formatBytes(attachment.size)}` : ''}
+          </p>
+          <Download className="size-4 opacity-0 group-hover/file:opacity-100 transition-opacity flex-shrink-0" />
+        </div>
+      </a>
     )
   }
 


### PR DESCRIPTION
Third item in the 0.16.1 WebKitGTK half-freeze set (follows #510).

When an image attachment fails to load — or its `blob:` URL is invalidated *after* it was displayed (sleep/wake, WebKit blob reclaim) — the error fallback collapsed the reserved aspect-ratio box to a compact horizontal card. That shifts every row below it; a burst of such invalidations (the `Failed to load resource: img blob:` clusters in `fluux.log`) is a layout-shift storm that feeds the message-list ResizeObserver scroll-correction loop.

The error state now reserves the same aspect-ratio box the loading and loaded states already use, so a failed/invalidated image holds its place instead of collapsing. The whole box remains a download link to the original URL.

Tradeoff: a permanently-broken image (genuine 404) now occupies the reserved box with an "unavailable" placeholder rather than a small card — consistent with the loading state and with the video error fallback.

Test: new regression test asserts the error state reserves an aspect-ratio box; existing error/onError tests still green.