### PR TITLE
fix(e2ee): re-run deferred decrypts after a key restore

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -277,7 +277,8 @@ function App() {
       }
       await plugin.restoreSecretKey(passphrase)
       setPendingIdentityChoice(null)
-      client.notifyE2EEKeyUnlocked?.()
+      // The plugin signals key-unlocked itself now (it re-runs deferred
+      // decrypts via the SDK), so no notifyE2EEKeyUnlocked() call is needed.
       addToast('success', t('settings.encryption.restoreSuccess'))
     },
     [client, t, addToast],
@@ -310,7 +311,6 @@ function App() {
       }
       await plugin.importKeyFromFile(pendingImportFile, passphrase)
       setPendingImportFile(null)
-      client.notifyE2EEKeyUnlocked?.()
       addToast('success', t('settings.encryption.restoreSuccess'))
     },
     [client, pendingImportFile, t, addToast],
@@ -326,7 +326,6 @@ function App() {
     }
     await plugin.retireAndGenerateIdentity()
     setPendingIdentityChoice(null)
-    client.notifyE2EEKeyUnlocked?.()
     addToast('success', t('settings.encryption.restoreSuccess'))
   }, [client, t, addToast])
 

--- a/apps/fluux/src/components/UnlockEncryptionDialog.tsx
+++ b/apps/fluux/src/components/UnlockEncryptionDialog.tsx
@@ -105,7 +105,9 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
         throw new Error(t('settings.encryption.backupPluginUnavailable'))
       }
       const result = await plugin.unlock(passphrase)
-      client.notifyE2EEKeyUnlocked()
+      // unlock() signals key-unlocked itself now — happy path directly, or via
+      // restoreSecretKey → doInstallKey on recovery — so the SDK re-runs
+      // deferred decrypts without an explicit notifyE2EEKeyUnlocked() here.
       if (result?.recovered) {
         setRecovered(true)
         setTimeout(() => onClose(true), 1500)
@@ -149,7 +151,6 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
         setNoRecovery(null)
         return
       }
-      client.notifyE2EEKeyUnlocked()
       onClose(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -314,7 +315,6 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
               selectedFingerprint,
             )
             setPicker(null)
-            client.notifyE2EEKeyUnlocked()
             onClose(true)
           }}
           onCancel={() => setPicker(null)}

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -69,6 +69,10 @@ const forceConflict = params.get('e2ee') === 'conflict'
 const demoOpenpgpPlugin = new DemoOpenPGPPlugin({ forceConflict })
 const noopXmpp = { sendStanza: async () => {}, queryDisco: async () => ({ features: [], identities: [] }), publishPEP: async () => {}, retractPEP: async () => {}, deletePEP: async () => {}, queryPEP: async () => [] as any[], subscribePEP: () => ({ unsubscribe: () => {} }) }
 demoClient.e2ee = new E2EEManager({ storage: new InMemoryStorageBackend(), xmpp: noopXmpp, account: { jid: 'you@fluux.chat' } })
