### PR TITLE
feat: show the file name in deferred media placeholders

### DIFF
--- a/apps/fluux/src/components/DeferredMediaPlaceholder.test.tsx
+++ b/apps/fluux/src/components/DeferredMediaPlaceholder.test.tsx
@@ -20,4 +20,13 @@ describe('DeferredMediaPlaceholder', () => {
     expect(screen.getByText('Load audio')).toBeInTheDocument()
     expect(screen.queryByText(/MB/)).not.toBeInTheDocument()
   })
+
+  it('shows the file name as a hint, alongside the label and size, when name is given', () => {
+    render(
+      <DeferredMediaPlaceholder variant="box" icon={ImageIcon} label="Load image" name="screenshot.png" sizeLabel="12.7 KB" onLoad={() => {}} />,
+    )
+    expect(screen.getByText('screenshot.png')).toBeInTheDocument()
+    expect(screen.getByText('Load image')).toBeInTheDocument()
+    expect(screen.getByText('12.7 KB')).toBeInTheDocument()
+  })
 })

--- a/apps/fluux/src/components/DeferredMediaPlaceholder.tsx
+++ b/apps/fluux/src/components/DeferredMediaPlaceholder.tsx
@@ -9,6 +9,8 @@ interface DeferredMediaPlaceholderProps {
   label: string
   /** Pre-formatted size string, e.g. "1.2 MB". Optional. */
   sizeLabel?: string
+  /** Optional file name, shown as a hint of what the media is. */
+  name?: string
   /** Box variant only: reserve the loaded media's aspect ratio to avoid layout shift. */
   aspectRatio?: number
   /** Box variant only: max width in px. */
@@ -22,7 +24,7 @@ interface DeferredMediaPlaceholderProps {
  * leaks no IP until the user explicitly taps.
  */
 export function DeferredMediaPlaceholder({
-  variant, icon: Icon, label, sizeLabel, aspectRatio, maxWidthPx, onLoad,
+  variant, icon: Icon, label, name, sizeLabel, aspectRatio, maxWidthPx, onLoad,
 }: DeferredMediaPlaceholderProps) {
   if (variant === 'box') {
     return (
@@ -39,6 +41,7 @@ export function DeferredMediaPlaceholder({
       >
         <Icon className="size-6" aria-hidden="true" />
         <span className="text-sm font-medium">{label}</span>
+        {name && <span className="text-xs max-w-full truncate" title={name}>{name}</span>}
         {sizeLabel && <span className="text-xs">{sizeLabel}</span>}
       </button>
     )
@@ -55,6 +58,7 @@ export function DeferredMediaPlaceholder({
       </div>
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-fluux-text truncate">{label}</p>
+        {name && <p className="text-xs text-fluux-muted truncate" title={name}>{name}</p>}
         {sizeLabel && <p className="text-xs text-fluux-muted">{sizeLabel}</p>}
       </div>
       <Download className="size-4 text-fluux-muted flex-shrink-0" aria-hidden="true" />

--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -97,6 +97,7 @@ export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoa
         variant="box"
         icon={ImageIcon}
         label={t('chat.loadImage')}
+        name={attachment.name}
         sizeLabel={attachment.size ? formatBytes(attachment.size) : undefined}
         aspectRatio={aspectRatio}
         maxWidthPx={maxWidthPx}
@@ -259,6 +260,7 @@ export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoa
         variant="box"
         icon={Film}
         label={t('chat.loadVideo')}
+        name={attachment.name}
         sizeLabel={attachment.size ? formatBytes(attachment.size) : undefined}
         aspectRatio={aspectRatio}
         maxWidthPx={448}
@@ -390,6 +392,7 @@ export function AudioAttachment({ attachment }: AttachmentProps) {
         variant="card"
         icon={Music}
         label={t('chat.loadAudio')}
+        name={attachment.name}
         sizeLabel={attachment.size ? formatBytes(attachment.size) : undefined}
         onLoad={approve}
       />

--- a/apps/fluux/src/components/TextFilePreview.tsx
+++ b/apps/fluux/src/components/TextFilePreview.tsx
@@ -33,6 +33,7 @@ export function TextFilePreview({ attachment, isSelected = false, isHovered = fa
         variant="card"
         icon={FileText}
         label={t('chat.loadFilePreview')}
+        name={attachment.name}
         sizeLabel={attachment.size ? formatBytes(attachment.size) : undefined}
         onLoad={approve}
       />


### PR DESCRIPTION
Follow-up to #570 (issue #36). When media is deferred (public room / stranger / "never" policy), the tap-to-load placeholder showed only a generic action label and size (e.g. "Load image", "12.7 KB"). It now also shows the **file name** as a hint of what the media is, so you can decide whether to load it.

Applies to every deferred media placeholder — images, video, audio, and text-file previews — via the shared `DeferredMediaPlaceholder` (new optional `name` prop) and each renderer passing `attachment.name`.