### PR TITLE
feat(diagnostics): attribute slow message-list renders (room-entry stall triage)

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next'
 import type { BaseMessage } from '@fluux/sdk'
 import { useMessageCopyFormatter } from '@/hooks'
 import { useViewportObserver } from '@/hooks/useViewportObserver'
+import { useRenderCostProbe } from '@/hooks/useRenderCostProbe'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { DateSeparator } from './DateSeparator'
 import { NewMessageMarker } from './NewMessageMarker'
@@ -119,6 +120,10 @@ export function MessageList<T extends BaseMessage>({
 }: MessageListProps<T>) {
   // Detect render loops before they freeze the UI
   detectRenderLoop('MessageList')
+
+  // Attribute slow message-list renders (room-entry stall triage on WebKitGTK):
+  // splits the cost into React commit vs browser layout/paint in fluux.log.
+  useRenderCostProbe('MessageList', () => `rows=${messages.length}, conversation=${conversationId}`)
 
   const { t } = useTranslation()
 

--- a/apps/fluux/src/hooks/useRenderCostProbe.ts
+++ b/apps/fluux/src/hooks/useRenderCostProbe.ts
@@ -1,0 +1,47 @@
+/**
+ * useRenderCostProbe — attribute a slow render to a component subtree.
+ *
+ * Brackets one commit of the calling component and its descendants and splits
+ * the cost into React work vs browser layout/paint (see `renderCostProbe.ts`).
+ * Logs a single rate-limited `console.warn` per cooldown when the total exceeds
+ * the threshold; the Tauri console forwarder ships it to fluux.log.
+ *
+ * Timing model (all `performance.now()`):
+ * - `renderStart` is read in the render body, before the subtree's children
+ *   render (this hook is called near the top of the component).
+ * - the `useLayoutEffect` fires after commit (DOM mutated, pre-paint):
+ *   `react = layoutEffect − renderStart`.
+ * - the `requestAnimationFrame` fires just before the next paint:
+ *   `layoutPaint = rAF − layoutEffect`.
+ *
+ * Diagnostic only: never changes behaviour.
+ */
+import { useLayoutEffect, useRef } from 'react'
+import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
+
+export function useRenderCostProbe(label: string, getContext: () => string): void {
+  // Read at render-body call time — before this component's children render.
+  const renderStart = performance.now()
+
+  // One probe instance per mounted component (rate-limit state lives here).
+  const probeRef = useRef<RenderCostProbe | null>(null)
+  if (probeRef.current === null) probeRef.current = createRenderCostProbe()
+
+  useLayoutEffect(() => {
+    const commitDone = performance.now()
+    const reactMs = commitDone - renderStart
+
+    requestAnimationFrame(() => {
+      const painted = performance.now()
+      const layoutPaintMs = painted - commitDone
+      const totalMs = reactMs + layoutPaintMs
+
+      if (probeRef.current?.record(totalMs, painted)) {
+        console.warn(
+          `[RenderCostProbe] ${label} render cost ~${Math.round(totalMs)}ms ` +
+          `(react=${Math.round(reactMs)}ms, layoutPaint=${Math.round(layoutPaintMs)}ms, ${getContext()})`
+        )
+      }
+    })
+  })
+}

--- a/apps/fluux/src/utils/renderCostProbe.test.ts
+++ b/apps/fluux/src/utils/renderCostProbe.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { createRenderCostProbe } from './renderCostProbe'
+
+describe('createRenderCostProbe', () => {
+  it('does not report renders below the threshold', () => {
+    const probe = createRenderCostProbe({ thresholdMs: 200, cooldownMs: 5000 })
+    expect(probe.record(50, 1000)).toBe(false)
+    expect(probe.record(199, 2000)).toBe(false)
+  })
+
+  it('reports a render at or above the threshold', () => {
+    const probe = createRenderCostProbe({ thresholdMs: 200, cooldownMs: 5000 })
+    expect(probe.record(200, 1000)).toBe(true)
+  })
+
+  it('suppresses repeat reports within the cooldown window', () => {
+    const probe = createRenderCostProbe({ thresholdMs: 200, cooldownMs: 5000 })
+    expect(probe.record(300, 1000)).toBe(true)
+    // Still slow, but within cooldown — one line per sustained slowdown, not per render.
+    expect(probe.record(300, 3000)).toBe(false)
+    expect(probe.record(300, 5999)).toBe(false)
+  })
+
+  it('reports again once the cooldown has elapsed', () => {
+    const probe = createRenderCostProbe({ thresholdMs: 200, cooldownMs: 5000 })
+    expect(probe.record(300, 1000)).toBe(true)
+    expect(probe.record(300, 6000)).toBe(true)
+  })
+})

--- a/apps/fluux/src/utils/renderCostProbe.ts
+++ b/apps/fluux/src/utils/renderCostProbe.ts
@@ -1,0 +1,61 @@
+/**
+ * Diagnostic-only probe for SLOW message-list renders.
+ *
+ * The stall sentinel (`stallSentinel.ts`) quantifies *that* the main thread
+ * blocked, but cannot attribute the cost. On WebKitGTK the prime suspect for a
+ * multi-second room-entry stall is mounting/laying out the non-virtualized
+ * message backlog (up to 1000 rich rows). This probe brackets that work and
+ * splits it into two halves so the next freeze in fluux.log says WHICH:
+ *
+ * - `react` — render-start → layout-effect: React reconciliation + commit
+ *   (DOM mutation) of the message subtree. A render-window cap reduces this.
+ * - `layoutPaint` — layout-effect → next rAF: the browser's layout/paint of
+ *   the committed DOM. `content-visibility` reduces this; a render cap reduces
+ *   both.
+ *
+ * Like the other monitors it never throttles or changes behaviour: it only
+ * tells the caller "this render was slow enough to log", rate-limited so a
+ * sustained slowdown produces one line per cooldown rather than one per render.
+ * The caller assembles the context (row count, conversation) on the warn path
+ * only.
+ *
+ * Pure threshold + cooldown logic, timestamps passed in, unit-testable.
+ */
+export interface RenderCostProbe {
+  /**
+   * Record one render whose total cost was `totalMs`, observed at `now` (ms,
+   * monotonic e.g. performance.now()). Returns true when the caller should log
+   * a diagnostic line (cost ≥ threshold and cooldown elapsed).
+   */
+  record(totalMs: number, now: number): boolean
+}
+
+export interface RenderCostProbeOptions {
+  /** Renders taking at least this long are reportable. */
+  thresholdMs?: number
+  /** Minimum gap between two reports, so a sustained slowdown logs once. */
+  cooldownMs?: number
+}
+
+// A list render over ~200ms is well past the frame budget and worth attributing;
+// normal updates (typing, a single new message) stay far below it.
+const DEFAULT_THRESHOLD_MS = 200
+const DEFAULT_COOLDOWN_MS = 5000
+
+export function createRenderCostProbe(
+  opts: RenderCostProbeOptions = {}
+): RenderCostProbe {
+  const thresholdMs = opts.thresholdMs ?? DEFAULT_THRESHOLD_MS
+  const cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS
+
+  let lastReportAt = Number.NEGATIVE_INFINITY
+
+  return {
+    record(totalMs: number, now: number): boolean {
+      if (totalMs < thresholdMs) return false
+      if (now - lastReportAt < cooldownMs) return false
+      lastReportAt = now
+      return true
+    },
+  }
+}


### PR DESCRIPTION
## Summary

A Linux/WebKitGTK user still hits a ~3s room-entry `[MainThreadStall]` in a large public MUC (Conversations Offtopic). The stall sentinel quantifies *that* the main thread blocked but can't attribute it. Evidence points at the non-virtualized message list (97-user room rules out presence/occupants; a stall on switching back into an already-joined room with `0` MAM messages isolates pure render cost), but `content-visibility` — the only prior Linux mitigation — was removed in #540, and the cause can't be reproduced on a macOS host.

This adds a triage probe rather than a blind fix. It brackets one `MessageList` commit and splits the cost into **React** (reconciliation + commit) vs **browser layout/paint**, logging a rate-limited line to fluux.log when a render exceeds 200ms:

```
[RenderCostProbe] MessageList render cost ~3100ms (react=2800ms, layoutPaint=300ms, rows=842, conversation=…)
```

The split decides the eventual fix: `react`-dominated → render-window cap; `layoutPaint`-dominated → `content-visibility` (Linux-gated); both → render-window cap.

## Changes
- `renderCostProbe.ts` — pure threshold + cooldown gate (mirrors `slowCorrectionMonitor`), unit-tested.
- `useRenderCostProbe.ts` — `renderStart → useLayoutEffect → rAF` timing split.
- `MessageList.tsx` — probe wired in (covers rooms and 1:1).

Diagnostic only — never changes behaviour. Always-on and rate-limited, consistent with `stallSentinel` / `SlowScrollCorrection`.