### PR TITLE
fix(media): web encrypted attachments fail to decrypt (Cache API scheme guard)

### DIFF
--- a/apps/fluux/src/utils/mediaCache.test.ts
+++ b/apps/fluux/src/utils/mediaCache.test.ts
@@ -42,7 +42,8 @@ vi.mock('@tauri-apps/plugin-http', () => ({
   fetch: (url: string, opts: unknown) => mockTauriFetch(url, opts),
 }))
 
-import { resolveMediaUrl, clearMediaCache, getMediaCacheSize, resetMediaUrlCache, peekMediaCache, peekEncryptedMediaCache, peekWebMediaCache, peekWebEncryptedMediaCache } from './mediaCache'
+import { resolveMediaUrl, resolveWebMediaUrl, resolveEncryptedMediaUrl, clearMediaCache, getMediaCacheSize, resetMediaUrlCache, peekMediaCache, peekEncryptedMediaCache, peekWebMediaCache, peekWebEncryptedMediaCache, resolveWebEncryptedMediaUrl } from './mediaCache'
+import { encryptFile } from '@fluux/sdk'
 
 describe('mediaCache', () => {
   beforeEach(() => {
@@ -241,6 +242,78 @@ describe('peekMediaCache (Tauri, network-free)', () => {
   })
 })
 
+describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMediaUrlCache()
+    mockIsTauri.mockReturnValue(true)
+    mockAppCacheDir.mockResolvedValue('/cache/com.processone.fluux')
+    mockJoin.mockImplementation((...args: string[]) => Promise.resolve(args.join('/')))
+    mockExists.mockResolvedValue(false)
+    mockMkdir.mockResolvedValue(undefined)
+    mockWriteFile.mockResolvedValue(undefined)
+    mockConvertFileSrc.mockImplementation((p: string) => `https://asset.localhost/${p}`)
+  })
+
+  it('fetches ciphertext, decrypts, writes plaintext, and returns a .dec asset URL', async () => {
+    const plaintext = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 8, 7])
+    const enc = await encryptFile(plaintext)
+    mockTauriFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(enc.ciphertext.slice().buffer),
+    })
+
+    const url = await resolveEncryptedMediaUrl('https://upload.example.com/enc.bin', {
+      cipher: 'aes-256-gcm',
+      key: enc.key,
+      iv: enc.iv,
+    })
+
+    expect(mockTauriFetch).toHaveBeenCalledWith('https://upload.example.com/enc.bin', { method: 'GET' })
+    // The DECRYPTED plaintext (not the ciphertext) is what gets written to the
+    // `.dec` cache file, so no AES key needs to persist across sessions.
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    const [writtenPath, writtenBytes] = mockWriteFile.mock.calls[0]
+    expect(writtenPath).toMatch(/\.dec$/)
+    expect(Array.from(writtenBytes as Uint8Array)).toEqual(Array.from(plaintext))
+    expect(url).toMatch(/^https:\/\/asset\.localhost\/.*\.dec$/)
+  })
+
+  it('serves the cached .dec file on a second call without re-fetching or re-decrypting', async () => {
+    const enc = await encryptFile(new Uint8Array([1, 1, 2, 3, 5, 8]))
+    mockTauriFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(enc.ciphertext.slice().buffer),
+    })
+    const httpsUrl = 'https://upload.example.com/enc-again.bin'
+    const encryption = { cipher: 'aes-256-gcm' as const, key: enc.key, iv: enc.iv }
+
+    const first = await resolveEncryptedMediaUrl(httpsUrl, encryption)
+    resetMediaUrlCache()               // drop in-memory index → consult filesystem
+    mockExists.mockResolvedValue(true) // the `.dec` plaintext now exists on disk
+    const second = await resolveEncryptedMediaUrl(httpsUrl, encryption)
+
+    expect(first).toMatch(/\.dec$/)
+    expect(second).toMatch(/\.dec$/)
+    // Second resolve is a pure cache hit: no download, no second decrypt+write.
+    expect(mockTauriFetch).toHaveBeenCalledTimes(1)
+    expect(mockWriteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws on a non-ok fetch without writing anything', async () => {
+    mockTauriFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' })
+
+    await expect(
+      resolveEncryptedMediaUrl('https://upload.example.com/missing.bin', {
+        cipher: 'aes-256-gcm',
+        key: new Uint8Array(32),
+        iv: new Uint8Array(12),
+      }),
+    ).rejects.toThrow('Fetch failed: 404 Not Found')
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})
+
 describe('peekEncryptedMediaCache (Tauri, network-free)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -296,6 +369,125 @@ describe('peekWebMediaCache (web Cache API, network-free)', () => {
   it('returns null when the Cache API is unavailable', async () => {
     vi.stubGlobal('caches', undefined)
     expect(await peekWebMediaCache('https://x/a.png')).toBeNull()
+  })
+})
+
+describe('resolveWebEncryptedMediaUrl (web Cache API, scheme safety)', () => {
+  const fetchSpy = vi.fn()
+  let store: Map<string, Response>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMediaUrlCache()
+    mockIsTauri.mockReturnValue(false)
+    store = new Map()
+    // Faithful Cache API mock: like a real browser, put() rejects any request
+    // whose URL scheme is not http/https. This is what catches a cache key
+    // such as `decrypted:https://...` (scheme = "decrypted").
+    vi.stubGlobal('caches', {
+      open: async () => ({
+        match: async (key: unknown) => store.get(String(key)),
+        put: async (key: unknown, res: Response) => {
+          const k = String(key)
+          const scheme = k.slice(0, k.indexOf(':'))
+          if (scheme !== 'http' && scheme !== 'https') {
+            throw new TypeError(
+              `Failed to execute 'put' on 'Cache': Request scheme '${scheme}' is unsupported`,
+            )
+          }
+          store.set(k, res)
+        },
+      }),
+      delete: async () => true,
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  it('fetches, decrypts, and caches without tripping the Cache API scheme guard', async () => {
+    const plaintext = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]) // PNG-ish
+    const enc = await encryptFile(plaintext)
+    fetchSpy.mockResolvedValue(new Response(new Blob([enc.ciphertext.slice()])))
+
+    const url = await resolveWebEncryptedMediaUrl('https://upload.example.com/file.bin', {
+      cipher: 'aes-256-gcm',
+      key: enc.key,
+      iv: enc.iv,
+    })
+
+    // A successful decrypt must yield a blob URL the renderer can use — not throw
+    // because the plaintext could not be written to the decrypted-media cache.
+    expect(url).toMatch(/^blob:/)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves the cached plaintext on a second call without re-fetching', async () => {
+    const enc = await encryptFile(new Uint8Array([10, 20, 30, 40]))
+    fetchSpy.mockResolvedValue(new Response(new Blob([enc.ciphertext.slice()])))
+
+    const httpsUrl = 'https://upload.example.com/again.bin'
+    const encryption = { cipher: 'aes-256-gcm' as const, key: enc.key, iv: enc.iv }
+
+    const first = await resolveWebEncryptedMediaUrl(httpsUrl, encryption)
+    resetMediaUrlCache() // drop the in-memory index so the Cache API is consulted
+    const second = await resolveWebEncryptedMediaUrl(httpsUrl, encryption)
+
+    expect(first).toMatch(/^blob:/)
+    expect(second).toMatch(/^blob:/)
+    // Second resolve is served from the persisted plaintext, not a new download.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolveWebMediaUrl (web Cache API, scheme safety)', () => {
+  const fetchSpy = vi.fn()
+  let store: Map<string, Response>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMediaUrlCache()
+    mockIsTauri.mockReturnValue(false)
+    store = new Map()
+    // Same faithful Cache API mock as the encrypted suite: put() rejects any
+    // request whose URL scheme is not http/https, mirroring the real browser.
+    vi.stubGlobal('caches', {
+      open: async () => ({
+        match: async (key: unknown) => store.get(String(key)),
+        put: async (key: unknown, res: Response) => {
+          const k = String(key)
+          const scheme = k.slice(0, k.indexOf(':'))
+          if (scheme !== 'http' && scheme !== 'https') {
+            throw new TypeError(
+              `Failed to execute 'put' on 'Cache': Request scheme '${scheme}' is unsupported`,
+            )
+          }
+          store.set(k, res)
+        },
+      }),
+      delete: async () => true,
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  it('fetches and caches plaintext without tripping the Cache API scheme guard', async () => {
+    fetchSpy.mockResolvedValue(new Response(new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })))
+
+    const url = await resolveWebMediaUrl('https://upload.example.com/plain.png')
+
+    expect(url).toMatch(/^blob:/)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves the cached bytes on a second call without re-fetching', async () => {
+    fetchSpy.mockResolvedValue(new Response(new Blob([new Uint8Array([4, 5, 6])], { type: 'image/png' })))
+    const httpsUrl = 'https://upload.example.com/plain-again.png'
+
+    const first = await resolveWebMediaUrl(httpsUrl)
+    resetMediaUrlCache() // drop the in-memory index so the Cache API is consulted
+    const second = await resolveWebMediaUrl(httpsUrl)
+
+    expect(first).toMatch(/^blob:/)
+    expect(second).toMatch(/^blob:/)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/fluux/src/utils/mediaCache.ts
+++ b/apps/fluux/src/utils/mediaCache.ts
@@ -359,7 +359,11 @@ export async function peekWebEncryptedMediaCache(httpsUrl: string): Promise<stri
   if (cached) return cached
 
   if (typeof caches === 'undefined') return null
-  const webCacheKey = `decrypted:${httpsUrl}`
+  // Key the dedicated decrypted-media cache with the plain https URL. The
+  // Cache API rejects put()/match() requests whose scheme is not http(s), so a
+  // synthetic prefix like `decrypted:` would make put() throw — a separate
+  // cache name (WEB_DECRYPTED_CACHE_NAME) already isolates it from plaintext.
+  const webCacheKey = httpsUrl
   const cache = await caches.open(WEB_DECRYPTED_CACHE_NAME)
   const cachedResponse = await cache.match(webCacheKey)
   if (cachedResponse) {
@@ -410,7 +414,9 @@ async function doResolveWebEncrypted(
   const peeked = await peekWebEncryptedMediaCache(httpsUrl)
   if (peeked) return peeked
 
-  const webCacheKey = `decrypted:${httpsUrl}`
+  // Plain https key: the Cache API rejects non-http(s) request schemes, so the
+  // key cannot carry a synthetic prefix. See peekWebEncryptedMediaCache.
+  const webCacheKey = httpsUrl
   const cache = await caches.open(WEB_DECRYPTED_CACHE_NAME)
 
   const response = await fetch(httpsUrl)


### PR DESCRIPTION
## Summary

Encrypted media attachments never displayed on the **web** build — they showed *"Image no longer available"* even after the upload-server CORS fix that let the ciphertext download succeed.

**Fix:** key the dedicated decrypted-media cache (`WEB_DECRYPTED_CACHE_NAME`) with the plain `https` URL. The separate cache name already isolates it from the plaintext cache, so no prefix is needed.