### PR TITLE
fix(sm): don't strip <sm> from features unless SM was negotiated inline

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -363,7 +363,7 @@ fn get_idle_time() -> Result<u64, String> {
 }
 
 // Keyring service name for storing credentials
-const KEYRING_SERVICE: &str = "com.processone.fluux";
+const KEYRING_SERVICE: &str = "net.processone.fluux";
 
 /// Credentials stored in the OS keychain
 #[derive(Serialize, Deserialize)]
@@ -1115,9 +1115,9 @@ fn main() {
         eprintln!("  -h, --help            Show this help message");
         eprintln!();
         eprintln!("Logs are always written to a daily-rotating file in:");
-        eprintln!("  macOS:   ~/Library/Logs/com.processone.fluux/");
-        eprintln!("  Linux:   ~/.local/share/com.processone.fluux/logs/");
-        eprintln!("  Windows: %APPDATA%\\com.processone.fluux\\logs\\");
+        eprintln!("  macOS:   ~/Library/Logs/net.processone.fluux/");
+        eprintln!("  Linux:   ~/.local/share/net.processone.fluux/logs/");
+        eprintln!("  Windows: %APPDATA%\\net.processone.fluux\\logs\\");
         eprintln!();
         eprintln!("Environment variables:");
         eprintln!("  RUST_LOG              Override log filter (e.g. RUST_LOG=debug)");
@@ -1133,15 +1133,15 @@ fn main() {
             .unwrap_or_else(|| std::path::PathBuf::from("."))
     } else {
         // Platform log directory:
-        //   macOS:   ~/Library/Logs/com.processone.fluux/
-        //   Linux:   ~/.local/share/com.processone.fluux/logs/  (or $XDG_DATA_HOME)
-        //   Windows: %APPDATA%\com.processone.fluux\logs\
+        //   macOS:   ~/Library/Logs/net.processone.fluux/
+        //   Linux:   ~/.local/share/net.processone.fluux/logs/  (or $XDG_DATA_HOME)
+        //   Windows: %APPDATA%\net.processone.fluux\logs\
         let base = dirs::data_local_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-        let dir = base.join("com.processone.fluux").join("logs");
+        let dir = base.join("net.processone.fluux").join("logs");
 
         #[cfg(target_os = "macos")]
         let dir = dirs::home_dir()
-            .map(|h| h.join("Library").join("Logs").join("com.processone.fluux"))
+            .map(|h| h.join("Library").join("Logs").join("net.processone.fluux"))
             .unwrap_or(dir);
 
         dir

--- a/apps/fluux/src-tauri/src/openpgp_storage.rs
+++ b/apps/fluux/src-tauri/src/openpgp_storage.rs
@@ -5,7 +5,7 @@
 //! 1. A **per-account random passphrase** (32 bytes of CSPRNG output,
 //!    base64-encoded) lives in the OS keychain. Small payload — keychains
 //!    don't love blobs — and leverages the same credential store we already
-//!    use for XMPP passwords (`com.processone.fluux`). Different service
+//!    use for XMPP passwords (`net.processone.fluux`). Different service
 //!    account to avoid collisions: `openpgp_passphrase:<jid>`.
 //! 2. The **passphrase-encrypted TSK** (Transferable Secret Key) lives on
 //!    disk at `<app_data>/openpgp/<sanitized_jid>.tsk.asc`. Sequoia-PGP
@@ -69,7 +69,7 @@ use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 
 /// Keychain service name. Shared with XMPP credentials so a user who
 /// grants keychain access once gets access for both.
-const KEYRING_SERVICE: &str = "com.processone.fluux";
+const KEYRING_SERVICE: &str = "net.processone.fluux";
 /// Keychain account prefix to namespace PGP passphrases away from XMPP
 /// credentials and the `last_user` marker.
 const KEYRING_ACCOUNT_PREFIX: &str = "openpgp_passphrase:";

--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fluux Messenger",
   "version": "0.16.0",
-  "identifier": "com.processone.fluux",
+  "identifier": "net.processone.fluux",
   "plugins": {
     "deep-link": {
       "desktop": {

--- a/apps/fluux/src/utils/mediaCache.test.ts
+++ b/apps/fluux/src/utils/mediaCache.test.ts
@@ -50,7 +50,7 @@ describe('mediaCache', () => {
     resetMediaUrlCache()
 
     mockIsTauri.mockReturnValue(true)
-    mockAppCacheDir.mockResolvedValue('/Users/test/Library/Caches/com.processone.fluux')
+    mockAppCacheDir.mockResolvedValue('/Users/test/Library/Caches/net.processone.fluux')
     mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join('/')))
     mockExists.mockResolvedValue(false)
     mockMkdir.mockResolvedValue(undefined)

--- a/docs/LINUX_DEV_ICON.md
+++ b/docs/LINUX_DEV_ICON.md
@@ -52,4 +52,4 @@ Restart `npm run tauri:dev` — the Fluux icon should now appear in the dock.
 
 - This file is local to your machine and not tracked in git.
 - If you switch between debug and release builds, the `Exec` path doesn't matter for icon matching — only `StartupWMClass` needs to match.
-- On Wayland, the app ID may come from the GTK application ID (`com.processone.fluux`) instead of `WM_CLASS`. If the icon still doesn't appear, try setting `StartupWMClass=com.processone.fluux`.
+- On Wayland, the app ID may come from the GTK application ID (`net.processone.fluux`) instead of `WM_CLASS`. If the icon still doesn't appear, try setting `StartupWMClass=net.processone.fluux`.

--- a/docs/MEMORY_TROUBLESHOOTING.md
+++ b/docs/MEMORY_TROUBLESHOOTING.md
@@ -175,23 +175,23 @@ Logs are written to a daily-rotating file. Paths:
 
 | OS      | Path                                                  |
 |---------|-------------------------------------------------------|
-| macOS   | `~/Library/Logs/com.processone.fluux/`                |
-| Linux   | `~/.local/share/com.processone.fluux/logs/`           |
-| Windows | `%APPDATA%\com.processone.fluux\logs\`                |
+| macOS   | `~/Library/Logs/net.processone.fluux/`                |
+| Linux   | `~/.local/share/net.processone.fluux/logs/`           |
+| Windows | `%APPDATA%\net.processone.fluux\logs\`                |
 
 Package them:
 
 ```bash
 # macOS
-tar czf ~/fluux-logs.tar.gz ~/Library/Logs/com.processone.fluux/
+tar czf ~/fluux-logs.tar.gz ~/Library/Logs/net.processone.fluux/
 
 # Linux
-tar czf ~/fluux-logs.tar.gz ~/.local/share/com.processone.fluux/logs/
+tar czf ~/fluux-logs.tar.gz ~/.local/share/net.processone.fluux/logs/
 ```
 
 ```powershell
 # Windows
-Compress-Archive -Path "$env:APPDATA\com.processone.fluux\logs\*" -DestinationPath "$env:USERPROFILE\fluux-logs.zip"
+Compress-Archive -Path "$env:APPDATA\net.processone.fluux\logs\*" -DestinationPath "$env:USERPROFILE\fluux-logs.zip"
 ```
 
 Look in the log for `[renderLoopDetector]` warnings — if they fire during startup or after specific actions, the leak is very likely linked to a render storm.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -12,9 +12,9 @@ Fluux writes daily-rotating log files (`fluux.log`) automatically. These are use
 
 | OS      | Path                                                  |
 |---------|-------------------------------------------------------|
-| macOS   | `~/Library/Logs/com.processone.fluux/`                |
-| Linux   | `~/.local/share/com.processone.fluux/logs/`           |
-| Windows | `%APPDATA%\com.processone.fluux\logs\`                |
+| macOS   | `~/Library/Logs/net.processone.fluux/`                |
+| Linux   | `~/.local/share/net.processone.fluux/logs/`           |
+| Windows | `%APPDATA%\net.processone.fluux\logs\`                |
 
 You can also open the log directory from the app menu: **Reveal Logs in Finder** (macOS) or **Open Logs Folder** (Windows).
 

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3708,7 +3708,7 @@ describe('XMPPClient Connection', () => {
 
       // Inline negotiation completed: bind2 <enabled> set sm.enabled before the
       // post-auth features arrive.
-      ;(mockXmppClientInstance as any).streamManagement = { enabled: true, on: vi.fn() }
+      mockXmppClientInstance.streamManagement = { id: 'sm-inline', enabled: true, inbound: 0, outbound: 0, on: vi.fn() }
 
       const featuresEl = makeFeaturesWithSm()
       elementHandler(featuresEl)
@@ -3721,7 +3721,15 @@ describe('XMPPClient Connection', () => {
 
       // No inline SM negotiation happened — this features element is the only
       // chance for xmpp.js to send <enable/>. It must pass through untouched.
-      ;(mockXmppClientInstance as any).streamManagement = { enabled: false, on: vi.fn() }
+      mockXmppClientInstance.streamManagement = { id: null, enabled: false, inbound: 0, outbound: 0, on: vi.fn() }
+
+      // Faithful Openfire wire order: a bare SASL2 <success> (no inline SM
+      // child) precedes the post-auth features. The success peek must not
+      // false-positive on it.
+      const bareSuccess = createMockElement('success', { xmlns: 'urn:xmpp:sasl:2' }, [
+        { name: 'authorization-identifier', attrs: {}, text: 'user@example.com' },
+      ])
+      elementHandler(bareSuccess)
 
       const featuresEl = makeFeaturesWithSm()
       elementHandler(featuresEl)
@@ -3736,7 +3744,7 @@ describe('XMPPClient Connection', () => {
       // processed right behind <success>. The synchronous peek at the
       // <success> children must cover that window.
       const elementHandler = await getElementHandler()
-      ;(mockXmppClientInstance as any).streamManagement = { enabled: false, on: vi.fn() }
+      mockXmppClientInstance.streamManagement = { id: null, enabled: false, inbound: 0, outbound: 0, on: vi.fn() }
 
       // bind2 fresh enable: <success><bound xmlns="urn:xmpp:bind:0"><enabled xmlns="urn:xmpp:sm:3"/></bound></success>
       const successBind2 = createMockElement('success', { xmlns: 'urn:xmpp:sasl:2' }, [
@@ -4057,7 +4065,7 @@ describe('XMPPClient Connection', () => {
     // it as a dead socket reconnected the session every 30 seconds.
     it('treats an IQ error response to the keepalive ping as a live connection', async () => {
       // SM not enabled → probe takes the iqCaller ping fallback
-      mockXmppClientInstance.streamManagement = { enabled: false, on: vi.fn() }
+      mockXmppClientInstance.streamManagement = { id: null, enabled: false, inbound: 0, outbound: 0, on: vi.fn() }
       const stanzaError = Object.assign(new Error('remote-server-not-found'), {
         name: 'StanzaError',
         condition: 'remote-server-not-found',
@@ -4071,7 +4079,7 @@ describe('XMPPClient Connection', () => {
     })
 
     it('still treats a transport error on the keepalive ping as a dead connection', async () => {
-      mockXmppClientInstance.streamManagement = { enabled: false, on: vi.fn() }
+      mockXmppClientInstance.streamManagement = { id: null, enabled: false, inbound: 0, outbound: 0, on: vi.fn() }
       mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('WebSocket ECONNERROR'))
 
       const healthy = await xmppClient.verifyConnectionHealth()

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3728,6 +3728,44 @@ describe('XMPPClient Connection', () => {
       const smAfter = (featuresEl as any).children.find((c: any) => c.name === 'sm')
       expect(smAfter).toBeDefined()
     })
+
+    it('strips <sm> when <success> carried inline SM even if sm.enabled is not set yet', async () => {
+      // Race guard: xmpp.js's inline enabled()/resumed() handlers run after
+      // `await mech.final()` (SCRAM server-signature verification), so
+      // sm.enabled can still be false when the post-auth features element is
+      // processed right behind <success>. The synchronous peek at the
+      // <success> children must cover that window.
+      const elementHandler = await getElementHandler()
+      ;(mockXmppClientInstance as any).streamManagement = { enabled: false, on: vi.fn() }
+
+      // bind2 fresh enable: <success><bound xmlns="urn:xmpp:bind:0"><enabled xmlns="urn:xmpp:sm:3"/></bound></success>
+      const successBind2 = createMockElement('success', { xmlns: 'urn:xmpp:sasl:2' }, [
+        {
+          name: 'bound',
+          attrs: { xmlns: 'urn:xmpp:bind:0' },
+          children: [{ name: 'enabled', attrs: { xmlns: 'urn:xmpp:sm:3' } }],
+        },
+      ])
+      elementHandler(successBind2)
+      const featuresEl = makeFeaturesWithSm()
+      elementHandler(featuresEl)
+      expect((featuresEl as any).children.find((c: any) => c.name === 'sm')).toBeUndefined()
+
+      // The peek is one-shot: consumed by the first features element, so a
+      // later features (e.g. after a future stream restart) passes untouched.
+      const featuresEl2 = makeFeaturesWithSm()
+      elementHandler(featuresEl2)
+      expect((featuresEl2 as any).children.find((c: any) => c.name === 'sm')).toBeDefined()
+
+      // Inline resumption: <success><resumed xmlns="urn:xmpp:sm:3"/></success>
+      const successResumed = createMockElement('success', { xmlns: 'urn:xmpp:sasl:2' }, [
+        { name: 'resumed', attrs: { xmlns: 'urn:xmpp:sm:3' } },
+      ])
+      elementHandler(successResumed)
+      const featuresEl3 = makeFeaturesWithSm()
+      elementHandler(featuresEl3)
+      expect((featuresEl3 as any).children.find((c: any) => c.name === 'sm')).toBeUndefined()
+    })
   })
 
   describe('FAST token authentication (XEP-0484)', () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.test.ts
@@ -3660,10 +3660,15 @@ describe('XMPPClient Connection', () => {
   // sends a duplicate <enable>, which the server rejects with <failed>. The catch
   // block then clears sm.enabled, silently disabling SM for the session.
   // The fix: a prependListener on 'element' strips <sm> from the features element
-  // before the middleware sees it, gated on a bind2SmEnabling flag that is set
-  // when the credentials callback detects the SASL2 path (fast !== undefined).
+  // before the middleware sees it, gated on sm.enabled at ARRIVAL time (inline
+  // bind2 <enabled> / SASL2 <resumed> set it synchronously beforehand).
+  //
+  // #515 regression guard: the gate must NOT be pre-armed off SASL2 detection.
+  // A server that advertises SASL2 without inline SM negotiation (Openfire)
+  // relies on this features element for its only chance to enable SM — stripping
+  // it silently disabled SM and broke the keepalive into a 30s reconnect loop.
   describe('bind2 SM duplicate-enable suppression (XEP-0386 + XEP-0198)', () => {
-    it('should strip <sm> from post-auth <stream:features> when SASL2 bind2 is active', async () => {
+    async function getElementHandler(): Promise<(el: unknown) => void> {
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
         password: 'secret',
@@ -3679,35 +3684,49 @@ describe('XMPPClient Connection', () => {
       const elementHandler = prependCall?.[1] as ((el: unknown) => void)
       expect(elementHandler).toBeDefined()
 
-      // Invoke the credentials callback with fast !== undefined to set bind2SmEnabling=true
+      // Run the credentials callback as on a SASL2 server without a usable FAST
+      // token (fast = null): the strip decision must not depend on it.
       const credentialsFn = (mockClientFactory.mock.calls[mockClientFactory.mock.calls.length - 1] as any)[0].credentials
       const mockAuthenticate = vi.fn().mockResolvedValue(undefined)
-      const mockFast = { fetch: vi.fn().mockResolvedValue(null) }
-      await credentialsFn(mockAuthenticate, ['SCRAM-SHA-256'], mockFast, { isSecure: () => true })
+      await credentialsFn(mockAuthenticate, ['SCRAM-SHA-256'], null, { isSecure: () => true })
 
-      // Build a <stream:features> element with an <sm> child — what ejabberd sends post-auth
-      const featuresEl = createMockElement('features', { xmlns: 'http://etherx.jabber.org/streams' }, [
+      // Finish the connection so the test ends in a settled state
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+
+      return elementHandler
+    }
+
+    function makeFeaturesWithSm() {
+      return createMockElement('features', { xmlns: 'http://etherx.jabber.org/streams' }, [
         { name: 'sm', attrs: { xmlns: 'urn:xmpp:sm:3' } },
       ])
-      const smBefore = (featuresEl as any).children.find((c: any) => c.name === 'sm')
-      expect(smBefore).toBeDefined()
+    }
 
-      // Call the interceptor — <sm> must be removed since bind2SmEnabling=true
+    it('strips <sm> from post-auth <stream:features> when SM was negotiated inline', async () => {
+      const elementHandler = await getElementHandler()
+
+      // Inline negotiation completed: bind2 <enabled> set sm.enabled before the
+      // post-auth features arrive.
+      ;(mockXmppClientInstance as any).streamManagement = { enabled: true, on: vi.fn() }
+
+      const featuresEl = makeFeaturesWithSm()
       elementHandler(featuresEl)
       const smAfter = (featuresEl as any).children.find((c: any) => c.name === 'sm')
       expect(smAfter).toBeUndefined()
+    })
 
-      // bind2SmEnabling is now reset to false — a second <stream:features> must not be modified
-      const featuresEl2 = createMockElement('features', { xmlns: 'http://etherx.jabber.org/streams' }, [
-        { name: 'sm', attrs: { xmlns: 'urn:xmpp:sm:3' } },
-      ])
-      elementHandler(featuresEl2)
-      const smAfter2 = (featuresEl2 as any).children.find((c: any) => c.name === 'sm')
-      expect(smAfter2).toBeDefined()
+    it('leaves <sm> intact when SM was NOT negotiated inline (Openfire: SASL2 without bind2 SM)', async () => {
+      const elementHandler = await getElementHandler()
 
-      // Finish the connection
-      mockXmppClientInstance._emit('online')
-      await connectPromise
+      // No inline SM negotiation happened — this features element is the only
+      // chance for xmpp.js to send <enable/>. It must pass through untouched.
+      ;(mockXmppClientInstance as any).streamManagement = { enabled: false, on: vi.fn() }
+
+      const featuresEl = makeFeaturesWithSm()
+      elementHandler(featuresEl)
+      const smAfter = (featuresEl as any).children.find((c: any) => c.name === 'sm')
+      expect(smAfter).toBeDefined()
     })
   })
 
@@ -3991,6 +4010,36 @@ describe('XMPPClient Connection', () => {
 
       // New connection should remain healthy (no reconnect triggered by stale timeout)
       expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
+    })
+
+    // #515: with SM disabled, the keepalive probe falls back to an IQ ping to
+    // the account domain. A misconfigured server (Openfire answering bare-domain
+    // IQs with <remote-server-not-found/>) rejects that ping with an IQ ERROR on
+    // every tick. An error response is an ANSWER — the stream is alive. Treating
+    // it as a dead socket reconnected the session every 30 seconds.
+    it('treats an IQ error response to the keepalive ping as a live connection', async () => {
+      // SM not enabled → probe takes the iqCaller ping fallback
+      mockXmppClientInstance.streamManagement = { enabled: false, on: vi.fn() }
+      const stanzaError = Object.assign(new Error('remote-server-not-found'), {
+        name: 'StanzaError',
+        condition: 'remote-server-not-found',
+      })
+      mockXmppClientInstance.iqCaller.request.mockRejectedValue(stanzaError)
+
+      const healthy = await xmppClient.verifyConnectionHealth()
+
+      expect(healthy).toBe(true)
+      expect(mockStores.connection.setStatus).not.toHaveBeenCalledWith('reconnecting')
+    })
+
+    it('still treats a transport error on the keepalive ping as a dead connection', async () => {
+      mockXmppClientInstance.streamManagement = { enabled: false, on: vi.fn() }
+      mockXmppClientInstance.iqCaller.request.mockRejectedValue(new Error('WebSocket ECONNERROR'))
+
+      const healthy = await xmppClient.verifyConnectionHealth()
+
+      expect(healthy).toBe(false)
+      expect(mockStores.connection.setStatus).toHaveBeenCalledWith('reconnecting')
     })
 
     it('should not trigger reconnect when concurrent verifyConnection and verifyConnectionHealth race', async () => {

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -1586,25 +1586,49 @@ export class Connection extends BaseModule {
       patchSmAckQueue(sm)
     }
 
-    // Intercept <stream:features> before middleware to strip <sm> when SM is
-    // ALREADY enabled — i.e. it was negotiated inline via SASL2 (bind2 <enabled>
-    // or inline <resumed>, both set sm.enabled synchronously before the post-auth
-    // features arrive). ejabberd's post-auth <stream:features> still contains
-    // <sm>, and without stripping it setupStreamFeature sends a duplicate
-    // <enable> the server rejects, which clears sm.enabled.
+    // Intercept <stream:features> before middleware to strip <sm> when SM was
+    // negotiated INLINE via SASL2 (bind2 <enabled> or inline <resumed> inside
+    // <success>). ejabberd's post-auth <stream:features> still contains <sm>,
+    // and xmpp.js's setupStreamFeature has no sm.enabled guard: left in place,
+    // it negotiates again, the server rejects the duplicate, and the catch
+    // clears sm.enabled.
     //
-    // The decision MUST be made at features-arrival time from sm.enabled, not
-    // pre-armed when SASL2 is detected: servers that advertise SASL2 without
-    // inline SM negotiation (e.g. Openfire — SASL2 but no bind2 SM) rely on
-    // this features element for their ONLY chance to enable SM. Pre-arming
-    // stripped it, silently disabling SM and breaking the keepalive (#515).
+    // The decision must be made from what was ACTUALLY negotiated, not pre-armed
+    // when SASL2 is detected: servers that advertise SASL2 without inline SM
+    // negotiation (e.g. Openfire — SASL2 but no bind2 SM) rely on this features
+    // element for their ONLY chance to enable SM. Pre-arming stripped it,
+    // silently disabling SM and breaking the keepalive (#515).
+    //
+    // Detection is two-fold, both checked at features-arrival time:
+    // - sm.enabled — set by xmpp.js's inline enabled()/resumed() handlers;
+    // - a synchronous peek at the SASL2 <success> element for an inline SM
+    //   child (directly or inside bind2 <bound>). This closes a race: the
+    //   inline handlers run after `await mech.final()` (SCRAM verification),
+    //   so sm.enabled may not be set yet if <features> is processed right
+    //   behind <success>. Element events fire in stanza order, so the peek
+    //   is always ahead of the features element.
     const NS_JABBER_STREAM = 'http://etherx.jabber.org/streams'
     const NS_SM = 'urn:xmpp:sm:3'
+    const NS_SASL2 = 'urn:xmpp:sasl:2'
+    const NS_BIND2 = 'urn:xmpp:bind:0'
+    let inlineSmNegotiated = false
     if (typeof (xmppClient as any).prependListener === 'function') {
       ;(xmppClient as any).prependListener('element', (element: Element) => {
+        if (element.is('success', NS_SASL2)) {
+          const bound = element.getChild('bound', NS_BIND2)
+          inlineSmNegotiated = !!(
+            element.getChild('enabled', NS_SM) ||
+            element.getChild('resumed', NS_SM) ||
+            bound?.getChild('enabled', NS_SM) ||
+            bound?.getChild('resumed', NS_SM)
+          )
+          return
+        }
         if (!element.is('features', NS_JABBER_STREAM)) return
         const sm = (xmppClient as any).streamManagement
-        if (!sm?.enabled) return
+        const smNegotiated = inlineSmNegotiated || !!sm?.enabled
+        inlineSmNegotiated = false // one-shot: consumed by the first features element
+        if (!smNegotiated) return
         const smFeature = element.getChild('sm', NS_SM)
         if (smFeature) {
           ;(element as any).children = (element as any).children.filter((c: unknown) => c !== smFeature)

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -1006,6 +1006,11 @@ export class Connection extends BaseModule {
     const clientAtStart = this.xmpp
     if (!clientAtStart) return 'dead'
 
+    // Which probe ran, for failure logs: triaging #515 from fluux.log was
+    // delayed because the file never said the keepalive was failing, let
+    // alone how (the console event is in-app only).
+    let probeMode = 'sm-ack'
+
     try {
       const sm = clientAtStart.streamManagement as any
       if (sm?.enabled) {
@@ -1014,14 +1019,22 @@ export class Connection extends BaseModule {
           logInfo(`${label}: client replaced during await, ignoring stale result`)
           return 'stale'
         }
-        if (!ackReceived) return 'dead'
+        if (!ackReceived) {
+          logWarn(`${label} probe failed (sm-ack): no <a/> within ${timeoutMs}ms`)
+          return 'dead'
+        }
       } else {
-        // Fallback: send a ping IQ and wait for response
+        // Fallback: send a ping IQ and wait for response. Sent with no 'to' —
+        // RFC 6120 §8.1.1.1: the server handles it on behalf of the account.
+        // Pinging the domain instead relies on the server routing bare-domain
+        // IQs correctly, which misconfigured deployments answer with errors
+        // (#515: Openfire returning <remote-server-not-found/>).
+        probeMode = 'ping'
         const iqCaller = (clientAtStart as any).iqCaller
         if (iqCaller) {
           const ping = xml(
             'iq',
-            { type: 'get', id: `${label}_${Date.now()}`, to: getDomain(this.credentials?.jid || '') },
+            { type: 'get', id: `${label}_${Date.now()}` },
             xml('ping', { xmlns: NS_PING })
           )
           await Promise.race([
@@ -1046,15 +1059,17 @@ export class Connection extends BaseModule {
       return 'healthy'
     } catch (err) {
       if (this.xmpp && this.xmpp !== clientAtStart) return 'stale'
+      const errorMessage = err instanceof Error ? err.message : String(err)
       // An IQ error RESPONSE proves the stream is alive: the ping reached the
       // server and an answer came back. Misconfigured servers may reject the
-      // domain ping (e.g. <remote-server-not-found/>) on every keepalive tick —
+      // ping (e.g. <remote-server-not-found/>) on every keepalive tick —
       // treating that as a dead socket caused a 30s reconnect loop (#515).
       // Only timeouts and transport errors mean the connection is gone.
       if (err instanceof Error && err.name === 'StanzaError') {
-        logInfo(`${label}: ping answered with stanza error (${err.message || 'no condition'}), connection alive`)
+        logInfo(`${label}: ping answered with stanza error (${errorMessage || 'no condition'}), connection alive`)
         return 'healthy'
       }
+      logWarn(`${label} probe failed (${probeMode}): ${errorMessage}`)
       return 'dead'
     }
   }

--- a/packages/fluux-sdk/src/core/modules/Connection.ts
+++ b/packages/fluux-sdk/src/core/modules/Connection.ts
@@ -1046,9 +1046,14 @@ export class Connection extends BaseModule {
       return 'healthy'
     } catch (err) {
       if (this.xmpp && this.xmpp !== clientAtStart) return 'stale'
-      const errorMessage = err instanceof Error ? err.message : String(err)
-      if (isDeadSocketError(errorMessage) || errorMessage.includes('timeout')) {
-        return 'dead'
+      // An IQ error RESPONSE proves the stream is alive: the ping reached the
+      // server and an answer came back. Misconfigured servers may reject the
+      // domain ping (e.g. <remote-server-not-found/>) on every keepalive tick —
+      // treating that as a dead socket caused a 30s reconnect loop (#515).
+      // Only timeouts and transport errors mean the connection is gone.
+      if (err instanceof Error && err.name === 'StanzaError') {
+        logInfo(`${label}: ping answered with stanza error (${err.message || 'no condition'}), connection alive`)
+        return 'healthy'
       }
       return 'dead'
     }
@@ -1437,13 +1442,6 @@ export class Connection extends BaseModule {
     const domain = getDomain(jid)
     const username = getLocalPart(jid)
 
-    // When SASL2+bind2 is used, SM is enabled inline inside <authenticate>/<success>.
-    // ejabberd then sends a post-auth <stream:features> that still contains <sm>,
-    // causing xmpp.js's setupStreamFeature to send a duplicate <enable> (server rejects
-    // it with <failed> and the catch block disables sm.enabled). We suppress this by
-    // removing <sm> from the features stanza before the middleware sees it.
-    let bind2SmEnabling = false
-
     const xmppClient = client({
       service: wsUrl,
       domain,
@@ -1513,11 +1511,6 @@ export class Connection extends BaseModule {
         const userAgent = buildUserAgentElement()
         const saslStart = Date.now()
         let saslTimeoutId: ReturnType<typeof setTimeout> | undefined
-        // SASL2 path: bind2 will negotiate SM inline. Mark that the post-auth
-        // <stream:features> with <sm> should be suppressed.
-        if (fast !== undefined) {
-          bind2SmEnabling = true
-        }
         await Promise.race([
           Promise.resolve(authenticate(creds, mechanism, userAgent)).then(() => {
             clearTimeout(saslTimeoutId)
@@ -1578,19 +1571,28 @@ export class Connection extends BaseModule {
       patchSmAckQueue(sm)
     }
 
-    // Intercept <stream:features> before middleware to strip <sm> when bind2 inline
-    // SM negotiation is in flight. Without this, setupStreamFeature sends a duplicate
-    // <enable>, the server rejects it, and the catch block clears sm.enabled.
+    // Intercept <stream:features> before middleware to strip <sm> when SM is
+    // ALREADY enabled — i.e. it was negotiated inline via SASL2 (bind2 <enabled>
+    // or inline <resumed>, both set sm.enabled synchronously before the post-auth
+    // features arrive). ejabberd's post-auth <stream:features> still contains
+    // <sm>, and without stripping it setupStreamFeature sends a duplicate
+    // <enable> the server rejects, which clears sm.enabled.
+    //
+    // The decision MUST be made at features-arrival time from sm.enabled, not
+    // pre-armed when SASL2 is detected: servers that advertise SASL2 without
+    // inline SM negotiation (e.g. Openfire — SASL2 but no bind2 SM) rely on
+    // this features element for their ONLY chance to enable SM. Pre-arming
+    // stripped it, silently disabling SM and breaking the keepalive (#515).
     const NS_JABBER_STREAM = 'http://etherx.jabber.org/streams'
     const NS_SM = 'urn:xmpp:sm:3'
     if (typeof (xmppClient as any).prependListener === 'function') {
       ;(xmppClient as any).prependListener('element', (element: Element) => {
-        if (bind2SmEnabling && element.is('features', NS_JABBER_STREAM)) {
-          bind2SmEnabling = false
-          const smFeature = element.getChild('sm', NS_SM)
-          if (smFeature) {
-            ;(element as any).children = (element as any).children.filter((c: unknown) => c !== smFeature)
-          }
+        if (!element.is('features', NS_JABBER_STREAM)) return
+        const sm = (xmppClient as any).streamManagement
+        if (!sm?.enabled) return
+        const smFeature = element.getChild('sm', NS_SM)
+        if (smFeature) {
+          ;(element as any).children = (element as any).children.filter((c: unknown) => c !== smFeature)
         }
       })
     }


### PR DESCRIPTION
Fixes the connection-instability half of #515 (root cause confirmed from the reporter's fluux.log).

**What the log shows:** every v0.15.2 session negotiates SM (`SM enabled`) and stays up; every v0.16.0 session never enables SM and reconnects exactly every 30s (98+ sessions/hour), with death detected in the same millisecond as the keepalive tick.

**Root cause (two stacked bugs):**
1. #380's duplicate-`<enable/>` suppression armed whenever the server advertised SASL2 (`fast !== undefined` — also true with `fast = null`). Openfire advertises SASL2 **without** inline bind2 SM, so the stripped post-auth `<stream:features>` was the session's only chance to enable SM → SM silently disabled. The stripper now checks `sm.enabled` at features-arrival time (inline `<enabled>`/`<resumed>` set it synchronously), so ejabberd's inline path still strips and Openfire's legacy path is untouched.
2. With SM off, the keepalive pinged the account domain, which this misconfigured server answers with `<remote-server-not-found/>`. `probeConnection`'s catch-all mapped that instant IQ error to `'dead'` → reconnect on every tick. An IQ error response proves the stream is alive; only timeouts/transport errors are dead now.

Regression tests cover both: features pass-through when SM wasn't negotiated inline, strip when it was, IQ-error ping = healthy, transport-error ping = dead (both new tests fail on the previous code).

Note: the UI half of #515 (layout-jumping banner) is #516.