### PR TITLE
fix(whisper): keep corrections, reactions, retractions, and typing private (XEP-0045 §7.5)

### DIFF
--- a/apps/fluux/src/components/RoomMessageInput.memo.test.tsx
+++ b/apps/fluux/src/components/RoomMessageInput.memo.test.tsx
@@ -16,7 +16,7 @@ import { RoomMessageInput } from './RoomView'
 const STABLE: ComponentProps<typeof RoomMessageInput> = {
   roomJid: 'room@conf.example.com',
   sendMessage: vi.fn(), sendCorrection: vi.fn(), retractMessage: vi.fn(),
-  sendChatState: vi.fn(), sendEasterEgg: vi.fn(), sendPoll: vi.fn(),
+  sendChatState: vi.fn(), sendWhisperChatState: vi.fn(), sendEasterEgg: vi.fn(), sendPoll: vi.fn(),
   replyingTo: null, onCancelReply: vi.fn(), editingMessage: null, onCancelEdit: vi.fn(),
   isConnected: true, sendWhisper: vi.fn(), whisperTarget: null,
 }

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1834,6 +1834,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
     // Clear draft immediately so sidebar updates
     clearDraft(roomJid)
 
+    // Whisper sends return early above, so a private URL never reaches link-preview generation (no room broadcast).
     // Process link preview in background (don't block on it)
     if (processLinkPreview && sendText) {
       processLinkPreview(messageId, sendText, roomJid, 'groupchat').catch(console.error)

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useRoomActive, useRoomEntity, useRoomOccupantCount, useContactIdentities, getBareJid, generateConsistentColorHexSync, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
+import { useRoomActive, useRoomEntity, useRoomOccupantCount, useContactIdentities, getBareJid, generateConsistentColorHexSync, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, WhisperCounterpartGoneError, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useMessageHoverState, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, isSmallScreen } from '@/hooks'
-import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
+import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, decideChatStateRoute, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar } from './Avatar'
@@ -78,7 +78,7 @@ const EMPTY_OCCUPANTS: Map<string, RoomOccupant> = new Map()
 export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = false, onShowOccupantsChange, onStartChat, onShowProfile, findOnPageRef, onSearchInConversation }: RoomViewProps) {
   detectRenderLoop('RoomView')
   const { t } = useTranslation()
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, sendWhisperChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId } = useRoomActive()
   const mediaPolicy = useSettingsStore((s) => s.mediaAutoDownload)
 
   // NOTE: Use focused selectors instead of useConnection() hook to avoid
@@ -570,6 +570,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             sendCorrection={sendCorrection}
             retractMessage={retractMessage}
             sendChatState={sendChatState}
+            sendWhisperChatState={sendWhisperChatState}
             sendEasterEgg={sendEasterEgg}
             sendPoll={sendPoll}
             onMessageSent={scrollToBottom}
@@ -1212,6 +1213,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   isCurrentMatch,
 }: RoomMessageBubbleWrapperProps) {
   const { t } = useTranslation()
+  const addToast = useToastStore((s) => s.addToast)
 
   // Moderation confirmation state
   const [showModerateConfirm, setShowModerateConfirm] = useState(false)
@@ -1263,7 +1265,13 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
       ? myReactions.filter(e => e !== emoji)
       : [...myReactions, emoji]
 
-    void sendReaction(roomJid, message.id, newReactions)
+    sendReaction(roomJid, message.id, newReactions).catch((e) => {
+      if (e instanceof WhisperCounterpartGoneError) {
+        addToast('info', t('rooms.whisperCounterpartGone', { nick: e.nick }))
+        return
+      }
+      throw e
+    })
   }
 
   // Handle poll vote — uses SDK vote() which enforces single/multi-vote rules
