### PR TITLE
fix(perf): extend per-keystroke reflow fix to rooms (RoomView)

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -496,7 +496,11 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             handleMouseMove(e, messageId)
           }}
           onMouseLeave={handleMouseLeave}
-          className="focus-zone flex-1 flex flex-col min-h-0 p-1 relative"
+          // `composer-active` hides the per-message hover toolbars while typing via
+          // CSS (index.css), instead of threading `isComposing` into every row's
+          // `hideToolbar` prop — which re-rendered (and relayouted) the whole
+          // non-virtualized room list on each typing burst (parity with ChatView).
+          className={`focus-zone flex-1 flex flex-col min-h-0 p-1 relative${isComposing ? ' composer-active' : ''}`}
         >
           {find.isOpen && (
             <FindOnPageBar
@@ -526,7 +530,6 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             lastOutgoingMessageId={lastOutgoingMessageId}
             lastMessageId={lastMessageId}
             typingUsers={filteredTypingUsers}
-            isComposing={isComposing}
             activeReactionPickerMessageId={activeReactionPickerMessageId}
             onReactionPickerChange={handleReactionPickerChange}
             retractMessage={retractMessage}
@@ -803,7 +806,6 @@ export const RoomMessageList = memo(function RoomMessageList({
   lastOutgoingMessageId,
   lastMessageId,
   typingUsers,
-  isComposing,
   activeReactionPickerMessageId,
   onReactionPickerChange,
   retractMessage,
@@ -847,7 +849,6 @@ export const RoomMessageList = memo(function RoomMessageList({
   lastOutgoingMessageId: string | null
   lastMessageId: string | null
   typingUsers: string[]
-  isComposing: boolean
   activeReactionPickerMessageId: string | null
   onReactionPickerChange: (messageId: string, isOpen: boolean) => void
   retractMessage: (roomJid: string, messageId: string) => Promise<void>
@@ -1027,7 +1028,7 @@ export const RoomMessageList = memo(function RoomMessageList({
         onEdit={onEdit}
         isLastOutgoing={msg.id === lastOutgoingMessageId}
         isLastMessage={msg.id === lastMessageId}
-        hideToolbar={isComposing || (activeReactionPickerMessageId !== null && activeReactionPickerMessageId !== msg.id)}
+        hideToolbar={activeReactionPickerMessageId !== null && activeReactionPickerMessageId !== msg.id}
         onReactionPickerChange={onReactionPickerChange}
         retractMessage={retractMessage}
         moderateMessage={moderateMessage}

--- a/apps/fluux/src/components/messageRowMemo.test.tsx
+++ b/apps/fluux/src/components/messageRowMemo.test.tsx
@@ -206,4 +206,19 @@ describe('message-row memo bailout (render-perf regression guard)', () => {
       expect(bubbleRenders[id]).toBe(initial[id])
     }
   })
+
+  it('RoomMessageList: starting to type (isComposing toggling) does not re-render existing rows', () => {
+    // Same decoupling as the 1:1 path: composing state hides hover toolbars via
+    // a container CSS class, not a per-row prop, so a typing burst must not
+    // re-render (and relayout) the whole room message list.
+    const msgs = roomMessages(5)
+    const { rerender } = render(<RoomMessageList messages={msgs} {...ROOM_PROPS} />)
+    const initial = { ...bubbleRenders }
+    expect(Object.keys(initial).sort()).toEqual(['r0', 'r1', 'r2', 'r3', 'r4'])
+
+    rerender(<RoomMessageList messages={msgs} {...{ ...ROOM_PROPS, isComposing: true }} />)
+    for (const id of Object.keys(initial)) {
+      expect(bubbleRenders[id]).toBe(initial[id])
+    }
+  })
 })


### PR DESCRIPTION
Follow-up to #635, which shipped the 1:1 path.