### PR TITLE
refactor(e2ee): single-source the OpenPGP UID + descriptive key-export filenames

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1469,6 +1469,9 @@ fn main() {
                     Ok(j) => j,
                     Err(_) => return, // NoEntry or access failure — quiet no-op
                 };
+                // Mirrors the canonical XEP-0373 §8.5 trust-anchor UID defined
+                // in TS at `src/e2ee/openpgpUserId.ts` (`accountUserId`). Keep in
+                // sync — generation and verification key off this exact form.
                 let user_id = format!("xmpp:{jid}");
                 prewarm_state.prewarm_if_persisted(jid, user_id);
             });

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -95,6 +95,7 @@ import {
   toXep0373Fingerprint,
   pubkeyMetadataFingerprintAttrs,
 } from './fingerprintCompare'
+import { accountUserId } from './openpgpUserId'
 import {
   clearKeyChangeAlert,
   getKeyChangeAlert,
@@ -1550,7 +1551,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
           rejections.push({ fingerprint, code: 'fingerprint_mismatch', detail, observedAt: now })
           continue
         }
-        const expectedUid = `xmpp:${peer}`
+        const expectedUid = accountUserId(peer)
         const uidMatch = validation.userIds.some(
           (uid) => uid.toLowerCase() === expectedUid.toLowerCase(),
         )

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.ts
@@ -22,6 +22,8 @@ import {
   type KeyBundle,
   classifyBoundaryError,
 } from './OpenPGPPluginBase'
