### PR TITLE
Mobile: tap-target sweep for long-tail screens (settings, admin, search, login)

### DIFF
--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -359,7 +359,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
                 <button
                   onClick={handleAddUser}
                   className="p-1.5 text-fluux-muted hover:text-fluux-brand hover:bg-fluux-hover
-                             rounded-lg transition-colors"
+                             rounded-lg transition-colors tap-target"
                   aria-label={t('admin.userList.addUser')}
                 >
                   <Plus className="size-5" />
@@ -425,7 +425,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
         {onBack && (
           <button
             onClick={onBack}
-            className="p-1 -ms-1 me-2 rounded hover:bg-fluux-hover md:hidden"
+            className="p-1 -ms-1 me-2 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back')}
           >
             <ArrowLeft className="size-5 text-fluux-muted rtl-mirror" />

--- a/apps/fluux/src/components/ContactProfileView.tsx
+++ b/apps/fluux/src/components/ContactProfileView.tsx
@@ -208,7 +208,7 @@ export function ContactProfileView({
           {onBack && (
             <button
               onClick={onBack}
-              className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden"
+              className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
               aria-label={t('common.back')}
             >
               <ArrowLeft className="size-5 text-fluux-muted rtl-mirror" />

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -433,7 +433,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
                 }}
                 disabled={isLoading}
                 className="absolute end-2 top-1/2 -translate-y-1/2 p-1 text-fluux-muted hover:text-fluux-text
-                           disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                           disabled:opacity-50 disabled:cursor-not-allowed transition-colors tap-target"
                 aria-label={showPassword ? t('login.hidePassword') : t('login.showPassword')}
               >
                 {showPassword ? (

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -279,7 +279,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
         {onBack && (
           <button
             onClick={handleBack}
-            className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden"
+            className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back', 'Back')}
           >
             <ArrowLeft className="size-5 text-fluux-muted rtl-mirror" />

--- a/apps/fluux/src/components/SettingsView.tsx
+++ b/apps/fluux/src/components/SettingsView.tsx
@@ -76,7 +76,7 @@ export function SettingsView({ onBack }: SettingsViewProps) {
         {onBack && (
           <button
             onClick={onBack}
-            className="p-1 -ms-1 me-2 rounded hover:bg-fluux-hover md:hidden"
+            className="p-1 -ms-1 me-2 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back')}
           >
             <ArrowLeft className="size-5 text-fluux-muted rtl-mirror" />

--- a/apps/fluux/src/components/contact-profile/ContactProfileHero.tsx
+++ b/apps/fluux/src/components/contact-profile/ContactProfileHero.tsx
@@ -105,7 +105,7 @@ export function ContactProfileHero({
                     type="button"
                     onClick={onStartEdit}
                     aria-label={t('contacts.rename')}
-                    className="p-1 ms-1 text-fluux-muted hover:text-fluux-text rounded opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                    className="p-1 ms-1 text-fluux-muted hover:text-fluux-text rounded opacity-0 group-hover:opacity-100 focus:opacity-100 touch:opacity-100 transition-opacity tap-target"
                   >
                     <Pencil className="size-4" />
                   </button>

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -907,7 +907,7 @@ export function EncryptionSettings() {
                   </code>
                   <button
                     onClick={handleCopyFingerprint}
-                    className="p-1.5 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover transition-colors"
+                    className="p-1.5 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover transition-colors tap-target"
                     title={t('settings.encryption.copyFingerprint')}
                     aria-label={t('settings.encryption.copyFingerprint')}
                   >
@@ -936,7 +936,7 @@ export function EncryptionSettings() {
             <button
               onClick={handleDismissLimitations}
               aria-label={t('common.close')}
-              className="flex-shrink-0 p-0.5 text-fluux-muted hover:text-fluux-text rounded transition-colors"
+              className="flex-shrink-0 p-0.5 text-fluux-muted hover:text-fluux-text rounded transition-colors tap-target"
             >
               <X className="size-3.5" />
             </button>

--- a/apps/fluux/src/components/settings-components/profile/OwnProfileHero.tsx
+++ b/apps/fluux/src/components/settings-components/profile/OwnProfileHero.tsx
@@ -192,13 +192,13 @@ export function OwnProfileHero({
           ) : (
             <div className="group relative flex items-center justify-center md:justify-start gap-1">
               <h1 className="text-xl font-bold text-fluux-text break-all">{displayName}</h1>
-              <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+              <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 touch:opacity-100 transition-opacity">
                 <Tooltip content={t('profile.editNickname')} position="top">
                   <button
                     type="button"
                     onClick={handleStartEdit}
                     disabled={!isConnected}
-                    className="p-1 text-fluux-muted hover:text-fluux-text rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="p-1 text-fluux-muted hover:text-fluux-text rounded disabled:opacity-50 disabled:cursor-not-allowed tap-target"
                     aria-label={t('profile.editNickname')}
                   >
                     <Pencil className="size-4" />
@@ -210,7 +210,7 @@ export function OwnProfileHero({
                       type="button"
                       onClick={handleClearNickname}
                       disabled={!isConnected || clearing === 'nickname'}
-                      className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50 disabled:cursor-not-allowed tap-target"
                       aria-label={t('profile.resetToUsername')}
                     >
                       <Trash2 className="size-4" />

--- a/apps/fluux/src/components/sidebar-components/EventsView.tsx
+++ b/apps/fluux/src/components/sidebar-components/EventsView.tsx
@@ -187,7 +187,7 @@ function SystemNotificationItem({ notification, onDismiss }: SystemNotificationI
         <Tooltip content={t('sidebar.dismiss')} position="left">
           <button
             onClick={onDismiss}
-            className="text-fluux-muted hover:text-fluux-text transition-colors"
+            className="text-fluux-muted hover:text-fluux-text transition-colors tap-target"
             aria-label={t('sidebar.dismiss')}
           >
             <X className="size-4" />

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -132,7 +132,8 @@ export function SearchView() {
           {query && (
             <button
               onClick={clearSearch}
-              className="absolute end-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-fluux-hover text-fluux-muted"
+              className="absolute end-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-fluux-hover text-fluux-muted tap-target"
+              aria-label={t('common.clear')}
             >
               <X className="size-3.5" />
             </button>
@@ -170,7 +171,8 @@ export function SearchView() {
           </span>
           <button
             onClick={() => setSearchScope(null)}
-            className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted flex-shrink-0"
+            className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted flex-shrink-0 tap-target"
+            aria-label={t('search.clearScope', 'Search all conversations')}
             title={t('search.clearScope', 'Search all conversations')}
           >
             <X className="size-3" />


### PR DESCRIPTION
Phase 4 (final) of the mobile/touch work — the long-tail sweep. Applies the touch-only `.tap-target` 44px hit-area to small icon buttons on lower-traffic screens. **Independent of #580/#581** (branches off `main`, only needs the `.tap-target` utility already merged in #578).

No behaviour change on desktop — `.tap-target` and the `touch:` variants are gated behind `(hover: none)/(pointer: coarse)`.

- **Back buttons:** Settings, Admin, Search-context, Contact-profile
- **Login:** show/hide-password toggle (every user hits this)
- **Search:** clear-query and clear-scope — the scope button also gains an `aria-label` (was `title`-only, invisible to touch + screen readers)
- **Admin:** add-user
- **Events:** dismiss-notification
- **Encryption settings:** copy-fingerprint, dismiss-limitations
- **Profile edit pencils** (own + contact): also `touch:opacity-100` so these group-hover-only controls are reachable on touch at all