### PR TITLE
fix(settings): open notification settings via a native command

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1027,6 +1027,39 @@ fn log_to_terminal(level: String, message: String) {
     }
 }
 
+/// Open the operating system's notification settings.
+///
+/// Uses a native process launch rather than the shell/opener plugins: their
+/// default scopes reject custom URL schemes (`x-apple.systempreferences:`,
+/// `ms-settings:`), and Linux has no notification-settings URL at all — it
+/// needs a control-center invocation. Best-effort; a failed launch is returned
+/// to the caller, which logs it.
+#[tauri::command]
+fn open_notification_settings() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open")
+        .arg("x-apple.systempreferences:com.apple.Notifications-Settings.extension")
+        .spawn();
+
+    #[cfg(target_os = "windows")]
+    let result = std::process::Command::new("cmd")
+        .args(["/C", "start", "", "ms-settings:notifications"])
+        .spawn();
+
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("gnome-control-center")
+        .arg("notifications")
+        .spawn();
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    let result: std::io::Result<std::process::Child> = Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "unsupported platform",
+    ));
+
+    result.map(|_| ()).map_err(|e| e.to_string())
+}
+
 /// Print startup diagnostics to stderr for debugging.
 fn print_startup_diagnostics() {
     eprintln!(
@@ -1274,6 +1307,7 @@ fn main() {
             start_xmpp_proxy,
             stop_xmpp_proxy,
             log_to_terminal,
+            open_notification_settings,
             openpgp::openpgp_ensure_key,
             openpgp::openpgp_prewarm,
             openpgp::openpgp_encrypt,

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
@@ -10,7 +10,7 @@
  * in System Settings yet — and on the web build, which has no OS pane to open.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 // Mutable mock state — `mock`-prefixed so vitest permits referencing them
 // inside the hoisted vi.mock factories.
@@ -87,6 +87,21 @@ describe('NotificationsSettings — system notification settings link', () => {
     render(<NotificationsSettings />)
 
     expect(await screen.findByText(LINK)).toBeInTheDocument()
+  })
+
+  it('opens the OS pane via the native command when the link is clicked', async () => {
+    // Regression: the link previously went through the shell `open` plugin,
+    // whose scope rejects the x-apple.systempreferences: scheme, so the click
+    // silently failed. It must now invoke the native open_notification_settings.
+    render(<NotificationsSettings />)
+    const link = await screen.findByRole('button', { name: LINK })
+    mockInvoke.mockClear() // drop the initial permission-state probe
+
+    fireEvent.click(link)
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith('open_notification_settings'),
+    )
   })
 
   it('hides the link while permission was never requested (macOS default), offering Enable instead', async () => {

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -38,17 +38,11 @@ async function checkNotificationPermission(): Promise<NotificationStatus> {
 
 async function openNotificationSettings(): Promise<void> {
   try {
-    const { open } = await import('@tauri-apps/plugin-shell')
-    const { platform } = await import('@tauri-apps/plugin-os')
-    const os = await platform()
-
-    if (os === 'macos') {
-      await open('x-apple.systempreferences:com.apple.Notifications-Settings.extension')
-    } else if (os === 'windows') {
-      await open('ms-settings:notifications')
-    } else if (os === 'linux') {
-      await open('gnome-control-center notifications')
-    }
+    // Go through a native command rather than the shell/opener plugins: their
+    // default scopes reject custom URL schemes (x-apple.systempreferences:,
+    // ms-settings:), and Linux needs a control-center invocation, not a URL.
+    const { invoke } = await import('@tauri-apps/api/core')
+    await invoke('open_notification_settings')
   } catch (error) {
     console.error('[Settings] Failed to open notification settings:', error)
   }


### PR DESCRIPTION
Follow-up to #545. The "open system notification settings" link shipped in that PR never actually opened anything: it went through the shell plugin's `open`, whose scope only allows mailto/tel/http(s), so the custom `x-apple.systempreferences:` scheme failed validation ("Scoped command argument ... failed regex validation") and the click silently no-op'd. The opener plugin's default scope is equally restrictive, and the Linux path was a command rather than a URL.

Replaces it with a native `open_notification_settings` command that launches the platform settings directly:
- macOS: `open x-apple.systempreferences:com.apple.Notifications-Settings.extension`
- Windows: `ms-settings:notifications`
- Linux: `gnome-control-center notifications`

Verified the macOS scheme opens System Settings (`open` exit 0). Adds a regression test asserting the click invokes the native command.