### PR TITLE
fix(perf): restore MAM-prepend scroll position under virtualization

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -8,8 +8,12 @@
  * must first call `virtualizer.ensureMessageMounted(id)` to bring it in — otherwise the
  * `querySelector('[data-message-id]')` never finds it and the jump silently no-ops. jsdom
  * has no layout, so the pixel positioning is verified on a real engine; here we pin the
- * integration CONTRACT (ensureMessageMounted is invoked with the right id), which is the
- * piece that has no other automated guard.
+ * integration CONTRACTS that have no other automated guard:
+ *  - jump sites call `ensureMessageMounted(id)` to bring an off-window row in;
+ *  - the MAM prepend restore reads the anchor offset from the VIRTUALIZER
+ *    (`getOffsetForMessageId`), not `querySelector(anchor).offsetTop` — the anchor is
+ *    windowed out on prepend, so the DOM read returns null and the old code fell back to
+ *    distance-from-bottom math that landed the viewport on the just-loaded older rows.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
@@ -17,19 +21,20 @@ import { MessageList, type MessageListProps } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
 
 const ensureMessageMounted = vi.fn((_id: string) => Promise.resolve())
+const getOffsetForMessageId = vi.fn((_id: string): number | null => 0)
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }))
 vi.mock('@/hooks', () => ({ useMessageCopyFormatter: vi.fn() }))
 
-// Inject a fake MessageVirtualizer (render-all window) with a spy ensureMessageMounted, so
-// the MessageList -> useMessageListScroll -> virtualizer wiring is observable in jsdom.
+// Inject a fake MessageVirtualizer (render-all window) with spies, so the
+// MessageList -> useMessageListScroll -> virtualizer wiring is observable in jsdom.
 vi.mock('./tanstackMessageVirtualizer', () => ({
   useTanstackMessageVirtualizer: (args: { items: { key: string }[] }) => ({
     getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
     getTotalSize: () => args.items.length * 40,
-    getOffsetForMessageId: () => 0,
+    getOffsetForMessageId,
     ensureMessageMounted,
     measureElement: () => {},
   }),
@@ -63,6 +68,8 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     // jsdom doesn't implement Element.scrollTo; the scroll-to-bottom path calls it.
     HTMLElement.prototype.scrollTo = vi.fn()
     ensureMessageMounted.mockClear()
+    getOffsetForMessageId.mockClear()
+    getOffsetForMessageId.mockImplementation(() => 0)
   })
   afterEach(() => localStorage.clear())
 
@@ -86,5 +93,46 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
   it('does not call ensureMessageMounted when there is no marker or target', () => {
     renderList()
     expect(ensureMessageMounted).not.toHaveBeenCalled()
+  })
+
+  it('restores the MAM-prepend scroll from the virtualizer offset, not the windowed-out DOM anchor', () => {
+    // After prepend the anchor (msg-0) is windowed out, so querySelector(anchor) returns
+    // null and the old code fell back to distance-from-bottom math (landing the viewport on
+    // the just-loaded older rows — the reported "position lost"). getOffsetForMessageId
+    // returns the anchor's offset even when it is unmounted, so the restore tracks it.
+    getOffsetForMessageId.mockImplementation((id) => (id === 'msg-0' ? 1000 : null))
+    const older: BaseMessage[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `older-${i}`, from: 'user@example.com', body: `Older ${i}`,
+      timestamp: new Date(2024, 0, 1, 11, i), isOutgoing: false, type: 'chat' as const,
+    }))
+    const props = { conversationId: 'conv-1', onScrollToTop: vi.fn(), isHistoryComplete: false, renderMessage: (m: BaseMessage) => <div>{m.body}</div> }
+
+    const { container, getByText, rerender } = render(<MessageList messages={makeMessages(50)} {...props} />)
+
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    let scrollTopVal = 0
+    const scrollTopSets: number[] = []
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => 5000, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { value: 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => scrollTopVal,
+      set: (v: number) => { scrollTopVal = v; scrollTopSets.push(v) },
+      configurable: true,
+    })
+
+    // Capture the anchor (msg-0, offsetFromTop 0 in jsdom) via the "Load earlier" button.
+    fireEvent.click(getByText('chat.loadEarlierMessages'))
+    getOffsetForMessageId.mockClear()
+    scrollTopSets.length = 0
+
+    // Older messages arrive -> firstId + count change -> the prepend restore runs.
+    rerender(<MessageList messages={[...older, ...makeMessages(50)]} {...props} />)
+
+    // The restore consulted the VIRTUALIZER for the windowed-out anchor and positioned by
+    // its offset (1000 - anchorOffsetFromTop 0). (A later, orthogonal scroll-to-bottom effect
+    // may overwrite the final value in this harness; the prepend positioning is what matters,
+    // and the exact pixel convergence is verified on a real engine.)
+    expect(getOffsetForMessageId).toHaveBeenCalledWith('msg-0')
+    expect(scrollTopSets).toContain(1000)
   })
 })

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { MessageVirtualizer } from './messageVirtualizer'
 
