### PR TITLE
fix: pre-release review fixes (proxy IPv6, E2EE key fetch, MAM parity, release metadata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Fluux Messenger are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.1] - 2026-06-15 
+## [0.16.1] - 2026-06-15
 
 ### Added
 

--- a/apps/fluux/src-tauri/src/xmpp_proxy/dns.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/dns.rs
@@ -54,6 +54,16 @@ pub enum ParsedServer {
     Domain(String),
 }
 
+/// Strip the surrounding brackets from an IPv6 host literal (`[::1]` → `::1`).
+/// Hosts are stored unbracketed because `lookup_host` and the TLS server-name
+/// expect the bare address; brackets are only syntax for the combined
+/// `[host]:port` form. Non-bracketed hosts pass through unchanged.
+fn debracket(host: &str) -> &str {
+    host.strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host)
+}
+
 /// Extract optional `?domain=` parameter from a URI path.
 /// Returns (host_port_part, optional_domain).
 fn split_domain_param(input: &str) -> (&str, Option<String>) {
@@ -85,7 +95,7 @@ pub fn parse_server_input(server: &str) -> ParsedServer {
         if let Some((host, port_str)) = host_port.rsplit_once(':') {
             if let Ok(port) = port_str.parse::<u16>() {
                 return ParsedServer::Direct(
-                    host.to_string(),
+                    debracket(host).to_string(),
                     port,
                     ConnectionMode::DirectTls,
                     domain,
@@ -94,7 +104,7 @@ pub fn parse_server_input(server: &str) -> ParsedServer {
         }
         // No port specified — default to 5223
         return ParsedServer::Direct(
-            host_port.to_string(),
+            debracket(host_port).to_string(),
             5223,
             ConnectionMode::DirectTls,
             domain,
@@ -106,11 +116,21 @@ pub fn parse_server_input(server: &str) -> ParsedServer {
         let (host_port, domain) = split_domain_param(rest);
         if let Some((host, port_str)) = host_port.rsplit_once(':') {
             if let Ok(port) = port_str.parse::<u16>() {
-                return ParsedServer::Direct(host.to_string(), port, ConnectionMode::Tcp, domain);
+                return ParsedServer::Direct(
+                    debracket(host).to_string(),
+                    port,
+                    ConnectionMode::Tcp,
+                    domain,
+                );
             }
         }
         // No port specified — default to 5222
-        return ParsedServer::Direct(host_port.to_string(), 5222, ConnectionMode::Tcp, domain);
+        return ParsedServer::Direct(
+            debracket(host_port).to_string(),
+            5222,
+            ConnectionMode::Tcp,
+            domain,
+        );
     }
 
     // host:port (no scheme) — use rsplit_once to handle IPv6 addresses
@@ -121,7 +141,7 @@ pub fn parse_server_input(server: &str) -> ParsedServer {
             } else {
                 ConnectionMode::Tcp
             };
-            return ParsedServer::Direct(host.to_string(), port, mode, None);
+            return ParsedServer::Direct(debracket(host).to_string(), port, mode, None);
         }
     }
 
@@ -366,6 +386,49 @@ mod tests {
                 ConnectionMode::Tcp,
                 None
             )
+        );
+    }
+
+    // --- IPv6 literal tests ---
+    // A bracketed IPv6 host must be stored WITHOUT brackets: lookup_host and the
+    // TLS server-name expect the bare address; brackets are only syntax for the
+    // combined `[host]:port` form.
+
+    #[test]
+    fn test_parse_bracketed_ipv6_host_port() {
+        assert_eq!(
+            parse_server_input("[::1]:5222"),
+            ParsedServer::Direct("::1".to_string(), 5222, ConnectionMode::Tcp, None)
+        );
+    }
+
+    #[test]
+    fn test_parse_bracketed_ipv6_tls_uri() {
+        assert_eq!(
+            parse_server_input("tls://[2001:db8::1]:5223"),
+            ParsedServer::Direct(
+                "2001:db8::1".to_string(),
+                5223,
+                ConnectionMode::DirectTls,
+                None
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_bracketed_ipv6_tcp_uri() {
+        assert_eq!(
+            parse_server_input("tcp://[fe80::1]:5222"),
+            ParsedServer::Direct("fe80::1".to_string(), 5222, ConnectionMode::Tcp, None)
+        );
+    }
+
+    #[test]
+    fn test_parse_bracketed_ipv6_no_port_defaults() {
+        // No explicit port → tls:// defaults to 5223, still debracketed.
+        assert_eq!(
+            parse_server_input("tls://[::1]"),
+            ParsedServer::Direct("::1".to_string(), 5223, ConnectionMode::DirectTls, None)
         );
     }
 

--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -15,7 +15,7 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '0.16.1',
-    date: '2026-06-15 ',
+    date: '2026-06-15',
     sections: [
       {
         type: 'added',

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -1492,8 +1492,18 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       const node = publicKeyDataNodeFor(variant)
       if (tried.has(node)) continue
       tried.add(node)
-      const items = await ctx.xmpp.queryPEP(jid, node, 1)
-      if (items.length > 0) return items
+      try {
+        const items = await ctx.xmpp.queryPEP(jid, node, 1)
+        if (items.length > 0) return items
+      } catch (err) {
+        // Servers disagree on how to answer a query for a node that does not
+        // exist: some return an empty result, others an item-not-found IQ
+        // error. A missing node means "try the next casing variant", not "give
+        // up" — so swallow not-found and continue. Re-throw anything else
+        // (timeout, server error) so the caller treats it as a real failure
+        // rather than silently masking it as "peer has no key".
+        if (classifyBoundaryError(err).code !== 'not-found') throw err
+      }
     }
     return []
   }

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -1987,6 +1987,59 @@ describe('WebOpenPGPPlugin', () => {
       expect(support.fingerprint?.toLowerCase()).toBe(bob.bundle.fingerprint.toLowerCase())
     })
 
+    it('resolves the lower-case data node even when the upper-case node returns item-not-found IQ error (#528 interop)', async () => {
+      // Same case-mismatch as the test above, but here the transport reflects
+      // how real servers (ejabberd, Prosody) answer a query for a node that
+      // does not exist: an item-not-found IQ error rather than an empty result.
+      // The tolerant query must SWALLOW that error and fall through to the next
+      // casing variant — otherwise the first variant aborts the whole lookup.
+      const { shared, alice, bob } = await buildCrossPublishedPair()
+
+      const upperFp = bob.bundle.fingerprint.toUpperCase()
+      expect(upperFp).not.toBe(bob.bundle.fingerprint)
+      shared.set(pepKey('bob@example.com', 'urn:xmpp:openpgp:0:public-keys'), [
+        {
+          id: 'current',
+          payload: {
+            name: 'public-keys-list',
+            attrs: { xmlns: 'urn:xmpp:openpgp:0' },
+            children: [
+              {
+                name: 'pubkey-metadata',
+                attrs: { 'v4-fingerprint': upperFp, date: '2024-01-01T00:00:00Z' },
+                children: [],
+              },
+            ],
+          },
+        },
+      ])
+
+      // A missing *data* node throws item-not-found (real-server behavior);
+      // every other absent node keeps the empty-result contract so unrelated
+      // lookups are undisturbed.
+      alice.ctx.xmpp.queryPEP = async (jid, node): Promise<PEPItem[]> => {
+        const items = shared.get(pepKey(jid, node))
+        if (items !== undefined) return items
+        if (node.startsWith('urn:xmpp:openpgp:0:public-keys:')) {
+          throw new Error('stanza error: item-not-found (node does not exist)')
+        }
+        return []
+      }
+
+      // The upper-case data node (variant tried first) genuinely does not exist.
+      expect(
+        shared.has(pepKey('bob@example.com', `urn:xmpp:openpgp:0:public-keys:${upperFp}`)),
+      ).toBe(false)
+      expect(
+        shared.has(pepKey('bob@example.com', `urn:xmpp:openpgp:0:public-keys:${bob.bundle.fingerprint}`)),
+      ).toBe(true)
+
+      const support = await alice.plugin.probePeer('bob@example.com')
+
+      expect(support.supported).toBe(true)
+      expect(support.fingerprint?.toLowerCase()).toBe(bob.bundle.fingerprint.toLowerCase())
+    })
+
     it('marks trust untrusted when the sender key is not cached at decrypt time', async () => {
       const { alice, bob } = await buildCrossPublishedPair()
 

--- a/fluux-messenger.doap
+++ b/fluux-messenger.doap
@@ -598,6 +598,20 @@
     <!-- Releases -->
     <release>
       <Version>
+        <revision>0.16.1</revision>
+        <created>2026-06-15</created>
+        <file-release rdf:resource="https://github.com/processone/fluux-messenger/releases/tag/v0.16.1"/>
+      </Version>
+    </release>
+    <release>
+      <Version>
+        <revision>0.16.0</revision>
+        <created>2026-06-10</created>
+        <file-release rdf:resource="https://github.com/processone/fluux-messenger/releases/tag/v0.16.0"/>
+      </Version>
+    </release>
+    <release>
+      <Version>
         <revision>0.15.2</revision>
         <created>2026-04-21</created>
         <file-release rdf:resource="https://github.com/processone/fluux-messenger/releases/tag/v0.15.2"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluux",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluux",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/*",
@@ -27,7 +27,7 @@
     },
     "apps/fluux": {
       "name": "@xmpp/fluux",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
         "@fluux/sdk": "*",
@@ -14872,7 +14872,7 @@
     },
     "packages/fluux-sdk": {
       "name": "@fluux/sdk",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@xmpp/client": "^0.14.0",

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -6,7 +6,7 @@ import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment, MAMQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
-import { findContinueCatchUpCursor, buildCatchUpStartTime, MAM_CACHE_LOAD_LIMIT, MAM_ROOM_FORWARD_MAX_PAGES_MANUAL } from '../utils/mamCatchUpUtils'
+import { findContinueCatchUpCursor, buildCatchUpStartTime, MAM_CACHE_LOAD_LIMIT, MAM_CATCHUP_FORWARD_MAX, MAM_ROOM_FORWARD_MAX_PAGES_MANUAL } from '../utils/mamCatchUpUtils'
 
 /**
  * Stable empty array references to prevent infinite re-renders.
@@ -357,6 +357,7 @@ export function useChatActive() {
         await client.chat.queryMAM({
           with: conversationId,
           start: buildCatchUpStartTime(cursor.timestamp),
+          max: MAM_CATCHUP_FORWARD_MAX,
           maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
         })
       }

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -13,9 +13,9 @@ pkgbase = fluux-messenger-bin
 	optdepends = xdg-utils: for opening URLs
 	provides = fluux-messenger
 	conflicts = fluux-messenger
-	source_x86_64 = fluux-messenger-bin-0.14.0_beta.2-x86_64.tar.gz::https://github.com/processone/fluux-messenger/releases/download/v0.14.0-beta.2/Fluux-Messenger_0.14.0-beta.2Linux_x64.tar.gz
+	source_x86_64 = fluux-messenger-bin-0.16.1-x86_64.tar.gz::https://github.com/processone/fluux-messenger/releases/download/v0.16.1/Fluux-Messenger_0.16.1_Linux_x64.tar.gz
 	sha256sums_x86_64 = SKIP
-	source_aarch64 = fluux-messenger-bin-0.14.0_beta.2-aarch64.tar.gz::https://github.com/processone/fluux-messenger/releases/download/v0.14.0-beta.2/Fluux-Messenger_0.14.0-beta.2Linux_arm64.tar.gz
+	source_aarch64 = fluux-messenger-bin-0.16.1-aarch64.tar.gz::https://github.com/processone/fluux-messenger/releases/download/v0.16.1/Fluux-Messenger_0.16.1_Linux_arm64.tar.gz
 	sha256sums_aarch64 = SKIP
 
 pkgname = fluux-messenger-bin

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,10 +1,38 @@
 fluux-messenger (0.16.1-1) unstable; urgency=medium
 
-  * MUC room creation, configuration, destruction, and user management
-  * XEP-0425 Message Moderation support
-  * XEP-0054 vCard display and editing
-  * Per-room ignored user management
-  * Font size setting and mobile layout improvements
-  * Fix deb dependency detection for older Linux distros
+  * macOS: clicking a notification now opens the exact conversation it belongs to (native notification routing)
+  * Desktop: relaunching the app focuses the already-running window instead of opening a second instance
+  * Linux: quit when the window is closed if the system tray is unavailable, so the app can always be reopened
+  * Login screen validates JID format locally before attempting to connect
+  * Enhanced freeze-triage diagnostic probes in fluux.log for troubleshooting
+  * Message list performance: off-screen rows skipped with content-visibility for reduced CPU on long histories
+  * Group chats: skip member-list discovery for rooms that forbid affiliation lists, reducing traffic and avoiding errors
+  * Group chats: occupant avatar updates coalesced on room join to reduce re-renders
+  * Empty state screens use consistent icons from the icon rail
+  * Group chat history: closed catch-up gaps that could silently drop a stretch of messages after long offline periods, with a "load missing messages" marker to recover them (also applied to 1:1 history)
+  * Connections: race IPv4 and IPv6 addresses (Happy Eyeballs) so a broken IPv6 route no longer stalls connecting
+  * OpenPGP: publish your public-key fingerprint in upper-case as required by XEP-0373, improving cross-client key discovery
+  * Presence pills shown in grey while reconnecting instead of disappearing
+  * Encrypted reactions no longer surface as a blank conversation preview
+  * Show a "decrypting…" placeholder while the encryption plugin is still loading instead of a blank message
+  * Opening a contact profile no longer bounces back to the conversation
+  * Link-preview images retried once before being hidden
+  * Stream Management: keep sm in stream features unless it was negotiated inline, fixing some reconnection cases
+  * Desktop: downloading an image now uses the native save dialog
+  * About dialog width reduced
+  * Reconnection details (spinner, retry countdown, cancel) moved back to the sidebar status area — the top connection banner made the UI jump on unstable connections
+  * OpenPGP: fingerprint case normalized in peer-verification trust checks (green lock now reliable across clients)
+  * MUC occupant avatar preserved across presence updates
+  * Desktop: system proxy bypassed for loopback XMPP bridge hop to prevent connection failures
+  * Whisper: allow continuing a whispered conversation from its conversation frame
+  * Whisper menu action uses correct verb form across all locales
+  * Reply-quote bubble uses the same sender color as the original message
+  * Message list: fixed undefined React key on certain message rows
+  * Reply-quote previews render as nested vertical bars instead of raw quote markers
+  * Composer resize scroll correction coalesced into animation frame for smoother behavior
+  * Content ResizeObserver correctly created on same-commit mounts
+  * Image attachment placeholder reserved in error state to prevent layout shift
+  * MAM: bodiless encrypted messages from archive surfaced instead of dropped
+  * MAM: backward-pagination cursor corrected for scroll-up history loading
 
- -- ProcessOne <contact@process-one.net>  Sun, 16 Mar 2026 12:00:00 +0000
+ -- ProcessOne <contact@process-one.net>  Mon, 15 Jun 2026 12:00:00 +0000

--- a/packaging/flatpak/com.processone.fluux.metainfo.xml
+++ b/packaging/flatpak/com.processone.fluux.metainfo.xml
@@ -90,32 +90,32 @@
   </content_rating>
 
   <releases>
-    <release version="0.16.1" date="2026-06-12">
+    <release version="0.16.1" date="2026-06-15">
       <description>
         <p>See release notes for details.</p>
       </description>
     </release>
-        <release version="0.16.0" date="2026-05-18">
+    <release version="0.16.0" date="2026-06-10">
       <description>
         <p>See release notes for details.</p>
       </description>
     </release>
-        <release version="0.15.2" date="2026-04-21">
+    <release version="0.15.2" date="2026-04-21">
       <description>
         <p>See release notes for details.</p>
       </description>
     </release>
-        <release version="0.15.1" date="2026-04-06">
+    <release version="0.15.1" date="2026-04-06">
       <description>
         <p>See release notes for details.</p>
       </description>
     </release>
-        <release version="0.15.0" date="2026-03-26">
+    <release version="0.15.0" date="2026-03-26">
       <description>
         <p>See release notes for details.</p>
       </description>
     </release>
-        <release version="0.14.0" date="2026-03-16">
+    <release version="0.14.0" date="2026-03-16">
       <description>
         <p>MUC room management, message moderation, vCard support, and dependency fixes for older Linux distros.</p>
       </description>

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -72,6 +72,16 @@ for (const file of VERSION_FILES) {
   console.log(`  ${file}: ${oldVersion} -> ${baseVersion}`)
 }
 
+// 1b. Regenerate package-lock.json so workspace versions match package.json
+// (--package-lock-only avoids reinstalling node_modules; it only re-syncs the lock)
+console.log('\nRegenerating package-lock.json...')
+try {
+  execSync('npm install --package-lock-only', { cwd: ROOT, stdio: 'inherit' })
+  console.log('  package-lock.json synced to ' + baseVersion)
+} catch (e) {
+  console.error('  Warning: npm install --package-lock-only failed — package-lock.json may be out of date')
+}
+
 // 2. Update SDK_VERSION constant
 console.log('\nUpdating SDK version constant...')
 const SDK_VERSION_FILE = 'packages/fluux-sdk/src/version.ts'
@@ -159,15 +169,16 @@ const aurSrcinfo = path.join(ROOT, 'packaging/aur/.SRCINFO')
 if (fs.existsSync(aurSrcinfo)) {
   let srcinfo = fs.readFileSync(aurSrcinfo, 'utf-8')
   srcinfo = srcinfo.replace(/pkgver = .*/g, `pkgver = ${baseVersion}`)
-  // Update source URLs with new version
-  srcinfo = srcinfo.replace(
-    /fluux-messenger-bin-[\d._]+-/g,
-    `fluux-messenger-bin-${baseVersion}-`
-  )
-  srcinfo = srcinfo.replace(
-    /download\/v[\d._-]+\/Fluux-Messenger_[\d._-]+/g,
-    `download/v${baseVersion}/Fluux-Messenger_${baseVersion}`
-  )
+  // Rebuild the source lines from scratch to mirror the PKGBUILD template
+  // exactly. Patching the old value by regex is fragile: it breaks on
+  // prerelease suffixes (e.g. "0.14.0-beta.2" contains letters) and on any
+  // URL-format drift between .SRCINFO and PKGBUILD.
+  const srcLine = (arch, urlArch) =>
+    `\tsource_${arch} = fluux-messenger-bin-${baseVersion}-${arch}.tar.gz` +
+    `::https://github.com/processone/fluux-messenger/releases/download/` +
+    `v${baseVersion}/Fluux-Messenger_${baseVersion}_Linux_${urlArch}.tar.gz`
+  srcinfo = srcinfo.replace(/^\tsource_x86_64 = .*/m, srcLine('x86_64', 'x64'))
+  srcinfo = srcinfo.replace(/^\tsource_aarch64 = .*/m, srcLine('aarch64', 'arm64'))
   fs.writeFileSync(aurSrcinfo, srcinfo)
   console.log(`  aur/.SRCINFO: ${baseVersion}`)
 }

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -61,6 +61,19 @@ const baseVersion = version.replace(/-.*$/, '')
 
 console.log(`\nPreparing release v${version}${baseVersion !== version ? ` (base version: ${baseVersion})` : ''}\n`)
 
+// Parse changelog.ts up front — it is the single source of truth for the
+// release date and per-section items that the packaging metadata (debian,
+// flatpak, doap) and CHANGELOG.md / RELEASE_NOTES.md all derive from. Parsing
+// here (rather than only at the CHANGELOG.md step) lets the packaging steps
+// reuse the same entry instead of carrying stale dates/items.
+const changelogEntries = parseChangelogTs(
+  fs.readFileSync(path.join(ROOT, CHANGELOG_TS), 'utf-8'),
+)
+const currentChangelogEntry = changelogEntries.find((e) => e.version === baseVersion)
+// Canonical release date (already trimmed by the parser); fall back to today
+// only when the entry hasn't been added to changelog.ts yet.
+const releaseDate = currentChangelogEntry?.date || new Date().toISOString().split('T')[0]
+
 // 1. Update version in package.json files
 console.log('Updating package.json files...')
 for (const file of VERSION_FILES) {
@@ -137,13 +150,31 @@ try {
 // 5. Update packaging version numbers
 console.log('\nUpdating packaging files...')
 
-// Debian changelog — update first entry version
+// Debian changelog — regenerate the top stanza from changelog.ts so the items
+// and date track the release instead of staying frozen at an older version.
+// Older stanzas (below the first ` -- maintainer` signature line) are preserved.
 const debChangelog = path.join(ROOT, 'packaging/debian/changelog')
 if (fs.existsSync(debChangelog)) {
   const debContent = fs.readFileSync(debChangelog, 'utf-8')
-  const updated = debContent.replace(/\([^)]*\)/, `(${baseVersion}-1)`)
-  fs.writeFileSync(debChangelog, updated)
-  console.log(`  debian/changelog: ${baseVersion}-1`)
+  const items = (currentChangelogEntry?.sections || []).flatMap((s) => s.items)
+  const body = items.length > 0
+    ? items.map((item) => `  * ${item}`).join('\n')
+    : `  * See release notes for v${baseVersion}`
+  // Debian wants an RFC 5322 date with offset (e.g. "Sun, 15 Jun 2026 ...").
+  const debDate = new Date(`${releaseDate}T12:00:00Z`).toUTCString().replace('GMT', '+0000')
+  const topStanza =
+    `fluux-messenger (${baseVersion}-1) unstable; urgency=medium\n\n` +
+    `${body}\n\n` +
+    ` -- ProcessOne <contact@process-one.net>  ${debDate}\n`
+  // Replace everything up to and including the first signature line; keep the rest.
+  const sigEnd = debContent.search(/^ -- .*\n/m)
+  let rest = ''
+  if (sigEnd !== -1) {
+    const afterSig = debContent.indexOf('\n', sigEnd) + 1
+    rest = debContent.slice(afterSig)
+  }
+  fs.writeFileSync(debChangelog, topStanza + rest)
+  console.log(`  debian/changelog: ${baseVersion}-1 (${items.length} items, ${debDate})`)
 }
 
 // RPM spec — update Version field
@@ -183,25 +214,54 @@ if (fs.existsSync(aurSrcinfo)) {
   console.log(`  aur/.SRCINFO: ${baseVersion}`)
 }
 
-// Flatpak metainfo — add new release entry (if not already present)
+// Flatpak metainfo — add a new release entry, or correct the date of an
+// existing one, using the canonical changelog.ts date (not "today", which
+// drifts when the release is tagged on a different day than it is dated).
 const flatpakMetainfo = path.join(ROOT, 'packaging/flatpak/com.processone.fluux.metainfo.xml')
 if (fs.existsSync(flatpakMetainfo)) {
   let metainfo = fs.readFileSync(flatpakMetainfo, 'utf-8')
-  if (!metainfo.includes(`version="${baseVersion}"`)) {
-    const today = new Date().toISOString().split('T')[0]
-    const newRelease = `    <release version="${baseVersion}" date="${today}">\n      <description>\n        <p>See release notes for details.</p>\n      </description>\n    </release>\n    `
-    metainfo = metainfo.replace(/(\s*<releases>\n)/, `$1${newRelease}`)
-    fs.writeFileSync(flatpakMetainfo, metainfo)
-    console.log(`  flatpak/metainfo: ${baseVersion}`)
+  const escaped = baseVersion.replace(/\./g, '\\.')
+  if (metainfo.includes(`version="${baseVersion}"`)) {
+    metainfo = metainfo.replace(
+      new RegExp(`(<release version="${escaped}" date=")[^"]*(")`),
+      `$1${releaseDate}$2`,
+    )
+    console.log(`  flatpak/metainfo: updated ${baseVersion} date → ${releaseDate}`)
   } else {
-    console.log(`  flatpak/metainfo: already has ${baseVersion}`)
+    const newRelease =
+      `    <release version="${baseVersion}" date="${releaseDate}">\n` +
+      `      <description>\n        <p>See release notes for details.</p>\n      </description>\n` +
+      `    </release>\n`
+    metainfo = metainfo.replace(/(<releases>\n)/, `$1${newRelease}`)
+    console.log(`  flatpak/metainfo: added ${baseVersion} (${releaseDate})`)
+  }
+  fs.writeFileSync(flatpakMetainfo, metainfo)
+}
+
+// DOAP — prepend a <release> entry for this version (newest on top). Mirrors
+// the existing <Version>/<revision>/<created>/<file-release> structure.
+const doapFile = path.join(ROOT, 'fluux-messenger.doap')
+if (fs.existsSync(doapFile)) {
+  let doap = fs.readFileSync(doapFile, 'utf-8')
+  if (doap.includes(`<revision>${baseVersion}</revision>`)) {
+    console.log(`  fluux-messenger.doap: already has ${baseVersion}`)
+  } else {
+    const entry =
+      `    <release>\n` +
+      `      <Version>\n` +
+      `        <revision>${baseVersion}</revision>\n` +
+      `        <created>${releaseDate}</created>\n` +
+      `        <file-release rdf:resource="https://github.com/processone/fluux-messenger/releases/tag/v${baseVersion}"/>\n` +
+      `      </Version>\n` +
+      `    </release>\n`
+    doap = doap.replace(/(<!-- Releases -->\n)/, `$1${entry}`)
+    fs.writeFileSync(doapFile, doap)
+    console.log(`  fluux-messenger.doap: added ${baseVersion} (${releaseDate})`)
   }
 }
 
-// 6. Generate CHANGELOG.md from changelog.ts
+// 6. Generate CHANGELOG.md from changelog.ts (entries already parsed up front)
 console.log('\nGenerating CHANGELOG.md from changelog.ts...')
-const changelogTsPath = path.join(ROOT, CHANGELOG_TS)
-const changelogTsContent = fs.readFileSync(changelogTsPath, 'utf-8')
 
 // Parse the changelog.ts file to extract entries
 // Uses a state-machine approach to handle complex strings
@@ -232,9 +292,10 @@ function parseChangelogTs(content) {
 
     const entryContent = content.slice(versionIndex, nextVersionIndex)
 
-    // Extract date
+    // Extract date (trim defensively so a stray trailing space in changelog.ts
+    // never propagates into CHANGELOG.md / packaging metadata)
     const dateMatch = entryContent.match(/date:\s*'([^']+)'/)
-    const date = dateMatch ? dateMatch[1] : ''
+    const date = dateMatch ? dateMatch[1].trim() : ''
 
     // Extract sections
     const sections = []
@@ -307,7 +368,7 @@ function parseChangelogTs(content) {
   return entries
 }
 
-const entries = parseChangelogTs(changelogTsContent)
+const entries = changelogEntries
 
 if (entries.length === 0) {
   console.error('  Error: Could not parse changelog.ts')


### PR DESCRIPTION
Addresses the Codex pre-release review findings.

## Real bugs
- **proxy/IPv6**: `[::1]:5222` kept the brackets on the host, so `lookup_host`/STARTTLS/`tls_name()` failed to resolve. Debracket at parse time across all `Direct` branches (`34a0785`).
- **e2ee**: `queryPublicKeyDataNodeTolerant` aborted on the first casing variant when the server answered a missing node with an `item-not-found` IQ error (ejabberd/Prosody) instead of an empty result — the remaining variants were never tried. Swallow `not-found` per variant, re-throw other errors (`b4bbe2c1`).

## Consistency / release metadata
- **mam**: manual 1:1 catch-up omitted `max`, falling back to 50/page while every other forward catch-up path uses 100. Aligned to `MAM_CATCHUP_FORWARD_MAX` (`827a20b7`).
- **release metadata**: `package-lock.json` stayed at 0.16.0 and `.SRCINFO` still pointed at the 0.14.0-beta.2 artifacts (`f460fd59`); debian/flatpak/DOAP/CHANGELOG had drifted from `changelog.ts` (stale items/dates, missing 0.16.0/0.16.1, trailing space). Synced the data and hardened `prepare-release.js` to drive every artifact from `changelog.ts` so it can't recur (`950daa95`).