### PR TITLE
refactor(chat): remove content-visibility from the message list

### DIFF
--- a/apps/fluux/src/hooks/useMessageHoverState.test.tsx
+++ b/apps/fluux/src/hooks/useMessageHoverState.test.tsx
@@ -238,39 +238,6 @@ describe('useMessageHoverState', () => {
     outside.remove()
   })
 
-  it('toggles the text-selecting class on the container while a selection is live', () => {
-    setup()
-    expect(container.classList.contains('text-selecting')).toBe(false)
-
-    selectTextInContainer()
-    expect(container.classList.contains('text-selecting')).toBe(true)
-
-    clearSelection()
-    expect(container.classList.contains('text-selecting')).toBe(false)
-  })
-
-  it('removes the text-selecting class after a plain click (mouseup with no selection)', () => {
-    setup()
-    selectTextInContainer()
-    expect(container.classList.contains('text-selecting')).toBe(true)
-
-    // Plain click collapses the selection: mousedown then mouseup with nothing selected
-    window.getSelection()!.removeAllRanges()
-    mouseDown(messageEl)
-    mouseUp()
-    act(() => vi.advanceTimersByTime(0))
-    expect(container.classList.contains('text-selecting')).toBe(false)
-  })
-
-  it('clears the text-selecting class when the conversation changes mid-selection', () => {
-    const { rerender } = setup('conv-1')
-    selectTextInContainer()
-    expect(container.classList.contains('text-selecting')).toBe(true)
-
-    rerender({ key: 'conv-2' })
-    expect(container.classList.contains('text-selecting')).toBe(false)
-  })
-
   it('resets hover when resetKey changes', () => {
     const { result, rerender } = setup('conv-1')
 

--- a/apps/fluux/src/hooks/useMessageHoverState.ts
+++ b/apps/fluux/src/hooks/useMessageHoverState.ts
@@ -11,13 +11,6 @@ export interface UseMessageHoverStateOptions {
   leaveDelayMs?: number
 }
 
-/**
- * Class set on the scroll container while a text selection is live. CSS uses it
- * to disable the `content-visibility` row-skipping optimization for the
- * duration of the selection.
- */
-const TEXT_SELECTING_CLASS = 'text-selecting'
-
 export interface MessageHoverState {
   hoveredMessageId: string | null
   handleMessageHover: (messageId: string) => void
@@ -63,20 +56,6 @@ export function useMessageHoverState({
     hoveredIdRef.current = id
     setHoveredMessageId(id)
   }, [])
-
-  // Mirror the selection-active state onto a class on the scroll container.
-  // While a text selection is live, that class lifts `content-visibility`
-  // containment on every message row (see `.text-selecting .message-row` in
-  // index.css). Rows participating in a selection — however many the user has
-  // dragged across — must keep painting normally; on WebKit a row whose
-  // containment toggles mid-selection can be skipped and visually vanish.
-  const setSelectionActive = useCallback(
-    (active: boolean) => {
-      selectionActiveRef.current = active
-      scrollRef.current?.classList.toggle(TEXT_SELECTING_CLASS, active)
-    },
-    [scrollRef]
-  )
 
   const clearTimer = (ref: RefObject<ReturnType<typeof setTimeout> | null>) => {
     if (ref.current !== null) {
@@ -154,7 +133,7 @@ export function useMessageHoverState({
       // Selection collapse from a plain click settles after mouseup
       setTimeout(() => {
         if (!hasSelectionInContainer()) {
-          setSelectionActive(false)
+          selectionActiveRef.current = false
           reArmForPointerRow()
         }
       }, 0)
@@ -163,7 +142,7 @@ export function useMessageHoverState({
     const onSelectionChange = () => {
       const active = hasSelectionInContainer()
       if (active === selectionActiveRef.current) return
-      setSelectionActive(active)
+      selectionActiveRef.current = active
       if (active) {
         clearTimer(intentTimerRef)
         clearTimer(leaveTimerRef)
@@ -189,46 +168,15 @@ export function useMessageHoverState({
       document.removeEventListener('selectionchange', onSelectionChange)
       window.removeEventListener('blur', onWindowBlur)
     }
-  }, [scrollRef, armIntentTimer, setHovered, setSelectionActive])
+  }, [scrollRef, armIntentTimer, setHovered])
 
   // Reset when switching conversation/room
   useEffect(() => {
     clearTimer(intentTimerRef)
     clearTimer(leaveTimerRef)
     lastEnteredRowRef.current = null
-    mouseDownRef.current = false
-    setSelectionActive(false)
     setHovered(null)
-  }, [resetKey, setHovered, setSelectionActive])
-
-  // Drop the hover once the hovered row scrolls out of the viewport.
-  //
-  // The toolbar paints into the row's `content-visibility` subtree. If the row
-  // is skipped (scrolled off-screen) while its toolbar is still shown, WebKit
-  // keeps the last painted frame and never repaints it when React later hides
-  // the toolbar — so scrolling back reveals a stale toolbar. Hiding the hover
-  // while the row is still on-screen forces a clean repaint before it's
-  // skipped. (No-op where IntersectionObserver is unavailable, e.g. jsdom.)
-  useEffect(() => {
-    if (hoveredMessageId === null) return
-    const container = scrollRef.current
-    if (!container || typeof IntersectionObserver === 'undefined') return
-    const row = container.querySelector(`[data-message-id="${CSS.escape(hoveredMessageId)}"]`)
-    if (!row) return
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => !entry.isIntersecting)) {
-          clearTimer(intentTimerRef)
-          clearTimer(leaveTimerRef)
-          setHovered(null)
-        }
-      },
-      { root: container, threshold: 0 }
-    )
-    observer.observe(row)
-    return () => observer.disconnect()
-  }, [hoveredMessageId, scrollRef, setHovered])
+  }, [resetKey, setHovered])
 
   // Clear pending timers on unmount
   useEffect(() => {

--- a/apps/fluux/src/hooks/useMessageSelection.test.tsx
+++ b/apps/fluux/src/hooks/useMessageSelection.test.tsx
@@ -70,19 +70,13 @@ describe('useMessageSelection', () => {
     })
   })
 
-  // Message rows use `content-visibility: auto` (.message-row in index.css) to
-  // skip off-screen layout/paint. That also paint-clips on-screen rows, which
-  // would cut the selection toolbar. Pointer cases are handled by :hover /
-  // :focus-within, but keyboard selection scrolls the row in WITHOUT moving DOM
-  // focus to it, so the hook tags the selected row with `message-row-decontain`
-  // (the CSS rule lifts containment for it). Guard that tagging here.
-  describe('content-visibility decontain marker', () => {
-    beforeEach(() => {
-      // jsdom does not implement scrollIntoView, which the selection effect calls
-      Element.prototype.scrollIntoView = vi.fn()
-    })
+  // Keyboard selection moves the highlight without moving DOM focus, so the
+  // hook scrolls the selected row into view explicitly.
+  describe('scroll-into-view on selection', () => {
+    it('scrolls the selected row into view', () => {
+      const scrollIntoView = vi.fn()
+      Element.prototype.scrollIntoView = scrollIntoView
 
-    it('marks only the selected row and clears the previous one', () => {
       const ids = ['msg-0', 'msg-1', 'msg-2']
       const els = ids.map((id) => {
         const el = document.createElement('div')
@@ -100,21 +94,7 @@ describe('useMessageSelection', () => {
       act(() => {
         result.current.setSelectedMessageId('msg-1')
       })
-      expect(els[1].classList.contains('message-row-decontain')).toBe(true)
-      expect(els[0].classList.contains('message-row-decontain')).toBe(false)
-
-      // Moving the selection re-tags and clears the previous marker
-      act(() => {
-        result.current.setSelectedMessageId('msg-2')
-      })
-      expect(els[1].classList.contains('message-row-decontain')).toBe(false)
-      expect(els[2].classList.contains('message-row-decontain')).toBe(true)
-
-      // Clearing selection removes the marker entirely
-      act(() => {
-        result.current.clearSelection()
-      })
-      expect(document.querySelectorAll('.message-row-decontain').length).toBe(0)
+      expect(scrollIntoView).toHaveBeenCalled()
 
       els.forEach((el) => el.remove())
     })

--- a/apps/fluux/src/hooks/useMessageSelection.ts
+++ b/apps/fluux/src/hooks/useMessageSelection.ts
@@ -86,27 +86,13 @@ export function useMessageSelection<T extends MessageLike>(
     }
   }, [selectedMessageId])
 
-  // Scroll selected message into view when keyboard navigating.
-  //
-  // Also lift `content-visibility` containment on the selected row. Message rows
-  // use `content-visibility: auto` (see `.message-row` in index.css) to skip
-  // off-screen layout/paint, but that applies paint containment to ON-screen
-  // rows too, which would clip the selection toolbar that paints above the row.
-  // Pointer interaction is covered by the `:hover` / `:focus-within` rules, but
-  // keyboard selection scrolls the row into view WITHOUT moving DOM focus to it,
-  // so neither rule fires — mark it explicitly. At most one row carries the
-  // marker, so the cleanup query is O(1).
+  // Scroll the selected message into view when keyboard navigating. (Keyboard
+  // selection moves the highlight without moving DOM focus, so we scroll it in
+  // explicitly.)
   useEffect(() => {
-    document
-      .querySelectorAll('.message-row-decontain')
-      .forEach((el) => el.classList.remove('message-row-decontain'))
-
     if (selectedMessageId) {
       const element = document.querySelector(`[data-message-id="${selectedMessageId}"]`) as HTMLElement
-      if (element) {
-        element.scrollIntoView({ block: 'nearest' })
-        element.classList.add('message-row-decontain')
-      }
+      element?.scrollIntoView({ block: 'nearest' })
     }
   }, [selectedMessageId])
 

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -560,49 +560,6 @@ input[type="range"]::-moz-range-thumb {
   border-radius: 0.5rem;
 }
 
-/*
- * Per-message render-cost containment.
- *
- * Busy rooms render their whole in-memory backlog (hundreds–thousands of
- * messages) into the DOM with no virtualization. On WebKitGTK (Linux/Tauri)
- * the message-list scroll-correction ResizeObserver then reflows that entire
- * tree every frame, pinning ~50% of a core at idle (the per-room "constant CPU"
- * report). `content-visibility: auto` lets the browser skip layout AND paint
- * for off-screen rows, so a reflow only touches the visible handful regardless
- * of backlog size. `contain-intrinsic-size: auto <h>` reserves an estimated
- * height for skipped rows (the `auto` keyword makes the browser remember each
- * row's real size once seen, so the scrollbar stays stable).
- *
- * CAVEAT: content-visibility:auto applies paint containment even to ON-screen
- * rows, which would clip the floating hover toolbar (`-top-7 -end-2`) and the
- * reaction-picker / more-menu dropdowns (`top-full` / `bottom-full`) that paint
- * OUTSIDE the row box. Only one row is ever interacted with at a time, so we
- * lift containment on the hovered/focused row, letting its overflow paint
- * normally while every other row stays contained.
- */
-.message-row {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 72px;
-}
-
-.message-row:hover,
-.message-row:focus-within,
-.message-row.message-row-decontain {
-  content-visibility: visible;
-}
-
-/*
- * While a text selection is live (class toggled by useMessageHoverState), lift
- * row-skipping for the whole list. A selection can span an unbounded number of
- * rows across a long scroll, and on WebKit a row whose `content-visibility`
- * toggles mid-selection can be skipped and visually vanish. Containment is
- * restored as soon as the selection clears, so idle scrolling keeps the
- * optimization.
- */
-.text-selecting .message-row {
-  content-visibility: visible;
-}
-
 /* Persistent highlight for search context view */
 .message-highlight-persistent {
   background-color: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);


### PR DESCRIPTION
## Why

`content-visibility: auto` on `.message-row` (#497, hardened in #538) was only ever load-bearing for the **Linux/WebKitGTK idle-CPU freeze**. On **macOS WKWebView** it provides no benefit and causes regressions:

- a row vanishes when its containment toggles mid text-selection;
- a hovered row's toolbar caches a stale frame and reappears on scroll-back;
- decontaining the list at selection start/end (the #538 fix) forces a full relayout — off-screen rows swap their `72px` estimate for real heights — which **jumps the scroll position** every time you start or end a selection.

Confirmed on desktop: row-vanish was fixed by #538 but the scroll-jump remained, so the optimization is net-negative on macOS.