### PR TITLE
feat(desktop): single-instance guard focuses running window on relaunch

### DIFF
--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1783,6 +1783,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
@@ -3370,7 +3371,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3463,7 +3464,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3912,7 +3913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4848,7 +4849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4907,7 +4908,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5547,7 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6166,6 +6167,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus 5.15.0",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6335,7 +6352,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6354,7 +6371,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6806,7 +6823,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6871,7 +6888,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7444,7 +7461,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -68,6 +68,14 @@ unicode-normalization = "0.1"
 # Updater plugin for auto-updates (desktop only)
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
+# Single-instance guard (desktop only). On Linux a second launch must focus the
+# already-running window instead of spawning a duplicate; the plugin acquires a
+# per-app lock (D-Bus name on Linux, named mutex on Windows) and forwards the new
+# process's argv to the live instance's callback. The `deep-link` feature routes
+# an `xmpp:` URL opened while Fluux is running into the existing window rather
+# than starting a second copy. macOS already enforces single-instance for the
+# app bundle natively, so the plugin is effectively a no-op there.
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 serde_json = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
 reqwest = { version = "0.13", features = ["blocking"] }

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1234,6 +1234,20 @@ fn main() {
     let graceful_shutdown_flag_for_run = graceful_shutdown_started.clone();
 
     let app = tauri::Builder::default()
+        // Single-instance guard MUST be the first plugin registered (Tauri
+        // requirement). When a second copy of Fluux is launched, the OS lock is
+        // already held, so the new process hands its argv to this callback and
+        // exits instead of opening a duplicate window. We restore the live
+        // window: unminimize, then show (Linux closes to the system tray, so the
+        // window may be hidden), re-clamp it on-screen, and focus it.
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.unminimize();
+                let _ = window.show();
+                ensure_window_visible(&window);
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())


### PR DESCRIPTION
Launching a second copy of Fluux on Linux (and Windows) opened a duplicate window. This registers `tauri-plugin-single-instance` so a relaunch focuses the already-running window instead.

## How it works
- The plugin is registered as the **first** plugin in the builder (Tauri requirement). The first instance holds an OS-level lock (D-Bus name on Linux, named mutex on Windows). A second launch finds the lock held, hands its `argv` to the live instance's callback, and exits immediately.
- The callback restores the existing `"main"` window: `unminimize()` → `show()` (Linux closes to the system tray, so the window may be hidden) → `ensure_window_visible()` (re-clamp on-screen) → `set_focus()`, reusing the same helpers already used at launch.

## Scope
- **Linux + Windows**: where this actually matters; both supported by the plugin.
- **macOS**: the OS already enforces single-instance for a bundled `.app`, so the plugin is effectively a no-op there. It builds in the desktop-only dependency block alongside the updater plugin.
- The `deep-link` feature on the plugin routes an `xmpp:` URL opened while Fluux is running into the existing window rather than spawning a second copy, complementing the existing deep-link registration.