### PR TITLE
feat(settings): always link to system notification settings on desktop

### DIFF
--- a/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * NotificationsSettings — the permanent "open system notification settings"
+ * shortcut.
+ *
+ * The OS notification pane is reachable from the panel whenever the app is
+ * already registered with the system notification center (permission granted
+ * or denied), on every desktop (Tauri) build. It stays hidden while the
+ * permission was never requested (macOS `default`/notdetermined) — there the
+ * in-card Enable button is the correct first action and the app isn't listed
+ * in System Settings yet — and on the web build, which has no OS pane to open.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mutable mock state — `mock`-prefixed so vitest permits referencing them
+// inside the hoisted vi.mock factories.
+let mockIsTauri = true
+let mockIsMac = true
+let mockPermState = 'granted'
+const mockInvoke = vi.fn(async (cmd: string) =>
+  cmd === 'notification_permission_state' ? mockPermState : undefined,
+)
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    useConnection: () => ({
+      webPushStatus: 'unavailable',
+      webPushEnabled: false,
+      isConnected: false,
+    }),
+    useXMPPContext: () => ({ client: {} }),
+  }
+})
+
+vi.mock('./types', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./types')>()
+  return { ...actual, isTauri: () => mockIsTauri }
+})
+
+vi.mock('@/utils/tauriPlatform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/tauriPlatform')>()
+  return { ...actual, isMacOSDesktop: () => Promise.resolve(mockIsMac) }
+})
+
+vi.mock('@/hooks/useNotificationPermission', () => ({
+  refreshNotificationPermission: vi.fn().mockResolvedValue(true),
+  requestNotificationPermission: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@/hooks/useWebPush', () => ({
+  isWebPushSupported: false,
+  requestWebPushRegistration: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mockInvoke }))
+
+import { NotificationsSettings } from './NotificationsSettings'
+
+const LINK = 'settings.openSystemNotificationSettings'
+
+describe('NotificationsSettings — system notification settings link', () => {
+  beforeEach(() => {
+    mockIsTauri = true
+    mockIsMac = true
+    mockPermState = 'granted'
+    mockInvoke.mockClear()
+  })
+
+  it('shows the OS-settings link when notifications are enabled (macOS, granted)', async () => {
+    render(<NotificationsSettings />)
+
+    expect(await screen.findByText(LINK)).toBeInTheDocument()
+    // Sanity: the status really reads "enabled" — i.e. this is the granted case
+    // from the user's screenshot, which previously had no link at all.
+    expect(screen.getByText('settings.notificationEnabled')).toBeInTheDocument()
+  })
+
+  it('shows the link when permission is denied', async () => {
+    mockPermState = 'denied'
+
+    render(<NotificationsSettings />)
+
+    expect(await screen.findByText(LINK)).toBeInTheDocument()
+  })
+
+  it('hides the link while permission was never requested (macOS default), offering Enable instead', async () => {
+    mockPermState = 'default'
+
+    render(<NotificationsSettings />)
+
+    // The native Enable button is the correct first action in this state…
+    expect(await screen.findByText('settings.requestPermission')).toBeInTheDocument()
+    // …and the system-settings link must not appear yet.
+    expect(screen.queryByText(LINK)).not.toBeInTheDocument()
+  })
+
+  it('does not render the link in the web build (not Tauri)', async () => {
+    mockIsTauri = false
+    mockIsMac = false
+
+    render(<NotificationsSettings />)
+
+    // The description always renders; once it's present the async permission
+    // check has settled, so the absence of the link is meaningful.
+    await screen.findByText('settings.notificationDescription')
+    expect(screen.queryByText(LINK)).not.toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -216,26 +216,29 @@ export function NotificationsSettings() {
             </button>
           )}
 
-          {/* Open OS settings: macOS once denied (the prompt won't reappear), or
-              other Tauri platforms which have no in-app prompt */}
-          {((isMac && notificationStatus === 'denied') ||
-            (isTauri() &&
-              !isMac &&
-              (notificationStatus === 'denied' || notificationStatus === 'default'))) && (
-            <button
-              onClick={openNotificationSettings}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
-                         bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"
-            >
-              <ExternalLink className="size-4" />
-              {t('settings.openSettings')}
-            </button>
-          )}
         </div>
 
-        <p className="text-xs text-fluux-muted">
-          {t('settings.notificationDescription')}
-        </p>
+        <div className="space-y-1.5">
+          <p className="text-xs text-fluux-muted">
+            {t('settings.notificationDescription')}
+          </p>
+
+          {/* Permanent shortcut to the OS notification settings. Shown once the
+              app is registered with the system notification center
+              (granted/denied) so the target pane actually lists the app; hidden
+              while still 'default' (never asked), where the in-card Enable button
+              is the correct first action. */}
+          {isTauri() &&
+            (notificationStatus === 'granted' || notificationStatus === 'denied') && (
+              <button
+                onClick={openNotificationSettings}
+                className="flex items-center gap-1.5 text-xs text-fluux-brand hover:text-fluux-text transition-colors"
+              >
+                <ExternalLink className="size-3.5" />
+                {t('settings.openSystemNotificationSettings')}
+              </button>
+            )}
+        </div>
 
         {/* Web Push registration (browser only, when connected) */}
         {isWebPushSupported && isConnected && (

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -639,7 +639,7 @@
         "notificationChecking": "جارٍ التحقق من الإذن...",
         "notificationDescription": "تنبهك إشعارات سطح المكتب بالرسائل الجديدة عندما يكون التطبيق في الخلفية.",
         "requestPermission": "تفعيل",
-        "openSettings": "فتح الإعدادات",
+        "openSystemNotificationSettings": "فتح إعدادات إشعارات النظام",
         "webPushStatus": "إشعارات الويب الفورية",
         "webPush_unavailable": "غير مدعوم من الخادم",
         "webPush_available": "متاح — انقر للتفعيل",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Праверка дазволу...",
         "notificationDescription": "Апавяшчэнні на працоўным стале паведамляюць пра новыя паведамленні, калі дадатак у фоне.",
         "requestPermission": "Уключыць",
-        "openSettings": "Адкрыць налады",
+        "openSystemNotificationSettings": "Адкрыць сістэмныя налады апавяшчэнняў",
         "webPushStatus": "Web push-апавяшчэнні",
         "webPush_unavailable": "Сервер не падтрымлівае",
         "webPush_available": "Даступна — націсніце, каб уключыць",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Проверка на разрешение...",
         "notificationDescription": "Известията на работния плот ви уведомяват за нови съобщения, когато приложението е във фонов режим.",
         "requestPermission": "Активирай",
-        "openSettings": "Отвори настройки",
+        "openSystemNotificationSettings": "Отвори системните настройки за известия",
         "webPushStatus": "Уеб push известия",
         "webPush_unavailable": "Не се поддържа от сървъра",
         "webPush_available": "Налично — натиснете за активиране",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Comprovant permisos...",
         "notificationDescription": "Les notificacions d'escriptori t'avisen de missatges nous quan l'aplicació està en segon pla.",
         "requestPermission": "Activa",
-        "openSettings": "Obre configuració",
+        "openSystemNotificationSettings": "Obre la configuració de notificacions del sistema",
         "webPushStatus": "Notificacions push web",
         "webPush_unavailable": "No compatible amb el servidor",
         "webPush_available": "Disponible — toca per activar",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Kontrola oprávnění...",
         "notificationDescription": "Oznámení na ploše vás upozorní na nové zprávy, když je aplikace na pozadí.",
         "requestPermission": "Povolit",
-        "openSettings": "Otevřít nastavení",
+        "openSystemNotificationSettings": "Otevřít systémové nastavení oznámení",
         "webPushStatus": "Webová push oznámení",
         "webPush_unavailable": "Server nepodporuje",
         "webPush_available": "K dispozici — klepněte pro aktivaci",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Tjekker tilladelse...",
         "notificationDescription": "Skrivebordsnotifikationer advarer dig om nye beskeder, når appen er i baggrunden.",
         "requestPermission": "Aktiver",
-        "openSettings": "Åbn indstillinger",
+        "openSystemNotificationSettings": "Åbn systemets notifikationsindstillinger",
         "webPushStatus": "Web-pushnotifikationer",
         "webPush_unavailable": "Ikke understøttet af serveren",
         "webPush_available": "Tilgængelig — tryk for at aktivere",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Berechtigung wird geprüft...",
         "notificationDescription": "Desktop-Benachrichtigungen informieren Sie über neue Nachrichten, wenn die App im Hintergrund ist.",
         "requestPermission": "Aktivieren",
-        "openSettings": "Einstellungen öffnen",
+        "openSystemNotificationSettings": "Systemeinstellungen für Benachrichtigungen öffnen",
         "webPushStatus": "Web-Push-Benachrichtigungen",
         "webPush_unavailable": "Vom Server nicht unterstützt",
         "webPush_available": "Verfügbar — tippen zum Aktivieren",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -640,7 +640,7 @@
         "notificationChecking": "Έλεγχος αδειών...",
         "notificationDescription": "Οι ειδοποιήσεις επιφάνειας εργασίας σας ειδοποιούν για νέα μηνύματα όταν η εφαρμογή είναι στο παρασκήνιο.",
         "requestPermission": "Ενεργοποίηση",
-        "openSettings": "Άνοιγμα ρυθμίσεων",
+        "openSystemNotificationSettings": "Άνοιγμα ρυθμίσεων ειδοποιήσεων συστήματος",
         "webPushStatus": "Ειδοποιήσεις web push",
         "webPush_unavailable": "Δεν υποστηρίζεται από τον διακομιστή",
         "webPush_available": "Διαθέσιμο — πατήστε για ενεργοποίηση",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -799,7 +799,7 @@
         "notificationChecking": "Checking permission...",
         "notificationDescription": "Desktop notifications alert you to new messages when the app is in the background.",
         "requestPermission": "Enable",
-        "openSettings": "Open Settings",
+        "openSystemNotificationSettings": "Open system notification settings",
         "webPushStatus": "Web Push Notifications",
         "webPush_unavailable": "Not supported by server",
         "webPush_available": "Available — tap to enable",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Verificando permisos...",
         "notificationDescription": "Las notificaciones de escritorio te alertan de nuevos mensajes cuando la aplicacion esta en segundo plano.",
         "requestPermission": "Activar",
-        "openSettings": "Abrir Ajustes",
+        "openSystemNotificationSettings": "Abrir los ajustes de notificaciones del sistema",
         "webPushStatus": "Notificaciones push web",
         "webPush_unavailable": "No compatible con el servidor",
         "webPush_available": "Disponible — toca para activar",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Õiguste kontrollimine...",
         "notificationDescription": "Töölaua teavitused hoiatavad sind uute sõnumite eest, kui rakendus on taustal.",
         "requestPermission": "Luba",
-        "openSettings": "Ava seaded",
+        "openSystemNotificationSettings": "Ava süsteemi teavituste seaded",
         "webPushStatus": "Veebi push-teavitused",
         "webPush_unavailable": "Server ei toeta",
         "webPush_available": "Saadaval — puuduta lubamiseks",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Tarkistetaan käyttöoikeutta...",
         "notificationDescription": "Työpöytäilmoitukset hälyttävät uusista viesteistä, kun sovellus on taustalla.",
         "requestPermission": "Ota käyttöön",
-        "openSettings": "Avaa asetukset",
+        "openSystemNotificationSettings": "Avaa järjestelmän ilmoitusasetukset",
         "webPushStatus": "Web-push-ilmoitukset",
         "webPush_unavailable": "Palvelin ei tue tätä",
         "webPush_available": "Käytettävissä — ota käyttöön napauttamalla",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -640,7 +640,7 @@
         "notificationChecking": "Vérification de la permission...",
         "notificationDescription": "Les notifications bureau vous alertent des nouveaux messages lorsque l'application est en arrière-plan.",
         "requestPermission": "Activer",
-        "openSettings": "Ouvrir les paramètres",
+        "openSystemNotificationSettings": "Ouvrir les réglages de notification du système",
         "webPushStatus": "Notifications Web Push",
         "webPush_unavailable": "Non supporté par le serveur",
         "webPush_available": "Disponible — appuyez pour activer",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Ag seiceáil ceada...",
         "notificationDescription": "Cuireann fógraí deisce ar an eolas thú faoi theachtaireachtaí nua nuair atá an aip sa chúlra.",
         "requestPermission": "Cumasaigh",
-        "openSettings": "Oscail Socruithe",
+        "openSystemNotificationSettings": "Oscail socruithe fógraí an chórais",
         "webPushStatus": "Fógraí brú gréasáin",
         "webPush_unavailable": "Ní thacaíonn an freastalaí leis",
         "webPush_available": "Ar fáil — tapáil le cumasú",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -639,7 +639,7 @@
         "notificationChecking": "בודק הרשאות...",
         "notificationDescription": "התראות שולחן עבודה מתריעות על הודעות חדשות כשהאפליקציה ברקע.",
         "requestPermission": "אפשר",
-        "openSettings": "פתח הגדרות",
+        "openSystemNotificationSettings": "פתח את הגדרות ההתראות של המערכת",
         "webPushStatus": "התראות Web Push",
         "webPush_unavailable": "לא נתמך על ידי השרת",
         "webPush_available": "זמין - לחץ להפעלה",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Provjera dopuštenja...",
         "notificationDescription": "Obavijesti na radnoj površini upozoravaju vas na nove poruke kada je aplikacija u pozadini.",
         "requestPermission": "Omogući",
-        "openSettings": "Otvori postavke",
+        "openSystemNotificationSettings": "Otvori postavke obavijesti sustava",
         "webPushStatus": "Web push obavijesti",
         "webPush_unavailable": "Poslužitelj ne podržava",
         "webPush_available": "Dostupno — dodirnite za omogućavanje",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Engedély ellenőrzése...",
         "notificationDescription": "Az asztali értesítések figyelmeztetik az új üzenetekre, amikor az alkalmazás a háttérben fut.",
         "requestPermission": "Engedélyezés",
-        "openSettings": "Beállítások megnyitása",
+        "openSystemNotificationSettings": "Rendszerértesítési beállítások megnyitása",
         "webPushStatus": "Webes push értesítések",
         "webPush_unavailable": "A szerver nem támogatja",
         "webPush_available": "Elérhető — érintse meg az aktiváláshoz",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Athuga heimild...",
         "notificationDescription": "Skjáborðstilkynningar láta þig vita af nýjum skilaboðum þegar forritið er í bakgrunni.",
         "requestPermission": "Virkja",
-        "openSettings": "Opna stillingar",
+        "openSystemNotificationSettings": "Opna tilkynningastillingar kerfisins",
         "webPushStatus": "Vef push-tilkynningar",
         "webPush_unavailable": "Ekki stutt af þjóni",
         "webPush_available": "Tiltækt — ýttu til að virkja",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Verifica permessi...",
         "notificationDescription": "Le notifiche desktop ti avvisano dei nuovi messaggi quando l'app e in background.",
         "requestPermission": "Attiva",
-        "openSettings": "Apri impostazioni",
+        "openSystemNotificationSettings": "Apri le impostazioni di notifica del sistema",
         "webPushStatus": "Notifiche push web",
         "webPush_unavailable": "Non supportato dal server",
         "webPush_available": "Disponibile — tocca per attivare",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Tikrinamas leidimas...",
         "notificationDescription": "Darbalaukio pranešimai įspėja apie naujas žinutes, kai programa veikia fone.",
         "requestPermission": "Įjungti",
-        "openSettings": "Atidaryti nustatymus",
+        "openSystemNotificationSettings": "Atidaryti sistemos pranešimų nustatymus",
         "webPushStatus": "Žiniatinklio push pranešimai",
         "webPush_unavailable": "Serveris nepalaiko",
         "webPush_available": "Galima — bakstelėkite, kad įjungtumėte",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -640,7 +640,7 @@
         "notificationChecking": "Pārbauda atļauju...",
         "notificationDescription": "Darbvirsmas paziņojumi brīdina par jauniem ziņojumiem, kad lietotne ir fonā.",
         "requestPermission": "Iespējot",
-        "openSettings": "Atvērt iestatījumus",
+        "openSystemNotificationSettings": "Atvērt sistēmas paziņojumu iestatījumus",
         "webPushStatus": "Tīmekļa push paziņojumi",
         "webPush_unavailable": "Serveris neatbalsta",
         "webPush_available": "Pieejams — pieskarieties, lai iespējotu",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Qed jiċċekkja l-permess...",
         "notificationDescription": "Notifiki desktop jallertak għal messaġġi ġodda meta l-app tkun fil-background.",
         "requestPermission": "Ixgħel",
-        "openSettings": "Iftaħ Settings",
+        "openSystemNotificationSettings": "Iftaħ is-settings tan-notifiki tas-sistema",
         "webPushStatus": "Notifiki Web Push",
         "webPush_unavailable": "Mhux appoġġjat mis-server",
         "webPush_available": "Disponibbli — miss biex tixgħel",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Sjekker tillatelse...",
         "notificationDescription": "Skrivebordsvarsler varsler deg om nye meldinger når appen er i bakgrunnen.",
         "requestPermission": "Aktiver",
-        "openSettings": "Åpne innstillinger",
+        "openSystemNotificationSettings": "Åpne systemets varslingsinnstillinger",
         "webPushStatus": "Web-pushvarsler",
         "webPush_unavailable": "Ikke støttet av serveren",
         "webPush_available": "Tilgjengelig — trykk for å aktivere",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Toestemming controleren...",
         "notificationDescription": "Desktopmeldingen waarschuwen je voor nieuwe berichten wanneer de app op de achtergrond staat.",
         "requestPermission": "Inschakelen",
-        "openSettings": "Instellingen openen",
+        "openSystemNotificationSettings": "Systeeminstellingen voor meldingen openen",
         "webPushStatus": "Web-pushmeldingen",
         "webPush_unavailable": "Niet ondersteund door server",
         "webPush_available": "Beschikbaar — tik om in te schakelen",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Sprawdzanie uprawnień...",
         "notificationDescription": "Powiadomienia pulpitu alertują o nowych wiadomościach, gdy aplikacja jest w tle.",
         "requestPermission": "Włącz",
-        "openSettings": "Otwórz ustawienia",
+        "openSystemNotificationSettings": "Otwórz systemowe ustawienia powiadomień",
         "webPushStatus": "Powiadomienia web push",
         "webPush_unavailable": "Nieobsługiwane przez serwer",
         "webPush_available": "Dostępne — dotknij, aby włączyć",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -641,7 +641,7 @@
         "notificationChecking": "A verificar permissão...",
         "notificationDescription": "As notificações de ambiente de trabalho alertam-no para novas mensagens quando a aplicação está em segundo plano.",
         "requestPermission": "Ativar",
-        "openSettings": "Abrir definições",
+        "openSystemNotificationSettings": "Abrir as definições de notificações do sistema",
         "webPushStatus": "Notificações push web",
         "webPush_unavailable": "Não suportado pelo servidor",
         "webPush_available": "Disponível — toque para ativar",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Se verifică permisiunea...",
         "notificationDescription": "Notificările desktop te alertează despre mesaje noi când aplicația este în fundal.",
         "requestPermission": "Activează",
-        "openSettings": "Deschide setările",
+        "openSystemNotificationSettings": "Deschide setările de notificări ale sistemului",
         "webPushStatus": "Notificări push web",
         "webPush_unavailable": "Nu este suportat de server",
         "webPush_available": "Disponibil — atinge pentru activare",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Проверка разрешения...",
         "notificationDescription": "Уведомления на рабочем столе оповещают о новых сообщениях, когда приложение свёрнуто.",
         "requestPermission": "Включить",
-        "openSettings": "Открыть настройки",
+        "openSystemNotificationSettings": "Открыть системные настройки уведомлений",
         "webPushStatus": "Web push-уведомления",
         "webPush_unavailable": "Не поддерживается сервером",
         "webPush_available": "Доступно — нажмите для включения",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -640,7 +640,7 @@
         "notificationChecking": "Kontroluje sa povolenie...",
         "notificationDescription": "Oznámenia na ploche vás upozornia na nové správy, keď je aplikácia na pozadí.",
         "requestPermission": "Povoliť",
-        "openSettings": "Otvoriť nastavenia",
+        "openSystemNotificationSettings": "Otvoriť systémové nastavenia oznámení",
         "webPushStatus": "Webové push notifikácie",
         "webPush_unavailable": "Server nepodporuje",
         "webPush_available": "K dispozícii — ťuknite pre aktiváciu",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -641,7 +641,7 @@
         "notificationChecking": "Preverjanje dovoljenja...",
         "notificationDescription": "Obvestila na namizju vas opozorijo na nova sporočila, ko je aplikacija v ozadju.",
         "requestPermission": "Omogoči",
-        "openSettings": "Odpri nastavitve",
+        "openSystemNotificationSettings": "Odpri sistemske nastavitve obvestil",
         "webPushStatus": "Spletna push obvestila",
         "webPush_unavailable": "Strežnik ne podpira",
         "webPush_available": "Na voljo — tapnite za vklop",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Kontrollerar behörighet...",
         "notificationDescription": "Skrivbordsaviseringar meddelar dig om nya meddelanden när appen är i bakgrunden.",
         "requestPermission": "Aktivera",
-        "openSettings": "Öppna inställningar",
+        "openSystemNotificationSettings": "Öppna systemets aviseringsinställningar",
         "webPushStatus": "Webb-pushnotiser",
         "webPush_unavailable": "Stöds inte av servern",
         "webPush_available": "Tillgängligt — tryck för att aktivera",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -639,7 +639,7 @@
         "notificationChecking": "Перевірка дозволу...",
         "notificationDescription": "Сповіщення на робочому столі сповіщають про нові повідомлення, коли додаток у фоні.",
         "requestPermission": "Увімкнути",
-        "openSettings": "Відкрити налаштування",
+        "openSystemNotificationSettings": "Відкрити системні налаштування сповіщень",
         "webPushStatus": "Web push-сповіщення",
         "webPush_unavailable": "Сервер не підтримує",
         "webPush_available": "Доступно — натисніть, щоб увімкнути",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -639,7 +639,7 @@
         "notificationChecking": "正在检查权限…",
         "notificationDescription": "当应用在后台时，桌面通知会提醒您有新消息。",
         "requestPermission": "启用",
-        "openSettings": "打开设置",
+        "openSystemNotificationSettings": "打开系统通知设置",
         "webPushStatus": "网页推送通知",
         "webPush_unavailable": "服务器不支持",
         "webPush_available": "可用 — 点击即可启用",


### PR DESCRIPTION
Surfaces the OS notification-settings shortcut as a permanent link in the Notifications preferences, instead of only showing it when permission is denied. Previously, users with notifications already enabled (the common case) had no way to reach the system pane from the panel.

The link appears on every desktop build once the app is registered with the system notification center (permission granted or denied). It stays hidden while permission was never requested on macOS — where the in-app Enable prompt is the correct first action and the app isn't listed in System Settings yet — and on the web build, which has no OS pane to open.

Replaces the now-orphaned `settings.openSettings` i18n key with a dedicated `settings.openSystemNotificationSettings` across all 33 locales. Includes a regression test covering the visible/hidden states.