### PR TITLE
feat: notify for delayed 1:1 messages on reconnect

### DIFF
--- a/apps/fluux/src/hooks/notificationCoalescer.test.ts
+++ b/apps/fluux/src/hooks/notificationCoalescer.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { createNotificationCoalescer } from './notificationCoalescer'
+
+describe('createNotificationCoalescer', () => {
+  it('is closed initially and add returns false (caller dispatches immediately)', () => {
+    const c = createNotificationCoalescer<string>()
+    expect(c.isOpen()).toBe(false)
+    expect(c.add('a', 'x')).toBe(false)
+  })
+
+  it('buffers latest payload per id while open and flushes one entry per id in insertion order', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    expect(c.isOpen()).toBe(true)
+    expect(c.add('a', 'a1')).toBe(true)
+    expect(c.add('a', 'a2')).toBe(true) // latest wins
+    expect(c.add('b', 'b1')).toBe(true)
+    expect(c.flush()).toEqual([
+      { id: 'a', payload: 'a2' },
+      { id: 'b', payload: 'b1' },
+    ])
+  })
+
+  it('flush closes the window and clears the buffer', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    c.add('a', 'a1')
+    c.flush()
+    expect(c.isOpen()).toBe(false)
+    expect(c.flush()).toEqual([])
+  })
+
+  it('drop clears the buffer and closes without returning entries', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    c.add('a', 'a1')
+    c.drop()
+    expect(c.isOpen()).toBe(false)
+    expect(c.flush()).toEqual([])
+  })
+})

--- a/apps/fluux/src/hooks/notificationCoalescer.ts
+++ b/apps/fluux/src/hooks/notificationCoalescer.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-id notification coalescer (pure, no timers).
+ *
+ * Used by useDesktopNotifications to collapse a reconnect "catch-up" burst into
+ * one notification per conversation. The owning hook controls timing (open the
+ * window on reconnect, flush after a fixed delay); this buffer only decides what
+ * to keep. While open, the latest payload per id wins; while closed, callers
+ * dispatch immediately.
+ */
+export interface CoalescedEntry<T> {
+  id: string
+  payload: T
+}
+
+export interface NotificationCoalescer<T> {
+  /** Whether the coalescing window is currently open. */
+  isOpen(): boolean
+  /** Open the window; subsequent add() calls buffer instead of returning false. */
+  open(): void
+  /** Buffer the latest payload for id. Returns true if buffered, false if window closed. */
+  add(id: string, payload: T): boolean
+  /** Return one entry per id (latest payload, insertion order), clear, and close. */
+  flush(): CoalescedEntry<T>[]
+  /** Clear the buffer and close without returning entries. */
+  drop(): void
+}
+
+export function createNotificationCoalescer<T>(): NotificationCoalescer<T> {
+  let open = false
+  const buffer = new Map<string, T>()
+
+  return {
+    isOpen: () => open,
+    open: () => {
+      open = true
+    },
+    add: (id, payload) => {
+      if (!open) return false
+      buffer.set(id, payload)
+      return true
+    },
+    flush: () => {
+      const entries = Array.from(buffer, ([id, payload]) => ({ id, payload }))
+      buffer.clear()
+      open = false
+      return entries
+    },
+    drop: () => {
+      buffer.clear()
+      open = false
+    },
+  }
+}

