### PR TITLE
chore(e2ee): log deferred reaction/retraction resolution (observability)

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1841,6 +1841,20 @@ export class XMPPClient {
     chatBindings: StoreBindings['chat'],
   ): void {
     const actorJid = getBareJid(placeholder.from)
+    // Diagnostic (race investigation): a deferred reaction/retraction can only
+    // attach to its target if that target is in the loaded set when this runs.
+    // retryPendingDecrypts is a one-shot pass (launch / key-unlock); nothing
+    // re-runs it when a target enters the store later via scroll/MAM. Record
+    // whether target + placeholder were present so a "resolved only after
+    // relaunch" report can be confirmed against the actual presence at apply
+    // time. Domains only — no message content.
+    const targetPresent = !!chatBindings.getMessage(conversationId, modification.targetId)
+    const placeholderPresent = !!chatBindings.getMessage(conversationId, placeholder.id)
+    logInfo(
+      `E2EE deferred modification: type=${modification.type} conv=${getDomain(conversationId)} ` +
+      `targetPresent=${targetPresent} placeholderPresent=${placeholderPresent}` +
+      (targetPresent ? '' : ' — target not loaded, signal cannot attach until a later pass'),
+    )
     if (modification.type === 'reactions') {
       chatBindings.updateReactions(conversationId, modification.targetId, actorJid, modification.emojis)
     } else {


### PR DESCRIPTION
## Summary

Adds a single diagnostic log line when a deferred bodiless signal (XEP-0444 reaction / XEP-0424 retraction) recovered from a deferred decrypt is applied to its target.

`retryPendingDecrypts` is a one-shot pass (fires on launch / key-unlock / plugin-register); nothing re-runs it when a reaction's target message enters the store later via scroll or a late MAM result. When that happens, the reaction can't attach and its placeholder lingers as a phantom "could not be decrypted" bubble until the next launch — a "resolved only after relaunch" symptom that is otherwise invisible in logs.

The line records, at apply time:
- `type` (reactions/retract)
- `conv` (domain only — no JID localpart, no content)
- `targetPresent` — was the target message loaded?
- `placeholderPresent` — was the placeholder in memory (vs durable-cache only)?

`targetPresent=false` on a reaction pinpoints the race. Kept in production (not a throwaway build) because the event is rare and the symptom is hard to reproduce on demand — having the trace already in the field lets us diagnose the next real occurrence without shipping a special build.

No behaviour change; logging only.