### PR TITLE
Add OMEMO-ready ratcheting hooks to the E2EE plugin trait

### DIFF
--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -2073,7 +2073,7 @@ describe('SequoiaPgpPlugin', () => {
       expect(claim).not.toBeNull()
       const bobHandle = await bob.plugin.openConversation({ kind: 'direct', peer: 'alice@example.com' })
       const decrypted = await bob.plugin.decrypt(bobHandle, claim!)
-      expect(decodeBodyFromPayload(decrypted.plaintext)).toBe('hello bob')
+      expect(decodeBodyFromPayload(decrypted.plaintext!)).toBe('hello bob')
       expect(decrypted.securityContext.protocolId).toBe('openpgp')
       expect(decrypted.securityContext.trust).toBe('tofu')
       expect(decrypted.securityContext.notes).toBeUndefined()
@@ -2093,7 +2093,7 @@ describe('SequoiaPgpPlugin', () => {
       const bobHandle = await bob.plugin.openConversation({ kind: 'direct', peer: 'alice@example.com' })
       const decrypted = await bob.plugin.decrypt(bobHandle, claim)
 
-      expect(decodeBodyFromPayload(decrypted.plaintext)).toBe('hi')
+      expect(decodeBodyFromPayload(decrypted.plaintext!)).toBe('hi')
       expect(decrypted.securityContext.trust).toBe('untrusted')
       expect(decrypted.securityContext.notes?.join(' ')).toMatch(/Sender key not cached/)
     })
@@ -2975,7 +2975,7 @@ describe('SequoiaPgpPlugin', () => {
         encodeBodyAsPayload('post-rotation greeting'),
       )
       const result = await pair.bob.plugin.decrypt(bobHandle, payload)
-      expect(decodeBodyFromPayload(result.plaintext)).toBe('post-rotation greeting')
+      expect(decodeBodyFromPayload(result.plaintext!)).toBe('post-rotation greeting')
       expect(result.securityContext.trust).toBe('tofu')
     })
   })

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -2109,7 +2109,7 @@ describe('WebOpenPGPPlugin', () => {
       const claim = bob.plugin.tryClaimInbound(payload.stanzaElement)!
       const decrypted = await bob.plugin.decrypt(bobHandle, claim)
 
-      expect(decodeBody(decrypted.plaintext)).toBe('hello bob')
+      expect(decodeBody(decrypted.plaintext!)).toBe('hello bob')
       expect(decrypted.securityContext.trust).toBe('tofu')
       expect(decrypted.securityContext.notes).toBeUndefined()
     })
@@ -2221,7 +2221,7 @@ describe('WebOpenPGPPlugin', () => {
       const claim = bob.plugin.tryClaimInbound(payload.stanzaElement)!
       const decrypted = await bob.plugin.decrypt(bobHandle, claim, { messageId: 'm-no-key' })
 
-      expect(decodeBody(decrypted.plaintext)).toBe('from alice')
+      expect(decodeBody(decrypted.plaintext!)).toBe('from alice')
       expect(decrypted.securityContext.trust).toBe('untrusted')
       expect(decrypted.securityContext.notes?.join(' ')).toMatch(/not cached/)
     })

--- a/packages/fluux-sdk/src/core/e2ee/E2EEManager.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/E2EEManager.test.ts
@@ -1109,3 +1109,152 @@ describe('E2EEManager — deferred decrypt support', () => {
     expect(cb).toHaveBeenCalledWith('openpgp')
   })
 })
