### PR TITLE
fix(chat): bottom-stick robustness under virtualization (re-assert, wider tolerance, scroll-on-send)

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -256,6 +256,7 @@ export function MessageList<T extends BaseMessage>({
     isHistoryComplete,
     typingUsersCount: typingUsers.length,
     lastMessageReactionsKey,
+    lastMessageIsOutgoing: lastMessage?.isOutgoing ?? false,
     staticMode,
     virtualizer: activeVirtualizer,
   })

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -255,6 +255,26 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     expect(scrollTopSets).toContain(5000)
   })
 
+  it('does NOT yank a scrolled-up reader to the bottom on an INCOMING message', () => {
+    // The counterpart to scroll-on-send: widening the scroll trigger must not break the rule
+    // that an incoming message leaves a reader who scrolled up where they are.
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-noyank" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const { scrollTopSets } = instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    // Reading history, far from the bottom -> isAtBottom false.
+    scroller.scrollTop = 1000
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+    scrollTopSets.length = 0
+
+    // An INCOMING message arrives (last message not outgoing) -> must NOT scroll to the bottom.
+    rerender(<MessageList messages={makeMessages(51)} conversationId="conv-noyank" {...props} />)
+    expect(scrollTopSets).not.toContain(5000)
+  })
+
   it('keeps following incoming messages within the wider at-bottom tolerance (100px from bottom)', () => {
     // A tall last message that measured slightly short used to leave the view >50px from the
     // bottom, flipping "at bottom" false so the next incoming message stopped following. The

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -136,3 +136,98 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     expect(scrollTopSets).toContain(1000)
   })
 })
+
+/**
+ * Bottom-stick under virtualization. Scroll-to-bottom sets `scrollTop = scrollHeight`, but the
+ * bottom rows then mount and measure TALLER than the fixed estimate, so getTotalSize (=
+ * scrollHeight) keeps growing AFTER the assignment. A one-shot assignment (or single rAF retry)
+ * leaves the last message below the fold — the reported "not perfectly at the bottom, last
+ * message hidden". The content ResizeObserver that re-pins on growth for the non-virtualized
+ * path is disabled under virtualization, so the hook must re-assert across frames instead.
+ *
+ * The harness flushes ONE settle frame at the estimated height, THEN grows scrollHeight — so a
+ * single deferred retry (which fires on that first frame) cannot reach the grown height; only a
+ * multi-frame re-assert can. (jsdom has no layout, so pixel convergence is a real-engine check;
+ * here we pin that growth after the initial scroll is followed.)
+ */
+describe('MessageList — virtualized bottom-stick re-asserts as rows measure', () => {
+  let realRaf: typeof requestAnimationFrame
+  let rafQueue: FrameRequestCallback[]
+  const flush = (frames: number) => {
+    for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0))
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafQueue.push(cb)
+      return rafQueue.length
+    }) as typeof requestAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = realRaf
+    localStorage.clear()
+  })
+
+  function instrumentScroller(scroller: HTMLElement, initialHeight: number) {
+    let scrollHeightVal = initialHeight
+    let scrollTopVal = 0
+    const scrollTopSets: number[] = []
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => scrollHeightVal, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { value: 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => scrollTopVal,
+      set: (v: number) => {
+        scrollTopVal = v
+        scrollTopSets.push(v)
+      },
+      configurable: true,
+    })
+    return { scrollTopSets, grow: (h: number) => { scrollHeightVal = h } }
+  }
+
+  const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div> }
+
+  it('re-pins to the bottom as scrollHeight grows after a fresh-conversation scroll-to-bottom', () => {
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-A" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const { scrollTopSets, grow } = instrumentScroller(scroller, 2000)
+    rafQueue.length = 0 // drop the initial conv-A render's frames
+
+    // Enter a fresh conversation -> scroll to the (estimated) bottom.
+    rerender(<MessageList messages={makeMessages(50)} conversationId="conv-B" {...props} />)
+    expect(scrollTopSets).toContain(2000)
+
+    // One settle frame at the estimate, THEN the bottom rows measure taller -> height grows.
+    scrollTopSets.length = 0
+    flush(1)
+    grow(3000)
+    flush(14)
+    expect(scrollTopSets).toContain(3000)
+  })
+
+  it('re-pins to the bottom as a new message row measures taller than the estimate', () => {
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-1" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const { scrollTopSets, grow } = instrumentScroller(scroller, 2000)
+    rafQueue.length = 0
+
+    // A new message arrives while at the bottom -> scroll to the (estimated) bottom.
+    scrollTopSets.length = 0
+    rerender(<MessageList messages={makeMessages(51)} conversationId="conv-1" {...props} />)
+    expect(scrollTopSets).toContain(2000)
+
+    scrollTopSets.length = 0
+    flush(1)
+    grow(3000)
+    flush(14)
+    expect(scrollTopSets).toContain(3000)
+  })
+})

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -230,4 +230,48 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     flush(14)
     expect(scrollTopSets).toContain(3000)
   })
