### PR TITLE
fix(e2ee): drop dead BOM-strip regex in detectArmorKind

### DIFF
--- a/apps/fluux/src/e2ee/armorDetect.test.ts
+++ b/apps/fluux/src/e2ee/armorDetect.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { detectArmorKind } from './armorDetect'
 
 describe('detectArmorKind', () => {
+  // A genuine U+FEFF byte-order mark (BOM), the kind text-mode file readers
+  // sometimes prepend. Constructed from its code point so the source stays
+  // all-ASCII and unambiguous. The original bug matched the literal 6-char
+  // text "backslash u F E F F" instead of this single code point.
+  const BOM = String.fromCharCode(0xfeff)
+
   it('detects a Fluux backup (PGP MESSAGE)', () => {
     const armored = `-----BEGIN PGP MESSAGE-----\nVersion: OpenPGP.js\n\nwcDM...\n-----END PGP MESSAGE-----\n`
     expect(detectArmorKind(armored)).toBe('message')
@@ -13,8 +19,16 @@ describe('detectArmorKind', () => {
   })
 
   it('tolerates leading whitespace and BOM', () => {
-    const armored = `\\uFEFF\n   \n-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nlQOY...\n-----END PGP PRIVATE KEY BLOCK-----\n`
+    const armored = `${BOM}\n   \n-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nlQOY...\n-----END PGP PRIVATE KEY BLOCK-----\n`
     expect(detectArmorKind(armored)).toBe('private-key')
+  })
+
+  it('detects a PGP MESSAGE with a real BOM prefix', () => {
+    // Guard the fixture: a mangled or empty BOM would still pass via
+    // trimStart() without ever exercising BOM handling.
+    expect(BOM.charCodeAt(0)).toBe(0xfeff)
+    const armored = `${BOM}-----BEGIN PGP MESSAGE-----\nVersion: OpenPGP.js\n\nwcDM...\n-----END PGP MESSAGE-----\n`
+    expect(detectArmorKind(armored)).toBe('message')
   })
 
   it('returns "unknown" for a public-key block', () => {

--- a/apps/fluux/src/e2ee/armorDetect.ts
+++ b/apps/fluux/src/e2ee/armorDetect.ts
@@ -15,7 +15,10 @@ const PRIVATE_KEY_HEADER = '-----BEGIN PGP PRIVATE KEY BLOCK-----'
 
 export function detectArmorKind(armored: string): ArmorKind {
   if (!armored) return 'unknown'
-  const trimmed = armored.replace(/^\\uFEFF/, '').trimStart()
+  // trimStart() also strips a leading BOM: U+FEFF (ZWNBSP) is an ECMAScript
+  // whitespace code point, so it is removed along with any leading
+  // whitespace/blank lines. No separate BOM-strip step is needed.
+  const trimmed = armored.trimStart()
   if (trimmed.startsWith(MESSAGE_HEADER)) return 'message'
   if (trimmed.startsWith(PRIVATE_KEY_HEADER)) return 'private-key'
   return 'unknown'


### PR DESCRIPTION
## Summary

Removes a dead BOM-strip regex in `detectArmorKind`. The pattern had an extra backslash, so it matched the literal text of a unicode escape instead of an actual U+FEFF byte-order mark; it never fired in practice because `trimStart()` already strips a leading BOM (U+FEFF is an ECMAScript whitespace code point).

`detectArmorKind` now relies on `trimStart()` with an explanatory comment. The existing "tolerates leading whitespace and BOM" test shared the same escaping bug (literal escape text, not a real BOM), so it is fixed to use a genuine BOM, and a new real-BOM "PGP MESSAGE" case is added.