### PR TITLE
fix(admin): align main header height with sidebar header

### DIFF
--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -456,7 +456,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
   return (
     <div className="flex-1 flex flex-col min-h-0 bg-fluux-sidebar">
       {/* Header */}
-      <div className={`flex items-center px-4 py-3 ${titleBarClass} border-b border-fluux-bg`}>
+      <div className={`h-14 flex items-center px-4 ${titleBarClass} border-b border-fluux-bg`}>
         {/* Back button - mobile only */}
         {onBack && (
           <button


### PR DESCRIPTION
The AdminView main-content header used `py-3` with no fixed height, making it shorter than the sidebar's fixed `h-14` (56px) header. As a result the "Administration" sidebar title and the "Vue d'ensemble du serveur" main title sat at different vertical positions across the divider.

Giving the main header the same `h-14` height aligns both title rows (verified in demo mode: both headers measure exactly 56px, both titles at top 16px / bottom 40px).