### PR TITLE
fix(mobile): suppress desktop hover toolbar on touch devices

### DIFF
--- a/apps/fluux/src/hooks/useMessageHoverState.test.tsx
+++ b/apps/fluux/src/hooks/useMessageHoverState.test.tsx
@@ -23,13 +23,34 @@ describe('useMessageHoverState', () => {
     container.appendChild(toolbar)
     document.body.appendChild(container)
     scrollRef = { current: container }
+    // These tests exercise the mouse hover toolbar, so default to a hovering
+    // pointer (the shared test-setup stub reports matches:false for every query,
+    // which would otherwise read as a touch device and suppress hover).
+    mockHoverCapability(true)
   })
 
   afterEach(() => {
     vi.useRealTimers()
     window.getSelection()?.removeAllRanges()
     container.remove()
+    // Drop any matchMedia stub so the next test falls back to the default
+    // (matchMedia absent → hover assumed, the desktop-oriented behaviour).
+    Reflect.deleteProperty(window, 'matchMedia')
   })
+
+  /** Stub matchMedia so `(hover: hover) and (pointer: fine)` reports `hasHover`. */
+  function mockHoverCapability(hasHover: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('hover: hover') ? hasHover : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia
+  }
 
   function setup(resetKey = 'conv-1') {
     return renderHook(
@@ -292,6 +313,39 @@ describe('useMessageHoverState', () => {
 
     addSpy.mockRestore()
     removeSpy.mockRestore()
+  })
+
+  it('never arms hover on a touch device (no hovering pointer)', () => {
+    // Mobile browsers synthesize mouseenter on tap; without a hover guard that
+    // would surface the desktop hover toolbar on touch (the long-press action
+    // sheet is the touch affordance instead).
+    mockHoverCapability(false)
+    const { result } = setup()
+
+    act(() => result.current.handleMessageHover('a'))
+    act(() => vi.advanceTimersByTime(500))
+    expect(result.current.hoveredMessageId).toBeNull()
+  })
+
+  it('does not re-arm hover on a touch device after a deferred mouseup', () => {
+    mockHoverCapability(false)
+    const { result } = setup()
+
+    mouseDown(messageEl)
+    act(() => result.current.handleMessageHover('b'))
+    mouseUp()
+    act(() => vi.advanceTimersByTime(0))
+    act(() => vi.advanceTimersByTime(500))
+    expect(result.current.hoveredMessageId).toBeNull()
+  })
+
+  it('still arms hover when a hovering pointer is present', () => {
+    mockHoverCapability(true)
+    const { result } = setup()
+
+    act(() => result.current.handleMessageHover('a'))
+    act(() => vi.advanceTimersByTime(200))
+    expect(result.current.hoveredMessageId).toBe('a')
   })
 
   it('keeps handler identities stable across re-renders', () => {

--- a/apps/fluux/src/hooks/useMessageHoverState.ts
+++ b/apps/fluux/src/hooks/useMessageHoverState.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { hasHover } from './useHasHover'
 
 export interface UseMessageHoverStateOptions {
   /** Scroll container of the message list — scopes mousedown/selection detection */
@@ -65,6 +66,11 @@ export function useMessageHoverState({
   }
 
   const armIntentTimer = useCallback((id: string) => {
+    // Touch devices have no hovering pointer, yet mobile browsers synthesize
+    // mouseenter on tap. Arming hover there would surface the desktop-only
+    // hover toolbar alongside the composer — the long-press action sheet is the
+    // touch affordance instead. Re-read live so a docked mouse re-enables it.
+    if (!hasHover()) return
     clearTimer(intentTimerRef)
     intentTimerRef.current = setTimeout(() => {
       intentTimerRef.current = null


### PR DESCRIPTION
On touch, long-pressing (or tapping) a message surfaced the desktop hover `MessageToolbar` on top of the composer — a confusing dual UI, since the long-press `MessageActionSheet` is the intended touch affordance.

The toolbar's visibility is driven by hover state from `useMessageHoverState`, but that hook was never gated on hover capability. Mobile browsers synthesize `mouseenter` on tap, which armed the hover state and showed the toolbar — despite `useHasHover`'s own doc stating the hover toolbar should be hover-only with the long-press sheet as the touch fallback.

Fix: guard `armIntentTimer` (the single path that sets a hovered id, reached by both `handleMessageHover` and the selection/mouseup re-arm) with `hasHover()`. Re-read live so a docked mouse re-enables it. Both 1:1 chats and rooms source `isHovered` from this hook, so one guard covers both.

Added touch-suppression / hover-preserved tests to `useMessageHoverState.test.tsx` (the shared `matchMedia` stub reports `matches:false` for every query, so the file now sets hover capability explicitly per test).