### PR TITLE
fix(perf,avatar): drop sleep-spanning render probes; heal dead avatar blobs

### DIFF
--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type ReactNode } from 'react'
+import { useState, useEffect, useRef, type ReactNode } from 'react'
 import { generateConsistentColorHexSync, type PresenceStatus, type PresenceShow } from '@fluux/sdk'
 import { APP_OFFLINE_PRESENCE_COLOR, PRESENCE_COLORS } from '@/constants/ui'
 
@@ -269,9 +269,27 @@ export function Avatar({
     ? { backgroundColor: PRESENCE_CSS_VARS[resolvedPresence] }
     : undefined
 
-  // Track image load errors to fall back to letter display
+  // Track image load errors to fall back to letter display.
   const [imgError, setImgError] = useState(false)
-  useEffect(() => { setImgError(false) }, [avatarUrl])
+  const imgRef = useRef<HTMLImageElement>(null)
+  // WebKit (Tauri webview) does not reliably fire `<img>` onError for a revoked
+  // `blob:` URL whose backing store it reclaimed across an OS sleep — the image
+  // silently fails to decode and the row shows a broken-image glyph instead of
+  // the letter fallback. Don't depend on the error event: after the load
+  // settles, a failed image is `complete` with `naturalWidth === 0`. Reset on
+  // URL change, check immediately if already settled, and re-check shortly after
+  // for the no-event case.
+  useEffect(() => {
+    setImgError(false)
+    if (!avatarUrl) return
+    const checkBroken = () => {
+      const img = imgRef.current
+      if (img && img.complete && img.naturalWidth === 0) setImgError(true)
+    }
+    checkBroken()
+    const timer = setTimeout(checkBroken, 1500)
+    return () => clearTimeout(timer)
+  }, [avatarUrl])
 
   // Animated GIF: show static first frame by default, animate on hover
   const staticFrame = useStaticFrame(avatarUrl)
@@ -309,11 +327,13 @@ export function Avatar({
     >
       {avatarUrl && !imgError ? (
         <img
+          ref={imgRef}
           src={staticFrame && !hovered ? staticFrame : avatarUrl}
           alt={displayName}
           className="w-full h-full rounded-full object-cover"
           draggable={false}
           onError={() => setImgError(true)}
+          onLoad={(e) => { if (e.currentTarget.naturalWidth === 0) setImgError(true) }}
         />
       ) : (
         // Letter fallback with consistent color

--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, memo, useCallback } from 'react'
+import React, { useState, useRef, useEffect, memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useListKeyboardNav, useRouteSync } from '@/hooks'
 import { detectRenderLoop, trackSelectorChange } from '@/utils/renderLoopDetector'
@@ -275,6 +275,11 @@ export const ConversationItem = memo(function ConversationItem({
   const draft = useChatStore((s) => s.drafts.get(conversation.id))
 
   const isGroupChat = conversation.type === 'groupchat'
+  // Room avatars render as a raw <img> (no Avatar fallback). A dead blob: URL
+  // (WebKit reclaim across sleep) would otherwise show a broken-image glyph;
+  // fall back to the Hash icon instead. Reset when the URL changes.
+  const [roomAvatarBroken, setRoomAvatarBroken] = useState(false)
+  useEffect(() => { setRoomAvatarBroken(false) }, [room?.avatar])
   const menuProps = getItemMenuProps(conversation)
   // While the long-press / context menu is open, highlight the targeted cell so
   // the user can clearly see which conversation the action will apply to.
@@ -316,12 +321,14 @@ export const ConversationItem = memo(function ConversationItem({
             keeps its full width and stops truncating short names. */}
         <div className="relative flex-shrink-0">
           {isGroupChat ? (
-            room?.avatar ? (
+            room?.avatar && !roomAvatarBroken ? (
               <img
                 src={room.avatar}
                 alt={conversation.name}
                 className="size-8 rounded-full object-cover"
                 draggable={false}
+                onError={() => setRoomAvatarBroken(true)}
+                onLoad={(e) => { if (e.currentTarget.naturalWidth === 0) setRoomAvatarBroken(true) }}
               />
             ) : (
               <Hash

--- a/apps/fluux/src/hooks/useRenderCostProbe.ts
+++ b/apps/fluux/src/hooks/useRenderCostProbe.ts
@@ -19,7 +19,24 @@
 import { useLayoutEffect, useRef } from 'react'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 
+// Timestamp (performance.now) of the last page visibility transition. When a
+// render's measurement window contains one, the render→commit gap is wall-clock
+// idle (tab hidden, or the laptop slept mid-render) rather than render work —
+// producing absurd "render cost" values (e.g. ~18min for 50 rows after an OS
+// sleep). We discard those, mirroring stallSentinel's document.hidden guard.
+let lastVisibilityChangeAt = Number.NEGATIVE_INFINITY
+let visibilityTrackingStarted = false
+function ensureVisibilityTracking(): void {
+  if (visibilityTrackingStarted || typeof document === 'undefined') return
+  visibilityTrackingStarted = true
+  document.addEventListener('visibilitychange', () => {
+    lastVisibilityChangeAt = performance.now()
+  })
+}
+
 export function useRenderCostProbe(label: string, getContext: () => string): void {
+  ensureVisibilityTracking()
+
   // Read at render-body call time — before this component's children render.
   const renderStart = performance.now()
 
@@ -36,7 +53,11 @@ export function useRenderCostProbe(label: string, getContext: () => string): voi
       const layoutPaintMs = painted - commitDone
       const totalMs = reactMs + layoutPaintMs
 
-      if (probeRef.current?.record(totalMs, painted)) {
+      // A visibility transition at/after renderStart means this window spanned a
+      // hidden/sleep period — the measured cost is idle wall clock, not render work.
+      const spannedHidden = lastVisibilityChangeAt >= renderStart || document.hidden
+
+      if (probeRef.current?.record(totalMs, painted, spannedHidden)) {
         console.warn(
           `[RenderCostProbe] ${label} render cost ~${Math.round(totalMs)}ms ` +
           `(react=${Math.round(reactMs)}ms, layoutPaint=${Math.round(layoutPaintMs)}ms, ${getContext()})`

--- a/apps/fluux/src/utils/renderCostProbe.test.ts
+++ b/apps/fluux/src/utils/renderCostProbe.test.ts
@@ -26,4 +26,18 @@ describe('createRenderCostProbe', () => {
     expect(probe.record(300, 1000)).toBe(true)
     expect(probe.record(300, 6000)).toBe(true)
   })
+
+  it('discards a measurement whose window spanned a hidden/sleep period', () => {
+    const probe = createRenderCostProbe({ thresholdMs: 200, cooldownMs: 5000 })
+    // An OS sleep makes the render→commit wall clock huge (e.g. ~18min for 50
+    // rows). Such a span is not render cost — never report it.
+    expect(probe.record(1_117_261, 1_117_261, true)).toBe(false)
+  })
+
+  it('does not consume the cooldown when discarding a spanned measurement', () => {
+    const probe = createRenderCostProbe({ thresholdMs: 200, cooldownMs: 5000 })
+    // A bogus spanned render must not block the next genuine slow render.
+    expect(probe.record(300, 1000, true)).toBe(false)
+    expect(probe.record(300, 1000, false)).toBe(true)
+  })
 })

--- a/apps/fluux/src/utils/renderCostProbe.ts
+++ b/apps/fluux/src/utils/renderCostProbe.ts
@@ -26,8 +26,14 @@ export interface RenderCostProbe {
    * Record one render whose total cost was `totalMs`, observed at `now` (ms,
    * monotonic e.g. performance.now()). Returns true when the caller should log
    * a diagnostic line (cost ≥ threshold and cooldown elapsed).
+   *
+   * `spannedHidden` flags that the measurement window crossed a page-hidden /
+   * OS-sleep boundary, where the render→commit wall clock measures idle time,
+   * not render work (e.g. ~18min for 50 rows after a laptop sleep). Such a
+   * sample is always discarded, and — being meaningless — does not consume the
+   * cooldown, so it never masks the next genuine slow render.
    */
-  record(totalMs: number, now: number): boolean
+  record(totalMs: number, now: number, spannedHidden?: boolean): boolean
 }
 
 export interface RenderCostProbeOptions {
@@ -51,7 +57,8 @@ export function createRenderCostProbe(
   let lastReportAt = Number.NEGATIVE_INFINITY
 
   return {
-    record(totalMs: number, now: number): boolean {
+    record(totalMs: number, now: number, spannedHidden = false): boolean {
+      if (spannedHidden) return false
       if (totalMs < thresholdMs) return false
       if (now - lastReportAt < cooldownMs) return false
       lastReportAt = now

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -960,6 +960,46 @@ describe('XMPPClient Own Avatar', () => {
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:occupant-avatar', expect.objectContaining({ nick: 'Carol' }))
     })
 
+    it('re-points a roster contact whose hash the mapping store missed', async () => {
+      emitSDKSpy.mockClear()
+
+      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      // A fresh URL exists for the contact's hash, but the IndexedDB mapping
+      // store does NOT list this JID (e.g. the avatar arrived via MUC
+      // vcard-temp presence, not a PEP/vCard fetch). The mapping loop misses it;
+      // the roster-store safety net must still re-point its dead blob.
+      vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-seb', 'blob:fresh-seb']]))
+      vi.mocked(getAllAvatarHashes).mockResolvedValue([])
+      mockStores.roster.sortedContacts.mockReturnValue([
+        { jid: 'seb@example.com', name: 'Seb', presence: 'online', subscription: 'both', avatar: 'blob:dead-seb', avatarHash: 'hash-seb' },
+      ])
+
+      await xmppClient.profile.refreshAllAvatarBlobUrls()
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('roster:avatar', {
+        jid: 'seb@example.com', avatar: 'blob:fresh-seb', avatarHash: 'hash-seb',
+      })
+    })
+
+    it('re-fetches a roster contact whose cached avatar bytes are gone', async () => {
+      emitSDKSpy.mockClear()
+
+      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      // Another contact is cached (so the size-0 short-circuit doesn't fire), but
+      // Seb's hash has no fresh URL → his bytes were evicted from IndexedDB.
+      // His pointer is a now-dead blob, so the safety net must re-fetch to heal.
+      vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-other', 'blob:other']]))
+      vi.mocked(getAllAvatarHashes).mockResolvedValue([])
+      const fetchSpy = vi.spyOn(xmppClient.profile, 'fetchAvatarData').mockResolvedValue()
+      mockStores.roster.sortedContacts.mockReturnValue([
+        { jid: 'seb@example.com', name: 'Seb', presence: 'online', subscription: 'both', avatar: 'blob:dead-seb', avatarHash: 'hash-seb' },
+      ])
+
+      await xmppClient.profile.refreshAllAvatarBlobUrls()
+
+      expect(fetchSpy).toHaveBeenCalledWith('seb@example.com', 'hash-seb')
+    })
+
     it('should re-point the current user\'s own avatar via connection:own-avatar', async () => {
       emitSDKSpy.mockClear()
 

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -1043,6 +1043,30 @@ export class Profile extends BaseModule {
         }
       }
 
+      // Safety net for roster contacts the mapping loop above missed. The loop
+      // only re-points JIDs present in the IndexedDB hash-mapping store, but a
+      // contact can hold a (now-dead) avatar blob without such a mapping — e.g.
+      // its avatar arrived via MUC vcard-temp presence rather than a PEP/vCard
+      // fetch, or the mapping/data was evicted. Without this, that contact keeps
+      // a dead blob: URL after a WebKit reclaim and renders as a broken image.
+      // Drive off the roster store (source of truth for live contacts + hashes):
+      //   - hash bytes still cached → re-point to the fresh URL (idempotent),
+      //   - hash bytes gone        → re-fetch so it heals instead of staying broken.
+      const contacts = this.deps.stores?.roster?.sortedContacts?.() ?? []
+      for (const contact of contacts) {
+        if (!contact.avatarHash) continue
+        const url = freshUrls.get(contact.avatarHash)
+        if (url) {
+          if (contact.avatar !== url) {
+            this.updateAvatar(contact.jid, url, contact.avatarHash)
+          }
+        } else if (!contact.avatar || contact.avatar.startsWith('blob:')) {
+          // Only refetch contacts whose current pointer is empty or a revoked
+          // blob: URL — leave data: URIs and other live pointers untouched.
+          this.fetchAvatarData(contact.jid, contact.avatarHash).catch(() => {})
+        }
+      }
+
       // MUC occupant avatars live in each room's occupant map (keyed by nick),
       // not in the contact/room hash store, so the loop above never touches
       // them. After blob invalidation (WebKit reclaiming memory on sleep, or


### PR DESCRIPTION
## Summary

Two fixes triggered by a log + screenshot taken after an ~11h laptop sleep.

**1. Bogus render-cost warnings.** `RenderCostProbe` logged impossible costs (`react=1117260ms` ≈ 18 min for 50 rows) because it brackets render→commit with `performance.now()` and had no guard for the page being hidden / the machine sleeping mid-render. The sibling `stallSentinel` already guards this; the probe didn't. Now any sample whose window spanned a `visibilitychange` (or fires while hidden) is discarded, without consuming the cooldown. Genuine pre-sleep stalls still log.

**2. Permanently-broken avatar after sleep.** WebKit reclaims a `blob:` URL's backing store across a long sleep (`WebKitBlobResource error 1`). `refreshAllAvatarBlobUrls` only re-points JIDs in the IndexedDB hash-*mapping* store, so a contact known via MUC vcard-temp presence could keep a dead blob. Two layers:
- **Source:** roster-store safety net in `refreshAllAvatarBlobUrls` — re-point every contact whose cached bytes survived, re-fetch the ones whose bytes were evicted. Uses existing bindings (`sortedContacts`/`updateAvatar`), no new SDK surface.
- **Resilience:** WebKit doesn't reliably fire `img.onerror` for a dead blob, so the letter fallback never triggered. `Avatar` now detects a failed image via a ref liveness check (`complete && naturalWidth === 0`, immediate + deferred) plus an `onLoad` empty check; the conversation-list room `<img>` (which had no fallback) now falls back to the Hash icon.