### PR TITLE
fix(e2ee): keep verified lock on pre-#544 messages lacking a signing fingerprint

### DIFF
--- a/apps/fluux/src/components/conversation/messageTrust.test.ts
+++ b/apps/fluux/src/components/conversation/messageTrust.test.ts
@@ -33,8 +33,21 @@ describe('resolveDisplayTrust', () => {
     expect(resolveDisplayTrust(ctx({ trust: 'tofu', fingerprint: FP_A }), undefined)).toBe('tofu')
   })
 
-  it('does NOT upgrade when the message carries no fingerprint', () => {
-    expect(resolveDisplayTrust(ctx({ trust: 'tofu' }), FP_A)).toBe('tofu')
+  // Legacy fallback: messages decrypted before #544 (which began baking the
+  // signing fingerprint) carry no `fingerprint` to match. Rather than force a
+  // peer's entire pre-#544 history grey, fall back to live JID-level
+  // verification — the same signal the conversation header chip uses.
+  it('upgrades a fingerprint-less message to verified when the peer is verified (legacy fallback)', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu' }), FP_A)).toBe('verified')
+  })
+
+  it('keeps a fingerprint-less baked-verified message verified when the peer is verified (legacy fallback)', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'verified' }), FP_A)).toBe('verified')
+  })
+
+  it('leaves a fingerprint-less message at tofu when the peer is not verified', () => {
+    expect(resolveDisplayTrust(ctx({ trust: 'tofu' }), undefined)).toBe('tofu')
+    expect(resolveDisplayTrust(ctx({ trust: 'verified' }), undefined)).toBe('tofu')
   })
 
   it('never upgrades an untrusted (signature-failed) message, even on a fingerprint match', () => {

--- a/apps/fluux/src/components/conversation/messageTrust.ts
+++ b/apps/fluux/src/components/conversation/messageTrust.ts
@@ -15,8 +15,11 @@ import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
  * downgrade (verified→tofu once cleared). Crucially the check is a fingerprint
  * MATCH, not the mere existence of a verified entry for the JID: otherwise a
  * rotated or server-substituted key would inherit a green lock the user never
- * granted it. A message whose signature did not verify (`untrusted` /
- * `rejected`), or a web-of-trust `introduced`, passes through untouched.
+ * granted it. The one exception is a legacy message that predates signing-
+ * fingerprint capture (no `fingerprint` baked): there's nothing to match, so
+ * it falls back to JID-level verification rather than going grey. A message
+ * whose signature did not verify (`untrusted` / `rejected`), or a web-of-trust
+ * `introduced`, passes through untouched.
  *
  * @param securityContext - the message's baked security context, if encrypted
  * @param verifiedFingerprint - the fingerprint the user verified for this peer
@@ -29,8 +32,16 @@ export function resolveDisplayTrust(
   if (!securityContext) return undefined
   const baked = securityContext.trust
   if (baked === 'tofu' || baked === 'verified') {
+    // Legacy fallback: messages decrypted before the signing fingerprint was
+    // captured carry no `fingerprint`. Force-downgrading them to tofu would
+    // grey out a verified peer's entire pre-capture history, so fall back to
+    // live JID-level verification — the same signal the conversation header
+    // chip uses. Messages decrypted with capture always carry a fingerprint
+    // and take the strict MATCH path below.
+    if (!securityContext.fingerprint) {
+      return verifiedFingerprint ? 'verified' : 'tofu'
+    }
     const fingerprintVerified =
-      !!securityContext.fingerprint &&
       !!verifiedFingerprint &&
       fingerprintsEqual(verifiedFingerprint, securityContext.fingerprint)
     return fingerprintVerified ? 'verified' : 'tofu'


### PR DESCRIPTION
#544 started requiring a per-message signing-fingerprint match for the green lock, and was also the first commit to bake that fingerprint in. Messages decrypted and cached before #544 have no fingerprint, and reconnect serves them from cache without re-decrypting — so a verified peer's entire pre-#544 history downgraded from verified (green) to tofu (grey): a green conversation header chip but grey per-message locks.

`resolveDisplayTrust` now falls back to live JID-level verification (the same signal the header chip uses) when a message carries no fingerprint. Fingerprint-bearing messages keep #544's strict match, so the guarantee going forward is unchanged. It runs at render time, so existing grey locks heal on the next reload — no re-decrypt or cache clear.