### PR TITLE
fix(muc): hide reactions/edits/retractions in IRC gateway rooms

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -301,6 +301,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
       prev.nickname !== activeRoom.nickname ||
       prev.joined !== activeRoom.joined ||
       prev.supportsReactions !== activeRoom.supportsReactions ||
+      prev.isIrcGateway !== activeRoom.isIrcGateway ||
       prev.occupants !== activeRoom.occupants ||
       prev.nickToJidCache !== activeRoom.nickToJidCache ||
       prev.nickToAvatarCache !== activeRoom.nickToAvatarCache
@@ -944,6 +945,7 @@ export const RoomMessageList = memo(function RoomMessageList({
         roomJid={room.jid}
         myNick={room.nickname}
         supportsReactions={room.supportsReactions !== false}
+        isIrcGateway={room.isIrcGateway === true}
         occupant={sender.occupant}
         avatarPresence={sender.avatarPresence}
         senderAvatar={sender.senderAvatar}
@@ -1032,6 +1034,7 @@ interface RoomMessageBubbleWrapperProps {
   roomJid: string
   myNick: string | undefined
   supportsReactions: boolean
+  isIrcGateway: boolean
   occupant: RoomOccupant | undefined
   avatarPresence: 'online' | 'away' | 'dnd' | 'offline' | undefined
   senderAvatar: string | undefined
@@ -1102,6 +1105,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   roomJid,
   myNick,
   supportsReactions,
+  isIrcGateway,
   occupant,
   avatarPresence,
   senderAvatar,
@@ -1342,6 +1346,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
         onReaction={supportsReactions ? handleReaction : undefined}
         getReactorName={getReactorName}
         canModerate={canModerateMsg}
+        isIrcGateway={isIrcGateway}
         onReply={() => onReply(message)}
         onEdit={() => onEdit(message)}
         onDelete={async () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -113,6 +113,10 @@ export interface MessageBubbleProps {
   // XEP-0425: Whether the current user can moderate (retract) this message
   canModerate?: boolean
 
+  // Room-specific: true for IRC gateway channels (Biboumi). IRC has no concept of
+  // retractions/corrections, so the edit + delete affordances are hidden. See #228.
+  isIrcGateway?: boolean
+
   // Right-click / long-press context menu on nick/avatar (for room occupant actions)
   onNickContextMenu?: (e: React.MouseEvent) => void
   onNickTouchStart?: (e: React.TouchEvent) => void
@@ -225,6 +229,9 @@ function arePropsEqual(prev: MessageBubbleProps, next: MessageBubbleProps): bool
   // Moderation permission
   if (prev.canModerate !== next.canModerate) return false
 
+  // IRC-gateway flag gates edit/delete affordances
+  if (prev.isIrcGateway !== next.isIrcGateway) return false
+
   // Mentions - compare by reference (parent should memoize)
   if (prev.mentions !== next.mentions) return false
   if (prev.nickname !== next.nickname) return false
@@ -285,6 +292,7 @@ export const MessageBubble = memo(function MessageBubble({
   nickname,
   knownNicks,
   canModerate,
+  isIrcGateway,
   onPollVote,
   onClosePoll,
   onNickContextMenu,
@@ -440,8 +448,8 @@ export const MessageBubble = memo(function MessageBubble({
             onDelete={onDelete}
             myReactions={reactionsEnabled ? myReactions : []}
             canReply={(!isLastMessage || inThread) && !counterpartGone}
-            canEdit={message.isOutgoing && isLastOutgoing}
-            canDelete={message.isOutgoing || canModerate === true}
+            canEdit={message.isOutgoing && isLastOutgoing && !isIrcGateway}
+            canDelete={(message.isOutgoing || canModerate === true) && !isIrcGateway}
             isHidden={hideToolbar || false}
             isSelected={isSelected || false}
             hasKeyboardSelection={hasKeyboardSelection || false}

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -1071,7 +1071,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: true, supportsReactions: true, supportsHats: false, name: 'Test Room' })
+      expect(result).toEqual({ supportsMAM: true, supportsReactions: true, supportsHats: false, isIrcGateway: false, name: 'Test Room' })
       expect(mockSendIQ).toHaveBeenCalledWith(
         expect.objectContaining({
           attrs: expect.objectContaining({
@@ -1099,7 +1099,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, name: 'Test Room' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, isIrcGateway: false, name: 'Test Room' })
     })
 
     it('returns supportsReactions: false for open semi-anonymous rooms without occupant-id', async () => {
@@ -1108,7 +1108,7 @@ describe('MUC Module', () => {
           name: 'query',
           attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
           children: [
-            { name: 'identity', attrs: { category: 'conference', type: 'text', name: 'IRC Bridge' } },
+            { name: 'identity', attrs: { category: 'conference', type: 'text', name: 'Open Room' } },
             { name: 'feature', attrs: { var: 'http://jabber.org/protocol/muc' } },
             { name: 'feature', attrs: { var: 'muc_semianonymous' } },
             { name: 'feature', attrs: { var: 'muc_open' } },
@@ -1120,7 +1120,30 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, name: 'IRC Bridge' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, isIrcGateway: false, name: 'Open Room' })
+    })
+
+    it('flags an IRC gateway (Biboumi: conference/irc + muc_nonanonymous) and disables reactions (issue #228)', async () => {
+      // Real Biboumi advertises a non-anonymous channel with a conference/irc
+      // identity. The stable-identity heuristic alone would (wrongly) keep
+      // reactions on, because muc_nonanonymous looks like stable identity.
+      const response = createMockElement('iq', { type: 'result', from: '#chan%irc.example.org@biboumi.example.org' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'conference', type: 'irc', name: '#chan on irc.example.org' } },
+            { name: 'feature', attrs: { var: 'http://jabber.org/protocol/muc' } },
+            { name: 'feature', attrs: { var: 'muc_nonanonymous' } },
+          ],
+        },
+      ])
+
+      mockSendIQ.mockResolvedValue(response)
+
+      const result = await muc.queryRoomFeatures('#chan%irc.example.org@biboumi.example.org')
+
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, isIrcGateway: true, name: '#chan on irc.example.org' })
     })
 
     it('returns supportsReactions: true for open semi-anonymous rooms with occupant-id', async () => {
@@ -1142,7 +1165,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, name: 'Modern Room' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, isIrcGateway: false, name: 'Modern Room' })
     })
 
     it('returns null when disco#info query fails', async () => {

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -263,6 +263,7 @@ export class MUC extends BaseModule {
             if (features.supportsReactions === true) updates.supportsReactions = true
             if (features.supportsMAM === true && !room.supportsMAM) updates.supportsMAM = true
             if (features.supportsHats === true && !room.supportsHats) updates.supportsHats = true
+            if (features.isIrcGateway === true && !room.isIrcGateway) updates.isIrcGateway = true
             if (Object.keys(updates).length > 0) {
               this.deps.emitSDK('room:updated', { roomJid, updates })
             }
@@ -459,6 +460,7 @@ export class MUC extends BaseModule {
     const supportsMAM = isQuickChat ? false : (roomFeatures?.supportsMAM ?? false)
     const supportsReactions = roomFeatures?.supportsReactions ?? false
     const supportsHats = roomFeatures?.supportsHats ?? false
+    const isIrcGateway = roomFeatures?.isIrcGateway ?? false
     const roomName = roomFeatures?.name || existingRoom?.name || getLocalPart(roomJid)
 
     if (!existingRoom) {
@@ -473,6 +475,7 @@ export class MUC extends BaseModule {
         supportsMAM,
         supportsReactions,
         supportsHats,
+        isIrcGateway,
         occupants: new Map(),
         messages: [],
         unreadCount: 0,
@@ -488,6 +491,7 @@ export class MUC extends BaseModule {
         supportsMAM,
         supportsReactions,
         supportsHats,
+        isIrcGateway,
         occupants: new Map() as Map<string, RoomOccupant>,
         selfOccupant: undefined,
         typingUsers: new Set() as Set<string>,
@@ -818,7 +822,7 @@ export class MUC extends BaseModule {
    *   since MAM provides a more reliable and complete archive
    * - Has a 10-second timeout to prevent hanging if remote server doesn't respond
    */
-  async queryRoomFeatures(roomJid: string): Promise<{ supportsMAM: boolean; supportsReactions: boolean; supportsHats: boolean; name?: string } | null> {
+  async queryRoomFeatures(roomJid: string): Promise<{ supportsMAM: boolean; supportsReactions: boolean; supportsHats: boolean; isIrcGateway: boolean; name?: string } | null> {
     try {
       const iq = xml(
         'iq',
@@ -844,19 +848,24 @@ export class MUC extends BaseModule {
         .map((f: Element) => f.attrs.var as string)
         .filter(Boolean)
 
-      const supportsMAM = features.includes(NS_MAM)
-      const supportsReactions = hasStableOccupantIdentity(features)
-      const supportsHats = features.includes(NS_HATS)
-
-      // Parse room name from identity element
+      // Parse the room identity (XEP-0030):
       // <identity category="conference" type="text" name="Room Name"/>
+      // IRC gateways (Biboumi et al.) advertise type="irc" instead of "text".
       const identity = query.getChildren('identity')
         .find((i: Element) => i.attrs.category === 'conference')
       const name = identity?.attrs.name as string | undefined
+      const isIrcGateway = identity?.attrs.type === 'irc'
 
-      logInfo(`Room features: ${roomJid} MAM=${supportsMAM} reactions=${supportsReactions} hats=${supportsHats}`)
+      const supportsMAM = features.includes(NS_MAM)
+      // IRC has no reactions concept (XEP-0444); on a gateway a reaction would
+      // degrade to a junk fallback line, so disable it even when the channel
+      // otherwise has stable occupant identity (muc_nonanonymous). See #228.
+      const supportsReactions = hasStableOccupantIdentity(features) && !isIrcGateway
+      const supportsHats = features.includes(NS_HATS)
 
-      return { supportsMAM, supportsReactions, supportsHats, name }
+      logInfo(`Room features: ${roomJid} MAM=${supportsMAM} reactions=${supportsReactions} hats=${supportsHats} irc=${isIrcGateway}`)
+
+      return { supportsMAM, supportsReactions, supportsHats, isIrcGateway, name }
     } catch (err) {
       // Room disco#info not available - that's fine, room may not exist yet
       // or may not support disco queries, or the query timed out

--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.ts
@@ -77,6 +77,7 @@ interface SerializedRoom {
   supportsMAM?: boolean
   supportsReactions?: boolean
   supportsHats?: boolean
+  isIrcGateway?: boolean
   messages: SerializedRoomMessage[]
 }
 
@@ -171,6 +172,7 @@ function serializeRoom(r: Room): SerializedRoom {
     supportsMAM: r.supportsMAM,
     supportsReactions: r.supportsReactions,
     supportsHats: r.supportsHats,
+    isIrcGateway: r.isIrcGateway,
     messages: r.messages.slice(-MAX_MESSAGES_PER_ROOM).map(serializeRoomMessage),
   }
 }

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -201,6 +201,11 @@ export interface RoomEntity {
   supportsReactions?: boolean
   /** True if room supports XEP-0317 Hats management */
   supportsHats?: boolean
+  /** True if the room is an IRC gateway channel (Biboumi et al.), detected via a
+   *  conference/irc disco#info identity. IRC has no concept of reactions
+   *  (XEP-0444), retractions (XEP-0424) or corrections (XEP-0308), so the UI
+   *  hides those affordances for these rooms. See issue #228. */
+  isIrcGateway?: boolean
 
   // Mute control
   /** When true, the room won't bubble up in the sidebar on new messages.

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -447,6 +447,7 @@ export const roomStore = createStore<RoomState>()(
         supportsMAM: room.supportsMAM,
         supportsReactions: room.supportsReactions,
         supportsHats: room.supportsHats,
+        isIrcGateway: room.isIrcGateway,
         muted: room.muted,
       }
       const meta: RoomMetadata = {
@@ -501,7 +502,7 @@ export const roomStore = createStore<RoomState>()(
       // Update entity fields if any changed
       const entityFields = ['name', 'nickname', 'joined', 'isJoining', 'subject', 'avatar',
         'avatarHash', 'avatarFromPresence', 'isBookmarked', 'autojoin', 'password', 'isQuickChat',
-        'supportsMAM', 'supportsReactions', 'supportsHats', 'muted'] as const
+        'supportsMAM', 'supportsReactions', 'supportsHats', 'isIrcGateway', 'muted'] as const
       const hasEntityUpdate = entityFields.some((f) => f in update)
 
       // Update metadata fields if any changed
@@ -536,6 +537,7 @@ export const roomStore = createStore<RoomState>()(
             supportsMAM: updatedRoom.supportsMAM,
             supportsReactions: updatedRoom.supportsReactions,
             supportsHats: updatedRoom.supportsHats,
+            isIrcGateway: updatedRoom.isIrcGateway,
             muted: updatedRoom.muted,
           })
         }


### PR DESCRIPTION
## Summary

IRC gateways (Biboumi, see #228) showed reaction, edit and delete affordances in their channels, even though IRC has no concept of reactions (XEP-0444), retractions (XEP-0424) or corrections (XEP-0308). The reactions gate keyed on *stable occupant identity*, and Biboumi advertises `muc_nonanonymous` — which the heuristic read as stable identity — so the affordances stayed on. Two earlier attempts missed because Biboumi passes the identity heuristic and answers disco#info fine.

Fluux now detects IRC gateways from the disco#info identity (`conference`/`type="irc"`, already parsed for the room name), stores it as `Room.isIrcGateway`, and hides reactions, editing (corrections) and deletion (retractions) for these rooms. **Replies stay enabled** — their quoted-text fallback is readable over IRC, and non-IRC bridges (Telegram/Matrix via slidge) that present as `conference/text` keep full features.