+import { accountUserId } from './openpgpUserId'
+import { keyExportFilename } from './keyExportNaming'
 
 /**
  * Typed wrapper over Tauri's `invoke`. Abstracted so tests can inject a
@@ -70,7 +72,7 @@ export class SequoiaPgpPlugin extends OpenPGPPluginBase {
     try {
       return await this.invoke<KeyBundle>('openpgp_ensure_key', {
         accountJid,
-        userId: `xmpp:${accountJid}`,
+        userId: accountUserId(accountJid),
       })
     } catch (err) {
       throw this.toPluginError('ensureKeyMaterial', err)
@@ -197,7 +199,7 @@ export class SequoiaPgpPlugin extends OpenPGPPluginBase {
     }
     const { save } = await import('@tauri-apps/plugin-dialog')
     const filePath = await save({
-      defaultPath: 'openpgp-backup.asc',
+      defaultPath: keyExportFilename('openpgp-backup', ctx.account.jid),
       filters: [{ name: 'OpenPGP Armor', extensions: ['asc', 'pgp', 'gpg'] }],
     })
     if (!filePath) return false
@@ -226,7 +228,7 @@ export class SequoiaPgpPlugin extends OpenPGPPluginBase {
     }
     const { save } = await import('@tauri-apps/plugin-dialog')
     const filePath = await save({
-      defaultPath: 'openpgp-private-key.asc',
+      defaultPath: keyExportFilename('openpgp-private-key', ctx.account.jid),
       filters: [{ name: 'OpenPGP Private Key', extensions: ['asc', 'pgp', 'gpg'] }],
     })
     if (!filePath) return false

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -31,6 +31,8 @@ import {
   type KeyBundle,
   type RestoreResult,
 } from './OpenPGPPluginBase'
+import { accountUserId } from './openpgpUserId'
+import { keyExportFilename } from './keyExportNaming'
 import { KeyPickerRequiredError, NoRecoveryAvailableError } from './recoveryErrors'
 import { clearSessionPassphrase, getSessionPassphrase, setSessionPassphrase } from './webPassphraseStore'
 import { USE_V6_KEYS } from './passphraseGenerator'
@@ -547,11 +549,12 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
       )
     }
     const armoredMessage = await this.backupEncrypt(ctx.account.jid, passphrase)
-    triggerBrowserDownload(armoredMessage, 'openpgp-backup.asc')
+    triggerBrowserDownload(armoredMessage, keyExportFilename('openpgp-backup', ctx.account.jid))
     return true
   }
 
   async exportPrivateKeyToFile(passphrase: string | null): Promise<boolean> {
+    const ctx = this.requireCtx()
     await this.requireUnlocked()
     if (!this.ownBundle || !this.ownPrivateKey) {
       throw new E2EEPluginError(
@@ -573,7 +576,7 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
     } else {
       armoredKey = this.ownPrivateKey.armor()
     }
-    triggerBrowserDownload(armoredKey, 'openpgp-private-key.asc')
+    triggerBrowserDownload(armoredKey, keyExportFilename('openpgp-private-key', ctx.account.jid))
     return true
   }
 
@@ -686,7 +689,7 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
     const { privateKey } = await generateKey({
       type: 'ecc',
       curve: (USE_V6_KEYS ? 'curve25519' : 'curve25519Legacy') as 'curve25519Legacy',
-      userIDs: [{ name: `xmpp:${accountJid}` }],
+      userIDs: [{ name: accountUserId(accountJid) }],
       format: 'object',
     })
     const encrypted = await encryptKey({ privateKey, passphrase })

--- a/apps/fluux/src/e2ee/keyExportNaming.test.ts
+++ b/apps/fluux/src/e2ee/keyExportNaming.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { keyExportFilename } from './keyExportNaming'
+
+describe('keyExportFilename', () => {
+  it('embeds the account JID so exports are self-describing', () => {
+    expect(keyExportFilename('openpgp-private-key', 'alice@example.org')).toBe(
+      'openpgp-private-key-alice@example.org.asc',
+    )
+    expect(keyExportFilename('openpgp-backup', 'alice@example.org')).toBe(
+      'openpgp-backup-alice@example.org.asc',
+    )
+  })
+
+  it('replaces filesystem-unsafe characters (resource separators, slashes)', () => {
+    expect(keyExportFilename('openpgp-private-key', 'alice@example.org/phone')).toBe(
+      'openpgp-private-key-alice@example.org_phone.asc',
+    )
+    expect(keyExportFilename('openpgp-backup', 'a/b\\c:d')).toBe('openpgp-backup-a_b_c_d.asc')
+  })
+
+  it('collapses runs and trims leading/trailing separators (no hidden file, no `..`)', () => {
+    expect(keyExportFilename('openpgp-backup', '..weird//jid..')).toBe('openpgp-backup-weird_jid.asc')
+  })
+
+  it('falls back to a bare name when the JID sanitizes to nothing', () => {
+    expect(keyExportFilename('openpgp-private-key', '')).toBe('openpgp-private-key.asc')
+    expect(keyExportFilename('openpgp-private-key', '   ')).toBe('openpgp-private-key.asc')
+    expect(keyExportFilename('openpgp-backup', '///')).toBe('openpgp-backup.asc')
+  })
+})

--- a/apps/fluux/src/e2ee/keyExportNaming.ts
+++ b/apps/fluux/src/e2ee/keyExportNaming.ts
@@ -1,0 +1,41 @@
+/**
+ * Descriptive, cross-platform-safe filenames for exported OpenPGP key files.
+ *
+ * Embedding the account JID makes the file self-describing once it lands in an
+ * external tool (gpg, OpenKeychain, Kleopatra) and stops exports for different
+ * accounts from colliding on a generic `openpgp-private-key.asc`. The key's
+ * own User ID is the bare `xmpp:user@domain` (XEP-0373 §8.5, no real name), so
+ * the receiving tool has nothing human-friendly to name the file from — the
+ * filename is the only place we can surface which account a key belongs to.
+ */
+
+/** Filename stem per export flavour. */
+export type KeyExportKind = 'openpgp-private-key' | 'openpgp-backup'
+
+/**
+ * Build the suggested filename for an exported key.
+ *
+ * @param kind  the export flavour (used as the filename stem)
+ * @param jid   the account bare JID the key belongs to
+ * @returns e.g. `openpgp-private-key-alice@example.org.asc`; falls back to
+ *          `<kind>.asc` when the JID sanitizes to nothing
+ */
+export function keyExportFilename(kind: KeyExportKind, jid: string): string {
+  const safeJid = sanitizeForFilename(jid)
+  return safeJid ? `${kind}-${safeJid}.asc` : `${kind}.asc`
+}
+
+/**
+ * Reduce a JID to characters every major filesystem accepts. Letters, digits
+ * and the readable JID punctuation (`. _ @ + -`) are kept; anything else
+ * (notably `/`, `\`, `:` and resource separators) becomes `_`. Runs are
+ * collapsed and leading/trailing separators trimmed so we never emit a hidden
+ * file (`.foo`) or a `..` path segment.
+ */
+function sanitizeForFilename(jid: string): string {
+  return jid
+    .trim()
+    .replace(/[^A-Za-z0-9._@+-]/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^[_.]+|[_.]+$/g, '')
+}

