### PR TITLE
fix(e2ee): heal stuck sidebar preview after deferred decrypt with trailing placeholder

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -674,6 +674,37 @@ describe('chatStore', () => {
       const after = chatStore.getState().conversationMeta.get('alice@example.com')
       expect(after?.lastMessage?.id).toBe(last.id)
     })
+
+    it('heals the preview when the deferred-decrypted message is the preview but a bodiless placeholder trails it', () => {
+      // Regression: an encrypted message becomes the preview, then an encrypted
+      // reaction arrives and is stored as a trailing bodiless placeholder. On
+      // unlock the real message decrypts via updateMessage, but it is no longer
+      // the *positionally* last array element (the placeholder trails it), so the
+      // old `isLastMessage` gate refused to refresh the sidebar — it stayed stuck
+      // on "[OpenPGP-encrypted message]". updateMessage must heal by identity:
+      // the updated message IS the current preview.
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      const encrypted: Message = {
+        ...createMessage('alice@example.com', '[OpenPGP-encrypted message]', false),
+        encryptedPayload: '<message><openpgp>real</openpgp></message>',
+      }
+      chatStore.getState().addMessage(encrypted)
+      chatStore.getState().addMessage(bodilessPlaceholder('alice@example.com'))
+
+      // Sanity: the encrypted message is the stored preview, placeholder trails it.
+      expect(chatStore.getState().conversationMeta.get('alice@example.com')?.lastMessage?.id).toBe(encrypted.id)
+
+      // Deferred decrypt resolves the real message (not positionally last).
+      chatStore.getState().updateMessage('alice@example.com', encrypted.id, {
+        body: 'Decrypted content',
+        encryptedPayload: undefined,
+      })
+
+      const preview = chatStore.getState().conversationMeta.get('alice@example.com')?.lastMessage
+      expect(preview?.id).toBe(encrypted.id)
+      expect(preview?.body).toBe('Decrypted content')
+      expect(preview?.encryptedPayload).toBeUndefined()
+    })
   })
 
   describe('clearMessageStanzaId', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1079,11 +1079,21 @@ export const chatStore = createStore<ChatState>()(
             void searchIndex.updateMessage(updatedMessage)
           }
 
-          // Update lastMessage if this was the last message in the conversation
+          // Refresh the lastMessage preview when this update touches it. Match
+          // positionally (the updated message is the newest array element) OR by
+          // identity (the updated message IS the current preview). The identity
+          // tier is load-bearing for deferred decrypt: an encrypted message can
+          // be the stored preview while a trailing bodiless-signal placeholder
+          // (an encrypted reaction/retraction) sits after it in the array, so a
+          // purely positional gate would leave the sidebar stuck on
+          // "[OpenPGP-encrypted message]" after the real message decrypts.
+          const meta = state.conversationMeta.get(conversationId)
+          const conv = state.conversations.get(conversationId)
           const isLastMessage = messageIndex === updatedConvMessages.length - 1
-          if (isLastMessage) {
-            const meta = state.conversationMeta.get(conversationId)
-            const conv = state.conversations.get(conversationId)
+          const isPreviewMessage =
+            !!meta?.lastMessage &&
+            findMessageIndexById([meta.lastMessage], updatedMessage.id) !== -1
+          if (isLastMessage || isPreviewMessage) {
             if (meta && conv) {
               // Update metadata map
               const newMeta = new Map(state.conversationMeta)


### PR DESCRIPTION
The sidebar preview could stay stuck on `[OpenPGP-encrypted message]` even when the conversation was open and the message was visibly decrypted.