@@ -1547,6 +1555,7 @@ interface RoomMessageInputProps {
   sendCorrection: (roomJid: string, messageId: string, newBody: string, attachment?: FileAttachment) => Promise<void>
   retractMessage: (roomJid: string, messageId: string) => Promise<void>
   sendChatState: (roomJid: string, state: ChatStateNotification) => Promise<void>
+  sendWhisperChatState: (roomJid: string, nick: string, state: ChatStateNotification) => Promise<void>
   sendEasterEgg: (roomJid: string, animation: string) => Promise<void>
   sendPoll: (roomJid: string, title: string, options: string[], settings?: Partial<import('@fluux/sdk').PollSettings>, description?: string, deadline?: string, customEmojis?: string[]) => Promise<string>
   onMessageSent?: () => void
@@ -1578,6 +1587,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
   sendCorrection,
   retractMessage,
   sendChatState,
+  sendWhisperChatState,
   sendEasterEgg,
   sendPoll,
   onMessageSent,
@@ -1738,13 +1748,29 @@ export const RoomMessageInput = memo(function RoomMessageInput({
 
   // Handle correction
   const handleCorrection = async (messageId: string, newBody: string, attachment?: import('@fluux/sdk').FileAttachment): Promise<boolean> => {
-    await sendCorrection(roomJid, messageId, newBody, attachment)
-    return true
+    try {
+      await sendCorrection(roomJid, messageId, newBody, attachment)
+      return true
+    } catch (e) {
+      if (e instanceof WhisperCounterpartGoneError) {
+        addToast('info', t('rooms.whisperCounterpartGone', { nick: e.nick }))
+        return false
+      }
+      throw e
+    }
   }
 
   // Handle retraction (when edit removes all content)
   const handleRetract = async (messageId: string): Promise<void> => {
-    await retractMessage(roomJid, messageId)
+    try {
+      await retractMessage(roomJid, messageId)
+    } catch (e) {
+      if (e instanceof WhisperCounterpartGoneError) {
+        addToast('info', t('rooms.whisperCounterpartGone', { nick: e.nick }))
+        return
+      }
+      throw e
+    }
   }
 
   // Handle send
@@ -1829,9 +1855,9 @@ export const RoomMessageInput = memo(function RoomMessageInput({
 
   // Handle typing state
   const handleTypingState = (state: 'composing' | 'paused') => {
-    if (shouldSendTypingNotifications) {
-      void sendChatState(roomJid, state)
-    }
+    const route = decideChatStateRoute(whisperTarget ?? null, shouldSendTypingNotifications)
+    if (route.target === 'whisper') void sendWhisperChatState(roomJid, route.nick, state)
+    else if (route.target === 'room') void sendChatState(roomJid, state)
   }
 
   // Clear references when text is cleared

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -27,6 +27,7 @@ import { PollCard } from './PollCard'
 import { PollClosedCard } from './PollClosedCard'
 import { Tooltip } from '../Tooltip'
 import { MessageActionSheet } from './MessageActionSheet'
+import { computeMessageActions } from './messageActionCapabilities'
 
 export interface MessageBubbleProps {
   // Core message data (using BaseMessage interface)
@@ -340,8 +341,23 @@ export const MessageBubble = memo(function MessageBubble({
   )
   const displayTrust = resolveDisplayTrust(message.securityContext, verifiedFingerprint)
 
+  const inThread = !!whisperThread
+  const counterpartGone = inThread && counterpartPresent === false
+
   // Whether reactions are enabled for this message (room has stable occupant identity)
   const reactionsEnabled = onReaction !== undefined
+
+  const actions = computeMessageActions({
+    isOutgoing: message.isOutgoing,
+    isPrivate: inThread,
+    isLastOutgoing,
+    isLastMessage,
+    inThread,
+    counterpartGone,
+    isIrcGateway: isIrcGateway ?? false,
+    canModerate: canModerate === true,
+    reactionsEnabled,
+  })
 
   // Wrap setShowReactionPicker to notify parent
   const setShowReactionPicker = (isOpen: boolean) => {
@@ -349,8 +365,9 @@ export const MessageBubble = memo(function MessageBubble({
     onReactionPickerChange?.(isOpen)
   }
 
-  const handleReaction = reactionsEnabled ? (emoji: string) => {
-    onReaction(emoji)
+  // actions.canReact implies reactionsEnabled (i.e. onReaction !== undefined).
+  const handleReaction = actions.canReact ? (emoji: string) => {
+    onReaction!(emoji)
     setShowReactionPicker(false)
   } : undefined
 
@@ -382,22 +399,17 @@ export const MessageBubble = memo(function MessageBubble({
 
   // Whisper thread (XEP-0045 §7.5): a same-counterpart private run renders as one
   // bounded "private with X" container; the strip on the first row carries the label.
-  const inThread = !!whisperThread
   const threadStart = whisperThread === 'start' || whisperThread === 'solo'
   const threadEnd = whisperThread === 'end' || whisperThread === 'solo'
-  // Counterpart left the room: the thread becomes read-only (can't reply privately).
-  const counterpartGone = inThread && counterpartPresent === false
   const outerRowClass = inThread
     ? `group flex gap-4 -mx-4 px-4 transition-colors ${threadStart ? 'pt-3' : ''} ${threadEnd ? 'pb-1.5' : ''}`
     : `group flex gap-4 ${hoverClass} -mx-4 px-4 py-0.5 transition-colors ${showAvatar ? 'pt-4' : ''}`
 
   // Action capabilities — shared by the hover toolbar (MessageToolbar) and the
   // touch action sheet (MessageActionSheet) so the two surfaces stay in lock-step.
-  const canReply = (!isLastMessage || inThread) && !counterpartGone
-  const canEdit = message.isOutgoing && isLastOutgoing && !isIrcGateway
-  const canDelete = (message.isOutgoing || canModerate === true) && !isIrcGateway
+  const { canReply, canEdit, canDelete } = actions
   const canCopyBody = !!message.body && !message.isRetracted && !message.encryptedPayload && !message.unsupportedEncryption
-  const hasMessageActions = !message.isRetracted && (reactionsEnabled || canReply || canEdit || canDelete || canCopyBody)
+  const hasMessageActions = !message.isRetracted && (actions.canReact || canReply || canEdit || canDelete || canCopyBody)
 
   // Long-press (touch) → open the action sheet; scrolling (touchmove) or lifting
   // before the threshold cancels it. longPressFired suppresses the click that a

--- a/apps/fluux/src/components/conversation/index.ts
+++ b/apps/fluux/src/components/conversation/index.ts
@@ -24,8 +24,8 @@ export type { MessageBubbleProps } from './MessageBubble'
 export { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage, canClosePoll } from './messageGrouping'
 export type { MessageGroup, WhisperThreadPosition } from './messageGrouping'
 
-export { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend } from './whisperTarget'
-export type { WhisperTarget, WhisperSendDecision } from './whisperTarget'
+export { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend, decideChatStateRoute } from './whisperTarget'
+export type { WhisperTarget, WhisperSendDecision, ChatStateRoute } from './whisperTarget'
 
 export { MessageList } from './MessageList'
 export type { MessageListProps } from './MessageList'

--- a/apps/fluux/src/components/conversation/messageActionCapabilities.test.ts
+++ b/apps/fluux/src/components/conversation/messageActionCapabilities.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { computeMessageActions } from './messageActionCapabilities'
+
+const base = {
+  isOutgoing: true, isPrivate: false, isLastOutgoing: true, isLastMessage: false,
+  inThread: false, counterpartGone: false, isIrcGateway: false, canModerate: false,
+  reactionsEnabled: true,
+}
+
+describe('computeMessageActions', () => {
+  it('public own last message: edit/delete/react/reply all allowed', () => {
+    const a = computeMessageActions(base)
+    expect(a).toEqual({ canReply: true, canEdit: true, canDelete: true, canReact: true })
+  })
+
+  it('whisper with the counterpart gone: every action disabled', () => {
+    const a = computeMessageActions({ ...base, isPrivate: true, inThread: true, counterpartGone: true })
+    expect(a).toEqual({ canReply: false, canEdit: false, canDelete: false, canReact: false })
+  })
+
+  it('incoming whisper: no moderation-based delete even for a moderator', () => {
+    const a = computeMessageActions({
+      ...base, isOutgoing: false, isPrivate: true, inThread: true, isLastOutgoing: false, canModerate: true,
+    })
+    expect(a.canDelete).toBe(false) // private message cannot be moderated
+    expect(a.canReact).toBe(true)   // can still react while counterpart present
+  })
+
+  it('public message a moderator can delete: moderation delete still allowed', () => {
+    const a = computeMessageActions({
+      ...base, isOutgoing: false, isLastOutgoing: false, canModerate: true,
+    })
+    expect(a.canDelete).toBe(true)
+  })
+
+  it('IRC gateway: no edit/delete', () => {
+    const a = computeMessageActions({ ...base, isIrcGateway: true })
+    expect(a.canEdit).toBe(false)
+    expect(a.canDelete).toBe(false)
+  })
+})

--- a/apps/fluux/src/components/conversation/messageActionCapabilities.test.ts
+++ b/apps/fluux/src/components/conversation/messageActionCapabilities.test.ts
@@ -38,4 +38,11 @@ describe('computeMessageActions', () => {
     expect(a.canEdit).toBe(false)
     expect(a.canDelete).toBe(false)
   })
+
+  it('own whisper with counterpart present: delete (retract) allowed', () => {
+    const a = computeMessageActions({ ...base, isPrivate: true, inThread: true })
+    expect(a.canDelete).toBe(true)
+    expect(a.canEdit).toBe(true)
+    expect(a.canReact).toBe(true)
+  })
 })

--- a/apps/fluux/src/components/conversation/messageActionCapabilities.ts
+++ b/apps/fluux/src/components/conversation/messageActionCapabilities.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure capability rules for a message's action surfaces (hover toolbar + touch
+ * action sheet). Extracted so the whisper (XEP-0045 §7.5) gating is testable.
+ *
+ * Whisper parity with a 1:1 DM:
+ * - own whisper: edit / delete (retract) / react / reply
+ * - incoming whisper: react / reply (NO edit; NO moderation-delete)
+ * - any whisper: disabled once the counterpart has left (counterpartGone)
+ */
+export interface MessageActionInputs {
+  isOutgoing: boolean
+  /** The message is a whisper (private MUC message). */
+  isPrivate: boolean
+  isLastOutgoing: boolean
+  isLastMessage: boolean
+  /** The message is rendered inside a whisper thread. */
+  inThread: boolean
+  /** Whisper counterpart has left the room (thread is read-only). */
+  counterpartGone: boolean
+  isIrcGateway: boolean
+  canModerate: boolean
+  /** The room exposes reactions (stable occupant identity available). */
+  reactionsEnabled: boolean
+}
+
+export interface MessageActionCapabilities {
+  canReply: boolean
+  canEdit: boolean
+  canDelete: boolean
+  canReact: boolean
+}
+
+export function computeMessageActions(i: MessageActionInputs): MessageActionCapabilities {
+  return {
+    canReply: (!i.isLastMessage || i.inThread) && !i.counterpartGone,
+    canEdit: i.isOutgoing && i.isLastOutgoing && !i.isIrcGateway && !i.counterpartGone,
+    // XEP-0045 §7.5: a private whisper cannot be moderated (no server archive), so
+    // the moderator path is suppressed for whispers; gate on counterpart presence.
+    canDelete: (i.isOutgoing || (i.canModerate && !i.isPrivate)) && !i.isIrcGateway && !i.counterpartGone,
+    canReact: i.reactionsEnabled && !i.counterpartGone,
+  }
+}

--- a/apps/fluux/src/components/conversation/whisperTarget.test.ts
+++ b/apps/fluux/src/components/conversation/whisperTarget.test.ts
@@ -9,7 +9,7 @@
  * nor sent at all once the counterpart has left.
  */
 import { describe, it, expect } from 'vitest'
-import { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend } from './whisperTarget'
+import { resolveWhisperTarget, whisperTargetPresent, decideWhisperSend, decideChatStateRoute } from './whisperTarget'
 
 const occ = (nick: string, occupantId?: string) => ({ nick, occupantId })
 const occupantsOf = (...list: { nick: string; occupantId?: string }[]) =>
@@ -89,5 +89,19 @@ describe('decideWhisperSend (send-time guard)', () => {
   it('refuses present-but-empty before checking presence (empty wins)', () => {
     const decision = decideWhisperSend({ nick: 'bob', occupantId: 'occ-1' }, '', occupantsOf())
     expect(decision).toEqual({ ok: false, reason: 'empty', nick: 'bob' })
+  })
+})
+
+describe('decideChatStateRoute', () => {
+  it('suppresses typing when notifications are disabled', () => {
+    expect(decideChatStateRoute({ nick: 'bob' }, false)).toEqual({ target: 'none' })
+  })
+
+  it('routes to the room when not whispering', () => {
+    expect(decideChatStateRoute(null, true)).toEqual({ target: 'room' })
+  })
+
+  it('routes privately to the whisper target', () => {
+    expect(decideChatStateRoute({ nick: 'bob' }, true)).toEqual({ target: 'whisper', nick: 'bob' })
   })
 })

--- a/apps/fluux/src/components/conversation/whisperTarget.ts
+++ b/apps/fluux/src/components/conversation/whisperTarget.ts
@@ -68,3 +68,21 @@ export function decideWhisperSend(
   }
   return { ok: true, nick: target.nick, body }
 }
+
+/**
+ * Where a composer chat-state (typing indicator) should go. While a whisper is
+ * being composed it must be addressed privately to the target (XEP-0045 §7.5),
+ * never broadcast to the room. `none` suppresses the state entirely.
+ */
+export type ChatStateRoute =
+  | { target: 'whisper'; nick: string }
+  | { target: 'room' }
+  | { target: 'none' }
+
+export function decideChatStateRoute(
+  whisperTarget: WhisperTarget | null,
+  shouldSendTypingNotifications: boolean,
+): ChatStateRoute {
+  if (!shouldSendTypingNotifications) return { target: 'none' }
+  return whisperTarget ? { target: 'whisper', nick: whisperTarget.nick } : { target: 'room' }
+}

--- a/docs/superpowers/plans/2026-06-24-whisper-operation-parity.md
+++ b/docs/superpowers/plans/2026-06-24-whisper-operation-parity.md
@@ -1,0 +1,1215 @@
+# Whisper Operation Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make corrections, reactions, retractions, and typing indicators on a whisper (XEP-0045 §7.5 private message) stay private — addressed to the one occupant, never broadcast to the room — both when sent and when received.
+
+**Architecture:** The SDK auto-detects when an operation targets a stored whisper (a `RoomMessage` with `isPrivate` + `whisperWith`) and rewrites the wire recipient to `room@conf/nick` (`type=chat`, `<x muc#user/>`, `<no-store/>`, origin-id reference). The receive side routes incoming whisper sub-feature stanzas through the existing room-scoped handlers (a whisper's `bareFrom`/`bareTo` already resolves to the room JID). The app keeps the action buttons on whisper bubbles, gated to 1:1-DM parity.
+
+**Tech Stack:** TypeScript, Zustand (vanilla stores), `@xmpp/client` (`xml` builder), React, Vitest, `@testing-library/react`.
+
+## Global Constraints
+
+- **Build the SDK before app typecheck:** after changing SDK types/exports run `npm run build:sdk`.
+- **Tests must pass with no stderr; typecheck and lint must pass before any commit.**
+- **No em-dashes / en-dashes in user-facing strings** (UI/i18n). Internal code comments and this doc are exempt.
+- **No `@xmpp/client` imports in the app** — the app consumes the SDK through hooks/types only.
+- **Whispers are `<no-store>`** — every whisper operation references the original by **origin-id** (`originId ?? id`), never a stanza-id, and carries `<no-store>`.
+- **Namespaces (already exported from `packages/fluux-sdk/src/core/namespaces.ts`):** `NS_MUC_USER='http://jabber.org/protocol/muc#user'`, `NS_HINTS='urn:xmpp:hints'`, `NS_REACTIONS='urn:xmpp:reactions:0'`, `NS_CORRECTION='urn:xmpp:message-correct:0'`, `NS_RETRACT='urn:xmpp:message-retract:1'`, `NS_OCCUPANT_ID='urn:xmpp:occupant-id:0'`, `NS_CHATSTATES='http://jabber.org/protocol/chatstates'`, `NS_OOB='jabber:x:oob'`. All are already imported in `Chat.ts`.
+
+## File Structure
+
+- `packages/fluux-sdk/src/core/errors.ts` — add `WhisperCounterpartGoneError` (next to `RoomJoinError`).
+- `packages/fluux-sdk/src/index.ts` — export the new error.
+- `packages/fluux-sdk/src/core/modules/Chat.ts` — `resolveWhisperRouting` helper; whisper branches in `sendCorrection`/`sendReaction`/`sendRetraction`; receive-side whisper sub-feature routing; new `sendWhisperChatState`.
+- `packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts` — all SDK whisper-operation tests.
+- `packages/fluux-sdk/src/hooks/{useRoomActive,useRoom,useRoomActions}.ts` — expose `sendWhisperChatState`.
+- `apps/fluux/src/components/conversation/messageActionCapabilities.ts` (new) — pure capability helper.
+- `apps/fluux/src/components/conversation/messageActionCapabilities.test.ts` (new) — its tests.
+- `apps/fluux/src/components/conversation/MessageBubble.tsx` — use the capability helper.
+- `apps/fluux/src/components/conversation/whisperTarget.ts` — add `decideChatStateRoute`.
+- `apps/fluux/src/components/conversation/whisperTarget.test.ts` — its tests.
+- `apps/fluux/src/components/RoomView.tsx` — route typing privately; catch `WhisperCounterpartGoneError`.
+
+---
+
+### Task 1: SDK whisper routing helper + `sendCorrection`
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/errors.ts`
+- Modify: `packages/fluux-sdk/src/index.ts:657`
+- Modify: `packages/fluux-sdk/src/core/modules/Chat.ts` (`sendCorrection` ~1237-1341; new `resolveWhisperRouting`)
+- Test: `packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts`
+
+**Interfaces:**
+- Produces: `class WhisperCounterpartGoneError extends Error { roomJid: string; nick: string }`
+- Produces: `private resolveWhisperRouting(roomJid: string, messageId: string): { recipient: string; referenceId: string; nick: string } | null` — returns `null` for non-whisper targets; **throws** `WhisperCounterpartGoneError` when the counterpart has left. Consumed by Tasks 2 and 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Chat.whisper.test.ts`. Add the error import at the top with the other imports:
+
+```typescript
+import { WhisperCounterpartGoneError } from '../errors'
+```
+
+Then add this describe block (after the existing `describe('incoming whispers', ...)`):
+
+```typescript
+describe('whisper operations (send)', () => {
+  const ROOM = 'room@conference.example.com'
+
+  function roomWithBob(occupants = new Map([
+    ['bob', { nick: 'bob', affiliation: 'member', role: 'participant', occupantId: 'occ-bob' }],
+  ])) {
+    return createMockRoom(ROOM, { joined: true, nickname: 'me', occupants })
+  }
+
+  function storedWhisper(overrides: Record<string, unknown> = {}) {
+    return {
+      type: 'groupchat', id: 'w-1', originId: 'w-1', roomJid: ROOM,
+      from: `${ROOM}/me`, nick: 'me', body: 'secret', timestamp: new Date(),
+      isOutgoing: true, isPrivate: true, whisperWith: 'bob', whisperWithOccupantId: 'occ-bob',
+      ...overrides,
+    }
+  }
+
+  it('sendCorrection on a whisper addresses room/nick privately (type=chat, muc#user, no-store, origin-id)', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+    vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+    await xmppClient.chat.sendCorrection(ROOM, 'w-1', 'fixed secret', 'groupchat')
+
+    const sent = mockXmppClientInstance.send.mock.calls[0][0]
+    expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+    expect(sent.attrs.type).toBe('chat')
+    const replace = sent.children.find((c: any) => c.name === 'replace')
+    expect(replace.attrs.id).toBe('w-1')
+    expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+    expect(sent.children.find((c: any) => c.name === 'no-store')).toBeDefined()
+  })
+
+  it('sendCorrection on a public room message still broadcasts to the room (no regression)', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+    vi.mocked(mockStores.room.getMessage).mockReturnValue({
+      type: 'groupchat', id: 'm-1', originId: 'm-1', roomJid: ROOM, from: `${ROOM}/me`,
+      nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
+    } as any)
+
+    await xmppClient.chat.sendCorrection(ROOM, 'm-1', 'hi fixed', 'groupchat')
+
+    const sent = mockXmppClientInstance.send.mock.calls[0][0]
+    expect(sent.attrs.to).toBe(ROOM)
+    expect(sent.attrs.type).toBe('groupchat')
+    expect(sent.children.find((c: any) => c.name === 'no-store')).toBeUndefined()
+  })
+
+  it('throws WhisperCounterpartGoneError and sends nothing when the counterpart has left', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob(new Map()))
+    vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+    await expect(
+      xmppClient.chat.sendCorrection(ROOM, 'w-1', 'x', 'groupchat'),
+    ).rejects.toThrow(WhisperCounterpartGoneError)
+    expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
+  })
+
+  it('re-resolves the current nick from occupant-id after a rename', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob(new Map([
+      ['bobby', { nick: 'bobby', affiliation: 'member', role: 'participant', occupantId: 'occ-bob' }],
+    ])))
+    vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+    await xmppClient.chat.sendCorrection(ROOM, 'w-1', 'fixed', 'groupchat')
+
+    expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.to).toBe(`${ROOM}/bobby`)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "whisper operations \(send\)"`
+Expected: FAIL — `WhisperCounterpartGoneError` is not exported / correction still goes to the room with `type=groupchat`.
+
+- [ ] **Step 3: Add the error class**
+
+In `packages/fluux-sdk/src/core/errors.ts`, after the `RoomJoinError` class, add:
+
+```typescript
+/**
+ * Thrown by the whisper operation send path (correction/reaction/retraction)
+ * when the target occupant is no longer present in the room — left, or the nick
+ * has been recycled by a different occupant-id. The operation must NEVER fall
+ * back to a public room broadcast, so the send path throws this instead.
+ */
+export class WhisperCounterpartGoneError extends Error {
+  readonly roomJid: string
+  readonly nick: string
+
+  constructor(roomJid: string, nick: string) {
+    super(`Whisper counterpart "${nick}" is no longer present in ${roomJid}`)
+    this.name = 'WhisperCounterpartGoneError'
+    this.roomJid = roomJid
+    this.nick = nick
+    Object.setPrototypeOf(this, WhisperCounterpartGoneError.prototype)
+  }
+}
+```
+
+- [ ] **Step 4: Export the error**
+
+In `packages/fluux-sdk/src/index.ts`, change line 657 from:
+
+```typescript
+export { RoomJoinError } from './core/errors'
+```
+
+to:
+
+```typescript
+export { RoomJoinError, WhisperCounterpartGoneError } from './core/errors'
+```
+
+- [ ] **Step 5: Add the `resolveWhisperRouting` helper**
+
+In `packages/fluux-sdk/src/core/modules/Chat.ts`, add this private method immediately before `getMessageReferenceId` (search for `private getMessageReferenceId`). It uses `WhisperCounterpartGoneError`, so add it to the existing import from `../errors` (search for the line importing `RoomJoinError` if present, otherwise add `import { WhisperCounterpartGoneError } from '../errors'` near the other core imports):
+
+```typescript
+  /**
+   * XEP-0045 §7.5: when an operation (correction/reaction/retraction) targets a
+   * stored whisper, address it privately to the one occupant — never broadcast to
+   * the room. Returns the private routing derived from the stored message, or null
+   * when the target is a normal public/1:1 message (caller keeps its existing path).
+   *
+   * The current nick is re-resolved from the counterpart's stable occupant-id
+   * (XEP-0421) so the operation survives a rename. If the counterpart has left
+   * (occupant-id gone, or nick gone in rooms without occupant-id), it throws
+   * WhisperCounterpartGoneError — it must NEVER fall back to the room-broadcast path.
+   */
+  private resolveWhisperRouting(
+    roomJid: string,
+    messageId: string,
+  ): { recipient: string; referenceId: string; nick: string } | null {
+    const msg = this.deps.stores?.room.getMessage(roomJid, messageId)
+    if (!msg?.isPrivate || !msg.whisperWith) return null
+
+    const occupants = this.deps.stores?.room.getRoom(roomJid)?.occupants
+    let nick: string | null = null
+    if (msg.whisperWithOccupantId && occupants) {
+      for (const [occNick, occ] of occupants) {
+        if (occ.occupantId === msg.whisperWithOccupantId) { nick = occNick; break }
+      }
+    } else if (occupants?.has(msg.whisperWith)) {
+      nick = msg.whisperWith
+    }
+    if (!nick) throw new WhisperCounterpartGoneError(roomJid, msg.whisperWith)
+
+    return { recipient: `${roomJid}/${nick}`, referenceId: msg.originId ?? messageId, nick }
+  }
+```
+
+- [ ] **Step 6: Wire `sendCorrection`**
+
+In `packages/fluux-sdk/src/core/modules/Chat.ts`, in `sendCorrection`, replace the opening recipient/original/referenceId computation. Change from:
+
+```typescript
+    const recipient = type === 'chat' ? getBareJid(to) : to
+
+    // XEP-0308 (Last Message Correction) has NO group-chat carve-out — unlike
+    // XEP-0461 replies, XEP-0444 reactions and XEP-0424 retractions, which all
+    // switch to the server/MUC stanza-id. A correction MUST reference the id the
+    // ORIGINAL SENDER assigned: the origin-id (XEP-0359) when present, otherwise
+    // the message id. Referencing the stanza-id breaks correction matching on
+    // compliant clients (they render the edit as a brand-new message).
+    const original = type === 'groupchat'
+      ? this.deps.stores?.room.getMessage(to, originalMessageId)
+      : this.deps.stores?.chat.getMessage(to, originalMessageId)
+    const referenceId = original?.originId ?? originalMessageId
+```
+
+to:
+
+```typescript
+    // XEP-0045 §7.5: if the target is a whisper, address the correction privately
+    // to the one occupant (type=chat to room/nick + muc#user + no-store) instead of
+    // broadcasting to the room. Throws WhisperCounterpartGoneError if they have left.
+    const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, originalMessageId) : null
+    const isWhisper = whisper !== null
+    const recipient = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+    const wireType: 'chat' | 'groupchat' = isWhisper ? 'chat' : type
+
+    // XEP-0308 (Last Message Correction) has NO group-chat carve-out — unlike
+    // XEP-0461 replies, XEP-0444 reactions and XEP-0424 retractions, which all
+    // switch to the server/MUC stanza-id. A correction MUST reference the id the
+    // ORIGINAL SENDER assigned: the origin-id (XEP-0359) when present, otherwise
+    // the message id. Referencing the stanza-id breaks correction matching on
+    // compliant clients (they render the edit as a brand-new message).
+    const original = type === 'groupchat'
+      ? this.deps.stores?.room.getMessage(to, originalMessageId)
+      : this.deps.stores?.chat.getMessage(to, originalMessageId)
+    const referenceId = isWhisper ? whisper.referenceId : (original?.originId ?? originalMessageId)
+```
+
+Then add the whisper markers. Find the line `children.push(createOriginIdElement(correctionStanzaId))` in `sendCorrection` and insert immediately after it:
+
+```typescript
+    if (isWhisper) {
+      children.push(xml('x', { xmlns: NS_MUC_USER }), xml('no-store', { xmlns: NS_HINTS }))
+    }
+```
+
+Finally, change the send line from:
+
+```typescript
+    await this.deps.sendStanza(xml('message', { to: recipient, type, id: correctionStanzaId }, ...children))
+```
+
+to:
+
+```typescript
+    await this.deps.sendStanza(xml('message', { to: recipient, type: wireType, id: correctionStanzaId }, ...children))
+```
+
+(The E2EE branch stays gated on `type === 'chat'`; a whisper has `type === 'groupchat'`, so it is already excluded. The optimistic `room:message-updated` emit also stays keyed on `type`.)
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "whisper operations \(send\)"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 8: Build SDK, typecheck, lint**
+
+Run: `npm run build:sdk && npm run typecheck` (from repo root)
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/errors.ts packages/fluux-sdk/src/index.ts packages/fluux-sdk/src/core/modules/Chat.ts packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+git commit -m "feat(whisper): route corrections privately to the occupant (XEP-0045 §7.5)"
+```
+
+---
+
+### Task 2: `sendReaction` whisper routing
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/modules/Chat.ts` (`sendReaction` ~1145-1208)
+- Test: `packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveWhisperRouting` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the `describe('whisper operations (send)', ...)` block in `Chat.whisper.test.ts`:
+
+```typescript
+it('sendReaction on a whisper addresses room/nick privately with no-store (not the room)', async () => {
+  await connectClient()
+  vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+  vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+  await xmppClient.chat.sendReaction(ROOM, 'w-1', ['👍'], 'groupchat')
+
+  const sent = mockXmppClientInstance.send.mock.calls[0][0]
+  expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+  expect(sent.attrs.type).toBe('chat')
+  const reactions = sent.children.find((c: any) => c.name === 'reactions')
+  expect(reactions.attrs.id).toBe('w-1')
+  expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+  expect(sent.children.find((c: any) => c.name === 'no-store')).toBeDefined()
+  expect(sent.children.find((c: any) => c.name === 'store')).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "sendReaction on a whisper"`
+Expected: FAIL — reaction goes to the room with `type=groupchat` and a `<store>` hint.
+
+- [ ] **Step 3: Wire `sendReaction`**
+
+In `sendReaction`, replace:
+
+```typescript
+    const recipient = type === 'chat' ? getBareJid(to) : to
+
+    // For MUC, prefer stanzaId (server-assigned, stable) over client-generated id
+    // Other clients (e.g. Gajim) reference messages by stanzaId in reactions
+    const referenceId = this.getMessageReferenceId(to, messageId, type)
+```
+
+with:
+
+```typescript
+    // XEP-0045 §7.5: a reaction on a whisper is addressed privately to the one
+    // occupant; whispers are <no-store> so the reference is the origin-id.
+    const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, messageId) : null
+    const isWhisper = whisper !== null
+    const recipient = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+    const wireType: 'chat' | 'groupchat' = isWhisper ? 'chat' : type
+
+    // For MUC, prefer stanzaId (server-assigned, stable) over client-generated id
+    // Other clients (e.g. Gajim) reference messages by stanzaId in reactions
+    const referenceId = isWhisper ? whisper.referenceId : this.getMessageReferenceId(to, messageId, type)
+```
+
+Then change the store-hint else-branch. Replace:
+
+```typescript
+    if (type === 'chat' && peerCanEncrypt) {
+      await this.applyE2EEToOutboundChat(recipient, '', children, Chat.E2EE_REACTION_KEYS, {
+        encryptBody: false,
+        outerBody: 'remove',
+        storeHint: 'store',
+      })
+    } else {
+      children.push(xml('store', { xmlns: NS_HINTS }))
+    }
+
+    const message = xml('message', { to: recipient, type, id: reactionStanzaId }, ...children)
+```
+
+with:
+
+```typescript
+    if (type === 'chat' && peerCanEncrypt) {
+      await this.applyE2EEToOutboundChat(recipient, '', children, Chat.E2EE_REACTION_KEYS, {
+        encryptBody: false,
+        outerBody: 'remove',
+        storeHint: 'store',
+      })
+    } else if (isWhisper) {
+      // Whisper reaction: muc#user marker + no-store (kept off the room archive).
+      children.push(xml('x', { xmlns: NS_MUC_USER }), xml('no-store', { xmlns: NS_HINTS }))
+    } else {
+      children.push(xml('store', { xmlns: NS_HINTS }))
+    }
+
+    const message = xml('message', { to: recipient, type: wireType, id: reactionStanzaId }, ...children)
+```
+
+(`peerCanEncrypt` stays false for a whisper because its computation is gated on `type === 'chat'`. The optimistic `room:reactions` emit stays keyed on `type === 'groupchat'`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "sendReaction on a whisper"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full whisper suite + typecheck**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts && cd .. && cd .. && npm run build:sdk && npm run typecheck`
+Expected: PASS, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/modules/Chat.ts packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+git commit -m "feat(whisper): route reactions privately to the occupant"
+```
+
+---
+
+### Task 3: `sendRetraction` whisper routing
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/modules/Chat.ts` (`sendRetraction` ~1368-1417)
+- Test: `packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveWhisperRouting` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside `describe('whisper operations (send)', ...)`:
+
+```typescript
+it('sendRetraction on a whisper addresses room/nick privately with no-store (not the room)', async () => {
+  await connectClient()
+  vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+  vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+  await xmppClient.chat.sendRetraction(ROOM, 'w-1', 'groupchat')
+
+  const sent = mockXmppClientInstance.send.mock.calls[0][0]
+  expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+  expect(sent.attrs.type).toBe('chat')
+  const retract = sent.children.find((c: any) => c.name === 'retract')
+  expect(retract.attrs.id).toBe('w-1')
+  expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+  expect(sent.children.find((c: any) => c.name === 'no-store')).toBeDefined()
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "sendRetraction on a whisper"`
+Expected: FAIL — retraction goes to the room with `type=groupchat`.
+
+- [ ] **Step 3: Wire `sendRetraction`**
+
+In `sendRetraction`, replace:
+
+```typescript
+    const recipient = type === 'chat' ? getBareJid(to) : to
+
+    // For MUC, prefer stanzaId (server-assigned, stable) for the retraction reference
+    const referenceId = this.getMessageReferenceId(to, originalMessageId, type)
+```
+
+with:
+
+```typescript
+    // XEP-0045 §7.5: a retraction of a whisper is addressed privately to the one
+    // occupant; whispers are <no-store> so the reference is the origin-id.
+    const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, originalMessageId) : null
+    const isWhisper = whisper !== null
+    const recipient = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+    const wireType: 'chat' | 'groupchat' = isWhisper ? 'chat' : type
+
+    // For MUC, prefer stanzaId (server-assigned, stable) for the retraction reference
+    const referenceId = isWhisper ? whisper.referenceId : this.getMessageReferenceId(to, originalMessageId, type)
+```
+
+Then find `createOriginIdElement(retractionStanzaId),` inside the `children` array of `sendRetraction`. After the `const children = [ ... ]` array literal closes, insert:
+
+```typescript
+    if (isWhisper) {
+      children.push(xml('x', { xmlns: NS_MUC_USER }), xml('no-store', { xmlns: NS_HINTS }))
+    }
+```
+
+Finally, change the send line from:
+
+```typescript
+    await this.deps.sendStanza(
+      xml('message', { to: recipient, type, id: retractionStanzaId }, ...children),
+    )
+```
+
+to:
+
+```typescript
+    await this.deps.sendStanza(
+      xml('message', { to: recipient, type: wireType, id: retractionStanzaId }, ...children),
+    )
+```
+
+(The E2EE branch stays gated on `type === 'chat'`; the optimistic emit stays keyed on `type`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "sendRetraction on a whisper"`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run build:sdk && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/modules/Chat.ts packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+git commit -m "feat(whisper): route retractions privately to the occupant"
+```
+
+---
+
+### Task 4: Receive-side — apply incoming whisper operations to the thread
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/modules/Chat.ts` (the `if (isWhisper) { ... }` branch ~254-265 in `handleMessageInternal`)
+- Test: `packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts`
+
+**Interfaces:**
+- Consumes existing private handlers: `handleIncomingReaction`, `handleIncomingRetraction`, `handleIncomingCorrection`, `processRoomWhisper`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new describe block to `Chat.whisper.test.ts`:
+
+```typescript
+describe('whisper operations (receive)', () => {
+  const ROOM = 'room@conference.example.com'
+
+  beforeEach(() => {
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(
+      createMockRoom(ROOM, { joined: true, nickname: 'me' }),
+    )
+  })
+
+  it('incoming whisper reaction updates the whisper thread, not a new whisper', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+
+    const stanza = createMockElement('message', {
+      from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'r-1',
+    }, [
+      { name: 'reactions', attrs: { xmlns: 'urn:xmpp:reactions:0', id: 'w-1' }, children: [{ name: 'reaction', text: '👍' }] },
+      { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+      { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+    ])
+    mockXmppClientInstance._emit('stanza', stanza)
+
+    expect(emitSDKSpy).toHaveBeenCalledWith('room:reactions', expect.objectContaining({
+      roomJid: ROOM, messageId: 'w-1', reactorNick: 'bob', emojis: ['👍'],
+    }))
+    expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+  })
+
+  it('incoming whisper correction updates the existing whisper (not a new whisper)', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+    vi.mocked(mockStores.room.getMessage).mockReturnValue({
+      id: 'bw-1', originId: 'bw-1', from: `${ROOM}/bob`, nick: 'bob', body: 'old',
+      isPrivate: true, whisperWith: 'bob', occupantId: 'occ-bob', timestamp: new Date(),
+    } as any)
+
+    const stanza = createMockElement('message', {
+      from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'corr-1',
+    }, [
+      { name: 'body', text: 'new text' },
+      { name: 'replace', attrs: { xmlns: 'urn:xmpp:message-correct:0', id: 'bw-1' } },
+      { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+      { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+    ])
+    mockXmppClientInstance._emit('stanza', stanza)
+
+    expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+      roomJid: ROOM, messageId: 'bw-1', updates: expect.objectContaining({ body: 'new text', isEdited: true }),
+    }))
+    expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+  })
+
+  it('incoming whisper retraction marks the whisper retracted (not a new whisper)', async () => {
+    await connectClient()
+    vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+    vi.mocked(mockStores.room.getMessage).mockReturnValue({
+      id: 'bw-1', from: `${ROOM}/bob`, nick: 'bob', occupantId: 'occ-bob',
+      isPrivate: true, whisperWith: 'bob', timestamp: new Date(),
+    } as any)
+
+    const stanza = createMockElement('message', {
+      from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'rt-1',
+    }, [
+      { name: 'body', text: 'This person attempted to retract a previous message...' },
+      { name: 'retract', attrs: { xmlns: 'urn:xmpp:message-retract:1', id: 'bw-1' } },
+      { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+      { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+    ])
+    mockXmppClientInstance._emit('stanza', stanza)
+
+    expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+      roomJid: ROOM, messageId: 'bw-1', updates: expect.objectContaining({ isRetracted: true }),
+    }))
+    expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "whisper operations \(receive\)"`
+Expected: FAIL — current code routes every whisper to `processRoomWhisper`, so it emits `room:whisper` and never `room:reactions`/`room:message-updated`.
+
+- [ ] **Step 3: Restructure the whisper branch**
+
+In `Chat.ts`, replace the whole `if (isWhisper) { ... }` block (currently ~254-265):
+
+```typescript
+    // Whisper short-circuit: handle before the public sub-feature handlers
+    // (chat states, reactions, corrections, retractions, moderation), which
+    // are out of scope for whispers in v1.
+    if (isWhisper) {
+      if (body || stanza.getChild('x', NS_OOB)) {
+        // from is non-null here: isWhisper guards !!from
+        const whisper = this.processRoomWhisper(stanza, from!, bareFrom, body || '', isSentCarbon)
+        if (whisper && !isSentCarbon) {
+          this.deps.emit('message', whisper as unknown as Message)
+        }
+        return { handled: true, message: whisper }
+      }
+      // Bodyless whisper (e.g. a stray chat-state): claim and drop in v1.
+      return { handled: true }
+    }
+```
+
+with:
+
+```typescript
+    // Whisper sub-features (XEP-0045 §7.5). A whisper carrying <reactions>/<retract>/
+    // <replace> is an operation on the EXISTING whisper thread, not a new whisper.
+    // A whisper's bareFrom/bareTo is the room JID, so the room-scoped handlers
+    // resolve the right conversation when type is forced to 'groupchat' (the wire
+    // type is 'chat' only per the private-message convention). Order matters:
+    // check operations before the new-body fall-through.
+    if (isWhisper) {
+      const whisperReactionsEl = stanza.getChild('reactions', NS_REACTIONS)
+      if (whisperReactionsEl) {
+        this.handleIncomingReaction(stanza, whisperReactionsEl, from!, bareFrom, bareTo, 'groupchat', isSentCarbon)
+        return { handled: true }
+      }
+
+      const whisperRetractEl = stanza.getChild('retract', NS_RETRACT)
+      if (whisperRetractEl?.attrs.id) {
+        // Consume even if it matches no stored message — the body is just the
+        // XEP-0428 fallback notice, never shown as a new whisper.
+        this.handleIncomingRetraction(
+          whisperRetractEl.attrs.id, from!, bareFrom, bareTo, 'groupchat', isSentCarbon,
+          stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id,
+        )
+        return { handled: true }
+      }
+
+      const whisperReplaceEl = stanza.getChild('replace', NS_CORRECTION)
+      if (whisperReplaceEl?.attrs.id && body && this.handleIncomingCorrection(
+        stanza, whisperReplaceEl.attrs.id, from!, bareFrom, bareTo, body, 'groupchat', isSentCarbon,
+      )) {
+        return { handled: true }
+      }
+
+      // Genuine new whisper (body or media), or a correction that matched no stored
+      // message (e.g. evicted) — show the (corrected) text as a whisper.
+      if (body || stanza.getChild('x', NS_OOB)) {
+        // from is non-null here: isWhisper guards !!from
+        const whisper = this.processRoomWhisper(stanza, from!, bareFrom, body || '', isSentCarbon)
+        if (whisper && !isSentCarbon) {
+          this.deps.emit('message', whisper as unknown as Message)
+        }
+        return { handled: true, message: whisper }
+      }
+      // Bodyless whisper (e.g. a stray chat-state): claim and drop.
+      return { handled: true }
+    }
+```
+
+- [ ] **Step 4: Run the receive tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "whisper operations \(receive\)"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full whisper suite (regression) + typecheck**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts && cd ../.. && npm run build:sdk && npm run typecheck`
+Expected: PASS — the existing incoming-whisper tests (plain new whisper, carbon, muc#user marker) still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/modules/Chat.ts packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+git commit -m "feat(whisper): apply incoming corrections/reactions/retractions to the thread"
+```
+
+---
+
+### Task 5: `sendWhisperChatState` + hook exposure
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/modules/Chat.ts` (new method after `sendChatState` ~1119)
+- Modify: `packages/fluux-sdk/src/hooks/useRoomActive.ts`, `useRoom.ts`, `useRoomActions.ts`
+- Test: `packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts`
+
+**Interfaces:**
+- Produces: `async sendWhisperChatState(roomJid: string, nick: string, state: ChatStateNotification): Promise<void>` — exposed on each room hook with the same signature. Consumed by Task 7.
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside `describe('whisper operations (send)', ...)` in `Chat.whisper.test.ts`:
+
+```typescript
+it('sendWhisperChatState sends a private chat-state to room/nick (muc#user, no-store)', async () => {
+  await connectClient()
+
+  await xmppClient.chat.sendWhisperChatState(ROOM, 'bob', 'composing')
+
+  const sent = mockXmppClientInstance.send.mock.calls[0][0]
+  expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+  expect(sent.attrs.type).toBe('chat')
+  expect(sent.children.find((c: any) => c.name === 'composing')).toBeDefined()
+  expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+  expect(sent.children.find((c: any) => c.name === 'no-store')).toBeDefined()
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "sendWhisperChatState"`
+Expected: FAIL — `sendWhisperChatState` is not a function.
+
+- [ ] **Step 3: Add the SDK method**
+
+In `Chat.ts`, immediately after the `sendChatState` method (after its closing `}` at ~1119), add:
+
+```typescript
+  /**
+   * Send a chat state (XEP-0085) privately to a single room occupant — the typing
+   * indicator for a whisper (XEP-0045 §7.5). Unlike sendChatState('groupchat'),
+   * which broadcasts to the room, this addresses room/nick with the muc#user marker
+   * and a no-store hint, so the room never sees that you are whispering.
+   */
+  async sendWhisperChatState(roomJid: string, nick: string, state: ChatStateNotification): Promise<void> {
+    const message = xml('message', { to: `${roomJid}/${nick}`, type: 'chat' },
+      xml(state, { xmlns: NS_CHATSTATES }),
+      xml('x', { xmlns: NS_MUC_USER }),
+      xml('no-store', { xmlns: NS_HINTS }),
+    )
+    await this.deps.sendStanza(message)
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/core/modules/Chat.whisper.test.ts -t "sendWhisperChatState"`
+Expected: PASS.
+
+- [ ] **Step 5: Expose on `useRoomActive`**
+
+In `packages/fluux-sdk/src/hooks/useRoomActive.ts`, after the `sendChatState` `useCallback` (search for `const sendChatState = useCallback`), add:
+
+```typescript
+  const sendWhisperChatState = useCallback(
+    async (roomJid: string, nick: string, state: ChatStateNotification) => {
+      await client.chat.sendWhisperChatState(roomJid, nick, state)
+    },
+    [client]
+  )
+```
+
+Then add `sendWhisperChatState,` to BOTH the returned object and its dependency array (search for the two existing `sendChatState,` entries near lines 443 and 480 and add the new name beside each).
+
+- [ ] **Step 6: Expose on `useRoom` and `useRoomActions`**
+
+Repeat Step 5 verbatim in `packages/fluux-sdk/src/hooks/useRoom.ts` (after `const sendChatState = useCallback` ~297; add beside the `sendChatState,` entries ~605 and ~657) and in `packages/fluux-sdk/src/hooks/useRoomActions.ts` (after ~198; beside `sendChatState,` ~430 and ~482). Confirm `ChatStateNotification` is imported in each file (it already is in `useRoomActive.ts:5`; add it to the type import in the other two if missing).
+
+- [ ] **Step 7: Build SDK + typecheck**
+
+Run: `npm run build:sdk && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/modules/Chat.ts packages/fluux-sdk/src/hooks/useRoomActive.ts packages/fluux-sdk/src/hooks/useRoom.ts packages/fluux-sdk/src/hooks/useRoomActions.ts packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+git commit -m "feat(whisper): add sendWhisperChatState for private typing indicators"
+```
+
+---
+
+### Task 6: App — pure capability helper + MessageBubble gating
+
+**Files:**
+- Create: `apps/fluux/src/components/conversation/messageActionCapabilities.ts`
+- Test: `apps/fluux/src/components/conversation/messageActionCapabilities.test.ts`
+- Modify: `apps/fluux/src/components/conversation/MessageBubble.tsx`
+
+**Interfaces:**
+- Produces: `computeMessageActions(inputs: MessageActionInputs): MessageActionCapabilities` with `{ canReply, canEdit, canDelete, canReact }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/components/conversation/messageActionCapabilities.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { computeMessageActions } from './messageActionCapabilities'
+
+const base = {
+  isOutgoing: true, isPrivate: false, isLastOutgoing: true, isLastMessage: false,
+  inThread: false, counterpartGone: false, isIrcGateway: false, canModerate: false,
+  reactionsEnabled: true,
+}
+
+describe('computeMessageActions', () => {
+  it('public own last message: edit/delete/react/reply all allowed', () => {
+    const a = computeMessageActions(base)
+    expect(a).toEqual({ canReply: true, canEdit: true, canDelete: true, canReact: true })
+  })
+
+  it('whisper with the counterpart gone: every action disabled', () => {
+    const a = computeMessageActions({ ...base, isPrivate: true, inThread: true, counterpartGone: true })
+    expect(a).toEqual({ canReply: false, canEdit: false, canDelete: false, canReact: false })
+  })
+
+  it('incoming whisper: no moderation-based delete even for a moderator', () => {
+    const a = computeMessageActions({
+      ...base, isOutgoing: false, isPrivate: true, inThread: true, isLastOutgoing: false, canModerate: true,
+    })
+    expect(a.canDelete).toBe(false) // private message cannot be moderated
+    expect(a.canReact).toBe(true)   // can still react while counterpart present
+  })
+
+  it('public message a moderator can delete: moderation delete still allowed', () => {
+    const a = computeMessageActions({
+      ...base, isOutgoing: false, isLastOutgoing: false, canModerate: true,
+    })
+    expect(a.canDelete).toBe(true)
+  })
+
+  it('IRC gateway: no edit/delete', () => {
+    const a = computeMessageActions({ ...base, isIrcGateway: true })
+    expect(a.canEdit).toBe(false)
+    expect(a.canDelete).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/conversation/messageActionCapabilities.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Create the helper**
+
+Create `apps/fluux/src/components/conversation/messageActionCapabilities.ts`:
+
+```typescript
+/**
+ * Pure capability rules for a message's action surfaces (hover toolbar + touch
+ * action sheet). Extracted so the whisper (XEP-0045 §7.5) gating is testable.
+ *
+ * Whisper parity with a 1:1 DM:
+ * - own whisper: edit / delete (retract) / react / reply
+ * - incoming whisper: react / reply (NO edit; NO moderation-delete)
+ * - any whisper: disabled once the counterpart has left (counterpartGone)
+ */
+export interface MessageActionInputs {
+  isOutgoing: boolean
+  /** The message is a whisper (private MUC message). */
+  isPrivate: boolean
+  isLastOutgoing: boolean
+  isLastMessage: boolean
+  /** The message is rendered inside a whisper thread. */
+  inThread: boolean
+  /** Whisper counterpart has left the room (thread is read-only). */
+  counterpartGone: boolean
+  isIrcGateway: boolean
+  canModerate: boolean
+  /** The room exposes reactions (stable occupant identity available). */
+  reactionsEnabled: boolean
+}
+
+export interface MessageActionCapabilities {
+  canReply: boolean
+  canEdit: boolean
+  canDelete: boolean
+  canReact: boolean
+}
+
+export function computeMessageActions(i: MessageActionInputs): MessageActionCapabilities {
+  return {
+    canReply: (!i.isLastMessage || i.inThread) && !i.counterpartGone,
+    canEdit: i.isOutgoing && i.isLastOutgoing && !i.isIrcGateway && !i.counterpartGone,
+    // XEP-0045 §7.5: a private whisper cannot be moderated (no server archive), so
+    // the moderator path is suppressed for whispers; gate on counterpart presence.
+    canDelete: (i.isOutgoing || (i.canModerate && !i.isPrivate)) && !i.isIrcGateway && !i.counterpartGone,
+    canReact: i.reactionsEnabled && !i.counterpartGone,
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/components/conversation/messageActionCapabilities.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Wire the helper into MessageBubble**
+
+In `apps/fluux/src/components/conversation/MessageBubble.tsx`:
+
+(a) Add the import near the other `./` imports (e.g. below the `MessageToolbar` import):
+
+```typescript
+import { computeMessageActions } from './messageActionCapabilities'
+```
+
+(b) Immediately BEFORE the line `// Whether reactions are enabled for this message (room has stable occupant identity)` (~line 343), insert:
+
+```typescript
+  const inThread = !!whisperThread
+  const counterpartGone = inThread && counterpartPresent === false
+```
+
+(c) Immediately AFTER `const reactionsEnabled = onReaction !== undefined` (~line 344), insert:
+
+```typescript
+  const actions = computeMessageActions({
+    isOutgoing: message.isOutgoing,
+    isPrivate: !!message.isPrivate,
+    isLastOutgoing,
+    isLastMessage,
+    inThread,
+    counterpartGone,
+    isIrcGateway,
+    canModerate: canModerate === true,
+    reactionsEnabled,
+  })
+```
+
+(d) Change the `handleReaction` guard. Replace `const handleReaction = reactionsEnabled ? (emoji: string) => {` with `const handleReaction = actions.canReact ? (emoji: string) => {`.
+
+(e) Remove the now-duplicate lines in the later block. The block currently reads:
+
+```typescript
+  const inThread = !!whisperThread
+  const threadStart = whisperThread === 'start' || whisperThread === 'solo'
+  const threadEnd = whisperThread === 'end' || whisperThread === 'solo'
+  // Counterpart left the room: the thread becomes read-only (can't reply privately).
+  const counterpartGone = inThread && counterpartPresent === false
+```
+
+Change it to (delete the `inThread` and `counterpartGone` lines, now defined above):
+
+```typescript
+  const threadStart = whisperThread === 'start' || whisperThread === 'solo'
+  const threadEnd = whisperThread === 'end' || whisperThread === 'solo'
+```
+
+(f) Replace the capability block:
+
+```typescript
+  const canReply = (!isLastMessage || inThread) && !counterpartGone
+  const canEdit = message.isOutgoing && isLastOutgoing && !isIrcGateway
+  const canDelete = (message.isOutgoing || canModerate === true) && !isIrcGateway
+  const canCopyBody = !!message.body && !message.isRetracted && !message.encryptedPayload && !message.unsupportedEncryption
+  const hasMessageActions = !message.isRetracted && (reactionsEnabled || canReply || canEdit || canDelete || canCopyBody)
+```
+
+with (destructure from `actions` so the existing JSX references to `canReply`/`canEdit`/`canDelete` keep working unchanged):
+
+```typescript
+  const { canReply, canEdit, canDelete } = actions
+  const canCopyBody = !!message.body && !message.isRetracted && !message.encryptedPayload && !message.unsupportedEncryption
+  const hasMessageActions = !message.isRetracted && (actions.canReact || canReply || canEdit || canDelete || canCopyBody)
+```
+
+- [ ] **Step 6: Typecheck + run the bubble tests**
+
+Run: `npm run typecheck && cd apps/fluux && npx vitest run src/components/conversation/MessageBubble.test.tsx src/components/conversation/messageActionCapabilities.test.ts`
+Expected: PASS — no regression in the existing MessageBubble tests; the new capability tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/components/conversation/messageActionCapabilities.ts apps/fluux/src/components/conversation/messageActionCapabilities.test.ts apps/fluux/src/components/conversation/MessageBubble.tsx
+git commit -m "feat(whisper): gate message actions to 1:1-DM parity on whisper bubbles"
+```
+
+---
+
+### Task 7: App — private typing routing + counterpart-gone handling
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/whisperTarget.ts`
+- Test: `apps/fluux/src/components/conversation/whisperTarget.test.ts`
+- Modify: `apps/fluux/src/components/RoomView.tsx`
+
+**Interfaces:**
+- Consumes: `sendWhisperChatState` from `useRoomActive` (Task 5); `WhisperCounterpartGoneError` from `@fluux/sdk` (Task 1).
+- Produces: `decideChatStateRoute(whisperTarget, shouldSendTypingNotifications): ChatStateRoute`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/fluux/src/components/conversation/whisperTarget.test.ts`:
+
+```typescript
+import { decideChatStateRoute } from './whisperTarget'
+
+describe('decideChatStateRoute', () => {
+  it('suppresses typing when notifications are disabled', () => {
+    expect(decideChatStateRoute({ nick: 'bob' }, false)).toEqual({ target: 'none' })
+  })
+
+  it('routes to the room when not whispering', () => {
+    expect(decideChatStateRoute(null, true)).toEqual({ target: 'room' })
+  })
+
+  it('routes privately to the whisper target', () => {
+    expect(decideChatStateRoute({ nick: 'bob' }, true)).toEqual({ target: 'whisper', nick: 'bob' })
+  })
+})
+```
+
+(If `whisperTarget.test.ts` does not exist yet, create it with the standard header: `import { describe, it, expect } from 'vitest'` plus the block above.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/conversation/whisperTarget.test.ts -t "decideChatStateRoute"`
+Expected: FAIL — `decideChatStateRoute` is not exported.
+
+- [ ] **Step 3: Add the pure router**
+
+Append to `apps/fluux/src/components/conversation/whisperTarget.ts`:
+
+```typescript
+/**
+ * Where a composer chat-state (typing indicator) should go. While a whisper is
+ * being composed it must be addressed privately to the target (XEP-0045 §7.5),
+ * never broadcast to the room. `none` suppresses the state entirely.
+ */
+export type ChatStateRoute =
+  | { target: 'whisper'; nick: string }
+  | { target: 'room' }
+  | { target: 'none' }
+
+export function decideChatStateRoute(
+  whisperTarget: WhisperTarget | null,
+  shouldSendTypingNotifications: boolean,
+): ChatStateRoute {
+  if (!shouldSendTypingNotifications) return { target: 'none' }
+  return whisperTarget ? { target: 'whisper', nick: whisperTarget.nick } : { target: 'room' }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/components/conversation/whisperTarget.test.ts -t "decideChatStateRoute"`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `sendWhisperChatState` through RoomView**
+
+In `apps/fluux/src/components/RoomView.tsx`:
+
+(a) Add `sendWhisperChatState` to the `useRoomActive()` destructure (line 81): insert `sendWhisperChatState,` next to `sendChatState,`.
+
+(b) In `RoomMessageInputProps` (search for `sendChatState: (roomJid: string, state: ChatStateNotification) => Promise<void>` ~1549), add below it:
+
+```typescript
+  sendWhisperChatState: (roomJid: string, nick: string, state: ChatStateNotification) => Promise<void>
+```
+
+(c) In the `RoomMessageInput` destructured params (search for `sendChatState,` ~1580), add `sendWhisperChatState,` beside it.
+
+(d) Where `RoomMessageInput` is rendered (search for `sendChatState={sendChatState}` ~572), add below it:
+
+```tsx
+            sendWhisperChatState={sendWhisperChatState}
+```
+
+(e) Add the import for the router. In the `@/hooks`/conversation imports area, import `decideChatStateRoute` from the whisper-target module. It is already imported as a sibling — confirm `whisperTarget` utilities are imported; if `decideWhisperSend` is imported from `./conversation/whisperTarget` (or `@/components/conversation/whisperTarget`), add `decideChatStateRoute` to that same import statement.
+
+(f) Replace `handleTypingState` (~1831):
+
+```typescript
+  const handleTypingState = (state: 'composing' | 'paused') => {
+    if (shouldSendTypingNotifications) {
+      void sendChatState(roomJid, state)
+    }
+  }
+```
+
+with:
+
+```typescript
+  const handleTypingState = (state: 'composing' | 'paused') => {
+    const route = decideChatStateRoute(whisperTarget, shouldSendTypingNotifications)
+    if (route.target === 'whisper') void sendWhisperChatState(roomJid, route.nick, state)
+    else if (route.target === 'room') void sendChatState(roomJid, state)
+  }
+```
+
+- [ ] **Step 6: Catch `WhisperCounterpartGoneError` in the operation handlers**
+
+In `RoomView.tsx`:
+
+(a) Add `WhisperCounterpartGoneError` to the existing `@fluux/sdk` import.
+
+(b) Wrap the whisper-capable operation calls so a race (counterpart leaves between render and click) surfaces the existing toast instead of an unhandled rejection. Replace `handleReaction` (~1249) body's `sendReaction` call site, `handleCorrection` (~1740), and `handleRetract` (~1746) to catch. For `handleCorrection`:
+
+```typescript
+  const handleCorrection = async (messageId: string, newBody: string, attachment?: import('@fluux/sdk').FileAttachment): Promise<boolean> => {
+    try {
+      await sendCorrection(roomJid, messageId, newBody, attachment)
+      return true
+    } catch (e) {
+      if (e instanceof WhisperCounterpartGoneError) {
+        addToast('info', t('rooms.whisperCounterpartGone', { nick: e.nick }))
+        return false
+      }
+      throw e
+    }
+  }
+```
+
+For `handleRetract`:
+
+```typescript
+  const handleRetract = async (messageId: string): Promise<void> => {
+    try {
+      await retractMessage(roomJid, messageId)
+    } catch (e) {
+      if (e instanceof WhisperCounterpartGoneError) {
+        addToast('info', t('rooms.whisperCounterpartGone', { nick: e.nick }))
+        return
+      }
+      throw e
+    }
+  }
+```
+
+For the reaction handler (`handleReaction` ~1249, in the bubble wrapper), wrap the `void sendReaction(...)` / `void votePoll(...)` calls similarly — change the regular-reaction path from `void sendReaction(roomJid, message.id, newReactions)` to:
+
+```typescript
+    sendReaction(roomJid, message.id, newReactions).catch((e) => {
+      if (e instanceof WhisperCounterpartGoneError) addToast('info', t('rooms.whisperCounterpartGone', { nick: e.nick }))
+      else console.error(e)
+    })
+```
+
+(Confirm `addToast` and `t` are in scope in each handler's component; both are already used elsewhere in `RoomView.tsx`. If `addToast` is not in scope in the bubble-wrapper component, pass it down or use the existing toast hook already imported in that component.)
+
+- [ ] **Step 7: Typecheck + run app tests**
+
+Run: `npm run build:sdk && npm run typecheck && cd apps/fluux && npx vitest run src/components/conversation/whisperTarget.test.ts src/components/RoomMessageInput.memo.test.tsx src/components/RoomView.test.tsx`
+Expected: PASS, no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/fluux/src/components/conversation/whisperTarget.ts apps/fluux/src/components/conversation/whisperTarget.test.ts apps/fluux/src/components/RoomView.tsx
+git commit -m "feat(whisper): private typing indicators + counterpart-gone handling"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS, no stderr.
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Manual smoke (demo mode if a whisper fixture exists, else a real room)**
+
+Verify, against a second client joined to the same room: edit / react / retract on a whisper are received privately by the counterpart and are NOT visible to other occupants; while composing a whisper, other occupants do not see a typing indicator; public-room edit/react/retract still work unchanged.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §1 Send-side routing → Tasks 1-3 (`resolveWhisperRouting` + the three send methods). ✓
+- §2 Receive-side matching → Task 4. ✓
+- §3 Reference-ids / no-store → `resolveWhisperRouting.referenceId = originId ?? id`; `<no-store>` appended in Tasks 1-3, 5. ✓
+- §4 Store updates / carbon sync → optimistic emits unchanged (keyed on `type`); carbon path covered by Task 4's receive routing (sent-carbon unwraps through `handleMessageInternal`). ✓
+- §5 UI capabilities → Task 6 (capability table encoded in `computeMessageActions`). ✓
+- §6 Typing indicator → Task 5 (`sendWhisperChatState`) + Task 7 (routing). ✓
+- §7 Link-preview guard → no behavioural change required; the whisper send path returns before `processLinkPreview`. (No task needed; documented as a non-change.) ✓
+- Edge cases (rename, counterpart-gone) → Task 1 helper + tests; (incoming correction before new-body) → Task 4 ordering. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step contains complete code and exact commands. ✓
+
+**3. Type consistency:** `resolveWhisperRouting` returns `{ recipient, referenceId, nick }` and is used identically in Tasks 1-3. `sendWhisperChatState(roomJid, nick, state)` signature matches across Chat.ts, the three hooks, and the RoomView prop. `computeMessageActions` inputs/outputs match between the helper and its MessageBubble call site. `decideChatStateRoute` return shape matches its consumer in `handleTypingState`. `WhisperCounterpartGoneError.nick` is read in the RoomView catch. ✓
+
+**Note for the implementer:** Task 7 Step 6 touches handlers in two different inner components of `RoomView.tsx` (the bubble wrapper for reactions, the input component for correction/retraction). Confirm `addToast`/`t` scope in each before wiring; if the reaction handler lacks `addToast`, prefer logging there and rely on the Task 6 button-gating (the SDK throw is a backstop, already covered by Task 1-3 tests).

--- a/docs/superpowers/specs/2026-06-24-whisper-operation-parity-design.md
+++ b/docs/superpowers/specs/2026-06-24-whisper-operation-parity-design.md
@@ -1,0 +1,203 @@
+# Whisper Operation Parity (XEP-0045 §7.5) — Design
+
+- **Date:** 2026-06-24
+- **Status:** Approved (design); pending implementation plan
+- **Related:** `packages/fluux-sdk/src/core/modules/Chat.ts` (`sendWhisper`, `sendCorrection`, `sendReaction`, `sendRetraction`, `sendChatState`, receive-side `handleMessageInternal`), `apps/fluux/src/components/RoomView.tsx`, `apps/fluux/src/components/conversation/MessageBubble.tsx`, `apps/fluux/src/components/conversation/whisperTarget.ts`. MUC reference-id rules: `memory/project_muc_reference_id_rules.md`.
+
+## Context
+
+A whisper (XEP-0045 §7.5 private message) is sent as `type='chat'` to `room@conf/nick` with an `<x xmlns='http://jabber.org/protocol/muc#user'/>` marker and a `<no-store>` hint (`Chat.ts:957` `sendWhisper`). It is addressed privately to a single occupant and is never archived on the server.
+
+Every other message operation routes through methods that model only **two** wire shapes:
+
+```ts
+const recipient = type === 'chat' ? getBareJid(to) : to   // chat → bare JID; groupchat → room JID
+```
+
+There is no whisper routing. The room hooks (`useRoomActive.ts:220`, `useRoom.ts`, `useRoomActions.ts`) hardcode `'groupchat'` for corrections, reactions, and retractions, and the room toolbar (`MessageBubble.tsx:397`) gates edit/react/delete on `isOutgoing`/`canModerate` with **no `isPrivate` check**. As a result, any operation on a whisper is re-sent as a **public groupchat message to the room bare JID** — broadcast to everyone in the room.
+
+Locally, the optimistic store update (`room:message-updated`) only patches the body and keeps `isPrivate: true`, so Fluux's own view still renders a private edit. This is the user-reported symptom: *"the message is no longer private once it is edited"* on the wire, while *"in Fluux itself everything looks correct."*
+
+### Audit (what leaks today)
+
+| Operation | XEP | Wire today on a whisper | Leaks |
+|---|---|---|---|
+| Correction (edit) | 0308 | `type=groupchat` → room JID, corrected body broadcast | Yes (reported) |
+| Reaction | 0444 | `type=groupchat` → room JID, `<reactions id=…>` referencing the whisper id | Yes |
+| Retraction (delete own) | 0424 | `type=groupchat` → room JID, retract referencing whisper id | Yes |
+| Typing while whispering | 0085 | `composing`/`paused` to room JID (`RoomView.tsx:1831`) | Yes (metadata) |
+| Moderation (delete incoming as mod) | 0425 | moderation referencing whisper id → room | Edge (server rejects; still wrong) |
+| Link preview (fastening) | 0422 | not sent — whisper send returns early (`RoomView.tsx:1766`) before `processLinkPreview` | No today (latent) |
+| Reply | 0461 | re-enters whisper mode (`RoomView.tsx:340`) | No (already whisper-aware) |
+
+The **receive side** already declares these sub-features out of scope: `Chat.ts:251-264` short-circuits any incoming whisper to `processRoomWhisper` *before* the reaction/correction/retract handlers, so a peer's whisper-correction renders as a brand-new whisper.
+
+## Goals
+
+- Corrections, reactions, and retractions on a whisper are addressed **privately to the one occupant** (`room@conf/nick`, `type=chat`, `muc#user`, `no-store`), never broadcast to the room — both when sent and when received.
+- Typing indicators while composing a whisper are sent **privately to the target**, not the room.
+- The leak is **structurally impossible**: a caller cannot re-introduce it by passing the wrong `type`.
+- Operations survive a counterpart **nick change** (re-resolved via occupant-id) and are **refused** (never broadcast) when the counterpart has left.
+- Own-device **carbon sync**: a whisper operation performed on one device applies correctly (as an edit/reaction/retraction, not a new whisper) on the user's other devices.
+- Zero regression to public room operations and 1:1 chat operations.
+
+## Non-goals
+
+- **MUC end-to-end encryption** for whispers or their operations. A whisper is a MUC-scoped private message and skips the 1:1 E2EE path today (`sendWhisper` applies no E2EE); whisper operations keep that behaviour. MUC E2EE remains a separate later phase.
+- **Server archival** of whispers or their operations. Whispers stay `<no-store>`; durability is local plus carbon sync only.
+- **Cross-client guarantees.** A non-Fluux (or older Fluux) client may not apply a whisper correction/reaction/retraction and may render it as a new private message. This is accepted graceful degradation, not a target.
+- **Local-only retraction when the counterpart has left.** For the MVP, whisper operations are gated on counterpart-present (consistent with the existing reply gate). Local-only retraction-when-gone is a possible follow-up.
+- Read receipts / chat markers in MUC (not sent today; out of scope).
+
+## Architecture
+
+The SDK owns all protocol routing; the app owns UI gating. The design keeps that boundary.
+
+### 1. Send-side routing — auto-detect (the core)
+
+A new private helper on `Chat`:
+
+```ts
+interface WhisperRouting {
+  recipient: string    // room@conf/<current nick>
+  referenceId: string  // originId ?? messageId (never stanza-id)
+  targetNick: string   // for optimistic events / diagnostics
+}
+
+private resolveWhisperRouting(roomJid: string, messageId: string): WhisperRouting | null
+```
+
+Behaviour:
+1. `const msg = this.deps.stores?.room.getMessage(roomJid, messageId)`.
+2. If `!msg?.isPrivate || !msg.whisperWith` → return `null` (normal public/1:1 path; today's behaviour is untouched).
+3. Resolve the **current nick** of the counterpart: find the occupant in `room.occupants` whose `occupantId === msg.whisperWithOccupantId`; fall back to `msg.whisperWith` when the room has no occupant-id support. (Same re-binding logic as `whisperTarget.ts`.)
+4. If the counterpart is **not present**, throw `WhisperCounterpartGoneError` (new SDK error, mirroring `E2EEEncryptionRequiredError`). The helper must **never** fall back to the room-broadcast path.
+5. Return `{ recipient: ${roomJid}/${currentNick}, referenceId: msg.originId ?? messageId, targetNick: currentNick }`.
+
+`sendCorrection` / `sendReaction` / `sendRetraction` each gain a small branch, taken only when `type === 'groupchat'`:
+
+```ts
+const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, messageId) : null
+const isWhisper = whisper !== null
+const recipient   = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+const wireType    = isWhisper ? 'chat' : type            // muc#user private message
+const referenceId = isWhisper ? whisper.referenceId : <existing reference logic>
+// when isWhisper: append <x muc#user/> and <no-store/> to children
+```
+
+**E2EE gating stays on the *original* `type`, not `wireType`.** The 1:1 E2EE branch in each method must read `type === 'chat' && !isWhisper`, so a whisper (original `type='groupchat'`) never triggers 1:1 encryption against `room@conf` (a wrong, non-1:1 JID). This matches `sendWhisper`, which applies no E2EE.
+
+`sendCorrection` already fetches the original message for the reference-id and optimistic update (`Chat.ts:1246`); the helper reuses that lookup. `sendReaction` and `sendRetraction` add the lookup up-front (replacing/augmenting `getMessageReferenceId` for the whisper case).
+
+**Wire example** — correcting your whisper to bob:
+
+```xml
+<message to='room@conf/bob' type='chat' id='new-uuid'>
+  <body>fixed text</body>
+  <replace xmlns='urn:xmpp:message-correct:0' id='origin-id-of-original-whisper'/>
+  <x xmlns='http://jabber.org/protocol/muc#user'/>
+  <origin-id xmlns='urn:xmpp:sid:0' id='new-uuid'/>
+  <no-store xmlns='urn:xmpp:hints'/>
+</message>
+```
+
+The **optimistic events are unchanged** (`room:message-updated`, `room:reactions`): they are keyed by message id in the room store, so they update the whisper in place and keep `isPrivate: true`. Only the wire recipient/type/markers change.
+
+### 2. Receive-side matching
+
+Restructure the `isWhisper` branch in `handleMessageInternal` (`Chat.ts:251-264`): before falling through to `processRoomWhisper` (a genuine new-body whisper), inspect the stanza for sub-feature elements and route them to the existing handlers, scoped to the room store:
+
+- `<replace>` present → incoming whisper **correction** → existing correction apply path (matches the stored whisper by `replace.id` against origin-id/id).
+- bodiless `<reactions>` → incoming whisper **reaction** → `handleIncomingReaction`.
+- `<retract>` → incoming whisper **retraction** → `handleIncomingRetraction`.
+- otherwise → `processRoomWhisper` (unchanged).
+
+**Why reuse the existing handlers** (vs. a separate whisper-operation handler): whispers already live in the room store keyed by id/origin-id; the sender-identity check works unchanged (`from = room@conf/bob` on both the correction and the original); and MUC correction matching is already origin-id-based (per `project_muc_reference_id_rules`). One code path, one set of edge cases. The only change is *where* the whisper branch hands off — it must check for these elements instead of unconditionally treating the stanza as a new whisper.
+
+This same path covers **carbon sync** (§4): an unwrapped sent-carbon whisper-correction flows through `handleMessageInternal` and applies as a correction on the second device. (`Chat.whisper.test.ts:189` already exercises the carbon-wrapped new-whisper case.)
+
+### 3. Reference-ids and `no-store`
+
+Whispers are `<no-store>` — no MAM, no server stanza-id. Therefore every whisper operation references the original by **origin-id** (`originId ?? id`), never stanza-id:
+
+- Corrections already use `originId ?? id` (`Chat.ts:1249`) — correct for whispers as-is.
+- Reactions and retractions currently use `getMessageReferenceId` = `stanzaId ?? id` (`Chat.ts:1705`). For a whisper there is no `stanzaId`, so the helper overrides this with `originId ?? id` via `WhisperRouting.referenceId`.
+
+Whisper operation stanzas also carry `<no-store>` so the server does not archive them.
+
+### 4. Store updates and carbon sync
+
+- Whispers are already locally durable (`noLocalStore` undefined). The optimistic events from §1 update the stored whisper in place (body + `isEdited` for corrections; reactions map for reactions; `isRetracted` + `retractedAt` for retractions), preserving `isPrivate`.
+- Carbon sync relies on §2: the operation stanza is delivered to the user's other devices as a sent-carbon, unwrapped, and routed through the same receive-side matching so it applies as an operation (not a new whisper). No separate carbon code is needed beyond the existing whisper-carbon unwrap.
+
+### 5. UI capabilities (RoomView / MessageBubble)
+
+Whisper bubbles keep their action buttons, now safe, with parity to a 1:1 DM:
+
+| | Own whisper | Incoming whisper |
+|---|---|---|
+| Edit (correct) | yes | — |
+| Delete (retract) | yes | — |
+| React | yes | yes |
+| Reply | yes (already) | yes (already) |
+| Moderate | — | — (gated off) |
+
+Concretely:
+- `canDelete` (`MessageBubble.tsx:398`) drops its `canModerate` branch for whispers: `canDelete = message.isOutgoing && !isIrcGateway` when `isPrivate` (you cannot moderate a private message; the server has no archived copy).
+- Edit / react / delete gate on **counterpart-present** for whispers, mirroring the existing reply gate (`canReply = ... && !counterpartGone`, `MessageBubble.tsx:396`). The bubble already receives `counterpartPresent` (`RoomView.tsx:1426`), so the gate reuses it.
+- The SDK throw from §1 is the backstop: the RoomView operation handlers (`handleCorrection`, `handleReaction`, `handleRetract`) catch `WhisperCounterpartGoneError` and surface the existing `rooms.whisperCounterpartGone` toast rather than crashing.
+
+### 6. Typing indicator (private chat-state)
+
+Typing is composer-driven (there is no stored target message, so §1's auto-detect does not apply). Add a dedicated SDK method:
+
+```ts
+async sendWhisperChatState(roomJid: string, nick: string, state: ChatStateNotification): Promise<void>
+```
+
+It sends the chat-state as `type='chat'` to `room@conf/nick` with the `muc#user` marker (and `no-store`). Exposed through the room hooks (`useRoomActive`, `useRoom`, `useRoomActions`).
+
+In `RoomView`, while a `whisperTarget` is active:
+- `handleTypingState` (`RoomView.tsx:1831`) routes `composing`/`paused` through `sendWhisperChatState(roomJid, whisperTarget.nick, state)` instead of `sendChatState(roomJid, ...)`.
+- The post-send `active` for whispers is already carried by the whisper stanza's own `<active>` element; the public-path `active` (`RoomView.tsx:1818`) is not reached because the whisper send returns early.
+
+### 7. Link preview (latent guard)
+
+No behavioural change. The whisper send path returns at `RoomView.tsx:1766` before `processLinkPreview`, so no whisper-URL preview is generated. Add a guard/comment at the `processLinkPreview` call site (and/or in the SDK `sendLinkPreview`) so a future refactor cannot start broadcasting a whisper-URL preview to the room.
+
+## Edge cases
+
+- **Counterpart renamed:** nick re-resolved from `whisperWithOccupantId` against the live occupant list; operation reaches the same person.
+- **Counterpart left / nick recycled by someone else:** `whisperTargetPresent` is false → UI gates the action; SDK throws `WhisperCounterpartGoneError` as a backstop. Never broadcast.
+- **Room without occupant-id support:** fall back to `msg.whisperWith` nick (best effort, same as the reply path).
+- **Poll vote via reactions:** `votePoll` routes through `sendReaction('groupchat')`, but a poll message is not `isPrivate`, so `resolveWhisperRouting` returns `null` → unchanged public path.
+- **Incoming whisper correction with a body:** the receive-side must check `<replace>` *before* the new-body whisper branch, otherwise it is mis-handled as a new whisper.
+- **Non-Fluux peer:** may render the operation as a new private message (accepted degradation).
+
+## Testing
+
+- **SDK** (`Chat.whisper.test.ts`):
+  - `sendCorrection`/`sendReaction`/`sendRetraction` on a private (whisper) message → `type=chat` to `room@conf/nick`, includes `muc#user` + `no-store`, reference uses origin-id, and the stanza `to` is the occupant JID (not the bare room).
+  - The same methods on a public room message → unchanged (`type=groupchat` to room JID).
+  - Counterpart gone → throws `WhisperCounterpartGoneError`, sends nothing.
+  - Nick changed → routed to the current nick resolved via occupant-id.
+  - Incoming whisper correction/reaction/retraction → applies to the existing whisper thread; asserts `room:whisper` is **not** emitted for a second (new) message.
+  - Whisper-correction sent-carbon → applies as a correction on the second device.
+- **App** (`RoomView`/`MessageBubble` memo tests):
+  - Whisper bubble exposes edit/react/delete per the capability table; moderation gated off; actions disabled when counterpart gone.
+  - `handleTypingState` routes through `sendWhisperChatState` while a whisper target is active, and through `sendChatState` otherwise.
+
+## Files touched (estimate)
+
+- `packages/fluux-sdk/src/core/modules/Chat.ts` — `resolveWhisperRouting`, the three send-method branches, the receive-side `isWhisper` restructure, `sendWhisperChatState`.
+- `packages/fluux-sdk/src/core/...` (errors) — `WhisperCounterpartGoneError`.
+- `packages/fluux-sdk/src/hooks/{useRoomActive,useRoom,useRoomActions}.ts` — expose `sendWhisperChatState` (correction/reaction/retraction signatures unchanged thanks to auto-detect).
+- `apps/fluux/src/components/RoomView.tsx` — typing routing, counterpart-gone catch + toast.
+- `apps/fluux/src/components/conversation/MessageBubble.tsx` — capability gating for whispers (drop moderate, gate on counterpart-present).
+- `packages/fluux-sdk/src/index.ts` — export the new error (and method via hooks).
+- Tests as above.
+
+## Risks
+
+- **Receive-side restructure** touches the hot `handleMessageInternal` path; the `<replace>`/`<reactions>`/`<retract>` checks must be ordered before the new-body whisper fall-through and must not change public-message handling. Mitigated by the existing whisper test suite plus new incoming-operation tests.
+- **Auto-detect depends on the target message being in the room store.** For an optimistically-rendered whisper it always is; a corner case is operating on a message that was evicted by memory windowing — the lookup would miss and the operation would take the public path. Mitigation: the windowing keeps the *active* room resident, and operations are only reachable from rendered (resident) bubbles, so the target is present. Worth an assertion/log if the lookup misses on a `groupchat` correction whose id matches no resident message.

--- a/packages/fluux-sdk/src/core/errors.ts
+++ b/packages/fluux-sdk/src/core/errors.ts
@@ -31,3 +31,22 @@ export class RoomJoinError extends Error {
     Object.setPrototypeOf(this, RoomJoinError.prototype)
   }
 }
+
+/**
+ * Thrown by the whisper operation send path (correction/reaction/retraction)
+ * when the target occupant is no longer present in the room — left, or the nick
+ * has been recycled by a different occupant-id. The operation must NEVER fall
+ * back to a public room broadcast, so the send path throws this instead.
+ */
+export class WhisperCounterpartGoneError extends Error {
+  readonly roomJid: string
+  readonly nick: string
+
+  constructor(roomJid: string, nick: string) {
+    super(`Whisper counterpart "${nick}" is no longer present in ${roomJid}`)
+    this.name = 'WhisperCounterpartGoneError'
+    this.roomJid = roomJid
+    this.nick = nick
+    Object.setPrototypeOf(this, WhisperCounterpartGoneError.prototype)
+  }
+}

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -249,10 +249,39 @@ export class Chat extends BaseModule {
       return { handled: false }
     }
 
-    // Whisper short-circuit: handle before the public sub-feature handlers
-    // (chat states, reactions, corrections, retractions, moderation), which
-    // are out of scope for whispers in v1.
+    // Whisper sub-features (XEP-0045 §7.5). A whisper carrying <reactions>/<retract>/
+    // <replace> is an operation on the EXISTING whisper thread, not a new whisper.
+    // A whisper's bareFrom/bareTo is the room JID, so the room-scoped handlers
+    // resolve the right conversation when type is forced to 'groupchat' (the wire
+    // type is 'chat' only per the private-message convention). Order matters:
+    // check operations before the new-body fall-through.
     if (isWhisper) {
+      const whisperReactionsEl = stanza.getChild('reactions', NS_REACTIONS)
+      if (whisperReactionsEl) {
+        this.handleIncomingReaction(stanza, whisperReactionsEl, from!, bareFrom, bareTo, 'groupchat', isSentCarbon)
+        return { handled: true }
+      }
+
+      const whisperRetractEl = stanza.getChild('retract', NS_RETRACT)
+      if (whisperRetractEl?.attrs.id) {
+        // Consume even if it matches no stored message — the body is just the
+        // XEP-0428 fallback notice, never shown as a new whisper.
+        this.handleIncomingRetraction(
+          whisperRetractEl.attrs.id, from!, bareFrom, bareTo, 'groupchat', isSentCarbon,
+          stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id,
+        )
+        return { handled: true }
+      }
+
+      const whisperReplaceEl = stanza.getChild('replace', NS_CORRECTION)
+      if (whisperReplaceEl?.attrs.id && body && this.handleIncomingCorrection(
+        stanza, whisperReplaceEl.attrs.id, from!, bareFrom, bareTo, body, 'groupchat', isSentCarbon,
+      )) {
+        return { handled: true }
+      }
+
+      // Genuine new whisper (body or media), or a correction that matched no stored
+      // message (e.g. evicted) — show the (corrected) text as a whisper.
       if (body || stanza.getChild('x', NS_OOB)) {
         // from is non-null here: isWhisper guards !!from
         const whisper = this.processRoomWhisper(stanza, from!, bareFrom, body || '', isSentCarbon)
@@ -261,7 +290,7 @@ export class Chat extends BaseModule {
         }
         return { handled: true, message: whisper }
       }
-      // Bodyless whisper (e.g. a stray chat-state): claim and drop in v1.
+      // Bodyless whisper (e.g. a stray chat-state): claim and drop.
       return { handled: true }
     }
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1149,6 +1149,21 @@ export class Chat extends BaseModule {
   }
 
   /**
+   * Send a chat state (XEP-0085) privately to a single room occupant — the typing
+   * indicator for a whisper (XEP-0045 §7.5). Unlike sendChatState('groupchat'),
+   * which broadcasts to the room, this addresses room/nick with the muc#user marker
+   * and a no-store hint, so the room never sees that you are whispering.
+   */
+  async sendWhisperChatState(roomJid: string, nick: string, state: ChatStateNotification): Promise<void> {
+    const message = xml('message', { to: `${roomJid}/${nick}`, type: 'chat' },
+      xml(state, { xmlns: NS_CHATSTATES }),
+      xml('x', { xmlns: NS_MUC_USER }),
+      xml('no-store', { xmlns: NS_HINTS }),
+    )
+    await this.deps.sendStanza(message)
+  }
+
+  /**
    * Send or update reactions on a message (XEP-0444).
    *
    * Reactions allow users to respond to messages with emoji without sending

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -33,6 +33,7 @@ import {
 import { dataToElement } from '../e2ee/stanzaAdapter'
 import type { E2EEManager } from '../e2ee'
 import { E2EEEncryptionRequiredError } from '../e2ee'
+import { WhisperCounterpartGoneError } from '../errors'
 import {
   decryptStanzaInPlace,
   deriveConversationContext,
@@ -1235,7 +1236,13 @@ export class Chat extends BaseModule {
    * - Corrected messages are marked with `isEdited: true`
    */
   async sendCorrection(to: string, originalMessageId: string, newBody: string, type: 'chat' | 'groupchat' = 'chat', attachment?: FileAttachment): Promise<void> {
-    const recipient = type === 'chat' ? getBareJid(to) : to
+    // XEP-0045 §7.5: if the target is a whisper, address the correction privately
+    // to the one occupant (type=chat to room/nick + muc#user + no-store) instead of
+    // broadcasting to the room. Throws WhisperCounterpartGoneError if they have left.
+    const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, originalMessageId) : null
+    const isWhisper = whisper !== null
+    const recipient = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+    const wireType: 'chat' | 'groupchat' = isWhisper ? 'chat' : type
 
     // XEP-0308 (Last Message Correction) has NO group-chat carve-out — unlike
     // XEP-0461 replies, XEP-0444 reactions and XEP-0424 retractions, which all
@@ -1246,7 +1253,7 @@ export class Chat extends BaseModule {
     const original = type === 'groupchat'
       ? this.deps.stores?.room.getMessage(to, originalMessageId)
       : this.deps.stores?.chat.getMessage(to, originalMessageId)
-    const referenceId = original?.originId ?? originalMessageId
+    const referenceId = isWhisper ? whisper.referenceId : (original?.originId ?? originalMessageId)
 
     // Build the body text, preserving user text when there's an attachment
     let bodyText = newBody
@@ -1310,6 +1317,10 @@ export class Chat extends BaseModule {
     const correctionStanzaId = generateUUID()
     children.push(createOriginIdElement(correctionStanzaId))
 
+    if (isWhisper) {
+      children.push(xml('x', { xmlns: NS_MUC_USER }), xml('no-store', { xmlns: NS_HINTS }))
+    }
+
     // Encrypt the corrected body for 1:1 chats. Without this an edit on
     // an encrypted conversation would push the plaintext correction to
     // the server. E2EE peers handle <replace> natively. MUC encryption
@@ -1326,7 +1337,7 @@ export class Chat extends BaseModule {
       throw new E2EEEncryptionRequiredError({ kind: 'direct', peer: recipient })
     }
 
-    await this.deps.sendStanza(xml('message', { to: recipient, type, id: correctionStanzaId }, ...children))
+    await this.deps.sendStanza(xml('message', { to: recipient, type: wireType, id: correctionStanzaId }, ...children))
 
     // SDK events only - bindings call store methods. Reuses the original
     // message fetched above for the correction reference.
@@ -1695,6 +1706,38 @@ export class Chat extends BaseModule {
       if (bareFrom === myBareJid) return
       this.deps.emitSDK('chat:typing', { conversationId: bareFrom, jid: bareFrom, isTyping })
     }
+  }
+
+  /**
+   * XEP-0045 §7.5: when an operation (correction/reaction/retraction) targets a
+   * stored whisper, address it privately to the one occupant — never broadcast to
+   * the room. Returns the private routing derived from the stored message, or null
+   * when the target is a normal public/1:1 message (caller keeps its existing path).
+   *
+   * The current nick is re-resolved from the counterpart's stable occupant-id
+   * (XEP-0421) so the operation survives a rename. If the counterpart has left
+   * (occupant-id gone, or nick gone in rooms without occupant-id), it throws
+   * WhisperCounterpartGoneError — it must NEVER fall back to the room-broadcast path.
+   */
+  private resolveWhisperRouting(
+    roomJid: string,
+    messageId: string,
+  ): { recipient: string; referenceId: string; nick: string } | null {
+    const msg = this.deps.stores?.room.getMessage(roomJid, messageId)
+    if (!msg?.isPrivate || !msg.whisperWith) return null
+
+    const occupants = this.deps.stores?.room.getRoom(roomJid)?.occupants
+    let nick: string | null = null
+    if (msg.whisperWithOccupantId && occupants) {
+      for (const [occNick, occ] of occupants) {
+        if (occ.occupantId === msg.whisperWithOccupantId) { nick = occNick; break }
+      }
+    } else if (occupants?.has(msg.whisperWith)) {
+      nick = msg.whisperWith
+    }
+    if (!nick) throw new WhisperCounterpartGoneError(roomJid, msg.whisperWith)
+
+    return { recipient: `${roomJid}/${nick}`, referenceId: msg.originId ?? messageId, nick }
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1385,10 +1385,15 @@ export class Chat extends BaseModule {
    * - A fallback message is included for clients that don't support XEP-0424
    */
   async sendRetraction(to: string, originalMessageId: string, type: 'chat' | 'groupchat' = 'chat'): Promise<void> {
-    const recipient = type === 'chat' ? getBareJid(to) : to
+    // XEP-0045 §7.5: a retraction of a whisper is addressed privately to the one
+    // occupant; whispers are <no-store> so the reference is the origin-id.
+    const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, originalMessageId) : null
+    const isWhisper = whisper !== null
+    const recipient = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+    const wireType: 'chat' | 'groupchat' = isWhisper ? 'chat' : type
 
     // For MUC, prefer stanzaId (server-assigned, stable) for the retraction reference
-    const referenceId = this.getMessageReferenceId(to, originalMessageId, type)
+    const referenceId = isWhisper ? whisper.referenceId : this.getMessageReferenceId(to, originalMessageId, type)
 
     // XEP-0424: Message Retraction with fallback for non-supporting clients
     const fallbackBody = 'This person attempted to retract a previous message, but it\'s unsupported by your client.'
@@ -1401,6 +1406,10 @@ export class Chat extends BaseModule {
       xml('fallback', { xmlns: NS_FALLBACK, for: NS_RETRACT }),
       createOriginIdElement(retractionStanzaId),
     ]
+
+    if (isWhisper) {
+      children.push(xml('x', { xmlns: NS_MUC_USER }), xml('no-store', { xmlns: NS_HINTS }))
+    }
 
     // Encrypt the retract element for 1:1 chats. On success the helper hides
     // the retraction (the English notice is replaced by the generic encrypted
@@ -1416,7 +1425,7 @@ export class Chat extends BaseModule {
     }
 
     await this.deps.sendStanza(
-      xml('message', { to: recipient, type, id: retractionStanzaId }, ...children),
+      xml('message', { to: recipient, type: wireType, id: retractionStanzaId }, ...children),
     )
 
     // SDK events only - optimistic update via bindings

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1144,11 +1144,16 @@ export class Chat extends BaseModule {
    * ```
    */
   async sendReaction(to: string, messageId: string, emojis: string[], type: 'chat' | 'groupchat' = 'chat'): Promise<void> {
-    const recipient = type === 'chat' ? getBareJid(to) : to
+    // XEP-0045 §7.5: a reaction on a whisper is addressed privately to the one
+    // occupant; whispers are <no-store> so the reference is the origin-id.
+    const whisper = type === 'groupchat' ? this.resolveWhisperRouting(to, messageId) : null
+    const isWhisper = whisper !== null
+    const recipient = isWhisper ? whisper.recipient : (type === 'chat' ? getBareJid(to) : to)
+    const wireType: 'chat' | 'groupchat' = isWhisper ? 'chat' : type
 
     // For MUC, prefer stanzaId (server-assigned, stable) over client-generated id
     // Other clients (e.g. Gajim) reference messages by stanzaId in reactions
-    const referenceId = this.getMessageReferenceId(to, messageId, type)
+    const referenceId = isWhisper ? whisper.referenceId : this.getMessageReferenceId(to, messageId, type)
 
     const reactionElements = emojis.map(emoji => xml('reaction', {}, emoji))
 
@@ -1190,11 +1195,14 @@ export class Chat extends BaseModule {
         outerBody: 'remove',
         storeHint: 'store',
       })
+    } else if (isWhisper) {
+      // Whisper reaction: muc#user marker + no-store (kept off the room archive).
+      children.push(xml('x', { xmlns: NS_MUC_USER }), xml('no-store', { xmlns: NS_HINTS }))
     } else {
       children.push(xml('store', { xmlns: NS_HINTS }))
     }
 
-    const message = xml('message', { to: recipient, type, id: reactionStanzaId }, ...children)
+    const message = xml('message', { to: recipient, type: wireType, id: reactionStanzaId }, ...children)
     await this.deps.sendStanza(message)
 
     // SDK events only - bindings call store methods

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -407,4 +407,81 @@ describe('MUC Whispers', () => {
       expect(sent.children.find((c: any) => c.name === 'x')).toBeUndefined()
     })
   })
+
+  describe('whisper operations (receive)', () => {
+    const ROOM = 'room@conference.example.com'
+
+    beforeEach(() => {
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(
+        createMockRoom(ROOM, { joined: true, nickname: 'me' }),
+      )
+    })
+
+    it('incoming whisper reaction updates the whisper thread, not a new whisper', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+
+      const stanza = createMockElement('message', {
+        from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'r-1',
+      }, [
+        { name: 'reactions', attrs: { xmlns: 'urn:xmpp:reactions:0', id: 'w-1' }, children: [{ name: 'reaction', text: '👍' }] },
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+      ])
+      mockXmppClientInstance._emit('stanza', stanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:reactions', expect.objectContaining({
+        roomJid: ROOM, messageId: 'w-1', reactorNick: 'bob', emojis: ['👍'],
+      }))
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+    })
+
+    it('incoming whisper correction updates the existing whisper (not a new whisper)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+      vi.mocked(mockStores.room.getMessage).mockReturnValue({
+        id: 'bw-1', originId: 'bw-1', from: `${ROOM}/bob`, nick: 'bob', body: 'old',
+        isPrivate: true, whisperWith: 'bob', occupantId: 'occ-bob', timestamp: new Date(),
+      } as any)
+
+      const stanza = createMockElement('message', {
+        from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'corr-1',
+      }, [
+        { name: 'body', text: 'new text' },
+        { name: 'replace', attrs: { xmlns: 'urn:xmpp:message-correct:0', id: 'bw-1' } },
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+      ])
+      mockXmppClientInstance._emit('stanza', stanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+        roomJid: ROOM, messageId: 'bw-1', updates: expect.objectContaining({ body: 'new text', isEdited: true }),
+      }))
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+    })
+
+    it('incoming whisper retraction marks the whisper retracted (not a new whisper)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+      vi.mocked(mockStores.room.getMessage).mockReturnValue({
+        id: 'bw-1', from: `${ROOM}/bob`, nick: 'bob', occupantId: 'occ-bob',
+        isPrivate: true, whisperWith: 'bob', timestamp: new Date(),
+      } as any)
+
+      const stanza = createMockElement('message', {
+        from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'rt-1',
+      }, [
+        { name: 'body', text: 'This person attempted to retract a previous message...' },
+        { name: 'retract', attrs: { xmlns: 'urn:xmpp:message-retract:1', id: 'bw-1' } },
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+      ])
+      mockXmppClientInstance._emit('stanza', stanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message-updated', expect.objectContaining({
+        roomJid: ROOM, messageId: 'bw-1', updates: expect.objectContaining({ isRetracted: true }),
+      }))
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -271,7 +271,10 @@ describe('MUC Whispers', () => {
 
     function storedWhisper(overrides: Record<string, unknown> = {}) {
       return {
-        type: 'groupchat', id: 'w-1', originId: 'w-1', roomJid: ROOM,
+        // id and originId are INTENTIONALLY different so that send tests can prove the
+        // code uses origin-id (not message-id) as the protocol reference. Whispers are
+        // <no-store>, so the correct reference is `originId ?? messageId`.
+        type: 'groupchat', id: 'w-msg-1', originId: 'w-1', roomJid: ROOM,
         from: `${ROOM}/me`, nick: 'me', body: 'secret', timestamp: new Date(),
         isOutgoing: true, isPrivate: true, whisperWith: 'bob', whisperWithOccupantId: 'occ-bob',
         ...overrides,
@@ -283,7 +286,10 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
-      await xmppClient.chat.sendCorrection(ROOM, 'w-1', 'fixed secret', 'groupchat')
+      // Pass the message-id (w-msg-1) to the operation; assert that the protocol
+      // reference is the origin-id (w-1). If the code used message-id, this would
+      // be 'w-msg-1' and the test would fail — proving origin-id is used.
+      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed secret', 'groupchat')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -318,7 +324,7 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
       await expect(
-        xmppClient.chat.sendCorrection(ROOM, 'w-1', 'x', 'groupchat'),
+        xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'x', 'groupchat'),
       ).rejects.toThrow(WhisperCounterpartGoneError)
       expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
     })
@@ -330,7 +336,7 @@ describe('MUC Whispers', () => {
       ])))
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
-      await xmppClient.chat.sendCorrection(ROOM, 'w-1', 'fixed', 'groupchat')
+      await xmppClient.chat.sendCorrection(ROOM, 'w-msg-1', 'fixed', 'groupchat')
 
       expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.to).toBe(`${ROOM}/bobby`)
     })
@@ -340,7 +346,8 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
-      await xmppClient.chat.sendReaction(ROOM, 'w-1', ['👍'], 'groupchat')
+      // Pass the message-id (w-msg-1); the protocol reference must be the origin-id (w-1).
+      await xmppClient.chat.sendReaction(ROOM, 'w-msg-1', ['👍'], 'groupchat')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -359,7 +366,8 @@ describe('MUC Whispers', () => {
       vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
       vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
 
-      await xmppClient.chat.sendRetraction(ROOM, 'w-1', 'groupchat')
+      // Pass the message-id (w-msg-1); the protocol reference must be the origin-id (w-1).
+      await xmppClient.chat.sendRetraction(ROOM, 'w-msg-1', 'groupchat')
 
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
@@ -415,9 +423,13 @@ describe('MUC Whispers', () => {
       const sent = mockXmppClientInstance.send.mock.calls[0][0]
       expect(sent.attrs.to).toBe(`${ROOM}/bob`)
       expect(sent.attrs.type).toBe('chat')
-      expect(sent.children.find((c: any) => c.name === 'composing')).toBeDefined()
+      const composingEl = sent.children.find((c: any) => c.name === 'composing')
+      expect(composingEl).toBeDefined()
+      expect(composingEl.attrs.xmlns).toBe('http://jabber.org/protocol/chatstates')
       expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
-      expect(sent.children.find((c: any) => c.name === 'no-store')).toBeDefined()
+      const noStoreEl = sent.children.find((c: any) => c.name === 'no-store')
+      expect(noStoreEl).toBeDefined()
+      expect(noStoreEl.attrs.xmlns).toBe('urn:xmpp:hints')
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -14,6 +14,7 @@ import {
   type MockXmppClient,
   type MockStoreBindings,
 } from '../test-utils'
+import { WhisperCounterpartGoneError } from '../errors'
 
 let mockXmppClientInstance: MockXmppClient
 
@@ -256,6 +257,82 @@ describe('MUC Whispers', () => {
       expect(mockStores.room.getRoom).toHaveBeenCalledWith('contact@example.com')
       expect(emitSDKSpy).toHaveBeenCalledWith('chat:message', expect.anything())
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+    })
+  })
+
+  describe('whisper operations (send)', () => {
+    const ROOM = 'room@conference.example.com'
+
+    function roomWithBob(occupants: Map<string, any> = new Map([
+      ['bob', { nick: 'bob', affiliation: 'member', role: 'participant', occupantId: 'occ-bob' }],
+    ])) {
+      return createMockRoom(ROOM, { joined: true, nickname: 'me', occupants })
+    }
+
+    function storedWhisper(overrides: Record<string, unknown> = {}) {
+      return {
+        type: 'groupchat', id: 'w-1', originId: 'w-1', roomJid: ROOM,
+        from: `${ROOM}/me`, nick: 'me', body: 'secret', timestamp: new Date(),
+        isOutgoing: true, isPrivate: true, whisperWith: 'bob', whisperWithOccupantId: 'occ-bob',
+        ...overrides,
+      }
+    }
+
+    it('sendCorrection on a whisper addresses room/nick privately (type=chat, muc#user, no-store, origin-id)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+      vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+      await xmppClient.chat.sendCorrection(ROOM, 'w-1', 'fixed secret', 'groupchat')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+      expect(sent.attrs.type).toBe('chat')
+      const replace = sent.children.find((c: any) => c.name === 'replace')
+      expect(replace.attrs.id).toBe('w-1')
+      expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+      const noStore = sent.children.find((c: any) => c.name === 'no-store')
+      expect(noStore).toBeDefined()
+      expect(noStore.attrs.xmlns).toBe('urn:xmpp:hints')
+    })
+
+    it('sendCorrection on a public room message still broadcasts to the room (no regression)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+      vi.mocked(mockStores.room.getMessage).mockReturnValue({
+        type: 'groupchat', id: 'm-1', originId: 'm-1', roomJid: ROOM, from: `${ROOM}/me`,
+        nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
+      } as any)
+
+      await xmppClient.chat.sendCorrection(ROOM, 'm-1', 'hi fixed', 'groupchat')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(ROOM)
+      expect(sent.attrs.type).toBe('groupchat')
+      expect(sent.children.find((c: any) => c.name === 'no-store')).toBeUndefined()
+    })
+
+    it('throws WhisperCounterpartGoneError and sends nothing when the counterpart has left', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob(new Map()))
+      vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+      await expect(
+        xmppClient.chat.sendCorrection(ROOM, 'w-1', 'x', 'groupchat'),
+      ).rejects.toThrow(WhisperCounterpartGoneError)
+      expect(mockXmppClientInstance.send).not.toHaveBeenCalled()
+    })
+
+    it('re-resolves the current nick from occupant-id after a rename', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob(new Map([
+        ['bobby', { nick: 'bobby', affiliation: 'member', role: 'participant', occupantId: 'occ-bob' }],
+      ])))
+      vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+      await xmppClient.chat.sendCorrection(ROOM, 'w-1', 'fixed', 'groupchat')
+
+      expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.to).toBe(`${ROOM}/bobby`)
     })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -334,5 +334,24 @@ describe('MUC Whispers', () => {
 
       expect(mockXmppClientInstance.send.mock.calls[0][0].attrs.to).toBe(`${ROOM}/bobby`)
     })
+
+    it('sendReaction on a whisper addresses room/nick privately with no-store (not the room)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+      vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+      await xmppClient.chat.sendReaction(ROOM, 'w-1', ['👍'], 'groupchat')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+      expect(sent.attrs.type).toBe('chat')
+      const reactions = sent.children.find((c: any) => c.name === 'reactions')
+      expect(reactions.attrs.id).toBe('w-1')
+      expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+      const noStore = sent.children.find((c: any) => c.name === 'no-store')
+      expect(noStore).toBeDefined()
+      expect(noStore.attrs.xmlns).toBe('urn:xmpp:hints')
+      expect(sent.children.find((c: any) => c.name === 'store')).toBeUndefined()
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -371,5 +371,40 @@ describe('MUC Whispers', () => {
       expect(noStore).toBeDefined()
       expect(noStore.attrs.xmlns).toBe('urn:xmpp:hints')
     })
+
+    it('sendReaction on a public room message still broadcasts to the room (no regression)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+      vi.mocked(mockStores.room.getMessage).mockReturnValue({
+        type: 'groupchat', id: 'm-1', originId: 'm-1', roomJid: ROOM,
+        from: `${ROOM}/me`, nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
+      } as any)
+
+      await xmppClient.chat.sendReaction(ROOM, 'm-1', ['👍'], 'groupchat')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(ROOM)
+      expect(sent.attrs.type).toBe('groupchat')
+      expect(sent.children.find((c: any) => c.name === 'no-store')).toBeUndefined()
+      expect(sent.children.find((c: any) => c.name === 'x')).toBeUndefined()
+      expect(sent.children.find((c: any) => c.name === 'store')).toBeDefined()
+    })
+
+    it('sendRetraction on a public room message still broadcasts to the room (no regression)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+      vi.mocked(mockStores.room.getMessage).mockReturnValue({
+        type: 'groupchat', id: 'm-1', originId: 'm-1', roomJid: ROOM,
+        from: `${ROOM}/me`, nick: 'me', body: 'hi', timestamp: new Date(), isOutgoing: true,
+      } as any)
+
+      await xmppClient.chat.sendRetraction(ROOM, 'm-1', 'groupchat')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(ROOM)
+      expect(sent.attrs.type).toBe('groupchat')
+      expect(sent.children.find((c: any) => c.name === 'no-store')).toBeUndefined()
+      expect(sent.children.find((c: any) => c.name === 'x')).toBeUndefined()
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -483,5 +483,49 @@ describe('MUC Whispers', () => {
       }))
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
     })
+
+    it('incoming whisper retraction with no matching message is consumed, not shown as a new whisper', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+      // getMessage is left at its fresh default (returns undefined) — no match.
+
+      const stanza = createMockElement('message', {
+        from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'rt-x',
+      }, [
+        { name: 'body', text: 'This person attempted to retract a previous message...' },
+        { name: 'retract', attrs: { xmlns: 'urn:xmpp:message-retract:1', id: 'nonexistent' } },
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+      ])
+      mockXmppClientInstance._emit('stanza', stanza)
+
+      // The body is the XEP-0428 fallback notice; it must NOT surface as a new whisper,
+      // and with no match there is nothing to update.
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:whisper', expect.anything())
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
+    })
+
+    it('incoming whisper correction with no matching message falls through to a new whisper', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(createMockRoom(ROOM, { joined: true, nickname: 'me' }))
+      // getMessage is left at its fresh default (returns undefined) — handleIncomingCorrection returns false.
+
+      const stanza = createMockElement('message', {
+        from: `${ROOM}/bob`, to: 'user@example.com', type: 'chat', id: 'corr-x',
+      }, [
+        { name: 'body', text: 'corrected but orphaned' },
+        { name: 'replace', attrs: { xmlns: 'urn:xmpp:message-correct:0', id: 'nonexistent' } },
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc#user' } },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-bob' } },
+      ])
+      mockXmppClientInstance._emit('stanza', stanza)
+
+      // No stored original to correct, so the corrected text is shown as a new whisper.
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:whisper', expect.objectContaining({
+        roomJid: ROOM,
+        message: expect.objectContaining({ body: 'corrected but orphaned', isPrivate: true }),
+      }))
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -353,5 +353,23 @@ describe('MUC Whispers', () => {
       expect(noStore.attrs.xmlns).toBe('urn:xmpp:hints')
       expect(sent.children.find((c: any) => c.name === 'store')).toBeUndefined()
     })
+
+    it('sendRetraction on a whisper addresses room/nick privately with no-store (not the room)', async () => {
+      await connectClient()
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(roomWithBob())
+      vi.mocked(mockStores.room.getMessage).mockReturnValue(storedWhisper() as any)
+
+      await xmppClient.chat.sendRetraction(ROOM, 'w-1', 'groupchat')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+      expect(sent.attrs.type).toBe('chat')
+      const retract = sent.children.find((c: any) => c.name === 'retract')
+      expect(retract.attrs.id).toBe('w-1')
+      expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+      const noStore = sent.children.find((c: any) => c.name === 'no-store')
+      expect(noStore).toBeDefined()
+      expect(noStore.attrs.xmlns).toBe('urn:xmpp:hints')
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.whisper.test.ts
@@ -406,6 +406,19 @@ describe('MUC Whispers', () => {
       expect(sent.children.find((c: any) => c.name === 'no-store')).toBeUndefined()
       expect(sent.children.find((c: any) => c.name === 'x')).toBeUndefined()
     })
+
+    it('sendWhisperChatState sends a private chat-state to room/nick (muc#user, no-store)', async () => {
+      await connectClient()
+
+      await xmppClient.chat.sendWhisperChatState(ROOM, 'bob', 'composing')
+
+      const sent = mockXmppClientInstance.send.mock.calls[0][0]
+      expect(sent.attrs.to).toBe(`${ROOM}/bob`)
+      expect(sent.attrs.type).toBe('chat')
+      expect(sent.children.find((c: any) => c.name === 'composing')).toBeDefined()
+      expect(sent.children.find((c: any) => c.name === 'x' && c.attrs.xmlns === 'http://jabber.org/protocol/muc#user')).toBeDefined()
+      expect(sent.children.find((c: any) => c.name === 'no-store')).toBeDefined()
+    })
   })
 
   describe('whisper operations (receive)', () => {

--- a/packages/fluux-sdk/src/hooks/useRoom.ts
+++ b/packages/fluux-sdk/src/hooks/useRoom.ts
@@ -301,6 +301,13 @@ export function useRoom() {
     [client]
   )
 
+  const sendWhisperChatState = useCallback(
+    async (roomJid: string, nick: string, state: ChatStateNotification) => {
+      await client.chat.sendWhisperChatState(roomJid, nick, state)
+    },
+    [client]
+  )
+
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
       await client.chat.sendEasterEgg(roomJid, 'groupchat', animation)
@@ -603,6 +610,7 @@ export function useRoom() {
       retractMessage,
       moderateMessage,
       sendChatState,
+      sendWhisperChatState,
       setBookmark,
       removeBookmark,
       setRoomNotifyAll,
@@ -655,6 +663,7 @@ export function useRoom() {
       retractMessage,
       moderateMessage,
       sendChatState,
+      sendWhisperChatState,
       setBookmark,
       removeBookmark,
       setRoomNotifyAll,

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -202,6 +202,13 @@ export function useRoomActions() {
     [client]
   )
 
+  const sendWhisperChatState = useCallback(
+    async (roomJid: string, nick: string, state: ChatStateNotification) => {
+      await client.chat.sendWhisperChatState(roomJid, nick, state)
+    },
+    [client]
+  )
+
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
       await client.chat.sendEasterEgg(roomJid, 'groupchat', animation)
@@ -428,6 +435,7 @@ export function useRoomActions() {
       retractMessage,
       moderateMessage,
       sendChatState,
+      sendWhisperChatState,
       setBookmark,
       removeBookmark,
       setRoomNotifyAll,
@@ -480,6 +488,7 @@ export function useRoomActions() {
       retractMessage,
       moderateMessage,
       sendChatState,
+      sendWhisperChatState,
       setBookmark,
       removeBookmark,
       setRoomNotifyAll,

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -252,6 +252,13 @@ export function useRoomActive() {
     [client]
   )
 
+  const sendWhisperChatState = useCallback(
+    async (roomJid: string, nick: string, state: ChatStateNotification) => {
+      await client.chat.sendWhisperChatState(roomJid, nick, state)
+    },
+    [client]
+  )
+
   const sendEasterEgg = useCallback(
     async (roomJid: string, animation: string) => {
       await client.chat.sendEasterEgg(roomJid, 'groupchat', animation)
@@ -441,6 +448,7 @@ export function useRoomActive() {
       retractMessage,
       moderateMessage,
       sendChatState,
+      sendWhisperChatState,
       setRoomNotifyAll,
       sendEasterEgg,
       clearAnimation,
@@ -478,6 +486,7 @@ export function useRoomActive() {
       retractMessage,
       moderateMessage,
       sendChatState,
+      sendWhisperChatState,
       setRoomNotifyAll,
       sendEasterEgg,
       clearAnimation,

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -654,7 +654,7 @@ export { classifyConnectionError, extractTransportErrorClass, humanizeTransportE
 export type { ConnectionErrorKind } from './core/modules/transportErrors'
 
 // MUC join failure error (rejected by client.muc.joinResult)
-export { RoomJoinError } from './core/errors'
+export { RoomJoinError, WhisperCounterpartGoneError } from './core/errors'
 
 // XEP-0045: MUC Permission Utilities
 export { canSetAffiliation, canSetRole, canKick, canBan, canModerate, getAvailableAffiliations, getAvailableRoles } from './utils/mucPermissions'


### PR DESCRIPTION
Whisper operations (XEP-0045 section 7.5, private MUC messages) previously broadcast to the whole room when you edited, reacted to, retracted, or typed in a whisper, a privacy leak: the edited message became public while Fluux itself still showed it as private.