### PR TITLE
test: speed up the JS and Rust test cycles

### DIFF
--- a/apps/fluux/src-tauri/src/openpgp_storage.rs
+++ b/apps/fluux/src-tauri/src/openpgp_storage.rs
@@ -59,7 +59,7 @@ use sequoia_openpgp::{
     packet::{key, Key, Packet},
     parse::Parse,
     serialize::SerializeInto,
-    types::{AEADAlgorithm, SymmetricAlgorithm},
+    types::{AEADAlgorithm, HashAlgorithm, SymmetricAlgorithm},
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -104,6 +104,12 @@ pub struct KeyStorage {
     /// passphrase file. Intended for unit tests: unit tests on macOS would
     /// otherwise pop a keychain authorization dialog.
     use_keychain: bool,
+    /// Argon2id cost override for the v6 at-rest KDF. `None` (production)
+    /// uses the RFC 9106 §4 second-option policy with a serial fallback;
+    /// `Some(_)` forces exactly those parameters. Set only by the test
+    /// constructors, which choose deliberately cheap costs so the suite
+    /// isn't dominated by a memory-hard KDF unrelated to what's under test.
+    argon2_override: Option<Argon2Params>,
 }
 
 impl KeyStorage {
@@ -113,17 +119,34 @@ impl KeyStorage {
         Self {
             base_dir,
             use_keychain: true,
+            argon2_override: None,
         }
     }
 
     /// Test-only constructor that skips the keychain (CI would otherwise
     /// fail on machines without a configured keychain, and developer
-    /// machines would pop up a macOS authorization dialog).
+    /// machines would pop up a macOS authorization dialog). Also forces the
+    /// cheap Argon2 cost so the ~200 crypto unit tests aren't dominated by a
+    /// memory-hard KDF; production cost is covered by the two tests that use
+    /// [`for_testing_production_kdf`].
     #[cfg(test)]
     pub fn for_testing(base_dir: PathBuf) -> Self {
         Self {
             base_dir,
             use_keychain: false,
+            argon2_override: Some(Argon2Params::CHEAP_FOR_TESTS),
+        }
+    }
+
+    /// Test-only constructor with the **production** Argon2 cost (no cheap
+    /// override) but still keychain-free. Used only by the tests that assert
+    /// the real RFC 9106 §4 parameters reach disk.
+    #[cfg(test)]
+    pub fn for_testing_production_kdf(base_dir: PathBuf) -> Self {
+        Self {
+            base_dir,
+            use_keychain: false,
+            argon2_override: None,
         }
     }
 
@@ -168,7 +191,7 @@ impl KeyStorage {
         let passphrase = random_passphrase()?;
         let backing = self.write_passphrase(jid, &passphrase)?;
         let password = Password::from(passphrase);
-        let encrypted = encrypt_cert_secrets(cert.clone(), &password)?;
+        let encrypted = encrypt_cert_secrets(cert.clone(), &password, self.argon2_override)?;
         let armored = encrypted
             .as_tsk()
             .armored()
@@ -367,6 +390,14 @@ impl Argon2Params {
     /// Serial fallback: if `p > 1` isn't accepted by the runtime, drop
     /// to `p = 1` and bump `t` so the defender does comparable work.
     pub const SERIAL_FALLBACK: Argon2Params = Argon2Params { t: 4, p: 1, m: 16 };
+
+    /// Deliberately minimal cost for unit tests only: `m = 2^10 KiB = 1 MiB`,
+    /// `t = 1`, `p = 1`. Still exercises the full Argon2id S2K + AES-256-OCB
+    /// wrap/unwrap round-trip, but ~200× cheaper than the production cost, so
+    /// the OpenPGP suite isn't bottlenecked on a memory-hard KDF. Never used
+    /// outside `#[cfg(test)]`.
+    #[cfg(test)]
+    pub const CHEAP_FOR_TESTS: Argon2Params = Argon2Params { t: 1, p: 1, m: 10 };
 }
 
 /// Records which Argon2 variant actually produced usable ciphertext the
@@ -422,15 +453,27 @@ fn make_argon2_s2k(params: Argon2Params) -> Result<S2K> {
 /// [`sequoia_openpgp::Profile::RFC9580`], but may still be loaded once
 /// from a pre-v6 install — fall back to the default Iterated+Salted S2K
 /// + CFB path. Argon2 S2K is not valid on v4 keys.
-fn encrypt_cert_secrets(cert: Cert, password: &Password) -> Result<Cert> {
+fn encrypt_cert_secrets(
+    cert: Cert,
+    password: &Password,
+    override_params: Option<Argon2Params>,
+) -> Result<Cert> {
     let mut packets: Vec<Packet> = Vec::new();
     for packet in cert.into_tsk().into_packets() {
         match packet {
             Packet::SecretKey(key) => {
-                packets.push(Packet::SecretKey(encrypt_key_secret(key, password)?));
+                packets.push(Packet::SecretKey(encrypt_key_secret(
+                    key,
+                    password,
+                    override_params,
+                )?));
             }
             Packet::SecretSubkey(key) => {
-                packets.push(Packet::SecretSubkey(encrypt_key_secret(key, password)?));
+                packets.push(Packet::SecretSubkey(encrypt_key_secret(
+                    key,
+                    password,
+                    override_params,
+                )?));
             }
             other => packets.push(other),
         }
@@ -443,12 +486,20 @@ fn encrypt_cert_secrets(cert: Cert, password: &Password) -> Result<Cert> {
 fn encrypt_key_secret<R>(
     key: Key<key::SecretParts, R>,
     password: &Password,
+    override_params: Option<Argon2Params>,
 ) -> Result<Key<key::SecretParts, R>>
 where
     R: key::KeyRole,
 {
     if key.version() >= 6 {
-        encrypt_v6_with_argon2(key, password)
+        encrypt_v6_with_argon2(key, password, override_params)
+    } else if override_params.is_some() {
+        // Test override: v4 keys take the classic Iterated+Salted S2K branch,
+        // whose sequoia default is the maximum OpenPGP iteration count
+        // (~65 MiB of SHA-256), run per packet on every save and load.
+        // Substitute a minimal count so the suite isn't dominated by the
+        // at-rest KDF. Production v4 keeps the default below.
+        encrypt_v4_with_cheap_s2k(key, password)
     } else {
         // RFC 9580 §3.7 restricts Argon2 to v6. Keep classic S2K for any
         // lingering v4 key — we don't generate v4 keys any more, but a
@@ -456,6 +507,27 @@ where
         key.encrypt_secret(password)
             .context("encrypt v4 secret key with default S2K")
     }
+}
+
+/// Test-only fast path for v4 secret packets. Mirrors the classic CFB +
+/// Iterated S2K protection that sequoia's default `encrypt_secret` produces,
+/// but with the minimal iteration count (the default is the maximum the
+/// format allows). Only reached when a [`KeyStorage`] carries an Argon2
+/// override — i.e. from the test constructors.
+fn encrypt_v4_with_cheap_s2k<R>(
+    key: Key<key::SecretParts, R>,
+    password: &Password,
+) -> Result<Key<key::SecretParts, R>>
+where
+    R: key::KeyRole,
+{
+    let s2k = S2K::new_iterated(HashAlgorithm::SHA256, 1024).context("build cheap test S2K")?;
+    let (pub_key, mut secret) = key.take_secret();
+    secret
+        .encrypt_in_place_with(&pub_key, s2k, SymmetricAlgorithm::AES256, None, password)
+        .context("encrypt v4 secret with cheap test S2K")?;
+    let (out, _) = pub_key.add_secret(secret);
+    Ok(out)
 }
 
 /// Try to wrap a v6 secret packet with Argon2id+OCB under our primary
@@ -466,10 +538,19 @@ where
 fn encrypt_v6_with_argon2<R>(
     key: Key<key::SecretParts, R>,
     password: &Password,
+    override_params: Option<Argon2Params>,
 ) -> Result<Key<key::SecretParts, R>>
 where
     R: key::KeyRole,
 {
+    // Test-only override: wrap with exactly the supplied (cheap) parameters,
+    // bypassing the production primary→fallback selection and its
+    // process-global variant recording (only meaningful for the real KDF
+    // policy). Production callers pass `None`.
+    if let Some(params) = override_params {
+        return attempt_argon2_encrypt(key, password, params);
+    }
+
     let primary_err =
         match attempt_argon2_encrypt(key.clone(), password, Argon2Params::RFC9106_SECOND_OPTION) {
             Ok(out) => {
@@ -911,7 +992,7 @@ mod tests {
     #[test]
     fn persisted_tsk_uses_argon2id_with_rfc9106_second_option() {
         let dir = fresh_tmp_dir();
-        let storage = KeyStorage::for_testing(dir.clone());
+        let storage = KeyStorage::for_testing_production_kdf(dir.clone());
         let cert = generate_cert("alice@example.com");
         storage.save("alice@example.com", &cert).unwrap();
 
@@ -949,6 +1030,76 @@ mod tests {
                 SymmetricAlgorithm::AES256,
                 "symmetric cipher must be AES-256"
             );
+        }
+    }
+
+    /// The fast path that keeps the ~200 OpenPGP unit tests cheap:
+    /// `KeyStorage::for_testing()` must wrap secret packets with the
+    /// minimal Argon2 cost parameters, NOT the 64 MiB RFC 9106 production
+    /// cost. Without this, every save/load runs a memory-hard KDF that has
+    /// nothing to do with the behaviour under test, costing tens of seconds
+    /// per test. Production cost is asserted separately by
+    /// `persisted_tsk_uses_argon2id_with_rfc9106_second_option`.
+    #[test]
+    fn for_testing_storage_uses_cheap_argon2_params() {
+        let dir = fresh_tmp_dir();
+        let storage = KeyStorage::for_testing(dir.clone());
+        let cert = generate_cert("alice@example.com");
+        storage.save("alice@example.com", &cert).unwrap();
+
+        let tsk_path = dir
+            .join("openpgp")
+            .join(format!("{}.tsk.asc", sanitize_jid("alice@example.com")));
+        let parts = inspect_on_disk_s2k(&tsk_path);
+        assert!(
+            !parts.is_empty(),
+            "expected at least one encrypted secret packet"
+        );
+        for (s2k, _aead, _symm) in parts {
+            match s2k {
+                S2K::Argon2 { t, p, m, .. } => {
+                    assert_eq!(
+                        (t, p, m),
+                        (1, 1, 10),
+                        "for_testing must use cheap Argon2 (m=2^10 KiB = 1 MiB, t=1, p=1)"
+                    );
+                }
+                other => panic!("expected Argon2 S2K on v6 secret, got {other:?}"),
+            }
+        }
+    }
+
+    /// The same fast path for v4 keys: with `USE_V6_KEYS = false` the openpgp
+    /// tests generate v4 certs, which take the classic Iterated+Salted S2K
+    /// branch (not Argon2). Sequoia's default there is the *maximum* OpenPGP
+    /// iteration count (~65 MiB of SHA-256 per packet), so `for_testing` must
+    /// substitute a minimal count or the v4 save/load tests dominate the suite.
+    #[test]
+    fn for_testing_storage_uses_cheap_classic_s2k_for_v4() {
+        let dir = fresh_tmp_dir();
+        let storage = KeyStorage::for_testing(dir.clone());
+        let cert = generate_v4_cert("legacy@example.com");
+        storage.save("legacy@example.com", &cert).unwrap();
+
+        let tsk_path = dir
+            .join("openpgp")
+            .join(format!("{}.tsk.asc", sanitize_jid("legacy@example.com")));
+        let parts = inspect_on_disk_s2k(&tsk_path);
+        assert!(
+            !parts.is_empty(),
+            "expected at least one encrypted secret packet"
+        );
+        for (s2k, _aead, _symm) in parts {
+            match s2k {
+                S2K::Iterated { hash_bytes, .. } => {
+                    assert!(
+                        hash_bytes <= 100_000,
+                        "for_testing v4 must use a cheap Iterated S2K; got hash_bytes={hash_bytes} \
+                         (sequoia's default is 0x3e00000 = 65_011_712)"
+                    );
+                }
+                other => panic!("expected Iterated S2K on v4 secret, got {other:?}"),
+            }
         }
     }
 
@@ -1043,7 +1194,7 @@ mod tests {
     #[test]
     fn argon2_variant_records_primary_choice_after_first_encrypt() {
         let dir = fresh_tmp_dir();
-        let storage = KeyStorage::for_testing(dir);
+        let storage = KeyStorage::for_testing_production_kdf(dir);
         let cert = generate_cert("alice@example.com");
         storage.save("alice@example.com", &cert).unwrap();
 

--- a/apps/fluux/src/components/Avatar.test.tsx
+++ b/apps/fluux/src/components/Avatar.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Pinned to jsdom: this file checks inline color/gradient styles whose serialization
+ * differs between DOM environments (jsdom normalizes #hex to rgb(); happy-dom, the
+ * default env, keeps the literal). These assertions/snapshots only hold under jsdom.
+ */
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { Avatar, getConsistentTextColor } from './Avatar'

--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Pinned to jsdom: this file checks inline color/gradient styles whose serialization
+ * differs between DOM environments (jsdom normalizes #hex to rgb(); happy-dom, the
+ * default env, keeps the literal). These assertions/snapshots only hold under jsdom.
+ */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Pinned to jsdom: this file checks inline color/gradient styles whose serialization
+ * differs between DOM environments (jsdom normalizes #hex to rgb(); happy-dom, the
+ * default env, keeps the literal). These assertions/snapshots only hold under jsdom.
+ */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'

--- a/apps/fluux/src/components/conversation/CollapsibleContent.test.tsx
+++ b/apps/fluux/src/components/conversation/CollapsibleContent.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Pinned to jsdom: this file checks inline color/gradient styles whose serialization
+ * differs between DOM environments (jsdom normalizes #hex to rgb(); happy-dom, the
+ * default env, keeps the literal). These assertions/snapshots only hold under jsdom.
+ */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { CollapsibleContent } from './CollapsibleContent'

--- a/apps/fluux/vitest.config.ts
+++ b/apps/fluux/vitest.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: 'jsdom',
+    // Default DOM environment. happy-dom is ~2x faster to construct than jsdom; tests that
+    // need jsdom-specific behavior opt back in per-file with `// @vitest-environment jsdom`.
+    environment: 'happy-dom',
     silent: true,
     setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:sdk": "npm run build -w @fluux/sdk",
     "build:app": "npm run build -w @xmpp/fluux",
     "test": "npm run test:run --workspaces --if-present",
+    "test:parallel": "node scripts/test-parallel.mjs",
     "test:coverage": "npm run test:coverage --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",

--- a/scripts/test-affected.sh
+++ b/scripts/test-affected.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Run only the tests affected by a set of changes, scoped to the right workspace.
+#
+# The full suite (`npm test`) runs ~7,300 tests across two workspaces (~70s). During
+# iteration you rarely need all of them: this routes changed files to their workspace
+# and runs `vitest related`, which selects exactly the test files that import each
+# changed module (its reverse-dependency graph).
+#
+# Usage:
+#   scripts/test-affected.sh                       # tests affected by uncommitted changes
+#   scripts/test-affected.sh <ref>                 # ...by changes since <ref> (e.g. main, HEAD~1)
+#   scripts/test-affected.sh <file> [<file>...]    # ...related to specific source/test files
+#
+# Notes:
+#   - Each workspace is run from its own directory (never bare from the repo root),
+#     so the `@/` and `@fluux/sdk` path aliases resolve correctly.
+#   - Changing a low-level module (a store or shared util) has a large reverse-dependency
+#     fan-in, so `related` will select most of that workspace. That is expected and correct;
+#     the win is largest for leaf modules (components, isolated utils).
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SDK_DIR="$ROOT/packages/fluux-sdk"
+APP_DIR="$ROOT/apps/fluux"
+
+# --- Collect the changed file list --------------------------------------------------
+
+changed=()
+if [ "$#" -gt 0 ] && [ -e "$1" ]; then
+  # Explicit file list
+  changed=("$@")
+else
+  # Git mode: changes vs a ref (default HEAD), plus untracked files
+  ref="${1:-HEAD}"
+  while IFS= read -r f; do [ -n "$f" ] && changed+=("$ROOT/$f"); done < <(
+    git -C "$ROOT" diff --name-only "$ref"
+    git -C "$ROOT" ls-files --others --exclude-standard
+  )
+fi
+
+# --- Route each file to its workspace -----------------------------------------------
+
+sdk_files=()
+app_files=()
+for f in "${changed[@]}"; do
+  # Skip anything that no longer exists (e.g. deletions) or isn't a TS/TSX source.
+  [ -f "$f" ] || continue
+  case "$f" in
+    *.ts | *.tsx) ;;
+    *) continue ;;
+  esac
+  abs="$(cd "$(dirname "$f")" && pwd)/$(basename "$f")"
+  case "$abs" in
+    "$SDK_DIR"/src/*) sdk_files+=("${abs#"$SDK_DIR"/}") ;;
+    "$APP_DIR"/src/*) app_files+=("${abs#"$APP_DIR"/}") ;;
+    *) echo "  (skipping non-test-source change: ${abs#"$ROOT"/})" ;;
+  esac
+done
+
+if [ "${#sdk_files[@]}" -eq 0 ] && [ "${#app_files[@]}" -eq 0 ]; then
+  echo "No changed test sources detected — nothing to run."
+  echo "(For a full run before committing, use: npm test)"
+  exit 0
+fi
+
+# --- Run vitest related, per affected workspace -------------------------------------
+
+status=0
+run_ws() {
+  local name="$1" dir="$2"; shift 2
+  echo ""
+  echo "▶ ${name}: vitest related $*"
+  ( cd "$dir" && npx vitest related "$@" --run --passWithNoTests ) || status=1
+}
+
+[ "${#sdk_files[@]}" -gt 0 ] && run_ws "@fluux/sdk" "$SDK_DIR" "${sdk_files[@]}"
+[ "${#app_files[@]}" -gt 0 ] && run_ws "@xmpp/fluux" "$APP_DIR" "${app_files[@]}"
+
+exit "$status"

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+//
+// Run both workspace test suites concurrently instead of in series.
+//
+// `npm test` runs the workspaces sequentially (SDK then app) — safe everywhere, and the
+// default CI gate. On a multi-core dev machine the two suites can overlap: this runs them
+// at the same time and reports a combined PASS/FAIL plus wall-clock time.
+//
+// Output from each workspace is line-prefixed ([sdk] / [app]) so the interleaved streams
+// stay readable. Exit code is non-zero if either workspace fails.
+//
+import { spawn } from 'node:child_process'
+
+const targets = [
+  { tag: 'sdk', args: ['run', 'test:run', '-w', '@fluux/sdk'] },
+  { tag: 'app', args: ['run', 'test:run', '-w', '@xmpp/fluux'] },
+]
+
+function run({ tag, args }) {
+  return new Promise((resolve) => {
+    const child = spawn('npm', args, { shell: process.platform === 'win32' })
+    const forward = (stream, out) => {
+      let buf = ''
+      stream.on('data', (chunk) => {
+        buf += chunk.toString()
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
+        for (const line of lines) out.write(`[${tag}] ${line}\n`)
+      })
+      stream.on('end', () => {
+        if (buf) out.write(`[${tag}] ${buf}\n`)
+      })
+    }
+    forward(child.stdout, process.stdout)
+    forward(child.stderr, process.stderr)
+    child.on('error', (err) => {
+      process.stderr.write(`[${tag}] failed to spawn: ${err.message}\n`)
+      resolve({ tag, code: 1 })
+    })
+    child.on('close', (code) => resolve({ tag, code: code ?? 1 }))
+  })
+}
+
+const start = Date.now()
+const results = await Promise.all(targets.map(run))
+const seconds = ((Date.now() - start) / 1000).toFixed(1)
+
+const bar = '='.repeat(48)
+process.stdout.write(`\n${bar}\n`)
+for (const r of results) {
+  process.stdout.write(`  ${r.tag.padEnd(4)} ${r.code === 0 ? 'PASS' : `FAIL (exit ${r.code})`}\n`)
+}
+process.stdout.write(`  wall time: ${seconds}s\n${bar}\n`)
+
+process.exit(results.some((r) => r.code !== 0) ? 1 : 0)


### PR DESCRIPTION
## Summary

Speeds up the developer test cycle in both workspaces.

**JS (`apps/fluux` + `packages/fluux-sdk`)**
- `scripts/test-affected.sh` — inner-loop runner that selects only the tests related to changed files (`vitest related`, routed to the right workspace).
- `scripts/test-parallel.mjs` + `npm run test:parallel` — run both workspaces concurrently.
- App vitest environment jsdom → happy-dom (~23% faster app suite). The four files that assert `rgb()`-serialized inline colors are pinned back to jsdom via `@vitest-environment` (jsdom normalizes `#hex`→`rgb()`, happy-dom keeps the literal).

**Rust (`apps/fluux/src-tauri`)**
- OpenPGP key-storage tests paid the production at-rest KDF on every save/load (64 MiB Argon2id for v6, sequoia's max-count classic S2K for v4). A test-only KDF override on `KeyStorage` cuts the full Rust suite from ~100s to ~19s. Production is unchanged — `new()` keeps the real parameters and two tests still assert RFC 9106.