### PR TITLE
fix(rooms): don't place new-message marker on replayed history

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -546,8 +546,11 @@ export const chatStore = createStore<ChatState>()(
             }
 
             const messages = get().messages.get(id) || []
-            // Compute marker position and mark as read atomically
-            const activated = notifState.onActivate(notifInput, messages)
+            // Compute marker position and mark as read atomically.
+            // 1:1 chats treat delayed messages as new (offline delivery), so the
+            // marker may land on a delayed message — unlike rooms, where delayed
+            // means MUC history replay.
+            const activated = notifState.onActivate(notifInput, messages, { treatDelayedAsNew: true })
 
             set((state) => {
               const newMetaEntry = {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3812,6 +3812,82 @@ describe('roomStore', () => {
   })
 })
 
+describe('setActiveRoom new-message marker — delayed = MUC/MAM history replay', () => {
+  // Regression guard: the marker (firstNewMessageId) drives scroll position on
+  // room open. For rooms, a delayed message is history replay (either MUC <history>
+  // for non-MAM rooms, or MAM-fetched archive — both carry isDelayed=true), NOT a
+  // new message. The marker must skip them, otherwise joining a room scrolls the
+  // user into the middle of replayed history instead of to the bottom.
+  // roomStore must call onActivate WITHOUT treatDelayedAsNew (unlike chatStore).
+  const ROOM = 'room@conference.example.com'
+
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  function delayedMsg(id: string, nick: string, ts: string): RoomMessage {
+    return {
+      type: 'groupchat',
+      id,
+      roomJid: ROOM,
+      from: `${ROOM}/${nick}`,
+      nick,
+      body: id,
+      timestamp: new Date(ts),
+      isOutgoing: false,
+      isDelayed: true,
+    }
+  }
+
+  function activateWith(messages: RoomMessage[], lastSeenMessageId: string, unreadCount: number) {
+    roomStore.getState().addRoom(createRoom(ROOM, { joined: true, messages, unreadCount }))
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      const existing = meta.get(ROOM)!
+      meta.set(ROOM, { ...existing, lastSeenMessageId })
+      return { roomMeta: meta }
+    })
+    roomStore.getState().setActiveRoom(ROOM)
+    return roomStore.getState().roomMeta.get(ROOM)?.firstNewMessageId
+  }
+
+  it('sets no marker when only delayed history follows lastSeen (MAM/MUC join)', () => {
+    const marker = activateWith(
+      [
+        createMessage('seen', ROOM, 'alice', 'seen message'),
+        delayedMsg('h-1', 'bob', '2025-01-15T10:00:00Z'),
+        delayedMsg('h-2', 'carol', '2025-01-15T10:30:00Z'),
+      ],
+      'seen',
+      2
+    )
+    expect(marker).toBeUndefined()
+  })
+
+  it('still sets the marker on a genuinely new live (non-delayed) message', () => {
+    const marker = activateWith(
+      [
+        createMessage('seen', ROOM, 'alice', 'seen message'),
+        createMessage('live', ROOM, 'bob', 'live message'), // isDelayed defaults to false
+      ],
+      'seen',
+      1
+    )
+    expect(marker).toBe('live')
+  })
+})
+
 describe('acknowledged non-anonymous rooms', () => {
   const ROOM = 'irc_%23chan@irc.example.com'
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -221,7 +221,7 @@ describe('onActivate', () => {
       makeMsg({ id: 'c', timestamp: new Date('2025-01-15T10:00:00Z') }),
     ]
     const state = makeState({ lastSeenMessageId: 'a' })
-    const result = onActivate(state, msgs)
+    const result = onActivate(state, msgs, { treatDelayedAsNew: true })
     // Delayed messages are valid new messages (offline delivery in 1:1 chats)
     expect(result.firstNewMessageId).toBe('b')
   })
@@ -336,7 +336,7 @@ describe('onActivate', () => {
         unreadCount: 2,
         lastReadAt: new Date('2025-01-15T09:30:00Z'),
       })
-      const result = onActivate(state, msgs)
+      const result = onActivate(state, msgs, { treatDelayedAsNew: true })
       expect(result.firstNewMessageId).toBe('delayed-1')
     })
   })
@@ -378,7 +378,7 @@ describe('onActivate', () => {
         makeMsg({ id: 'new-2', timestamp: new Date('2025-01-15T10:30:00Z'), isDelayed: true }),
       ]
       const state = makeState({ unreadCount: 2 })
-      const result = onActivate(state, msgs)
+      const result = onActivate(state, msgs, { treatDelayedAsNew: true })
       expect(result.firstNewMessageId).toBe('new-1')
     })
 
