### PR TITLE
fix(perf): scroll-to-bottom landed mid-conversation (remove collapsing adaptive estimate)

### DIFF
--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { MessageVirtualizer } from './messageVirtualizer'
 
@@ -22,28 +22,19 @@ interface Args {
 export function useTanstackMessageVirtualizer({
   items, indexById, scrollRef, estimateSize = 64,
 }: Args): MessageVirtualizer {
-  // Adaptive row-height estimate: seeded at `estimateSize`, then tracks a running average
-  // of measured (mounted) rows. A constant estimate makes a large mostly-UNMEASURED array
-  // drift — and MAM prepend is the worst case: it inserts rows above the viewport that are
-  // never mounted (so never measured), so getTotalSize and the anchor offset are off by the
-  // estimate error of every prepended row. An average that matches real rows keeps both close.
-  const avgSizeRef = useRef(estimateSize)
+  // NOTE: a measured running-average `estimateSize` was tried (to tighten the MAM-prepend
+  // immediate restore, whose prepended rows are unmeasured) but REMOVED — it fed back at the
+  // bottom (the trailing footer/empty items drag the average down each render) and collapsed
+  // getTotalSize, which made scroll-to-bottom (`scrollTop = scrollHeight`) land in the middle
+  // of the conversation. A constant estimate keeps getTotalSize stable; the prepend restore
+  // stays accurate via getOffsetForMessageId + the scroll hook's per-frame re-assert, which
+  // re-reads the offset as the prepended rows measure.
   const virtualizer = useVirtualizer<HTMLElement, Element>({
     count: items.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => avgSizeRef.current,
+    estimateSize: () => estimateSize,
     getItemKey: (index) => items[index].key,
     overscan: 12,
-  })
-
-  // Recompute the running average from the measured sizes of the mounted window after each
-  // commit. Ref-only (no setState) so it never itself triggers a render; the updated estimate
-  // applies to unmeasured rows on the next natural render (scroll / items change / prepend).
-  useEffect(() => {
-    const mounted = virtualizer.getVirtualItems()
-    if (mounted.length === 0) return
-    const avg = mounted.reduce((sum, it) => sum + it.size, 0) / mounted.length
-    if (avg > 0) avgSizeRef.current = Math.round(avgSizeRef.current * 0.7 + avg * 0.3)
   })
 
   const getOffsetForMessageId = useCallback((id: string): number | null => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -21,8 +21,9 @@ import { buildScopedStorageKey } from '../utils/storageScope'
 // regardless of array size, so the limit is raised to allow real scroll-back — at the old
 // 1000 a prepend at the cap trimmed the just-loaded older batch straight back off.
 // FUTURE: the goal is to remove this cap entirely (unlimited scroll-back — "go back anywhere
-// in time"). Pair removal with the adaptive size estimate so getTotalSize/scrollbar stay
-// sane on huge arrays; Phase-1 conversation-switch eviction bounds RAM. 5000 is interim.
+// in time"). Removal needs an estimate strategy that keeps getTotalSize/scrollbar accurate on
+// a huge mostly-estimated array (a running-average estimate was tried but collapsed — see
+// tanstackMessageVirtualizer); Phase-1 conversation-switch eviction bounds RAM. 5000 is interim.
 const MAX_MESSAGES_PER_CONVERSATION = 5000
 const STORAGE_KEY_BASE = 'xmpp-chat-storage'
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -40,8 +40,9 @@ import { buildScopedStorageKey } from '../utils/storageScope'
  * batch straight back off (load-older became a no-op past 1000).
  *
  * FUTURE: the goal is to remove this cap entirely (unlimited scroll-back — "go back anywhere
- * in time"). Pair removal with the adaptive size estimate so getTotalSize/scrollbar stay sane
- * on huge arrays; Phase-1 conversation-switch eviction bounds RAM. 5000 is an interim step.
+ * in time"). Removal needs an estimate strategy that keeps getTotalSize/scrollbar accurate on
+ * a huge mostly-estimated array (a running-average estimate was tried but collapsed — see
+ * tanstackMessageVirtualizer); Phase-1 conversation-switch eviction bounds RAM. 5000 is interim.
  */
 const MAX_MESSAGES_PER_ROOM = 5000
 


### PR DESCRIPTION
Follow-up to #641. Opening a conversation sometimes landed in the **middle** instead of the bottom.