### PR TITLE
Add overflow (kebab) menu to 1:1 chat header

### DIFF
--- a/apps/fluux/src/components/ChatHeader.test.tsx
+++ b/apps/fluux/src/components/ChatHeader.test.tsx
@@ -311,4 +311,101 @@ describe('ChatHeader', () => {
       expect(header).toHaveAttribute('data-tauri-drag-region', 'true')
     })
   })
+
+  describe('Conversation menu (kebab)', () => {
+    const openMenu = () =>
+      fireEvent.click(screen.getByRole('button', { name: 'contacts.actionsMenu' }))
+
+    it('renders a conversation menu for a 1:1 chat', () => {
+      render(
+        <ChatHeader
+          name="Alice"
+          type="chat"
+          jid="alice@example.com"
+          onShowProfile={vi.fn()}
+          isArchived={false}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'contacts.actionsMenu' })).toBeInTheDocument()
+    })
+
+    it('opens a Contact info item that calls onShowProfile', () => {
+      const onShowProfile = vi.fn()
+      render(
+        <ChatHeader
+          name="Alice"
+          type="chat"
+          jid="alice@example.com"
+          onShowProfile={onShowProfile}
+          isArchived={false}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+        />
+      )
+
+      openMenu()
+      fireEvent.click(screen.getByText('sidebar.viewProfile'))
+      expect(onShowProfile).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows Archive (not Unarchive) for an unarchived chat and calls onArchive', () => {
+      const onArchive = vi.fn()
+      render(
+        <ChatHeader
+          name="Alice"
+          type="chat"
+          jid="alice@example.com"
+          onShowProfile={vi.fn()}
+          isArchived={false}
+          onArchive={onArchive}
+          onUnarchive={vi.fn()}
+        />
+      )
+
+      openMenu()
+      expect(screen.queryByText('conversations.unarchive')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByText('conversations.archive'))
+      expect(onArchive).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows Unarchive (not Archive) for an archived chat and calls onUnarchive', () => {
+      const onUnarchive = vi.fn()
+      render(
+        <ChatHeader
+          name="Alice"
+          type="chat"
+          jid="alice@example.com"
+          onShowProfile={vi.fn()}
+          isArchived={true}
+          onArchive={vi.fn()}
+          onUnarchive={onUnarchive}
+        />
+      )
+
+      openMenu()
+      expect(screen.queryByText('conversations.archive')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByText('conversations.unarchive'))
+      expect(onUnarchive).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not render the conversation menu in group chat mode', () => {
+      render(
+        <ChatHeader
+          name="Room"
+          type="groupchat"
+          jid="room@conf.example.com"
+          isArchived={false}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+        />
+      )
+
+      expect(
+        screen.queryByRole('button', { name: 'contacts.actionsMenu' })
+      ).not.toBeInTheDocument()
+    })
+  })
 })

--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -12,9 +12,10 @@ import { Avatar } from './Avatar'
 import { useWindowDrag } from '@/hooks'
 import { getTranslatedStatusText } from '@/utils/statusText'
 import { Tooltip } from './Tooltip'
-import { ArrowLeft, Clock, Hash, Lock, LockOpen, Loader2, Search, ShieldAlert, ShieldCheck, ShieldOff, ShieldX } from 'lucide-react'
+import { Archive, ArchiveRestore, ArrowLeft, Clock, Hash, Lock, LockOpen, Loader2, Search, ShieldAlert, ShieldCheck, ShieldOff, ShieldX, User } from 'lucide-react'
 import type { ConversationEncryptionState } from '@/hooks/useConversationEncryptionState'
 import { useWebUnlockDialogStore } from '@/stores/webUnlockDialogStore'
