### PR TITLE
feat(media): auto-load own-message media in public rooms

### DIFF
--- a/apps/fluux/src/components/FileAttachments.test.tsx
+++ b/apps/fluux/src/components/FileAttachments.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ImageAttachment, VideoAttachment, AudioAttachment } from './FileAttachments'
+import { MessageAttachments } from './MessageAttachments'
 import { MediaAutoloadProvider } from '@/contexts'
 import { __resetApprovedMediaUrlsForTest } from '@/utils/mediaAutoload'
 import type { FileAttachment } from '@fluux/sdk'
@@ -382,5 +383,36 @@ describe('ImageAttachment cached-while-deferred', () => {
     expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:fetched')
     // Peek must be disabled when the fetch path is active.
     expect(useCachedMediaUrlSpy).toHaveBeenLastCalledWith('https://x/a.jpg', undefined, false)
+  })
+})
+
+describe('MessageAttachments own-message threading', () => {
+  beforeEach(() => {
+    __resetApprovedMediaUrlsForTest()
+    useAttachmentUrlSpy.mockImplementation((_u: string | undefined, _e: unknown, enabled: boolean) => ({
+      url: enabled ? 'blob:loaded' : null,
+      isLoading: false,
+      error: null,
+    }))
+    useCachedMediaUrlSpy.mockReturnValue({ cachedUrl: null, isPeeking: false })
+  })
+
+  it('loads an own-message image inline even when autoLoad is false', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <MessageAttachments attachment={deferralImageAttachment} isOwnMessage />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByRole('img')).toBeInTheDocument()
+    expect(screen.queryByText('chat.loadImage')).not.toBeInTheDocument()
+  })
+
+  it('defers a non-own image when autoLoad is false', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <MessageAttachments attachment={deferralImageAttachment} />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('chat.loadImage')).toBeInTheDocument()
   })
 })

--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -26,6 +26,8 @@ interface AttachmentProps {
   attachment: FileAttachment
   /** Called when image/video loads - useful for scroll adjustment */
   onLoad?: () => void
+  /** When true (the local user's own message), bypass media-autoload deferral. */
+  isOwnMessage?: boolean
 }
 
 /**
@@ -33,7 +35,7 @@ interface AttachmentProps {
  * Falls back to main URL when no thumbnail is provided (e.g., from other XMPP clients)
  * Uses direct media URLs for browser/WebView loading.
  */
