### PR TITLE
fix: scroll-to-bottom button skips wasted marker step

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
@@ -353,6 +353,45 @@ describe('MessageList FAB badge and scroll behavior', () => {
       }
     })
 
+    it('should scroll straight to bottom in one click when the marker is already visible', () => {
+      const messages = createTestMessages(10)
+      const firstNewMessageId = 'msg-5'
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          firstNewMessageId={firstNewMessageId}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      // Marker is at offsetTop 800; the user is positioned just above it (633),
+      // so the marker is already within the viewport — NOT further down. This is
+      // the on-open state (init auto-scrolls to the marker). A single click must
+      // reach the bottom, with no wasted "scroll to marker" step.
+      const scrollCtx = setupScrollContainer({ scrollHeight: 2000, clientHeight: 500, initialScrollTop: 633 })
+      if (!scrollCtx) return
+
+      const markerElement = scrollCtx.container.querySelector('[data-message-id="msg-5"]') as HTMLElement
+      if (markerElement) {
+        Object.defineProperty(markerElement, 'offsetTop', { value: 800, configurable: true })
+      }
+
+      // Make the FAB visible by dispatching a scroll event at the current position.
+      act(() => { scrollCtx.container.dispatchEvent(new Event('scroll')) })
+
+      const fab = scrollCtx.container.parentElement?.querySelector('button[aria-label="chat.scrollToBottom"]') as HTMLButtonElement
+      expect(fab).toBeTruthy()
+
+      act(() => { fireEvent.click(fab) })
+
+      expect(scrollCtx.scrollToSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 2000, behavior: 'smooth' })
+      )
+    })
+
     it('should scroll to bottom on second click after scrolling to marker', () => {
       const messages = createTestMessages(10)
       const firstNewMessageId = 'msg-5'
@@ -367,7 +406,10 @@ describe('MessageList FAB badge and scroll behavior', () => {
         />
       )
 
-      const scrollCtx = setupScrollContainer({ scrollHeight: 2000, clientHeight: 500 })
+      // Start above the marker (scrollTop 0, marker at offsetTop 800) so the marker
+      // is genuinely further down. The scrollTo spy updates scrollTop, so the second
+      // click sees the post-first-click position — just like the real DOM.
+      const scrollCtx = setupScrollContainer({ scrollHeight: 2000, clientHeight: 500, initialScrollTop: 0 })
       if (!scrollCtx) return
 
       const markerElement = scrollCtx.container.querySelector('[data-message-id="msg-5"]') as HTMLElement
@@ -375,16 +417,19 @@ describe('MessageList FAB badge and scroll behavior', () => {
         Object.defineProperty(markerElement, 'offsetTop', { value: 800, configurable: true })
       }
 
-      simulateScrollUp(scrollCtx.container)
+      // Make the FAB visible at the current (top) position.
+      act(() => { scrollCtx.container.dispatchEvent(new Event('scroll')) })
 
       const fab = scrollCtx.container.parentElement?.querySelector('button[aria-label="chat.scrollToBottom"]') as HTMLButtonElement
       if (!fab) return
 
-      // First click - goes to marker
+      // First click - goes to marker (marker is below the viewport)
       act(() => { fireEvent.click(fab) })
+      const firstCallTop = scrollCtx.scrollToSpy.mock.calls[0]?.[0]?.top
+      expect(firstCallTop).not.toBe(2000)
       scrollCtx.scrollToSpy.mockClear()
 
-      // Second click - should go to bottom
+      // Second click - marker is now within the viewport, so go to bottom
       act(() => { fireEvent.click(fab) })
 
       expect(scrollCtx.scrollToSpy).toHaveBeenCalledWith(

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -157,9 +157,6 @@ export function useMessageListScroll({
   // Last scroll data (for saving on conversation switch)
   const lastScrollDataRef = useRef<{ top: number; height: number; client: number } | null>(null)
 
-  // Track whether we've already scrolled to the new message marker (for two-step FAB behavior)
-  const hasScrolledToMarkerRef = useRef(false)
-
   // Track whether user has scrolled at least once since the marker was set.
   // Prevents the marker from being cleared immediately on initial load/scroll-to-marker.
   const userHasScrolledSinceMarkerRef = useRef(false)
@@ -378,19 +375,27 @@ export function useMessageListScroll({
     const scroller = scrollerRef.current
     if (!scroller) return
 
-    // Two-step behavior: first click scrolls to new message marker, second to bottom
-    if (firstNewMessageId && !hasScrolledToMarkerRef.current) {
+    // Two-step behavior: scroll to the new message marker only when it exists AND
+    // is still further down than the current viewport (not yet visible). Otherwise —
+    // including when the marker is already on screen or scrolled above — go straight
+    // to the bottom. This is a live position check rather than a one-shot latch, so a
+    // single click always makes progress toward the bottom: no wasted click when the
+    // user is already sitting at the marker (e.g. right after opening a conversation,
+    // where the init effect auto-scrolls to the marker).
+    if (firstNewMessageId) {
       const escapedId = CSS.escape(firstNewMessageId)
       const messageElement = scroller.querySelector(`[data-message-id="${escapedId}"]`)
 
       if (messageElement) {
         const elementTop = (messageElement as HTMLElement).offsetTop
         const viewportHeight = scroller.clientHeight
-        const targetScrollTop = Math.max(0, elementTop - viewportHeight / 3)
+        const viewportBottom = scroller.scrollTop + viewportHeight
 
-        scroller.scrollTo({ top: targetScrollTop, behavior: 'smooth' })
-        hasScrolledToMarkerRef.current = true
-        return
+        if (elementTop > viewportBottom) {
+          const targetScrollTop = Math.max(0, elementTop - viewportHeight / 3)
+          scroller.scrollTo({ top: targetScrollTop, behavior: 'smooth' })
+          return
+        }
       }
     }
 
@@ -710,7 +715,6 @@ export function useMessageListScroll({
     scrolledAwayFromTopRef.current = false
     lastScrollDataRef.current = null
     prependRef.current = null
-    hasScrolledToMarkerRef.current = false
     setShowScrollToBottom(false)
 
     // Clear any pending media load batch
@@ -1188,7 +1192,6 @@ export function useMessageListScroll({
   const prevFirstNewMessageIdRef = useRef(firstNewMessageId)
   useEffect(() => {
     if (firstNewMessageId !== prevFirstNewMessageIdRef.current) {
-      hasScrolledToMarkerRef.current = false
       userHasScrolledSinceMarkerRef.current = false
       prevFirstNewMessageIdRef.current = firstNewMessageId
     }


### PR DESCRIPTION
The scroll-to-bottom FAB is meant to stop at the new-message marker when it's further down the conversation, and go to the bottom otherwise. In practice it often took several clicks to reach the bottom.

**Cause:** the FAB decided "marker vs. bottom" using a one-shot latch keyed only on the marker id — it never checked whether the marker was actually below the current viewport. Since opening a conversation with unread messages auto-scrolls to the marker, the first click re-scrolled to the marker the user was already sitting at (appearing to do nothing), and only a second click reached the bottom.

**Fix:** replace the latch with a live position check — scroll to the marker only when it exists *and* is still further down than the viewport; otherwise go straight to the bottom. A single click now always makes downward progress. Removes the `hasScrolledToMarkerRef` ref and its reset sites. Also fixes the `⌘↓`/`Ctrl+↓` and `End` shortcuts, which share the handler.