### PR TITLE
refactor: scope room freshness constant; document test microtask depth

### DIFF
--- a/apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.catchup.test.tsx
@@ -86,6 +86,11 @@ const msg = (id: string, body: string) => ({
 
 // showConversationNotification is async (awaits the avatar URL before calling
 // showWebNotification), so assertions must let queued microtasks settle.
+// Three awaits cover the current dispatch chain depth (avatar-URL resolve →
+// showWebNotification). If that chain grows another `await`, bump this count —
+// the immediate-dispatch test would otherwise see 0 calls before the chain
+// settles. (The windowed tests use vi.advanceTimersByTimeAsync, which drains
+// microtasks between timers and isn't sensitive to this depth.)
 const flushMicrotasks = async () => {
   await Promise.resolve()
   await Promise.resolve()

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -421,9 +421,6 @@ export function onMessageSeen(
 // Should-Notify Functions
 // ---------------------------------------------------------------------------
 
-/** Freshness threshold: messages older than 5 minutes never trigger notifications. */
-const FRESHNESS_THRESHOLD_MS = 5 * 60 * 1000
-
 /**
  * Should a conversation message trigger a notification?
  *
@@ -446,6 +443,13 @@ export function shouldNotifyConversation(
 }
 
 /**
+ * Room freshness threshold: MUC messages older than 5 minutes never trigger
+ * notifications. Rooms (unlike conversations) still gate on age to suppress
+ * history replay; conversations use the unseen check instead.
+ */
+const ROOM_FRESHNESS_THRESHOLD_MS = 5 * 60 * 1000
+
+/**
  * Should a room message trigger a notification?
  *
  * Returns { shouldNotify, isMention } for the notification handler.
@@ -459,7 +463,7 @@ export function shouldNotifyRoom(
 ): { shouldNotify: boolean; isMention: boolean } {
   const isMention = msg.isMention ?? false
   if (msg.isOutgoing || msg.isDelayed) return { shouldNotify: false, isMention }
-  if (Date.now() - msg.timestamp.getTime() > FRESHNESS_THRESHOLD_MS) return { shouldNotify: false, isMention }
+  if (Date.now() - msg.timestamp.getTime() > ROOM_FRESHNESS_THRESHOLD_MS) return { shouldNotify: false, isMention }
   if (ctx.isActive && ctx.windowVisible) return { shouldNotify: false, isMention }
 
   return { shouldNotify: isMention || notifyAll, isMention }


### PR DESCRIPTION
Two small follow-up cleanups from the #586 final review (both deferred Minors):

- Rename `FRESHNESS_THRESHOLD_MS` → `ROOM_FRESHNESS_THRESHOLD_MS` and move it adjacent to its only caller, `shouldNotifyRoom`. After #586, conversations use the unseen check and only rooms still gate on age, so the old name no longer signalled its MUC-only scope.
- Document why `flushMicrotasks` in the catch-up test uses three awaits (covers the avatar-URL → showWebNotification dispatch chain) so the depth isn't a silent trap if the chain grows.

No behavior change. Typecheck + affected suites pass.