### PR TITLE
fix(e2ee): coalesce decrypt retries + stop retrying malformed payloads + correct fingerprint metadata

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -278,7 +278,15 @@ export function classifyBoundaryError(err: unknown): { kind: E2EEErrorKind; code
   if (msg.includes('backup input is a public key')) {
     return { kind: 'permanent', code: 'malformed-backup' }
   }
-  if (msg.includes('parse ') || msg.includes('not valid')) {
+  if (
+    msg.includes('parse ') ||
+    msg.includes('not valid') ||
+    // openpgp.js readMessage/readKey on bytes that are not valid OpenPGP:
+    // "Error during parsing. This message / key probably does not conform to
+    // a valid OpenPGP format." Structurally malformed → never decrypts.
+    msg.includes('during parsing') ||
+    msg.includes('conform to a valid openpgp')
+  ) {
     return { kind: 'permanent', code: 'malformed-data' }
   }
   if (msg.includes('item-not-found')) return { kind: 'permanent', code: 'not-found' }
@@ -1694,7 +1702,16 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       ? this.ownBundle?.publicArmored ?? null
       : this.peerKeys.get(peer)?.publicArmored ?? null
 
-    const output = await this.decryptWithOwnKey(ctx.account.jid, ciphertext, senderPublicArmored)
+    let output: DecryptOutput
+    try {
+      output = await this.decryptWithOwnKey(ctx.account.jid, ciphertext, senderPublicArmored)
+    } catch (err) {
+      // Classify raw backend errors (e.g. openpgp.js "Error during parsing …"
+      // on a structurally malformed payload) into a typed E2EEPluginError so
+      // the SDK can tell a terminal 'malformed-data' failure from a retryable
+      // one. Already-typed errors (key-locked, …) pass through unchanged.
+      throw this.toPluginError('decrypt', err)
+    }
 
     const envelope = this.unwrapOrRethrow(output.plaintext)
     // XEP-0373 §3.1 reflection defence. Received messages: the envelope

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -90,7 +90,11 @@ import {
   publishVerificationsToServer,
   saveAppliedVerificationsVersion,
 } from './verificationSync'
-import { fingerprintsEqual, toXep0373Fingerprint } from './fingerprintCompare'
+import {
+  fingerprintsEqual,
+  toXep0373Fingerprint,
+  pubkeyMetadataFingerprintAttrs,
+} from './fingerprintCompare'
 import {
   clearKeyChangeAlert,
   getKeyChangeAlert,
@@ -1335,9 +1339,10 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
         {
           name: 'pubkey-metadata',
           attrs: {
-            // XEP-0373 §4.1: the v4 fingerprint string is upper-case hex.
-            'v4-fingerprint': toXep0373Fingerprint(bundle.fingerprint),
-            'v6-fingerprint': toXep0373Fingerprint(bundle.fingerprint),
+            // XEP-0373 §4.1: fingerprint string is upper-case hex. Emit only
+            // the version-appropriate attribute (v4 = 40 hex, v6 = 64 hex) so
+            // we never advertise a malformed v6 fingerprint for a v4 key.
+            ...pubkeyMetadataFingerprintAttrs(bundle.fingerprint),
             date: new Date().toISOString(),
           },
           children: [],

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -607,12 +607,11 @@ describe('SequoiaPgpPlugin', () => {
       expect(metaPub.item.payload.attrs.xmlns).toBe('urn:xmpp:openpgp:0')
       const metadataChild = findChild(metaPub.item.payload, 'pubkey-metadata')
       expect(metadataChild).toBeDefined()
-      // We emit BOTH attribute names with the same value (our v6 fp):
-      // `v4-fingerprint` keeps legacy XEP parsers happy; `v6-fingerprint`
-      // is the semantically accurate one and what we ourselves prefer on
-      // read.
+      // Advertise only the attribute matching the key version. This mock fp
+      // (like the v4 keys both backends produce today) is not 64 hex chars,
+      // so it is published as v4-fingerprint with no (malformed) v6 attribute.
       expect(metadataChild!.attrs['v4-fingerprint']).toBe(fp)
-      expect(metadataChild!.attrs['v6-fingerprint']).toBe(fp)
+      expect(metadataChild!.attrs['v6-fingerprint']).toBeUndefined()
       // `date` is an ISO 8601 timestamp; we don't pin the exact value
       // but it must be parseable.
       expect(Date.parse(metadataChild!.attrs.date)).not.toBeNaN()
@@ -2824,10 +2823,12 @@ describe('SequoiaPgpPlugin', () => {
       expect(postRotation[0].node).toBe(`${METADATA_NODE}:${fp}`)
       expect(postRotation[1].node).toBe(METADATA_NODE)
 
-      // Metadata re-advertises the SAME fingerprint (unchanged identity).
+      // Metadata re-advertises the SAME fingerprint (unchanged identity),
+      // under the version-matched attribute (v4 for this non-64-char fp).
       const meta = findChild(postRotation[1].item.payload, 'pubkey-metadata')
       expect(meta).toBeDefined()
-      expect(meta!.attrs['v6-fingerprint']).toBe(fp)
+      expect(meta!.attrs['v4-fingerprint']).toBe(fp)
+      expect(meta!.attrs['v6-fingerprint']).toBeUndefined()
     })
 
     it('passes the rotated public armor to the PEP data node', async () => {

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -349,14 +349,16 @@ describe('WebOpenPGPPlugin', () => {
       expect(bundle.fingerprint).toMatch(/^[a-f0-9]{40}$/)
       const upper = bundle.fingerprint.toUpperCase()
 
-      // Metadata node: v4-fingerprint and v6-fingerprint must be upper-case hex.
+      // Metadata node: a v4 (40-hex) key advertises v4-fingerprint in
+      // upper-case hex and must NOT advertise a (malformed 40-hex)
+      // v6-fingerprint.
       const metaItems = shared.get(pepKey('alice@example.com', 'urn:xmpp:openpgp:0:public-keys'))
       expect(metaItems).toBeDefined()
       const pubkeyMeta = (metaItems![0].payload as XMLElementData).children.find(
         (c): c is XMLElementData => typeof c !== 'string' && c.name === 'pubkey-metadata',
       )
       expect(pubkeyMeta?.attrs['v4-fingerprint']).toBe(upper)
-      expect(pubkeyMeta?.attrs['v6-fingerprint']).toBe(upper)
+      expect(pubkeyMeta?.attrs['v6-fingerprint']).toBeUndefined()
       expect(pubkeyMeta?.attrs['v4-fingerprint']).toMatch(/^[A-F0-9]{40}$/)
 
       // Data node id must use the same upper-case fingerprint, never the lower-case one.

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -567,6 +567,32 @@ describe('WebOpenPGPPlugin', () => {
       expect(decrypted.signerFingerprint).not.toBeNull()
     })
 
+    it('decrypt rejects a structurally malformed ciphertext as permanent malformed-data (never retried)', async () => {
+      // A payload whose bytes are not valid OpenPGP (e.g. legacy/corrupt
+      // test-era ciphertext) makes openpgp.js readMessage throw "Error during
+      // parsing … does not conform to a valid OpenPGP format". That is
+      // terminal, so the plugin must surface a permanent 'malformed-data'
+      // E2EEPluginError — the SDK uses that to stop re-stashing it for retry.
+      const plugin = new TestableWebOpenPGPPlugin()
+      const { ctx } = makeCtx('alice@example.com')
+      setSessionPassphrase('hunter2-strong-passphrase')
+      await plugin.init(ctx)
+      await plugin.callEnsureKeyMaterial('alice@example.com')
+
+      const garbageB64 = Buffer.from('this is not an OpenPGP message at all').toString('base64')
+      const claim = plugin.tryClaimInbound({
+        name: 'openpgp',
+        attrs: { xmlns: 'urn:xmpp:openpgp:0' },
+        children: [garbageB64],
+      })!
+      const handle = await plugin.openConversation({ kind: 'direct', peer: 'bob@example.com' })
+
+      await expect(plugin.decrypt(handle, claim)).rejects.toMatchObject({
+        kind: 'permanent',
+        code: 'malformed-data',
+      })
+    })
+
     it('decrypts without a sender public key (no verification possible)', async () => {
       const plugin = new TestableWebOpenPGPPlugin()
       const { ctx } = makeCtx('alice@example.com')

--- a/apps/fluux/src/e2ee/fingerprintCompare.test.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.test.ts
@@ -3,6 +3,7 @@ import {
   fingerprintsEqual,
   normalizeFingerprint,
   toXep0373Fingerprint,
+  pubkeyMetadataFingerprintAttrs,
 } from './fingerprintCompare'
 
 describe('fingerprintCompare', () => {
@@ -39,6 +40,26 @@ describe('fingerprintCompare', () => {
     it('is idempotent on already upper-case input (Sequoia)', () => {
       const upper = 'AABBCCDDEEFF00112233445566778899AABBCCDD'
       expect(toXep0373Fingerprint(upper)).toBe(upper)
+    })
+  })
+
+  describe('pubkeyMetadataFingerprintAttrs', () => {
+    // A v4 fingerprint is 40 hex chars (SHA-1); a v6 fingerprint is 64 hex
+    // chars (SHA-256). Advertising a 40-hex value under `v6-fingerprint` is a
+    // malformed v6 advertisement — emit only the attribute that matches the
+    // key version.
+    it('advertises a 40-hex (v4) fingerprint as v4-fingerprint only', () => {
+      const fp = 'aabbccddeeff00112233445566778899aabbccdd' // 40 hex, lower
+      const attrs = pubkeyMetadataFingerprintAttrs(fp)
+      expect(attrs['v4-fingerprint']).toBe(fp.toUpperCase())
+      expect(attrs['v6-fingerprint']).toBeUndefined()
+    })
+
+    it('advertises a 64-hex (v6) fingerprint as v6-fingerprint only', () => {
+      const fp = 'a'.repeat(64) // 64 hex, v6
+      const attrs = pubkeyMetadataFingerprintAttrs(fp)
+      expect(attrs['v6-fingerprint']).toBe('A'.repeat(64))
+      expect(attrs['v4-fingerprint']).toBeUndefined()
     })
   })
 })

--- a/apps/fluux/src/e2ee/fingerprintCompare.ts
+++ b/apps/fluux/src/e2ee/fingerprintCompare.ts
@@ -37,3 +37,19 @@ export function fingerprintsEqual(a: string, b: string): boolean {
 export function toXep0373Fingerprint(fingerprint: string): string {
   return fingerprint.replace(/\s+/g, '').toUpperCase()
 }
+
+/**
+ * Build the `<pubkey-metadata>` fingerprint attribute(s) for an own-key
+ * publish, choosing the attribute that matches the key version.
+ *
+ * An OpenPGP v4 fingerprint is 40 hex chars (SHA-1); a v6 fingerprint is 64
+ * hex chars (SHA-256). Earlier code emitted BOTH `v4-fingerprint` and
+ * `v6-fingerprint` set to the same value, which advertises a malformed
+ * 40-hex `v6-fingerprint` for the v4 keys openpgp.js produces. Emit only the
+ * version-appropriate attribute so peers never read a bogus v6 fingerprint
+ * (parsers prefer `v6-fingerprint` over `v4-fingerprint`).
+ */
+export function pubkeyMetadataFingerprintAttrs(fingerprint: string): Record<string, string> {
+  const fp = toXep0373Fingerprint(fingerprint)
+  return fp.length === 64 ? { 'v6-fingerprint': fp } : { 'v4-fingerprint': fp }
+}

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -692,4 +692,70 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(msg?.encryptedPayload).toBeUndefined()
     })
   })
+
+  describe('concurrent-retry coalescing', () => {
+    // Regression guard: on a fresh web session two triggers fire close
+    // together — plugin-registration (key still locked) and key-unlocked
+    // (passphrase entered). The unlock retry used to hit the re-entrancy
+    // guard while the registration pass was still in flight and return 0,
+    // silently dropping the work. The user saw "entered passphrase, nothing
+    // decrypted" and had to re-enter the passphrase to get a non-colliding
+    // retry. A retry requested mid-pass must instead run a second full pass
+    // after the first completes.
+    const flush = () => new Promise((r) => setTimeout(r, 0))
+
+    it('runs a second pass when a retry is requested while one is in flight', async () => {
+      // Sibling durable-cache tests override this mock and afterEach only
+      // clearAllMocks() (which keeps mockResolvedValue implementations), so
+      // pin the durable pass to empty here for isolation.
+      vi.mocked(messageCache.getMessagesWithEncryptedPayload).mockResolvedValue([])
+
+      chatStore.getState().addConversation({
+        id: 'alice@example.com',
+        name: 'Alice',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      // Message stays pending across passes, so it remains eligible and we
+      // can count how many full passes touched it.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'pending-1',
+        conversationId: 'alice@example.com',
+        from: 'alice@example.com',
+        body: '[could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+
+      // Gate the first pass inside its decrypt collaborator so a second
+      // retry is requested while pass #1 is still running.
+      let releaseGate!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseGate = resolve
+      })
+      let passes = 0
+      ;(xmppClient as unknown as { retryDecryptSingle: () => Promise<unknown> }).retryDecryptSingle =
+        vi.fn(async () => {
+          passes++
+          if (passes === 1) await gate
+          return { kind: 'pending' as const }
+        })
+
+      const inFlight = xmppClient.retryPendingDecrypts()
+      await flush() // let pass #1 park on the gate
+
+      // Second trigger arrives while pass #1 is still running.
+      await xmppClient.retryPendingDecrypts()
+
+      releaseGate()
+      await inFlight
+      await flush() // let the coalesced re-run execute
+      await flush()
+
+      expect(passes).toBe(2)
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -421,6 +421,15 @@ export class XMPPClient {
   private isRetryingDecrypts = false
 
   /**
+   * Set when a retry is requested while {@link retryPendingDecrypts} is
+   * already running. The in-flight pass re-runs once on completion so a
+   * trigger that arrives mid-pass (e.g. key-unlocked landing while the
+   * plugin-registered pass is still in flight) is coalesced, never dropped.
+   * @internal
+   */
+  private retryDecryptsRequested = false
+
+  /**
    * Monotonically increasing session generation counter.
    * Incremented each time handleConnectionSuccess runs.
    * Used by handleFreshSession/handleSmResumption to detect stale runs and abort early
@@ -1637,7 +1646,12 @@ export class XMPPClient {
    * @returns the number of messages successfully decrypted
    */
   async retryPendingDecrypts(): Promise<number> {
-    if (this.isRetryingDecrypts) return 0
+    if (this.isRetryingDecrypts) {
+      // A pass is already running. Remember the request so the in-flight
+      // pass re-runs on completion rather than dropping this trigger.
+      this.retryDecryptsRequested = true
+      return 0
+    }
     const manager = this.e2ee
     if (!manager || !manager.hasPlugins()) return 0
     if (!this.stores) return 0
@@ -1775,6 +1789,13 @@ export class XMPPClient {
       }
     } finally {
       this.isRetryingDecrypts = false
+    }
+
+    // A trigger that arrived mid-pass was coalesced — run once more so its
+    // newly-available state (e.g. a just-unlocked key) is applied.
+    if (this.retryDecryptsRequested) {
+      this.retryDecryptsRequested = false
+      decryptedCount += await this.retryPendingDecrypts()
     }
 
     return decryptedCount

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
@@ -340,6 +340,24 @@ describe('stanzaDecrypt encrypted payload stash on failure', () => {
     expect(result.securityContext?.trust).toBe('rejected')
     expect(result.encryptedPayloadXml).toBeUndefined()
   })
+
+  it('does not stash a structurally malformed payload (permanent, never retried)', async () => {
+    // A 'malformed-data' failure means the ciphertext is not valid OpenPGP and
+    // will never decrypt regardless of keys (e.g. legacy/corrupt test-era
+    // messages). It must NOT be stashed for retry — otherwise it re-fails on
+    // every reconnect. It is also not a security rejection.
+    const manager = await makeManager(
+      new ThrowingSignaturePlugin(
+        new E2EEPluginError('permanent', 'malformed-data', 'not a valid OpenPGP message'),
+      ),
+    )
+    const stanza = buildStanza()
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+    expect(result.attempted).toBe(true)
+    expect(result.securityContext?.trust).not.toBe('rejected')
+    expect(result.encryptedPayloadXml).toBeUndefined()
+    expect(readStashedEncryptedPayload(stanza)).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
@@ -197,6 +197,10 @@ export async function decryptStanzaInPlace(
   let securityContext: SecurityContext | null = null
   let authoredAt: Date | null = null
   let failureReason: string | null = null
+  // Set when the failure is a structurally malformed payload (not valid
+  // OpenPGP): it will never decrypt regardless of keys, so it is terminal —
+  // do NOT stash for retry. Distinct from a signature rejection.
+  let terminalFailure = false
 
   try {
     const messageId = stanza.attrs.id
@@ -235,6 +239,9 @@ export async function decryptStanzaInPlace(
         trust: 'rejected',
         notes: [failureReason],
       }
+    } else if (isE2EEPluginError(err) && err.kind === 'permanent' && err.code === 'malformed-data') {
+      // Ciphertext is not valid OpenPGP — terminal, never retried.
+      terminalFailure = true
     }
   }
 
@@ -257,7 +264,9 @@ export async function decryptStanzaInPlace(
             ? 'rejected: invalid signature — bodiless signal dropped'
             : isRejection
               ? 'rejected: invalid signature'
-              : 'retryable'
+              : terminalFailure
+                ? 'permanent: malformed payload — not retried'
+                : 'retryable'
         }): ${failureReason}`,
       )
     if (isRejection) {
@@ -275,9 +284,10 @@ export async function decryptStanzaInPlace(
       // a placeholder body would surface a forged reaction as a ghost text
       // message. The warn above records the drop in the E2EE events log.
     } else {
-      // Decrypt failure (key locked, plugin missing, etc.): stash for
-      // deferred retry and keep the sender's fallback body hint.
-      stashPayload(stanza, originalStanzaXml)
+      // Decrypt failure. A structurally malformed payload is terminal — never
+      // stash it (it would re-fail every reconnect). Everything else (key
+      // locked, plugin missing, etc.) is retryable: stash for deferred retry.
+      if (!terminalFailure) stashPayload(stanza, originalStanzaXml)
       if (!stanza.getChild('body')) {
         stanza.children.push(
           xml('body', {}, COULD_NOT_DECRYPT_BODY),
@@ -286,7 +296,7 @@ export async function decryptStanzaInPlace(
       securityContext = {
         protocolId: claim.plugin.descriptor.id,
         trust: 'untrusted',
-        notes: ['Could not decrypt'],
+        notes: [terminalFailure ? 'Could not decrypt (malformed)' : 'Could not decrypt'],
       }
     }
   } else if (plaintext !== null) {
@@ -352,7 +362,7 @@ export async function decryptStanzaInPlace(
     attempted: true,
     ...(securityContext && { securityContext }),
     ...(authoredAt && { authoredAt }),
-    ...((failureReason !== null && securityContext?.trust !== 'rejected' || needsDeferredVerification) && {
+    ...((failureReason !== null && !terminalFailure && securityContext?.trust !== 'rejected' || needsDeferredVerification) && {
       encryptedPayloadXml: originalStanzaXml,
     }),
   }


### PR DESCRIPTION
Three related E2EE fixes, diagnosed from a web session where restoring a key + entering the passphrase left messages undecrypted until the passphrase was re-entered.

### 1. Coalesce concurrent `retryPendingDecrypts` (the spurious second passphrase prompt)
On a fresh web session two retry triggers fire close together — plugin-registration (key still locked) and key-unlocked (passphrase entered). The re-entrancy guard returned `0` and dropped the second trigger with no re-run, so the unlock retry was silently lost. Added a `retryDecryptsRequested` flag so an in-flight pass re-runs once on completion — coalesce instead of drop.

### 2. Stop retrying structurally malformed payloads
Legacy/corrupt (test-era) ciphertext makes openpgp.js throw "Error during parsing … does not conform to a valid OpenPGP format". This fell through classification as transient and was logged `(retryable)` and re-stashed, so it re-failed on every reconnect. It's now classified as permanent `malformed-data`, the raw backend error is wrapped into a typed `E2EEPluginError`, and `stanzaDecrypt` treats it as terminal (no stash). It is not a security rejection.

### 3. Advertise only the version-matched pubkey fingerprint
Own-key metadata published both `v4-fingerprint` and `v6-fingerprint` set to the same value — a malformed 40-hex `v6-fingerprint` for the v4 keys both backends produce today. Now emits only the attribute matching the key version (64 hex → v6, else v4).