### PR TITLE
fix(e2ee): confirm the verified lock against the message's signing fingerprint

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -358,11 +358,14 @@ describe('MessageBubble', () => {
       // securityContext.trust does NOT change, so the bubble must derive the
       // displayed trust from the live verification store.
       const peer = 'verifytest@example.com'
+      const fingerprint = 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555'
       clearPeerVerified(peer)
       const props = createDefaultProps({
         message: createTestMessage({
           from: peer,
-          securityContext: { protocolId: 'openpgp', trust: 'tofu' },
+          // The message carries its signing fingerprint; the live upgrade keys
+          // on a MATCH against the verified one, not mere JID existence.
+          securityContext: { protocolId: 'openpgp', trust: 'tofu', fingerprint },
         }),
       })
       const { container } = render(<MessageBubble {...props} />)
@@ -373,7 +376,7 @@ describe('MessageBubble', () => {
       // User confirms the peer's fingerprint out-of-band — a store update only,
       // no prop/securityContext change on the message.
       act(() => {
-        setPeerVerified(peer, 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555')
+        setPeerVerified(peer, fingerprint)
       })
 
       expect(
@@ -387,11 +390,12 @@ describe('MessageBubble', () => {
 
     it('downgrades a verified lock back to tofu when verification is cleared', () => {
       const peer = 'verifytest2@example.com'
-      setPeerVerified(peer, 'FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000')
+      const fingerprint = 'FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000'
+      setPeerVerified(peer, fingerprint)
       const props = createDefaultProps({
         message: createTestMessage({
           from: peer,
-          securityContext: { protocolId: 'openpgp', trust: 'verified' },
+          securityContext: { protocolId: 'openpgp', trust: 'verified', fingerprint },
         }),
       })
       const { container } = render(<MessageBubble {...props} />)

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -18,6 +18,7 @@ import { EncryptedPlaceholder } from './EncryptedPlaceholder'
 import { UnsupportedEncryptionNotice } from './UnsupportedEncryptionNotice'
 import { MessageReactions } from './MessageReactions'
 import { scrollToMessage, isActionMessage, type WhisperThreadPosition } from './messageGrouping'
+import { resolveDisplayTrust } from './messageTrust'
 import { MessageAttachments } from '../MessageAttachments'
 import { LinkPreviewCard } from '../LinkPreviewCard'
 import { UserInfoPopover } from './UserInfoPopover'
@@ -302,21 +303,17 @@ export const MessageBubble = memo(function MessageBubble({
   const [showErrorDetails, setShowErrorDetails] = useState(false)
 
   // Trust color must track verification LIVE, not freeze at decrypt time.
-  // The plugin bakes `verified`/`tofu` onto the message when it's decrypted;
-  // if the user verifies the peer later, the stored value never updates. So
-  // derive the displayed trust here from the live verification store, keyed on
-  // the conversation peer. The store only changes on explicit verify/un-verify
-  // (never during sync/typing), so this per-peer subscription is cheap.
-  const peerVerified = useVerifiedPeerKeysStore(
-    (s) => !!s.verifiedFingerprintByJid[getBareJid(message.from)],
+  // The plugin bakes `verified`/`tofu` onto the message when it's decrypted; if
+  // the user verifies the peer later, that baked value never updates. So derive
+  // the displayed trust from the live verification store — but confirm the
+  // verified fingerprint against THIS message's signing key (resolveDisplayTrust),
+  // so a rotated or server-substituted key can't inherit a stale verified lock.
+  // The store only changes on explicit verify/un-verify (never during
+  // sync/typing), so this per-peer subscription is cheap.
+  const verifiedFingerprint = useVerifiedPeerKeysStore(
+    (s) => s.verifiedFingerprintByJid[getBareJid(message.from)],
   )
-  const displayTrust =
-    message.securityContext &&
-    (message.securityContext.trust === 'tofu' || message.securityContext.trust === 'verified')
-      ? peerVerified
-        ? 'verified'
-        : 'tofu'
-      : message.securityContext?.trust
+  const displayTrust = resolveDisplayTrust(message.securityContext, verifiedFingerprint)
 
   // Whether reactions are enabled for this message (room has stable occupant identity)
   const reactionsEnabled = onReaction !== undefined

--- a/apps/fluux/src/components/conversation/messageTrust.test.ts
+++ b/apps/fluux/src/components/conversation/messageTrust.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import type { MessageSecurityContext } from '@fluux/sdk'
+import { resolveDisplayTrust } from './messageTrust'
+
+const FP_A = 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555'
+const FP_B = 'FFFF6666EEEE7777DDDD8888CCCC9999BBBB0000'
+
+const ctx = (over: Partial<MessageSecurityContext>): MessageSecurityContext => ({
+  protocolId: 'openpgp',
+  trust: 'tofu',
+  ...over,
+})
+
+describe('resolveDisplayTrust', () => {
+  it('returns undefined when there is no security context', () => {
+    expect(resolveDisplayTrust(undefined, FP_A)).toBeUndefined()
+  })
+
+  it('upgrades tofu → verified when the message fingerprint matches the verified one', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu', fingerprint: FP_A }), FP_A)).toBe('verified')
+  })
+
+  it('matches case-insensitively (Sequoia UPPER vs openpgp.js lower)', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu', fingerprint: FP_A.toLowerCase() }), FP_A)).toBe('verified')
+  })
+
+  it('does NOT upgrade when a DIFFERENT key is verified (rotation / server substitution)', () => {
+    // Peer was verified under FP_A; this message is signed by FP_B → must stay tofu.
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu', fingerprint: FP_B }), FP_A)).toBe('tofu')
+  })
+
+  it('does NOT upgrade when the peer has no verified fingerprint', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu', fingerprint: FP_A }), undefined)).toBe('tofu')
+  })
+
+  it('does NOT upgrade when the message carries no fingerprint', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu' }), FP_A)).toBe('tofu')
+  })
+
+  it('never upgrades an untrusted (signature-failed) message, even on a fingerprint match', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'untrusted', fingerprint: FP_A }), FP_A)).toBe('untrusted')
+  })
+
+  it('passes a rejected trust through unchanged', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'rejected', fingerprint: FP_A }), FP_A)).toBe('rejected')
+  })
+
+  it('keeps a baked verified trust when its fingerprint is still verified', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'verified', fingerprint: FP_A }), FP_A)).toBe('verified')
+  })
+
+  it('downgrades a baked verified to tofu when the peer is no longer verified', () => {
+    // Baked `verified` means verified AT decrypt time; if the user later clears
+    // the verification, the live lock must fall back to tofu.
+    expect(resolveDisplayTrust(ctx({ trust: 'verified', fingerprint: FP_A }), undefined)).toBe('tofu')
+  })
+
+  it('downgrades a baked verified to tofu when a DIFFERENT key is now verified', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'verified', fingerprint: FP_B }), FP_A)).toBe('tofu')
+  })
+})

