### PR TITLE
fix: Tier-3 UX fixes + macOS notification logging

### DIFF
--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -193,7 +193,17 @@ pub fn post(n: NativeNotification) -> Result<(), String> {
         &content,
         None::<&UNNotificationTrigger>, // nil trigger = deliver immediately
     );
-    current_center().addNotificationRequest_withCompletionHandler(&request, None);
+    // Log a rejected enqueue instead of dropping it silently: the OS can refuse
+    // a request (bad attachment, authorization revoked mid-session, …) and a
+    // silent failure makes the next "no banner" report undiagnosable. The
+    // handler runs on a background queue.
+    use block2::RcBlock;
+    let handler = RcBlock::new(|err: *mut NSError| {
+        if let Some(err) = unsafe { err.as_ref() } {
+            tracing::warn!(error = ?err, "native notification could not be scheduled");
+        }
+    });
+    current_center().addNotificationRequest_withCompletionHandler(&request, Some(&handler));
     Ok(())
 }
 

--- a/apps/fluux/src/components/LinkPreviewCard.test.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.test.tsx
@@ -66,4 +66,29 @@ describe('LinkPreviewCard', () => {
 
     expect(getByText('Some pull request')).toBeInTheDocument()
   })
+
+  it('shows the image again when the preview image URL changes after one was hidden', () => {
+    const previewA: LinkPreview = { ...preview, image: 'https://host/a.png' }
+    const previewB: LinkPreview = { ...preview, image: 'https://host/b.png' }
+    const { container, rerender } = render(<LinkPreviewCard preview={previewA} />)
+
+    // Exhaust retries for image A → hidden ('gone').
+    fireEvent.error(container.querySelector('img')!)
+    act(() => {
+      vi.advanceTimersByTime(IMAGE_RETRY_DELAY_MS)
+    })
+    fireEvent.error(container.querySelector('img')!)
+    act(() => {
+      vi.advanceTimersByTime(IMAGE_RETRY_DELAY_MS * 10)
+    })
+    expect(container.querySelector('img')).toBeNull()
+
+    // The instance is reused (React reconciliation) for a preview with a new
+    // image — the stale 'gone'/spent-attempt state must reset so the new, valid
+    // image shows.
+    rerender(<LinkPreviewCard preview={previewB} />)
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img).toHaveAttribute('src', previewB.image)
+  })
 })

--- a/apps/fluux/src/components/LinkPreviewCard.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.tsx
@@ -29,6 +29,19 @@ export function LinkPreviewCard({ preview, onLoad }: LinkPreviewCardProps) {
     if (retryTimer.current) clearTimeout(retryTimer.current)
   }, [])
 
+  // Reset the retry state when the image URL changes: this component instance
+  // can be reused (React reconciliation) for a message whose preview image
+  // differs, so a stale 'gone' / spent-attempt from the previous URL would
+  // otherwise suppress a new, valid image.
+  useEffect(() => {
+    if (retryTimer.current) {
+      clearTimeout(retryTimer.current)
+      retryTimer.current = null
+    }
+    setAttempt(0)
+    setImagePhase('showing')
+  }, [preview.image])
+
   const handleImageError = () => {
     if (attempt + 1 >= MAX_IMAGE_ATTEMPTS) {
       setImagePhase('gone')

--- a/apps/fluux/src/hooks/useMessageHoverState.test.tsx
+++ b/apps/fluux/src/hooks/useMessageHoverState.test.tsx
@@ -249,6 +249,22 @@ describe('useMessageHoverState', () => {
     expect(result.current.hoveredMessageId).toBeNull()
   })
 
+  it('resets the mousedown latch when resetKey changes (switch mid-drag without a mouseup)', () => {
+    const { result, rerender } = setup('conv-1')
+
+    // Drag starts in conversation 1, but no mouseup reaches the list — the user
+    // switches conversation via the keyboard / a notification click.
+    mouseDown(messageEl)
+
+    rerender({ key: 'conv-2' })
+
+    // The toolbar must work again in the new conversation: a stuck mousedown
+    // latch would suppress hover indefinitely.
+    act(() => result.current.handleMessageHover('a'))
+    act(() => vi.advanceTimersByTime(200))
+    expect(result.current.hoveredMessageId).toBe('a')
+  })
+
   it('resets the mousedown latch on window blur', () => {
     const { result } = setup()
 

--- a/apps/fluux/src/hooks/useMessageHoverState.ts
+++ b/apps/fluux/src/hooks/useMessageHoverState.ts
@@ -170,11 +170,16 @@ export function useMessageHoverState({
     }
   }, [scrollRef, armIntentTimer, setHovered])
 
-  // Reset when switching conversation/room
+  // Reset when switching conversation/room. Also clear the drag/selection
+  // latches: switching mid-drag (e.g. via the keyboard or a notification click)
+  // means no mouseup ever reaches the list, so a stuck `mouseDownRef` /
+  // `selectionActiveRef` would suppress the toolbar in the new conversation.
   useEffect(() => {
     clearTimer(intentTimerRef)
     clearTimer(leaveTimerRef)
     lastEnteredRowRef.current = null
+    mouseDownRef.current = false
+    selectionActiveRef.current = false
     setHovered(null)
   }, [resetKey, setHovered])
 


### PR DESCRIPTION
### Fixes
- **chat: reset hover latches on conversation switch** — `useMessageHoverState`'s resetKey effect cleared the hover timers but not the `mousedown`/`selection` latches, so switching conversation mid-drag (no mouseup reaches the list — keyboard quick-switch, notification click) left the per-message toolbar suppressed in the new conversation. Regressed when #540 stripped the content-visibility machinery.
- **ui: reset link-preview retry state on URL change** — `LinkPreviewCard`'s `attempt`/`imagePhase` weren't keyed on `preview.image`, so a reused card instance kept a previous URL's "hidden after repeated failure" state and never showed the new, valid image.
- **notifications/macos: log a rejected notification enqueue** — `post()` passed a nil completion handler to `addNotificationRequest` and always returned `Ok(())`, so a request the OS refused (bad attachment, authorization revoked mid-session) failed silently. Now logs the `NSError`.

### Deliberately NOT included (Tier-4 Linux)
On inspection the remaining Tier-4 items are intentional trade-offs whose "obvious fix" would regress, so the current code is left as-is:
- **GUI-proxy bypass** — the "no env proxy → direct" behaviour is documented and intentional. WebKit's loopback `ignore_hosts` requires `Custom` mode; falling back to `Default` would route the loopback XMPP bridge through the proxy, reintroducing #499. A correct fix needs GNOME/KDE proxy resolution (GProxyResolver) — a dedicated Linux change.
- **DBus tray probe** — already bounded at 1s on a worker thread. Memoizing it at startup would trade that bounded stall for a window-stranding risk if the tray host disappears later (exactly what `should_hide_to_tray` guards against).
- **single-instance CSD workaround** — a genuine bug (relaunch-from-hidden can leave a dead titlebar), but Linux-only and not compile-verifiable on the macOS dev host; deferred to a Linux-verified follow-up.