### PR TITLE
fix(deps): restore serialize-javascript dropped from lockfile by transitive override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12483,6 +12483,16 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@tauri-apps/plugin-deep-link": "^2.4.7"
   },
   "overrides": {
-    "serialize-javascript": "7.0.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "zod-validation-error": "4.0.2",


### PR DESCRIPTION
## Summary

The "Publish Live Demo to Github Pages" workflow failed on `main` with `Cannot find module 'serialize-javascript'` during the PWA service-worker build (`@rollup/plugin-terser` → `serialize-javascript`, via `vite-plugin-pwa` → `workbox-build`).

Renovate PR #599 bumped the `serialize-javascript` npm `overrides` entry — a **transitive-only** dependency whose sole consumer `@rollup/plugin-terser@1.0.0` requires `^7.0.3` — and, in regenerating the lockfile, **deleted the `node_modules/serialize-javascript` node from `package-lock.json` without writing a replacement**. `npm ci` (strict-lockfile) then installed nothing for it, so the build crashed when the terser plugin `require()`d it.

This is the known npm bug where an `overrides` entry on a transitive-only package gets dropped from `package-lock.json` on regeneration. Keeping the override and re-running `npm install` does **not** repair it (verified locally — npm refuses to install the node while the transitive-only override exists).

## Fix

- Remove the now-redundant `serialize-javascript` override from `package.json`. `^7.0.3` resolves to `7.0.6` (latest) naturally — still safe, above the CVE-2026-34043 DoS fix (7.0.5) that #354 originally pinned for. With no transitive-only override left, the drop can't recur.
- Restore the `serialize-javascript@7.0.6` node in `package-lock.json` (surgical, +10 lines — avoids the ~200-entry churn of a full clean regen).