### PR TITLE
fix(notifications): macOS native notifications silently suppressed + Settings permission UX

### DIFF
--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -110,7 +110,7 @@ webkit2gtk = { version = "=2.0.2", features = ["v2_32"] }
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSThread", "NSProcessInfo", "NSDictionary", "NSArray", "NSError", "NSURL"] }
 objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication"] }
-objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNNotificationTrigger", "UNNotificationAttachment", "UNError", "block2"] }
+objc2-user-notifications = { version = "0.3", features = ["UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotification", "UNNotificationTrigger", "UNNotificationAttachment", "UNNotificationSettings", "UNError", "block2"] }
 block2 = "0.6"
 
 [profile.release]

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -1,18 +1,22 @@
 //! macOS native notifications via `UNUserNotificationCenter`.
 
 use crate::notifications::backend::{AuthState, NativeNotification, NavTarget};
+use core::ptr::NonNull;
 use objc2::rc::Retained;
 use objc2::runtime::{Bool, NSObject, NSObjectProtocol, ProtocolObject};
 use objc2::{define_class, msg_send, AnyThread};
 use objc2_foundation::{NSError, NSString};
 use objc2_user_notifications::{
-    UNAuthorizationOptions, UNMutableNotificationContent, UNNotification,
+    UNAuthorizationOptions, UNAuthorizationStatus, UNMutableNotificationContent, UNNotification,
     UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
-    UNNotificationTrigger, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
+    UNNotificationSettings, UNNotificationTrigger, UNUserNotificationCenter,
+    UNUserNotificationCenterDelegate,
 };
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
 /// App handle for emitting `notification-activated` from the delegate.
@@ -24,10 +28,6 @@ static PENDING_TARGET: Mutex<Option<NavTarget>> = Mutex::new(None);
 /// Whether the JS `notification-activated` listener is attached. Set by the JS
 /// layer via `set_notification_listener_ready` once its `listen()` resolves.
 static LISTENER_READY: AtomicBool = AtomicBool::new(false);
-
-/// Cached authorization state. 0 = NotDetermined, 1 = Granted, 2 = Denied.
-/// Set by the async authorization callback.
-static AUTH: AtomicU8 = AtomicU8::new(0);
 
 /// Keeps the notification-center delegate alive for the app's lifetime.
 /// `setDelegate:` stores it as a weak reference, so we must own it here.
