### PR TITLE
fix(mam): recover stale catch-up cursors + forward-fill empty-cache gaps

### DIFF
--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -111,7 +111,7 @@ export function setupChatSideEffects(
       // Last-resort anchor: forward-fill from the persisted preview timestamp when
       // the cache is empty, instead of a before:'' fetch-latest that skips a gap.
       const lastTimestamp = chatStore.getState().getConversationLastTimestamp(conversationId)
-      const q = selectCatchUpQuery(cachedMessages, sessionStartTime, gapStart, lastTimestamp)
+      const q = selectCatchUpQuery(cachedMessages, { sessionStartTime, forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
       await client.chat.queryMAM({
         with: conversation.id,
         ...q,

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -104,9 +104,11 @@ export function setupChatSideEffects(
       const cachedMessages = chatStore.getState().messages.get(conversationId) || []
 
       // Shared cursor policy (same as rooms): forward from the newest pre-session
-      // message, else fetch latest. Forward catch-up paginates oldest-first to
-      // completion (maxAutoPages), matching rooms.
-      const q = selectCatchUpQuery(cachedMessages, sessionStartTime)
+      // message, or from a persisted gap boundary when one exists, else fetch
+      // latest. Forward catch-up paginates oldest-first to completion
+      // (maxAutoPages), matching rooms.
+      const gapStart = chatStore.getState().conversationGaps.get(conversationId)?.start
+      const q = selectCatchUpQuery(cachedMessages, sessionStartTime, gapStart)
       await client.chat.queryMAM({
         with: conversation.id,
         ...q,

--- a/packages/fluux-sdk/src/core/chatSideEffects.ts
+++ b/packages/fluux-sdk/src/core/chatSideEffects.ts
@@ -108,7 +108,10 @@ export function setupChatSideEffects(
       // latest. Forward catch-up paginates oldest-first to completion
       // (maxAutoPages), matching rooms.
       const gapStart = chatStore.getState().conversationGaps.get(conversationId)?.start
-      const q = selectCatchUpQuery(cachedMessages, sessionStartTime, gapStart)
+      // Last-resort anchor: forward-fill from the persisted preview timestamp when
+      // the cache is empty, instead of a before:'' fetch-latest that skips a gap.
+      const lastTimestamp = chatStore.getState().getConversationLastTimestamp(conversationId)
+      const q = selectCatchUpQuery(cachedMessages, sessionStartTime, gapStart, lastTimestamp)
       await client.chat.queryMAM({
         with: conversation.id,
         ...q,

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -137,6 +137,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
         }))
       },
       getConversationGapStart: (conversationId: string) => chatStore.getState().conversationGaps.get(conversationId)?.start,
+      getConversationLastTimestamp: (conversationId: string) => chatStore.getState().getConversationLastTimestamp(conversationId),
       getArchivedConversations: () => {
         const state = chatStore.getState()
         const result = []
@@ -208,6 +209,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       setNotifyAll: roomStore.getState().setNotifyAll,
       joinedRooms: roomStore.getState().joinedRooms,
       getRoomGapStart: (roomJid: string) => roomStore.getState().roomGaps.get(roomJid)?.start,
+      getRoomLastTimestamp: (roomJid: string) => roomStore.getState().getRoomLastTimestamp(roomJid),
       triggerAnimation: roomStore.getState().triggerAnimation,
       // XEP-0313: MAM support for MUC rooms
       setRoomMAMLoading: roomStore.getState().setRoomMAMLoading,

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -136,6 +136,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
           messages: state.messages.get(conv.id) || [],
         }))
       },
+      getConversationGapStart: (conversationId: string) => chatStore.getState().conversationGaps.get(conversationId)?.start,
       getArchivedConversations: () => {
         const state = chatStore.getState()
         const result = []
@@ -206,6 +207,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       removeBookmark: roomStore.getState().removeBookmark,
       setNotifyAll: roomStore.getState().setNotifyAll,
       joinedRooms: roomStore.getState().joinedRooms,
+      getRoomGapStart: (roomJid: string) => roomStore.getState().roomGaps.get(roomJid)?.start,
       triggerAnimation: roomStore.getState().triggerAnimation,
       // XEP-0313: MAM support for MUC rooms
       setRoomMAMLoading: roomStore.getState().setRoomMAMLoading,

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -471,6 +471,30 @@ describe('MAM Background Catch-Up', () => {
       }))
     })
 
+    it('uses a persisted conversation gap boundary before newer cached messages', async () => {
+      await connectClient()
+
+      const gapStart = new Date('2026-05-14T09:00:00.000Z')
+      const newerAboveGap = new Date('2026-06-01T12:00:00.000Z')
+
+      const messages = [
+        { type: 'chat' as const, id: 'newer', conversationId: 'alice@example.com', from: 'alice@example.com', body: 'newer', timestamp: newerAboveGap, isOutgoing: false, isDelayed: false },
+      ]
+      vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages }] as any)
+      vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(gapStart.getTime())
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        with: 'alice@example.com',
+        start: '2026-05-14T09:00:00.001Z',
+      }))
+    })
+
   describe('catchUpAllRooms', () => {
     it('should do nothing when there are no joined rooms', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -495,6 +495,31 @@ describe('MAM Background Catch-Up', () => {
       }))
     })
 
