### PR TITLE
fix(mam): discover MAM support on the bare JID for Prosody compatibility

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Discovery.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.test.ts
@@ -535,5 +535,132 @@ describe('XMPPClient Disco', () => {
         category: 'connection'
       })
     })
+
+    // --- MAM advertised on the bare JID only (Prosody) ---
+    // XEP-0313 §3 requires MAM support to be advertised on the *archiving* JID
+    // (the user's bare JID). ejabberd additionally mirrors it onto the server
+    // domain; Prosody does not. fetchServerInfo must fall back to the bare-JID
+    // archive disco so 1:1 history sync isn't disabled on Prosody-style servers.
+    it('includes MAM in server features when only the bare JID advertises it (Prosody)', async () => {
+      const domainResponse = createMockElement('iq', { type: 'result', from: 'example.com' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'server', type: 'im', name: 'Prosody' } },
+            { name: 'feature', attrs: { var: 'http://jabber.org/protocol/disco#info' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:carbons:2' } },
+          ],
+        },
+      ])
+      const bareJidResponse = createMockElement('iq', { type: 'result', from: 'user@example.com' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'account', type: 'registered' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:mam:2' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:mam:2#extended' } },
+          ],
+        },
+      ])
+
+      mockXmppClientInstance.iqCaller.request.mockImplementation((iq: any) => {
+        const to = iq?.attrs?.to
+        if (to === 'example.com') return Promise.resolve(domainResponse)
+        if (to === 'user@example.com') return Promise.resolve(bareJidResponse)
+        return Promise.resolve(getDefaultIQResponse(iq))
+      })
+
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'password',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+      await waitForAsyncOps()
+
+      const serverInfoCall = emitSDKSpy.mock.calls.find((call: unknown[]) => call[0] === 'connection:server-info')
+      expect(serverInfoCall).toBeDefined()
+      const serverInfo = (serverInfoCall![1] as { info: { features: string[] } }).info
+      expect(serverInfo.features).toContain('urn:xmpp:mam:2')
+    })
+
+    it('does not send a bare-JID fallback query when the domain already advertises MAM (ejabberd)', async () => {
+      // ejabberd shape: the server domain advertises MAM directly.
+      const domainResponse = createMockElement('iq', { type: 'result', from: 'example.com' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'server', type: 'im', name: 'ejabberd' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:carbons:2' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:mam:2' } },
+          ],
+        },
+      ])
+
+      mockXmppClientInstance.iqCaller.request.mockImplementation((iq: any) => {
+        const to = iq?.attrs?.to
+        if (to === 'example.com') return Promise.resolve(domainResponse)
+        return Promise.resolve(getDefaultIQResponse(iq))
+      })
+
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'password',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+      await waitForAsyncOps()
+
+      // Server features still report MAM (no regression for ejabberd)...
+      const serverInfoCall = emitSDKSpy.mock.calls.find((call: unknown[]) => call[0] === 'connection:server-info')
+      const serverInfo = (serverInfoCall![1] as { info: { features: string[] } }).info
+      expect(serverInfo.features).toContain('urn:xmpp:mam:2')
+
+      // ...and no extra bare-JID round-trip was made.
+      const sentFallback = (mockXmppClientInstance.iqCaller.request as ReturnType<typeof vi.fn>).mock.calls.some(
+        (call: any[]) => typeof call[0]?.attrs?.id === 'string' && call[0].attrs.id.startsWith('mam_support_')
+      )
+      expect(sentFallback).toBe(false)
+    })
+
+    it('does not report MAM when neither the domain nor the bare JID advertise it', async () => {
+      const noMamResponse = createMockElement('iq', { type: 'result' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'server', type: 'im', name: 'Prosody' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:carbons:2' } },
+          ],
+        },
+      ])
+
+      mockXmppClientInstance.iqCaller.request.mockImplementation((iq: any) => {
+        const xmlns = iq?.children?.[0]?.attrs?.xmlns
+        if (xmlns === 'http://jabber.org/protocol/disco#info') return Promise.resolve(noMamResponse)
+        return Promise.resolve(getDefaultIQResponse(iq))
+      })
+
+      const connectPromise = xmppClient.connect({
+        jid: 'user@example.com',
+        password: 'password',
+        server: 'example.com',
+        skipDiscovery: true,
+      })
+      mockXmppClientInstance._emit('online')
+      await connectPromise
+      await waitForAsyncOps()
+
+      const serverInfoCall = emitSDKSpy.mock.calls.find((call: unknown[]) => call[0] === 'connection:server-info')
+      const serverInfo = (serverInfoCall![1] as { info: { features: string[] } }).info
+      expect(serverInfo.features).not.toContain('urn:xmpp:mam:2')
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Discovery.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.ts
@@ -167,10 +167,24 @@ export class Discovery extends BaseModule {
       }))
 
       // Parse features
