### PR TITLE
fix(mam): valid backward-pagination cursor — fix scroll-up item-not-found

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -291,6 +291,68 @@ describe('XMPPClient MAM', () => {
       expect(result.messages[1].isOutgoing).toBe(true)
     })
 
+    it('should select the stanza-id stamped by the own archive when several are present (XEP-0359 by-aware)', async () => {
+      // A MAM entry in the user's 1:1 archive can carry multiple
+      // <stanza-id by="..."/>. Only the one stamped by the queried archive
+      // (the user's own bare JID) is a valid RSM cursor — parseArchiveMessage
+      // must keep that one, not a foreign id that came in on the original stanza.
+      let stanzaListener: ((stanza: any) => void) | null = null
+      const originalOn = mockXmppClientInstance.on
+      mockXmppClientInstance.on = vi.fn().mockImplementation((event: string, listener: Function) => {
+        if (event === 'stanza') {
+          stanzaListener = listener as (stanza: any) => void
+        }
+        return originalOn.call(mockXmppClientInstance, event, listener)
+      }) as typeof mockXmppClientInstance.on
+
+      await connectClient()
+      vi.mocked(mockStores.connection.getJid).mockReturnValue('me@example.com/myresource')
+
+      mockXmppClientInstance.iqCaller.request = vi.fn().mockImplementation(async (iq) => {
+        const queryChild = iq.children?.find((c: any) => c.name === 'query')
+        const actualQueryId = queryChild?.attrs?.queryid || 'mam_query_byaware'
+
+        if (stanzaListener) {
+          const msg = createMockElement('message', { from: 'example.com' }, [
+            {
+              name: 'result',
+              attrs: { xmlns: 'urn:xmpp:mam:2', queryid: actualQueryId, id: 'archive-rsm-id' },
+              children: [
+                {
+                  name: 'forwarded',
+                  attrs: { xmlns: 'urn:xmpp:forward:0' },
+                  children: [
+                    { name: 'delay', attrs: { xmlns: 'urn:xmpp:delay', stamp: '2024-01-15T10:00:00Z' } },
+                    {
+                      name: 'message',
+                      attrs: { from: 'alice@example.com/resource', to: 'me@example.com', type: 'chat', id: 'msg-byaware' },
+                      children: [
+                        { name: 'body', text: 'Multi-archive entry' },
+                        // Foreign first (e.g. carried over from the sender's server), own second.
+                        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'alice-server.example.org' } },
+                        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-archive-id', by: 'me@example.com' } },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ])
+          stanzaListener(msg)
+        }
+
+        return createMockElement('iq', { type: 'result' }, [
+          { name: 'fin', attrs: { xmlns: 'urn:xmpp:mam:2', complete: 'true' }, children: [] },
+        ])
+      })
+
+      const result = await xmppClient.chat.queryMAM({ with: 'alice@example.com' })
+
+      expect(result.messages.length).toBe(1)
+      expect(result.messages[0].body).toBe('Multi-archive entry')
+      expect(result.messages[0].stanzaId).toBe('own-archive-id')
+    })
+
     it('should set MAM loading state during query', async () => {
       await connectClient()
       const mamResponse = createMockElement('iq', { type: 'result' }, [

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -198,6 +198,95 @@ describe('XMPPClient Message', () => {
     })
   })
 
+  describe('XEP-0359 by-aware stanza-id selection', () => {
+    // Connected JID is user@example.com, so the user's own archive `by` is the
+    // bare JID. A message can carry several <stanza-id by="..."/> — only the one
+    // stamped by the queried archive is a valid MAM cursor / cross-client ref.
+    it('1:1: stores the stanza-id stamped by the user\'s own archive, not a foreign one', async () => {
+      await connectClient()
+
+      const messageStanza = createMockElement('message', {
+        from: 'contact@example.com/resource',
+        to: 'user@example.com',
+        type: 'chat',
+        id: 'msg-1',
+      }, [
+        { name: 'body', text: 'Hello!' },
+        // Foreign id first (e.g. stamped by the sender's server), own id second.
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'contact-server.example.org' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-archive-id', by: 'user@example.com' } },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
+        message: expect.objectContaining({
+          id: 'msg-1',
+          stanzaId: 'own-archive-id',
+        })
+      })
+    })
+
+    it('MUC: stores the stanza-id stamped by the room archive, not a foreign one', async () => {
+      await connectClient()
+
+      mockStores.room.getRoom.mockReturnValue({
+        jid: 'room@conference.example.com',
+        name: 'room',
+        nickname: 'TestUser',
+        joined: true,
+        isBookmarked: false,
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set<string>(),
+        occupants: new Map(),
+        messages: [],
+      })
+
+      const messageStanza = createMockElement('message', {
+        from: 'room@conference.example.com/Alice',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'msg-2',
+      }, [
+        { name: 'body', text: 'Hi room!' },
+        // The user's own server may also stamp a stanza-id (carbon-style); the
+        // MUC archive id (by = room JID) is the one we must keep.
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'user-server-id', by: 'user@example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'room-archive-id', by: 'room@conference.example.com' } },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message', expect.objectContaining({
+        message: expect.objectContaining({
+          id: 'msg-2',
+          stanzaId: 'room-archive-id',
+        })
+      }))
+    })
+
+    it('1:1: falls back to the only stanza-id when none matches the own archive', async () => {
+      await connectClient()
+
+      const messageStanza = createMockElement('message', {
+        from: 'contact@example.com/resource',
+        to: 'user@example.com',
+        type: 'chat',
+        id: 'msg-3',
+      }, [
+        { name: 'body', text: 'Single archive' },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'only-id', by: 'user@example.com' } },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', {
+        message: expect.objectContaining({ id: 'msg-3', stanzaId: 'only-id' })
+      })
+    })
+  })
+
   describe('message carbons (XEP-0280)', () => {
     it('should process received carbon and extract forwarded message', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1774,8 +1774,11 @@ export class Chat extends BaseModule {
     if (!conversationId) return false
 
     // Capture the correction stanza's own stanza-id so replies referencing
-    // the corrected version's archive entry can resolve to the original message
-    const correctionStanzaId = parseStanzaId(stanza)
+    // the corrected version's archive entry can resolve to the original message.
+    // XEP-0359: pick the id stamped by the relevant archive — the room itself
+    // for MUC, our own archive (bare JID) for 1:1.
+    const correctionExpectedBy = type === 'groupchat' ? conversationId : myBareJid
+    const correctionStanzaId = parseStanzaId(stanza, correctionExpectedBy)
 
     // SDK events only - bindings call store methods
     if (type === 'groupchat') {
@@ -1936,6 +1939,9 @@ export class Chat extends BaseModule {
     const parsed = parseMessageContent({
       messageEl: stanza,
       body,
+      // XEP-0359: the valid stanza-id for a 1:1 message is the one stamped by
+      // the user's own archive (bare JID), so it works as a MAM cursor.
+      expectedStanzaIdBy: myBareJid,
       ...(authoredAt && { authoredAt }),
     })
     const isCorrection = !!stanza.getChild('replace', NS_CORRECTION)
@@ -2004,6 +2010,9 @@ export class Chat extends BaseModule {
       body,
       preserveFullReplyToJid: true,
       messageContext: 'room',
+      // XEP-0359: in a MUC the archive that matters is the room itself, so the
+      // valid stanza-id is the one stamped by the room bare JID.
+      expectedStanzaIdBy: roomJid,
       ...(roomAuthoredAt && { authoredAt: roomAuthoredAt }),
     })
     const isCorrection = !!stanza.getChild('replace', NS_CORRECTION)

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -242,7 +242,7 @@ export class MAM extends BaseModule {
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
             const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
             await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, forwardedTimestamp)
-            if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp)) {
+            if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp, getBareJid(this.deps.getCurrentJid() ?? ''))) {
               continue
             }
             const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
@@ -385,7 +385,7 @@ export class MAM extends BaseModule {
           for (const { forwarded, messageEl, archiveId } of rawEntries) {
             const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
             await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, forwardedTimestamp)
-            if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp)) {
+            if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp, roomJid)) {
               continue
             }
             const msg = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
@@ -512,7 +512,7 @@ export class MAM extends BaseModule {
         const to = getBareJid(messageEl.attrs.to || '')
         const conversationId = from === ownBareJid ? to : from
         await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, forwardedTimestamp)
-        if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp)) {
+        if (this.collectModification(messageEl, modifications, (from) => getBareJid(from), forwardedTimestamp, ownBareJid)) {
           continue
         }
         const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
@@ -574,7 +574,7 @@ export class MAM extends BaseModule {
       for (const { forwarded, messageEl, archiveId } of rawEntries) {
         const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
         await this.decryptArchiveEntryIfNeeded(messageEl, roomJid, forwardedTimestamp)
-        if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp)) {
+        if (this.collectModification(messageEl, modifications, (from) => from, forwardedTimestamp, roomJid)) {
           continue
         }
         const msg = this.parseRoomArchiveMessage(forwarded, roomJid, myNickname, archiveId)
@@ -1359,7 +1359,8 @@ export class MAM extends BaseModule {
     messageEl: Element,
     modifications: MAMModifications,
     normalizeFrom: (from: string) => string,
-    timestamp?: Date
+    timestamp?: Date,
+    expectedStanzaIdBy?: string
   ): boolean {
     const from = messageEl.attrs.from
     if (!from) return false
@@ -1377,8 +1378,10 @@ export class MAM extends BaseModule {
       const bodyText = messageEl.getChildText('body')
       if (bodyText) {
         // Capture the correction stanza's own stanza-id so replies referencing
-        // the corrected version's archive entry can resolve to the original message
-        const correctionStanzaId = parseStanzaId(messageEl)
+        // the corrected version's archive entry can resolve to the original message.
+        // XEP-0359: prefer the id stamped by the queried archive (own bare JID
+        // for 1:1, room JID for MUC) so it is a valid cross-client reference.
+        const correctionStanzaId = parseStanzaId(messageEl, expectedStanzaIdBy)
         modifications.corrections.push({
           targetId: replaceEl.attrs.id,
           from: normalizeFrom(from),
@@ -1746,13 +1749,16 @@ export class MAM extends BaseModule {
     if (!body && !messageEl.getChild('x', NS_OOB)) return null
 
     const bareFrom = getBareJid(from)
-    const isOutgoing = bareFrom === getBareJid(this.deps.getCurrentJid() ?? '')
+    const ownBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
+    const isOutgoing = bareFrom === ownBareJid
     const authoredAt = readStashedAuthoredAt(messageEl)
     const parsed = parseMessageContent({
       messageEl,
       body: body || '',
       delayEl,
       forceDelayed: true,
+      // XEP-0359: 1:1 archive — prefer the stanza-id stamped by our own archive.
+      expectedStanzaIdBy: ownBareJid,
       ...(authoredAt && { authoredAt }),
     })
 
@@ -1820,6 +1826,8 @@ export class MAM extends BaseModule {
       forceDelayed: true,
       preserveFullReplyToJid: true,
       messageContext: 'room',
+      // XEP-0359: MUC archive — prefer the stanza-id stamped by the room itself.
+      expectedStanzaIdBy: roomJid,
       ...(roomAuthoredAt && { authoredAt: roomAuthoredAt }),
     })
 

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyRetraction, applyCorrection, parseOobData, parseMessageContent, parseOriginId, createOriginIdElement } from './messagingUtils'
+import { applyRetraction, applyCorrection, parseOobData, parseMessageContent, parseOriginId, parseStanzaId, createOriginIdElement } from './messagingUtils'
 import { createMockElement } from '../test-utils'
 
 describe('messagingUtils', () => {
@@ -514,6 +514,128 @@ describe('messagingUtils', () => {
       ])
 
       expect(parseOriginId(stanza)).toBeUndefined()
+    })
+  })
+
+  describe('parseStanzaId (XEP-0359 by-aware)', () => {
+    it('returns the first stanza-id id when no expected by is given', () => {
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Hello' },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'first-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'second-id', by: 'user@example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza)).toBe('first-id')
+    })
+
+    it('prefers the stanza-id whose by matches the expected archive (foreign first, own second)', () => {
+      // Per XEP-0359/0313 a message can carry multiple <stanza-id by="..."/>.
+      // Only the id stamped by the queried archive is a valid MAM cursor.
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Hello' },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-id', by: 'user@example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza, 'user@example.com')).toBe('own-id')
+    })
+
+    it('compares by-attribute on a bare-JID basis', () => {
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-id', by: 'user@example.com' } },
+      ])
+
+      // Caller may pass a full JID; matching is on the bare form.
+      expect(parseStanzaId(stanza, 'user@example.com/resource')).toBe('own-id')
+    })
+
+    it('falls back to the first stanza-id when no by matches the expected archive', () => {
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'other-id', by: 'other.example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza, 'user@example.com')).toBe('foreign-id')
+    })
+
+    it('returns undefined when there is no stanza-id element', () => {
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Hello' },
+      ])
+
+      expect(parseStanzaId(stanza, 'user@example.com')).toBeUndefined()
+    })
+
+    it('matches the expected archive even when it is the first stanza-id (order-independent)', () => {
+      // The matching id comes FIRST here — guards against a regression that
+      // simply returns the last stanza-id instead of the by-matched one.
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-id', by: 'user@example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza, 'user@example.com')).toBe('own-id')
+    })
+
+    it('skips a by-matching stanza-id that has no id attribute and falls back to a usable id', () => {
+      // A malformed <stanza-id by="me"/> with no id must not shadow a real id.
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', by: 'user@example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza, 'user@example.com')).toBe('foreign-id')
+    })
+
+    it('treats an empty-string expectedBy like no expected archive (call-site safety)', () => {
+      // Call sites pass getBareJid(getCurrentJid() ?? '') which is '' before the
+      // JID is known — must not throw and must fall back to first-match.
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'first-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'second-id', by: 'user@example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza, '')).toBe('first-id')
+    })
+
+    it('never matches a stanza-id that has no by attribute against an expected archive', () => {
+      // A <stanza-id> without a by is ambiguous; it can only serve as fallback,
+      // never as a by-match.
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'no-by-id' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-id', by: 'user@example.com' } },
+      ])
+
+      expect(parseStanzaId(stanza, 'user@example.com')).toBe('own-id')
+      // With no expected archive, the first (by-less) id is returned.
+      expect(parseStanzaId(stanza)).toBe('no-by-id')
+    })
+  })
+
+  describe('parseMessageContent - by-aware stanza-id selection', () => {
+    it('selects the stanza-id matching expectedStanzaIdBy', () => {
+      const messageEl = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Hello' },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-id', by: 'user@example.com' } },
+      ])
+
+      const result = parseMessageContent({ messageEl, body: 'Hello', expectedStanzaIdBy: 'user@example.com' })
+
+      expect(result.stanzaId).toBe('own-id')
+    })
+
+    it('falls back to the first stanza-id when expectedStanzaIdBy is omitted', () => {
+      const messageEl = createMockElement('message', { id: 'msg-1' }, [
+        { name: 'body', text: 'Hello' },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'foreign-id', by: 'muc.example.com' } },
+        { name: 'stanza-id', attrs: { xmlns: 'urn:xmpp:sid:0', id: 'own-id', by: 'user@example.com' } },
+      ])
+
+      const result = parseMessageContent({ messageEl, body: 'Hello' })
+
+      expect(result.stanzaId).toBe('foreign-id')
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.ts
@@ -232,10 +232,35 @@ export function parseOobData(stanza: Element): FileAttachment | undefined {
 
 /**
  * Parse XEP-0359 stanza-id from a message element.
- * Returns the first stanza-id found (typically assigned by server or MUC service).
+ *
+ * Per XEP-0359/XEP-0313 a message can carry multiple `<stanza-id by="..."/>`
+ * elements stamped by different archiving entities (e.g. the user's own server
+ * AND a MUC service). Only the id stamped by the *queried* archive is valid as
+ * a MAM RSM pagination cursor (`<before>`) or a stable cross-client reference —
+ * using a foreign one makes mod_mam reject backward queries with
+ * `item-not-found`.
+ *
+ * When `expectedBy` is provided, prefers the `<stanza-id>` whose `by` matches it
+ * (compared on a bare-JID basis): the user's own bare JID for 1:1 chats, the
+ * room bare JID for MUC. Falls back to the first stanza-id when no `by` matches
+ * or when `expectedBy` is omitted (preserving legacy single-archive behaviour).
+ *
+ * @param messageEl - The message element to read the stanza-id from.
+ * @param expectedBy - Bare (or full) JID of the archive whose stanza-id is wanted.
  */
-export function parseStanzaId(messageEl: Element): string | undefined {
+export function parseStanzaId(messageEl: Element, expectedBy?: string): string | undefined {
   const stanzaIdEls = messageEl.getChildren('stanza-id', NS_STANZA_ID)
+
+  if (expectedBy) {
+    const expectedBare = getBareJid(expectedBy)
+    for (const el of stanzaIdEls) {
+      if (el.attrs.id && el.attrs.by && getBareJid(el.attrs.by) === expectedBare) {
+        return el.attrs.id
+      }
+    }
+  }
+
+  // Fallback: first stanza-id carrying an id (legacy single-archive behaviour).
   for (const el of stanzaIdEls) {
     if (el.attrs.id) {
       return el.attrs.id
@@ -286,6 +311,13 @@ export interface ParseMessageContentOptions {
    * that have no authenticated timestamp omit this field.
    */
   authoredAt?: Date
+  /**
+   * Bare (or full) JID of the archive whose XEP-0359 `<stanza-id>` should be
+   * selected when the message carries several from different archiving entities
+   * (see {@link parseStanzaId}). Pass the user's own bare JID for 1:1 chats and
+   * the room bare JID for MUC. Omit to keep first-match behaviour.
+   */
+  expectedStanzaIdBy?: string
 }
 
 /**
@@ -315,6 +347,7 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
     messageContext = 'chat',
     preserveFullReplyToJid = false,
     authoredAt,
+    expectedStanzaIdBy,
   } = options
 
   const fallbackTargets = messageContext === 'room' ? ROOM_FALLBACK_TARGETS : CHAT_FALLBACK_TARGETS
@@ -340,8 +373,10 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
     timestamp = authoredAt
   }
 
-  // XEP-0359: Unique stanza ID (server-assigned) and origin ID (sender-assigned)
-  const stanzaId = parseStanzaId(messageEl)
+  // XEP-0359: Unique stanza ID (server-assigned) and origin ID (sender-assigned).
+  // Prefer the stanza-id stamped by the queried archive (expectedStanzaIdBy) so
+  // it is valid as a MAM pagination cursor and cross-client reference.
+  const stanzaId = parseStanzaId(messageEl, expectedStanzaIdBy)
   const originId = parseOriginId(messageEl)
 
   // XEP-0393: Message styling hints

--- a/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.test.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.test.ts
@@ -190,6 +190,53 @@ describe('createFetchOlderHistory', () => {
     })
   })
 
+  describe('graceful recovery (item-not-found)', () => {
+    const oldestTs = new Date('2026-06-01T10:00:00.000Z')
+
+    it('retries with a timestamp window when the backward query fails with item-not-found', async () => {
+      vi.mocked(deps.loadFromCache).mockResolvedValue([])
+      vi.mocked(deps.queryMAM).mockRejectedValue({ condition: 'item-not-found' })
+      deps.getOldestTimestamp = vi.fn(() => oldestTs)
+      deps.queryMAMByEndTime = vi.fn(() => Promise.resolve())
+      fetchOlderHistory = createFetchOlderHistory(deps)
+
+      await fetchOlderHistory('conv-1')
+
+      expect(deps.queryMAMByEndTime).toHaveBeenCalledWith('conv-1', oldestTs.toISOString())
+    })
+
+    it('does not retry when the query fails with a different condition', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.mocked(deps.loadFromCache).mockResolvedValue([])
+      vi.mocked(deps.queryMAM).mockRejectedValue({ condition: 'forbidden' })
+      deps.getOldestTimestamp = vi.fn(() => oldestTs)
+      deps.queryMAMByEndTime = vi.fn(() => Promise.resolve())
+      fetchOlderHistory = createFetchOlderHistory(deps)
+
+      await fetchOlderHistory('conv-1')
+
+      expect(deps.queryMAMByEndTime).not.toHaveBeenCalled()
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
+    it('queries by timestamp window when there is no archive cursor (chat)', async () => {
+      // Oldest in-memory message has no stanzaId, so no valid `before` cursor —
+      // recover by fetching the page before the oldest message's timestamp.
+      deps.errorLogPrefix = 'Failed to fetch older chat history'
+      vi.mocked(deps.getOldestMessageId).mockReturnValue(undefined)
+      vi.mocked(deps.loadFromCache).mockResolvedValue([])
+      deps.getOldestTimestamp = vi.fn(() => oldestTs)
+      deps.queryMAMByEndTime = vi.fn(() => Promise.resolve())
+      fetchOlderHistory = createFetchOlderHistory(deps)
+
+      await fetchOlderHistory('conv-1')
+
+      expect(deps.queryMAM).not.toHaveBeenCalled()
+      expect(deps.queryMAMByEndTime).toHaveBeenCalledWith('conv-1', oldestTs.toISOString())
+    })
+  })
+
   describe('error handling', () => {
     it('logs error when cache loading fails', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.ts
@@ -8,6 +8,7 @@
 
 import type { MAMQueryState } from '../../core/types'
 import { connectionStore } from '../../stores'
+import { isItemNotFoundError } from './mamCursor'
 
 /**
  * Dependencies required to create the fetchOlderHistory callback.
@@ -41,9 +42,13 @@ export interface FetchOlderHistoryDeps {
   loadFromCache: (id: string, limit: number) => Promise<unknown[]>
 
   /**
-   * Get the stanza ID of the oldest message currently in memory.
-   * Used as the pagination cursor when querying MAM for older messages.
-   * Returns undefined if no messages exist or oldest message has no stanza ID.
+   * Get the server archive ID (XEP-0359 stanza-id) of the oldest in-memory
+   * message that has one. Used as the MAM `before` pagination cursor.
+   *
+   * Returns undefined when no in-memory message carries a server-assigned
+   * archive ID. Callers MUST NOT substitute a client-generated id: a client id
+   * is not a valid archive entry and the server rejects it with
+   * `item-not-found`, dead-ending "load older history".
    */
   getOldestMessageId: (id: string) => string | undefined
 
@@ -52,6 +57,21 @@ export interface FetchOlderHistoryDeps {
    * Called when cache is exhausted and MAM is not complete.
    */
   queryMAM: (id: string, beforeId: string) => Promise<void>
+
+  /**
+   * Optional: timestamp of the oldest in-memory message. Used for the
+   * id-independent recovery query when no valid archive cursor is available or
+   * the server rejects the cursor with `item-not-found`.
+   */
+  getOldestTimestamp?: (id: string) => Date | undefined
+
+  /**
+   * Optional: query MAM for messages archived before a timestamp (XEP-0313
+   * `end` filter). This recovery path does not depend on an opaque archive id,
+   * so it works even when the oldest in-memory message has no stanzaId or the
+   * cursor is stale. Only the 1:1 chat archive supports the `end` filter.
+   */
+  queryMAMByEndTime?: (id: string, endIso: string) => Promise<void>
 
   /**
    * Error message prefix for logging.
@@ -83,8 +103,23 @@ export function createFetchOlderHistory(
     loadFromCache,
     getOldestMessageId,
     queryMAM,
+    getOldestTimestamp,
+    queryMAMByEndTime,
     errorLogPrefix,
   } = deps
+
+  /**
+   * Recover by fetching the page of messages archived before the oldest
+   * in-memory message's timestamp. Id-independent, so it works when no valid
+   * archive cursor is available. No-op when the dependency or timestamp is
+   * missing (e.g. room MAM, which has no `end` filter).
+   */
+  const recoverByTimestamp = async (id: string): Promise<boolean> => {
+    const oldestTimestamp = getOldestTimestamp?.(id)
+    if (!queryMAMByEndTime || !oldestTimestamp) return false
+    await queryMAMByEndTime(id, oldestTimestamp.toISOString())
+    return true
+  }
 
   return async (targetId?: string): Promise<void> => {
     // Guard: Don't attempt MAM query if not connected
@@ -117,17 +152,37 @@ export function createFetchOlderHistory(
       // Cache exhausted - fall back to MAM if not complete
       if (mamState.isHistoryComplete) return
 
-      // Use the oldest in-memory message's stanza ID as the pagination cursor.
-      // This is more reliable than mamState.oldestFetchedId because:
+      // Use the oldest in-memory message's archive id (XEP-0359 stanza-id) as
+      // the pagination cursor. This is more reliable than mamState.oldestFetchedId
+      // because:
       // 1. The initial MAM query may have used 'start' filter to only fetch NEW messages
       // 2. We need to paginate from the actual oldest message we have, not what MAM returned
-      const beforeId = getOldestMessageId(id) || ''
+      // getOldestMessageId never returns a client-generated id — that would be
+      // rejected by the server with item-not-found.
+      const beforeId = getOldestMessageId(id)
+      const isChat = errorLogPrefix.includes('chat')
 
-      // For chat MAM, we need a valid cursor to paginate backwards
-      // For room MAM, empty string means "get latest" which is valid for first query
-      if (!beforeId && errorLogPrefix.includes('chat')) return
+      // No valid archive cursor available.
+      if (!beforeId) {
+        // Chat: recover via a timestamp window if possible; otherwise there is
+        // nothing safe to send (a client id would be rejected), so skip.
+        if (isChat) {
+          await recoverByTimestamp(id)
+          return
+        }
+        // Room MAM: empty string means "get latest", valid for the first query.
+        await queryMAM(id, '')
+        return
+      }
 
-      await queryMAM(id, beforeId)
+      try {
+        await queryMAM(id, beforeId)
+      } catch (error) {
+        // A stale or non-archive cursor makes the server return item-not-found.
+        // Recover with an id-independent timestamp window before giving up.
+        if (isItemNotFoundError(error) && (await recoverByTimestamp(id))) return
+        throw error
+      }
     } catch (error) {
       console.error(`${errorLogPrefix}:`, error)
     } finally {

--- a/packages/fluux-sdk/src/hooks/shared/index.ts
+++ b/packages/fluux-sdk/src/hooks/shared/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { createFetchOlderHistory, type FetchOlderHistoryDeps } from './createFetchOlderHistory'
+export { pickOldestArchiveId, isItemNotFoundError } from './mamCursor'

--- a/packages/fluux-sdk/src/hooks/shared/mamCursor.test.ts
+++ b/packages/fluux-sdk/src/hooks/shared/mamCursor.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { pickOldestArchiveId, isItemNotFoundError } from './mamCursor'
+
+// Minimal message shape the helper operates on; `id` mirrors the real
+// client-generated id that must never be used as a cursor.
+type TestMessage = { stanzaId?: string; id?: string }
+
+describe('pickOldestArchiveId', () => {
+  it('returns undefined for an empty list', () => {
+    expect(pickOldestArchiveId([])).toBeUndefined()
+  })
+
+  it('returns the oldest message stanzaId when present', () => {
+    const messages: TestMessage[] = [
+      { stanzaId: 'archive-1', id: 'uuid-1' },
+      { stanzaId: 'archive-2', id: 'uuid-2' },
+    ]
+    expect(pickOldestArchiveId(messages)).toBe('archive-1')
+  })
+
+  it('skips leading messages without a stanzaId and returns the first archived one', () => {
+    // Oldest message is an outgoing message with no server archive id.
+    const messages: TestMessage[] = [
+      { id: 'uuid-sent' }, // outgoing, never assigned a stanzaId
+      { stanzaId: 'archive-2', id: 'uuid-2' },
+    ]
+    expect(pickOldestArchiveId(messages)).toBe('archive-2')
+  })
+
+  it('returns undefined when no message carries a stanzaId (never falls back to client id)', () => {
+    // This is the item-not-found trigger: a client UUID is not a valid archive id.
+    const messages: TestMessage[] = [{ id: 'uuid-sent' }, { id: 'uuid-2' }]
+    expect(pickOldestArchiveId(messages)).toBeUndefined()
+  })
+
+  it('treats an empty-string stanzaId as absent', () => {
+    const messages: TestMessage[] = [
+      { stanzaId: '', id: 'uuid-1' },
+      { stanzaId: 'archive-2', id: 'uuid-2' },
+    ]
+    expect(pickOldestArchiveId(messages)).toBe('archive-2')
+  })
+})
+
+describe('isItemNotFoundError', () => {
+  it('detects a StanzaError by its condition', () => {
+    expect(isItemNotFoundError({ condition: 'item-not-found' })).toBe(true)
+  })
+
+  it('detects item-not-found from the error message', () => {
+    expect(isItemNotFoundError(new Error('item-not-found'))).toBe(true)
+  })
+
+  it('returns false for other conditions', () => {
+    expect(isItemNotFoundError({ condition: 'forbidden' })).toBe(false)
+    expect(isItemNotFoundError(new Error('timeout'))).toBe(false)
+    expect(isItemNotFoundError(null)).toBe(false)
+    expect(isItemNotFoundError(undefined)).toBe(false)
+  })
+})

--- a/packages/fluux-sdk/src/hooks/shared/mamCursor.ts
+++ b/packages/fluux-sdk/src/hooks/shared/mamCursor.ts
@@ -1,0 +1,47 @@
+/**
+ * Helpers for choosing a safe MAM backward-pagination cursor.
+ *
+ * XEP-0313 RSM `<before>` must reference a server-assigned archive id
+ * (XEP-0359 stanza-id) that exists in the *queried* archive. Sending any
+ * other value — most commonly a client-generated message id — makes
+ * ejabberd's mod_mam reject the query with `item-not-found`, which dead-ends
+ * "load older history". Outgoing messages never receive a stanzaId, so the
+ * oldest in-memory message frequently lacks one; these helpers ensure we
+ * never use a non-archive id as the cursor.
+ */
+
+/** Minimal shape needed to pick a pagination cursor. */
+interface ArchivableMessage {
+  /** XEP-0359 server-assigned archive id. Absent on outgoing / unarchived messages. */
+  stanzaId?: string
+}
+
+/**
+ * Return the server archive id (stanza-id) of the oldest in-memory message
+ * that has one, scanning from oldest to newest. Messages are stored
+ * oldest-first, so the first message carrying a stanzaId is the oldest valid
+ * cursor: querying `before` it re-includes any stanzaId-less neighbours
+ * (harmless duplicates) while correctly advancing into older history.
+ *
+ * Returns undefined when no in-memory message carries a stanzaId. Callers MUST
+ * NOT substitute a client-generated id — the server rejects it with
+ * `item-not-found`.
+ */
+export function pickOldestArchiveId(messages: ArchivableMessage[]): string | undefined {
+  for (const message of messages) {
+    if (message.stanzaId) return message.stanzaId
+  }
+  return undefined
+}
+
+/**
+ * True when an error represents a MAM `item-not-found` stanza error — the
+ * server could not locate the RSM cursor in the archive. Detected via the
+ * XMPP StanzaError `condition` (preferred) or the error message as a fallback.
+ */
+export function isItemNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  if ((error as { condition?: string }).condition === 'item-not-found') return true
+  if (error instanceof Error && error.message.includes('item-not-found')) return true
+  return false
+}

--- a/packages/fluux-sdk/src/hooks/useChat.fetchOlderHistory.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChat.fetchOlderHistory.regression.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression guard for the MAM "item-not-found" scroll-up bug.
+ *
+ * `fetchOlderHistory` must NEVER send a client-generated message id as the RSM
+ * `<before>` cursor — the server rejects it with item-not-found and dead-ends
+ * "load older history". These tests exercise the real hook wiring
+ * (useChat → createFetchOlderHistory → client.chat.queryMAM) to prove the
+ * cursor is always a server stanzaId, or the id-independent timestamp recovery,
+ * but never a client UUID. They fail against the original
+ * `messages[0].stanzaId || messages[0].id` cursor.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useChat } from './useChat'
+import type { Message } from '../core/types'
+import { chatStore, connectionStore } from '../stores'
+import { XMPPProvider } from '../provider'
+import { createMockXMPPClientForHooks } from '../core/test-utils'
+
+const mockClient = createMockXMPPClientForHooks()
+
+vi.mock('../provider', async () => {
+  const actual = await vi.importActual('../provider')
+  return { ...actual, useXMPPContext: () => ({ client: mockClient }) }
+})
+
+// Empty cache so fetchOlderHistory falls through to the MAM path.
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return { ...actual, getMessages: vi.fn().mockResolvedValue([]) }
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <XMPPProvider>{children}</XMPPProvider>
+}
+
+const CONV = 'alice@example.com'
+
+function seedMessages(messages: Message[]) {
+  chatStore.setState({
+    conversations: new Map(),
+    conversationEntities: new Map(),
+    conversationMeta: new Map(),
+    messages: new Map(),
+    mamQueryStates: new Map(),
+    activeConversationId: null,
+  })
+  chatStore.getState().addConversation({ id: CONV, name: 'Alice', type: 'chat', unreadCount: 0 })
+  chatStore.setState((s) => {
+    const m = new Map(s.messages)
+    m.set(CONV, messages)
+    return { messages: m }
+  })
+  chatStore.getState().setActiveConversation(CONV)
+  connectionStore.getState().setStatus('online')
+}
+
+const outgoing = (id: string, ts: string): Message => ({
+  type: 'chat', id, originId: id, conversationId: CONV,
+  from: 'me@example.com/desktop', body: 'hi', timestamp: new Date(ts), isOutgoing: true,
+})
+const incoming = (id: string, ts: string, stanzaId: string): Message => ({
+  type: 'chat', id, conversationId: CONV, from: CONV, body: 'hi',
+  timestamp: new Date(ts), isOutgoing: false, stanzaId,
+})
+
+describe('useChat fetchOlderHistory — MAM cursor regression', () => {
+  beforeEach(() => {
+    vi.mocked(mockClient.chat.queryMAM).mockReset().mockResolvedValue(undefined)
+  })
+
+  it('uses the oldest server stanzaId as the cursor — never the client id — when the oldest message is outgoing', async () => {
+    // Oldest message is one we sent (no stanzaId); a later received message has one.
+    seedMessages([
+      outgoing('uuid-sent', '2026-06-01T10:00:00Z'),
+      incoming('r1', '2026-06-01T10:05:00Z', 'archive-1'),
+    ])
+    const { result } = renderHook(() => useChat(), { wrapper })
+
+    await act(async () => {
+      await result.current.fetchOlderHistory()
+    })
+
+    expect(mockClient.chat.queryMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({ with: CONV, before: 'archive-1' })
+    // The client UUID must never be used as a cursor.
+    const before = vi.mocked(mockClient.chat.queryMAM).mock.calls[0][0].before
+    expect(before).not.toBe('uuid-sent')
+  })
+
+  it('recovers via a timestamp window — never the client id — when no in-memory message has a stanzaId', async () => {
+    seedMessages([
+      outgoing('uuid-1', '2026-06-01T10:00:00Z'),
+      outgoing('uuid-2', '2026-06-01T10:05:00Z'),
+    ])
+    const { result } = renderHook(() => useChat(), { wrapper })
+
+    await act(async () => {
+      await result.current.fetchOlderHistory()
+    })
+
+    // Recovery: query by the `end` timestamp of the oldest message, empty before.
+    expect(mockClient.chat.queryMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({
+      with: CONV,
+      end: new Date('2026-06-01T10:00:00Z').toISOString(),
+      before: '',
+    })
+    // No call ever uses a client UUID as `before`.
+    for (const [opts] of vi.mocked(mockClient.chat.queryMAM).mock.calls) {
+      expect(['uuid-1', 'uuid-2']).not.toContain(opts.before)
+    }
+  })
+})

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -5,7 +5,7 @@ import { useChatStore, useConnectionStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment, MAMQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
-import { createFetchOlderHistory } from './shared'
+import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 
 /**
  * Stable empty array references to prevent infinite re-renders.
@@ -361,16 +361,18 @@ export function useChat() {
         getMAMState: (id) => chatStore.getState().getMAMQueryState(id),
         setMAMLoading: (id, loading) => chatStore.getState().setMAMLoading(id, loading),
         loadFromCache: (id, limit) => chatStore.getState().loadOlderMessagesFromCache(id, limit),
-        getOldestMessageId: (id) => {
-          const messages = chatStore.getState().messages.get(id)
-          if (!messages || messages.length === 0) return undefined
-          // Use stanzaId (MAM archive ID) for pagination cursor, fall back to message id
-          return messages[0].stanzaId || messages[0].id
-        },
+        getOldestMessageId: (id) => pickOldestArchiveId(chatStore.getState().messages.get(id) ?? []),
+        getOldestTimestamp: (id) => chatStore.getState().messages.get(id)?.[0]?.timestamp,
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)
           if (conversation) {
             await client.chat.queryMAM({ with: conversation.id, before: beforeId })
+          }
+        },
+        queryMAMByEndTime: async (id, endIso) => {
+          const conversation = chatStore.getState().conversations.get(id)
+          if (conversation) {
+            await client.chat.queryMAM({ with: conversation.id, end: endIso, before: '' })
           }
         },
         errorLogPrefix: 'Failed to fetch older chat history',

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { chatStore, connectionStore } from '../stores'
 import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment } from '../core'
-import { createFetchOlderHistory } from './shared'
+import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 
 /**
  * Action-only counterpart to `useChat()`.
@@ -177,15 +177,18 @@ export function useChatActions() {
         getMAMState: (id) => chatStore.getState().getMAMQueryState(id),
         setMAMLoading: (id, loading) => chatStore.getState().setMAMLoading(id, loading),
         loadFromCache: (id, limit) => chatStore.getState().loadOlderMessagesFromCache(id, limit),
-        getOldestMessageId: (id) => {
-          const messages = chatStore.getState().messages.get(id)
-          if (!messages || messages.length === 0) return undefined
-          return messages[0].stanzaId || messages[0].id
-        },
+        getOldestMessageId: (id) => pickOldestArchiveId(chatStore.getState().messages.get(id) ?? []),
+        getOldestTimestamp: (id) => chatStore.getState().messages.get(id)?.[0]?.timestamp,
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)
           if (conversation) {
             await client.chat.queryMAM({ with: conversation.id, before: beforeId })
+          }
+        },
+        queryMAMByEndTime: async (id, endIso) => {
+          const conversation = chatStore.getState().conversations.get(id)
+          if (conversation) {
+            await client.chat.queryMAM({ with: conversation.id, end: endIso, before: '' })
           }
         },
         errorLogPrefix: 'Failed to fetch older chat history',

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -5,7 +5,7 @@ import { useChatStore, useConnectionStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment, MAMQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
-import { createFetchOlderHistory } from './shared'
+import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 
 /**
  * Stable empty array references to prevent infinite re-renders.
@@ -309,15 +309,18 @@ export function useChatActive() {
         getMAMState: (id) => chatStore.getState().getMAMQueryState(id),
         setMAMLoading: (id, loading) => chatStore.getState().setMAMLoading(id, loading),
         loadFromCache: (id, limit) => chatStore.getState().loadOlderMessagesFromCache(id, limit),
-        getOldestMessageId: (id) => {
-          const messages = chatStore.getState().messages.get(id)
-          if (!messages || messages.length === 0) return undefined
-          return messages[0].stanzaId || messages[0].id
-        },
+        getOldestMessageId: (id) => pickOldestArchiveId(chatStore.getState().messages.get(id) ?? []),
+        getOldestTimestamp: (id) => chatStore.getState().messages.get(id)?.[0]?.timestamp,
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)
           if (conversation) {
             await client.chat.queryMAM({ with: conversation.id, before: beforeId })
+          }
+        },
+        queryMAMByEndTime: async (id, endIso) => {
+          const conversation = chatStore.getState().conversations.get(id)
+          if (conversation) {
+            await client.chat.queryMAM({ with: conversation.id, end: endIso, before: '' })
           }
         },
         errorLogPrefix: 'Failed to fetch older chat history',

--- a/packages/fluux-sdk/src/hooks/useRoom.fetchOlderHistory.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useRoom.fetchOlderHistory.regression.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression guard for the MAM "item-not-found" scroll-up bug — MUC variant.
+ *
+ * Room `fetchOlderHistory` must NEVER send a client-generated message id as the
+ * RSM `<before>` cursor. This exercises the real hook wiring
+ * (useRoom → createFetchOlderHistory → client.chat.queryRoomMAM) to prove the
+ * cursor is a server stanzaId, or the empty-string "get latest" sentinel, but
+ * never a client UUID. Fails against the original
+ * `messages[0].stanzaId || messages[0].id` cursor.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useRoom } from './useRoom'
+import type { Room, RoomMessage } from '../core/types'
+import { roomStore, connectionStore } from '../stores'
+import { XMPPProvider } from '../provider'
+import { createMockXMPPClientForHooks } from '../core/test-utils'
+
+const mockClient = createMockXMPPClientForHooks()
+
+vi.mock('../provider', async () => {
+  const actual = await vi.importActual('../provider')
+  return { ...actual, useXMPPContext: () => ({ client: mockClient }) }
+})
+
+// Empty cache so fetchOlderHistory falls through to the MAM path.
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return { ...actual, getMessages: vi.fn().mockResolvedValue([]) }
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <XMPPProvider>{children}</XMPPProvider>
+}
+
+const ROOM = 'room@conference.example.com'
+
+function createRoom(messages: RoomMessage[]): Room {
+  return {
+    jid: ROOM,
+    name: 'room',
+    nickname: 'me',
+    joined: true,
+    isBookmarked: false,
+    occupants: new Map(),
+    messages,
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set(),
+  }
+}
+
+function seedRoom(messages: RoomMessage[]) {
+  roomStore.setState({ rooms: new Map(), activeRoomJid: null })
+  roomStore.getState().addRoom(createRoom(messages))
+  roomStore.getState().setActiveRoom(ROOM)
+  connectionStore.getState().setStatus('online')
+}
+
+const own = (id: string, ts: string): RoomMessage => ({
+  type: 'groupchat', id, originId: id, roomJid: ROOM, from: `${ROOM}/me`, nick: 'me',
+  body: 'hi', timestamp: new Date(ts), isOutgoing: true,
+})
+const other = (id: string, ts: string, stanzaId: string): RoomMessage => ({
+  type: 'groupchat', id, roomJid: ROOM, from: `${ROOM}/bob`, nick: 'bob',
+  body: 'hi', timestamp: new Date(ts), isOutgoing: false, stanzaId,
+})
+
+describe('useRoom fetchOlderHistory — MUC MAM cursor regression', () => {
+  beforeEach(() => {
+    vi.mocked(mockClient.chat.queryRoomMAM).mockReset().mockResolvedValue(undefined)
+  })
+
+  it('uses the oldest server stanzaId as the cursor — never the client id — when the oldest message is our own', async () => {
+    seedRoom([
+      own('uuid-own', '2026-06-01T10:00:00Z'),
+      other('s1', '2026-06-01T10:05:00Z', 'archive-1'),
+    ])
+    const { result } = renderHook(() => useRoom(), { wrapper })
+
+    await act(async () => {
+      await result.current.fetchOlderHistory()
+    })
+
+    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({ roomJid: ROOM, before: 'archive-1' })
+    const before = vi.mocked(mockClient.chat.queryRoomMAM).mock.calls[0][0].before
+    expect(before).not.toBe('uuid-own')
+  })
+
+  it('falls back to the empty "get latest" cursor — never the client id — when no message has a stanzaId', async () => {
+    seedRoom([
+      own('uuid-1', '2026-06-01T10:00:00Z'),
+      own('uuid-2', '2026-06-01T10:05:00Z'),
+    ])
+    const { result } = renderHook(() => useRoom(), { wrapper })
+
+    await act(async () => {
+      await result.current.fetchOlderHistory()
+    })
+
+    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith({ roomJid: ROOM, before: '' })
+    const before = vi.mocked(mockClient.chat.queryRoomMAM).mock.calls[0][0].before
+    expect(['uuid-1', 'uuid-2']).not.toContain(before)
+  })
+})

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -4,7 +4,7 @@ import { roomStore } from '../stores'
 import { useRoomStore, useAdminStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
 import type { MentionReference, ChatStateNotification, FileAttachment, RSMRequest, AdminRoom, RSMResponse, MAMQueryState, RoomAffiliation, RoomRole, PollData, PollSettings } from '../core/types'
-import { createFetchOlderHistory } from './shared'
+import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 
 /**
  * Stable empty array reference to prevent infinite re-renders.
@@ -551,13 +551,7 @@ export function useRoom() {
         getMAMState: (id) => roomStore.getState().getRoomMAMQueryState(id),
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),
         loadFromCache: (id, limit) => roomStore.getState().loadOlderMessagesFromCache(id, limit),
-        getOldestMessageId: (id) => {
-          const room = roomStore.getState().rooms.get(id)
-          const messages = room?.messages
-          if (!messages || messages.length === 0) return undefined
-          // Use stanzaId (MAM archive ID) for pagination cursor, fall back to message id
-          return messages[0].stanzaId || messages[0].id
-        },
+        getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
         queryMAM: async (id, beforeId) => {
           await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
         },

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -13,7 +13,7 @@ import type {
   PollData,
   PollSettings,
 } from '../core/types'
-import { createFetchOlderHistory } from './shared'
+import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 
 /**
  * Action-only counterpart to `useRoom()`.
@@ -366,12 +366,7 @@ export function useRoomActions() {
         getMAMState: (id) => roomStore.getState().getRoomMAMQueryState(id),
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),
         loadFromCache: (id, limit) => roomStore.getState().loadOlderMessagesFromCache(id, limit),
-        getOldestMessageId: (id) => {
-          const room = roomStore.getState().rooms.get(id)
-          const messages = room?.messages
-          if (!messages || messages.length === 0) return undefined
-          return messages[0].stanzaId || messages[0].id
-        },
+        getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
         queryMAM: async (id, beforeId) => {
           await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
         },

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -3,7 +3,7 @@ import { roomStore, connectionStore } from '../stores'
 import { useRoomStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
 import type { Room, RoomMessage, MentionReference, ChatStateNotification, FileAttachment, MAMQueryState, RoomAffiliation, RoomRole, PollData, PollSettings } from '../core/types'
-import { createFetchOlderHistory } from './shared'
+import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 import {
   findNewestMessage,
   buildCatchUpStartTime,
@@ -340,12 +340,7 @@ export function useRoomActive() {
         getMAMState: (id) => roomStore.getState().getRoomMAMQueryState(id),
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),
         loadFromCache: (id, limit) => roomStore.getState().loadOlderMessagesFromCache(id, limit),
-        getOldestMessageId: (id) => {
-          const room = roomStore.getState().rooms.get(id)
-          const messages = room?.messages
-          if (!messages || messages.length === 0) return undefined
-          return messages[0].stanzaId || messages[0].id
-        },
+        getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
         queryMAM: async (id, beforeId) => {
           await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
         },

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1653,6 +1653,93 @@ describe('chatStore', () => {
       })
     })
 
+    describe('stanzaId backfill (closes the MAM cursor data gap)', () => {
+      it('backfills stanzaId onto an outgoing message when its archived copy arrives via MAM', () => {
+        chatStore.getState().addConversation(createConversation('alice@example.com'))
+
+        // Outgoing message as created by sendMessage: client originId, no stanzaId.
+        const sent: Message = {
+          type: 'chat',
+          id: 'uuid-sent',
+          originId: 'uuid-sent',
+          conversationId: 'alice@example.com',
+          from: 'me@example.com/desktop',
+          body: 'hello',
+          timestamp: new Date('2024-01-15T12:00:00Z'),
+          isOutgoing: true,
+        }
+        chatStore.getState().addMessage(sent)
+
+        // Archived copy from MAM: same origin-id, now carries the server stanzaId,
+        // bare `from`. It is a duplicate (matched by originId) and would otherwise
+        // be dropped without ever giving the live message a stanzaId.
+        const archived: Message = {
+          type: 'chat',
+          id: 'uuid-sent',
+          originId: 'uuid-sent',
+          conversationId: 'alice@example.com',
+          from: 'me@example.com',
+          body: 'hello',
+          timestamp: new Date('2024-01-15T12:00:00Z'),
+          isOutgoing: true,
+          stanzaId: 'archive-99',
+        }
+
+        chatStore.getState().mergeMAMMessages(
+          'alice@example.com',
+          [archived],
+          { count: 1, first: 'archive-99', last: 'archive-99' },
+          true,
+          'forward'
+        )
+
+        const messages = chatStore.getState().messages.get('alice@example.com')
+        expect(messages?.length).toBe(1) // still deduplicated
+        expect(messages?.[0].stanzaId).toBe('archive-99') // but now backfilled
+        expect(messageCache.updateMessage).toHaveBeenCalledWith(
+          'uuid-sent',
+          expect.objectContaining({ stanzaId: 'archive-99' })
+        )
+      })
+
+      it('backfills stanzaId onto an outgoing message when a duplicate carbon arrives via addMessage', () => {
+        chatStore.getState().addConversation(createConversation('alice@example.com'))
+
+        const sent: Message = {
+          type: 'chat',
+          id: 'uuid-2',
+          originId: 'uuid-2',
+          conversationId: 'alice@example.com',
+          from: 'me@example.com/desktop',
+          body: 'hi there',
+          timestamp: new Date('2024-01-15T12:00:00Z'),
+          isOutgoing: true,
+        }
+        chatStore.getState().addMessage(sent)
+
+        const carbon: Message = {
+          type: 'chat',
+          id: 'uuid-2',
+          originId: 'uuid-2',
+          conversationId: 'alice@example.com',
+          from: 'me@example.com',
+          body: 'hi there',
+          timestamp: new Date('2024-01-15T12:00:00Z'),
+          isOutgoing: true,
+          stanzaId: 'archive-carbon',
+        }
+        chatStore.getState().addMessage(carbon)
+
+        const messages = chatStore.getState().messages.get('alice@example.com')
+        expect(messages?.length).toBe(1)
+        expect(messages?.[0].stanzaId).toBe('archive-carbon')
+        expect(messageCache.updateMessage).toHaveBeenCalledWith(
+          'uuid-2',
+          expect.objectContaining({ stanzaId: 'archive-carbon' })
+        )
+      })
+    })
+
     describe('mergeMAMMessages', () => {
       it('should merge MAM messages with existing messages', () => {
         chatStore.getState().addConversation(createConversation('alice@example.com'))

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -8,7 +8,7 @@ import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
 import * as draftState from './shared/draftState'
-import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages } from './shared/messageArrayUtils'
+import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages, backfillArchiveIds } from './shared/messageArrayUtils'
 import { shouldUpdateLastMessage } from './shared/lastMessageUtils'
 import * as notifState from './shared/notificationState'
 import { connectionStore } from './connectionStore'
@@ -654,7 +654,18 @@ export const chatStore = createStore<ChatState>()(
           const isDuplicate = isMessageDuplicate(msg, existingKeys, getChatMessageKeys)
 
           if (isDuplicate) {
-            return state // Don't add duplicate message
+            // The duplicate may be the archived/carbon copy of an outgoing
+            // message that has no stanzaId yet. Backfill the server archive id
+            // onto the in-memory copy (matched by originId) so backward MAM
+            // pagination has a valid cursor — then still skip adding the dup.
+            const { messages: backfilled, patched } = backfillArchiveIds(convMessages, [msg], getChatMessageKeys)
+            if (patched.length === 0) return state
+            for (const p of patched) {
+              void messageCache.updateMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+            }
+            const patchedMap = new Map(state.messages)
+            patchedMap.set(msg.conversationId, backfilled)
+            return { messages: patchedMap }
           }
 
           // Save to IndexedDB + search index only if the message is locally persistable
@@ -1118,7 +1129,16 @@ export const chatStore = createStore<ChatState>()(
       mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction) => {
         set((state) => {
           // Get existing messages for this conversation
-          const existingMessages = state.messages.get(conversationId) || []
+          const rawExisting = state.messages.get(conversationId) || []
+
+          // Backfill server stanzaIds from archived copies onto stanzaId-less
+          // in-memory messages (e.g. outgoing messages) before merging, so the
+          // live copy gains a valid backward-pagination cursor. The archived
+          // copy itself still dedups away below.
+          const { messages: existingMessages, patched } = backfillArchiveIds(rawExisting, mamMessages, getChatMessageKeys)
+          for (const p of patched) {
+            void messageCache.updateMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+          }
 
           // Choose merge strategy based on direction:
           // - Backward (scroll up for older): optimized prepend avoids full re-sort
@@ -1149,9 +1169,16 @@ export const chatStore = createStore<ChatState>()(
           )
 
           // If no new messages (all duplicates), only update MAM state - skip messages/conversations
-          // This prevents unnecessary re-renders when merging duplicates
+          // This prevents unnecessary re-renders when merging duplicates.
+          // Exception: if we backfilled stanzaIds onto existing messages, persist
+          // that patched array (trimmed === existingMessages here) to the store.
           if (newMessages.length === 0) {
-            return { mamQueryStates: newStates }
+            if (patched.length === 0) {
+              return { mamQueryStates: newStates }
+            }
+            const backfilledMap = new Map(state.messages)
+            backfilledMap.set(conversationId, trimmed)
+            return { messages: backfilledMap, mamQueryStates: newStates }
           }
 
           // Persist only locally-persistable messages to IndexedDB

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.test.ts
@@ -7,6 +7,7 @@ import {
   trimMessages,
   mergeAndProcessMessages,
   prependOlderMessages,
+  backfillArchiveIds,
 } from './messageArrayUtils'
 
 // Test message type
@@ -750,6 +751,91 @@ describe('messageArrayUtils', () => {
       // The last message in the array should be the newest — this is used for
       // lastMessage sidebar preview in mergeMAMMessages
       expect(merged[merged.length - 1].id).toBe('msg-4')
+    })
+  })
+
+  describe('backfillArchiveIds', () => {
+    // Mirrors chatStore's getChatMessageKeys (stanzaId / originId / from+id).
+    const getKeys = (m: TestMessage): string[] => {
+      const keys: string[] = []
+      if (m.stanzaId) keys.push(`stanzaId:${m.stanzaId}`)
+      if (m.originId) keys.push(`originId:${m.originId}`)
+      keys.push(`from:${m.from}:id:${m.id}`)
+      return keys
+    }
+
+    const msg = (over: Partial<TestMessage>): TestMessage => ({
+      id: 'x',
+      from: 'me@example.com',
+      body: 'hi',
+      timestamp: new Date('2026-06-01T10:00:00Z'),
+      ...over,
+    })
+
+    it('backfills stanzaId onto an outgoing message from its archived copy (matched by originId)', () => {
+      // Outgoing message in memory: only a client originId, no server archive id.
+      const existing = [msg({ id: 'uuid-1', originId: 'uuid-1' })]
+      // Archived copy from MAM: carries the server stanzaId and the same origin-id,
+      // but its bare `from` differs from the live message's full JID.
+      const incoming = [msg({ id: 'uuid-1', originId: 'uuid-1', stanzaId: 'archive-1', from: 'me@example.com/phone' })]
+
+      const { messages, patched } = backfillArchiveIds(existing, incoming, getKeys)
+
+      expect(messages[0].stanzaId).toBe('archive-1')
+      expect(patched).toHaveLength(1)
+      expect(patched[0].id).toBe('uuid-1')
+    })
+
+    it('returns the same array reference when there is nothing to backfill', () => {
+      const existing = [msg({ id: 'uuid-1', originId: 'uuid-1', stanzaId: 'archive-1' })]
+      const incoming = [msg({ id: 'uuid-1', originId: 'uuid-1', stanzaId: 'archive-1' })]
+
+      const { messages, patched } = backfillArchiveIds(existing, incoming, getKeys)
+
+      expect(messages).toBe(existing)
+      expect(patched).toHaveLength(0)
+    })
+
+    it('does not overwrite an existing stanzaId', () => {
+      const existing = [msg({ id: 'uuid-1', originId: 'uuid-1', stanzaId: 'original' })]
+      const incoming = [msg({ id: 'uuid-1', originId: 'uuid-1', stanzaId: 'different' })]
+
+      const { messages, patched } = backfillArchiveIds(existing, incoming, getKeys)
+
+      expect(messages[0].stanzaId).toBe('original')
+      expect(patched).toHaveLength(0)
+    })
+
+    it('ignores incoming messages that carry no stanzaId', () => {
+      const existing = [msg({ id: 'uuid-1', originId: 'uuid-1' })]
+      const incoming = [msg({ id: 'uuid-1', originId: 'uuid-1' })]
+
+      const { messages, patched } = backfillArchiveIds(existing, incoming, getKeys)
+
+      expect(messages).toBe(existing)
+      expect(patched).toHaveLength(0)
+    })
+
+    it('does not patch unrelated messages', () => {
+      const existing = [msg({ id: 'uuid-1', originId: 'uuid-1' })]
+      const incoming = [msg({ id: 'uuid-2', originId: 'uuid-2', stanzaId: 'archive-2' })]
+
+      const { messages, patched } = backfillArchiveIds(existing, incoming, getKeys)
+
+      expect(messages).toBe(existing)
+      expect(patched).toHaveLength(0)
+    })
+
+    it('backfills originId too when the existing message lacks it', () => {
+      // Existing matched only by from+id (no originId yet); donor supplies both.
+      const existing = [msg({ id: 'uuid-1' })]
+      const incoming = [msg({ id: 'uuid-1', originId: 'uuid-1', stanzaId: 'archive-1' })]
+
+      const { messages, patched } = backfillArchiveIds(existing, incoming, getKeys)
+
+      expect(messages[0].stanzaId).toBe('archive-1')
+      expect(messages[0].originId).toBe('uuid-1')
+      expect(patched).toHaveLength(1)
     })
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -103,6 +103,78 @@ export function isMessageDuplicate<T>(
 }
 
 /**
+ * Identity fields an archived/echoed copy of a message can carry.
+ */
+export interface ArchiveIdentifiableMessage {
+  stanzaId?: string
+  originId?: string
+}
+
+/**
+ * Backfill the server `stanzaId` (and `originId`) onto existing in-memory
+ * messages from their archived/echoed duplicates.
+ *
+ * Outgoing messages are created with only a client `originId` and no server
+ * `stanzaId` (the server assigns it on archiving). When their archived copy
+ * later arrives via MAM (or a carbon) it carries the `stanzaId` but is dropped
+ * as a duplicate, so the live copy never receives one — which breaks backward
+ * MAM pagination, whose RSM cursor must be a server archive id. This patches
+ * the missing fields, matching an incoming "donor" to an existing message by
+ * any shared identity key (e.g. `originId`).
+ *
+ * Pure: never mutates inputs. Returns the SAME `existing` array reference when
+ * nothing changed, so callers can cheaply skip a store update; otherwise a
+ * copy-on-write array with the patched messages plus the list of patches (for
+ * persistence).
+ */
+export function backfillArchiveIds<T extends ArchiveIdentifiableMessage>(
+  existing: T[],
+  incoming: T[],
+  getKeys: (message: T) => string[]
+): { messages: T[]; patched: T[] } {
+  // Only incoming messages that carry a stanzaId can donate one.
+  const donors = incoming.filter((m) => m.stanzaId)
+  if (donors.length === 0) return { messages: existing, patched: [] }
+
+  // Index every identity key of each donor so an existing message can find its
+  // matching archived copy by any shared key.
+  const donorByKey = new Map<string, T>()
+  for (const donor of donors) {
+    for (const key of getKeys(donor)) {
+      if (!donorByKey.has(key)) donorByKey.set(key, donor)
+    }
+  }
+
+  let messages = existing
+  const patched: T[] = []
+  for (let i = 0; i < existing.length; i++) {
+    const current = existing[i]
+    if (current.stanzaId) continue // already has a server archive id
+
+    let donor: T | undefined
+    for (const key of getKeys(current)) {
+      const match = donorByKey.get(key)
+      if (match) {
+        donor = match
+        break
+      }
+    }
+    if (!donor?.stanzaId) continue
+
+    const updated: T = {
+      ...current,
+      stanzaId: donor.stanzaId,
+      ...(!current.originId && donor.originId ? { originId: donor.originId } : {}),
+    }
+    if (messages === existing) messages = [...existing] // copy-on-write
+    messages[i] = updated
+    patched.push(updated)
+  }
+
+  return { messages, patched }
+}
+
+/**
  * Sort messages by timestamp in ascending order (oldest first).
  *
  * @param messages - Array of messages to sort


### PR DESCRIPTION
## Problem

Scrolling up to load older 1:1 history failed with `item-not-found` and dead-ended — every subsequent scroll-up re-failed:

```
[Fluux] MAM query: …@..., max=50, backward
[Fluux] MAM error: …@... — item-not-found
Failed to fetch older chat history: StanzaError: item-not-found
```

## Root cause

The RSM `<before>` cursor was not a valid archive id in the queried archive, so ejabberd `mod_mam` rejected it. Three contributing defects:

1. **Client-UUID cursor** — every hook computed the cursor as `messages[0].stanzaId || messages[0].id`. Outgoing messages never get a server `stanzaId` (and were never backfilled), so when the oldest in-memory message was one you'd sent, the cursor degraded to a client UUID.
2. **`parseStanzaId` ignored `by`** — it returned the first `<stanza-id>` regardless of archiving entity, so a foreign id (e.g. injected by the sender's server) could be used against your own archive.
3. **No recovery** — the error was only logged, never recovered from.

## Fix

- **Valid cursor** — new `pickOldestArchiveId` helper returns the oldest in-memory message that actually carries a server `stanzaId`, never a client id. Wired into all six chat/room fetch-older hooks.
- **Graceful recovery** — on `item-not-found` (or when no archive cursor exists), chat retries once via an id-independent timestamp window (XEP-0313 `end` filter). Room path unchanged.
- **`by`-aware stanza-id selection** — `parseStanzaId(el, expectedBy?)` prefers the `<stanza-id>` whose `by` matches the queried archive (own bare JID for 1:1, room JID for MUC), threaded through `parseMessageContent`/`collectModification` and every parse site.
- **Backfill at the source** — new `backfillArchiveIds` helper patches the server `stanzaId` (matched by `originId`) onto an outgoing message when its archived copy arrives via MAM or carbon, instead of silently dropping the duplicate. Persisted to IndexedDB.