### PR TITLE
fix(e2ee): refresh sidebar preview after deferred decrypt

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -442,6 +442,48 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(decryptSpy).toHaveBeenCalledTimes(1)
       expect(count).toBe(1)
     })
+
+    it('refreshes the sidebar preview when the durable-decrypted message is the conversation lastMessage', async () => {
+      // Reported bug: the key is unlocked while a conversation is NOT open, so its
+      // last message is decrypted via the durable cache only. The bubble shows the
+      // cleartext on open, but the sidebar preview stayed "[OpenPGP-encrypted
+      // message]" because nothing refreshed the in-memory lastMessage.
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode('hello'),
+        senderDevice: { jid: 'carol@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      const encryptedPreview = {
+        type: 'chat' as const,
+        id: 'durable-preview-1',
+        conversationId: 'carol@example.com',
+        from: 'carol@example.com',
+        body: '[OpenPGP-encrypted message]',
+        timestamp: new Date('2026-06-13T18:48:00Z'),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      }
+
+      // Conversation is in the sidebar (preview = the encrypted message) but its
+      // messages are NOT loaded — the ciphertext lives only in the durable cache.
+      chatStore.getState().addConversation({
+        id: 'carol@example.com',
+        name: 'Carol',
+        type: 'chat',
+        lastMessage: encryptedPreview,
+        unreadCount: 1,
+      })
+      vi.mocked(messageCache.getMessagesWithEncryptedPayload).mockResolvedValue([encryptedPreview])
+
+      await xmppClient.retryPendingDecrypts()
+
+      const conv = chatStore.getState().conversations.get('carol@example.com')
+      expect(conv?.lastMessage?.body).toBe('hello')
+      expect(conv?.lastMessage?.encryptedPayload).toBeUndefined()
+      // The metadata map (what the sidebar subscribes to) is healed too.
+      expect(chatStore.getState().conversationMeta.get('carol@example.com')?.lastMessage?.body).toBe('hello')
+    })
   })
 
   describe('deferred-decrypt of bodiless modifications', () => {

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1747,12 +1747,17 @@ export class XMPPClient {
           manager, msg.encryptedPayload, msg.from, conversationId,
         )
         if (outcome.kind === 'decrypted') {
-          await cacheUpdateMessage(msg.id, {
+          const updates = {
             body: outcome.body,
             ...(outcome.securityContext && { securityContext: outcome.securityContext }),
             ...(outcome.attachment && { attachment: outcome.attachment }),
             encryptedPayload: undefined,
-          })
+          }
+          await cacheUpdateMessage(msg.id, updates)
+          // The conversation's messages aren't loaded (durable path), so the
+          // in-memory sidebar preview would keep the "[OpenPGP-encrypted
+          // message]" fallback. Heal it when this message IS the preview.
+          chatBindings.refreshLastMessageContent?.(conversationId, msg.id, updates)
           decryptedCount++
         } else if (outcome.kind === 'modification') {
           // Conversation isn't loaded in memory. Apply best-effort to the
@@ -1770,17 +1775,21 @@ export class XMPPClient {
             // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
             await cacheDeleteMessage(msg.id)
           } else {
-            await cacheUpdateMessage(msg.id, {
+            const updates = {
               body: MESSAGE_REJECTED_BODY,
               ...(outcome.securityContext && { securityContext: outcome.securityContext }),
               encryptedPayload: undefined,
-            })
+            }
+            await cacheUpdateMessage(msg.id, updates)
+            chatBindings.refreshLastMessageContent?.(conversationId, msg.id, updates)
           }
         } else if (outcome.kind === 'unsupported') {
-          await cacheUpdateMessage(msg.id, {
+          const updates = {
             encryptedPayload: undefined,
             unsupportedEncryption: outcome.info,
-          })
+          }
+          await cacheUpdateMessage(msg.id, updates)
+          chatBindings.refreshLastMessageContent?.(conversationId, msg.id, updates)
         }
       }
 

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -126,6 +126,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       markAllNeedsCatchUp: chatStore.getState().markAllNeedsCatchUp,
       clearNeedsCatchUp: chatStore.getState().clearNeedsCatchUp,
       updateLastMessagePreview: chatStore.getState().updateLastMessagePreview,
+      refreshLastMessageContent: chatStore.getState().refreshLastMessageContent,
       loadMessagesFromCache: chatStore.getState().loadMessagesFromCache,
       getAllConversations: () => {
         const state = chatStore.getState()

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -97,6 +97,9 @@ export interface StoreBindings {
     clearNeedsCatchUp: (conversationId: string) => void
     // Update sidebar preview without affecting message history
     updateLastMessagePreview: (conversationId: string, lastMessage: Message) => void
+    // Refresh the preview's content in place, but only when it is the referenced
+    // message — heals a deferred-decrypted lastMessage for an unopened conversation.
+    refreshLastMessageContent?: (conversationId: string, messageId: string, updates: Partial<Message>) => void
     // Load messages from IndexedDB cache into the conversation's in-memory message array
     loadMessagesFromCache?: (conversationId: string, options?: { limit?: number }) => Promise<unknown>
     // Get all conversations for MAM catch-up

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -2728,6 +2728,144 @@ describe('chatStore', () => {
     })
   })
 
+  describe('refreshLastMessageContent', () => {
+    const conversationId = 'alice@example.com'
+    const fixedTs = new Date('2024-01-15T12:00:00Z')
+
+    function makeMsg(id: string, body: string, extra: Partial<Message> = {}): Message {
+      return {
+        type: 'chat',
+        id,
+        conversationId,
+        from: conversationId,
+        body,
+        timestamp: new Date(fixedTs.getTime()),
+        isOutgoing: false,
+        ...extra,
+      }
+    }
+
+    it('heals the preview in place when it is the referenced message (same id and timestamp)', () => {
+      chatStore.getState().addConversation(createConversation(conversationId))
+      chatStore.getState().addMessage(makeMsg('m1', '[OpenPGP-encrypted message]', { encryptedPayload: '<x/>' }))
+      expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.body)
+        .toBe('[OpenPGP-encrypted message]')
+
+      // Deferred decrypt: same message, same timestamp, new body. The strict-newer
+      // updateLastMessagePreview would refuse this — refreshLastMessageContent must not.
+      chatStore.getState().refreshLastMessageContent(conversationId, 'm1', {
+        body: 'decrypted hello',
+        encryptedPayload: undefined,
+      })
+
+      const meta = chatStore.getState().conversationMeta.get(conversationId)
+      expect(meta?.lastMessage?.body).toBe('decrypted hello')
+      expect(meta?.lastMessage?.encryptedPayload).toBeUndefined()
+      // Combined map (backward-compat) is healed too.
+      expect(chatStore.getState().conversations.get(conversationId)?.lastMessage?.body)
+        .toBe('decrypted hello')
+    })
+
+    it('does NOT touch the preview when the referenced message is not the current preview', () => {
+      // Safety contract: a different (e.g. older) message decrypted in the durable
+      // pass must never hijack the preview. This is what prevents a stale overwrite.
+      chatStore.getState().addConversation(createConversation(conversationId))
+      chatStore.getState().addMessage(makeMsg('current', 'current preview'))
+
+      chatStore.getState().refreshLastMessageContent(conversationId, 'some-other-id', {
+        body: 'should not appear',
+      })
+
+      expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.body)
+        .toBe('current preview')
+    })
+
+    it('matches the preview across id tiers (stanzaId)', () => {
+      chatStore.getState().addConversation(createConversation(conversationId))
+      chatStore.getState().addMessage(makeMsg('m1', '[OpenPGP-encrypted message]', { stanzaId: 'stanza-9' }))
+
+      chatStore.getState().refreshLastMessageContent(conversationId, 'stanza-9', { body: 'cleartext' })
+
+      expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.body).toBe('cleartext')
+    })
+
+    it('does nothing (and does not throw) for a non-existent conversation', () => {
+      expect(() => {
+        chatStore.getState().refreshLastMessageContent('nobody@example.com', 'm1', { body: 'x' })
+      }).not.toThrow()
+      expect(chatStore.getState().conversations.has('nobody@example.com')).toBe(false)
+    })
+  })
+
+  describe('loadMessagesFromCache — deferred-decrypt preview heal on open', () => {
+    const conversationId = 'alice@example.com'
+    const ts = new Date('2026-06-13T18:48:00Z')
+
+    function encryptedPreview(): Message {
+      return {
+        type: 'chat',
+        id: 'm1',
+        conversationId,
+        from: conversationId,
+        body: '[OpenPGP-encrypted message]',
+        timestamp: new Date(ts.getTime()),
+        isOutgoing: false,
+        encryptedPayload: '<x/>',
+      }
+    }
+
+    afterEach(() => {
+      vi.mocked(messageCache.getMessages).mockReset()
+      vi.mocked(messageCache.getMessages).mockResolvedValue([])
+    })
+
+    it('heals a stale encrypted preview when the cache copy of the same message is now decrypted', async () => {
+      // The user's reported state: the message was decrypted in the durable cache
+      // while the conversation was closed, but the persisted sidebar preview still
+      // points at the encrypted copy (same id and timestamp — strict-newer refuses).
+      chatStore.getState().addConversation({ ...createConversation(conversationId), lastMessage: encryptedPreview() })
+
+      const decrypted: Message = { ...encryptedPreview(), body: 'now decrypted', encryptedPayload: undefined }
+      vi.mocked(messageCache.getMessages).mockResolvedValue([decrypted])
+
+      await chatStore.getState().loadMessagesFromCache(conversationId)
+
+      expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.body).toBe('now decrypted')
+      expect(chatStore.getState().conversations.get(conversationId)?.lastMessage?.body).toBe('now decrypted')
+    })
+
+    it('does NOT churn the preview when the same-id cache copy is still encrypted (key locked)', async () => {
+      chatStore.getState().addConversation({ ...createConversation(conversationId), lastMessage: encryptedPreview() })
+      vi.mocked(messageCache.getMessages).mockResolvedValue([encryptedPreview()])
+
+      await chatStore.getState().loadMessagesFromCache(conversationId)
+
+      expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.body)
+        .toBe('[OpenPGP-encrypted message]')
+    })
+  })
+
+  describe('mergeMAMMessages — deferred-decrypt preview heal', () => {
+    const conversationId = 'alice@example.com'
+    const ts = new Date('2026-06-13T18:48:00Z')
+
+    it('heals a stale encrypted preview when MAM brings in the decrypted copy of that message', () => {
+      const encryptedPreview: Message = {
+        type: 'chat', id: 'm1', conversationId, from: conversationId,
+        body: '[OpenPGP-encrypted message]', timestamp: new Date(ts.getTime()),
+        isOutgoing: false, encryptedPayload: '<x/>',
+      }
+      chatStore.getState().addConversation({ ...createConversation(conversationId), lastMessage: encryptedPreview })
+
+      // MAM catch-up of the unopened conversation re-delivers the same message,
+      // now decrypted (same id and timestamp, encrypted stash cleared).
+      const decrypted: Message = { ...encryptedPreview, body: 'now decrypted', encryptedPayload: undefined }
+      chatStore.getState().mergeMAMMessages(conversationId, [decrypted], {}, true, 'forward')
+
+      expect(chatStore.getState().conversationMeta.get(conversationId)?.lastMessage?.body).toBe('now decrypted')
+    })
+  })
+
   describe('activeConversations', () => {
     it('should return only non-archived conversations', () => {
       // Create multiple conversations

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -10,7 +10,7 @@ import type { MAMQueryDirection } from './shared/mamState'
 import { computeGapEnd, syncGap, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages, backfillArchiveIds } from './shared/messageArrayUtils'
-import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
+import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage, isResolvedSamePreview } from './shared/lastMessageUtils'
 import * as notifState from './shared/notificationState'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey } from '../utils/storageScope'
@@ -188,6 +188,21 @@ interface ChatState {
    * @param lastMessage - The most recent message from MAM
    */
   updateLastMessagePreview: (conversationId: string, lastMessage: Message) => void
+  /**
+   * Apply an in-place content update to a conversation's lastMessage preview,
+   * but only when the preview IS the referenced message (matched across the
+   * XEP-0359 id tiers). Used by the durable-cache deferred-decrypt pass: when a
+   * conversation's preview message is decrypted while its messages aren't loaded
+   * in memory, {@link updateMessage} can't reach it and the timestamp-gated
+   * {@link updateLastMessagePreview} won't replace a same-timestamp message — so
+   * the sidebar would keep showing "[OpenPGP-encrypted message]". This refreshes
+   * the preview's content (body/securityContext/attachment/encryptedPayload)
+   * without touching the messages array.
+   * @param conversationId - Conversation JID
+   * @param messageId - id / stanzaId / originId of the decrypted message
+   * @param updates - Partial content to merge into the preview message
+   */
+  refreshLastMessageContent: (conversationId: string, messageId: string, updates: Partial<Message>) => void
   // IndexedDB message loading
   loadMessagesFromCache: (conversationId: string, options?: { limit?: number; before?: Date }) => Promise<Message[]>
   loadOlderMessagesFromCache: (conversationId: string, limit?: number) => Promise<Message[]>
@@ -1253,11 +1268,17 @@ export const chatStore = createStore<ChatState>()(
           // Update lastMessage with the newest previewable message after
           // merge/sort, skipping bodiless signal placeholders (e.g. undecrypted
           // encrypted reactions). A real message also supersedes an existing
-          // stuck placeholder even when older.
+          // stuck placeholder even when older. isResolvedSamePreview additionally
+          // heals a preview stuck on the encrypted fallback when MAM brings in the
+          // now-decrypted copy of that same message (same id/timestamp).
           const lastMessage = findLastPreviewableMessage(trimmed)
           const meta = state.conversationMeta.get(conversationId)
           const conv = state.conversations.get(conversationId)
-          if (meta && conv && lastMessage && shouldReplaceLastMessage(meta.lastMessage, lastMessage)) {
+          if (
+            meta && conv && lastMessage &&
+            (shouldReplaceLastMessage(meta.lastMessage, lastMessage) ||
+              isResolvedSamePreview(meta.lastMessage, lastMessage))
+          ) {
             // Update metadata map
             const newMeta = new Map(state.conversationMeta)
             newMeta.set(conversationId, { ...meta, lastMessage })
@@ -1317,6 +1338,30 @@ export const chatStore = createStore<ChatState>()(
         })
       },
 
+      refreshLastMessageContent: (conversationId, messageId, updates) => {
+        set((state) => {
+          const meta = state.conversationMeta.get(conversationId)
+          const conv = state.conversations.get(conversationId)
+          // Fall back to the combined map for persist/test states that lack meta.
+          const existing = meta?.lastMessage ?? conv?.lastMessage
+          if (!existing) return state
+
+          // Only touch the preview when it IS this message — matched across the
+          // id/stanzaId/originId tiers so a MAM-id copy still resolves.
+          if (findMessageIndexById([existing], messageId) === -1) return state
+
+          const updated = { ...existing, ...updates }
+
+          const newMeta = new Map(state.conversationMeta)
+          if (meta) newMeta.set(conversationId, { ...meta, lastMessage: updated })
+
+          const newConversations = new Map(state.conversations)
+          if (conv) newConversations.set(conversationId, { ...conv, lastMessage: updated })
+
+          return { conversationMeta: newMeta, conversations: newConversations }
+        })
+      },
+
       // Load messages from IndexedDB cache for a conversation
       // For initial load (no 'before'), loads the LATEST 100 messages to show most recent first
       loadMessagesFromCache: async (conversationId, options = {}) => {
@@ -1359,7 +1404,16 @@ export const chatStore = createStore<ChatState>()(
               const lastMessage = findLastPreviewableMessage(trimmed)
               const meta = state.conversationMeta.get(conversationId)
               const conv = state.conversations.get(conversationId)
-              if (meta && conv && lastMessage && shouldReplaceLastMessage(meta.lastMessage, lastMessage)) {
+              // Replace when newer/a stuck placeholder, OR when this is the same
+              // message resolved in the cache (deferred decrypt) while the preview
+              // kept the encrypted fallback — shouldReplaceLastMessage's
+              // strictly-newer gate would otherwise leave the sidebar stuck on
+              // "[OpenPGP-encrypted message]".
+              if (
+                meta && conv && lastMessage &&
+                (shouldReplaceLastMessage(meta.lastMessage, lastMessage) ||
+                  isResolvedSamePreview(meta.lastMessage, lastMessage))
+              ) {
                 // Update metadata map
                 const newMeta = new Map(state.conversationMeta)
                 newMeta.set(conversationId, { ...meta, lastMessage })

--- a/packages/fluux-sdk/src/stores/shared/lastMessageUtils.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/lastMessageUtils.test.ts
@@ -17,7 +17,7 @@ vi.mock('zustand/middleware', () => ({
   persist: (fn: unknown) => fn,
 }))
 
-import { shouldUpdateLastMessage, shouldReplaceLastMessage, findLastNonIgnoredMessage, isPreviewableMessage, findLastPreviewableMessage } from './lastMessageUtils'
+import { shouldUpdateLastMessage, shouldReplaceLastMessage, findLastNonIgnoredMessage, isPreviewableMessage, findLastPreviewableMessage, isResolvedSamePreview } from './lastMessageUtils'
 import { ignoreStore } from '../ignoreStore'
 import type { RoomMessage } from '../../core/types'
 
@@ -93,6 +93,38 @@ describe('shouldReplaceLastMessage', () => {
   it('replaces a stuck non-previewable placeholder even with an older candidate', () => {
     // The heal case: a real (older) message supersedes a newer bodiless placeholder.
     expect(shouldReplaceLastMessage(placeholder, older)).toBe(true)
+  })
+})
+
+describe('isResolvedSamePreview', () => {
+  // The helper inspects identity + encryption state only; `encryptedPayload`
+  // presence stands in for "encrypted fallback" vs "resolved cleartext".
+  it('is true when the same message lost its encrypted stash (deferred decrypt)', () => {
+    const encrypted = { id: 'm1', encryptedPayload: '<x/>' }
+    const resolved = { id: 'm1' }
+    expect(isResolvedSamePreview(encrypted, resolved)).toBe(true)
+  })
+
+  it('is false when the existing preview was never encrypted', () => {
+    expect(isResolvedSamePreview({ id: 'm1' }, { id: 'm1' })).toBe(false)
+  })
+
+  it('is false when the candidate is still encrypted (key still locked)', () => {
+    const encrypted = { id: 'm1', encryptedPayload: '<x/>' }
+    expect(isResolvedSamePreview(encrypted, { id: 'm1', encryptedPayload: '<x/>' })).toBe(false)
+  })
+
+  it('is false for a genuinely different message', () => {
+    expect(isResolvedSamePreview({ id: 'm1', encryptedPayload: '<x/>' }, { id: 'm2' })).toBe(false)
+  })
+
+  it('is false when there is no existing preview', () => {
+    expect(isResolvedSamePreview(undefined, { id: 'm1' })).toBe(false)
+  })
+
+  it('matches across id tiers (existing stanzaId === candidate id)', () => {
+    const encrypted = { id: 'local-1', stanzaId: 's1', encryptedPayload: '<x/>' }
+    expect(isResolvedSamePreview(encrypted, { id: 's1' })).toBe(true)
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/lastMessageUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/lastMessageUtils.ts
@@ -7,6 +7,7 @@
 
 import type { BaseMessage, RoomMessage } from '../../core/types'
 import { ignoreStore, isMessageFromIgnoredUser } from '../ignoreStore'
+import { findMessageIndexById } from '../../utils/messageLookup'
 
 /**
  * Generic interface for messages with an optional timestamp.
@@ -80,6 +81,40 @@ export function shouldReplaceLastMessage<T extends PreviewableMessage & MessageW
   if (!existing) return true
   if (!isPreviewableMessage(existing)) return true
   return shouldUpdateLastMessage(existing, candidate)
+}
+
+/** Identity + encryption-state fields needed to recognise a resolved preview. */
+interface ResolvablePreview {
+  id: string
+  stanzaId?: string
+  originId?: string
+  correctionStanzaIds?: string[]
+  encryptedPayload?: string
+}
+
+/**
+ * Whether `candidate` is the SAME underlying message as the current `existing`
+ * preview but now *resolved* — its encrypted stash cleared (a deferred decrypt,
+ * rejection, or unsupported-encryption resolution) while `existing` still holds
+ * the encrypted fallback.
+ *
+ * A bulk reload (durable cache or MAM merge) uses this to heal a preview stuck on
+ * "[OpenPGP-encrypted message]": {@link shouldReplaceLastMessage} gates on a
+ * strictly-newer timestamp and refuses a same-id, same-timestamp content change,
+ * so without this the sidebar would never update after decryption. It only ever
+ * promotes encrypted → resolved (never the reverse), so it cannot clobber a
+ * fresher cleartext preview with a stale ciphertext copy.
+ *
+ * @param existing - The current preview message (may be undefined)
+ * @param candidate - The freshly (re)loaded copy of a previewable message
+ */
+export function isResolvedSamePreview(
+  existing: ResolvablePreview | undefined,
+  candidate: ResolvablePreview,
+): boolean {
+  if (!existing?.encryptedPayload) return false
+  if (candidate.encryptedPayload) return false
+  return findMessageIndexById([existing], candidate.id) !== -1
 }
 
 /**


### PR DESCRIPTION
The sidebar preview stayed on `[OpenPGP-encrypted message]` after a message was decrypted, when the key was unlocked while that conversation wasn't open.

Such a message is decrypted via the durable-cache path of `retryPendingDecrypts`, which wrote the cleartext to IndexedDB only — the in-memory `lastMessage` kept the encrypted fallback. The preview-refresh paths gate on a strictly-newer timestamp, so a same-id/same-timestamp decrypt could never replace it.

- `isResolvedSamePreview` (encrypted→resolved only, so a key-locked MAM refresh can't clobber a decrypted preview) heals the preview in `loadMessagesFromCache` (on open) and `mergeMAMMessages` (on catch-up).
- New `refreshLastMessageContent` store binding, called from the durable decrypt path, heals the sidebar at unlock even for closed conversations.
