### PR TITLE
feat(admin): remove redundant Statistics sidebar entry

### DIFF
--- a/apps/fluux/src/components/AdminDashboard.tsx
+++ b/apps/fluux/src/components/AdminDashboard.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import {
   ChevronRight,
   Users,
-  BarChart3,
   Megaphone,
   Loader2,
   Server,
@@ -56,9 +55,6 @@ export function AdminDashboard({ activeCategory, onCategoryChange }: AdminDashbo
     }
   }
 
-  // Check if we have stats commands
-  const hasStats = commandsByCategory.stats.length > 0
-
   // Check if we have other/uncategorized commands
   const hasOther = commandsByCategory.other.length > 0
 
@@ -95,17 +91,6 @@ export function AdminDashboard({ activeCategory, onCategoryChange }: AdminDashbo
 
   return (
     <div className="px-2 py-2 space-y-1">
-      {/* Statistics Category - opens the ServerOverview dashboard (non-expanding) */}
-      {hasStats && (
-        <CategoryButton
-          icon={BarChart3}
-          label={t('admin.categories.statistics')}
-          isActive={activeCategory === 'stats'}
-          onClick={() => onCategoryChange(activeCategory === 'stats' ? null : 'stats')}
-          hasExpandableContent={false}
-        />
-      )}
-
       {/* Users Category */}
       <CategoryButton
         icon={Users}


### PR DESCRIPTION
The server overview is now the admin home, auto-selected on desktop and reachable via the "Administration" title — so the dedicated "Statistiques" sidebar entry just re-selected the same view.

Removes the Statistics `CategoryButton` along with its now-dead `hasStats` gate and unused `BarChart3` import. The `stats` category, `ServerOverview`, and its i18n keys are kept intact; the sidebar now shows Utilisateurs / Salons / Annonces / Autres.