### PR TITLE
fix(chat): prevent content-visibility paint glitches during text selection

### DIFF
--- a/apps/fluux/src/hooks/useMessageHoverState.test.tsx
+++ b/apps/fluux/src/hooks/useMessageHoverState.test.tsx
@@ -238,6 +238,39 @@ describe('useMessageHoverState', () => {
     outside.remove()
   })
 
+  it('toggles the text-selecting class on the container while a selection is live', () => {
+    setup()
+    expect(container.classList.contains('text-selecting')).toBe(false)
+
+    selectTextInContainer()
+    expect(container.classList.contains('text-selecting')).toBe(true)
+
+    clearSelection()
+    expect(container.classList.contains('text-selecting')).toBe(false)
+  })
+
+  it('removes the text-selecting class after a plain click (mouseup with no selection)', () => {
+    setup()
+    selectTextInContainer()
+    expect(container.classList.contains('text-selecting')).toBe(true)
+
+    // Plain click collapses the selection: mousedown then mouseup with nothing selected
+    window.getSelection()!.removeAllRanges()
+    mouseDown(messageEl)
+    mouseUp()
+    act(() => vi.advanceTimersByTime(0))
+    expect(container.classList.contains('text-selecting')).toBe(false)
+  })
+
+  it('clears the text-selecting class when the conversation changes mid-selection', () => {
+    const { rerender } = setup('conv-1')
+    selectTextInContainer()
+    expect(container.classList.contains('text-selecting')).toBe(true)
+
+    rerender({ key: 'conv-2' })
+    expect(container.classList.contains('text-selecting')).toBe(false)
+  })
+
   it('resets hover when resetKey changes', () => {
     const { result, rerender } = setup('conv-1')
 

--- a/apps/fluux/src/hooks/useMessageHoverState.ts
+++ b/apps/fluux/src/hooks/useMessageHoverState.ts
@@ -11,6 +11,13 @@ export interface UseMessageHoverStateOptions {
   leaveDelayMs?: number
 }
 
+/**
+ * Class set on the scroll container while a text selection is live. CSS uses it
+ * to disable the `content-visibility` row-skipping optimization for the
+ * duration of the selection.
+ */
+const TEXT_SELECTING_CLASS = 'text-selecting'
+
 export interface MessageHoverState {
   hoveredMessageId: string | null
   handleMessageHover: (messageId: string) => void
@@ -56,6 +63,20 @@ export function useMessageHoverState({
     hoveredIdRef.current = id
     setHoveredMessageId(id)
   }, [])
+
+  // Mirror the selection-active state onto a class on the scroll container.
+  // While a text selection is live, that class lifts `content-visibility`
+  // containment on every message row (see `.text-selecting .message-row` in
+  // index.css). Rows participating in a selection — however many the user has
+  // dragged across — must keep painting normally; on WebKit a row whose
+  // containment toggles mid-selection can be skipped and visually vanish.
+  const setSelectionActive = useCallback(
+    (active: boolean) => {
+      selectionActiveRef.current = active
+      scrollRef.current?.classList.toggle(TEXT_SELECTING_CLASS, active)
+    },
+    [scrollRef]
+  )
 
   const clearTimer = (ref: RefObject<ReturnType<typeof setTimeout> | null>) => {
     if (ref.current !== null) {
@@ -133,7 +154,7 @@ export function useMessageHoverState({
       // Selection collapse from a plain click settles after mouseup
       setTimeout(() => {
         if (!hasSelectionInContainer()) {
-          selectionActiveRef.current = false
+          setSelectionActive(false)
           reArmForPointerRow()
         }
       }, 0)
@@ -142,7 +163,7 @@ export function useMessageHoverState({
     const onSelectionChange = () => {
       const active = hasSelectionInContainer()
       if (active === selectionActiveRef.current) return
-      selectionActiveRef.current = active
+      setSelectionActive(active)
       if (active) {
         clearTimer(intentTimerRef)
         clearTimer(leaveTimerRef)
@@ -168,15 +189,46 @@ export function useMessageHoverState({
       document.removeEventListener('selectionchange', onSelectionChange)
       window.removeEventListener('blur', onWindowBlur)
     }
-  }, [scrollRef, armIntentTimer, setHovered])
+  }, [scrollRef, armIntentTimer, setHovered, setSelectionActive])
 
   // Reset when switching conversation/room
   useEffect(() => {
     clearTimer(intentTimerRef)
     clearTimer(leaveTimerRef)
     lastEnteredRowRef.current = null
+    mouseDownRef.current = false
+    setSelectionActive(false)
     setHovered(null)
-  }, [resetKey, setHovered])
+  }, [resetKey, setHovered, setSelectionActive])
+
+  // Drop the hover once the hovered row scrolls out of the viewport.
+  //
+  // The toolbar paints into the row's `content-visibility` subtree. If the row
+  // is skipped (scrolled off-screen) while its toolbar is still shown, WebKit
+  // keeps the last painted frame and never repaints it when React later hides
+  // the toolbar — so scrolling back reveals a stale toolbar. Hiding the hover
+  // while the row is still on-screen forces a clean repaint before it's
+  // skipped. (No-op where IntersectionObserver is unavailable, e.g. jsdom.)
+  useEffect(() => {
+    if (hoveredMessageId === null) return
+    const container = scrollRef.current
+    if (!container || typeof IntersectionObserver === 'undefined') return
+    const row = container.querySelector(`[data-message-id="${CSS.escape(hoveredMessageId)}"]`)
+    if (!row) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => !entry.isIntersecting)) {
+          clearTimer(intentTimerRef)
+          clearTimer(leaveTimerRef)
+          setHovered(null)
+        }
+      },
+      { root: container, threshold: 0 }
+    )
+    observer.observe(row)
+    return () => observer.disconnect()
+  }, [hoveredMessageId, scrollRef, setHovered])
 
   // Clear pending timers on unmount
   useEffect(() => {

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -591,6 +591,18 @@ input[type="range"]::-moz-range-thumb {
   content-visibility: visible;
 }
 
+/*
+ * While a text selection is live (class toggled by useMessageHoverState), lift
+ * row-skipping for the whole list. A selection can span an unbounded number of
+ * rows across a long scroll, and on WebKit a row whose `content-visibility`
+ * toggles mid-selection can be skipped and visually vanish. Containment is
+ * restored as soon as the selection clears, so idle scrolling keeps the
+ * optimization.
+ */
+.text-selecting .message-row {
+  content-visibility: visible;
+}
+
 /* Persistent highlight for search context view */
 .message-highlight-persistent {
   background-color: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);


### PR DESCRIPTION
On WebKit (Tauri desktop), the `content-visibility: auto` row-skipping optimization on `.message-row` mispaints during and after a text selection:

- **A row vanishes** ("hides a row before the selection") when its containment toggles `visible → auto` mid-selection.
- **A toolbar gets stuck** — hovering a row, then text-selecting and scrolling it off-screen, leaves WebKit caching the row's last painted frame; React's later "hide toolbar" never repaints the skipped subtree, so scrolling back shows a stale toolbar.

## Fix
- While a text selection is live, `useMessageHoverState` toggles a `text-selecting` class on the scroll container; CSS lifts `content-visibility` containment for the whole list for that window. A selection can span an unbounded number of rows across a long scroll, so this scales without per-row span math. Containment is restored the instant the selection clears, keeping the idle-scroll optimization.
- An `IntersectionObserver` clears the hover once the hovered row leaves the viewport, so its toolbar is hidden and repainted while still on-screen — before the row can be skipped and cached.

Verified in the Chromium preview: class toggling + the `content-visibility` flip, plus the plain-click and conversation-switch cleanup paths (3 new unit tests, 20 total green; typecheck + lint clean). The visual symptoms are WebKit-only and need confirming in the desktop app.

Note: decontaining the whole list at selection-start forces layout of off-screen rows; if a very long conversation hitches when selection begins, the fallback is to narrow decontainment to the viewport + spanned rows.