### PR TITLE
fix(muc): gate moderation on XEP-0425 room disco support

### DIFF
--- a/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
@@ -82,6 +82,20 @@ describe('resolveRoomSender', () => {
     const s = resolveRoomSender(msg({ isOutgoing: true }), r, new Map(), self)
     expect(s.canModerate).toBe(false)
   })
+  it('canModerate is false when the room does not support moderation (XEP-0425, supportsModeration === false)', () => {
+    const self = { nick: 'me', role: 'moderator', affiliation: 'member' } as any
+    const alice = { nick: 'alice', role: 'participant', affiliation: 'none' } as any
+    const r = room({ occupants: new Map([['alice', alice], ['me', self]]), supportsModeration: false })
+    const s = resolveRoomSender(msg({}), r, new Map(), self)
+    expect(s.canModerate).toBe(false)
+  })
+  it('canModerate stays true when supportsModeration is undefined (disco unresolved — optimistic)', () => {
+    const self = { nick: 'me', role: 'moderator', affiliation: 'member' } as any
+    const alice = { nick: 'alice', role: 'participant', affiliation: 'none' } as any
+    const r = room({ occupants: new Map([['alice', alice], ['me', self]]) })
+    const s = resolveRoomSender(msg({}), r, new Map(), self)
+    expect(s.canModerate).toBe(true)
+  })
   it('counterpartPresent is false for a private message when the counterpart is absent', () => {
     const s = resolveRoomSender(msg({ isPrivate: true, whisperWith: 'alice' }), room({}), new Map(), undefined)
     expect(s.counterpartPresent).toBe(false)

--- a/apps/fluux/src/components/conversation/roomSenderResolution.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.ts
@@ -32,7 +32,11 @@ export function resolveRoomSender(
       if (occ.occupantId === message.occupantId) { occupant = occ; occupantIdMatchNick = occ.nick; break }
     }
   }
-  const canModerateMsg = !message.isOutgoing && selfOccupant
+  // XEP-0425 §2: only offer moderation when the room advertises message-moderate:1
+  // on its own disco#info. `room.supportsModeration` is tri-state — `false` means
+  // disco confirmed it's unsupported (hide); `undefined` (disco unresolved) stays
+  // optimistic so the affordance doesn't flicker on join. See F3.
+  const canModerateMsg = !message.isOutgoing && selfOccupant && room.supportsModeration !== false
     ? canModerate(selfOccupant.role, selfOccupant.affiliation, occupant?.affiliation ?? 'none')
     : false
   // senderBareJidForBan intentionally has NO occupant-id fallback — matches pre-refactor ban-permission behavior

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -568,11 +568,6 @@ export function createStoreBindings(
     stores.admin.setMucServiceJid(mucServiceJid)
   })
 