+
+  it('scrolls to the bottom on a SENT (outgoing) message even when the user had scrolled up', () => {
+    // When you send a message you expect to see it, wherever you were reading. An incoming
+    // message while scrolled up must NOT yank you down, but your own outgoing message must.
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-send" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const { scrollTopSets } = instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    // User scrolls far up -> isAtBottom flips false (incoming would no longer auto-follow).
+    scroller.scrollTop = 1000
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+    scrollTopSets.length = 0
+
+    // The user SENDS a message (last message is outgoing) -> must scroll to the bottom.
+    const sent: BaseMessage = {
+      id: 'sent-1', from: 'me@example.com', body: 'my reply',
+      timestamp: new Date(2024, 0, 1, 13, 0), isOutgoing: true, type: 'chat',
+    }
+    rerender(<MessageList messages={[...makeMessages(50), sent]} conversationId="conv-send" {...props} />)
+    expect(scrollTopSets).toContain(5000)
+  })
+
+  it('keeps following incoming messages within the wider at-bottom tolerance (100px from bottom)', () => {
+    // A tall last message that measured slightly short used to leave the view >50px from the
+    // bottom, flipping "at bottom" false so the next incoming message stopped following. The
+    // wider tolerance keeps a near-bottom view (100px) following.
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-tol" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const { scrollTopSets } = instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    // Sit 100px above the real bottom (between the old 50px threshold and the new one).
+    scroller.scrollTop = 5000 - 500 - 100
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+    scrollTopSets.length = 0
+
+    rerender(<MessageList messages={makeMessages(51)} conversationId="conv-tol" {...props} />)
+    expect(scrollTopSets).toContain(5000)
+  })
 })

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -294,4 +294,30 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     rerender(<MessageList messages={makeMessages(51)} conversationId="conv-tol" {...props} />)
     expect(scrollTopSets).toContain(5000)
   })
+
+  it('restores a scrolled-up position on conversation switch instead of jumping to the bottom (virtualized)', () => {
+    // Returning to a conversation you'd scrolled up in must restore that position, not
+    // scroll-to-bottom. The flag-OFF suite covers this; this pins it with the virtualizer wired.
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-r1" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const { scrollTopSets } = instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    // Scroll up to 200 and let the scroll handler record the position + anchor.
+    scroller.scrollTop = 200
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+
+    // Switch away (saves conv-r1's position) then back (should restore it).
+    rerender(<MessageList messages={makeMessages(50)} conversationId="conv-r2" {...props} />)
+    scrollTopSets.length = 0
+    rerender(<MessageList messages={makeMessages(50)} conversationId="conv-r1" {...props} />)
+
+    // Restored to the saved scroll position (200), not scrolled to the bottom (5000). Under
+    // virtualization the anchor is typically windowed out, so the saved-pixel fallback is what
+    // runs — pinning it guards against a refactor that regresses restore into a scroll-to-bottom.
+    expect(scrollTopSets).toContain(200)
+    expect(scrollTopSets).not.toContain(5000)
+  })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -92,6 +92,34 @@ function restoreToAnchor(scroller: HTMLElement, anchor: ScrollAnchor): boolean {
   return true
 }
 
