### PR TITLE
fix(e2ee): classify malformed OpenPGP ciphertext as terminal, not retryable

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -303,7 +303,16 @@ export function classifyBoundaryError(err: unknown): { kind: E2EEErrorKind; code
     // "Error during parsing. This message / key probably does not conform to
     // a valid OpenPGP format." Structurally malformed → never decrypts.
     msg.includes('during parsing') ||
-    msg.includes('conform to a valid openpgp')
+    msg.includes('conform to a valid openpgp') ||
+    // Sequoia stream decryptor fed bytes that are not parseable OpenPGP at
+    // all: "Malformed packet: Malformed CTB: MSB of ptag … not set (ptag is
+    // a dash, perhaps this is an ASCII-armor encoded message)". Like the
+    // openpgp.js cases above, no key change can ever open structurally
+    // invalid bytes, so this is terminal — without it the failure falls
+    // through to `transient/unknown` and stanzaDecrypt re-stashes the
+    // message, making retryPendingDecrypts re-attempt (and re-log) it on
+    // every launch forever.
+    msg.includes('malformed packet')
   ) {
     return { kind: 'permanent', code: 'malformed-data' }
   }

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -3145,6 +3145,26 @@ describe('SequoiaPgpPlugin', () => {
       expect(code).toBe('key-unrecoverable')
     })
 
+    it('classifies a Sequoia malformed-packet decrypt failure as permanent malformed-data', () => {
+      // Real production failure (dev-era / corrupt ciphertext): the stored
+      // <openpgp> payload is not parseable OpenPGP at all. Sequoia's stream
+      // decryptor reports "Malformed CTB: MSB of ptag not set (ptag is a
+      // dash, perhaps this is an ASCII-armor encoded message)". No key change
+      // can ever open structurally invalid bytes, so this MUST be a PERMANENT
+      // `malformed-data` — otherwise stanzaDecrypt re-stashes it and
+      // retryPendingDecrypts re-attempts (and re-logs) it on every launch
+      // forever.
+      const { kind, code } = SequoiaPgpPlugin.classifyBoundaryError(
+        new Error(
+          'SequoiaPgpPlugin: decrypt: open decryptor: Malformed packet: Malformed CTB: ' +
+            'MSB of ptag (0b00101101) not set (ptag is a dash, perhaps this is an ' +
+            'ASCII-armor encoded message).',
+        ),
+      )
+      expect(kind).toBe('permanent')
+      expect(code).toBe('malformed-data')
+    })
+
     it('init() swallows an unrecoverable local key and flags recovery instead of throwing', async () => {
       // The stored passphrase no longer decrypts the on-disk TSK. init()
       // must NOT throw (which would fail registration and hide the recovery


### PR DESCRIPTION
## Summary

Unparseable OpenPGP ciphertext was treated as a *transient* decrypt failure, so it got re-stashed and re-attempted on **every launch forever** — leaving a permanent "could not be decrypted" placeholder and a burst of `[E2EE] decrypt failed … (retryable)` WARN logs at each start.

Root cause: Sequoia's structural-parse error (`open decryptor: Malformed packet: Malformed CTB: MSB of ptag … not set (ptag is a dash, … ASCII-armor …)`) matched no pattern in `classifyBoundaryError`, falling through to `{ kind: 'transient', code: 'unknown' }`. `stanzaDecrypt` only marks a failure terminal (no stash, no retry) when it's `permanent` + `malformed-data`.

Fix: match `malformed packet` in the `malformed-data` branch (alongside the existing openpgp.js cases). Bytes that aren't parseable OpenPGP never decrypt regardless of key state, so the failure is terminal: no re-stash, stable placeholder ("Could not decrypt (malformed)"), no retry churn. Messages already stashed under the old behaviour self-heal in one final retry that clears the stash (`retryDecryptSingle` sees no `encryptedPayloadXml`, since `stanzaDecrypt` gates it on `!terminalFailure`).