### PR TITLE
fix(ux): reduce About modal width

### DIFF
--- a/apps/fluux/src/components/AboutModal.tsx
+++ b/apps/fluux/src/components/AboutModal.tsx
@@ -24,7 +24,7 @@ export function AboutModal({ onClose }: AboutModalProps) {
   }
 
   return (
-    <ModalShell title={t('about.title')} onClose={onClose} width="w-80">
+    <ModalShell title={t('about.title')} onClose={onClose} width="max-w-xs">
       <div className="p-6 text-center">
         <img
           src="/logo.png"


### PR DESCRIPTION
Use `max-w-xs` instead of `w-80` so the width constraint works correctly with ModalShell's `w-full` base class — the previous `w-80` was overridden, making the modal too wide.