### PR TITLE
fix(perf): stop per-keystroke message-list reflow while typing (chat + rooms)

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -421,7 +421,11 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
       <div
         ref={mainContentRef as React.RefObject<HTMLDivElement>}
         tabIndex={0}
-        className="focus-zone flex-1 flex flex-col min-h-0 p-1 relative"
+        // `composer-active` hides the per-message hover toolbars while typing via
+        // CSS (index.css), instead of threading `isComposing` into every row's
+        // `hideToolbar` prop — which re-rendered (and relayouted) the whole
+        // non-virtualized list on each typing burst.
+        className={`focus-zone flex-1 flex flex-col min-h-0 p-1 relative${isComposing ? ' composer-active' : ''}`}
         onKeyDown={handleMessageListKeyDown}
         onMouseMove={(e) => {
           // Find which message is being hovered (for keyboard nav starting point)
@@ -459,7 +463,6 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
             onEdit={setEditingMessage}
             lastOutgoingMessageId={lastOutgoingMessageId}
             lastMessageId={lastMessageId}
-            isComposing={isComposing}
             activeReactionPickerMessageId={activeReactionPickerMessageId}
             onReactionPickerChange={handleReactionPickerChange}
             retractMessage={retractMessage}
@@ -552,7 +555,6 @@ export const ChatMessageList = memo(function ChatMessageList({
   onEdit,
   lastOutgoingMessageId,
   lastMessageId,
-  isComposing,
   activeReactionPickerMessageId,
   onReactionPickerChange,
   retractMessage,
@@ -592,7 +594,6 @@ export const ChatMessageList = memo(function ChatMessageList({
   onEdit: (message: Message) => void
   lastOutgoingMessageId: string | null
   lastMessageId: string | null
-  isComposing: boolean
   activeReactionPickerMessageId: string | null
   onReactionPickerChange: (messageId: string, isOpen: boolean) => void
   retractMessage: (conversationId: string, messageId: string) => Promise<void>
@@ -647,7 +648,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       onEdit={onEdit}
       isLastOutgoing={msg.id === lastOutgoingMessageId}
       isLastMessage={msg.id === lastMessageId}
-      hideToolbar={isComposing || (activeReactionPickerMessageId !== null && activeReactionPickerMessageId !== msg.id)}
+      hideToolbar={activeReactionPickerMessageId !== null && activeReactionPickerMessageId !== msg.id}
       onReactionPickerChange={onReactionPickerChange}
       retractMessage={retractMessage}
       retryMessage={retryMessage}

--- a/apps/fluux/src/components/MessageComposer.autosize.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.autosize.test.tsx
@@ -131,4 +131,89 @@ describe('MessageComposer autosize', () => {
     unmount()
     expect(roDisconnected).toBeGreaterThan(0)
   })
+
+  // --- Per-keystroke forced-layout avoidance --------------------------------
+  // resizeToContent ran on every keystroke and unconditionally (a) reset the
+  // textarea to height:auto and (b) called onInputResize. The auto-reset
+  // changes the composer's box, relayouting the flex column — including the
+  // entire non-virtualized message list — and onInputResize then reads the
+  // list's scrollHeight, forcing a second full layout. In a long conversation
+  // every keystroke therefore paid a full message-list reflow (~30ms measured
+  // at ~900 messages). The composer must not disturb layout when the typed
+  // text does not change the composer's height.
+  const renderWithResize = (value: string, onInputResize: () => void) =>
+    render(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value={value}
+        onValueChange={() => {}}
+        onInputResize={onInputResize}
+      />
+    )
+
+  it('does not fire onInputResize on an append that leaves the height unchanged', () => {
+    const onInputResize = vi.fn()
+    mockScrollHeight = 48
+    const { rerender } = renderWithResize('Hello', onInputResize)
+    onInputResize.mockClear() // ignore the mount-time sizing call
+
+    // Append one character on the same line — height is unchanged.
+    rerender(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value="Hello!"
+        onValueChange={() => {}}
+        onInputResize={onInputResize}
+      />
+    )
+
+    expect(onInputResize).not.toHaveBeenCalled()
+  })
+
+  it('fires onInputResize and grows when an append wraps to a new line', () => {
+    const onInputResize = vi.fn()
+    mockScrollHeight = 48
+    const { container, rerender } = renderWithResize('Hello', onInputResize)
+    onInputResize.mockClear()
+
+    mockScrollHeight = 72 // content now needs a second line
+    rerender(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value="Hello world that now wraps onto a second line"
+        onValueChange={() => {}}
+        onInputResize={onInputResize}
+      />
+    )
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.style.height).toBe('72px')
+    expect(onInputResize).toHaveBeenCalled()
+  })
+
+  it('shrinks (and fires onInputResize) when text is deleted back to one line', () => {
+    const onInputResize = vi.fn()
+    mockScrollHeight = 72
+    const { container, rerender } = renderWithResize('two\nlines', onInputResize)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.style.height).toBe('72px')
+    onInputResize.mockClear()
+
+    mockScrollHeight = 48 // deleted back to one line
+    rerender(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value="two"
+        onValueChange={() => {}}
+        onInputResize={onInputResize}
+      />
+    )
+
+    expect(textarea.style.height).toBe('48px')
+    expect(onInputResize).toHaveBeenCalled()
+  })
 })

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -311,25 +311,58 @@ export function MessageComposer({
   // below doesn't re-subscribe on parent re-renders.
   const onInputResizeRef = useRef(onInputResize)
   onInputResizeRef.current = onInputResize
-  const resizeToContent = useCallback(() => {
+  // Autosize bookkeeping. The previous textarea value and the height we last
+  // set let us skip the layout-disturbing work on keystrokes that cannot
+  // change the composer's height (the common case). Resetting to height:auto
+  // is what dirties the flex column — and therefore relayouts the entire,
+  // non-virtualized message list — so a plain append must avoid it. See
+  // MessageComposer.autosize.test.tsx for the regression guard.
+  const prevValueRef = useRef('')
+  const lastSetHeightRef = useRef(0)
+  const countLines = (s: string) => {
+    let n = 1
+    for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 10) n++
+    return n
+  }
+  const resizeToContent = useCallback((forceRemeasure = false) => {
     const textarea = inputRef.current
     if (!textarea) return
 
-    // Save scroll position before resizing
-    const savedScrollTop = textarea.scrollTop
-
-    textarea.style.height = 'auto'
     // This value must match the CSS line-height in .message-input (index.css)
     const lineHeight = 24
     const minHeight = lineHeight
     const maxHeight = lineHeight * 8
+
+    const value = textarea.value
+    const prev = prevValueRef.current
+    prevValueRef.current = value
+
+    // A shrink is only possible when characters or whole lines were removed,
+    // and never below the single-line minimum. `forceRemeasure` (a width
+    // change) can re-wrap in either direction, so it always remeasures.
+    const couldShrink = value.length < prev.length || countLines(value) < countLines(prev)
+    const mayShrink = forceRemeasure || (couldShrink && lastSetHeightRef.current > minHeight)
+
+    const savedScrollTop = textarea.scrollTop
+    // Only collapse to `auto` when a shrink is possible. With overflow-y:auto,
+    // scrollHeight reflects the full content height even without the reset, so
+    // growth is still detected — without dirtying the surrounding layout.
+    if (mayShrink) textarea.style.height = 'auto'
     const scrollHeight = textarea.scrollHeight
     const newHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight)
-    textarea.style.height = `${newHeight}px`
 
-    // Restore scroll position after height change
-    // The browser will naturally keep the cursor visible during typing,
-    // but resizing can reset scroll. Only restore if we're at max height.
+    // Fast path: a non-shrinking edit that leaves the height unchanged touched
+    // nothing, so there is no height to write, no scroll to restore, and no
+    // listener to notify. This is what keeps continuous typing off the
+    // message-list reflow path.
+    if (!mayShrink && newHeight === lastSetHeightRef.current) return
+
+    textarea.style.height = `${newHeight}px`
+    lastSetHeightRef.current = newHeight
+
+    // Restore scroll position after height change. The browser keeps the cursor
+    // visible during typing, but resizing can reset scroll. Only restore if
+    // we're at max height.
     if (scrollHeight > maxHeight) {
       textarea.scrollTop = savedScrollTop
     }
@@ -357,7 +390,7 @@ export function MessageComposer({
       const width = entries[0]?.contentRect.width
       if (width === undefined || width === lastWidth) return
       lastWidth = width
-      resizeToContent()
+      resizeToContent(true)
     })
     observer.observe(textarea)
     return () => observer.disconnect()

--- a/apps/fluux/src/components/messageRowMemo.test.tsx
+++ b/apps/fluux/src/components/messageRowMemo.test.tsx
@@ -177,6 +177,24 @@ describe('message-row memo bailout (render-perf regression guard)', () => {
     }
   })
 
+  it('ChatMessageList: starting to type (isComposing toggling) does not re-render existing rows', () => {
+    // `isComposing` flips true on the first keystroke and false ~1.5s after the
+    // last. It used to be threaded into every row's `hideToolbar`, so each
+    // typing burst re-rendered (and relayouted) the whole list. Hiding hover
+    // toolbars while composing is now a container CSS concern, so the rows must
+    // NOT re-render when composing state changes.
+    const msgs = chatMessages(5)
+    const { rerender } = render(<ChatMessageList messages={msgs} {...CHAT_PROPS} />)
+    const initial = { ...bubbleRenders }
+    expect(Object.keys(initial).sort()).toEqual(['c0', 'c1', 'c2', 'c3', 'c4'])
+
+    // Same messages array — only composing state changed.
+    rerender(<ChatMessageList messages={msgs} {...{ ...CHAT_PROPS, isComposing: true }} />)
+    for (const id of Object.keys(initial)) {
+      expect(bubbleRenders[id]).toBe(initial[id])
+    }
+  })
+
   it('RoomMessageList: appending a message does not re-render existing rows', () => {
     const msgs = roomMessages(5)
     const { rerender } = render(<RoomMessageList messages={msgs} {...ROOM_PROPS} />)

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -562,6 +562,18 @@ html, body {
   outline-offset: -2px !important;
 }
 
+/*
+ * Hide the per-message floating hover toolbars while the user is composing.
+ * Driven by the `composer-active` class toggled on the message area (ChatView),
+ * so starting/stopping typing does NOT re-render every message row. The 1:1
+ * toolbar uses controlled hover (an opacity utility class), which this beats on
+ * specificity. See ChatView.tsx and messageRowMemo.test.tsx.
+ */
+.composer-active [data-message-toolbar] {
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* Font size slider styling */
 input[type="range"] {
   -webkit-appearance: none;


### PR DESCRIPTION
## Problem

Typing in a long conversation (1:1 or room) lagged: text rendered well behind the keystrokes and caught up gradually, and an encrypted send then took several seconds (the green-shield send button greyed out for the duration). Every keystroke did main-thread work proportional to the number of messages resident in the open conversation, because the message list is not virtualized. On web the openpgp.js encrypt then runs on an already-saturated main thread, which is what stretches the send out.

## Fix

Two coupling points dragged the whole message list into each keystroke:

**1. The composer forced a full layout on every keystroke.** `MessageComposer.resizeToContent` (shared by the 1:1 and room composers) reset the textarea to `height:auto` and called `onInputResize` on every keystroke. The auto-reset changes the composer box, relayouting the flex column (and every message row), and `onInputResize` reads the list `scrollHeight`, forcing a second full layout. It now skips both when the typed text cannot change the composer height (the common case), and only remeasures on an actual grow/shrink. Measured ~61 ms to ~43 ms main-thread block per keystroke at ~820 messages.

**2. `isComposing` was a prop on every message row.** It was threaded into `hideToolbar` on every bubble, so the whole list re-rendered and relayouted at the start and end of every typing burst. Both `ChatView` (1:1) and `RoomView` (MUC) now toggle a single shared `composer-active` class on the message area, and CSS hides the hover toolbars (`[data-message-toolbar]`, the shared `MessageToolbar` element); `isComposing` no longer reaches the list components or the rows.

## Guards

- New autosize tests: the composer does not fire `onInputResize` on a no-height-change keystroke, and still grows/shrinks correctly.
- Message-row memo guard: toggling composing state does not re-render existing rows in either the 1:1 or the room list.

## Notes

The residual per-keystroke list cost and very long conversations are addressed by message virtualization, tracked separately.