+/**
+ * Re-assert scroll-to-bottom across several frames (virtualized path only).
+ *
+ * Under virtualization the bottom rows mount and measure AFTER the scroll, so getTotalSize
+ * (= scrollHeight) keeps growing past the initial `scrollTop = scrollHeight` assignment when a
+ * row turns out taller than the fixed estimate — a one-shot assignment leaves the last message
+ * below the fold ("not perfectly at the bottom"). The content ResizeObserver that re-pins on
+ * growth for the non-virtualized path is disabled under virtualization (correcting the @tanstack
+ * spacer there feeds back into the virtualizer), so we re-pin here instead: bounded to ~250ms
+ * and gated on isAtBottom so a user scroll-up mid-settle cancels it. This is the bottom analog
+ * of the prepend momentum re-assert, which re-reads its target each frame as the estimate ->
+ * measured convergence settles.
+ */
+function reassertScrollToBottom(
+  scrollerRef: React.RefObject<HTMLDivElement | null>,
+  isAtBottomRef: React.MutableRefObject<boolean>,
+) {
+  let framesRemaining = 15 // ~250ms at 60fps
+  const step = () => {
+    const scroller = scrollerRef.current
+    if (framesRemaining <= 0 || !scroller || !isAtBottomRef.current) return
+    framesRemaining--
+    scroller.scrollTop = scroller.scrollHeight
+    requestAnimationFrame(step)
+  }
+  requestAnimationFrame(step)
+}
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -908,18 +936,25 @@ export function useMessageListScroll({
         // which triggers when messageCount changes.
         void scroller.offsetHeight  // Force layout calculation
         scroller.scrollTop = scroller.scrollHeight
-
-        requestAnimationFrame(() => {
-          if (scrollerRef.current) {
-            scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
-            debugLog('CONVERSATION SWITCH: scrolled to bottom (deferred)', {
-              scrollTop: scrollerRef.current.scrollTop,
-              scrollHeight: scrollerRef.current.scrollHeight,
-            })
-          }
-        })
-
         isAtBottomRef.current = true
+
+        if (latestRef.current.virtualizer) {
+          // Virtualized: the bottom rows measure taller than the estimate AFTER this assignment,
+          // so getTotalSize grows and a one-shot scroll leaves the last message hidden. Re-assert
+          // across frames (the content ResizeObserver that handles this for flag-OFF is disabled
+          // under virtualization).
+          reassertScrollToBottom(scrollerRef, isAtBottomRef)
+        } else {
+          requestAnimationFrame(() => {
+            if (scrollerRef.current) {
+              scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
+              debugLog('CONVERSATION SWITCH: scrolled to bottom (deferred)', {
+                scrollTop: scrollerRef.current.scrollTop,
+                scrollHeight: scrollerRef.current.scrollHeight,
+              })
+            }
+          })
+        }
       }
     }
 
@@ -1299,6 +1334,8 @@ export function useMessageListScroll({
         scrollTopBefore: scroller.scrollTop,
       })
       scroller.scrollTop = scroller.scrollHeight
