### PR TITLE
build(macos): run local dev builds under a separate notification identity

### DIFF
--- a/apps/fluux/package.json
+++ b/apps/fluux/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf dist",
     "clean:all": "rm -rf dist node_modules src-tauri/target",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev -- -- --verbose",
+    "tauri:dev": "./scripts/tauri-dev.sh",
     "tauri:build": "./scripts/tauri-build.sh",
     "tauri:install": "./scripts/tauri-install.sh"
   },

--- a/apps/fluux/scripts/tauri-build.sh
+++ b/apps/fluux/scripts/tauri-build.sh
@@ -16,6 +16,11 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TAURI_CONF="$SCRIPT_DIR/../src-tauri/tauri.conf.json"
+# Local builds use a separate dev identity (com.processone.fluux.dev / "Fluux
+# Messenger Dev") so macOS notification grants never collide with an installed
+# production "Fluux Messenger". CI/release builds use tauri-action with the base
+# config and are unaffected. See src-tauri/tauri.dev.conf.json.
+DEV_CONF="$SCRIPT_DIR/../src-tauri/tauri.dev.conf.json"
 
 # Cross-platform sed in-place edit using temp file (avoids macOS sed -i '' issues)
 sed_inplace() {
@@ -63,6 +68,27 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# Apply the dev identity override to every `tauri build` invocation below.
+EXTRA_ARGS+=(--config "$DEV_CONF")
+
+# Sign local builds with a stable identity when one is available, so the macOS
+# notification grant survives Rust rebuilds. Ad-hoc signing (the default when no
+# identity is set) re-pins the grant to the binary's CDHash, so every Rust
+# rebuild resets the permission. Create the identity once via Keychain Access ->
+# Certificate Assistant -> Create a Certificate (name "Fluux Dev", Self-Signed
+# Root, Code Signing). Export APPLE_SIGNING_IDENTITY yourself to override. CI is
+# unaffected — it builds via tauri-action, not this script.
+DEV_SIGNING_IDENTITY="Fluux Dev"
+if [[ "$OSTYPE" == "darwin"* ]] && [ -z "$APPLE_SIGNING_IDENTITY" ]; then
+    if security find-identity -v -p codesigning 2>/dev/null | grep -qF "$DEV_SIGNING_IDENTITY"; then
+        export APPLE_SIGNING_IDENTITY="$DEV_SIGNING_IDENTITY"
+        echo "Signing local build with '$DEV_SIGNING_IDENTITY' (durable notification grant)."
+    else
+        echo "No '$DEV_SIGNING_IDENTITY' code-signing identity found — building ad-hoc."
+        echo "  (Notification permission resets on each Rust rebuild; see this script's header to fix.)"
+    fi
+fi
 
 # macOS multi-arch builds
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/apps/fluux/scripts/tauri-dev.sh
+++ b/apps/fluux/scripts/tauri-dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Run the Tauri dev app under a SEPARATE dev identity (com.processone.fluux.dev,
+# product "Fluux Messenger Dev") via src-tauri/tauri.dev.conf.json.
+#
+# Why: macOS binds notification authorization to the app's code signature + bundle
+# id. Sharing the production identifier means a locally-built (ad-hoc signed) app
+# cannot match the production grant, so notifications read as "not granted". A
+# distinct dev identity gets its own authorization and never collides with an
+# installed "Fluux Messenger". CI/release builds use the base config, unaffected.
+#
+# Note: `tauri dev` runs the UNBUNDLED debug binary (no .app), which macOS will
+# not reliably authorize for notifications and cannot be code-signed here. To
+# test native notifications, build a real bundle: `npm run tauri:install`.
+# See docs/DEVELOPER.md → "macOS Notifications in Local Development".
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEV_CONF="$SCRIPT_DIR/../src-tauri/tauri.dev.conf.json"
+
+exec tauri dev --config "$DEV_CONF" -- -- --verbose

--- a/apps/fluux/scripts/tauri-install.sh
+++ b/apps/fluux/scripts/tauri-install.sh
@@ -14,7 +14,11 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-APP_NAME="Fluux Messenger"
+# Local installs use the dev identity/name (see scripts/tauri-build.sh and
+# src-tauri/tauri.dev.conf.json), so they live alongside the production
+# "Fluux Messenger" instead of overwriting it — keeping each app's macOS
+# notification grant intact.
+APP_NAME="Fluux Messenger Dev"
 DEST="/Applications/${APP_NAME}.app"
 
 # Forward all arguments to tauri-build.sh

--- a/apps/fluux/src-tauri/tauri.dev.conf.json
+++ b/apps/fluux/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Fluux Messenger Dev",
+  "identifier": "com.processone.fluux.dev"
+}

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -30,9 +30,51 @@ Open http://localhost:5173 and connect with your XMPP credentials.
 | `npm run test`        | Run all tests                       |
 | `npm run typecheck`   | Type-check all packages             |
 | `npm run lint`        | Run ESLint on all packages          |
-| `npm run tauri:dev`   | Run desktop app in development mode |
-| `npm run tauri:build` | Build desktop app for distribution  |
-| `npm run screenshots` | Generate demo screenshots (see below)|
+| `npm run tauri:dev`     | Run desktop app in development mode                          |
+| `npm run tauri:build`   | Build the desktop app locally                                |
+| `npm run tauri:install` | Build + install the desktop app into `/Applications` (macOS) |
+| `npm run screenshots`   | Generate demo screenshots (see below)                        |
+
+## macOS Notifications in Local Development
+
+Local desktop builds run under a **separate dev identity** so they never collide with an installed production Fluux:
+
+| Build | Bundle identifier | App name |
+|-------|-------------------|----------|
+| Production (release, built in CI) | `com.processone.fluux` | Fluux Messenger |
+| Local (`tauri:dev` / `tauri:build` / `tauri:install`) | `com.processone.fluux.dev` | Fluux Messenger Dev |
+
+The override lives in `apps/fluux/src-tauri/tauri.dev.conf.json` and is merged in by the local scripts via `--config`. CI/release builds use the base config and are **never** affected — Tauri only auto-merges `tauri.<platform>.conf.json` files, so `tauri.dev.conf.json` applies only when a script passes it explicitly. (To build locally with the *production* identity — e.g. to test the release artifact — use the raw `npm run tauri build`, which uses the base config.)
+
+### Why a separate identity
+
+macOS binds notification authorization (`UNUserNotificationCenter`) to the app's **code signature *and* bundle id**, not the bundle id alone. A locally-built app that shares the production identifier inherits — but cannot match — the grant given to the signed production build, so notifications silently read as *"permission not granted"* even though **System Settings → Notifications** still lists the app as allowed. (The dock badge keeps working, because it needs no authorization.) A distinct `.dev` identity gets its own authorization and never disturbs the production grant.
+
+### Test notifications with `tauri:install`, not `tauri:dev`
+
+`tauri dev` runs the **unbundled** debug binary (it never produces a `.app`), which macOS will not reliably authorize for notifications — so it is not the tool for testing native notifications, and there is nothing to code-sign there. Build and install a real bundle instead:
+
+```bash
+npm run tauri:install   # → "Fluux Messenger Dev.app" in /Applications, alongside prod
+```
+
+Launch **Fluux Messenger Dev**, accept the macOS prompt, and notifications fire. Use `tauri:dev` for everything else (UI, hot-reload).
+
+### Durable grants across rebuilds (optional)
+
+Local builds are **ad-hoc signed** by default, which pins the grant to the binary's exact CDHash — so it resets on every **Rust** rebuild (frontend-only rebuilds keep it). To make the grant survive every rebuild, sign with a stable **self-signed** identity. No Apple Developer account is needed: these are *local* notifications (`UNUserNotificationCenter`), not APNs push — there is no App ID, provisioning profile, or Apple Developer console involved.
+
+**Create the certificate (once, ~1 min):**
+
+1. Open **Keychain Access** → menu **Certificate Assistant → Create a Certificate…**
+   - **Name:** `Fluux Dev`
+   - **Identity Type:** Self-Signed Root
+   - **Certificate Type:** Code Signing
+2. Rebuild and install: `npm run tauri:install`
+
+`scripts/tauri-build.sh` auto-detects a `Fluux Dev` code-signing identity and signs the build with it (logging `Signing local build with 'Fluux Dev'…`); without it, the build falls back to ad-hoc. Export `APPLE_SIGNING_IDENTITY="<name>"` to use a different identity. Create the certificate **before** your first grant on the Dev app, otherwise you will just need to click *Allow* once more after switching from ad-hoc to signed.
+
+> Local dev only. The distributed release is signed with a real **Developer ID** certificate and **notarized** in CI — see [RELEASE.md](RELEASE.md). Nothing here changes the release path.
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary

Local macOS builds shared the production bundle id (`com.processone.fluux`) but are ad-hoc signed, so they could not match the notification grant macOS binds to the signed production build — native notifications silently read as "permission not granted" while System Settings still showed the app as allowed (the dock badge kept updating, since it needs no authorization).

Local `tauri:dev` / `tauri:build` / `tauri:install` now run under a separate dev identity `com.processone.fluux.dev` ("Fluux Messenger Dev"), installed **alongside** the production app instead of overwriting it. `tauri-build.sh` auto-signs with a self-signed "Fluux Dev" code-signing identity when present (so the grant survives Rust rebuilds), falling back to ad-hoc otherwise.

CI/release is unaffected: `tauri-action` builds the base config, and Tauri never auto-merges `tauri.dev.conf.json` (only the `tauri.<platform>.conf.json` names).

See `docs/DEVELOPER.md` → "macOS Notifications in Local Development".