@@ -149,7 +149,10 @@ fn handle_activation(identifier: &str) {
 pub fn setup(app: &AppHandle) {
     let _ = APP_HANDLE.set(app.clone());
     set_delegate();
-    request_authorization();
+    // Surface the OS prompt early without blocking the main thread. The live
+    // status is read later via `authorization_state()`, so the async result of
+    // this request is intentionally ignored.
+    prime_authorization();
 }
 
 pub fn post(n: NativeNotification) -> Result<(), String> {
@@ -190,28 +193,73 @@ pub fn post(n: NativeNotification) -> Result<(), String> {
     Ok(())
 }
 
-pub fn authorization_state() -> AuthState {
-    match AUTH.load(Ordering::SeqCst) {
-        1 => AuthState::Granted,
-        2 => AuthState::Denied,
-        _ => AuthState::NotDetermined,
+fn map_status(status: UNAuthorizationStatus) -> AuthState {
+    // Provisional/Ephemeral both permit delivery, so treat them as granted.
+    if status == UNAuthorizationStatus::Authorized
+        || status == UNAuthorizationStatus::Provisional
+        || status == UNAuthorizationStatus::Ephemeral
+    {
+        AuthState::Granted
+    } else if status == UNAuthorizationStatus::Denied {
+        AuthState::Denied
+    } else {
+        AuthState::NotDetermined
     }
 }
 
+/// Read the live authorization status from the OS. Unlike a cached flag this
+/// survives restarts and avoids the startup race where the app connected (and
+/// the permission check ran) before any async auth callback had populated
+/// in-memory state. The completion handler runs on a background queue, so this
+/// blocks briefly for the answer — it MUST run off the main thread (the command
+/// wraps it in `spawn_blocking`).
+pub fn authorization_state() -> AuthState {
+    use block2::RcBlock;
+    let (tx, rx) = mpsc::channel::<AuthState>();
+    let handler = RcBlock::new(move |settings: NonNull<UNNotificationSettings>| {
+        // SAFETY: the system passes a valid, non-null settings object that is
+        // alive for the duration of this callback.
+        let status = unsafe { settings.as_ref().authorizationStatus() };
+        let _ = tx.send(map_status(status));
+    });
+    current_center().getNotificationSettingsWithCompletionHandler(&handler);
+    rx.recv_timeout(Duration::from_secs(2))
+        .unwrap_or(AuthState::NotDetermined)
+}
+
+/// Fire an authorization request without waiting. Used at startup to surface the
+/// OS prompt early; the result is read later via `authorization_state()`.
+fn prime_authorization() {
+    use block2::RcBlock;
+    let options = UNAuthorizationOptions::Alert
+        | UNAuthorizationOptions::Sound
+        | UNAuthorizationOptions::Badge;
+    let handler = RcBlock::new(|_granted: Bool, _err: *mut NSError| {});
+    current_center().requestAuthorizationWithOptions_completionHandler(options, &handler);
+}
+
+/// Request authorization and wait for the user's decision, returning the real
+/// result rather than a pre-callback placeholder. First run shows a system
+/// prompt; the completion handler fires on a background queue, so this blocks
+/// until the user answers — it MUST run off the main thread (the command wraps
+/// it in `spawn_blocking`).
 pub fn request_authorization() -> AuthState {
     use block2::RcBlock;
     let options = UNAuthorizationOptions::Alert
         | UNAuthorizationOptions::Sound
         | UNAuthorizationOptions::Badge;
-    // The completion handler is a heap-allocated `RcBlock` whose closure only
-    // touches a `'static` atomic; the center copies the block.
-    let handler = RcBlock::new(|granted: Bool, _err: *mut NSError| {
-        AUTH.store(if granted.as_bool() { 1 } else { 2 }, Ordering::SeqCst);
+    let (tx, rx) = mpsc::channel::<AuthState>();
+    let handler = RcBlock::new(move |granted: Bool, _err: *mut NSError| {
+        let _ = tx.send(if granted.as_bool() {
+            AuthState::Granted
+        } else {
+            AuthState::Denied
+        });
     });
     current_center().requestAuthorizationWithOptions_completionHandler(options, &handler);
-    // The callback is async; return the currently-known state. Callers re-poll
-    // `authorization_state()` after the OS prompt resolves.
-    authorization_state()
+    // The prompt is user-driven; allow ample time before falling back.
+    rx.recv_timeout(Duration::from_secs(300))
+        .unwrap_or(AuthState::NotDetermined)
 }
 
 pub fn take_pending_target() -> Option<NavTarget> {

--- a/apps/fluux/src-tauri/src/notifications/mod.rs
+++ b/apps/fluux/src-tauri/src/notifications/mod.rs
@@ -40,16 +40,23 @@ pub fn post_notification(
     })
 }
 
+// Async so Tauri runs them off the main thread: the macOS helpers block on an
+// async OS callback, which would otherwise freeze the UI (sync commands run on
+// the main thread).
 #[cfg(target_os = "macos")]
 #[tauri::command]
-pub fn notification_permission_state() -> AuthState {
-    macos::authorization_state()
+pub async fn notification_permission_state() -> AuthState {
+    tauri::async_runtime::spawn_blocking(macos::authorization_state)
+        .await
+        .unwrap_or(AuthState::NotDetermined)
 }
 
 #[cfg(target_os = "macos")]
 #[tauri::command]
-pub fn request_notification_permission() -> AuthState {
-    macos::request_authorization()
+pub async fn request_notification_permission() -> AuthState {
+    tauri::async_runtime::spawn_blocking(macos::request_authorization)
+        .await
+        .unwrap_or(AuthState::NotDetermined)
 }
 
 #[cfg(target_os = "macos")]

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -3,6 +3,11 @@ import { useTranslation } from 'react-i18next'
 import { Bell, BellOff, ExternalLink, Send } from 'lucide-react'
 import { useConnection, useXMPPContext, connectionStore } from '@fluux/sdk'
 import { isTauri } from './types'
+import { isMacOSDesktop } from '@/utils/tauriPlatform'
+import {
+  refreshNotificationPermission,
+  requestNotificationPermission,
+} from '@/hooks/useNotificationPermission'
 import { isWebPushSupported, requestWebPushRegistration } from '@/hooks/useWebPush'
 
 type NotificationStatus = 'checking' | 'granted' | 'denied' | 'default' | 'unavailable'
@@ -10,6 +15,15 @@ type NotificationStatus = 'checking' | 'granted' | 'denied' | 'default' | 'unava
 async function checkNotificationPermission(): Promise<NotificationStatus> {
   try {
     if (isTauri()) {
+      // macOS uses the native UNUserNotificationCenter command — the same
+      // source of truth as the posting gate — so Settings can't disagree with
+      // whether notifications actually fire. It also distinguishes "not yet
+      // asked" (notdetermined) from "denied", which the plugin can't.
+      if (await isMacOSDesktop()) {
+        const { invoke } = await import('@tauri-apps/api/core')
+        const state = await invoke<string>('notification_permission_state')
+        return state === 'granted' ? 'granted' : state === 'denied' ? 'denied' : 'default'
+      }
       const { isPermissionGranted } = await import('@tauri-apps/plugin-notification')
       const granted = await isPermissionGranted()
       return granted ? 'granted' : 'denied'
@@ -95,7 +109,12 @@ export function NotificationsSettings() {
   const { client } = useXMPPContext()
   const { webPushStatus, webPushEnabled, isConnected } = useConnection()
   const [notificationStatus, setNotificationStatus] = useState<NotificationStatus>('checking')
+  const [isMac, setIsMac] = useState(false)
   const [disabling, setDisabling] = useState(false)
+
+  useEffect(() => {
+    void isMacOSDesktop().then(setIsMac)
+  }, [])
 
   useEffect(() => {
     void checkNotificationPermission()
@@ -103,9 +122,33 @@ export function NotificationsSettings() {
       .catch(() => setNotificationStatus('unavailable'))
   }, [])
 
+  // Re-check when the window regains focus so the status (and the runtime gate)
+  // updates after the user flips the permission in System Settings and returns.
+  useEffect(() => {
+    const refresh = () => {
+      void checkNotificationPermission()
+        .then(setNotificationStatus)
+        .catch(() => setNotificationStatus('unavailable'))
+      void refreshNotificationPermission()
+    }
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', refresh)
+    return () => {
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', refresh)
+    }
+  }, [])
+
   const handleRequestPermission = async () => {
     const status = await requestWebNotificationPermission()
     setNotificationStatus(status)
+  }
+
+  // macOS: show the native permission prompt, then refresh the display and the
+  // runtime gate so notifications start working immediately (no restart).
+  const handleEnableMac = async () => {
+    await requestNotificationPermission()
+    setNotificationStatus(await checkNotificationPermission())
   }
 
   const handleDisableWebPush = async () => {
@@ -149,8 +192,8 @@ export function NotificationsSettings() {
             </div>
           </div>
 
-          {/* Web: Request permission button */}
-          {!isTauri && notificationStatus === 'default' && (
+          {/* Web: request permission in-page */}
+          {!isTauri() && notificationStatus === 'default' && (
             <button
               onClick={handleRequestPermission}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
@@ -161,8 +204,24 @@ export function NotificationsSettings() {
             </button>
           )}
 
-          {/* Tauri: Open system settings button */}
-          {isTauri() && (notificationStatus === 'denied' || notificationStatus === 'default') && (
+          {/* macOS: trigger the native OS prompt when permission was never asked */}
+          {isMac && notificationStatus === 'default' && (
+            <button
+              onClick={handleEnableMac}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
+                         bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"
+            >
+              <Bell className="size-4" />
+              {t('settings.requestPermission')}
+            </button>
+          )}
+
+          {/* Open OS settings: macOS once denied (the prompt won't reappear), or
+              other Tauri platforms which have no in-app prompt */}
+          {((isMac && notificationStatus === 'denied') ||
+            (isTauri() &&
+              !isMac &&
+              (notificationStatus === 'denied' || notificationStatus === 'default'))) && (
             <button
               onClick={openNotificationSettings}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text

--- a/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
@@ -43,7 +43,8 @@ vi.mock('./useNavigateToTarget', () => ({
 }))
 vi.mock('./useNotificationPermission', () => ({
   isTauri: true,
-  useNotificationPermission: () => ({ current: true }),
+  useNotificationPermission: () => {},
+  getNotificationPermissionGranted: () => true,
 }))
 vi.mock('./useNotificationEvents', () => ({
   useNotificationEvents: (h: typeof handlers) => { handlers = h },

--- a/apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
@@ -28,7 +28,8 @@ vi.mock('./useNavigateToTarget', () => ({
 }))
 vi.mock('./useNotificationPermission', () => ({
   isTauri: true,
-  useNotificationPermission: () => ({ current: true }),
+  useNotificationPermission: () => {},
+  getNotificationPermissionGranted: () => true,
 }))
 vi.mock('./useNotificationEvents', () => ({ useNotificationEvents: vi.fn() }))
 vi.mock('@fluux/sdk', () => ({ rosterStore: { getState: () => ({ getContact: () => undefined }) }, usePresence: () => ({ presenceStatus: 'online' }) }))

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -9,7 +9,11 @@ import type { Options as NotificationOptions } from '@tauri-apps/plugin-notifica
 import { isMacOSDesktop } from '@/utils/tauriPlatform'
 import { useNotificationEvents } from './useNotificationEvents'
 import { useNavigateToTarget } from './useNavigateToTarget'
-import { useNotificationPermission, isTauri } from './useNotificationPermission'
+import {
+  useNotificationPermission,
+  getNotificationPermissionGranted,
+  isTauri,
+} from './useNotificationPermission'
 import { getNotificationAvatarUrl } from '@/utils/notificationAvatar'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { notificationDebug } from '@/utils/notificationDebug'
@@ -27,7 +31,7 @@ import { routeNotificationTarget } from '@/utils/notificationRouting'
  */
 export function useDesktopNotifications(): void {
   const { navigateToConversation, navigateToRoom } = useNavigateToTarget()
-  const permissionGranted = useNotificationPermission()
+  useNotificationPermission()
   const { presenceStatus } = usePresence()
   const { t } = useTranslation()
 
@@ -112,7 +116,7 @@ export function useDesktopNotifications(): void {
   // Show conversation notification
   const showConversationNotification = async (conv: Conversation, message: Message) => {
     if (presenceStatusRef.current === 'dnd') return
-    if (!permissionGranted.current) {
+    if (!getNotificationPermissionGranted()) {
       notificationDebug.desktopNotification({
         title: conv.name || message.from.split('@')[0],
         body: '(permission not granted)',
@@ -169,7 +173,7 @@ export function useDesktopNotifications(): void {
   // Show room notification
   const showRoomNotification = async (room: Room, message: RoomMessage) => {
     if (presenceStatusRef.current === 'dnd') return
-    if (!permissionGranted.current) {
+    if (!getNotificationPermissionGranted()) {
       notificationDebug.desktopNotification({
         title: `${message.nick} @ ${room.name}`,
         body: '(permission not granted)',

--- a/apps/fluux/src/hooks/useDndNotificationSuppression.test.tsx
+++ b/apps/fluux/src/hooks/useDndNotificationSuppression.test.tsx
@@ -66,7 +66,8 @@ vi.mock('./useNavigateToTarget', () => ({
 
 const mockPermissionGranted = { current: true }
 vi.mock('./useNotificationPermission', () => ({
-  useNotificationPermission: () => mockPermissionGranted,
+  useNotificationPermission: () => {},
+  getNotificationPermissionGranted: () => mockPermissionGranted.current,
   isTauri: false,
 }))
 

--- a/apps/fluux/src/hooks/useEventsDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useEventsDesktopNotifications.ts
@@ -1,7 +1,11 @@
 import { useEffect, useRef } from 'react'
 import { useEvents, usePresence } from '@fluux/sdk'
 import { sendNotification } from '@tauri-apps/plugin-notification'
-import { useNotificationPermission, isTauri } from './useNotificationPermission'
+import {
+  useNotificationPermission,
+  getNotificationPermissionGranted,
+  isTauri,
+} from './useNotificationPermission'
 
 /**
  * Hook to show desktop notifications for new events (subscription requests).
@@ -13,11 +17,11 @@ export function useEventsDesktopNotifications(): void {
   const { subscriptionRequests } = useEvents()
   const { presenceStatus } = usePresence()
   const prevRequestsRef = useRef<typeof subscriptionRequests>([])
-  const permissionGranted = useNotificationPermission()
+  useNotificationPermission()
 
   // Watch for new subscription requests
   useEffect(() => {
-    if (!permissionGranted.current) return
+    if (!getNotificationPermissionGranted()) return
     if (presenceStatus === 'dnd') {
       prevRequestsRef.current = subscriptionRequests
       return
@@ -57,5 +61,5 @@ export function useEventsDesktopNotifications(): void {
     }
 
     prevRequestsRef.current = subscriptionRequests
-  }, [subscriptionRequests, permissionGranted, presenceStatus])
+  }, [subscriptionRequests, presenceStatus])
 }

--- a/apps/fluux/src/hooks/useNotificationPermission.ts
+++ b/apps/fluux/src/hooks/useNotificationPermission.ts
@@ -1,82 +1,93 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useConnectionStore } from '@fluux/sdk/react'
 import {
   isPermissionGranted,
   requestPermission,
 } from '@tauri-apps/plugin-notification'
+import { isMacOSDesktop } from '@/utils/tauriPlatform'
 
 export const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
-// Module-level state shared across all consumers — permission is requested once per session
+// Module-level shared state — the single source of truth for "may we post a
+// desktop notification". Consumers read it via getNotificationPermissionGranted()
+// rather than holding a ref, so a mid-session grant (e.g. from the Settings
+// screen, or after the user flips the OS toggle) takes effect everywhere without
+// an app restart.
 let permissionChecked = false
-let cachedPermission = false
+let granted = false
+
+/** Current notification permission, as last read. Read by the notification hooks. */
+export function getNotificationPermissionGranted(): boolean {
+  return granted
+}
 
 /**
- * Hook that requests notification permission (Tauri or Web) once per session.
- * Returns a ref indicating whether permission was granted.
- *
- * Both useDesktopNotifications and useEventsDesktopNotifications share this
- * so the permission prompt only fires once regardless of which hook mounts first.
+ * Read the current permission WITHOUT prompting. macOS desktop uses the native
+ * UNUserNotificationCenter command (the same source of truth as the posting
+ * gate); other Tauri platforms use the notification plugin; web reads the
+ * Notification API.
  */
-export function useNotificationPermission(): React.RefObject<boolean> {
+async function readPermission(): Promise<boolean> {
+  if (isTauri) {
+    if (await isMacOSDesktop()) {
+      const { invoke } = await import('@tauri-apps/api/core')
+      return (await invoke<string>('notification_permission_state')) === 'granted'
+    }
+    return await isPermissionGranted()
+  }
+  if (typeof Notification === 'undefined') return false
+  return Notification.permission === 'granted'
+}
+
+/** Prompt for permission, showing the OS dialog when the state is undetermined. */
+async function promptPermission(): Promise<boolean> {
+  if (isTauri) {
+    if (await isMacOSDesktop()) {
+      const { invoke } = await import('@tauri-apps/api/core')
+      return (await invoke<string>('request_notification_permission')) === 'granted'
+    }
+    return (await requestPermission()) === 'granted'
+  }
+  if (typeof Notification === 'undefined') return false
+  if (Notification.permission === 'granted') return true
+  if (Notification.permission === 'denied') return false
+  return (await Notification.requestPermission()) === 'granted'
+}
+
+/**
+ * Re-read permission (no prompt) and update the shared state. Call after the
+ * window regains focus or the user changes the OS setting so consumers pick up
+ * the new value immediately.
+ */
+export async function refreshNotificationPermission(): Promise<boolean> {
+  granted = await readPermission()
+  return granted
+}
+
+/**
+ * Prompt for permission and update the shared state. Used by the once-per-session
+ * login flow and the Settings "Enable" action.
+ */
+export async function requestNotificationPermission(): Promise<boolean> {
+  granted = await promptPermission()
+  permissionChecked = true
+  return granted
+}
+
+/**
+ * Request notification permission once per session, after the user comes online.
+ * The module-level latch means the prompt fires only once regardless of how many
+ * consumers mount. Components read the result via getNotificationPermissionGranted().
+ */
+export function useNotificationPermission(): void {
   const status = useConnectionStore((s) => s.status)
-  const permissionGranted = useRef(cachedPermission)
 
   useEffect(() => {
     if (status !== 'online') return
-
-    if (permissionChecked) {
-      permissionGranted.current = cachedPermission
-      return
-    }
-
-    const check = async () => {
-      try {
-        if (isTauri) {
-          const { isMacOSDesktop } = await import('@/utils/tauriPlatform')
-          if (await isMacOSDesktop()) {
-            const { invoke } = await import('@tauri-apps/api/core')
-            let state = await invoke<string>('notification_permission_state')
-            if (state === 'notdetermined') {
-              state = await invoke<string>('request_notification_permission')
-            }
-            permissionGranted.current = state === 'granted'
-            if (!permissionGranted.current) {
-              console.log(
-                '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
-              )
-            }
-          } else {
-            let granted = await isPermissionGranted()
-            if (!granted) {
-              const permission = await requestPermission()
-              granted = permission === 'granted'
-            }
-            permissionGranted.current = granted
-            if (!granted) {
-              console.log(
-                '[Notifications] Permission not granted. On macOS, go to System Settings → Notifications to enable.',
-              )
-            }
-          }
-        } else {
-          if (typeof Notification === 'undefined') return
-          if (Notification.permission === 'granted') {
-            permissionGranted.current = true
-          } else if (Notification.permission !== 'denied') {
-            const permission = await Notification.requestPermission()
-            permissionGranted.current = permission === 'granted'
-          }
-        }
-        cachedPermission = permissionGranted.current
-        permissionChecked = true
-      } catch (error) {
-        console.error('[Notifications] Error requesting permission:', error)
-      }
-    }
-
-    void check()
+    if (permissionChecked) return
+    permissionChecked = true
+    void requestNotificationPermission().catch((error) => {
+      console.error('[Notifications] Error requesting permission:', error)
+    })
   }, [status])
-
-  return permissionGranted
 }


### PR DESCRIPTION
Fixes macOS native notifications being silently suppressed (badge updated, no banner), and reconciles the Settings → Notifications screen with the native permission path.