### PR TITLE
fix(mam): surface bodiless encrypted archive messages instead of dropping them

### DIFF
--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -426,6 +426,99 @@ describe('MAM E2EE wiring', () => {
     expect((msg as { encryptedPayload?: unknown }).encryptedPayload).toBeUndefined()
   })
 
+  it('surfaces a self-outgoing OMEMO archive entry that has NO fallback body (issue #135)', async () => {
+    // Regression for issue #135: "messages sent while Fluux was closed are not
+    // shown". The reporter sends from Gajim, which (unlike Conversations) omits
+    // the optional XEP-0380 fallback <body> on OMEMO messages. The own-sent copy
+    // is replayed from MAM (self-outgoing, from === ownBareJid). Fluux has no
+    // OMEMO plugin, so it cannot decrypt and there is NO fallback body to show.
+    //
+    // parseArchiveMessage's "no body, no attachment → drop" gate then silently
+    // discards the entry — so the user never sees their own sent message. The
+    // incoming direction survives only because the *peer's* client included a
+    // fallback body. This makes the drop look direction-specific when it is
+    // really "any encrypted entry that arrives without a fallback body".
+    //
+    // The entry MUST surface as an outgoing, unsupported-encryption placeholder.
+    const forwardedMessage = xml(
+      'message',
+      { from: ME + '/gajim', to: PEER, type: 'chat', id: 'mam-omemo-self-nobody' },
+      // No <body> — Gajim omitted the OMEMO fallback.
+      xml('encrypted', { xmlns: 'eu.siacs.conversations.axolotl' },
+        xml('header', { sid: '654321' }),
+        xml('payload', {}, 'BBBB'),
+      ),
+    )
+    const archiveEntry = buildMAMResult({
+      archiveId: 'arch-omemo-self-nobody',
+      forwardedMessage,
+    })
+
+    const resultPromise = harness.mam.queryArchive({ with: PEER, max: 10 })
+    await harness.iqPending()
+    const entries = [...harness.collectors.entries()]
+    if (entries.length === 0) throw new Error('No collector registered')
+    const [queryId, collector] = entries[0]
+    archiveEntry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+    collector(archiveEntry)
+    harness.resolveNextIQ(
+      xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+    )
+    const result = await resultPromise
+
+    // BUG (#135): the entry is currently dropped at the "no body" gate, so
+    // result.messages is empty. It must instead surface so the user sees it.
+    expect(result.messages).toHaveLength(1)
+    const msg = result.messages[0]
+    expect(msg.isOutgoing).toBe(true)
+    expect(msg.unsupportedEncryption).toBeDefined()
+    expect(msg.unsupportedEncryption!.namespace).toBe('eu.siacs.conversations.axolotl')
+    // No fallback body: the entry surfaces with an empty body and the UI
+    // renders a placeholder from `unsupportedEncryption` (MessageBubble's
+    // render precedence), so the user still sees that an encrypted message
+    // exists rather than the entry being silently dropped.
+    expect(msg.body).toBe('')
+  })
+
+  it('surfaces a bodiless OMEMO MUC archive entry instead of dropping it (issue #135, rooms)', async () => {
+    // parseRoomArchiveMessage has the same "no body, no attachment → drop" gate
+    // as the 1:1 path. An OMEMO room message whose sender omitted the optional
+    // XEP-0380 fallback <body> must still surface as an unsupported-encryption
+    // placeholder, not be silently discarded.
+    const ROOM = 'room@conference.example.com'
+    const forwardedMessage = xml(
+      'message',
+      { from: ROOM + '/alice', to: ME, type: 'groupchat', id: 'mam-room-omemo-nobody' },
+      // No <body> — sender omitted the OMEMO fallback.
+      xml('encrypted', { xmlns: 'eu.siacs.conversations.axolotl' },
+        xml('header', { sid: '777' }),
+        xml('payload', {}, 'CCCC'),
+      ),
+    )
+    const archiveEntry = buildMAMResult({
+      archiveId: 'arch-room-omemo-nobody',
+      forwardedMessage,
+    })
+
+    const resultPromise = harness.mam.queryRoomArchive({ roomJid: ROOM, max: 10 })
+    await harness.iqPending()
+    const entries = [...harness.collectors.entries()]
+    if (entries.length === 0) throw new Error('No collector registered')
+    const [queryId, collector] = entries[0]
+    archiveEntry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+    collector(archiveEntry)
+    harness.resolveNextIQ(
+      xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+    )
+    const result = await resultPromise
+
+    expect(result.messages).toHaveLength(1)
+    const msg = result.messages[0]
+    expect(msg.unsupportedEncryption).toBeDefined()
+    expect(msg.unsupportedEncryption!.namespace).toBe('eu.siacs.conversations.axolotl')
+    expect(msg.body).toBe('')
+  })
+
   describe('no E2EE manager (archive replayed before E2EE init)', () => {
     let noMgrHarness: TestHarness
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1741,9 +1741,21 @@ export class MAM extends BaseModule {
     if (messageEl.getChild('replace', NS_CORRECTION)) return null
     if (messageEl.getChild('reactions', NS_REACTIONS)) return null
 
-    // Accept messages with body OR OOB attachment (file-only messages have no body)
     if (!from) return null
-    if (!body && !messageEl.getChild('x', NS_OOB)) return null
+
+    // E2EE markers stashed by the preceding decrypt pass. An encrypted entry we
+    // could not decrypt (unsupported protocol like OMEMO, or stashed for retry)
+    // may carry NO usable <body> — e.g. a client that omits the optional
+    // XEP-0380 fallback (notably on its own sent copy). Such an entry must still
+    // surface: the UI renders a placeholder from these fields. Dropping it on
+    // the "no body" gate silently loses the message — see issue #135.
+    const encryptedPayload = readStashedEncryptedPayload(messageEl)
+    const unsupportedEncryption = readStashedUnsupportedEncryption(messageEl)
+    const hasEncryptedContent = encryptedPayload !== undefined || unsupportedEncryption !== undefined
+
+    // Accept messages with body OR OOB attachment OR encrypted content
+    // (file-only messages have no body; encrypted-but-bodiless render a placeholder)
+    if (!body && !messageEl.getChild('x', NS_OOB) && !hasEncryptedContent) return null
 
     const bareFrom = getBareJid(from)
     const isOutgoing = bareFrom === getBareJid(this.deps.getCurrentJid() ?? '')
@@ -1763,8 +1775,6 @@ export class MAM extends BaseModule {
     const messageId = messageEl.attrs.id || generateStableMessageId(from, parsed.timestamp, body || '')
 
     const securityContext = this.archiveSecurityContext(messageEl)
-    const encryptedPayload = readStashedEncryptedPayload(messageEl)
-    const unsupportedEncryption = readStashedUnsupportedEncryption(messageEl)
 
     return {
       type: 'chat',
@@ -1803,11 +1813,21 @@ export class MAM extends BaseModule {
     if (messageEl.getChild('replace', NS_CORRECTION)) return null
     if (messageEl.getChild('reactions', NS_REACTIONS)) return null
 
-    // Accept messages with body, OOB attachment, or poll elements
     if (!from) return null
+
+    // E2EE markers stashed by the preceding decrypt pass. An encrypted entry we
+    // could not decrypt (unsupported protocol like OMEMO, or stashed for retry)
+    // may carry NO usable <body> when the sender omits the optional XEP-0380
+    // fallback. It must still surface — the UI renders a placeholder from these
+    // fields — rather than being dropped on the "no body" gate. See issue #135.
+    const roomEncryptedPayload = readStashedEncryptedPayload(messageEl)
+    const roomUnsupportedEncryption = readStashedUnsupportedEncryption(messageEl)
+    const hasEncryptedContent = roomEncryptedPayload !== undefined || roomUnsupportedEncryption !== undefined
+
+    // Accept messages with body, OOB attachment, poll elements, or encrypted content
     const hasPoll = !!messageEl.getChild('poll', NS_POLL)
     const hasPollClosed = !!messageEl.getChild('poll-closed', NS_POLL)
-    if (!body && !messageEl.getChild('x', NS_OOB) && !hasPoll && !hasPollClosed) return null
+    if (!body && !messageEl.getChild('x', NS_OOB) && !hasPoll && !hasPollClosed && !hasEncryptedContent) return null
 
     const nick = getResource(from) || ''
     // Case-insensitive nickname comparison - some servers may change case
@@ -1833,8 +1853,6 @@ export class MAM extends BaseModule {
     const occupantId = messageEl.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
 
     const roomSecurityContext = this.archiveSecurityContext(messageEl)
-    const roomEncryptedPayload = readStashedEncryptedPayload(messageEl)
-    const roomUnsupportedEncryption = readStashedUnsupportedEncryption(messageEl)
 
     const message: RoomMessage = {
       type: 'groupchat',


### PR DESCRIPTION
## Summary

On MAM catch-up, both `parseArchiveMessage` (1:1) and `parseRoomArchiveMessage` (MUC) dropped any archived entry with no `<body>` and no attachment **before** checking the stashed E2EE markers. An encrypted message we cannot decrypt (an unsupported protocol like OMEMO, or one stashed for retry) may carry no fallback `<body>` when the sending client omits the optional XEP-0380 fallback — notably on its own sent copy. Those entries were silently lost.

The fix reads the `unsupportedEncryption` / `encryptedPayload` markers before the "no body" gate and lets encrypted entries through. The UI already renders a placeholder from those fields (`EncryptedPlaceholder` / `UnsupportedEncryptionNotice`), so no synthesized body is needed.