### PR TITLE
fix(e2ee): don't raise the trust-state alarm when the secret key is merely unavailable

### DIFF
--- a/apps/fluux/src/components/TrustStateCompromisedBanner.test.tsx
+++ b/apps/fluux/src/components/TrustStateCompromisedBanner.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TrustStateCompromisedBanner } from './TrustStateCompromisedBanner'
+import { useTrustStateStatusStore } from '@/stores/trustStateStatusStore'
+import type { TrustStateStatus } from '@/stores/trustStateStatusStore'
+
+// Mock react-i18next — returns the key as the translation (avoids missing-key fallback noise)
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+// Mock @fluux/sdk — only useXMPPContext is needed by this component
+vi.mock('@fluux/sdk', () => ({
+  useXMPPContext: () => ({
+    client: { e2ee: null },
+  }),
+}))
+
+beforeEach(() => {
+  useTrustStateStatusStore.setState({ status: 'uninitialized', mismatchDetails: undefined })
+})
+
+const silent: TrustStateStatus[] = ['uninitialized', 'sealed', 'pending-seal', 'awaiting-key']
+
+describe('TrustStateCompromisedBanner', () => {
+  it.each(silent)('renders nothing for status %s', (status) => {
+    useTrustStateStatusStore.setState({ status })
+    const { container } = render(<TrustStateCompromisedBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the warning only for compromised', () => {
+    useTrustStateStatusStore.setState({ status: 'compromised' })
+    render(<TrustStateCompromisedBanner />)
+    expect(screen.getByText('Trust state integrity check failed')).toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -653,6 +653,8 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       ownFingerprint,
       isSecretKeyUnavailableError,
     )
+    const reason = details && details.length ? ` (${details.join('; ')})` : ''
+    this.ctx.logger.info(`Trust-state verdict: ${status}${reason}`)
     if (status === 'pending-seal') {
       await this.sealTrustStateNow()
       return

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -125,6 +125,7 @@ import { usePinnedPrimaryFingerprintsStore } from '@/stores/pinnedPrimaryFingerp
 import { useKeyChangeAlertsStore } from '@/stores/keyChangeAlertsStore'
 import { setTrustStateStatus } from '@/stores/trustStateStatusStore'
 import { withPassphraseFormatHeader } from './passphraseFormatHeader'
+import { isSecretKeyUnavailableError } from './keyUnavailable'
 
 // ---------------------------------------------------------------------------
 // XEP-0373 constants
@@ -650,6 +651,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
       (ciphertext, senderPub) => this.decryptWithOwnKey(jid, ciphertext, senderPub),
       ownPublicArmored,
       ownFingerprint,
+      isSecretKeyUnavailableError,
     )
     if (status === 'pending-seal') {
       await this.sealTrustStateNow()

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -642,7 +642,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     }
   }
 
-  private async verifyTrustStateOnInit(): Promise<void> {
+  protected async verifyTrustStateOnInit(): Promise<void> {
     const ownPublicArmored = this.ownBundle?.publicArmored
     const ownFingerprint = this.ownBundle?.fingerprint
     if (!ownPublicArmored || !ownFingerprint || !this.ctx) return
@@ -885,6 +885,13 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     // locally so history stays decryptable. Re-run deferred decrypts so any
     // still-stashed messages are recovered immediately.
     ctx.notifyKeyUnlocked?.()
+    // The secret key is now usable again — re-run the trust-state seal check so
+    // a deferred `awaiting-key` verdict resolves. `init()` returns early without
+    // activating subscriptions on key-unrecoverable, so recovery must BOTH
+    // ensure subscriptions are active AND run the verification explicitly for
+    // the case where they already were.
+    this.activateSubscriptions() // idempotent: activates subs (+ verifies) if not yet active
+    void this.verifyTrustStateOnInit() // explicit re-check when subs were already active
 
     return { fingerprint: bundle.fingerprint }
   }
@@ -1177,6 +1184,13 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     // stashed while the key was absent stay "could not be decrypted" until an
     // unrelated trigger (reconnect, app restart) re-registers the plugin.
     ctx.notifyKeyUnlocked?.()
+    // The secret key is now usable again — re-run the trust-state seal check so
+    // a deferred `awaiting-key` verdict resolves (to `sealed` for an unchanged
+    // cert). `init()` returns early without activating subscriptions on
+    // key-unrecoverable, so recovery must BOTH ensure subscriptions are active
+    // AND run the verification explicitly for the case where they already were.
+    this.activateSubscriptions() // idempotent: activates subs (+ verifies) if not yet active
+    void this.verifyTrustStateOnInit() // explicit re-check when subs were already active
 
     return { fingerprint: bundle.fingerprint }
   }

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -660,6 +660,19 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     setTrustStateStatus(status, details)
   }
 
+  /**
+   * Re-verify the trust-state seal after the secret key becomes usable again
+   * (recovery / unlock). `activateSubscriptions()` is idempotent (guarded) and
+   * runs the seal check on first activation; the explicit `verifyTrustStateOnInit()`
+   * covers the case where subscriptions were already active (so the guard skips
+   * the internal check). Resolves a deferred `awaiting-key` verdict to `sealed`
+   * for an unchanged cert. Fire-and-forget: the verify catches internally.
+   */
+  protected reverifyTrustStateAfterKeyChange(): void {
+    this.activateSubscriptions()
+    void this.verifyTrustStateOnInit()
+  }
+
   async resealTrustState(): Promise<void> {
     const ownPublicArmored = this.ownBundle?.publicArmored
     if (!ownPublicArmored || !this.ctx) return
@@ -885,13 +898,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     // locally so history stays decryptable. Re-run deferred decrypts so any
     // still-stashed messages are recovered immediately.
     ctx.notifyKeyUnlocked?.()
-    // The secret key is now usable again — re-run the trust-state seal check so
-    // a deferred `awaiting-key` verdict resolves. `init()` returns early without
-    // activating subscriptions on key-unrecoverable, so recovery must BOTH
-    // ensure subscriptions are active AND run the verification explicitly for
-    // the case where they already were.
-    this.activateSubscriptions() // idempotent: activates subs (+ verifies) if not yet active
-    void this.verifyTrustStateOnInit() // explicit re-check when subs were already active
+    this.reverifyTrustStateAfterKeyChange()
 
     return { fingerprint: bundle.fingerprint }
   }
@@ -1184,13 +1191,7 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     // stashed while the key was absent stay "could not be decrypted" until an
     // unrelated trigger (reconnect, app restart) re-registers the plugin.
     ctx.notifyKeyUnlocked?.()
-    // The secret key is now usable again — re-run the trust-state seal check so
-    // a deferred `awaiting-key` verdict resolves (to `sealed` for an unchanged
-    // cert). `init()` returns early without activating subscriptions on
-    // key-unrecoverable, so recovery must BOTH ensure subscriptions are active
-    // AND run the verification explicitly for the case where they already were.
-    this.activateSubscriptions() // idempotent: activates subs (+ verifies) if not yet active
-    void this.verifyTrustStateOnInit() // explicit re-check when subs were already active
+    this.reverifyTrustStateAfterKeyChange()
 
     return { fingerprint: bundle.fingerprint }
   }

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -2795,6 +2795,37 @@ describe('SequoiaPgpPlugin', () => {
     })
   })
 
