### PR TITLE
feat(notifications): native macOS notification click-to-the-right-chat

### DIFF
--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-user-notifications",
  "quick-xml 0.40.1",
  "reqwest 0.13.4",
  "rustls",
@@ -3795,7 +3796,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
+ "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-core-location",
  "objc2-foundation",
 ]
 

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -90,9 +90,9 @@ webkit2gtk = { version = "=2.0.2", features = ["v2_32"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo", "NSDictionary", "NSArray", "NSError"] }
+objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo", "NSDictionary", "NSArray", "NSError", "NSURL"] }
 objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication"] }
-objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNNotificationTrigger", "UNError", "block2"] }
+objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNNotificationTrigger", "UNNotificationAttachment", "UNError", "block2"] }
 block2 = "0.6"
 
 [profile.release]

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -90,8 +90,9 @@ webkit2gtk = { version = "=2.0.2", features = ["v2_32"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo"] }
+objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo", "NSDictionary", "NSArray", "NSError"] }
 objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication"] }
+objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNError"] }
 block2 = "0.6"
 
 [profile.release]

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -92,7 +92,7 @@ webkit2gtk = { version = "=2.0.2", features = ["v2_32"] }
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo", "NSDictionary", "NSArray", "NSError"] }
 objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication"] }
-objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNError"] }
+objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNNotificationTrigger", "UNError", "block2"] }
 block2 = "0.6"
 
 [profile.release]

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1277,7 +1277,9 @@ fn main() {
             #[cfg(target_os = "macos")]
             notifications::request_notification_permission,
             #[cfg(target_os = "macos")]
-            notifications::take_pending_notification_target
+            notifications::take_pending_notification_target,
+            #[cfg(target_os = "macos")]
+            notifications::set_notification_listener_ready
         ])
         .on_page_load(move |webview, payload| {
             // Always inject console-forwarding script so SDK diagnostic logs

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1269,7 +1269,15 @@ fn main() {
             openpgp::openpgp_backup_import,
             openpgp::openpgp_backup_import_all,
             openpgp::openpgp_backup_import_selected,
-            openpgp::openpgp_rotate_encryption_subkey
+            openpgp::openpgp_rotate_encryption_subkey,
+            #[cfg(target_os = "macos")]
+            notifications::post_notification,
+            #[cfg(target_os = "macos")]
+            notifications::notification_permission_state,
+            #[cfg(target_os = "macos")]
+            notifications::request_notification_permission,
+            #[cfg(target_os = "macos")]
+            notifications::take_pending_notification_target
         ])
         .on_page_load(move |webview, payload| {
             // Always inject console-forwarding script so SDK diagnostic logs
@@ -1358,6 +1366,10 @@ fn main() {
             }
         })
         .setup(move |app| {
+            // Wire up native notification backends (macOS: request auth now;
+            // the delegate / click routing lands in a later task).
+            notifications::setup(app.handle());
+
             // OpenPGP key storage needs the per-user app data dir. Resolve
             // it here (inside setup, where `app.path()` is available) and
             // hand the state to the Tauri managed-state system. Falling

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -201,6 +201,7 @@ mod openpgp;
 mod openpgp_backup;
 mod openpgp_export;
 mod openpgp_storage;
+mod notifications;
 
 #[cfg(target_os = "macos")]
 mod idle {

--- a/apps/fluux/src-tauri/src/notifications/backend.rs
+++ b/apps/fluux/src-tauri/src/notifications/backend.rs
@@ -1,0 +1,35 @@
+//! Platform-agnostic surface for native OS notifications.
+//!
+//! Each desktop platform implements `NotificationBackend`. Today only macOS
+//! has a concrete backend (`super::macos`); Windows/Linux keep using the
+//! Tauri notification plugin from the JS side until backends land here.
+
+use serde::Serialize;
+
+/// Where a notification click should navigate.
+#[derive(Debug, Clone, Serialize)]
+pub struct NavTarget {
+    #[serde(rename = "navType")]
+    pub nav_type: String, // "conversation" | "room"
+    #[serde(rename = "navTarget")]
+    pub nav_target: String, // bare JID
+}
+
+/// A notification to present.
+#[derive(Debug, Clone)]
+pub struct NativeNotification {
+    pub title: String,
+    pub body: String,
+    pub target: NavTarget,
+    /// Absolute file path to an image attachment, if any (added in a later task).
+    pub avatar_path: Option<String>,
+}
+
+/// Authorization state, mirrored to the JS permission gate.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthState {
+    Granted,
+    Denied,
+    NotDetermined,
+}

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -10,7 +10,7 @@ use objc2_user_notifications::{
     UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
     UNNotificationTrigger, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
 };
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::sync::OnceLock;
 use tauri::{AppHandle, Emitter, Manager};
@@ -20,6 +20,10 @@ static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
 
 /// Target stashed when a click fires before the webview is ready (cold start).
 static PENDING_TARGET: Mutex<Option<NavTarget>> = Mutex::new(None);
+
+/// Whether the JS `notification-activated` listener is attached. Set by the JS
+/// layer via `set_notification_listener_ready` once its `listen()` resolves.
+static LISTENER_READY: AtomicBool = AtomicBool::new(false);
 
 /// Cached authorization state. 0 = NotDetermined, 1 = Granted, 2 = Denied.
 /// Set by the async authorization callback.
@@ -89,8 +93,14 @@ fn set_delegate() {
     let _ = DELEGATE.set(delegate);
 }
 
-/// Parse "<navType>:<navTarget>" and route it. Emits to the webview if one is
-/// ready, otherwise stashes for the startup drain (cold start).
+/// Mark whether the JS `notification-activated` listener is attached. Called by
+/// the JS layer once its `listen()` has resolved, and reset to false on unmount.
+pub fn set_listener_ready(ready: bool) {
+    LISTENER_READY.store(ready, Ordering::SeqCst);
+}
+
+/// Parse "<navType>:<navTarget>" and route it. Emits to the webview if the JS
+/// listener is attached, otherwise stashes for the startup drain (cold start).
 fn handle_activation(identifier: &str) {
     let Some((nav_type, nav_target)) = identifier.split_once(':') else {
         return;
@@ -101,21 +111,24 @@ fn handle_activation(identifier: &str) {
     };
 
     let app = APP_HANDLE.get();
-    let window = app.and_then(|a| a.get_webview_window("main"));
 
-    if let Some(win) = &window {
+    // Always bring the window forward on a click.
+    if let Some(win) = app.and_then(|a| a.get_webview_window("main")) {
         let _ = win.show();
         let _ = win.set_focus();
     }
 
-    match app {
-        Some(a) if window.is_some() => {
+    // Emit only if the JS listener is attached; otherwise stash for the
+    // startup drain. On a cold start the delegate fires before the React
+    // bundle has registered its listener, so the "main" window existing is
+    // NOT a reliable readiness signal — the explicit flag is.
+    if LISTENER_READY.load(Ordering::SeqCst) {
+        if let Some(a) = app {
             let _ = a.emit("notification-activated", target);
-        }
-        _ => {
-            *PENDING_TARGET.lock().unwrap() = Some(target);
+            return;
         }
     }
+    *PENDING_TARGET.lock().unwrap() = Some(target);
 }
 
 pub fn setup(app: &AppHandle) {

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -38,6 +38,25 @@ fn current_center() -> Retained<UNUserNotificationCenter> {
     UNUserNotificationCenter::currentNotificationCenter()
 }
 
+/// Encode a nav target into a notification identifier. The identifier survives
+/// cold start (the OS persists it), so the click handler can recover the target
+/// without any in-memory state. Format: "<navType>:<navTarget>" — navType never
+/// contains ':'; navTarget is a bare JID.
+fn encode_identifier(target: &NavTarget) -> String {
+    format!("{}:{}", target.nav_type, target.nav_target)
+}
+
+/// Parse an identifier produced by `encode_identifier`. Splits on the FIRST ':'
+/// only, so a navTarget that itself contains ':' is preserved intact. Returns
+/// `None` if there is no delimiter.
+fn parse_identifier(identifier: &str) -> Option<NavTarget> {
+    let (nav_type, nav_target) = identifier.split_once(':')?;
+    Some(NavTarget {
+        nav_type: nav_type.to_string(),
+        nav_target: nav_target.to_string(),
+    })
+}
+
 define_class!(
     #[unsafe(super(NSObject))]
     #[name = "FluuxNotificationDelegate"]
@@ -102,12 +121,8 @@ pub fn set_listener_ready(ready: bool) {
 /// Parse "<navType>:<navTarget>" and route it. Emits to the webview if the JS
 /// listener is attached, otherwise stashes for the startup drain (cold start).
 fn handle_activation(identifier: &str) {
-    let Some((nav_type, nav_target)) = identifier.split_once(':') else {
+    let Some(target) = parse_identifier(identifier) else {
         return;
-    };
-    let target = NavTarget {
-        nav_type: nav_type.to_string(),
-        nav_target: nav_target.to_string(),
     };
 
     let app = APP_HANDLE.get();
@@ -164,7 +179,7 @@ pub fn post(n: NativeNotification) -> Result<(), String> {
     // Identifier carries the nav target and survives cold start.
     // Format: "<navType>:<navTarget>" — navType has no ':'; navTarget is a
     // bare JID. Parsed on the FIRST ':' so JIDs are safe.
-    let identifier = NSString::from_str(&format!("{}:{}", n.target.nav_type, n.target.nav_target));
+    let identifier = NSString::from_str(&encode_identifier(&n.target));
 
     let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
         &identifier,
@@ -201,4 +216,45 @@ pub fn request_authorization() -> AuthState {
 
 pub fn take_pending_target() -> Option<NavTarget> {
     PENDING_TARGET.lock().unwrap().take()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_conversation() {
+        let t = NavTarget {
+            nav_type: "conversation".to_string(),
+            nav_target: "alice@example.com".to_string(),
+        };
+        let parsed = parse_identifier(&encode_identifier(&t)).expect("parses");
+        assert_eq!(parsed.nav_type, "conversation");
+        assert_eq!(parsed.nav_target, "alice@example.com");
+    }
+
+    #[test]
+    fn round_trips_room_bare_jid() {
+        let t = NavTarget {
+            nav_type: "room".to_string(),
+            nav_target: "team@conference.example.com".to_string(),
+        };
+        let parsed = parse_identifier(&encode_identifier(&t)).expect("parses");
+        assert_eq!(parsed.nav_type, "room");
+        assert_eq!(parsed.nav_target, "team@conference.example.com");
+    }
+
+    #[test]
+    fn parse_splits_on_first_colon_only() {
+        // A navTarget containing ':' must be preserved intact (only the first
+        // colon delimits navType).
+        let parsed = parse_identifier("room:team@host/weird:resource").expect("parses");
+        assert_eq!(parsed.nav_type, "room");
+        assert_eq!(parsed.nav_target, "team@host/weird:resource");
+    }
+
+    #[test]
+    fn parse_rejects_missing_delimiter() {
+        assert!(parse_identifier("no-delimiter-here").is_none());
+    }
 }

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -1,0 +1,33 @@
+//! macOS native notifications via `UNUserNotificationCenter`.
+
+use crate::notifications::backend::{AuthState, NativeNotification, NavTarget};
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use tauri::AppHandle;
+
+/// App handle for emitting `notification-activated` from the delegate.
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+
+/// Target stashed when a click fires before the webview is ready (cold start).
+static PENDING_TARGET: Mutex<Option<NavTarget>> = Mutex::new(None);
+
+pub fn setup(_app: &AppHandle) {
+    // A later task fills this in: store APP_HANDLE, set the delegate, request authorization.
+}
+
+pub fn post(_n: NativeNotification) -> Result<(), String> {
+    // A later task fills this in.
+    Ok(())
+}
+
+pub fn authorization_state() -> AuthState {
+    AuthState::NotDetermined // later task
+}
+
+pub fn request_authorization() -> AuthState {
+    AuthState::NotDetermined // later task
+}
+
+pub fn take_pending_target() -> Option<NavTarget> {
+    PENDING_TARGET.lock().unwrap().take()
+}

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -1,6 +1,14 @@
 //! macOS native notifications via `UNUserNotificationCenter`.
 
 use crate::notifications::backend::{AuthState, NativeNotification, NavTarget};
+use objc2::rc::Retained;
+use objc2::runtime::Bool;
+use objc2_foundation::{NSError, NSString};
+use objc2_user_notifications::{
+    UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
+    UNNotificationTrigger, UNUserNotificationCenter,
+};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::sync::OnceLock;
 use tauri::AppHandle;
@@ -11,21 +19,64 @@ static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
 /// Target stashed when a click fires before the webview is ready (cold start).
 static PENDING_TARGET: Mutex<Option<NavTarget>> = Mutex::new(None);
 
-pub fn setup(_app: &AppHandle) {
-    // A later task fills this in: store APP_HANDLE, set the delegate, request authorization.
+/// Cached authorization state. 0 = NotDetermined, 1 = Granted, 2 = Denied.
+/// Set by the async authorization callback.
+static AUTH: AtomicU8 = AtomicU8::new(0);
+
+/// The system notification center. Always valid inside a bundled app.
+fn current_center() -> Retained<UNUserNotificationCenter> {
+    UNUserNotificationCenter::currentNotificationCenter()
 }
 
-pub fn post(_n: NativeNotification) -> Result<(), String> {
-    // A later task fills this in.
+pub fn setup(app: &AppHandle) {
+    let _ = APP_HANDLE.set(app.clone());
+    // NOTE: the delegate (click routing / foreground presentation) is wired up
+    // in a later task. Here we only store the handle and request authorization.
+    request_authorization();
+}
+
+pub fn post(n: NativeNotification) -> Result<(), String> {
+    let content = UNMutableNotificationContent::new();
+    content.setTitle(&NSString::from_str(&n.title));
+    content.setBody(&NSString::from_str(&n.body));
+
+    // Identifier carries the nav target and survives cold start.
+    // Format: "<navType>:<navTarget>" — navType has no ':'; navTarget is a
+    // bare JID. Parsed on the FIRST ':' (later task) so JIDs are safe.
+    // (A later task attaches n.avatar_path here.)
+    let identifier = NSString::from_str(&format!("{}:{}", n.target.nav_type, n.target.nav_target));
+
+    let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+        &identifier,
+        &content,
+        None::<&UNNotificationTrigger>, // nil trigger = deliver immediately
+    );
+    current_center().addNotificationRequest_withCompletionHandler(&request, None);
     Ok(())
 }
 
 pub fn authorization_state() -> AuthState {
-    AuthState::NotDetermined // later task
+    match AUTH.load(Ordering::SeqCst) {
+        1 => AuthState::Granted,
+        2 => AuthState::Denied,
+        _ => AuthState::NotDetermined,
+    }
 }
 
 pub fn request_authorization() -> AuthState {
-    AuthState::NotDetermined // later task
+    use block2::RcBlock;
+    let options = UNAuthorizationOptions::Alert
+        | UNAuthorizationOptions::Sound
+        | UNAuthorizationOptions::Badge;
+    // The completion handler is a heap-allocated `RcBlock` whose closure only
+    // touches a `'static` atomic; the center copies the block.
+    let handler = RcBlock::new(|granted: Bool, _err: *mut NSError| {
+        AUTH.store(if granted.as_bool() { 1 } else { 2 }, Ordering::SeqCst);
+    });
+    current_center().requestAuthorizationWithOptions_completionHandler(options, &handler);
+    // The callback is async; return the currently-known state. Callers re-poll
+    // `authorization_state()` after the OS prompt resolves.
+    authorization_state()
 }
 
 pub fn take_pending_target() -> Option<NavTarget> {

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -2,16 +2,18 @@
 
 use crate::notifications::backend::{AuthState, NativeNotification, NavTarget};
 use objc2::rc::Retained;
-use objc2::runtime::Bool;
+use objc2::runtime::{Bool, NSObject, NSObjectProtocol, ProtocolObject};
+use objc2::{define_class, msg_send, AnyThread};
 use objc2_foundation::{NSError, NSString};
 use objc2_user_notifications::{
-    UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
-    UNNotificationTrigger, UNUserNotificationCenter,
+    UNAuthorizationOptions, UNMutableNotificationContent, UNNotification,
+    UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
+    UNNotificationTrigger, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
 };
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::sync::OnceLock;
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter, Manager};
 
 /// App handle for emitting `notification-activated` from the delegate.
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
@@ -23,15 +25,102 @@ static PENDING_TARGET: Mutex<Option<NavTarget>> = Mutex::new(None);
 /// Set by the async authorization callback.
 static AUTH: AtomicU8 = AtomicU8::new(0);
 
+/// Keeps the notification-center delegate alive for the app's lifetime.
+/// `setDelegate:` stores it as a weak reference, so we must own it here.
+static DELEGATE: OnceLock<Retained<NotificationDelegate>> = OnceLock::new();
+
 /// The system notification center. Always valid inside a bundled app.
 fn current_center() -> Retained<UNUserNotificationCenter> {
     UNUserNotificationCenter::currentNotificationCenter()
 }
 
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "FluuxNotificationDelegate"]
+    struct NotificationDelegate;
+
+    unsafe impl NSObjectProtocol for NotificationDelegate {}
+
+    unsafe impl UNUserNotificationCenterDelegate for NotificationDelegate {
+        // void userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
+        #[unsafe(method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:))]
+        fn did_receive(
+            &self,
+            _center: &UNUserNotificationCenter,
+            response: &UNNotificationResponse,
+            completion: &block2::DynBlock<dyn Fn()>,
+        ) {
+            let identifier = response.notification().request().identifier();
+            handle_activation(&identifier.to_string());
+            completion.call(());
+        }
+
+        // void userNotificationCenter:willPresentNotification:withCompletionHandler:
+        #[unsafe(method(userNotificationCenter:willPresentNotification:withCompletionHandler:))]
+        fn will_present(
+            &self,
+            _center: &UNUserNotificationCenter,
+            _notification: &UNNotification,
+            completion: &block2::DynBlock<dyn Fn(UNNotificationPresentationOptions)>,
+        ) {
+            // Show notifications for background chats even while the app is
+            // frontmost — the JS layer already decides whether to notify.
+            let opts = UNNotificationPresentationOptions::Banner
+                | UNNotificationPresentationOptions::List
+                | UNNotificationPresentationOptions::Sound;
+            completion.call((opts,));
+        }
+    }
+);
+
+impl NotificationDelegate {
+    fn new() -> Retained<Self> {
+        // SAFETY: standard NSObject allocation/init for a defined subclass with
+        // no instance variables.
+        unsafe { msg_send![super(Self::alloc().set_ivars(())), init] }
+    }
+}
+
+fn set_delegate() {
+    let delegate = NotificationDelegate::new();
+    let proto = ProtocolObject::from_ref(&*delegate);
+    current_center().setDelegate(Some(proto));
+    // Keep the delegate alive for the app's lifetime (weak property).
+    let _ = DELEGATE.set(delegate);
+}
+
+/// Parse "<navType>:<navTarget>" and route it. Emits to the webview if one is
+/// ready, otherwise stashes for the startup drain (cold start).
+fn handle_activation(identifier: &str) {
+    let Some((nav_type, nav_target)) = identifier.split_once(':') else {
+        return;
+    };
+    let target = NavTarget {
+        nav_type: nav_type.to_string(),
+        nav_target: nav_target.to_string(),
+    };
+
+    let app = APP_HANDLE.get();
+    let window = app.and_then(|a| a.get_webview_window("main"));
+
+    if let Some(win) = &window {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+
+    match app {
+        Some(a) if window.is_some() => {
+            let _ = a.emit("notification-activated", target);
+        }
+        _ => {
+            *PENDING_TARGET.lock().unwrap() = Some(target);
+        }
+    }
+}
+
 pub fn setup(app: &AppHandle) {
     let _ = APP_HANDLE.set(app.clone());
-    // NOTE: the delegate (click routing / foreground presentation) is wired up
-    // in a later task. Here we only store the handle and request authorization.
+    set_delegate();
     request_authorization();
 }
 

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -129,10 +129,28 @@ pub fn post(n: NativeNotification) -> Result<(), String> {
     content.setTitle(&NSString::from_str(&n.title));
     content.setBody(&NSString::from_str(&n.body));
 
+    // Attach the contact/room avatar as a thumbnail when a local file path is
+    // provided (the JS layer wrote the blob to a temp file).
+    if let Some(path) = n.avatar_path.as_deref() {
+        use objc2_foundation::{NSArray, NSURL};
+        use objc2_user_notifications::UNNotificationAttachment;
+        let url = NSURL::fileURLWithPath(&NSString::from_str(path));
+        // SAFETY: `identifier`, `url` are valid for the call; `options` is nil.
+        let attachment = unsafe {
+            UNNotificationAttachment::attachmentWithIdentifier_URL_options_error(
+                &NSString::from_str("avatar"),
+                &url,
+                None,
+            )
+        };
+        if let Ok(att) = attachment {
+            content.setAttachments(&NSArray::from_slice(&[&*att]));
+        }
+    }
+
     // Identifier carries the nav target and survives cold start.
     // Format: "<navType>:<navTarget>" — navType has no ':'; navTarget is a
-    // bare JID. Parsed on the FIRST ':' (later task) so JIDs are safe.
-    // (A later task attaches n.avatar_path here.)
+    // bare JID. Parsed on the FIRST ':' so JIDs are safe.
     let identifier = NSString::from_str(&format!("{}:{}", n.target.nav_type, n.target.nav_target));
 
     let request = UNNotificationRequest::requestWithIdentifier_content_trigger(

--- a/apps/fluux/src-tauri/src/notifications/mod.rs
+++ b/apps/fluux/src-tauri/src/notifications/mod.rs
@@ -4,10 +4,14 @@
 //! message it already received). Server-initiated push is out of scope — see
 //! the design spec. Web Push lives entirely on the JS side behind `!isTauri`.
 
+// The backend types are consumed only by the macOS commands and `macos.rs`;
+// gate the module so non-macOS builds don't see them as dead code (`-D warnings`).
+#[cfg(target_os = "macos")]
 pub mod backend;
 #[cfg(target_os = "macos")]
 mod macos;
 
+#[cfg(target_os = "macos")]
 use backend::{AuthState, NativeNotification, NavTarget};
 use tauri::AppHandle;
 

--- a/apps/fluux/src-tauri/src/notifications/mod.rs
+++ b/apps/fluux/src-tauri/src/notifications/mod.rs
@@ -53,3 +53,9 @@ pub fn request_notification_permission() -> AuthState {
 pub fn take_pending_notification_target() -> Option<NavTarget> {
     macos::take_pending_target()
 }
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn set_notification_listener_ready(ready: bool) {
+    macos::set_listener_ready(ready);
+}

--- a/apps/fluux/src-tauri/src/notifications/mod.rs
+++ b/apps/fluux/src-tauri/src/notifications/mod.rs
@@ -1,0 +1,55 @@
+//! Native notification presentation + click routing.
+//!
+//! Local notifications only (the running app shows an OS notification for a
+//! message it already received). Server-initiated push is out of scope — see
+//! the design spec. Web Push lives entirely on the JS side behind `!isTauri`.
+
+pub mod backend;
+#[cfg(target_os = "macos")]
+mod macos;
+
+use backend::{AuthState, NativeNotification, NavTarget};
+use tauri::AppHandle;
+
+/// Wire up the active backend. Called from the Tauri `setup` hook.
+pub fn setup(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    macos::setup(app);
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn post_notification(
+    title: String,
+    body: String,
+    nav_type: String,
+    nav_target: String,
+    avatar_path: Option<String>,
+) -> Result<(), String> {
+    macos::post(NativeNotification {
+        title,
+        body,
+        target: NavTarget { nav_type, nav_target },
+        avatar_path,
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn notification_permission_state() -> AuthState {
+    macos::authorization_state()
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn request_notification_permission() -> AuthState {
+    macos::request_authorization()
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn take_pending_notification_target() -> Option<NavTarget> {
+    macos::take_pending_target()
+}

--- a/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// vi.mock factories are hoisted to top of file, so mocks that reference vi.fn()
+// vars must be declared with vi.hoisted() to be available before hoisting.
+const {
+  invoke,
+  sendNotification,
+  onAction,
+  listen,
+  isMacOSDesktop,
+  platform,
+  navigateToConversation,
+  navigateToRoom,
+} = vi.hoisted(() => ({
+  invoke: vi.fn().mockResolvedValue(null),
+  sendNotification: vi.fn(),
+  onAction: vi.fn(() => Promise.resolve({ unregister: vi.fn() })),
+  listen: vi.fn(() => Promise.resolve(() => {})),
+  isMacOSDesktop: vi.fn(),
+  platform: vi.fn().mockResolvedValue('macos'),
+  navigateToConversation: vi.fn(),
+  navigateToRoom: vi.fn(),
+}))
+
+// Capture the handlers the hook registers with useNotificationEvents.
+let handlers: {
+  onConversationMessage?: (conv: unknown, msg: unknown) => unknown
+  onRoomMessage?: (room: unknown, msg: unknown) => unknown
+} = {}
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }))
+vi.mock('@tauri-apps/api/event', () => ({ listen }))
+vi.mock('@tauri-apps/plugin-notification', () => ({ sendNotification, onAction }))
+vi.mock('@tauri-apps/plugin-os', () => ({ platform }))
+vi.mock('@/utils/tauriPlatform', () => ({ isMacOSDesktop }))
+vi.mock('@/utils/notificationAvatar', () => ({ getNotificationAvatarUrl: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('@/utils/messagePreviewText', () => ({ formatLocalizedPreview: () => 'body text' }))
+vi.mock('@/utils/notificationDebug', () => ({ notificationDebug: { desktopNotification: vi.fn() } }))
+vi.mock('@/utils/webNotification', () => ({ showWebNotification: vi.fn() }))
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({ navigateToConversation, navigateToRoom, navigateToContact: vi.fn() }),
+}))
+vi.mock('./useNotificationPermission', () => ({
+  isTauri: true,
+  useNotificationPermission: () => ({ current: true }),
+}))
+vi.mock('./useNotificationEvents', () => ({
+  useNotificationEvents: (h: typeof handlers) => { handlers = h },
+}))
+vi.mock('@fluux/sdk', () => ({
+  rosterStore: { getState: () => ({ getContact: () => undefined }) },
+  usePresence: () => ({ presenceStatus: 'online' }),
+}))
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+
+import { useDesktopNotifications } from './useDesktopNotifications'
+
+describe('useDesktopNotifications posting + guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    handlers = {}
+    platform.mockResolvedValue('macos')
+    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+  })
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+  })
+
+  it('posts a conversation via the native command on macOS', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    renderHook(() => useDesktopNotifications())
+    await handlers.onConversationMessage?.({ id: 'alice@example.com', name: 'Alice' }, { from: 'alice@example.com' })
+    expect(invoke).toHaveBeenCalledWith('post_notification', {
+      title: 'Alice',
+      body: 'body text',
+      navType: 'conversation',
+      navTarget: 'alice@example.com',
+      avatarPath: null,
+    })
+    expect(sendNotification).not.toHaveBeenCalled()
+  })
+
+  it('posts a room via the native command on macOS', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    renderHook(() => useDesktopNotifications())
+    await handlers.onRoomMessage?.({ jid: 'team@conf.example.com', name: 'Team' }, { nick: 'bob' })
+    expect(invoke).toHaveBeenCalledWith('post_notification', {
+      title: 'bob @ Team',
+      body: 'body text',
+      navType: 'room',
+      navTarget: 'team@conf.example.com',
+      avatarPath: null,
+    })
+    expect(sendNotification).not.toHaveBeenCalled()
+  })
+
+  it('posts via the plugin (sendNotification) on non-macOS Tauri', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    renderHook(() => useDesktopNotifications())
+    await handlers.onConversationMessage?.({ id: 'alice@example.com', name: 'Alice' }, { from: 'alice@example.com' })
+    expect(sendNotification).toHaveBeenCalled()
+    expect(invoke).not.toHaveBeenCalledWith('post_notification', expect.anything())
+  })
+
+  it('does NOT call onAction on macOS desktop (mobile-only guard)', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    platform.mockResolvedValue('macos')
+    renderHook(() => useDesktopNotifications())
+    await vi.waitFor(() => expect(listen).toHaveBeenCalled())
+    // let the mobile IIFE resolve its dynamic import + platform() before asserting the negative
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it('DOES call onAction on mobile (ios)', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    platform.mockResolvedValue('ios')
+    renderHook(() => useDesktopNotifications())
+    await vi.waitFor(() => expect(onAction).toHaveBeenCalled())
+  })
+})

--- a/apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const navigateToConversation = vi.fn()
+const navigateToRoom = vi.fn()
+let eventCb: ((e: { payload: unknown }) => void) | undefined
+const drainResult = { current: null as unknown }
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (_name: string, cb: (e: { payload: unknown }) => void) => {
+    eventCb = cb
+    return Promise.resolve(() => {})
+  },
+}))
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (cmd: string) =>
+    cmd === 'take_pending_notification_target'
+      ? Promise.resolve(drainResult.current)
+      : Promise.resolve(null),
+}))
+vi.mock('@tauri-apps/plugin-notification', () => ({
+  sendNotification: vi.fn(),
+  onAction: vi.fn(() => Promise.resolve({ unregister: vi.fn() })),
+}))
+vi.mock('@tauri-apps/plugin-os', () => ({ platform: () => Promise.resolve('macos') }))
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({ navigateToConversation, navigateToRoom, navigateToContact: vi.fn() }),
+}))
+vi.mock('./useNotificationPermission', () => ({
+  isTauri: true,
+  useNotificationPermission: () => ({ current: true }),
+}))
+vi.mock('./useNotificationEvents', () => ({ useNotificationEvents: vi.fn() }))
+vi.mock('@fluux/sdk', () => ({ rosterStore: { getState: () => ({ getContact: () => undefined }) }, usePresence: () => ({ presenceStatus: 'online' }) }))
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+
+import { useDesktopNotifications } from './useDesktopNotifications'
+
+describe('useDesktopNotifications click routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    eventCb = undefined
+    drainResult.current = null
+    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+  })
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+  })
+
+  it('routes a notification-activated event through the shared router', async () => {
+    renderHook(() => useDesktopNotifications())
+    await vi.waitFor(() => expect(eventCb).toBeTypeOf('function'))
+    eventCb!({ payload: { navType: 'room', navTarget: 'team@conf.example.com' } })
+    expect(navigateToRoom).toHaveBeenCalledWith('team@conf.example.com')
+  })
+
+  it('drains a pending target on startup', async () => {
+    drainResult.current = { navType: 'conversation', navTarget: 'a@example.com' }
+    renderHook(() => useDesktopNotifications())
+    await vi.waitFor(() => expect(navigateToConversation).toHaveBeenCalledWith('a@example.com'))
+  })
+})

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -22,7 +22,7 @@ import { routeNotificationTarget } from '@/utils/notificationRouting'
  * - Shows notification for messages in non-active conversations
  * - Shows notification for mentions in MUC rooms
  * - Clicking notification focuses the conversation/room and switches view
- * - Uses Tauri notification API with onAction() for click handling
+ * - macOS: posts natively (UNUserNotificationCenter), routes clicks via the 'notification-activated' event; mobile uses onAction()
  * - Falls back to web Notification API for non-Tauri environments
  */
 export function useDesktopNotifications(): void {
@@ -135,7 +135,7 @@ export function useDesktopNotifications(): void {
           body,
           navType: 'conversation',
           navTarget: conv.id,
-          avatarPath: null, // avatar attachment added in a later task
+          avatarPath: avatarUrl?.startsWith('file://') ? avatarUrl.replace(/^file:\/\//, '') : null,
         })
       } else {
         sendNotification({
@@ -191,7 +191,7 @@ export function useDesktopNotifications(): void {
           body,
           navType: 'room',
           navTarget: room.jid,
-          avatarPath: null, // avatar attachment added in a later task
+          avatarPath: avatarUrl?.startsWith('file://') ? avatarUrl.replace(/^file:\/\//, '') : null,
         })
       } else {
         sendNotification({

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -2,8 +2,10 @@ import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { rosterStore, usePresence } from '@fluux/sdk'
 import type { Conversation, Message, Room, RoomMessage } from '@fluux/sdk'
+import { invoke } from '@tauri-apps/api/core'
 import { sendNotification, onAction } from '@tauri-apps/plugin-notification'
 import type { Options as NotificationOptions } from '@tauri-apps/plugin-notification'
+import { isMacOSDesktop } from '@/utils/tauriPlatform'
 import { useNotificationEvents } from './useNotificationEvents'
 import { useNavigateToTarget } from './useNavigateToTarget'
 import { useNotificationPermission, isTauri } from './useNotificationPermission'
@@ -93,12 +95,22 @@ export function useDesktopNotifications(): void {
     const avatarUrl = await getNotificationAvatarUrl(contact?.avatar, contact?.avatarHash)
 
     if (isTauri) {
-      sendNotification({
-        title,
-        body,
-        attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
-        extra: { navType: 'conversation', navTarget: conv.id },
-      })
+      if (await isMacOSDesktop()) {
+        await invoke('post_notification', {
+          title,
+          body,
+          navType: 'conversation',
+          navTarget: conv.id,
+          avatarPath: null, // avatar attachment added in a later task
+        })
+      } else {
+        sendNotification({
+          title,
+          body,
+          attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
+          extra: { navType: 'conversation', navTarget: conv.id },
+        })
+      }
     } else {
       await showWebNotification(
         title,
@@ -139,12 +151,22 @@ export function useDesktopNotifications(): void {
     const avatarUrl = await getNotificationAvatarUrl(room.avatar, room.avatarHash)
 
     if (isTauri) {
-      sendNotification({
-        title,
-        body,
-        attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
-        extra: { navType: 'room', navTarget: room.jid },
-      })
+      if (await isMacOSDesktop()) {
+        await invoke('post_notification', {
+          title,
+          body,
+          navType: 'room',
+          navTarget: room.jid,
+          avatarPath: null, // avatar attachment added in a later task
+        })
+      } else {
+        sendNotification({
+          title,
+          body,
+          attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
+          extra: { navType: 'room', navTarget: room.jid },
+        })
+      }
     } else {
       await showWebNotification(
         title,

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -67,18 +67,24 @@ export function useDesktopNotifications(): void {
     let unlistenEvent: (() => void) | undefined
     let unlistenMobile: (() => void) | undefined
 
-    // Desktop: Tauri event + cold-start drain.
+    // Desktop: Tauri event + cold-start drain. Register the listener, tell the
+    // native side it's ready, THEN drain any target stashed before readiness
+    // (cold start: the delegate fires before this effect mounts).
     void listen('notification-activated', (e) => route(e.payload)).then((un) => {
-      if (cancelled) un()
-      else unlistenEvent = un
+      if (cancelled) {
+        un()
+        return
+      }
+      unlistenEvent = un
+      void invoke('set_notification_listener_ready', { ready: true })
+        .then(() => invoke('take_pending_notification_target'))
+        .then((target) => {
+          if (!cancelled && target) route(target)
+        })
+        .catch(() => {
+          // Commands are macOS-only; absent elsewhere — ignore.
+        })
     })
-    void invoke('take_pending_notification_target')
-      .then((target) => {
-        if (!cancelled && target) route(target)
-      })
-      .catch(() => {
-        // Command is macOS-only; absent elsewhere — ignore.
-      })
 
     // Mobile: onAction (iOS/Android only).
     void (async () => {
@@ -91,12 +97,13 @@ export function useDesktopNotifications(): void {
           navTarget: notification.extra?.navTarget,
         })
       })
-      if (cancelled) listener.unregister()
+      if (cancelled) void listener.unregister()
       else unlistenMobile = listener.unregister
     })()
 
     return () => {
       cancelled = true
+      void invoke('set_notification_listener_ready', { ready: false }).catch(() => {})
       unlistenEvent?.()
       unlistenMobile?.()
     }

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { rosterStore, usePresence } from '@fluux/sdk'
 import type { Conversation, Message, Room, RoomMessage } from '@fluux/sdk'
 import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
 import { sendNotification, onAction } from '@tauri-apps/plugin-notification'
 import type { Options as NotificationOptions } from '@tauri-apps/plugin-notification'
 import { isMacOSDesktop } from '@/utils/tauriPlatform'
@@ -13,6 +14,7 @@ import { getNotificationAvatarUrl } from '@/utils/notificationAvatar'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { notificationDebug } from '@/utils/notificationDebug'
 import { showWebNotification } from '@/utils/webNotification'
+import { routeNotificationTarget } from '@/utils/notificationRouting'
 
 /**
  * Hook to show desktop notifications for new messages and room mentions.
@@ -43,28 +45,60 @@ export function useDesktopNotifications(): void {
     presenceStatusRef.current = presenceStatus
   }, [presenceStatus])
 
-  // Handle notification clicks via Tauri onAction listener
+  // Handle notification clicks.
+  //
+  // Desktop (macOS native): the Rust delegate emits "notification-activated"
+  // and stashes a target for cold starts (drained on mount). Mobile: the
+  // plugin's onAction() is the click source — but registerListener only exists
+  // on iOS/Android, so guard it there (on desktop it rejects with
+  // "not allowed by ACL"). Web routes clicks in sw.ts and is untouched here.
   useEffect(() => {
     if (!isTauri) return
 
-    let unlisten: (() => void) | undefined
+    const route = (payload: unknown) => {
+      const p = (payload ?? {}) as { navType?: string; navTarget?: string }
+      routeNotificationTarget(p.navType, p.navTarget, {
+        navigateToConversation: navigateToConversationRef.current,
+        navigateToRoom: navigateToRoomRef.current,
+      })
+    }
 
-    void onAction((notification: NotificationOptions) => {
-      const navType = notification.extra?.navType as string | undefined
-      const navTarget = notification.extra?.navTarget as string | undefined
-      if (!navTarget) return
+    let cancelled = false
+    let unlistenEvent: (() => void) | undefined
+    let unlistenMobile: (() => void) | undefined
 
-      if (navType === 'room') {
-        navigateToRoomRef.current(navTarget)
-      } else {
-        navigateToConversationRef.current(navTarget)
-      }
-    }).then((listener) => {
-      unlisten = listener.unregister
+    // Desktop: Tauri event + cold-start drain.
+    void listen('notification-activated', (e) => route(e.payload)).then((un) => {
+      if (cancelled) un()
+      else unlistenEvent = un
     })
+    void invoke('take_pending_notification_target')
+      .then((target) => {
+        if (!cancelled && target) route(target)
+      })
+      .catch(() => {
+        // Command is macOS-only; absent elsewhere — ignore.
+      })
+
+    // Mobile: onAction (iOS/Android only).
+    void (async () => {
+      const { platform } = await import('@tauri-apps/plugin-os')
+      const os = await platform()
+      if (cancelled || (os !== 'ios' && os !== 'android')) return
+      const listener = await onAction((notification: NotificationOptions) => {
+        route({
+          navType: notification.extra?.navType,
+          navTarget: notification.extra?.navTarget,
+        })
+      })
+      if (cancelled) listener.unregister()
+      else unlistenMobile = listener.unregister
+    })()
 
     return () => {
-      unlisten?.()
+      cancelled = true
+      unlistenEvent?.()
+      unlistenMobile?.()
     }
   }, [])
 

--- a/apps/fluux/src/hooks/useNotificationPermission.ts
+++ b/apps/fluux/src/hooks/useNotificationPermission.ts
@@ -33,16 +33,31 @@ export function useNotificationPermission(): React.RefObject<boolean> {
     const check = async () => {
       try {
         if (isTauri) {
-          let granted = await isPermissionGranted()
-          if (!granted) {
-            const permission = await requestPermission()
-            granted = permission === 'granted'
-          }
-          permissionGranted.current = granted
-          if (!granted) {
-            console.log(
-              '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
-            )
+          const { isMacOSDesktop } = await import('@/utils/tauriPlatform')
+          if (await isMacOSDesktop()) {
+            const { invoke } = await import('@tauri-apps/api/core')
+            let state = await invoke<string>('notification_permission_state')
+            if (state === 'notdetermined') {
+              state = await invoke<string>('request_notification_permission')
+            }
+            permissionGranted.current = state === 'granted'
+            if (!permissionGranted.current) {
+              console.log(
+                '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
+              )
+            }
+          } else {
+            let granted = await isPermissionGranted()
+            if (!granted) {
+              const permission = await requestPermission()
+              granted = permission === 'granted'
+            }
+            permissionGranted.current = granted
+            if (!granted) {
+              console.log(
+                '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
+              )
+            }
           }
         } else {
           if (typeof Notification === 'undefined') return

--- a/apps/fluux/src/utils/notificationRouting.test.ts
+++ b/apps/fluux/src/utils/notificationRouting.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { routeNotificationTarget } from './notificationRouting'
+
+describe('routeNotificationTarget', () => {
+  const nav = () => ({ navigateToConversation: vi.fn(), navigateToRoom: vi.fn() })
+
+  it('routes a room target to navigateToRoom', () => {
+    const n = nav()
+    routeNotificationTarget('room', 'team@conf.example.com', n)
+    expect(n.navigateToRoom).toHaveBeenCalledWith('team@conf.example.com')
+    expect(n.navigateToConversation).not.toHaveBeenCalled()
+  })
+
+  it('routes a conversation target to navigateToConversation', () => {
+    const n = nav()
+    routeNotificationTarget('conversation', 'a@example.com', n)
+    expect(n.navigateToConversation).toHaveBeenCalledWith('a@example.com')
+    expect(n.navigateToRoom).not.toHaveBeenCalled()
+  })
+
+  it('defaults unknown navType to conversation', () => {
+    const n = nav()
+    routeNotificationTarget(undefined, 'a@example.com', n)
+    expect(n.navigateToConversation).toHaveBeenCalledWith('a@example.com')
+  })
+
+  it('does nothing without a target', () => {
+    const n = nav()
+    routeNotificationTarget('room', undefined, n)
+    expect(n.navigateToRoom).not.toHaveBeenCalled()
+    expect(n.navigateToConversation).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/utils/notificationRouting.ts
+++ b/apps/fluux/src/utils/notificationRouting.ts
@@ -1,0 +1,24 @@
+/**
+ * Route a notification activation to the right view.
+ *
+ * Shared by every notification click source so routing logic lives in one
+ * place: the desktop `notification-activated` Tauri event, the cold-start
+ * drain, and the mobile `onAction` path.
+ */
+export interface NotificationNavigators {
+  navigateToConversation: (id: string) => void
+  navigateToRoom: (jid: string) => void
+}
+
+export function routeNotificationTarget(
+  navType: string | undefined,
+  navTarget: string | undefined,
+  nav: NotificationNavigators,
+): void {
+  if (!navTarget) return
+  if (navType === 'room') {
+    nav.navigateToRoom(navTarget)
+  } else {
+    nav.navigateToConversation(navTarget)
+  }
+}

--- a/apps/fluux/src/utils/tauriPlatform.ts
+++ b/apps/fluux/src/utils/tauriPlatform.ts
@@ -1,0 +1,20 @@
+/**
+ * Cached check for "running in the Tauri desktop app on macOS".
+ * Used to route notification posting through the native UNUserNotificationCenter
+ * command on macOS while other platforms keep the Tauri notification plugin.
+ */
+const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+
+let cached: boolean | undefined
+
+export async function isMacOSDesktop(): Promise<boolean> {
+  if (!isTauri) return false
+  if (cached !== undefined) return cached
+  try {
+    const { platform } = await import('@tauri-apps/plugin-os')
+    cached = (await platform()) === 'macos'
+  } catch {
+    cached = false
+  }
+  return cached
+}

--- a/docs/superpowers/plans/2026-06-13-macos-notification-click-routing.md
+++ b/docs/superpowers/plans/2026-06-13-macos-notification-click-routing.md
@@ -1,0 +1,1066 @@
+# macOS Notification Click-to-the-Right-Chat — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clicking a macOS desktop notification navigates to the exact conversation/room it was about (including from a cold start), by posting natively through `UNUserNotificationCenter` and bridging the click into the app's existing React-Router navigation.
+
+**Architecture:** A self-contained Rust module `src-tauri/src/notifications/` owns native notification presentation + click capture behind a `NotificationBackend` trait (macOS backend only for now). The macOS backend posts via `UNUserNotificationCenter`, encodes the nav target in the notification **identifier** (`"<navType>:<navTarget>"`, survives cold start), and an objc2 `UNUserNotificationCenterDelegate` parses the click, focuses the window, and emits a `notification-activated` Tauri event (or stashes it for a startup drain if the webview isn't ready). The JS side is platform-agnostic: on macOS it `invoke`s `post_notification` and routes the event/drain through one shared helper. Windows/Linux keep `sendNotification` and the web stack is untouched.
+
+**Tech Stack:** Rust + Tauri 2 + objc2 0.6 (`objc2`, `objc2-foundation`, `objc2-user-notifications`, `block2`) on macOS; React + TypeScript + Vitest on the JS side; `@tauri-apps/api` (`invoke`, `event`), `@tauri-apps/plugin-os`.
+
+**Spec:** [docs/superpowers/specs/2026-06-13-macos-notification-click-routing-design.md](../specs/2026-06-13-macos-notification-click-routing-design.md)
+
+**Branch:** `feat/macos-notification-click-routing` (already created off `main`).
+
+---
+
+## A note on the Rust phase (read before starting Task 1)
+
+The objc2 delegate/posting code below is grounded in the project's existing objc2 usage (`apps/fluux/src-tauri/src/main.rs` `mod macos`, lines ~816–1014) and objc2 0.6 conventions, but **objc2 bindings are feature-gated and version-precise**. Treat the compiler as the source of truth for two things:
+
+1. **Feature flags.** objc2 emits errors like *"the type `UNUserNotificationCenter` requires the feature `UNUserNotificationCenter`"*. When you see one, add that exact feature to the `objc2-user-notifications` / `objc2-foundation` dependency in `Cargo.toml`.
+2. **Generated method signatures.** The exact parameter types of the two delegate methods (especially the completion-handler block types) are defined by the generated `UNUserNotificationCenterDelegate` trait. Open the trait in `~/.cargo/registry/src/*/objc2-user-notifications-0.3.2/src/` after the first `cargo build` downloads it, and mirror its method signatures exactly.
+
+So each Rust task ends with `cargo build` and a *fix-against-the-compiler* step. This is the real workflow for native FFI, not a placeholder. The structure, the project idioms, and the data flow in the code below are correct; the residual work is mechanical signature/feature matching.
+
+---
+
+## File Structure
+
+**Rust (macOS-gated):**
+- Create `apps/fluux/src-tauri/src/notifications/mod.rs` — module surface: `setup()`, Tauri commands, `NavTarget` type, re-exports.
+- Create `apps/fluux/src-tauri/src/notifications/backend.rs` — `NotificationBackend` trait + shared types (`NativeNotification`, `NavTarget`, `AuthState`).
+- Create `apps/fluux/src-tauri/src/notifications/macos.rs` — `UNUserNotificationCenter` backend + objc2 delegate.
+- Modify `apps/fluux/src-tauri/Cargo.toml:91-95` — add `objc2-user-notifications`, extend `objc2-foundation` features.
+- Modify `apps/fluux/src-tauri/src/main.rs` — `mod notifications;` (near line 199), register commands in `invoke_handler` (line 1248), call `notifications::setup(app)` in `setup` hook (line 1359).
+
+**JS:**
+- Create `apps/fluux/src/utils/notificationRouting.ts` — pure `routeNotificationTarget(...)` helper.
+- Create `apps/fluux/src/utils/notificationRouting.test.ts` — its test.
+- Create `apps/fluux/src/utils/tauriPlatform.ts` — cached `isMacOSDesktop()`.
+- Modify `apps/fluux/src/hooks/useDesktopNotifications.ts` — macOS posting branch; replace desktop `onAction` with `notification-activated` listener + startup drain; keep mobile `onAction` guarded.
+- Create `apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx` — listener/drain/routing test.
+- Modify `apps/fluux/src/hooks/useNotificationPermission.ts` — macOS UN permission branch.
+
+---
+
+## Phase 1 — Rust native notifications module
+
+### Task 1: Dependencies + module scaffold (compiles, no behavior yet)
+
+**Files:**
+- Modify: `apps/fluux/src-tauri/Cargo.toml:91-95`
+- Create: `apps/fluux/src-tauri/src/notifications/backend.rs`
+- Create: `apps/fluux/src-tauri/src/notifications/macos.rs`
+- Create: `apps/fluux/src-tauri/src/notifications/mod.rs`
+- Modify: `apps/fluux/src-tauri/src/main.rs` (add `mod notifications;`)
+
+- [ ] **Step 1: Add the objc2 dependencies (macOS target).** Replace the macOS dependency block at `Cargo.toml:91-95`:
+
+```toml
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo", "NSDictionary", "NSArray", "NSError"] }
+objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication"] }
+objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNMutableNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNError"] }
+block2 = "0.6"
+```
+
+> If `cargo build` later reports a missing feature (e.g. `UNNotificationPresentationOptions`, `UNNotificationSettings`), add it here. The feature name always equals the type name the error mentions.
+
+- [ ] **Step 2: Create the backend trait** at `apps/fluux/src-tauri/src/notifications/backend.rs`:
+
+```rust
+//! Platform-agnostic surface for native OS notifications.
+//!
+//! Each desktop platform implements `NotificationBackend`. Today only macOS
+//! has a concrete backend (`super::macos`); Windows/Linux keep using the
+//! Tauri notification plugin from the JS side until backends land here.
+
+use serde::Serialize;
+
+/// Where a notification click should navigate.
+#[derive(Debug, Clone, Serialize)]
+pub struct NavTarget {
+    #[serde(rename = "navType")]
+    pub nav_type: String, // "conversation" | "room"
+    #[serde(rename = "navTarget")]
+    pub nav_target: String, // bare JID
+}
+
+/// A notification to present.
+#[derive(Debug, Clone)]
+pub struct NativeNotification {
+    pub title: String,
+    pub body: String,
+    pub target: NavTarget,
+    /// Absolute file path to an image attachment, if any (added in Task 8).
+    pub avatar_path: Option<String>,
+}
+
+/// Authorization state, mirrored to the JS permission gate.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthState {
+    Granted,
+    Denied,
+    NotDetermined,
+}
+```
+
+- [ ] **Step 3: Create the macOS backend stub** at `apps/fluux/src-tauri/src/notifications/macos.rs` (real implementation lands in Tasks 2–3; this compiles now):
+
+```rust
+//! macOS native notifications via `UNUserNotificationCenter`.
+
+use crate::notifications::backend::{AuthState, NativeNotification, NavTarget};
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use tauri::AppHandle;
+
+/// App handle for emitting `notification-activated` from the delegate.
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+
+/// Target stashed when a click fires before the webview is ready (cold start).
+static PENDING_TARGET: Mutex<Option<NavTarget>> = Mutex::new(None);
+
+pub fn setup(_app: &AppHandle) {
+    // Task 2 fills this in: store APP_HANDLE, set the delegate, request authorization.
+}
+
+pub fn post(_n: NativeNotification) -> Result<(), String> {
+    // Task 2 fills this in.
+    Ok(())
+}
+
+pub fn authorization_state() -> AuthState {
+    AuthState::NotDetermined // Task 2
+}
+
+pub fn request_authorization() -> AuthState {
+    AuthState::NotDetermined // Task 2
+}
+
+pub fn take_pending_target() -> Option<NavTarget> {
+    PENDING_TARGET.lock().unwrap().take()
+}
+```
+
+- [ ] **Step 4: Create the module surface** at `apps/fluux/src-tauri/src/notifications/mod.rs`:
+
+```rust
+//! Native notification presentation + click routing.
+//!
+//! Local notifications only (the running app shows an OS notification for a
+//! message it already received). Server-initiated push is out of scope — see
+//! the design spec. Web Push lives entirely on the JS side behind `!isTauri`.
+
+pub mod backend;
+#[cfg(target_os = "macos")]
+mod macos;
+
+use backend::{AuthState, NativeNotification, NavTarget};
+use tauri::AppHandle;
+
+/// Wire up the active backend. Called from the Tauri `setup` hook.
+pub fn setup(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    macos::setup(app);
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn post_notification(
+    title: String,
+    body: String,
+    nav_type: String,
+    nav_target: String,
+    avatar_path: Option<String>,
+) -> Result<(), String> {
+    macos::post(NativeNotification {
+        title,
+        body,
+        target: NavTarget { nav_type, nav_target },
+        avatar_path,
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn notification_permission_state() -> AuthState {
+    macos::authorization_state()
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn request_notification_permission() -> AuthState {
+    macos::request_authorization()
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn take_pending_notification_target() -> Option<NavTarget> {
+    macos::take_pending_target()
+}
+```
+
+- [ ] **Step 5: Declare the module in main.rs.** After `mod openpgp_storage;` (around `apps/fluux/src-tauri/src/main.rs:203`) add:
+
+```rust
+mod notifications;
+```
+
+- [ ] **Step 6: Build.** Run:
+
+```bash
+cd apps/fluux/src-tauri && cargo build 2>&1 | tail -20
+```
+
+Expected: compiles (warnings about unused functions are fine). If a feature-flag error appears, add the named feature to `Cargo.toml` per Step 1's note and rebuild.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add apps/fluux/src-tauri/Cargo.toml apps/fluux/src-tauri/Cargo.lock apps/fluux/src-tauri/src/notifications/ apps/fluux/src-tauri/src/main.rs
+git commit -m "feat(notifications): scaffold native notifications module (macOS)"
+```
+
+---
+
+### Task 2: macOS posting + authorization + command registration
+
+**Files:**
+- Modify: `apps/fluux/src-tauri/src/notifications/macos.rs`
+- Modify: `apps/fluux/src-tauri/src/main.rs` (`invoke_handler` line 1248, `setup` hook line 1359)
+
+- [ ] **Step 1: Implement posting + authorization** in `macos.rs`. Replace `setup`, `post`, `authorization_state`, `request_authorization` with:
+
+```rust
+use objc2::rc::Retained;
+use objc2_foundation::{NSString, NSError};
+use objc2_user_notifications::{
+    UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
+    UNUserNotificationCenter,
+};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+// 0 = NotDetermined, 1 = Granted, 2 = Denied. Set by the auth callback.
+static AUTH: AtomicU8 = AtomicU8::new(0);
+
+fn current_center() -> Retained<UNUserNotificationCenter> {
+    // SAFETY: `currentNotificationCenter` is always valid in a bundled app.
+    unsafe { UNUserNotificationCenter::currentNotificationCenter() }
+}
+
+pub fn setup(app: &AppHandle) {
+    let _ = APP_HANDLE.set(app.clone());
+    set_delegate(); // defined in Task 3
+    request_authorization();
+}
+
+pub fn post(n: NativeNotification) -> Result<(), String> {
+    unsafe {
+        let content = UNMutableNotificationContent::new();
+        content.setTitle(&NSString::from_str(&n.title));
+        content.setBody(&NSString::from_str(&n.body));
+        // Identifier carries the nav target and survives cold start.
+        // Format: "<navType>:<navTarget>" — navType has no ':'; navTarget is a
+        // bare JID. Parsed on the FIRST ':' so JIDs are safe.
+        let identifier = NSString::from_str(&format!("{}:{}", n.target.nav_type, n.target.nav_target));
+        // Task 8 attaches `n.avatar_path` here.
+        let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+            &identifier,
+            &content,
+            None, // nil trigger = deliver immediately
+        );
+        current_center().addNotificationRequest_withCompletionHandler(&request, None);
+    }
+    Ok(())
+}
+
+pub fn authorization_state() -> AuthState {
+    match AUTH.load(Ordering::SeqCst) {
+        1 => AuthState::Granted,
+        2 => AuthState::Denied,
+        _ => AuthState::NotDetermined,
+    }
+}
+
+pub fn request_authorization() -> AuthState {
+    use block2::RcBlock;
+    unsafe {
+        let options = UNAuthorizationOptions::Alert
+            | UNAuthorizationOptions::Sound
+            | UNAuthorizationOptions::Badge;
+        let handler = RcBlock::new(|granted: bool, _err: *mut NSError| {
+            AUTH.store(if granted { 1 } else { 2 }, Ordering::SeqCst);
+        });
+        current_center().requestAuthorizationWithOptions_completionHandler(options, &handler);
+    }
+    authorization_state()
+}
+```
+
+> **Fix-against-the-compiler:** the exact method names above follow objc2's selector→snake convention (`addNotificationRequest:withCompletionHandler:` → `addNotificationRequest_withCompletionHandler`). If a name or the auth-handler block signature differs, open `objc2-user-notifications-0.3.2/src/` and match. The completion-handler block param type for `requestAuthorization...` is `void (^)(BOOL, NSError * _Nullable)`.
+
+- [ ] **Step 2: Register the commands.** In `apps/fluux/src-tauri/src/main.rs`, inside `tauri::generate_handler![ ... ]` (starts line 1248), add (macOS commands are `cfg`-gated in the module, so guard the registration too):
+
+```rust
+            #[cfg(target_os = "macos")]
+            notifications::post_notification,
+            #[cfg(target_os = "macos")]
+            notifications::notification_permission_state,
+            #[cfg(target_os = "macos")]
+            notifications::request_notification_permission,
+            #[cfg(target_os = "macos")]
+            notifications::take_pending_notification_target,
+```
+
+> `generate_handler!` supports `#[cfg(...)]` on individual entries.
+
+- [ ] **Step 3: Call setup from the Tauri setup hook.** In the `.setup(move |app| { ... })` closure (line 1359), add near the top of the closure body:
+
+```rust
+            notifications::setup(app.handle());
+```
+
+- [ ] **Step 4: Build.**
+
+```bash
+cd apps/fluux/src-tauri && cargo build 2>&1 | tail -20
+```
+
+Expected: compiles. Resolve any feature/signature errors per the note at the top.
+
+- [ ] **Step 5: Manual smoke test (signed dev build).** From repo root:
+
+```bash
+npm run tauri:dev
+```
+
+When the app is running, open devtools console and run:
+
+```js
+await window.__TAURI_INTERNALS__.invoke('post_notification', { title: 'Test', body: 'Hello', navType: 'conversation', navTarget: 'a@example.com', avatarPath: null })
+```
+
+Expected: a macOS notification banner appears (accept the authorization prompt the first time). If it does not appear, check `await window.__TAURI_INTERNALS__.invoke('notification_permission_state')` — it must be `"granted"`. This validates the dev-build signing identity (the one real risk).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/fluux/src-tauri/src/notifications/macos.rs apps/fluux/src-tauri/src/main.rs apps/fluux/src-tauri/Cargo.toml apps/fluux/src-tauri/Cargo.lock
+git commit -m "feat(notifications): post macOS notifications via UNUserNotificationCenter"
+```
+
+---
+
+### Task 3: Delegate — capture click, emit event, stash for cold start
+
+**Files:**
+- Modify: `apps/fluux/src-tauri/src/notifications/macos.rs`
+
+- [ ] **Step 1: Add the delegate + emit logic.** Add to `macos.rs`:
+
+```rust
+use objc2::{define_class, msg_send, DefinedClass};
+use objc2::runtime::{NSObject, NSObjectProtocol, ProtocolObject};
+use objc2_user_notifications::{
+    UNNotification, UNNotificationPresentationOptions, UNNotificationResponse,
+    UNUserNotificationCenterDelegate,
+};
+use tauri::{Emitter, Manager};
+
+static DELEGATE: OnceLock<Retained<NotificationDelegate>> = OnceLock::new();
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "FluuxNotificationDelegate"]
+    struct NotificationDelegate;
+
+    unsafe impl NSObjectProtocol for NotificationDelegate {}
+
+    unsafe impl UNUserNotificationCenterDelegate for NotificationDelegate {
+        // void userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
+        #[unsafe(method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:))]
+        fn did_receive(
+            &self,
+            _center: &UNUserNotificationCenter,
+            response: &UNNotificationResponse,
+            completion: &block2::DynBlock<dyn Fn()>,
+        ) {
+            // SAFETY: response graph is valid for the duration of this call.
+            let identifier = unsafe {
+                response.notification().request().identifier()
+            };
+            handle_activation(&identifier.to_string());
+            completion.call(());
+        }
+
+        // void userNotificationCenter:willPresentNotification:withCompletionHandler:
+        #[unsafe(method(userNotificationCenter:willPresentNotification:withCompletionHandler:))]
+        fn will_present(
+            &self,
+            _center: &UNUserNotificationCenter,
+            _notification: &UNNotification,
+            completion: &block2::DynBlock<dyn Fn(UNNotificationPresentationOptions)>,
+        ) {
+            // Show notifications for background chats even while the app is
+            // frontmost — the JS layer already decides whether to notify.
+            let opts = UNNotificationPresentationOptions::Banner
+                | UNNotificationPresentationOptions::List
+                | UNNotificationPresentationOptions::Sound;
+            completion.call((opts,));
+        }
+    }
+);
+
+impl NotificationDelegate {
+    fn new() -> Retained<Self> {
+        // SAFETY: standard NSObject allocation/init for a defined subclass.
+        unsafe { msg_send![Self::alloc(), init] }
+    }
+}
+
+fn set_delegate() {
+    let delegate = NotificationDelegate::new();
+    let proto = ProtocolObject::from_ref(&*delegate);
+    // SAFETY: setter takes an optional delegate conforming to the protocol.
+    unsafe { current_center().setDelegate(Some(proto)) };
+    // Keep the delegate alive for the app's lifetime.
+    let _ = DELEGATE.set(delegate);
+}
+
+/// Parse "<navType>:<navTarget>" and route it. Emits to the webview if one is
+/// ready, otherwise stashes for the startup drain (cold start).
+fn handle_activation(identifier: &str) {
+    let Some((nav_type, nav_target)) = identifier.split_once(':') else {
+        return;
+    };
+    let target = NavTarget {
+        nav_type: nav_type.to_string(),
+        nav_target: nav_target.to_string(),
+    };
+
+    let app = APP_HANDLE.get();
+    let window = app.and_then(|a| a.get_webview_window("main"));
+
+    if let Some(win) = &window {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+
+    match app {
+        Some(a) if window.is_some() => {
+            // Emit; if the webview hasn't mounted its listener yet the drain
+            // still covers it, so also stash defensively on cold start only.
+            let _ = a.emit("notification-activated", target);
+        }
+        _ => {
+            *PENDING_TARGET.lock().unwrap() = Some(target);
+        }
+    }
+}
+```
+
+> **Fix-against-the-compiler:** the two delegate method signatures (param names/order, and especially the `block2::DynBlock<dyn Fn(...)>` completion types) must match the generated `UNUserNotificationCenterDelegate` trait exactly. After this build downloads the crate, read `objc2-user-notifications-0.3.2/src/.../UNUserNotificationCenter.rs`, find the trait, and copy the method signatures verbatim. `NSString::to_string()` comes from `objc2_foundation`; if unavailable use `identifier.to_string()` via `Display` or `unsafe { identifier.as_str(...) }` per the crate.
+
+- [ ] **Step 2: Build.**
+
+```bash
+cd apps/fluux/src-tauri && cargo build 2>&1 | tail -25
+```
+
+Expected: compiles after signature matching.
+
+- [ ] **Step 3: Manual smoke test.** `npm run tauri:dev`, then in devtools:
+
+```js
+window.__TAURI_INTERNALS__.invoke('post_notification', { title: 'Click me', body: 'route test', navType: 'room', navTarget: 'team@conf.example.com', avatarPath: null })
+// Add a temporary listener:
+const { listen } = window.__TAURI__.event
+listen('notification-activated', e => console.log('ACTIVATED', e.payload))
+```
+
+Click the banner. Expected console: `ACTIVATED {navType: 'room', navTarget: 'team@conf.example.com'}` and the window focuses. Then quit the app, re-run, post + click from a cold start, and verify `await window.__TAURI_INTERNALS__.invoke('take_pending_notification_target')` returns the target.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add apps/fluux/src-tauri/src/notifications/macos.rs
+git commit -m "feat(notifications): route macOS notification clicks via delegate + event"
+```
+
+---
+
+## Phase 2 — JS wiring
+
+### Task 4: Shared routing helper (pure, TDD)
+
+**Files:**
+- Create: `apps/fluux/src/utils/notificationRouting.ts`
+- Test: `apps/fluux/src/utils/notificationRouting.test.ts`
+
+- [ ] **Step 1: Write the failing test** at `apps/fluux/src/utils/notificationRouting.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { routeNotificationTarget } from './notificationRouting'
+
+describe('routeNotificationTarget', () => {
+  const nav = () => ({ navigateToConversation: vi.fn(), navigateToRoom: vi.fn() })
+
+  it('routes a room target to navigateToRoom', () => {
+    const n = nav()
+    routeNotificationTarget('room', 'team@conf.example.com', n)
+    expect(n.navigateToRoom).toHaveBeenCalledWith('team@conf.example.com')
+    expect(n.navigateToConversation).not.toHaveBeenCalled()
+  })
+
+  it('routes a conversation target to navigateToConversation', () => {
+    const n = nav()
+    routeNotificationTarget('conversation', 'a@example.com', n)
+    expect(n.navigateToConversation).toHaveBeenCalledWith('a@example.com')
+    expect(n.navigateToRoom).not.toHaveBeenCalled()
+  })
+
+  it('defaults unknown navType to conversation', () => {
+    const n = nav()
+    routeNotificationTarget(undefined, 'a@example.com', n)
+    expect(n.navigateToConversation).toHaveBeenCalledWith('a@example.com')
+  })
+
+  it('does nothing without a target', () => {
+    const n = nav()
+    routeNotificationTarget('room', undefined, n)
+    expect(n.navigateToRoom).not.toHaveBeenCalled()
+    expect(n.navigateToConversation).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails.**
+
+```bash
+cd apps/fluux && npx vitest run src/utils/notificationRouting.test.ts
+```
+
+Expected: FAIL — `routeNotificationTarget` is not defined.
+
+- [ ] **Step 3: Implement** `apps/fluux/src/utils/notificationRouting.ts`:
+
+```ts
+/**
+ * Route a notification activation to the right view.
+ *
+ * Shared by every notification click source so routing logic lives in one
+ * place: the desktop `notification-activated` Tauri event, the cold-start
+ * drain, and the mobile `onAction` path.
+ */
+export interface NotificationNavigators {
+  navigateToConversation: (id: string) => void
+  navigateToRoom: (jid: string) => void
+}
+
+export function routeNotificationTarget(
+  navType: string | undefined,
+  navTarget: string | undefined,
+  nav: NotificationNavigators,
+): void {
+  if (!navTarget) return
+  if (navType === 'room') {
+    nav.navigateToRoom(navTarget)
+  } else {
+    nav.navigateToConversation(navTarget)
+  }
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes.**
+
+```bash
+cd apps/fluux && npx vitest run src/utils/notificationRouting.test.ts
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/fluux/src/utils/notificationRouting.ts apps/fluux/src/utils/notificationRouting.test.ts
+git commit -m "feat(notifications): shared notification routing helper"
+```
+
+---
+
+### Task 5: macOS platform helper + posting branch
+
+**Files:**
+- Create: `apps/fluux/src/utils/tauriPlatform.ts`
+- Modify: `apps/fluux/src/hooks/useDesktopNotifications.ts`
+
+- [ ] **Step 1: Create the cached platform helper** `apps/fluux/src/utils/tauriPlatform.ts`:
+
+```ts
+/**
+ * Cached check for "running in the Tauri desktop app on macOS".
+ * Used to route notification posting through the native UNUserNotificationCenter
+ * command on macOS while other platforms keep the Tauri notification plugin.
+ */
+const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+
+let cached: boolean | undefined
+
+export async function isMacOSDesktop(): Promise<boolean> {
+  if (!isTauri) return false
+  if (cached !== undefined) return cached
+  try {
+    const { platform } = await import('@tauri-apps/plugin-os')
+    cached = (await platform()) === 'macos'
+  } catch {
+    cached = false
+  }
+  return cached
+}
+```
+
+- [ ] **Step 2: Add the macOS posting branch.** In `apps/fluux/src/hooks/useDesktopNotifications.ts`, add imports near the top:
+
+```ts
+import { invoke } from '@tauri-apps/api/core'
+import { isMacOSDesktop } from '@/utils/tauriPlatform'
+```
+
+Then replace the conversation posting block (currently `if (isTauri) { sendNotification({...}) } else { ... }`, lines ~95–113) with:
+
+```ts
+    if (isTauri) {
+      if (await isMacOSDesktop()) {
+        await invoke('post_notification', {
+          title,
+          body,
+          navType: 'conversation',
+          navTarget: conv.id,
+          avatarPath: null, // avatar attachment added in Task 8
+        })
+      } else {
+        sendNotification({
+          title,
+          body,
+          attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
+          extra: { navType: 'conversation', navTarget: conv.id },
+        })
+      }
+    } else {
+      await showWebNotification(
+        title,
+        {
+          body,
+          icon: avatarUrl || './icon-512.png',
+          tag: conv.id,
+          onClick: () => navigateToConversation(conv.id),
+        },
+        { from: conv.id, type: 'conversation' },
+      )
+    }
+```
+
+And the room posting block (lines ~141–158) with:
+
+```ts
+    if (isTauri) {
+      if (await isMacOSDesktop()) {
+        await invoke('post_notification', {
+          title,
+          body,
+          navType: 'room',
+          navTarget: room.jid,
+          avatarPath: null, // avatar attachment added in Task 8
+        })
+      } else {
+        sendNotification({
+          title,
+          body,
+          attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
+          extra: { navType: 'room', navTarget: room.jid },
+        })
+      }
+    } else {
+      await showWebNotification(
+        title,
+        {
+          body,
+          icon: avatarUrl || './icon-512.png',
+          tag: `room-${room.jid}`,
+          onClick: () => navigateToRoom(room.jid),
+        },
+        { from: room.jid, type: 'room' },
+      )
+    }
+```
+
+- [ ] **Step 3: Typecheck.**
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Run the existing notification-hook tests** to confirm no regression (they mock `@tauri-apps/plugin-notification`; the new `invoke`/`isMacOSDesktop` are only hit when `isMacOSDesktop()` resolves true, which it won't under jsdom since `__TAURI_INTERNALS__` is absent):
+
+```bash
+cd apps/fluux && npx vitest run src/hooks/useDesktopNotifications
+```
+
+Expected: PASS (or "no tests" — there is no existing test for this hook; the run must not error on import).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/fluux/src/utils/tauriPlatform.ts apps/fluux/src/hooks/useDesktopNotifications.ts
+git commit -m "feat(notifications): post via native command on macOS desktop"
+```
+
+---
+
+### Task 6: Click routing — event listener + cold-start drain (TDD)
+
+**Files:**
+- Modify: `apps/fluux/src/hooks/useDesktopNotifications.ts`
+- Test: `apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx`
+
+- [ ] **Step 1: Write the failing test** at `apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx`. It mounts the hook in a Tauri-like environment, fires a `notification-activated` event, and asserts the shared router runs:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const navigateToConversation = vi.fn()
+const navigateToRoom = vi.fn()
+let eventCb: ((e: { payload: unknown }) => void) | undefined
+const drainResult = { current: null as unknown }
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (_name: string, cb: (e: { payload: unknown }) => void) => {
+    eventCb = cb
+    return Promise.resolve(() => {})
+  },
+}))
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (cmd: string) =>
+    cmd === 'take_pending_notification_target'
+      ? Promise.resolve(drainResult.current)
+      : Promise.resolve(null),
+}))
+vi.mock('@tauri-apps/plugin-notification', () => ({
+  sendNotification: vi.fn(),
+  onAction: vi.fn(() => Promise.resolve({ unregister: vi.fn() })),
+}))
+vi.mock('@tauri-apps/plugin-os', () => ({ platform: () => Promise.resolve('macos') }))
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({ navigateToConversation, navigateToRoom, navigateToContact: vi.fn() }),
+}))
+vi.mock('./useNotificationPermission', () => ({
+  isTauri: true,
+  useNotificationPermission: () => ({ current: true }),
+}))
+vi.mock('./useNotificationEvents', () => ({ useNotificationEvents: vi.fn() }))
+vi.mock('@fluux/sdk', () => ({ rosterStore: { getState: () => ({ getContact: () => undefined }) }, usePresence: () => ({ presenceStatus: 'online' }) }))
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+
+import { useDesktopNotifications } from './useDesktopNotifications'
+
+describe('useDesktopNotifications click routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    eventCb = undefined
+    drainResult.current = null
+    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+  })
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+  })
+
+  it('routes a notification-activated event through the shared router', async () => {
+    renderHook(() => useDesktopNotifications())
+    // Let the effect's async listen() subscription settle.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(eventCb).toBeTypeOf('function')
+    eventCb!({ payload: { navType: 'room', navTarget: 'team@conf.example.com' } })
+    expect(navigateToRoom).toHaveBeenCalledWith('team@conf.example.com')
+  })
+
+  it('drains a pending target on startup', async () => {
+    drainResult.current = { navType: 'conversation', navTarget: 'a@example.com' }
+    renderHook(() => useDesktopNotifications())
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(navigateToConversation).toHaveBeenCalledWith('a@example.com')
+  })
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails.**
+
+```bash
+cd apps/fluux && npx vitest run src/hooks/useDesktopNotifications.routing.test.tsx
+```
+
+Expected: FAIL — the hook still uses `onAction`, so neither `navigateToRoom` (via event) nor the drain runs.
+
+- [ ] **Step 3: Replace the click-handling effect.** In `apps/fluux/src/hooks/useDesktopNotifications.ts`, replace the entire `// Handle notification clicks via Tauri onAction listener` effect (lines ~44–67) with:
+
+```ts
+  // Handle notification clicks.
+  //
+  // Desktop (macOS native): the Rust delegate emits "notification-activated"
+  // and stashes a target for cold starts (drained on mount). Mobile: the
+  // plugin's onAction() is the click source — but registerListener only exists
+  // on iOS/Android, so guard it there (on desktop it rejects with
+  // "not allowed by ACL"). Web routes clicks in sw.ts and is untouched here.
+  useEffect(() => {
+    if (!isTauri) return
+
+    const route = (payload: unknown) => {
+      const p = (payload ?? {}) as { navType?: string; navTarget?: string }
+      routeNotificationTarget(p.navType, p.navTarget, {
+        navigateToConversation: navigateToConversationRef.current,
+        navigateToRoom: navigateToRoomRef.current,
+      })
+    }
+
+    let cancelled = false
+    let unlistenEvent: (() => void) | undefined
+    let unlistenMobile: (() => void) | undefined
+
+    // Desktop: Tauri event + cold-start drain.
+    void listen('notification-activated', (e) => route(e.payload)).then((un) => {
+      if (cancelled) un()
+      else unlistenEvent = un
+    })
+    void invoke('take_pending_notification_target')
+      .then((target) => {
+        if (!cancelled && target) route(target)
+      })
+      .catch(() => {
+        // Command is macOS-only; absent elsewhere — ignore.
+      })
+
+    // Mobile: onAction (iOS/Android only).
+    void (async () => {
+      const { platform } = await import('@tauri-apps/plugin-os')
+      const os = await platform()
+      if (cancelled || (os !== 'ios' && os !== 'android')) return
+      const listener = await onAction((notification: NotificationOptions) => {
+        route({
+          navType: notification.extra?.navType,
+          navTarget: notification.extra?.navTarget,
+        })
+      })
+      if (cancelled) listener.unregister()
+      else unlistenMobile = listener.unregister
+    })()
+
+    return () => {
+      cancelled = true
+      unlistenEvent?.()
+      unlistenMobile?.()
+    }
+  }, [])
+```
+
+Add the imports near the top of the file:
+
+```ts
+import { listen } from '@tauri-apps/api/event'
+import { routeNotificationTarget } from '@/utils/notificationRouting'
+```
+
+(`invoke` was already imported in Task 5.)
+
+- [ ] **Step 4: Run the routing test, verify it passes.**
+
+```bash
+cd apps/fluux && npx vitest run src/hooks/useDesktopNotifications.routing.test.tsx
+```
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Typecheck.**
+
+```bash
+npm run typecheck
+```
+
+Expected: passes. (`NotificationOptions` is already imported in the file.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/fluux/src/hooks/useDesktopNotifications.ts apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
+git commit -m "feat(notifications): route desktop notification clicks via event + cold-start drain"
+```
+
+---
+
+### Task 7: macOS permission via UN commands
+
+**Files:**
+- Modify: `apps/fluux/src/hooks/useNotificationPermission.ts`
+
+- [ ] **Step 1: Add a macOS UN branch.** In `apps/fluux/src/hooks/useNotificationPermission.ts`, replace the `if (isTauri) { ... }` block (lines ~35–46) with:
+
+```ts
+        if (isTauri) {
+          const { isMacOSDesktop } = await import('@/utils/tauriPlatform')
+          if (await isMacOSDesktop()) {
+            const { invoke } = await import('@tauri-apps/api/core')
+            let state = await invoke<string>('notification_permission_state')
+            if (state === 'notdetermined') {
+              state = await invoke<string>('request_notification_permission')
+            }
+            permissionGranted.current = state === 'granted'
+            if (!permissionGranted.current) {
+              console.log(
+                '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
+              )
+            }
+          } else {
+            let granted = await isPermissionGranted()
+            if (!granted) {
+              const permission = await requestPermission()
+              granted = permission === 'granted'
+            }
+            permissionGranted.current = granted
+            if (!granted) {
+              console.log(
+                '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
+              )
+            }
+          }
+        } else {
+```
+
+> The macOS UN authorization is already requested in `notifications::setup` at startup, so this primarily reads the state and re-requests if still undetermined.
+
+- [ ] **Step 2: Typecheck.**
+
+```bash
+npm run typecheck
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Run the full app test suite** (this hook is widely mocked; confirm nothing breaks):
+
+```bash
+cd apps/fluux && npx vitest run
+```
+
+Expected: all pass / skipped as before.
+
+- [ ] **Step 4: Manual smoke (signed dev build).** Fresh launch with notifications not yet authorized → the macOS authorization prompt appears once. Post a notification for a background chat, click it → app focuses the right conversation/room.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/fluux/src/hooks/useNotificationPermission.ts
+git commit -m "feat(notifications): back macOS permission gate with UN authorization"
+```
+
+---
+
+## Phase 3 — Avatars (parity)
+
+### Task 8: Avatar attachment on macOS notifications
+
+**Files:**
+- Modify: `apps/fluux/src/utils/notificationAvatar.ts` (add a file-path resolver) — confirm its current API first
+- Modify: `apps/fluux/src/hooks/useDesktopNotifications.ts` (pass `avatarPath`)
+- Modify: `apps/fluux/src-tauri/src/notifications/macos.rs` (attach the file)
+
+- [ ] **Step 1: Inspect the current avatar source.** Read `apps/fluux/src/utils/notificationAvatar.ts`:
+
+```bash
+sed -n '1,80p' apps/fluux/src/utils/notificationAvatar.ts
+```
+
+Determine whether `getNotificationAvatarUrl` yields a `blob:` URL, a `file:`/asset path, or a data URL. `UNNotificationAttachment` requires a **local file path**. If the value is a blob/data URL, add a helper that writes the bytes to a temp file (via `@tauri-apps/plugin-fs` `writeFile` into `tempDir()`), returning the absolute path; if it is already a filesystem path, pass it through. Implement that helper in `notificationAvatar.ts` as `getNotificationAvatarFilePath(...)` returning `Promise<string | null>`.
+
+> This step's exact code depends on what Step 1 reveals; the decision (temp-file vs passthrough) is explicit, not open-ended. Pick the branch that matches the actual return type.
+
+- [ ] **Step 2: Pass the path from the posting branch.** In `useDesktopNotifications.ts`, in both macOS `invoke('post_notification', …)` calls (Task 5), replace `avatarPath: null` with a resolved path:
+
+```ts
+          avatarPath: await getNotificationAvatarFilePath(/* contact/room avatar args */),
+```
+
+- [ ] **Step 3: Attach the file in Rust.** In `macos.rs` `post()`, before adding the request, when `n.avatar_path` is `Some(path)`:
+
+```rust
+        if let Some(path) = n.avatar_path.as_deref() {
+            use objc2_foundation::NSURL;
+            use objc2_user_notifications::UNNotificationAttachment;
+            let url = NSURL::fileURLWithPath(&NSString::from_str(path));
+            if let Ok(att) = UNNotificationAttachment::attachmentWithIdentifier_URL_options_error(
+                &NSString::from_str("avatar"),
+                &url,
+                None,
+            ) {
+                content.setAttachments(&objc2_foundation::NSArray::from_slice(&[&*att]));
+            }
+        }
+```
+
+Add the `UNNotificationAttachment` feature to the `objc2-user-notifications` dependency and `NSURL` to `objc2-foundation` features. Build and fix signatures per the top-of-phase note.
+
+- [ ] **Step 4: Build + typecheck.**
+
+```bash
+cd apps/fluux/src-tauri && cargo build 2>&1 | tail -20
+cd .. && npm run typecheck
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Manual smoke.** Post a conversation notification for a contact with an avatar → the banner shows the avatar thumbnail; clicking still routes correctly.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/fluux/src/utils/notificationAvatar.ts apps/fluux/src/hooks/useDesktopNotifications.ts apps/fluux/src-tauri/src/notifications/macos.rs apps/fluux/src-tauri/Cargo.toml apps/fluux/src-tauri/Cargo.lock
+git commit -m "feat(notifications): attach avatar thumbnails to macOS notifications"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `npm run typecheck` — clean.
+- [ ] `npm run lint` — no new errors/warnings in touched files.
+- [ ] `npm test` — SDK + app suites pass.
+- [ ] `cd apps/fluux/src-tauri && cargo build` — clean.
+- [ ] Manual (signed dev build): background-chat notification → click → right conversation; → right room; cold-start click → right chat; avatar visible.
+- [ ] Confirm the **web** build is unaffected: `npm run dev`, open `http://localhost:5173`, verify notifications still go through the service worker (no `invoke`/`notification-activated` usage on web).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Native UN posting + delegate + `notification-activated` event → Tasks 2, 3. ✓
+- Platform-agnostic JS routing (shared helper) → Tasks 4, 6. ✓
+- Cold-start drain → Tasks 3 (Rust stash + command), 6 (JS drain). ✓
+- UN-backed authorization / permission alignment → Tasks 2 (request), 7 (JS gate). ✓
+- Isolated `notifications/` module with `NotificationBackend` trait → Task 1. ✓
+- macOS posting replaced, Win/Linux keep `sendNotification`, web untouched → Task 5 (branch), Final verification (web check). ✓
+- Mobile `onAction` kept + guarded to iOS/Android → Task 6. ✓ (self-sufficient; does not depend on PR #525 merging)
+- Avatars sequenced last → Task 8. ✓
+
+**Placeholder scan:** The two intentionally compiler-resolved areas (objc2 feature flags, generated delegate signatures) and the avatar-source branch in Task 8 are explicit decisions framed by the actual workflow, not vague "handle it later" — each names exactly what to check and where. No bare TODOs.
+
+**Type consistency:** `NavTarget { navType, navTarget }` is the single payload shape across Rust (`#[serde(rename)]`), the `notification-activated` event, `take_pending_notification_target`, and the JS `routeNotificationTarget(navType, navTarget, …)`. The command name `post_notification` and its params (`title, body, navType, navTarget, avatarPath`) match between `mod.rs` and both JS call sites. `isMacOSDesktop()` is defined in Task 5 and reused in Task 7.

--- a/docs/superpowers/specs/2026-06-13-macos-notification-click-routing-design.md
+++ b/docs/superpowers/specs/2026-06-13-macos-notification-click-routing-design.md
@@ -1,0 +1,105 @@
+# macOS notification click-to-the-right-chat — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (brainstorming) — pending spec review → implementation plan
+**Branch:** `feat/macos-notification-click-routing`
+**Related:** PR #525 (`fix/notification-onaction-platform-guard`) — guards the dead mobile-only `onAction` path; this feature reworks that same area on desktop.
+
+## Problem
+
+Clicking a desktop (macOS) notification does **not** navigate to the conversation/room it was about. The app currently posts notifications carrying `extra: { navType, navTarget }` and tries to route clicks via `@tauri-apps/plugin-notification`'s `onAction()`. That API is mobile-only:
+
+- `tauri-plugin-notification` 2.3.3 registers only three commands in its **desktop** `invoke_handler` — `notify`, `request_permission`, `is_permission_granted` (verified in the crate's `src/lib.rs`). `onAction()` invokes `register_listener`, which exists only on iOS/Android, so on desktop it rejects with `Command plugin:notification|registerListener not allowed by ACL`.
+- On macOS the plugin posts through `notify-rust` (the deprecated `NSUserNotification` API), whose click responses are never surfaced to the webview. In dev it even impersonates `com.apple.Terminal`'s bundle id.
+
+Net effect today: clicking a macOS notification raises the window (via the existing `NSApplicationDidBecomeActiveNotification` observer in `main.rs` → `set_focus()`) but lands on whatever chat was already open — never the right one.
+
+## Goals
+
+- Clicking a macOS notification navigates to the exact conversation/room it represents, including when multiple notifications are pending.
+- Reuse the app's existing navigation (`navigateToConversation` / `navigateToRoom`) and event infrastructure.
+- Structure the JS side so Windows/Linux can route clicks later by emitting the same event — no JS rework.
+
+## Non-goals / invariants
+
+- **Windows/Linux click routing** is out of scope for now (different native mechanisms: WinRT toast activation, libnotify actions). They keep today's `sendNotification` (notifications still show; clicks just don't route yet).
+- **The Web Push + service-worker stack is untouched.** `apps/fluux/src/sw.ts` (push + notification-click handling), `apps/fluux/src/hooks/useWebPush.ts` (PushManager + VAPID), `apps/fluux/src/utils/webNotification.ts`, and the `./sw.js` registration in `main.tsx` are all gated on `!isTauri`. This feature lives entirely behind `isTauri === true && platform() === 'macos'`. The two stacks are mutually exclusive across the `isTauri` fork and cannot collide. Web notification clicks continue to route through `sw.ts`.
+- **All native code stays behind the `isTauri` guard.** The `notification-activated` listener and the cold-start drain must sit inside `if (!isTauri) return`, so the web bundle never calls Tauri event/`invoke` APIs.
+- Avatars are preserved as a sequenced follow-up (build step 4), not a regression we accept permanently.
+
+## Why native `UNUserNotificationCenter`
+
+A click callback only reaches a `UNUserNotificationCenterDelegate` for notifications **posted through `UNUserNotificationCenter`**. `notify-rust`/`mac-notification-sys` post through the legacy API, so a hybrid (post via Tauri, click via UN) is impossible. To get the click we must also post via UN. Approved trade-off: on macOS we replace posting with our own native command; Tauri's plugin stays loaded for Windows/Linux and is simply not called for posting on macOS.
+
+The dependency tree already carries what we need: `objc2`, `objc2-foundation`, `objc2-app-kit`, `objc2-user-notifications`. `main.rs` already uses objc2 (`NSNotificationCenter` observers via `RcBlock`) and `tauri::Emitter` for webview events throughout — so both halves follow established patterns.
+
+Rejected alternatives:
+- **Heuristic (stash target, navigate on app-activation):** can't tell *which* notification was clicked (wrong chat with multiple pending) and would hijack navigation on every Cmd-Tab/dock activation. Rejected on correctness.
+- **Wait for upstream desktop actions in `tauri-plugin-notification`:** indefinite timeline, gap has existed for years. We may upstream our work later but cannot depend on it.
+
+## Architecture & data flow
+
+```
+post (background chat)                          click
+   JS useDesktopNotifications                   macOS notification
+     (macOS branch)                                  │
+   invoke("post_notification",                  UN delegate (Rust)
+     {title, body, navType, navTarget,            didReceiveResponse
+      avatarPath?})                                  │
+        │                                       window.set_focus() +
+   Rust UNUserNotificationCenter ──posts──▶     emit("notification-activated",
+     content.userInfo = {navType, navTarget}      {navType, navTarget})
+                                                     │
+                                                JS listen("notification-activated")
+                                                  + startup drain
+                                                     │
+                                                navigateToTarget(navType, navTarget)
+```
+
+The JS routing side is platform-agnostic: it listens for `notification-activated`. macOS emits it natively now; other platforms can emit the same event later.
+
+## Components
+
+### Rust — new `apps/fluux/src-tauri/src/notifications.rs` (macOS-gated)
+
+- **Command `post_notification(title, body, nav_type, nav_target, avatar_path: Option<String>)`** — builds a `UNMutableNotificationContent`, sets `userInfo = {navType, navTarget}`, adds a `UNNotificationRequest` (immediate trigger). Registered in the `invoke_handler` under `#[cfg(target_os = "macos")]`.
+- **Delegate** — an objc2 `define_class!` `NSObject` conforming to `UNUserNotificationCenterDelegate`, assigned as `UNUserNotificationCenter.current().delegate` in the Tauri `setup` hook (Apple requires the delegate be set before launch completes):
+  - `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` → read `userInfo`, `set_focus()` the main window, `emit("notification-activated", {navType, navTarget})`, call the completion handler.
+  - `userNotificationCenter:willPresentNotification:withCompletionHandler:` → return `.banner | .list | .sound` so notifications for **background** chats still display while the app is frontmost (the JS layer already decides whether to notify, so the OS should not suppress them).
+- **Authorization** — request UN authorization (alert + sound + badge) once at setup. Expose `notification_permission_state()` and `request_notification_permission()` so the macOS permission UI reflects UN status rather than the legacy plugin's.
+- **Cold-start drain** — if the app was quit and is relaunched by a notification click, the delegate can fire before the webview mounts. Store the pending target in Rust state (e.g. a `Mutex<Option<NavTarget>>`); expose `take_pending_notification_target()` that JS drains on startup. Live events cover the common tray/background-running case; the drain covers cold start. This mirrors the existing deep-link cold-start handling.
+
+### JS
+
+- `useNavigateToTarget.ts` / `useDesktopNotifications.ts` — extract one shared `navigateToTarget(navType, navTarget)` helper (room → `navigateToRoom`, else → `navigateToConversation`). Both the desktop event path and the retained mobile `onAction` path route through it (no duplication).
+- `useDesktopNotifications.ts` posting branch — on macOS (`isTauri && platform() === 'macos'`), call `invoke("post_notification", …)`; keep `sendNotification` for Windows/Linux and `showWebNotification` for web, unchanged. Determine macOS once and reuse.
+- `useDesktopNotifications.ts` click branch — replace the desktop `onAction` subscription with `listen("notification-activated", …)` **plus** a one-time startup drain of `take_pending_notification_target()`. Keep the mobile `onAction` subscription guarded to iOS/Android (the guard from PR #525), since mobile still uses it.
+- `useNotificationPermission.ts` — macOS branch uses the new UN permission commands; other platforms unchanged.
+
+### Avatars (build step 4, parity)
+
+`UNNotificationAttachment` needs a **file path**, but `getNotificationAvatarUrl` currently yields a blob URL. The plan must resolve this — either write the avatar to a temp file before invoking the command, or have Rust resolve the cached avatar path from a hash. Land text + routing first; add the attachment without regressing the avatar that macOS shows today. (Open implementation detail to settle in the plan: confirm whether the current `attachments` avatar even renders under the legacy API, which sets the parity bar.)
+
+## Build order (incremental, de-risks signing early)
+
+1. **Minimal native notification + click event end-to-end** — post a hard-coded notification via UN, delegate emits `notification-activated`, a temporary JS log confirms it. Validates the dev-build signing identity and UN authorization before any real wiring. (App is already signed/notarized for release; this confirms the `tauri dev` identity, which may sign ad-hoc.)
+2. **Wire real posting + JS routing + cold-start drain** — macOS posting branch, shared `navigateToTarget`, event listener, startup drain.
+3. **Permission-state alignment** — UN-backed `useNotificationPermission` macOS branch + settings UI.
+4. **Avatar attachments** — feature parity.
+
+## Testing
+
+- **JS unit:** shared `navigateToTarget` routing; the event-listener and startup-drain handlers (mock `@tauri-apps/api/event` `listen` + `invoke`), following the existing notification-hook test patterns. Assert the web path and `!isTauri` guard are untouched.
+- **Rust:** keep the delegate thin; `userInfo` encode/decode is a small testable unit. The delegate itself is validated manually via build step 1.
+- **Manual (signed dev build):** click a background-chat notification → jumps to the right conversation and the right room; repeat from a fully quit state (cold-start drain).
+
+## Risks
+
+- **Dev-build signing/authorization for UN** — mitigated by build step 1 validating it first. Low, since release builds are signed/notarized.
+- **UN delegate vs tao/wry** — confirm wry doesn't install its own `UNUserNotificationCenter` delegate that we'd clobber (or vice versa). Validate in build step 1.
+- **Double authorization prompt** — ensure we don't prompt via both the legacy plugin and UN on macOS; macOS permission flow should go through UN only.
+- **Coexistence with PR #525** — this feature reworks the `onAction` area. The implementation branch should rebase onto / merge after #525 so the mobile `onAction` guard is preserved.
+
+## Extensibility
+
+Windows and Linux later implement their own native click capture (WinRT toast activation / libnotify actions) and emit the **same** `notification-activated` event. No JS changes required — the routing side is already platform-agnostic.

--- a/docs/superpowers/specs/2026-06-13-macos-notification-click-routing-design.md
+++ b/docs/superpowers/specs/2026-06-13-macos-notification-click-routing-design.md
@@ -22,7 +22,8 @@ Net effect today: clicking a macOS notification raises the window (via the exist
 
 ## Non-goals / invariants
 
-- **Windows/Linux click routing** is out of scope for now (different native mechanisms: WinRT toast activation, libnotify actions). They keep today's `sendNotification` (notifications still show; clicks just don't route yet).
+- **Windows/Linux click routing** is out of scope for now (different native mechanisms: WinRT toast activation, libnotify actions). They keep today's `sendNotification` (notifications still show; clicks just don't route yet). The module is structured so their native backends slot in later behind one interface.
+- **Server-initiated push** (APNs / FCM / a push gateway / XEP-0357 client) is explicitly **out of scope**. This module owns *local notification presentation* — showing an OS notification for a message the running app already received over its live connection, and routing the click. "Push" (waking/informing the app when it isn't connected) is a separate, larger subsystem and keeps that name; this module is named `notifications` to stay accurate and avoid colliding with the existing Web Push stack.
 - **The Web Push + service-worker stack is untouched.** `apps/fluux/src/sw.ts` (push + notification-click handling), `apps/fluux/src/hooks/useWebPush.ts` (PushManager + VAPID), `apps/fluux/src/utils/webNotification.ts`, and the `./sw.js` registration in `main.tsx` are all gated on `!isTauri`. This feature lives entirely behind `isTauri === true && platform() === 'macos'`. The two stacks are mutually exclusive across the `isTauri` fork and cannot collide. Web notification clicks continue to route through `sw.ts`.
 - **All native code stays behind the `isTauri` guard.** The `notification-activated` listener and the cold-start drain must sit inside `if (!isTauri) return`, so the web bundle never calls Tauri event/`invoke` APIs.
 - Avatars are preserved as a sequenced follow-up (build step 4), not a regression we accept permanently.
@@ -60,14 +61,46 @@ The JS routing side is platform-agnostic: it listens for `notification-activated
 
 ## Components
 
-### Rust — new `apps/fluux/src-tauri/src/notifications.rs` (macOS-gated)
+### Rust — new `apps/fluux/src-tauri/src/notifications/` module
 
-- **Command `post_notification(title, body, nav_type, nav_target, avatar_path: Option<String>)`** — builds a `UNMutableNotificationContent`, sets `userInfo = {navType, navTarget}`, adds a `UNNotificationRequest` (immediate trigger). Registered in the `invoke_handler` under `#[cfg(target_os = "macos")]`.
-- **Delegate** — an objc2 `define_class!` `NSObject` conforming to `UNUserNotificationCenterDelegate`, assigned as `UNUserNotificationCenter.current().delegate` in the Tauri `setup` hook (Apple requires the delegate be set before launch completes):
-  - `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` → read `userInfo`, `set_focus()` the main window, `emit("notification-activated", {navType, navTarget})`, call the completion handler.
+Rather than a one-off file, isolate a self-contained module that owns native notification presentation + click routing, with a per-platform backend behind one interface. This serves the committed "extensible to Windows/Linux" goal — the seam is warranted, not speculative — and lets us retire `tauri-plugin-notification` for posting as backends land.
+
+```
+src-tauri/src/notifications/
+  mod.rs       — public surface: Tauri commands, setup() (selects + wires the active
+                 backend, sets it up to emit "notification-activated"), shared types
+                 (NativeNotification, NavTarget, AuthorizationState), and re-exports.
+  backend.rs   — the NotificationBackend trait + shared types (platform-agnostic).
+  macos.rs     — #[cfg(target_os = "macos")] UNUserNotificationCenter backend + delegate.
+  (future) windows.rs, linux.rs
+```
+
+**`NotificationBackend` trait** (the interface every platform implements):
+
+- `post(&self, n: NativeNotification) -> Result<()>`
+- `authorization_state(&self) -> Result<AuthorizationState>`
+- `request_authorization(&self) -> Result<AuthorizationState>`
+- `take_pending_target(&self) -> Option<NavTarget>`
+
+The active backend is selected at compile time in `mod.rs`. macOS is the only concrete backend now; on other platforms the commands are absent (`#[cfg(target_os = "macos")]`) and JS keeps calling `sendNotification` there. A backend is constructed with the `AppHandle` (or an emit closure) so it can emit `notification-activated` and `set_focus()` on click.
+
+**Tauri commands** (thin; dispatch to the active backend), registered under `#[cfg(target_os = "macos")]`:
+
+- `post_notification(title, body, nav_type, nav_target, avatar_path: Option<String>)`
+- `notification_permission_state()`
+- `request_notification_permission()`
+- `take_pending_notification_target()`
+
+**macOS backend (`macos.rs`)** — the concrete `UNUserNotificationCenter` implementation:
+
+- `post` builds a `UNMutableNotificationContent`, sets `userInfo = {navType, navTarget}`, adds a `UNNotificationRequest` (immediate trigger).
+- **Delegate** — an objc2 `define_class!` `NSObject` conforming to `UNUserNotificationCenterDelegate`, assigned as `UNUserNotificationCenter.current().delegate` in the module's `setup()` (called from the Tauri `setup` hook; Apple requires the delegate be set before launch completes):
+  - `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` → read `userInfo`, `set_focus()` the main window, `emit("notification-activated", {navType, navTarget})` (or stash as pending if no webview yet), call the completion handler.
   - `userNotificationCenter:willPresentNotification:withCompletionHandler:` → return `.banner | .list | .sound` so notifications for **background** chats still display while the app is frontmost (the JS layer already decides whether to notify, so the OS should not suppress them).
-- **Authorization** — request UN authorization (alert + sound + badge) once at setup. Expose `notification_permission_state()` and `request_notification_permission()` so the macOS permission UI reflects UN status rather than the legacy plugin's.
-- **Cold-start drain** — if the app was quit and is relaunched by a notification click, the delegate can fire before the webview mounts. Store the pending target in Rust state (e.g. a `Mutex<Option<NavTarget>>`); expose `take_pending_notification_target()` that JS drains on startup. Live events cover the common tray/background-running case; the drain covers cold start. This mirrors the existing deep-link cold-start handling.
+- **Authorization** — request UN authorization (alert + sound + badge) once at setup; `authorization_state`/`request_authorization` back the macOS permission UI so it reflects UN status rather than the legacy plugin's.
+- **Cold-start** — if the app was quit and is relaunched by a notification click, the delegate can fire before the webview mounts. The backend holds the pending target in a `Mutex<Option<NavTarget>>`; `take_pending_target()` drains it. Live events cover the common tray/background-running case; the drain covers cold start, mirroring the existing deep-link handling.
+
+**Promotion path (not now):** if we later want to reuse this outside Fluux, the module can graduate to a standalone `tauri-plugin-*` crate. YAGNI for now — an in-app module is the pragmatic home.
 
 ### JS
 
@@ -82,7 +115,7 @@ The JS routing side is platform-agnostic: it listens for `notification-activated
 
 ## Build order (incremental, de-risks signing early)
 
-1. **Minimal native notification + click event end-to-end** — post a hard-coded notification via UN, delegate emits `notification-activated`, a temporary JS log confirms it. Validates the dev-build signing identity and UN authorization before any real wiring. (App is already signed/notarized for release; this confirms the `tauri dev` identity, which may sign ad-hoc.)
+1. **Module skeleton + minimal native notification + click event end-to-end** — scaffold `notifications/` (`backend.rs` trait, `macos.rs`, `mod.rs` with `setup()`), then post a hard-coded notification via UN, have the delegate emit `notification-activated`, and confirm with a temporary JS log. Validates the dev-build signing identity and UN authorization before any real wiring. (App is already signed/notarized for release; this confirms the `tauri dev` identity, which may sign ad-hoc.)
 2. **Wire real posting + JS routing + cold-start drain** — macOS posting branch, shared `navigateToTarget`, event listener, startup drain.
 3. **Permission-state alignment** — UN-backed `useNotificationPermission` macOS branch + settings UI.
 4. **Avatar attachments** — feature parity.


### PR DESCRIPTION
## Summary

Clicking a macOS desktop notification now navigates to the exact conversation/room it was about — including from a cold start. Previously the click was effectively a no-op: `tauri-plugin-notification`'s `onAction` is mobile-only, so on desktop it rejected with `Command plugin:notification|registerListener not allowed by ACL`, and a click only raised the window onto whatever chat was already open.

## Approach

- **New isolated Rust module** `apps/fluux/src-tauri/src/notifications/` (a `NotificationBackend` trait + a macOS backend) that posts via `UNUserNotificationCenter` (objc2). The nav target is encoded in the notification **identifier** (`"<navType>:<navTarget>"`), which the OS persists — so a click survives a cold start with no in-memory state. Windows/Linux backends can slot in behind the same trait later.
- An objc2 `UNUserNotificationCenterDelegate` captures the click, focuses the window, and emits a `notification-activated` Tauri event. `willPresent` returns banner/list/sound so background-chat notifications still show while the app is focused.
- A JS-driven **readiness flag** gates emit-vs-stash: until the React listener is attached (e.g. cold start, where the delegate fires before the bundle mounts), clicks are stashed and drained on mount; afterwards they emit live.
- The **JS side is platform-agnostic** — it routes the event (and the mobile `onAction` path, now correctly guarded to iOS/Android) through one shared helper. Avatars are attached as `UNNotificationAttachment`.
- macOS permission now flows through `UNUserNotificationCenter` authorization. **Windows/Linux keep `sendNotification`; the web Web-Push/service-worker stack is untouched** — all native code is behind `isTauri`/`isMacOSDesktop`, so the two stacks are mutually exclusive.

## Notes

- **Supersedes #525** — this reimplements that mobile-`onAction` guard, so #525 can be closed if this merges.
- **Needs hands-on macOS verification** (signed dev build): click → right conversation/room, the cold-start path, and the avatar thumbnail. A notification click can't be exercised by automated tests, so this is the one remaining manual check before merge.