--- a/apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, cleanup } from '@testing-library/react'
+
+// Capture the conversation handler passed to useNotificationEvents.
+let capturedOnConversationMessage:
+  | ((conv: unknown, message: unknown) => void)
+  | undefined
+
+// Drive connection status from the test.
+let currentStatus = 'connecting'
+const setStatus = (s: string) => {
+  currentStatus = s
+}
+
+const showWebNotification = vi.fn()
+
+vi.mock('./useNotificationEvents', () => ({
+  useNotificationEvents: (handlers: {
+    onConversationMessage?: (conv: unknown, message: unknown) => void
+  }) => {
+    capturedOnConversationMessage = handlers.onConversationMessage
+  },
+}))
+
+vi.mock('./useNotificationPermission', () => ({
+  useNotificationPermission: () => {},
+  getNotificationPermissionGranted: () => true,
+  isTauri: false,
+}))
+
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({
+    navigateToConversation: vi.fn(),
+    navigateToRoom: vi.fn(),
+  }),
+}))
+
+vi.mock('@/utils/webNotification', () => ({
+  showWebNotification: (...args: unknown[]) => showWebNotification(...args),
+}))
+
+vi.mock('@/utils/notificationAvatar', () => ({
+  getNotificationAvatarUrl: () => Promise.resolve(undefined),
+}))
+
+vi.mock('@/utils/messagePreviewText', () => ({
+  formatLocalizedPreview: (m: { body?: string }) => m.body ?? '',
+}))
+
+vi.mock('@/utils/notificationDebug', () => ({
+  notificationDebug: { desktopNotification: vi.fn() },
+}))
+
+vi.mock('@/utils/notificationRouting', () => ({
+  routeNotificationTarget: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+vi.mock('@fluux/sdk', () => ({
+  rosterStore: { getState: () => ({ getContact: () => undefined }) },
+  usePresence: () => ({ presenceStatus: 'online' }),
+  useConnectionStatus: () => ({ status: currentStatus }),
+}))
+
+import { useDesktopNotifications } from './useDesktopNotifications'
+
+const conv = (id: string) => ({
+  id,
+  name: id,
+  unreadCount: 1,
+  lastSeenMessageId: undefined,
+})
+const msg = (id: string, body: string) => ({
+  id,
+  from: `${id}@example.com`,
+  body,
+  timestamp: new Date(),
+  isOutgoing: false,
+})
+
+// showConversationNotification is async (awaits the avatar URL before calling
+// showWebNotification), so assertions must let queued microtasks settle.
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useDesktopNotifications catch-up window', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    showWebNotification.mockClear()
+    capturedOnConversationMessage = undefined
+    currentStatus = 'connecting'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('coalesces a reconnect burst into one notification per conversation', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+
+    // Transition into online → catch-up window opens.
+    act(() => {
+      setStatus('online')
+      rerender()
+    })
+
+    act(() => {
+      capturedOnConversationMessage?.(conv('alice'), msg('a1', 'a'))
+      capturedOnConversationMessage?.(conv('alice'), msg('a2', 'b'))
+      capturedOnConversationMessage?.(conv('bob'), msg('b1', 'c'))
+    })
+
+    // Nothing fired yet — all buffered.
+    expect(showWebNotification).not.toHaveBeenCalled()
+
+    // Window closes after CATCHUP_WINDOW_MS (3000); async advance flushes the
+    // awaited avatar-URL chain inside the flushed dispatches.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(showWebNotification).toHaveBeenCalledTimes(2) // alice + bob
+  })
+
+  it('dispatches immediately outside the catch-up window', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+    // Commit the status-change render synchronously first, then advance time in a
+    // separate async act (split acts avoid React 19's deferred-commit timing bug).
+    act(() => {
+      setStatus('online')
+      rerender()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000) // window opens then closes
+    })
+    showWebNotification.mockClear()
+
+    await act(async () => {
+      capturedOnConversationMessage?.(conv('carol'), msg('c1', 'd'))
+      await flushMicrotasks()
+    })
+
+    expect(showWebNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops buffered notifications when the connection leaves online', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+    act(() => {
+      setStatus('online')
+      rerender()
+    })
+    act(() => {
+      capturedOnConversationMessage?.(conv('dave'), msg('d1', 'e'))
+    })
+
+    // Commit the 'reconnecting' transition synchronously so its effect drops the
+    // buffer and clears the timer BEFORE fake time advances.
+    act(() => {
+      setStatus('reconnecting')
+      rerender()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(showWebNotification).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx
@@ -153,6 +153,30 @@ describe('useDesktopNotifications catch-up window', () => {
     expect(showWebNotification).toHaveBeenCalledTimes(1)
   })
 
+  it('includes the unread count in the title when a conversation has multiple unread', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+
+    act(() => {
+      setStatus('online')
+      rerender()
+    })
+
+    // Use a conv with unreadCount: 3 to exercise the "(N)" suffix branch.
+    const multiUnreadConv = { id: 'eve', name: 'eve', unreadCount: 3, lastSeenMessageId: undefined }
+    act(() => {
+      capturedOnConversationMessage?.(multiUnreadConv, msg('e1', 'hello'))
+    })
+
+    expect(showWebNotification).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(showWebNotification).toHaveBeenCalledTimes(1)
+    expect(showWebNotification.mock.calls[0][0]).toContain('(3)')
+  })
+
   it('drops buffered notifications when the connection leaves online', async () => {
     const { rerender } = renderHook(() => useDesktopNotifications())
     act(() => {

--- a/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
@@ -52,6 +52,7 @@ vi.mock('./useNotificationEvents', () => ({
 vi.mock('@fluux/sdk', () => ({
   rosterStore: { getState: () => ({ getContact: () => undefined }) },
   usePresence: () => ({ presenceStatus: 'online' }),
+  useConnectionStatus: () => ({ status: 'disconnected' }),
 }))
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
 

--- a/apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
@@ -32,7 +32,7 @@ vi.mock('./useNotificationPermission', () => ({
   getNotificationPermissionGranted: () => true,
 }))
 vi.mock('./useNotificationEvents', () => ({ useNotificationEvents: vi.fn() }))
-vi.mock('@fluux/sdk', () => ({ rosterStore: { getState: () => ({ getContact: () => undefined }) }, usePresence: () => ({ presenceStatus: 'online' }) }))
+vi.mock('@fluux/sdk', () => ({ rosterStore: { getState: () => ({ getContact: () => undefined }) }, usePresence: () => ({ presenceStatus: 'online' }), useConnectionStatus: () => ({ status: 'disconnected' }) }))
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
 
 import { useDesktopNotifications } from './useDesktopNotifications'

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -248,10 +248,20 @@ export function useDesktopNotifications(): void {
     showConvNotifRef.current = showConversationNotification
   })
 
-  // Open a catch-up window on each transition into 'online' (fresh connect,
-  // SM resume, or post-wake verify→online). Buffer per-conversation during the
-  // window; flush one notification per conversation when it closes. Drop the
-  // buffer if the connection leaves 'online' before flushing.
+  // Open a catch-up window on each transition INTO 'online' from a non-online
+  // status. This covers every path that carries a real reconnect backlog:
+  // fresh connect (login), socket-died/SM-resume, and long-sleep reconnect —
+  // all of which transit 'reconnecting' first. It intentionally does NOT cover
+  // the verify-pass short-sleep path (connected → verifying → connected), where
+  // the connection never dropped: the state machine maps 'verifying' to 'online'
+  // (status never leaves 'online'), no online/resumed event fires, and there is
+  // no backlog flush — messages arrive live. Coalescing that path would require
+  // a wake-triggered window that delays every live notification after each
+  // unlock, which is not worth it for a typically-empty trickle. See the design
+  // doc's Non-goals.
+  // Buffer per-conversation during the window; flush one notification per
+  // conversation when it closes. Drop the buffer if the connection leaves
+  // 'online' before flushing.
   useEffect(() => {
     const prev = prevStatusRef.current
     prevStatusRef.current = status

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { rosterStore, usePresence } from '@fluux/sdk'
+import { rosterStore, usePresence, useConnectionStatus } from '@fluux/sdk'
 import type { Conversation, Message, Room, RoomMessage } from '@fluux/sdk'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
@@ -19,6 +19,11 @@ import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { notificationDebug } from '@/utils/notificationDebug'
 import { showWebNotification } from '@/utils/webNotification'
 import { routeNotificationTarget } from '@/utils/notificationRouting'
+import { createNotificationCoalescer } from './notificationCoalescer'
+
+/** Duration of the post-reconnect window during which offline-delivery
+ *  notifications are coalesced to one per conversation. */
+const CATCHUP_WINDOW_MS = 3000
 
 /**
  * Hook to show desktop notifications for new messages and room mentions.
@@ -39,6 +44,16 @@ export function useDesktopNotifications(): void {
   const navigateToConversationRef = useRef(navigateToConversation)
   const navigateToRoomRef = useRef(navigateToRoom)
   const presenceStatusRef = useRef(presenceStatus)
+
+  const { status } = useConnectionStatus()
+  const prevStatusRef = useRef(status)
+  const windowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const coalescerRef = useRef(
+    createNotificationCoalescer<{ conv: Conversation; message: Message }>(),
+  )
+  const showConvNotifRef = useRef<(conv: Conversation, message: Message) => void>(
+    () => {},
+  )
 
   useEffect(() => {
     navigateToConversationRef.current = navigateToConversation
@@ -126,7 +141,9 @@ export function useDesktopNotifications(): void {
     }
 
     const senderName = message.from.split('@')[0]
-    const title = conv.name || senderName
+    const baseTitle = conv.name || senderName
+    // When a reconnect backlog collapsed into one notification, surface the count.
+    const title = conv.unreadCount > 1 ? `${baseTitle} (${conv.unreadCount})` : baseTitle
     const body = formatLocalizedPreview(message, t)
 
     notificationDebug.desktopNotification({
@@ -226,9 +243,62 @@ export function useDesktopNotifications(): void {
     }
   }
 
+  // Keep a ref to the latest dispatcher so the window-close timer is never stale.
+  useEffect(() => {
+    showConvNotifRef.current = showConversationNotification
+  })
+
+  // Open a catch-up window on each transition into 'online' (fresh connect,
+  // SM resume, or post-wake verify→online). Buffer per-conversation during the
+  // window; flush one notification per conversation when it closes. Drop the
+  // buffer if the connection leaves 'online' before flushing.
+  useEffect(() => {
+    const prev = prevStatusRef.current
+    prevStatusRef.current = status
+    const coalescer = coalescerRef.current
+
+    if (status === 'online' && prev !== 'online') {
+      coalescer.open()
+      if (windowTimerRef.current) clearTimeout(windowTimerRef.current)
+      windowTimerRef.current = setTimeout(() => {
+        windowTimerRef.current = null
+        for (const { payload } of coalescer.flush()) {
+          void showConvNotifRef.current(payload.conv, payload.message)
+        }
+      }, CATCHUP_WINDOW_MS)
+    }
+
+    if (status !== 'online' && prev === 'online') {
+      if (windowTimerRef.current) {
+        clearTimeout(windowTimerRef.current)
+        windowTimerRef.current = null
+      }
+      coalescer.drop()
+    }
+  }, [status])
+
+  // Drop any pending buffer on unmount.
+  useEffect(
+    () => () => {
+      if (windowTimerRef.current) clearTimeout(windowTimerRef.current)
+      coalescerRef.current.drop()
+    },
+    [],
+  )
+
+  // Route conversation notifications through the coalescer while the window is open.
+  const handleConversationMessage = async (conv: Conversation, message: Message) => {
+    const coalescer = coalescerRef.current
+    if (coalescer.isOpen()) {
+      coalescer.add(conv.id, { conv, message })
+      return
+    }
+    await showConversationNotification(conv, message)
+  }
+
   // Subscribe to notification events
   useNotificationEvents({
-    onConversationMessage: showConversationNotification,
+    onConversationMessage: handleConversationMessage,
     onRoomMessage: showRoomNotification,
   })
 }

--- a/docs/superpowers/plans/2026-06-18-reconnect-delayed-message-notifications.md
+++ b/docs/superpowers/plans/2026-06-18-reconnect-delayed-message-notifications.md
@@ -1,0 +1,849 @@
+# Delayed 1:1 Message Notifications on Reconnect — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make unseen 1:1 messages delivered on reconnect (SM replay / offline flush) fire native notifications — one per conversation — while the window is hidden or the app is inactive.
+
+**Architecture:** Two parts. (1) SDK: replace the `isDelayed` + 5-min-freshness blocks in `shouldNotifyConversation()` with an *unseen* check driven by `unreadCount`/`lastSeenMessageId`, so notify-worthiness mirrors unread-worthiness. (2) App: a pure per-conversation coalescer plus a short "catch-up window" (opened on each transition into the `online` status) that collapses a reconnect burst into one notification per conversation; live messages outside the window stay immediate.
+
+**Tech Stack:** TypeScript, Zustand (SDK stores), React hooks, Vitest, Tauri (`@tauri-apps/plugin-notification` + native macOS path).
+
+## Global Constraints
+
+- Rooms (MUC) notification behavior MUST NOT change: only `shouldNotifyConversation` changes; `shouldNotifyRoom` keeps its `isDelayed` block. New `EntityContext` fields are **optional**.
+- Scope is live delivery paths only (SM replay + offline flush). MAM catch-up (`mergeMAMMessages`) stays notification-free.
+- `CATCHUP_WINDOW_MS = 3000`.
+- Coalescing lives entirely in the app layer; the SDK only decides "notify-worthy."
+- After editing SDK source in this worktree, run `npm run build:sdk` and ensure the app resolves the rebuilt `@fluux/sdk` (worktree resolves `@fluux/sdk` to the root repo's `dist`; sync the built dist to the root's `packages/fluux-sdk/dist`). SDK's own tests use local source and pass without this; only the app→SDK boundary needs it.
+- Per-workspace test runs: `cd packages/fluux-sdk && npx vitest run <file>` for SDK; `cd apps/fluux && npx vitest run <file>` for app. Do not run bare `vitest` from repo root.
+- Never include a Claude footer in commits.
+
+---
+
+## File Structure
+
+- `packages/fluux-sdk/src/stores/shared/notificationState.ts` — gate + `EntityContext` (Task 1).
+- `packages/fluux-sdk/src/stores/shared/notificationState.test.ts` — rewrite + add cases (Task 1).
+- `packages/fluux-sdk/src/hooks/useNotificationEvents.ts` — pass new ctx fields (Task 2).
+- `packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx` — ctx wiring + dedup (Task 2).
+- `apps/fluux/src/hooks/notificationCoalescer.ts` — new pure buffer (Task 3).
+- `apps/fluux/src/hooks/notificationCoalescer.test.ts` — new (Task 3).
+- `apps/fluux/src/hooks/useDesktopNotifications.ts` — catch-up window + coalescing (Task 4).
+- `apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx` — new focused test (Task 4).
+
+---
+
+## Task 1: SDK gate — unseen-based `shouldNotifyConversation`
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/shared/notificationState.ts` (`EntityContext` ~62-65; `shouldNotifyConversation` ~429-437)
+- Test: `packages/fluux-sdk/src/stores/shared/notificationState.test.ts` (fixtures ~41-44; `shouldNotifyConversation` block ~592-621)
+
+**Interfaces:**
+- Produces: `shouldNotifyConversation(msg: NotificationMessage, ctx: EntityContext): boolean` — unchanged signature. `EntityContext` gains optional `unreadCount?: number` and `lastSeenMessageId?: string`.
+
+- [ ] **Step 1: Update the `EntityContext` fixtures and rewrite the `shouldNotifyConversation` test block**
+
+In `notificationState.test.ts`, replace the four context fixtures (lines ~41-44) with versions that carry an unseen message:
+
+```ts
+const ACTIVE_VISIBLE: EntityContext = { isActive: true, windowVisible: true, unreadCount: 1 }
+const ACTIVE_HIDDEN: EntityContext = { isActive: true, windowVisible: false, unreadCount: 1 }
+const INACTIVE_VISIBLE: EntityContext = { isActive: false, windowVisible: true, unreadCount: 1 }
+const INACTIVE_HIDDEN: EntityContext = { isActive: false, windowVisible: false, unreadCount: 1 }
+```
+
+Then replace the entire `describe('shouldNotifyConversation', ...)` block (lines ~592-621) with:
+
+```ts
+describe('shouldNotifyConversation', () => {
+  it('returns true for incoming unseen message when user cannot see it', () => {
+    const msg = makeMsg()
+    expect(shouldNotifyConversation(msg, INACTIVE_VISIBLE)).toBe(true)
+    expect(shouldNotifyConversation(msg, INACTIVE_HIDDEN)).toBe(true)
+    expect(shouldNotifyConversation(msg, ACTIVE_HIDDEN)).toBe(true)
+  })
+
+  it('returns false when user sees it (active + visible)', () => {
+    expect(shouldNotifyConversation(makeMsg(), ACTIVE_VISIBLE)).toBe(false)
+  })
+
+  it('returns false for outgoing messages', () => {
+    expect(shouldNotifyConversation(makeMsg({ isOutgoing: true }), INACTIVE_HIDDEN)).toBe(false)
+  })
+
+  it('returns true for a delayed but unseen message (reconnect offline delivery)', () => {
+    expect(shouldNotifyConversation(makeMsg({ isDelayed: true }), INACTIVE_HIDDEN)).toBe(true)
+  })
+
+  it('returns true for an old but unseen message (freshness is not a gate)', () => {
+    const hoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000)
+    expect(
+      shouldNotifyConversation(makeMsg({ timestamp: hoursAgo, isDelayed: true }), INACTIVE_HIDDEN),
+    ).toBe(true)
+  })
+
+  it('returns false when there is nothing unseen (unreadCount 0)', () => {
+    expect(
+      shouldNotifyConversation(makeMsg(), { isActive: false, windowVisible: false, unreadCount: 0 }),
+    ).toBe(false)
+  })
+
+  it('returns false when lastMessage is the already-seen message', () => {
+    expect(
+      shouldNotifyConversation(makeMsg({ id: 'm5' }), {
+        isActive: false,
+        windowVisible: false,
+        unreadCount: 1,
+        lastSeenMessageId: 'm5',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false when context omits unreadCount (defensive default)', () => {
+    expect(
+      shouldNotifyConversation(makeMsg(), { isActive: false, windowVisible: false }),
+    ).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/notificationState.test.ts -t "shouldNotifyConversation"`
+Expected: FAIL — the delayed/old/unreadCount cases fail against the current `isDelayed`+freshness gate.
+
+- [ ] **Step 3: Extend `EntityContext` in `notificationState.ts`**
+
+Replace the `EntityContext` interface (lines ~61-65):
+
+```ts
+/** Context about the entity's current visibility and unread state. */
+export interface EntityContext {
+  isActive: boolean
+  windowVisible: boolean
+  /** Current unread count for the entity; used to decide notify-worthiness. */
+  unreadCount?: number
+  /** ID of the last message the user has seen; suppresses re-notify of seen content. */
+  lastSeenMessageId?: string
+}
+```
+
+- [ ] **Step 4: Rewrite `shouldNotifyConversation`**
+
+Replace the function body (lines ~429-437) and update its doc comment:
+
+```ts
+/**
+ * Should a conversation message trigger a notification?
+ *
+ * Notify-worthiness mirrors unread-worthiness: notify for an incoming message the
+ * user has not yet seen, when they can't currently see it (not active, or window
+ * hidden). Delivery mechanism (isDelayed) and message age are intentionally NOT
+ * discriminators — an offline/replayed message delivered on reconnect is "new to me".
+ * The unseen check (unreadCount + lastSeenMessageId) keeps MAM history backfill and
+ * re-synced duplicates silent and is self-limiting (lastSeenMessageId only advances).
+ */
+export function shouldNotifyConversation(
+  msg: NotificationMessage,
+  ctx: EntityContext
+): boolean {
+  if (msg.isOutgoing) return false
+  if (ctx.isActive && ctx.windowVisible) return false
+  if ((ctx.unreadCount ?? 0) <= 0) return false
+  if (msg.id === ctx.lastSeenMessageId) return false
+  return true
+}
+```
+
+- [ ] **Step 5: Run the full notificationState test file**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/notificationState.test.ts`
+Expected: PASS (all describe blocks, including the untouched `shouldNotifyRoom` block).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/stores/shared/notificationState.ts packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+git commit -m "feat(sdk): notify for unseen delayed 1:1 messages (drop isDelayed/freshness gate)"
+```
+
+---
+
+## Task 2: SDK hook — pass unread context + prove the wiring
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/hooks/useNotificationEvents.ts` (~126-134)
+- Test: `packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx`
+
+**Interfaces:**
+- Consumes: `shouldNotifyConversation` with the extended `EntityContext` (Task 1).
+- Produces: no signature change; `onConversationMessage(conv, message)` now fires for delayed-but-unseen messages.
+
+- [ ] **Step 1: Add the failing wiring + dedup tests**
+
+Append to `useNotificationEvents.test.tsx` inside the top-level `describe('useNotificationEvents', ...)`, after the existing blocks:
+
+```ts
+describe('conversation reconnect delivery', () => {
+  it('notifies for a delayed, unseen incoming message', () => {
+    const onConversationMessage = vi.fn()
+    renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+    act(() => {
+      mockConversations.set('alice@example.com', {
+        id: 'alice@example.com',
+        name: 'Alice',
+        unreadCount: 1,
+        lastSeenMessageId: undefined,
+        lastMessage: {
+          id: 'm1',
+          timestamp: new Date(),
+          isOutgoing: false,
+          isDelayed: true,
+          from: 'alice@example.com',
+        },
+      })
+      triggerChatStoreUpdate()
+    })
+
+    expect(onConversationMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not notify when the latest message is already seen', () => {
+    const onConversationMessage = vi.fn()
+    renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+    act(() => {
+      mockConversations.set('bob@example.com', {
+        id: 'bob@example.com',
+        name: 'Bob',
+        unreadCount: 0,
+        lastSeenMessageId: 'm1',
+        lastMessage: {
+          id: 'm1',
+          timestamp: new Date(),
+          isOutgoing: false,
+          isDelayed: true,
+          from: 'bob@example.com',
+        },
+      })
+      triggerChatStoreUpdate()
+    })
+
+    expect(onConversationMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not notify twice for the same message id', () => {
+    const onConversationMessage = vi.fn()
+    renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+    const conv = {
+      id: 'carol@example.com',
+      name: 'Carol',
+      unreadCount: 1,
+      lastSeenMessageId: undefined,
+      lastMessage: {
+        id: 'm9',
+        timestamp: new Date(),
+        isOutgoing: false,
+        isDelayed: false,
+        from: 'carol@example.com',
+      },
+    }
+    act(() => {
+      mockConversations.set('carol@example.com', conv)
+      triggerChatStoreUpdate()
+      triggerChatStoreUpdate() // same lastMessage id → no second notification
+    })
+
+    expect(onConversationMessage).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify the first one fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/hooks/useNotificationEvents.test.tsx -t "conversation reconnect delivery"`
+Expected: FAIL on "notifies for a delayed, unseen incoming message" — the hook does not yet pass `unreadCount`/`lastSeenMessageId`, so `shouldNotifyConversation` sees `unreadCount` undefined → `false`.
+
+- [ ] **Step 3: Pass the unread context from the hook**
+
+In `useNotificationEvents.ts`, replace the `shouldNotifyConversation(...)` call (lines ~126-134) with:
+
+```ts
+          const notify = shouldNotifyConversation(
+            {
+              id: conv.lastMessage.id,
+              timestamp: conv.lastMessage.timestamp,
+              isOutgoing: conv.lastMessage.isOutgoing,
+              isDelayed: conv.lastMessage.isDelayed,
+            },
+            {
+              isActive,
+              windowVisible,
+              unreadCount: conv.unreadCount,
+              lastSeenMessageId: conv.lastSeenMessageId,
+            }
+          )
+```
+
+- [ ] **Step 4: Run the new tests and the full file**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/hooks/useNotificationEvents.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Rebuild the SDK so the app resolves the new behavior/types**
+
+Run: `npm run build:sdk`
+Then ensure the app boundary resolves the rebuilt dist (worktree resolves `@fluux/sdk` to the root repo's `dist`):
+
+Run: `rsync -a --delete packages/fluux-sdk/dist/ ../../packages/fluux-sdk/dist/ 2>/dev/null || cp -R packages/fluux-sdk/dist/. ../../packages/fluux-sdk/dist/`
+Expected: no error. (If the worktree already has a `node_modules/@fluux/sdk` symlink to its own package, this is a no-op; the goal is that `cd apps/fluux && npx tsc` sees the new optional `EntityContext` fields.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/hooks/useNotificationEvents.ts packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+git commit -m "feat(sdk): pass unread context into conversation notify decision"
+```
+
+---
+
+## Task 3: App — pure notification coalescer
+
+**Files:**
+- Create: `apps/fluux/src/hooks/notificationCoalescer.ts`
+- Test: `apps/fluux/src/hooks/notificationCoalescer.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface CoalescedEntry<T> { id: string; payload: T }`
+  - `interface NotificationCoalescer<T> { isOpen(): boolean; open(): void; add(id: string, payload: T): boolean; flush(): CoalescedEntry<T>[]; drop(): void }`
+  - `function createNotificationCoalescer<T>(): NotificationCoalescer<T>`
+  - `add` returns `true` when buffered (window open), `false` when the caller should dispatch immediately. `flush` returns one entry per id (latest payload, insertion order) and closes the window. `drop` clears + closes without returning entries.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/fluux/src/hooks/notificationCoalescer.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { createNotificationCoalescer } from './notificationCoalescer'
+
+describe('createNotificationCoalescer', () => {
+  it('is closed initially and add returns false (caller dispatches immediately)', () => {
+    const c = createNotificationCoalescer<string>()
+    expect(c.isOpen()).toBe(false)
+    expect(c.add('a', 'x')).toBe(false)
+  })
+
+  it('buffers latest payload per id while open and flushes one entry per id in insertion order', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    expect(c.isOpen()).toBe(true)
+    expect(c.add('a', 'a1')).toBe(true)
+    expect(c.add('a', 'a2')).toBe(true) // latest wins
+    expect(c.add('b', 'b1')).toBe(true)
+    expect(c.flush()).toEqual([
+      { id: 'a', payload: 'a2' },
+      { id: 'b', payload: 'b1' },
+    ])
+  })
+
+  it('flush closes the window and clears the buffer', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    c.add('a', 'a1')
+    c.flush()
+    expect(c.isOpen()).toBe(false)
+    expect(c.flush()).toEqual([])
+  })
+
+  it('drop clears the buffer and closes without returning entries', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    c.add('a', 'a1')
+    c.drop()
+    expect(c.isOpen()).toBe(false)
+    expect(c.flush()).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/notificationCoalescer.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the coalescer**
+
+Create `apps/fluux/src/hooks/notificationCoalescer.ts`:
+
+```ts
+/**
+ * Per-id notification coalescer (pure, no timers).
+ *
+ * Used by useDesktopNotifications to collapse a reconnect "catch-up" burst into
+ * one notification per conversation. The owning hook controls timing (open the
+ * window on reconnect, flush after a fixed delay); this buffer only decides what
+ * to keep. While open, the latest payload per id wins; while closed, callers
+ * dispatch immediately.
+ */
+export interface CoalescedEntry<T> {
+  id: string
+  payload: T
+}
+
+export interface NotificationCoalescer<T> {
+  /** Whether the coalescing window is currently open. */
+  isOpen(): boolean
+  /** Open the window; subsequent add() calls buffer instead of returning false. */
+  open(): void
+  /** Buffer the latest payload for id. Returns true if buffered, false if window closed. */
+  add(id: string, payload: T): boolean
+  /** Return one entry per id (latest payload, insertion order), clear, and close. */
+  flush(): CoalescedEntry<T>[]
+  /** Clear the buffer and close without returning entries. */
+  drop(): void
+}
+
+export function createNotificationCoalescer<T>(): NotificationCoalescer<T> {
+  let open = false
+  const buffer = new Map<string, T>()
+
+  return {
+    isOpen: () => open,
+    open: () => {
+      open = true
+    },
+    add: (id, payload) => {
+      if (!open) return false
+      buffer.set(id, payload)
+      return true
+    },
+    flush: () => {
+      const entries = Array.from(buffer, ([id, payload]) => ({ id, payload }))
+      buffer.clear()
+      open = false
+      return entries
+    },
+    drop: () => {
+      buffer.clear()
+      open = false
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/notificationCoalescer.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/hooks/notificationCoalescer.ts apps/fluux/src/hooks/notificationCoalescer.test.ts
+git commit -m "feat(app): add pure per-conversation notification coalescer"
+```
+
+---
+
+## Task 4: App — catch-up window wiring in `useDesktopNotifications`
+
+**Files:**
+- Modify: `apps/fluux/src/hooks/useDesktopNotifications.ts` (imports ~1-21; component body ~32-50; `showConversationNotification` title ~128-129; `useNotificationEvents({...})` ~230-233)
+- Test: `apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `createNotificationCoalescer` (Task 3); `useConnectionStatus` from `@fluux/sdk` returning `{ status: ConnectionStatus }`.
+- Produces: notifications routed through a catch-up window; no exported signature change.
+
+- [ ] **Step 1: Write the failing catch-up test**
+
+Create `apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx`:
+
+```tsx
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, cleanup } from '@testing-library/react'
+
+// Capture the conversation handler passed to useNotificationEvents.
+let capturedOnConversationMessage:
+  | ((conv: unknown, message: unknown) => void)
+  | undefined
+
+// Drive connection status from the test.
+let currentStatus = 'connecting'
+const setStatus = (s: string) => {
+  currentStatus = s
+}
+
+const showWebNotification = vi.fn()
+
+vi.mock('./useNotificationEvents', () => ({
+  useNotificationEvents: (handlers: {
+    onConversationMessage?: (conv: unknown, message: unknown) => void
+  }) => {
+    capturedOnConversationMessage = handlers.onConversationMessage
+  },
+}))
+
+vi.mock('./useNotificationPermission', () => ({
+  useNotificationPermission: () => {},
+  getNotificationPermissionGranted: () => true,
+  isTauri: false,
+}))
+
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({
+    navigateToConversation: vi.fn(),
+    navigateToRoom: vi.fn(),
+  }),
+}))
+
+vi.mock('@/utils/webNotification', () => ({
+  showWebNotification: (...args: unknown[]) => showWebNotification(...args),
+}))
+
+vi.mock('@/utils/notificationAvatar', () => ({
+  getNotificationAvatarUrl: () => Promise.resolve(undefined),
+}))
+
+vi.mock('@/utils/messagePreviewText', () => ({
+  formatLocalizedPreview: (m: { body?: string }) => m.body ?? '',
+}))
+
+vi.mock('@/utils/notificationDebug', () => ({
+  notificationDebug: { desktopNotification: vi.fn() },
+}))
+
+vi.mock('@/utils/notificationRouting', () => ({
+  routeNotificationTarget: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+vi.mock('@fluux/sdk', () => ({
+  rosterStore: { getState: () => ({ getContact: () => undefined }) },
+  usePresence: () => ({ presenceStatus: 'online' }),
+  useConnectionStatus: () => ({ status: currentStatus }),
+}))
+
+import { useDesktopNotifications } from './useDesktopNotifications'
+
+const conv = (id: string) => ({
+  id,
+  name: id,
+  unreadCount: 1,
+  lastSeenMessageId: undefined,
+})
+const msg = (id: string, body: string) => ({
+  id,
+  from: `${id}@example.com`,
+  body,
+  timestamp: new Date(),
+  isOutgoing: false,
+})
+
+// showConversationNotification is async (awaits the avatar URL before calling
+// showWebNotification), so assertions must let queued microtasks settle.
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useDesktopNotifications catch-up window', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    showWebNotification.mockClear()
+    capturedOnConversationMessage = undefined
+    currentStatus = 'connecting'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('coalesces a reconnect burst into one notification per conversation', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+
+    // Transition into online → catch-up window opens.
+    act(() => {
+      setStatus('online')
+      rerender()
+    })
+
+    act(() => {
+      capturedOnConversationMessage?.(conv('alice'), msg('a1', 'a'))
+      capturedOnConversationMessage?.(conv('alice'), msg('a2', 'b'))
+      capturedOnConversationMessage?.(conv('bob'), msg('b1', 'c'))
+    })
+
+    // Nothing fired yet — all buffered.
+    expect(showWebNotification).not.toHaveBeenCalled()
+
+    // Window closes after CATCHUP_WINDOW_MS (3000); async advance flushes the
+    // awaited avatar-URL chain inside the flushed dispatches.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(showWebNotification).toHaveBeenCalledTimes(2) // alice + bob
+  })
+
+  it('dispatches immediately outside the catch-up window', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+    await act(async () => {
+      setStatus('online')
+      rerender()
+      await vi.advanceTimersByTimeAsync(3000) // window opens then closes
+    })
+    showWebNotification.mockClear()
+
+    await act(async () => {
+      capturedOnConversationMessage?.(conv('carol'), msg('c1', 'd'))
+      await flushMicrotasks()
+    })
+
+    expect(showWebNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops buffered notifications when the connection leaves online', async () => {
+    const { rerender } = renderHook(() => useDesktopNotifications())
+    act(() => {
+      setStatus('online')
+      rerender()
+    })
+    act(() => {
+      capturedOnConversationMessage?.(conv('dave'), msg('d1', 'e'))
+    })
+
+    // Connection drops before the window flushes.
+    await act(async () => {
+      setStatus('reconnecting')
+      rerender()
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(showWebNotification).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useDesktopNotifications.catchup.test.tsx`
+Expected: FAIL — with no window, the burst dispatches immediately (3 calls, not the coalesced 2) and the drop test still fires a notification.
+
+- [ ] **Step 3: Add imports and constants**
+
+In `useDesktopNotifications.ts`, update the SDK import (line 3) to add `useConnectionStatus`:
+
+```ts
+import { rosterStore, usePresence, useConnectionStatus } from '@fluux/sdk'
+```
+
+Add the coalescer import after the `useNotificationEvents` import (after line 10):
+
+```ts
+import { createNotificationCoalescer } from './notificationCoalescer'
+```
+
+Add a module-level constant just below the imports (after line 21):
+
+```ts
+/** Duration of the post-reconnect window during which offline-delivery
+ *  notifications are coalesced to one per conversation. */
+const CATCHUP_WINDOW_MS = 3000
+```
+
+- [ ] **Step 4: Add the window state, dispatcher ref, and handler in the component body**
+
+In `useDesktopNotifications()`, after the existing `presenceStatusRef` declaration (line ~41) add:
+
+```ts
+  const { status } = useConnectionStatus()
+  const prevStatusRef = useRef(status)
+  const windowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const coalescerRef = useRef(
+    createNotificationCoalescer<{ conv: Conversation; message: Message }>(),
+  )
+  const showConvNotifRef = useRef<(conv: Conversation, message: Message) => void>(
+    () => {},
+  )
+```
+
+- [ ] **Step 5: Add the unread-count suffix to the title**
+
+In `showConversationNotification` (lines ~128-130), replace:
+
+```ts
+    const senderName = message.from.split('@')[0]
+    const title = conv.name || senderName
+    const body = formatLocalizedPreview(message, t)
+```
+
+with:
+
+```ts
+    const senderName = message.from.split('@')[0]
+    const baseTitle = conv.name || senderName
+    // When a reconnect backlog collapsed into one notification, surface the count.
+    const title = conv.unreadCount > 1 ? `${baseTitle} (${conv.unreadCount})` : baseTitle
+    const body = formatLocalizedPreview(message, t)
+```
+
+- [ ] **Step 6: Wire the dispatcher ref, window effect, and coalescing handler**
+
+Immediately before the `useNotificationEvents({ ... })` call (line ~230), add:
+
+```ts
+  // Keep a ref to the latest dispatcher so the window-close timer is never stale.
+  useEffect(() => {
+    showConvNotifRef.current = showConversationNotification
+  })
+
+  // Open a catch-up window on each transition into 'online' (fresh connect,
+  // SM resume, or post-wake verify→online). Buffer per-conversation during the
+  // window; flush one notification per conversation when it closes. Drop the
+  // buffer if the connection leaves 'online' before flushing.
+  useEffect(() => {
+    const prev = prevStatusRef.current
+    prevStatusRef.current = status
+    const coalescer = coalescerRef.current
+
+    if (status === 'online' && prev !== 'online') {
+      coalescer.open()
+      if (windowTimerRef.current) clearTimeout(windowTimerRef.current)
+      windowTimerRef.current = setTimeout(() => {
+        windowTimerRef.current = null
+        for (const { payload } of coalescer.flush()) {
+          void showConvNotifRef.current(payload.conv, payload.message)
+        }
+      }, CATCHUP_WINDOW_MS)
+    }
+
+    if (status !== 'online' && prev === 'online') {
+      if (windowTimerRef.current) {
+        clearTimeout(windowTimerRef.current)
+        windowTimerRef.current = null
+      }
+      coalescer.drop()
+    }
+  }, [status])
+
+  // Drop any pending buffer on unmount.
+  useEffect(
+    () => () => {
+      if (windowTimerRef.current) clearTimeout(windowTimerRef.current)
+      coalescerRef.current.drop()
+    },
+    [],
+  )
+
+  // Route conversation notifications through the coalescer while the window is open.
+  const handleConversationMessage = (conv: Conversation, message: Message) => {
+    const coalescer = coalescerRef.current
+    if (coalescer.isOpen()) {
+      coalescer.add(conv.id, { conv, message })
+      return
+    }
+    void showConversationNotification(conv, message)
+  }
+```
+
+Then change the `useNotificationEvents` call (lines ~230-233) to use the new handler:
+
+```ts
+  useNotificationEvents({
+    onConversationMessage: handleConversationMessage,
+    onRoomMessage: showRoomNotification,
+  })
+```
+
+- [ ] **Step 7: Run the catch-up tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useDesktopNotifications.catchup.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Add `useConnectionStatus` to the existing test mocks**
+
+`useDesktopNotifications` now calls `useConnectionStatus()`. The `posting` and `routing` tests fully replace `@fluux/sdk` with local mocks (not `importOriginal`), so `useConnectionStatus` would be `undefined` and throw. Add it to both, returning a non-online status so no catch-up window opens (preserving their immediate-dispatch assumptions).
+
+In `apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx` (line ~35), change the mock to:
+
+```ts
+vi.mock('@fluux/sdk', () => ({ rosterStore: { getState: () => ({ getContact: () => undefined }) }, usePresence: () => ({ presenceStatus: 'online' }), useConnectionStatus: () => ({ status: 'disconnected' }) }))
+```
+
+In `apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx` (lines ~52-54), add the line inside the mock object:
+
+```ts
+vi.mock('@fluux/sdk', () => ({
+  rosterStore: { getState: () => ({ getContact: () => undefined }) },
+  usePresence: () => ({ presenceStatus: 'online' }),
+  useConnectionStatus: () => ({ status: 'disconnected' }),
+```
+
+(Leave the remaining lines of each existing mock unchanged.)
+
+- [ ] **Step 9: Run the existing desktop-notification tests for regressions**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useDesktopNotifications.posting.test.tsx src/hooks/useDesktopNotifications.routing.test.tsx`
+Expected: PASS. (These exercise the immediate-dispatch path, which is unchanged when no catch-up window is open — status is `'disconnected'` in those tests.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/fluux/src/hooks/useDesktopNotifications.ts apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx apps/fluux/src/hooks/useDesktopNotifications.routing.test.tsx
+git commit -m "feat(app): coalesce reconnect notifications into one per conversation"
+```
+
+---
+
+## Task 5: Full verification + manual check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck the whole repo**
+
+Run: `npm run typecheck`
+Expected: PASS. If the app fails on the new optional `EntityContext` fields, re-run Task 2 Step 5 (rebuild SDK + sync dist).
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Run the SDK and app test suites for the touched areas**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/notificationState.test.ts src/hooks/useNotificationEvents.test.tsx`
+Then: `cd apps/fluux && npx vitest run src/hooks/notificationCoalescer.test.ts src/hooks/useDesktopNotifications.catchup.test.tsx src/hooks/useDesktopNotifications.posting.test.tsx src/hooks/useDesktopNotifications.routing.test.tsx`
+Expected: all PASS, no stderr.
+
+- [ ] **Step 4: Manual verification (window hidden) — record the result**
+
+Build/run the desktop app (`npm run tauri:dev`). Then:
+1. Connect; hide the window to tray (red button).
+2. Sleep the Mac > 12 min (forces SM expiry → offline-flush). From another client, send several 1:1 messages across 2+ conversations during the sleep.
+3. Wake **without** opening the window. Expect: one native notification per conversation, count in the title for multi-message conversations; unread badge consistent.
+4. Repeat with a ~3-min sleep (SM-resume path) for the same expectation.
+
+Expected: notifications appear per conversation; no per-message storm; no notification for a conversation that was already open+visible.
+
+- [ ] **Step 5: Final commit if any verification fixes were needed**
+
+```bash
+git add -A
+git commit -m "test: verify reconnect notification coalescing"
+```
+
+(Skip if nothing changed.)

--- a/docs/superpowers/plans/2026-06-18-reconnect-delayed-message-notifications.md
+++ b/docs/superpowers/plans/2026-06-18-reconnect-delayed-message-notifications.md
@@ -601,9 +601,16 @@ describe('useDesktopNotifications catch-up window', () => {
 
   it('dispatches immediately outside the catch-up window', async () => {
     const { rerender } = renderHook(() => useDesktopNotifications())
-    await act(async () => {
+    // Commit the status-change render SYNCHRONOUSLY first, then advance time in a
+    // separate async act. Under React 19 + @testing-library/react 16, a rerender()
+    // inside an `await act(async)` defers its commit past advanceTimersByTimeAsync,
+    // so the window-close timer would be scheduled at the wrong fake-time. Split
+    // acts (matching the first test) avoid this.
+    act(() => {
       setStatus('online')
       rerender()
+    })
+    await act(async () => {
       await vi.advanceTimersByTimeAsync(3000) // window opens then closes
     })
     showWebNotification.mockClear()
@@ -626,10 +633,13 @@ describe('useDesktopNotifications catch-up window', () => {
       capturedOnConversationMessage?.(conv('dave'), msg('d1', 'e'))
     })
 
-    // Connection drops before the window flushes.
-    await act(async () => {
+    // Commit the 'reconnecting' transition synchronously so its effect drops the
+    // buffer and clears the timer BEFORE fake time advances.
+    act(() => {
       setStatus('reconnecting')
       rerender()
+    })
+    await act(async () => {
       await vi.advanceTimersByTimeAsync(3000)
     })
 
@@ -750,13 +760,15 @@ Immediately before the `useNotificationEvents({ ... })` call (line ~230), add:
   )
 
   // Route conversation notifications through the coalescer while the window is open.
-  const handleConversationMessage = (conv: Conversation, message: Message) => {
+  // async + await (not fire-and-forget): callers that await the handler — including
+  // the existing posting test — must see the async dispatch complete.
+  const handleConversationMessage = async (conv: Conversation, message: Message) => {
     const coalescer = coalescerRef.current
     if (coalescer.isOpen()) {
       coalescer.add(conv.id, { conv, message })
       return
     }
-    void showConversationNotification(conv, message)
+    await showConversationNotification(conv, message)
   }
 ```
 

--- a/docs/superpowers/specs/2026-06-18-reconnect-delayed-message-notifications-design.md
+++ b/docs/superpowers/specs/2026-06-18-reconnect-delayed-message-notifications-design.md
@@ -63,6 +63,19 @@ missed messages only through MAM; that case is explicitly out of scope for this 
 - Per-message notifications for an offline backlog.
 - Summary-style "N messages in M chats" aggregation across conversations.
 - MAM-only deployments without offline storage.
+- **Coalescing the verify-pass short-sleep path.** The catch-up window opens on
+  transitions into `online` from a non-online status, which covers every path
+  that carries a real reconnect backlog (fresh connect, socket-died/SM-resume,
+  long-sleep reconnect — all transit `reconnecting`). It does NOT cover the case
+  where the connection *survives* a brief sleep (`connected → verifying →
+  connected`): the state machine maps `verifying` to `online` so the status never
+  leaves `online`, no `online`/`resumed` event is emitted, and there is no
+  backlog flush — buffered messages arrive as normal live stanzas. Those still
+  notify correctly (the bug is fixed), just one-per-message rather than coalesced.
+  Coalescing this path would require a wake-triggered window that delays every
+  live notification by the window duration after each screen-unlock, even when
+  there is no backlog — not worth it for a typically-empty trickle on a brief
+  sleep.
 
 ## Design
 

--- a/docs/superpowers/specs/2026-06-18-reconnect-delayed-message-notifications-design.md
+++ b/docs/superpowers/specs/2026-06-18-reconnect-delayed-message-notifications-design.md
@@ -1,0 +1,260 @@
+# Notifications for delayed 1:1 messages on reconnect
+
+**Date:** 2026-06-18
+**Status:** Design — approved, pending spec review
+
+## Problem
+
+When the client reconnects after sleep/wake — especially with the window hidden to
+tray (red close button) on macOS — 1:1 messages that arrived during the disconnect do
+**not** fire native notifications. The unread badge updates, but no banner appears.
+
+Root cause: the notification gate `shouldNotifyConversation()`
+(`packages/fluux-sdk/src/stores/shared/notificationState.ts`) hard-blocks any message
+flagged `isDelayed`, and separately drops anything older than a 5-minute freshness
+window:
+
+```ts
+if (msg.isOutgoing || msg.isDelayed) return false
+if (Date.now() - msg.timestamp.getTime() > FRESHNESS_THRESHOLD_MS) return false
+```
+
+Messages delivered on reconnect carry an XEP-0203 `<delay/>` stamp, so `isDelayed` is
+`true` and the message is suppressed before the window-visibility logic ever runs.
+
+This is inconsistent with the unread-count path, which already treats a delayed 1:1
+message as genuine new offline delivery via the `treatDelayedAsNew: true` flag that
+`chatStore.addMessage` passes. So today the badge increments but the notification does
+not fire.
+
+### Delivery paths (and why "live paths only" is complete here)
+
+- **Short sleep (< SM session timeout, ~10 min):** the server resumes the stream
+  (XEP-0198) and replays undelivered stanzas as live `<message>` stanzas. These reach
+  the notify gate.
+- **Long sleep (SM session expired):** the server reroutes the undelivered stanzas
+  through offline storage (`mod_offline`), and they are flushed as live `<message>` +
+  `<delay/>` stanzas on the next fresh session. These reach the notify gate.
+- **MAM catch-up** runs on fresh sessions but is **history/archive sync** — by the time
+  it runs, genuinely-missed messages already arrived via offline storage. MAM merges go
+  through `mergeMAMMessages()`, which bypasses the notify path entirely, and must stay
+  notification-free.
+
+Both real delivery paths (SM replay, offline flush) are "live paths" that reach the
+gate. Fixing the gate fixes both at once.
+
+**Caveat (recorded, out of scope):** this completeness assumes server-side offline
+storage is enabled. A MAM-only deployment with `mod_offline` disabled would route
+missed messages only through MAM; that case is explicitly out of scope for this change.
+
+## Goals
+
+- Delayed 1:1 messages that the user has **not yet seen** fire a native notification on
+  reconnect, in all relevant delivery paths (SM replay, offline flush), with the window
+  hidden or the app inactive.
+- No notification storm: an offline backlog collapses to **one notification per
+  conversation** (newest message as the body, unread count surfaced).
+- MAM history backfill, scroll-back, and re-synced duplicates stay silent.
+- Room (MUC) notification behavior is unchanged.
+
+## Non-goals
+
+- Notifying from the MAM catch-up path (`mergeMAMMessages`).
+- Per-message notifications for an offline backlog.
+- Summary-style "N messages in M chats" aggregation across conversations.
+- MAM-only deployments without offline storage.
+
+## Design
+
+### Core principle: notify-worthiness mirrors unread-worthiness
+
+Today the notify decision and the unread decision diverge. The unread path uses
+`treatDelayedAsNew` + `lastSeenMessageId` and correctly counts a delayed offline message
+as new. The notify path uses a cruder `isDelayed` + freshness block. The fix makes the
+notify decision ask the same question the unread logic already answers: **is this an
+incoming message the user has not seen yet?**
+
+Delivery mechanism (`isDelayed`) and message age stop being discriminators. **Unseen**
+becomes the discriminator. This keeps MAM history backfill and re-synced duplicates
+silent (they do not leave an unseen incoming `lastMessage` with `unreadCount > 0`), and
+it fixes every live delivery path simultaneously.
+
+### Part 1 — Gate change (SDK)
+
+**File:** `packages/fluux-sdk/src/stores/shared/notificationState.ts`
+
+Extend `EntityContext` with two **optional** fields (optional so the room path and
+existing callers are unaffected):
+
+```ts
+interface EntityContext {
+  isActive: boolean
+  windowVisible: boolean
+  unreadCount?: number
+  lastSeenMessageId?: string
+}
+```
+
+Rewrite `shouldNotifyConversation()`:
+
+```ts
+export function shouldNotifyConversation(
+  msg: NotificationMessage,
+  ctx: EntityContext
+): boolean {
+  if (msg.isOutgoing) return false
+  if (ctx.isActive && ctx.windowVisible) return false   // user can see it
+  if ((ctx.unreadCount ?? 0) <= 0) return false          // nothing unseen
+  if (msg.id === ctx.lastSeenMessageId) return false     // already seen
+  return true                                            // unseen incoming → notify
+}
+```
+
+Notes:
+- The `isDelayed` block and the `FRESHNESS_THRESHOLD_MS` block are **removed**.
+  "Unseen" is self-limiting: once the user sees a message, `lastSeenMessageId` advances
+  and it never re-notifies; the reconnect burst is bounded by coalescing (Part 2).
+- `shouldNotifyRoom()` is **not changed** — it keeps its `isDelayed` block, since a MUC
+  `<delay/>` means history replay.
+
+**File:** `packages/fluux-sdk/src/hooks/useNotificationEvents.ts`
+
+The conversation notify call site already has `conv` in hand. Pass the new context
+fields:
+
+```ts
+const notify = shouldNotifyConversation(
+  { id: conv.lastMessage.id, timestamp: conv.lastMessage.timestamp,
+    isOutgoing: conv.lastMessage.isOutgoing, isDelayed: conv.lastMessage.isDelayed },
+  { isActive, windowVisible,
+    unreadCount: conv.unreadCount, lastSeenMessageId: conv.lastSeenMessageId },
+)
+```
+
+### Part 2 — Coalescing + catch-up window (app)
+
+**Files:** `apps/fluux/src/hooks/useDesktopNotifications.ts` + new
+`apps/fluux/src/hooks/notificationCoalescer.ts` (pure, unit-testable module).
+
+`notificationCoalescer.ts` — a pure buffer keyed by conversation id:
+
+- `open()` — begin coalescing (called when the catch-up window opens).
+- `add(id, payload)` — while a window is open, buffer the latest payload per id
+  (latest-wins). While closed, the caller dispatches immediately instead.
+- `flush()` — emit one entry per buffered id (newest payload), clear the buffer.
+- `drop()` — clear without emitting (used on disconnect/unmount).
+
+`useDesktopNotifications.ts` wraps `showConversationNotification`:
+
+- **Catch-up window** opens on each transition of the connection into `online` /
+  `resumed` from a non-online state (covers fresh login, short-sleep SM resume, and
+  long-sleep offline flush). It lasts a fixed `CATCHUP_WINDOW_MS` (~3000 ms) — long
+  enough for the offline-flush burst, short enough not to delay the first live message.
+- **During the window:** `onConversationMessage` routes into the coalescer (`add`).
+- **At window close:** `flush()` calls the real `showConversationNotification` once per
+  conversation. The body is the newest message; the title surfaces the unread count read
+  from the conversation at flush time (e.g. `"Alice (3)"`).
+- **Outside the window:** live messages call `showConversationNotification` immediately,
+  exactly as today.
+- **On disconnect / unmount:** `drop()` — never fire stale notifications after the
+  connection drops.
+
+Coalescing lives entirely in the app (presentation/batching concern). The SDK only
+decides "notify-worthy."
+
+### Edge cases & boundaries
+
+- **Rooms unchanged.** Only `shouldNotifyConversation` changes; `EntityContext`'s new
+  fields are optional.
+- **Dedup is free.** The unseen check keys on `lastSeenMessageId` + message id, and the
+  notify hook fires only on `lastMessage` id change — so offline-flush and SM-replay of
+  the same id cannot double-notify, and a later MAM re-merge of already-seen history
+  stays silent.
+- **DND / permission** checks stay inside `showConversationNotification`, which the
+  coalescer calls once at flush — so flush-time state wins.
+- **Active + visible** conversation returns `false` in the gate (never buffered).
+- **Count semantics:** the "(N)" suffix reads the conversation's `unreadCount` at flush
+  time, not the buffered message count (they can differ if some were already seen).
+
+## Testing
+
+Infrastructure already exists (mock stores in the SDK; app hook test files such as
+`useDesktopNotifications.posting.test.tsx`, `useNotificationEvents.test.tsx`). The gap is
+**cases**, plus several existing `shouldNotifyConversation` tests that assert the *old*
+behavior and must be rewritten. The coalescer and the window trigger are net-new code
+with no coverage today.
+
+### Rewrite (existing tests that encode removed behavior)
+
+`packages/fluux-sdk/src/stores/shared/notificationState.test.ts`, `shouldNotifyConversation` block:
+- Invert/replace `returns false for delayed messages` (currently asserts suppression).
+- Remove/replace `returns false for stale messages (>5 minutes old)` and
+  `returns true for fresh messages (<5 minutes old)` — freshness is no longer a gate.
+- Update the shared `EntityContext` fixtures (`INACTIVE_HIDDEN`, `ACTIVE_VISIBLE`, etc.)
+  to include `unreadCount` / `lastSeenMessageId`.
+
+### New — pure (high confidence)
+
+`notificationState.test.ts`:
+- delayed + unseen (`unreadCount > 0`, `id !== lastSeenMessageId`) → **notify**.
+- delayed + already-seen (`id === lastSeenMessageId`) → no.
+- `unreadCount === 0` → no.
+- old-but-unseen offline message (timestamp hours ago, unseen) → **notify** (proves
+  freshness removal is intentional).
+- outgoing → no; active + visible → no.
+
+New `apps/fluux/src/hooks/notificationCoalescer.test.ts`:
+- burst across M conversations inside an open window → exactly M flushed entries, each
+  the newest payload.
+- "(N)" suffix reads `unreadCount` at flush time.
+- `add` outside an open window → caller dispatches immediately (no buffering).
+- `drop()` clears without emitting.
+
+### New — timer / wiring (weakest spot, deliberate attention)
+
+`useDesktopNotifications` tests (mirror existing `.posting`/`.routing` test files), using
+`vi.useFakeTimers()`:
+- connection transition into `online` / `resumed` opens the window; messages during the
+  window coalesce; window close (timer) flushes one-per-conversation.
+- a message arriving just after window close notifies immediately.
+- disconnect during an open window drops the buffer (no notification).
+- DND active at flush time suppresses the flushed notification.
+
+`useNotificationEvents.test.tsx`:
+- hook passes `unreadCount` / `lastSeenMessageId` into the context.
+- same message id observed twice → only one notification (hook-level dedup).
+
+### Integration / manual (cannot be a pure unit test)
+
+Offline-flush burst end-to-end: multiple `isDelayed` `addMessage` calls during the
+catch-up window produce exactly one notification per conversation. Validate with the
+demo / `emitSDK` harness, or the live sleep/wake procedure below. Recorded as the
+integration verification step, not claimed as unit coverage.
+
+## Manual verification (window hidden)
+
+1. Connect; hide the window to tray (red button).
+2. Sleep the Mac > 12 min (forces SM expiry → offline-flush path). From another client,
+   send 1:1 messages to the account during the sleep.
+3. Wake **without** opening the window. Expect: one native notification per conversation,
+   with the unread count; badge consistent.
+4. Repeat with a ~3-min sleep (SM-resume path) for the same expectation.
+
+## Files touched
+
+- `packages/fluux-sdk/src/stores/shared/notificationState.ts` — gate + `EntityContext`.
+- `packages/fluux-sdk/src/hooks/useNotificationEvents.ts` — pass new ctx fields.
+- `packages/fluux-sdk/src/stores/shared/notificationState.test.ts` — rewrite + add cases.
+- `apps/fluux/src/hooks/useDesktopNotifications.ts` — window + coalescing wiring.
+- `apps/fluux/src/hooks/notificationCoalescer.ts` (new) + `notificationCoalescer.test.ts` (new).
+- `apps/fluux/src/hooks/useNotificationEvents.test.tsx` — ctx wiring + dedup.
+- `apps/fluux/src/hooks/useDesktopNotifications.*.test.tsx` — window/flush/drop/DND.
+
+## Build / dev gotcha
+
+This changes the SDK `EntityContext` type. In a worktree the app typecheck resolves
+`@fluux/sdk` to the **root** repo's built `dist`. After editing SDK source, run
+`npm run build:sdk` and sync the built dist to the root's
+`packages/fluux-sdk/dist` (and ensure the `node_modules/@fluux/sdk` symlink) so the app
+typecheck/tests see the new shape. If notification-state exports change, update the
+`@fluux/sdk` `vi.mock` in `test-setup.ts` and `ChatLayout.test.tsx`.

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -277,7 +277,7 @@ describe('useNotificationEvents', () => {
     })
   })
 
-  describe('conversation message freshness checks', () => {
+  describe('conversation unseen-gate (no age gate)', () => {
     it('should notify for an old conversation message that is still unread (no age gate)', () => {
       const onConversationMessage = vi.fn()
       const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000)

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -278,13 +278,13 @@ describe('useNotificationEvents', () => {
   })
 
   describe('conversation message freshness checks', () => {
-    it('should not notify for old conversation messages even if isDelayed is not set', () => {
+    it('should notify for an old conversation message that is still unread (no age gate)', () => {
       const onConversationMessage = vi.fn()
       const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000)
 
       renderHook(() => useNotificationEvents({ onConversationMessage }))
 
-      // Add a conversation with an old message
+      // Add a conversation with an old but unread message
       act(() => {
         mockConversations.set('user@example.com', {
           id: 'user@example.com',
@@ -302,8 +302,9 @@ describe('useNotificationEvents', () => {
         triggerChatStoreUpdate()
       })
 
-      // Should NOT have notified because the message is too old
-      expect(onConversationMessage).not.toHaveBeenCalled()
+      // Should notify: message age is not a discriminator for 1:1 conversations —
+      // an offline-delivered message delivered on reconnect is "new to me"
+      expect(onConversationMessage).toHaveBeenCalledOnce()
     })
 
     it('should notify for fresh conversation messages', () => {
@@ -548,7 +549,7 @@ describe('useNotificationEvents', () => {
   })
 
   describe('window visibility', () => {
-    it('should notify when window is not visible and conversation is active', () => {
+    it('should NOT notify when window is not visible but conversation has no unread messages', () => {
       const onConversationMessage = vi.fn()
       const now = new Date()
       mockWindowVisible = false
@@ -561,12 +562,12 @@ describe('useNotificationEvents', () => {
         triggerChatStoreUpdate()
       })
 
-      // Add a conversation with a fresh message (the active one)
+      // Add a conversation with a fresh message (the active one) but unreadCount: 0
       act(() => {
         mockConversations.set('user@example.com', {
           id: 'user@example.com',
           name: 'Test User',
-          unreadCount: 0, // Active conversation, no unread
+          unreadCount: 0, // No unread — user has already seen this
           lastMessage: {
             id: 'msg1',
             conversationId: 'user@example.com',
@@ -579,7 +580,42 @@ describe('useNotificationEvents', () => {
         triggerChatStoreUpdate()
       })
 
-      // Should notify because window is not visible
+      // Should NOT notify because unreadCount is 0 (user has already seen this message)
+      expect(onConversationMessage).not.toHaveBeenCalled()
+    })
+
+    it('should notify when window is not visible and conversation has unread messages', () => {
+      const onConversationMessage = vi.fn()
+      const now = new Date()
+      mockWindowVisible = false
+      mockActiveConversationId = 'user@example.com'
+
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      // First trigger with no conversations
+      act(() => {
+        triggerChatStoreUpdate()
+      })
+
+      // Add a conversation with a fresh message and unreadCount > 0
+      act(() => {
+        mockConversations.set('user@example.com', {
+          id: 'user@example.com',
+          name: 'Test User',
+          unreadCount: 1, // Has unread messages — user hasn't seen this yet
+          lastMessage: {
+            id: 'msg1',
+            conversationId: 'user@example.com',
+            from: 'user@example.com',
+            body: 'New message while tab is hidden',
+            timestamp: now,
+            isOutgoing: false,
+          },
+        })
+        triggerChatStoreUpdate()
+      })
+
+      // Should notify because window is not visible and there are unread messages
       expect(onConversationMessage).toHaveBeenCalledOnce()
     })
 
@@ -616,6 +652,82 @@ describe('useNotificationEvents', () => {
 
       // Should NOT notify because window is visible and conversation is active
       expect(onConversationMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('conversation reconnect delivery', () => {
+    it('notifies for a delayed, unseen incoming message', () => {
+      const onConversationMessage = vi.fn()
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      act(() => {
+        mockConversations.set('alice@example.com', {
+          id: 'alice@example.com',
+          name: 'Alice',
+          unreadCount: 1,
+          lastSeenMessageId: undefined,
+          lastMessage: {
+            id: 'm1',
+            timestamp: new Date(),
+            isOutgoing: false,
+            isDelayed: true,
+            from: 'alice@example.com',
+          },
+        })
+        triggerChatStoreUpdate()
+      })
+
+      expect(onConversationMessage).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not notify when the latest message is already seen', () => {
+      const onConversationMessage = vi.fn()
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      act(() => {
+        mockConversations.set('bob@example.com', {
+          id: 'bob@example.com',
+          name: 'Bob',
+          unreadCount: 0,
+          lastSeenMessageId: 'm1',
+          lastMessage: {
+            id: 'm1',
+            timestamp: new Date(),
+            isOutgoing: false,
+            isDelayed: true,
+            from: 'bob@example.com',
+          },
+        })
+        triggerChatStoreUpdate()
+      })
+
+      expect(onConversationMessage).not.toHaveBeenCalled()
+    })
+
+    it('does not notify twice for the same message id', () => {
+      const onConversationMessage = vi.fn()
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      const conv = {
+        id: 'carol@example.com',
+        name: 'Carol',
+        unreadCount: 1,
+        lastSeenMessageId: undefined,
+        lastMessage: {
+          id: 'm9',
+          timestamp: new Date(),
+          isOutgoing: false,
+          isDelayed: false,
+          from: 'carol@example.com',
+        },
+      }
+      act(() => {
+        mockConversations.set('carol@example.com', conv)
+        triggerChatStoreUpdate()
+        triggerChatStoreUpdate() // same lastMessage id → no second notification
+      })
+
+      expect(onConversationMessage).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
@@ -39,10 +39,12 @@ interface PrevRoomState {
  *
  * This hook handles all the filtering logic:
  * - Skip outgoing messages
- * - Skip delayed/historical messages (from MAM)
- * - Skip messages older than 5 minutes
+ * - For 1:1 conversations: notify only when the message is unseen (unreadCount > 0 and
+ *   message id differs from lastSeenMessageId); delivery mechanism and message age are not
+ *   discriminators — an offline-delivered message is "new to me"
  * - Skip if window is visible AND conversation/room is active
- * - For rooms: respect notifyAll/notifyAllPersistent settings
+ * - For rooms: skip delayed/historical messages and messages older than 5 minutes;
+ *   respect notifyAll/notifyAllPersistent settings
  *
  * @remarks
  * Uses Zustand store subscriptions instead of reactive hooks to avoid
@@ -130,7 +132,12 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
               isOutgoing: conv.lastMessage.isOutgoing,
               isDelayed: conv.lastMessage.isDelayed,
             },
-            { isActive, windowVisible }
+            {
+              isActive,
+              windowVisible,
+              unreadCount: conv.unreadCount,
+              lastSeenMessageId: conv.lastSeenMessageId,
+            }
           )
 
           if (notify) {

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -38,10 +38,10 @@ function makeState(overrides: Partial<EntityNotificationState> = {}): EntityNoti
   }
 }
 
-const ACTIVE_VISIBLE: EntityContext = { isActive: true, windowVisible: true }
-const ACTIVE_HIDDEN: EntityContext = { isActive: true, windowVisible: false }
-const INACTIVE_VISIBLE: EntityContext = { isActive: false, windowVisible: true }
-const INACTIVE_HIDDEN: EntityContext = { isActive: false, windowVisible: false }
+const ACTIVE_VISIBLE: EntityContext = { isActive: true, windowVisible: true, unreadCount: 1 }
+const ACTIVE_HIDDEN: EntityContext = { isActive: true, windowVisible: false, unreadCount: 1 }
+const INACTIVE_VISIBLE: EntityContext = { isActive: false, windowVisible: true, unreadCount: 1 }
+const INACTIVE_HIDDEN: EntityContext = { isActive: false, windowVisible: false, unreadCount: 1 }
 
 // ---------------------------------------------------------------------------
 // onMessageReceived
@@ -590,7 +590,7 @@ describe('onMessageSeen', () => {
 // ---------------------------------------------------------------------------
 
 describe('shouldNotifyConversation', () => {
-  it('returns true for incoming message when user cannot see it', () => {
+  it('returns true for incoming unseen message when user cannot see it', () => {
     const msg = makeMsg()
     expect(shouldNotifyConversation(msg, INACTIVE_VISIBLE)).toBe(true)
     expect(shouldNotifyConversation(msg, INACTIVE_HIDDEN)).toBe(true)
@@ -605,18 +605,38 @@ describe('shouldNotifyConversation', () => {
     expect(shouldNotifyConversation(makeMsg({ isOutgoing: true }), INACTIVE_HIDDEN)).toBe(false)
   })
 
-  it('returns false for delayed messages', () => {
-    expect(shouldNotifyConversation(makeMsg({ isDelayed: true }), INACTIVE_HIDDEN)).toBe(false)
+  it('returns true for a delayed but unseen message (reconnect offline delivery)', () => {
+    expect(shouldNotifyConversation(makeMsg({ isDelayed: true }), INACTIVE_HIDDEN)).toBe(true)
   })
 
-  it('returns false for stale messages (>5 minutes old)', () => {
-    const staleTimestamp = new Date(Date.now() - 6 * 60 * 1000)
-    expect(shouldNotifyConversation(makeMsg({ timestamp: staleTimestamp }), INACTIVE_HIDDEN)).toBe(false)
+  it('returns true for an old but unseen message (freshness is not a gate)', () => {
+    const hoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000)
+    expect(
+      shouldNotifyConversation(makeMsg({ timestamp: hoursAgo, isDelayed: true }), INACTIVE_HIDDEN),
+    ).toBe(true)
   })
 
-  it('returns true for fresh messages (<5 minutes old)', () => {
-    const freshTimestamp = new Date(Date.now() - 60 * 1000)
-    expect(shouldNotifyConversation(makeMsg({ timestamp: freshTimestamp }), INACTIVE_HIDDEN)).toBe(true)
+  it('returns false when there is nothing unseen (unreadCount 0)', () => {
+    expect(
+      shouldNotifyConversation(makeMsg(), { isActive: false, windowVisible: false, unreadCount: 0 }),
+    ).toBe(false)
+  })
+
+  it('returns false when lastMessage is the already-seen message', () => {
+    expect(
+      shouldNotifyConversation(makeMsg({ id: 'm5' }), {
+        isActive: false,
+        windowVisible: false,
+        unreadCount: 1,
+        lastSeenMessageId: 'm5',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false when context omits unreadCount (defensive default)', () => {
+    expect(
+      shouldNotifyConversation(makeMsg(), { isActive: false, windowVisible: false }),
+    ).toBe(false)
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -58,10 +58,14 @@ export interface NotificationMessage {
   isMention?: boolean
 }
 
-/** Context about the entity's current visibility. */
+/** Context about the entity's current visibility and unread state. */
 export interface EntityContext {
   isActive: boolean
   windowVisible: boolean
+  /** Current unread count for the entity; used to decide notify-worthiness. */
+  unreadCount?: number
+  /** ID of the last message the user has seen; suppresses re-notify of seen content. */
+  lastSeenMessageId?: string
 }
 
 /** Options for message-received notification handling. */
@@ -423,16 +427,21 @@ const FRESHNESS_THRESHOLD_MS = 5 * 60 * 1000
 /**
  * Should a conversation message trigger a notification?
  *
- * Returns true for incoming, non-delayed, fresh messages when the user
- * can't see the conversation (not active, or window hidden).
+ * Notify-worthiness mirrors unread-worthiness: notify for an incoming message the
+ * user has not yet seen, when they can't currently see it (not active, or window
+ * hidden). Delivery mechanism (isDelayed) and message age are intentionally NOT
+ * discriminators — an offline/replayed message delivered on reconnect is "new to me".
+ * The unseen check (unreadCount + lastSeenMessageId) keeps MAM history backfill and
+ * re-synced duplicates silent and is self-limiting (lastSeenMessageId only advances).
  */
 export function shouldNotifyConversation(
   msg: NotificationMessage,
   ctx: EntityContext
 ): boolean {
-  if (msg.isOutgoing || msg.isDelayed) return false
-  if (Date.now() - msg.timestamp.getTime() > FRESHNESS_THRESHOLD_MS) return false
+  if (msg.isOutgoing) return false
   if (ctx.isActive && ctx.windowVisible) return false
+  if ((ctx.unreadCount ?? 0) <= 0) return false
+  if (msg.id === ctx.lastSeenMessageId) return false
   return true
 }
 


### PR DESCRIPTION
## Summary

Restores native desktop notifications for unseen 1:1 messages that arrive on reconnect after sleep/wake (including when the window is hidden to tray), collapsed to one notification per conversation.

Previously, `shouldNotifyConversation` hard-blocked any `isDelayed` message and dropped anything older than 5 minutes. Messages delivered on reconnect (classic offline-flush, SM replay) carry an XEP-0203 `<delay/>` stamp, so they bumped the unread badge but never produced a banner.

## Changes

- **SDK gate:** `shouldNotifyConversation` now mirrors unread-worthiness — it notifies for an incoming message the user hasn't seen yet (`unreadCount > 0` and `id !== lastSeenMessageId`) instead of gating on `isDelayed`/age. `EntityContext` gains optional `unreadCount`/`lastSeenMessageId`; `useNotificationEvents` passes them. Rooms (`shouldNotifyRoom`) are unchanged — they still treat `<delay/>` as history replay.
- **App coalescing:** a pure `notificationCoalescer` plus a ~3s catch-up window in `useDesktopNotifications`, opened on each transition into `online`, collapses a reconnect burst into one notification per conversation (newest message + unread-count suffix). Live messages outside the window stay immediate.

## Scope

Covers the paths that carry a real backlog (fresh session, socket-died/SM-resume, long-sleep reconnect). MAM history backfill, scroll-back, and re-synced duplicates stay silent. The verify-pass short-sleep path (connection survives, no event, no backlog flush) is intentionally a non-goal — documented in the design doc.