-      const features = query.getChildren('feature')
+      let features = query.getChildren('feature')
         .map((feature: Element) => feature.attrs.var as string)
         .filter(Boolean)
         .sort()
+
+      // XEP-0313 §3: MAM support is advertised on the *archiving* JID — the
+      // user's own bare JID — not necessarily the server domain. ejabberd
+      // mirrors it onto the domain too, but Prosody advertises `urn:xmpp:mam:2`
+      // only on the account JID. Without this fallback the domain-only disco
+      // reports MAM unsupported on Prosody and all 1:1 history sync is silently
+      // disabled. Only pay the extra round-trip when the domain didn't already
+      // advertise MAM.
+      if (!features.includes(NS_MAM)) {
+        const accountMamFeatures = await this.fetchAccountMamFeatures(currentJid)
+        if (accountMamFeatures.length > 0) {
+          features = [...new Set([...features, ...accountMamFeatures])].sort()
+        }
+      }
 
       // Emit SDK event for server info
       const serverInfo = { domain, identities, features }
@@ -202,6 +216,40 @@ export class Discovery extends BaseModule {
     } catch (err) {
       // Server disco#info not available - that's fine, not all servers support it
       logWarn(`Server disco#info failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  /**
+   * Query the user's own bare JID — the archiving JID per XEP-0313 §3 — for MAM
+   * support. Used as a fallback when the server-domain disco doesn't advertise
+   * MAM: Prosody advertises `urn:xmpp:mam:2` only on the account JID, whereas
+   * ejabberd mirrors it onto the domain as well.
+   *
+   * @param currentJid - The connected full JID
+   * @returns The MAM-family feature namespaces advertised by the bare JID
+   *   (e.g. `urn:xmpp:mam:2`, `urn:xmpp:mam:2#extended`), or an empty array.
+   */
+  private async fetchAccountMamFeatures(currentJid: string): Promise<string[]> {
+    const bareJid = getBareJid(currentJid)
+    if (!bareJid) return []
+
+    try {
+      const iq = xml(
+        'iq',
+        { type: 'get', to: bareJid, id: `mam_support_${generateUUID()}` },
+        xml('query', { xmlns: NS_DISCO_INFO })
+      )
+      const result = await this.deps.sendIQ(iq)
+      const query = result.getChild('query', NS_DISCO_INFO)
+      if (!query) return []
+
+      return query.getChildren('feature')
+        .map((feature: Element) => feature.attrs.var as string)
+        .filter((v: string) => typeof v === 'string' && v.startsWith(NS_MAM))
+    } catch (err) {
+      // Bare-JID disco failed — treat as no MAM support, don't block connection.
+      logWarn(`Account MAM disco failed: ${err instanceof Error ? err.message : String(err)}`)
+      return []
     }
   }
 


### PR DESCRIPTION
One-to-one chats were empty on Prosody. Fluux discovered MAM support only from the server-domain disco#info, but per XEP-0313 §3 MAM is advertised on the archiving JID — the user's bare JID. ejabberd mirrors it onto the domain so the check passed; Prosody advertises `urn:xmpp:mam:2` only on the bare JID, so every 1:1 MAM gate read false and DM history sync was silently disabled.

`fetchServerInfo` now falls back to a bare-JID disco#info when the domain doesn't advertise MAM, unioning the account's MAM features into `serverInfo.features`. The fallback runs only when the domain lacks MAM, so ejabberd is unaffected.

Reported in https://github.com/processone/fluux-messenger/discussions/311