### PR TITLE
Mobile: tablet occupant panel as an overlay drawer

### DIFF
--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -504,7 +504,8 @@ export function OccupantPanel({
             <Tooltip content={t('rooms.closePanel')} position="left">
               <button
                 onClick={onClose}
-                className="p-1 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
+                aria-label={t('rooms.closePanel')}
+                className="p-1 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
               >
                 <X className="size-4" />
               </button>

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -611,17 +611,31 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
         {warningDialog}
       </div>
 
-      {/* Occupant panel (inline sidebar, desktop only — mobile uses full-screen in ChatLayout) */}
+      {/* Occupant panel (>=768px; <768 uses the full-screen panel in ChatLayout).
+          Below lg it's a right-edge drawer over a dimmed backdrop so it doesn't
+          squeeze the chat into a narrow column on tablets; at lg+ there's room
+          for it as an in-flow side column. */}
       {showOccupants && !isSmallScreen() && (
-        <OccupantPanel
-          room={activeRoom}
-          contactsByJid={contactsByJid}
-          ownAvatar={ownAvatar}
-          onClose={handleCloseOccupants}
-          onStartChat={onStartChat}
-          onWhisper={enterWhisperMode}
-          onShowProfile={onShowProfile}
-        />
+        <>
+          <button
+            type="button"
+            aria-hidden="true"
+            tabIndex={-1}
+            onClick={handleCloseOccupants}
+            className="fixed inset-0 z-30 bg-black/50 lg:hidden"
+          />
+          <div className="fixed inset-y-0 end-0 z-40 flex shadow-xl animate-drawer-in lg:static lg:z-auto lg:shadow-none">
+            <OccupantPanel
+              room={activeRoom}
+              contactsByJid={contactsByJid}
+              ownAvatar={ownAvatar}
+              onClose={handleCloseOccupants}
+              onStartChat={onStartChat}
+              onWhisper={enterWhisperMode}
+              onShowProfile={onShowProfile}
+            />
+          </div>
+        </>
       )}
 
       {/* Christmas easter egg animation */}

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -485,6 +485,16 @@ html, body {
   }
 }
 
+/* Tablet occupant drawer: below lg the OccupantPanel is an overlay that slides */
+/* in from the inline-end edge (RTL-aware). The animation is scoped below lg — */
+/* at lg+ the panel is an in-flow column and must not animate or transform. */
+@keyframes drawer-in-end { from { transform: translateX(100%); } to { transform: translateX(0); } }
+@keyframes drawer-in-end-rtl { from { transform: translateX(-100%); } to { transform: translateX(0); } }
+@media (max-width: 1023px) {
+  .animate-drawer-in { animation: drawer-in-end 220ms cubic-bezier(0.32, 0.72, 0, 1); }
+  [dir="rtl"] .animate-drawer-in { animation: drawer-in-end-rtl 220ms cubic-bezier(0.32, 0.72, 0, 1); }
+}
+
 /* Allow native rubber band effect within scrollable elements (macOS) */
 /* Using 'auto' enables the visual bounce, while 'none' on html/body prevents whole-page bounce */
 /* -webkit-overflow-scrolling: touch enables momentum/bounce scrolling in WebKit */


### PR DESCRIPTION
On tablets (md–lg, 768–1023px) the room occupant panel opened as a 4th in-flow column, squeezing the chat to ~370px. It now slides in as a **right-edge drawer over a dimmed backdrop** (tap the backdrop or the X to close), leaving the chat at full width behind it.

- At **lg+** (≥1024px) it stays the in-flow side column, exactly as before.
- **Below md** (<768px) the existing full-screen panel in ChatLayout is unchanged.
- Pure responsive CSS — no JS breakpoint: the same render is a `fixed` drawer below `lg` and `lg:static` in-flow column at `lg+`; the backdrop is `lg:hidden`.

Changes:
- `RoomView`: wrap the occupant panel in a backdrop + drawer container
- `index.css`: RTL-aware `.animate-drawer-in` slide-in, scoped below `lg`
- `OccupantPanel`: `tap-target` + `aria-label` on the close button