+import { OverflowMenu, type OverflowMenuItem } from './OverflowMenu'
 
 export interface ChatHeaderProps {
   name: string
@@ -29,6 +30,12 @@ export interface ChatHeaderProps {
   onEnableEncryptionClick?: () => void
   /** Open the contact profile / management screen. 1:1 chats only. */
   onShowProfile?: () => void
+  /** Whether the conversation is archived — selects the menu's Archive vs Unarchive item. 1:1 chats only. */
+  isArchived?: boolean
+  /** Archive the conversation from the overflow menu. 1:1 chats only. */
+  onArchive?: () => void
+  /** Unarchive the conversation from the overflow menu. 1:1 chats only. */
+  onUnarchive?: () => void
 }
 
 export function ChatHeader({
@@ -43,6 +50,9 @@ export function ChatHeader({
   onDisableEncryptionClick,
   onEnableEncryptionClick,
   onShowProfile,
+  isArchived,
+  onArchive,
+  onUnarchive,
 }: ChatHeaderProps) {
   const { t } = useTranslation()
   const isGroupChat = type === 'groupchat'
@@ -54,6 +64,20 @@ export function ChatHeader({
   const fullContact = useRosterStore((s) => jid ? s.contacts.get(jid) : undefined)
   const contactTime = useContactTime(!isGroupChat ? jid : null)
   useLastActivity(!isGroupChat ? jid : null)
+
+  // Overflow (kebab) menu — 1:1 chats only. Surfaces contact info and the
+  // archive toggle, which otherwise live behind the name tap / sidebar.
+  const menuItems: OverflowMenuItem[] = []
+  if (!isGroupChat) {
+    if (onShowProfile) {
+      menuItems.push({ key: 'profile', label: t('sidebar.viewProfile'), icon: User, onClick: onShowProfile })
+    }
+    if (isArchived && onUnarchive) {
+      menuItems.push({ key: 'unarchive', label: t('conversations.unarchive'), icon: ArchiveRestore, onClick: onUnarchive })
+    } else if (!isArchived && onArchive) {
+      menuItems.push({ key: 'archive', label: t('conversations.archive'), icon: Archive, onClick: onArchive })
+    }
+  }
 
   return (
     <header className={`h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3`} {...dragRegionProps}>
@@ -148,6 +172,16 @@ export function ChatHeader({
         >
           <Search className="size-4" />
         </button>
+      )}
+
+      {/* Overflow (kebab) menu — 1:1 chats only */}
+      {menuItems.length > 0 && (
+        <OverflowMenu
+          ariaLabel={t('contacts.actionsMenu')}
+          items={menuItems}
+          buttonClassName="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          iconClassName="size-4"
+        />
       )}
     </header>
   )

--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -328,6 +328,10 @@ vi.mock('lucide-react', () => ({
   ChevronDown: () => <span data-testid="icon-chevron-down">Down</span>,
   Lock: () => <span data-testid="icon-lock">Lock</span>,
   ShieldCheck: () => <span data-testid="icon-shield-check">ShieldCheck</span>,
+  Archive: () => <span data-testid="icon-archive">Archive</span>,
+  ArchiveRestore: () => <span data-testid="icon-archive-restore">Unarchive</span>,
+  User: () => <span data-testid="icon-user">User</span>,
+  MoreVertical: () => <span data-testid="icon-more-vertical">More</span>,
 }))
 
 // Create hoisted mock for MessageComposer (React 19: ref is a regular prop)

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -45,7 +45,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -371,6 +371,17 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
         onShowProfile={
           activeConversation.type === 'chat' && onShowProfile
             ? () => onShowProfile(activeConversation.id)
+            : undefined
+        }
+        isArchived={activeConversation.type === 'chat' ? isArchived(activeConversation.id) : undefined}
+        onArchive={
+          activeConversation.type === 'chat'
+            ? () => archiveConversation(activeConversation.id)
+            : undefined
+        }
+        onUnarchive={
+          activeConversation.type === 'chat'
+            ? () => unarchiveConversation(activeConversation.id)
             : undefined
         }
       />

--- a/apps/fluux/src/components/OverflowMenu.test.tsx
+++ b/apps/fluux/src/components/OverflowMenu.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Archive, User } from 'lucide-react'
+import { OverflowMenu, type OverflowMenuItem } from './OverflowMenu'
+
+const makeItems = (): OverflowMenuItem[] => [
+  { key: 'profile', label: 'View profile', icon: User, onClick: vi.fn() },
+  { key: 'archive', label: 'Archive', icon: Archive, onClick: vi.fn() },
+]
+
+describe('OverflowMenu', () => {
+  it('renders the trigger with the given aria-label and keeps items hidden until opened', () => {
+    render(<OverflowMenu ariaLabel="More actions" items={makeItems()} />)
+
+    const trigger = screen.getByRole('button', { name: 'More actions' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('View profile')).not.toBeInTheDocument()
+  })
+
+  it('opens the menu when the trigger is clicked', () => {
+    render(<OverflowMenu ariaLabel="More actions" items={makeItems()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+
+    expect(screen.getByRole('button', { name: 'More actions' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('View profile')).toBeInTheDocument()
+    expect(screen.getByText('Archive')).toBeInTheDocument()
+  })
+
+  it('calls the item handler and closes the menu when an item is clicked', () => {
+    const items = makeItems()
+    render(<OverflowMenu ariaLabel="More actions" items={items} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    fireEvent.click(screen.getByText('View profile'))
+
+    expect(items[0].onClick).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('View profile')).not.toBeInTheDocument()
+  })
+
+  it('closes the menu when Escape is pressed', () => {
+    render(<OverflowMenu ariaLabel="More actions" items={makeItems()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    expect(screen.getByText('Archive')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+  })
+
+  it('closes the menu when clicking outside', () => {
+    render(
+      <div>
+        <span data-testid="outside">outside</span>
+        <OverflowMenu ariaLabel="More actions" items={makeItems()} />
+      </div>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    expect(screen.getByText('Archive')).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+  })
+
+  it('does not fire the handler for a disabled item', () => {
+    const onClick = vi.fn()
+    render(
+      <OverflowMenu
+        ariaLabel="More actions"
+        items={[{ key: 'x', label: 'Disabled item', icon: User, onClick, disabled: true }]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    const item = screen.getByText('Disabled item').closest('button') as HTMLButtonElement
+    expect(item).toBeDisabled()
+
+    fireEvent.click(item)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing when there are no items', () => {
+    const { container } = render(<OverflowMenu ariaLabel="More actions" items={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/fluux/src/components/OverflowMenu.tsx
+++ b/apps/fluux/src/components/OverflowMenu.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+import { MoreVertical, type LucideIcon } from 'lucide-react'
+import { useClickOutside } from '@/hooks/useClickOutside'
+
+export interface OverflowMenuItem {
+  /** Stable key for the list. */
+  key: string
+  /** Visible label. */
+  label: string
+  icon: LucideIcon
+  /** Invoked when the item is selected. The menu closes automatically. */
+  onClick: () => void
+  /** Renders the item in the destructive (red) style. */
+  danger?: boolean
+  /** Disables the item (no click, dimmed). */
+  disabled?: boolean
+}
+
+interface OverflowMenuProps {
+  /** Accessible label for the kebab trigger button. */
+  ariaLabel: string
+  /** Menu items. When empty the component renders nothing. */
+  items: OverflowMenuItem[]
+  /** Override the trigger button classes (defaults to the kebab touch-target style). */
+  buttonClassName?: string
+  /** Override the MoreVertical icon classes. */
+  iconClassName?: string
+  /** Override the dropdown container classes. */
+  menuClassName?: string
+}
+
+const DEFAULT_BUTTON_CLASS =
+  'p-2 rounded-lg text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center'
+const DEFAULT_MENU_CLASS =
+  'absolute end-0 mt-1 z-50 w-56 bg-fluux-sidebar border border-fluux-hover rounded-lg shadow-lg py-1'
+
+/**
+ * Generic kebab (overflow) menu: a `MoreVertical` trigger that opens a
+ * dropdown of actions. Handles open state, click-outside and Escape to close,
+ * and `role="menu"`/`role="menuitem"` semantics. Selecting an item closes the
+ * menu and fires its `onClick`.
+ */
+export function OverflowMenu({
+  ariaLabel,
+  items,
+  buttonClassName = DEFAULT_BUTTON_CLASS,
+  iconClassName = 'size-5',
+  menuClassName = DEFAULT_MENU_CLASS,
+}: OverflowMenuProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useClickOutside(menuRef, () => setIsOpen(false), isOpen)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [isOpen])
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        className={buttonClassName}
+      >
+        <MoreVertical className={iconClassName} />
+      </button>
+
+      {isOpen && (
+        <div role="menu" className={menuClassName}>
+          {items.map(({ key, label, icon: Icon, onClick, danger, disabled }) => (
+            <button
+              key={key}
+              role="menuitem"
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                setIsOpen(false)
+                onClick()
+              }}
+              className={`w-full flex items-center gap-2 px-3 py-2.5 text-start text-sm transition-colors hover:bg-fluux-active disabled:opacity-50 disabled:cursor-not-allowed ${danger ? 'text-fluux-red' : 'text-fluux-text'}`}
+            >
+              <Icon className="size-4 flex-shrink-0" />
+              <span>{label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -411,7 +411,7 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
         >
           <div className="sidebar-scroll h-full overflow-y-auto rounded-sm py-0.5 px-0.5">
             <SidebarZoneContext.Provider value={sidebarListRef}>
-              <div key={sidebarView} style={{ animation: 'sidebar-view-enter 150ms ease-out' }}>
+              <div key={sidebarView} className="h-full md:h-auto" style={{ animation: 'sidebar-view-enter 150ms ease-out' }}>
               {sidebarView === 'messages' ? (
                 <ConversationList />
               ) : sidebarView === 'directory' ? (

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -33,6 +33,23 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
           </p>
         </div>
       </div>
+      <div
+        class="relative"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          aria-label="contacts.actionsMenu"
+          class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          type="button"
+        >
+          <span
+            data-testid="icon-more-vertical"
+          >
+            More
+          </span>
+        </button>
+      </div>
     </header>
     <div
       class="focus-zone flex-1 flex flex-col min-h-0 p-1 relative"
@@ -475,6 +492,23 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
             Online
           </p>
         </div>
+      </div>
+      <div
+        class="relative"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          aria-label="contacts.actionsMenu"
+          class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          type="button"
+        >
+          <span
+            data-testid="icon-more-vertical"
+          >
+            More
+          </span>
+        </button>
       </div>
     </header>
     <div

--- a/apps/fluux/src/components/contact-profile/ContactActionsMenu.test.tsx
+++ b/apps/fluux/src/components/contact-profile/ContactActionsMenu.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ContactActionsMenu } from './ContactActionsMenu'
+
+// i18n mock: t returns the key verbatim, so labels render as their keys.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+const noop = () => {}
+
+const baseProps = {
+  isInRoster: true,
+  isBlocked: false,
+  canAdd: false,
+  onRename: noop,
+  onRemove: noop,
+  onBlock: noop,
+  onUnblock: noop,
+  onAdd: noop,
+}
+
+const openMenu = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'contacts.actionsMenu' }))
+
+describe('ContactActionsMenu', () => {
+  it('renders rename, block and remove for a roster contact', () => {
+    render(<ContactActionsMenu {...baseProps} />)
+    openMenu()
+
+    expect(screen.getByText('contacts.rename')).toBeInTheDocument()
+    expect(screen.getByText('contacts.blockUser')).toBeInTheDocument()
+    expect(screen.getByText('contacts.removeFromRoster')).toBeInTheDocument()
+    expect(screen.queryByText('contacts.unblockUser')).not.toBeInTheDocument()
+    expect(screen.queryByText('contacts.addToContacts')).not.toBeInTheDocument()
+  })
+
+  it('shows unblock instead of block when the contact is blocked', () => {
+    render(<ContactActionsMenu {...baseProps} isBlocked />)
+    openMenu()
+
+    expect(screen.getByText('contacts.unblockUser')).toBeInTheDocument()
+    expect(screen.queryByText('contacts.blockUser')).not.toBeInTheDocument()
+  })
+
+  it('shows add-to-contacts for a non-roster contact and calls onAdd', () => {
+    const onAdd = vi.fn()
+    render(
+      <ContactActionsMenu {...baseProps} isInRoster={false} canAdd onAdd={onAdd} />,
+    )
+    openMenu()
+
+    fireEvent.click(screen.getByText('contacts.addToContacts'))
+    expect(onAdd).toHaveBeenCalledTimes(1)
+    // No roster-only actions for a stranger.
+    expect(screen.queryByText('contacts.rename')).not.toBeInTheDocument()
+    expect(screen.queryByText('contacts.removeFromRoster')).not.toBeInTheDocument()
+  })
+
+  it('calls onBlock when the block item is clicked', () => {
+    const onBlock = vi.fn()
+    render(<ContactActionsMenu {...baseProps} onBlock={onBlock} />)
+    openMenu()
+
+    fireEvent.click(screen.getByText('contacts.blockUser'))
+    expect(onBlock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/fluux/src/components/contact-profile/ContactActionsMenu.tsx
+++ b/apps/fluux/src/components/contact-profile/ContactActionsMenu.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Ban, MoreVertical, Pencil, Trash2, UserPlus } from 'lucide-react'
-import { useClickOutside } from '@/hooks/useClickOutside'
+import { Ban, Pencil, Trash2, UserPlus } from 'lucide-react'
+import { OverflowMenu, type OverflowMenuItem } from '../OverflowMenu'
 
 interface ContactActionsMenuProps {
   isInRoster: boolean
@@ -25,73 +24,23 @@ export function ContactActionsMenu({
   onAdd,
 }: ContactActionsMenuProps) {
   const { t } = useTranslation()
-  const [isOpen, setIsOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
 
-  useClickOutside(menuRef, () => setIsOpen(false), isOpen)
-
-  useEffect(() => {
-    if (!isOpen) return
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false)
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [isOpen])
-
-  const close = () => setIsOpen(false)
-
-  const items: Array<{ key: string; label: string; icon: typeof Pencil; onClick: () => void; danger?: boolean }> = []
+  const items: OverflowMenuItem[] = []
 
   if (isInRoster) {
-    items.push({ key: 'rename', label: t('contacts.rename'), icon: Pencil, onClick: () => { close(); onRename() } })
+    items.push({ key: 'rename', label: t('contacts.rename'), icon: Pencil, onClick: onRename })
   }
   if (canAdd) {
-    items.push({ key: 'add', label: t('contacts.addToContacts'), icon: UserPlus, onClick: () => { close(); onAdd() } })
+    items.push({ key: 'add', label: t('contacts.addToContacts'), icon: UserPlus, onClick: onAdd })
   }
   if (isBlocked) {
-    items.push({ key: 'unblock', label: t('contacts.unblockUser'), icon: Ban, onClick: () => { close(); onUnblock() } })
+    items.push({ key: 'unblock', label: t('contacts.unblockUser'), icon: Ban, onClick: onUnblock })
   } else {
-    items.push({ key: 'block', label: t('contacts.blockUser'), icon: Ban, onClick: () => { close(); onBlock() }, danger: true })
+    items.push({ key: 'block', label: t('contacts.blockUser'), icon: Ban, onClick: onBlock, danger: true })
   }
   if (isInRoster) {
-    items.push({ key: 'remove', label: t('contacts.removeFromRoster'), icon: Trash2, onClick: () => { close(); onRemove() }, danger: true })
+    items.push({ key: 'remove', label: t('contacts.removeFromRoster'), icon: Trash2, onClick: onRemove, danger: true })
   }
 
-  if (items.length === 0) return null
-
-  return (
-    <div className="relative" ref={menuRef}>
-      <button
-        type="button"
-        onClick={() => setIsOpen((open) => !open)}
-        aria-label={t('contacts.actionsMenu')}
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        className="p-2 rounded-lg text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center"
-      >
-        <MoreVertical className="size-5" />
-      </button>
-
-      {isOpen && (
-        <div
-          role="menu"
-          className="absolute end-0 mt-1 z-50 w-56 bg-fluux-sidebar border border-fluux-hover rounded-lg shadow-lg py-1"
-        >
-          {items.map(({ key, label, icon: Icon, onClick, danger }) => (
-            <button
-              key={key}
-              role="menuitem"
-              type="button"
-              onClick={onClick}
-              className={`w-full flex items-center gap-2 px-3 py-2.5 text-start text-sm transition-colors hover:bg-fluux-active ${danger ? 'text-fluux-red' : 'text-fluux-text'}`}
-            >
-              <Icon className="size-4 flex-shrink-0" />
-              <span>{label}</span>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  )
+  return <OverflowMenu ariaLabel={t('contacts.actionsMenu')} items={items} />
 }

--- a/docs/UX_REVIEW.md
+++ b/docs/UX_REVIEW.md
@@ -243,7 +243,7 @@ width — but a few rough edges:
 
 | #    | Issue                                                                                                                                                                                                     | Recommendation                                                                                                                   | Sev | Eff |
 |------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|-----|-----|
-| 12.1 | ⚠️ **Partially addressed.** RoomHeader (group chats) now has a mobile kebab/overflow menu (notifications + room management), but ChatHeader (1:1) still has no overflow menu — only back / avatar / name / encryption / search.                                                                   | Add a kebab menu on the right of the header that opens a mobile sheet with: View members · Mute · Block · Conversation settings. | M   | M   |
+| 12.1 | ✅ **Resolved.** ChatHeader (1:1) now has an overflow (kebab) menu (`OverflowMenu`, shared with the contact-profile kebab) offering **View profile** and **Archive/Unarchive**. Mute is N/A for 1:1 (no per-conversation mute exists); Block stays on the contact-profile screen. | Add a kebab menu on the right of the header that opens a mobile sheet with: View members · Mute · Block · Conversation settings. | M   | M   |
 | 12.2 | ⚠️ **Partially addressed.** The mobile "+" button now has an `aria-label`, but still no visible tooltip for sighted users, and the attachment/reply/edit affordances remain hidden behind it. | Tooltip + a small "+" → "Attachments / GIF / Reply" sheet.                                                                       | L   | S   |
 | 12.3 | The icon rail on mobile is the same width as desktop (~56 px) which feels too wide on a 375 px viewport — eats 15 % of horizontal space.                                                                  | Reduce the icon-rail width on `<sm` breakpoints; consider a bottom-tab pattern below 480 px.                                     | L   | M   |
 | 12.4 | **No swipe gesture to go back** from chat → conversation list (only the `←` button).                                                                                                                      | Add `react-swipeable` left-edge swipe → close chat. Big mobile DX win.                                                           | M   | M   |
@@ -356,7 +356,7 @@ A copy-paste checklist for triage. Severity in brackets.
 [x] [M] Floating "↓ N new" pill on the chat list — §2.3
 [ ] [M] Read-receipts (XEP-0184) with double-checkmark on last message — §2.2
 [ ] [M] Render upload progress UI tied to SDK's UploadState — §14.4 (partial: % shown in send button; bar/tray still open)
-[ ] [M] Mobile: kebab menu in chat header for members/mute/settings — §12.1 (done for rooms; 1:1 ChatHeader still open)
+[x] [M] Mobile: kebab menu in chat header — §12.1 (shipped: 1:1 ChatHeader overflow menu with View profile + Archive/Unarchive, via shared OverflowMenu component)
 [ ] [M] Mobile: left-edge swipe to go back — §12.4
 [ ] [M] Server-status dashboard in Admin empty state — §10.1
 [x] [M] Server (optional) auto-expand on connection failure — §1.2 (auto-expand shipped; Cmd+, hint still not surfaced)


### PR DESCRIPTION
## Summary

- Adds an overflow (kebab) menu to the 1:1 `ChatHeader` with **View profile** and **Archive/Unarchive**, addressing UX_REVIEW §12.1. Extracts a shared `OverflowMenu` component from the contact-profile kebab so both reuse the same trigger / dropdown / a11y shell.
- Fixes sidebar empty-list states to center on mobile (full-screen) while staying top-aligned in the desktop sidebar, where the main pane already shows its own centered placeholder.