### PR TITLE
fix(ui): highlight the targeted cell/message when a long-press menu opens

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -471,7 +471,7 @@ export const MessageBubble = memo(function MessageBubble({
 
       {/* Content */}
       <div
-        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''}`}
+        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''}`}
         onTouchStart={handleContentTouchStart}
         onTouchEnd={cancelLongPress}
         onTouchMove={cancelLongPress}

--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -264,7 +264,7 @@ export const ConversationItem = memo(function ConversationItem({
   const { t, i18n } = useTranslation()
   const connectionStatus = useConnectionStore((s) => s.status)
   const forceOffline = connectionStatus !== 'online'
-  const { getItemMenuProps, isOpen, longPressTriggered } = useSidebarListMenu<Conversation>()
+  const { getItemMenuProps, isOpen, longPressTriggered, targetItem } = useSidebarListMenu<Conversation>()
   const currentLang = i18n.language.split('-')[0]
   const timeFormat = useSettingsStore((s) => s.timeFormat)
 
@@ -276,6 +276,9 @@ export const ConversationItem = memo(function ConversationItem({
 
   const isGroupChat = conversation.type === 'groupchat'
   const menuProps = getItemMenuProps(conversation)
+  // While the long-press / context menu is open, highlight the targeted cell so
+  // the user can clearly see which conversation the action will apply to.
+  const isMenuTarget = isOpen && targetItem?.id === conversation.id
 
   const handleClick = () => {
     if (isOpen || longPressTriggered.current) return
@@ -298,13 +301,15 @@ export const ConversationItem = memo(function ConversationItem({
         onMouseEnter={onMouseEnter}
         onMouseMove={onMouseMove}
         className={`w-full relative px-2 py-1.5 rounded border flex items-center gap-3 text-start cursor-pointer
-                    transition-colors ${isActive
+                    transition-colors ${isMenuTarget ? 'ring-2 ring-fluux-brand ring-inset z-10' : ''} ${isActive
                       ? "bg-fluux-sidebar-item-active text-fluux-text border-transparent before:content-[''] before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-r-full before:bg-fluux-sidebar-item-active-accent"
-                      : isSelected
-                        ? 'bg-fluux-hover text-fluux-text border-fluux-brand'
-                        : isKeyboardNav
-                          ? 'text-fluux-muted border-transparent'
-                          : 'text-fluux-muted border-transparent hover:bg-fluux-hover hover:text-fluux-text'}`}
+                      : isMenuTarget
+                        ? 'bg-fluux-hover text-fluux-text border-transparent'
+                        : isSelected
+                          ? 'bg-fluux-hover text-fluux-text border-fluux-brand'
+                          : isKeyboardNav
+                            ? 'text-fluux-muted border-transparent'
+                            : 'text-fluux-muted border-transparent hover:bg-fluux-hover hover:text-fluux-text'}`}
       >
         {/* Avatar wrapper — the unread badge overlays the avatar (UX_REVIEW §3.1)
             instead of taking its own flex column, so the name/preview column


### PR DESCRIPTION
When a context/action menu opens via long-press on touch (or right-click on desktop), the targeted item is now clearly highlighted so it's unambiguous which item the action will apply to.

- **Sidebar conversations**: the targeted conversation cell gets a brand-colored inset ring + hover background while its menu is open (reuses the existing `targetItem` from `useSidebarListMenu`).
- **Messages**: the targeted message bubble reuses the existing selection background (`bg-fluux-selection`) while its long-press action sheet is open, so it stands out against the dimmed backdrop.

Both highlights clear automatically when the menu/sheet closes.