### PR TITLE
fix(notifications): only register notification onAction listener on mobile

### DIFF
--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -41,27 +41,46 @@ export function useDesktopNotifications(): void {
     presenceStatusRef.current = presenceStatus
   }, [presenceStatus])
 
-  // Handle notification clicks via Tauri onAction listener
+  // Handle notification clicks via Tauri onAction listener.
+  //
+  // onAction() subscribes through the plugin's `register_listener` command,
+  // which tauri-plugin-notification only implements on mobile (iOS/Android).
+  // On desktop that command is not registered, so calling it rejects with
+  // "Command plugin:notification|registerListener not allowed by ACL". Guard
+  // on the platform so we only subscribe where the command actually exists.
   useEffect(() => {
     if (!isTauri) return
 
     let unlisten: (() => void) | undefined
+    let cancelled = false
 
-    void onAction((notification: NotificationOptions) => {
-      const navType = notification.extra?.navType as string | undefined
-      const navTarget = notification.extra?.navTarget as string | undefined
-      if (!navTarget) return
+    void (async () => {
+      const { platform } = await import('@tauri-apps/plugin-os')
+      const os = await platform()
+      if (os !== 'ios' && os !== 'android') return
 
-      if (navType === 'room') {
-        navigateToRoomRef.current(navTarget)
+      const listener = await onAction((notification: NotificationOptions) => {
+        const navType = notification.extra?.navType as string | undefined
+        const navTarget = notification.extra?.navTarget as string | undefined
+        if (!navTarget) return
+
+        if (navType === 'room') {
+          navigateToRoomRef.current(navTarget)
+        } else {
+          navigateToConversationRef.current(navTarget)
+        }
+      })
+
+      // The component may have unmounted while we awaited the import/listener.
+      if (cancelled) {
+        void listener.unregister()
       } else {
-        navigateToConversationRef.current(navTarget)
+        unlisten = listener.unregister
       }
-    }).then((listener) => {
-      unlisten = listener.unregister
-    })
+    })()
 
     return () => {
+      cancelled = true
       unlisten?.()
     }
   }, [])


### PR DESCRIPTION
## Summary

The desktop console logged `Unhandled Promise Rejection: Command plugin:notification|registerListener not allowed by ACL` on every startup.

Root cause: `useDesktopNotifications` calls `onAction()` to route notification clicks. `onAction()` subscribes through the plugin's `register_listener` command, which `tauri-plugin-notification` (2.3.3) only wires into its `invoke_handler` on **mobile** (iOS/Android) — on desktop only `notify`, `request_permission`, and `is_permission_granted` are registered. So the call rejects with the generic "not allowed by ACL" error even though the capability grants `notification:allow-register-listener`, and the click handler could never fire on desktop regardless.

This guards the subscription on `platform()` (via `@tauri-apps/plugin-os`, already a dependency and already used in `NotificationsSettings.tsx`) so it only runs on iOS/Android where the command exists. A `cancelled` flag handles the component unmounting while the async import/listener resolves.

Note: this does not add desktop click-to-navigate (still a Tauri desktop limitation that would require a native macOS `UNUserNotificationCenter` delegate). Clicking a desktop notification still raises the window; it just won't jump to the specific conversation. `sendNotification` (showing notifications) is unaffected — `notify` is registered on desktop.