### PR TITLE
Mobile: tap-target cascade + pinch-zoom accessibility

### DIFF
--- a/apps/fluux/demo.html
+++ b/apps/fluux/demo.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Fluux Messenger — Demo</title>
     <meta name="theme-color" content="#1a1b1e" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#d8dadf" media="(prefers-color-scheme: light)" />

--- a/apps/fluux/index.html
+++ b/apps/fluux/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <!-- Pinch-zoom is intentionally NOT disabled (accessibility); the 300ms tap
+         delay is handled via `touch-action: manipulation` in index.css instead. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Fluux Messenger</title>
 
     <!-- PWA Meta Tags - theme-color for Android status bar -->

--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -85,7 +85,7 @@ export function ChatHeader({
       {onBack && (
         <button
           onClick={onBack}
-          className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden"
+          className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
           aria-label={t('conversations.backToConversations')}
         >
           <ArrowLeft className="size-5 text-fluux-muted rtl-mirror" />
@@ -167,7 +167,8 @@ export function ChatHeader({
       {onSearchInConversation && (
         <button
           onClick={onSearchInConversation}
-          className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+          aria-label={t('chat.searchInConversation', 'Search in conversation')}
           title={t('chat.searchInConversation', 'Search in conversation')}
         >
           <Search className="size-4" />
@@ -179,7 +180,7 @@ export function ChatHeader({
         <OverflowMenu
           ariaLabel={t('contacts.actionsMenu')}
           items={menuItems}
-          buttonClassName="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          buttonClassName="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
           iconClassName="size-4"
         />
       )}
@@ -194,7 +195,7 @@ function formatFingerprint(fp: string): string {
 function KeyLockedIcon({ fingerprint }: { fingerprint?: string }) {
   const { t } = useTranslation()
   const openWebUnlockDialog = useWebUnlockDialogStore((s) => s.openWebUnlockDialog)
-  const btnClass = 'p-1.5 rounded transition-colors'
+  const btnClass = 'p-1.5 rounded transition-colors tap-target'
   const tooltip = (
     <div>
       <div>{t('chat.encryption.keyLockedTooltip')}</div>
@@ -233,7 +234,7 @@ function EncryptionIcon({
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
-  const btnClass = 'p-1.5 rounded transition-colors'
+  const btnClass = 'p-1.5 rounded transition-colors tap-target'
 
   useEffect(() => {
     if (!open) return

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -814,7 +814,7 @@ export function MessageComposer({
                   handleFileClick()
                 }}
                 disabled={!isUploadSupported}
-                className={`w-full flex items-center gap-3 px-3 py-2 text-sm text-start transition-colors ${
+                className={`w-full flex items-center gap-3 px-3 py-2 touch:py-3 text-sm text-start transition-colors ${
                   isUploadSupported
                     ? 'text-fluux-text hover:bg-fluux-hover'
                     : 'text-fluux-muted/50 cursor-not-allowed'
@@ -830,7 +830,7 @@ export function MessageComposer({
                     setShowAttachMenu(false)
                     onCreatePoll()
                   }}
-                  className="w-full flex items-center gap-3 px-3 py-2 text-sm text-start text-fluux-text hover:bg-fluux-hover transition-colors"
+                  className="w-full flex items-center gap-3 px-3 py-2 touch:py-3 text-sm text-start text-fluux-text hover:bg-fluux-hover transition-colors"
                 >
                   <BarChart3 className="size-4 flex-shrink-0" />
                   {t('poll.create', 'Create Poll')}

--- a/apps/fluux/src/components/ModalShell.tsx
+++ b/apps/fluux/src/components/ModalShell.tsx
@@ -50,7 +50,7 @@ export function ModalShell({
             <button
               onClick={onClose}
               aria-label={t('common.close')}
-              className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover"
+              className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover tap-target"
             >
               <X className="size-4" />
             </button>

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -142,7 +142,7 @@ export function RoomHeader({
       {onBack && (
         <button
           onClick={onBack}
-          className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden"
+          className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
           aria-label={t('rooms.backToRooms')}
         >
           <ArrowLeft className="size-5 text-fluux-muted rtl-mirror" />
@@ -179,7 +179,7 @@ export function RoomHeader({
         <Tooltip content={t('rooms.notificationSettings')} position="bottom" disabled={showNotifyMenu}>
           <button
             onClick={() => setShowNotifyMenu(!showNotifyMenu)}
-            className={`flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors
+            className={`flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target
                        ${notifyMode !== 'mentions'
                          ? 'bg-fluux-brand/20 text-fluux-brand'
                          : 'hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text'
@@ -248,7 +248,7 @@ export function RoomHeader({
       <Tooltip content={t('rooms.inviteMember')} position="bottom">
         <button
           onClick={() => setShowInviteModal(true)}
-          className="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          className="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
           aria-label={t('rooms.inviteMember')}
         >
           <UserPlus className="size-4" />
@@ -261,7 +261,7 @@ export function RoomHeader({
           <Tooltip content={t('rooms.manageRoom')} position="bottom" disabled={showOwnerMenu}>
             <button
               onClick={() => setShowOwnerMenu(!showOwnerMenu)}
-              className={`flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors
+              className={`flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target
                          ${showOwnerMenu
                            ? 'bg-fluux-hover text-fluux-text'
                            : 'hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text'
@@ -393,7 +393,8 @@ export function RoomHeader({
         <Tooltip content={t('chat.searchInConversation', 'Search in conversation')} position="bottom">
           <button
             onClick={onSearchInConversation}
-            className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+            className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+            aria-label={t('chat.searchInConversation', 'Search in conversation')}
           >
             <Search className="size-4" />
           </button>
@@ -404,7 +405,7 @@ export function RoomHeader({
       <Tooltip content={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')} position="bottom">
         <button
           onClick={onToggleOccupants}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
                      ${showOccupants
                        ? 'bg-fluux-brand/20 text-fluux-brand'
                        : 'hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text'

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           aria-label="contacts.actionsMenu"
-          class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
           type="button"
         >
           <span
@@ -500,7 +500,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
           aria-expanded="false"
           aria-haspopup="menu"
           aria-label="contacts.actionsMenu"
-          class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+          class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
           type="button"
         >
           <span

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
           >
             <button
               aria-label="rooms.notificationSettings"
-              class="flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors
+              class="flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target
                        hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
             >
               <span
@@ -66,7 +66,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
         >
           <button
             aria-label="rooms.inviteMember"
-            class="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+            class="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
           >
             <span
               data-testid="icon-user-plus"
@@ -80,7 +80,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
         >
           <button
             aria-label="rooms.showMembers"
-            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
                      hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
           >
             <span

--- a/apps/fluux/src/components/conversation/MessageReactions.tsx
+++ b/apps/fluux/src/components/conversation/MessageReactions.tsx
@@ -77,7 +77,7 @@ export const MessageReactions = memo(function MessageReactions({
               }
               onReaction(emoji)
             } : undefined}
-            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 touch:px-2.5 touch:py-1.5 rounded-full text-xs
                        border transition-colors ${
                          myReactions.includes(emoji)
                            ? 'bg-fluux-brand/20 border-fluux-brand'

--- a/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
@@ -222,7 +222,7 @@ interface MenuButtonProps {
 }
 
 export function MenuButton({ onClick, icon, label, variant = 'default', className = '' }: MenuButtonProps) {
-  const baseClasses = 'w-full px-3 py-2 flex items-center gap-3 text-start transition-colors'
+  const baseClasses = 'w-full px-3 py-2 touch:py-3 flex items-center gap-3 text-start transition-colors'
   const variantClasses = variant === 'danger'
     ? 'text-fluux-red hover:bg-fluux-red hover:text-white'
     : 'text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent'

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -407,7 +407,8 @@ html, body {
   /* Disable iOS/Safari text-size auto-adjust when rotating */
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
-  /* Prevent double-tap zoom on touch devices; pinch-zoom already disabled via viewport meta */
+  /* Remove the 300ms tap delay (double-tap-to-zoom) on touch; pinch-zoom stays
+     available via the viewport meta for accessibility. */
   touch-action: manipulation;
 }
 


### PR DESCRIPTION
Phase 2 of the mobile/touch work (follows #578) — a pure ergonomic pass, **no behaviour change**.

On touch devices, small icon buttons and menu rows now meet the 44px hit-area guideline. On desktop (hover / fine pointer) everything is byte-for-byte unchanged, because the `.tap-target` utility and `touch:` variants are gated behind `(hover: none)/(pointer: coarse)`.

- **ModalShell** close button → `.tap-target` (cascades to every modal)
- **ChatHeader / RoomHeader** icon buttons (back, search, invite, encryption, kebab, notify / manage / occupants) → `.tap-target`; the search button also gains an `aria-label` (it previously had only a hover `title`, invisible to touch and screen readers)
- shared **MenuButton** rows → `touch:py-3` (sidebar context menus + the action sheet)
- composer attach / poll menu rows → `touch:py-3`
- reaction pills → larger touch padding
- viewport meta drops `user-scalable=no` / `maximum-scale` so **pinch-zoom** works (accessibility); `touch-action: manipulation` already removes the 300ms tap delay