### PR TITLE
perf(message-list): finish virtualization integration behind the flag

### DIFF
--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -7,6 +7,10 @@
  */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Asserts the non-virtualized message list (still shipping until the old path is removed);
+// the virtualized render is covered by MessageList.virtualized.test.tsx + unit tests.
+vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ChatView } from './ChatView'
 import type { Message, Contact, Conversation } from '@fluux/sdk'

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -633,8 +633,8 @@ export const ChatMessageList = memo(function ChatMessageList({
   }
 
   // Clipboard metadata for a message, faithful to ChatMessageBubble's senderName so a
-  // virtualized copy spanning unmounted rows reconstructs identically (see MessageList
-  // formatMessageForCopy). Called only at copy time, so its per-render cost is nil.
+  // virtualized multi-message copy reconstructs identically from the array (see
+  // MessageList formatMessageForCopy). Called only at copy time, so per-render cost is nil.
   const formatMessageForCopy = (msg: Message): CopyMessageMeta => ({
     id: msg.id,
     from: msg.isOutgoing

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo, useImperativeHandle, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
+import { format } from 'date-fns'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
+import type { CopyMessageMeta } from '@/utils/buildCopyText'
 import { useChatActive, useContactIdentities, useReferencedMessage, getBareJid, getLocalPart, getMyReactions, useXMPPContext, type Message, type ContactIdentity } from '@fluux/sdk'
 import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -630,6 +632,19 @@ export const ChatMessageList = memo(function ChatMessageList({
     return contactsByJid.get(bareJid)?.name || bareJid.split('@')[0]
   }
 
+  // Clipboard metadata for a message, faithful to ChatMessageBubble's senderName so a
+  // virtualized copy spanning unmounted rows reconstructs identically (see MessageList
+  // formatMessageForCopy). Called only at copy time, so its per-render cost is nil.
+  const formatMessageForCopy = (msg: Message): CopyMessageMeta => ({
+    id: msg.id,
+    from: msg.isOutgoing
+      ? (ownNickname || msg.from.split('@')[0])
+      : (contactsByJid.get(msg.from.split('/')[0])?.name || msg.from.split('@')[0]),
+    time: formatTime(msg.timestamp),
+    body: msg.body || '',
+    date: format(msg.timestamp, 'yyyy-MM-dd'),
+  })
+
   // Render function for messages
   // The onMediaLoad parameter is provided by MessageList from useMessageListScroll hook
   const renderMessage = (msg: Message, idx: number, groupMessages: Message[], _showNewMarker: boolean, onMediaLoad: () => void) => (
@@ -681,6 +696,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       typingUsers={typingUsers}
       formatTypingUser={formatTypingUser}
       renderMessage={renderMessage}
+      formatMessageForCopy={formatMessageForCopy}
       lastSentMessageId={lastSentMessageId}
       onScrollToTop={onScrollToTop}
       isLoadingOlder={isLoadingOlder}

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -7,6 +7,10 @@
  */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Asserts the non-virtualized message list (still shipping until the old path is removed);
+// the virtualized render is covered by MessageList.virtualized.test.tsx + unit tests.
+vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { RoomView } from './RoomView'
 import type { RoomMessage, Room, RoomOccupant, Contact } from '@fluux/sdk'

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -11,6 +11,7 @@ import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar } from './Avatar'
 import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './conversation/roomSenderResolution'
 import { format } from 'date-fns'
+import type { CopyMessageMeta } from '@/utils/buildCopyText'
 import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, Users, MessageCircle, EyeOff, User, Settings, Ear, X } from 'lucide-react'
 import { ChristmasAnimation } from './ChristmasAnimation'
 import { TextInput, TextArea } from './ui/TextInput'
@@ -972,6 +973,17 @@ export const RoomMessageList = memo(function RoomMessageList({
   // props only for X's rows; every other row's shallow memo bails. The row no longer
   // sees `room` (a fresh Map ref every presence stanza), so it stops re-rendering on
   // unrelated presence churn.
+  // Clipboard metadata for a message, faithful to the row's resolvedSenderName so a
+  // virtualized copy spanning unmounted rows reconstructs identically (see MessageList
+  // formatMessageForCopy). Called only at copy time, so its per-render cost is nil.
+  const formatMessageForCopy = (msg: RoomMessage): CopyMessageMeta => ({
+    id: msg.id,
+    from: resolveRoomSender(msg, room, contactsByJid, selfOccupant).resolvedSenderName,
+    time: formatTime(msg.timestamp),
+    body: msg.body || '',
+    date: format(msg.timestamp, 'yyyy-MM-dd'),
+  })
+
   const renderMessage = (msg: RoomMessage, idx: number, groupMessages: RoomMessage[]) => {
     const sender = resolveRoomSender(msg, room, contactsByJid, selfOccupant)
 
@@ -1072,6 +1084,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       isLoadingOlder={isLoadingOlder}
       isHistoryComplete={isHistoryComplete}
       renderMessage={renderMessage}
+      formatMessageForCopy={formatMessageForCopy}
       lastSentMessageId={lastSentMessageId}
       forwardGapTimestamp={forwardGapTimestamp}
       onCatchUpHistory={onCatchUpHistory}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -974,8 +974,8 @@ export const RoomMessageList = memo(function RoomMessageList({
   // sees `room` (a fresh Map ref every presence stanza), so it stops re-rendering on
   // unrelated presence churn.
   // Clipboard metadata for a message, faithful to the row's resolvedSenderName so a
-  // virtualized copy spanning unmounted rows reconstructs identically (see MessageList
-  // formatMessageForCopy). Called only at copy time, so its per-render cost is nil.
+  // virtualized multi-message copy reconstructs identically from the array (see
+  // MessageList formatMessageForCopy). Called only at copy time, so per-render cost is nil.
   const formatMessageForCopy = (msg: RoomMessage): CopyMessageMeta => ({
     id: msg.id,
     from: resolveRoomSender(msg, room, contactsByJid, selfOccupant).resolvedSenderName,

--- a/apps/fluux/src/components/conversation/MessageList.keys.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.keys.test.tsx
@@ -14,6 +14,10 @@
  * (two distinct messages with `id: undefined` are not duplicates).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Asserts the non-virtualized message list (still shipping until the old path is removed);
+// the virtualized render is covered by MessageList.virtualized.test.tsx + unit tests.
+vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
 import { render } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -8,6 +8,11 @@
  * - Container height changes (e.g., composer resize)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Asserts the non-virtualized scroll machinery (offsetTop/scrollHeight reads on the
+// fully-mounted DOM — still shipping until the old path is removed). Force the flag OFF;
+// virtualized scroll is verified via the scroll-hook unit tests + the real-engine pass.
+vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
 import { render, screen, act } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -94,8 +94,9 @@ export interface MessageListProps<T extends BaseMessage> {
   /**
    * Maps a message to its clipboard metadata, faithful to the rendered bubble (the
    * caller resolves the display name / time the same way it builds each row). Only
-   * consumed on the virtualized path: it lets a copy that spans unmounted rows be
-   * reconstructed from the in-memory array instead of dropping the off-screen middle.
+   * consumed on the virtualized path: a multi-message copy is reconstructed from the
+   * in-memory array so the rows carry correct dates/names (the virtualized DOM splits
+   * date separators into separate windowed items the pure-DOM copy can't follow).
    */
   formatMessageForCopy?: (message: T) => CopyMessageMeta
 }

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -27,6 +27,7 @@ import { groupMessagesByDate, shouldShowAvatar } from './messageGrouping'
 import { useMessageListScroll } from './useMessageListScroll'
 import { MessageWidthProvider } from './messageWidthContext'
 import { isFeatureEnabled } from '@/utils/featureFlags'
+import type { CopyMessageMeta } from '@/utils/buildCopyText'
 import { buildMessageListItems, type RenderItem } from './messageListItems'
 import { useTanstackMessageVirtualizer } from './tanstackMessageVirtualizer'
 import { Loader2, ChevronUp, ChevronDown } from 'lucide-react'
@@ -90,6 +91,13 @@ export interface MessageListProps<T extends BaseMessage> {
   onCatchUpHistory?: () => void
   /** If true, show loading indicator on the gap marker */
   isCatchingUp?: boolean
+  /**
+   * Maps a message to its clipboard metadata, faithful to the rendered bubble (the
+   * caller resolves the display name / time the same way it builds each row). Only
+   * consumed on the virtualized path: it lets a copy that spans unmounted rows be
+   * reconstructed from the in-memory array instead of dropping the off-screen middle.
+   */
+  formatMessageForCopy?: (message: T) => CopyMessageMeta
 }
 
 // ============================================================================
@@ -121,6 +129,7 @@ export function MessageList<T extends BaseMessage>({
   forwardGapTimestamp,
   onCatchUpHistory,
   isCatchingUp,
+  formatMessageForCopy,
 }: MessageListProps<T>) {
   // Detect render loops before they freeze the UI
   detectRenderLoop('MessageList')
@@ -271,7 +280,15 @@ export function MessageList<T extends BaseMessage>({
   // COPY FORMATTING (ensures date is always included)
   // --------------------------------------------------------------------------
 
-  useMessageCopyFormatter({ containerRef: scrollContainerRef })
+  // Store-backed copy is virtualized-only: when off-screen rows are unmounted, a
+  // spanning selection is reconstructed from `deduplicatedMessages` via the caller's
+  // faithful formatter. Passing `undefined` on the flag-OFF path keeps the legacy
+  // pure-DOM copy behavior byte-for-byte unchanged.
+  useMessageCopyFormatter({
+    containerRef: scrollContainerRef,
+    messages: virtualized ? deduplicatedMessages : undefined,
+    formatForCopy: virtualized ? formatMessageForCopy : undefined,
+  })
 
   // --------------------------------------------------------------------------
   // RENDER: Message list (always render scroll container to preserve position)

--- a/apps/fluux/src/components/messageRowMemo.test.tsx
+++ b/apps/fluux/src/components/messageRowMemo.test.tsx
@@ -17,6 +17,11 @@
  * of the inner MessageBubble, keyed by message id.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Row-render-count guard for the non-virtualized full-mount path (still shipping until
+// the old path is removed). Force the flag OFF so all rows mount and the counts are
+// comparable; virtualization mounts only the window, a separate concern.
+vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
 import { render } from '@testing-library/react'
 
 // Count inner MessageBubble renders by message id. Both ChatMessageBubble and

--- a/apps/fluux/src/components/roomRowPresenceMemo.test.tsx
+++ b/apps/fluux/src/components/roomRowPresenceMemo.test.tsx
@@ -22,6 +22,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/react'
 
+// Row-render-count guard for the non-virtualized full-mount path (still shipping until
+// the old path is removed). Force the flag OFF so all rows mount and the counts are
+// comparable; virtualization mounts only the window, a separate concern.
+vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
+
 // Count inner MessageBubble renders by message id. RoomMessageBubbleWrapper renders
 // <MessageBubble message={message} .../>, so the id is available on the mock's props.
 const bubbleRenders: Record<string, number> = {}

--- a/apps/fluux/src/hooks/useMessageCopyFormatter.test.tsx
+++ b/apps/fluux/src/hooks/useMessageCopyFormatter.test.tsx
@@ -226,10 +226,14 @@ describe('useMessageCopyFormatter', () => {
     expect(output).toMatch(/January 15, 2024/)
   })
 
-  // Virtualization: a selection can span rows that have been unmounted from the DOM
-  // (only the visible window + overscan is mounted). The middle messages must come
-  // from the in-memory array, not be silently dropped.
-  it('reconstructs unmounted middle messages from the in-memory array when the selection spans off-screen rows', async () => {
+  // Virtualization: the windowed DOM is incomplete (it lacks date separators and any
+  // rows outside the window), so a multi-message copy must source its content from the
+  // in-memory array, not the DOM. Proven here by mounting only the endpoints and leaving
+  // the middle rows out of the DOM: a DOM-only path would drop them; the array path keeps
+  // them. (A real selection is always within the contiguous mounted window — the browser
+  // collapses a selection that would span an unmounted row — but the array-vs-DOM sourcing
+  // is exactly what this asserts.)
+  it('sources a multi-message copy from the in-memory array, not the incomplete virtualized DOM', async () => {
     type Meta = { id: string; from: string; time: string; body: string; date: string }
     const messages: Meta[] = Array.from({ length: 5 }, (_, i) => ({
       id: `m${i + 1}`, from: `U${i + 1}`, time: `14:0${i}`, body: `Body ${i + 1}`, date: '2024-01-15',

--- a/apps/fluux/src/hooks/useMessageCopyFormatter.test.tsx
+++ b/apps/fluux/src/hooks/useMessageCopyFormatter.test.tsx
@@ -226,6 +226,48 @@ describe('useMessageCopyFormatter', () => {
     expect(output).toMatch(/January 15, 2024/)
   })
 
+  // Virtualization: a selection can span rows that have been unmounted from the DOM
+  // (only the visible window + overscan is mounted). The middle messages must come
+  // from the in-memory array, not be silently dropped.
+  it('reconstructs unmounted middle messages from the in-memory array when the selection spans off-screen rows', async () => {
+    type Meta = { id: string; from: string; time: string; body: string; date: string }
+    const messages: Meta[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `m${i + 1}`, from: `U${i + 1}`, time: `14:0${i}`, body: `Body ${i + 1}`, date: '2024-01-15',
+    }))
+    const formatForCopy = (m: Meta) => ({ id: m.id, from: m.from, time: m.time, body: m.body, date: m.date })
+
+    renderHook(() => useMessageCopyFormatter({ containerRef, messages, formatForCopy }))
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)) })
+
+    // Only the first and last rows are mounted (the virtualized window); m2-m4 unmounted.
+    const group = document.createElement('div')
+    group.appendChild(createDateSeparator('2024-01-15'))
+    const first = createMessageElement('m1', 'U1', '14:00', 'Body 1')
+    const last = createMessageElement('m5', 'U5', '14:04', 'Body 5')
+    group.appendChild(first)
+    group.appendChild(last)
+    container.appendChild(group)
+
+    // Select from inside m1's text to inside m5's text (both endpoints mounted).
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    const range = document.createRange()
+    range.setStart(first.querySelector('span')!.firstChild!, 0)
+    range.setEnd(last.querySelector('span')!.firstChild!, 1)
+    selection.addRange(range)
+
+    const preventDefault = vi.fn()
+    const setData = vi.fn()
+    container.dispatchEvent(createMockClipboardEvent(setData, preventDefault))
+
+    expect(preventDefault).toHaveBeenCalled()
+    const output: string = setData.mock.calls[0][1]
+    // Every message in the span is present, including the unmounted middle.
+    for (const body of ['Body 1', 'Body 2', 'Body 3', 'Body 4', 'Body 5']) {
+      expect(output).toContain(body)
+    }
+  })
+
   it('should clean up event listener on unmount', async () => {
     const removeEventListenerSpy = vi.spyOn(container, 'removeEventListener')
 

--- a/apps/fluux/src/hooks/useMessageCopyFormatter.ts
+++ b/apps/fluux/src/hooks/useMessageCopyFormatter.ts
@@ -1,31 +1,97 @@
 /**
  * useMessageCopyFormatter - Formats copied message content with proper date headers.
  *
- * When copying messages from the chat, this hook ensures:
+ * When copying across multiple messages, this hook ensures:
  * 1. A date header is always included at the top
  * 2. Messages are formatted consistently: "Nick HH:MM\nMessage"
+ *
+ * Two collection paths feed the same pure formatter (`buildCopyText`):
+ *  - DOM path (default / non-virtualized): read each mounted row's `data-message-*`
+ *    attributes for the rows the selection intersects.
+ *  - Store-backed path (virtualized callers pass `messages` + `formatForCopy`): when
+ *    the selection spans rows that have been unmounted from the DOM (only the visible
+ *    window is mounted), reconstruct the full span from the in-memory array so no
+ *    message is silently dropped.
  */
 
-import { useEffect, useState } from 'react'
-import { format, parseISO } from 'date-fns'
+import { useEffect, useRef, useState } from 'react'
+import { buildCopyText, type CopyMessageMeta } from '@/utils/buildCopyText'
 
-interface UseMessageCopyFormatterOptions {
+interface UseMessageCopyFormatterOptions<T extends { id: string }> {
   /** Callback ref setter - returns the element when set */
   containerRef: React.RefObject<HTMLElement | null>
   /** Locale for date formatting */
   locale?: string
+  /**
+   * In-memory ordered message array. Supplying this (with `formatForCopy`) enables
+   * store-backed reconstruction for selections that span unmounted virtualized rows.
+   * Omit on the non-virtualized path to keep the pure-DOM behavior unchanged.
+   */
+  messages?: T[]
+  /** Maps a message to its copy metadata, faithful to the rendered bubble (the caller
+   *  resolves the display name / time the same way it builds the row). */
+  formatForCopy?: (message: T) => CopyMessageMeta
+}
+
+/** Resolve the message-row id a selection boundary falls within. Works for a row that
+ *  was unmounted mid-scroll too: the virtualized row's subtree stays intact while the
+ *  Range references it, so `closest()` still finds the `data-message-id` ancestor. */
+function rowIdAtBoundary(node: Node): string | null {
+  const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element | null)
+  return el?.closest?.('[data-message-id]')?.getAttribute('data-message-id') ?? null
+}
+
+/** Collect copy metadata from the mounted rows the selection intersects (DOM path). */
+function collectDomSelection(container: HTMLElement, range: Range): CopyMessageMeta[] {
+  // Only the actual MessageBubble carries data-message-from (not the wrapper div).
+  const elements = container.querySelectorAll('[data-message-from]')
+  const meta: CopyMessageMeta[] = []
+  const seen = new Set<string>()
+
+  elements.forEach((el) => {
+    if (!range.intersectsNode(el)) return
+    const id = el.getAttribute('data-message-id') || ''
+    if (seen.has(id)) return
+    seen.add(id)
+
+    const from = el.getAttribute('data-message-from') || ''
+    const time = el.getAttribute('data-message-time') || ''
+    const body = el.getAttribute('data-message-body') || ''
+
+    // Date from the parent group's date separator.
+    // Structure: <div group> > <div data-date-separator> + <div wrapper> > <bubble>
+    let groupDiv = el.parentElement?.parentElement
+    let dateEl = groupDiv?.querySelector('[data-date-separator]')
+    if (!dateEl && groupDiv?.parentElement) {
+      groupDiv = groupDiv.parentElement
+      dateEl = groupDiv?.querySelector('[data-date-separator]')
+    }
+    const date = dateEl?.getAttribute('data-date-separator') || ''
+
+    meta.push({ id, from, time, body, date })
+  })
+  return meta
 }
 
 /**
  * Formats the selected content when copying from the message list.
  * Ensures date context is always present at the top.
  */
-export function useMessageCopyFormatter({
+export function useMessageCopyFormatter<T extends { id: string } = { id: string }>({
   containerRef,
   locale = 'en',
-}: UseMessageCopyFormatterOptions): void {
+  messages,
+  formatForCopy,
+}: UseMessageCopyFormatterOptions<T>): void {
   // Track container element in state to trigger effect when ref is set
   const [container, setContainer] = useState<HTMLElement | null>(null)
+
+  // Latest-refs so the copy listener reads current data WITHOUT re-binding on every
+  // new message (re-subscribing the listener per message would be wasteful churn).
+  const messagesRef = useRef(messages)
+  messagesRef.current = messages
+  const formatForCopyRef = useRef(formatForCopy)
+  formatForCopyRef.current = formatForCopy
 
   // Sync ref to state (check on every render)
   useEffect(() => {
@@ -45,114 +111,43 @@ export function useMessageCopyFormatter({
       const range = selection.getRangeAt(0)
       if (!container.contains(range.commonAncestorContainer)) return
 
-      // Check if selection is entirely within a single message bubble
-      // If so, let the browser's default copy behavior handle it (just copy the selected text)
+      // Check if selection is entirely within a single message bubble.
+      // If so, let the browser's default copy behavior handle it (partial text).
       const startMessage = range.startContainer.parentElement?.closest('[data-message-id]')
       const endMessage = range.endContainer.parentElement?.closest('[data-message-id]')
       if (startMessage && endMessage && startMessage === endMessage) {
-        // Selection is within a single message - use default browser copy
         return
       }
 
-      // Get all selected message elements - only get the ones with data-message-from
-      // (the actual MessageBubble, not the wrapper div)
-      const messageElements = container.querySelectorAll('[data-message-from]')
-      const selectedMessages: Array<{
-        id: string
-        from: string
-        time: string
-        body: string
-        date: string
-      }> = []
+      const setClipboard = (text: string | null) => {
+        if (text == null) return
+        e.preventDefault()
+        e.clipboardData?.setData('text/plain', text)
+      }
 
-      let earliestDate: string | null = null
-      const seenIds = new Set<string>()
-
-      messageElements.forEach((el) => {
-        if (range.intersectsNode(el)) {
-          const id = el.getAttribute('data-message-id') || ''
-
-          // Skip duplicates
-          if (seenIds.has(id)) return
-          seenIds.add(id)
-
-          const from = el.getAttribute('data-message-from') || ''
-          const time = el.getAttribute('data-message-time') || ''
-          const body = el.getAttribute('data-message-body') || ''
-
-          // Find the date from the parent group's date separator
-          // Structure: <div group> > <div data-date-separator> + <div wrapper> > <div MessageBubble>
-          // Walk up to find the group container, then find the date separator
-          let groupDiv = el.parentElement?.parentElement
-          let dateEl = groupDiv?.querySelector('[data-date-separator]')
-
-          // If not found, try one level up
-          if (!dateEl && groupDiv?.parentElement) {
-            groupDiv = groupDiv.parentElement
-            dateEl = groupDiv?.querySelector('[data-date-separator]')
-          }
-
-          const date = dateEl?.getAttribute('data-date-separator') || ''
-
-          // Track earliest date found (for fallback when some messages don't have dates)
-          if (date && date.length > 0 && (!earliestDate || date < earliestDate)) {
-            earliestDate = date
-          }
-
-          if (body) {
-            selectedMessages.push({ id, from, time, body, date })
+      // Store-backed path (virtualized): reconstruct the full span from the in-memory
+      // array, so messages whose rows are unmounted are not dropped. The array is the
+      // source of truth for ordering AND for the rows the DOM no longer has.
+      const msgs = messagesRef.current
+      const format = formatForCopyRef.current
+      if (msgs && format) {
+        const startId = rowIdAtBoundary(range.startContainer)
+        const endId = rowIdAtBoundary(range.endContainer)
+        if (startId && endId && startId !== endId) {
+          const i0 = msgs.findIndex((m) => m.id === startId)
+          const i1 = msgs.findIndex((m) => m.id === endId)
+          if (i0 !== -1 && i1 !== -1) {
+            const lo = Math.min(i0, i1)
+            const hi = Math.max(i0, i1)
+            setClipboard(buildCopyText(msgs.slice(lo, hi + 1).map(format)))
+            return
           }
         }
-      })
-
-      // If we have selected messages across multiple bubbles, format the output
-      if (selectedMessages.length > 1) {
-        // Use today's date as fallback if no date separator was found
-        const fallbackDate = earliestDate || format(new Date(), 'yyyy-MM-dd')
-
-        // Group by date for proper formatting
-        const messagesByDate = new Map<string, typeof selectedMessages>()
-
-        selectedMessages.forEach((msg) => {
-          const dateKey = msg.date || fallbackDate
-          if (!messagesByDate.has(dateKey)) {
-            messagesByDate.set(dateKey, [])
-          }
-          messagesByDate.get(dateKey)!.push(msg)
-        })
-
-        // Build formatted output
-        const lines: string[] = []
-
-        // Sort dates chronologically
-        const sortedDates = [...messagesByDate.keys()].sort()
-
-        sortedDates.forEach((dateStr, dateIndex) => {
-          // Add date header
-          try {
-            const date = parseISO(dateStr)
-            const formattedDate = format(date, 'EEEE, MMMM d, yyyy')
-            if (dateIndex > 0) lines.push('') // Empty line between date groups
-            lines.push(`— ${formattedDate} —`)
-          } catch {
-            lines.push(`— ${dateStr} —`)
-          }
-
-          // Add messages for this date
-          const msgs = messagesByDate.get(dateStr)!
-          msgs.forEach((msg) => {
-            if (msg.from && msg.time) {
-              lines.push(`${msg.from} ${msg.time}`)
-            }
-            lines.push(msg.body)
-          })
-        })
-
-        // Set the formatted text to clipboard
-        const output = lines.join('\n')
-        e.preventDefault()
-        e.clipboardData?.setData('text/plain', output)
+        // Endpoints unresolved → fall through to the DOM path (best effort).
       }
+
+      // DOM path: collect metadata from the mounted rows the selection intersects.
+      setClipboard(buildCopyText(collectDomSelection(container, range)))
     }
 
     container.addEventListener('copy', handleCopy)

--- a/apps/fluux/src/hooks/useMessageCopyFormatter.ts
+++ b/apps/fluux/src/hooks/useMessageCopyFormatter.ts
@@ -8,10 +8,19 @@
  * Two collection paths feed the same pure formatter (`buildCopyText`):
  *  - DOM path (default / non-virtualized): read each mounted row's `data-message-*`
  *    attributes for the rows the selection intersects.
- *  - Store-backed path (virtualized callers pass `messages` + `formatForCopy`): when
- *    the selection spans rows that have been unmounted from the DOM (only the visible
- *    window is mounted), reconstruct the full span from the in-memory array so no
- *    message is silently dropped.
+ *  - Store-backed path (virtualized callers pass `messages` + `formatForCopy`):
+ *    reconstruct the selected range from the in-memory array. This is needed because
+ *    the virtualized DOM flattens date separators into separate windowed items, so the
+ *    pure-DOM date walk below can't find them; sourcing from the array keeps the
+ *    dates/names faithful.
+ *
+ * NOTE (verified on Blink, DOM-spec, same on WebKit): a selection can only ever be
+ * WITHIN the mounted window. Virtualized rows are removed from the DOM as they scroll
+ * out, and removing a node relocates any live Range boundary to the parent — so the
+ * browser COLLAPSES a selection the instant it would span an unmounted row. There is
+ * therefore no "spanning unmounted rows" case to recover; copying across rows that are
+ * far off-screen is not achievable with DOM virtualization (a known limitation vs the
+ * old full-mount behavior).
  */
 
 import { useEffect, useRef, useState } from 'react'
@@ -33,9 +42,9 @@ interface UseMessageCopyFormatterOptions<T extends { id: string }> {
   formatForCopy?: (message: T) => CopyMessageMeta
 }
 
-/** Resolve the message-row id a selection boundary falls within. Works for a row that
- *  was unmounted mid-scroll too: the virtualized row's subtree stays intact while the
- *  Range references it, so `closest()` still finds the `data-message-id` ancestor. */
+/** Resolve the message-row id a selection boundary falls within. The boundary is always
+ *  on a mounted row (a selection can't span unmounted virtualized rows — the browser
+ *  collapses it; see the file header), so `closest()` finds the `data-message-id`. */
 function rowIdAtBoundary(node: Node): string | null {
   const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element | null)
   return el?.closest?.('[data-message-id]')?.getAttribute('data-message-id') ?? null
@@ -125,9 +134,10 @@ export function useMessageCopyFormatter<T extends { id: string } = { id: string 
         e.clipboardData?.setData('text/plain', text)
       }
 
-      // Store-backed path (virtualized): reconstruct the full span from the in-memory
-      // array, so messages whose rows are unmounted are not dropped. The array is the
-      // source of truth for ordering AND for the rows the DOM no longer has.
+      // Store-backed path (virtualized): reconstruct the selected range from the
+      // in-memory array (the source of truth for ordering AND dates/names), because the
+      // virtualized DOM lacks the date separators the DOM path reads. Endpoints are
+      // always mounted (a selection can't span unmounted rows — see the file header).
       const msgs = messagesRef.current
       const format = formatForCopyRef.current
       if (msgs && format) {

--- a/apps/fluux/src/hooks/useViewportObserver.test.tsx
+++ b/apps/fluux/src/hooks/useViewportObserver.test.tsx
@@ -628,6 +628,111 @@ describe('useViewportObserver', () => {
   })
 
   // ========================================================================
+  // MutationObserver — rows removed (virtualized window churn)
+  // ========================================================================
+
+  it('unobserves removed message elements via MutationObserver', () => {
+    const scrollContainerRef = createScrollContainer(['msg-1', 'msg-2'])
+
+    renderHook(() =>
+      useViewportObserver({
+        scrollContainerRef,
+        conversationId: 'conv-1',
+        onMessageSeen: vi.fn(),
+        enabled: true,
+      }),
+    )
+
+    const io = ioInstances[0]
+    // A row scrolls out of the virtualized window and is unmounted from the DOM.
+    const removed = scrollContainerRef.current.querySelector('[data-message-id="msg-1"]')!
+
+    act(() => {
+      moCallback(
+        [{ addedNodes: [], removedNodes: [removed], type: 'childList' } as unknown as MutationRecord],
+        {} as MutationObserver,
+      )
+    })
+
+    // Without this, the IntersectionObserver keeps a growing set of detached rows as
+    // the user scrolls a large virtualized room — the very leak virtualization fixes.
+    expect(io.unobserve).toHaveBeenCalledWith(removed)
+  })
+
+  it('unobserves nested message elements removed via MutationObserver', () => {
+    const scrollContainerRef = createScrollContainer(['msg-1'])
+
+    renderHook(() =>
+      useViewportObserver({
+        scrollContainerRef,
+        conversationId: 'conv-1',
+        onMessageSeen: vi.fn(),
+        enabled: true,
+      }),
+    )
+
+    const io = ioInstances[0]
+
+    // A windowed wrapper div containing a message row mounts, then unmounts.
+    const wrapper = document.createElement('div')
+    const nested = document.createElement('div')
+    nested.dataset.messageId = 'msg-2'
+    wrapper.appendChild(nested)
+
+    act(() => {
+      moCallback(
+        [{ addedNodes: [wrapper], removedNodes: [], type: 'childList' } as unknown as MutationRecord],
+        {} as MutationObserver,
+      )
+    })
+    expect(io.observe).toHaveBeenCalledWith(nested)
+
+    act(() => {
+      moCallback(
+        [{ addedNodes: [], removedNodes: [wrapper], type: 'childList' } as unknown as MutationRecord],
+        {} as MutationObserver,
+      )
+    })
+    expect(io.unobserve).toHaveBeenCalledWith(nested)
+  })
+
+  it('does not report a removed row as bottom-most after it leaves the window', () => {
+    const onMessageSeen = vi.fn()
+    const scrollContainerRef = createScrollContainer(['msg-1', 'msg-2'])
+
+    renderHook(() =>
+      useViewportObserver({
+        scrollContainerRef,
+        conversationId: 'conv-1',
+        onMessageSeen,
+        enabled: true,
+      }),
+    )
+
+    const el1 = scrollContainerRef.current.querySelector('[data-message-id="msg-1"]')!
+    const el2 = scrollContainerRef.current.querySelector('[data-message-id="msg-2"]')!
+    const entryFor = (target: Element, isIntersecting: boolean, bottom: number) => {
+      target.getBoundingClientRect = () => ({ bottom, top: bottom - 40, left: 0, right: 300, width: 300, height: 40, x: 0, y: bottom - 40, toJSON: () => ({}) }) as DOMRect
+      return { target, isIntersecting, boundingClientRect: { bottom } as DOMRectReadOnly, intersectionRatio: isIntersecting ? 0.6 : 0, intersectionRect: {} as DOMRectReadOnly, rootBounds: null, time: performance.now() } as IntersectionObserverEntry
+    }
+
+    // Both visible; msg-2 (bottom 300) is bottom-most.
+    act(() => { ioCallback([entryFor(el1, true, 100), entryFor(el2, true, 300)], {} as IntersectionObserver) })
+    expect(onMessageSeen).toHaveBeenLastCalledWith('msg-2')
+    act(() => { vi.advanceTimersByTime(300) })
+
+    // msg-2's row is unmounted (removed) WITHOUT an intervening IO "not intersecting".
+    // Its stale entry must be pruned so a scroll-driven recompute reports the real
+    // bottom-most remaining row (msg-1), not the detached msg-2.
+    act(() => {
+      moCallback([{ addedNodes: [], removedNodes: [el2], type: 'childList' } as unknown as MutationRecord], {} as MutationObserver)
+    })
+    act(() => { scrollContainerRef.current.dispatchEvent(new Event('scroll')) })
+
+    expect(onMessageSeen).toHaveBeenLastCalledWith('msg-1')
+  })
+
+  // ========================================================================
   // Visible entries tracking (leave/enter cycles)
   // ========================================================================
 

--- a/apps/fluux/src/hooks/useViewportObserver.ts
+++ b/apps/fluux/src/hooks/useViewportObserver.ts
@@ -161,30 +161,35 @@ export function useViewportObserver({
     const messageElements = scrollContainer.querySelectorAll('[data-message-id]')
     messageElements.forEach((el) => observer.observe(el))
 
-    // Re-observe when new messages are added (MutationObserver)
+    // Track which rows the message list mounts/unmounts. With virtualization, only the
+    // visible window + overscan is mounted: rows scroll in (added) and out (removed) as
+    // the user scrolls, so the observer must follow the window, not assume rows persist.
     const mutationObserver = new MutationObserver((mutations) => {
-      let changed = false
       for (const mutation of mutations) {
+        // Newly mounted rows start being observed; the IO fires automatically for any
+        // that are already visible (e.g. when the user is pinned to the bottom).
         for (const node of mutation.addedNodes) {
           if (node instanceof HTMLElement) {
-            // Check if the node itself has data-message-id
+            if (node.dataset.messageId) observer.observe(node)
+            node.querySelectorAll('[data-message-id]').forEach((el) => observer.observe(el))
+          }
+        }
+        // Unmounted rows stop being observed and are pruned from the visible set. Without
+        // this the IO's observed set and visibleEntries grow unbounded as a large room is
+        // scrolled, and a detached row could linger as a stale "bottom-most visible"
+        // candidate (its mocked/last rect still comparing > 0).
+        for (const node of mutation.removedNodes) {
+          if (node instanceof HTMLElement) {
             if (node.dataset.messageId) {
-              observer.observe(node)
-              changed = true
+              observer.unobserve(node)
+              visibleEntries.delete(node)
             }
-            // Check children for message elements
-            const children = node.querySelectorAll('[data-message-id]')
-            children.forEach((el) => {
-              observer.observe(el)
-              changed = true
+            node.querySelectorAll('[data-message-id]').forEach((el) => {
+              observer.unobserve(el)
+              visibleEntries.delete(el)
             })
           }
         }
-      }
-      // If new messages were added and user is at bottom, the IO callback
-      // will fire automatically for newly visible elements
-      if (changed) {
-        // No additional action needed — IntersectionObserver handles it
       }
     })
 

--- a/apps/fluux/src/utils/buildCopyText.test.ts
+++ b/apps/fluux/src/utils/buildCopyText.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest'
+import { buildCopyText } from './buildCopyText'
+
+describe('buildCopyText', () => {
+  it('formats two messages on the same date under one date header', () => {
+    const out = buildCopyText([
+      { id: '1', from: 'Alice', time: '14:30', body: 'Hello', date: '2024-01-15' },
+      { id: '2', from: 'Bob', time: '14:31', body: 'Hi there', date: '2024-01-15' },
+    ])
+    expect(out).toBe(['— Monday, January 15, 2024 —', 'Alice 14:30', 'Hello', 'Bob 14:31', 'Hi there'].join('\n'))
+  })
+
+  it('returns null for a single message (native browser copy handles it)', () => {
+    expect(buildCopyText([{ id: '1', from: 'Alice', time: '14:30', body: 'Hello', date: '2024-01-15' }])).toBeNull()
+  })
+
+  it('returns null when fewer than two messages have a body', () => {
+    expect(
+      buildCopyText([
+        { id: '1', from: 'Alice', time: '14:30', body: 'Hello', date: '2024-01-15' },
+        { id: '2', from: 'Bob', time: '14:31', body: '', date: '2024-01-15' },
+      ]),
+    ).toBeNull()
+  })
+
+  it('groups across two dates, sorted ascending, with a blank line between groups', () => {
+    const out = buildCopyText([
+      { id: '2', from: 'Bob', time: '09:00', body: 'Second day', date: '2024-01-16' },
+      { id: '1', from: 'Alice', time: '14:30', body: 'First day', date: '2024-01-15' },
+    ])
+    expect(out).toBe(
+      [
+        '— Monday, January 15, 2024 —',
+        'Alice 14:30',
+        'First day',
+        '',
+        '— Tuesday, January 16, 2024 —',
+        'Bob 09:00',
+        'Second day',
+      ].join('\n'),
+    )
+  })
+
+  it('omits the "From HH:MM" header line when from or time is missing', () => {
+    const out = buildCopyText([
+      { id: '1', from: '', time: '', body: 'Anon one', date: '2024-01-15' },
+      { id: '2', from: 'Bob', time: '14:31', body: 'Named two', date: '2024-01-15' },
+    ])
+    expect(out).toBe(['— Monday, January 15, 2024 —', 'Anon one', 'Bob 14:31', 'Named two'].join('\n'))
+  })
+
+  it('falls back to the provided fallback date for messages with no date', () => {
+    const out = buildCopyText(
+      [
+        { id: '1', from: 'Alice', time: '14:30', body: 'No date one', date: '' },
+        { id: '2', from: 'Bob', time: '14:31', body: 'No date two', date: '' },
+      ],
+      { fallbackDate: '2024-01-15' },
+    )
+    expect(out).toBe(['— Monday, January 15, 2024 —', 'Alice 14:30', 'No date one', 'Bob 14:31', 'No date two'].join('\n'))
+  })
+
+  it('uses the raw date string as the header when it is not a parseable ISO date', () => {
+    const out = buildCopyText([
+      { id: '1', from: 'Alice', time: '14:30', body: 'One', date: 'Today' },
+      { id: '2', from: 'Bob', time: '14:31', body: 'Two', date: 'Today' },
+    ])
+    expect(out).toBe(['— Today —', 'Alice 14:30', 'One', 'Bob 14:31', 'Two'].join('\n'))
+  })
+})

--- a/apps/fluux/src/utils/buildCopyText.ts
+++ b/apps/fluux/src/utils/buildCopyText.ts
@@ -1,0 +1,68 @@
+/**
+ * buildCopyText — formats a multi-message clipboard selection as date-grouped text.
+ *
+ * Pure (no DOM) so it can serve BOTH copy paths identically:
+ *  - the mounted-DOM path (`useMessageCopyFormatter`), which reads metadata from
+ *    `data-message-*` attributes, and
+ *  - the store-backed path, which reconstructs the metadata from the in-memory
+ *    message array when a virtualized selection spans unmounted rows.
+ *
+ * Output mirrors the long-standing inline formatter: messages grouped by date,
+ * each date preceded by a "— Weekday, Month D, YYYY —" header (blank line between
+ * groups), each message as "From HH:MM\nbody". Returns null when fewer than two
+ * messages carry a body — single-message selections fall back to the browser's
+ * native copy.
+ */
+import { format, parseISO } from 'date-fns'
+
+export interface CopyMessageMeta {
+  id: string
+  from: string
+  time: string
+  body: string
+  /** Date-separator key ('yyyy-MM-dd'), or '' when unknown (uses the fallback). */
+  date: string
+}
+
+export function buildCopyText(
+  messages: CopyMessageMeta[],
+  opts: { fallbackDate?: string } = {},
+): string | null {
+  // Only messages with a body participate (matches the legacy DOM path); a single
+  // message is left to the native browser copy.
+  const withBody = messages.filter((m) => m.body)
+  if (withBody.length <= 1) return null
+
+  // Fallback date for messages that carry none: caller-provided, else the earliest
+  // dated message, else today. The `new Date()` branch is only reached when NOTHING
+  // is dated and no fallback was given (kept deterministic in tests by those inputs).
+  const dated = withBody.map((m) => m.date).filter((d) => d.length > 0)
+  const earliestDate = dated.length ? dated.reduce((a, b) => (b < a ? b : a)) : undefined
+  const fallbackDate = opts.fallbackDate ?? earliestDate ?? format(new Date(), 'yyyy-MM-dd')
+
+  const byDate = new Map<string, CopyMessageMeta[]>()
+  for (const msg of withBody) {
+    const key = msg.date || fallbackDate
+    const bucket = byDate.get(key)
+    if (bucket) bucket.push(msg)
+    else byDate.set(key, [msg])
+  }
+
+  const lines: string[] = []
+  const sortedDates = [...byDate.keys()].sort()
+  sortedDates.forEach((dateStr, dateIndex) => {
+    if (dateIndex > 0) lines.push('')
+    let header: string
+    try {
+      header = format(parseISO(dateStr), 'EEEE, MMMM d, yyyy')
+    } catch {
+      header = dateStr
+    }
+    lines.push(`— ${header} —`)
+    for (const msg of byDate.get(dateStr)!) {
+      if (msg.from && msg.time) lines.push(`${msg.from} ${msg.time}`)
+      lines.push(msg.body)
+    }
+  })
+  return lines.join('\n')
+}

--- a/apps/fluux/src/utils/buildCopyText.ts
+++ b/apps/fluux/src/utils/buildCopyText.ts
@@ -5,7 +5,8 @@
  *  - the mounted-DOM path (`useMessageCopyFormatter`), which reads metadata from
  *    `data-message-*` attributes, and
  *  - the store-backed path, which reconstructs the metadata from the in-memory
- *    message array when a virtualized selection spans unmounted rows.
+ *    message array for the virtualized list (whose windowed DOM lacks the date
+ *    separators the DOM path reads).
  *
  * Output mirrors the long-standing inline formatter: messages grouped by date,
  * each date preceded by a "— Weekday, Month D, YYYY —" header (blank line between

--- a/apps/fluux/src/utils/featureFlags.test.ts
+++ b/apps/fluux/src/utils/featureFlags.test.ts
@@ -4,14 +4,22 @@ import { isFeatureEnabled } from './featureFlags'
 describe('isFeatureEnabled', () => {
   beforeEach(() => localStorage.clear())
 
-  it('defaults to false when the flag is unset', () => {
+  it('enableMessageVirtualization defaults to true (ON) when unset', () => {
+    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(true)
+  })
+
+  it('is disabled only when the stored value is exactly "false"', () => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'false')
     expect(isFeatureEnabled('enableMessageVirtualization')).toBe(false)
   })
 
-  it('is true only when the stored value is exactly "true"', () => {
+  it('an explicit "true" keeps it enabled', () => {
     localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
     expect(isFeatureEnabled('enableMessageVirtualization')).toBe(true)
+  })
+
+  it('any other stored value falls back to the default (ON)', () => {
     localStorage.setItem('fluux:flags:enableMessageVirtualization', '1')
-    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(false)
+    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(true)
   })
 })

--- a/apps/fluux/src/utils/featureFlags.ts
+++ b/apps/fluux/src/utils/featureFlags.ts
@@ -1,14 +1,25 @@
 export type FeatureFlag = 'enableMessageVirtualization'
 
+/** Default state per flag (the shipped behavior when localStorage has no override). */
+const FLAG_DEFAULTS: Record<FeatureFlag, boolean> = {
+  // Message-list virtualization: ON by default. Bounds the mounted DOM to the visible
+  // window so per-interaction cost (typing, scroll, room entry) no longer scales with
+  // resident message count, and cures the WebKitGTK large-room switch freeze.
+  enableMessageVirtualization: true,
+}
+
 /**
- * Dev/bake feature flags, persisted in localStorage (`fluux:flags:<flag>`). Default OFF.
- * Flip on for a session with:
- *   localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+ * Dev/bake feature flags. The default is per-flag (see FLAG_DEFAULTS); a localStorage
+ * override (`fluux:flags:<flag>`) forces the flag on (`'true'`) or off (`'false'`):
+ *   localStorage.setItem('fluux:flags:enableMessageVirtualization', 'false') // opt out
  */
 export function isFeatureEnabled(flag: FeatureFlag): boolean {
   try {
-    return localStorage.getItem(`fluux:flags:${flag}`) === 'true'
+    const stored = localStorage.getItem(`fluux:flags:${flag}`)
+    if (stored === 'true') return true
+    if (stored === 'false') return false
+    return FLAG_DEFAULTS[flag]
   } catch {
-    return false
+    return FLAG_DEFAULTS[flag]
   }
 }

--- a/docs/superpowers/specs/2026-06-23-message-view-virtualization-design.md
+++ b/docs/superpowers/specs/2026-06-23-message-view-virtualization-design.md
@@ -109,6 +109,20 @@ Intercept the `copy` event on the scroll container. The selection's two endpoint
 
 This is a pure function (`{ startId, endId, messages } → text`) and is unit-tested as such.
 
+> **Verified correction (2026-06-24, Blink; DOM-spec, so same on WebKit).** The premise
+> above — that a selection can *span* unmounted rows — is **false**. Removing a node from
+> the DOM relocates any live Range boundary to the parent (per the DOM spec's node-remove
+> steps), so the browser **collapses** a selection the instant a selected row scrolls out
+> and unmounts (measured: a 92-char selection → 0, `isCollapsed`, both boundaries on the
+> spacer). You therefore **cannot** select across off-screen virtualized rows, and the
+> `messages.slice(startId..endId)` "spanning" reconstruction never triggers. What ships:
+> the store-backed path reconstructs the **within-window** selection from the array so the
+> virtualized rows carry correct dates/names (the windowed DOM splits date separators into
+> separate items the DOM walk can't follow). Copying a very large range in one gesture is a
+> **known limitation** of DOM virtualization vs the old full-mount path (and vs the #540
+> `content-visibility` attempt, which kept rows in the DOM). A virtualization-friendly bulk
+> copy (a select-mode, or ⌘A → copy the loaded range from the array) is a follow-up.
+
 ## Alignment module
 
 A pure, DOM-free, unit-tested module `messageScrollAlignment.ts` centralizes the scroll math (today scattered as inline magic numbers):

--- a/packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md
+++ b/packages/fluux-sdk/src/stores/RENDER_PERF_TESTS.md
@@ -20,3 +20,38 @@ To assert a background message re-renders only its row, render the component
 against the REAL store (override the global `@fluux/sdk` app mock in that test
 file with `vi.unmock` / `importActual`) and count renders with a module-level
 counter or React Profiler. Account for StrictMode double-rendering.
+
+## Node-count guard — message-list virtualization (demo measurement, not a unit test)
+The message list is windowed behind `enableMessageVirtualization`. Its win is a
+**bounded mounted DOM**: switching into a large room must mount only the visible
+window + overscan, not the whole backlog. jsdom has no layout, so the virtualizer
+mounts nothing there and the structural tests (`MessageList.virtualized.test.tsx`)
+use a render-all `@tanstack` mock — they CANNOT assert the bound. The bound is a
+**demo-mode measurement** in a real layout engine (the same proxy that validated the
+occupant panel, 32/501), because node count is platform-independent (the WebKitGTK
+switch freeze is layout cost; node count is its proxy and is measurable on Blink too).
+
+**Guard:** with the flag ON, switching into a 1000-message room mounts **≤ ~60
+`.message-row`** (vs ~1000). Reproduce:
+
+1. `npm run dev`, open
+   `http://localhost:5173/demo.html?stress=rooms:1,messages:1000,occupants:97,activate:1,msgStep:0&tutorial=false`
+2. Demo init clears `fluux:*` localStorage (`apps/fluux/src/demo.tsx`), so set the flag
+   AFTER load then re-mount the list (navigate `#/` then back into the room — no reload):
+   `localStorage.setItem('fluux:flags:enableMessageVirtualization','true')`
+3. Measure: `__perf.domNodes('[data-message-list]')` (needs `&perf=1`), or directly
+   `document.querySelectorAll('.message-row').length`.
+
+**Measured (2026-06-24, Chromium/Blink via the preview harness):**
+
+| state                    | `.message-row` | nodes in `[data-message-list]` |
+|--------------------------|----------------|--------------------------------|
+| flag OFF (baseline)      | 1000           | 47011                          |
+| flag ON, window at top   | 14             | 688                            |
+| flag ON, scrolled middle | 33             | 1585                           |
+
+Both flag-ON states are far under the ≤60 target (~68× node reduction), and the
+window tracks scroll (indices 0–15 → 530–562 after a mid-list scroll). The WebKitGTK
+freeze going away (3 s → a few hundred ms) is the confirmatory **real-engine** check
+that the two-platform pass (`docs/superpowers/plans/2026-06-23-message-view-virtualization.md`
+Task 11) runs on Linux; node count is the engine-independent regression signal.


### PR DESCRIPTION
## Summary

Enables message-list virtualization **by default** (`enableMessageVirtualization` now defaults ON; `localStorage` `'false'` opts out). This bounds the mounted DOM to the visible window so per-interaction cost (typing, scroll, room entry) no longer scales with resident message count (the residual typing lag after #635/#636) and cures the WebKitGTK multi-second large-room switch freeze.

Completes the integration behind the flag, then flips it:

- **Store-backed copy** for the virtualized list — reconstructs a multi-message selection from the in-memory array via a faithful per-message formatter (ChatView/RoomView resolve names/times exactly as their bubbles do), so virtualized rows carry correct dates the windowed DOM can't supply. Flag-OFF DOM copy is byte-identical.
- **Read-marker viewport observer** now unobserves + prunes removed rows (it only handled additions), bounding the IntersectionObserver set to the mounted window.
- **Node-count guard** documented in `RENDER_PERF_TESTS.md`.
- **Flag default flipped ON**; six suites that assert the still-present non-virtualized path opt out via a local `vi.mock`.

## Verified in a real engine (Chromium/Blink, via the preview)

- **Node count bounded:** flag ON = **14 rows at top / 33 mid-scroll** vs **1000** OFF (`47011 → 688` nodes); window tracks scroll.
- **Multi-message copy within the visible window:** works, faithful output (`— Wednesday, June 24, 2026 —` / `U0_81 01:00 / stress message 566`).
- **Read marker:** flag ON ≡ flag OFF (no regression).

### Known limitation (verified, accepted)

You **cannot** drag-select-copy across rows that have scrolled off-screen. Removing a node relocates live Range boundaries to the parent (DOM spec), so the browser **collapses** a selection the instant a selected row unmounts (measured: 92-char selection → 0, `isCollapsed`) — the same on WebKit. Within-window copy works; bulk-range copy is a follow-up (a select-mode / ⌘A that copies from the array).