### PR TITLE
fix: link-preview "Show image" control no longer opens the link

### DIFF
--- a/apps/fluux/src/components/LinkPreviewCard.test.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.test.tsx
@@ -105,9 +105,10 @@ describe('LinkPreviewCard image deferral', () => {
         <LinkPreviewCard preview={preview} />
       </MediaAutoloadProvider>,
     )
-    expect(screen.getByText('T')).toBeInTheDocument()            // text still renders
     expect(container.querySelector('img')).toBeNull()            // OG image suppressed
-    expect(screen.getByRole('button')).toBeInTheDocument()       // the "show image" control
+    const control = screen.getByRole('button')                   // the "show image" control
+    expect(control).toBeInTheDocument()
+    expect(control).toHaveTextContent('T')                       // shows the link title
   })
 
   it('shows the image after tapping the control', () => {

--- a/apps/fluux/src/components/LinkPreviewCard.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.tsx
@@ -97,10 +97,13 @@ export function LinkPreviewCard({ preview, onLoad }: LinkPreviewCardProps) {
           tabIndex={0}
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); approveImage() }}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); approveImage() } }}
-          className="aspect-video bg-fluux-hover/60 hover:bg-fluux-hover flex flex-col items-center justify-center gap-2 text-fluux-muted transition-colors cursor-pointer"
+          className="aspect-video bg-fluux-hover/60 hover:bg-fluux-hover flex flex-col items-center justify-center gap-1.5 px-4 text-center text-fluux-muted transition-colors cursor-pointer"
         >
           <ImageIcon className="size-6" aria-hidden="true" />
           <span className="text-sm font-medium">{t('chat.showLinkImage')}</span>
+          {preview.title && (
+            <span className="text-xs line-clamp-2">{preview.title}</span>
+          )}
         </div>
       )}
 

--- a/apps/fluux/src/utils/externalLinkHandler.test.ts
+++ b/apps/fluux/src/utils/externalLinkHandler.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The handler dynamically imports the Tauri shell plugin; capture the mock.
+const openMock = vi.hoisted(() => vi.fn())
+vi.mock('@tauri-apps/plugin-shell', () => ({ open: openMock }))
+// Force the Tauri branch so the handler actually registers.
+vi.mock('./tauri', () => ({ isTauri: () => true }))
+
+import { setupExternalLinkHandler } from './externalLinkHandler'
+
+function click(el: Element) {
+  el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+}
+
+describe('setupExternalLinkHandler', () => {
+  let cleanup: (() => void) | undefined
+
+  beforeEach(() => {
+    openMock.mockClear()
+    cleanup = setupExternalLinkHandler()
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    document.body.innerHTML = ''
+  })
+
+  it('opens an external link in the system browser', async () => {
+    document.body.innerHTML = '<a href="https://example.com/x">link text</a>'
+    click(document.querySelector('a')!)
+    await vi.waitFor(() => expect(openMock).toHaveBeenCalledWith('https://example.com/x'))
+  })
+
+  it('opens when clicking non-interactive content inside the link', async () => {
+    document.body.innerHTML = '<a href="https://example.com/y"><span>inner</span></a>'
+    click(document.querySelector('span')!)
+    await vi.waitFor(() => expect(openMock).toHaveBeenCalledWith('https://example.com/y'))
+  })
+
+  it('does NOT open when the click lands on a <button> nested in the link', async () => {
+    document.body.innerHTML = '<a href="https://example.com/z"><button type="button">go</button></a>'
+    const btn = document.querySelector('button')!
+    // The control handles its own click (as the real React component does),
+    // so the anchor never navigates.
+    btn.addEventListener('click', (e) => e.preventDefault())
+    click(btn)
+    await Promise.resolve()
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT open when the click lands on a role="button" control nested in the link (deferred media)', async () => {
+    document.body.innerHTML = '<a href="https://example.com/w"><div role="button">Show image</div></a>'
+    const control = document.querySelector('[role="button"]')!
+    control.addEventListener('click', (e) => e.preventDefault())
+    click(control)
+    await Promise.resolve()
+    expect(openMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/utils/externalLinkHandler.ts
+++ b/apps/fluux/src/utils/externalLinkHandler.ts
@@ -29,8 +29,17 @@ export function setupExternalLinkHandler(): (() => void) | undefined {
   if (!isTauri()) return undefined
 
   const handler = (event: MouseEvent) => {
-    const anchor = (event.target as Element)?.closest?.('a')
+    const target = event.target as Element | null
+    const anchor = target?.closest?.('a')
     if (!anchor) return
+
+    // A click on an interactive control nested inside the link (e.g. the
+    // "Show image" button in a deferred link-preview card) belongs to that
+    // control, not the link — let it handle the click instead of navigating.
+    // This handler runs in the capture phase, so the nested control's own
+    // preventDefault/stopPropagation cannot stop it; this guard is what does.
+    const interactive = target?.closest?.('button, [role="button"]')
+    if (interactive && anchor.contains(interactive)) return
 
     const href = anchor.getAttribute('href')
     if (!href) return


### PR DESCRIPTION
Follow-up to #570 (issue #36), on the deferred link-preview image control.

**Bug fix — clicking "Show image" opened the link.** The Tauri external-link handler (`externalLinkHandler.ts`) listens on `document` in the **capture phase**, so it intercepted the click on the control (a `div[role="button"]` nested inside the preview card's `<a>`) and navigated before the control's React `onClick` could `preventDefault`. The handler now skips when a click lands on a `button`/`[role="button"]` nested inside the link, letting the control handle it. Adds a regression test.

**Enhancement — show the link title in the control.** The deferred placeholder now also shows the link's title (`preview.title`), so you can tell what the hidden image belongs to before loading it.