### PR TITLE
fix(chat): default message-list virtualization OFF until scroll integration is reworked

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -191,7 +191,7 @@ export function MessageList<T extends BaseMessage>({
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   // --------------------------------------------------------------------------
-  // VIRTUALIZATION (behind the enableMessageVirtualization flag, default ON)
+  // VIRTUALIZATION (behind the enableMessageVirtualization flag, default OFF)
   // --------------------------------------------------------------------------
 
   const showLoading = !!(isLoading && loadingState)

--- a/apps/fluux/src/utils/featureFlags.test.ts
+++ b/apps/fluux/src/utils/featureFlags.test.ts
@@ -4,22 +4,22 @@ import { isFeatureEnabled } from './featureFlags'
 describe('isFeatureEnabled', () => {
   beforeEach(() => localStorage.clear())
 
-  it('enableMessageVirtualization defaults to true (ON) when unset', () => {
-    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(true)
-  })
-
-  it('is disabled only when the stored value is exactly "false"', () => {
-    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'false')
+  it('enableMessageVirtualization defaults to false (OFF) when unset', () => {
     expect(isFeatureEnabled('enableMessageVirtualization')).toBe(false)
   })
 
-  it('an explicit "true" keeps it enabled', () => {
+  it('an explicit "true" enables it (opt-in)', () => {
     localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
     expect(isFeatureEnabled('enableMessageVirtualization')).toBe(true)
   })
 
-  it('any other stored value falls back to the default (ON)', () => {
+  it('an explicit "false" keeps it disabled', () => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'false')
+    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(false)
+  })
+
+  it('any other stored value falls back to the default (OFF)', () => {
     localStorage.setItem('fluux:flags:enableMessageVirtualization', '1')
-    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(true)
+    expect(isFeatureEnabled('enableMessageVirtualization')).toBe(false)
   })
 })

--- a/apps/fluux/src/utils/featureFlags.ts
+++ b/apps/fluux/src/utils/featureFlags.ts
@@ -2,10 +2,15 @@ export type FeatureFlag = 'enableMessageVirtualization'
 
 /** Default state per flag (the shipped behavior when localStorage has no override). */
 const FLAG_DEFAULTS: Record<FeatureFlag, boolean> = {
-  // Message-list virtualization: ON by default. Bounds the mounted DOM to the visible
-  // window so per-interaction cost (typing, scroll, room entry) no longer scales with
-  // resident message count, and cures the WebKitGTK large-room switch freeze.
-  enableMessageVirtualization: true,
+  // Message-list virtualization: OFF by default. It bounds the mounted DOM to the visible
+  // window (per-interaction render cost stops scaling with resident message count, and it
+  // cures the WebKitGTK large-room switch freeze), but its scroll integration is not yet
+  // sound: the app manages scroll imperatively (prepend restore, scroll-to-bottom,
+  // bottom-stick) assuming accurate, stable heights, while @tanstack reports estimated,
+  // shifting heights. The result is prepend drift, scroll-to-bottom landing on a blank
+  // window, and bottom-stick oscillation. Kept OFF until scroll ownership is reworked so the
+  // virtualizer owns scroll position. Opt in for testing via the localStorage override below.
+  enableMessageVirtualization: false,
 }
 
 /**


### PR DESCRIPTION
## Summary

Message-list virtualization has been ON by default since #638, but its scroll integration is not sound and breaks core UX:
- prepend (load-older on scroll-up) does not hold the viewport
- the scroll-to-bottom button can land on a blank window until the user scrolls
- bottom-stick oscillates after a prepend