### PR TITLE
feat(console): surface MUC join and invite errors in the XMPP console

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -2663,6 +2663,40 @@ describe('XMPPClient Message', () => {
       })
     })
 
+    it('logs an error event to the XMPP console when an invitation is rejected', async () => {
+      await connectClient()
+
+      const errorStanza = createMockElement('message', {
+        from: 'room@conference.example.com',
+        to: 'user@example.com',
+        type: 'error',
+      }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+          children: [
+            { name: 'invite', attrs: { to: 'target@example.com' } },
+          ],
+        },
+        {
+          name: 'error',
+          attrs: { type: 'auth' },
+          children: [
+            { name: 'forbidden', attrs: { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' } },
+          ],
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', errorStanza)
+
+      // The invitation rejection lands in the exportable console as an error
+      // event (the transient toast alone wouldn't survive in a shared log).
+      const consoleEvent = emitSDKSpy.mock.calls.find((c: unknown[]) => c[0] === 'console:event')
+      expect(consoleEvent?.[1]).toMatchObject({ category: 'error' })
+      expect(consoleEvent?.[1].message).toContain('room@conference.example.com')
+      expect(consoleEvent?.[1].message).toContain('Forbidden')
+    })
+
     it('should not emit room:invite-error for non-invitation errors', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1642,11 +1642,18 @@ export class Chat extends BaseModule {
     const mucUser = stanza.getChild('x', NS_MUC_USER)
     const invite = mucUser?.getChild('invite')
     if (invite) {
+      const reason = formatXMPPError(error)
       this.deps.emitSDK('room:invite-error', {
         roomJid: bareFrom,
-        error: formatXMPPError(error),
+        error: reason,
         condition: error.condition,
         errorType: error.type,
+      })
+      // Surface in the exportable XMPP console as an at-a-glance error event;
+      // the toast is transient and wouldn't survive in a shared log.
+      this.deps.emitSDK('console:event', {
+        message: `MUC invitation to ${bareFrom} rejected: ${reason}`,
+        category: 'error',
       })
       return
     }

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -2159,6 +2159,33 @@ describe('MUC Module', () => {
       await expect(result).rejects.toMatchObject({ condition: 'not-authorized', errorType: 'auth' })
     })
 
+    it('logs an error event to the XMPP console when a join fails', async () => {
+      await muc.joinRoom('room@conference.example.org', 'mynick')
+      const result = muc.joinResult('room@conference.example.org')
+      result.catch(() => {}) // avoid unhandled-rejection noise before we assert
+
+      const errorPresence = createMockElement('presence', {
+        from: 'room@conference.example.org/mynick',
+        type: 'error',
+      }, [
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc' } },
+        {
+          name: 'error',
+          attrs: { type: 'auth' },
+          children: [
+            { name: 'not-authorized', attrs: { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' } },
+          ],
+        },
+      ])
+      muc.handle(errorPresence)
+      await expect(result).rejects.toMatchObject({ condition: 'not-authorized' })
+
+      const consoleEvent = mockEmitSDK.mock.calls.find((c) => c[0] === 'console:event')
+      expect(consoleEvent?.[1]).toMatchObject({ category: 'error' })
+      expect(consoleEvent?.[1].message).toContain('room@conference.example.org')
+      expect(consoleEvent?.[1].message).toContain('Not authorized')
+    })
+
     it('rejects joinResult() with conflict for an error presence carrying no <x>', async () => {
       await muc.joinRoom('room@conference.example.org', 'mynick')
       const result = muc.joinResult('room@conference.example.org')

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -395,7 +395,11 @@ export class MUC extends BaseModule {
    */
   private failJoin(stanza: Element, roomJid: string): void {
     const error = parseXMPPError(stanza)
-    console.error(`[MUC] Room error for ${roomJid}: ${error ? formatXMPPError(error) : 'unknown'}`)
+    const reason = error ? formatXMPPError(error) : 'unknown'
+    console.error(`[MUC] Room error for ${roomJid}: ${reason}`)
+    // Surface in the exportable XMPP console as an at-a-glance error event
+    // (the raw error stanza is already logged, this is the readable summary).
+    this.deps.emitSDK('console:event', { message: `Failed to join ${roomJid}: ${reason}`, category: 'error' })
     this.clearPendingJoin(roomJid) // stops the retry on terminal errors
     this.pendingOccupants.delete(roomJid)
     // SDK event only - binding calls store.updateRoom


### PR DESCRIPTION
Join failures and rejected MUC invitations previously surfaced only as a transient inline error or toast. This emits a `console:event` (category `error`) at the SDK origin for both, so the exportable XMPP console carries an at-a-glance error timeline that survives in a shared log.

- `MUC.failJoin` → `Failed to join <room>: <reason>`
- `Chat.handleErrorMessage` (invite branch) → `MUC invitation to <room> rejected: <reason>`

Reuses the existing `formatXMPPError` summary and the existing `console:event` → `addEvent` binding. The raw error stanzas were already captured by `addPacket`; this adds the human-readable summary on top.