--- a/apps/fluux/src/components/conversation/messageTrust.ts
+++ b/apps/fluux/src/components/conversation/messageTrust.ts
@@ -1,0 +1,39 @@
+import type { MessageSecurityContext } from '@fluux/sdk'
+import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
+
+/**
+ * Resolve the trust level to DISPLAY for a message's E2EE lock, given the
+ * peer's out-of-band-verified fingerprint (or `undefined` if the peer was
+ * never verified).
+ *
+ * The plugin bakes `trust` at decrypt time, but the user can verify (or
+ * un-verify) a peer LATER, so the displayed verified/tofu lock must track the
+ * LIVE store rather than the frozen baked value. For a signature-verified
+ * message (`tofu`/`verified`) the lock is `verified` only while the user
+ * currently has THIS message's signing fingerprint verified, and `tofu`
+ * otherwise — both the live upgrade (tofu→verified once verified) and the live
+ * downgrade (verified→tofu once cleared). Crucially the check is a fingerprint
+ * MATCH, not the mere existence of a verified entry for the JID: otherwise a
+ * rotated or server-substituted key would inherit a green lock the user never
+ * granted it. A message whose signature did not verify (`untrusted` /
+ * `rejected`), or a web-of-trust `introduced`, passes through untouched.
+ *
+ * @param securityContext - the message's baked security context, if encrypted
+ * @param verifiedFingerprint - the fingerprint the user verified for this peer
+ * @returns the trust level to render, or `undefined` for cleartext messages
+ */
+export function resolveDisplayTrust(
+  securityContext: MessageSecurityContext | undefined,
+  verifiedFingerprint: string | undefined,
+): MessageSecurityContext['trust'] | undefined {
+  if (!securityContext) return undefined
+  const baked = securityContext.trust
+  if (baked === 'tofu' || baked === 'verified') {
+    const fingerprintVerified =
+      !!securityContext.fingerprint &&
+      !!verifiedFingerprint &&
+      fingerprintsEqual(verifiedFingerprint, securityContext.fingerprint)
+    return fingerprintVerified ? 'verified' : 'tofu'
+  }
+  return baked
+}

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -2036,6 +2036,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       protocolId: OPENPGP_DESCRIPTOR.id,
       trust,
       ...(notes.length > 0 && { notes }),
+      ...(output.signerFingerprint && { fingerprint: output.signerFingerprint }),
     }
   }
 