-  on('admin:muc-service-mam', ({ supportsMAM }) => {
-    const stores = getStores()
-    stores.admin.setMucServiceSupportsMAM(supportsMAM)
-  })
-
   // ============================================================================
   // Console Events (optional, for debugging)
   // ============================================================================

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -2096,7 +2096,7 @@ describe('XMPPClient', () => {
       if (convSync) vi.spyOn(convSync, 'fetchConversations').mockResolvedValue([])
       vi.spyOn(xmppClient.muc, 'queryRoomFeatures').mockResolvedValue({
         supportsMAM: false, supportsReactions: true, supportsHats: false,
-        isNonAnonymous: true, isPrivate: false, isIrcGateway: false, name: 'Public',
+        isNonAnonymous: true, isPrivate: false, isIrcGateway: false, supportsModeration: false, name: 'Public',
       })
       return vi.spyOn(xmppClient.muc, 'joinRoom').mockResolvedValue()
     }

--- a/packages/fluux-sdk/src/core/bookmarkItem.test.ts
+++ b/packages/fluux-sdk/src/core/bookmarkItem.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { parseBookmarkItem } from './bookmarkItem'
+import { createMockElement } from './test-utils'
+import { NS_BOOKMARKS, NS_FLUUX } from './namespaces'
+
+const item = (id: string | undefined, conferenceChildren: Array<Record<string, unknown>> | null, confAttrs: Record<string, string> = {}) =>
+  createMockElement('item', id ? { id } : {}, conferenceChildren === null ? [] : [
+    { name: 'conference', attrs: { xmlns: NS_BOOKMARKS, ...confAttrs }, children: conferenceChildren },
+  ])
+
+describe('parseBookmarkItem', () => {
+  it('parses a full XEP-0402 conference item', () => {
+    const el = item('room@conf.example.com', [
+      { name: 'nick', text: 'me' },
+      { name: 'password', text: 's3cret' },
+      { name: 'extensions', children: [{ name: 'notify', attrs: { xmlns: NS_FLUUX }, text: 'all' }] },
+    ], { name: 'My Room', autojoin: 'true' })
+
+    expect(parseBookmarkItem(el)).toEqual({
+      jid: 'room@conf.example.com', name: 'My Room', nick: 'me', autojoin: true, password: 's3cret', notifyAll: true,
+    })
+  })
+
+  it('treats autojoin="1" as true', () => {
+    expect(parseBookmarkItem(item('r@c', [], { autojoin: '1' }))?.autojoin).toBe(true)
+  })
+
+  it('defaults autojoin to false and notifyAll to false when absent', () => {
+    const parsed = parseBookmarkItem(item('r@c', []))
+    expect(parsed?.autojoin).toBe(false)
+    expect(parsed?.notifyAll).toBe(false)
+  })
+
+  it('falls back to the JID local part when the conference has no name', () => {
+    expect(parseBookmarkItem(item('lobby@conf.example.com', []))?.name).toBe('lobby')
+  })
+
+  it('leaves nick and password undefined when absent', () => {
+    const parsed = parseBookmarkItem(item('r@c', []))
+    expect(parsed?.nick).toBeUndefined()
+    expect(parsed?.password).toBeUndefined()
+  })
+
+  it('returns null for an item with no conference child', () => {
+    expect(parseBookmarkItem(item('r@c', null))).toBeNull()
+  })
+
+  it('returns null for a conference item with no id (malformed)', () => {
+    expect(parseBookmarkItem(item(undefined, []))).toBeNull()
+  })
+})

--- a/packages/fluux-sdk/src/core/bookmarkItem.ts
+++ b/packages/fluux-sdk/src/core/bookmarkItem.ts
@@ -1,0 +1,43 @@
+import { Element } from '@xmpp/client'
+import { getLocalPart } from './jid'
+import { NS_BOOKMARKS, NS_FLUUX } from './namespaces'
+
+/**
+ * A parsed XEP-0402 `<conference>` bookmark item.
+ *
+ * `nick` is left raw (possibly `undefined`) so callers can apply their own
+ * default — `fetchBookmarks` only auto-joins when a nick is present, while the
+ * live-notification path substitutes `'user'`.
+ */
+export interface ParsedBookmark {
+  jid: string
+  name: string
+  nick?: string
+  autojoin: boolean
+  password?: string
+  notifyAll: boolean
+}
+
+/**
+ * Parse a single XEP-0402 bookmark `<item>` (the `<conference>` payload keyed
+ * by the room JID in `item@id`). Returns `null` when the item carries no
+ * `<conference xmlns='urn:xmpp:bookmarks:1'>` or has no id.
+ *
+ * Shared by {@link MUC.fetchBookmarks} (initial load) and the PEP
+ * live-notification handler so both read bookmarks identically.
+ */
+export function parseBookmarkItem(item: Element): ParsedBookmark | null {
+  const conference = item.getChild('conference', NS_BOOKMARKS)
+  if (!conference) return null
+
+  const jid = item.attrs.id // XEP-0402: the room JID is the item id
+  if (!jid) return null
+
+  const name = conference.attrs.name || getLocalPart(jid)
+  const autojoin = conference.attrs.autojoin === '1' || conference.attrs.autojoin === 'true'
+  const nick = conference.getChildText('nick') || undefined
+  const password = conference.getChildText('password') || undefined
+  const notifyAll = conference.getChild('extensions')?.getChild('notify', NS_FLUUX)?.getText() === 'all'
+
+  return { jid, name, nick, autojoin, password, notifyAll }
+}

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -237,8 +237,6 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       setEntityCounts: adminStore.getState().setEntityCounts,
       setMucServiceJid: adminStore.getState().setMucServiceJid,
       getMucServiceJid: () => adminStore.getState().mucServiceJid,
-      setMucServiceSupportsMAM: adminStore.getState().setMucServiceSupportsMAM,
-      getMucServiceSupportsMAM: () => adminStore.getState().mucServiceSupportsMAM,
       // Vhost management
       setVhosts: adminStore.getState().setVhosts,
       setSelectedVhost: adminStore.getState().setSelectedVhost,

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -1315,89 +1315,16 @@ describe('MUC Module', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       mockSendIQ.mockRejectedValue(new Error('Room disco timeout'))
 
-      // Even if MUC service supports MAM globally, we don't fallback
-      // because the room may have MAM explicitly disabled
-      mockStores.admin.getMucServiceSupportsMAM.mockReturnValue(true)
-
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      // Should return null, not fallback to service MAM
+      // Room-level MAM can be disabled even when the MUC service supports it,
+      // so a failed room disco must return null, never fall back to service MAM.
       expect(result).toBeNull()
       warnSpy.mockRestore()
     })
   })
 