+  describe('trust-state verdict instrumentation', () => {
+    // Task 4: After computing the trust-state verdict, the plugin must log it
+    // via ctx.logger.info so it lands in both the webview console (fluux.log)
+    // and the in-app console store (via the E2EE diagnostic logger fan-out).
+
+    it('logs the trust-state verdict via ctx.logger.info after init', async () => {
+      const { ctx } = makeContext('me@example.com')
+      const infoCalls: string[] = []
+      ctx.logger.info = (message: string) => { infoCalls.push(message) }
+
+      await plugin.init(ctx)
+
+      // A trust-state verdict log must be emitted (status can be any non-trivial
+      // value: pending-seal on first run, sealed on subsequent, etc.)
+      expect(infoCalls.some((m) => /trust.?state/i.test(m))).toBe(true)
+    })
+
+    it('includes the verdict status in the log message', async () => {
+      const { ctx } = makeContext('me@example.com')
+      const infoCalls: string[] = []
+      ctx.logger.info = (message: string) => { infoCalls.push(message) }
+
+      await plugin.init(ctx)
+
+      const verdictLog = infoCalls.find((m) => /trust.?state/i.test(m))
+      expect(verdictLog).toBeDefined()
+      // The message must contain a recognizable status keyword
+      expect(verdictLog).toMatch(/sealed|pending-seal|awaiting-key|compromised|uninitialized/)
+    })
+  })
+
   describe('backup sync marker (getBackedUpFingerprint)', () => {
     // The marker lets the UI answer "is my local key already backed up?"
     // without re-prompting for the passphrase. These tests pin the

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -134,6 +134,11 @@ function makeFakeRust() {
 
   let nextFingerprint = 1
   const accounts = new Map<string, KeyBundle>()
+  // One-shot decrypt-failure hook (test-only). When set, the NEXT
+  // `openpgp_decrypt` invoke rejects with an E2EEPluginError carrying this
+  // code, then the hook clears itself. Lets a test drive the trust-state
+  // seal check into `awaiting-key` (key-unavailable) without a real keychain.
+  let nextDecryptFailureCode: E2EEPluginError['code'] | null = null
 
   const makeArmored = (fp: string, uid: string, kind: string, rotation = 0) =>
     makeOpenPgpArmor(
@@ -196,6 +201,11 @@ function makeFakeRust() {
         ) as T
       }
       case 'openpgp_decrypt': {
+        if (nextDecryptFailureCode) {
+          const code = nextDecryptFailureCode
+          nextDecryptFailureCode = null
+          throw new E2EEPluginError('permanent', code, `simulated ${code} on decrypt`)
+        }
         const jid = args!.accountJid as string
         const bundle = accounts.get(jid)
         if (!bundle) throw new Error(`no key for ${jid}`)
@@ -358,7 +368,16 @@ function makeFakeRust() {
     }
   }
 
-  return { invoke, accounts }
+  /**
+   * Arm a one-shot decrypt failure: the next `openpgp_decrypt` invoke rejects
+   * with an `E2EEPluginError` carrying `code` (e.g. `'key-unrecoverable'`).
+   * Test-only hook used to defer the trust-state seal check to `awaiting-key`.
+   */
+  const failNextOwnDecryptWith = (code: E2EEPluginError['code']) => {
+    nextDecryptFailureCode = code
+  }
+
+  return { invoke, accounts, failNextOwnDecryptWith }
 }
 
 /**
@@ -2709,6 +2728,70 @@ describe('SequoiaPgpPlugin', () => {
       expect(
         deletedNodes.filter((n) => n.startsWith('urn:xmpp:openpgp:0:public-keys:')),
       ).toHaveLength(0)
+    })
+
+    it('re-verifies the trust state after recovery (awaiting-key -> sealed)', async () => {
+      // Regression: when the secret key is unavailable at init time (keychain /
+      // TSK desync), the seal check defers to `awaiting-key` instead of raising
+      // the false "compromised" alarm. Once the user recovers the key, the
+      // recovery completion must RE-RUN the seal check so the deferred verdict
+      // resolves to `sealed` for the unchanged cert — otherwise the trust state
+      // stays stuck at `awaiting-key` until an unrelated reconnect/restart.
+      const { getTrustStateStatus } = await import('@/stores/trustStateStatusStore')
+      const pinStore = await import('@/stores/pinnedPrimaryFingerprintsStore')
+
+      // Phase 1 — a first plugin instance seals the trust state. A pin makes the
+      // stores non-empty so a real seal (encrypted-to-self) is written, and a
+      // secret-key backup is published so the later recovery can restore it.
+      const { ctx: ctxA } = makeContext('me@example.com')
+      await plugin.init(ctxA)
+      pinStore.usePinnedPrimaryFingerprintsStore.setState({
+        pinnedFingerprintByJid: { 'peer@example.com': 'PEERFP000000' },
+      })
+      const passthroughA = plugin as unknown as {
+        verifyTrustStateOnInit(): Promise<void>
+      }
+      // The pin mutation schedules a debounced reseal; force the seal now so it
+      // exists deterministically before the deferred-verify phase.
+      await passthroughA.verifyTrustStateOnInit()
+      await plugin.backupSecretKey('shared-pp')
+      const backup = await plugin.fetchSecretKeyBackup()
+      expect(backup).toBeTruthy()
+      expect(getTrustStateStatus()).toBe('sealed')
+
+      // Phase 2 — a fresh plugin (same JID + key + seal) initialises, then its
+      // seal check is driven while the secret key is momentarily unusable: the
+      // decrypt throws key-unrecoverable, so the verdict defers to
+      // `awaiting-key`. We arm the one-shot failure immediately before invoking
+      // the seal check so only that decrypt is affected (init's own
+      // `verifyTrustStateOnInit` is fire-and-forget, so we re-drive it
+      // deterministically here).
+      const pluginB = new SequoiaPgpPlugin({ invoke: fake.invoke })
+      const { ctx: ctxB } = makeContext('me@example.com')
+      ctxB.xmpp.publishPEP(SECRET_KEY_NODE, {
+        id: 'current',
+        payload: {
+          name: 'secretkey',
+          attrs: { xmlns: 'urn:xmpp:openpgp:0' },
+          children: [encodeOpenPgpArmorForXep0373(backup!)],
+        },
+      })
+      await pluginB.init(ctxB)
+      const passthroughB = pluginB as unknown as {
+        verifyTrustStateOnInit(): Promise<void>
+      }
+      fake.failNextOwnDecryptWith('key-unrecoverable')
+      await passthroughB.verifyTrustStateOnInit()
+      expect(getTrustStateStatus()).toBe('awaiting-key')
+
+      // Phase 3 — recovery restores the same cert; the recovery completion must
+      // re-run the seal check, which now decrypts cleanly against the unchanged
+      // cert and resolves to `sealed`. The re-verify is fire-and-forget
+      // (`void this.verifyTrustStateOnInit()`), so flush the microtask/timer
+      // queue before asserting the resolved verdict.
+      await pluginB.restoreSecretKey('shared-pp')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(getTrustStateStatus()).toBe('sealed')
     })
   })
 

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -667,12 +667,8 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
         throw new KeyPickerRequiredError(result.candidates, result.backupContext)
       }
       // restoreSecretKey installed + published the recovered key and set the
-      // session passphrase. Activate subscriptions and report recovery.
-      // (restoreSecretKey → doInstallKey already re-verifies the trust state;
-      // the explicit call keeps parity for the case where subs were already
-      // active and is a harmless no-op otherwise.)
-      this.activateSubscriptions()
-      void this.verifyTrustStateOnInit()
+      // session passphrase. Report recovery.
+      // restoreSecretKey() -> doInstallKey() already re-verifies the trust state.
       return { recovered: true }
     }
   }

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -640,6 +640,12 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
       // below routes through restoreSecretKey → doInstallKey, which already
       // notifies, so only this happy path needs an explicit call.)
       this.requireCtx().notifyKeyUnlocked?.()
+      // The key is usable now — re-run the trust-state seal check so a deferred
+      // `awaiting-key` verdict resolves to `sealed`. `init()` returns early
+      // (no subscriptions) when the key was locked, so `activateSubscriptions()`
+      // above runs it for that case; this explicit call covers re-unlock where
+      // subscriptions were already active.
+      void this.verifyTrustStateOnInit()
       return { recovered: false }
     } catch (err) {
       if (!isRecoverableLocalFailure(err)) {
@@ -662,7 +668,11 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
       }
       // restoreSecretKey installed + published the recovered key and set the
       // session passphrase. Activate subscriptions and report recovery.
+      // (restoreSecretKey → doInstallKey already re-verifies the trust state;
+      // the explicit call keeps parity for the case where subs were already
+      // active and is a harmless no-op otherwise.)
       this.activateSubscriptions()
+      void this.verifyTrustStateOnInit()
       return { recovered: true }
     }
   }

--- a/apps/fluux/src/e2ee/keyUnavailable.test.ts
+++ b/apps/fluux/src/e2ee/keyUnavailable.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { E2EEPluginError } from '@fluux/sdk'
+import { isSecretKeyUnavailableError } from './keyUnavailable'
+
+describe('isSecretKeyUnavailableError', () => {
+  it('is true for key-unrecoverable and key-locked E2EEPluginErrors', () => {
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('permanent', 'key-unrecoverable', 'x'))).toBe(true)
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('transient', 'key-locked', 'x'))).toBe(true)
+  })
+  it('is false for other E2EEPluginError codes', () => {
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('permanent', 'wrong-passphrase', 'x'))).toBe(false)
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('permanent', 'malformed-key', 'x'))).toBe(false)
+  })
+  it('is false for non-plugin errors', () => {
+    expect(isSecretKeyUnavailableError(new Error('boom'))).toBe(false)
+    expect(isSecretKeyUnavailableError('nope')).toBe(false)
+    expect(isSecretKeyUnavailableError(undefined)).toBe(false)
+  })
+})

--- a/apps/fluux/src/e2ee/keyUnavailable.ts
+++ b/apps/fluux/src/e2ee/keyUnavailable.ts
@@ -1,0 +1,13 @@
+import { E2EEPluginError } from '@fluux/sdk'
+
+/**
+ * True when an error means the local secret key was not usable (locked, or
+ * unrecoverable / recovering) — as opposed to a genuine cryptographic failure.
+ * Used to avoid mistaking "the key could not run" for "trust data was tampered".
+ */
+export function isSecretKeyUnavailableError(err: unknown): boolean {
+  return (
+    err instanceof E2EEPluginError &&
+    (err.code === 'key-unrecoverable' || err.code === 'key-locked')
+  )
+}

--- a/apps/fluux/src/e2ee/trustStateIntegrity.test.ts
+++ b/apps/fluux/src/e2ee/trustStateIntegrity.test.ts
@@ -35,6 +35,16 @@ describe('verifyTrustStateSeal: key-unavailable classification', () => {
     expect(res.status).toBe('awaiting-key')
   })
 
+  it('returns awaiting-key when decrypt fails with a key-locked (transient) error', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptLocked = async () => {
+      throw new E2EEPluginError('transient', 'key-locked', 'key is locked')
+    }
+    const res = await verifyTrustStateSeal(decryptLocked, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('awaiting-key')
+  })
+
   it('still returns compromised when decrypt fails for a non-key reason', async () => {
     setPins({ 'peer@example.com': 'PEERFP' })
     await sealTrustState(passthroughEncrypt, OWN_PUBLIC)

--- a/apps/fluux/src/e2ee/trustStateIntegrity.test.ts
+++ b/apps/fluux/src/e2ee/trustStateIntegrity.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { E2EEPluginError } from '@fluux/sdk'
+import { sealTrustState, verifyTrustStateSeal } from './trustStateIntegrity'
+import { usePinnedPrimaryFingerprintsStore } from '@/stores/pinnedPrimaryFingerprintsStore'
+import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
+import { useKeyChangeAlertsStore } from '@/stores/keyChangeAlertsStore'
+
+const OWN_FP = 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555'
+const OWN_PUBLIC = 'OWN-PUBLIC-ARMOR'
+const passthroughEncrypt = async (plaintext: string) => plaintext
+
+// Predicate the plugin will supply (see Task 2). Inlined here to test the gate.
+const isKeyUnavailable = (err: unknown) =>
+  err instanceof E2EEPluginError && (err.code === 'key-unrecoverable' || err.code === 'key-locked')
+
+function setPins(pins: Record<string, string>) {
+  usePinnedPrimaryFingerprintsStore.setState({ pinnedFingerprintByJid: pins })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  usePinnedPrimaryFingerprintsStore.setState({ pinnedFingerprintByJid: {} })
+  useVerifiedPeerKeysStore.setState({ verifiedFingerprintByJid: {} })
+  useKeyChangeAlertsStore.setState({ alertsByJid: {} })
+})
+
+describe('verifyTrustStateSeal: key-unavailable classification', () => {
+  it('returns awaiting-key (not compromised) when decrypt fails because the secret key is unavailable', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptUnavailable = async () => {
+      throw new E2EEPluginError('permanent', 'key-unrecoverable', 'cannot unlock')
+    }
+    const res = await verifyTrustStateSeal(decryptUnavailable, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('awaiting-key')
+  })
+
+  it('still returns compromised when decrypt fails for a non-key reason', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptBroken = async () => { throw new Error('garbage') }
+    const res = await verifyTrustStateSeal(decryptBroken, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('compromised')
+  })
+
+  it('still returns compromised when the seal decrypts but pins no longer match', async () => {
+    setPins({ 'peer@example.com': 'OLDFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    setPins({ 'peer@example.com': 'TAMPERED' }) // mutate after sealing
+    const decryptOriginal = async (ciphertext: string) => ({
+      plaintext: ciphertext, signatureVerified: true, signerFingerprint: OWN_FP, signaturePresent: true,
+    })
+    const res = await verifyTrustStateSeal(decryptOriginal, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('compromised')
+  })
+
+  it('still returns compromised on a foreign signature (decrypt succeeded => key was usable)', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptForeign = async (ciphertext: string) => ({
+      plaintext: ciphertext, signatureVerified: true, signerFingerprint: 'FFFFFFFF', signaturePresent: true,
+    })
+    const res = await verifyTrustStateSeal(decryptForeign, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('compromised')
+  })
+
+  it('returns sealed when decrypt succeeds and pins match', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptOk = async (ciphertext: string) => ({
+      plaintext: ciphertext, signatureVerified: true, signerFingerprint: OWN_FP, signaturePresent: true,
+    })
+    const res = await verifyTrustStateSeal(decryptOk, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('sealed')
+  })
+
+  it('defaults to current behavior when no predicate is passed (decrypt failure => compromised)', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptUnavailable = async () => {
+      throw new E2EEPluginError('permanent', 'key-unrecoverable', 'cannot unlock')
+    }
+    const res = await verifyTrustStateSeal(decryptUnavailable, OWN_PUBLIC, OWN_FP)
+    expect(res.status).toBe('compromised')
+  })
+})

--- a/apps/fluux/src/e2ee/trustStateIntegrity.ts
+++ b/apps/fluux/src/e2ee/trustStateIntegrity.ts
@@ -130,7 +130,7 @@ export async function verifyTrustStateSeal(
     decrypted = await decryptFn(sealArmored, ownPublicArmored)
   } catch (err) {
     // A decrypt failure because the secret key is unavailable (locked /
-    // unrecoverable / recovering) is NOT a tamper signal — there is simply no
+    // unrecoverable) is NOT a tamper signal — there is simply no
     // verdict yet. Only a decrypt failure with a usable key is suspicious.
     if (isKeyUnavailable(err)) return { status: 'awaiting-key' }
     if (storesAreEmpty()) return { status: 'pending-seal' }

--- a/apps/fluux/src/e2ee/trustStateIntegrity.ts
+++ b/apps/fluux/src/e2ee/trustStateIntegrity.ts
@@ -115,6 +115,7 @@ export async function verifyTrustStateSeal(
   decryptFn: DecryptFn,
   ownPublicArmored: string,
   ownFingerprint: string,
+  isKeyUnavailable: (err: unknown) => boolean = () => false,
 ): Promise<{ status: TrustStateStatus; details?: string[] }> {
   const sealArmored = localStorage.getItem(getSealKey())
 
@@ -127,7 +128,11 @@ export async function verifyTrustStateSeal(
   let decrypted: Awaited<ReturnType<DecryptFn>>
   try {
     decrypted = await decryptFn(sealArmored, ownPublicArmored)
-  } catch {
+  } catch (err) {
+    // A decrypt failure because the secret key is unavailable (locked /
+    // unrecoverable / recovering) is NOT a tamper signal — there is simply no
+    // verdict yet. Only a decrypt failure with a usable key is suspicious.
+    if (isKeyUnavailable(err)) return { status: 'awaiting-key' }
     if (storesAreEmpty()) return { status: 'pending-seal' }
     return { status: 'compromised', details: ['Trust state seal could not be decrypted'] }
   }

--- a/apps/fluux/src/stores/trustStateStatusStore.ts
+++ b/apps/fluux/src/stores/trustStateStatusStore.ts
@@ -6,6 +6,7 @@ import { create } from 'zustand'
  * - `uninitialized` — fresh install, no trust state to protect yet.
  * - `sealed`        — signed blob matches current stores.
  * - `pending-seal`  — stores populated but no blob yet (migration).
+ * - `awaiting-key`  — the secret key was not usable, so the seal could not be checked; no verdict yet.
  * - `compromised`   — blob absent/invalid/stale when stores non-empty.
  *
  * Not persisted: the check runs on every plugin init after the key
@@ -15,6 +16,7 @@ export type TrustStateStatus =
   | 'uninitialized'
   | 'sealed'
   | 'pending-seal'
+  | 'awaiting-key'
   | 'compromised'
 
 interface TrustStateStatusState {

--- a/docs/superpowers/plans/2026-06-20-trust-state-awaiting-key.md
+++ b/docs/superpowers/plans/2026-06-20-trust-state-awaiting-key.md
@@ -1,0 +1,394 @@
+# Trust-state `awaiting-key` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the trust-state integrity check from raising the "compromised" alarm when the only problem is that the secret key was not usable at verification time; resolve to the correct verdict once the key is available; and instrument the transitions.
+
+**Architecture:** Add a non-alarming `awaiting-key` status. In `verifyTrustStateSeal`, a decrypt failure caused by an *unavailable secret key* (recognized via an injected predicate) returns `awaiting-key` instead of `compromised`. The OpenPGP plugin supplies the predicate and re-runs the verification after a recovery/unlock so a deferred state resolves to `sealed` for an unchanged cert. The change is monotonic — it can only remove false alarms; every genuine tamper signal still returns `compromised`.
+
+**Tech Stack:** TypeScript, React, Zustand, Vitest. Spec: `docs/superpowers/specs/2026-06-20-trust-state-awaiting-key-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `apps/fluux/src/stores/trustStateStatusStore.ts` | Add the `awaiting-key` status value | T1 |
+| `apps/fluux/src/e2ee/trustStateIntegrity.ts` | Classify key-unavailable decrypt failures as `awaiting-key`; transition logging | T1, T4 |
+| `apps/fluux/src/e2ee/trustStateIntegrity.test.ts` (new) | Unit tests for the classification (reproduction + no-weakening) | T1 |
+| `apps/fluux/src/e2ee/OpenPGPPluginBase.ts` | Supply the key-unavailable predicate; re-verify after recovery; instrumentation | T2, T3, T4 |
+| `apps/fluux/src/e2ee/keyUnavailable.ts` (new) | Pure `isSecretKeyUnavailableError` predicate | T2 |
+| `apps/fluux/src/e2ee/keyUnavailable.test.ts` (new) | Predicate unit test | T2 |
+| `apps/fluux/src/components/TrustStateCompromisedBanner.test.tsx` (new) | Confirm `awaiting-key` renders no banner | T5 |
+
+## Execution order
+T1 → T2 → T3 → T4 → T5. T1 adds the status + the core classification (pure, fully unit-tested). T2 adds the predicate the plugin passes in. T3 wires the re-verify after recovery. T4 adds instrumentation. T5 confirms banner gating. Each task: strict TDD, commit at the end. Test command: `cd apps/fluux && npx vitest run <path>`. Pre-commit gate (CLAUDE.md): tests green no stderr, `npm run typecheck`, lint clean.
+
+---
+
+### Task 1: `awaiting-key` status + `verifyTrustStateSeal` classification
+
+**Files:**
+- Modify: `apps/fluux/src/stores/trustStateStatusStore.ts` (the `TrustStateStatus` union + doc comment)
+- Modify: `apps/fluux/src/e2ee/trustStateIntegrity.ts` (`verifyTrustStateSeal` signature + decrypt catch, ~`:114-133`)
+- Test: `apps/fluux/src/e2ee/trustStateIntegrity.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test.** Create `apps/fluux/src/e2ee/trustStateIntegrity.test.ts`. It uses the public `sealTrustState` to write a seal (so the test never needs the private scoped key — both writer and reader use the same `getSealKey()`), then drives `verifyTrustStateSeal` with stub decrypt fns, mirroring the decrypt-stub style of `verificationSync.test.ts`:
+
+```ts
+import { describe, expect, it, beforeEach } from 'vitest'
+import { E2EEPluginError } from '@fluux/sdk'
+import { sealTrustState, verifyTrustStateSeal } from './trustStateIntegrity'
+import { usePinnedPrimaryFingerprintsStore } from '@/stores/pinnedPrimaryFingerprintsStore'
+import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
+import { useKeyChangeAlertsStore } from '@/stores/keyChangeAlertsStore'
+
+const OWN_FP = 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555'
+const OWN_PUBLIC = 'OWN-PUBLIC-ARMOR'
+const passthroughEncrypt = async (plaintext: string) => plaintext
+
+// Predicate the plugin will supply (see Task 2). Inlined here to test the gate.
+const isKeyUnavailable = (err: unknown) =>
+  err instanceof E2EEPluginError && (err.code === 'key-unrecoverable' || err.code === 'key-locked')
+
+function setPins(pins: Record<string, string>) {
+  usePinnedPrimaryFingerprintsStore.setState({ pinnedFingerprintByJid: pins })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  usePinnedPrimaryFingerprintsStore.setState({ pinnedFingerprintByJid: {} })
+  useVerifiedPeerKeysStore.setState({ verifiedFingerprintByJid: {} })
+  useKeyChangeAlertsStore.setState({ alertsByJid: {} })
+})
+
+describe('verifyTrustStateSeal: key-unavailable classification', () => {
+  it('returns awaiting-key (not compromised) when decrypt fails because the secret key is unavailable', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptUnavailable = async () => {
+      throw new E2EEPluginError('permanent', 'key-unrecoverable', 'cannot unlock')
+    }
+    const res = await verifyTrustStateSeal(decryptUnavailable, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('awaiting-key')
+  })
+
+  it('still returns compromised when decrypt fails for a non-key reason', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptBroken = async () => { throw new Error('garbage') }
+    const res = await verifyTrustStateSeal(decryptBroken, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('compromised')
+  })
+
+  it('still returns compromised when the seal decrypts but pins no longer match', async () => {
+    setPins({ 'peer@example.com': 'OLDFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    setPins({ 'peer@example.com': 'TAMPERED' }) // mutate after sealing
+    const decryptOriginal = async (ciphertext: string) => ({
+      plaintext: ciphertext, signatureVerified: true, signerFingerprint: OWN_FP, signaturePresent: true,
+    })
+    const res = await verifyTrustStateSeal(decryptOriginal, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('compromised')
+  })
+
+  it('still returns compromised on a foreign signature (decrypt succeeded => key was usable)', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptForeign = async (ciphertext: string) => ({
+      plaintext: ciphertext, signatureVerified: true, signerFingerprint: 'FFFFFFFF', signaturePresent: true,
+    })
+    const res = await verifyTrustStateSeal(decryptForeign, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('compromised')
+  })
+
+  it('returns sealed when decrypt succeeds and pins match', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptOk = async (ciphertext: string) => ({
+      plaintext: ciphertext, signatureVerified: true, signerFingerprint: OWN_FP, signaturePresent: true,
+    })
+    const res = await verifyTrustStateSeal(decryptOk, OWN_PUBLIC, OWN_FP, isKeyUnavailable)
+    expect(res.status).toBe('sealed')
+  })
+
+  it('defaults to current behavior when no predicate is passed (decrypt failure => compromised)', async () => {
+    setPins({ 'peer@example.com': 'PEERFP' })
+    await sealTrustState(passthroughEncrypt, OWN_PUBLIC)
+    const decryptUnavailable = async () => {
+      throw new E2EEPluginError('permanent', 'key-unrecoverable', 'cannot unlock')
+    }
+    const res = await verifyTrustStateSeal(decryptUnavailable, OWN_PUBLIC, OWN_FP)
+    expect(res.status).toBe('compromised')
+  })
+})
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** `cd apps/fluux && npx vitest run src/e2ee/trustStateIntegrity.test.ts` — the first test fails (`expected 'compromised' ... 'awaiting-key'`) because `verifyTrustStateSeal` has no `isKeyUnavailable` param and `'awaiting-key'` is not a valid status.
+
+- [ ] **Step 3: Minimal implementation.**
+
+In `trustStateStatusStore.ts`, add the status to the union and the doc comment:
+```ts
+export type TrustStateStatus =
+  | 'uninitialized'
+  | 'sealed'
+  | 'pending-seal'
+  | 'awaiting-key'
+  | 'compromised'
+```
+(Add a doc line: `` - `awaiting-key`   — the secret key was not usable, so the seal could not be checked; no verdict yet. ``)
+
+In `trustStateIntegrity.ts`, add the parameter (default preserves behavior) and classify the catch:
+```ts
+export async function verifyTrustStateSeal(
+  decryptFn: DecryptFn,
+  ownPublicArmored: string,
+  ownFingerprint: string,
+  isKeyUnavailable: (err: unknown) => boolean = () => false,
+): Promise<{ status: TrustStateStatus; details?: string[] }> {
+```
+Change ONLY the decrypt catch (currently `:128-133`):
+```ts
+  let decrypted: Awaited<ReturnType<DecryptFn>>
+  try {
+    decrypted = await decryptFn(sealArmored, ownPublicArmored)
+  } catch (err) {
+    // A decrypt failure because the secret key is unavailable (locked /
+    // unrecoverable / recovering) is NOT a tamper signal — there is simply no
+    // verdict yet. Only a decrypt failure with a usable key is suspicious.
+    if (isKeyUnavailable(err)) return { status: 'awaiting-key' }
+    if (storesAreEmpty()) return { status: 'pending-seal' }
+    return { status: 'compromised', details: ['Trust state seal could not be decrypted'] }
+  }
+```
+
+- [ ] **Step 4: Run it — expect PASS.** `cd apps/fluux && npx vitest run src/e2ee/trustStateIntegrity.test.ts` — all six pass. Then `cd apps/fluux && npx tsc --noEmit -p tsconfig.json` clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add apps/fluux/src/stores/trustStateStatusStore.ts apps/fluux/src/e2ee/trustStateIntegrity.ts apps/fluux/src/e2ee/trustStateIntegrity.test.ts
+git commit -m "fix(e2ee): classify key-unavailable trust-seal decrypt failures as awaiting-key, not compromised"
+```
+
+---
+
+### Task 2: `isSecretKeyUnavailableError` predicate + wire into `verifyTrustStateOnInit`
+
+**Files:**
+- Create: `apps/fluux/src/e2ee/keyUnavailable.ts`
+- Test: `apps/fluux/src/e2ee/keyUnavailable.test.ts` (new)
+- Modify: `apps/fluux/src/e2ee/OpenPGPPluginBase.ts` (`verifyTrustStateOnInit`, ~`:649-653`)
+
+- [ ] **Step 1: Write the failing test.** Create `apps/fluux/src/e2ee/keyUnavailable.test.ts`:
+```ts
+import { describe, expect, it } from 'vitest'
+import { E2EEPluginError } from '@fluux/sdk'
+import { isSecretKeyUnavailableError } from './keyUnavailable'
+
+describe('isSecretKeyUnavailableError', () => {
+  it('is true for key-unrecoverable and key-locked E2EEPluginErrors', () => {
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('permanent', 'key-unrecoverable', 'x'))).toBe(true)
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('transient', 'key-locked', 'x'))).toBe(true)
+  })
+  it('is false for other E2EEPluginError codes', () => {
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('permanent', 'wrong-passphrase', 'x'))).toBe(false)
+    expect(isSecretKeyUnavailableError(new E2EEPluginError('permanent', 'malformed-key', 'x'))).toBe(false)
+  })
+  it('is false for non-plugin errors', () => {
+    expect(isSecretKeyUnavailableError(new Error('boom'))).toBe(false)
+    expect(isSecretKeyUnavailableError('nope')).toBe(false)
+    expect(isSecretKeyUnavailableError(undefined)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** `cd apps/fluux && npx vitest run src/e2ee/keyUnavailable.test.ts` — fails: module/function not found.
+
+- [ ] **Step 3: Minimal implementation.** Create `apps/fluux/src/e2ee/keyUnavailable.ts`:
+```ts
+import { E2EEPluginError } from '@fluux/sdk'
+
+/**
+ * True when an error means the local secret key was not usable (locked, or
+ * unrecoverable / recovering) — as opposed to a genuine cryptographic failure.
+ * Used to avoid mistaking "the key could not run" for "trust data was tampered".
+ */
+export function isSecretKeyUnavailableError(err: unknown): boolean {
+  return (
+    err instanceof E2EEPluginError &&
+    (err.code === 'key-unrecoverable' || err.code === 'key-locked')
+  )
+}
+```
+In `OpenPGPPluginBase.ts`, import it and pass it as the 4th arg in `verifyTrustStateOnInit` (`:649-653`):
+```ts
+    const { status, details } = await verifyTrustStateSeal(
+      (ciphertext, senderPub) => this.decryptWithOwnKey(jid, ciphertext, senderPub),
+      ownPublicArmored,
+      ownFingerprint,
+      isSecretKeyUnavailableError,
+    )
+```
+(Add `import { isSecretKeyUnavailableError } from './keyUnavailable'` near the other e2ee imports.)
+
+- [ ] **Step 4: Run it — expect PASS.** `cd apps/fluux && npx vitest run src/e2ee/keyUnavailable.test.ts` — passes. Then `cd apps/fluux && npx tsc --noEmit -p tsconfig.json` clean (confirms the new arg typechecks against `verifyTrustStateSeal`).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add apps/fluux/src/e2ee/keyUnavailable.ts apps/fluux/src/e2ee/keyUnavailable.test.ts apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+git commit -m "feat(e2ee): supply key-unavailable predicate to the trust-state seal check"
+```
+
+---
+
+### Task 3: Re-verify the trust-state after recovery / unlock
+
+**Files:**
+- Modify: `apps/fluux/src/e2ee/OpenPGPPluginBase.ts` (`doInstallKey` ~`:1177`, `retireAndGenerateIdentity` ~`:885`)
+- Modify: `apps/fluux/src/e2ee/WebOpenPGPPlugin.ts` (`unlock`, ~`:637`/`:665`) — confirm parity
+- Test: `apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts` (extend; reuse the existing `makeContext` harness at ~`:468-558`)
+
+**Context:** `verifyTrustStateOnInit` runs only from `activateSubscriptions` (`:616`). The recovery completions (`doInstallKey:1177`, `retireAndGenerateIdentity:885`) currently call only `ctx.notifyKeyUnlocked()`, so a state left at `awaiting-key` (or a stale verdict) never re-resolves once the key is back. Make recovery re-run the verification.
+
+- [ ] **Step 1: Write the failing test.** In `SequoiaPgpPlugin.test.ts`, add a test using the existing `makeContext` harness. Drive the plugin so the seal check first sees an unavailable key (status `awaiting-key`), then complete a recovery and assert the status re-resolves to `sealed`. Concretely (adapt to the harness's `fake.invoke` decrypt hook — the harness lets you make `decryptWithOwnKey` throw a `key-unrecoverable` E2EEPluginError during the initial seal check, then succeed after recovery):
+```ts
+it('re-verifies the trust state after recovery (awaiting-key -> sealed)', async () => {
+  const { ctx } = makeContext('me@example.com')
+  const plugin = new SequoiaPgpPlugin({ invoke: fake.invoke })
+  // Arrange: a valid seal exists for the own key, but the first decrypt-to-self
+  // throws key-unrecoverable (desync), so the seal check defers.
+  fake.failNextOwnDecryptWith('key-unrecoverable')
+  await plugin.init(ctx)
+  expect(getTrustStateStatus()).toBe('awaiting-key')
+
+  // Act: recovery restores the same cert; the next decrypt succeeds.
+  await plugin.restoreSecretKey('correct horse battery staple')
+
+  // Assert: the seal validates against the unchanged cert.
+  expect(getTrustStateStatus()).toBe('sealed')
+})
+```
+If the existing `fake` invoke harness has no per-call decrypt-failure hook, add one (a single-shot `failNextOwnDecryptWith(code)` that makes the next `decrypt` invoke reject with that classified message) — keep it confined to the test harness.
+
+- [ ] **Step 2: Run it — expect FAIL.** `cd apps/fluux && npx vitest run src/e2ee/SequoiaPgpPlugin.test.ts -t "re-verifies the trust state after recovery"` — fails: after `restoreSecretKey`, status stays `awaiting-key` (recovery never re-runs the seal check).
+
+- [ ] **Step 3: Minimal implementation.** In `OpenPGPPluginBase.ts`, after the key is installed in both recovery completions, re-run the seal check. At the end of `doInstallKey` (after `ctx.notifyKeyUnlocked?.()`, `:1177`) and `retireAndGenerateIdentity` (after `:885`):
+```ts
+    ctx.notifyKeyUnlocked?.()
+    // The secret key is now usable again — re-run the trust-state seal check so a
+    // deferred `awaiting-key` verdict resolves (to `sealed` for an unchanged cert).
+    this.activateSubscriptions()   // idempotent: sets up subs if not yet active
+    void this.verifyTrustStateOnInit()  // explicit re-check even when subs were already active
+```
+(`activateSubscriptions` is guarded against double-activation at `:575`; the explicit `verifyTrustStateOnInit` covers the case where subscriptions were already active.) Confirm `WebOpenPGPPlugin.unlock` (`:637`/`:665`) ends with the same re-check (it already calls `activateSubscriptions`; add the explicit `void this.verifyTrustStateOnInit()` if subs may already be active there).
+
+- [ ] **Step 4: Run it — expect PASS.** `cd apps/fluux && npx vitest run src/e2ee/SequoiaPgpPlugin.test.ts` (full file) and `src/e2ee/WebOpenPGPPlugin.test.ts` — green, no stderr. `cd apps/fluux && npx tsc --noEmit -p tsconfig.json` clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add apps/fluux/src/e2ee/OpenPGPPluginBase.ts apps/fluux/src/e2ee/WebOpenPGPPlugin.ts apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+git commit -m "fix(e2ee): re-verify trust-state seal after key recovery/unlock"
+```
+
+---
+
+### Task 4: Instrument trust-state transitions
+
+**Files:**
+- Modify: `apps/fluux/src/e2ee/OpenPGPPluginBase.ts` (`verifyTrustStateOnInit`, ~`:644-659`)
+- Test: `apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test.** Assert that on a non-trivial verdict the plugin records a console-store event so future incidents are diagnosable. Using the harness (the `ctx` exposes the console/security hooks; use whichever the plugin already writes to — `consoleStore.addEvent` is the app-wide console). Add:
+```ts
+it('logs the trust-state verdict after init', async () => {
+  const events: string[] = []
+  const spy = vi.spyOn(consoleStore.getState(), 'addEvent').mockImplementation((m: string) => { events.push(m) })
+  const { ctx } = makeContext('me@example.com')
+  const plugin = new SequoiaPgpPlugin({ invoke: fake.invoke })
+  await plugin.init(ctx)
+  expect(events.some((e) => /trust.?state/i.test(e))).toBe(true)
+  spy.mockRestore()
+})
+```
+(Import `consoleStore` from the SDK as the existing plugin code does, e.g. `import { consoleStore } from '@fluux/sdk'` — match the existing import in `OpenPGPPluginBase.ts`.)
+
+- [ ] **Step 2: Run it — expect FAIL.** `cd apps/fluux && npx vitest run src/e2ee/SequoiaPgpPlugin.test.ts -t "logs the trust-state verdict"` — fails: no trust-state console event emitted.
+
+- [ ] **Step 3: Minimal implementation.** In `verifyTrustStateOnInit` (`:644-659`), after computing `{ status, details }` and before/at `setTrustStateStatus`, log to both the webview console and the in-app console store:
+```ts
+    const reason = details && details.length ? ` (${details.join('; ')})` : ''
+    console.log(`[E2EE] Trust-state verdict: ${status}${reason}`)
+    this.ctx?.console?.addEvent?.(`Trust-state integrity: ${status}${reason}`, 'security')
+    if (status === 'pending-seal') {
+      await this.sealTrustStateNow()
+      return
+    }
+    setTrustStateStatus(status, details)
+```
+(Use the plugin's existing console-store accessor — match how `OpenPGPPluginBase.ts` already emits console events elsewhere, e.g. via `ctx.console.addEvent` or an imported `consoleStore`; the category string should match the existing convention.)
+
+- [ ] **Step 4: Run it — expect PASS.** `cd apps/fluux && npx vitest run src/e2ee/SequoiaPgpPlugin.test.ts` — green. `npx tsc --noEmit -p tsconfig.json` clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add apps/fluux/src/e2ee/OpenPGPPluginBase.ts apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+git commit -m "feat(e2ee): instrument trust-state integrity verdict transitions"
+```
+
+---
+
+### Task 5: Confirm `awaiting-key` renders no banner
+
+**Files:**
+- Test: `apps/fluux/src/components/TrustStateCompromisedBanner.test.tsx` (new)
+
+The banner already gates on `status !== 'compromised'` (`TrustStateCompromisedBanner.tsx:30`), so `awaiting-key` is silent today. This test locks that in so a future change can't accidentally surface it.
+
+- [ ] **Step 1: Write the failing test (then make it pass without prod change, characterizing the contract).** Create `apps/fluux/src/components/TrustStateCompromisedBanner.test.tsx`:
+```tsx
+import { describe, expect, it, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TrustStateCompromisedBanner } from './TrustStateCompromisedBanner'
+import { useTrustStateStatusStore } from '@/stores/trustStateStatusStore'
+import type { TrustStateStatus } from '@/stores/trustStateStatusStore'
+
+beforeEach(() => {
+  useTrustStateStatusStore.setState({ status: 'uninitialized', mismatchDetails: undefined })
+})
+
+const silent: TrustStateStatus[] = ['uninitialized', 'sealed', 'pending-seal', 'awaiting-key']
+
+describe('TrustStateCompromisedBanner', () => {
+  it.each(silent)('renders nothing for status %s', (status) => {
+    useTrustStateStatusStore.setState({ status })
+    const { container } = render(<TrustStateCompromisedBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the warning only for compromised', () => {
+    useTrustStateStatusStore.setState({ status: 'compromised' })
+    render(<TrustStateCompromisedBanner />)
+    expect(screen.getByText(/integrity check failed|tampered/i)).toBeInTheDocument()
+  })
+})
+```
+(If `TrustStateCompromisedBanner` needs a client/provider prop, wrap it the way other component tests in `apps/fluux/src/components/*.test.tsx` do — follow the nearest existing banner test for the provider boilerplate.)
+
+- [ ] **Step 2: Run it.** `cd apps/fluux && npx vitest run src/components/TrustStateCompromisedBanner.test.tsx` — the `awaiting-key` case passes (banner already silent) and the `compromised` case passes. If the `compromised` text matcher mismatches, adjust to the actual i18n string at `en.json:settings.encryption.trustStateCompromised.title`.
+
+- [ ] **Step 3: Full app suite + gates.** `cd apps/fluux && npx vitest run` (whole suite, no stderr), `npx tsc --noEmit -p tsconfig.json`, `npm run lint`. All clean.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add apps/fluux/src/components/TrustStateCompromisedBanner.test.tsx
+git commit -m "test(e2ee): lock in that awaiting-key (and other non-compromised) statuses show no banner"
+```
+
+---
+
+## Self-review notes
+- **Spec coverage:** §4.1 awaiting-key → T1; §4.2 classification → T1; §4.3 re-verify after recovery → T3; §4.4 instrumentation → T4; §4.5 banner unchanged → T5 (characterization); §6 tests → T1 (reproduction + no-weakening + default-arg), T2 (predicate), T3 (recovery resolves), T5 (banner gating).
+- **Security boundary:** only the decrypt-catch `isKeyUnavailable(err)` branch changes verdicts, and only from compromised→awaiting-key when the key was unavailable. T1's no-weakening cases pin that mismatch / foreign-sig / non-key-error / (default-arg) still return `compromised`.
+- **Harness uncertainty (T3/T4):** the exact `fake.invoke` decrypt-failure hook and the plugin's console accessor are confirmed against `SequoiaPgpPlugin.test.ts` / `OpenPGPPluginBase.ts` at implementation time; if the single-shot decrypt-failure hook doesn't exist, add it to the test harness (test-only).

--- a/docs/superpowers/specs/2026-06-20-trust-state-awaiting-key-design.md
+++ b/docs/superpowers/specs/2026-06-20-trust-state-awaiting-key-design.md
@@ -1,0 +1,99 @@
+# Trust-state integrity: don't alarm when the key is merely unavailable
+
+- **Date:** 2026-06-20
+- **Status:** Draft — awaiting maintainer review
+- **Area:** E2EE / OpenPGP trust-state integrity (app layer)
+- **Related:** PR #608 (OpenPGP keychain/TSK passphrase desync recovery), `apps/fluux/src/e2ee/trustStateIntegrity.ts`, [feedback: security iconography calm by default]
+
+## 1. Problem
+
+After a benign OpenPGP key **recovery** (the #608 keychain/TSK passphrase desync — the cert is unchanged, only the at-rest wrapping passphrase is fixed), the Encryption settings screen showed the **trust-state "compromised" banner**: *"Local trust data may have been tampered with. Silent key re-pinning is blocked to prevent key substitution"* with a *"Re-verify and continue"* button ([en.json:707-708](apps/fluux/src/i18n/locales/en.json), [TrustStateCompromisedBanner.tsx](apps/fluux/src/components/TrustStateCompromisedBanner.tsx)).
+
+This is a **false positive**. The recovery preserved the same certificate, so the same peers are pinned and the encrypt-to-self trust-state seal is still valid; nothing was tampered with and nothing needs re-pinning. Being told your trust data "may have been tampered with" — and being pushed to re-verify contacts whose keys never changed — is both alarming and wrong.
+
+## 2. Root cause
+
+The trust-state seal is a signed, encrypt-to-self blob of the TOFU pins + verified peers + key-change alerts, validated on init once the key is available ([trustStateIntegrity.ts:95-161](apps/fluux/src/e2ee/trustStateIntegrity.ts)). Its decrypt-failure branch is:
+
+```ts
+try {
+  decrypted = await decryptFn(sealArmored, ownPublicArmored)
+} catch {
+  if (storesAreEmpty()) return { status: 'pending-seal' }
+  return { status: 'compromised', details: ['Trust state seal could not be decrypted'] }
+}
+```
+
+It treats **every** decrypt failure as `'compromised'` — even though the codebase already distinguishes *"the secret key is unavailable"* (`key-locked` transient / `key-unrecoverable` permanent) from a genuine decrypt failure ([OpenPGPPluginBase.ts:272-313](apps/fluux/src/e2ee/OpenPGPPluginBase.ts)). A decrypt failure because the key isn't usable yet is **not** evidence of tampering — but the catch block discards the error class and alarms anyway.
+
+Compounding it: the status is re-evaluated per session and **not persisted** ([trustStateStatusStore.ts](apps/fluux/src/stores/trustStateStatusStore.ts)), the integrity check is deliberately deferred while the key is `key-unrecoverable` (init returns early without `activateSubscriptions`, [OpenPGPPluginBase.ts:553-561](apps/fluux/src/e2ee/OpenPGPPluginBase.ts)), but the recovery-completion path does not reliably **re-run** the verification once the key is back — so a deferred/transient state has no clean path to resolve to `sealed`.
+
+Finally, **none of these transitions are logged** to the webview console, so the original incident is not diagnosable from `~/Library/Logs/com.processone.fluux/*` — only the in-app console store would have anything, and the recovery path doesn't record there either.
+
+## 3. Goal, security boundary, non-goals
+
+**Goal:** stop the trust-state integrity check from raising the "compromised" alarm when the only problem is that the secret key was not usable at verification time; resolve to the correct verdict once the key is available; and make the transitions diagnosable.
+
+**Security boundary (chosen):** *minimal & security-safe* — the change must **only ever remove false alarms**, never weaken a real tamper signal. Specifically, all of these still return `compromised`: the seal decrypts but the pins/verified/alerts don't match current storage; the signature is foreign/invalid (decrypt succeeded ⇒ key was usable); the payload is malformed; the seal is absent while the key is usable.
+
+**Non-goals (explicitly out of scope):**
+- Auto-resealing when the encryption **subkey** genuinely changed (fingerprint unchanged) — that trades detection strength for convenience and was declined.
+- Reworking the banner copy.
+- Changing what the seal protects or how it is bound.
+
+## 4. Design
+
+### 4.1 New status `awaiting-key`
+Add `awaiting-key` to `TrustStateStatus` ([trustStateStatusStore.ts](apps/fluux/src/stores/trustStateStatusStore.ts)): *the seal could not be checked because the secret key was not usable; no verdict yet.* It renders **no banner** — `TrustStateCompromisedBanner` remains gated strictly on `status === 'compromised'`.
+
+### 4.2 Classify the decrypt failure in `verifyTrustStateSeal`
+Add an injected predicate parameter `isKeyUnavailable?: (err: unknown) => boolean` (default `() => false`, preserving current behavior for callers/tests that don't pass it). Change the decrypt catch to bind the error and consult it:
+
+```ts
+} catch (err) {
+  if (isKeyUnavailable(err)) return { status: 'awaiting-key' }
+  if (storesAreEmpty()) return { status: 'pending-seal' }
+  return { status: 'compromised', details: ['Trust state seal could not be decrypted'] }
+}
+```
+
+This is the entire security-relevant change, and it is monotonic — it can only convert a former `compromised`/`pending-seal` into `awaiting-key` when the key was unavailable. No other branch changes. The predicate is supplied by the plugin (which owns the `E2EEPluginError` codes), keeping `trustStateIntegrity.ts` headless and the function a pure, injectable unit.
+
+The plugin passes a predicate recognizing key-unavailability, e.g. `err instanceof E2EEPluginError && (err.code === 'key-locked' || err.code === 'key-unrecoverable')` (exact recognizer confirmed against `errors.ts` during implementation).
+
+### 4.3 Re-verify when the key becomes available
+`verifyTrustStateOnInit` must run (or re-run) after the secret key becomes usable — i.e., after a successful recovery / unlock, not only on the first activation. The implementation plan will enumerate the exact completion points (`doInstallKey`, `retireAndGenerateIdentity`, `WebOpenPGPPlugin.unlock`, and the `notifyKeyUnlocked` path) and ensure each drives a re-verification, with the existing double-activation guard ([OpenPGPPluginBase.ts:575](apps/fluux/src/e2ee/OpenPGPPluginBase.ts)) not blocking the re-check. For an unchanged cert this resolves `awaiting-key → sealed` with **zero user action**.
+
+### 4.4 Instrumentation
+On every trust-state verdict, log the status + reason/details (and, for the decrypt-failure branch, whether it was classified key-unavailable) to **both** the webview console (so it lands in `fluux.log`) and the in-app console store. This makes any future trust-state incident diagnosable from logs — the gap that made this incident unanalyzable.
+
+### 4.5 What does NOT change
+The seal format, the encrypt-to-self binding, the pins-mismatch/foreign-signature/malformed-payload/seal-absent-while-usable branches, and the banner copy. The `'compromised'` path is reachable exactly as before for genuine tampering.
+
+## 5. Security analysis
+
+The seal defends against localStorage tampering: an attacker who edits `pinnedFingerprintByJid` to substitute a peer's key is caught because the signed seal (which they cannot forge) still holds the correct pins → pins-mismatch → `compromised`. That path is untouched.
+
+An attacker can also **delete or corrupt** the seal to force the absent/undecryptable branches. This design keeps those as `compromised` **when the key is usable**. The only relaxation is: a decrypt failure *attributable to the secret key being unavailable* is treated as "no verdict yet" rather than "tampered." That is sound because (a) it is not a tamper signal — the key simply could not run, and (b) once the key is available (§4.3) the seal is checked for real, so a genuine deletion/corruption with a usable key still alarms. Net: strictly fewer false alarms, identical true-positive coverage.
+
+## 6. Testing (the verification — logs cannot be)
+
+Pure-function unit tests on `verifyTrustStateSeal` (it takes injected `encryptFn`/`decryptFn`, so no jsdom/keys needed), plus store/banner gating:
+
+- **Reproduction (the bug):** seal valid, `decryptFn` throws a key-unavailable error, `isKeyUnavailable` returns true, stores non-empty → asserts `awaiting-key`, **not** `compromised`.
+- **No weakening (true positives preserved):** (a) decrypt succeeds but pins differ → `compromised`; (b) decrypt succeeds, signature foreign → `compromised`; (c) decrypt throws a *non*-key-unavailable error (`isKeyUnavailable` false) with non-empty stores → `compromised`; (d) seal absent while initialized + stores non-empty → `compromised`.
+- **Default-arg behavior:** omitting `isKeyUnavailable` preserves today's behavior (every decrypt failure → `compromised`/`pending-seal`) so existing callers/tests are unaffected.
+- **Banner gating:** `awaiting-key` renders no `TrustStateCompromisedBanner`; `compromised` still does.
+- **Recovery resolves:** an `awaiting-key` verdict followed by the key becoming available re-runs verification and lands on `sealed` for an unchanged cert (integration-level test of the §4.3 wiring; scope confirmed in the plan).
+- **Plugin predicate:** the plugin's `isKeyUnavailable` recognizer returns true for `key-locked`/`key-unrecoverable` `E2EEPluginError`s and false for a generic error.
+
+## 7. Files touched (anticipated)
+- `apps/fluux/src/stores/trustStateStatusStore.ts` — add `awaiting-key`.
+- `apps/fluux/src/e2ee/trustStateIntegrity.ts` — `isKeyUnavailable` param + decrypt-catch classification + transition logging.
+- `apps/fluux/src/e2ee/OpenPGPPluginBase.ts` — pass the predicate into `verifyTrustStateSeal`; ensure re-verify after recovery/unlock; instrumentation.
+- `apps/fluux/src/e2ee/WebOpenPGPPlugin.ts` / the Sequoia (desktop) plugin — re-verify-after-unlock parity (confirm during implementation).
+- `apps/fluux/src/components/TrustStateCompromisedBanner.tsx` — confirm gating stays `compromised`-only (likely no change).
+- Tests alongside the above.
+
+## 8. Verification gate
+`npm test` (app) green, no stderr; `npm run typecheck`; lint clean. The reproduction test must fail before the §4.2 change and pass after.


### PR DESCRIPTION
After a benign OpenPGP key recovery (the keychain/TSK passphrase desync handled in #608 — the certificate is unchanged, only the at-rest wrapping is fixed), the Encryption settings screen wrongly showed the **trust-state "compromised" banner** ("Local trust data may have been tampered with… re-verify"). The recovery preserved the same cert, so the same peers are pinned and the encrypt-to-self trust seal is still valid, nothing was tampered with and no re-verification was needed.

Removes the false alert.