-export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoad }: AttachmentProps) {
+export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoad, isOwnMessage }: AttachmentProps) {
   const { t } = useTranslation()
   const isImage = attachment.mediaType?.startsWith('image/') ?? false
   const [lightboxOpen, setLightboxOpen] = useState(false)
@@ -53,7 +55,7 @@ export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoa
   const [loadError, setLoadError] = useState(() => failedUrlCache.has(originalImageSrc))
 
   // Media-autoload gating: defer fetch unless policy allows or user tapped
-  const { shouldLoad, approve } = useDeferredMedia(originalImageSrc)
+  const { shouldLoad, approve } = useDeferredMedia(originalImageSrc, isOwnMessage)
 
   // Fetch + decrypt if encrypted (XEP-0454), or proxy through the platform
   // cache for plaintext. Branches internal to the hook; renderer is
@@ -225,7 +227,7 @@ export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoa
  * Video attachment with inline player and info bar
  * Uses direct media URLs for browser/WebView loading.
  */
-export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoad }: AttachmentProps) {
+export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoad, isOwnMessage }: AttachmentProps) {
   const { t } = useTranslation()
   const isVideo = attachment.mediaType?.startsWith('video/') ?? false
 
@@ -233,7 +235,7 @@ export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoa
   const [loadError, setLoadError] = useState(() => failedUrlCache.has(attachment.url))
 
   // Media-autoload gating: defer fetch unless policy allows or user tapped
-  const { shouldLoad, approve } = useDeferredMedia(attachment.url)
+  const { shouldLoad, approve } = useDeferredMedia(attachment.url, isOwnMessage)
 
   // Resolve URL for video playback (only when it's a video). Both main
   // file and poster/thumbnail go through useAttachmentUrl so the
@@ -376,7 +378,7 @@ export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoa
  * Audio attachment with inline player
  * Uses direct media URLs for browser/WebView loading.
  */
-export function AudioAttachment({ attachment }: AttachmentProps) {
+export function AudioAttachment({ attachment, isOwnMessage }: AttachmentProps) {
   const { t } = useTranslation()
   const isAudio = (attachment.mediaType?.startsWith('audio/') ?? false) && !attachment.thumbnail
 
@@ -384,7 +386,7 @@ export function AudioAttachment({ attachment }: AttachmentProps) {
   const [loadError, setLoadError] = useState(() => failedUrlCache.has(attachment.url))
 
   // Media-autoload gating: defer fetch unless policy allows or user tapped
-  const { shouldLoad, approve } = useDeferredMedia(attachment.url)
+  const { shouldLoad, approve } = useDeferredMedia(attachment.url, isOwnMessage)
 
   // Resolve URL for audio playback (only when it's audio). Encrypted
   // audio is transparently fetched + decrypted.

--- a/apps/fluux/src/components/LinkPreviewCard.test.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.test.tsx
@@ -120,4 +120,13 @@ describe('LinkPreviewCard image deferral', () => {
     fireEvent.click(screen.getByRole('button'))
     expect(container.querySelector('img')).not.toBeNull()
   })
+
+  it('shows the OG image for an own-message preview even when autoLoad is false', () => {
+    const { container } = render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <LinkPreviewCard preview={preview} isOwnMessage />
+      </MediaAutoloadProvider>,
+    )
+    expect(container.querySelector('img')).not.toBeNull()
+  })
 })

--- a/apps/fluux/src/components/LinkPreviewCard.tsx
+++ b/apps/fluux/src/components/LinkPreviewCard.tsx
@@ -20,14 +20,16 @@ const MAX_IMAGE_ATTEMPTS = 2
 interface LinkPreviewCardProps {
   preview: LinkPreview
   onLoad?: () => void
+  /** When true (the local user's own message), bypass media-autoload deferral. */
+  isOwnMessage?: boolean
 }
 
-export function LinkPreviewCard({ preview, onLoad }: LinkPreviewCardProps) {
+export function LinkPreviewCard({ preview, onLoad, isOwnMessage }: LinkPreviewCardProps) {
   const [attempt, setAttempt] = useState(0)
   const [imagePhase, setImagePhase] = useState<'showing' | 'waiting' | 'gone'>('showing')
   const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { t } = useTranslation()
-  const { shouldLoad: showImage, approve: approveImage } = useDeferredMedia(preview.image ?? '')
+  const { shouldLoad: showImage, approve: approveImage } = useDeferredMedia(preview.image ?? '', isOwnMessage)
 
   useEffect(() => () => {
     if (retryTimer.current) clearTimeout(retryTimer.current)

--- a/apps/fluux/src/components/MessageAttachments.tsx
+++ b/apps/fluux/src/components/MessageAttachments.tsx
@@ -24,6 +24,8 @@ interface MessageAttachmentsProps {
   isSelected?: boolean
   /** Whether the parent message is hovered (for gradient adaptation) */
   isHovered?: boolean
+  /** Whether the parent message is the local user's own (bypasses media-autoload deferral). */
+  isOwnMessage?: boolean
 }
 
 /**
@@ -31,7 +33,7 @@ interface MessageAttachmentsProps {
  * Each attachment component internally checks if it should render
  * based on the attachment's media type.
  */
-export function MessageAttachments({ attachment, onMediaLoad, isSelected, isHovered }: MessageAttachmentsProps) {
+export function MessageAttachments({ attachment, onMediaLoad, isSelected, isHovered, isOwnMessage }: MessageAttachmentsProps) {
   if (!attachment) return null
 
   const canPreview = canPreviewAsText(attachment.mediaType, attachment.name)
@@ -39,16 +41,16 @@ export function MessageAttachments({ attachment, onMediaLoad, isSelected, isHove
   return (
     <>
       {/* Image attachment preview */}
-      <ImageAttachment attachment={attachment} onLoad={onMediaLoad} />
+      <ImageAttachment attachment={attachment} onLoad={onMediaLoad} isOwnMessage={isOwnMessage} />
 
       {/* Video attachment with inline player */}
-      <VideoAttachment attachment={attachment} onLoad={onMediaLoad} />
+      <VideoAttachment attachment={attachment} onLoad={onMediaLoad} isOwnMessage={isOwnMessage} />
 
       {/* Audio attachment with inline player */}
-      <AudioAttachment attachment={attachment} />
+      <AudioAttachment attachment={attachment} isOwnMessage={isOwnMessage} />
 
       {/* Text file preview (code, markdown, json, etc.) */}
-      {canPreview && <TextFilePreview attachment={attachment} isSelected={isSelected} isHovered={isHovered} />}
+      {canPreview && <TextFilePreview attachment={attachment} isSelected={isSelected} isHovered={isHovered} isOwnMessage={isOwnMessage} />}
 
       {/* Document/file attachment card (PDF, Word, etc.) */}
       {shouldShowFileCard(attachment, canPreview) && (

--- a/apps/fluux/src/components/TextFilePreview.tsx
+++ b/apps/fluux/src/components/TextFilePreview.tsx
@@ -12,16 +12,18 @@ interface TextFilePreviewProps {
   isSelected?: boolean
   /** Whether the parent message is hovered (for gradient adaptation) */
   isHovered?: boolean
+  /** When true (the local user's own message), bypass media-autoload deferral. */
+  isOwnMessage?: boolean
 }
 
 /**
  * Renders an inline text file preview with the file content displayed
  * in a code block, plus a download card below.
  */
-export function TextFilePreview({ attachment, isSelected = false, isHovered = false }: TextFilePreviewProps) {
+export function TextFilePreview({ attachment, isSelected = false, isHovered = false, isOwnMessage }: TextFilePreviewProps) {
   const { t } = useTranslation()
   const canPreview = canPreviewAsText(attachment.mediaType, attachment.name)
-  const { shouldLoad, approve } = useDeferredMedia(attachment.url)
+  const { shouldLoad, approve } = useDeferredMedia(attachment.url, isOwnMessage)
   const { content, isLoading, error, isTruncated } = useTextPreview(attachment.url, canPreview && shouldLoad)
 
   // Don't render anything if this isn't a text file

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -623,10 +623,10 @@ export const MessageBubble = memo(function MessageBubble({
           )}
 
           {/* File attachments (image, video, audio, text preview, document card) - hidden for retracted */}
-          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={onMediaLoad} isSelected={isSelected} isHovered={isHovered} />}
+          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={onMediaLoad} isSelected={isSelected} isHovered={isHovered} isOwnMessage={message.isOutgoing} />}
 
           {/* Link preview - hidden for retracted */}
-          {!message.isRetracted && message.linkPreview && <LinkPreviewCard preview={message.linkPreview} onLoad={onMediaLoad} />}
+          {!message.isRetracted && message.linkPreview && <LinkPreviewCard preview={message.linkPreview} onLoad={onMediaLoad} isOwnMessage={message.isOutgoing} />}
 
           {/* Poll display - hidden for retracted */}
           {!message.isRetracted && message.poll && (

--- a/apps/fluux/src/hooks/useDeferredMedia.test.tsx
+++ b/apps/fluux/src/hooks/useDeferredMedia.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MediaAutoloadProvider } from '@/contexts'
+import { useDeferredMedia } from './useDeferredMedia'
+import { __resetApprovedMediaUrlsForTest } from '@/utils/mediaAutoload'
+
+function Probe({ url, isOwnMessage }: { url: string; isOwnMessage?: boolean }) {
+  const { shouldLoad } = useDeferredMedia(url, isOwnMessage)
+  return <span>{shouldLoad ? 'load' : 'defer'}</span>
+}
+
+describe('useDeferredMedia', () => {
+  beforeEach(() => __resetApprovedMediaUrlsForTest())
+
+  it('defers when the context auto-load is false and the message is not own', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <Probe url="https://x/a.jpg" />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('defer')).toBeInTheDocument()
+  })
+
+  it('loads own-message media even when the context auto-load is false', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <Probe url="https://x/b.jpg" isOwnMessage />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('load')).toBeInTheDocument()
+  })
+
+  it('still auto-loads non-own media when the context auto-load is true', () => {
+    render(
+      <MediaAutoloadProvider autoLoad>
+        <Probe url="https://x/c.jpg" />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('load')).toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/hooks/useDeferredMedia.ts
+++ b/apps/fluux/src/hooks/useDeferredMedia.ts
@@ -4,14 +4,20 @@ import { approveMediaUrl, isMediaUrlApproved } from '@/utils/mediaAutoload'
 
 /**
  * Gates a single remote-media fetch behind the conversation's media-autoload
- * policy. Returns whether the media should load now (the policy auto-loads, or
- * the user already tapped this URL this session) plus an `approve` callback to
- * call when the user taps to load.
+ * policy. Returns whether the media should load now (the policy auto-loads, the
+ * user already tapped this URL this session, or the message is the local user's
+ * own) plus an `approve` callback to call when the user taps to load.
+ *
+ * `isOwnMessage` short-circuits the deferral: content the local user authored
+ * carries no IP-leak or safety cost, so it always loads regardless of policy.
  */
-export function useDeferredMedia(sourceUrl: string): { shouldLoad: boolean; approve: () => void } {
+export function useDeferredMedia(
+  sourceUrl: string,
+  isOwnMessage = false,
+): { shouldLoad: boolean; approve: () => void } {
   const autoLoad = useMediaAutoload()
   const [approved, setApproved] = useState(() => isMediaUrlApproved(sourceUrl))
-  const shouldLoad = autoLoad || approved
+  const shouldLoad = autoLoad || approved || isOwnMessage
   const approve = () => {
     approveMediaUrl(sourceUrl)
     setApproved(true)

--- a/docs/superpowers/plans/2026-06-22-own-message-media-autoload.md
+++ b/docs/superpowers/plans/2026-06-22-own-message-media-autoload.md
@@ -1,0 +1,410 @@
+# Own-Message Media Autoload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the local user's own sent media (images, video, audio, text-file previews, link-preview images) inline automatically, even where the media-autoload policy would otherwise defer it to a "tap to load" placeholder (notably public rooms and 1:1 stranger chats).
+
+**Architecture:** Layer a per-message override on top of the existing per-conversation media-autoload gate. The single gate `useDeferredMedia(url)` gains an `isOwnMessage` flag that short-circuits the deferral. `message.isOutgoing` is threaded from `MessageBubble` down through the attachment/preview renderers to the gate. No SDK change.
+
+**Tech Stack:** React, TypeScript, Zustand, Vitest, @testing-library/react.
+
+## Global Constraints
+
+- App-only change. Do not modify `packages/fluux-sdk`. `message.isOutgoing` already exists on the message type.
+- Own content always loads under all policies, including "Never". The autoload policy governs only other people's remote media.
+- No new user setting, no change to `computeMediaAutoload` or `ConversationTrust`.
+- No em-dashes or en-dashes in any user-facing text (this change adds none, but the rule stands).
+- Pre-commit gate (from CLAUDE.md): unit tests pass with no errors or stderr, `npm run typecheck` passes, `npm run lint` passes.
+- Work happens on branch `feat/own-message-media-autoload` (already created). Squash-merge to main via PR.
+
+---
+
+### Task 1: Add `isOwnMessage` to the `useDeferredMedia` gate
+
+**Files:**
+- Modify: `apps/fluux/src/hooks/useDeferredMedia.ts`
+- Test: `apps/fluux/src/hooks/useDeferredMedia.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `useMediaAutoload()` (boolean context), `isMediaUrlApproved`, `approveMediaUrl`, `__resetApprovedMediaUrlsForTest` from `@/utils/mediaAutoload`; `MediaAutoloadProvider` from `@/contexts`.
+- Produces: `useDeferredMedia(sourceUrl: string, isOwnMessage?: boolean): { shouldLoad: boolean; approve: () => void }`. `isOwnMessage` defaults to `false`. When `true`, `shouldLoad` is forced `true`. Task 2 relies on this two-arg signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/hooks/useDeferredMedia.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MediaAutoloadProvider } from '@/contexts'
+import { useDeferredMedia } from './useDeferredMedia'
+import { __resetApprovedMediaUrlsForTest } from '@/utils/mediaAutoload'
+
+function Probe({ url, isOwnMessage }: { url: string; isOwnMessage?: boolean }) {
+  const { shouldLoad } = useDeferredMedia(url, isOwnMessage)
+  return <span>{shouldLoad ? 'load' : 'defer'}</span>
+}
+
+describe('useDeferredMedia', () => {
+  beforeEach(() => __resetApprovedMediaUrlsForTest())
+
+  it('defers when the context auto-load is false and the message is not own', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <Probe url="https://x/a.jpg" />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('defer')).toBeInTheDocument()
+  })
+
+  it('loads own-message media even when the context auto-load is false', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <Probe url="https://x/b.jpg" isOwnMessage />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('load')).toBeInTheDocument()
+  })
+
+  it('still auto-loads non-own media when the context auto-load is true', () => {
+    render(
+      <MediaAutoloadProvider autoLoad>
+        <Probe url="https://x/c.jpg" />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('load')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useDeferredMedia.test.tsx`
+Expected: the second test ("loads own-message media...") FAILS. Before the change the hook ignores the second argument, so `shouldLoad` stays `false` and the probe renders `defer` instead of `load`. (The other two tests already pass.)
+
+- [ ] **Step 3: Implement the minimal change**
+
+Replace the body of `apps/fluux/src/hooks/useDeferredMedia.ts` with:
+
+```ts
+import { useState } from 'react'
+import { useMediaAutoload } from '@/contexts'
+import { approveMediaUrl, isMediaUrlApproved } from '@/utils/mediaAutoload'
+
+/**
+ * Gates a single remote-media fetch behind the conversation's media-autoload
+ * policy. Returns whether the media should load now (the policy auto-loads, the
+ * user already tapped this URL this session, or the message is the local user's
+ * own) plus an `approve` callback to call when the user taps to load.
+ *
+ * `isOwnMessage` short-circuits the deferral: content the local user authored
+ * carries no IP-leak or safety cost, so it always loads regardless of policy.
+ */
+export function useDeferredMedia(
+  sourceUrl: string,
+  isOwnMessage = false,
+): { shouldLoad: boolean; approve: () => void } {
+  const autoLoad = useMediaAutoload()
+  const [approved, setApproved] = useState(() => isMediaUrlApproved(sourceUrl))
+  const shouldLoad = autoLoad || approved || isOwnMessage
+  const approve = () => {
+    approveMediaUrl(sourceUrl)
+    setApproved(true)
+  }
+  return { shouldLoad, approve }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useDeferredMedia.test.tsx`
+Expected: all three tests PASS, no stderr.
+
+- [ ] **Step 5: Typecheck and commit**
+
+Run: `npm run typecheck`
+Expected: passes (no errors).
+
+```bash
+git add apps/fluux/src/hooks/useDeferredMedia.ts apps/fluux/src/hooks/useDeferredMedia.test.tsx
+git commit -m "feat(media): add isOwnMessage bypass to useDeferredMedia gate"
+```
+
+---
+
+### Task 2: Thread `isOwnMessage` from MessageBubble through every media renderer
+
+**Files:**
+- Modify: `apps/fluux/src/components/FileAttachments.tsx` (AttachmentProps + ImageAttachment:36,56 + VideoAttachment:228,236 + AudioAttachment:379,387)
+- Modify: `apps/fluux/src/components/TextFilePreview.tsx` (props + 21,24)
+- Modify: `apps/fluux/src/components/MessageAttachments.tsx` (props + 34,42,45,48,51)
+- Modify: `apps/fluux/src/components/LinkPreviewCard.tsx` (props + 25,30)
+- Modify: `apps/fluux/src/components/conversation/MessageBubble.tsx:626,629`
+- Test: `apps/fluux/src/components/FileAttachments.test.tsx` (extend), `apps/fluux/src/components/LinkPreviewCard.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `useDeferredMedia(url, isOwnMessage)` from Task 1.
+- Produces: optional `isOwnMessage?: boolean` prop on `AttachmentProps`, `MessageAttachmentsProps`, `TextFilePreviewProps`, `LinkPreviewCardProps`. `MessageBubble` passes `message.isOutgoing` to `<MessageAttachments>` and `<LinkPreviewCard>`.
+
+- [ ] **Step 1: Write the failing wiring tests**
+
+In `apps/fluux/src/components/FileAttachments.test.tsx`, add an import for `MessageAttachments` at the top (next to the existing `./FileAttachments` import):
+
+```tsx
+import { MessageAttachments } from './MessageAttachments'
+```
+
+Then append this describe block at the end of the file (it reuses the module-level `deferralImageAttachment` and the hoisted `@/hooks` mock already defined in this file):
+
+```tsx
+describe('MessageAttachments own-message threading', () => {
+  beforeEach(() => {
+    __resetApprovedMediaUrlsForTest()
+    useAttachmentUrlSpy.mockImplementation((_u: string | undefined, _e: unknown, enabled: boolean) => ({
+      url: enabled ? 'blob:loaded' : null,
+      isLoading: false,
+      error: null,
+    }))
+    useCachedMediaUrlSpy.mockReturnValue({ cachedUrl: null, isPeeking: false })
+  })
+
+  it('loads an own-message image inline even when autoLoad is false', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <MessageAttachments attachment={deferralImageAttachment} isOwnMessage />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByRole('img')).toBeInTheDocument()
+    expect(screen.queryByText('chat.loadImage')).not.toBeInTheDocument()
+  })
+
+  it('defers a non-own image when autoLoad is false', () => {
+    render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <MessageAttachments attachment={deferralImageAttachment} />
+      </MediaAutoloadProvider>,
+    )
+    expect(screen.getByText('chat.loadImage')).toBeInTheDocument()
+  })
+})
+```
+
+In `apps/fluux/src/components/LinkPreviewCard.test.tsx`, add this test inside the existing `describe('LinkPreviewCard image deferral', ...)` block (it uses that block's local `preview` const):
+
+```tsx
+  it('shows the OG image for an own-message preview even when autoLoad is false', () => {
+    const { container } = render(
+      <MediaAutoloadProvider autoLoad={false}>
+        <LinkPreviewCard preview={preview} isOwnMessage />
+      </MediaAutoloadProvider>,
+    )
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/components/FileAttachments.test.tsx src/components/LinkPreviewCard.test.tsx`
+Expected: the two new "own-message" tests FAIL. The `isOwnMessage` prop is not yet threaded, so the own image still shows the `chat.loadImage` placeholder (no `img`) and the own preview suppresses its image. The "defers a non-own image" test passes.
+
+- [ ] **Step 3: Add `isOwnMessage` to `AttachmentProps` and the three FileAttachments renderers**
+
+In `apps/fluux/src/components/FileAttachments.tsx`, extend `AttachmentProps` (currently lines 25-29):
+
+```ts
+interface AttachmentProps {
+  attachment: FileAttachment
+  /** Called when image/video loads - useful for scroll adjustment */
+  onLoad?: () => void
+  /** When true (the local user's own message), bypass media-autoload deferral. */
+  isOwnMessage?: boolean
+}
+```
+
+Update `ImageAttachment` signature (line 36) and its `useDeferredMedia` call (line 56):
+
+```ts
+export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoad, isOwnMessage }: AttachmentProps) {
+```
+
+```ts
+  const { shouldLoad, approve } = useDeferredMedia(originalImageSrc, isOwnMessage)
+```
+
+Update `VideoAttachment` signature (line 228) and its `useDeferredMedia` call (line 236):
+
+```ts
+export const VideoAttachment = memo(function VideoAttachment({ attachment, onLoad, isOwnMessage }: AttachmentProps) {
+```
+
+```ts
+  const { shouldLoad, approve } = useDeferredMedia(attachment.url, isOwnMessage)
+```
+
+Update `AudioAttachment` signature (line 379) and its `useDeferredMedia` call (line 387):
+
+```ts
+export function AudioAttachment({ attachment, isOwnMessage }: AttachmentProps) {
+```
+
+```ts
+  const { shouldLoad, approve } = useDeferredMedia(attachment.url, isOwnMessage)
+```
+
+- [ ] **Step 4: Add `isOwnMessage` to `TextFilePreview`**
+
+In `apps/fluux/src/components/TextFilePreview.tsx`, extend `TextFilePreviewProps` (lines 9-15):
+
+```ts
+interface TextFilePreviewProps {
+  attachment: FileAttachment
+  /** Whether the parent message is selected (for gradient adaptation) */
+  isSelected?: boolean
+  /** Whether the parent message is hovered (for gradient adaptation) */
+  isHovered?: boolean
+  /** When true (the local user's own message), bypass media-autoload deferral. */
+  isOwnMessage?: boolean
+}
+```
+
+Update the signature (line 21) and the `useDeferredMedia` call (line 24):
+
+```ts
+export function TextFilePreview({ attachment, isSelected = false, isHovered = false, isOwnMessage }: TextFilePreviewProps) {
+```
+
+```ts
+  const { shouldLoad, approve } = useDeferredMedia(attachment.url, isOwnMessage)
+```
+
+- [ ] **Step 5: Forward `isOwnMessage` through `MessageAttachments`**
+
+In `apps/fluux/src/components/MessageAttachments.tsx`, extend `MessageAttachmentsProps` (lines 19-27) by adding:
+
+```ts
+  /** Whether the parent message is the local user's own (bypasses media-autoload deferral). */
+  isOwnMessage?: boolean
+```
+
+Update the signature (line 34):
+
+```ts
+export function MessageAttachments({ attachment, onMediaLoad, isSelected, isHovered, isOwnMessage }: MessageAttachmentsProps) {
+```
+
+Pass `isOwnMessage` to the gated renderers (lines 42, 45, 48, 51). `FileAttachmentCard` (line 54) does not gate, so leave it unchanged:
+
+```tsx
+      {/* Image attachment preview */}
+      <ImageAttachment attachment={attachment} onLoad={onMediaLoad} isOwnMessage={isOwnMessage} />
+
+      {/* Video attachment with inline player */}
+      <VideoAttachment attachment={attachment} onLoad={onMediaLoad} isOwnMessage={isOwnMessage} />
+
+      {/* Audio attachment with inline player */}
+      <AudioAttachment attachment={attachment} isOwnMessage={isOwnMessage} />
+
+      {/* Text file preview (code, markdown, json, etc.) */}
+      {canPreview && <TextFilePreview attachment={attachment} isSelected={isSelected} isHovered={isHovered} isOwnMessage={isOwnMessage} />}
+```
+
+- [ ] **Step 6: Add `isOwnMessage` to `LinkPreviewCard`**
+
+In `apps/fluux/src/components/LinkPreviewCard.tsx`, extend `LinkPreviewCardProps` (lines 20-23):
+
+```ts
+interface LinkPreviewCardProps {
+  preview: LinkPreview
+  onLoad?: () => void
+  /** When true (the local user's own message), bypass media-autoload deferral. */
+  isOwnMessage?: boolean
+}
+```
+
+Update the signature (line 25) and the `useDeferredMedia` call (line 30):
+
+```ts
+export function LinkPreviewCard({ preview, onLoad, isOwnMessage }: LinkPreviewCardProps) {
+```
+
+```ts
+  const { shouldLoad: showImage, approve: approveImage } = useDeferredMedia(preview.image ?? '', isOwnMessage)
+```
+
+- [ ] **Step 7: Pass `message.isOutgoing` from `MessageBubble`**
+
+In `apps/fluux/src/components/conversation/MessageBubble.tsx`, update line 626:
+
+```tsx
+          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={onMediaLoad} isSelected={isSelected} isHovered={isHovered} isOwnMessage={message.isOutgoing} />}
+```
+
+And line 629:
+
+```tsx
+          {!message.isRetracted && message.linkPreview && <LinkPreviewCard preview={message.linkPreview} onLoad={onMediaLoad} isOwnMessage={message.isOutgoing} />}
+```
+
+- [ ] **Step 8: Run the wiring tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/components/FileAttachments.test.tsx src/components/LinkPreviewCard.test.tsx`
+Expected: all tests PASS, no stderr. The own-message image now renders inline and the own-message preview image shows.
+
+- [ ] **Step 9: Run the full pre-commit gate**
+
+Run: `npm test`
+Expected: all workspace tests pass, no errors or stderr.
+
+Run: `npm run typecheck`
+Expected: passes.
+
+Run: `npm run lint`
+Expected: passes.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/fluux/src/components/FileAttachments.tsx apps/fluux/src/components/TextFilePreview.tsx apps/fluux/src/components/MessageAttachments.tsx apps/fluux/src/components/LinkPreviewCard.tsx apps/fluux/src/components/conversation/MessageBubble.tsx apps/fluux/src/components/FileAttachments.test.tsx apps/fluux/src/components/LinkPreviewCard.test.tsx
+git commit -m "feat(media): auto-load own-message media in public rooms"
+```
+
+---
+
+### Task 3: Verify in the running app
+
+**Files:** none (manual/preview verification).
+
+This confirms the full thread end to end, which the unit tests cannot (MessageBubble passing `message.isOutgoing` is exercised here).
+
+- [ ] **Step 1: Start the dev server and open demo mode**
+
+Run the app (preview tooling or `npm run dev`) and open `http://localhost:5173/demo.html`. Ensure the media-autoload policy is the default `private-only` (Settings > media auto-download), so public-room media defers.
+
+- [ ] **Step 2: Confirm the behavior in a public room**
+
+Open a public (non members-only) room. Confirm:
+- An image you sent renders inline (no "tap to load" placeholder).
+- A link you posted shows its preview image inline.
+- Another participant's image/link still shows the "tap to load" placeholder (unchanged behavior).
+
+If the demo seed has no own image/link in a public room, send one (or verify against a real account joined to a public room). Capture a screenshot of an own image rendered inline next to a peer's deferred placeholder as proof.
+
+- [ ] **Step 3: Spot-check "Never" policy**
+
+Set media auto-download to "Never". Confirm your own sent image/link still renders inline, while other people's media defers. This validates the "own content always loads, under all policies" decision.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Own sent media renders inline automatically, wherever it would otherwise defer" -> Task 1 (gate) + Task 2 (threading).
+- "Covers image, video, audio, text-file preview, link-preview image" -> Task 2 Steps 3-6 touch all five gated renderers.
+- "App-only, no SDK change" -> all files under `apps/fluux`.
+- "Other people's media unchanged" -> `isOwnMessage` defaults to `false`; non-own tests in Task 1 and Task 2 assert deferral is preserved.
+- "Under all policies including Never" -> `shouldLoad = autoLoad || approved || isOwnMessage` is policy-independent; Task 3 Step 3 verifies.
+- "Add useDeferredMedia.test.tsx; optionally extend FileAttachments.test.tsx" -> Task 1 creates the hook test; Task 2 extends FileAttachments.test.tsx (MessageAttachments wiring) and LinkPreviewCard.test.tsx.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases". Every code step shows complete code.
+
+**Type consistency:** `useDeferredMedia(sourceUrl, isOwnMessage?)` defined in Task 1 is used with two args throughout Task 2. `isOwnMessage?: boolean` is the identical optional-prop name on `AttachmentProps`, `MessageAttachmentsProps`, `TextFilePreviewProps`, `LinkPreviewCardProps`. `MessageBubble` passes `message.isOutgoing` (existing `BaseMessage` field).

--- a/docs/superpowers/specs/2026-06-22-own-message-media-autoload-design.md
+++ b/docs/superpowers/specs/2026-06-22-own-message-media-autoload-design.md
@@ -1,0 +1,139 @@
+# Own-Message Media Autoload - Design
+
+**Date:** 2026-06-22
+**Status:** Approved design, ready for implementation plan
+
+## Problem
+
+The app gates remote-media fetches (images, video, audio, text-file previews,
+link-preview images) behind a privacy policy. The default policy is
+`private-only` (settingsStore.ts:68), which in a public room computes
+`mediaAutoLoad = false` (RoomView.tsx:444). Every remote item then defers to a
+"tap to load" placeholder (FileAttachments.tsx:107).
+
+That deferral makes no distinction for the local user's own messages. The
+concrete result:
+
+- Post an image in a public room and you see "tap to load" on the image you
+  just sent.
+- Share a link and its preview image defers too (the og:image is third-party,
+  so it is never in cache and stays a placeholder).
+
+The deferral exists for a real reason: auto-loading a stranger's remote URL
+leaks your IP and signals engagement to a URL chosen by someone else. But that
+threat model does not apply to content the local user authored. There is no
+privacy or safety cost to loading media you sent yourself.
+
+`message.isOutgoing` already cleanly identifies the local user's own messages,
+including sent-carbons (copies of messages you sent from another device).
+
+## Goals
+
+- The local user's own sent media renders inline automatically, without a
+  "tap to load" step, wherever it would otherwise defer.
+- Covers every gated media type: image, video, audio, text-file preview, and
+  link-preview image.
+- App-only change. No SDK change (the `isOutgoing` flag already exists on the
+  message).
+- No behavior change for other people's media: it still follows the autoload
+  policy exactly as today.
+
+## Non-Goals
+
+- No change to `computeMediaAutoload` or the `ConversationTrust` model.
+- No new user setting. This is unconditional behavior derived from message
+  authorship.
+- No change to the session approved-URL mechanism or the cache-peek path.
+
+## Decisions (from brainstorming)
+
+- **Own content always loads, under all policies including "Never."** The
+  autoload policy governs only other people's remote media. There is no privacy
+  or safety reason to hide content you authored, and a "tap to load" on an image
+  you just sent is poor UX. (User decision.)
+- **Universal scope.** The exemption applies anywhere your own media could
+  otherwise defer: public rooms and 1:1 stranger chats alike. It naturally has
+  no effect where media already auto-loads.
+- **Per-message seam.** Conversation trust is per-conversation, but
+  own-vs-other is per-message, so the exemption is layered in the per-message
+  gate (`useDeferredMedia`), not in `computeMediaAutoload`.
+
+## Approach
+
+Chosen: thread a per-message `isOwnMessage` flag into the existing
+`useDeferredMedia` gate and OR it into the load decision.
+
+Rejected alternatives:
+
+- **Per-message `MediaAutoloadProvider` wrapper** (`autoLoad={true}` around own
+  bubbles): a context provider per message bubble is heavier and muddies the
+  context's per-conversation meaning.
+- **Auto-approve own URLs via `approveMediaUrl()`**: side-effecting the shared
+  session approved-set during render is wrong and order-dependent.
+
+## Design
+
+### 1. Gate
+
+`useDeferredMedia` gains a second parameter, defaulting to `false` so existing
+callers are unaffected:
+
+```ts
+export function useDeferredMedia(
+  sourceUrl: string,
+  isOwnMessage = false,
+): { shouldLoad: boolean; approve: () => void } {
+  const autoLoad = useMediaAutoload()
+  const [approved, setApproved] = useState(() => isMediaUrlApproved(sourceUrl))
+  const shouldLoad = autoLoad || approved || isOwnMessage
+  // ...unchanged
+}
+```
+
+### 2. Threading `isOwnMessage = message.isOutgoing`
+
+- **MessageBubble.tsx**: pass `isOwnMessage={message.isOutgoing}` to
+  `<MessageAttachments>` (MessageBubble.tsx:626) and `<LinkPreviewCard>`
+  (MessageBubble.tsx:629).
+- **MessageAttachments.tsx**: add `isOwnMessage?: boolean` to
+  `MessageAttachmentsProps`; forward it to the gated renderers
+  (`ImageAttachment`, `VideoAttachment`, `AudioAttachment`, and the text-file
+  preview). `FileAttachmentCard` does not gate, so it needs no change.
+- **FileAttachments.tsx**: add `isOwnMessage?: boolean` to `AttachmentProps`;
+  in `ImageAttachment`, `VideoAttachment`, `AudioAttachment`, pass it as the
+  second arg to `useDeferredMedia` (FileAttachments.tsx:56,236,387).
+- **TextFilePreview.tsx**: accept `isOwnMessage?: boolean` and pass it to
+  `useDeferredMedia` (TextFilePreview.tsx:24).
+- **LinkPreviewCard.tsx**: add `isOwnMessage?: boolean` and pass it to
+  `useDeferredMedia` (LinkPreviewCard.tsx:30).
+
+### 3. Unchanged
+
+- `computeMediaAutoload` and `ConversationTrust` are untouched.
+- The cache-peek path (`useCachedMediaUrl`) and session approved-set are
+  untouched. For own messages `shouldLoad` is now `true`, so the normal fetch
+  path runs and the cache-peek branch is simply skipped.
+
+## Testing
+
+The hook has no dedicated test today. Existing coverage lives in
+`mediaAutoload.test.ts` (the pure `computeMediaAutoload`),
+`MediaAutoloadContext.test.tsx`, `FileAttachments.test.tsx`, and
+`LinkPreviewCard.test.tsx`.
+
+- Add `apps/fluux/src/hooks/useDeferredMedia.test.tsx`: with `renderHook`
+  wrapped in `MediaAutoloadProvider autoLoad={false}`, assert
+  `isOwnMessage = true` yields `shouldLoad === true`, and `isOwnMessage = false`
+  (and the omitted default) still yields `shouldLoad === false`.
+- Optionally extend `FileAttachments.test.tsx` to assert an own-message image
+  renders inline (no deferred placeholder) when the context defers.
+
+## Files touched
+
+- `apps/fluux/src/hooks/useDeferredMedia.ts`
+- `apps/fluux/src/components/conversation/MessageBubble.tsx`
+- `apps/fluux/src/components/MessageAttachments.tsx`
+- `apps/fluux/src/components/FileAttachments.tsx`
+- `apps/fluux/src/components/TextFilePreview.tsx`
+- `apps/fluux/src/components/LinkPreviewCard.tsx`
+- `apps/fluux/src/hooks/useDeferredMedia.test.tsx` (new)


### PR DESCRIPTION
## Summary

In public rooms (and 1:1 chats with non-contacts), the media-autoload policy defers remote media to a "tap to load" placeholder so the client does not leak your IP to content posted by other people. Under the default `private-only` policy this also deferred your **own** sent media, so an image you just posted to a public room showed up as a placeholder, and the preview image of a link you shared stayed hidden.

This exempts your own messages from the deferral. Content you authored carries no IP-leak or safety cost, so it now loads inline regardless of policy (including "Never"). Other people's media is unchanged and still follows the policy exactly as before.