### PR TITLE
fix(ux): show grey presence pills while reconnecting, not transparent

### DIFF
--- a/apps/fluux/src/components/Avatar.test.tsx
+++ b/apps/fluux/src/components/Avatar.test.tsx
@@ -101,6 +101,29 @@ describe('Avatar', () => {
       const presenceIndicator = container.querySelector('.rounded-full.border-2.absolute')
       expect(presenceIndicator).not.toBeInTheDocument()
     })
+
+    it('shows a grey (not transparent) pill when forceOffline is true', () => {
+      // While the app is reconnecting, ConversationList passes forceOffline.
+      // The pill must show the offline grey, never a transparent (border-only) pill.
+      const { container } = render(
+        <Avatar identifier="alice" name="Alice" presence="online" forceOffline />
+      )
+      const pill = container.querySelector('.rounded-full.border-2.absolute') as HTMLElement
+      expect(pill).toBeInTheDocument()
+      // Grey comes from the APP_OFFLINE_PRESENCE_COLOR class, not an inline color.
+      expect(pill).toHaveClass('bg-slate-500')
+      // A leftover inline backgroundColor: undefined rendered the pill transparent.
+      expect(pill.style.backgroundColor).toBe('')
+    })
+
+    it('does not grey out the pill when online (not forced offline)', () => {
+      const { container } = render(
+        <Avatar identifier="alice" name="Alice" presence="online" />
+      )
+      const pill = container.querySelector('.rounded-full.border-2.absolute') as HTMLElement
+      expect(pill).toBeInTheDocument()
+      expect(pill).not.toHaveClass('bg-slate-500')
+    })
   })
 
   describe('Sizes', () => {

--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -261,8 +261,12 @@ export function Avatar({
     dnd: 'var(--fluux-presence-dnd)',
     offline: 'var(--fluux-presence-offline)',
   }
-  const presenceBgStyle = resolvedPresence
-    ? { backgroundColor: isOffline ? undefined : PRESENCE_CSS_VARS[resolvedPresence] }
+  // When offline (app reconnecting), let the className path apply the grey
+  // APP_OFFLINE_PRESENCE_COLOR instead of an inline color. A truthy style object
+  // with backgroundColor: undefined would suppress that class and leave the pill
+  // transparent (border-only).
+  const presenceBgStyle = resolvedPresence && !isOffline
+    ? { backgroundColor: PRESENCE_CSS_VARS[resolvedPresence] }
     : undefined
 
   // Track image load errors to fall back to letter display


### PR DESCRIPTION
## Problem

While the app is reconnecting, the presence pills on sidebar avatars rendered **transparent** (border only) instead of grey.

## Fix

Make `presenceBgStyle` falsy when offline so the className path applies the already-computed grey class:

```js
const presenceBgStyle = resolvedPresence && !isOffline
  ? { backgroundColor: PRESENCE_CSS_VARS[resolvedPresence] }
  : undefined
```

The `transition-colors` animation is preserved across the class/inline boundary (background still animates green→grey→green).