+      // Virtualized: re-pin as the new row measures past the estimate (see reassertScrollToBottom).
+      if (latestRef.current.virtualizer) reassertScrollToBottom(scrollerRef, isAtBottomRef)
     } else if (isNewMessage) {
       debugLog('NEW MSG NO SCROLL (not at bottom)', {
         messageCount,
@@ -1334,12 +1371,16 @@ export function useMessageListScroll({
   useLayoutEffect(() => {
     if (isAtBottomRef.current && scrollerRef.current) {
       scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
+      // Virtualized: the typing-indicator row measures past the estimate after this assignment.
+      if (latestRef.current.virtualizer) reassertScrollToBottom(scrollerRef, isAtBottomRef)
     }
   }, [typingUsersCount, isAtBottomRef])
 
   useLayoutEffect(() => {
     if (isAtBottomRef.current && scrollerRef.current) {
       scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
+      // Virtualized: a reaction added to the last row grows it past the estimate.
+      if (latestRef.current.virtualizer) reassertScrollToBottom(scrollerRef, isAtBottomRef)
     }
   }, [lastMessageReactionsKey, isAtBottomRef])
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -37,7 +37,12 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 // CONSTANTS
 // ============================================================================
 
-const AT_BOTTOM_THRESHOLD = 50 // pixels from bottom to consider "at bottom"
+// Pixels from the bottom still considered "at bottom" (auto-follow new messages). Generous
+// on purpose: a tall last message can measure taller than the estimate and leave the view a
+// little short of the real bottom; too tight a threshold would flip "at bottom" false and stop
+// following. Still well under FAB_THRESHOLD so the scroll-to-bottom button only shows when the
+// user has genuinely scrolled up.
+const AT_BOTTOM_THRESHOLD = 150
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
 const LOAD_COOLDOWN_MS = 500 // minimum time between load triggers
 const SAVE_THROTTLE_MS = 100 // minimum time between position saves
@@ -139,6 +144,10 @@ export interface UseMessageListScrollOptions {
   isHistoryComplete?: boolean
   typingUsersCount: number
   lastMessageReactionsKey: string
+  /** Whether the newest message is the local user's own (outgoing). When a NEW such message
+   *  appears we scroll to the bottom regardless of position — you always want to see what you
+   *  just sent — whereas an incoming message only auto-follows when already near the bottom. */
+  lastMessageIsOutgoing?: boolean
   /** When true, disables all auto-scroll behaviors (conversation switch scroll,
    *  ResizeObserver auto-scroll, new message scroll-to-bottom, target message scroll).
    *  Used by read-only preview views (search context, activity context) that manage
@@ -181,6 +190,7 @@ export function useMessageListScroll({
   isHistoryComplete,
   typingUsersCount,
   lastMessageReactionsKey,
+  lastMessageIsOutgoing = false,
   staticMode = false,
   virtualizer,
 }: UseMessageListScrollOptions): UseMessageListScrollResult {
@@ -1326,14 +1336,20 @@ export function useMessageListScroll({
     }
 
     const isNewMessage = messageCount > prevMessageCountRef.current
-    if (isNewMessage && isAtBottomRef.current) {
+    // Scroll to the bottom when a new message arrives AND either we're already near the bottom
+    // (auto-follow) OR the message is the user's own send — you always want to see what you
+    // just sent, even from a scrolled-up position. An incoming message while scrolled up does
+    // NOT yank the reader down.
+    if (isNewMessage && (isAtBottomRef.current || lastMessageIsOutgoing)) {
       debugLog('NEW MSG SCROLL TO BOTTOM', {
         messageCount,
         prevCount: prevMessageCountRef.current,
         isAtBottom: isAtBottomRef.current,
+        outgoing: lastMessageIsOutgoing,
         scrollTopBefore: scroller.scrollTop,
       })
       scroller.scrollTop = scroller.scrollHeight
+      isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
       // Virtualized: re-pin as the new row measures past the estimate (see reassertScrollToBottom).
       if (latestRef.current.virtualizer) reassertScrollToBottom(scrollerRef, isAtBottomRef)
     } else if (isNewMessage) {
@@ -1345,7 +1361,7 @@ export function useMessageListScroll({
     }
 
     prevMessageCountRef.current = messageCount
-  }, [messageCount, isAtBottomRef, staticMode])
+  }, [messageCount, isAtBottomRef, staticMode, lastMessageIsOutgoing])
 
   // ==========================================================================
   // EFFECT: Reset marker scroll tracking when firstNewMessageId changes


### PR DESCRIPTION
Follow-up to #642, addressing three user-reported gaps where scroll-to-bottom didn't reach / stay at / return to the real bottom under virtualization. #642 fixed "lands mid-conversation"; this PR fixes the residuals, each reproduced first and verified in the demo.

Fixes:

1. Last message partially hidden on open (re-assert)
2. Incoming messages stopped following after a small drift (wider tolerance)
3. Sending from a scrolled-up position didn't show your message (scroll-on-send)