@@ -22,12 +22,28 @@ interface Args {
 export function useTanstackMessageVirtualizer({
   items, indexById, scrollRef, estimateSize = 64,
 }: Args): MessageVirtualizer {
+  // Adaptive row-height estimate: seeded at `estimateSize`, then tracks a running average
+  // of measured (mounted) rows. A constant estimate makes a large mostly-UNMEASURED array
+  // drift — and MAM prepend is the worst case: it inserts rows above the viewport that are
+  // never mounted (so never measured), so getTotalSize and the anchor offset are off by the
+  // estimate error of every prepended row. An average that matches real rows keeps both close.
+  const avgSizeRef = useRef(estimateSize)
   const virtualizer = useVirtualizer<HTMLElement, Element>({
     count: items.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => estimateSize,
+    estimateSize: () => avgSizeRef.current,
     getItemKey: (index) => items[index].key,
     overscan: 12,
+  })
+
+  // Recompute the running average from the measured sizes of the mounted window after each
+  // commit. Ref-only (no setState) so it never itself triggers a render; the updated estimate
+  // applies to unmeasured rows on the next natural render (scroll / items change / prepend).
+  useEffect(() => {
+    const mounted = virtualizer.getVirtualItems()
+    if (mounted.length === 0) return
+    const avg = mounted.reduce((sum, it) => sum + it.size, 0) / mounted.length
+    if (avg > 0) avgSizeRef.current = Math.round(avgSizeRef.current * 0.7 + avg * 0.3)
   })
 
   const getOffsetForMessageId = useCallback((id: string): number | null => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1098,22 +1098,44 @@ export function useMessageListScroll({
     let usedMethod = 'none'
 
     if (saved.anchorMessageId) {
-      const anchorElement = scroller.querySelector(
-        `[data-message-id="${saved.anchorMessageId}"]`
-      ) as HTMLElement | null
+      // Virtualized: read the anchor's offset from the virtualizer. It is valid even when
+      // the anchor row has been WINDOWED OUT of the DOM — which is exactly what prepend
+      // does: react-virtual re-centers its window on the just-inserted rows at the
+      // unchanged scrollTop, so the anchor (now far below) is unmounted. The DOM
+      // querySelector below returns null there and forces the distance-from-bottom
+      // fallback, which lands the viewport on the newly-loaded older rows (the bug).
+      const virtualOffset =
+        latestRef.current.virtualizer?.getOffsetForMessageId(saved.anchorMessageId) ?? null
 
-      if (anchorElement) {
-        // Position the anchor element at the same offset from viewport top as before
-        newScrollTop = anchorElement.offsetTop - saved.anchorOffsetFromTop
-        usedMethod = 'element-based'
+      if (virtualOffset != null) {
+        newScrollTop = virtualOffset - saved.anchorOffsetFromTop
+        usedMethod = 'virtualizer-offset'
 
-        debugLog('PREPEND RESTORE (element-based)', {
+        debugLog('PREPEND RESTORE (virtualizer offset)', {
           anchorMessageId: saved.anchorMessageId,
-          anchorOffsetTop: anchorElement.offsetTop,
+          virtualOffset,
           savedOffsetFromTop: saved.anchorOffsetFromTop,
           newScrollTop,
           maxScrollTop,
         })
+      } else {
+        const anchorElement = scroller.querySelector(
+          `[data-message-id="${saved.anchorMessageId}"]`
+        ) as HTMLElement | null
+
+        if (anchorElement) {
+          // Position the anchor element at the same offset from viewport top as before
+          newScrollTop = anchorElement.offsetTop - saved.anchorOffsetFromTop
+          usedMethod = 'element-based'
+
+          debugLog('PREPEND RESTORE (element-based)', {
+            anchorMessageId: saved.anchorMessageId,
+            anchorOffsetTop: anchorElement.offsetTop,
+            savedOffsetFromTop: saved.anchorOffsetFromTop,
+            newScrollTop,
+            maxScrollTop,
+          })
+        }
       }
     }
 
@@ -1182,16 +1204,14 @@ export function useMessageListScroll({
       if (framesRemaining <= 0 || !scrollerRef.current) return
       framesRemaining--
 
-      // When virtualized, re-read the anchor's now-measured offset and re-anchor each
-      // frame — the 2-step convergence (@tanstack's estimated offset settles after the
-      // new rows measure; the spike showed this converges in ~1 step). Flag-OFF holds
-      // the fixed target (unchanged behavior).
+      // When virtualized, re-read the anchor's offset from the virtualizer each frame and
+      // re-anchor — it is valid even while the anchor is windowed out, and it tracks the
+      // @tanstack estimate -> measured convergence as the just-prepended rows settle.
+      // Flag-OFF holds the fixed target (unchanged behavior).
       let target = targetScrollTop
       if (latestRef.current.virtualizer && saved.anchorMessageId) {
-        const el = scrollerRef.current.querySelector(
-          `[data-message-id="${CSS.escape(saved.anchorMessageId)}"]`,
-        ) as HTMLElement | null
-        if (el) target = el.offsetTop - saved.anchorOffsetFromTop
+        const virtualOffset = latestRef.current.virtualizer.getOffsetForMessageId(saved.anchorMessageId)
+        if (virtualOffset != null) target = virtualOffset - saved.anchorOffsetFromTop
       }
 
       const currentScrollTop = scrollerRef.current.scrollTop

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -24,7 +24,7 @@ import { DemoTutorialProvider } from './demo/tutorial/DemoTutorialProvider'
 import { buildDemoData, buildDemoAnimation } from './demo/demoData'
 import { getDiscoverableRooms } from './demo/rooms'
 import { parseStressParam, installPerfHarness } from './demo/perfHarness'
-import { installDemoLoadOlder } from './demo/demoLoadOlder'
+import { installDemoLoadOlder, seedStressConversation } from './demo/demoLoadOlder'
 import App from './App'
 import i18n from './i18n'
 import './index.css'
@@ -62,6 +62,9 @@ if (stressScenario) {
   // Defer so the first paint happens before the load starts.
   setTimeout(() => {
     demoClient.runStressScenario(stressScenario)
+    // Also seed an immediately-virtualized 1:1 (stress-contact@...) so MAM scroll-up /
+    // prepend-anchor restore can be tested in chats too, not just rooms.
+    seedStressConversation(stressScenario.messagesPerRoom ?? 150)
     if (stressScenario.activate) {
       // After seeding finishes, navigate into the first seeded room to surface the
       // switch-mount cost. Room JIDs are `stress-<i>@conference.<domain>` (see

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -24,6 +24,7 @@ import { DemoTutorialProvider } from './demo/tutorial/DemoTutorialProvider'
 import { buildDemoData, buildDemoAnimation } from './demo/demoData'
 import { getDiscoverableRooms } from './demo/rooms'
 import { parseStressParam, installPerfHarness } from './demo/perfHarness'
+import { installDemoLoadOlder } from './demo/demoLoadOlder'
 import App from './App'
 import i18n from './i18n'
 import './index.css'
@@ -52,6 +53,9 @@ const demoAnimation = buildDemoAnimation()
 const demoClient = new DemoClient()
 demoClient.populateDemo(demoData)
 demoClient.setDiscoverableRooms(getDiscoverableRooms())
+// Make MAM scroll-up ("load older") prepend synthetic older messages in demo mode, so the
+// prepend-anchor scroll restore can be exercised without a server.
+installDemoLoadOlder(demoClient)
 
 const stressScenario = parseStressParam(params)
 if (stressScenario) {

--- a/apps/fluux/src/demo/demoLoadOlder.ts
+++ b/apps/fluux/src/demo/demoLoadOlder.ts
@@ -1,88 +1,151 @@
 /**
- * Demo "load older messages" (MAM scroll-up) support.
+ * Demo "load older messages" (MAM scroll-up) support for rooms AND 1:1 chats.
  *
  * The real client answers `fetchOlderHistory` by querying MAM and prepending the result
- * via `roomStore.mergeRoomMAMMessages(..., 'backward')`. The demo has no server, so we
- * patch `client.chat.queryRoomMAM` to synthesize a batch of OLDER messages on demand and
- * feed them through the exact same store path. This makes scroll-up actually prepend in
- * demo mode — needed to exercise the prepend-anchor scroll restore (and, with
- * virtualization, to reproduce/verify the anchor behavior on a real layout engine).
+ * via `roomStore.mergeRoomMAMMessages` / `chatStore.mergeMAMMessages` ('backward'). The
+ * demo has no server, so we patch `client.chat.queryRoomMAM` (rooms) and `client.chat.queryMAM`
+ * (1:1) to synthesize a batch of OLDER messages on demand and feed them through the exact
+ * same store path. This makes scroll-up actually prepend in demo mode — needed to exercise
+ * the prepend-anchor scroll restore (and verify it on a real engine).
  *
- * Gated to `stress-*` rooms so the curated demo rooms keep their finite history.
+ * Gated to `stress-*` rooms and the `stress-contact` 1:1 so curated demo conversations keep
+ * their finite history. `seedStressConversation()` seeds an immediately-virtualized 1:1.
  */
-import type { RoomMessage } from '@fluux/sdk'
-import { roomStore } from '@fluux/sdk/stores'
+import type { RoomMessage, Message, Conversation } from '@fluux/sdk'
+import { roomStore, chatStore } from '@fluux/sdk/stores'
 
-/** Total synthetic older messages available per stress room before history is "complete". */
-const MAX_OLDER_PER_ROOM = 400
+/** Total synthetic older messages available per conversation before history is "complete". */
+const MAX_OLDER = 400
 const BATCH = 50
+const STRESS_CONTACT_JID = 'stress-contact@fluux.chat'
+const SELF_JID = 'you@fluux.chat'
 
-/** Build a batch of messages strictly older than `oldest`, in chronological order, with
- *  deliberately varied heights (every 4th wraps to several lines) so the virtualizer's
- *  constant size estimate diverges from measured — which is what surfaces a prepend jump. */
-function buildOlderBatch(roomJid: string, oldest: RoomMessage, startIdx: number, count: number): RoomMessage[] {
+/** A body that is deliberately tall every 4th message, so the virtualizer's size estimate
+ *  diverges from measured — the height variance is what makes a prepend-anchor jump visible. */
+function bodyFor(idx: number): string {
+  return idx % 4 === 0
+    ? `older message ${idx} — intentionally long so it wraps across several lines and measures much ` +
+      `taller than the size estimate. That height variance is exactly what makes a prepend-anchor ` +
+      `jump visible. More text on the next line. And a third line to be sure it wraps.`
+    : `older message ${idx}`
+}
+
+/** Build older RoomMessages (strictly older than `oldest`, chronological within the batch). */
+function buildOlderRoomBatch(roomJid: string, oldest: RoomMessage, startIdx: number, count: number): RoomMessage[] {
   const roomIdx = roomJid.match(/stress-(\d+)/)?.[1] ?? '0'
   const baseTs = oldest.timestamp.getTime()
-  const batch: RoomMessage[] = []
-  for (let k = 0; k < count; k++) {
+  return Array.from({ length: count }, (_, k) => {
     const idx = startIdx + k
     const nick = `U${roomIdx}_${idx % 8}`
-    const tall = idx % 4 === 0
-    const body = tall
-      ? `older message ${idx} — intentionally long so it wraps across several lines and measures much ` +
-        `taller than the size estimate. That height variance is exactly what makes a prepend-anchor ` +
-        `jump visible. More text on the next line. And a third line to be sure it wraps.`
-      : `older message ${idx}`
-    batch.push({
-      type: 'groupchat',
-      // Strictly older than `oldest`, chronological within the batch (k=0 is the oldest).
+    return {
+      type: 'groupchat' as const,
       timestamp: new Date(baseTs - (count - k) * 60_000),
       id: `${roomJid}::older-${idx}`,
       from: `${roomJid}/${nick}`,
       nick,
-      body,
+      body: bodyFor(idx),
       isOutgoing: false,
       roomJid,
-    })
-  }
-  return batch
+    }
+  })
 }
 
-type MAMable = { chat: { queryRoomMAM: (opts: { roomJid: string; before?: string }) => Promise<unknown> } }
+/** Build older 1:1 Messages (strictly older than `oldest`, chronological within the batch). */
+function buildOlderChatBatch(conversationId: string, oldest: Message, startIdx: number, count: number): Message[] {
+  const baseTs = oldest.timestamp.getTime()
+  return Array.from({ length: count }, (_, k) => {
+    const idx = startIdx + k
+    const outgoing = idx % 7 === 0
+    return {
+      type: 'chat' as const,
+      conversationId,
+      timestamp: new Date(baseTs - (count - k) * 60_000),
+      id: `${conversationId}::older-${idx}`,
+      from: outgoing ? SELF_JID : conversationId,
+      body: bodyFor(idx),
+      isOutgoing: outgoing,
+    }
+  })
+}
 
-/** Patch the demo client so MAM scroll-up prepends synthetic older messages (stress rooms). */
+type MAMable = {
+  chat: {
+    queryRoomMAM: (opts: { roomJid: string; before?: string }) => Promise<unknown>
+    queryMAM: (opts: { with: string; before?: string }) => Promise<unknown>
+  }
+}
+
+/** Patch the demo client so MAM scroll-up prepends synthetic older messages
+ *  (stress-* rooms and the stress-contact 1:1). */
 export function installDemoLoadOlder(client: MAMable): void {
-  const generated = new Map<string, number>()
+  const roomGenerated = new Map<string, number>()
+  const chatGenerated = new Map<string, number>()
 
   client.chat.queryRoomMAM = async ({ roomJid }) => {
     const rs = roomStore.getState()
-    // Non-stress (curated) rooms have finite history — report complete immediately.
     if (!roomJid.startsWith('stress-')) {
       rs.mergeRoomMAMMessages(roomJid, [], { count: 0 }, true, 'backward')
       return { messages: [], complete: true }
     }
-
-    // Mimic a network round-trip so the prepend lands asynchronously, as in production.
-    await new Promise((r) => setTimeout(r, 80))
-
+    await new Promise((r) => setTimeout(r, 80)) // mimic a network round-trip
     const oldest = rs.getRoom(roomJid)?.messages?.[0]
-    const start = generated.get(roomJid) ?? 0
-    if (!oldest || start >= MAX_OLDER_PER_ROOM) {
+    const start = roomGenerated.get(roomJid) ?? 0
+    if (!oldest || start >= MAX_OLDER) {
       rs.mergeRoomMAMMessages(roomJid, [], { count: 0 }, true, 'backward')
       return { messages: [], complete: true }
     }
-
-    const count = Math.min(BATCH, MAX_OLDER_PER_ROOM - start)
-    const batch = buildOlderBatch(roomJid, oldest, start, count)
-    generated.set(roomJid, start + count)
-    const complete = start + count >= MAX_OLDER_PER_ROOM
-    rs.mergeRoomMAMMessages(
-      roomJid,
-      batch,
-      { first: batch[0].id, last: batch[batch.length - 1].id, count: batch.length },
-      complete,
-      'backward',
-    )
+    const count = Math.min(BATCH, MAX_OLDER - start)
+    const batch = buildOlderRoomBatch(roomJid, oldest, start, count)
+    roomGenerated.set(roomJid, start + count)
+    const complete = start + count >= MAX_OLDER
+    rs.mergeRoomMAMMessages(roomJid, batch, { first: batch[0].id, last: batch[batch.length - 1].id, count: batch.length }, complete, 'backward')
     return { messages: batch, complete }
   }
+
+  client.chat.queryMAM = async ({ with: jid }) => {
+    const cs = chatStore.getState()
+    if (!jid.startsWith('stress-')) {
+      cs.mergeMAMMessages(jid, [], { count: 0 }, true, 'backward')
+      return { messages: [], complete: true }
+    }
+    await new Promise((r) => setTimeout(r, 80))
+    const oldest = cs.messages.get(jid)?.[0]
+    const start = chatGenerated.get(jid) ?? 0
+    if (!oldest || start >= MAX_OLDER) {
+      cs.mergeMAMMessages(jid, [], { count: 0 }, true, 'backward')
+      return { messages: [], complete: true }
+    }
+    const count = Math.min(BATCH, MAX_OLDER - start)
+    const batch = buildOlderChatBatch(jid, oldest, start, count)
+    chatGenerated.set(jid, start + count)
+    const complete = start + count >= MAX_OLDER
+    cs.mergeMAMMessages(jid, batch, { first: batch[0].id, last: batch[batch.length - 1].id, count: batch.length }, complete, 'backward')
+    return { messages: batch, complete }
+  }
+}
+
+/** Seed an immediately-virtualized stress 1:1 conversation with `messageCount` messages, so
+ *  the prepend-anchor restore can be tested in 1:1 chats (parallel to the stress room).
+ *  Returns the conversation JID. */
+export function seedStressConversation(messageCount: number): string {
+  const cs = chatStore.getState()
+  const conv: Conversation = { id: STRESS_CONTACT_JID, name: 'Stress Contact', type: 'chat', unreadCount: 0 }
+  cs.addConversation(conv)
+  const baseTs = Date.now() - messageCount * 60_000
+  const seed: Message[] = Array.from({ length: messageCount }, (_, i) => {
+    const outgoing = i % 7 === 0
+    return {
+      type: 'chat' as const,
+      conversationId: STRESS_CONTACT_JID,
+      timestamp: new Date(baseTs + i * 60_000),
+      id: `${STRESS_CONTACT_JID}::seed-${i}`,
+      from: outgoing ? SELF_JID : STRESS_CONTACT_JID,
+      body: i % 5 === 0 ? `seed message ${i} — a longer one that wraps onto a second line for height variance.` : `seed message ${i}`,
+      isOutgoing: outgoing,
+    }
+  })
+  // 'backward' merge into the empty conversation = the seed, with history left incomplete so
+  // scroll-up keeps loading synthetic older messages.
+  cs.mergeMAMMessages(STRESS_CONTACT_JID, seed, { first: seed[0]?.id, last: seed[seed.length - 1]?.id, count: seed.length }, false, 'backward')
+  return STRESS_CONTACT_JID
 }

--- a/apps/fluux/src/demo/demoLoadOlder.ts
+++ b/apps/fluux/src/demo/demoLoadOlder.ts
@@ -1,0 +1,88 @@
+/**
+ * Demo "load older messages" (MAM scroll-up) support.
+ *
+ * The real client answers `fetchOlderHistory` by querying MAM and prepending the result
+ * via `roomStore.mergeRoomMAMMessages(..., 'backward')`. The demo has no server, so we
+ * patch `client.chat.queryRoomMAM` to synthesize a batch of OLDER messages on demand and
+ * feed them through the exact same store path. This makes scroll-up actually prepend in
+ * demo mode — needed to exercise the prepend-anchor scroll restore (and, with
+ * virtualization, to reproduce/verify the anchor behavior on a real layout engine).
+ *
+ * Gated to `stress-*` rooms so the curated demo rooms keep their finite history.
+ */
+import type { RoomMessage } from '@fluux/sdk'
+import { roomStore } from '@fluux/sdk/stores'
+
+/** Total synthetic older messages available per stress room before history is "complete". */
+const MAX_OLDER_PER_ROOM = 400
+const BATCH = 50
+
+/** Build a batch of messages strictly older than `oldest`, in chronological order, with
+ *  deliberately varied heights (every 4th wraps to several lines) so the virtualizer's
+ *  constant size estimate diverges from measured — which is what surfaces a prepend jump. */
+function buildOlderBatch(roomJid: string, oldest: RoomMessage, startIdx: number, count: number): RoomMessage[] {
+  const roomIdx = roomJid.match(/stress-(\d+)/)?.[1] ?? '0'
+  const baseTs = oldest.timestamp.getTime()
+  const batch: RoomMessage[] = []
+  for (let k = 0; k < count; k++) {
+    const idx = startIdx + k
+    const nick = `U${roomIdx}_${idx % 8}`
+    const tall = idx % 4 === 0
+    const body = tall
+      ? `older message ${idx} — intentionally long so it wraps across several lines and measures much ` +
+        `taller than the size estimate. That height variance is exactly what makes a prepend-anchor ` +
+        `jump visible. More text on the next line. And a third line to be sure it wraps.`
+      : `older message ${idx}`
+    batch.push({
+      type: 'groupchat',
+      // Strictly older than `oldest`, chronological within the batch (k=0 is the oldest).
+      timestamp: new Date(baseTs - (count - k) * 60_000),
+      id: `${roomJid}::older-${idx}`,
+      from: `${roomJid}/${nick}`,
+      nick,
+      body,
+      isOutgoing: false,
+      roomJid,
+    })
+  }
+  return batch
+}
+
+type MAMable = { chat: { queryRoomMAM: (opts: { roomJid: string; before?: string }) => Promise<unknown> } }
+
+/** Patch the demo client so MAM scroll-up prepends synthetic older messages (stress rooms). */
+export function installDemoLoadOlder(client: MAMable): void {
+  const generated = new Map<string, number>()
+
+  client.chat.queryRoomMAM = async ({ roomJid }) => {
+    const rs = roomStore.getState()
+    // Non-stress (curated) rooms have finite history — report complete immediately.
+    if (!roomJid.startsWith('stress-')) {
+      rs.mergeRoomMAMMessages(roomJid, [], { count: 0 }, true, 'backward')
+      return { messages: [], complete: true }
+    }
+
+    // Mimic a network round-trip so the prepend lands asynchronously, as in production.
+    await new Promise((r) => setTimeout(r, 80))
+
+    const oldest = rs.getRoom(roomJid)?.messages?.[0]
+    const start = generated.get(roomJid) ?? 0
+    if (!oldest || start >= MAX_OLDER_PER_ROOM) {
+      rs.mergeRoomMAMMessages(roomJid, [], { count: 0 }, true, 'backward')
+      return { messages: [], complete: true }
+    }
+
+    const count = Math.min(BATCH, MAX_OLDER_PER_ROOM - start)
+    const batch = buildOlderBatch(roomJid, oldest, start, count)
+    generated.set(roomJid, start + count)
+    const complete = start + count >= MAX_OLDER_PER_ROOM
+    rs.mergeRoomMAMMessages(
+      roomJid,
+      batch,
+      { first: batch[0].id, last: batch[batch.length - 1].id, count: batch.length },
+      complete,
+      'backward',
+    )
+    return { messages: batch, complete }
+  }
+}

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1144,11 +1144,11 @@ describe('chatStore', () => {
     })
 
     it('should store messages in memory (display buffer) without localStorage limit', () => {
-      // Messages are stored in memory for display, with a high limit (1000)
+      // Messages are stored in memory for display, with a high limit (5000)
       // This test verifies we can store more than the old 100 message limit
       chatStore.getState().addConversation(createConversation('alice@example.com'))
 
-      // Add 500 messages (was limited to 100 before, now can go up to 1000)
+      // Add 500 messages (was limited to 100 before, now can go up to 5000)
       for (let i = 0; i < 500; i++) {
         chatStore.getState().addMessage(createMessage('alice@example.com', `Message ${i}`))
       }
@@ -2271,16 +2271,17 @@ describe('chatStore', () => {
       it('should trim messages to MAX_MESSAGES_PER_CONVERSATION', () => {
         chatStore.getState().addConversation(createConversation('alice@example.com'))
 
-        // Create 1100 MAM messages (more than MAX_MESSAGES_PER_CONVERSATION which is 1000)
+        // Create 5100 MAM messages (more than MAX_MESSAGES_PER_CONVERSATION which is 5000)
+        const total = 5100
         const mamMessages: Message[] = []
-        for (let i = 0; i < 1100; i++) {
+        for (let i = 0; i < total; i++) {
           mamMessages.push({
             type: 'chat',
             id: `mam-msg-${i}`,
             conversationId: 'alice@example.com',
             from: 'alice@example.com',
             body: `Message ${i}`,
-            timestamp: new Date(Date.now() - (1100 - i) * 60000), // Ordered by time
+            timestamp: new Date(Date.now() - (total - i) * 60000), // Ordered by time
             isOutgoing: false,
             stanzaId: `stanza-${i}`,
           })
@@ -2289,18 +2290,18 @@ describe('chatStore', () => {
         chatStore.getState().mergeMAMMessages(
           'alice@example.com',
           mamMessages,
-          { count: 1100 },
+          { count: total },
           true,
           'backward'
         )
 
-        // Should be trimmed to MAX_MESSAGES (1000) - this is the display buffer limit
+        // Should be trimmed to MAX_MESSAGES (5000) - this is the display buffer limit
         // All messages are still stored in IndexedDB
         const messages = chatStore.getState().messages.get('alice@example.com')
-        expect(messages?.length).toBeLessThanOrEqual(1000)
+        expect(messages?.length).toBeLessThanOrEqual(5000)
 
         // Should keep the most recent messages
-        expect(messages?.[messages.length - 1].body).toBe('Message 1099')
+        expect(messages?.[messages.length - 1].body).toBe(`Message ${total - 1}`)
       })
 
       it('should create conversation messages array if it does not exist', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -16,10 +16,11 @@ import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey } from '../utils/storageScope'
 
 // Maximum messages to keep in memory per conversation (display buffer)
-// This is a memory/performance tradeoff - higher values allow smoother scrolling
-// but use more RAM. 1000 is enough for typical usage with lazy loading.
-// All messages are stored in IndexedDB regardless of this limit.
-const MAX_MESSAGES_PER_CONVERSATION = 1000
+// Purely an in-memory bound (messages live in IndexedDB, not localStorage). Before view
+// virtualization this mainly capped DOM nodes; now the message list windows its DOM
+// regardless of array size, so the limit is raised to allow real scroll-back — at the old
+// 1000 a prepend at the cap trimmed the just-loaded older batch straight back off.
+const MAX_MESSAGES_PER_CONVERSATION = 5000
 const STORAGE_KEY_BASE = 'xmpp-chat-storage'
 
 /**

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -20,6 +20,9 @@ import { buildScopedStorageKey } from '../utils/storageScope'
 // virtualization this mainly capped DOM nodes; now the message list windows its DOM
 // regardless of array size, so the limit is raised to allow real scroll-back — at the old
 // 1000 a prepend at the cap trimmed the just-loaded older batch straight back off.
+// FUTURE: the goal is to remove this cap entirely (unlimited scroll-back — "go back anywhere
+// in time"). Pair removal with the adaptive size estimate so getTotalSize/scrollbar stay
+// sane on huge arrays; Phase-1 conversation-switch eviction bounds RAM. 5000 is interim.
 const MAX_MESSAGES_PER_CONVERSATION = 5000
 const STORAGE_KEY_BASE = 'xmpp-chat-storage'
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -38,6 +38,10 @@ import { buildScopedStorageKey } from '../utils/storageScope'
  * its DOM regardless of array size, so the limit is raised to allow real scroll-back —
  * at the old 1000 a `prependOlderMessages` at the cap trimmed the just-loaded older
  * batch straight back off (load-older became a no-op past 1000).
+ *
+ * FUTURE: the goal is to remove this cap entirely (unlimited scroll-back — "go back anywhere
+ * in time"). Pair removal with the adaptive size estimate so getTotalSize/scrollbar stay sane
+ * on huge arrays; Phase-1 conversation-switch eviction bounds RAM. 5000 is an interim step.
  */
 const MAX_MESSAGES_PER_ROOM = 5000
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -32,8 +32,14 @@ import { buildScopedStorageKey } from '../utils/storageScope'
 /**
  * Maximum messages to keep in memory per room.
  * Older messages are still available in IndexedDB and can be loaded on demand.
+ *
+ * This is purely an in-memory bound (messages live in IndexedDB, not localStorage).
+ * Before view virtualization it mainly capped DOM nodes; now the message list windows
+ * its DOM regardless of array size, so the limit is raised to allow real scroll-back —
+ * at the old 1000 a `prependOlderMessages` at the cap trimmed the just-loaded older
+ * batch straight back off (load-older became a no-op past 1000).
  */
-const MAX_MESSAGES_PER_ROOM = 1000
+const MAX_MESSAGES_PER_ROOM = 5000
 
 /**
  * Carry a previously-resolved avatar across a presence update.


### PR DESCRIPTION
Fixes the reported regression: with virtualization on, **loading older messages lost the scroll position** — the view jumped onto the just-loaded older rows.

## Fix
- **Anchor restore** reads the offset from the virtualizer (`getOffsetForMessageId`), which is valid for unmounted rows — the design's intended rebind that was never wired up. Falls back to the DOM read on the flag-OFF path (unchanged).
- **Adaptive size estimate**: the `@tanstack` adapter now uses a running average of measured rows instead of a constant 64px, so the prepended-but-unmeasured rows estimate close to real and the immediate restore is accurate.
- Guard: `MessageList.virtualizedScroll.test.tsx` asserts the prepend restore positions from the virtualizer offset (verified to fail when the rebind is reverted).