### PR TITLE
fix(ux): retry link-preview images once before hiding them

### DIFF
--- a/apps/fluux/src/components/LinkPreviewCard.test.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import { LinkPreviewCard, IMAGE_RETRY_DELAY_MS } from './LinkPreviewCard'
+import type { LinkPreview } from '@fluux/sdk'
+
+const preview: LinkPreview = {
+  url: 'https://github.com/processone/fluux-messenger/pull/493',
+  title: 'Some pull request',
+  image: 'https://opengraph.githubassets.com/abc/processone/fluux-messenger/pull/493',
+}
+
+describe('LinkPreviewCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the preview image', () => {
+    const { container } = render(<LinkPreviewCard preview={preview} />)
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('retries the image after a transient load error instead of hiding it', () => {
+    const { container } = render(<LinkPreviewCard preview={preview} />)
+
+    // Transient failure (e.g. a rate-limited revalidation): the image element
+    // is removed while waiting...
+    fireEvent.error(container.querySelector('img')!)
+    expect(container.querySelector('img')).toBeNull()
+
+    // ...then re-mounted after the retry delay so the browser re-requests it.
+    act(() => {
+      vi.advanceTimersByTime(IMAGE_RETRY_DELAY_MS)
+    })
+    const retried = container.querySelector('img')
+    expect(retried).not.toBeNull()
+    expect(retried).toHaveAttribute('src', preview.image)
+  })
+
+  it('hides the image after the retry also fails', () => {
+    const { container } = render(<LinkPreviewCard preview={preview} />)
+
+    fireEvent.error(container.querySelector('img')!)
+    act(() => {
+      vi.advanceTimersByTime(IMAGE_RETRY_DELAY_MS)
+    })
+    fireEvent.error(container.querySelector('img')!)
+
+    act(() => {
+      vi.advanceTimersByTime(IMAGE_RETRY_DELAY_MS * 10)
+    })
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('still renders title and description while the image is gone', () => {
+    const { container, getByText } = render(<LinkPreviewCard preview={preview} />)
+
+    fireEvent.error(container.querySelector('img')!)
+    act(() => {
+      vi.advanceTimersByTime(IMAGE_RETRY_DELAY_MS)
+    })
+    fireEvent.error(container.querySelector('img')!)
+
+    expect(getByText('Some pull request')).toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/components/LinkPreviewCard.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.tsx
@@ -2,9 +2,18 @@
  * LinkPreviewCard - Displays a link preview with OGP metadata
  */
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ExternalLink } from 'lucide-react'
 import type { LinkPreview } from '@fluux/sdk'
+
+/**
+ * Preview images are often served with `cache-control: max-age=0` (e.g. GitHub's
+ * OG card service), so every mount revalidates against the host — which may answer
+ * 429 when rate-limited even though the cached copy is fine. One delayed retry
+ * recovers those transient failures without hammering a rate-limited host.
+ */
+export const IMAGE_RETRY_DELAY_MS = 3000
+const MAX_IMAGE_ATTEMPTS = 2
 
 interface LinkPreviewCardProps {
   preview: LinkPreview
@@ -12,7 +21,25 @@ interface LinkPreviewCardProps {
 }
 
 export function LinkPreviewCard({ preview, onLoad }: LinkPreviewCardProps) {
-  const [imageError, setImageError] = useState(false)
+  const [attempt, setAttempt] = useState(0)
+  const [imagePhase, setImagePhase] = useState<'showing' | 'waiting' | 'gone'>('showing')
+  const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (retryTimer.current) clearTimeout(retryTimer.current)
+  }, [])
+
+  const handleImageError = () => {
+    if (attempt + 1 >= MAX_IMAGE_ATTEMPTS) {
+      setImagePhase('gone')
+      return
+    }
+    setImagePhase('waiting')
+    retryTimer.current = setTimeout(() => {
+      setAttempt((a) => a + 1)
+      setImagePhase('showing')
+    }, IMAGE_RETRY_DELAY_MS)
+  }
 
   // Extract domain from URL for display
   let domain: string
@@ -30,17 +57,21 @@ export function LinkPreviewCard({ preview, onLoad }: LinkPreviewCardProps) {
       rel="noopener noreferrer"
       className="block mt-2 max-w-md border border-fluux-border rounded-lg overflow-hidden bg-fluux-bg/60 hover:bg-fluux-hover/60 transition-colors"
     >
-      {/* Image preview - hidden entirely on error */}
-      {preview.image && !imageError && (
+      {/* Image preview - retried once on error, hidden entirely when it keeps failing */}
+      {preview.image && imagePhase !== 'gone' && (
         <div className="aspect-video bg-fluux-bg/80 overflow-hidden">
-          <img
-            src={preview.image}
-            alt=""
-            className="w-full h-full object-cover"
-            loading="lazy"
-            onLoad={onLoad}
-            onError={() => setImageError(true)}
-          />
+          {imagePhase === 'showing' && (
+            <img
+              // A fresh element per attempt makes the browser re-request the same URL
+              key={attempt}
+              src={preview.image}
+              alt=""
+              className="w-full h-full object-cover"
+              loading="lazy"
+              onLoad={onLoad}
+              onError={handleImageError}
+            />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Link-preview images (e.g. GitHub's `opengraph.githubassets.com` cards) are served with `cache-control: max-age=0`, so every mount triggers a revalidation request — and a rate-limited host answers 429 even though the cached copy is fine. `LinkPreviewCard` latched `onError` permanently, blanking the image for the rest of the mount.

The card now retries the image once after 3s (fresh `<img>` element, same URL so the HTTP cache still applies) and only hides it when the retry also fails. Title/description always stay visible.