### PR TITLE
feat(admin): default to server overview as admin home

### DIFF
--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { Sidebar, type SidebarView } from './Sidebar'
@@ -153,6 +153,7 @@ function ChatLayoutContent() {
   // NOTE: Don't use useAdmin() hook - it subscribes to many values. Use focused selectors.
   const adminSession = useAdminStore((s) => s.currentSession)
   const adminCategory = useAdminStore((s) => s.activeCategory)
+  const adminIsAdmin = useAdminStore((s) => s.isAdmin)
   const clearAdminSession = () => {
     adminStore.getState().setCurrentSession(null)
     adminStore.getState().setTargetJid(null)
@@ -728,6 +729,16 @@ function ChatLayoutContent() {
     }
     setAdminCategory(category)
   }
+
+  // Admin "home": on a wide screen, default to the server overview (stats) when
+  // entering the admin panel with nothing selected. Runs before paint to avoid a
+  // flash of the empty placeholder. Mobile keeps the list-first convention so the
+  // category list shows first, and non-admins still see the access-denied state.
+  useLayoutEffect(() => {
+    if (sidebarView !== 'admin' || isSmallScreen()) return
+    if (!adminIsAdmin || adminCategory || adminSession) return
+    adminStore.getState().setActiveCategory('stats')
+  }, [sidebarView, adminIsAdmin, adminCategory, adminSession])
 
   // Handle managing a user from roster context menu
   const handleManageUser = (jid: string) => {

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -298,7 +298,16 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
         {/* Header - with drag region for window movement */}
         <div className={`h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm`} {...dragRegionProps}>
           <h1 className="flex-1 font-semibold text-fluux-text truncate">
-            {sidebarView === 'messages' ? t('sidebar.messages')
+            {sidebarView === 'admin' && isAdmin ? (
+              // Clicking the title returns to the admin "home" (server overview)
+              <button
+                type="button"
+                onClick={() => onAdminCategoryChange?.('stats')}
+                className="text-start hover:text-fluux-brand transition-colors"
+              >
+                {t('sidebar.admin')}
+              </button>
+            ) : sidebarView === 'messages' ? t('sidebar.messages')
               : sidebarView === 'rooms' ? t('sidebar.rooms')
               : sidebarView === 'directory' ? t('sidebar.connections')
               : sidebarView === 'archive' ? t('sidebar.archive')


### PR DESCRIPTION
Entering the admin panel now opens the server overview (Statistics) as its "Home" instead of the empty "Select a command" placeholder.

- On a wide screen, entering Admin defaults to the `stats` category (the `ServerOverview` dashboard), with the **Statistiques** sidebar item highlighted. Set via a `useLayoutEffect` so there's no flash of the old placeholder.
- The **Administration** sidebar header is now clickable and returns to this home from any sub-view (Users, Rooms, …).
- Mobile keeps the list-first convention (gated on screen size); non-admins still see the access-denied state (gated on `isAdmin`).