+
+/** Archived stanza child that FakePlugin(xmlns) will claim. */
+function archiveChild(xmlns: string): XMLElementData {
+  return { name: 'enc', attrs: { xmlns }, children: [] }
+}
+
+describe('E2EEManager — decryptArchiveBatch', () => {
+  const target: ConversationTarget = { kind: 'direct', peer: 'bob@example.com' }
+
+  it('hands a same-plugin page to decryptArchiveBatch in one call', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(strongDescriptor, 'urn:test:strong')
+    const batch = vi.fn(async (_h: ConversationHandle, items: { payload: EncryptedPayload }[]) =>
+      items.map((_, i) => ({
+        plaintext: new Uint8Array([i]),
+        senderDevice: { jid: 'bob@example.com', deviceId: 'd1' },
+        securityContext: { protocolId: strongDescriptor.id, trust: 'tofu' as const },
+      })),
+    )
+    ;(plugin as E2EEPlugin).decryptArchiveBatch = batch
+    await mgr.register(plugin)
+
+    const children = [archiveChild('urn:test:strong'), archiveChild('urn:test:strong')]
+    const results = await mgr.decryptArchiveBatch(children, target)
+
+    expect(batch).toHaveBeenCalledTimes(1)
+    expect(batch.mock.calls[0][1]).toHaveLength(2)
+    expect(results.map((r) => r?.plaintext?.[0])).toEqual([0, 1])
+    expect(plugin.closedHandles).toBe(1) // one shared handle for the page
+  })
+
+  it('forwards per-item context positionally to the batch', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(strongDescriptor, 'urn:test:strong')
+    const batch = vi.fn(async (_h: ConversationHandle, items: { context?: { messageId?: string } }[]) =>
+      items.map(() => ({
+        plaintext: new Uint8Array([1]),
+        senderDevice: { jid: 'bob@example.com', deviceId: 'd1' },
+        securityContext: { protocolId: strongDescriptor.id, trust: 'tofu' as const },
+      })),
+    )
+    ;(plugin as E2EEPlugin).decryptArchiveBatch = batch
+    await mgr.register(plugin)
+
+    const children = [archiveChild('urn:test:strong'), archiveChild('urn:test:strong')]
+    await mgr.decryptArchiveBatch(children, target, [{ messageId: 'm0' }, undefined])
+
+    const items = batch.mock.calls[0][1]
+    expect(items[0].context).toEqual({ messageId: 'm0' })
+    expect(items[1].context).toBeUndefined()
+  })
+
+  it('falls back to per-item decryptArchive when the plugin has no batch hook', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(strongDescriptor, 'urn:test:strong')
+    await mgr.register(plugin)
+
+    const children = [archiveChild('urn:test:strong'), archiveChild('urn:test:strong')]
+    const results = await mgr.decryptArchiveBatch(children, target)
+
+    // FakePlugin has no decryptArchive → host falls back to decrypt() (0x42).
+    expect(results.map((r) => r?.plaintext?.[0])).toEqual([0x42, 0x42])
+  })
+
+  it('keeps index alignment with a null slot for an unclaimed item (no batch fast-path)', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(strongDescriptor, 'urn:test:strong')
+    const batch = vi.fn()
+    ;(plugin as E2EEPlugin).decryptArchiveBatch = batch as never
+    await mgr.register(plugin)
+
+    const children = [archiveChild('urn:test:strong'), archiveChild('urn:unclaimed')]
+    const results = await mgr.decryptArchiveBatch(children, target)
+
+    expect(batch).not.toHaveBeenCalled() // not all items claimed → no fast path
+    expect(results[0]?.plaintext?.[0]).toBe(0x42)
+    expect(results[1]).toBeNull()
+  })
+})
+
+describe('E2EEManager — repairSession', () => {
+  const target: ConversationTarget = { kind: 'direct', peer: 'bob@example.com' }
+
+  it('invokes the plugin repairSession with the handle and peer', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(strongDescriptor, 'urn:test:strong')
+    const repair = vi.fn(async (_h: ConversationHandle, _peer: BareJID) => {})
+    ;(plugin as E2EEPlugin).repairSession = repair
+    await mgr.register(plugin)
+
+    const ok = await mgr.repairSession(target)
+
+    expect(ok).toBe(true)
+    expect(repair).toHaveBeenCalledTimes(1)
+    expect(repair.mock.calls[0][1]).toBe('bob@example.com')
+    expect(plugin.closedHandles).toBe(1)
+  })
+
+  it('returns false when the selected plugin is stateless (no repairSession)', async () => {
+    const mgr = makeManager()
+    await mgr.register(new FakePlugin(strongDescriptor, 'urn:test:strong'))
+    expect(await mgr.repairSession(target)).toBe(false)
+  })
+
+  it('returns false when no plugin supports the conversation', async () => {
+    const mgr = makeManager()
+    expect(await mgr.repairSession(target)).toBe(false)
+  })
+
+  it('swallows a throwing repairSession and returns false', async () => {
+    const { logger, calls } = makeSpyLogger()
+    const mgr = makeManagerWithLogger(logger)
+    const plugin = new FakePlugin(strongDescriptor, 'urn:test:strong')
+    ;(plugin as E2EEPlugin).repairSession = vi.fn(async () => {
+      throw new Error('desync')
+    })
+    await mgr.register(plugin)
+
+    expect(await mgr.repairSession(target)).toBe(false)
+    expect(calls.some((c) => c.level === 'warn' && c.message.includes('repairSession failed'))).toBe(true)
+    expect(plugin.closedHandles).toBe(1) // handle still closed on failure
+  })
+})
+
+describe('E2EEManager — configure', () => {
+  it('forwards options verbatim to the plugin configure hook', async () => {
+    const mgr = makeManager()
+    const plugin = new FakePlugin(weakDescriptor, 'urn:test:weak')
+    const configure = vi.fn(async () => {})
+    ;(plugin as E2EEPlugin).configure = configure
+    await mgr.register(plugin)
+
+    const opts = { rotationCadence: 'daily', staleDeviceDays: 30 }
+    await mgr.configure('openpgp', opts)
+
+    expect(configure).toHaveBeenCalledWith(opts)
+  })
+
+  it('resolves silently when the plugin has no configure hook', async () => {
+    const mgr = makeManager()
+    await mgr.register(new FakePlugin(weakDescriptor, 'urn:test:weak'))
+    await expect(mgr.configure('openpgp', { x: 1 })).resolves.toBeUndefined()
+  })
+
+  it('throws when no plugin is registered under the id', async () => {
+    const mgr = makeManager()
+    await expect(mgr.configure('omemo:2', {})).rejects.toThrow(/no plugin registered/)
+  })
+})

