### PR TITLE
fix(rooms): match @mention pill color to the mentioned person's name color

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -9,7 +9,7 @@ import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, wh
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar } from './Avatar'
-import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor } from './conversation/roomSenderResolution'
+import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './conversation/roomSenderResolution'
 import { format } from 'date-fns'
 import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, Users, MessageCircle, EyeOff, User, Settings, Ear, X } from 'lucide-react'
 import { ChristmasAnimation } from './ChristmasAnimation'
@@ -907,6 +907,20 @@ export const RoomMessageList = memo(function RoomMessageList({
   knownNicksRef.current = stableNickSet(room.occupants, knownNicksRef.current)
   const knownNicks = knownNicksRef.current
 
+  // Stable nick→color resolver for inline @mention pills. Mirrors the sender-name
+  // color (resolveSenderColor, incl. a roster contact's XEP-0392 color) so a mention
+  // matches the mentioned person's displayed color instead of a bare nick hash.
+  // Backed by a ref so its identity stays stable across presence churn — passing a
+  // fresh closure would bust every memoized row. Reads the latest room/contacts/theme
+  // at call time, which is render time of each body (kept current by the rows that
+  // re-render). See [project_reply_scroll_freeze] for the derived-value class.
+  const mentionColorCtxRef = useRef({ room, contactsByJid, isDarkMode })
+  mentionColorCtxRef.current = { room, contactsByJid, isDarkMode }
+  const resolveMentionColor = useCallback((nick: string) => {
+    const ctx = mentionColorCtxRef.current
+    return resolveNickColor(nick, ctx.room, ctx.contactsByJid, ctx.isDarkMode ?? true)
+  }, [])
+
   // The current user's own occupant record (stable ref across presence churn unless
   // our own role/affiliation changes). Used per-row to compute moderation permission.
   const selfOccupant = useMemo(
@@ -1002,6 +1016,7 @@ export const RoomMessageList = memo(function RoomMessageList({
         replyBareJid={replyBareJid}
         knownNicks={knownNicks}
         contactsByJid={contactsByJid}
+        resolveMentionColor={resolveMentionColor}
         ownAvatar={ownAvatar}
         sendReaction={sendReaction}
         votePoll={votePoll}
@@ -1095,6 +1110,9 @@ interface RoomMessageBubbleWrapperProps {
   replyBareJid: string | undefined
   knownNicks: ReadonlySet<string>
   contactsByJid: Map<string, ContactIdentity>
+  // Stable nick→color resolver for inline @mention pills (built in the list layer
+  // where `room` is available; this row intentionally never sees `room`).
+  resolveMentionColor: (nick: string) => string | undefined
   ownAvatar?: string | null
   sendReaction: (roomJid: string, messageId: string, emojis: string[]) => Promise<void>
   votePoll: (roomJid: string, messageId: string, optionEmoji: string, currentMyReactions: string[], poll: PollData, isClosed?: boolean) => Promise<void>
@@ -1162,6 +1180,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   replyBareJid,
   knownNicks,
   contactsByJid,
+  resolveMentionColor,
   ownAvatar,
   sendReaction,
   votePoll,
@@ -1401,6 +1420,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
         mentions={message.mentions}
         nickname={myNick}
         knownNicks={knownNicks}
+        resolveMentionColor={resolveMentionColor}
         whisperWith={message.whisperWith}
         whisperThread={whisperThread}
         counterpartPresent={counterpartPresent}

--- a/apps/fluux/src/components/conversation/MessageBody.tsx
+++ b/apps/fluux/src/components/conversation/MessageBody.tsx
@@ -40,6 +40,8 @@ export interface MessageBodyProps {
   nickname?: string
   /** Known occupant nicknames in the room (for IRC-style prefix mention highlighting) */
   knownNicks?: ReadonlySet<string>
+  /** Resolver giving an @mention pill the same color as the mentioned person's name */
+  resolveMentionColor?: (nick: string) => string | undefined
   /** Whether the app is in dark mode (for mention color generation) */
   isDarkMode?: boolean
   /** Search terms to highlight in the message body (from search query) */
@@ -69,6 +71,7 @@ export const MessageBody = memo(function MessageBody({
   mentions,
   nickname,
   knownNicks,
+  resolveMentionColor,
   isDarkMode,
   highlightTerms,
   isCurrentMatch,
@@ -106,7 +109,7 @@ export const MessageBody = memo(function MessageBody({
           {senderName}
         </span>
         {' '}
-        {wrap(noStyling ? getActionText(body) : renderStyledMessage(getActionText(body), mentions, nickname, knownNicks, isDarkMode))}
+        {wrap(noStyling ? getActionText(body) : renderStyledMessage(getActionText(body), mentions, nickname, knownNicks, isDarkMode, resolveMentionColor))}
         {isEdited && (
           <EditedIndicator
             originalBody={originalBody}
@@ -120,7 +123,7 @@ export const MessageBody = memo(function MessageBody({
   // Regular message
   return (
     <div dir="auto" className="text-fluux-text break-words whitespace-pre-wrap leading-[1.375]">
-      {wrap(noStyling ? body : renderStyledMessage(body, mentions, nickname, knownNicks, isDarkMode))}
+      {wrap(noStyling ? body : renderStyledMessage(body, mentions, nickname, knownNicks, isDarkMode, resolveMentionColor))}
       {isEdited && <EditedIndicator originalBody={originalBody} />}
     </div>
   )

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -111,6 +111,10 @@ export interface MessageBubbleProps {
   // Room-specific: known occupant nicks for IRC-style prefix mention highlighting
   knownNicks?: ReadonlySet<string>
 
+  // Room-specific: stable resolver giving a mention pill the same color as the
+  // mentioned person's name (roster contact's XEP-0392 color, else nick hash).
+  resolveMentionColor?: (nick: string) => string | undefined
+
   // XEP-0425: Whether the current user can moderate (retract) this message
   canModerate?: boolean
 
@@ -292,6 +296,7 @@ export const MessageBubble = memo(function MessageBubble({
   mentions,
   nickname,
   knownNicks,
+  resolveMentionColor,
   canModerate,
   isIrcGateway,
   onPollVote,
@@ -610,6 +615,7 @@ export const MessageBubble = memo(function MessageBubble({
               mentions={mentions}
               nickname={nickname}
               knownNicks={knownNicks}
+              resolveMentionColor={resolveMentionColor}
               isDarkMode={isDarkMode}
               highlightTerms={highlightTerms}
               isCurrentMatch={isCurrentMatch}

--- a/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor } from './roomSenderResolution'
+import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './roomSenderResolution'
 import { getConsistentTextColor } from '../Avatar'
 import type { RoomOccupant, Room, RoomMessage } from '@fluux/sdk'
 
@@ -178,5 +178,26 @@ describe('resolveSenderColor', () => {
   })
   it('falls back to the nick-hash color when the contact has no pre-calculated colors', () => {
     expect(resolveSenderColor('alice', { jid: 'alice@x' } as any, false)).toBe(getConsistentTextColor('alice', false))
+  })
+})
+
+describe('resolveNickColor', () => {
+  // Regression: an inline @mention pill colored from the bare nick hash disagreed
+  // with the mentioned person's name color, which uses the roster contact's
+  // XEP-0392 color. Both must share resolveSenderColor for the same nick→JID→contact.
+  const contact = { jid: 'alice@x', colorLight: '#7b4500', colorDark: '#ffa54c' } as any
+  it('uses the contact color when the nick maps to a JID via the live occupant', () => {
+    const r = room({
+      occupants: new Map([['alice', occ('alice', { jid: 'alice@x/res' })]]),
+    })
+    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), true)).toBe('#ffa54c')
+  })
+  it('uses the contact color when the JID comes from nickToJidCache', () => {
+    const r = room({ occupants: new Map(), nickToJidCache: new Map([['alice', 'alice@x']]) })
+    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), false)).toBe('#7b4500')
+  })
+  it('falls back to the nick-hash color for an unknown nick (no JID / not a contact)', () => {
+    const r = room({ occupants: new Map(), nickToJidCache: new Map() })
+    expect(resolveNickColor('ghost', r, new Map(), true)).toBe(getConsistentTextColor('ghost', true))
   })
 })

--- a/apps/fluux/src/components/conversation/roomSenderResolution.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.ts
@@ -108,6 +108,26 @@ export function resolveSenderColor(
   return contactColor || getConsistentTextColor(identifier, isDarkMode)
 }
 
+/**
+ * Display color for an arbitrary room nick (e.g. an inline @mention), using the
+ * SAME resolution as the sender-name color: a roster contact's pre-calculated
+ * XEP-0392 color when the nick maps to a known bare JID, otherwise the nick-hash
+ * color. Keeps a mention pill consistent with the mentioned person's name color.
+ * Mirrors the senderBareJid resolution in resolveRoomSender (occupant JID, then
+ * nickToJidCache) minus the occupant-id fallback, which only applies to the sender.
+ */
+export function resolveNickColor(
+  nick: string,
+  room: Pick<Room, 'occupants' | 'nickToJidCache'>,
+  contactsByJid: ReadonlyMap<string, ContactIdentity>,
+  isDarkMode: boolean,
+): string {
+  const occupant = room.occupants.get(nick)
+  const bareJid = occupant?.jid ? getBareJid(occupant.jid) : room.nickToJidCache?.get(nick)
+  const contact = bareJid ? contactsByJid.get(bareJid) : undefined
+  return resolveSenderColor(nick, contact, isDarkMode)
+}
+
 export function selectSelfOccupant(
   occupants: ReadonlyMap<string, RoomOccupant>,
   myNick: string | undefined,

--- a/apps/fluux/src/utils/messageStyles.test.tsx
+++ b/apps/fluux/src/utils/messageStyles.test.tsx
@@ -637,6 +637,30 @@ Steps to follow:
       expect(mentionSpans[1].textContent).toBe('@carol')
     })
 
+    // Mention color must match the sender's displayed color (e.g. a roster
+    // contact's XEP-0392 color), not just the nick hash. renderStyledMessage
+    // takes a resolveMentionColor callback so RoomView can supply the same
+    // color resolution used for the nickname header.
+    it('colors the mention with the resolver result', () => {
+      const resolve = (id: string) => (id === 'alice' ? 'var(--contact-alice)' : undefined)
+      const { container } = render(
+        <div>{renderStyledMessage('Hello @alice!', undefined, 'myNick', undefined, true, resolve)}</div>
+      )
+      const mention = container.querySelector('[data-mention="alice"]') as HTMLElement
+      expect(mention).toBeTruthy()
+      expect(mention.style.color).toBe('var(--contact-alice)')
+    })
+
+    it('falls back to the nick-hash color when the resolver returns undefined', () => {
+      const resolve = () => undefined
+      const { container } = render(
+        <div>{renderStyledMessage('Hello @bob!', undefined, 'myNick', undefined, true, resolve)}</div>
+      )
+      const mention = container.querySelector('[data-mention="bob"]') as HTMLElement
+      expect(mention).toBeTruthy()
+      expect(mention.style.color).toBeTruthy()
+    })
+
     // Unicode nickname support (regression tests)
     it('renders mention with accented characters', () => {
       const container = renderRoomText('@Jérôme is here')

--- a/apps/fluux/src/utils/messageStyles.tsx
+++ b/apps/fluux/src/utils/messageStyles.tsx
@@ -273,7 +273,7 @@ function parseStyledText(
 /**
  * Render a styled segment to React elements
  */
-function renderSegment(segment: StyledSegment, index: number, isDarkMode?: boolean): React.ReactNode {
+function renderSegment(segment: StyledSegment, index: number, isDarkMode?: boolean, resolveMentionColor?: (identifier: string) => string | undefined): React.ReactNode {
   switch (segment.type) {
     case 'bold':
       return <strong key={index} className="font-semibold">{segment.content}</strong>
@@ -303,9 +303,12 @@ function renderSegment(segment: StyledSegment, index: number, isDarkMode?: boole
         </a>
       )
     case 'mention': {
-      // Use per-user consistent color when identifier is available, otherwise fall back to brand
+      // Use per-user consistent color when identifier is available, otherwise fall back to brand.
+      // Prefer the caller's resolver (which mirrors the sender-name color, including a roster
+      // contact's XEP-0392 color) so the mention pill matches the person's displayed color;
+      // fall back to the nick hash when no resolver is supplied or it can't resolve the nick.
       const color = segment.identifier
-        ? getConsistentTextColor(segment.identifier, isDarkMode ?? true)
+        ? (resolveMentionColor?.(segment.identifier) ?? getConsistentTextColor(segment.identifier, isDarkMode ?? true))
         : undefined
       const style = color
         ? { color, backgroundColor: `${color}15` }
@@ -652,7 +655,7 @@ export function renderTextWithLinks(text: string): React.ReactNode {
  * @param mentions - Optional XEP-0372 mention references for precise highlighting
  * @param nickname - Optional user nickname for IRC-style mention detection fallback
  */
-export function renderStyledMessage(text: string, mentions?: MentionReference[], nickname?: string, knownNicks?: ReadonlySet<string>, isDarkMode?: boolean): React.ReactNode {
+export function renderStyledMessage(text: string, mentions?: MentionReference[], nickname?: string, knownNicks?: ReadonlySet<string>, isDarkMode?: boolean, resolveMentionColor?: (identifier: string) => string | undefined): React.ReactNode {
   // Normalize line endings: CRLF -> LF, CR -> LF
   const normalizedText = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 
@@ -698,7 +701,7 @@ export function renderStyledMessage(text: string, mentions?: MentionReference[],
     // Render text before code block
     if (match.index > lastIndex) {
       const before = normalizedText.slice(lastIndex, match.index)
-      parts.push(...renderTextBlock(before, partIndex, mentionRanges, lastIndex, isDarkMode, disableMentionFallback))
+      parts.push(...renderTextBlock(before, partIndex, mentionRanges, lastIndex, isDarkMode, disableMentionFallback, resolveMentionColor))
       partIndex += 100 // Leave room for sub-indices
     }
 
@@ -714,12 +717,12 @@ export function renderStyledMessage(text: string, mentions?: MentionReference[],
 
   // Render remaining text
   if (lastIndex < normalizedText.length) {
-    parts.push(...renderTextBlock(normalizedText.slice(lastIndex), partIndex, mentionRanges, lastIndex, isDarkMode, disableMentionFallback))
+    parts.push(...renderTextBlock(normalizedText.slice(lastIndex), partIndex, mentionRanges, lastIndex, isDarkMode, disableMentionFallback, resolveMentionColor))
   }
 
   // If no code blocks, render the whole thing
   if (parts.length === 0) {
-    return renderTextBlock(normalizedText, 0, mentionRanges, 0, isDarkMode, disableMentionFallback)
+    return renderTextBlock(normalizedText, 0, mentionRanges, 0, isDarkMode, disableMentionFallback, resolveMentionColor)
   }
 
   return parts
@@ -734,7 +737,8 @@ function renderTextBlock(
   mentionRanges: MentionRange[] | null = null,
   textOffset: number = 0,
   isDarkMode?: boolean,
-  disableMentionFallback: boolean = false
+  disableMentionFallback: boolean = false,
+  resolveMentionColor?: (identifier: string) => string | undefined
 ): React.ReactNode[] {
   const lines = text.split('\n')
   const result: React.ReactNode[] = []
@@ -751,7 +755,7 @@ function renderTextBlock(
           quoteBuffer,
           1,
           index,
-          (content, idx, offset) => renderInline(content, idx, mentionRanges, offset, isDarkMode, disableMentionFallback),
+          (content, idx, offset) => renderInline(content, idx, mentionRanges, offset, isDarkMode, disableMentionFallback, resolveMentionColor),
           true
         )
       )
@@ -769,7 +773,7 @@ function renderTextBlock(
         >
           {ulBuffer.lines.map((line, i) => (
             <li key={i} className="text-fluux-text">
-              {renderInline(line, index + i, mentionRanges, ulBuffer!.lineOffsets[i], isDarkMode, disableMentionFallback)}
+              {renderInline(line, index + i, mentionRanges, ulBuffer!.lineOffsets[i], isDarkMode, disableMentionFallback, resolveMentionColor)}
             </li>
           ))}
         </ul>
@@ -791,7 +795,7 @@ function renderTextBlock(
         >
           {olBuffer.items.map((item, i) => (
             <li key={i} className="text-fluux-text">
-              {renderInline(item.content, index + i, mentionRanges, item.offset, isDarkMode, disableMentionFallback)}
+              {renderInline(item.content, index + i, mentionRanges, item.offset, isDarkMode, disableMentionFallback, resolveMentionColor)}
             </li>
           ))}
         </ol>
@@ -878,7 +882,7 @@ function renderTextBlock(
 
       result.push(
         <div key={`heading-${index++}`} className={`${headingClasses} mt-1`}>
-          {renderInline(headingCheck.content, index, mentionRanges, lineOffset + prefixLength, isDarkMode, disableMentionFallback)}
+          {renderInline(headingCheck.content, index, mentionRanges, lineOffset + prefixLength, isDarkMode, disableMentionFallback, resolveMentionColor)}
         </div>
       )
 
@@ -892,7 +896,7 @@ function renderTextBlock(
     if (line || i < lines.length - 1) {
       result.push(
         <React.Fragment key={`line-${index++}`}>
-          {renderInline(line, index, mentionRanges, lineOffset, isDarkMode, disableMentionFallback)}
+          {renderInline(line, index, mentionRanges, lineOffset, isDarkMode, disableMentionFallback, resolveMentionColor)}
           {i < lines.length - 1 && <br />}
         </React.Fragment>
       )
@@ -915,12 +919,13 @@ function renderInline(
   mentionRanges: MentionRange[] | null = null,
   textOffset: number = 0,
   isDarkMode?: boolean,
-  disableMentionFallback: boolean = false
+  disableMentionFallback: boolean = false,
+  resolveMentionColor?: (identifier: string) => string | undefined
 ): React.ReactNode {
   if (!text) return null
   const segments = parseInlineStyles(text, mentionRanges, textOffset, disableMentionFallback)
   if (segments.length === 1 && segments[0].type === 'text') {
     return segments[0].content
   }
-  return segments.map((seg, i) => renderSegment(seg, keyBase * 1000 + i, isDarkMode))
+  return segments.map((seg, i) => renderSegment(seg, keyBase * 1000 + i, isDarkMode, resolveMentionColor))
 }


### PR DESCRIPTION
## Summary

The inline `@mention` pill was colored from the bare nick hash (`getConsistentTextColor`), while the sender name uses `resolveSenderColor`, which prefers a roster contact's XEP-0392 color (hashed from the bare JID). For a mentioned person who is a roster contact, the two diverged — e.g. a red `@prefiks` pill next to a blue `prefiks` name.

## Changes

- Add `resolveNickColor()` in `roomSenderResolution.ts` — shared nick → JID → contact resolution that delegates to `resolveSenderColor`, so a mention and the name use one source of truth.
- Thread an optional `resolveMentionColor` resolver through `renderStyledMessage` → `MessageBody` → `MessageBubble`; the mention case prefers it and falls back to the nick hash.
- `RoomView` builds the resolver in the list layer (where `room` is in scope), backed by a ref + `useCallback` so its identity is stable across presence churn and does not bust the memoized rows.

In 1:1 chat and search no resolver is passed, so behavior is unchanged.