### PR TITLE
docs(changelog): drop content-visibility line from 0.16.1

### DIFF
--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -30,7 +30,6 @@ export const changelog: ChangelogEntry[] = [
       {
         type: 'changed',
         items: [
-          'Message list performance: off-screen rows skipped with content-visibility for reduced CPU on long histories',
           'Group chats: skip member-list discovery for rooms that forbid affiliation lists, reducing traffic and avoiding errors',
           'Group chats: occupant avatar updates coalesced on room join to reduce re-renders',
           'Empty state screens use consistent icons from the icon rail',


### PR DESCRIPTION
The content-visibility message-list optimization was removed in #540, so the 0.16.1 changelog should no longer advertise it.