### PR TITLE
fix(diagnostics): discard render-cost samples spanning window blur/focus

### DIFF
--- a/apps/fluux/src/hooks/useRenderCostProbe.ts
+++ b/apps/fluux/src/hooks/useRenderCostProbe.ts
@@ -17,25 +17,35 @@
  * Diagnostic only: never changes behaviour.
  */
 import { useLayoutEffect, useRef } from 'react'
-import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
+import { createRenderCostProbe, spansIdleWindow, type RenderCostProbe } from '@/utils/renderCostProbe'
 
-// Timestamp (performance.now) of the last page visibility transition. When a
-// render's measurement window contains one, the render→commit gap is wall-clock
-// idle (tab hidden, or the laptop slept mid-render) rather than render work —
-// producing absurd "render cost" values (e.g. ~18min for 50 rows after an OS
-// sleep). We discard those, mirroring stallSentinel's document.hidden guard.
-let lastVisibilityChangeAt = Number.NEGATIVE_INFINITY
-let visibilityTrackingStarted = false
-function ensureVisibilityTracking(): void {
-  if (visibilityTrackingStarted || typeof document === 'undefined') return
-  visibilityTrackingStarted = true
-  document.addEventListener('visibilitychange', () => {
-    lastVisibilityChangeAt = performance.now()
-  })
+// Timestamp (performance.now) of the last backgrounding transition — page
+// visibility OR window focus. When a render's measurement window contains one
+// (or the app is backgrounded at sample time), the render→commit gap is
+// wall-clock idle (tab hidden, app switched away, or the laptop slept mid-render)
+// rather than render work — producing absurd "render cost" values (e.g. ~18min
+// for 50 rows after an OS sleep, or ~10s after an app switch). We discard those,
+// mirroring stallSentinel's document.hidden guard.
+//
+// focus/blur matters because switching apps on desktop (Tauri/WebKit) blurs the
+// window WITHOUT hiding the page: no visibilitychange fires and document.hidden
+// stays false, yet the OS throttles/App-Naps the unfocused window. Tracking only
+// visibilitychange would miss this — the common cause of bogus warnings.
+let lastBackgroundBoundaryAt = Number.NEGATIVE_INFINITY
+let backgroundTrackingStarted = false
+function ensureBackgroundTracking(): void {
+  if (backgroundTrackingStarted || typeof document === 'undefined') return
+  backgroundTrackingStarted = true
+  const mark = () => {
+    lastBackgroundBoundaryAt = performance.now()
+  }
+  document.addEventListener('visibilitychange', mark)
+  window.addEventListener('focus', mark)
+  window.addEventListener('blur', mark)
 }
 
 export function useRenderCostProbe(label: string, getContext: () => string): void {
-  ensureVisibilityTracking()
+  ensureBackgroundTracking()
 
   // Read at render-body call time — before this component's children render.
   const renderStart = performance.now()
@@ -53,9 +63,14 @@ export function useRenderCostProbe(label: string, getContext: () => string): voi
       const layoutPaintMs = painted - commitDone
       const totalMs = reactMs + layoutPaintMs
 
-      // A visibility transition at/after renderStart means this window spanned a
-      // hidden/sleep period — the measured cost is idle wall clock, not render work.
-      const spannedHidden = lastVisibilityChangeAt >= renderStart || document.hidden
+      // A backgrounding transition at/after renderStart — or being hidden/unfocused
+      // at sample time — means this window spanned a hidden/blurred/sleep period:
+      // the measured cost is idle wall clock, not render work.
+      const spannedHidden = spansIdleWindow(renderStart, {
+        lastBoundaryAt: lastBackgroundBoundaryAt,
+        isHidden: document.hidden,
+        hasFocus: typeof document.hasFocus === 'function' ? document.hasFocus() : true,
+      })
 
       if (probeRef.current?.record(totalMs, painted, spannedHidden)) {
         console.warn(

--- a/apps/fluux/src/utils/renderCostProbe.test.ts
+++ b/apps/fluux/src/utils/renderCostProbe.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createRenderCostProbe } from './renderCostProbe'
+import { createRenderCostProbe, spansIdleWindow } from './renderCostProbe'
 
 describe('createRenderCostProbe', () => {
   it('does not report renders below the threshold', () => {
@@ -39,5 +39,47 @@ describe('createRenderCostProbe', () => {
     // A bogus spanned render must not block the next genuine slow render.
     expect(probe.record(300, 1000, true)).toBe(false)
     expect(probe.record(300, 1000, false)).toBe(true)
+  })
+})
+
+describe('spansIdleWindow', () => {
+  // A focused, visible app with no backgrounding transition during the window —
+  // the only case where the wall-clock measurement reflects real render work.
+  it('keeps a sample when focused, visible, and no recent boundary', () => {
+    expect(
+      spansIdleWindow(1000, { lastBoundaryAt: 500, isHidden: false, hasFocus: true }),
+    ).toBe(false)
+  })
+
+  it('discards a sample taken while the page is hidden (tab switch / minimize)', () => {
+    expect(
+      spansIdleWindow(1000, { lastBoundaryAt: 500, isHidden: true, hasFocus: true }),
+    ).toBe(true)
+  })
+
+  // App switch on desktop: the window loses OS focus but stays visible, so
+  // document.hidden is false and no visibilitychange fires. The OS throttles /
+  // App-Naps the unfocused window, so the render→commit wall clock is idle time.
+  it('discards a sample taken while the window is unfocused (app switch)', () => {
+    expect(
+      spansIdleWindow(1000, { lastBoundaryAt: 500, isHidden: false, hasFocus: false }),
+    ).toBe(true)
+  })
+
+  // Blurred then refocused within the window: by sample time focus is back and the
+  // page was never hidden, so the focus/blur boundary timestamp is the only signal.
+  it('discards a sample whose window contained a focus/blur boundary at or after renderStart', () => {
+    expect(
+      spansIdleWindow(1000, { lastBoundaryAt: 1000, isHidden: false, hasFocus: true }),
+    ).toBe(true)
+    expect(
+      spansIdleWindow(1000, { lastBoundaryAt: 4000, isHidden: false, hasFocus: true }),
+    ).toBe(true)
+  })
+
+  it('ignores a boundary that landed strictly before the render started', () => {
+    expect(
+      spansIdleWindow(1000, { lastBoundaryAt: 999, isHidden: false, hasFocus: true }),
+    ).toBe(false)
   })
 })

--- a/apps/fluux/src/utils/renderCostProbe.ts
+++ b/apps/fluux/src/utils/renderCostProbe.ts
@@ -43,6 +43,42 @@ export interface RenderCostProbeOptions {
   cooldownMs?: number
 }
 
+/**
+ * App-backgrounding state sampled when a measurement completes. The caller reads
+ * these from the DOM (`document.hidden`, `document.hasFocus()`) and tracks
+ * `lastBoundaryAt` as the most recent `performance.now()` of any backgrounding
+ * transition (`visibilitychange`, window `blur`, or window `focus`).
+ */
+export interface IdleWindowSample {
+  /** performance.now() of the most recent visibility/focus/blur transition. */
+  lastBoundaryAt: number
+  /** document.hidden at sample time (tab hidden, minimized). */
+  isHidden: boolean
+  /** document.hasFocus() at sample time (window holds OS focus). */
+  hasFocus: boolean
+}
+
+/**
+ * True when a render's measurement window `[renderStart, sample]` overlapped a
+ * period where the app was backgrounded, so the render→commit wall clock counts
+ * throttled / suspended idle time (App Nap, window occlusion, OS sleep) rather
+ * than render work. Such samples are meaningless and must be discarded.
+ *
+ * Three ways the window can be tainted:
+ * - the page is hidden at sample time (tab switch / minimize), or
+ * - the window is unfocused at sample time (another app is in front), or
+ * - a visibility/focus/blur transition landed at/after `renderStart` — e.g. the
+ *   user blurred mid-render and refocused (focus is back by sample time, so the
+ *   boundary timestamp is the only remaining signal).
+ *
+ * `visibilitychange` alone is insufficient: switching apps on desktop blurs the
+ * window WITHOUT hiding the page, so it fires `blur`/`focus` but not
+ * `visibilitychange` and leaves `document.hidden` false.
+ */
+export function spansIdleWindow(renderStart: number, sample: IdleWindowSample): boolean {
+  return sample.isHidden || !sample.hasFocus || sample.lastBoundaryAt >= renderStart
+}
+
 // A list render over ~200ms is well past the frame budget and worth attributing;
 // normal updates (typing, a single new message) stay far below it.
 const DEFAULT_THRESHOLD_MS = 200


### PR DESCRIPTION
## Summary

After message virtualization shipped, `[RenderCostProbe] MessageList render cost ~10027ms (react=10026ms, layoutPaint=1ms, rows=90)` warnings still appeared — but these are false-positive measurements, not real renders. The numbers are physically impossible as render CPU: `react` is multi-second while `layoutPaint` is 1ms (only the windowed rows mount), and the real work beside them logs sub-second (`MAM result … 337ms`).

The probe measures `commitDone − renderStart` with `performance.now()`, which is wall-clock. When the user switches to another app, macOS/WebKit throttles or App-Naps the unfocused-but-still-visible window while wall-clock keeps advancing; a measurement window open across that gap reports the time-away as render cost. The warnings appear on refocus.

The probe already discarded this exact artifact for the laptop-sleep / tab-hidden case (`spannedHidden`), but it only watched `visibilitychange` / `document.hidden`. An app switch on desktop fires neither (`document.hidden` stays false) — the blind spot.

## Change

- `renderCostProbe.ts`: new pure `spansIdleWindow(renderStart, { lastBoundaryAt, isHidden, hasFocus })` helper. A sample is discarded when the page is hidden, the window is unfocused, or a visibility/focus/blur transition landed at/after `renderStart`.
- `useRenderCostProbe.ts`: tracks `focus`/`blur` alongside `visibilitychange`, and routes the decision through `spansIdleWindow` (reading `document.hidden` + `document.hasFocus()` at sample time).