--- a/apps/fluux/src/e2ee/openpgpUserId.test.ts
+++ b/apps/fluux/src/e2ee/openpgpUserId.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { accountUserId } from './openpgpUserId'
+
+describe('accountUserId', () => {
+  it('builds the bare XEP-0373 §8.5 trust-anchor UID', () => {
+    expect(accountUserId('alice@example.org')).toBe('xmpp:alice@example.org')
+  })
+
+  it('adds no real-name component (the XMPP address is the only trust anchor)', () => {
+    // Must stay free of `<…>` / `(…)` so both Sequoia and openpgp.js emit the
+    // exact same User ID packet and verification matches across platforms.
+    expect(accountUserId('bob@example.com')).not.toMatch(/[<>()]/)
+  })
+
+  it('matches the format peer-key verification expects', () => {
+    const peer = 'carol@example.net'
+    expect(accountUserId(peer)).toBe(`xmpp:${peer}`)
+  })
+})

--- a/apps/fluux/src/e2ee/openpgpUserId.ts
+++ b/apps/fluux/src/e2ee/openpgpUserId.ts
@@ -1,0 +1,19 @@
+/**
+ * Canonical XEP-0373 §8.5 trust-anchor User ID for an account or peer JID.
+ *
+ * The spec requires the bare `xmpp:user@domain` form with NO real-name
+ * component — "the XMPP address is the only trust anchor here" — so both the
+ * Sequoia (desktop) and openpgp.js (web) key generators emit exactly this
+ * string, and peer-key verification matches against it.
+ *
+ * This is the single source of truth: key generation and verification both
+ * route through it so they can never drift. A divergence here would silently
+ * break cross-client verification (a web-generated key failing on desktop, or
+ * vice-versa).
+ *
+ * NOTE: the Rust prewarm path (`src-tauri/src/main.rs`, `format!("xmpp:{jid}")`)
+ * mirrors this in another language and must be kept in sync by hand.
+ */
+export function accountUserId(jid: string): string {
+  return `xmpp:${jid}`
+}


### PR DESCRIPTION
## Summary

Two small, no-crypto cleanups to the OpenPGP (XEP-0373) plugins, prompted by a user noticing their exported key shows up as `<no name>` in OpenKeychain.

**1. Single source of truth for the trust-anchor User ID.** The XEP-0373 §8.5 UID (`xmpp:<jid>`) was spelled out independently in four places — two generators, peer-key verification, and the Rust prewarm path. They produce the same string today, but nothing enforced that, and a divergence would silently break cross-client verification. Extracted `accountUserId(jid)` and routed the desktop generator, web generator, and verifier through it; the Rust prewarm carries a cross-reference comment.

**2. Descriptive export filenames.** Exported key files were hardcoded to a generic `openpgp-private-key.asc` / `openpgp-backup.asc`, so exports for different accounts collided and the file wasn't self-describing once imported elsewhere. New `keyExportFilename` helper embeds the (sanitized) account JID: `openpgp-private-key-<jid>.asc`.

Note: the `<no name>` an external tool shows is the key's own UID, which XEP-0373 §8.5 intentionally leaves name-less ("the XMPP address is the only trust anchor") — so the key itself is deliberately left unchanged; only the filename is improved.