### PR TITLE
fix(admin): wrap long server version + single-column overview on mobile

### DIFF
--- a/apps/fluux/src/components/ServerOverview.tsx
+++ b/apps/fluux/src/components/ServerOverview.tsx
@@ -68,7 +68,7 @@ export function ServerOverview() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
           {presentCards.map(card => {
             const Icon = card.icon
             const value = stats![card.key] as NonNullable<ServerStats[keyof ServerStats]>
@@ -78,7 +78,7 @@ export function ServerOverview() {
                   <Icon className="size-4" />
                   <span className="text-xs font-medium">{t(card.labelKey)}</span>
                 </div>
-                <div className="text-2xl font-semibold text-fluux-text truncate" title={String(value)}>
+                <div className="text-2xl font-semibold text-fluux-text break-words" title={String(value)}>
                   {card.format(value, durationUnits)}
                 </div>
               </div>


### PR DESCRIPTION
Two small fixes to the admin server overview dashboard:

- **Server version no longer truncated.** The version card used `truncate`, clipping values like `ejabberd 26.01 (demo)` to `ejab…`. Switched to `break-words` so long values wrap; short numeric stats are unaffected.
- **Single column on mobile.** Grid changed from `grid-cols-2 lg:grid-cols-3` to `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`: 1 column below 768px, 2 on tablet, 3 on desktop (unchanged).

Verified in demo mode (admin → Statistiques) at desktop and 375px mobile widths.