+    it('forward-fills from the persisted last-known timestamp when the message cache is empty (issue #135)', async () => {
+      await connectClient()
+
+      // Persisted conversation with a preview but NO cached messages this run
+      // (e.g. never opened): must FORWARD-fill from the preview timestamp, not a
+      // before:'' fetch-latest that would silently skip the offline gap.
+      const lastKnown = new Date('2026-05-14T09:00:00.000Z')
+      vi.mocked(mockStores.chat.getAllConversations).mockReturnValue([{ id: 'alice@example.com', messages: [] }] as any)
+      vi.mocked(mockStores.chat.getConversationGapStart!).mockReturnValue(undefined)
+      vi.mocked(mockStores.chat.getConversationLastTimestamp!).mockReturnValue(lastKnown.getTime())
+
+      const querySpy = vi.spyOn(xmppClient.mam, 'queryArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
+
+      const catchUpPromise = xmppClient.mam.catchUpAllConversations({ sessionStartTime: new Date('2026-06-14T12:00:00Z').getTime() })
+      await waitForAsyncOps(20, 100)
+      await catchUpPromise
+
+      expect(querySpy).toHaveBeenCalledWith(expect.objectContaining({
+        with: 'alice@example.com',
+        start: '2026-05-14T09:00:00.001Z',
+      }))
+      // Must NOT degrade to a backward fetch-latest.
+      expect(querySpy).not.toHaveBeenCalledWith(expect.objectContaining({ before: '' }))
+    })
+
   describe('catchUpAllRooms', () => {
     it('should do nothing when there are no joined rooms', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -942,7 +942,7 @@ export class MAM extends BaseModule {
           // from the persisted preview timestamp instead of a before:'' fetch-latest
           // that would skip a large offline gap (issue #135).
           const lastTimestamp = this.deps.stores?.chat.getConversationLastTimestamp?.(conv.id)
-          const q = selectCatchUpQuery(messages, sessionStartTime, gapStart, lastTimestamp)
+          const q = selectCatchUpQuery(messages, { sessionStartTime, forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
           await this.queryArchive({
             with: conv.id,
             ...q,
@@ -1107,7 +1107,7 @@ export class MAM extends BaseModule {
     // Last-resort anchor: forward-fill from the persisted preview timestamp when the
     // cache is empty, instead of a before:'' fetch-latest that skips a large gap.
     const lastTimestamp = this.deps.stores?.room.getRoomLastTimestamp?.(roomJid)
-    const q = selectCatchUpQuery(messages, sessionStartTime, gapStart, lastTimestamp)
+    const q = selectCatchUpQuery(messages, { sessionStartTime, forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
     await this.queryRoomArchive({
       roomJid,
       ...q,

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -934,9 +934,11 @@ export class MAM extends BaseModule {
           const messages = updatedConv?.messages || conv.messages || []
 
           // Shared cursor policy (same as rooms) — forward from the newest
-          // pre-session message, else fetch latest. Forward catch-up paginates
-          // oldest-first to completion (maxAutoPages), matching rooms.
-          const q = selectCatchUpQuery(messages, sessionStartTime)
+          // pre-session message, or from a persisted gap boundary when one
+          // exists, else fetch latest. Forward catch-up paginates oldest-first
+          // to completion (maxAutoPages), matching rooms.
+          const gapStart = this.deps.stores?.chat.getConversationGapStart?.(conv.id)
+          const q = selectCatchUpQuery(messages, sessionStartTime, gapStart)
           await this.queryArchive({
             with: conv.id,
             ...q,
@@ -1095,8 +1097,10 @@ export class MAM extends BaseModule {
     const updatedRoom = this.deps.stores?.room.getRoom(roomJid)
     const messages = updatedRoom?.messages || []
     // Shared cursor policy: forward from the newest pre-session message (so a live
-    // message in the catch-up window can't poison the cursor), else fetch latest.
-    const q = selectCatchUpQuery(messages, sessionStartTime)
+    // message in the catch-up window can't poison the cursor), or from a
+    // persisted gap boundary when one exists, else fetch latest.
+    const gapStart = this.deps.stores?.room.getRoomGapStart?.(roomJid)
+    const q = selectCatchUpQuery(messages, sessionStartTime, gapStart)
     await this.queryRoomArchive({
       roomJid,
       ...q,

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -938,7 +938,11 @@ export class MAM extends BaseModule {
           // exists, else fetch latest. Forward catch-up paginates oldest-first
           // to completion (maxAutoPages), matching rooms.
           const gapStart = this.deps.stores?.chat.getConversationGapStart?.(conv.id)
-          const q = selectCatchUpQuery(messages, sessionStartTime, gapStart)
+          // Last-resort anchor: if the message cache is empty this run, forward-fill
+          // from the persisted preview timestamp instead of a before:'' fetch-latest
+          // that would skip a large offline gap (issue #135).
+          const lastTimestamp = this.deps.stores?.chat.getConversationLastTimestamp?.(conv.id)
+          const q = selectCatchUpQuery(messages, sessionStartTime, gapStart, lastTimestamp)
           await this.queryArchive({
             with: conv.id,
             ...q,
@@ -1100,7 +1104,10 @@ export class MAM extends BaseModule {
     // message in the catch-up window can't poison the cursor), or from a
     // persisted gap boundary when one exists, else fetch latest.
     const gapStart = this.deps.stores?.room.getRoomGapStart?.(roomJid)
-    const q = selectCatchUpQuery(messages, sessionStartTime, gapStart)
+    // Last-resort anchor: forward-fill from the persisted preview timestamp when the
+    // cache is empty, instead of a before:'' fetch-latest that skips a large gap.
+    const lastTimestamp = this.deps.stores?.room.getRoomLastTimestamp?.(roomJid)
+    const q = selectCatchUpQuery(messages, sessionStartTime, gapStart, lastTimestamp)
     await this.queryRoomArchive({
       roomJid,
       ...q,

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -118,7 +118,10 @@ export function setupRoomSideEffects(
       // live message in the catch-up window can't poison the cursor), or from a
       // persisted gap boundary when one exists, else latest.
       const gapStart = roomStore.getState().roomGaps.get(roomJid)?.start
-      const q = selectCatchUpQuery(messages, sessionStartTime, gapStart)
+      // Last-resort anchor: forward-fill from the persisted preview timestamp when
+      // the cache is empty, instead of a before:'' fetch-latest that skips a gap.
+      const lastTimestamp = roomStore.getState().getRoomLastTimestamp(roomJid)
+      const q = selectCatchUpQuery(messages, sessionStartTime, gapStart, lastTimestamp)
       await client.chat.queryRoomMAM({
         roomJid,
         ...q,

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -121,7 +121,7 @@ export function setupRoomSideEffects(
       // Last-resort anchor: forward-fill from the persisted preview timestamp when
       // the cache is empty, instead of a before:'' fetch-latest that skips a gap.
       const lastTimestamp = roomStore.getState().getRoomLastTimestamp(roomJid)
-      const q = selectCatchUpQuery(messages, sessionStartTime, gapStart, lastTimestamp)
+      const q = selectCatchUpQuery(messages, { sessionStartTime, forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
       await client.chat.queryRoomMAM({
         roomJid,
         ...q,

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -115,8 +115,10 @@ export function setupRoomSideEffects(
       const roomAfterCache = roomStore.getState().rooms.get(roomJid)
       const messages = roomAfterCache?.messages || []
       // Shared cursor policy: forward from the newest pre-session message (so a
-      // live message in the catch-up window can't poison the cursor), else latest.
-      const q = selectCatchUpQuery(messages, sessionStartTime)
+      // live message in the catch-up window can't poison the cursor), or from a
+      // persisted gap boundary when one exists, else latest.
+      const gapStart = roomStore.getState().roomGaps.get(roomJid)?.start
+      const q = selectCatchUpQuery(messages, sessionStartTime, gapStart)
       await client.chat.queryRoomMAM({
         roomJid,
         ...q,

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -661,6 +661,7 @@ export const createMockStores = (): MockStoreBindings => ({
     loadMessagesFromCache: vi.fn().mockResolvedValue([]),
     getAllConversations: vi.fn().mockReturnValue([]),
     getConversationGapStart: vi.fn().mockReturnValue(undefined),
+    getConversationLastTimestamp: vi.fn().mockReturnValue(undefined),
     getArchivedConversations: vi.fn().mockReturnValue([]),
     archiveConversation: vi.fn(),
     unarchiveConversation: vi.fn(),
@@ -718,6 +719,7 @@ export const createMockStores = (): MockStoreBindings => ({
     setNotifyAll: vi.fn(),
     joinedRooms: vi.fn().mockReturnValue([]),
     getRoomGapStart: vi.fn().mockReturnValue(undefined),
+    getRoomLastTimestamp: vi.fn().mockReturnValue(undefined),
     triggerAnimation: vi.fn(),
     // XEP-0313: MAM support for MUC rooms
     setRoomMAMLoading: vi.fn(),

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -660,6 +660,7 @@ export const createMockStores = (): MockStoreBindings => ({
     updateLastMessagePreview: vi.fn(),
     loadMessagesFromCache: vi.fn().mockResolvedValue([]),
     getAllConversations: vi.fn().mockReturnValue([]),
+    getConversationGapStart: vi.fn().mockReturnValue(undefined),
     getArchivedConversations: vi.fn().mockReturnValue([]),
     archiveConversation: vi.fn(),
     unarchiveConversation: vi.fn(),
@@ -716,6 +717,7 @@ export const createMockStores = (): MockStoreBindings => ({
     removeBookmark: vi.fn(),
     setNotifyAll: vi.fn(),
     joinedRooms: vi.fn().mockReturnValue([]),
+    getRoomGapStart: vi.fn().mockReturnValue(undefined),
     triggerAnimation: vi.fn(),
     // XEP-0313: MAM support for MUC rooms
     setRoomMAMLoading: vi.fn(),

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -104,6 +104,8 @@ export interface StoreBindings {
     loadMessagesFromCache?: (conversationId: string, options?: { limit?: number }) => Promise<unknown>
     // Get all conversations for MAM catch-up
     getAllConversations: () => Array<{ id: string; messages: Message[] }>
+    // Persisted forward-gap boundary for automatic catch-up recovery
+    getConversationGapStart?: (conversationId: string) => number | undefined
     // Smart MAM: archived conversation preview refresh
     getArchivedConversations?: () => Array<{ id: string; messages: Message[] }>
     archiveConversation?: (id: string) => void
@@ -176,6 +178,8 @@ export interface StoreBindings {
     setNotifyAll: (roomJid: string, notifyAll: boolean, persistent?: boolean) => void
     // Query methods
     joinedRooms: () => Room[]
+    // Persisted forward-gap boundary for automatic catch-up recovery
+    getRoomGapStart?: (roomJid: string) => number | undefined
     // Easter egg animations
     triggerAnimation?: (roomJid: string, animation: string) => void
     // XEP-0313: MAM support for MUC rooms

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -106,6 +106,8 @@ export interface StoreBindings {
     getAllConversations: () => Array<{ id: string; messages: Message[] }>
     // Persisted forward-gap boundary for automatic catch-up recovery
     getConversationGapStart?: (conversationId: string) => number | undefined
+    // Persisted last-known message timestamp (entity preview) — last-resort forward catch-up cursor
+    getConversationLastTimestamp?: (conversationId: string) => number | undefined
     // Smart MAM: archived conversation preview refresh
     getArchivedConversations?: () => Array<{ id: string; messages: Message[] }>
     archiveConversation?: (id: string) => void
@@ -180,6 +182,8 @@ export interface StoreBindings {
     joinedRooms: () => Room[]
     // Persisted forward-gap boundary for automatic catch-up recovery
     getRoomGapStart?: (roomJid: string) => number | undefined
+    // Persisted last-known message timestamp (entity preview) — last-resort forward catch-up cursor
+    getRoomLastTimestamp?: (roomJid: string) => number | undefined
     // Easter egg animations
     triggerAnimation?: (roomJid: string, animation: string) => void
     // XEP-0313: MAM support for MUC rooms

--- a/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.test.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.test.ts
@@ -196,13 +196,34 @@ describe('createFetchOlderHistory', () => {
     it('retries with a timestamp window when the backward query fails with item-not-found', async () => {
       vi.mocked(deps.loadFromCache).mockResolvedValue([])
       vi.mocked(deps.queryMAM).mockRejectedValue({ condition: 'item-not-found' })
+      deps.clearInvalidArchiveCursor = vi.fn()
       deps.getOldestTimestamp = vi.fn(() => oldestTs)
       deps.queryMAMByEndTime = vi.fn(() => Promise.resolve())
       fetchOlderHistory = createFetchOlderHistory(deps)
 
       await fetchOlderHistory('conv-1')
 
+      expect(deps.clearInvalidArchiveCursor).toHaveBeenCalledWith('conv-1', 'msg-oldest-stanza-id')
       expect(deps.queryMAMByEndTime).toHaveBeenCalledWith('conv-1', oldestTs.toISOString())
+    })
+
+    it('clears a stale room cursor and retries with the next archive cursor', async () => {
+      deps.errorLogPrefix = 'Failed to fetch older room history'
+      vi.mocked(deps.loadFromCache).mockResolvedValue([])
+      vi.mocked(deps.queryMAM)
+        .mockRejectedValueOnce({ condition: 'item-not-found' })
+        .mockResolvedValueOnce(undefined)
+      deps.clearInvalidArchiveCursor = vi.fn()
+      vi.mocked(deps.getOldestMessageId)
+        .mockReturnValueOnce('stale-origin-id')
+        .mockReturnValueOnce('archive-next')
+      fetchOlderHistory = createFetchOlderHistory(deps)
+
+      await fetchOlderHistory('room-1')
+
+      expect(deps.clearInvalidArchiveCursor).toHaveBeenCalledWith('room-1', 'stale-origin-id')
+      expect(deps.queryMAM).toHaveBeenNthCalledWith(1, 'room-1', 'stale-origin-id')
+      expect(deps.queryMAM).toHaveBeenNthCalledWith(2, 'room-1', 'archive-next')
     })
 
     it('does not retry when the query fails with a different condition', async () => {

--- a/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.ts
+++ b/packages/fluux-sdk/src/hooks/shared/createFetchOlderHistory.ts
@@ -59,6 +59,14 @@ export interface FetchOlderHistoryDeps {
   queryMAM: (id: string, beforeId: string) => Promise<void>
 
   /**
+   * Optional: clear a stale local stanzaId after the server proves it is not an
+   * archive cursor. This repairs old caches where a sender/origin id was stored
+   * in the stanzaId slot, preventing every future retry from choosing the same
+   * bad cursor again.
+   */
+  clearInvalidArchiveCursor?: (id: string, cursor: string) => void | Promise<void>
+
+  /**
    * Optional: timestamp of the oldest in-memory message. Used for the
    * id-independent recovery query when no valid archive cursor is available or
    * the server rejects the cursor with `item-not-found`.
@@ -103,6 +111,7 @@ export function createFetchOlderHistory(
     loadFromCache,
     getOldestMessageId,
     queryMAM,
+    clearInvalidArchiveCursor,
     getOldestTimestamp,
     queryMAMByEndTime,
     errorLogPrefix,
@@ -179,8 +188,24 @@ export function createFetchOlderHistory(
         await queryMAM(id, beforeId)
       } catch (error) {
         // A stale or non-archive cursor makes the server return item-not-found.
-        // Recover with an id-independent timestamp window before giving up.
-        if (isItemNotFoundError(error) && (await recoverByTimestamp(id))) return
+        // First scrub that cursor from the loaded cache so future attempts do
+        // not keep selecting the same poisoned stanzaId, then recover with an
+        // id-independent timestamp window (1:1) or the next available cursor.
+        if (isItemNotFoundError(error)) {
+          await clearInvalidArchiveCursor?.(id, beforeId)
+          if (await recoverByTimestamp(id)) return
+
+          const replacementBeforeId = getOldestMessageId(id)
+          if (replacementBeforeId && replacementBeforeId !== beforeId) {
+            await queryMAM(id, replacementBeforeId)
+            return
+          }
+
+          if (!isChat) {
+            await queryMAM(id, '')
+            return
+          }
+        }
         throw error
       }
     } catch (error) {

--- a/packages/fluux-sdk/src/hooks/shared/mamCursor.test.ts
+++ b/packages/fluux-sdk/src/hooks/shared/mamCursor.test.ts
@@ -3,7 +3,7 @@ import { pickOldestArchiveId, isItemNotFoundError } from './mamCursor'
 
 // Minimal message shape the helper operates on; `id` mirrors the real
 // client-generated id that must never be used as a cursor.
-type TestMessage = { stanzaId?: string; id?: string }
+type TestMessage = { stanzaId?: string; originId?: string; id?: string }
 
 describe('pickOldestArchiveId', () => {
   it('returns undefined for an empty list', () => {
@@ -33,6 +33,22 @@ describe('pickOldestArchiveId', () => {
     expect(pickOldestArchiveId(messages)).toBeUndefined()
   })
 
+  it('skips stale origin ids that were persisted in the stanzaId slot', () => {
+    const messages: TestMessage[] = [
+      { id: 'uuid-sent', originId: 'uuid-sent', stanzaId: 'uuid-sent' },
+      { id: 'received', stanzaId: 'archive-2' },
+    ]
+    expect(pickOldestArchiveId(messages)).toBe('archive-2')
+  })
+
+  it('returns undefined when every stanzaId is actually an origin id', () => {
+    const messages: TestMessage[] = [
+      { id: 'uuid-1', originId: 'uuid-1', stanzaId: 'uuid-1' },
+      { id: 'uuid-2', originId: 'uuid-2', stanzaId: 'uuid-2' },
+    ]
+    expect(pickOldestArchiveId(messages)).toBeUndefined()
+  })
+
   it('treats an empty-string stanzaId as absent', () => {
     const messages: TestMessage[] = [
       { stanzaId: '', id: 'uuid-1' },
@@ -49,6 +65,10 @@ describe('isItemNotFoundError', () => {
 
   it('detects item-not-found from the error message', () => {
     expect(isItemNotFoundError(new Error('item-not-found'))).toBe(true)
+  })
+
+  it('detects item not found from spaced/cased error messages', () => {
+    expect(isItemNotFoundError(new Error('Item not found'))).toBe(true)
   })
 
   it('returns false for other conditions', () => {

--- a/packages/fluux-sdk/src/hooks/shared/mamCursor.ts
+++ b/packages/fluux-sdk/src/hooks/shared/mamCursor.ts
@@ -12,6 +12,10 @@
 
 /** Minimal shape needed to pick a pagination cursor. */
 interface ArchivableMessage {
+  /** Client-generated stanza id. Useful only to recognize stale self-copied ids. */
+  id?: string
+  /** XEP-0359 sender-assigned id. Not a valid archive pagination cursor. */
+  originId?: string
   /** XEP-0359 server-assigned archive id. Absent on outgoing / unarchived messages. */
   stanzaId?: string
 }
@@ -29,7 +33,7 @@ interface ArchivableMessage {
  */
 export function pickOldestArchiveId(messages: ArchivableMessage[]): string | undefined {
   for (const message of messages) {
-    if (message.stanzaId) return message.stanzaId
+    if (message.stanzaId && message.stanzaId !== message.originId) return message.stanzaId
   }
   return undefined
 }
@@ -42,6 +46,9 @@ export function pickOldestArchiveId(messages: ArchivableMessage[]): string | und
 export function isItemNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
   if ((error as { condition?: string }).condition === 'item-not-found') return true
-  if (error instanceof Error && error.message.includes('item-not-found')) return true
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+    return message.includes('item-not-found') || message.includes('item not found')
+  }
   return false
 }

--- a/packages/fluux-sdk/src/hooks/useChat.fetchOlderHistory.regression.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChat.fetchOlderHistory.regression.test.tsx
@@ -91,6 +91,25 @@ describe('useChat fetchOlderHistory — MAM cursor regression', () => {
     expect(before).not.toBe('uuid-sent')
   })
 
+  it('skips an old origin-id accidentally persisted as stanzaId', async () => {
+    const stale = outgoing('uuid-sent', '2026-06-01T10:00:00Z')
+    stale.stanzaId = 'uuid-sent'
+    seedMessages([
+      stale,
+      incoming('r1', '2026-06-01T10:05:00Z', 'archive-1'),
+    ])
+    const { result } = renderHook(() => useChat(), { wrapper })
+
+    await act(async () => {
+      await result.current.fetchOlderHistory()
+    })
+
+    expect(mockClient.chat.queryMAM).toHaveBeenCalledTimes(1)
+    expect(mockClient.chat.queryMAM).toHaveBeenCalledWith({ with: CONV, before: 'archive-1' })
+    const before = vi.mocked(mockClient.chat.queryMAM).mock.calls[0][0].before
+    expect(before).not.toBe('uuid-sent')
+  })
+
   it('recovers via a timestamp window — never the client id — when no in-memory message has a stanzaId', async () => {
     seedMessages([
       outgoing('uuid-1', '2026-06-01T10:00:00Z'),

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -6,6 +6,7 @@ import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment, MAMQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
+import { selectCatchUpQuery, MAM_CATCHUP_FORWARD_MAX, MAM_ROOM_FORWARD_MAX_PAGES } from '../utils/mamCatchUpUtils'
 
 /**
  * Stable empty array references to prevent infinite re-renders.
@@ -326,19 +327,14 @@ export function useChat() {
           cachedMessages = chatStore.getState().messages.get(targetId)
         }
 
-        const newestCachedMessage = cachedMessages?.[cachedMessages.length - 1]
+        const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
+        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart)
 
-        // Build query options
-        const queryOptions: { with: string; start?: string } = { with: conversation.id }
-
-        // If we have cached messages, use 'start' to only fetch messages AFTER the newest
-        // Add 1ms to avoid re-fetching the exact same message
-        if (newestCachedMessage?.timestamp) {
-          const startTime = new Date(newestCachedMessage.timestamp.getTime() + 1)
-          queryOptions.start = startTime.toISOString()
-        }
-
-        await client.chat.queryMAM(queryOptions)
+        await client.chat.queryMAM({
+          with: conversation.id,
+          ...q,
+          ...(q.start ? { max: MAM_CATCHUP_FORWARD_MAX, maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES } : {}),
+        })
       } catch (error) {
         console.error('Failed to fetch history:', error)
       } finally {
@@ -362,6 +358,7 @@ export function useChat() {
         setMAMLoading: (id, loading) => chatStore.getState().setMAMLoading(id, loading),
         loadFromCache: (id, limit) => chatStore.getState().loadOlderMessagesFromCache(id, limit),
         getOldestMessageId: (id) => pickOldestArchiveId(chatStore.getState().messages.get(id) ?? []),
+        clearInvalidArchiveCursor: (id, cursor) => chatStore.getState().clearMessageStanzaId(id, cursor),
         getOldestTimestamp: (id) => chatStore.getState().messages.get(id)?.[0]?.timestamp,
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -328,7 +328,8 @@ export function useChat() {
         }
 
         const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
-        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart)
+        const lastTimestamp = chatStore.getState().getConversationLastTimestamp(targetId)
+        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart, lastTimestamp)
 
         await client.chat.queryMAM({
           with: conversation.id,

--- a/packages/fluux-sdk/src/hooks/useChat.ts
+++ b/packages/fluux-sdk/src/hooks/useChat.ts
@@ -329,7 +329,7 @@ export function useChat() {
 
         const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
         const lastTimestamp = chatStore.getState().getConversationLastTimestamp(targetId)
-        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart, lastTimestamp)
+        const q = selectCatchUpQuery(cachedMessages ?? [], { forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
 
         await client.chat.queryMAM({
           with: conversation.id,

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -3,6 +3,7 @@ import { chatStore, connectionStore } from '../stores'
 import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment } from '../core'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
+import { selectCatchUpQuery, MAM_CATCHUP_FORWARD_MAX, MAM_ROOM_FORWARD_MAX_PAGES } from '../utils/mamCatchUpUtils'
 
 /**
  * Action-only counterpart to `useChat()`.
@@ -147,16 +148,14 @@ export function useChatActions() {
           cachedMessages = chatStore.getState().messages.get(targetId)
         }
 
-        const newestCachedMessage = cachedMessages?.[cachedMessages.length - 1]
+        const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
+        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart)
 
-        const queryOptions: { with: string; start?: string } = { with: conversation.id }
-
-        if (newestCachedMessage?.timestamp) {
-          const startTime = new Date(newestCachedMessage.timestamp.getTime() + 1)
-          queryOptions.start = startTime.toISOString()
-        }
-
-        await client.chat.queryMAM(queryOptions)
+        await client.chat.queryMAM({
+          with: conversation.id,
+          ...q,
+          ...(q.start ? { max: MAM_CATCHUP_FORWARD_MAX, maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES } : {}),
+        })
       } catch (error) {
         console.error('Failed to fetch history:', error)
       } finally {
@@ -178,6 +177,7 @@ export function useChatActions() {
         setMAMLoading: (id, loading) => chatStore.getState().setMAMLoading(id, loading),
         loadFromCache: (id, limit) => chatStore.getState().loadOlderMessagesFromCache(id, limit),
         getOldestMessageId: (id) => pickOldestArchiveId(chatStore.getState().messages.get(id) ?? []),
+        clearInvalidArchiveCursor: (id, cursor) => chatStore.getState().clearMessageStanzaId(id, cursor),
         getOldestTimestamp: (id) => chatStore.getState().messages.get(id)?.[0]?.timestamp,
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -149,7 +149,8 @@ export function useChatActions() {
         }
 
         const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
-        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart)
+        const lastTimestamp = chatStore.getState().getConversationLastTimestamp(targetId)
+        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart, lastTimestamp)
 
         await client.chat.queryMAM({
           with: conversation.id,

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -150,7 +150,7 @@ export function useChatActions() {
 
         const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
         const lastTimestamp = chatStore.getState().getConversationLastTimestamp(targetId)
-        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart, lastTimestamp)
+        const q = selectCatchUpQuery(cachedMessages ?? [], { forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
 
         await client.chat.queryMAM({
           with: conversation.id,

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -6,7 +6,7 @@ import { useXMPPContext } from '../provider'
 import type { Conversation, ChatStateNotification, FileAttachment, MAMQueryState, Message } from '../core'
 import { NS_MAM } from '../core/namespaces'
 import { createFetchOlderHistory, pickOldestArchiveId } from './shared'
-import { findContinueCatchUpCursor, buildCatchUpStartTime, MAM_CACHE_LOAD_LIMIT, MAM_CATCHUP_FORWARD_MAX, MAM_ROOM_FORWARD_MAX_PAGES_MANUAL } from '../utils/mamCatchUpUtils'
+import { findContinueCatchUpCursor, buildCatchUpStartTime, selectCatchUpQuery, MAM_CACHE_LOAD_LIMIT, MAM_CATCHUP_FORWARD_MAX, MAM_ROOM_FORWARD_MAX_PAGES, MAM_ROOM_FORWARD_MAX_PAGES_MANUAL } from '../utils/mamCatchUpUtils'
 
 /**
  * Stable empty array references to prevent infinite re-renders.
@@ -287,15 +287,14 @@ export function useChatActive() {
           cachedMessages = chatStore.getState().messages.get(targetId)
         }
 
-        const newestCachedMessage = cachedMessages?.[cachedMessages.length - 1]
-        const queryOptions: { with: string; start?: string } = { with: conversation.id }
+        const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
+        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart)
 
-        if (newestCachedMessage?.timestamp) {
-          const startTime = new Date(newestCachedMessage.timestamp.getTime() + 1)
-          queryOptions.start = startTime.toISOString()
-        }
-
-        await client.chat.queryMAM(queryOptions)
+        await client.chat.queryMAM({
+          with: conversation.id,
+          ...q,
+          ...(q.start ? { max: MAM_CATCHUP_FORWARD_MAX, maxAutoPages: MAM_ROOM_FORWARD_MAX_PAGES } : {}),
+        })
       } catch (error) {
         console.error('Failed to fetch history:', error)
       } finally {
@@ -317,6 +316,7 @@ export function useChatActive() {
         setMAMLoading: (id, loading) => chatStore.getState().setMAMLoading(id, loading),
         loadFromCache: (id, limit) => chatStore.getState().loadOlderMessagesFromCache(id, limit),
         getOldestMessageId: (id) => pickOldestArchiveId(chatStore.getState().messages.get(id) ?? []),
+        clearInvalidArchiveCursor: (id, cursor) => chatStore.getState().clearMessageStanzaId(id, cursor),
         getOldestTimestamp: (id) => chatStore.getState().messages.get(id)?.[0]?.timestamp,
         queryMAM: async (id, beforeId) => {
           const conversation = chatStore.getState().conversations.get(id)

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -289,7 +289,7 @@ export function useChatActive() {
 
         const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
         const lastTimestamp = chatStore.getState().getConversationLastTimestamp(targetId)
-        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart, lastTimestamp)
+        const q = selectCatchUpQuery(cachedMessages ?? [], { forwardGapTimestamp: gapStart, fallbackNewestTimestamp: lastTimestamp })
 
         await client.chat.queryMAM({
           with: conversation.id,

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -288,7 +288,8 @@ export function useChatActive() {
         }
 
         const gapStart = chatStore.getState().conversationGaps.get(targetId)?.start
-        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart)
+        const lastTimestamp = chatStore.getState().getConversationLastTimestamp(targetId)
+        const q = selectCatchUpQuery(cachedMessages ?? [], undefined, gapStart, lastTimestamp)
 
         await client.chat.queryMAM({
           with: conversation.id,

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -552,6 +552,7 @@ export function useRoom() {
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),
         loadFromCache: (id, limit) => roomStore.getState().loadOlderMessagesFromCache(id, limit),
         getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
+        clearInvalidArchiveCursor: (id, cursor) => roomStore.getState().clearMessageStanzaId(id, cursor),
         queryMAM: async (id, beforeId) => {
           await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
         },

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -367,6 +367,7 @@ export function useRoomActions() {
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),
         loadFromCache: (id, limit) => roomStore.getState().loadOlderMessagesFromCache(id, limit),
         getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
+        clearInvalidArchiveCursor: (id, cursor) => roomStore.getState().clearMessageStanzaId(id, cursor),
         queryMAM: async (id, beforeId) => {
           await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
         },

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -344,6 +344,7 @@ export function useRoomActive() {
         setMAMLoading: (id, loading) => roomStore.getState().setRoomMAMLoading(id, loading),
         loadFromCache: (id, limit) => roomStore.getState().loadOlderMessagesFromCache(id, limit),
         getOldestMessageId: (id) => pickOldestArchiveId(roomStore.getState().rooms.get(id)?.messages ?? []),
+        clearInvalidArchiveCursor: (id, cursor) => roomStore.getState().clearMessageStanzaId(id, cursor),
         queryMAM: async (id, beforeId) => {
           await client.chat.queryRoomMAM({ roomJid: id, before: beforeId })
         },

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -676,6 +676,72 @@ describe('chatStore', () => {
     })
   })
 
+  describe('clearMessageStanzaId', () => {
+    it('strips a stale stanzaId from the in-memory message and IndexedDB', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      const msg = { ...createMessage('alice@example.com', 'sent', true), stanzaId: 'uuid-sent', originId: 'uuid-sent' }
+      chatStore.getState().addMessage(msg)
+
+      chatStore.getState().clearMessageStanzaId('alice@example.com', 'uuid-sent')
+
+      expect(chatStore.getState().getMessage('alice@example.com', msg.id)?.stanzaId).toBeUndefined()
+      expect(messageCache.updateMessage).toHaveBeenCalledWith(msg.id, { stanzaId: undefined })
+    })
+
+    it('heals the lastMessage preview when the cleared message was the preview', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      const msg = { ...createMessage('alice@example.com', 'sent', true), stanzaId: 'uuid-sent', originId: 'uuid-sent' }
+      chatStore.getState().addMessage(msg)
+      expect(chatStore.getState().conversationMeta.get('alice@example.com')?.lastMessage?.stanzaId).toBe('uuid-sent')
+
+      chatStore.getState().clearMessageStanzaId('alice@example.com', 'uuid-sent')
+
+      const preview = chatStore.getState().conversationMeta.get('alice@example.com')?.lastMessage
+      expect(preview?.id).toBe(msg.id)
+      expect(preview?.stanzaId).toBeUndefined()
+    })
+
+    it('is a no-op when no message carries the given stanzaId', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      const msg = { ...createMessage('alice@example.com', 'real', false), stanzaId: 'archive-1' }
+      chatStore.getState().addMessage(msg)
+      vi.mocked(messageCache.updateMessage).mockClear()
+
+      chatStore.getState().clearMessageStanzaId('alice@example.com', 'not-present')
+
+      expect(chatStore.getState().getMessage('alice@example.com', msg.id)?.stanzaId).toBe('archive-1')
+      expect(messageCache.updateMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getConversationLastTimestamp', () => {
+    it('returns the meta lastMessage timestamp in epoch ms', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      const ts = new Date('2026-05-14T09:00:00.000Z')
+      chatStore.getState().addMessage({ ...createMessage('alice@example.com', 'hi', false), timestamp: ts })
+
+      expect(chatStore.getState().getConversationLastTimestamp('alice@example.com')).toBe(ts.getTime())
+    })
+
+    it('falls back to the combined conversations map when no meta entry exists', () => {
+      const ts = new Date('2026-05-14T09:00:00.000Z')
+      const lastMessage = { ...createMessage('bob@example.com', 'hi', false), timestamp: ts }
+      // Persist-rehydration / legacy shape: combined map populated, meta absent.
+      chatStore.setState({
+        conversationMeta: new Map(),
+        conversations: new Map([['bob@example.com', { ...createConversation('bob@example.com'), lastMessage }]]),
+      })
+
+      expect(chatStore.getState().getConversationLastTimestamp('bob@example.com')).toBe(ts.getTime())
+    })
+
+    it('returns undefined when the conversation has no last message', () => {
+      chatStore.getState().addConversation(createConversation('carol@example.com'))
+      expect(chatStore.getState().getConversationLastTimestamp('carol@example.com')).toBeUndefined()
+      expect(chatStore.getState().getConversationLastTimestamp('unknown@example.com')).toBeUndefined()
+    })
+  })
+
   describe('markAsRead', () => {
     it('should reset unreadCount to 0', () => {
       const conv = { ...createConversation('alice@example.com'), unreadCount: 10 }

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -148,6 +148,7 @@ interface ChatState {
   clearAllTyping: () => void
   updateReactions: (conversationId: string, messageId: string, reactorJid: string, emojis: string[]) => void
   updateMessage: (conversationId: string, messageId: string, updates: Partial<Message>) => void
+  clearMessageStanzaId: (conversationId: string, stanzaId: string) => void
   /**
    * Hard-remove a message from the conversation, the search index, and the
    * durable cache. Used when a stanza that was provisionally stored as a
@@ -1084,6 +1085,42 @@ export const chatStore = createStore<ChatState>()(
 
               return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
             }
+          }
+
+          return { messages: newMessages }
+        })
+      },
+
+      clearMessageStanzaId: (conversationId, stanzaId) => {
+        set((state) => {
+          const convMessages = state.messages.get(conversationId)
+          if (!convMessages) return state
+
+          const messageIndex = convMessages.findIndex((message) => message.stanzaId === stanzaId)
+          if (messageIndex === -1) return state
+
+          const newMessages = new Map(state.messages)
+          const updatedConvMessages = [...convMessages]
+          const { stanzaId: _staleStanzaId, ...updatedMessage } = convMessages[messageIndex]
+          updatedConvMessages[messageIndex] = updatedMessage
+          newMessages.set(conversationId, updatedConvMessages)
+
+          void messageCache.updateMessage(convMessages[messageIndex].id, { stanzaId: undefined })
+
+          const meta = state.conversationMeta.get(conversationId)
+          const conv = state.conversations.get(conversationId)
+          const wasLastMessage =
+            !!meta?.lastMessage &&
+            (meta.lastMessage.id === updatedMessage.id || meta.lastMessage.stanzaId === stanzaId)
+
+          if (meta && conv && wasLastMessage) {
+            const newMeta = new Map(state.conversationMeta)
+            newMeta.set(conversationId, { ...meta, lastMessage: updatedMessage })
+
+            const newConversations = new Map(state.conversations)
+            newConversations.set(conversationId, { ...conv, lastMessage: updatedMessage })
+
+            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
           }
 
           return { messages: newMessages }

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -158,6 +158,13 @@ interface ChatState {
    */
   removeMessage: (conversationId: string, messageId: string) => void
   getMessage: (conversationId: string, messageId: string) => Message | undefined
+  /**
+   * Epoch ms of the conversation's persisted last-known message (the entity
+   * preview), or undefined. Used as a last-resort forward catch-up cursor so a
+   * persisted conversation whose message cache is empty this run still
+   * forward-fills its offline gap instead of a `before:''` fetch-latest.
+   */
+  getConversationLastTimestamp: (conversationId: string) => number | undefined
   triggerAnimation: (conversationId: string, animation: string) => void
   clearAnimation: () => void
   // Draft management
@@ -1131,6 +1138,16 @@ export const chatStore = createStore<ChatState>()(
         const convMessages = get().messages.get(conversationId)
         if (!convMessages) return undefined
         return findMessageById(convMessages, messageId)
+      },
+
+      getConversationLastTimestamp: (conversationId) => {
+        const state = get()
+        // Prefer conversationMeta (frequently-updated); fall back to the combined
+        // conversations map for backward compat with persist/tests.
+        const lastMessage =
+          state.conversationMeta.get(conversationId)?.lastMessage ??
+          state.conversations.get(conversationId)?.lastMessage
+        return lastMessage?.timestamp?.getTime()
       },
 
       removeMessage: (conversationId, messageId) => {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1322,6 +1322,63 @@ describe('roomStore', () => {
     })
   })
 
+  describe('clearMessageStanzaId', () => {
+    const ROOM = 'test@conference.example.com'
+
+    it('strips a stale stanzaId from the in-memory message, the preview, and IndexedDB', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      const msg = { ...createMessage('m1', ROOM, 'me', 'sent', true), stanzaId: 'uuid-sent', originId: 'uuid-sent' }
+      roomStore.getState().addMessage(ROOM, msg)
+
+      roomStore.getState().clearMessageStanzaId(ROOM, 'uuid-sent')
+
+      expect(roomStore.getState().rooms.get(ROOM)?.messages[0].stanzaId).toBeUndefined()
+      expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage?.stanzaId).toBeUndefined()
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith('m1', { stanzaId: undefined })
+    })
+
+    it('is a no-op when no message carries the given stanzaId', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      const msg = { ...createMessage('m1', ROOM, 'alice', 'real'), stanzaId: 'archive-1' }
+      roomStore.getState().addMessage(ROOM, msg)
+      vi.mocked(messageCache.updateRoomMessage).mockClear()
+
+      roomStore.getState().clearMessageStanzaId(ROOM, 'not-present')
+
+      expect(roomStore.getState().rooms.get(ROOM)?.messages[0].stanzaId).toBe('archive-1')
+      expect(messageCache.updateRoomMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getRoomLastTimestamp', () => {
+    const ROOM = 'test@conference.example.com'
+
+    it('returns the meta lastMessage timestamp in epoch ms', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      const ts = new Date('2026-05-14T09:00:00.000Z')
+      roomStore.getState().addMessage(ROOM, { ...createMessage('m1', ROOM, 'alice', 'hi'), timestamp: ts })
+
+      expect(roomStore.getState().getRoomLastTimestamp(ROOM)).toBe(ts.getTime())
+    })
+
+    it('falls back to the combined rooms map when no meta entry exists', () => {
+      const ts = new Date('2026-05-14T09:00:00.000Z')
+      const lastMessage = { ...createMessage('m1', ROOM, 'alice', 'hi'), timestamp: ts }
+      roomStore.setState({
+        roomMeta: new Map(),
+        rooms: new Map([[ROOM, createRoom(ROOM, { lastMessage })]]),
+      })
+
+      expect(roomStore.getState().getRoomLastTimestamp(ROOM)).toBe(ts.getTime())
+    })
+
+    it('returns undefined when the room has no last message', () => {
+      roomStore.getState().addRoom(createRoom(ROOM, { joined: true }))
+      expect(roomStore.getState().getRoomLastTimestamp(ROOM)).toBeUndefined()
+      expect(roomStore.getState().getRoomLastTimestamp('unknown@conference.example.com')).toBeUndefined()
+    })
+  })
+
   describe('markAsRead', () => {
     it('should reset unread count to zero', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com', { unreadCount: 5 }))

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -312,6 +312,7 @@ export interface RoomState {
   }) => void
   updateReactions: (roomJid: string, messageId: string, reactorNick: string, emojis: string[]) => void
   updateMessage: (roomJid: string, messageId: string, updates: Partial<RoomMessage>) => void
+  clearMessageStanzaId: (roomJid: string, stanzaId: string) => void
   getMessage: (roomJid: string, messageId: string) => RoomMessage | undefined
   markAsRead: (roomJid: string) => void
   setActiveRoom: (roomJid: string | null) => void
@@ -1160,6 +1161,45 @@ export const roomStore = createStore<RoomState>()(
           newMeta.set(roomJid, { ...existingMeta, lastMessage })
           result.roomMeta = newMeta
         }
+      }
+
+      return result
+    })
+  },
+
+  clearMessageStanzaId: (roomJid, stanzaId) => {
+    set((state) => {
+      const existing = state.rooms.get(roomJid)
+      if (!existing) return state
+
+      const targetIdx = existing.messages.findIndex((message) => message.stanzaId === stanzaId)
+      if (targetIdx === -1) return state
+
+      const newMessages = [...existing.messages]
+      const { stanzaId: _staleStanzaId, ...updatedMessage } = existing.messages[targetIdx]
+      newMessages[targetIdx] = updatedMessage
+
+      void messageCache.updateRoomMessage(existing.messages[targetIdx].id, { stanzaId: undefined })
+
+      const newRooms = new Map(state.rooms)
+      newRooms.set(roomJid, { ...existing, messages: newMessages })
+
+      const newRuntime = new Map(state.roomRuntime)
+      const existingRuntime = newRuntime.get(roomJid)
+      if (existingRuntime) {
+        newRuntime.set(roomJid, { ...existingRuntime, messages: newMessages })
+      }
+
+      const result: Partial<RoomState> = { rooms: newRooms, roomRuntime: newRuntime }
+      const meta = state.roomMeta.get(roomJid)
+      const wasLastMessage =
+        !!meta?.lastMessage &&
+        (meta.lastMessage.id === updatedMessage.id || meta.lastMessage.stanzaId === stanzaId)
+
+      if (meta && wasLastMessage) {
+        const newMeta = new Map(state.roomMeta)
+        newMeta.set(roomJid, { ...meta, lastMessage: updatedMessage })
+        result.roomMeta = newMeta
       }
 
       return result

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -314,6 +314,13 @@ export interface RoomState {
   updateMessage: (roomJid: string, messageId: string, updates: Partial<RoomMessage>) => void
   clearMessageStanzaId: (roomJid: string, stanzaId: string) => void
   getMessage: (roomJid: string, messageId: string) => RoomMessage | undefined
+  /**
+   * Epoch ms of the room's persisted last-known message (the entity preview),
+   * or undefined. Used as a last-resort forward catch-up cursor so a persisted
+   * room whose message cache is empty this run still forward-fills its offline
+   * gap instead of a `before:''` fetch-latest.
+   */
+  getRoomLastTimestamp: (roomJid: string) => number | undefined
   markAsRead: (roomJid: string) => void
   setActiveRoom: (roomJid: string | null) => void
   /**
@@ -1210,6 +1217,16 @@ export const roomStore = createStore<RoomState>()(
     const room = get().rooms.get(roomJid)
     if (!room) return undefined
     return findMessageById(room.messages, messageId)
+  },
+
+  getRoomLastTimestamp: (roomJid) => {
+    const state = get()
+    // Prefer roomMeta (frequently-updated); fall back to the combined rooms map
+    // for backward compat with persist/tests.
+    const lastMessage =
+      state.roomMeta.get(roomJid)?.lastMessage ??
+      state.rooms.get(roomJid)?.lastMessage
+    return lastMessage?.timestamp?.getTime()
   },
 
   markAsRead: (roomJid) => {

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -188,6 +188,14 @@ describe('selectCatchUpQuery', () => {
       start: '2026-02-01T00:00:00.001Z',
     })
   })
+
+  it('prefers a persisted forward gap boundary over newer cached messages', () => {
+    const gapStart = new Date('2026-05-14T09:00:00Z').getTime()
+    const newerAboveGap = new Date('2026-06-01T12:00:00Z')
+    expect(selectCatchUpQuery([{ timestamp: newerAboveGap }], sessionStart, gapStart)).toEqual({
+      start: '2026-05-14T09:00:00.001Z',
+    })
+  })
 })
 
 // ============================================================================

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -166,25 +166,25 @@ describe('selectCatchUpQuery', () => {
   it('returns a forward start from the newest PRE-session message', () => {
     const monthOld = new Date('2026-05-14T09:00:00Z')
     const live = new Date('2026-06-14T12:00:05Z')
-    expect(selectCatchUpQuery([{ timestamp: monthOld }, { timestamp: live }], sessionStart)).toEqual({
+    expect(selectCatchUpQuery([{ timestamp: monthOld }, { timestamp: live }], { sessionStartTime: sessionStart })).toEqual({
       start: '2026-05-14T09:00:00.001Z',
     })
   })
 
   it('returns backward (before:"") when only this-session messages exist', () => {
-    expect(selectCatchUpQuery([{ timestamp: new Date('2026-06-14T12:00:05Z') }], sessionStart)).toEqual({
+    expect(selectCatchUpQuery([{ timestamp: new Date('2026-06-14T12:00:05Z') }], { sessionStartTime: sessionStart })).toEqual({
       before: '',
     })
   })
 
   it('returns backward (before:"") for an empty message list', () => {
-    expect(selectCatchUpQuery([], sessionStart)).toEqual({ before: '' })
+    expect(selectCatchUpQuery([], { sessionStartTime: sessionStart })).toEqual({ before: '' })
   })
 
   it('uses the global newest when no sessionStartTime is given (legacy behavior)', () => {
     const a = new Date('2026-01-01T00:00:00Z')
     const b = new Date('2026-02-01T00:00:00Z')
-    expect(selectCatchUpQuery([{ timestamp: a }, { timestamp: b }], undefined)).toEqual({
+    expect(selectCatchUpQuery([{ timestamp: a }, { timestamp: b }])).toEqual({
       start: '2026-02-01T00:00:00.001Z',
     })
   })
@@ -192,7 +192,7 @@ describe('selectCatchUpQuery', () => {
   it('prefers a persisted forward gap boundary over newer cached messages', () => {
     const gapStart = new Date('2026-05-14T09:00:00Z').getTime()
     const newerAboveGap = new Date('2026-06-01T12:00:00Z')
-    expect(selectCatchUpQuery([{ timestamp: newerAboveGap }], sessionStart, gapStart)).toEqual({
+    expect(selectCatchUpQuery([{ timestamp: newerAboveGap }], { sessionStartTime: sessionStart, forwardGapTimestamp: gapStart })).toEqual({
       start: '2026-05-14T09:00:00.001Z',
     })
   })
@@ -202,27 +202,27 @@ describe('selectCatchUpQuery', () => {
     // fall back to the last-known preview timestamp and FORWARD-fill the gap,
     // instead of a before:"" fetch-latest that would skip a large offline gap.
     const lastKnown = new Date('2026-05-14T09:00:00Z').getTime()
-    expect(selectCatchUpQuery([], sessionStart, undefined, lastKnown)).toEqual({
+    expect(selectCatchUpQuery([], { sessionStartTime: sessionStart, fallbackNewestTimestamp: lastKnown })).toEqual({
       start: '2026-05-14T09:00:00.001Z',
     })
   })
 
   it('ignores a fallback at/after session start so a live preview update cannot poison the cursor', () => {
     const live = new Date('2026-06-14T12:00:05Z').getTime() // >= sessionStart
-    expect(selectCatchUpQuery([], sessionStart, undefined, live)).toEqual({ before: '' })
+    expect(selectCatchUpQuery([], { sessionStartTime: sessionStart, fallbackNewestTimestamp: live })).toEqual({ before: '' })
   })
 
   it('prefers a real pre-session cached message over the fallback timestamp', () => {
     const cached = new Date('2026-06-10T09:00:00Z') // pre-session, newer than fallback
     const fallback = new Date('2026-01-01T00:00:00Z').getTime()
-    expect(selectCatchUpQuery([{ timestamp: cached }], sessionStart, undefined, fallback)).toEqual({
+    expect(selectCatchUpQuery([{ timestamp: cached }], { sessionStartTime: sessionStart, fallbackNewestTimestamp: fallback })).toEqual({
       start: '2026-06-10T09:00:00.001Z',
     })
   })
 
   it('uses the fallback when sessionStartTime is omitted (hook fetch-history path)', () => {
     const lastKnown = new Date('2026-05-14T09:00:00Z').getTime()
-    expect(selectCatchUpQuery([], undefined, undefined, lastKnown)).toEqual({
+    expect(selectCatchUpQuery([], { fallbackNewestTimestamp: lastKnown })).toEqual({
       start: '2026-05-14T09:00:00.001Z',
     })
   })
@@ -230,7 +230,7 @@ describe('selectCatchUpQuery', () => {
   it('lets a persisted gap boundary win over the fallback timestamp', () => {
     const gapStart = new Date('2026-04-01T00:00:00Z').getTime()
     const fallback = new Date('2026-05-14T09:00:00Z').getTime()
-    expect(selectCatchUpQuery([], sessionStart, gapStart, fallback)).toEqual({
+    expect(selectCatchUpQuery([], { sessionStartTime: sessionStart, forwardGapTimestamp: gapStart, fallbackNewestTimestamp: fallback })).toEqual({
       start: '2026-04-01T00:00:00.001Z',
     })
   })

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -196,6 +196,44 @@ describe('selectCatchUpQuery', () => {
       start: '2026-05-14T09:00:00.001Z',
     })
   })
+
+  it('forward-fills from the persisted last-known timestamp when no cached message anchors the cursor', () => {
+    // Empty message cache (e.g. a persisted conversation never opened this run):
+    // fall back to the last-known preview timestamp and FORWARD-fill the gap,
+    // instead of a before:"" fetch-latest that would skip a large offline gap.
+    const lastKnown = new Date('2026-05-14T09:00:00Z').getTime()
+    expect(selectCatchUpQuery([], sessionStart, undefined, lastKnown)).toEqual({
+      start: '2026-05-14T09:00:00.001Z',
+    })
+  })
+
+  it('ignores a fallback at/after session start so a live preview update cannot poison the cursor', () => {
+    const live = new Date('2026-06-14T12:00:05Z').getTime() // >= sessionStart
+    expect(selectCatchUpQuery([], sessionStart, undefined, live)).toEqual({ before: '' })
+  })
+
+  it('prefers a real pre-session cached message over the fallback timestamp', () => {
+    const cached = new Date('2026-06-10T09:00:00Z') // pre-session, newer than fallback
+    const fallback = new Date('2026-01-01T00:00:00Z').getTime()
+    expect(selectCatchUpQuery([{ timestamp: cached }], sessionStart, undefined, fallback)).toEqual({
+      start: '2026-06-10T09:00:00.001Z',
+    })
+  })
+
+  it('uses the fallback when sessionStartTime is omitted (hook fetch-history path)', () => {
+    const lastKnown = new Date('2026-05-14T09:00:00Z').getTime()
+    expect(selectCatchUpQuery([], undefined, undefined, lastKnown)).toEqual({
+      start: '2026-05-14T09:00:00.001Z',
+    })
+  })
+
+  it('lets a persisted gap boundary win over the fallback timestamp', () => {
+    const gapStart = new Date('2026-04-01T00:00:00Z').getTime()
+    const fallback = new Date('2026-05-14T09:00:00Z').getTime()
+    expect(selectCatchUpQuery([], sessionStart, gapStart, fallback)).toEqual({
+      start: '2026-04-01T00:00:00.001Z',
+    })
+  })
 })
 
 // ============================================================================

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -118,11 +118,21 @@ export interface CatchUpQuery {
  * When `sessionStartTime` is omitted, falls back to the global newest message.
  * If a persisted forward gap exists, it wins: the query resumes from that
  * recorded gap boundary instead of from newer cached messages above the hole.
+ *
+ * `fallbackNewestTimestamp` is the conversation's persisted last-known message
+ * timestamp (from the entity preview). It is used as a last resort — only when
+ * no cached message and no gap give a cursor — so a persisted conversation whose
+ * message cache is empty this run still FORWARD-fills its offline gap to
+ * completion, instead of a backward `{ before: '' }` fetch-latest that grabs
+ * only the newest page and silently skips a large gap (issue #135). A fallback
+ * at/after `sessionStartTime` is ignored so a live preview update arriving
+ * post-connect can't poison the cursor (same guard as the cached-message path).
  */
 export function selectCatchUpQuery(
   messages: Array<{ timestamp?: Date }>,
   sessionStartTime?: number,
   forwardGapTimestamp?: number,
+  fallbackNewestTimestamp?: number,
 ): CatchUpQuery {
   if (forwardGapTimestamp !== undefined) {
     return { start: buildCatchUpStartTime(new Date(forwardGapTimestamp)) }
@@ -130,7 +140,14 @@ export function selectCatchUpQuery(
   const cursor = sessionStartTime !== undefined
     ? findCatchUpCursorMessage(messages, sessionStartTime)
     : findNewestMessage(messages)
-  return cursor?.timestamp ? { start: buildCatchUpStartTime(cursor.timestamp) } : { before: '' }
+  if (cursor?.timestamp) return { start: buildCatchUpStartTime(cursor.timestamp) }
+  if (
+    fallbackNewestTimestamp !== undefined &&
+    (sessionStartTime === undefined || fallbackNewestTimestamp < sessionStartTime)
+  ) {
+    return { start: buildCatchUpStartTime(new Date(fallbackNewestTimestamp)) }
+  }
+  return { before: '' }
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -107,46 +107,63 @@ export interface CatchUpQuery {
 }
 
 /**
+ * Optional inputs for {@link selectCatchUpQuery}. All are epoch-ms timestamps;
+ * grouped into an options object (rather than positional args) so the three
+ * `number | undefined` values can't be transposed at a call site.
+ */
+export interface CatchUpQueryOptions {
+  /** Epoch ms the session connected. The cached cursor excludes this-session
+   *  messages so a live message can't poison it. Omitted → use the global newest. */
+  sessionStartTime?: number
+  /** Epoch ms of a recorded forward gap. When set it WINS: resume from the hole
+   *  boundary instead of from newer cached messages above it. */
+  forwardGapTimestamp?: number
+  /** Epoch ms of the entity's persisted preview (`lastMessage`). Last resort —
+   *  used only when no cached message and no gap give a cursor — so a persisted
+   *  conversation whose message cache is empty this run still FORWARD-fills its
+   *  offline gap instead of a `{ before: '' }` fetch-latest that grabs only the
+   *  newest page and silently skips a large gap (issue #135). */
+  fallbackNewestTimestamp?: number
+}
+
+/**
  * The single, shared catch-up cursor policy for BOTH 1:1 and MUC forward
  * catch-up (background sync + active-entity side effects). Centralized so the
  * cursor logic can't drift between the chat and room paths — which is exactly
  * how the session-start fix once landed in rooms but not 1:1.
  *
- * Returns a forward `{ start }` from the newest message that predates the
- * session (so a live message in the catch-up window can't poison the cursor),
- * or `{ before: '' }` to fetch the latest when nothing pre-session is held.
- * When `sessionStartTime` is omitted, falls back to the global newest message.
- * If a persisted forward gap exists, it wins: the query resumes from that
- * recorded gap boundary instead of from newer cached messages above the hole.
- *
- * `fallbackNewestTimestamp` is the conversation's persisted last-known message
- * timestamp (from the entity preview). It is used as a last resort — only when
- * no cached message and no gap give a cursor — so a persisted conversation whose
- * message cache is empty this run still FORWARD-fills its offline gap to
- * completion, instead of a backward `{ before: '' }` fetch-latest that grabs
- * only the newest page and silently skips a large gap (issue #135). A fallback
- * at/after `sessionStartTime` is ignored so a live preview update arriving
- * post-connect can't poison the cursor (same guard as the cached-message path).
+ * Picks a forward `{ start }` from the highest-priority available anchor —
+ * recorded gap boundary, else newest pre-session cached message, else the
+ * persisted preview timestamp — or `{ before: '' }` to fetch the latest when
+ * none is held. A fallback at/after `sessionStartTime` is ignored so a live
+ * preview update arriving post-connect can't poison the cursor.
  */
 export function selectCatchUpQuery(
   messages: Array<{ timestamp?: Date }>,
-  sessionStartTime?: number,
-  forwardGapTimestamp?: number,
-  fallbackNewestTimestamp?: number,
+  options: CatchUpQueryOptions = {},
 ): CatchUpQuery {
+  const { sessionStartTime, forwardGapTimestamp, fallbackNewestTimestamp } = options
+
+  // A recorded forward gap wins: resume from the hole boundary.
   if (forwardGapTimestamp !== undefined) {
     return { start: buildCatchUpStartTime(new Date(forwardGapTimestamp)) }
   }
+
+  // Normal case: forward from the newest message that predates the session.
   const cursor = sessionStartTime !== undefined
     ? findCatchUpCursorMessage(messages, sessionStartTime)
     : findNewestMessage(messages)
   if (cursor?.timestamp) return { start: buildCatchUpStartTime(cursor.timestamp) }
+
+  // Last resort: the persisted preview timestamp (cache empty this run), guarded
+  // so a live preview update can't poison the cursor.
   if (
     fallbackNewestTimestamp !== undefined &&
     (sessionStartTime === undefined || fallbackNewestTimestamp < sessionStartTime)
   ) {
     return { start: buildCatchUpStartTime(new Date(fallbackNewestTimestamp)) }
   }
+
   return { before: '' }
 }
 

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -116,11 +116,17 @@ export interface CatchUpQuery {
  * session (so a live message in the catch-up window can't poison the cursor),
  * or `{ before: '' }` to fetch the latest when nothing pre-session is held.
  * When `sessionStartTime` is omitted, falls back to the global newest message.
+ * If a persisted forward gap exists, it wins: the query resumes from that
+ * recorded gap boundary instead of from newer cached messages above the hole.
  */
 export function selectCatchUpQuery(
   messages: Array<{ timestamp?: Date }>,
   sessionStartTime?: number,
+  forwardGapTimestamp?: number,
 ): CatchUpQuery {
+  if (forwardGapTimestamp !== undefined) {
+    return { start: buildCatchUpStartTime(new Date(forwardGapTimestamp)) }
+  }
   const cursor = sessionStartTime !== undefined
     ? findCatchUpCursorMessage(messages, sessionStartTime)
     : findNewestMessage(messages)


### PR DESCRIPTION
Hardens MAM catch-up against three ways the offline gap (incl. own-sent messages) can silently go missing. Relates to #135.

## Changes

**1. Heal polluted archive cursors (backward scroll-up).**
The first public release (`7a265f3a`) wrote the client/origin id into the `stanzaId` slot of outgoing messages, and that value persists in IndexedDB. #514 stopped new pollution but never healed old caches, so `pickOldestArchiveId` kept surfacing the poisoned id and the server kept rejecting scroll-up with `item-not-found`, across restarts.
- `pickOldestArchiveId` now skips a `stanzaId === originId` (a client id can never be a server archive id).
- On `item-not-found`, the bad `stanzaId` is scrubbed from memory **and** IndexedDB (`clearMessageStanzaId`) so future retries can't pick it again; then recovery falls back to a timestamp window (1:1) or the next valid cursor.

**2. Auto-fill recorded forward gaps.**
Automatic 1:1 and room catch-up now resume from the persisted gap boundary (`conversationGaps` / `roomGaps`) when one exists, so a previously recorded hole gets filled instead of skipped. Converges: a forward query that completes clears the gap; an incomplete one advances the marker.

**3. Forward-fill when the message cache is empty.**
A persisted conversation/room with a preview but no cached messages this run fell through to a backward `before:''` fetch-latest that grabs only the newest page and skips a large gap. It now forward-fills from the persisted last-known (`lastMessage`) timestamp and paginates to completion, with the same session-start guard so a live preview update can't poison the cursor. Centralized via new `getConversationLastTimestamp` / `getRoomLastTimestamp` accessors so the chat and room paths can't drift.

## Tests
Unit tests cover the `stanzaId` heal (`clearMessageStanzaId`, chat + room), the new preview accessors incl. the meta→combined-map fallback, and every `selectCatchUpQuery` branch (gap / cached / empty-cache fallback); the 1:1 sweep forward-fill + gap-boundary are covered at the integration level. The shared catch-up cursor helper takes a `CatchUpQueryOptions` object (no transposable positional timestamps).

## Notes
This does not address server-side MAM behavior (e.g. whether the archive returns the own-sent leg for a `start`-filtered window) — a real `fluux.log` from a reopen-after-offline repro is still needed to confirm that path for #135.