-  describe('discoverMucService MAM detection', () => {
-    it('emits admin:muc-service-mam event when MUC service supports MAM', async () => {
-      // Mock disco#items response
-      const itemsResponse = createMockElement('iq', { type: 'result' }, [
-        {
-          name: 'query',
-          attrs: { xmlns: 'http://jabber.org/protocol/disco#items' },
-          children: [
-            { name: 'item', attrs: { jid: 'conference.example.com' } },
-          ],
-        },
-      ])
-
-      // Mock disco#info response for conference service with MAM support
-      const infoResponse = createMockElement('iq', { type: 'result' }, [
-        {
-          name: 'query',
-          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
-          children: [
-            { name: 'identity', attrs: { category: 'conference', type: 'text', name: 'MUC' } },
-            { name: 'feature', attrs: { var: 'http://jabber.org/protocol/muc' } },
-            { name: 'feature', attrs: { var: 'urn:xmpp:mam:2' } },
-          ],
-        },
-      ])
-
-      mockSendIQ
-        .mockResolvedValueOnce(itemsResponse)
-        .mockResolvedValueOnce(infoResponse)
-
-      const result = await muc.discoverMucService()
-
-      expect(result).toBe('conference.example.com')
-      expect(mockEmitSDK).toHaveBeenCalledWith('admin:muc-service-mam', { supportsMAM: true })
-    })
-
-    it('emits admin:muc-service-mam with false when MUC service does not support MAM', async () => {
-      // Mock disco#items response
-      const itemsResponse = createMockElement('iq', { type: 'result' }, [
-        {
-          name: 'query',
-          attrs: { xmlns: 'http://jabber.org/protocol/disco#items' },
-          children: [
-            { name: 'item', attrs: { jid: 'conference.example.com' } },
-          ],
-        },
-      ])
-
-      // Mock disco#info response for conference service WITHOUT MAM
-      const infoResponse = createMockElement('iq', { type: 'result' }, [
-        {
-          name: 'query',
-          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
-          children: [
-            { name: 'identity', attrs: { category: 'conference', type: 'text', name: 'MUC' } },
-            { name: 'feature', attrs: { var: 'http://jabber.org/protocol/muc' } },
-            // No MAM feature
-          ],
-        },
-      ])
-
-      mockSendIQ
-        .mockResolvedValueOnce(itemsResponse)
-        .mockResolvedValueOnce(infoResponse)
-
-      const result = await muc.discoverMucService()
-
-      expect(result).toBe('conference.example.com')
-      expect(mockEmitSDK).toHaveBeenCalledWith('admin:muc-service-mam', { supportsMAM: false })
-    })
-
+  describe('discoverMucService', () => {
     it('emits admin:muc-service event with discovered JID', async () => {
       const itemsResponse = createMockElement('iq', { type: 'result' }, [
         {

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -797,6 +797,26 @@ describe('MUC Module', () => {
       })
     })
 
+    it('preserves a known supportsModeration value when a re-join disco fails (F3: no clobber to unknown)', async () => {
+      // Existing, not-yet-joined room a prior disco resolved as moderation-unsupported.
+      mockStores.room.getRoom.mockReturnValue({
+        jid: 'room@conference.example.org', name: 'room', joined: false, isJoining: false,
+        nickname: 'mynick', isBookmarked: true, supportsModeration: false,
+        occupants: new Map(), messages: [], unreadCount: 0, mentionsCount: 0,
+        typingUsers: new Set<string>(),
+      })
+      // The re-join disco#info fails → queryRoomFeatures resolves null.
+      mockSendIQ.mockRejectedValue(new Error('disco timeout'))
+
+      await muc.joinRoom('room@conference.example.org', 'mynick').catch(() => {})
+
+      // The known `false` must survive — NOT be clobbered to undefined (optimistic).
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:updated', expect.objectContaining({
+        roomJid: 'room@conference.example.org',
+        updates: expect.objectContaining({ supportsModeration: false }),
+      }))
+    })
+
     it('skips join if already joined (avoids presence issues)', async () => {
       // Simulate already being in the room
       mockStores.room.getRoom.mockReturnValue({
@@ -1071,7 +1091,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: true, supportsReactions: true, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, name: 'Test Room' })
+      expect(result).toEqual({ supportsMAM: true, supportsReactions: true, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, supportsModeration: false, name: 'Test Room' })
       expect(mockSendIQ).toHaveBeenCalledWith(
         expect.objectContaining({
           attrs: expect.objectContaining({
@@ -1099,7 +1119,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, name: 'Test Room' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, supportsModeration: false, name: 'Test Room' })
     })
 
     it('returns supportsReactions: false for open semi-anonymous rooms without occupant-id', async () => {
@@ -1120,7 +1140,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, name: 'Open Room' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, supportsModeration: false, name: 'Open Room' })
     })
 
     it('flags an IRC gateway (Biboumi: conference/irc + muc_nonanonymous) and disables reactions (issue #228)', async () => {
@@ -1143,7 +1163,46 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('#chan%irc.example.org@biboumi.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, isNonAnonymous: true, isPrivate: false, isIrcGateway: true, name: '#chan on irc.example.org' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: false, supportsHats: false, isNonAnonymous: true, isPrivate: false, isIrcGateway: true, supportsModeration: false, name: '#chan on irc.example.org' })
+    })
+
+    it('returns supportsModeration: true when the room advertises message-moderate:1 (XEP-0425)', async () => {
+      const response = createMockElement('iq', { type: 'result', from: 'room@conference.example.org' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'conference', type: 'text', name: 'Moderated Room' } },
+            { name: 'feature', attrs: { var: 'http://jabber.org/protocol/muc' } },
+            { name: 'feature', attrs: { var: 'urn:xmpp:message-moderate:1' } },
+          ],
+        },
+      ])
+
+      mockSendIQ.mockResolvedValue(response)
+
+      const result = await muc.queryRoomFeatures('room@conference.example.org')
+
+      expect(result?.supportsModeration).toBe(true)
+    })
+
+    it('returns supportsModeration: false when the room does not advertise message-moderate:1', async () => {
+      const response = createMockElement('iq', { type: 'result', from: 'room@conference.example.org' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/disco#info' },
+          children: [
+            { name: 'identity', attrs: { category: 'conference', type: 'text', name: 'Plain Room' } },
+            { name: 'feature', attrs: { var: 'http://jabber.org/protocol/muc' } },
+          ],
+        },
+      ])
+
+      mockSendIQ.mockResolvedValue(response)
+
+      const result = await muc.queryRoomFeatures('room@conference.example.org')
+
+      expect(result?.supportsModeration).toBe(false)
     })
 
     it('returns supportsReactions: true for open semi-anonymous rooms with occupant-id', async () => {
@@ -1165,7 +1224,7 @@ describe('MUC Module', () => {
 
       const result = await muc.queryRoomFeatures('room@conference.example.org')
 
-      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, name: 'Modern Room' })
+      expect(result).toEqual({ supportsMAM: false, supportsReactions: true, supportsHats: false, isNonAnonymous: false, isPrivate: false, isIrcGateway: false, supportsModeration: false, name: 'Modern Room' })
     })
 
     it('reports isNonAnonymous + non-private for a non-anonymous public room', async () => {

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -470,6 +470,11 @@ export class MUC extends BaseModule {
     const isNonAnonymous = roomFeatures?.isNonAnonymous ?? false
     const isPrivate = roomFeatures?.isPrivate ?? false
     const isIrcGateway = roomFeatures?.isIrcGateway ?? false
+    // Tri-state (F3): deliberately NOT `?? false` like the flags above. Keep
+    // `undefined` when disco didn't resolve so the moderation affordance stays
+    // optimistic, and preserve a previously-resolved value rather than clobbering
+    // it to unknown on a failed re-disco.
+    const supportsModeration = roomFeatures ? roomFeatures.supportsModeration : existingRoom?.supportsModeration
     const roomName = roomFeatures?.name || existingRoom?.name || getLocalPart(roomJid)
 
     if (!existingRoom) {
@@ -487,6 +492,7 @@ export class MUC extends BaseModule {
         isNonAnonymous,
         isPrivate,
         isIrcGateway,
+        supportsModeration,
         occupants: new Map(),
         messages: [],
         unreadCount: 0,
@@ -505,6 +511,7 @@ export class MUC extends BaseModule {
         isNonAnonymous,
         isPrivate,
         isIrcGateway,
+        supportsModeration,
         occupants: new Map() as Map<string, RoomOccupant>,
         selfOccupant: undefined,
         typingUsers: new Set() as Set<string>,
@@ -880,10 +887,14 @@ export class MUC extends BaseModule {
       // real-JID-exposure warning (issue #37) can stay fail-safe.
       const isNonAnonymous = isNonAnonymousRoom(features)
       const isPrivate = isPrivateRoom(features)
+      // XEP-0425 §2: a MUC that supports moderated retraction MUST advertise this
+      // on its own disco#info. Gate the moderation affordance on it (F3) so we
+      // never offer a moderator an action the room will reject.
+      const supportsModeration = features.includes(NS_MESSAGE_MODERATE)
 
-      logInfo(`Room features: ${roomJid} MAM=${supportsMAM} reactions=${supportsReactions} hats=${supportsHats} nonAnon=${isNonAnonymous} private=${isPrivate} irc=${isIrcGateway}`)
+      logInfo(`Room features: ${roomJid} MAM=${supportsMAM} reactions=${supportsReactions} hats=${supportsHats} nonAnon=${isNonAnonymous} private=${isPrivate} moderation=${supportsModeration} irc=${isIrcGateway}`)
 
-      return { supportsMAM, supportsReactions, supportsHats, isNonAnonymous, isPrivate, isIrcGateway, name }
+      return { supportsMAM, supportsReactions, supportsHats, isNonAnonymous, isPrivate, isIrcGateway, supportsModeration, name }
     } catch (err) {
       // Room disco#info not available - that's fine, room may not exist yet
       // or may not support disco queries, or the query timed out

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -793,20 +793,10 @@ export class MUC extends BaseModule {
         )
 
         if (identity) {
-          // Check if the MUC service supports MAM globally (XEP-0313)
-          // This is useful as a fallback when individual room disco fails
-          const features = infoQuery?.getChildren('feature')
-            .map((f: Element) => f.attrs.var as string)
-            .filter(Boolean) ?? []
-          const serviceSupportsMAM = features.includes(NS_MAM)
-
-          logInfo(`MUC service: ${jid} (MAM=${serviceSupportsMAM})`)
+          logInfo(`MUC service: ${jid}`)
 
           // Emit MUC service JID so the admin store can populate it
           this.deps.emitSDK('admin:muc-service', { mucServiceJid: jid })
-
-          // Emit service-level MAM support for use as fallback
-          this.deps.emitSDK('admin:muc-service-mam', { supportsMAM: serviceSupportsMAM })
 
           return jid
         }

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -4,6 +4,7 @@ import { getBareJid, getLocalPart, getResource, getDomain } from '../jid'
 import { generateUUID } from '../../utils/uuid'
 import { generateQuickChatSlug } from '../wordlist'
 import { hasStableOccupantIdentity, isNonAnonymousRoom, isPrivateRoom } from '../roomCapabilities'
+import { parseBookmarkItem } from '../bookmarkItem'
 import {
   NS_MUC,
   NS_MUC_USER,
@@ -1389,20 +1390,9 @@ export class MUC extends BaseModule {
       if (!items) return { roomsToAutojoin, allRoomJids }
 
       for (const item of items.getChildren('item')) {
-        // XEP-0402: conference element is directly under item with xmlns="urn:xmpp:bookmarks:1"
-        const conference = item.getChild('conference', NS_BOOKMARKS)
-        if (!conference) continue
-
-        const jid = item.attrs.id // In XEP-0402, the room JID is the item id
-        const name = conference.attrs.name || getLocalPart(jid)
-        const autojoin = conference.attrs.autojoin === '1' || conference.attrs.autojoin === 'true'
-        const nick = conference.getChildText('nick')
-        const password = conference.getChildText('password') || undefined
-
-        // Check for notify extension
-        const extensions = conference.getChild('extensions')
-        const notifyEl = extensions?.getChild('notify', NS_FLUUX)
-        const notifyAll = notifyEl?.getText() === 'all'
+        const parsed = parseBookmarkItem(item)
+        if (!parsed) continue
+        const { jid, name, autojoin, nick, password, notifyAll } = parsed
 
         allRoomJids.push(jid)
 

--- a/packages/fluux-sdk/src/core/modules/PubSub.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.test.ts
@@ -198,6 +198,66 @@ describe('PubSub Module', () => {
     })
   })
 
+  describe('bookmarks (XEP-0402 live sync)', () => {
+    const bookmarkEvent = (from: string, itemsChildren: Array<Record<string, unknown>>) =>
+      createMockElement('message', { from, to: 'user@example.com' }, [
+        {
+          name: 'event',
+          attrs: { xmlns: 'http://jabber.org/protocol/pubsub#event' },
+          children: [
+            { name: 'items', attrs: { node: 'urn:xmpp:bookmarks:1' }, children: itemsChildren },
+          ],
+        },
+      ])
+
+    it('emits room:bookmark when our own account pushes a bookmark notification', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit('stanza', bookmarkEvent('user@example.com', [
+        {
+          name: 'item',
+          attrs: { id: 'room@conference.example.com' },
+          children: [
+            {
+              name: 'conference',
+              attrs: { xmlns: 'urn:xmpp:bookmarks:1', name: 'My Room', autojoin: 'true' },
+              children: [{ name: 'nick', text: 'mynick' }],
+            },
+          ],
+        },
+      ]))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:bookmark', {
+        roomJid: 'room@conference.example.com',
+        bookmark: { name: 'My Room', nick: 'mynick', autojoin: true, password: undefined, notifyAll: false },
+      })
+    })
+
+    it('emits room:bookmark-removed on an incoming bookmark retraction', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit('stanza', bookmarkEvent('user@example.com', [
+        { name: 'retract', attrs: { id: 'room@conference.example.com' } },
+      ]))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:bookmark-removed', { roomJid: 'room@conference.example.com' })
+    })
+
+    it('ignores a bookmark notification spoofed from another account', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit('stanza', bookmarkEvent('attacker@evil.com', [
+        {
+          name: 'item',
+          attrs: { id: 'evil@conference.example.com' },
+          children: [{ name: 'conference', attrs: { xmlns: 'urn:xmpp:bookmarks:1', name: 'Evil' } }],
+        },
+      ]))
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:bookmark', expect.anything())
+    })
+  })
+
   describe('stanza handling', () => {
     it('should return true (handled) for PubSub event messages', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/PubSub.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.ts
@@ -9,6 +9,7 @@
  * Native PEP nodes handled in-place:
  * - XEP-0084: User Avatar (avatar metadata notifications)
  * - XEP-0172: User Nickname
+ * - XEP-0402: PEP Native Bookmarks (live multi-device room-bookmark sync)
  *
  * Additional nodes (crypto, MLS KeyPackages, etc.) are served through the
  * generic {@link PubSub.subscribe} mechanism — callers register a callback
@@ -20,10 +21,11 @@ import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
 import { getBareJid } from '../jid'
-import { NS_PUBSUB, NS_NICK, NS_OPENPGP_PUBLIC_KEYS } from '../namespaces'
+import { NS_PUBSUB, NS_NICK, NS_OPENPGP_PUBLIC_KEYS, NS_BOOKMARKS } from '../namespaces'
 import { generateUUID } from '../../utils/uuid'
 import { dataToElement, elementToData } from '../e2ee/stanzaAdapter'
 import type { PEPItem, Subscription, XMLElementData } from '../e2ee'
+import { parseBookmarkItem } from '../bookmarkItem'
 
 /**
  * Options accepted by {@link PubSub.publish}. These map to XEP-0060
@@ -129,6 +131,13 @@ export class PubSub extends BaseModule {
     // fingerprint doesn't get masked by a stale positive entry either.
     if (node === NS_OPENPGP_PUBLIC_KEYS) {
       this.invalidateOpenPgpKeys(bareFrom)
+    }
+
+    // XEP-0402: PEP Native Bookmarks. A headline here means another of our own
+    // clients added/changed/removed a room bookmark — keep the room list in
+    // sync live instead of only on the next reconnect's fetchBookmarks.
+    if (node === NS_BOOKMARKS) {
+      this.handleBookmarksUpdate(bareFrom, items)
     }
 
     // Dispatch to any user-registered subscribers for (bareFrom, node).
@@ -304,6 +313,42 @@ export class PubSub extends BaseModule {
     if (nick) {
       // SDK event only - binding calls store.updateContact
       this.deps.emitSDK('roster:contact-updated', { jid: bareFrom, updates: { name: nick } })
+    }
+  }
+
+  /**
+   * Handle an XEP-0402 PEP bookmark notification (live multi-device sync).
+   *
+   * Only our OWN account publishes to our bookmarks node, so we ignore events
+   * whose `from` is not our bare JID — this prevents a contact from injecting
+   * rooms into our list. `<item>` children add/update a bookmark (the store's
+   * setBookmark creates the room if we don't have it yet); `<retract>` removes
+   * one.
+   */
+  private handleBookmarksUpdate(bareFrom: string, items: Element): void {
+    const ownBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
+    if (!ownBareJid || bareFrom !== ownBareJid) return
+
+    for (const item of items.getChildren('item')) {
+      const parsed = parseBookmarkItem(item)
+      if (!parsed) continue
+      this.deps.emitSDK('room:bookmark', {
+        roomJid: parsed.jid,
+        bookmark: {
+          name: parsed.name,
+          nick: parsed.nick || 'user',
+          autojoin: parsed.autojoin,
+          password: parsed.password,
+          notifyAll: parsed.notifyAll,
+        },
+      })
+    }
+
+    for (const retract of items.getChildren('retract')) {
+      const roomJid = retract.attrs.id
+      if (roomJid) {
+        this.deps.emitSDK('room:bookmark-removed', { roomJid })
+      }
     }
   }
 

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -747,8 +747,6 @@ export const createMockStores = (): MockStoreBindings => ({
     setEntityCounts: vi.fn(),
     setMucServiceJid: vi.fn(),
     getMucServiceJid: vi.fn().mockReturnValue(null),
-    setMucServiceSupportsMAM: vi.fn(),
-    getMucServiceSupportsMAM: vi.fn().mockReturnValue(null),
     setVhosts: vi.fn(),
     setSelectedVhost: vi.fn(),
     selectedVhost: null,

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -218,8 +218,6 @@ export interface StoreBindings {
     setEntityCounts: (counts: Partial<EntityCounts>) => void
     setMucServiceJid: (jid: string | null) => void
     getMucServiceJid: () => string | null
-    setMucServiceSupportsMAM: (supportsMAM: boolean | null) => void
-    getMucServiceSupportsMAM: () => boolean | null
     // Vhost management
     setVhosts: (vhosts: string[]) => void
     setSelectedVhost: (vhost: string | null) => void

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -212,6 +212,10 @@ export interface RoomEntity {
    *  (XEP-0444), retractions (XEP-0424) or corrections (XEP-0308), so the UI
    *  hides those affordances for these rooms. See issue #228. */
   isIrcGateway?: boolean
+  /** True if the room supports XEP-0425 moderated message retraction
+   *  (`urn:xmpp:message-moderate:1` on the room's disco#info). `undefined` until
+   *  room disco resolves; the moderation affordance shows unless this is `false`. */
+  supportsModeration?: boolean
 
   // Mute control
   /** When true, the room won't bubble up in the sidebar on new messages.
@@ -315,6 +319,9 @@ export interface RoomFeatures {
   /** Room is an IRC gateway channel (Biboumi et al.), detected via a conference/irc
    *  disco#info identity. IRC has no reactions/retractions/corrections concept (see #228) */
   isIrcGateway: boolean
+  /** Room supports XEP-0425 moderated message retraction, advertised as
+   *  `urn:xmpp:message-moderate:1` on the room's own disco#info. */
+  supportsModeration: boolean
   /** Display name from the conference identity, if advertised */
   name?: string
 }

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -576,11 +576,6 @@ export interface AdminEvents {
   'admin:muc-service': {
     mucServiceJid: string
   }
-
-  /** MUC service MAM support discovered */
-  'admin:muc-service-mam': {
-    supportsMAM: boolean
-  }
 }
 
 // ============================================================================

--- a/packages/fluux-sdk/src/stores/adminStore.ts
+++ b/packages/fluux-sdk/src/stores/adminStore.ts
@@ -97,8 +97,6 @@ export interface AdminState {
   userList: EntityListState<AdminUser>
   roomList: EntityListState<AdminRoom>
   mucServiceJid: string | null
-  /** Whether the MUC service advertises MAM support globally (XEP-0313) */
-  mucServiceSupportsMAM: boolean | null
 
   // Actions
   setIsAdmin: (isAdmin: boolean) => void
@@ -123,12 +121,10 @@ export interface AdminState {
   appendRoomList: (items: AdminRoom[], pagination: RSMResponse) => void
   resetRoomList: () => void
   setMucServiceJid: (jid: string | null) => void
-  setMucServiceSupportsMAM: (supportsMAM: boolean | null) => void
 
   // Getters
   getCurrentSession: () => AdminSession | null
   getMucServiceJid: () => string | null
-  getMucServiceSupportsMAM: () => boolean | null
 
   reset: () => void
 }
@@ -159,7 +155,6 @@ const initialState = {
   userList: initialEntityListState<AdminUser>(),
   roomList: initialEntityListState<AdminRoom>(),
   mucServiceJid: null as string | null,
-  mucServiceSupportsMAM: null as boolean | null,
 }
 
 export const adminStore = createStore<AdminState>((set, get) => ({
@@ -231,12 +226,10 @@ export const adminStore = createStore<AdminState>((set, get) => ({
   }),
 
   setMucServiceJid: (jid) => set({ mucServiceJid: jid }),
-  setMucServiceSupportsMAM: (supportsMAM) => set({ mucServiceSupportsMAM: supportsMAM }),
 
   // Getters
   getCurrentSession: () => get().currentSession,
   getMucServiceJid: () => get().mucServiceJid,
-  getMucServiceSupportsMAM: () => get().mucServiceSupportsMAM,
 
   reset: () => set(initialState),
 }))

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -144,6 +144,23 @@ describe('roomStore', () => {
     })
   })
 
+  describe('anonymity flag entity propagation (F6)', () => {
+    it('propagates isNonAnonymous/isPrivate to the room entity on addRoom', () => {
+      roomStore.getState().addRoom({ ...createRoom('r@conference.example.com'), isNonAnonymous: true, isPrivate: false })
+      const entity = roomStore.getState().roomEntities.get('r@conference.example.com')
+      expect(entity?.isNonAnonymous).toBe(true)
+      expect(entity?.isPrivate).toBe(false)
+    })
+
+    it('updates isNonAnonymous/isPrivate on the entity via updateRoom', () => {
+      roomStore.getState().addRoom(createRoom('r@conference.example.com'))
+      roomStore.getState().updateRoom('r@conference.example.com', { isNonAnonymous: true, isPrivate: true })
+      const entity = roomStore.getState().roomEntities.get('r@conference.example.com')
+      expect(entity?.isNonAnonymous).toBe(true)
+      expect(entity?.isPrivate).toBe(true)
+    })
+  })
+
   describe('updateRoom', () => {
     it('should update an existing room', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com', { name: 'Test' }))

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -131,6 +131,19 @@ describe('roomStore', () => {
     })
   })
 
+  describe('supportsModeration entity propagation (F3 / XEP-0425)', () => {
+    it('propagates supportsModeration to the room entity on addRoom', () => {
+      roomStore.getState().addRoom({ ...createRoom('mod@conference.example.com'), supportsModeration: true })
+      expect(roomStore.getState().roomEntities.get('mod@conference.example.com')?.supportsModeration).toBe(true)
+    })
+
+    it('updates supportsModeration on the entity via updateRoom', () => {
+      roomStore.getState().addRoom({ ...createRoom('mod@conference.example.com'), supportsModeration: undefined })
+      roomStore.getState().updateRoom('mod@conference.example.com', { supportsModeration: false })
+      expect(roomStore.getState().roomEntities.get('mod@conference.example.com')?.supportsModeration).toBe(false)
+    })
+  })
+
   describe('updateRoom', () => {
     it('should update an existing room', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com', { name: 'Test' }))

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -501,6 +501,8 @@ export const roomStore = createStore<RoomState>()(
         supportsHats: room.supportsHats,
         supportsModeration: room.supportsModeration,
         isIrcGateway: room.isIrcGateway,
+        isNonAnonymous: room.isNonAnonymous,
+        isPrivate: room.isPrivate,
         muted: room.muted,
       }
       const meta: RoomMetadata = {
@@ -555,7 +557,7 @@ export const roomStore = createStore<RoomState>()(
       // Update entity fields if any changed
       const entityFields = ['name', 'nickname', 'joined', 'isJoining', 'subject', 'avatar',
         'avatarHash', 'avatarFromPresence', 'isBookmarked', 'autojoin', 'password', 'isQuickChat',
-        'supportsMAM', 'supportsReactions', 'supportsHats', 'supportsModeration', 'isIrcGateway', 'muted'] as const
+        'supportsMAM', 'supportsReactions', 'supportsHats', 'supportsModeration', 'isIrcGateway', 'isNonAnonymous', 'isPrivate', 'muted'] as const
       const hasEntityUpdate = entityFields.some((f) => f in update)
 
       // Update metadata fields if any changed
@@ -592,6 +594,8 @@ export const roomStore = createStore<RoomState>()(
             supportsHats: updatedRoom.supportsHats,
             supportsModeration: updatedRoom.supportsModeration,
             isIrcGateway: updatedRoom.isIrcGateway,
+            isNonAnonymous: updatedRoom.isNonAnonymous,
+            isPrivate: updatedRoom.isPrivate,
             muted: updatedRoom.muted,
           })
         }

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -499,6 +499,7 @@ export const roomStore = createStore<RoomState>()(
         supportsMAM: room.supportsMAM,
         supportsReactions: room.supportsReactions,
         supportsHats: room.supportsHats,
+        supportsModeration: room.supportsModeration,
         isIrcGateway: room.isIrcGateway,
         muted: room.muted,
       }
@@ -554,7 +555,7 @@ export const roomStore = createStore<RoomState>()(
       // Update entity fields if any changed
       const entityFields = ['name', 'nickname', 'joined', 'isJoining', 'subject', 'avatar',
         'avatarHash', 'avatarFromPresence', 'isBookmarked', 'autojoin', 'password', 'isQuickChat',
-        'supportsMAM', 'supportsReactions', 'supportsHats', 'isIrcGateway', 'muted'] as const
+        'supportsMAM', 'supportsReactions', 'supportsHats', 'supportsModeration', 'isIrcGateway', 'muted'] as const
       const hasEntityUpdate = entityFields.some((f) => f in update)
 
       // Update metadata fields if any changed
@@ -589,6 +590,7 @@ export const roomStore = createStore<RoomState>()(
             supportsMAM: updatedRoom.supportsMAM,
             supportsReactions: updatedRoom.supportsReactions,
             supportsHats: updatedRoom.supportsHats,
+            supportsModeration: updatedRoom.supportsModeration,
             isIrcGateway: updatedRoom.isIrcGateway,
             muted: updatedRoom.muted,
           })


### PR DESCRIPTION
Four interop/consistency fixes from a Prosody/ejabberd disco audit (verified against real disco logs + the relevant XEP "Discovering support" sections).

**Gate moderation on XEP-0425 room disco support** — gate the MUC moderation affordance on the room's own `urn:xmpp:message-moderate:1` disco support. `supportsModeration` is tri-state: `false` (disco confirmed unsupported) hides the action; `undefined` (disco unresolved) stays optimistic so it doesn't flicker on join. Without this, moderators are shown a "delete for all" action that Prosody — and any server without XEP-0425 — silently rejects. ejabberd rooms that advertise the feature are unaffected.

**Remove dead MUC-service MAM probe** — `discoverMucService` computed a service-level MAM flag (`mucServiceSupportsMAM` / `admin:muc-service-mam` / get+set) that nothing ever read; `queryRoomFeatures` deliberately does not fall back to service MAM (per-room MAM can be disabled independently). Removes the dead event/store/bindings/tests; the used `mucServiceJid` discovery is untouched.

**Live bookmark sync (XEP-0402 +notify)** — Fluux advertises `urn:xmpp:bookmarks:1+notify` but never handled the resulting PEP headlines, so a bookmark added/removed on another device only appeared after the next reconnect. Adds a bookmarks branch in `PubSub.handlePubSubEvent` that emits the existing, tested `room:bookmark` / `room:bookmark-removed` events (guarded to our own bare JID so a contact can't inject rooms). Parsing is shared with `fetchBookmarks` via a new `parseBookmarkItem` helper.

**Write isNonAnonymous/isPrivate to the RoomEntity** — these were declared on the `RoomEntity` type but never written to the entity map, so `roomEntities.get(jid).isNonAnonymous` was always `undefined`. No live bug (consumers read the combined room or fresh disco), but a footgun for any future entity-subscribing consumer of this real-JID-exposure safety field. Completes the entity wiring the moderation change started.