@@ -394,6 +394,73 @@ describe('onActivate', () => {
         makeMsg({ id: 'out-2', timestamp: new Date('2025-01-15T09:30:00Z'), isOutgoing: true }),
       ]
       const state = makeState({ unreadCount: 1 })
+      const result = onActivate(state, msgs)
+      expect(result.firstNewMessageId).toBeUndefined()
+    })
+  })
+
+  describe('room mode (treatDelayedAsNew=false): delayed = history replay, not new', () => {
+    // For rooms, isDelayed means "MUC history replay" (not a new message), so the
+    // marker must skip delayed messages — otherwise joining a room scrolls the user
+    // into the middle of replayed history instead of to the bottom.
+
+    it('forward scan skips delayed history after lastSeenMessageId', () => {
+      const msgs: NotificationMessage[] = [
+        makeMsg({ id: 'a', timestamp: new Date('2025-01-15T09:00:00Z') }),
+        makeMsg({ id: 'b', timestamp: new Date('2025-01-15T09:30:00Z'), isDelayed: true }),
+        makeMsg({ id: 'c', timestamp: new Date('2025-01-15T10:00:00Z'), isDelayed: true }),
+      ]
+      const state = makeState({ lastSeenMessageId: 'a' })
+      // Only delayed (history) messages follow → no marker → scroll to bottom
+      const result = onActivate(state, msgs, { treatDelayedAsNew: false })
+      expect(result.firstNewMessageId).toBeUndefined()
+    })
+
+    it('forward scan lands on the first non-delayed (live) message', () => {
+      const msgs: NotificationMessage[] = [
+        makeMsg({ id: 'a', timestamp: new Date('2025-01-15T09:00:00Z') }),
+        makeMsg({ id: 'b', timestamp: new Date('2025-01-15T09:30:00Z'), isDelayed: true }),
+        makeMsg({ id: 'c', timestamp: new Date('2025-01-15T10:00:00Z') }),
+      ]
+      const state = makeState({ lastSeenMessageId: 'a' })
+      const result = onActivate(state, msgs, { treatDelayedAsNew: false })
+      expect(result.firstNewMessageId).toBe('c')
+    })
+
+    it('lastReadAt fallback skips delayed history', () => {
+      const msgs: NotificationMessage[] = [
+        makeMsg({ id: 'old-1', timestamp: new Date('2025-01-15T09:00:00Z') }),
+        makeMsg({ id: 'delayed-1', timestamp: new Date('2025-01-15T10:00:00Z'), isDelayed: true }),
+        makeMsg({ id: 'delayed-2', timestamp: new Date('2025-01-15T10:30:00Z'), isDelayed: true }),
+      ]
+      const state = makeState({
+        lastSeenMessageId: 'very-old-msg',
+        unreadCount: 2,
+        lastReadAt: new Date('2025-01-15T09:30:00Z'),
+      })
+      const result = onActivate(state, msgs, { treatDelayedAsNew: false })
+      expect(result.firstNewMessageId).toBeUndefined()
+    })
+
+    it('brand-new room with pure history replay (all delayed) sets no marker', () => {
+      // Joining a room with no prior read state: the server replays history as
+      // delayed messages. None are "new", so there must be no marker → bottom.
+      const msgs: NotificationMessage[] = [
+        makeMsg({ id: 'h-1', timestamp: new Date('2025-01-15T09:00:00Z'), isDelayed: true }),
+        makeMsg({ id: 'h-2', timestamp: new Date('2025-01-15T10:00:00Z'), isDelayed: true }),
+        makeMsg({ id: 'h-3', timestamp: new Date('2025-01-15T10:30:00Z'), isDelayed: true }),
+      ]
+      const state = makeState({ unreadCount: 2 })
+      const result = onActivate(state, msgs, { treatDelayedAsNew: false })
+      expect(result.firstNewMessageId).toBeUndefined()
+    })
+
+    it('defaults to room-safe (skips delayed) when no option is passed', () => {
+      const msgs: NotificationMessage[] = [
+        makeMsg({ id: 'a', timestamp: new Date('2025-01-15T09:00:00Z') }),
+        makeMsg({ id: 'b', timestamp: new Date('2025-01-15T09:30:00Z'), isDelayed: true }),
+      ]
+      const state = makeState({ lastSeenMessageId: 'a' })
       const result = onActivate(state, msgs)
       expect(result.firstNewMessageId).toBeUndefined()
     })

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -167,13 +167,25 @@ export function onMessageReceived(
  * Scans messages to find the first unseen message (after lastSeenMessageId)
  * and sets the marker, then marks as read.
  *
- * The marker is placed at the first incoming (non-outgoing, non-delayed) message
- * after the lastSeenMessageId position.
+ * The marker is placed at the first incoming message after the lastSeenMessageId
+ * position. Whether a delayed message qualifies depends on `treatDelayedAsNew`,
+ * mirroring `onMessageReceived`:
+ * - 1:1 chats pass `true` — `isDelayed` means "delivered while offline" = new.
+ * - Rooms pass `false` (default) — `isDelayed` means "MUC history replay" = not
+ *   new, so the marker skips it (otherwise joining a room scrolls into the middle
+ *   of replayed history instead of to the bottom).
  */
 export function onActivate(
   state: EntityNotificationState,
-  messages: NotificationMessage[]
+  messages: NotificationMessage[],
+  options?: { treatDelayedAsNew?: boolean }
 ): EntityNotificationState {
+  const { treatDelayedAsNew = false } = options ?? {}
+  // A message qualifies as a "new" marker candidate when it's incoming and either
+  // we treat delayed messages as new (1:1) or it isn't a delayed/history message.
+  const isNewCandidate = (msg: NotificationMessage) =>
+    !msg.isOutgoing && (treatDelayedAsNew || !msg.isDelayed)
+
   let firstNewMessageId: string | undefined = undefined
   let updatedLastSeenMessageId = state.lastSeenMessageId
 
@@ -185,7 +197,7 @@ export function onActivate(
       // Scan forward from lastSeenMessageId to find first unseen incoming message
       for (let i = lastSeenIdx + 1; i < messages.length; i++) {
         const msg = messages[i]
-        if (!msg.isOutgoing) {
+        if (isNewCandidate(msg)) {
           firstNewMessageId = msg.id
           break
         }
@@ -207,18 +219,18 @@ export function onActivate(
 
       if (hasUsableLastReadAt) {
         const firstNew = messages.find(
-          (msg) => msg.timestamp > fallbackReadAt && !msg.isOutgoing
+          (msg) => msg.timestamp > fallbackReadAt && isNewCandidate(msg)
         )
         if (firstNew) {
           firstNewMessageId = firstNew.id
         }
       } else if (state.unreadCount > 0) {
         // No usable lastReadAt — use unreadCount to place marker at the Nth
-        // message from the end (counting only incoming, non-delayed messages).
+        // message from the end (counting only incoming new-candidate messages).
         let remaining = state.unreadCount
         for (let i = messages.length - 1; i >= 0; i--) {
           const m = messages[i]
-          if (!m.isOutgoing) {
+          if (isNewCandidate(m)) {
             remaining--
             if (remaining === 0) {
               firstNewMessageId = m.id
@@ -227,9 +239,9 @@ export function onActivate(
           }
         }
         // If we ran out of messages before exhausting unreadCount,
-        // place marker at the first incoming message.
+        // place marker at the first incoming new-candidate message.
         if (remaining > 0) {
-          const firstIncoming = messages.find((m) => !m.isOutgoing)
+          const firstIncoming = messages.find(isNewCandidate)
           if (firstIncoming) {
             firstNewMessageId = firstIncoming.id
           }
@@ -249,7 +261,7 @@ export function onActivate(
       ? state.lastReadAt
       : new Date(state.lastReadAt as unknown as string)
     const firstNew = messages.find(
-      (msg) => msg.timestamp > lastReadAt && !msg.isOutgoing
+      (msg) => msg.timestamp > lastReadAt && isNewCandidate(msg)
     )
     if (firstNew) {
       firstNewMessageId = firstNew.id
@@ -260,7 +272,7 @@ export function onActivate(
     let remaining = state.unreadCount
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]
-      if (!m.isOutgoing) {
+      if (isNewCandidate(m)) {
         remaining--
         if (remaining === 0) {
           firstNewMessageId = m.id
@@ -269,7 +281,7 @@ export function onActivate(
       }
     }
     if (remaining > 0) {
-      const firstIncoming = messages.find((m) => !m.isOutgoing)
+      const firstIncoming = messages.find(isNewCandidate)
       if (firstIncoming) {
         firstNewMessageId = firstIncoming.id
       }


### PR DESCRIPTION
## Summary

Joining a room (e.g. double-clicking a bookmark) scrolled the message list into the **middle of replayed history** instead of to the bottom.

`onActivate` (which computes `firstNewMessageId`, the marker that drives scroll position) is **shared** by `chatStore` and `roomStore`, but `isDelayed` means opposite things:

- **1:1 chat:** `isDelayed` = delivered while offline → genuinely **new**
- **Room:** `isDelayed` = MUC/MAM history replay → **not new**

Commit `a2fbfca4` removed the `!isDelayed` guard from `onActivate` globally to fix the 1:1 marker. That was correct for chats, but on room join it made replayed history eligible as the marker.

## Fix

Add a `treatDelayedAsNew` option to `onActivate`, mirroring the existing `onMessageReceived` convention:
- `chatStore` opts in (`true`) — preserves the 1:1 offline-delivery behavior.
- `roomStore` uses the room-safe default (`false`) — restores scroll-to-bottom on join.

Source-agnostic: covers both MAM-fetched archive and MUC `<history>` replay (both carry `isDelayed=true`).

## Tests

- `onActivate` branch coverage for room mode (forward scan, `lastReadAt` fallback, brand-new pure-history, default behavior).
- `roomStore` `setActiveRoom` wiring tests that lock the room-safe default — verified to fail against the pre-fix behavior.