--- a/packages/fluux-sdk/src/core/e2ee/E2EEManager.ts
+++ b/packages/fluux-sdk/src/core/e2ee/E2EEManager.ts
@@ -4,6 +4,7 @@ import { isE2EEPluginError } from './errors'
 import { createPluginStorage, type StorageBackend } from './PluginStorage'
 import type {
   AccountInfo,
+  ArchiveDecryptItem,
   BareJID,
   ConversationTarget,
   DecryptResult,
@@ -12,6 +13,7 @@ import type {
   EncryptedPayload,
   InboundDecryptContext,
   Logger,
+  PluginConfiguration,
   PluginContext,
   SecurityContextUpdate,
   XMLElementData,
@@ -568,6 +570,88 @@ export class E2EEManager {
     } finally {
       await claim.plugin.closeConversation(handle).catch(() => {})
     }
+  }
+
+  /**
+   * Batched archive decrypt — for a whole page of MAM stanzas from the same
+   * conversation. When every element is claimed by a single plugin that
+   * implements {@link E2EEPlugin.decryptArchiveBatch}, the page is handed over
+   * in one call so a ratcheting plugin can freeze its session state once
+   * instead of per message. Otherwise the host falls back to looping
+   * {@link E2EEManager.decryptArchive} per item.
+   *
+   * The returned array is index-aligned to `stanzaChildren`; an element that
+   * no plugin claims is `null` in its slot (the fallback path), and the batch
+   * fast path is only taken when *all* items are claimed by the same plugin.
+   * `contexts`, when supplied, is also positional — `contexts[i]` accompanies
+   * `stanzaChildren[i]`.
+   */
+  async decryptArchiveBatch(
+    stanzaChildren: XMLElementData[],
+    senderTarget: ConversationTarget,
+    contexts?: (InboundDecryptContext | undefined)[],
+  ): Promise<(DecryptResult | null)[]> {
+    const claims = stanzaChildren.map((child) => this.claimInbound(child))
+    const claimedPlugins = new Set(claims.filter((c) => c !== null).map((c) => c!.plugin))
+    const onlyPlugin = claimedPlugins.size === 1 ? [...claimedPlugins][0] : null
+    const allClaimed = claims.every((c) => c !== null)
+
+    if (onlyPlugin && allClaimed && onlyPlugin.decryptArchiveBatch) {
+      const handle = await onlyPlugin.openConversation(senderTarget)
+      try {
+        const items: ArchiveDecryptItem[] = claims.map((c, i) => ({
+          payload: c!.payload,
+          ...(contexts?.[i] && { context: contexts[i] }),
+        }))
+        return await onlyPlugin.decryptArchiveBatch(handle, items)
+      } finally {
+        await onlyPlugin.closeConversation(handle).catch(() => {})
+      }
+    }
+
+    const results: (DecryptResult | null)[] = []
+    for (let i = 0; i < stanzaChildren.length; i++) {
+      results.push(await this.decryptArchive(stanzaChildren[i], senderTarget, contexts?.[i]))
+    }
+    return results
+  }
+
+  /**
+   * Rebuild a desynchronized session with the conversation peer. Called by the
+   * host when a decrypt reports {@link DecryptStatus} `broken-session`. Selects
+   * the plugin for `target` (same selection as the live send/decrypt path) and
+   * invokes {@link E2EEPlugin.repairSession}. Returns `false` when no plugin is
+   * available or the selected plugin is stateless (no `repairSession`) — there
+   * is then nothing to repair.
+   */
+  async repairSession(target: ConversationTarget): Promise<boolean> {
+    const plugin = await this.selectStrategy(target)
+    if (!plugin?.repairSession) return false
+    const peer = target.kind === 'direct' ? target.peer : target.room
+    const handle = await plugin.openConversation(target)
+    try {
+      await plugin.repairSession(handle, peer)
+      return true
+    } catch (err) {
+      this.logger.warn(`repairSession failed for ${targetLabel(target)} via ${plugin.descriptor.id}`, err)
+      return false
+    } finally {
+      await plugin.closeConversation(handle).catch(() => {})
+    }
+  }
+
+  /**
+   * Forward admin-tunable settings to a registered plugin. The host does not
+   * interpret {@link PluginConfiguration} — each plugin validates its own keys.
+   * Throws if no plugin is registered under `pluginId`; resolves silently when
+   * the plugin has no `configure` hook (it has no tunables).
+   */
+  async configure(pluginId: string, options: PluginConfiguration): Promise<void> {
+    const plugin = this.plugins.get(pluginId)
+    if (!plugin) {
+      throw new Error(`E2EEManager.configure: no plugin registered with id '${pluginId}'`)
+    }
+    await plugin.configure?.(options)
   }
 
   /**

--- a/packages/fluux-sdk/src/core/e2ee/index.ts
+++ b/packages/fluux-sdk/src/core/e2ee/index.ts
@@ -8,10 +8,12 @@
 
 export type {
   AccountInfo,
+  ArchiveDecryptItem,
   BareJID,
   ConversationHandle,
   ConversationTarget,
   DecryptResult,
+  DecryptStatus,
   DeviceIdentifier,
   DiscoFeature,
   DiscoResult,
@@ -24,6 +26,7 @@ export type {
   Logger,
   PEPItem,
   PeerSupport,
+  PluginConfiguration,
   PluginContext,
   PluginStorage,
   ProtocolFeatures,

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
@@ -886,3 +886,123 @@ describe('decryptStanzaInPlace — failure logging routes through the manager lo
     expect(warn!.message).not.toContain('eve@')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Ratcheting status: control-message (silent consume) + broken-session (repair)
+// ---------------------------------------------------------------------------
+
+/** Returns a `control-message` result: decrypt advanced the session but there
+ *  is no user-visible plaintext (a key-transport / ratchet-advance message). */
+class ControlMessagePlugin extends FakeE2EEPlugin {
+  constructor() {
+    super(undefined)
+  }
+  override async decrypt(): Promise<DecryptResult> {
+    return {
+      status: 'control-message',
+      senderDevice: { jid: 'peer@example.com', deviceId: 'dev' },
+      securityContext: { protocolId: TEST_PROTOCOL_ID, trust: 'tofu' },
+    }
+  }
+}
+
+/** Returns a `broken-session` result and records repairSession invocations. */
+class BrokenSessionPlugin extends FakeE2EEPlugin {
+  public repairCalls: { peer: string }[] = []
+  constructor() {
+    super(undefined)
+  }
+  override async decrypt(): Promise<DecryptResult> {
+    return {
+      status: 'broken-session',
+      senderDevice: { jid: 'peer@example.com', deviceId: 'dev' },
+      securityContext: { protocolId: TEST_PROTOCOL_ID, trust: 'untrusted', notes: ['ratchet gap'] },
+    }
+  }
+  async repairSession(_h: ConversationHandle, peer: string): Promise<void> {
+    this.repairCalls.push({ peer })
+  }
+}
+
+function bodilessStanza(): Element {
+  return xml(
+    'message',
+    { from: 'peer@example.com/resource', id: 'mc', type: 'chat' },
+    xml('enc', { xmlns: TEST_NAMESPACE }),
+  ) as Element
+}
+
+describe('stanzaDecrypt — control-message status', () => {
+  it('consumes a bodiless control message silently (no placeholder body)', async () => {
+    const manager = await makeManager(new ControlMessagePlugin())
+    const stanza = bodilessStanza()
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(result.attempted).toBe(true)
+    // No plaintext → no body is synthesized for a control message.
+    expect(stanza.getChild('body')).toBeUndefined()
+    // The encrypted child is still stripped so it isn't re-claimed.
+    expect(stanza.getChild('enc')).toBeUndefined()
+    // Not a failure → nothing stashed for deferred retry.
+    expect(result.encryptedPayloadXml).toBeUndefined()
+    expect(result.securityContext?.trust).toBe('tofu')
+  })
+
+  it('does not overwrite an existing fallback body with a placeholder', async () => {
+    const manager = await makeManager(new ControlMessagePlugin())
+    const stanza = buildStanza() // carries a '[Encrypted message]' hint body
+
+    await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    // Control message leaves the sender hint as-is — it is neither replaced
+    // with plaintext nor with a could-not-decrypt placeholder.
+    expect(stanza.getChild('body')?.text()).toBe('[Encrypted message]')
+  })
+})
+
+describe('stanzaDecrypt — broken-session status', () => {
+  it('shows a could-not-decrypt placeholder and triggers session repair', async () => {
+    const plugin = new BrokenSessionPlugin()
+    const manager = await makeManager(plugin)
+    const stanza = buildStanza()
+
+    const result = await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+    // repairSession is fire-and-forget; let the microtask/selectStrategy settle.
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(result.attempted).toBe(true)
+    expect(stanza.getChild('body')?.text()).toBe(COULD_NOT_DECRYPT_BODY)
+    expect(result.securityContext?.trust).toBe('untrusted')
+    expect(result.securityContext?.notes?.[0]).toContain('session needs repair')
+    // Not stashed for a plain retry — repair is the recovery path.
+    expect(result.encryptedPayloadXml).toBeUndefined()
+    expect(plugin.repairCalls).toEqual([{ peer: 'peer@example.com' }])
+  })
+
+  it('does not stash a broken-session message for deferred retry', async () => {
+    const manager = await makeManager(new BrokenSessionPlugin())
+    const stanza = buildStanza()
+
+    await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    expect(readStashedEncryptedPayload(stanza)).toBeUndefined()
+  })
+
+  it('logs the broken-session disposition (not retryable, not rejected)', async () => {
+    const { logger, calls } = makeSpyLogger()
+    const manager = new E2EEManager({
+      storage: new InMemoryStorageBackend(),
+      xmpp: stubXmppPrimitives(),
+      account: { jid: 'me@example.com' },
+      logger,
+    })
+    await manager.register(new BrokenSessionPlugin())
+    const stanza = buildStanza()
+
+    await decryptStanzaInPlace(stanza, manager, 'peer@example.com')
+
+    const warn = calls.find((c) => c.level === 'warn' && c.message.includes('decrypt failed'))
+    expect(warn?.message).toContain('broken session')
+  })
+})

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
@@ -201,6 +201,10 @@ export async function decryptStanzaInPlace(
   // OpenPGP): it will never decrypt regardless of keys, so it is terminal —
   // do NOT stash for retry. Distinct from a signature rejection.
   let terminalFailure = false
+  // Set when a ratcheting plugin reports `broken-session`: the session is
+  // desynced and a plain retry cannot help. We trigger E2EEManager.repairSession
+  // and, like a terminal failure, do NOT stash for deferred retry.
+  let sessionNeedsRepair = false
 
   try {
     const messageId = stanza.attrs.id
@@ -225,9 +229,25 @@ export async function decryptStanzaInPlace(
         ? await manager.decryptArchive(claim.payload.stanzaElement, target, context)
         : await manager.decryptInbound(claim.payload.stanzaElement, target, context)
     if (result) {
-      plaintext = new TextDecoder().decode(result.plaintext)
-      securityContext = result.securityContext
-      if (result.authoredAt) authoredAt = result.authoredAt
+      const status = result.status ?? 'ok'
+      if (status === 'broken-session') {
+        // Ratchet desync — the message cannot be opened until the session is
+        // rebuilt. Trigger repair (fire-and-forget; a plain retry can't fix a
+        // desync) and fall through to the failure path below for the
+        // placeholder + untrusted security context. Not stashed for retry.
+        sessionNeedsRepair = true
+        failureReason = result.securityContext?.notes?.[0] ?? 'broken session'
+        void manager.repairSession(target).catch(() => {})
+      } else {
+        // `ok` and `unverifiable` carry plaintext; `control-message` carries
+        // none (a key-transport / ratchet-advance message). When plaintext is
+        // absent, nothing is decoded and no body is synthesized below — the
+        // control message is consumed silently. Trust comes from the plugin's
+        // securityContext either way (`unverifiable` reports a reduced trust).
+        if (result.plaintext) plaintext = new TextDecoder().decode(result.plaintext)
+        securityContext = result.securityContext
+        if (result.authoredAt) authoredAt = result.authoredAt
+      }
     } else {
       failureReason = 'no plugin claimed the payload'
     }
@@ -266,7 +286,9 @@ export async function decryptStanzaInPlace(
               ? 'rejected: invalid signature'
               : terminalFailure
                 ? 'permanent: malformed payload — not retried'
-                : 'retryable'
+                : sessionNeedsRepair
+                  ? 'broken session — repair triggered, not retried'
+                  : 'retryable'
         }): ${failureReason}`,
       )
     if (isRejection) {
@@ -284,19 +306,22 @@ export async function decryptStanzaInPlace(
       // a placeholder body would surface a forged reaction as a ghost text
       // message. The warn above records the drop in the E2EE events log.
     } else {
-      // Decrypt failure. A structurally malformed payload is terminal — never
-      // stash it (it would re-fail every reconnect). Everything else (key
-      // locked, plugin missing, etc.) is retryable: stash for deferred retry.
-      if (!terminalFailure) stashPayload(stanza, originalStanzaXml)
+      // Decrypt failure. A structurally malformed payload is terminal and a
+      // broken session won't heal on a plain retry — never stash either (it
+      // would re-fail every reconnect; repair drives the broken-session fix).
+      // Everything else (key locked, plugin missing, etc.) is retryable: stash
+      // for deferred retry.
+      const noRetry = terminalFailure || sessionNeedsRepair
+      if (!noRetry) stashPayload(stanza, originalStanzaXml)
       const existingBody = stanza.getChild('body')
-      if (terminalFailure && existingBody) {
-        // The payload will NEVER decrypt, so the sender's XEP-0373 fallback
-        // <body> (cleartext the sender controls) must not stand in as the
-        // message — it would otherwise be shown verbatim forever and counted as
-        // a successful decrypt when retryPendingDecrypts re-runs. Replace it
-        // with the placeholder, mirroring the signature-rejection path above. A
-        // RETRYABLE failure instead keeps the hint: a later successful retry
-        // replaces it with the real plaintext.
+      if (noRetry && existingBody) {
+        // The payload won't be opened by a retry, so the sender's XEP-0373
+        // fallback <body> (cleartext the sender controls) must not stand in as
+        // the message — it would otherwise be shown verbatim forever and
+        // counted as a successful decrypt when retryPendingDecrypts re-runs.
+        // Replace it with the placeholder, mirroring the signature-rejection
+        // path above. A RETRYABLE failure instead keeps the hint: a later
+        // successful retry replaces it with the real plaintext.
         existingBody.children = [COULD_NOT_DECRYPT_BODY]
       } else if (!existingBody) {
         stanza.children.push(xml('body', {}, COULD_NOT_DECRYPT_BODY))
@@ -304,7 +329,13 @@ export async function decryptStanzaInPlace(
       securityContext = {
         protocolId: claim.plugin.descriptor.id,
         trust: 'untrusted',
-        notes: [terminalFailure ? 'Could not decrypt (malformed)' : 'Could not decrypt'],
+        notes: [
+          terminalFailure
+            ? 'Could not decrypt (malformed)'
+            : sessionNeedsRepair
+              ? 'Could not decrypt (session needs repair)'
+              : 'Could not decrypt',
+        ],
       }
     }
   } else if (plaintext !== null) {
@@ -370,7 +401,7 @@ export async function decryptStanzaInPlace(
     attempted: true,
     ...(securityContext && { securityContext }),
     ...(authoredAt && { authoredAt }),
-    ...((failureReason !== null && !terminalFailure && securityContext?.trust !== 'rejected' || needsDeferredVerification) && {
+    ...((failureReason !== null && !terminalFailure && !sessionNeedsRepair && securityContext?.trust !== 'rejected' || needsDeferredVerification) && {
       encryptedPayloadXml: originalStanzaXml,
     }),
   }

--- a/packages/fluux-sdk/src/core/e2ee/types.ts
+++ b/packages/fluux-sdk/src/core/e2ee/types.ts
@@ -139,8 +139,44 @@ export interface SecurityContext {
   fingerprint?: string
 }
 
+/**
+ * Outcome discriminant for a decrypt attempt. Stateless protocols (OpenPGP)
+ * only ever produce `ok` (or throw); stateful ratcheting protocols (OMEMO,
+ * MLS) need the richer set:
+ *
+ * - `ok`              — plaintext recovered; surface it to the user.
+ * - `control-message` — decrypt succeeded and advanced the session, but there
+ *                       is no user-visible content (a key-transport / empty
+ *                       ratchet-advance message). {@link DecryptResult.plaintext}
+ *                       is absent. The host consumes it silently — it must NOT
+ *                       synthesize a placeholder body.
+ * - `broken-session`  — the session is desynchronized (e.g. a ratchet step was
+ *                       missed); decrypt cannot succeed until the session is
+ *                       repaired. The host triggers {@link E2EEPlugin.repairSession}
+ *                       and surfaces a could-not-decrypt placeholder rather than
+ *                       stashing for a plain retry (a retry alone won't fix it).
+ * - `unverifiable`    — plaintext was recovered but the sender's identity could
+ *                       not be authenticated. {@link DecryptResult.securityContext}
+ *                       carries the (untrusted/rejected) trust; the host shows
+ *                       the content with the reduced trust state.
+ */
+export type DecryptStatus = 'ok' | 'control-message' | 'broken-session' | 'unverifiable'
+
 export interface DecryptResult {
-  plaintext: Uint8Array
+  /**
+   * Recovered plaintext bytes. Optional because ratcheting protocols emit
+   * control / key-transport messages that advance session state but carry no
+   * user-visible body — see {@link DecryptStatus} `control-message`. When
+   * `status` is `ok` (or omitted) this MUST be present; for `control-message`
+   * and `broken-session` it is absent.
+   */
+  plaintext?: Uint8Array
+  /**
+   * What kind of result this is. Omitted is equivalent to `'ok'` so existing
+   * stateless plugins (OpenPGP, the dummy plugin) need no change — they return
+   * `plaintext` and the host treats it as a normal decrypt.
+   */
+  status?: DecryptStatus
   senderDevice: DeviceIdentifier
   securityContext: SecurityContext
   /**
@@ -223,6 +259,27 @@ export interface InboundDecryptContext {
  * - `archive` — the stanza was retrieved via XEP-0313 MAM replay.
  */
 export type InboundSource = 'live' | 'archive'
+
+/**
+ * One archived message to decrypt as part of a batch — see
+ * {@link E2EEPlugin.decryptArchiveBatch}. Bundles the extracted payload with
+ * its optional per-message context (stanza id, archive timestamp) so a
+ * ratcheting plugin can decrypt a whole MAM page against frozen session state
+ * in a single call instead of re-deriving state once per message.
+ */
+export interface ArchiveDecryptItem {
+  payload: EncryptedPayload
+  context?: InboundDecryptContext
+}
+
+/**
+ * Admin-tunable, plugin-internal settings forwarded verbatim through
+ * {@link E2EEPlugin.configure}. The host does not interpret the contents —
+ * each plugin documents and validates its own keys (e.g. signed-prekey
+ * rotation cadence, stale-device policy, device-list refresh interval). Opaque
+ * by design so the host needs no knowledge of any protocol's options.
+ */
+export type PluginConfiguration = Record<string, unknown>
 
 /**
  * Notification a plugin emits after re-evaluating a previously-delivered
@@ -475,6 +532,48 @@ export interface E2EEPlugin {
     payload: EncryptedPayload,
     context?: InboundDecryptContext,
   ): Promise<DecryptResult>
+
+  /**
+   * Optional: decrypt a whole page of archived messages in one call.
+   *
+   * MAM catch-up replays many messages at once. Calling
+   * {@link E2EEPlugin.decryptArchive} once per message forces a ratcheting
+   * plugin to load and re-freeze its session state on every message; a batch
+   * lets it freeze once and walk the page. The returned array MUST be aligned
+   * to `items` by index — element `i` is the result for `items[i]`. A plugin
+   * that cannot decrypt a particular item should still occupy its slot (e.g.
+   * with a `broken-session` / `unverifiable` {@link DecryptResult}) rather than
+   * shifting later results.
+   *
+   * Plugins without batch needs omit this — the host falls back to looping
+   * {@link E2EEPlugin.decryptArchive} (then {@link E2EEPlugin.decrypt}), which
+   * is semantically identical for stateless protocols.
+   */
+  decryptArchiveBatch?(handle: ConversationHandle, items: ArchiveDecryptItem[]): Promise<DecryptResult[]>
+
+  /**
+   * Optional: rebuild a desynchronized session with `peer`.
+   *
+   * Ratcheting protocols can lose session sync (a dropped message, a device
+   * reset, key material that no longer lines up). When {@link E2EEPlugin.decrypt}
+   * reports {@link DecryptStatus} `broken-session`, the host calls this to let
+   * the plugin re-handshake — typically by discarding the broken session and
+   * sending an empty/key-transport message to re-establish the ratchet. The
+   * call should be idempotent and safe to invoke repeatedly. Stateless
+   * protocols (OpenPGP) have no session to repair and omit this.
+   */
+  repairSession?(handle: ConversationHandle, peer: BareJID): Promise<void>
+
+  /**
+   * Optional: apply admin-tunable, plugin-internal settings.
+   *
+   * The host forwards {@link PluginConfiguration} verbatim without interpreting
+   * it (e.g. signed-prekey rotation cadence, stale-device ignoring,
+   * device-list refresh policy). Plugins validate their own keys and ignore
+   * unknown ones. Safe to call more than once; later calls supersede earlier
+   * ones. Plugins with no tunables omit this.
+   */
+  configure?(options: PluginConfiguration): Promise<void>
 
   /** List verification methods this protocol supports (may be empty). */
   getVerificationMethods(): VerificationMethod[]

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -407,11 +407,13 @@ export {
 export type { SigncryptEnvelope } from './core/e2ee'
 export type {
   AccountInfo,
+  ArchiveDecryptItem,
   BareJID,
   CapabilityCacheOptions,
   ConversationHandle,
   ConversationTarget,
   DecryptResult,
+  DecryptStatus,
   DeviceIdentifier,
   DiscoFeature,
   DiscoResult,
@@ -427,6 +429,7 @@ export type {
   PEPItem,
   PeerSupport,
   PinnedStrategy,
+  PluginConfiguration,
   PluginContext,
   PluginStorage,
   ProtocolFeatures,


### PR DESCRIPTION
Extends the E2EE plugin trait with the four accommodations ratcheting protocols (OMEMO, MLS) need — ahead of any OMEMO implementation — so the trait is stable before Phase 2 rather than refactored mid-flight. These are the hooks the E2EE architecture lists under "Ratcheting protocol considerations" and that the current OpenPGP-shaped trait was missing. Purely additive: existing OpenPGP/Dummy plugins are unchanged.

## What changed

- **Optional `plaintext` + `DecryptStatus`** (`ok | control-message | broken-session | unverifiable`, absent ⇒ `ok`). `stanzaDecrypt` now consumes control messages silently (no body synthesized, no retry stash) and, on a broken session, shows a could-not-decrypt placeholder and triggers repair instead of stashing for a plain retry.
- **`decryptArchiveBatch`** trait hook + `E2EEManager.decryptArchiveBatch()` so a plugin can decrypt a whole MAM page against frozen session state in one call. Batch fast-path only when every item is claimed by one batch-capable plugin; otherwise loops the existing single `decryptArchive`. Index-aligned, `null` slot for unclaimed. `MAM.ts` adoption deferred (no consumer yet).
- **`repairSession`** trait hook + `E2EEManager.repairSession()` for ratchet desync; returns `false` for stateless plugins.
- **`configure`** trait hook + `E2EEManager.configure()` passthrough for admin-tunable plugin options (opaque `PluginConfiguration`).

New types `ArchiveDecryptItem`, `DecryptStatus`, `PluginConfiguration` exported from the SDK.