### PR TITLE
fix(a11y): own-message name colour now meets WCAG AA in both themes

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -760,9 +760,9 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     ? (ownNickname || message.from.split('@')[0])
     : (senderContact?.name || message.from.split('@')[0])
 
-  // Get sender color: accent for own messages, contact's pre-calculated color, or fallback to generation
+  // Get sender color: dedicated AA-safe self color for own messages, contact's pre-calculated color, or fallback to generation
   const senderColor = message.isOutgoing
-    ? 'var(--fluux-text-accent)'
+    ? 'var(--fluux-text-self)'
     : senderContact
       ? (isDarkMode ? senderContact.colorDark : senderContact.colorLight) || getConsistentTextColor(message.from.split('/')[0], isDarkMode)
       : getConsistentTextColor(message.from.split('/')[0], isDarkMode)
@@ -796,8 +796,8 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       return fallbackId ? fallbackId.split('@')[0] : 'Unknown'
     },
     (originalMsg, fallbackId, dark) => {
-      // Own messages: use accent color
-      if (originalMsg?.isOutgoing) return 'var(--fluux-text-accent)'
+      // Own messages: use the dedicated AA-safe self color
+      if (originalMsg?.isOutgoing) return 'var(--fluux-text-self)'
       const senderId = originalMsg?.from.split('/')[0] || fallbackId?.split('/')[0]
       if (!senderId) return 'var(--fluux-brand)'
       const contact = contactsByJid.get(senderId)

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1186,9 +1186,9 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
 
   const contact = senderBareJid ? contactsByJid.get(senderBareJid) : undefined
 
-  // Get sender color: accent for own messages, contact's pre-calculated color, or fallback to nick-based generation
+  // Get sender color: dedicated AA-safe self color for own messages, contact's pre-calculated color, or fallback to nick-based generation
   const senderColor = message.isOutgoing
-    ? 'var(--fluux-text-accent)'
+    ? 'var(--fluux-text-self)'
     : resolveSenderColor(resolvedSenderName, contact, isDarkMode ?? true)
 
   // Get my current reactions to this message (room — uses nick)
@@ -1230,8 +1230,8 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
       return fallbackId ? fallbackId.split('/').pop() || 'Unknown' : 'Unknown'
     },
     (originalMsg, fallbackId, dark) => {
-      // Own messages: use accent color
-      if (originalMsg?.isOutgoing) return 'var(--fluux-text-accent)'
+      // Own messages: use the dedicated AA-safe self color
+      if (originalMsg?.isOutgoing) return 'var(--fluux-text-self)'
       const nick = originalMsg?.nick || (fallbackId ? fallbackId.split('/').pop() : undefined)
       if (!nick) return 'var(--fluux-brand)'
       // Same contact-color preference as the main senderColor above, so the

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -416,7 +416,7 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
       // Check if it's own message
       if (roomMsg.isOutgoing) {
         senderName = ownNickname || roomMsg.nick
-        senderColor = 'var(--fluux-text-accent)'
+        senderColor = 'var(--fluux-text-self)'
         avatarUrl = ownAvatar || undefined
       }
     } else {
@@ -425,7 +425,7 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
         ? (ownNickname || msg.from.split('@')[0])
         : (contact?.name || msg.from.split('@')[0])
       senderColor = msg.isOutgoing
-        ? 'var(--fluux-text-accent)'
+        ? 'var(--fluux-text-self)'
         : contact
           ? (isDarkMode ? contact.colorDark : contact.colorLight) || getConsistentTextColor(msg.from.split('/')[0], isDarkMode)
           : getConsistentTextColor(msg.from.split('/')[0], isDarkMode)
@@ -447,7 +447,7 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
         return fallbackId ? fallbackId.split('@')[0] : 'Unknown'
       },
       (originalMsg, fallbackId, dark) => {
-        if (originalMsg?.isOutgoing) return 'var(--fluux-text-accent)'
+        if (originalMsg?.isOutgoing) return 'var(--fluux-text-self)'
         const senderId = originalMsg?.from.split('/')[0] || fallbackId?.split('/')[0]
         if (!senderId) return 'var(--fluux-brand)'
         const contact = contactsByJid.get(senderId)

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -371,7 +371,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       >
                         <span
                           class="font-medium"
-                          style="color: var(--fluux-text-accent);"
+                          style="color: var(--fluux-text-self);"
                         >
                           Me
                         </span>

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -136,6 +136,11 @@
   --fluux-text-on-accent: #ffffff;
   --fluux-text-accent: var(--fluux-bg-accent);
   --fluux-text-link: var(--fluux-color-blue);
+  /* Own-message ("you") name. The raw brand accent (hsl 235 86% 65%) only
+     reaches ~2.8:1 on the dark message background, so a dedicated brand-indigo
+     value is used, tuned to clear WCAG AA on both the resting and hover message
+     backgrounds. Dark default here; .light overrides below. */
+  --fluux-text-self: #a5b4fc;
 
   /* Status (named by purpose, not color) */
   --fluux-status-success: var(--fluux-color-green);
@@ -308,6 +313,11 @@
   --fluux-color-blue: #0969da;
   --fluux-color-blue-rgb: 9, 105, 218;
   --fluux-color-gray: #9ca3af;
+
+  /* Own-message ("you") name — brand-indigo darkened for WCAG AA on the white
+     message background and its hover state (the raw accent only reached ~4.6:1
+     at rest and failed on hover). */
+  --fluux-text-self: #4f46e5;
 
   /* Private (whisper) — deeper violet for contrast on light backgrounds */
   --fluux-private: hsl(270, 70%, 48%);

--- a/docs/UX_REVIEW.md
+++ b/docs/UX_REVIEW.md
@@ -263,8 +263,8 @@ specific gaps:
 
 | #    | Issue                                                                                                                                    | Recommendation                                                     | Sev | Eff |
 |------|------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|-----|-----|
-| 13.1 | **The composer's "Message Emma Wilson" placeholder looks slightly disabled** — its grey-on-light contrast is borderline against WCAG AA. | Bump placeholder colour to meet 4.5:1 (currently appears ≈ 3.5:1). | M   | S   |
-| 13.2 | The "you" name colour (blue) and "Emma Wilson" name colour (pink) have **lower contrast in light theme** than dark.                      | Verify both pass AA at 16 px regular weight; deepen if not.        | L   | S   |
+| 13.1 | ✅ **Resolved (already passes AA).** The composer placeholder uses `text-fluux-muted` = `#4a4d54` in light, rendered on the `bg-fluux-hover` input bar (`#dcdee3`) = **6.29:1**, above the 4.5:1 AA threshold. The original "≈3.5:1" estimate matched the lighter `text-faint` (`#80848e`, 3.74:1 on white), a token the composer does not use. | Verified — `MessageComposer.tsx:38` (`placeholder:text-fluux-muted`); light tokens at `index.css:303,299`. | M   | S   |
+| 13.2 | ✅ **Resolved.** Peer names (e.g. pink "Emma Wilson") use HSLuv consistent colour (perceptually-uniform `L=35` light / `L=65` dark) = **7.78:1 light / 4.70:1 dark** — AA-clear in both themes; the review's "lower contrast in light" was **inverted** (light is the higher-contrast theme). The real failure was the **"you"** own-message name, which reused the raw brand accent (`hsl(235 86% 65%)`) and failed AA in 3 of 4 states (light-hover 3.38:1, dark 2.78/2.62:1; light-rest only 4.55:1). Fixed with a dedicated, theme-tuned `--fluux-text-self` (brand-indigo `#4f46e5` light / `#a5b4fc` dark) = ≥4.6:1 on rest **and** hover in both themes. | Shipped — `index.css:143,320`; own-message sites `ChatView.tsx:765,800`, `RoomView.tsx:1191,1234`, `SearchContextView.tsx:419,428,450`. | L   | S   |
 
 ---
 
@@ -362,7 +362,7 @@ A copy-paste checklist for triage. Severity in brackets.
 [x] [M] Server (optional) auto-expand on connection failure — §1.2 (auto-expand shipped; Cmd+, hint still not surfaced)
 [ ] [M] Auto-expand Settings search when categories > 6 — §7.4
 [ ] [M] Differentiate "Block user" from "Remove from contacts" — §6.4
-[ ] [M] Light-theme placeholder + name colours WCAG AA pass — §13.1, §13.2
+[x] [M] Light-theme placeholder + name colours WCAG AA pass — §13.1, §13.2 (§13.1 verified passing at 6.29:1; §13.2 "you" name fixed via AA-safe --fluux-text-self, peer names already passed)
 [x] [M] Settings: "Web Push · Not supported" needs context or hide — §7.1
 [x] [M] Conversation list: move unread badge onto avatar — §3.1
 [ ] [M] Surface ⌘K shortcut in chrome — §11.1


### PR DESCRIPTION
## Summary

The "you" own-message name reused the brand accent (`hsl(235 86% 65%)`), a UI fill colour, as body text and failed WCAG AA on most message backgrounds (light-hover 3.38:1, dark 2.78/2.62:1; light-rest only 4.55:1).

This adds a dedicated, theme-tuned `--fluux-text-self` token (brand-indigo `#4f46e5` light / `#a5b4fc` dark, ≥4.6:1 on both rest and hover) and repoints the seven own-message-name sites (ChatView, RoomView, SearchContextView) to it.

Peer names (HSLuv consistent colour) already pass AA in both themes; the review's "pink lower in light" claim was inverted. Also marks UX_REVIEW §13.1 (composer placeholder) verified passing at 6.29:1, no code change needed there.

Resolves UX_REVIEW §13.1 and §13.2.