### PR TITLE
fix(e2ee): publish XEP-0373 OpenPGP fingerprint in upper-case (#528)

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -90,7 +90,7 @@ import {
   publishVerificationsToServer,
   saveAppliedVerificationsVersion,
 } from './verificationSync'
-import { fingerprintsEqual } from './fingerprintCompare'
+import { fingerprintsEqual, toXep0373Fingerprint } from './fingerprintCompare'
 import {
   clearKeyChangeAlert,
   getKeyChangeAlert,
@@ -130,6 +130,11 @@ const PUBLIC_KEYS_METADATA_NODE = 'urn:xmpp:openpgp:0:public-keys'
 const SECRET_KEY_NODE = 'urn:xmpp:openpgp:0:secret-key'
 const CURRENT_ITEM_ID = 'current'
 
+// Builds a public-key data node id for the fingerprint exactly as given. The
+// PEP node id is case-sensitive, so callers must pass the fingerprint in the
+// case it was advertised: for OUR OWN key, the XEP-0373 §4.1 upper-case wire
+// form (via `toXep0373Fingerprint`); for a PEER's key, the verbatim string the
+// peer published in its `v4`/`v6-fingerprint` metadata.
 function publicKeyDataNodeFor(fingerprint: string): string {
   return `${PUBLIC_KEYS_METADATA_NODE}:${fingerprint}`
 }
@@ -1275,7 +1280,8 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     try {
       dataItems = await ctx.xmpp.queryPEP(
         ctx.account.jid,
-        publicKeyDataNodeFor(bundle.fingerprint),
+        // Query the same upper-case node we publish (XEP-0373 §4.1).
+        publicKeyDataNodeFor(toXep0373Fingerprint(bundle.fingerprint)),
         1,
       )
     } catch {
@@ -1315,7 +1321,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       ],
     }
     await this.publishWithPreconditionHeal(
-      publicKeyDataNodeFor(bundle.fingerprint),
+      publicKeyDataNodeFor(toXep0373Fingerprint(bundle.fingerprint)),
       { id: CURRENT_ITEM_ID, payload },
       { accessModel: 'open', persistItems: true, maxItems: 1 },
     )
@@ -1329,8 +1335,9 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
         {
           name: 'pubkey-metadata',
           attrs: {
-            'v4-fingerprint': bundle.fingerprint,
-            'v6-fingerprint': bundle.fingerprint,
+            // XEP-0373 §4.1: the v4 fingerprint string is upper-case hex.
+            'v4-fingerprint': toXep0373Fingerprint(bundle.fingerprint),
+            'v6-fingerprint': toXep0373Fingerprint(bundle.fingerprint),
             date: new Date().toISOString(),
           },
           children: [],
@@ -1379,7 +1386,8 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
   ): Promise<void> {
     if (oldFingerprint === newFingerprint) return
     const ctx = this.requireCtx()
-    const node = publicKeyDataNodeFor(oldFingerprint)
+    // Retract the node we actually published — the XEP-0373 §4.1 upper-case form.
+    const node = publicKeyDataNodeFor(toXep0373Fingerprint(oldFingerprint))
     try {
       await ctx.xmpp.deletePEP(node)
       ctx.logger.debug(

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -1278,11 +1278,11 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
 
     let dataItems: PEPItem[]
     try {
-      dataItems = await ctx.xmpp.queryPEP(
+      // We publish the upper-case node (XEP-0373 §4.1); query that first, but
+      // stay case-tolerant for a pre-#528 lower-case node not yet re-published.
+      dataItems = await this.queryPublicKeyDataNodeTolerant(
         ctx.account.jid,
-        // Query the same upper-case node we publish (XEP-0373 §4.1).
-        publicKeyDataNodeFor(toXep0373Fingerprint(bundle.fingerprint)),
-        1,
+        toXep0373Fingerprint(bundle.fingerprint),
       )
     } catch {
       clearOwnKeyConflict()
@@ -1457,6 +1457,34 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     }
   }
 
+  /**
+   * Query a public-key data node tolerantly across fingerprint case.
+   *
+   * XEP-0373 §4.1 mandates upper-case, but a peer (or our own pre-#528 nodes)
+   * may have published a data node under a different case than it advertises.
+   * Per Postel's law we accept either: try the fingerprint verbatim first
+   * (the spec-compliant peer hits immediately, no extra round-trip), then the
+   * canonical upper- and lower-case variants. Returns the first non-empty
+   * result, or `[]` if none of the variants resolve.
+   */
+  private async queryPublicKeyDataNodeTolerant(
+    jid: BareJID,
+    fingerprint: string,
+  ): Promise<PEPItem[]> {
+    const ctx = this.requireCtx()
+    const canonical = toXep0373Fingerprint(fingerprint)
+    const variants = [fingerprint, canonical, canonical.toLowerCase()]
+    const tried = new Set<string>()
+    for (const variant of variants) {
+      const node = publicKeyDataNodeFor(variant)
+      if (tried.has(node)) continue
+      tried.add(node)
+      const items = await ctx.xmpp.queryPEP(jid, node, 1)
+      if (items.length > 0) return items
+    }
+    return []
+  }
+
   private async fetchAdvertisedKey(
     peer: BareJID,
     fingerprint: string,
@@ -1465,7 +1493,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     const ctx = this.requireCtx()
     const now = new Date().toISOString()
     try {
-      const items = await ctx.xmpp.queryPEP(peer, publicKeyDataNodeFor(fingerprint), 1)
+      const items = await this.queryPublicKeyDataNodeTolerant(peer, fingerprint)
       for (const item of items) {
         const armored = parsePublicKeyDataItem(item.payload)
         if (!armored) continue

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -20,6 +20,7 @@ import {
   xml,
   type PEPItem,
   type PluginContext,
+  type XMLElementData,
   type XMPPPrimitives,
 } from '@fluux/sdk'
 import { WebOpenPGPPlugin } from './WebOpenPGPPlugin'
@@ -333,6 +334,40 @@ describe('WebOpenPGPPlugin', () => {
       expect(bundle.fingerprint).toMatch(/^[a-f0-9]{40}$/)
       expect(bundle.publicArmored).toContain('BEGIN PGP PUBLIC KEY BLOCK')
       expect(bundle.keychainBacked).toBe(false)
+    })
+
+    it('publishes the own public-key node id and v4/v6-fingerprint in upper-case (XEP-0373 §4.1, issue #528)', async () => {
+      const shared: SharedPep = new Map()
+      setSessionPassphrase('hunter2-strong-passphrase')
+      const plugin = new TestableWebOpenPGPPlugin()
+      // init() → ensureIdentity() generates the key and publishes both PEP nodes.
+      await plugin.init(makeCtxWithWritablePep('alice@example.com', shared).ctx)
+      const bundle = await plugin.callEnsureKeyMaterial('alice@example.com')
+
+      // The internal bundle representation stays lower-case (openpgp.js form);
+      // only the wire form is upper-cased.
+      expect(bundle.fingerprint).toMatch(/^[a-f0-9]{40}$/)
+      const upper = bundle.fingerprint.toUpperCase()
+
+      // Metadata node: v4-fingerprint and v6-fingerprint must be upper-case hex.
+      const metaItems = shared.get(pepKey('alice@example.com', 'urn:xmpp:openpgp:0:public-keys'))
+      expect(metaItems).toBeDefined()
+      const pubkeyMeta = (metaItems![0].payload as XMLElementData).children.find(
+        (c): c is XMLElementData => typeof c !== 'string' && c.name === 'pubkey-metadata',
+      )
+      expect(pubkeyMeta?.attrs['v4-fingerprint']).toBe(upper)
+      expect(pubkeyMeta?.attrs['v6-fingerprint']).toBe(upper)
+      expect(pubkeyMeta?.attrs['v4-fingerprint']).toMatch(/^[A-F0-9]{40}$/)
+
+      // Data node id must use the same upper-case fingerprint, never the lower-case one.
+      expect(
+        shared.has(pepKey('alice@example.com', `urn:xmpp:openpgp:0:public-keys:${upper}`)),
+      ).toBe(true)
+      expect(
+        shared.has(
+          pepKey('alice@example.com', `urn:xmpp:openpgp:0:public-keys:${bundle.fingerprint}`),
+        ),
+      ).toBe(false)
     })
 
     it('does not generate or store a key when the server lacks PEP support', async () => {
@@ -1695,8 +1730,11 @@ describe('WebOpenPGPPlugin', () => {
       expect(result.fingerprint).not.toBe(oldFp2)
 
       // Step 5: the new public key was published — both data and metadata nodes.
+      // The data node id uses the XEP-0373 §4.1 upper-case fingerprint (issue #528).
       const publishedNodes = publishCalls.map((c) => c.node)
-      expect(publishedNodes).toContain(`urn:xmpp:openpgp:0:public-keys:${result.fingerprint}`)
+      expect(publishedNodes).toContain(
+        `urn:xmpp:openpgp:0:public-keys:${result.fingerprint.toUpperCase()}`,
+      )
       expect(publishedNodes).toContain('urn:xmpp:openpgp:0:public-keys')
     })
 

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -1919,6 +1919,46 @@ describe('WebOpenPGPPlugin', () => {
       expect(decrypted.securityContext.notes).toBeUndefined()
     })
 
+    it('resolves a peer that advertises upper-case but published its data node lower-case (#528 tolerance)', async () => {
+      // Postel's law: even though XEP-0373 §4.1 mandates upper-case, a peer may
+      // advertise one case while having published its data node under the
+      // other. We must still find and cache the key.
+      const { shared, alice, bob } = await buildCrossPublishedPair()
+
+      // Re-advertise Bob's fingerprint in UPPER-case while his data node stays
+      // at the lower-case id seeded by publishKeyToSharedPep (the mismatch).
+      const upperFp = bob.bundle.fingerprint.toUpperCase()
+      expect(upperFp).not.toBe(bob.bundle.fingerprint) // sanity: there IS a case difference
+      shared.set(pepKey('bob@example.com', 'urn:xmpp:openpgp:0:public-keys'), [
+        {
+          id: 'current',
+          payload: {
+            name: 'public-keys-list',
+            attrs: { xmlns: 'urn:xmpp:openpgp:0' },
+            children: [
+              {
+                name: 'pubkey-metadata',
+                attrs: { 'v4-fingerprint': upperFp, date: '2024-01-01T00:00:00Z' },
+                children: [],
+              },
+            ],
+          },
+        },
+      ])
+      // Confirm the data node really only exists under the lower-case id.
+      expect(
+        shared.has(pepKey('bob@example.com', `urn:xmpp:openpgp:0:public-keys:${upperFp}`)),
+      ).toBe(false)
+      expect(
+        shared.has(pepKey('bob@example.com', `urn:xmpp:openpgp:0:public-keys:${bob.bundle.fingerprint}`)),
+      ).toBe(true)
+
+      const support = await alice.plugin.probePeer('bob@example.com')
+
+      expect(support.supported).toBe(true)
+      expect(support.fingerprint?.toLowerCase()).toBe(bob.bundle.fingerprint.toLowerCase())
+    })
+
     it('marks trust untrusted when the sender key is not cached at decrypt time', async () => {
       const { alice, bob } = await buildCrossPublishedPair()
 

--- a/apps/fluux/src/e2ee/fingerprintCompare.test.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { fingerprintsEqual, normalizeFingerprint } from './fingerprintCompare'
+import {
+  fingerprintsEqual,
+  normalizeFingerprint,
+  toXep0373Fingerprint,
+} from './fingerprintCompare'
 
 describe('fingerprintCompare', () => {
   it('treats UPPERCASE (Sequoia) and lowercase (openpgp.js) of the same key as equal', () => {
@@ -19,5 +23,22 @@ describe('fingerprintCompare', () => {
 
   it('normalizeFingerprint lower-cases and strips whitespace', () => {
     expect(normalizeFingerprint('AA BB\tCC\nDD')).toBe('aabbccdd')
+  })
+
+  describe('toXep0373Fingerprint', () => {
+    it('upper-cases lowercase (openpgp.js) hex per XEP-0373 §4.1', () => {
+      expect(toXep0373Fingerprint('9e0b9bc6f81e0b27cb74dbdb8dce4320ca12b83e')).toBe(
+        '9E0B9BC6F81E0B27CB74DBDB8DCE4320CA12B83E',
+      )
+    })
+
+    it('strips whitespace separators', () => {
+      expect(toXep0373Fingerprint('9e0b 9bc6\tf81e\n0b27')).toBe('9E0B9BC6F81E0B27')
+    })
+
+    it('is idempotent on already upper-case input (Sequoia)', () => {
+      const upper = 'AABBCCDDEEFF00112233445566778899AABBCCDD'
+      expect(toXep0373Fingerprint(upper)).toBe(upper)
+    })
   })
 })

--- a/apps/fluux/src/e2ee/fingerprintCompare.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.ts
@@ -23,3 +23,17 @@ export function normalizeFingerprint(fingerprint: string): string {
 export function fingerprintsEqual(a: string, b: string): boolean {
   return normalizeFingerprint(a) === normalizeFingerprint(b)
 }
+
+/**
+ * Canonical XEP-0373 wire form: strip whitespace and UPPER-case the hex.
+ *
+ * XEP-0373 §4.1 mandates that the OpenPGP v4 fingerprint string — used both as
+ * the `urn:xmpp:openpgp:0:public-keys:<FINGERPRINT>` data node id and as the
+ * `v4-fingerprint` metadata attribute — is "encoded as a hexadecimal string
+ * using upper case characters". openpgp.js (the web backend) emits lower-case,
+ * so own-key PEP publishing must canonicalise through this helper. Idempotent
+ * for the native Sequoia backend, which already emits upper-case.
+ */
+export function toXep0373Fingerprint(fingerprint: string): string {
+  return fingerprint.replace(/\s+/g, '').toUpperCase()
+}


### PR DESCRIPTION
Fixes #528.

While testing XEP-0373/XEP-0374 interop against DinoX, Fluux was found to publish its OpenPGP public-key PEP nodes with a **lower-case** fingerprint. XEP-0373 §4.1 requires the v4 fingerprint string — used both as the `urn:xmpp:openpgp:0:public-keys:<FINGERPRINT>` data-node id and as the `v4-fingerprint` metadata attribute — to be "encoded as a hexadecimal string using upper case characters". A spec-strict client querying the upper-case node never finds a key published under the lower-case node.

## Fix

**Publish upper-case (compliance).** New `toXep0373Fingerprint()` wire-form helper (strip whitespace + upper-case), applied at the four own-key PEP sites in the shared `OpenPGPPluginBase`: the published data-node id, the `v4`/`v6-fingerprint` attributes, the own-key consistency query, and the stale-node retract. One change fixes both the Web and Sequoia backends and is idempotent for Sequoia.

**Read tolerantly (Postel's law).** A peer (or our own pre-fix nodes) may advertise one case while having published the data node under the other. Data-node reads now go through `queryPublicKeyDataNodeTolerant`, which tries the fingerprint verbatim first (a spec-compliant peer hits immediately, no extra round-trip) then the canonical upper- and lower-case variants. Applied to both the peer fetch and the own-key consistency check. The served key is still validated against the advertised fingerprint (case-insensitively) and the expected UID, so accepting either case is no trust regression. This mirrors the lower-case fallback DinoX already added.