+// The demo builds its manager directly, so it misses XMPPClient's callback
+// wiring. Mirror the one that drives deferred-decrypt retries after a key
+// restore (see XMPPClient.setupE2EEManagerCallbacks).
+demoClient.e2ee.onKeyUnlocked(() => demoClient.notifyE2EEKeyUnlocked())
 void demoClient.e2ee.register(demoOpenpgpPlugin).then(() => {
   useEncryptionSettingsStore.getState().setOpenpgpEnabled(true)
   useEncryptionSettingsStore.getState().notifyPluginRegistered()

--- a/apps/fluux/src/demo/DemoOpenPGPPlugin.ts
+++ b/apps/fluux/src/demo/DemoOpenPGPPlugin.ts
@@ -65,6 +65,7 @@ export class DemoOpenPGPPlugin implements E2EEPlugin {
   readonly descriptor = OPENPGP_DESCRIPTOR
 
   private state: DemoE2EEState
+  private ctx: PluginContext | null = null
 
   constructor(opts?: { forceConflict?: boolean }) {
     this.state = {
@@ -78,7 +79,9 @@ export class DemoOpenPGPPlugin implements E2EEPlugin {
 
   // --- E2EEPlugin interface ---
 
-  async init(_ctx: PluginContext) {}
+  async init(ctx: PluginContext) {
+    this.ctx = ctx
+  }
   async shutdown() {}
 
   async ensureIdentity(): Promise<IdentityInfo> {
@@ -193,6 +196,7 @@ export class DemoOpenPGPPlugin implements E2EEPlugin {
     const fp = this.state.backupFingerprint ?? DEMO_FINGERPRINT
     this.state.fingerprint = fp
     this.state.forceNoLocalKey = false
+    this.ctx?.notifyKeyUnlocked?.()
     return { fingerprint: fp }
   }
 
@@ -204,6 +208,7 @@ export class DemoOpenPGPPlugin implements E2EEPlugin {
     await delay(500)
     this.state.fingerprint = selectedFingerprint
     this.state.forceNoLocalKey = false
+    this.ctx?.notifyKeyUnlocked?.()
     return { fingerprint: selectedFingerprint }
   }
 
@@ -239,6 +244,7 @@ export class DemoOpenPGPPlugin implements E2EEPlugin {
     const fp = randomFingerprint()
     this.state.fingerprint = fp
     this.state.forceNoLocalKey = false
+    this.ctx?.notifyKeyUnlocked?.()
     return { fingerprint: fp }
   }
 

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -831,6 +831,11 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
 
     clearOwnKeyConflict()
 
+    // The replacement identity is usable now; the retired [E] subkey is kept
+    // locally so history stays decryptable. Re-run deferred decrypts so any
+    // still-stashed messages are recovered immediately.
+    ctx.notifyKeyUnlocked?.()
+
     return { fingerprint: bundle.fingerprint }
   }
 
@@ -1116,6 +1121,12 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
         `${this.pluginName()}: public key publish after install failed: ${formatError(err)}`,
       )
     }
+
+    // The key just became usable (restore / file import / picker). Tell the
+    // host so it re-runs deferred decrypts immediately — otherwise messages
+    // stashed while the key was absent stay "could not be decrypted" until an
+    // unrelated trigger (reconnect, app restart) re-registers the plugin.
+    ctx.notifyKeyUnlocked?.()
 
     return { fingerprint: bundle.fingerprint }
   }

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -480,6 +480,12 @@ function makeContext(accountJid: string): {
    * an upgrade for the right messageId.
    */
   securityUpdates: SecurityContextUpdate[]
+  /**
+   * Number of `notifyKeyUnlocked()` calls. Tests assert that a user-driven
+   * key install (restore / import / picker / replace) fires it so the host
+   * re-runs deferred decrypts.
+   */
+  keyUnlocks: { count: number }
 } {
   const peerNodes = new Map<string, PEPItem[]>() // keyed "jid\0node"
   const published: Array<{
@@ -490,6 +496,7 @@ function makeContext(accountJid: string): {
   const retracted: Array<{ node: string; itemId: string }> = []
   const deletedNodes: string[] = []
   const securityUpdates: SecurityContextUpdate[] = []
+  const keyUnlocks = { count: 0 }
 
   const xmpp: XMPPPrimitives = {
     sendStanza: async () => {},
@@ -538,6 +545,9 @@ function makeContext(accountJid: string): {
     reportSecurityContextUpdate: (update) => {
       securityUpdates.push(update)
     },
+    notifyKeyUnlocked: () => {
+      keyUnlocks.count++
+    },
   }
   const peerPublish = (peer: string, node: string, item: PEPItem) => {
     const key = `${peer}\u0000${node}`
@@ -545,7 +555,7 @@ function makeContext(accountJid: string): {
     existing.push(item)
     peerNodes.set(key, existing)
   }
-  return { ctx, published, retracted, deletedNodes, peerPublish, securityUpdates }
+  return { ctx, published, retracted, deletedNodes, peerPublish, securityUpdates, keyUnlocks }
 }
 
 describe('SequoiaPgpPlugin', () => {
@@ -2595,6 +2605,48 @@ describe('SequoiaPgpPlugin', () => {
       // Unused to silence "published is declared but never read" from the
       // device A context.
       void publishedA
+    })
+
+    it('fires ctx.notifyKeyUnlocked() after restoreSecretKey, but NOT on init', async () => {
+      // Regression: a restored key must tell the host to re-run deferred
+      // decrypts, otherwise messages stashed while the key was absent stay
+      // "could not be decrypted" until the next reconnect. The passive key
+      // load in init() must NOT fire it (plugin registration already
+      // triggers a retry — a second one would be redundant).
+      const { ctx: ctxA } = makeContext('me@example.com')
+      await plugin.init(ctxA)
+      await plugin.backupSecretKey('shared-pp')
+      const backup = await plugin.fetchSecretKeyBackup()
+
+      fake.accounts.clear()
+      const pluginB = new SequoiaPgpPlugin({ invoke: fake.invoke })
+      const { ctx: ctxB, keyUnlocks } = makeContext('me@example.com')
+      await pluginB.init(ctxB)
+      // init's passive load is covered by the plugin-registered retry.
+      expect(keyUnlocks.count).toBe(0)
+
+      ctxB.xmpp.publishPEP(SECRET_KEY_NODE, {
+        id: 'current',
+        payload: {
+          name: 'secretkey',
+          attrs: { xmlns: 'urn:xmpp:openpgp:0' },
+          children: [encodeOpenPgpArmorForXep0373(backup!)],
+        },
+      })
+
+      await pluginB.restoreSecretKey('shared-pp')
+      expect(keyUnlocks.count).toBe(1)
+    })
+
+    it('fires ctx.notifyKeyUnlocked() after retireAndGenerateIdentity', async () => {
+      // The retained [E] subkey keeps history decryptable, so re-running
+      // deferred decrypts after a replacement is worthwhile.
+      const { ctx, keyUnlocks } = makeContext('me@example.com')
+      await plugin.init(ctx)
+      expect(keyUnlocks.count).toBe(0)
+
+      await plugin.retireAndGenerateIdentity()
+      expect(keyUnlocks.count).toBe(1)
     })
 
     it('restoreSecretKey deletes the stale per-fingerprint data node when the primary FP changes', async () => {

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -2323,6 +2323,26 @@ describe('WebOpenPGPPlugin', () => {
       expect(fresh.getOwnFingerprint()).toBe(fp)
     })
 
+    it('fires ctx.notifyKeyUnlocked() on a normal local unlock, but NOT on init', async () => {
+      // Web parity with the Sequoia restore path: a successful unlock must tell
+      // the host so deferred decrypts re-run. init()'s locked load must NOT.
+      const backend = new InMemoryStorageBackend()
+      const setup = new WebOpenPGPPlugin()
+      setSessionPassphrase(PP)
+      await setup.init(makeCtx('alice@example.com', backend).ctx)
+
+      clearSessionPassphrase()
+      const fresh = new WebOpenPGPPlugin()
+      const ctx = makeCtx('alice@example.com', backend).ctx
+      const notifyKeyUnlocked = vi.fn()
+      ctx.notifyKeyUnlocked = notifyKeyUnlocked
+      await fresh.init(ctx) // key is locked → init returns early, no unlock signal
+      expect(notifyKeyUnlocked).not.toHaveBeenCalled()
+
+      await fresh.unlock(PP)
+      expect(notifyKeyUnlocked).toHaveBeenCalledTimes(1)
+    })
+
     it('recovers a stale local key from the server backup (rotated passphrase)', async () => {
       const shared: SharedPep = new Map()
       const sourceBackend = new InMemoryStorageBackend()

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -634,6 +634,11 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
       // Happy path: decrypt the local key and publish/subscribe.
       await this.ensureIdentity()
       this.activateSubscriptions()
+      // The local key is now decrypted into memory — re-run deferred decrypts
+      // so messages stashed while locked are recovered. (The recovery branch
+      // below routes through restoreSecretKey → doInstallKey, which already
+      // notifies, so only this happy path needs an explicit call.)
+      this.requireCtx().notifyKeyUnlocked?.()
       return { recovered: false }
     } catch (err) {
       if (!isRecoverableLocalFailure(err)) {

--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -758,4 +758,65 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(passes).toBe(2)
     })
   })
+
+  describe('key-unlocked wiring (ensureE2EEManager)', () => {
+    it('decrypts a stashed message when the plugin signals notifyKeyUnlocked()', async () => {
+      // End-to-end guard for the centralized restore→retry trigger. Build the
+      // manager through the REAL XMPPClient path (ensureE2EEManager, which
+      // wires onKeyUnlocked) rather than the hand-attached manager used by the
+      // other tests, then have the plugin fire ctx.notifyKeyUnlocked() — the
+      // signal a key restore/unlock emits — and assert the stashed message
+      // actually decrypts. Covers the links the per-unit tests leave un-joined:
+      // manager.onKeyUnlocked → notifyE2EEKeyUnlocked → retryPendingDecrypts.
+      const client = new XMPPClient({ debug: false })
+      ;(client as unknown as { currentJid: string }).currentJid = 'me@example.com/web'
+      ;(client as unknown as { ensureE2EEManager: () => void }).ensureE2EEManager()
+      const plugin = new DummyPlaintextPlugin()
+      await client.e2ee!.register(plugin)
+      const ctx = (plugin as unknown as { ctx: { notifyKeyUnlocked?: () => void } }).ctx
+
+      // DummyPlaintextPlugin decrypts to trust:'untrusted', which re-stashes
+      // for deferred verification instead of committing. Mock decryptArchive to
+      // return 'verified' so the retry commits the body — the wiring is what
+      // this test exercises, not the crypto (covered by stanzaDecrypt tests).
+      vi.spyOn(client.e2ee!, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode('hello'),
+        senderDevice: { jid: 'carol@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      chatStore.getState().addConversation({
+        id: 'carol@example.com',
+        name: 'Carol',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'msg-stashed-until-unlock',
+        conversationId: 'carol@example.com',
+        from: 'carol@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date(),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+
+      // notifyE2EEKeyUnlocked fires retryPendingDecrypts fire-and-forget (and is
+      // double-triggered via the e2ee:key-unlocked event — the coalescing guard
+      // dedupes it). Spy to prove the unlock kicked off the retry, then await
+      // every pass it started so the decrypt settles before asserting.
+      const retrySpy = vi.spyOn(client, 'retryPendingDecrypts')
+      ctx.notifyKeyUnlocked?.()
+      expect(retrySpy).toHaveBeenCalled() // the wiring fired
+      await Promise.all(retrySpy.mock.results.map((r) => Promise.resolve(r.value)))
+
+      const msg = (chatStore.getState().messages.get('carol@example.com') ?? []).find(
+        (m) => m.id === 'msg-stashed-until-unlock',
+      )
+      expect(msg?.body).toBe('hello')
+      expect(msg?.encryptedPayload).toBeUndefined()
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -2112,6 +2112,14 @@ export class XMPPClient {
     this.e2ee.onPeerKeysChanged((peer) => {
       void this.retryPendingDecryptsForPeer(peer)
     })
+    // When a plugin reports the local key just became usable (passphrase
+    // entered, server backup restored, key file imported, identity replaced),
+    // run the same retry as notifyE2EEKeyUnlocked. Driving this from the plugin
+    // means every restore site is covered automatically — UI code no longer
+    // has to remember to call notifyE2EEKeyUnlocked at each one.
+    this.e2ee.onKeyUnlocked(() => {
+      this.notifyE2EEKeyUnlocked()
+    })
   }
 
   /**

--- a/packages/fluux-sdk/src/core/e2ee/E2EEManager.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/E2EEManager.test.ts
@@ -300,6 +300,35 @@ describe('E2EEManager — registration', () => {
   })
 })
 
+describe('E2EEManager — key-unlocked channel', () => {
+  it('routes ctx.notifyKeyUnlocked() to the onKeyUnlocked callback', async () => {
+    const mgr = makeManager()
+    const onUnlocked = vi.fn()
+    mgr.onKeyUnlocked(onUnlocked)
+
+    const plugin = new FakePlugin(weakDescriptor, 'urn:test:weak')
+    const initSpy = vi.spyOn(plugin, 'init')
+    await mgr.register(plugin)
+
+    const ctx = initSpy.mock.calls[0][0]
+    // The host wires the channel; the plugin fires it on a user-driven
+    // key-availability change (restore / import / unlock / replace).
+    expect(onUnlocked).not.toHaveBeenCalled()
+    ctx.notifyKeyUnlocked?.()
+    expect(onUnlocked).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when no onKeyUnlocked callback is registered', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(weakDescriptor, 'urn:test:weak')
+    const initSpy = vi.spyOn(plugin, 'init')
+    await mgr.register(plugin)
+
+    const ctx = initSpy.mock.calls[0][0]
+    expect(() => ctx.notifyKeyUnlocked?.()).not.toThrow()
+  })
+})
+
 describe('E2EEManager — strategy selection', () => {
   it('picks highest securityLevel among mutually-supported plugins', async () => {
     const mgr = makeManager()

--- a/packages/fluux-sdk/src/core/e2ee/E2EEManager.ts
+++ b/packages/fluux-sdk/src/core/e2ee/E2EEManager.ts
@@ -89,6 +89,7 @@ export class E2EEManager {
   private readonly forcedPlaintextConversations = new Set<string>()
   private pluginRegisteredCallback: ((pluginId: string) => void) | null = null
   private peerKeysChangedCallback: ((peer: BareJID) => void) | null = null
+  private keyUnlockedCallback: (() => void) | null = null
   // PEP key-change notifications can race plugin registration: the server
   // bursts headline pushes immediately on stream open, but plugins finish
   // their async init (IndexedDB hydration, key unwrap) seconds later. We
@@ -155,6 +156,7 @@ export class E2EEManager {
       logger: this.logger,
       account: this.account,
       reportSecurityContextUpdate: (update) => this.dispatchSecurityContextUpdate(update),
+      notifyKeyUnlocked: () => this.keyUnlockedCallback?.(),
     }
     await plugin.init(ctx)
     this.plugins.set(id, plugin)
@@ -218,6 +220,17 @@ export class E2EEManager {
   /** Set a callback invoked whenever a peer's key material changes via PEP. */
   onPeerKeysChanged(cb: (peer: BareJID) => void): void {
     this.peerKeysChangedCallback = cb
+  }
+
+  /**
+   * Set a callback invoked whenever a plugin reports (via
+   * {@link PluginContext.notifyKeyUnlocked}) that the local private key just
+   * became usable through a user action — restore, import, unlock, or
+   * identity replacement. The host re-runs deferred decrypts so messages
+   * stashed while the key was absent are recovered immediately.
+   */
+  onKeyUnlocked(cb: () => void): void {
+    this.keyUnlockedCallback = cb
   }
 
   /** Force all outbound sends to this target to skip encryption entirely. Inbound decryption is unaffected. */

--- a/packages/fluux-sdk/src/core/e2ee/types.ts
+++ b/packages/fluux-sdk/src/core/e2ee/types.ts
@@ -380,6 +380,25 @@ export interface PluginContext {
    * {@link SecurityContext} via {@link DecryptResult} instead).
    */
   reportSecurityContextUpdate(update: SecurityContextUpdate): void
+
+  /**
+   * Plugin-driven channel for telling the host that the local private key
+   * has just become usable through a user action — passphrase entered,
+   * server backup restored, key file imported, or identity replaced. The
+   * host re-runs every pending deferred decrypt (see
+   * {@link XMPPClient.retryPendingDecrypts}) so messages that arrived while
+   * the key was locked or absent are decrypted immediately, without each UI
+   * restore site having to remember to call
+   * {@link XMPPClient.notifyE2EEKeyUnlocked} (one such site being missed is
+   * exactly how restored messages stayed "could not be decrypted").
+   *
+   * Wired by {@link E2EEManager} at {@link E2EEManager.register} time;
+   * optional so hand-rolled hosts and tests may omit it — plugins invoke it
+   * defensively as `ctx.notifyKeyUnlocked?.()`. Plugins MUST NOT call it from
+   * `init`'s passive key load: registration already triggers a retry via the
+   * plugin-registered event, so firing here too would be redundant.
+   */
+  notifyKeyUnlocked?(): void
 }
 
 /**


### PR DESCRIPTION
## Summary

Restoring or unlocking the OpenPGP key from desktop **Settings → Encryption** never triggered the deferred-decrypt retry, so messages that arrived while the key was absent stayed "could not be decrypted" until the next reconnect (which re-registers the plugin and fires the retry). `notifyE2EEKeyUnlocked` was called by the web restore dialogs (`App.tsx`, `UnlockEncryptionDialog`) but **not** by `EncryptionSettings` — the only restore entry point on desktop.

## Fix

A centralized plugin→host channel so every restore path triggers the retry automatically, instead of each UI site having to remember to call it:

- New optional `PluginContext.notifyKeyUnlocked` (mirrors `reportSecurityContextUpdate`); `E2EEManager.onKeyUnlocked` + `XMPPClient` wires it to `retryPendingDecrypts`.
- `OpenPGPPluginBase` fires it from the key-acquisition choke points (`doInstallKey`, `retireAndGenerateIdentity`) and the Web `unlock` happy path; deliberately not from `init`'s passive load (plugin registration already retries).
- Removes the 6 now-redundant `notifyE2EEKeyUnlocked` UI calls. Demo plugin/manager wired for parity.

Tests: an end-to-end guard (plugin signals key-unlocked → a stashed message actually decrypts through the real `ensureE2EEManager` wiring) plus per-path guards that restore/unlock/replace fire the trigger while `init` does not.