### PR TITLE
fix(mam): close MUC + 1:1 history-gap catch-up holes (silent gaps, recovery, parity)

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -42,7 +42,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -450,6 +450,9 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
           onScrollToTop={fetchOlderHistory}
           isLoadingOlder={activeMAMState?.isLoading ?? false}
           isHistoryComplete={activeMAMState?.isHistoryComplete ?? false}
+          forwardGapTimestamp={activeMAMState?.forwardGapTimestamp}
+          onCatchUpHistory={continueChatCatchUp}
+          isCatchingUp={activeMAMState?.isLoading ?? false}
           // SDK auto-fetches cache + MAM in background, no blocking spinner needed
           isInitialLoading={false}
           highlightTerms={find.highlightTerms}
@@ -543,6 +546,9 @@ export const ChatMessageList = memo(function ChatMessageList({
   highlightTerms,
   currentMatchId,
   lastSentMessageId,
+  forwardGapTimestamp,
+  onCatchUpHistory,
+  isCatchingUp,
 }: {
   messages: Message[]
   contactsByJid: Map<string, ContactIdentity>
@@ -580,6 +586,9 @@ export const ChatMessageList = memo(function ChatMessageList({
   highlightTerms?: string[]
   currentMatchId?: string
   lastSentMessageId?: string | null
+  forwardGapTimestamp?: number
+  onCatchUpHistory?: () => void
+  isCatchingUp?: boolean
 }) {
   const { t } = useTranslation()
   const { formatTime, effectiveTimeFormat } = useTimeFormat()
@@ -648,6 +657,9 @@ export const ChatMessageList = memo(function ChatMessageList({
       onScrollToTop={onScrollToTop}
       isLoadingOlder={isLoadingOlder}
       isHistoryComplete={isHistoryComplete}
+      forwardGapTimestamp={forwardGapTimestamp}
+      onCatchUpHistory={onCatchUpHistory}
+      isCatchingUp={isCatchingUp}
       isLoading={isInitialLoading}
       loadingState={
         <div className="flex-1 flex items-center justify-center text-fluux-muted">

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -386,9 +386,9 @@ export function createStoreBindings(
     stores.room.setRoomMAMError(roomJid, error)
   })
 
-  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction }) => {
+  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker }) => {
     const stores = getStores()
-    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction)
+    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker)
   })
 
   on('room:members', ({ roomJid, members }) => {

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -391,8 +391,10 @@ describe('setupBackgroundSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(10_000)
 
       expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(1)
+      // Must pass the session-start time so the forward cursor excludes live
+      // messages that arrive during the 10s catch-up window (silent-gap fix).
       expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledWith(
-        expect.objectContaining({ concurrency: 2 })
+        expect.objectContaining({ concurrency: 2, sessionStartTime: expect.any(Number) })
       )
     })
 

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -486,6 +486,73 @@ describe('setupBackgroundSyncSideEffects', () => {
     })
   })
 
+  describe('late MAM-ready room retry (issue D)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      roomStore.getState().setActiveRoom(null)
+      roomStore.getState().reset()
+    })
+
+    const addRoom = (jid: string, supportsMAM: boolean) =>
+      roomStore.getState().addRoom({
+        jid, name: jid, nickname: 'me', joined: true, isBookmarked: true, supportsMAM,
+        occupants: new Map(), messages: [], unreadCount: 0, mentionsCount: 0, typingUsers: new Set(),
+      })
+
+    it('catches up a non-active room whose MAM support resolves AFTER the initial 10s pass', async () => {
+      addRoom('late@conference.example.com', false) // disco not resolved at pass time
+      connectionStore.getState().setServerInfo({ identities: [], domain: 'example.com', features: [NS_MAM] })
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+      simulateFreshSession(mockClient)
+
+      // Initial 10s pass — room is not MAM-ready, so it's not covered and not retried yet.
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+
+      // Disco resolves AFTER the pass → late retry fires for this room.
+      roomStore.getState().updateRoom('late@conference.example.com', { supportsMAM: true })
+
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledWith('late@conference.example.com', expect.any(Number))
+      })
+    })
+
+    it('does not retry the ACTIVE room (handled by roomSideEffects) when its MAM resolves late', async () => {
+      addRoom('active@conference.example.com', false)
+      roomStore.getState().setActiveRoom('active@conference.example.com')
+      connectionStore.getState().setServerInfo({ identities: [], domain: 'example.com', features: [NS_MAM] })
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+      simulateFreshSession(mockClient)
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      roomStore.getState().updateRoom('active@conference.example.com', { supportsMAM: true })
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalledWith('active@conference.example.com', expect.anything())
+    })
+
+    it('does not retry before the initial pass (the pass will cover it)', async () => {
+      addRoom('early@conference.example.com', false)
+      connectionStore.getState().setServerInfo({ identities: [], domain: 'example.com', features: [NS_MAM] })
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+      simulateFreshSession(mockClient)
+
+      // MAM resolves BEFORE the 10s pass — covered by catchUpAllRooms, not the watcher.
+      await vi.advanceTimersByTimeAsync(2_000)
+      roomStore.getState().updateRoom('early@conference.example.com', { supportsMAM: true })
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+    })
+  })
+
   describe('room member discovery (Stage 5)', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -84,6 +84,11 @@ describe('setupBackgroundSyncSideEffects', () => {
       await vi.waitFor(() => {
         expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
+      // Must pass sessionStartTime so the 1:1 forward cursor excludes live messages
+      // that arrive during catch-up (parity with rooms / Bug A).
+      expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionStartTime: expect.any(Number) })
+      )
     })
 
     it('should defer catch-up to serverInfo discovery when MAM not immediately available', async () => {

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -55,6 +55,10 @@ export function setupBackgroundSyncSideEffects(
   let isFreshSession = false
   // Timer for delayed room catch-up (cleared on cleanup or disconnect)
   let roomCatchUpTimer: ReturnType<typeof setTimeout> | undefined
+  // Epoch ms of the current fresh session's connection. Used as the forward
+  // catch-up cursor boundary so live messages arriving during the 10s room
+  // catch-up window can't poison the cursor and silently skip the offline gap.
+  let sessionStartTime: number | undefined
 
   // --- E2EE capability warm-up ---
 
@@ -193,7 +197,7 @@ export function setupBackgroundSyncSideEffects(
       void (async () => {
         try {
           logInfo('Background sync: room catch-up (delayed 10s)')
-          await client.mam.catchUpAllRooms({ concurrency: 2, exclude: activeRoomJid })
+          await client.mam.catchUpAllRooms({ concurrency: 2, exclude: activeRoomJid, sessionStartTime })
         } catch {
           // Silently ignore MAM catch-up errors
         }
@@ -223,6 +227,7 @@ export function setupBackgroundSyncSideEffects(
   const unsubscribeOnline = client.on('online', () => {
     backgroundSyncDone = false
     isFreshSession = true
+    sessionStartTime = Date.now()
 
     logInfo('Background sync: fresh session — checking MAM support')
 

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -60,6 +60,20 @@ export function setupBackgroundSyncSideEffects(
   // catch-up window can't poison the cursor and silently skip the offline gap.
   let sessionStartTime: number | undefined
 
+  // --- Late-MAM room retry (issue D) ---
+  // A room whose disco resolves supportsMAM AFTER the single 10s catch-up pass
+  // was previously dropped with no retry (only the ACTIVE room has a supportsMAM
+  // watcher in roomSideEffects). We track rooms already handled this session and,
+  // once the initial pass has run, catch up any non-active room that becomes
+  // MAM-ready afterwards.
+  const mamHandledRooms = new Set<string>()
+  let initialRoomPassDone = false
+
+  function resetRoomRetryState(): void {
+    mamHandledRooms.clear()
+    initialRoomPassDone = false
+  }
+
   // --- E2EE capability warm-up ---
 
   /**
@@ -201,6 +215,13 @@ export function setupBackgroundSyncSideEffects(
         } catch {
           // Silently ignore MAM catch-up errors
         }
+        // Record every room covered by this pass (MAM-ready now, plus the active
+        // room handled by roomSideEffects) so the late-MAM watcher only retries
+        // rooms whose support resolves AFTER this point (issue D).
+        for (const room of roomStore.getState().joinedRooms()) {
+          if (room.supportsMAM || room.jid === activeRoomJid) mamHandledRooms.add(room.jid)
+        }
+        initialRoomPassDone = true
         // Stage 5: Room member discovery (sequential, gentle on server)
         try {
           const joinedRooms = roomStore.getState().joinedRooms()
@@ -228,6 +249,7 @@ export function setupBackgroundSyncSideEffects(
     backgroundSyncDone = false
     isFreshSession = true
     sessionStartTime = Date.now()
+    resetRoomRetryState()
 
     logInfo('Background sync: fresh session — checking MAM support')
 
@@ -261,12 +283,41 @@ export function setupBackgroundSyncSideEffects(
     (status) => {
       if (status !== 'online' && previousStatus === 'online') {
         isFreshSession = false
+        resetRoomRetryState()
         if (roomCatchUpTimer) {
           clearTimeout(roomCatchUpTimer)
           roomCatchUpTimer = undefined
         }
       }
       previousStatus = status
+    }
+  )
+
+  // Late-MAM room retry (issue D): catch up a non-active room whose disco resolves
+  // supportsMAM AFTER the initial 10s pass. Keyed on the set of MAM-ready, joined,
+  // non-Quick-Chat room JIDs so it only fires when that set actually changes.
+  const unsubscribeRoomMAM = roomStore.subscribe(
+    (state) =>
+      [...state.rooms.values()]
+        .filter((r) => r.supportsMAM && r.joined && !r.isQuickChat)
+        .map((r) => r.jid)
+        .sort()
+        .join(','),
+    () => {
+      // Only retry after the initial pass; before it, the pass will cover them.
+      if (!initialRoomPassDone || !isFreshSession) return
+      if (!client.isConnected()) return
+
+      const activeRoomJid = roomStore.getState().activeRoomJid
+      for (const room of roomStore.getState().joinedRooms()) {
+        if (!room.supportsMAM || room.isQuickChat) continue
+        if (mamHandledRooms.has(room.jid)) continue
+        mamHandledRooms.add(room.jid)
+        // The active room is handled by roomSideEffects' own supportsMAM watcher.
+        if (room.jid === activeRoomJid) continue
+        logInfo(`Background sync: late MAM-ready room — catching up ${room.jid}`)
+        void client.mam.catchUpRoom(room.jid, sessionStartTime)
+      }
     }
   )
 
@@ -314,6 +365,7 @@ export function setupBackgroundSyncSideEffects(
     unsubscribeResumed()
     unsubscribeConnection()
     unsubscribeServerInfo()
+    unsubscribeRoomMAM()
     unsubscribePluginRegistered()
     unsubscribeKeyUnlocked()
     if (roomCatchUpTimer) {

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -171,7 +171,7 @@ export function setupBackgroundSyncSideEffects(
       try {
         // Stage 1: Conversation catch-up (skip active — handled by chatSideEffects)
         logInfo('Background sync: conversation catch-up')
-        await client.mam.catchUpAllConversations({ concurrency: 2, exclude: activeConversationId })
+        await client.mam.catchUpAllConversations({ concurrency: 2, exclude: activeConversationId, sessionStartTime })
 
         // Stage 2: Roster discovery (hourly cooldown)
         if (shouldDiscoverRoster()) {

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -17,8 +17,7 @@ import { NS_MAM } from './namespaces'
 import { logInfo } from './logger'
 import { getDomain } from './jid'
 import {
-  findNewestMessage,
-  buildCatchUpStartTime,
+  selectCatchUpQuery,
   isConnectionError,
   MAM_CACHE_LOAD_LIMIT,
 } from '../utils/mamCatchUpUtils'
@@ -50,6 +49,11 @@ export function setupChatSideEffects(
 
   // Track whether we've initiated a fetch for each conversation
   const fetchInitiated = new Set<string>()
+
+  // Epoch ms of the current fresh session's connection (set on 'online'). Forward
+  // catch-up cursor excludes messages received this session so a live message
+  // can't poison it and silently skip the offline gap (parity with rooms / Bug A).
+  let sessionStartTime: number | undefined
 
   /**
    * Triggers MAM fetch for the active conversation if needed.
@@ -97,14 +101,11 @@ export function setupChatSideEffects(
 
       // Re-read messages after cache load (store was mutated)
       const cachedMessages = chatStore.getState().messages.get(conversationId) || []
-      const newestMessage = findNewestMessage(cachedMessages)
 
-      const queryOptions: { with: string; start?: string } = { with: conversation.id }
-      if (newestMessage?.timestamp) {
-        queryOptions.start = buildCatchUpStartTime(newestMessage.timestamp)
-      }
-
-      await client.chat.queryMAM(queryOptions)
+      // Shared cursor policy (same as rooms): forward from the newest pre-session
+      // message, else fetch latest.
+      const q = selectCatchUpQuery(cachedMessages, sessionStartTime)
+      await client.chat.queryMAM({ with: conversation.id, ...q })
       logInfo('Chat: MAM sync complete')
     } catch (error) {
       // Allow retry on next conversation switch or reconnect
@@ -168,6 +169,7 @@ export function setupChatSideEffects(
   // 'online' fires only on fresh sessions (not SM resumption).
   const unsubscribeOnline = client.on('online', () => {
     isFreshSession = true
+    sessionStartTime = Date.now()
 
     const activeConversationId = chatStore.getState().activeConversationId
     if (activeConversationId) {

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -20,6 +20,7 @@ import {
   selectCatchUpQuery,
   isConnectionError,
   MAM_CACHE_LOAD_LIMIT,
+  MAM_ROOM_FORWARD_MAX_PAGES,
 } from '../utils/mamCatchUpUtils'
 
 /**
@@ -103,9 +104,14 @@ export function setupChatSideEffects(
       const cachedMessages = chatStore.getState().messages.get(conversationId) || []
 
       // Shared cursor policy (same as rooms): forward from the newest pre-session
-      // message, else fetch latest.
+      // message, else fetch latest. Forward catch-up paginates oldest-first to
+      // completion (maxAutoPages), matching rooms.
       const q = selectCatchUpQuery(cachedMessages, sessionStartTime)
-      await client.chat.queryMAM({ with: conversation.id, ...q })
+      await client.chat.queryMAM({
+        with: conversation.id,
+        ...q,
+        ...(q.start ? { maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES } : {}),
+      })
       logInfo('Chat: MAM sync complete')
     } catch (error) {
       // Allow retry on next conversation switch or reconnect

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -426,6 +426,31 @@ describe('MAM Background Catch-Up', () => {
     })
   })
 
+    it('uses the newest PRE-session message as the forward cursor, ignoring a live message (1:1 parity)', async () => {
+      await connectClient()
+
+      const monthOld = new Date('2026-05-14T09:00:00.000Z')
+      const liveThisSession = new Date('2026-06-14T12:00:05.000Z')
+      const sessionStartTime = new Date('2026-06-14T12:00:00.000Z').getTime()
+
+      const messages = [
+        { type: 'chat' as const, id: 'old', conversationId: 'alice@example.com', from: 'alice@example.com', body: 'old', timestamp: monthOld, isOutgoing: false, isDelayed: false },
+        { type: 'chat' as const, id: 'live', conversationId: 'alice@example.com', from: 'alice@example.com', body: 'live', timestamp: liveThisSession, isOutgoing: false, isDelayed: false },
+      ]
+      vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime })
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        with: 'alice@example.com',
+        start: '2026-05-14T09:00:00.001Z', // monthOld + 1ms — NOT liveThisSession + 1ms
+      }))
+    })
+
   describe('catchUpAllRooms', () => {
     it('should do nothing when there are no joined rooms', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -836,6 +836,43 @@ describe('MAM Background Catch-Up', () => {
       expect(callCount).toBeGreaterThanOrEqual(2)
     })
 
+    it('defaults to a 45-day repair window', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
+        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
+      ] as any)
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
+
+      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('console:event', {
+        message: 'Force catch-up for 1 room(s) from last 45 days',
+        category: 'sm',
+      })
+    })
+
+    it('sets preserveGapMarker so the bounded repair never hides a real gap marker', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
+        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
+      ] as any)
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
+
+      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:mam-messages', expect.objectContaining({
+        preserveGapMarker: true,
+      }))
+    })
+
     it('should emit console event with room count and days', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -651,6 +651,67 @@ describe('MAM Background Catch-Up', () => {
       })
     })
 
+    it('uses the newest PRE-session message as the forward cursor, ignoring a live message from this session', async () => {
+      // Regression for the silent month-long gap: a MUC-only user opens the app
+      // after a month. The cache ends a month ago; a live message lands in the
+      // catch-up window. The forward cursor must be the month-old message, NOT
+      // the live one — otherwise the query starts from "now", returns nothing,
+      // completes, and silently skips the entire offline gap.
+      await connectClient()
+
+      const monthOld = new Date('2026-05-14T09:00:00.000Z')
+      const liveThisSession = new Date('2026-06-14T12:00:05.000Z')
+      const sessionStartTime = new Date('2026-06-14T12:00:00.000Z').getTime()
+
+      const roomMessages = [
+        { type: 'groupchat', id: 'old', roomJid: 'room1@conference.example.com', from: 'room1@conference.example.com/a', body: 'old', timestamp: monthOld, isOutgoing: false, isDelayed: false },
+        { type: 'groupchat', id: 'live', roomJid: 'room1@conference.example.com', from: 'room1@conference.example.com/b', body: 'live', timestamp: liveThisSession, isOutgoing: false, isDelayed: false },
+      ]
+      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
+        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, nickname: 'me', messages: roomMessages },
+      ] as any)
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({
+        jid: 'room1@conference.example.com', nickname: 'me', messages: roomMessages,
+      } as any)
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.catchUpAllRooms({ sessionStartTime })
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        roomJid: 'room1@conference.example.com',
+        start: '2026-05-14T09:00:00.001Z', // monthOld + 1ms — NOT liveThisSession + 1ms
+      }))
+    })
+
+    it('falls back to the global newest message when no sessionStartTime is given (backward compat)', async () => {
+      await connectClient()
+
+      const newest = new Date('2026-01-20T10:00:00.000Z')
+      const roomMessages = [
+        { type: 'groupchat', id: 'm1', roomJid: 'room1@conference.example.com', from: 'room1@conference.example.com/a', body: 'hi', timestamp: newest, isOutgoing: false, isDelayed: false },
+      ]
+      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
+        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, nickname: 'me', messages: roomMessages },
+      ] as any)
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({
+        jid: 'room1@conference.example.com', nickname: 'me', messages: roomMessages,
+      } as any)
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        roomJid: 'room1@conference.example.com',
+        start: '2026-01-20T10:00:00.001Z',
+      }))
+    })
+
     it('should skip excluded room', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -959,6 +959,29 @@ describe('MAM Background Catch-Up', () => {
     })
   })
 
+  describe('forward catch-up gap logging (1:1)', () => {
+    it('emits a console event when a 1:1 forward catch-up ends incomplete (a gap remains)', async () => {
+      await connectClient()
+
+      // complete=false, no rsm cursor → forward pagination stops with isComplete=false
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(false))
+
+      const queryPromise = xmppClient.mam.queryArchive({
+        with: 'alice@example.com',
+        start: '2026-05-01T00:00:00.000Z',
+        max: 100,
+        maxAutoPages: 50, // opt into forward pagination
+      })
+      await waitForAsyncOps(20, 100)
+      await queryPromise
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('console:event', expect.objectContaining({
+        message: expect.stringContaining('incomplete'),
+        category: 'sm',
+      }))
+    })
+  })
+
   describe('forward catch-up gap logging', () => {
     it('emits a console event when a forward catch-up ends incomplete (a gap remains)', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -426,6 +426,26 @@ describe('MAM Background Catch-Up', () => {
     })
   })
 
+    it('opts into forward auto-pagination (oldest-first to completion) for the catch-up — parity with rooms', async () => {
+      await connectClient()
+
+      const messages = [
+        { type: 'chat' as const, id: 'm1', conversationId: 'alice@example.com', from: 'alice@example.com', body: 'hi', timestamp: new Date('2026-05-14T09:00:00.000Z'), isOutgoing: false, isDelayed: false },
+      ]
+      vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        with: 'alice@example.com',
+        maxAutoPages: expect.any(Number),
+      }))
+    })
+
     it('uses the newest PRE-session message as the forward cursor, ignoring a live message (1:1 parity)', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -14,6 +14,7 @@ import {
   type MockXmppClient,
   type MockStoreBindings,
 } from '../test-utils'
+import { MAM_ROOM_FORWARD_MAX_PAGES_MANUAL } from '../../utils/mamCatchUpUtils'
 
 let mockXmppClientInstance: MockXmppClient
 
@@ -855,6 +856,25 @@ describe('MAM Background Catch-Up', () => {
       })
     })
 
+    it('paginates with the manual cap so the repair can fill large gaps to completion', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
+        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
+      ] as any)
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.forceCatchUpAllRooms()
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
+      }))
+    })
+
     it('sets preserveGapMarker so the bounded repair never hides a real gap marker', async () => {
       await connectClient()
 
@@ -891,6 +911,48 @@ describe('MAM Background Catch-Up', () => {
         message: 'Force catch-up for 1 room(s) from last 3 days',
         category: 'sm',
       })
+    })
+  })
+
+  describe('forward catch-up gap logging', () => {
+    it('emits a console event when a forward catch-up ends incomplete (a gap remains)', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
+      // complete=false, no rsm cursor → forward pagination stops with isComplete=false
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(false))
+
+      const queryPromise = xmppClient.mam.queryRoomArchive({
+        roomJid: 'room1@conference.example.com',
+        start: '2026-05-01T00:00:00.000Z',
+        max: 100,
+      })
+      await waitForAsyncOps(20, 100)
+      await queryPromise
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('console:event', expect.objectContaining({
+        message: expect.stringContaining('incomplete'),
+        category: 'sm',
+      }))
+    })
+
+    it('does NOT emit the incomplete-gap event when the forward catch-up completes', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.room.getRoom).mockReturnValue({ nickname: 'me' } as any)
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse(true))
+
+      const queryPromise = xmppClient.mam.queryRoomArchive({
+        roomJid: 'room1@conference.example.com',
+        start: '2026-05-01T00:00:00.000Z',
+        max: 100,
+      })
+      await waitForAsyncOps(20, 100)
+      await queryPromise
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('console:event', expect.objectContaining({
+        message: expect.stringContaining('incomplete'),
+      }))
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -175,16 +175,24 @@ export class MAM extends BaseModule {
    * @returns Query result with messages, completion status, and pagination info
    */
   async queryArchive(options: MAMQueryOptions): Promise<MAMResult> {
-    const { with: withJid, max = 50, before = '', start, end } = options
+    const { with: withJid, max = 50, before = '', start, end, maxAutoPages: maxAutoPagesOpt } = options
     const conversationId = getBareJid(withJid)
     const mamStart = Date.now()
 
+    // Opt-in forward catch-up: paginate OLDEST-first via the `after` cursor to
+    // completion (parity with rooms). Only when a caller explicitly passes
+    // maxAutoPages alongside `start`; every other caller keeps the default
+    // single-page, newest-first, skip-non-displayable behavior.
+    const isForwardPaginate = !!start && maxAutoPagesOpt !== undefined && maxAutoPagesOpt > 0
+
     // Track total messages across automatic pagination
     const allMessages: Message[] = []
-    let currentBefore = before
+    // Forward pagination ignores `before` (oldest-first from `start`); backward keeps it.
+    let currentBefore = isForwardPaginate ? undefined : before
+    let currentAfter: string | undefined
     let isComplete = false
     let lastRsm: RSMResponse = {}
-    const maxAutoPages = 5 // Limit automatic pagination to avoid infinite loops
+    const maxAutoPages = isForwardPaginate ? maxAutoPagesOpt : 5 // cap to avoid infinite loops
 
     this.deps.emitSDK('chat:mam-loading', { conversationId, isLoading: true })
 
@@ -206,7 +214,7 @@ export class MAM extends BaseModule {
           formFields.push(xml('field', { var: 'end' }, xml('value', {}, end)))
         }
 
-        const iq = this.buildMAMQuery(queryId, formFields, max, currentBefore)
+        const iq = this.buildMAMQuery(queryId, formFields, max, currentBefore, undefined, currentAfter)
 
         const collectedMessages: Message[] = []
         const modifications: MAMModifications = { retractions: [], corrections: [], fastenings: [], reactions: [] }
@@ -259,22 +267,31 @@ export class MAM extends BaseModule {
           isComplete = complete
           lastRsm = rsm
 
-          // If we got displayable messages or archive is complete, stop paginating
-          if (collectedMessages.length > 0 || complete) {
-            break
-          }
-
-          // No displayable messages but archive has more - continue with next page
-          // Use the 'first' ID as the 'before' cursor for backward pagination
-          if (rsm.first) {
-            currentBefore = rsm.first
-            this.deps.emitSDK('console:event', {
-              message: `Page ${page + 1} had no displayable messages, fetching older...`,
-              category: 'sm',
-            })
+          if (isForwardPaginate) {
+            // Forward catch-up: accumulate every page, advance via `after` until complete.
+            if (complete) break
+            if (rsm.last) {
+              currentAfter = rsm.last
+            } else {
+              break
+            }
           } else {
-            // No pagination cursor available, stop
-            break
+            // If we got displayable messages or archive is complete, stop paginating
+            if (collectedMessages.length > 0 || complete) {
+              break
+            }
+            // No displayable messages but archive has more - continue with next page
+            // Use the 'first' ID as the 'before' cursor for backward pagination
+            if (rsm.first) {
+              currentBefore = rsm.first
+              this.deps.emitSDK('console:event', {
+                message: `Page ${page + 1} had no displayable messages, fetching older...`,
+                category: 'sm',
+              })
+            } else {
+              // No pagination cursor available, stop
+              break
+            }
           }
         } finally {
           unregister()
@@ -295,6 +312,16 @@ export class MAM extends BaseModule {
         complete: isComplete,
         direction,
       })
+
+      // Surface unresolved gaps for diagnosis (parity with rooms): a forward
+      // catch-up that ends without reaching live means a hole remains.
+      if (isForwardPaginate && !isComplete) {
+        this.deps.emitSDK('console:event', {
+          message: `Conversation catch-up incomplete for ${conversationId} — gap remains after ${allMessages.length} msg(s)`,
+          category: 'sm',
+        })
+      }
+
       return { messages: allMessages, complete: isComplete, rsm: lastRsm }
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error'
@@ -893,12 +920,14 @@ export class MAM extends BaseModule {
           const messages = updatedConv?.messages || conv.messages || []
 
           // Shared cursor policy (same as rooms) — forward from the newest
-          // pre-session message, else fetch latest.
+          // pre-session message, else fetch latest. Forward catch-up paginates
+          // oldest-first to completion (maxAutoPages), matching rooms.
           const q = selectCatchUpQuery(messages, sessionStartTime)
           await this.queryArchive({
             with: conv.id,
             ...q,
             max: q.start ? MAM_CATCHUP_FORWARD_MAX : MAM_CATCHUP_BACKWARD_MAX,
+            ...(q.start ? { maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES } : {}),
           })
         } catch (_error) {
           // Silently ignore — individual failures shouldn't affect others

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -35,6 +35,7 @@ import { executeWithConcurrency } from '../../utils/concurrencyUtils'
 import { parseRSMResponse } from '../../utils/rsm'
 import {
   findNewestMessage,
+  findCatchUpCursorMessage,
   buildCatchUpStartTime,
   isConnectionError,
   MAM_CATCHUP_FORWARD_MAX,
@@ -985,9 +986,13 @@ export class MAM extends BaseModule {
    * @param options - Optional configuration
    * @param options.concurrency - Maximum parallel requests (default: 2)
    * @param options.exclude - Room JID to skip (e.g., the active room already handled by side effects)
+   * @param options.sessionStartTime - Epoch ms when the current session connected. When
+   *   provided, the forward cursor is the newest message *before* this time, so a live
+   *   message arriving during the catch-up window can't poison the cursor and silently
+   *   skip the offline gap. Omit to fall back to the global newest message.
    */
-  async catchUpAllRooms(options: { concurrency?: number; exclude?: string | null } = {}): Promise<void> {
-    const { concurrency = 2, exclude } = options
+  async catchUpAllRooms(options: { concurrency?: number; exclude?: string | null; sessionStartTime?: number } = {}): Promise<void> {
+    const { concurrency = 2, exclude, sessionStartTime } = options
     const joinedRooms = this.deps.stores?.room.joinedRooms() || []
 
     // Filter for MAM-enabled, non-Quick Chat rooms (and exclude active room if specified)
@@ -1016,17 +1021,23 @@ export class MAM extends BaseModule {
           // Re-read room after cache load (store was mutated)
           const updatedRoom = this.deps.stores?.room.getRoom(room.jid)
           const messages = updatedRoom?.messages || []
-          const newestMessage = findNewestMessage(messages)
+          // Use the newest PRE-session message as the forward cursor so a live
+          // message arriving during the catch-up window can't push the cursor to
+          // "now" and silently skip the offline gap. Falls back to the global
+          // newest when the session start is unknown.
+          const cursorMessage = sessionStartTime !== undefined
+            ? findCatchUpCursorMessage(messages, sessionStartTime)
+            : findNewestMessage(messages)
 
-          if (newestMessage?.timestamp) {
-            // Forward query from the last known message
+          if (cursorMessage?.timestamp) {
+            // Forward query from the last known contiguous message
             await this.queryRoomArchive({
               roomJid: room.jid,
-              start: buildCatchUpStartTime(newestMessage.timestamp),
+              start: buildCatchUpStartTime(cursorMessage.timestamp),
               max: MAM_CATCHUP_FORWARD_MAX,
             })
           } else {
-            // No messages (empty) — fetch latest from MAM
+            // No pre-session messages — fetch latest from MAM
             await this.queryRoomArchive({
               roomJid: room.jid,
               before: '',

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1045,26 +1045,7 @@ export class MAM extends BaseModule {
       mamRooms,
       async (room) => {
         try {
-          if (this.deps.stores?.connection.getStatus() !== 'online') return
-
-          // Load IndexedDB cache first so we know the newest cached message
-          // and can do a proper forward catch-up instead of fetching only latest.
-          // Without this, room.messages is empty after app restart (runtime-only),
-          // causing a backward "before:''" query that creates gaps with old cache.
-          await this.deps.stores?.room.loadMessagesFromCache(room.jid, { limit: MAM_CACHE_LOAD_LIMIT })
-
-          // Re-read room after cache load (store was mutated)
-          const updatedRoom = this.deps.stores?.room.getRoom(room.jid)
-          const messages = updatedRoom?.messages || []
-          // Shared cursor policy: forward from the newest pre-session message
-          // (so a live message in the catch-up window can't poison the cursor),
-          // else fetch latest.
-          const q = selectCatchUpQuery(messages, sessionStartTime)
-          await this.queryRoomArchive({
-            roomJid: room.jid,
-            ...q,
-            max: q.start ? MAM_CATCHUP_FORWARD_MAX : MAM_CATCHUP_BACKWARD_MAX,
-          })
+          await this.catchUpRoom(room.jid, sessionStartTime)
         } catch (_error) {
           // Silently ignore — individual failures shouldn't affect others
         }
@@ -1073,6 +1054,40 @@ export class MAM extends BaseModule {
     )
 
     logInfo(`Background catch-up for ${mamRooms.length} room(s) — complete`)
+  }
+
+  /**
+   * Forward catch-up for a single joined room (cache-aware, shared cursor policy).
+   *
+   * Extracted so both the bulk `catchUpAllRooms()` pass and the late-MAM retry
+   * (a room whose disco resolves `supportsMAM` AFTER the initial background pass)
+   * use identical logic. The caller is responsible for filtering (joined, MAM,
+   * non-Quick-Chat, not the active room).
+   *
+   * @param roomJid - Room JID to catch up
+   * @param sessionStartTime - Epoch ms of the current session; forward cursor
+   *   excludes messages received this session (see `selectCatchUpQuery`).
+   */
+  async catchUpRoom(roomJid: string, sessionStartTime?: number): Promise<void> {
+    if (this.deps.stores?.connection.getStatus() !== 'online') return
+
+    // Load IndexedDB cache first so we know the newest cached message and can do a
+    // proper forward catch-up instead of fetching only latest. Without this,
+    // room.messages is empty after app restart (runtime-only), causing a backward
+    // "before:''" query that creates gaps with old cache.
+    await this.deps.stores?.room.loadMessagesFromCache(roomJid, { limit: MAM_CACHE_LOAD_LIMIT })
+
+    // Re-read room after cache load (store was mutated)
+    const updatedRoom = this.deps.stores?.room.getRoom(roomJid)
+    const messages = updatedRoom?.messages || []
+    // Shared cursor policy: forward from the newest pre-session message (so a live
+    // message in the catch-up window can't poison the cursor), else fetch latest.
+    const q = selectCatchUpQuery(messages, sessionStartTime)
+    await this.queryRoomArchive({
+      roomJid,
+      ...q,
+      max: q.start ? MAM_CATCHUP_FORWARD_MAX : MAM_CATCHUP_BACKWARD_MAX,
+    })
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -42,6 +42,7 @@ import {
   MAM_CATCHUP_BACKWARD_MAX,
   MAM_CACHE_LOAD_LIMIT,
   MAM_ROOM_FORWARD_MAX_PAGES,
+  MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
 } from '../../utils/mamCatchUpUtils'
 import {
   NS_MAM,
@@ -321,14 +322,16 @@ export class MAM extends BaseModule {
    * @returns Query result with messages, completion status, and pagination info
    */
   async queryRoomArchive(options: RoomMAMQueryOptions): Promise<RoomMAMResult> {
-    const { roomJid, max = 50, before, after, start, preserveGapMarker } = options
+    const { roomJid, max = 50, before, after, start, preserveGapMarker, maxAutoPages: maxAutoPagesOpt } = options
     const roomMamStart = Date.now()
     const isForward = !!start
     const roomDirection = isForward ? 'forward' : 'backward'
 
     // For forward catch-up queries, auto-paginate to retrieve all missed messages.
     // Backward queries (scroll-up) remain single-page — the caller controls pagination.
-    const maxAutoPages = isForward ? MAM_ROOM_FORWARD_MAX_PAGES : 1
+    // User-initiated repair passes a higher cap (maxAutoPagesOpt) so it fills large
+    // gaps to completion instead of stopping at the background limit.
+    const maxAutoPages = isForward ? (maxAutoPagesOpt ?? MAM_ROOM_FORWARD_MAX_PAGES) : 1
     const allMessages: RoomMessage[] = []
     let isComplete = false
     let lastRsm: RSMResponse = {}
@@ -437,6 +440,16 @@ export class MAM extends BaseModule {
       }
 
       logInfo(`Room MAM result: ${roomJid} → ${allMessages.length} msg(s), complete=${isComplete}, ${Date.now() - roomMamStart}ms`)
+
+      // Surface unresolved gaps for diagnosis: a forward catch-up that ends without
+      // reaching live (complete=false) means a hole remains. Visible in the in-app
+      // console so we can measure gap prevalence before investing in range tracking.
+      if (isForward && !isComplete) {
+        this.deps.emitSDK('console:event', {
+          message: `Room catch-up incomplete for ${roomJid} — gap remains after ${allMessages.length} msg(s)`,
+          category: 'sm',
+        })
+      }
 
       return { messages: allMessages, complete: isComplete, rsm: lastRsm }
     } catch (error) {
@@ -1097,6 +1110,7 @@ export class MAM extends BaseModule {
             roomJid: room.jid,
             start,
             max: MAM_CATCHUP_FORWARD_MAX,
+            maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
             preserveGapMarker: true,
           })
         } catch (_error) {

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -34,9 +34,7 @@ import { generateUUID, generateStableMessageId } from '../../utils/uuid'
 import { executeWithConcurrency } from '../../utils/concurrencyUtils'
 import { parseRSMResponse } from '../../utils/rsm'
 import {
-  findNewestMessage,
-  findCatchUpCursorMessage,
-  buildCatchUpStartTime,
+  selectCatchUpQuery,
   isConnectionError,
   MAM_CATCHUP_FORWARD_MAX,
   MAM_CATCHUP_BACKWARD_MAX,
@@ -859,9 +857,11 @@ export class MAM extends BaseModule {
    * @param options - Optional configuration
    * @param options.concurrency - Maximum parallel requests (default: 2)
    * @param options.exclude - Conversation ID to skip (e.g., the active conversation already handled by side effects)
+   * @param options.sessionStartTime - Epoch ms of the current fresh session; forward cursor
+   *   excludes messages received this session so a live message can't poison it (see Bug A).
    */
-  async catchUpAllConversations(options: { concurrency?: number; exclude?: string | null } = {}): Promise<void> {
-    const { concurrency = 2, exclude } = options
+  async catchUpAllConversations(options: { concurrency?: number; exclude?: string | null; sessionStartTime?: number } = {}): Promise<void> {
+    const { concurrency = 2, exclude, sessionStartTime } = options
     let conversations = this.deps.stores?.chat.getAllConversations() || []
     if (exclude) {
       conversations = conversations.filter((c) => c.id !== exclude)
@@ -891,23 +891,15 @@ export class MAM extends BaseModule {
           // Re-read messages after cache load (store was mutated)
           const updatedConv = this.deps.stores?.chat.getAllConversations()?.find(c => c.id === conv.id)
           const messages = updatedConv?.messages || conv.messages || []
-          const newestMessage = findNewestMessage(messages)
 
-          if (newestMessage?.timestamp) {
-            // Forward query from the last known message
-            await this.queryArchive({
-              with: conv.id,
-              start: buildCatchUpStartTime(newestMessage.timestamp),
-              max: MAM_CATCHUP_FORWARD_MAX,
-            })
-          } else {
-            // No messages (empty) — fetch latest from MAM
-            await this.queryArchive({
-              with: conv.id,
-              before: '',
-              max: MAM_CATCHUP_BACKWARD_MAX,
-            })
-          }
+          // Shared cursor policy (same as rooms) — forward from the newest
+          // pre-session message, else fetch latest.
+          const q = selectCatchUpQuery(messages, sessionStartTime)
+          await this.queryArchive({
+            with: conv.id,
+            ...q,
+            max: q.start ? MAM_CATCHUP_FORWARD_MAX : MAM_CATCHUP_BACKWARD_MAX,
+          })
         } catch (_error) {
           // Silently ignore — individual failures shouldn't affect others
         }
@@ -1035,29 +1027,15 @@ export class MAM extends BaseModule {
           // Re-read room after cache load (store was mutated)
           const updatedRoom = this.deps.stores?.room.getRoom(room.jid)
           const messages = updatedRoom?.messages || []
-          // Use the newest PRE-session message as the forward cursor so a live
-          // message arriving during the catch-up window can't push the cursor to
-          // "now" and silently skip the offline gap. Falls back to the global
-          // newest when the session start is unknown.
-          const cursorMessage = sessionStartTime !== undefined
-            ? findCatchUpCursorMessage(messages, sessionStartTime)
-            : findNewestMessage(messages)
-
-          if (cursorMessage?.timestamp) {
-            // Forward query from the last known contiguous message
-            await this.queryRoomArchive({
-              roomJid: room.jid,
-              start: buildCatchUpStartTime(cursorMessage.timestamp),
-              max: MAM_CATCHUP_FORWARD_MAX,
-            })
-          } else {
-            // No pre-session messages — fetch latest from MAM
-            await this.queryRoomArchive({
-              roomJid: room.jid,
-              before: '',
-              max: MAM_CATCHUP_BACKWARD_MAX,
-            })
-          }
+          // Shared cursor policy: forward from the newest pre-session message
+          // (so a live message in the catch-up window can't poison the cursor),
+          // else fetch latest.
+          const q = selectCatchUpQuery(messages, sessionStartTime)
+          await this.queryRoomArchive({
+            roomJid: room.jid,
+            ...q,
+            max: q.start ? MAM_CATCHUP_FORWARD_MAX : MAM_CATCHUP_BACKWARD_MAX,
+          })
         } catch (_error) {
           // Silently ignore — individual failures shouldn't affect others
         }

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -321,7 +321,7 @@ export class MAM extends BaseModule {
    * @returns Query result with messages, completion status, and pagination info
    */
   async queryRoomArchive(options: RoomMAMQueryOptions): Promise<RoomMAMResult> {
-    const { roomJid, max = 50, before, after, start } = options
+    const { roomJid, max = 50, before, after, start, preserveGapMarker } = options
     const roomMamStart = Date.now()
     const isForward = !!start
     const roomDirection = isForward ? 'forward' : 'backward'
@@ -412,6 +412,7 @@ export class MAM extends BaseModule {
             rsm,
             complete,
             direction,
+            preserveGapMarker,
           })
 
           allMessages.push(...collectedMessages)
@@ -1058,17 +1059,22 @@ export class MAM extends BaseModule {
    * Force a full MAM catch-up for all joined rooms over a given time window.
    *
    * Unlike `catchUpAllRooms()` which starts from the newest cached message,
-   * this method queries from a fixed start date (default: 7 days ago) to
+   * this method queries from a fixed start date (default: 45 days ago) to
    * fill any gaps left by previous incomplete catch-ups. The store's merge
    * logic deduplicates messages that already exist.
    *
-   * Intended for manual use via a UI action (e.g., sidebar menu item).
+   * Manual recovery tool for repairing a local archive (sidebar "Catch up all
+   * rooms"); expected to be removed once catch-up is proven reliable. Because it
+   * is a *bounded* repair (a fixed window, not the contiguous edge), it sets
+   * `preserveGapMarker` so a windowed completion can't hide a real gap older than
+   * the window or plant a spurious one inside it. The 45-day default covers a
+   * realistic "app closed for ~a month" absence.
    *
-   * @param options.days - Number of days to catch up (default: 7)
+   * @param options.days - Number of days to catch up (default: 45)
    * @param options.concurrency - Max concurrent MAM queries (default: 2)
    */
   async forceCatchUpAllRooms(options: { days?: number; concurrency?: number } = {}): Promise<void> {
-    const { days = 7, concurrency = 2 } = options
+    const { days = 45, concurrency = 2 } = options
     const joinedRooms = this.deps.stores?.room.joinedRooms() || []
     const mamRooms = joinedRooms.filter((r) => r.supportsMAM && !r.isQuickChat)
     if (mamRooms.length === 0) return
@@ -1091,6 +1097,7 @@ export class MAM extends BaseModule {
             roomJid: room.jid,
             start,
             max: MAM_CATCHUP_FORWARD_MAX,
+            preserveGapMarker: true,
           })
         } catch (_error) {
           // Silently ignore — individual failures shouldn't affect others

--- a/packages/fluux-sdk/src/core/roomSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.test.ts
@@ -376,6 +376,58 @@ describe('setupRoomSideEffects', () => {
       loadSpy.mockRestore()
     })
 
+    it('uses the newest PRE-session message as the catch-up cursor, ignoring a live message from this session', async () => {
+      // Regression for the silent month-long gap: after a long offline period the
+      // active room's cache ends a month ago; a live message lands during catch-up.
+      // The forward cursor must be the month-old message, not the live one.
+      const monthOld = new Date(Date.now() - 30 * 86_400_000)
+      const liveThisSession = new Date(Date.now() + 60_000) // clearly after sessionStart
+
+      roomStore.getState().addRoom({
+        jid: 'room@conference.example.com',
+        name: 'Test Room',
+        nickname: 'testuser',
+        joined: true,
+        supportsMAM: true,
+        occupants: new Map(),
+        messages: [],
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set(),
+        isBookmarked: true,
+      })
+
+      roomStore.getState().setActiveRoom('room@conference.example.com')
+
+      const messages = [
+        { type: 'groupchat' as const, id: 'old', roomJid: 'room@conference.example.com', from: 'room@conference.example.com/alice', nick: 'alice', body: 'month-old', timestamp: monthOld, isOutgoing: false },
+        { type: 'groupchat' as const, id: 'live', roomJid: 'room@conference.example.com', from: 'room@conference.example.com/bob', nick: 'bob', body: 'live', timestamp: liveThisSession, isOutgoing: false },
+      ]
+      const loadSpy = vi.spyOn(roomStore.getState(), 'loadMessagesFromCache')
+        .mockImplementation(async (roomJid: string) => {
+          const room = roomStore.getState().rooms.get(roomJid)
+          if (room) roomStore.getState().updateRoom(roomJid, { messages })
+          return messages
+        })
+
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupRoomSideEffects(mockClient)
+
+      simulateFreshSession(mockClient)
+
+      await vi.waitFor(() => {
+        expect(mockClient.chat.queryRoomMAM).toHaveBeenCalledWith(
+          expect.objectContaining({ roomJid: 'room@conference.example.com', start: expect.any(String) })
+        )
+      })
+
+      const call = (mockClient.chat.queryRoomMAM as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(call).not.toHaveProperty('before')
+      expect(new Date(call.start).getTime()).toBe(monthOld.getTime() + 1)
+
+      loadSpy.mockRestore()
+    })
+
     it('should use backward query (before) when cache is empty after reconnection', async () => {
       roomStore.getState().addRoom({
         jid: 'room@conference.example.com',

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -20,6 +20,7 @@ import { roomStore, connectionStore } from '../stores'
 import { logInfo } from './logger'
 import {
   findNewestMessage,
+  findCatchUpCursorMessage,
   buildCatchUpStartTime,
   isConnectionError,
   MAM_CATCHUP_FORWARD_MAX,
@@ -46,6 +47,11 @@ export function setupRoomSideEffects(
 
   // Track whether we've initiated a fetch for each room
   const fetchInitiated = new Set<string>()
+
+  // Epoch ms of the current fresh session's connection (set on 'online'). Used as
+  // the forward catch-up cursor boundary so a live message arriving during catch-up
+  // can't poison the cursor and silently skip the offline gap.
+  let sessionStartTime: number | undefined
 
   /**
    * Triggers MAM fetch for the active room if needed (catchup).
@@ -110,17 +116,22 @@ export function setupRoomSideEffects(
       // Re-read room after cache load (store was mutated)
       const roomAfterCache = roomStore.getState().rooms.get(roomJid)
       const messages = roomAfterCache?.messages || []
-      const newestMessage = findNewestMessage(messages)
+      // Use the newest PRE-session message as the forward cursor so a live message
+      // arriving during catch-up can't push the cursor to "now" and silently skip
+      // the offline gap. Falls back to the global newest when session start is unknown.
+      const cursorMessage = sessionStartTime !== undefined
+        ? findCatchUpCursorMessage(messages, sessionStartTime)
+        : findNewestMessage(messages)
 
-      if (newestMessage?.timestamp) {
-        // Query for messages AFTER the newest known message (catchup)
+      if (cursorMessage?.timestamp) {
+        // Query for messages AFTER the newest known contiguous message (catchup)
         await client.chat.queryRoomMAM({
           roomJid,
-          start: buildCatchUpStartTime(newestMessage.timestamp),
+          start: buildCatchUpStartTime(cursorMessage.timestamp),
           max: MAM_CATCHUP_FORWARD_MAX,
         })
       } else {
-        // No cached messages - fetch latest
+        // No pre-session messages - fetch latest
         await client.chat.queryRoomMAM({
           roomJid,
           before: '', // Empty = get latest
@@ -191,6 +202,10 @@ export function setupRoomSideEffects(
   // Fresh session: catch up MAM for the active room.
   // 'online' fires only on fresh sessions (not SM resumption).
   const unsubscribeOnline = client.on('online', () => {
+    // Record the session start before any catch-up so the forward cursor excludes
+    // live messages that arrive after reconnect (silent-gap fix).
+    sessionStartTime = Date.now()
+
     const activeRoomJid = roomStore.getState().activeRoomJid
     if (activeRoomJid) {
       if (debug) console.log('[SideEffects] Room: Fresh session, catching up active room', activeRoomJid)

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -19,9 +19,7 @@ import type { SideEffectsOptions } from './chatSideEffects'
 import { roomStore, connectionStore } from '../stores'
 import { logInfo } from './logger'
 import {
-  findNewestMessage,
-  findCatchUpCursorMessage,
-  buildCatchUpStartTime,
+  selectCatchUpQuery,
   isConnectionError,
   MAM_CATCHUP_FORWARD_MAX,
   MAM_CATCHUP_BACKWARD_MAX,
@@ -116,28 +114,14 @@ export function setupRoomSideEffects(
       // Re-read room after cache load (store was mutated)
       const roomAfterCache = roomStore.getState().rooms.get(roomJid)
       const messages = roomAfterCache?.messages || []
-      // Use the newest PRE-session message as the forward cursor so a live message
-      // arriving during catch-up can't push the cursor to "now" and silently skip
-      // the offline gap. Falls back to the global newest when session start is unknown.
-      const cursorMessage = sessionStartTime !== undefined
-        ? findCatchUpCursorMessage(messages, sessionStartTime)
-        : findNewestMessage(messages)
-
-      if (cursorMessage?.timestamp) {
-        // Query for messages AFTER the newest known contiguous message (catchup)
-        await client.chat.queryRoomMAM({
-          roomJid,
-          start: buildCatchUpStartTime(cursorMessage.timestamp),
-          max: MAM_CATCHUP_FORWARD_MAX,
-        })
-      } else {
-        // No pre-session messages - fetch latest
-        await client.chat.queryRoomMAM({
-          roomJid,
-          before: '', // Empty = get latest
-          max: MAM_CATCHUP_BACKWARD_MAX,
-        })
-      }
+      // Shared cursor policy: forward from the newest pre-session message (so a
+      // live message in the catch-up window can't poison the cursor), else latest.
+      const q = selectCatchUpQuery(messages, sessionStartTime)
+      await client.chat.queryRoomMAM({
+        roomJid,
+        ...q,
+        max: q.start ? MAM_CATCHUP_FORWARD_MAX : MAM_CATCHUP_BACKWARD_MAX,
+      })
       logInfo('Room: MAM catch-up complete')
     } catch (error) {
       // Allow backup handlers (room:joined, supportsMAM watcher) to retry

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -46,6 +46,7 @@ export function createMockClient() {
       refreshArchivedConversationPreviews: vi.fn().mockResolvedValue(undefined),
       catchUpAllConversations: vi.fn().mockResolvedValue(undefined),
       catchUpAllRooms: vi.fn().mockResolvedValue(undefined),
+      catchUpRoom: vi.fn().mockResolvedValue(undefined),
       discoverNewConversationsFromRoster: vi.fn().mockResolvedValue(undefined),
     },
     muc: {

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -88,6 +88,12 @@ export interface RoomMAMQueryOptions {
   after?: string
   /** Filter messages after this timestamp (ISO 8601 format) */
   start?: string
+  /**
+   * When true, the resulting merge leaves the forward gap marker untouched.
+   * Used by bounded "force repair" queries so a windowed completion can't hide
+   * a real gap older than the window (nor plant a spurious one inside it).
+   */
+  preserveGapMarker?: boolean
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -56,6 +56,14 @@ export interface MAMQueryOptions {
   start?: string
   /** End timestamp - only fetch messages before this time (ISO 8601 format) */
   end?: string
+  /**
+   * Opt-in forward auto-pagination for catch-up (parity with rooms). When set
+   * (with `start`), the query paginates OLDEST-first via the `after` cursor up to
+   * this many pages until `complete`, instead of the default single newest-first
+   * page. Omit for all other callers (targeted range / context fetch) to keep the
+   * existing single-page behavior.
+   */
+  maxAutoPages?: number
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -94,6 +94,12 @@ export interface RoomMAMQueryOptions {
    * a real gap older than the window (nor plant a spurious one inside it).
    */
   preserveGapMarker?: boolean
+  /**
+   * Max auto-pagination pages for a forward catch-up. Defaults to the background
+   * cap; user-initiated repair passes a higher value to paginate large gaps to
+   * completion. Ignored for backward (single-page) queries.
+   */
+  maxAutoPages?: number
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -370,6 +370,8 @@ export interface RoomEvents {
     rsm: RSMResponse
     complete: boolean
     direction: MAMQueryDirection
+    /** When true, leave the gap marker untouched (bounded force-repair queries). */
+    preserveGapMarker?: boolean
   }
 
   /** Room member affiliations discovered (XEP-0045 admin query) */

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -6,6 +6,7 @@ import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment, MAMQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
+import { findContinueCatchUpCursor, buildCatchUpStartTime, MAM_CACHE_LOAD_LIMIT, MAM_ROOM_FORWARD_MAX_PAGES_MANUAL } from '../utils/mamCatchUpUtils'
 
 /**
  * Stable empty array references to prevent infinite re-renders.
@@ -124,6 +125,11 @@ export function useChatActive() {
     if (!s.activeConversationId) return undefined
     return s.mamQueryStates.get(s.activeConversationId)?.oldestFetchedId
   })
+  // Gap marker sourced from the PERSISTED conversationGaps (survives reload), parity with rooms.
+  const mamForwardGapTimestamp = useChatStore((s) => {
+    if (!s.activeConversationId) return undefined
+    return s.conversationGaps.get(s.activeConversationId)?.start
+  })
 
   const activeMAMState = useMemo((): MAMQueryState | null => {
     if (!activeConversationId) return null
@@ -133,9 +139,10 @@ export function useChatActive() {
       isHistoryComplete: mamIsHistoryComplete,
       isCaughtUpToLive: mamIsCaughtUpToLive,
       oldestFetchedId: mamOldestFetchedId,
+      forwardGapTimestamp: mamForwardGapTimestamp,
       error: null,
     }
-  }, [activeConversationId, mamIsLoading, mamHasQueried, mamIsHistoryComplete, mamIsCaughtUpToLive, mamOldestFetchedId])
+  }, [activeConversationId, mamIsLoading, mamHasQueried, mamIsHistoryComplete, mamIsCaughtUpToLive, mamOldestFetchedId, mamForwardGapTimestamp])
 
   // --- Actions (all stable callbacks) ---
 
@@ -328,6 +335,36 @@ export function useChatActive() {
     [client]
   )
 
+  // "Load missing messages": continue a forward catch-up from the recorded gap
+  // boundary (parity with rooms' continueRoomCatchUp). Paginates oldest-first to
+  // completion via the manual cap.
+  const continueChatCatchUp = useCallback(async () => {
+    const conversationId = chatStore.getState().activeConversationId
+    if (!conversationId) return
+    if (connectionStore.getState().status !== 'online') return
+
+    const mamState = chatStore.getState().getMAMQueryState(conversationId)
+    if (mamState.isLoading) return
+
+    chatStore.getState().setMAMLoading(conversationId, true)
+
+    try {
+      await chatStore.getState().loadMessagesFromCache(conversationId, { limit: MAM_CACHE_LOAD_LIMIT })
+      const messages = chatStore.getState().messages.get(conversationId) || []
+      const gapStart = chatStore.getState().conversationGaps.get(conversationId)?.start
+      const cursor = findContinueCatchUpCursor(messages, gapStart)
+      if (cursor?.timestamp) {
+        await client.chat.queryMAM({
+          with: conversationId,
+          start: buildCatchUpStartTime(cursor.timestamp),
+          maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
+        })
+      }
+    } catch {
+      chatStore.getState().setMAMLoading(conversationId, false)
+    }
+  }, [client])
+
   // --- Return ---
 
   const actions = useMemo(
@@ -355,6 +392,7 @@ export function useChatActive() {
       updateLastSeenMessageId,
       fetchHistory,
       fetchOlderHistory,
+      continueChatCatchUp,
     }),
     [
       sendMessage, setActiveConversation, addConversation, deleteConversation,
@@ -362,6 +400,7 @@ export function useChatActive() {
       sendChatState, sendReaction, sendCorrection, retractMessage, retryMessage,
       sendEasterEgg, clearAnimation, clearTargetMessageId, setDraft, getDraft, clearDraft,
       clearFirstNewMessageId, updateLastSeenMessageId, fetchHistory, fetchOlderHistory,
+      continueChatCatchUp,
     ]
   )
 

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -5,10 +5,11 @@ import { useXMPPContext } from '../provider'
 import type { Room, RoomMessage, MentionReference, ChatStateNotification, FileAttachment, MAMQueryState, RoomAffiliation, RoomRole, PollData, PollSettings } from '../core/types'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
 import {
-  findNewestMessage,
+  findContinueCatchUpCursor,
   buildCatchUpStartTime,
   MAM_CATCHUP_FORWARD_MAX,
   MAM_CACHE_LOAD_LIMIT,
+  MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
 } from '../utils/mamCatchUpUtils'
 
 /**
@@ -370,13 +371,17 @@ export function useRoomActive() {
       await roomStore.getState().loadMessagesFromCache(roomJid, { limit: MAM_CACHE_LOAD_LIMIT })
       const room = roomStore.getState().rooms.get(roomJid)
       const messages = room?.messages || []
-      const newestMessage = findNewestMessage(messages)
+      // Continue from the recorded gap boundary so the forward query fills the HOLE.
+      // The global newest message sits AFTER the hole, so resuming from it would skip
+      // the gap entirely. Paginate with the manual cap to fill large gaps to completion.
+      const cursor = findContinueCatchUpCursor(messages, mamState.forwardGapTimestamp)
 
-      if (newestMessage?.timestamp) {
+      if (cursor?.timestamp) {
         await client.chat.queryRoomMAM({
           roomJid,
-          start: buildCatchUpStartTime(newestMessage.timestamp),
+          start: buildCatchUpStartTime(cursor.timestamp),
           max: MAM_CATCHUP_FORWARD_MAX,
+          maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
         })
       }
     } catch {

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -107,9 +107,11 @@ export function useRoomActive() {
     if (!s.activeRoomJid) return undefined
     return s.mamQueryStates.get(s.activeRoomJid)?.oldestFetchedId
   })
+  // Source the gap marker from the PERSISTED roomGaps (survives reload), not the
+  // ephemeral mamQueryStates.forwardGapTimestamp which is lost on reload.
   const mamForwardGapTimestamp = useRoomStore((s) => {
     if (!s.activeRoomJid) return undefined
-    return s.mamQueryStates.get(s.activeRoomJid)?.forwardGapTimestamp
+    return s.roomGaps.get(s.activeRoomJid)?.start
   })
 
   // Memoize the MAM state object to maintain stable reference
@@ -371,10 +373,11 @@ export function useRoomActive() {
       await roomStore.getState().loadMessagesFromCache(roomJid, { limit: MAM_CACHE_LOAD_LIMIT })
       const room = roomStore.getState().rooms.get(roomJid)
       const messages = room?.messages || []
-      // Continue from the recorded gap boundary so the forward query fills the HOLE.
-      // The global newest message sits AFTER the hole, so resuming from it would skip
-      // the gap entirely. Paginate with the manual cap to fill large gaps to completion.
-      const cursor = findContinueCatchUpCursor(messages, mamState.forwardGapTimestamp)
+      // Continue from the recorded (persisted) gap boundary so the forward query
+      // fills the HOLE. The global newest message sits AFTER the hole, so resuming
+      // from it would skip the gap. Paginate with the manual cap to fill it fully.
+      const gapStart = roomStore.getState().roomGaps.get(roomJid)?.start
+      const cursor = findContinueCatchUpCursor(messages, gapStart)
 
       if (cursor?.timestamp) {
         await client.chat.queryRoomMAM({

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -83,6 +83,7 @@ describe('chatStore', () => {
       activeConversationId: null,
       archivedConversations: new Set(),
       mamQueryStates: new Map(),
+      conversationGaps: new Map(),
       // Reset other ephemeral state
       typingStates: new Map(),
       drafts: new Map(),
@@ -110,6 +111,50 @@ describe('chatStore', () => {
     it('should return empty array for activeMessages when none selected', () => {
       const state = chatStore.getState()
       expect(state.activeMessages()).toEqual([])
+    })
+  })
+
+  describe('mergeMAMMessages gap tracking (persisted conversationGaps)', () => {
+    const cid = 'alice@example.com'
+
+    it('records a GapInterval when a forward catch-up ends incomplete (parity with rooms)', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const recent = { ...createMessage(cid, 'recent'), id: 'recent', timestamp: new Date('2026-06-10T00:00:00Z') }
+      chatStore.getState().addMessage(recent)
+
+      const fetched = { ...createMessage(cid, 'edge'), id: 'edge', timestamp: new Date('2026-05-14T09:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [fetched], {}, false, 'forward')
+
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
+        start: new Date('2026-05-14T09:00:00Z').getTime(), // newest fetched
+        end: new Date('2026-06-10T00:00:00Z').getTime(),   // oldest held above the gap
+      })
+    })
+
+    it('clears the gap when a forward catch-up completes', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState({ conversationGaps: new Map([[cid, { start: 1000, end: 5000 }]]) })
+
+      chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward')
+
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+    })
+
+    it('persists conversationGaps to the account-scoped chat storage (survives reload, no cross-account leak)', () => {
+      localStorageMock.clear() // drop the empty bare-key write from beforeEach's scope-null setState
+      setStorageScopeJid('alice@example.com')
+      chatStore.getState().addConversation(createConversation(cid))
+      const recent = { ...createMessage(cid, 'recent'), id: 'recent', timestamp: new Date('2026-06-10T00:00:00Z') }
+      chatStore.getState().addMessage(recent)
+      const fetched = { ...createMessage(cid, 'edge'), id: 'edge', timestamp: new Date('2026-05-14T09:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [fetched], {}, false, 'forward')
+
+      const scoped = localStorageMock._store['xmpp-chat-storage:alice@example.com']
+      expect(scoped).toBeDefined()
+      expect(scoped).toContain('conversationGaps')
+      expect(scoped).toContain(String(new Date('2026-05-14T09:00:00Z').getTime()))
+      // Never the bare (unscoped) key.
+      expect(localStorageMock._store['xmpp-chat-storage']).toBeUndefined()
     })
   })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -7,6 +7,7 @@ import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
+import { computeGapEnd, syncGap, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages, backfillArchiveIds } from './shared/messageArrayUtils'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
@@ -106,6 +107,9 @@ interface ChatState {
   drafts: Map<string, string>
   // XEP-0313: MAM query state per conversation (ephemeral, not persisted)
   mamQueryStates: Map<string, MAMQueryState>
+  // Persisted history-gap intervals per conversation (in the account-scoped chat
+  // blob; drives the gap marker). Parity with roomStore.roomGaps.
+  conversationGaps: Map<string, GapInterval>
   // Target message to scroll to after navigation (ephemeral, not persisted)
   targetMessageId: string | null
 
@@ -203,13 +207,14 @@ interface PersistedState {
   conversations: [string, Conversation][]
   archivedConversations?: string[] // Optional for backwards compatibility
   drafts?: [string, string][] // Optional for backwards compatibility
+  conversationGaps?: [string, GapInterval][] // Optional for backwards compatibility
   // Legacy fields, kept for backwards compatibility when reading old storage
   messages?: [string, Message[]][] // May exist in old storage, will be migrated
   activeConversationId?: string | null
 }
 
 // Serialize Maps to arrays for JSON storage
-function serializeState(state: Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'archivedConversations' | 'drafts'>): PersistedState {
+function serializeState(state: Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'archivedConversations' | 'drafts'> & { conversationGaps?: Map<string, GapInterval> }): PersistedState {
   return {
     // Serialize separated maps (Phase 6)
     conversationEntities: Array.from(state.conversationEntities.entries()),
@@ -219,12 +224,14 @@ function serializeState(state: Pick<ChatState, 'conversationEntities' | 'convers
     // Messages are NOT stored in localStorage - they're in IndexedDB
     archivedConversations: Array.from(state.archivedConversations),
     drafts: Array.from(state.drafts.entries()),
+    // Persisted history gaps (account-scoped via the chat storage key)
+    conversationGaps: Array.from((state.conversationGaps ?? new Map<string, GapInterval>()).entries()),
   }
 }
 
 // Deserialize arrays back to Maps, reset unread counts, restore Date objects
 // Also handles migration of old localStorage messages to IndexedDB
-function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'drafts'> {
+function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'drafts' | 'conversationGaps'> {
   // Helper to restore Date objects in lastMessage
   const restoreLastMessage = (lastMessage?: Message): Message | undefined => {
     if (!lastMessage) return undefined
@@ -328,6 +335,9 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
   // Restore drafts (backwards compatible - default to empty map)
   const drafts = new Map(persisted.drafts || [])
 
+  // Restore history gaps (backwards compatible - default to empty map)
+  const conversationGaps = new Map<string, GapInterval>(persisted.conversationGaps || [])
+
   return {
     conversationEntities,
     conversationMeta,
@@ -338,10 +348,11 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
     activeConversationId: null,
     archivedConversations,
     drafts,
+    conversationGaps,
   }
 }
 
-function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'targetMessageId'> {
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId'> {
   return {
     conversationEntities: new Map(),
     conversationMeta: new Map(),
@@ -353,6 +364,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
     activeAnimation: null,
     drafts: new Map(),
     mamQueryStates: new Map(),
+    conversationGaps: new Map(),
     targetMessageId: null,
   }
 }
@@ -363,7 +375,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
  * Legacy versions stored chat data under a single unscoped key. For safety, we only migrate
  * conversation lists (active + archived classification) and intentionally skip drafts/messages.
  */
-function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'targetMessageId'> | null {
+function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId'> | null {
   if (!jid) return null
 
   const legacyKey = getLegacyStorageKey()
@@ -402,7 +414,7 @@ function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatSt
   }
 }
 
-function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'targetMessageId'> {
+function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId'> {
   const baseState = createEmptyChatState()
   const scopedStorageKey = getScopedStorageKey(jid)
 
@@ -423,6 +435,7 @@ function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationE
       activeConversationId: restored.activeConversationId,
       archivedConversations: restored.archivedConversations,
       drafts: restored.drafts,
+      conversationGaps: restored.conversationGaps,
     }
   } catch {
     try {
@@ -1185,6 +1198,12 @@ export const chatStore = createStore<ChatState>()(
                   MAX_MESSAGES_PER_CONVERSATION
                 )
 
+          // Newest fetched message timestamp marks the gap edge for an incomplete
+          // forward catch-up (parity with rooms).
+          const newestFetchedTimestamp = direction === 'forward' && mamMessages.length > 0
+            ? Math.max(...mamMessages.map(m => m.timestamp?.getTime() ?? 0))
+            : undefined
+
           // Update MAM query state with pagination cursor using the two-marker approach
           // This must always be updated to track query completion and cursors
           const newStates = mamState.setMAMQueryCompleted(
@@ -1192,8 +1211,20 @@ export const chatStore = createStore<ChatState>()(
             conversationId,
             complete,
             direction,
-            rsm.first // Pagination cursor for fetching older messages
+            rsm.first, // Pagination cursor for fetching older messages
+            newestFetchedTimestamp
           )
+
+          // Mirror the forward gap into the PERSISTED conversationGaps (account-scoped
+          // via the chat storage blob) so the marker survives a reload. Forward
+          // complete=false sets it, complete=true clears it; backward leaves it.
+          // `end` = oldest message held above the gap.
+          let newGaps = state.conversationGaps
+          if (direction === 'forward') {
+            const gapStart = newStates.get(conversationId)?.forwardGapTimestamp
+            const gapEnd = gapStart !== undefined ? computeGapEnd(trimmed, gapStart) : undefined
+            newGaps = syncGap(state.conversationGaps, conversationId, gapStart, gapEnd)
+          }
 
           // If no new messages (all duplicates), only update MAM state - skip messages/conversations
           // This prevents unnecessary re-renders when merging duplicates.
@@ -1201,11 +1232,11 @@ export const chatStore = createStore<ChatState>()(
           // that patched array (trimmed === existingMessages here) to the store.
           if (newMessages.length === 0) {
             if (patched.length === 0) {
-              return { mamQueryStates: newStates }
+              return { mamQueryStates: newStates, conversationGaps: newGaps }
             }
             const backfilledMap = new Map(state.messages)
             backfilledMap.set(conversationId, trimmed)
-            return { messages: backfilledMap, mamQueryStates: newStates }
+            return { messages: backfilledMap, mamQueryStates: newStates, conversationGaps: newGaps }
           }
 
           // Persist only locally-persistable messages to IndexedDB
@@ -1235,10 +1266,10 @@ export const chatStore = createStore<ChatState>()(
             const newConversations = new Map(state.conversations)
             newConversations.set(conversationId, { ...conv, lastMessage })
 
-            return { messages: newMessagesMap, mamQueryStates: newStates, conversationMeta: newMeta, conversations: newConversations }
+            return { messages: newMessagesMap, mamQueryStates: newStates, conversationMeta: newMeta, conversations: newConversations, conversationGaps: newGaps }
           }
 
-          return { messages: newMessagesMap, mamQueryStates: newStates }
+          return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: newGaps }
         })
       },
 
@@ -1457,6 +1488,8 @@ export const chatStore = createStore<ChatState>()(
         archivedConversations: state.archivedConversations,
         // Persist drafts so they survive page reloads
         drafts: state.drafts,
+        // Persist history gaps so the "Load missing messages" marker survives reload
+        conversationGaps: state.conversationGaps,
       }),
     }
     )

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -108,6 +108,7 @@ describe('roomStore', () => {
       activeRoomJid: null,
       drafts: new Map(),
       mamQueryStates: new Map(),
+      roomGaps: new Map(),
     })
     vi.clearAllMocks()
   })
@@ -1722,6 +1723,68 @@ describe('roomStore', () => {
   })
 
   // ==================== Occupant Tests ====================
+
+  describe('mergeRoomMAMMessages gap tracking (persisted roomGaps)', () => {
+    const jid = 'room@conference.example.com'
+
+    it('records a persisted GapInterval when a forward catch-up ends incomplete', () => {
+      const recent: RoomMessage = {
+        type: 'groupchat', id: 'recent', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'recent', timestamp: new Date('2026-06-10T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { messages: [recent] }))
+
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'edge', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'edge', timestamp: new Date('2026-05-14T09:00:00Z'), isOutgoing: false,
+      }
+      // Forward catch-up truncated (complete=false) at the edge message.
+      roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, false, 'forward')
+
+      const gap = roomStore.getState().roomGaps.get(jid)
+      expect(gap).toEqual({
+        start: new Date('2026-05-14T09:00:00Z').getTime(), // newest fetched
+        end: new Date('2026-06-10T00:00:00Z').getTime(),   // oldest held above the gap
+      })
+    })
+
+    it('clears the persisted gap when a forward catch-up completes', () => {
+      roomStore.getState().addRoom(createRoom(jid))
+      roomStore.setState({ roomGaps: new Map([[jid, { start: 1000, end: 5000 }]]) })
+
+      roomStore.getState().mergeRoomMAMMessages(jid, [], {}, true, 'forward')
+
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('leaves the persisted gap untouched when preserveGapMarker is set (bounded repair)', () => {
+      roomStore.getState().addRoom(createRoom(jid))
+      roomStore.setState({ roomGaps: new Map([[jid, { start: 1000, end: 5000 }]]) })
+
+      // A bounded force repair completes within its window — must not clear an older gap.
+      roomStore.getState().mergeRoomMAMMessages(jid, [], {}, true, 'forward', true)
+
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({ start: 1000, end: 5000 })
+    })
+
+    it('persists roomGaps to localStorage so the marker survives a reload', () => {
+      const recent: RoomMessage = {
+        type: 'groupchat', id: 'recent', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'recent', timestamp: new Date('2026-06-10T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { messages: [recent] }))
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'edge', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'edge', timestamp: new Date('2026-05-14T09:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, false, 'forward')
+
+      const persisted = Object.values(localStorageMock._store).some(
+        (v) => typeof v === 'string' && v.includes('2026-05-14') === false && v.includes(String(new Date('2026-05-14T09:00:00Z').getTime())),
+      )
+      expect(persisted).toBe(true)
+    })
+  })
 
   describe('addOccupant', () => {
     it('should add an occupant to a room', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { roomStore } from './roomStore'
 import type { Room, RoomMessage } from '../core/types'
 import { getLocalPart } from '../core/jid'
-import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -1765,6 +1765,30 @@ describe('roomStore', () => {
       roomStore.getState().mergeRoomMAMMessages(jid, [], {}, true, 'forward', true)
 
       expect(roomStore.getState().roomGaps.get(jid)).toEqual({ start: 1000, end: 5000 })
+    })
+
+    it('scopes persisted gaps to the user JID (no cross-account leak)', () => {
+      localStorageMock.clear() // isolate from other tests' unscoped writes
+      setStorageScopeJid('alice@example.com')
+      try {
+        const recent: RoomMessage = {
+          type: 'groupchat', id: 'recent', roomJid: jid, from: `${jid}/b`, nick: 'b',
+          body: 'recent', timestamp: new Date('2026-06-10T00:00:00Z'), isOutgoing: false,
+        }
+        roomStore.getState().addRoom(createRoom(jid, { messages: [recent] }))
+        const fetched: RoomMessage = {
+          type: 'groupchat', id: 'edge', roomJid: jid, from: `${jid}/a`, nick: 'a',
+          body: 'edge', timestamp: new Date('2026-05-14T09:00:00Z'), isOutgoing: false,
+        }
+        roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, false, 'forward')
+
+        // Stored under the per-account key — NOT the bare key, NOT another account's key.
+        expect(localStorageMock._store['fluux-room-gaps:alice@example.com']).toBeDefined()
+        expect(localStorageMock._store['fluux-room-gaps']).toBeUndefined()
+        expect(localStorageMock._store['fluux-room-gaps:bob@example.com']).toBeUndefined()
+      } finally {
+        _resetStorageScopeForTesting()
+      }
     })
 
     it('persists roomGaps to localStorage so the marker survives a reload', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -20,7 +20,7 @@ import * as searchIndex from '../utils/searchIndex'
 import type { GetMessagesOptions } from '../utils/messageCache'
 import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
-import { computeGapEnd, syncRoomGap, serializeRoomGaps, deserializeRoomGaps, type GapInterval } from './shared/roomGap'
+import { computeGapEnd, syncGap, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages } from './shared/messageArrayUtils'
 import { shouldUpdateLastMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
@@ -173,7 +173,7 @@ function getRoomGapsStorageKey(jid?: string | null): string {
 function loadGapsFromStorage(jid?: string | null): Map<string, GapInterval> {
   try {
     const stored = localStorage.getItem(getRoomGapsStorageKey(jid))
-    if (stored) return deserializeRoomGaps(stored)
+    if (stored) return deserializeGaps(stored)
   } catch {
     // Ignore parse/storage errors
   }
@@ -182,7 +182,7 @@ function loadGapsFromStorage(jid?: string | null): Map<string, GapInterval> {
 
 function saveGapsToStorage(gaps: Map<string, GapInterval>, jid?: string | null): void {
   try {
-    localStorage.setItem(getRoomGapsStorageKey(jid), serializeRoomGaps(gaps))
+    localStorage.setItem(getRoomGapsStorageKey(jid), serializeGaps(gaps))
   } catch {
     // Ignore storage errors (quota exceeded, etc.)
   }
@@ -1888,7 +1888,7 @@ export const roomStore = createStore<RoomState>()(
       if (direction === 'forward' && !preserveGapMarker) {
         const gapStart = newStates.get(roomJid)?.forwardGapTimestamp
         const gapEnd = gapStart !== undefined ? computeGapEnd(merged, gapStart) : undefined
-        newGaps = syncRoomGap(state.roomGaps, roomJid, gapStart, gapEnd)
+        newGaps = syncGap(state.roomGaps, roomJid, gapStart, gapEnd)
         if (newGaps !== state.roomGaps) saveGapsToStorage(newGaps)
       }
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -337,7 +337,7 @@ export interface RoomState {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection) => void
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean) => void
   getRoomMAMQueryState: (roomJid: string) => MAMQueryState
   resetRoomMAMStates: () => void
   /** Mark all rooms as needing a catch-up MAM query (called on reconnect) */
@@ -1801,7 +1801,7 @@ export const roomStore = createStore<RoomState>()(
     }))
   },
 
-  mergeRoomMAMMessages: (roomJid, mamMessages, rsm, complete, direction) => {
+  mergeRoomMAMMessages: (roomJid, mamMessages, rsm, complete, direction, preserveGapMarker = false) => {
     set((state) => {
       const room = state.rooms.get(roomJid)
       if (!room) return state
@@ -1841,7 +1841,8 @@ export const roomStore = createStore<RoomState>()(
         complete,
         direction,
         rsm.first, // Pagination cursor for fetching older messages
-        newestFetchedTimestamp
+        newestFetchedTimestamp,
+        preserveGapMarker
       )
 
       // If no new messages (all duplicates), only update MAM state - skip room messages

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -20,6 +20,7 @@ import * as searchIndex from '../utils/searchIndex'
 import type { GetMessagesOptions } from '../utils/messageCache'
 import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
+import { computeGapEnd, syncRoomGap, serializeRoomGaps, deserializeRoomGaps, type GapInterval } from './shared/roomGap'
 import * as draftState from './shared/draftState'
 import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages } from './shared/messageArrayUtils'
 import { shouldUpdateLastMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
@@ -158,6 +159,36 @@ function saveDismissedPollsToStorage(dismissedPolls: Map<string, Set<string>>, j
 }
 
 /**
+ * localStorage persistence for room history gaps (`GapInterval` per room).
+ * Persisted separately (like drafts) so the "Load missing messages" marker
+ * survives a reload — the next session's catch-up cursor sits above the gap and
+ * would not re-detect it.
+ */
+const ROOM_GAPS_STORAGE_KEY_BASE = 'fluux-room-gaps'
+
+function getRoomGapsStorageKey(jid?: string | null): string {
+  return buildScopedStorageKey(ROOM_GAPS_STORAGE_KEY_BASE, jid)
+}
+
+function loadGapsFromStorage(jid?: string | null): Map<string, GapInterval> {
+  try {
+    const stored = localStorage.getItem(getRoomGapsStorageKey(jid))
+    if (stored) return deserializeRoomGaps(stored)
+  } catch {
+    // Ignore parse/storage errors
+  }
+  return new Map()
+}
+
+function saveGapsToStorage(gaps: Map<string, GapInterval>, jid?: string | null): void {
+  try {
+    localStorage.setItem(getRoomGapsStorageKey(jid), serializeRoomGaps(gaps))
+  } catch {
+    // Ignore storage errors (quota exceeded, etc.)
+  }
+}
+
+/**
  * Stable empty array references to prevent infinite re-renders.
  * When computed selectors return empty results, they should return these
  * constants instead of creating new [] instances each time.
@@ -250,6 +281,8 @@ export interface RoomState {
   dismissedPollIds: Map<string, Set<string>>
   // MAM query states per room (for rooms with MAM enabled)
   mamQueryStates: Map<string, MAMQueryState>
+  // Persisted history-gap intervals per room (survives reload; drives the gap marker)
+  roomGaps: Map<string, GapInterval>
   // Target message to scroll to after navigation (ephemeral)
   targetMessageId: string | null
 
@@ -372,7 +405,8 @@ function createEmptyRoomState(
   drafts: Map<string, string> = new Map(),
   votedPollIds: Map<string, Set<string>> = new Map(),
   dismissedPollIds: Map<string, Set<string>> = new Map(),
-): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'targetMessageId'> {
+  roomGaps: Map<string, GapInterval> = new Map(),
+): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'targetMessageId'> {
   return {
     rooms: new Map(),
     roomEntities: new Map(),
@@ -384,13 +418,14 @@ function createEmptyRoomState(
     votedPollIds,
     dismissedPollIds,
     mamQueryStates: new Map(),
+    roomGaps,
     targetMessageId: null,
   }
 }
 
 export const roomStore = createStore<RoomState>()(
   subscribeWithSelector((set, get) => ({
-  ...createEmptyRoomState(loadDraftsFromStorage(), loadVotedPollsFromStorage(), loadDismissedPollsFromStorage()), // Restore drafts and poll state from localStorage
+  ...createEmptyRoomState(loadDraftsFromStorage(), loadVotedPollsFromStorage(), loadDismissedPollsFromStorage(), loadGapsFromStorage()), // Restore drafts, poll state, and history gaps from localStorage
 
   addRoom: (room) => {
     set((state) => {
@@ -890,7 +925,7 @@ export const roomStore = createStore<RoomState>()(
   getRoom: (roomJid) => get().rooms.get(roomJid),
 
   switchAccount: (jid) => {
-    set(createEmptyRoomState(loadDraftsFromStorage(jid), loadVotedPollsFromStorage(jid), loadDismissedPollsFromStorage(jid)))
+    set(createEmptyRoomState(loadDraftsFromStorage(jid), loadVotedPollsFromStorage(jid), loadDismissedPollsFromStorage(jid), loadGapsFromStorage(jid)))
   },
 
   reset: () => {
@@ -901,6 +936,7 @@ export const roomStore = createStore<RoomState>()(
     localStorage.removeItem(getRoomDraftsStorageKey())
     localStorage.removeItem(getRoomVotedPollsStorageKey())
     localStorage.removeItem(getRoomDismissedPollsStorageKey())
+    localStorage.removeItem(getRoomGapsStorageKey())
     set(createEmptyRoomState())
   },
 
@@ -1845,10 +1881,21 @@ export const roomStore = createStore<RoomState>()(
         preserveGapMarker
       )
 
+      // Mirror the (reliable, complete=false-driven) forward gap into the PERSISTED
+      // roomGaps map so the marker survives a reload. `end` = oldest message held
+      // above the gap. preserveGapMarker (bounded force repair) leaves it untouched.
+      let newGaps = state.roomGaps
+      if (direction === 'forward' && !preserveGapMarker) {
+        const gapStart = newStates.get(roomJid)?.forwardGapTimestamp
+        const gapEnd = gapStart !== undefined ? computeGapEnd(merged, gapStart) : undefined
+        newGaps = syncRoomGap(state.roomGaps, roomJid, gapStart, gapEnd)
+        if (newGaps !== state.roomGaps) saveGapsToStorage(newGaps)
+      }
+
       // If no new messages (all duplicates), only update MAM state - skip room messages
       // This prevents unnecessary re-renders when merging duplicates
       if (newFromMAM.length === 0) {
-        return { mamQueryStates: newStates }
+        return { mamQueryStates: newStates, roomGaps: newGaps }
       }
 
       // Persist only locally-persistable messages to IndexedDB
@@ -1879,7 +1926,7 @@ export const roomStore = createStore<RoomState>()(
         newMeta.set(roomJid, { ...existingMeta, lastMessage })
       }
 
-      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, mamQueryStates: newStates }
+      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: newGaps }
     })
   },
 

--- a/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
   computeGapEnd,
-  syncRoomGap,
-  serializeRoomGaps,
-  deserializeRoomGaps,
+  syncGap,
+  serializeGaps,
+  deserializeGaps,
   type GapInterval,
-} from './roomGap'
+} from './mamGap'
 
 describe('computeGapEnd', () => {
   const start = new Date('2026-05-14T09:00:00Z').getTime()
@@ -34,46 +34,46 @@ describe('computeGapEnd', () => {
   })
 })
 
-describe('syncRoomGap', () => {
+describe('syncGap', () => {
   it('records a gap interval when start is defined', () => {
-    const result = syncRoomGap(new Map(), 'room@x', 1000, 5000)
+    const result = syncGap(new Map(), 'room@x', 1000, 5000)
     expect(result.get('room@x')).toEqual({ start: 1000, end: 5000 })
   })
 
   it('omits end when undefined (gap extends to live)', () => {
-    const result = syncRoomGap(new Map(), 'room@x', 1000, undefined)
+    const result = syncGap(new Map(), 'room@x', 1000, undefined)
     expect(result.get('room@x')).toEqual({ start: 1000 })
   })
 
   it('clears the gap when start is undefined', () => {
     const gaps = new Map<string, GapInterval>([['room@x', { start: 1000, end: 5000 }]])
-    const result = syncRoomGap(gaps, 'room@x', undefined, undefined)
+    const result = syncGap(gaps, 'room@x', undefined, undefined)
     expect(result.has('room@x')).toBe(false)
   })
 
   it('returns the same map reference when nothing changes (no spurious writes)', () => {
     const gaps = new Map<string, GapInterval>([['room@x', { start: 1000, end: 5000 }]])
-    expect(syncRoomGap(gaps, 'room@x', 1000, 5000)).toBe(gaps)
+    expect(syncGap(gaps, 'room@x', 1000, 5000)).toBe(gaps)
   })
 
   it('returns the same map reference when clearing an already-absent gap', () => {
     const gaps = new Map<string, GapInterval>()
-    expect(syncRoomGap(gaps, 'room@x', undefined, undefined)).toBe(gaps)
+    expect(syncGap(gaps, 'room@x', undefined, undefined)).toBe(gaps)
   })
 })
 
-describe('serializeRoomGaps / deserializeRoomGaps', () => {
+describe('serializeGaps / deserializeGaps', () => {
   it('round-trips a gap map', () => {
     const gaps = new Map<string, GapInterval>([
       ['a@x', { start: 1000, end: 5000 }],
       ['b@x', { start: 2000 }],
     ])
-    const restored = deserializeRoomGaps(serializeRoomGaps(gaps))
+    const restored = deserializeGaps(serializeGaps(gaps))
     expect(restored.get('a@x')).toEqual({ start: 1000, end: 5000 })
     expect(restored.get('b@x')).toEqual({ start: 2000 })
   })
 
   it('returns an empty map for malformed JSON', () => {
-    expect(deserializeRoomGaps('not json').size).toBe(0)
+    expect(deserializeGaps('not json').size).toBe(0)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/mamGap.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.ts
@@ -15,7 +15,7 @@
  * a real gap are indistinguishable by timestamp, and ejabberd archive ids are
  * non-sequential.
  *
- * @module Stores/Shared/RoomGap
+ * @module Stores/Shared/MamGap
  */
 
 /** A known hole in a room's archived history. */
@@ -52,7 +52,7 @@ export function computeGapEnd(messages: Array<{ timestamp?: Date }>, start: numb
  * Copy-on-write: returns the SAME map reference when nothing changes, so callers
  * can skip persistence and re-renders.
  */
-export function syncRoomGap(
+export function syncGap(
   gaps: Map<string, GapInterval>,
   jid: string,
   start: number | undefined,
@@ -75,12 +75,12 @@ export function syncRoomGap(
 }
 
 /** Serialize the gap map for localStorage (`[jid, GapInterval][]`). */
-export function serializeRoomGaps(gaps: Map<string, GapInterval>): string {
+export function serializeGaps(gaps: Map<string, GapInterval>): string {
   return JSON.stringify(Array.from(gaps.entries()))
 }
 
 /** Parse the gap map from localStorage; returns an empty map on any error. */
-export function deserializeRoomGaps(json: string): Map<string, GapInterval> {
+export function deserializeGaps(json: string): Map<string, GapInterval> {
   try {
     const entries = JSON.parse(json) as [string, GapInterval][]
     return new Map(entries)

--- a/packages/fluux-sdk/src/stores/shared/mamState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.test.ts
@@ -185,6 +185,34 @@ describe('mamState utilities', () => {
       })
     })
 
+    it('clears an existing forwardGapTimestamp on a completing forward query (default)', () => {
+      const states = new Map<string, MAMQueryState>([
+        ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
+      ])
+      const result = setMAMQueryCompleted(states, 'room-1', true, 'forward')
+      expect(result.get('room-1')?.forwardGapTimestamp).toBeUndefined()
+    })
+
+    it('preserveGapMarker keeps an existing forwardGapTimestamp on a completing forward query', () => {
+      // A bounded force repair must NOT hide a real gap marker just because its
+      // own (windowed) forward query happened to complete.
+      const states = new Map<string, MAMQueryState>([
+        ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
+      ])
+      const result = setMAMQueryCompleted(states, 'room-1', true, 'forward', undefined, undefined, true)
+      expect(result.get('room-1')?.forwardGapTimestamp).toBe(1000)
+      expect(result.get('room-1')?.isCaughtUpToLive).toBe(true) // other markers still update
+    })
+
+    it('preserveGapMarker does not overwrite forwardGapTimestamp on an incomplete forward query', () => {
+      const states = new Map<string, MAMQueryState>([
+        ['room-1', { ...DEFAULT_MAM_STATE, forwardGapTimestamp: 1000 }],
+      ])
+      // Without preserve this would set forwardGapTimestamp = 5000 (this page's newest).
+      const result = setMAMQueryCompleted(states, 'room-1', false, 'forward', undefined, 5000, true)
+      expect(result.get('room-1')?.forwardGapTimestamp).toBe(1000)
+    })
+
     it('sets isHistoryComplete=false for incomplete backward query', () => {
       const states = new Map<string, MAMQueryState>()
       const result = setMAMQueryCompleted(states, 'conv-1', false, 'backward', 'msg-123')

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -85,7 +85,8 @@ export function setMAMQueryCompleted(
   complete: boolean,
   direction: MAMQueryDirection,
   oldestFetchedId?: string,
-  newestFetchedTimestamp?: number
+  newestFetchedTimestamp?: number,
+  preserveGapMarker = false
 ): Map<string, MAMQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
@@ -101,9 +102,18 @@ export function setMAMQueryCompleted(
 
   // Track gap position for incomplete forward catch-ups.
   // Set when forward catch-up ends without complete=true, cleared when caught up.
-  const forwardGapTimestamp = direction === 'forward'
-    ? (complete ? undefined : newestFetchedTimestamp)
-    : current.forwardGapTimestamp
+  //
+  // `preserveGapMarker` leaves the existing marker untouched (neither set nor
+  // cleared). Used by bounded "force repair" queries (forceCatchUpAllRooms),
+  // which start from a fixed window — not the contiguous edge — so their
+  // completion says nothing about whether older history is contiguous. Letting
+  // such a query clear the marker would hide a real gap older than the window;
+  // letting it set one would plant a spurious marker inside the window.
+  const forwardGapTimestamp = preserveGapMarker
+    ? current.forwardGapTimestamp
+    : direction === 'forward'
+      ? (complete ? undefined : newestFetchedTimestamp)
+      : current.forwardGapTimestamp
 
   newStates.set(id, {
     isLoading: false,

--- a/packages/fluux-sdk/src/stores/shared/roomGap.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/roomGap.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeGapEnd,
+  syncRoomGap,
+  serializeRoomGaps,
+  deserializeRoomGaps,
+  type GapInterval,
+} from './roomGap'
+
+describe('computeGapEnd', () => {
+  const start = new Date('2026-05-14T09:00:00Z').getTime()
+
+  it('returns the oldest message timestamp strictly after the gap start', () => {
+    const messages = [
+      { timestamp: new Date('2026-05-14T08:00:00Z') }, // before start — ignored
+      { timestamp: new Date('2026-06-10T12:00:00Z') }, // above gap
+      { timestamp: new Date('2026-06-01T09:00:00Z') }, // oldest above gap → the end
+    ]
+    expect(computeGapEnd(messages, start)).toBe(new Date('2026-06-01T09:00:00Z').getTime())
+  })
+
+  it('returns undefined when nothing is newer than the gap start (gap extends to live)', () => {
+    const messages = [
+      { timestamp: new Date('2026-05-14T08:00:00Z') },
+      { timestamp: new Date(start) }, // exactly at start — not strictly after
+    ]
+    expect(computeGapEnd(messages, start)).toBeUndefined()
+  })
+
+  it('ignores messages without timestamps', () => {
+    expect(computeGapEnd([{}, { timestamp: new Date('2026-07-01T00:00:00Z') }, {}], start)).toBe(
+      new Date('2026-07-01T00:00:00Z').getTime(),
+    )
+  })
+})
+
+describe('syncRoomGap', () => {
+  it('records a gap interval when start is defined', () => {
+    const result = syncRoomGap(new Map(), 'room@x', 1000, 5000)
+    expect(result.get('room@x')).toEqual({ start: 1000, end: 5000 })
+  })
+
+  it('omits end when undefined (gap extends to live)', () => {
+    const result = syncRoomGap(new Map(), 'room@x', 1000, undefined)
+    expect(result.get('room@x')).toEqual({ start: 1000 })
+  })
+
+  it('clears the gap when start is undefined', () => {
+    const gaps = new Map<string, GapInterval>([['room@x', { start: 1000, end: 5000 }]])
+    const result = syncRoomGap(gaps, 'room@x', undefined, undefined)
+    expect(result.has('room@x')).toBe(false)
+  })
+
+  it('returns the same map reference when nothing changes (no spurious writes)', () => {
+    const gaps = new Map<string, GapInterval>([['room@x', { start: 1000, end: 5000 }]])
+    expect(syncRoomGap(gaps, 'room@x', 1000, 5000)).toBe(gaps)
+  })
+
+  it('returns the same map reference when clearing an already-absent gap', () => {
+    const gaps = new Map<string, GapInterval>()
+    expect(syncRoomGap(gaps, 'room@x', undefined, undefined)).toBe(gaps)
+  })
+})
+
+describe('serializeRoomGaps / deserializeRoomGaps', () => {
+  it('round-trips a gap map', () => {
+    const gaps = new Map<string, GapInterval>([
+      ['a@x', { start: 1000, end: 5000 }],
+      ['b@x', { start: 2000 }],
+    ])
+    const restored = deserializeRoomGaps(serializeRoomGaps(gaps))
+    expect(restored.get('a@x')).toEqual({ start: 1000, end: 5000 })
+    expect(restored.get('b@x')).toEqual({ start: 2000 })
+  })
+
+  it('returns an empty map for malformed JSON', () => {
+    expect(deserializeRoomGaps('not json').size).toBe(0)
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/roomGap.ts
+++ b/packages/fluux-sdk/src/stores/shared/roomGap.ts
@@ -1,0 +1,90 @@
+/**
+ * Persisted room history-gap metadata.
+ *
+ * A `GapInterval` records a *known* hole in a room's archived history: messages
+ * are held below `start` and (when `end` is set) above `end`, with a gap in
+ * between. Unlike the ephemeral `forwardGapTimestamp` in `mamQueryStates`, room
+ * gaps are persisted to localStorage so the "Load missing messages" marker
+ * survives a reload — otherwise the next session's catch-up cursor (which sits
+ * *above* the gap after the session-start fix) would never re-detect it, leaving
+ * the gap silent again.
+ *
+ * Detection is driven ONLY by the reliable signal: a forward catch-up that ended
+ * `complete=false` (the server said there is more, and we stopped at the page
+ * cap). We never infer holes from timestamp discontinuities — a quiet period and
+ * a real gap are indistinguishable by timestamp, and ejabberd archive ids are
+ * non-sequential.
+ *
+ * @module Stores/Shared/RoomGap
+ */
+
+/** A known hole in a room's archived history. */
+export interface GapInterval {
+  /** Epoch ms of the newest message held *below* the gap (where it starts). */
+  start: number
+  /** Epoch ms of the oldest message held *above* the gap, or undefined if the
+   *  gap extends to the live edge (nothing newer is held yet). */
+  end?: number
+}
+
+/**
+ * Find the upper bound of a gap: the oldest message strictly newer than `start`.
+ * Returns undefined when nothing is held above the gap (it extends to live).
+ *
+ * Robust to unsorted input.
+ */
+export function computeGapEnd(messages: Array<{ timestamp?: Date }>, start: number): number | undefined {
+  let end: number | undefined
+  for (const message of messages) {
+    const ts = message.timestamp?.getTime()
+    if (ts === undefined || ts <= start) continue
+    if (end === undefined || ts < end) end = ts
+  }
+  return end
+}
+
+/**
+ * Pure transition for the per-room gap map.
+ *
+ * - `start` defined → record/update the gap interval for `jid`.
+ * - `start` undefined → clear the gap for `jid`.
+ *
+ * Copy-on-write: returns the SAME map reference when nothing changes, so callers
+ * can skip persistence and re-renders.
+ */
+export function syncRoomGap(
+  gaps: Map<string, GapInterval>,
+  jid: string,
+  start: number | undefined,
+  end: number | undefined,
+): Map<string, GapInterval> {
+  const existing = gaps.get(jid)
+
+  if (start === undefined) {
+    if (!existing) return gaps
+    const next = new Map(gaps)
+    next.delete(jid)
+    return next
+  }
+
+  if (existing && existing.start === start && existing.end === end) return gaps
+
+  const next = new Map(gaps)
+  next.set(jid, end === undefined ? { start } : { start, end })
+  return next
+}
+
+/** Serialize the gap map for localStorage (`[jid, GapInterval][]`). */
+export function serializeRoomGaps(gaps: Map<string, GapInterval>): string {
+  return JSON.stringify(Array.from(gaps.entries()))
+}
+
+/** Parse the gap map from localStorage; returns an empty map on any error. */
+export function deserializeRoomGaps(json: string): Map<string, GapInterval> {
+  try {
+    const entries = JSON.parse(json) as [string, GapInterval][]
+    return new Map(entries)
+  } catch {
+    return new Map()
+  }
+}

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -3,6 +3,7 @@ import {
   findNewestMessage,
   findCatchUpCursorMessage,
   findContinueCatchUpCursor,
+  selectCatchUpQuery,
   buildCatchUpStartTime,
   isConnectionError,
   MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
@@ -152,6 +153,40 @@ describe('findContinueCatchUpCursor', () => {
 
   it('returns undefined with no gap marker and no messages', () => {
     expect(findContinueCatchUpCursor([], undefined)).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// selectCatchUpQuery (shared cursor policy for chat + room)
+// ============================================================================
+
+describe('selectCatchUpQuery', () => {
+  const sessionStart = new Date('2026-06-14T12:00:00Z').getTime()
+
+  it('returns a forward start from the newest PRE-session message', () => {
+    const monthOld = new Date('2026-05-14T09:00:00Z')
+    const live = new Date('2026-06-14T12:00:05Z')
+    expect(selectCatchUpQuery([{ timestamp: monthOld }, { timestamp: live }], sessionStart)).toEqual({
+      start: '2026-05-14T09:00:00.001Z',
+    })
+  })
+
+  it('returns backward (before:"") when only this-session messages exist', () => {
+    expect(selectCatchUpQuery([{ timestamp: new Date('2026-06-14T12:00:05Z') }], sessionStart)).toEqual({
+      before: '',
+    })
+  })
+
+  it('returns backward (before:"") for an empty message list', () => {
+    expect(selectCatchUpQuery([], sessionStart)).toEqual({ before: '' })
+  })
+
+  it('uses the global newest when no sessionStartTime is given (legacy behavior)', () => {
+    const a = new Date('2026-01-01T00:00:00Z')
+    const b = new Date('2026-02-01T00:00:00Z')
+    expect(selectCatchUpQuery([{ timestamp: a }, { timestamp: b }], undefined)).toEqual({
+      start: '2026-02-01T00:00:00.001Z',
+    })
   })
 })
 

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest'
 import {
   findNewestMessage,
   findCatchUpCursorMessage,
+  findContinueCatchUpCursor,
   buildCatchUpStartTime,
   isConnectionError,
+  MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
   MAM_CATCHUP_FORWARD_MAX,
   MAM_CATCHUP_BACKWARD_MAX,
   MAM_BACKGROUND_CONCURRENCY,
@@ -118,6 +120,48 @@ describe('findCatchUpCursorMessage', () => {
     // Deliberately unsorted.
     const messages = [{ timestamp: live }, { timestamp: older }, {}, { timestamp: newerPre }]
     expect(findCatchUpCursorMessage(messages, sessionStart)?.timestamp).toBe(newerPre)
+  })
+})
+
+// ============================================================================
+// findContinueCatchUpCursor
+// ============================================================================
+
+describe('findContinueCatchUpCursor', () => {
+  it('returns the gap-boundary timestamp when a gap marker exists, ignoring newer messages', () => {
+    // "Load missing messages": the cursor must be the gap boundary so the forward
+    // query fills the HOLE — not the global newest, which sits AFTER the hole.
+    const gapBoundary = new Date('2026-05-14T09:00:00Z')
+    const recentAfterHole = new Date('2026-06-14T12:00:00Z')
+    const messages = [{ timestamp: gapBoundary }, { timestamp: recentAfterHole }]
+    const result = findContinueCatchUpCursor(messages, gapBoundary.getTime())
+    expect(result?.timestamp.getTime()).toBe(gapBoundary.getTime())
+  })
+
+  it('returns the gap boundary even when the message cache is empty', () => {
+    const gapBoundary = new Date('2026-05-14T09:00:00Z')
+    expect(findContinueCatchUpCursor([], gapBoundary.getTime())?.timestamp.getTime()).toBe(gapBoundary.getTime())
+  })
+
+  it('falls back to the newest message when there is no gap marker', () => {
+    const older = new Date('2026-01-01T00:00:00Z')
+    const newest = new Date('2026-02-01T00:00:00Z')
+    const result = findContinueCatchUpCursor([{ timestamp: older }, { timestamp: newest }], undefined)
+    expect(result?.timestamp).toBe(newest)
+  })
+
+  it('returns undefined with no gap marker and no messages', () => {
+    expect(findContinueCatchUpCursor([], undefined)).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// Manual repair pagination cap
+// ============================================================================
+
+describe('MAM_ROOM_FORWARD_MAX_PAGES_MANUAL', () => {
+  it('is larger than the background forward cap so user-initiated repair paginates further', () => {
+    expect(MAM_ROOM_FORWARD_MAX_PAGES_MANUAL).toBeGreaterThan(MAM_ROOM_FORWARD_MAX_PAGES)
   })
 })
 

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   findNewestMessage,
+  findCatchUpCursorMessage,
   buildCatchUpStartTime,
   isConnectionError,
   MAM_CATCHUP_FORWARD_MAX,
@@ -57,6 +58,66 @@ describe('findNewestMessage', () => {
       { timestamp: t3 },
     ])
     expect(result?.timestamp).toBe(t3)
+  })
+})
+
+// ============================================================================
+// findCatchUpCursorMessage
+// ============================================================================
+
+describe('findCatchUpCursorMessage', () => {
+  const sessionStart = new Date('2026-06-14T12:00:00Z').getTime()
+
+  it('returns undefined for an empty array', () => {
+    expect(findCatchUpCursorMessage([], sessionStart)).toBeUndefined()
+  })
+
+  it('returns undefined when every message has no timestamp', () => {
+    expect(findCatchUpCursorMessage([{}, {}], sessionStart)).toBeUndefined()
+  })
+
+  it('returns undefined when every message is from the current session (>= sessionStart)', () => {
+    // Room first joined this session — only live messages, no prior history.
+    const messages = [
+      { timestamp: new Date('2026-06-14T12:00:05Z') },
+      { timestamp: new Date('2026-06-14T12:00:10Z') },
+    ]
+    expect(findCatchUpCursorMessage(messages, sessionStart)).toBeUndefined()
+  })
+
+  it('returns the global newest when all messages predate the session (clean cold-start)', () => {
+    const t1 = new Date('2026-05-01T00:00:00Z')
+    const t2 = new Date('2026-05-14T09:00:00Z') // newest, still a month before sessionStart
+    const messages = [{ timestamp: t1 }, { timestamp: t2 }]
+    expect(findCatchUpCursorMessage(messages, sessionStart)?.timestamp).toBe(t2)
+  })
+
+  it('ignores live messages received this session and returns the newest PRE-session message', () => {
+    // THE regression case: a live message lands in the catch-up window. The cursor
+    // must be the month-old pre-session message, NOT the live one — otherwise the
+    // forward query starts from "now" and silently skips the offline gap.
+    const monthOld = new Date('2026-05-14T09:00:00Z')
+    const liveDuringWindow = new Date('2026-06-14T12:00:05Z')
+    const messages = [
+      { timestamp: monthOld },
+      { timestamp: liveDuringWindow }, // arrived after reconnect — must be excluded
+    ]
+    expect(findCatchUpCursorMessage(messages, sessionStart)?.timestamp).toBe(monthOld)
+  })
+
+  it('excludes a message exactly at sessionStart (strictly before)', () => {
+    const atStart = new Date(sessionStart)
+    const before = new Date(sessionStart - 1000)
+    expect(findCatchUpCursorMessage([{ timestamp: before }, { timestamp: atStart }], sessionStart)?.timestamp).toBe(before)
+  })
+
+  it('returns the newest pre-session message regardless of array order', () => {
+    const older = new Date('2026-04-01T00:00:00Z')
+    const newerPre = new Date('2026-05-14T09:00:00Z')
+    const live = new Date('2026-06-14T12:30:00Z')
+    // Deliberately unsorted.
+    const messages = [{ timestamp: live }, { timestamp: older }, {}, { timestamp: newerPre }]
+    expect(findCatchUpCursorMessage(messages, sessionStart)?.timestamp).toBe(newerPre)
   })
 })
 

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -33,6 +33,13 @@ export const MAM_ROOM_CATCHUP_DELAY_MS = 10_000
  *  The loop still breaks early on `complete=true`. */
 export const MAM_ROOM_FORWARD_MAX_PAGES = 50
 
+/** Max auto-pagination pages for a USER-INITIATED forward catch-up (manual "Catch up
+ *  all rooms" repair and the "Load missing messages" continue action). Far higher than
+ *  the background cap (500 × 100 = 50 000 stanzas) so a deliberate repair paginates to
+ *  completion instead of silently stopping mid-gap. The loop still breaks on
+ *  `complete=true`; this is only a runaway backstop. */
+export const MAM_ROOM_FORWARD_MAX_PAGES_MANUAL = 500
+
 // ============================================================================
 // Functions
 // ============================================================================
@@ -90,6 +97,28 @@ export function findCatchUpCursorMessage(
     }
   }
   return cursor
+}
+
+/**
+ * Pick the cursor for a user-initiated "continue catch-up" (the "Load missing
+ * messages" button).
+ *
+ * When a forward gap marker exists (`forwardGapTimestamp`), the cursor must be
+ * the gap boundary so the forward query fills the HOLE — the global newest
+ * message sits *after* the hole, so resuming from it would skip the gap entirely
+ * (the original "Load missing" bug). Falls back to the newest message when there
+ * is no recorded gap.
+ *
+ * @param messages - Candidate messages (any order)
+ * @param forwardGapTimestamp - Epoch ms of the recorded forward gap, or undefined
+ * @returns The message-like cursor to start the forward query from, or undefined
+ */
+export function findContinueCatchUpCursor(
+  messages: Array<{ timestamp?: Date }>,
+  forwardGapTimestamp: number | undefined
+): { timestamp: Date } | undefined {
+  if (forwardGapTimestamp !== undefined) return { timestamp: new Date(forwardGapTimestamp) }
+  return findNewestMessage(messages)
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -99,6 +99,34 @@ export function findCatchUpCursorMessage(
   return cursor
 }
 
+/** Result of {@link selectCatchUpQuery}: a forward `start` filter, or a backward
+ *  `before: ''` (fetch latest) when there is no usable pre-session cursor. */
+export interface CatchUpQuery {
+  start?: string
+  before?: string
+}
+
+/**
+ * The single, shared catch-up cursor policy for BOTH 1:1 and MUC forward
+ * catch-up (background sync + active-entity side effects). Centralized so the
+ * cursor logic can't drift between the chat and room paths — which is exactly
+ * how the session-start fix once landed in rooms but not 1:1.
+ *
+ * Returns a forward `{ start }` from the newest message that predates the
+ * session (so a live message in the catch-up window can't poison the cursor),
+ * or `{ before: '' }` to fetch the latest when nothing pre-session is held.
+ * When `sessionStartTime` is omitted, falls back to the global newest message.
+ */
+export function selectCatchUpQuery(
+  messages: Array<{ timestamp?: Date }>,
+  sessionStartTime?: number,
+): CatchUpQuery {
+  const cursor = sessionStartTime !== undefined
+    ? findCatchUpCursorMessage(messages, sessionStartTime)
+    : findNewestMessage(messages)
+  return cursor?.timestamp ? { start: buildCatchUpStartTime(cursor.timestamp) } : { before: '' }
+}
+
 /**
  * Pick the cursor for a user-initiated "continue catch-up" (the "Load missing
  * messages" button).

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -54,6 +54,45 @@ export function findNewestMessage(messages: Array<{ timestamp?: Date }>): { time
 }
 
 /**
+ * Pick the forward catch-up cursor message: the newest message that predates
+ * the current session.
+ *
+ * Forward catch-up fetches everything *after* a cursor, so the cursor must be
+ * the end of the history we already hold contiguously — NOT the global newest
+ * message. After a long offline period the cache ends at the last pre-offline
+ * message, but a live message arriving in the catch-up window (or any message
+ * received this session) is newer. Using `findNewestMessage` there would start
+ * the forward query from "now", return zero results, complete immediately, and
+ * **silently skip the entire offline gap** (no gap marker, because a completed
+ * forward query clears `forwardGapTimestamp`).
+ *
+ * By excluding messages with `timestamp >= sessionStartTime`, the cursor stays
+ * on the pre-session edge, so the forward query fills the gap up to live.
+ *
+ * Robust to unsorted input: scans for the maximum timestamp strictly before
+ * `sessionStartTime`.
+ *
+ * @param messages - Candidate messages (cache + live), any order
+ * @param sessionStartTime - Epoch ms when the current session connected; messages
+ *   at or after this are treated as this-session traffic and excluded
+ * @returns The newest pre-session message, or undefined if none predate the session
+ */
+export function findCatchUpCursorMessage(
+  messages: Array<{ timestamp?: Date }>,
+  sessionStartTime: number
+): { timestamp: Date } | undefined {
+  let cursor: { timestamp: Date } | undefined
+  for (const message of messages) {
+    const ts = message.timestamp?.getTime()
+    if (ts === undefined || ts >= sessionStartTime) continue
+    if (!cursor || ts > cursor.timestamp.getTime()) {
+      cursor = message as { timestamp: Date }
+    }
+  }
+  return cursor
+}
+
+/**
  * Build a MAM `start` filter value from the newest cached message.
  *
  * Adds 1 ms to avoid re-fetching the cursor message itself. This


### PR DESCRIPTION
## Summary

Fixes the recurring MUC "history gap" where a client opened after a long absence silently failed to download an entire month of archived messages that were present in MAM — and extends the same robustness and recovery to 1:1 chats.

**Root cause:** forward catch-up keyed its cursor off the *global newest message in the store*. A live message arriving during the post-connect catch-up window (or any message newer than the contiguous cache tail) poisoned the cursor, so the forward query started from "now", returned nothing, completed, and recorded no gap marker — the offline gap vanished silently. The manual "Catch up all rooms" repair defaulted to 7 days and so couldn't reach a month-old gap.

## What changed

- **Anchor the catch-up cursor to session start.** Forward catch-up now resumes from the newest message *before* the current session, so a live message in the catch-up window can't push the cursor past the gap. A single shared cursor policy (`selectCatchUpQuery`) drives all four catch-up sites (1:1 + rooms) so the two paths can't drift again.
- **Manual repair widened 7 → 45 days** and no longer wipes a real gap marker (`preserveGapMarker`); user-initiated catch-up and "Load missing" paginate to completion (50k cap) instead of stopping at the 5000 background cap.
- **"Load missing messages" actually fills the hole** — resumes from the recorded gap boundary, not the global newest (which sits *after* the hole).
- **Persisted gap markers** (`GapInterval`, account-scoped) so a known gap survives a reload — for both rooms and 1:1. Detection is driven solely by the reliable `complete=false` signal (no timestamp-discontinuity heuristic; ejabberd archive ids are non-sequential).
- **Full 1:1 ↔ room parity** — 1:1 forward catch-up now paginates oldest-first to completion and gains the same gap-marker + "Load missing" UX; shared `mamGap` module backs both stores.
- **Late-MAM room retry** — a non-active room whose MAM support resolves *after* the initial 10s pass is now caught up (previously dropped with no retry).

## Notes

- Gap metadata is scoped to the user JID for both stores (`fluux-room-gaps:<jid>` and the account-scoped chat blob) — no cross-account leak of which rooms/conversations have gaps; covered by explicit scoping tests.
- The 5000-stanza background cap is intentionally kept — the now-reliable gap marker is the escape valve, and an incomplete-forward `console:event` surfaces cap hits for monitoring before deciding to raise it.
- Deferred (flagged for follow-up): contiguous archived-id range tracking, the only thing that fully heals gaps already baked into a pre-fix cache.