### PR TITLE
perf(muc): skip member discovery for rooms that forbid affiliation lists

### DIFF
--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -1599,29 +1599,29 @@ describe('MUC Module', () => {
       ])
     }
 
-    it('queries all three affiliations and returns combined results', async () => {
+    it('queries all three affiliations (member first) and returns combined results', async () => {
       mockSendIQ
-        .mockResolvedValueOnce(createAffiliationResponse('owner', [{ jid: 'alice@example.org', nick: 'Alice' }]))
-        .mockResolvedValueOnce(createAffiliationResponse('admin', [{ jid: 'bob@example.org', nick: 'Bob' }]))
         .mockResolvedValueOnce(createAffiliationResponse('member', [
           { jid: 'carol@example.org', nick: 'Carol' },
           { jid: 'dave@example.org' },
         ]))
+        .mockResolvedValueOnce(createAffiliationResponse('admin', [{ jid: 'bob@example.org', nick: 'Bob' }]))
+        .mockResolvedValueOnce(createAffiliationResponse('owner', [{ jid: 'alice@example.org', nick: 'Alice' }]))
 
       const result = await muc.queryRoomMembers(roomJid)
 
       expect(result).toHaveLength(4)
-      expect(result[0]).toEqual({ jid: 'alice@example.org', nick: 'Alice', affiliation: 'owner' })
-      expect(result[1]).toEqual({ jid: 'bob@example.org', nick: 'Bob', affiliation: 'admin' })
-      expect(result[2]).toEqual({ jid: 'carol@example.org', nick: 'Carol', affiliation: 'member' })
-      expect(result[3]).toEqual({ jid: 'dave@example.org', nick: undefined, affiliation: 'member' })
+      expect(result[0]).toEqual({ jid: 'carol@example.org', nick: 'Carol', affiliation: 'member' })
+      expect(result[1]).toEqual({ jid: 'dave@example.org', nick: undefined, affiliation: 'member' })
+      expect(result[2]).toEqual({ jid: 'bob@example.org', nick: 'Bob', affiliation: 'admin' })
+      expect(result[3]).toEqual({ jid: 'alice@example.org', nick: 'Alice', affiliation: 'owner' })
     })
 
     it('emits room:members SDK event when members found', async () => {
       mockSendIQ
-        .mockResolvedValueOnce(createAffiliationResponse('owner', [{ jid: 'alice@example.org', nick: 'Alice' }]))
-        .mockResolvedValueOnce(createAffiliationResponse('admin', []))
         .mockResolvedValueOnce(createAffiliationResponse('member', []))
+        .mockResolvedValueOnce(createAffiliationResponse('admin', []))
+        .mockResolvedValueOnce(createAffiliationResponse('owner', [{ jid: 'alice@example.org', nick: 'Alice' }]))
 
       await muc.queryRoomMembers(roomJid)
 
@@ -1654,23 +1654,63 @@ describe('MUC Module', () => {
       expect(result[0].jid).toBe('alice@example.org')
     })
 
-    it('continues with other affiliations when one fails', async () => {
+    it('continues with other affiliations when one fails with a non-forbidden error', async () => {
       mockSendIQ
-        .mockRejectedValueOnce(new Error('forbidden'))
-        .mockResolvedValueOnce(createAffiliationResponse('admin', []))
-        .mockResolvedValueOnce(createAffiliationResponse('member', [{ jid: 'carol@example.org', nick: 'Carol' }]))
+        .mockRejectedValueOnce(new Error('IQ timeout after 10000ms'))
+        .mockResolvedValueOnce(createAffiliationResponse('admin', [{ jid: 'bob@example.org', nick: 'Bob' }]))
+        .mockResolvedValueOnce(createAffiliationResponse('owner', []))
 
       const result = await muc.queryRoomMembers(roomJid)
 
       expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({ jid: 'carol@example.org', nick: 'Carol', affiliation: 'member' })
+      expect(result[0]).toEqual({ jid: 'bob@example.org', nick: 'Bob', affiliation: 'admin' })
+      expect(mockSendIQ).toHaveBeenCalledTimes(3)
     })
 
-    it('returns empty array when all affiliations fail', async () => {
+    it('short-circuits on forbidden: skips the remaining affiliation queries', async () => {
+      const forbidden = Object.assign(new Error('forbidden - Access denied'), { condition: 'forbidden' })
+      mockSendIQ.mockRejectedValueOnce(forbidden)
+
+      const result = await muc.queryRoomMembers(roomJid)
+
+      expect(result).toEqual([])
+      expect(mockSendIQ).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not re-query a room whose member list was forbidden (session cache)', async () => {
+      const forbidden = Object.assign(new Error('forbidden'), { condition: 'forbidden' })
+      mockSendIQ.mockRejectedValueOnce(forbidden)
+      await muc.queryRoomMembers(roomJid)
+      mockSendIQ.mockClear()
+
+      const result = await muc.queryRoomMembers(roomJid)
+
+      expect(result).toEqual([])
+      expect(mockSendIQ).not.toHaveBeenCalled()
+    })
+
+    it('still queries other rooms after one room was forbidden', async () => {
+      const forbidden = Object.assign(new Error('forbidden'), { condition: 'forbidden' })
+      mockSendIQ.mockRejectedValueOnce(forbidden)
+      await muc.queryRoomMembers(roomJid)
+      mockSendIQ.mockClear()
+
       mockSendIQ
-        .mockRejectedValueOnce(new Error('forbidden'))
-        .mockRejectedValueOnce(new Error('not-allowed'))
-        .mockRejectedValueOnce(new Error('forbidden'))
+        .mockResolvedValueOnce(createAffiliationResponse('member', [{ jid: 'carol@example.org', nick: 'Carol' }]))
+        .mockResolvedValueOnce(createAffiliationResponse('admin', []))
+        .mockResolvedValueOnce(createAffiliationResponse('owner', []))
+
+      const result = await muc.queryRoomMembers('other@conference.example.org')
+
+      expect(result).toHaveLength(1)
+      expect(mockSendIQ).toHaveBeenCalledTimes(3)
+    })
+
+    it('returns empty array when all affiliations fail with non-forbidden errors', async () => {
+      mockSendIQ
+        .mockRejectedValueOnce(new Error('remote-server-timeout'))
+        .mockRejectedValueOnce(new Error('remote-server-timeout'))
+        .mockRejectedValueOnce(new Error('remote-server-timeout'))
 
       const result = await muc.queryRoomMembers(roomJid)
 
@@ -1705,9 +1745,9 @@ describe('MUC Module', () => {
       const emptyResponse = createMockElement('iq', { type: 'result' }, [])
 
       mockSendIQ
-        .mockResolvedValueOnce(emptyResponse)
-        .mockResolvedValueOnce(emptyResponse)
         .mockResolvedValueOnce(createAffiliationResponse('member', [{ jid: 'carol@example.org' }]))
+        .mockResolvedValueOnce(emptyResponse)
+        .mockResolvedValueOnce(emptyResponse)
 
       const result = await muc.queryRoomMembers(roomJid)
 
@@ -1734,8 +1774,8 @@ describe('MUC Module', () => {
         expect(query).toBeDefined()
       }
 
-      // Check affiliations in order: owner, admin, member
-      const affiliations = ['owner', 'admin', 'member']
+      // Check affiliations in order: member first (cheapest forbidden probe), then admin, owner
+      const affiliations = ['member', 'admin', 'owner']
       for (let i = 0; i < 3; i++) {
         const iq = mockSendIQ.mock.calls[i][0]
         const query = iq.getChild('query', 'http://jabber.org/protocol/muc#admin')

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -36,7 +36,7 @@ import type {
   RSMResponse,
   AdminRoom,
 } from '../types'
-import { parseXMPPError, formatXMPPError } from '../../utils/xmppError'
+import { parseXMPPError, formatXMPPError, hasErrorCondition } from '../../utils/xmppError'
 import { buildDataFormSubmit, parseDataForm } from '../../utils/dataForm'
 import { logInfo, logWarn, logError as logErr } from '../logger'
 
@@ -116,6 +116,14 @@ export class MUC extends BaseModule {
    * This reduces store updates from ~50 to ~1 for large rooms.
    */
   private pendingOccupants = new Map<string, RoomOccupant[]>()
+
+  /**
+   * Rooms whose affiliation lists the server refused to share (forbidden).
+   * Remembered for the client's lifetime so member discovery isn't retried
+   * (3 IQs + warnings) on every reconnect. A restart — or a permission change
+   * followed by a restart — clears it.
+   */
+  private membersForbiddenRooms = new Set<string>()
 
   handle(stanza: Element): boolean | void {
     if (stanza.is('presence')) {
@@ -1692,14 +1700,19 @@ export class MUC extends BaseModule {
    * @remarks
    * - Requires at least member affiliation to query in most room configurations
    * - Nick attribute is optional in the response; some items may only have JID
-   * - Each affiliation is queried separately; failures on one don't block others
+   * - `member` is queried first: servers gate all three lists the same way for
+   *   unprivileged users, so a `forbidden` answer skips the remaining queries and
+   *   is remembered for the client's lifetime (no re-query on every reconnect).
+   *   Other failures (e.g. timeouts) don't block the remaining affiliations.
    */
   async queryRoomMembers(
     roomJid: string
   ): Promise<Array<{ jid: string; nick?: string; affiliation: RoomAffiliation }>> {
+    if (this.membersForbiddenRooms.has(roomJid)) return []
+
     const allMembers: Array<{ jid: string; nick?: string; affiliation: RoomAffiliation }> = []
 
-    const affiliations: RoomAffiliation[] = ['owner', 'admin', 'member']
+    const affiliations: RoomAffiliation[] = ['member', 'admin', 'owner']
 
     for (const affiliation of affiliations) {
       try {
@@ -1726,8 +1739,14 @@ export class MUC extends BaseModule {
           })
         }
       } catch (err) {
-        // Some affiliations may not be queryable depending on room config
-        // and our own affiliation level. Log but continue with others.
+        if (hasErrorCondition(err, 'forbidden')) {
+          // The room config doesn't let us retrieve affiliation lists; the other
+          // queries would be forbidden too. Skip them and don't retry this session.
+          this.membersForbiddenRooms.add(roomJid)
+          logWarn(`Member discovery forbidden for ${roomJid} — skipping for this session`)
+          break
+        }
+        // Transient failure (timeout, server hiccup): continue with the others.
         logWarn(`Member query failed for ${roomJid} (${affiliation}): ${err instanceof Error ? err.message : String(err)}`)
       }
     }

--- a/packages/fluux-sdk/src/utils/xmppError.ts
+++ b/packages/fluux-sdk/src/utils/xmppError.ts
@@ -91,3 +91,15 @@ export function formatXMPPError(error: XMPPStanzaError): string {
   words[0] = words[0].charAt(0).toUpperCase() + words[0].slice(1)
   return words.join(' ')
 }
+
+/**
+ * Check whether a caught error carries the given RFC 6120 defined condition.
+ *
+ * xmpp.js iqCaller rejections are StanzaErrors exposing `.condition`
+ * (e.g. 'forbidden'); the error message is checked as a fallback for
+ * errors that only carry the condition in their text.
+ */
+export function hasErrorCondition(err: unknown, condition: string): boolean {
+  if ((err as { condition?: string } | null)?.condition === condition) return true
+  return err instanceof Error && err.message.includes(condition)
+}


### PR DESCRIPTION
`queryRoomMembers` fired all three XEP-0045 affiliation queries (owner/admin/member) per room on every fresh session. For rooms where we lack permission (e.g. board@muc.xmpp.org as a plain member) that meant 3 IQ round-trips and 3 console warnings per reconnect.

Changes:
- Query `member` first — servers gate all three lists the same way for unprivileged users, so it's the cheapest probe.
- On a `forbidden` answer: skip the remaining affiliation queries, log one warning instead of three, and remember the refusal for the client's lifetime so reconnects don't retry it. (A permission change picks up again after app restart.)
- Non-forbidden failures (timeouts) keep the old behavior: continue with the other affiliations.
- New `hasErrorCondition` helper in `utils/xmppError.ts` for checking RFC 6120 conditions on caught IQ errors.