@@ -2065,6 +2066,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       protocolId: OPENPGP_DESCRIPTOR.id,
       trust,
       ...(notes.length > 0 && { notes }),
+      ...(output.signerFingerprint && { fingerprint: output.signerFingerprint }),
     }
   }
 

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -3128,6 +3128,11 @@ describe('SequoiaPgpPlugin', () => {
       const decrypted = await bob.plugin.decrypt(bobHandle, claim)
 
       expect(decrypted.securityContext.trust).toBe('verified')
+      // The signer fingerprint is surfaced so the UI can confirm the verified
+      // lock against the ACTUAL signing key (consumed by resolveDisplayTrust).
+      expect(decrypted.securityContext.fingerprint?.toLowerCase()).toBe(
+        alice.plugin.getOwnFingerprint()?.toLowerCase(),
+      )
       // No notes — verified is the cleanest possible state, no warnings
       // surfaced. (BTBV `trusted` likewise had no notes; this just
       // confirms the upgrade doesn't accidentally introduce a note.)

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1971,6 +1971,7 @@ export class XMPPClient {
           protocolId: result.securityContext.protocolId,
           trust: result.securityContext.trust,
           ...(result.securityContext.notes && { notes: result.securityContext.notes }),
+          ...(result.securityContext.fingerprint && { fingerprint: result.securityContext.fingerprint }),
         }
       }
 

--- a/packages/fluux-sdk/src/core/e2ee/types.ts
+++ b/packages/fluux-sdk/src/core/e2ee/types.ts
@@ -129,6 +129,14 @@ export interface SecurityContext {
   trust: 'verified' | 'introduced' | 'tofu' | 'untrusted' | 'rejected'
   /** Optional free-form notes (e.g. "subkey 3 days old"). */
   notes?: string[]
+  /**
+   * Fingerprint of the key that signed this message, when the protocol exposes
+   * one (OpenPGP). The host stashes it onto the message's
+   * {@link MessageSecurityContext} so the UI can confirm the verified lock
+   * against the ACTUAL signing key — a rotated/substituted key must not inherit
+   * a stale out-of-band verification.
+   */
+  fingerprint?: string
 }
 
 export interface DecryptResult {

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -445,6 +445,7 @@ export class Chat extends BaseModule {
       protocolId: stash.protocolId,
       trust: stash.trust,
       ...(stash.notes && { notes: stash.notes }),
+      ...(stash.fingerprint && { fingerprint: stash.fingerprint }),
     }
   }
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1778,6 +1778,7 @@ export class MAM extends BaseModule {
       protocolId: stash.protocolId,
       trust: stash.trust,
       ...(stash.notes && { notes: stash.notes }),
+      ...(stash.fingerprint && { fingerprint: stash.fingerprint }),
     }
   }
 

--- a/packages/fluux-sdk/src/core/types/message-base.ts
+++ b/packages/fluux-sdk/src/core/types/message-base.ts
@@ -238,4 +238,11 @@ export interface MessageSecurityContext {
   trust: 'verified' | 'introduced' | 'tofu' | 'untrusted' | 'rejected'
   /** Optional display notes (e.g. "subkey 3 days old"). */
   notes?: string[]
+  /**
+   * Fingerprint of the key that signed this message, when the protocol exposes
+   * one (OpenPGP). Lets the UI confirm the verified lock against the ACTUAL
+   * signing key rather than "some key for this JID was verified once" — a
+   * rotated or server-substituted key must not inherit a stale verification.
+   */
+  fingerprint?: string
 }


### PR DESCRIPTION
Follow-up from the 0.16.1 review (deferred from #543).

`MessageBubble` derived the "verified" lock from the mere existence of a verified entry for the sender's bare JID, not from a match against THIS message's signing key — so a peer verified under one key who later rotated (or whose key the server substituted) showed a green lock on a message signed by an unverified key.

- `SecurityContext` (plugin) and `MessageSecurityContext` (message) gain an optional `fingerprint`, populated by the OpenPGP plugin from the verified signer fingerprint and threaded through the archive / live / deferred-retry security-context mappings.
- New `resolveDisplayTrust()` (pure, unit-tested): the verified/tofu lock tracks the live verification store keyed on a fingerprint **match** — live upgrade (tofu→verified once the user verifies) and downgrade (verified→tofu once cleared), but never a false-green on a rotated/substituted key. `untrusted`/`rejected` pass through unchanged.
- `MessageBubble` compares the message's fingerprint against the verified one. `isPeerVerified` already did the correct normalized (case-insensitive) compare; it just wasn't used by the bubble.

The failure direction is safe: when the fingerprint can't be confirmed (absent, mismatched, or verification cleared) the lock shows tofu, never a false verified.