### PR TITLE
fix(mds): new-message divider restores to the synced read position; make it session-only

### DIFF
--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -102,6 +102,7 @@ vi.mock('@fluux/sdk', () => ({
     clearAnimation: mockClearAnimation,
     clearFirstNewMessageId: mockClearFirstNewMessageId,
     updateLastSeenMessageId: vi.fn(),
+    firstNewMessageId: undefined,
     supportsMAM: mockSupportsMAM,
     activeMAMState: mockActiveMAMState,
     fetchHistory: mockFetchHistory,

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -47,7 +47,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, firstNewMessageId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -472,7 +472,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
             selectedMessageId={selectedMessageId}
             hasKeyboardSelection={hasKeyboardSelection}
             showToolbarForSelection={showToolbarForSelection}
-            firstNewMessageId={activeConversation.firstNewMessageId}
+            firstNewMessageId={firstNewMessageId}
             targetMessageId={targetMessageId}
             clearTargetMessageId={clearTargetMessageId}
             clearFirstNewMessageId={handleClearFirstNewMessageId}

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -145,6 +145,7 @@ vi.mock('@fluux/sdk', () => ({
     sendEasterEgg: vi.fn(),
     clearAnimation: mockClearAnimation,
     clearFirstNewMessageId: mockClearFirstNewMessageId,
+    firstNewMessageId: undefined,
     joinRoom: mockJoinRoom,
     joinResult: mockJoinResult,
     setRoomAvatar: mockSetRoomAvatar,

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -79,7 +79,7 @@ const EMPTY_OCCUPANTS: Map<string, RoomOccupant> = new Map()
 export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = false, onShowOccupantsChange, onStartChat, onShowProfile, findOnPageRef, onSearchInConversation }: RoomViewProps) {
   detectRenderLoop('RoomView')
   const { t } = useTranslation()
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, sendWhisperChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, sendWhisperChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId, firstNewMessageId } = useRoomActive()
   const mediaPolicy = useSettingsStore((s) => s.mediaAutoDownload)
 
   // NOTE: Use focused selectors instead of useConnection() hook to avoid
@@ -538,7 +538,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             selectedMessageId={selectedMessageId}
             hasKeyboardSelection={hasKeyboardSelection}
             showToolbarForSelection={showToolbarForSelection}
-            firstNewMessageId={activeRoom.firstNewMessageId}
+            firstNewMessageId={firstNewMessageId}
             targetMessageId={targetMessageId}
             clearTargetMessageId={clearTargetMessageId}
             clearFirstNewMessageId={handleClearFirstNewMessageId}

--- a/docs/superpowers/plans/2026-06-25-new-message-marker-session-state.md
+++ b/docs/superpowers/plans/2026-06-25-new-message-marker-session-state.md
@@ -1,0 +1,1207 @@
+# New-Message Marker as Session State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `lastSeenMessageId` the single durable, MDS-synced read position, move the new-message divider (`firstNewMessageId`) into a session-only per-store map, and fix the bug where opening a conversation restores the divider to a stale position when the XEP-0490 read marker resolved late.
+
+**Architecture:** The pure `notificationState` module stays the divider-derivation engine and is not modified. Each store stops storing `firstNewMessageId` inside its metadata map and instead parks it in a new session-only `firstNewMessageMarkers: Map<jid, messageId>` that is never persisted. `activateConversation` / `activateRoom` resolve a pending MDS marker (via the existing `applyRemoteDisplayed`) before `onActivate` derives the divider, so the divider reflects the synced read position.
+
+**Tech Stack:** TypeScript, Zustand vanilla stores (`subscribeWithSelector`; chat also wraps `persist`), Vitest, React hooks.
+
+## Global Constraints
+
+- Reference spec: `docs/superpowers/specs/2026-06-25-new-message-marker-session-state-design.md`.
+- `notificationState.ts` (`packages/fluux-sdk/src/stores/shared/notificationState.ts`) MUST NOT change. It remains the derivation engine; `EntityNotificationState` keeps `firstNewMessageId` as its computed currency.
+- `lastSeenMessageId` stays in `conversationMeta` / `roomMeta` and stays persisted for chat. Do NOT touch its persistence or the MDS publisher (`mdsSideEffects.ts`).
+- New session field name: `firstNewMessageMarkers` (Map<string, string>, jid to messageId). Never add it to any serialize / partialize output.
+- SDK store unit tests run from `packages/fluux-sdk`: `npx vitest run <path>`.
+- After changing SDK types, rebuild the SDK before app typecheck: `npm run build:sdk`.
+- Final gate before any "done" claim: `npm run typecheck` and `npm test` pass with no errors or stderr (per `.claude/CLAUDE.md`).
+- No em-dashes or en-dashes in any user-facing string (none are added here, but keep code comments plain too).
+- Commit after each task. Never include any Claude footer in commit messages.
+
+---
+
+## File Structure
+
+SDK (source):
+- `packages/fluux-sdk/src/core/types/chat.ts` — remove `firstNewMessageId` from `ConversationMetadata`.
+- `packages/fluux-sdk/src/core/types/room.ts` — remove `firstNewMessageId` from `RoomMetadata`.
+- `packages/fluux-sdk/src/stores/chatStore.ts` — add `firstNewMessageMarkers`; activation fix; route writes; drop the legacy deserialize line.
+- `packages/fluux-sdk/src/stores/roomStore.ts` — add `firstNewMessageMarkers`; activation fix; route writes; drop `firstNewMessageId` from `updateRoom` routing.
+- `packages/fluux-sdk/src/stores/chatSelectors.ts` — `firstNewMessageIdFor` reads the map.
+- `packages/fluux-sdk/src/stores/roomSelectors.ts` — `firstNewMessageIdFor` reads the map.
+- `packages/fluux-sdk/src/hooks/useChatActive.ts` — source the active marker from the map; expose it as a standalone field.
+- `packages/fluux-sdk/src/hooks/useRoomActive.ts` — source the active marker from the map; expose it as a standalone field.
+
+SDK (tests):
+- `packages/fluux-sdk/src/stores/chatStore.mds.test.ts` — add activation-fix test + de-persistence test.
+- `packages/fluux-sdk/src/stores/roomStore.mds.test.ts` — add activation-fix test.
+
+App:
+- `apps/fluux/src/components/ChatView.tsx` — read `firstNewMessageId` from the hook, not from `activeConversation`.
+- `apps/fluux/src/components/RoomView.tsx` — read `firstNewMessageId` from the hook, not from `activeRoom`.
+
+Untouched on purpose: `notificationState.ts`, `mdsSideEffects.ts`, `serializeState`/`partialize` (the divider de-persists automatically once it leaves the metadata type).
+
+---
+
+## Task 1: Chat restore-bug fix (resolve pending MDS marker at activation)
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/chatStore.ts` (the `activateConversation` action, ~604-612)
+- Test: `packages/fluux-sdk/src/stores/chatStore.mds.test.ts`
+
+**Interfaces:**
+- Consumes: existing `applyRemoteDisplayed(conversationId, stanzaId, messagesOverride?)`, `loadMessagesFromCache`, `setActiveConversation`.
+- Produces: no signature change to `activateConversation: (id: string | null) => Promise<void>`; behavior change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/fluux-sdk/src/stores/chatStore.mds.test.ts`. First add the selector import at the top of the file (after the existing imports on lines 10-12):
+
+```typescript
+import { chatSelectors } from './chatSelectors'
+```
+
+Then append this `describe` block at the end of the file:
+
+```typescript
+describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  it('folds a pending remote read marker into lastSeenMessageId before deriving the divider', async () => {
+    const cid = 'juliet@capulet.example'
+    const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3'), msg('m4', 's4')]
+    seedMessages(cid, messages)
+
+    // Local read is stale at m2; a remote device read up to s4, seeded as pending
+    // before the messages were loaded (the fresh-session MDS seed ordering).
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's4' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's4' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+
+    // The pending marker is resolved at activation, advancing the read position.
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
+    // So the divider reflects the synced read (m4 is the last message → nothing new),
+    // NOT the stale 'm3' it would show if the marker resolved after onActivate.
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/chatStore.mds.test.ts -t "folds a pending remote read marker"`
+Expected: FAIL. `lastSeenMessageId` is `'m2'` (pending not resolved at activation) and the divider is `'m3'`.
+
+- [ ] **Step 3: Implement the fix**
+
+In `packages/fluux-sdk/src/stores/chatStore.ts`, replace the `activateConversation` action (currently ~604-612):
+
+```typescript
+      activateConversation: async (id) => {
+        const token = ++activationToken
+        if (id) {
+          await get().loadMessagesFromCache(id, { limit: 100 })
+          // A newer activation started while the cache read was in flight
+          if (token !== activationToken) return
+        }
+        get().setActiveConversation(id)
+      },
+```
+
+with:
+
+```typescript
+      activateConversation: async (id) => {
+        const token = ++activationToken
+        if (id) {
+          await get().loadMessagesFromCache(id, { limit: 100 })
+          // A newer activation started while the cache read was in flight
+          if (token !== activationToken) return
+          // XEP-0490: fold any pending remote read position into lastSeenMessageId
+          // BEFORE setActiveConversation derives the new-message divider. The fresh
+          // session MDS seed runs before messages load, so the marker is stashed as
+          // pendingRemoteDisplayedStanzaId; resolve it now (forward-only, against the
+          // just-loaded messages) so the divider reflects reads synced from other
+          // devices instead of the stale local position.
+          const pending = get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId
+          if (pending) get().applyRemoteDisplayed(id, pending)
+        }
+        get().setActiveConversation(id)
+      },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/chatStore.mds.test.ts`
+Expected: PASS (all tests in the file, including the new one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/src/stores/chatStore.ts packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+git commit -m "fix(mds): resolve pending read marker at chat activation so the new-message divider lands at the synced position"
+```
+
+---
+
+## Task 2: Room restore-bug fix (resolve pending MDS marker at activation)
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/roomStore.ts` (the `activateRoom` action, ~1445-1455)
+- Test: `packages/fluux-sdk/src/stores/roomStore.mds.test.ts`
+
+**Interfaces:**
+- Consumes: existing `applyRemoteDisplayed(roomJid, stanzaId, messagesOverride?)`, `loadMessagesFromCache`, `setActiveRoom`.
+- Produces: no signature change to `activateRoom: (roomJid: string | null) => Promise<void>`; behavior change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Add the selector import near the top of `packages/fluux-sdk/src/stores/roomStore.mds.test.ts` (after line 5):
+
+```typescript
+import { roomSelectors } from './roomSelectors'
+```
+
+Append this `describe` block at the end of the file:
+
+```typescript
+describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  it('folds a pending remote room marker into lastSeenMessageId before deriving the divider', async () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)], 'm2')
+    // A remote device read up to s4, seeded as pending before messages loaded.
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      const existing = m.get(ROOM)!
+      m.set(ROOM, { ...existing, pendingRemoteDisplayedStanzaId: 's4' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m4')
+    expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBeUndefined()
+  })
+})
+```
+
+Note: this test's `beforeEach` already includes `firstNewMessageMarkers: new Map()`, which the store gains in Task 4. Until Task 4 lands it is an inert extra key on the partial `setState` (zustand shallow-merges), so it is harmless now and correct later.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.mds.test.ts -t "folds a pending remote room marker"`
+Expected: FAIL. `lastSeenMessageId` is `'m2'` and the divider is `'m3'`.
+
+- [ ] **Step 3: Implement the fix**
+
+In `packages/fluux-sdk/src/stores/roomStore.ts`, replace the `activateRoom` action (currently ~1445-1455):
+
+```typescript
+  activateRoom: async (roomJid) => {
+    const token = ++activationToken
+    if (roomJid) {
+      await get().loadMessagesFromCache(roomJid, { limit: 100 })
+      // A newer activation started while the cache read was in flight
+      if (token !== activationToken) return
+    }
+    get().setActiveRoom(roomJid)
+  },
+```
+
+with:
+
+```typescript
+  activateRoom: async (roomJid) => {
+    const token = ++activationToken
+    if (roomJid) {
+      await get().loadMessagesFromCache(roomJid, { limit: 100 })
+      // A newer activation started while the cache read was in flight
+      if (token !== activationToken) return
+      // XEP-0490: fold any pending remote read position into lastSeenMessageId
+      // BEFORE setActiveRoom derives the new-message divider (parity with
+      // chatStore.activateConversation). Forward-only against the loaded messages.
+      const pending = get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId
+      if (pending) get().applyRemoteDisplayed(roomJid, pending)
+    }
+    get().setActiveRoom(roomJid)
+  },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.mds.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/src/stores/roomStore.ts packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+git commit -m "fix(mds): resolve pending read marker at room activation so the new-message divider lands at the synced position"
+```
+
+---
+
+## Task 3: Chat divider into a session-only map (de-persist + decouple)
+
+This task removes `firstNewMessageId` from `ConversationMetadata`, adds the session map, routes all writes, and rewires the selector / hook / view. The TypeScript compiler is the checklist: once the field leaves the type, every remaining write or read is a compile error to fix.
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/types/chat.ts:112`
+- Modify: `packages/fluux-sdk/src/stores/chatStore.ts` (state interface ~97-119; `createEmptyChatState` ~389-404; `addConversation` ~628; `setActiveConversation` ~547/551/579/583/593; `addMessage` ~776/787; `markAsRead` ~846; `clearFirstNewMessageId` ~860-885; `deserializeState` ~342)
+- Modify: `packages/fluux-sdk/src/stores/chatSelectors.ts:231`
+- Modify: `packages/fluux-sdk/src/hooks/useChatActive.ts`
+- Modify: `apps/fluux/src/components/ChatView.tsx:475`
+- Test: `packages/fluux-sdk/src/stores/chatStore.mds.test.ts`
+
+**Interfaces:**
+- Produces: `ChatState.firstNewMessageMarkers: Map<string, string>` (session-only); `chatSelectors.firstNewMessageIdFor(id)` now reads it; `useChatActive()` returns a top-level `firstNewMessageId?: string` for the active conversation.
+- Consumes: `notifState.onActivate/onDeactivate/onClearMarker/onMessageReceived` return values (unchanged).
+
+- [ ] **Step 1: Write the failing tests (map home + de-persistence)**
+
+Append to `packages/fluux-sdk/src/stores/chatStore.mds.test.ts`:
+
+```typescript
+describe('chatStore — new-message divider is session-only', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  it('parks the divider in firstNewMessageMarkers, not in conversationMeta', () => {
+    const cid = 'juliet@capulet.example'
+    // m1 outgoing-read baseline, then two incoming unread messages.
+    const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')]
+    seedMessages(cid, messages)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    chatStore.getState().setActiveConversation(cid)
+
+    // Divider derived at m2 (first unread after m1) and stored in the session map.
+    expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m2')
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m2')
+    // The metadata entry carries NO divider field.
+    expect('firstNewMessageId' in (chatStore.getState().conversationMeta.get(cid) as object)).toBe(false)
+  })
+
+  it('never writes the divider to persisted storage', () => {
+    const cid = 'juliet@capulet.example'
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 1, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 1, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+    chatStore.getState().setActiveConversation(cid)
+    expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m2')
+
+    // Whatever the persist middleware wrote must not mention the divider.
+    const dump = JSON.stringify(localStorage)
+    expect(dump.includes('firstNewMessageId')).toBe(false)
+    expect(dump.includes('firstNewMessageMarkers')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/chatStore.mds.test.ts -t "session-only"`
+Expected: FAIL — `firstNewMessageMarkers` does not exist yet (`undefined.get` throws), and `firstNewMessageId` is still in meta and persisted.
+
+- [ ] **Step 3: Remove the field from the metadata type**
+
+In `packages/fluux-sdk/src/core/types/chat.ts`, delete these two lines from `ConversationMetadata` (currently ~111-112):
+
+```typescript
+  /** ID of the first unread message (calculated when switching to conversation) */
+  firstNewMessageId?: string
+```
+
+(`Conversation extends ConversationEntity, ConversationMetadata` therefore also loses the field. That is intended.)
+
+- [ ] **Step 4: Add the session map to the store state and initial state**
+
+In `packages/fluux-sdk/src/stores/chatStore.ts`, add to the `ChatState` interface after the `targetMessageId: string | null` data field (~119):
+
+```typescript
+  // Session-only new-message divider per conversation (jid -> messageId). Derived
+  // at activation from lastSeenMessageId; never persisted (absent from serializeState).
+  firstNewMessageMarkers: Map<string, string>
+```
+
+In `createEmptyChatState`, add `firstNewMessageMarkers` to BOTH the `Pick<...>` return type and the returned object. The return type union must include it:
+
+```typescript
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId' | 'firstNewMessageMarkers'> {
+  return {
+    conversationEntities: new Map(),
+    conversationMeta: new Map(),
+    conversations: new Map(),
+    messages: new Map(),
+    activeConversationId: null,
+    archivedConversations: new Set(),
+    typingStates: new Map(),
+    activeAnimation: null,
+    drafts: new Map(),
+    mamQueryStates: new Map(),
+    conversationGaps: new Map(),
+    targetMessageId: null,
+    firstNewMessageMarkers: new Map(),
+  }
+}
+```
+
+Note: `reset()` calls `createEmptyChatState()`, so the map is cleared on logout automatically. `deserializeState` does not return `firstNewMessageMarkers`, so after a rehydrate it falls back to the store's default empty map — correct (no divider until activation).
+
+- [ ] **Step 5: Route the `setActiveConversation` writes to the map**
+
+In `setActiveConversation`, the deactivate-previous branch currently writes the cleared marker into meta and conversations (~547, ~551). Replace the `set((state) => { ... })` body of that branch so it removes the previous conversation's map entry instead. Replace lines ~540-554:
+
+```typescript
+          set((state) => {
+            const newMessages = new Map(state.messages)
+            newMessages.delete(prevId)
+            if (!hadMarker) {
+              return { messages: newMessages }
+            }
+            const newMeta = new Map(state.conversationMeta)
+            if (prevMeta) newMeta.set(prevId, { ...prevMeta, firstNewMessageId: clearedFirstNewMessageId })
+            const newConversations = new Map(state.conversations)
+            const prevConv = newConversations.get(prevId)
+            if (prevConv) {
+              newConversations.set(prevId, { ...prevConv, firstNewMessageId: clearedFirstNewMessageId })
+            }
+            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+          })
+```
+
+with (note `clearedFirstNewMessageId` from `onDeactivate` is always `undefined`, so we just delete the entry):
+
+```typescript
+          set((state) => {
+            const newMessages = new Map(state.messages)
+            newMessages.delete(prevId)
+            if (!hadMarker) {
+              return { messages: newMessages }
+            }
+            const newMarkers = new Map(state.firstNewMessageMarkers)
+            newMarkers.delete(prevId)
+            return { messages: newMessages, firstNewMessageMarkers: newMarkers }
+          })
+```
+
+In the same action, the activate branch builds `newMetaEntry` (with `firstNewMessageId: activated.firstNewMessageId`, ~583) and a combined-map entry (~593). Replace lines ~577-596:
+
+```typescript
+            set((state) => {
+              const newMetaEntry = {
+                ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined, firstNewMessageId: undefined }),
+                unreadCount: activated.unreadCount,
+                lastReadAt: activated.lastReadAt,
+                lastSeenMessageId: activated.lastSeenMessageId,
+                firstNewMessageId: activated.firstNewMessageId,
+              }
+              const newMeta = new Map(state.conversationMeta)
+              newMeta.set(id, newMetaEntry)
+              const newConversations = new Map(state.conversations)
+              newConversations.set(id, {
+                ...conv,
+                unreadCount: activated.unreadCount,
+                lastReadAt: activated.lastReadAt,
+                lastSeenMessageId: activated.lastSeenMessageId,
+                firstNewMessageId: activated.firstNewMessageId,
+              })
+              return { conversationMeta: newMeta, conversations: newConversations, activeConversationId: id }
+            })
+```
+
+with:
+
+```typescript
+            set((state) => {
+              const newMetaEntry = {
+                ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined }),
+                unreadCount: activated.unreadCount,
+                lastReadAt: activated.lastReadAt,
+                lastSeenMessageId: activated.lastSeenMessageId,
+              }
+              const newMeta = new Map(state.conversationMeta)
+              newMeta.set(id, newMetaEntry)
+              const newConversations = new Map(state.conversations)
+              newConversations.set(id, {
+                ...conv,
+                unreadCount: activated.unreadCount,
+                lastReadAt: activated.lastReadAt,
+                lastSeenMessageId: activated.lastSeenMessageId,
+              })
+              const newMarkers = new Map(state.firstNewMessageMarkers)
+              if (activated.firstNewMessageId) newMarkers.set(id, activated.firstNewMessageId)
+              else newMarkers.delete(id)
+              return { conversationMeta: newMeta, conversations: newConversations, activeConversationId: id, firstNewMessageMarkers: newMarkers }
+            })
+```
+
+- [ ] **Step 6: Route the `addMessage` write to the map**
+
+In `addMessage`, remove `firstNewMessageId` from the meta entry (~776) and the combined entry (~787), and update the map from `notif.firstNewMessageId`. The two `set` objects must drop the `firstNewMessageId:` line; then change the three `return` statements in this block to also carry the markers map. Replace the block from `// Update metadata map` (~768) through the final `return` (~803):
+
+```typescript
+            // Update metadata map
+            const newMeta = new Map(state.conversationMeta)
+            newMeta.set(msg.conversationId, {
+              ...meta,
+              unreadCount: notif.unreadCount,
+              lastReadAt: notif.lastReadAt,
+              lastMessage: previewMessage,
+              lastSeenMessageId: notif.lastSeenMessageId,
+              firstNewMessageId: notif.firstNewMessageId,
+            })
+
+            // Update combined map for backward compatibility
+            const newConversations = new Map(state.conversations)
+            newConversations.set(msg.conversationId, {
+              ...conv,
+              unreadCount: notif.unreadCount,
+              lastReadAt: notif.lastReadAt,
+              lastMessage: previewMessage,
+              lastSeenMessageId: notif.lastSeenMessageId,
+              firstNewMessageId: notif.firstNewMessageId,
+            })
+
+            // Auto-unarchive conversation when new incoming message arrives
+            // (outgoing messages should not trigger unarchive)
+            if (!msg.isOutgoing) {
+              const newArchived = new Set(state.archivedConversations)
+              if (newArchived.has(msg.conversationId)) {
+                newArchived.delete(msg.conversationId)
+                return {
+                  messages: newMessages,
+                  conversationMeta: newMeta,
+                  conversations: newConversations,
+                  archivedConversations: newArchived,
+                }
+              }
+            }
+
+            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+```
+
+with:
+
+```typescript
+            // Update metadata map
+            const newMeta = new Map(state.conversationMeta)
+            newMeta.set(msg.conversationId, {
+              ...meta,
+              unreadCount: notif.unreadCount,
+              lastReadAt: notif.lastReadAt,
+              lastMessage: previewMessage,
+              lastSeenMessageId: notif.lastSeenMessageId,
+            })
+
+            // Update combined map for backward compatibility
+            const newConversations = new Map(state.conversations)
+            newConversations.set(msg.conversationId, {
+              ...conv,
+              unreadCount: notif.unreadCount,
+              lastReadAt: notif.lastReadAt,
+              lastMessage: previewMessage,
+              lastSeenMessageId: notif.lastSeenMessageId,
+            })
+
+            // Session-only divider: onMessageReceived only sets it for the active,
+            // window-hidden case; otherwise it is preserved. Mirror that into the map.
+            const newMarkers = new Map(state.firstNewMessageMarkers)
+            if (notif.firstNewMessageId) newMarkers.set(msg.conversationId, notif.firstNewMessageId)
+            else newMarkers.delete(msg.conversationId)
+
+            // Auto-unarchive conversation when new incoming message arrives
+            // (outgoing messages should not trigger unarchive)
+            if (!msg.isOutgoing) {
+              const newArchived = new Set(state.archivedConversations)
+              if (newArchived.has(msg.conversationId)) {
+                newArchived.delete(msg.conversationId)
+                return {
+                  messages: newMessages,
+                  conversationMeta: newMeta,
+                  conversations: newConversations,
+                  archivedConversations: newArchived,
+                  firstNewMessageMarkers: newMarkers,
+                }
+              }
+            }
+
+            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
+```
+
+- [ ] **Step 7: Drop the divider from the `markAsRead` fallback and `addConversation`**
+
+In `markAsRead`, the inline default object (~846) lists `firstNewMessageId: undefined`. Change:
+
+```typescript
+          const newMetaEntry = {
+            ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined, firstNewMessageId: undefined }),
+            unreadCount: updated.unreadCount,
+            lastReadAt: updated.lastReadAt,
+          }
+```
+
+to:
+
+```typescript
+          const newMetaEntry = {
+            ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined }),
+            unreadCount: updated.unreadCount,
+            lastReadAt: updated.lastReadAt,
+          }
+```
+
+In `addConversation` (~622-629), remove the `firstNewMessageId` line from the `meta` object:
+
+```typescript
+          const meta: ConversationMetadata = {
+            unreadCount: conv.unreadCount,
+            lastMessage: conv.lastMessage,
+            lastReadAt: conv.lastReadAt,
+            lastSeenMessageId: conv.lastSeenMessageId,
+            firstNewMessageId: conv.firstNewMessageId,
+          }
+```
+
+to:
+
+```typescript
+          const meta: ConversationMetadata = {
+            unreadCount: conv.unreadCount,
+            lastMessage: conv.lastMessage,
+            lastReadAt: conv.lastReadAt,
+            lastSeenMessageId: conv.lastSeenMessageId,
+          }
+```
+
+- [ ] **Step 8: Rewrite `clearFirstNewMessageId` to clear the map**
+
+Replace the whole `clearFirstNewMessageId` action (~860-885) with a version that operates on the map:
+
+```typescript
+      clearFirstNewMessageId: (conversationId) => {
+        set((state) => {
+          if (!state.firstNewMessageMarkers.has(conversationId)) return state
+          const newMarkers = new Map(state.firstNewMessageMarkers)
+          newMarkers.delete(conversationId)
+          return { firstNewMessageMarkers: newMarkers }
+        })
+      },
+```
+
+(`notifState.onClearMarker` is no longer needed here; its only job was to null the field. If `onClearMarker` is now unused across the codebase, leave it — it is covered by `notificationState.test.ts` and removing it is out of scope.)
+
+- [ ] **Step 9: Drop the legacy deserialize line**
+
+In `deserializeState`, the legacy-format branch builds a `conversationMeta` entry (~337-343) that sets `firstNewMessageId: conv.firstNewMessageId`. Remove that one line:
+
+```typescript
+      conversationMeta.set(id, {
+        unreadCount: conv.unreadCount,
+        lastMessage: conv.lastMessage,
+        lastReadAt: conv.lastReadAt,
+        lastSeenMessageId: conv.lastSeenMessageId,
+        firstNewMessageId: conv.firstNewMessageId,
+      })
+```
+
+becomes:
+
+```typescript
+      conversationMeta.set(id, {
+        unreadCount: conv.unreadCount,
+        lastMessage: conv.lastMessage,
+        lastReadAt: conv.lastReadAt,
+        lastSeenMessageId: conv.lastSeenMessageId,
+      })
+```
+
+(The new-format branch spreads `...meta`; any stale `firstNewMessageId` in old persisted data is carried at runtime but is not in the type and is never read — harmless. `serializeState` writes whatever is in `conversationMeta`, which no longer contains the divider, so it de-persists automatically.)
+
+- [ ] **Step 10: Repoint the selector to the map**
+
+In `packages/fluux-sdk/src/stores/chatSelectors.ts`, change `firstNewMessageIdFor` (~231):
+
+```typescript
+  firstNewMessageIdFor: (conversationId: string) => (state: ChatState): string | undefined => {
+    return state.conversations.get(conversationId)?.firstNewMessageId
+  },
+```
+
+to:
+
+```typescript
+  firstNewMessageIdFor: (conversationId: string) => (state: ChatState): string | undefined => {
+    return state.firstNewMessageMarkers.get(conversationId)
+  },
+```
+
+- [ ] **Step 11: Source the active marker from the map in `useChatActive` and expose it**
+
+In `packages/fluux-sdk/src/hooks/useChatActive.ts`, change the `activeFirstNewMessageId` selector to read the map:
+
+```typescript
+  const activeFirstNewMessageId = useChatStore((s) => {
+    if (!s.activeConversationId) return undefined
+    return s.conversationMeta.get(s.activeConversationId)?.firstNewMessageId
+  })
+```
+
+to:
+
+```typescript
+  const activeFirstNewMessageId = useChatStore((s) => {
+    if (!s.activeConversationId) return undefined
+    return s.firstNewMessageMarkers.get(s.activeConversationId)
+  })
+```
+
+In the `activeConversation` `useMemo`, remove the now-invalid `firstNewMessageId` property from the reconstructed object:
+
+```typescript
+    return {
+      id: activeConversationId,
+      name: activeConvName,
+      type: activeConvType,
+      firstNewMessageId: activeFirstNewMessageId,
+      // Not used by active view components — sidebar uses useChat() for these
+      unreadCount: 0,
+      lastMessage: undefined,
+      lastReadAt: undefined,
+      lastSeenMessageId: undefined,
+    }
+```
+
+to:
+
+```typescript
+    return {
+      id: activeConversationId,
+      name: activeConvName,
+      type: activeConvType,
+      // Not used by active view components — sidebar uses useChat() for these
+      unreadCount: 0,
+      lastMessage: undefined,
+      lastReadAt: undefined,
+      lastSeenMessageId: undefined,
+    }
+```
+
+In the final return `useMemo` object, add `firstNewMessageId: activeFirstNewMessageId` as a top-level field and add `activeFirstNewMessageId` to its dependency array. Change:
+
+```typescript
+  return useMemo(
+    () => ({
+      activeConversationId,
+      activeConversation,
+      activeMessages,
+      activeTypingUsers,
+      activeAnimation,
+      targetMessageId,
+      supportsMAM,
+      activeMAMState,
+      ...actions,
+    }),
+    [
+      activeConversationId, activeConversation, activeMessages,
+      activeTypingUsers, activeAnimation, targetMessageId, supportsMAM, activeMAMState,
+      actions,
+    ]
+  )
+```
+
+to:
+
+```typescript
+  return useMemo(
+    () => ({
+      activeConversationId,
+      activeConversation,
+      firstNewMessageId: activeFirstNewMessageId,
+      activeMessages,
+      activeTypingUsers,
+      activeAnimation,
+      targetMessageId,
+      supportsMAM,
+      activeMAMState,
+      ...actions,
+    }),
+    [
+      activeConversationId, activeConversation, activeFirstNewMessageId, activeMessages,
+      activeTypingUsers, activeAnimation, targetMessageId, supportsMAM, activeMAMState,
+      actions,
+    ]
+  )
+```
+
+- [ ] **Step 12: Read the divider from the hook in `ChatView`**
+
+In `apps/fluux/src/components/ChatView.tsx`, find where `useChatActive()` is destructured (it currently pulls `activeConversation`) and add `firstNewMessageId` to that destructure. Then change line ~475:
+
+```tsx
+            firstNewMessageId={activeConversation.firstNewMessageId}
+```
+
+to:
+
+```tsx
+            firstNewMessageId={firstNewMessageId}
+```
+
+(The downstream `ChatViewInner` prop named `firstNewMessageId` at ~567 and its use at ~689 are unchanged — only the source of the value at the `useChatActive` call site changes.)
+
+- [ ] **Step 13: Rebuild SDK and run typecheck + tests**
+
+```bash
+npm run build:sdk
+npm run typecheck
+```
+Expected: PASS (no references to `conversationMeta.firstNewMessageId` or `Conversation.firstNewMessageId` remain).
+
+```bash
+cd packages/fluux-sdk && npx vitest run src/stores/chatStore.mds.test.ts src/stores/chatStore.test.ts src/stores/chatSelectors.test.ts src/hooks/useChat.test.tsx
+```
+Expected: PASS, including the Task 1 activation test and the Task 3 session-only tests. If `chatStore.test.ts` or `chatSelectors.test.ts` assert `meta.firstNewMessageId`, update those assertions to read via `firstNewMessageMarkers` / `firstNewMessageIdFor` (same behavior, new home).
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/types/chat.ts packages/fluux-sdk/src/stores/chatStore.ts packages/fluux-sdk/src/stores/chatStore.mds.test.ts packages/fluux-sdk/src/stores/chatSelectors.ts packages/fluux-sdk/src/hooks/useChatActive.ts apps/fluux/src/components/ChatView.tsx
+git commit -m "refactor(chat): move new-message divider to a session-only map; de-persist it"
+```
+
+---
+
+## Task 4: Room divider into a session-only map (decouple, symmetric with chat)
+
+Same shape as Task 3 for rooms. Rooms were never persisted, so there is no de-persist step; this is the architectural symmetry. The compiler is again the checklist.
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/types/room.ts:251`
+- Modify: `packages/fluux-sdk/src/stores/roomStore.ts` (state interface ~307-334; `createEmptyRoomState` ~471-493; `addRoom` ~533; `updateRoom` metaFields ~582 and write ~633; `addMessage` ~1098/1118; `setActiveRoom` ~1380/1386/1421/1433; `clearFirstNewMessageId` ~1457-1483)
+- Modify: `packages/fluux-sdk/src/stores/roomSelectors.ts:327`
+- Modify: `packages/fluux-sdk/src/hooks/useRoomActive.ts`
+- Modify: `apps/fluux/src/components/RoomView.tsx:541`
+- Test: `packages/fluux-sdk/src/stores/roomStore.mds.test.ts`
+
+**Interfaces:**
+- Produces: `RoomState.firstNewMessageMarkers: Map<string, string>`; `roomSelectors.firstNewMessageIdFor(jid)` reads it; `useRoomActive()` returns a top-level `firstNewMessageId?: string` for the active room.
+
+- [ ] **Step 1: Write the failing test (map home)**
+
+Append to `packages/fluux-sdk/src/stores/roomStore.mds.test.ts`:
+
+```typescript
+describe('roomStore — new-message divider is session-only', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  it('parks the divider in firstNewMessageMarkers, not in roomMeta', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      const existing = m.get(ROOM)!
+      m.set(ROOM, { ...existing, unreadCount: 2 })
+      return { roomMeta: m }
+    })
+
+    roomStore.getState().setActiveRoom(ROOM)
+
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('m2')
+    expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBe('m2')
+    expect('firstNewMessageId' in (roomStore.getState().roomMeta.get(ROOM) as object)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.mds.test.ts -t "session-only"`
+Expected: FAIL — `firstNewMessageMarkers` is undefined.
+
+- [ ] **Step 3: Remove the field from `RoomMetadata`**
+
+In `packages/fluux-sdk/src/core/types/room.ts`, delete these two lines from `RoomMetadata` (~250-251):
+
+```typescript
+  /** ID of the first unread message (calculated when switching to room) */
+  firstNewMessageId?: string
+```
+
+(`Room extends RoomEntity, RoomMetadata, RoomRuntime` loses the field too. Intended.)
+
+- [ ] **Step 4: Add the session map to `RoomState` and `createEmptyRoomState`**
+
+In `packages/fluux-sdk/src/stores/roomStore.ts`, add to the `RoomState` interface after `targetMessageId: string | null` (~334):
+
+```typescript
+  // Session-only new-message divider per room (jid -> messageId). Derived at
+  // activation from lastSeenMessageId; never persisted.
+  firstNewMessageMarkers: Map<string, string>
+```
+
+In `createEmptyRoomState`, add `'firstNewMessageMarkers'` to the `Pick<...>` return type union and `firstNewMessageMarkers: new Map(),` to the returned object (mirroring Task 3 Step 4).
+
+- [ ] **Step 5: Remove the divider from `addRoom` and `updateRoom`**
+
+In `addRoom` (~533), remove `firstNewMessageId: room.firstNewMessageId` from the `meta` object it builds.
+
+In `updateRoom`, remove `'firstNewMessageId'` from the `metaFields` array (~582):
+
+```typescript
+      const metaFields = ['unreadCount', 'mentionsCount', 'typingUsers', 'notifyAll',
+        'notifyAllPersistent', 'lastReadAt', 'firstNewMessageId', 'lastInteractedAt'] as const
+```
+
+becomes:
+
+```typescript
+      const metaFields = ['unreadCount', 'mentionsCount', 'typingUsers', 'notifyAll',
+        'notifyAllPersistent', 'lastReadAt', 'lastInteractedAt'] as const
+```
+
+and remove `firstNewMessageId: updatedRoom.firstNewMessageId,` from the `newMeta.set(roomJid, { ... })` object inside the `if (hasMetaUpdate)` block (~633).
+
+- [ ] **Step 6: Route the `addMessage` write to the map**
+
+In `addMessage`, remove `firstNewMessageId: updated.firstNewMessageId,` from BOTH the combined `newRooms.set(...)` object (~1098) and the `newMeta.set(...)` object (~1118). Then update the map and add it to the return. Change the tail of the action:
+
+```typescript
+      // Update metadata
+      const newMeta = new Map(state.roomMeta)
+      if (existingMeta) {
+        newMeta.set(roomJid, {
+          ...existingMeta,
+          unreadCount: updated.unreadCount,
+          mentionsCount: updated.mentionsCount,
+          lastReadAt: updated.lastReadAt,
+          firstNewMessageId: updated.firstNewMessageId,
+          lastMessage,
+          lastInteractedAt: newLastInteractedAt,
+        })
+      }
+
+      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta }
+```
+
+to:
+
+```typescript
+      // Update metadata
+      const newMeta = new Map(state.roomMeta)
+      if (existingMeta) {
+        newMeta.set(roomJid, {
+          ...existingMeta,
+          unreadCount: updated.unreadCount,
+          mentionsCount: updated.mentionsCount,
+          lastReadAt: updated.lastReadAt,
+          lastMessage,
+          lastInteractedAt: newLastInteractedAt,
+        })
+      }
+
+      // Session-only divider (parity with chatStore.addMessage).
+      const newMarkers = new Map(state.firstNewMessageMarkers)
+      if (updated.firstNewMessageId) newMarkers.set(roomJid, updated.firstNewMessageId)
+      else newMarkers.delete(roomJid)
+
+      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
+```
+
+(Also remove the `firstNewMessageId: updated.firstNewMessageId,` line from the earlier `newRooms.set(roomJid, { ...existing, ... })` at ~1098.)
+
+- [ ] **Step 7: Route the `setActiveRoom` writes to the map**
+
+In `setActiveRoom`, the deactivate-previous branch writes the cleared marker to the combined room (~1380) and meta (~1386). Replace its `set((state) => { ... })`:
+
+```typescript
+      set((state) => {
+        // Evict from the runtime mirror (messages live here).
+        const newRuntime = new Map(state.roomRuntime)
+        const prevRuntime = newRuntime.get(prevJid)
+        if (prevRuntime && prevRuntime.messages.length > 0) {
+          newRuntime.set(prevJid, { ...prevRuntime, messages: [] })
+        }
+
+        // Evict from the combined map mirror; carry the (possibly cleared) marker.
+        const newRooms = new Map(state.rooms)
+        const prevRoom = newRooms.get(prevJid)
+        if (prevRoom) {
+          const updatedPrevRoom = { ...prevRoom, messages: [] }
+          if (hadMarker) updatedPrevRoom.firstNewMessageId = clearedFirstNewMessageId
+          newRooms.set(prevJid, updatedPrevRoom)
+        }
+
+        const newMeta = new Map(state.roomMeta)
+        if (prevMeta && hadMarker) {
+          newMeta.set(prevJid, { ...prevMeta, firstNewMessageId: clearedFirstNewMessageId })
+        }
+
+        return { roomRuntime: newRuntime, rooms: newRooms, roomMeta: newMeta }
+      })
+```
+
+with (`clearedFirstNewMessageId` is always `undefined`, so just delete the entry):
+
+```typescript
+      set((state) => {
+        // Evict from the runtime mirror (messages live here).
+        const newRuntime = new Map(state.roomRuntime)
+        const prevRuntime = newRuntime.get(prevJid)
+        if (prevRuntime && prevRuntime.messages.length > 0) {
+          newRuntime.set(prevJid, { ...prevRuntime, messages: [] })
+        }
+
+        // Evict from the combined map mirror.
+        const newRooms = new Map(state.rooms)
+        const prevRoom = newRooms.get(prevJid)
+        if (prevRoom) {
+          newRooms.set(prevJid, { ...prevRoom, messages: [] })
+        }
+
+        const newMarkers = new Map(state.firstNewMessageMarkers)
+        if (hadMarker) newMarkers.delete(prevJid)
+
+        return { roomRuntime: newRuntime, rooms: newRooms, firstNewMessageMarkers: newMarkers }
+      })
+```
+
+In the activate branch, remove `firstNewMessageId: activated.firstNewMessageId,` from `newMetaEntry` (~1421) and from the `newRooms.set(roomJid, { ...room, ... })` object (~1433), then carry the map. Replace the `set((state) => { ... })`:
+
+```typescript
+        set((state) => {
+          const newMetaEntry = {
+            ...(meta ?? { unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>() }),
+            unreadCount: activated.unreadCount,
+            mentionsCount: activated.mentionsCount,
+            lastReadAt: activated.lastReadAt,
+            lastSeenMessageId: activated.lastSeenMessageId,
+            firstNewMessageId: activated.firstNewMessageId,
+            lastInteractedAt: newLastInteractedAt,
+          }
+          const newMeta = new Map(state.roomMeta)
+          newMeta.set(roomJid, newMetaEntry)
+          const newRooms = new Map(state.rooms)
+          newRooms.set(roomJid, {
+            ...room,
+            unreadCount: activated.unreadCount,
+            mentionsCount: activated.mentionsCount,
+            lastReadAt: activated.lastReadAt,
+            lastSeenMessageId: activated.lastSeenMessageId,
+            firstNewMessageId: activated.firstNewMessageId,
+            lastInteractedAt: newLastInteractedAt,
+          })
+          return { roomMeta: newMeta, rooms: newRooms, activeRoomJid: roomJid }
+        })
+```
+
+with:
+
+```typescript
+        set((state) => {
+          const newMetaEntry = {
+            ...(meta ?? { unreadCount: 0, mentionsCount: 0, typingUsers: new Set<string>() }),
+            unreadCount: activated.unreadCount,
+            mentionsCount: activated.mentionsCount,
+            lastReadAt: activated.lastReadAt,
+            lastSeenMessageId: activated.lastSeenMessageId,
+            lastInteractedAt: newLastInteractedAt,
+          }
+          const newMeta = new Map(state.roomMeta)
+          newMeta.set(roomJid, newMetaEntry)
+          const newRooms = new Map(state.rooms)
+          newRooms.set(roomJid, {
+            ...room,
+            unreadCount: activated.unreadCount,
+            mentionsCount: activated.mentionsCount,
+            lastReadAt: activated.lastReadAt,
+            lastSeenMessageId: activated.lastSeenMessageId,
+            lastInteractedAt: newLastInteractedAt,
+          })
+          const newMarkers = new Map(state.firstNewMessageMarkers)
+          if (activated.firstNewMessageId) newMarkers.set(roomJid, activated.firstNewMessageId)
+          else newMarkers.delete(roomJid)
+          return { roomMeta: newMeta, rooms: newRooms, activeRoomJid: roomJid, firstNewMessageMarkers: newMarkers }
+        })
+```
+
+- [ ] **Step 8: Rewrite `clearFirstNewMessageId` to clear the map**
+
+Replace the whole room `clearFirstNewMessageId` action (~1457-1483) with:
+
+```typescript
+  clearFirstNewMessageId: (roomJid) => {
+    set((state) => {
+      if (!state.firstNewMessageMarkers.has(roomJid)) return state
+      const newMarkers = new Map(state.firstNewMessageMarkers)
+      newMarkers.delete(roomJid)
+      return { firstNewMessageMarkers: newMarkers }
+    })
+  },
+```
+
+- [ ] **Step 9: Repoint the room selector**
+
+In `packages/fluux-sdk/src/stores/roomSelectors.ts`, change `firstNewMessageIdFor` (~327):
+
+```typescript
+  firstNewMessageIdFor: (roomJid: string) => (state: RoomState): string | undefined => {
+    return state.rooms.get(roomJid)?.firstNewMessageId
+  },
+```
+
+to:
+
+```typescript
+  firstNewMessageIdFor: (roomJid: string) => (state: RoomState): string | undefined => {
+    return state.firstNewMessageMarkers.get(roomJid)
+  },
+```
+
+- [ ] **Step 10: Source the active marker from the map in `useRoomActive` and expose it**
+
+In `packages/fluux-sdk/src/hooks/useRoomActive.ts`, add a selector that reads the map (next to the existing `activeRoomMeta` selector, ~61):
+
+```typescript
+  const activeFirstNewMessageId = useRoomStore((s) => {
+    if (!s.activeRoomJid) return undefined
+    return s.firstNewMessageMarkers.get(s.activeRoomJid)
+  })
+```
+
+The `activeRoom` `useMemo` spreads `...activeRoomMeta`, which no longer carries the divider; that is correct. Add `firstNewMessageId: activeFirstNewMessageId` as a top-level field of the hook's return object and include `activeFirstNewMessageId` in that return memo's dependency array (mirror Task 3 Step 11). If `useRoomActive` has no outer return memo, return it as a plain top-level property alongside `activeRoom`.
+
+- [ ] **Step 11: Read the divider from the hook in `RoomView`**
+
+In `apps/fluux/src/components/RoomView.tsx`, add `firstNewMessageId` to the `useRoomActive()` destructure, then change line ~541:
+
+```tsx
+            firstNewMessageId={activeRoom.firstNewMessageId}
+```
+
+to:
+
+```tsx
+            firstNewMessageId={firstNewMessageId}
+```
+
+(The inner-component prop `firstNewMessageId` at ~817/860 and its use at ~1071 are unchanged.)
+
+- [ ] **Step 12: Rebuild SDK and run typecheck + tests**
+
+```bash
+npm run build:sdk
+npm run typecheck
+```
+Expected: PASS (no `roomMeta.firstNewMessageId` / `Room.firstNewMessageId` references remain).
+
+```bash
+cd packages/fluux-sdk && npx vitest run src/stores/roomStore.mds.test.ts src/stores/roomStore.test.ts src/stores/roomStore.mds.test.ts src/stores/roomSelectors.test.ts src/hooks/useRoom.test.tsx
+```
+Expected: PASS. Update any `roomStore.test.ts` assertions that read `meta.firstNewMessageId` / `room.firstNewMessageId` to read via `firstNewMessageMarkers` / `firstNewMessageIdFor`.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/types/room.ts packages/fluux-sdk/src/stores/roomStore.ts packages/fluux-sdk/src/stores/roomStore.mds.test.ts packages/fluux-sdk/src/stores/roomSelectors.ts packages/fluux-sdk/src/hooks/useRoomActive.ts apps/fluux/src/components/RoomView.tsx
+git commit -m "refactor(room): move new-message divider to a session-only map (symmetry with chat)"
+```
+
+---
+
+## Task 5: Full verification and spec commit
+
+**Files:**
+- No source changes (verification + docs).
+
+- [ ] **Step 1: Build SDK and typecheck the whole monorepo**
+
+Run: `npm run build:sdk && npm run typecheck`
+Expected: PASS with no errors.
+
+- [ ] **Step 2: Run the entire test suite**
+
+Run: `npm test`
+Expected: PASS, no errors, no stderr. Pay special attention to: `chatStore.test.ts`, `roomStore.test.ts`, `chatSelectors.test.ts`, `roomSelectors.test.ts`, `notificationState.test.ts` (must be untouched and green), `useChat.test.tsx`, `useRoom.test.tsx`, and any app test that mocks `useChatActive`/`useRoomActive` (ensure the mock exposes the new top-level `firstNewMessageId`).
+
+- [ ] **Step 3: Run the linter**
+
+Run: `npm run lint`
+Expected: PASS (no unused-import warnings; if `onClearMarker` import became unused in a store, remove that import).
+
+- [ ] **Step 4: Manual smoke (demo mode), optional but recommended**
+
+Per `.claude/CLAUDE.md`: `npm run dev`, open `http://localhost:5173/demo.html`. Open a conversation/room with unread messages, confirm the "new messages" divider renders and scroll lands on it; switch away and back, confirm the divider recomputes. Reload the page, confirm no stale divider survives before activation.
+
+- [ ] **Step 5: Commit the design spec**
+
+```bash
+git add docs/superpowers/specs/2026-06-25-new-message-marker-session-state-design.md docs/superpowers/plans/2026-06-25-new-message-marker-session-state.md
+git commit -m "docs: spec + plan for session-only new-message divider (XEP-0490 read-position cleanup)"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Spec 4.1 session map → Task 3 Step 4 (chat), Task 4 Step 4 (room).
+- Spec 4.2 type removal → Task 3 Step 3, Task 4 Step 3.
+- Spec 4.3 notificationState unchanged → Global Constraints + no task touches it.
+- Spec 4.4 store routing → Task 3 Steps 5-9, Task 4 Steps 5-8.
+- Spec 4.5 activation bug fix → Task 1, Task 2.
+- Spec 4.6 selectors/hooks/views → Task 3 Steps 10-12, Task 4 Steps 9-11.
+- Spec 6 frozen-while-active → preserved: `onMessageSeen`/`applyRemoteDisplayed` never write the divider map; only activation and `addMessage`'s active-hidden path do.
+- Spec 7 testing → Task 1/2 (activation), Task 3 Step 1 (map home + de-persist), Task 4 Step 1 (map home).
+- Spec 8 migration → Task 3 Step 9 (legacy line dropped; new-format spread harmless).
+
+**Placeholder scan:** none — every step has exact code or exact commands.
+
+**Type consistency:** new field `firstNewMessageMarkers: Map<string, string>` used identically in both stores; selector returns `string | undefined`; hooks expose top-level `firstNewMessageId?: string`. `applyRemoteDisplayed`, `loadMessagesFromCache`, `setActiveConversation`/`setActiveRoom` signatures unchanged.

--- a/docs/superpowers/specs/2026-06-25-new-message-marker-session-state-design.md
+++ b/docs/superpowers/specs/2026-06-25-new-message-marker-session-state-design.md
@@ -1,0 +1,231 @@
+# New-message marker as session state (post XEP-0490 read-position cleanup)
+
+Date: 2026-06-25
+Status: Approved design, pending spec review
+Related: `docs/XEP-CONVERSATION_SYNC.md` (XEP-0490 implementation), `packages/fluux-sdk/src/core/mdsSideEffects.ts`
+
+## 1. Background and problem
+
+XEP-0490 (Message Displayed Synchronization) now owns the per-conversation read
+position. The SDK seeds it from the MDS PEP node on a fresh session and publishes
+forward advances back to the node. Read state is therefore authoritative on the
+server and synced across a user's devices.
+
+The app keeps two per-entity markers:
+
+- `lastSeenMessageId`: the read position. "How far have I read." Now also MDS-synced.
+- `firstNewMessageId`: the "new messages" divider. "Where to draw the divider, and
+  where to scroll when the conversation opens." Derived from `lastSeenMessageId` by
+  `notificationState.onActivate` at activation time.
+
+Persistence is asymmetric today, which the original framing got wrong:
+
+- `chatStore` wraps the `persist` middleware (`chatStore.ts:486`), and its custom
+  `serializeState` writes the whole `conversationMeta` entry, so `firstNewMessageId`
+  **is persisted** for 1:1 conversations.
+- `roomStore` uses only `subscribeWithSelector` (`roomStore.ts:496`), with no `persist`
+  middleware. `roomMeta` is never serialized, so the room divider is **already
+  in-memory only** and recomputes on activation.
+
+So the de-persist cleanup is a chat-only concern, while the restore bug (section 1.2)
+and the architectural separation apply to both. We adopt a symmetric model anyway: both
+metadata types become purely durable, and both stores park the divider in a dedicated
+session map, so the divider can never be persisted in either store and the two stores
+stay consistent.
+
+Persisting `firstNewMessageId` (chat) causes two problems.
+
+### 1.1 Vestigial persistence
+
+`firstNewMessageId` is recomputed on every activation (`onActivate`) and is read
+**only for the active entity** (`useChatActive.ts:61`, `ChatView.tsx:475`,
+`RoomView.tsx:541`, `MessageList.tsx`, `useMessageListScroll.ts`). Nothing reads the
+persisted value before activation overwrites it (`activeConversationId` is always
+persisted as `null`, `chatStore.ts:1740`). The persisted copy never does any work.
+
+### 1.2 The "restore to the wrong place" bug
+
+Root cause, as a causal chain:
+
+1. On a fresh session the MDS seed runs on the `online` event, before any messages
+   are loaded, so `applyRemoteDisplayed` cannot map the incoming stanza-id to a local
+   message and stashes it as `pendingRemoteDisplayedStanzaId` (`chatStore.ts:933`).
+2. When the user opens a conversation, `activateConversation` (`chatStore.ts:604`)
+   calls `loadMessagesFromCache` then `setActiveConversation`. `loadMessagesFromCache`
+   does **not** resolve a pending marker (only `mergeMAMMessages` does, at
+   `chatStore.ts:1487`).
+3. `onActivate` therefore derives the divider from a **stale** `lastSeenMessageId`.
+4. When the pending marker later resolves, `applyRemoteDisplayed` advances
+   `lastSeenMessageId` via `onMessageSeen`, which by design touches **only**
+   `lastSeenMessageId`, never `firstNewMessageId` (`notificationState.ts:396`).
+5. The divider stays frozen at the stale position. The conversation-switch scroll
+   effect only re-runs when `firstNewMessageId` itself changes (`useMessageListScroll.ts:943`),
+   so the scroll position is never corrected until the next activation.
+
+Net effect: opening a conversation you have already read on another device can show
+already-read messages as "new" and scroll to the old boundary, and it does not
+self-correct within the session.
+
+Wire-timing evidence (capture `xmpp-log-2026-06-25-105927.txt`): the MDS fetch result
+lands at 10:56:40.488, the very first result after auth, while the per-conversation
+MAM messages begin arriving at 10:56:41.186 and continue for seconds. Every marker is
+stashed pending at seed time; whether it resolves before the user opens a given
+conversation is a race.
+
+## 2. Goals and non-goals
+
+Goals:
+
+- Make the read position the single durable, MDS-synced source of truth.
+- Make the new-message divider a session-only derived marker, fully decoupled from
+  persisted metadata.
+- Fix the restore bug: the divider must be derived from the synced read position at
+  open time.
+
+Non-goals:
+
+- Dropping `lastSeenMessageId` persistence. It is load-bearing: offline-first display
+  before the connection is up, and MDS's own durable buffer for the "ahead-of-node"
+  re-publish on the next fresh session (`mdsSideEffects.ts` header).
+- Re-deriving the divider while a conversation is active (see section 6, decided:
+  leave frozen).
+- Any change to the XEP-0490 wire protocol or publish logic.
+
+## 3. State model
+
+| Marker | Question | Persisted | MDS-synced | Home |
+| --- | --- | --- | --- | --- |
+| `lastSeenMessageId` | how far have I read | yes (keep) | yes | `conversationMeta` / `roomMeta` |
+| new-message divider | where to draw the divider / scroll on open | no (change) | no | new session-only map |
+
+## 4. Design
+
+### 4.1 Session marker map (the "cleaner" separation)
+
+Add a session-only map to `ChatState` and `RoomState`, keyed by entity bare JID:
+
+```
+firstNewMessageMarkers: Map<string, string>   // jid -> messageId (provisional name)
+```
+
+It is never serialized (absent from `serializeState` / `partialize`) and is reset to
+an empty map by `reset()` / logout. The divider is no longer part of any persisted
+metadata or of the combined conversation/room object.
+
+### 4.2 Type changes
+
+- Remove `firstNewMessageId` from `ConversationMetadata` (`chat.ts:112`) and
+  `RoomMetadata` (`room.ts:251`).
+- `Conversation` (`chat.ts:134`) and `Room` (`room.ts:304`) inherit from the metadata
+  types, so the field leaves the combined objects as well. This is intentional: the
+  divider is not part of a conversation's identity or durable metadata.
+
+### 4.3 notificationState stays the derivation engine (unchanged)
+
+The pure functions are not modified. `EntityNotificationState` keeps
+`firstNewMessageId` as its computed currency: `onActivate` derives it, `onDeactivate`
+and `markAsRead` clear it, the incoming-while-active-and-window-hidden path sets it
+(`notificationState.ts:151`), and `onMessageSeen` preserves it. Only the **store**
+changes where it stores the result.
+
+### 4.4 Store routing
+
+Everywhere the stores currently read or write `meta.firstNewMessageId`, route to the
+session map instead:
+
+- Build the `EntityNotificationState` input from `meta` (read position etc.) plus
+  `firstNewMessageMarkers.get(jid)`.
+- After calling the pure function, write `lastSeenMessageId` / `lastReadAt` /
+  `unreadCount` to `meta`, and set or delete the divider in `firstNewMessageMarkers`.
+
+Chat sites: `setActiveConversation` (activation result and the deactivate-previous
+branch), `markAsRead` / `clearFirstNewMessageId`, and the incoming-message path.
+Mirror in `roomStore`, including the `metaFields` routing list at `roomStore.ts:582`
+and the combined-map plumbing, so no stale divider lingers on the in-memory combined
+`rooms` map.
+
+### 4.5 Activation resolves the synced position first (the bug fix)
+
+In `activateConversation` (`chatStore.ts:604`) and `activateRoom` (`roomStore.ts:1445`),
+between `loadMessagesFromCache` and `setActive*`, resolve any pending MDS marker:
+
+```
+await loadMessagesFromCache(id, { limit: 100 })
+const pending = get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId
+if (pending) get().applyRemoteDisplayed(id, pending)  // forward-only, against now-loaded messages
+get().setActiveConversation(id)                        // onActivate derives the divider from the synced position
+```
+
+`applyRemoteDisplayed` already resolves forward-only against loaded messages and clears
+the pending mark. `onActivate` then draws the divider from the synced
+`lastSeenMessageId`. No new resolution logic, only correct sequencing.
+
+### 4.6 Selectors and hooks
+
+- `chatSelectors.firstNewMessageIdFor` (`chatSelectors.ts:231`) and
+  `roomSelectors.firstNewMessageIdFor` (`roomSelectors.ts:326`) read from
+  `firstNewMessageMarkers`.
+- `useChatActive` (`useChatActive.ts:60`) sources the active marker from
+  `firstNewMessageMarkers` and exposes it as a standalone value (decoupled from the
+  reconstructed conversation object). Room active hook does the same for `RoomView`.
+- `ChatView.tsx:475` and `RoomView.tsx:541` read the marker from the hook as a
+  standalone value (one line each).
+
+## 5. Components and data flow
+
+```
+incoming msg / open / scroll-past
+        |
+        v
+notificationState pure fns  --(firstNewMessageId in EntityNotificationState)-->
+        |
+        v
+store: write read-state -> meta (persisted, MDS-synced)
+       write divider     -> firstNewMessageMarkers (session only)
+        |
+        v
+selectors / useChatActive / useRoomActive  -> ChatView / RoomView -> MessageList + useMessageListScroll
+```
+
+Read position flows out to the wire via the existing `mdsSideEffects` publisher,
+unchanged. The divider never leaves the session map.
+
+## 6. Edge behavior
+
+- Marker's message not in the cached window at activation (older than the loaded 100,
+  or not yet cached): `applyRemoteDisplayed` cannot resolve it, so the divider uses
+  `onActivate`'s existing `lastReadAt` / `unreadCount` fallbacks and self-heals on the
+  next activation. Narrow residual, strictly better than today.
+- Sync resolves while the conversation is active (MAM merge mid-view, or a live remote
+  read from another device): leave the divider frozen. It was placed at activation;
+  moving it under an active reader is worse than a slightly late divider. The fix
+  targets the open / restore moment, which is what "restore the right place" means.
+
+## 7. Testing
+
+- Failing test first (reproduces the bug): seed a pending remote marker for a
+  conversation whose target message is in cache, call `activateConversation`, assert
+  the divider sits at the synced position rather than the stale one. Mirror for rooms.
+- De-persistence: `serializeState` output contains no `firstNewMessageId`; a
+  persisted-then-reloaded store has no divider until activation; the persisted shape
+  has no `firstNewMessageMarkers` key.
+- Regression guards: forward-only / no-regress on `lastSeenMessageId` still hold; the
+  divider clears on deactivate and on scroll-past; frozen-while-active holds.
+
+## 8. Migration and compatibility
+
+Old persisted `conversationMeta` / `roomMeta` may still contain `firstNewMessageId`.
+Deserialize ignores it (the field leaves the type; the legacy read at
+`chatStore.ts:342` is dropped). No data migration is needed; the divider recomputes on
+the next activation.
+
+## 9. Risks
+
+- The touch surface spans both stores, their metadata types, two selector modules, two
+  active-view hooks, and two app components. Mitigated by leaving `notificationState`
+  untouched, by the marker already being isolated in single selectors, and by per-area
+  behavior and render-count tests.
+- The combined in-memory `conversations` / `rooms` maps and the `roomStore.ts:582`
+  `metaFields` list must be updated consistently, or a stale divider could linger on
+  the combined map. Covered by repointing all reads to `firstNewMessageMarkers` and
+  removing the field from the metadata types (a compile error surfaces any missed site).

--- a/packages/fluux-sdk/src/core/types/chat.ts
+++ b/packages/fluux-sdk/src/core/types/chat.ts
@@ -108,8 +108,6 @@ export interface ConversationMetadata {
   lastReadAt?: Date
   /** ID of the last message the user saw in the viewport (persisted, only advances forward) */
   lastSeenMessageId?: string
-  /** ID of the first unread message (calculated when switching to conversation) */
-  firstNewMessageId?: string
   /**
    * XEP-0490: a remote device reported reading up to this stanza-id, but the
    * message is not yet in the local cache. Resolved to lastSeenMessageId once

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -247,8 +247,6 @@ export interface RoomMetadata {
   lastReadAt?: Date
   /** ID of the last message the user saw in the viewport (persisted, only advances forward) */
   lastSeenMessageId?: string
-  /** ID of the first unread message (calculated when switching to room) */
-  firstNewMessageId?: string
   /**
    * XEP-0490: a remote device reported reading up to this stanza-id, but the
    * message is not yet in the loaded room cache. Resolved to lastSeenMessageId

--- a/packages/fluux-sdk/src/hooks/renderStability.helpers.tsx
+++ b/packages/fluux-sdk/src/hooks/renderStability.helpers.tsx
@@ -39,7 +39,6 @@ export function createConversation(id: string, options: Partial<Conversation> = 
     lastMessage: options.lastMessage,
     lastReadAt: options.lastReadAt,
     lastSeenMessageId: options.lastSeenMessageId,
-    firstNewMessageId: options.firstNewMessageId,
   }
 }
 

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -47,7 +47,7 @@ export function useChatActive() {
 
   // Use focused selectors from separated entity/meta maps to avoid re-renders
   // when unrelated conversations change. Entity fields (id, name, type) are stable;
-  // metadata fields (firstNewMessageId) change rarely compared to lastMessage/unreadCount.
+  // the new-message divider comes from the session-only firstNewMessageMarkers map.
   const activeConvName = useChatStore((s) => {
     if (!s.activeConversationId) return null
     return s.conversationEntities.get(s.activeConversationId)?.name ?? null
@@ -58,7 +58,7 @@ export function useChatActive() {
   })
   const activeFirstNewMessageId = useChatStore((s) => {
     if (!s.activeConversationId) return undefined
-    return s.conversationMeta.get(s.activeConversationId)?.firstNewMessageId
+    return s.firstNewMessageMarkers.get(s.activeConversationId)
   })
 
   // Reconstruct a stable activeConversation object from individual primitive fields.
@@ -70,14 +70,13 @@ export function useChatActive() {
       id: activeConversationId,
       name: activeConvName,
       type: activeConvType,
-      firstNewMessageId: activeFirstNewMessageId,
       // Not used by active view components — sidebar uses useChat() for these
       unreadCount: 0,
       lastMessage: undefined,
       lastReadAt: undefined,
       lastSeenMessageId: undefined,
     }
-  }, [activeConversationId, activeConvName, activeConvType, activeFirstNewMessageId])
+  }, [activeConversationId, activeConvName, activeConvType])
 
   // Don't use useShallow for messages - when messages are prepended, we need React to re-render
   const activeMessages = useChatStore((s) => {
@@ -417,6 +416,7 @@ export function useChatActive() {
     () => ({
       activeConversationId,
       activeConversation,
+      firstNewMessageId: activeFirstNewMessageId,
       activeMessages,
       activeTypingUsers,
       activeAnimation,
@@ -426,7 +426,7 @@ export function useChatActive() {
       ...actions,
     }),
     [
-      activeConversationId, activeConversation, activeMessages,
+      activeConversationId, activeConversation, activeFirstNewMessageId, activeMessages,
       activeTypingUsers, activeAnimation, targetMessageId, supportsMAM, activeMAMState,
       actions,
     ]

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -63,6 +63,11 @@ export function useRoomActive() {
     return s.roomMeta.get(s.activeRoomJid)
   })
 
+  const activeFirstNewMessageId = useRoomStore((s) => {
+    if (!s.activeRoomJid) return undefined
+    return s.firstNewMessageMarkers.get(s.activeRoomJid)
+  })
+
   const activeRoomRuntime = useRoomStore((s) => {
     if (!s.activeRoomJid) return undefined
     return s.roomRuntime.get(s.activeRoomJid)
@@ -520,6 +525,7 @@ export function useRoomActive() {
       activeAnimation,
       targetMessageId,
       activeMAMState,
+      firstNewMessageId: activeFirstNewMessageId,
 
       // Actions (spread memoized actions)
       ...actions,
@@ -532,6 +538,7 @@ export function useRoomActive() {
       activeAnimation,
       targetMessageId,
       activeMAMState,
+      activeFirstNewMessageId,
       actions,
     ]
   )

--- a/packages/fluux-sdk/src/stores/chatSelectors.referenceStability.test.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.referenceStability.test.ts
@@ -12,7 +12,6 @@ function createConversation(id: string, options: Partial<Conversation> = {}): Co
     lastMessage: options.lastMessage,
     lastReadAt: options.lastReadAt,
     lastSeenMessageId: options.lastSeenMessageId,
-    firstNewMessageId: options.firstNewMessageId,
   }
 }
 

--- a/packages/fluux-sdk/src/stores/chatSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.test.ts
@@ -18,6 +18,7 @@ function createMockState(overrides: Partial<ChatState> = {}): ChatState {
     activeAnimation: null,
     drafts: new Map(),
     mamQueryStates: new Map(),
+    firstNewMessageMarkers: new Map(),
     // Actions are not needed for selector tests
     activeConversation: () => null,
     activeMessages: () => [],
@@ -353,11 +354,9 @@ describe('chatSelectors', () => {
   })
 
   describe('firstNewMessageIdFor', () => {
-    it('should return firstNewMessageId for conversation', () => {
-      const conversations = new Map([
-        ['user@example.com', createMockConversation('user@example.com', { firstNewMessageId: 'msg-123' })],
-      ])
-      const state = createMockState({ conversations })
+    it('should return firstNewMessageId from the session-only markers map', () => {
+      const firstNewMessageMarkers = new Map([['user@example.com', 'msg-123']])
+      const state = createMockState({ firstNewMessageMarkers })
       expect(chatSelectors.firstNewMessageIdFor('user@example.com')(state)).toBe('msg-123')
     })
   })

--- a/packages/fluux-sdk/src/stores/chatSelectors.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.ts
@@ -229,7 +229,7 @@ export const chatSelectors = {
    * Get firstNewMessageId for a specific conversation (for new message marker).
    */
   firstNewMessageIdFor: (conversationId: string) => (state: ChatState): string | undefined => {
-    return state.conversations.get(conversationId)?.firstNewMessageId
+    return state.firstNewMessageMarkers.get(conversationId)
   },
 
   // ============================================================

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -209,6 +209,35 @@ describe('chatStore — new-message divider is session-only', () => {
     expect('firstNewMessageId' in (chatStore.getState().conversationMeta.get(cid) as object)).toBe(false)
   })
 
+  it('deactivating a conversation deletes its marker (switching to another conversation)', () => {
+    const cidA = 'juliet@capulet.example'
+    const cidB = 'romeo@montague.example'
+
+    // Seed conversation A with one read message and one unread message.
+    seedMessages(cidA, [msg('a1', 'sa1'), msg('a2', 'sa2')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cidA, { unreadCount: 1, lastSeenMessageId: 'a1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cidA, { id: cidA, name: cidA, type: 'chat', unreadCount: 1, lastSeenMessageId: 'a1' })
+      // Seed conversation B with no unread so its activation sets no marker.
+      newMeta.set(cidB, { unreadCount: 0 })
+      newConvs.set(cidB, { id: cidB, name: cidB, type: 'chat', unreadCount: 0 })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+    seedMessages(cidB, [msg('b1', 'sb1')])
+
+    // Activate A — should park the divider at a2.
+    chatStore.getState().setActiveConversation(cidA)
+    expect(chatStore.getState().firstNewMessageMarkers.get(cidA)).toBe('a2')
+
+    // Switching to B must delete A's marker (the deactivate branch).
+    chatStore.getState().setActiveConversation(cidB)
+    expect(chatStore.getState().firstNewMessageMarkers.get(cidA)).toBeUndefined()
+    // B has no unread, so it should not gain a marker either.
+    expect(chatStore.getState().firstNewMessageMarkers.get(cidB)).toBeUndefined()
+  })
+
   it('never writes the divider to persisted storage', () => {
     const cid = 'juliet@capulet.example'
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { chatStore } from './chatStore'
+import { chatSelectors } from './chatSelectors'
 import type { Message } from '../core/types/chat'
 
 // Mock localStorage (required by chatStore's persist middleware)
@@ -180,5 +181,33 @@ describe('chatStore.applyRemoteDisplayed', () => {
     const meta = chatStore.getState().conversationMeta.get(cid)
     expect(meta?.lastSeenMessageId).toBe('m5')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
+  })
+})
+
+describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  it('folds a pending remote read marker into lastSeenMessageId before deriving the divider', async () => {
+    const cid = 'juliet@capulet.example'
+    const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3'), msg('m4', 's4')]
+    seedMessages(cid, messages)
+
+    // Local read is stale at m2; a remote device read up to s4, seeded as pending
+    // before the messages were loaded (the fresh-session MDS seed ordering).
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's4' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's4' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+
+    // The pending marker is resolved at activation, advancing the read position.
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
+    // So the divider reflects the synced read (m4 is the last message → nothing new),
+    // NOT the stale 'm3' it would show if the marker resolved after onActivate.
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -184,6 +184,51 @@ describe('chatStore.applyRemoteDisplayed', () => {
   })
 })
 
+describe('chatStore — new-message divider is session-only', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  it('parks the divider in firstNewMessageMarkers, not in conversationMeta', () => {
+    const cid = 'juliet@capulet.example'
+    // m1 outgoing-read baseline, then two incoming unread messages.
+    const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')]
+    seedMessages(cid, messages)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    chatStore.getState().setActiveConversation(cid)
+
+    // Divider derived at m2 (first unread after m1) and stored in the session map.
+    expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m2')
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m2')
+    // The metadata entry carries NO divider field.
+    expect('firstNewMessageId' in (chatStore.getState().conversationMeta.get(cid) as object)).toBe(false)
+  })
+
+  it('never writes the divider to persisted storage', () => {
+    const cid = 'juliet@capulet.example'
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 1, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 1, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+    chatStore.getState().setActiveConversation(cid)
+    expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m2')
+
+    // Whatever the persist middleware wrote must not mention the divider.
+    const dump = JSON.stringify(localStorage)
+    expect(dump.includes('firstNewMessageId')).toBe(false)
+    expect(dump.includes('firstNewMessageMarkers')).toBe(false)
+  })
+})
+
 describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
   beforeEach(() => chatStore.getState().reset())
 

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1013,8 +1013,7 @@ describe('chatStore', () => {
       }).not.toThrow()
 
       // Should have set the new messages marker since the message is after lastReadAt
-      const conv = chatStore.getState().conversations.get('alice@example.com')
-      expect(conv?.firstNewMessageId).toBe('msg1')
+      expect(chatStore.getState().firstNewMessageMarkers.get('alice@example.com')).toBe('msg1')
     })
   })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -117,6 +117,9 @@ interface ChatState {
   conversationGaps: Map<string, GapInterval>
   // Target message to scroll to after navigation (ephemeral, not persisted)
   targetMessageId: string | null
+  // Session-only new-message divider per conversation (jid -> messageId). Derived
+  // at activation from lastSeenMessageId; never persisted (absent from serializeState).
+  firstNewMessageMarkers: Map<string, string>
 
   // Computed
   activeConversation: () => Conversation | null
@@ -339,7 +342,6 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
         lastMessage: conv.lastMessage,
         lastReadAt: conv.lastReadAt,
         lastSeenMessageId: conv.lastSeenMessageId,
-        firstNewMessageId: conv.firstNewMessageId,
       })
     }
   }
@@ -386,7 +388,7 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
   }
 }
 
-function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId'> {
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId' | 'firstNewMessageMarkers'> {
   return {
     conversationEntities: new Map(),
     conversationMeta: new Map(),
@@ -400,6 +402,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
     mamQueryStates: new Map(),
     conversationGaps: new Map(),
     targetMessageId: null,
+    firstNewMessageMarkers: new Map(),
   }
 }
 
@@ -409,7 +412,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
  * Legacy versions stored chat data under a single unscoped key. For safety, we only migrate
  * conversation lists (active + archived classification) and intentionally skip drafts/messages.
  */
-function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId'> | null {
+function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId' | 'firstNewMessageMarkers'> | null {
   if (!jid) return null
 
   const legacyKey = getLegacyStorageKey()
@@ -448,7 +451,7 @@ function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatSt
   }
 }
 
-function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId'> {
+function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId' | 'firstNewMessageMarkers'> {
   const baseState = createEmptyChatState()
   const scopedStorageKey = getScopedStorageKey(jid)
 
@@ -525,17 +528,7 @@ export const chatStore = createStore<ChatState>()(
         // rehydrated by activateConversation on return. Meta / lastMessage are
         // preserved, so the sidebar preview and unread badge are unaffected.
         if (prevId && prevId !== id) {
-          const prevMeta = get().conversationMeta.get(prevId)
-          const hadMarker = !!prevMeta?.firstNewMessageId
-          const clearedFirstNewMessageId = hadMarker
-            ? notifState.onDeactivate({
-                unreadCount: prevMeta!.unreadCount,
-                mentionsCount: 0,
-                lastReadAt: prevMeta!.lastReadAt,
-                lastSeenMessageId: prevMeta!.lastSeenMessageId,
-                firstNewMessageId: prevMeta!.firstNewMessageId,
-              }).firstNewMessageId
-            : undefined
+          const hadMarker = get().firstNewMessageMarkers.has(prevId)
 
           set((state) => {
             const newMessages = new Map(state.messages)
@@ -543,14 +536,9 @@ export const chatStore = createStore<ChatState>()(
             if (!hadMarker) {
               return { messages: newMessages }
             }
-            const newMeta = new Map(state.conversationMeta)
-            if (prevMeta) newMeta.set(prevId, { ...prevMeta, firstNewMessageId: clearedFirstNewMessageId })
-            const newConversations = new Map(state.conversations)
-            const prevConv = newConversations.get(prevId)
-            if (prevConv) {
-              newConversations.set(prevId, { ...prevConv, firstNewMessageId: clearedFirstNewMessageId })
-            }
-            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+            const newMarkers = new Map(state.firstNewMessageMarkers)
+            newMarkers.delete(prevId)
+            return { messages: newMessages, firstNewMessageMarkers: newMarkers }
           })
         }
 
@@ -564,7 +552,7 @@ export const chatStore = createStore<ChatState>()(
               mentionsCount: 0,
               lastReadAt: meta?.lastReadAt ?? conv.lastReadAt,
               lastSeenMessageId: meta?.lastSeenMessageId ?? conv.lastSeenMessageId,
-              firstNewMessageId: meta?.firstNewMessageId ?? conv.firstNewMessageId,
+              firstNewMessageId: undefined,
             }
 
             const messages = get().messages.get(id) || []
@@ -576,11 +564,10 @@ export const chatStore = createStore<ChatState>()(
 
             set((state) => {
               const newMetaEntry = {
-                ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined, firstNewMessageId: undefined }),
+                ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined }),
                 unreadCount: activated.unreadCount,
                 lastReadAt: activated.lastReadAt,
                 lastSeenMessageId: activated.lastSeenMessageId,
-                firstNewMessageId: activated.firstNewMessageId,
               }
               const newMeta = new Map(state.conversationMeta)
               newMeta.set(id, newMetaEntry)
@@ -590,9 +577,11 @@ export const chatStore = createStore<ChatState>()(
                 unreadCount: activated.unreadCount,
                 lastReadAt: activated.lastReadAt,
                 lastSeenMessageId: activated.lastSeenMessageId,
-                firstNewMessageId: activated.firstNewMessageId,
               })
-              return { conversationMeta: newMeta, conversations: newConversations, activeConversationId: id }
+              const newMarkers = new Map(state.firstNewMessageMarkers)
+              if (activated.firstNewMessageId) newMarkers.set(id, activated.firstNewMessageId)
+              else newMarkers.delete(id)
+              return { conversationMeta: newMeta, conversations: newConversations, activeConversationId: id, firstNewMessageMarkers: newMarkers }
             })
             return
           }
@@ -633,7 +622,6 @@ export const chatStore = createStore<ChatState>()(
             lastMessage: conv.lastMessage,
             lastReadAt: conv.lastReadAt,
             lastSeenMessageId: conv.lastSeenMessageId,
-            firstNewMessageId: conv.firstNewMessageId,
           }
 
           const newEntities = new Map(state.conversationEntities)
@@ -759,7 +747,7 @@ export const chatStore = createStore<ChatState>()(
                 mentionsCount: 0,
                 lastReadAt: meta.lastReadAt,
                 lastSeenMessageId: meta.lastSeenMessageId,
-                firstNewMessageId: meta.firstNewMessageId,
+                firstNewMessageId: state.firstNewMessageMarkers.get(msg.conversationId),
               },
               msg,
               { isActive, windowVisible },
@@ -781,7 +769,6 @@ export const chatStore = createStore<ChatState>()(
               lastReadAt: notif.lastReadAt,
               lastMessage: previewMessage,
               lastSeenMessageId: notif.lastSeenMessageId,
-              firstNewMessageId: notif.firstNewMessageId,
             })
 
             // Update combined map for backward compatibility
@@ -792,8 +779,13 @@ export const chatStore = createStore<ChatState>()(
               lastReadAt: notif.lastReadAt,
               lastMessage: previewMessage,
               lastSeenMessageId: notif.lastSeenMessageId,
-              firstNewMessageId: notif.firstNewMessageId,
             })
+
+            // Session-only divider: onMessageReceived only sets it for the active,
+            // window-hidden case; otherwise it is preserved. Mirror that into the map.
+            const newMarkers = new Map(state.firstNewMessageMarkers)
+            if (notif.firstNewMessageId) newMarkers.set(msg.conversationId, notif.firstNewMessageId)
+            else newMarkers.delete(msg.conversationId)
 
             // Auto-unarchive conversation when new incoming message arrives
             // (outgoing messages should not trigger unarchive)
@@ -806,11 +798,12 @@ export const chatStore = createStore<ChatState>()(
                   conversationMeta: newMeta,
                   conversations: newConversations,
                   archivedConversations: newArchived,
+                  firstNewMessageMarkers: newMarkers,
                 }
               }
             }
 
-            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
           }
 
           return { messages: newMessages }
@@ -830,7 +823,7 @@ export const chatStore = createStore<ChatState>()(
             mentionsCount: 0,
             lastReadAt: meta?.lastReadAt ?? conv.lastReadAt,
             lastSeenMessageId: meta?.lastSeenMessageId ?? conv.lastSeenMessageId,
-            firstNewMessageId: meta?.firstNewMessageId ?? conv.firstNewMessageId,
+            firstNewMessageId: state.firstNewMessageMarkers.get(conversationId),
           }
 
           const messages = state.messages.get(conversationId) || []
@@ -851,7 +844,7 @@ export const chatStore = createStore<ChatState>()(
           }
 
           const newMetaEntry = {
-            ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined, firstNewMessageId: undefined }),
+            ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined }),
             unreadCount: updated.unreadCount,
             lastReadAt: updated.lastReadAt,
           }
@@ -867,28 +860,10 @@ export const chatStore = createStore<ChatState>()(
 
       clearFirstNewMessageId: (conversationId) => {
         set((state) => {
-          const meta = state.conversationMeta.get(conversationId)
-          const conv = state.conversations.get(conversationId)
-          if (!meta || !meta.firstNewMessageId) return state
-
-          const cleared = notifState.onClearMarker({
-            unreadCount: meta.unreadCount,
-            mentionsCount: 0,
-            lastReadAt: meta.lastReadAt,
-            lastSeenMessageId: meta.lastSeenMessageId,
-            firstNewMessageId: meta.firstNewMessageId,
-          })
-
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, { ...meta, firstNewMessageId: cleared.firstNewMessageId })
-
-          if (conv) {
-            const newConversations = new Map(state.conversations)
-            newConversations.set(conversationId, { ...conv, firstNewMessageId: cleared.firstNewMessageId })
-            return { conversationMeta: newMeta, conversations: newConversations }
-          }
-
-          return { conversationMeta: newMeta }
+          if (!state.firstNewMessageMarkers.has(conversationId)) return state
+          const newMarkers = new Map(state.firstNewMessageMarkers)
+          newMarkers.delete(conversationId)
+          return { firstNewMessageMarkers: newMarkers }
         })
       },
 
@@ -905,7 +880,7 @@ export const chatStore = createStore<ChatState>()(
               mentionsCount: 0,
               lastReadAt: meta.lastReadAt,
               lastSeenMessageId: meta.lastSeenMessageId,
-              firstNewMessageId: meta.firstNewMessageId,
+              firstNewMessageId: state.firstNewMessageMarkers.get(conversationId),
             },
             messageId,
             messages
@@ -960,7 +935,7 @@ export const chatStore = createStore<ChatState>()(
               mentionsCount: 0,
               lastReadAt: meta.lastReadAt,
               lastSeenMessageId: meta.lastSeenMessageId,
-              firstNewMessageId: meta.firstNewMessageId,
+              firstNewMessageId: state.firstNewMessageMarkers.get(conversationId),
             },
             match.id,
             messages

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -607,6 +607,14 @@ export const chatStore = createStore<ChatState>()(
           await get().loadMessagesFromCache(id, { limit: 100 })
           // A newer activation started while the cache read was in flight
           if (token !== activationToken) return
+          // XEP-0490: fold any pending remote read position into lastSeenMessageId
+          // BEFORE setActiveConversation derives the new-message divider. The fresh
+          // session MDS seed runs before messages load, so the marker is stashed as
+          // pendingRemoteDisplayedStanzaId; resolve it now (forward-only, against the
+          // just-loaded messages) so the divider reflects reads synced from other
+          // devices instead of the stale local position.
+          const pending = get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId
+          if (pending) get().applyRemoteDisplayed(id, pending)
         }
         get().setActiveConversation(id)
       },

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -324,7 +324,7 @@ export const roomSelectors = {
    * Get firstNewMessageId for a specific room (for new message marker).
    */
   firstNewMessageIdFor: (roomJid: string) => (state: RoomState): string | undefined => {
-    return state.rooms.get(roomJid)?.firstNewMessageId
+    return state.firstNewMessageMarkers.get(roomJid)
   },
 
   /**

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -99,6 +99,7 @@ describe('roomStore.applyRemoteDisplayed', () => {
       drafts: new Map(),
       mamQueryStates: new Map(),
       roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
     })
     vi.clearAllMocks()
   })
@@ -168,6 +169,7 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       drafts: new Map(),
       mamQueryStates: new Map(),
       roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
     })
     vi.clearAllMocks()
   })
@@ -220,5 +222,31 @@ describe('roomStore — new-message divider is session-only', () => {
     expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('m2')
     expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBe('m2')
     expect('firstNewMessageId' in (roomStore.getState().roomMeta.get(ROOM) as object)).toBe(false)
+  })
+
+  it('deactivating a room deletes its marker (switching to another room)', () => {
+    const ROOM_B = 'other@conference.example'
+
+    // Seed room A with one read message and two unread so activation sets a divider at m2.
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      const existing = m.get(ROOM)!
+      m.set(ROOM, { ...existing, unreadCount: 2 })
+      return { roomMeta: m }
+    })
+
+    // Seed room B with no unread so switching to it sets no marker.
+    seedRoom(ROOM_B, [rmsg('b1', 'sb1', 10)], 'b1')
+
+    // Activate ROOM — divider should be placed at m2.
+    roomStore.getState().setActiveRoom(ROOM)
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('m2')
+
+    // Switch to ROOM_B — must delete ROOM's marker (the deactivate branch).
+    roomStore.getState().setActiveRoom(ROOM_B)
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBeUndefined()
+    // ROOM_B has no unread, so it should not gain a marker.
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM_B)).toBeUndefined()
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { roomStore } from './roomStore'
+import { roomSelectors } from './roomSelectors'
 import type { Room, RoomMessage } from '../core/types/room'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
@@ -152,5 +153,39 @@ describe('roomStore.applyRemoteDisplayed', () => {
     const meta = roomStore.getState().roomMeta.get(ROOM)
     expect(meta?.lastSeenMessageId).toBe('m5')
     expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
+  })
+})
+
+describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  it('folds a pending remote room marker into lastSeenMessageId before deriving the divider', async () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)], 'm2')
+    // A remote device read up to s4, seeded as pending before messages loaded.
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      const existing = m.get(ROOM)!
+      m.set(ROOM, { ...existing, pendingRemoteDisplayedStanzaId: 's4' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m4')
+    expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBeUndefined()
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -188,3 +188,37 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBeUndefined()
   })
 })
+
+describe('roomStore — new-message divider is session-only', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  it('parks the divider in firstNewMessageMarkers, not in roomMeta', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      const existing = m.get(ROOM)!
+      m.set(ROOM, { ...existing, unreadCount: 2 })
+      return { roomMeta: m }
+    })
+
+    roomStore.getState().setActiveRoom(ROOM)
+
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('m2')
+    expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBe('m2')
+    expect('firstNewMessageId' in (roomStore.getState().roomMeta.get(ROOM) as object)).toBe(false)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -168,7 +168,6 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       drafts: new Map(),
       mamQueryStates: new Map(),
       roomGaps: new Map(),
-      firstNewMessageMarkers: new Map(),
     })
     vi.clearAllMocks()
   })

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3924,7 +3924,7 @@ describe('setActiveRoom new-message marker — delayed = MUC/MAM history replay'
       return { roomMeta: meta }
     })
     roomStore.getState().setActiveRoom(ROOM)
-    return roomStore.getState().roomMeta.get(ROOM)?.firstNewMessageId
+    return roomStore.getState().firstNewMessageMarkers.get(ROOM)
   }
 
   it('sets no marker when only delayed history follows lastSeen (MAM/MUC join)', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -332,6 +332,9 @@ export interface RoomState {
   acknowledgedNonAnonymousRooms: Set<string>
   // Target message to scroll to after navigation (ephemeral)
   targetMessageId: string | null
+  // Session-only new-message divider per room (jid -> messageId). Derived at
+  // activation from lastSeenMessageId; never persisted.
+  firstNewMessageMarkers: Map<string, string>
 
   // Actions
   addRoom: (room: Room) => void
@@ -474,7 +477,7 @@ function createEmptyRoomState(
   dismissedPollIds: Map<string, Set<string>> = new Map(),
   roomGaps: Map<string, GapInterval> = new Map(),
   acknowledgedNonAnonymousRooms: Set<string> = new Set(),
-): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'acknowledgedNonAnonymousRooms' | 'targetMessageId'> {
+): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'acknowledgedNonAnonymousRooms' | 'targetMessageId' | 'firstNewMessageMarkers'> {
   return {
     rooms: new Map(),
     roomEntities: new Map(),
@@ -489,6 +492,7 @@ function createEmptyRoomState(
     roomGaps,
     acknowledgedNonAnonymousRooms,
     targetMessageId: null,
+    firstNewMessageMarkers: new Map(),
   }
 }
 
@@ -530,7 +534,6 @@ export const roomStore = createStore<RoomState>()(
         notifyAllPersistent: room.notifyAllPersistent,
         lastReadAt: room.lastReadAt,
         lastSeenMessageId: room.lastSeenMessageId,
-        firstNewMessageId: room.firstNewMessageId,
         lastMessage: room.messages?.length > 0 ? findLastNonIgnoredMessage(room.messages, room.jid, room.nickToJidCache) : undefined,
         lastInteractedAt: room.lastInteractedAt,
       }
@@ -579,7 +582,7 @@ export const roomStore = createStore<RoomState>()(
 
       // Update metadata fields if any changed
       const metaFields = ['unreadCount', 'mentionsCount', 'typingUsers', 'notifyAll',
-        'notifyAllPersistent', 'lastReadAt', 'firstNewMessageId', 'lastInteractedAt'] as const
+        'notifyAllPersistent', 'lastReadAt', 'lastInteractedAt'] as const
       const hasMetaUpdate = metaFields.some((f) => f in update)
 
       // Update runtime fields if any changed
@@ -630,7 +633,6 @@ export const roomStore = createStore<RoomState>()(
             notifyAll: updatedRoom.notifyAll,
             notifyAllPersistent: updatedRoom.notifyAllPersistent,
             lastReadAt: updatedRoom.lastReadAt,
-            firstNewMessageId: updatedRoom.firstNewMessageId,
             lastInteractedAt: updatedRoom.lastInteractedAt,
           })
         }
@@ -1060,7 +1062,7 @@ export const roomStore = createStore<RoomState>()(
         mentionsCount: existingMeta?.mentionsCount ?? existing.mentionsCount,
         lastReadAt: existingMeta?.lastReadAt ?? existing.lastReadAt,
         lastSeenMessageId: existingMeta?.lastSeenMessageId ?? existing.lastSeenMessageId,
-        firstNewMessageId: existingMeta?.firstNewMessageId ?? existing.firstNewMessageId,
+        firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
       }
 
       const updated = notifState.onMessageReceived(
@@ -1095,7 +1097,6 @@ export const roomStore = createStore<RoomState>()(
         unreadCount: updated.unreadCount,
         mentionsCount: updated.mentionsCount,
         lastReadAt: updated.lastReadAt,
-        firstNewMessageId: updated.firstNewMessageId,
         lastMessage,
         lastInteractedAt: newLastInteractedAt,
       })
@@ -1115,13 +1116,17 @@ export const roomStore = createStore<RoomState>()(
           unreadCount: updated.unreadCount,
           mentionsCount: updated.mentionsCount,
           lastReadAt: updated.lastReadAt,
-          firstNewMessageId: updated.firstNewMessageId,
           lastMessage,
           lastInteractedAt: newLastInteractedAt,
         })
       }
 
-      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta }
+      // Session-only divider (parity with chatStore.addMessage).
+      const newMarkers = new Map(state.firstNewMessageMarkers)
+      if (updated.firstNewMessageId) newMarkers.set(roomJid, updated.firstNewMessageId)
+      else newMarkers.delete(roomJid)
+
+      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
     })
   },
 
@@ -1310,7 +1315,7 @@ export const roomStore = createStore<RoomState>()(
         mentionsCount: meta?.mentionsCount ?? existing.mentionsCount,
         lastReadAt: meta?.lastReadAt ?? existing.lastReadAt,
         lastSeenMessageId: meta?.lastSeenMessageId ?? existing.lastSeenMessageId,
-        firstNewMessageId: meta?.firstNewMessageId ?? existing.firstNewMessageId,
+        firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
       }
 
       const runtime = state.roomRuntime.get(roomJid)
@@ -1352,17 +1357,7 @@ export const roomStore = createStore<RoomState>()(
     // (no longer every visited room holds up to MAX_MESSAGES_PER_ROOM) and shrinks
     // the DOM mounted on the next switch into a large room.
     if (prevJid && prevJid !== roomJid) {
-      const prevMeta = get().roomMeta.get(prevJid)
-      const hadMarker = !!prevMeta?.firstNewMessageId
-      const clearedFirstNewMessageId = hadMarker
-        ? notifState.onDeactivate({
-            unreadCount: prevMeta!.unreadCount,
-            mentionsCount: prevMeta!.mentionsCount,
-            lastReadAt: prevMeta!.lastReadAt,
-            lastSeenMessageId: prevMeta!.lastSeenMessageId,
-            firstNewMessageId: prevMeta!.firstNewMessageId,
-          }).firstNewMessageId
-        : undefined
+      const hadMarker = get().firstNewMessageMarkers.has(prevJid)
 
       set((state) => {
         // Evict from the runtime mirror (messages live here).
@@ -1372,21 +1367,17 @@ export const roomStore = createStore<RoomState>()(
           newRuntime.set(prevJid, { ...prevRuntime, messages: [] })
         }
 
-        // Evict from the combined map mirror; carry the (possibly cleared) marker.
+        // Evict from the combined map mirror.
         const newRooms = new Map(state.rooms)
         const prevRoom = newRooms.get(prevJid)
         if (prevRoom) {
-          const updatedPrevRoom = { ...prevRoom, messages: [] }
-          if (hadMarker) updatedPrevRoom.firstNewMessageId = clearedFirstNewMessageId
-          newRooms.set(prevJid, updatedPrevRoom)
+          newRooms.set(prevJid, { ...prevRoom, messages: [] })
         }
 
-        const newMeta = new Map(state.roomMeta)
-        if (prevMeta && hadMarker) {
-          newMeta.set(prevJid, { ...prevMeta, firstNewMessageId: clearedFirstNewMessageId })
-        }
+        const newMarkers = new Map(state.firstNewMessageMarkers)
+        if (hadMarker) newMarkers.delete(prevJid)
 
-        return { roomRuntime: newRuntime, rooms: newRooms, roomMeta: newMeta }
+        return { roomRuntime: newRuntime, rooms: newRooms, firstNewMessageMarkers: newMarkers }
       })
     }
 
@@ -1399,7 +1390,7 @@ export const roomStore = createStore<RoomState>()(
           mentionsCount: meta?.mentionsCount ?? room.mentionsCount,
           lastReadAt: meta?.lastReadAt ?? room.lastReadAt,
           lastSeenMessageId: meta?.lastSeenMessageId ?? room.lastSeenMessageId,
-          firstNewMessageId: meta?.firstNewMessageId ?? room.firstNewMessageId,
+          firstNewMessageId: get().firstNewMessageMarkers.get(roomJid),
         }
 
         const runtime = get().roomRuntime.get(roomJid)
@@ -1418,7 +1409,6 @@ export const roomStore = createStore<RoomState>()(
             mentionsCount: activated.mentionsCount,
             lastReadAt: activated.lastReadAt,
             lastSeenMessageId: activated.lastSeenMessageId,
-            firstNewMessageId: activated.firstNewMessageId,
             lastInteractedAt: newLastInteractedAt,
           }
           const newMeta = new Map(state.roomMeta)
@@ -1430,10 +1420,12 @@ export const roomStore = createStore<RoomState>()(
             mentionsCount: activated.mentionsCount,
             lastReadAt: activated.lastReadAt,
             lastSeenMessageId: activated.lastSeenMessageId,
-            firstNewMessageId: activated.firstNewMessageId,
             lastInteractedAt: newLastInteractedAt,
           })
-          return { roomMeta: newMeta, rooms: newRooms, activeRoomJid: roomJid }
+          const newMarkers = new Map(state.firstNewMessageMarkers)
+          if (activated.firstNewMessageId) newMarkers.set(roomJid, activated.firstNewMessageId)
+          else newMarkers.delete(roomJid)
+          return { roomMeta: newMeta, rooms: newRooms, activeRoomJid: roomJid, firstNewMessageMarkers: newMarkers }
         })
         return
       }
@@ -1461,29 +1453,10 @@ export const roomStore = createStore<RoomState>()(
 
   clearFirstNewMessageId: (roomJid) => {
     set((state) => {
-      const existing = state.rooms.get(roomJid)
-      const meta = state.roomMeta.get(roomJid)
-      const hasFirstNewMessage = meta?.firstNewMessageId ?? existing?.firstNewMessageId
-      if (!existing || !hasFirstNewMessage) return state
-
-      const notifInput: notifState.EntityNotificationState = {
-        unreadCount: meta?.unreadCount ?? existing.unreadCount,
-        mentionsCount: meta?.mentionsCount ?? existing.mentionsCount,
-        lastReadAt: meta?.lastReadAt ?? existing.lastReadAt,
-        lastSeenMessageId: meta?.lastSeenMessageId ?? existing.lastSeenMessageId,
-        firstNewMessageId: meta?.firstNewMessageId ?? existing.firstNewMessageId,
-      }
-      const cleared = notifState.onClearMarker(notifInput)
-
-      const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...existing, firstNewMessageId: cleared.firstNewMessageId })
-
-      const newMeta = new Map(state.roomMeta)
-      if (meta) {
-        newMeta.set(roomJid, { ...meta, firstNewMessageId: cleared.firstNewMessageId })
-      }
-
-      return { rooms: newRooms, roomMeta: newMeta }
+      if (!state.firstNewMessageMarkers.has(roomJid)) return state
+      const newMarkers = new Map(state.firstNewMessageMarkers)
+      newMarkers.delete(roomJid)
+      return { firstNewMessageMarkers: newMarkers }
     })
   },
 
@@ -1501,7 +1474,7 @@ export const roomStore = createStore<RoomState>()(
         mentionsCount: meta?.mentionsCount ?? existing.mentionsCount,
         lastReadAt: meta?.lastReadAt ?? existing.lastReadAt,
         lastSeenMessageId: meta?.lastSeenMessageId ?? existing.lastSeenMessageId,
-        firstNewMessageId: meta?.firstNewMessageId ?? existing.firstNewMessageId,
+        firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
       }
       const updated = notifState.onMessageSeen(notifInput, messageId, messages)
       if (updated === notifInput) return state
@@ -1547,7 +1520,7 @@ export const roomStore = createStore<RoomState>()(
           mentionsCount: meta.mentionsCount,
           lastReadAt: meta.lastReadAt,
           lastSeenMessageId: meta.lastSeenMessageId,
-          firstNewMessageId: meta.firstNewMessageId,
+          firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
         },
         match.id,
         messages

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1448,6 +1448,11 @@ export const roomStore = createStore<RoomState>()(
       await get().loadMessagesFromCache(roomJid, { limit: 100 })
       // A newer activation started while the cache read was in flight
       if (token !== activationToken) return
+      // XEP-0490: fold any pending remote read position into lastSeenMessageId
+      // BEFORE setActiveRoom derives the new-message divider (parity with
+      // chatStore.activateConversation). Forward-only against the loaded messages.
+      const pending = get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId
+      if (pending) get().applyRemoteDisplayed(roomJid, pending)
     }
     get().setActiveRoom(roomJid)
   },


### PR DESCRIPTION
## Summary

Two coupled changes to XEP-0490 (Message Displayed Synchronization) read-position handling.

### 1. Restore the new-message divider to the synced read position (bug fix)

On a fresh session the MDS read marker for a conversation can arrive before that conversation's messages are loaded, so it is stashed as `pendingRemoteDisplayedStanzaId`. Activation loaded messages and then derived the "new message" divider, but never resolved the pending marker first, so the divider (and the scroll-to-divider on open) was computed from a stale local read position. Opening a conversation already read on another device could show those messages as new and restore to the wrong place, and it did not self-correct within the session.

`activateConversation` / `activateRoom` now resolve the pending marker (via the existing forward-only `applyRemoteDisplayed`) before deriving the divider, so it lands at the device-synced position.

### 2. Make the new-message divider session-only state

The divider (`firstNewMessageId`) is a derived, per-activation UI marker, yet it lived inside the durable metadata types. For 1:1 chats it was persisted, which is vestigial (it is recomputed on every activation and read only for the active conversation) and could drift across the late-sync window. It is now removed from `ConversationMetadata` / `RoomMetadata` and parked in a session-only `firstNewMessageMarkers` map per store, so it can never be persisted. For chat this de-persists it; rooms were never persisted, so the change there is architectural symmetry.

The pure `notificationState` derivation engine is unchanged; only where the store parks the computed value changed. The "frozen while active" behavior (the divider does not jump when a sync resolves mid-view) is preserved.