### PR TITLE
perf(sidebar): id-only subscriptions for ConversationList + ContactList

### DIFF
--- a/apps/fluux/src/components/sidebar-components/ContactList.memo.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.memo.test.tsx
@@ -54,21 +54,30 @@ vi.mock('@/utils/statusText', () => ({ getTranslatedStatusText: () => '' }))
 
 vi.mock('@/utils/renderLoopDetector', () => ({ detectRenderLoop: () => {} }))
 
+// ContactList now subscribes to the group-encoded sidebar entries and each ContactItem
+// self-subscribes to its own contact by jid. The mocks drive both.
 const removeContact = vi.fn()
 const renameContact = vi.fn(async () => {})
-let mockContacts: Contact[] = []
+let mockEntries: string[] = []
+let mockContacts = new Map<string, Contact>()
 
 vi.mock('@fluux/sdk', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@fluux/sdk')>()
   return {
     ...actual,
-    useRoster: () => ({ sortedContacts: mockContacts, removeContact, renameContact }),
+    useContactIdentities: () => new Map(),
+    useRosterActions: () => ({ removeContact, renameContact }),
     useAdminPermissions: () => ({ isAdmin: false, hasUserCommands: false, canManageUser: () => false }),
+    rosterStore: { getState: () => ({ contacts: mockContacts }) },
   }
 })
 
 vi.mock('@fluux/sdk/react', () => ({
   useConnectionStore: (selector: (s: { status: string }) => unknown) => selector({ status: 'online' }),
+  // Serves both the parent's `contactSidebarEntries()` selector and each row's
+  // `contacts.get(jid)` selector.
+  useRosterStore: (selector: (s: { contactSidebarEntries: () => string[]; contacts: Map<string, Contact> }) => unknown) =>
+    selector({ contactSidebarEntries: () => mockEntries, contacts: mockContacts }),
 }))
 
 const makeContact = (jid: string, over: Partial<Contact> = {}): Contact => ({
@@ -79,33 +88,36 @@ const makeContact = (jid: string, over: Partial<Contact> = {}): Contact => ({
   ...over,
 }) as Contact
 
-describe('ContactList row memoization', () => {
+describe('ContactList id-only subscription', () => {
   beforeEach(() => { avatarRenders.count = 0 })
 
-  it('re-renders only the changed contact row when a single contact updates', () => {
+  it('renders one row per contact from the sidebar entries', () => {
     const alice = makeContact('alice@example.com')
     const bob = makeContact('bob@example.com')
-    const carol = makeContact('carol@example.com')
-    mockContacts = [alice, bob, carol]
+    const carol = makeContact('carol@example.com', { presence: 'offline' })
+    mockContacts = new Map([[alice.jid, alice], [bob.jid, bob], [carol.jid, carol]])
+    mockEntries = ['online alice@example.com', 'online bob@example.com', 'offline carol@example.com']
 
-    // Stable props that must NOT break the row memo across the re-render.
+    render(<ContactList onSelectContact={() => {}} />)
+
+    expect(avatarRenders.count).toBe(3)
+  })
+
+  it('memoizes rows: re-rendering the parent with unchanged entries re-renders no row', () => {
+    const alice = makeContact('alice@example.com')
+    const bob = makeContact('bob@example.com')
+    mockContacts = new Map([[alice.jid, alice], [bob.jid, bob]])
+    mockEntries = ['online alice@example.com', 'online bob@example.com']
+
     const onSelectContact = () => {}
     const { rerender } = render(<ContactList onSelectContact={onSelectContact} />)
-
-    expect(avatarRenders.count).toBeGreaterThan(0)
-    const perRowCost = avatarRenders.count / 3 // avatars per row at mount (3 online contacts)
     const afterMount = avatarRenders.count
+    expect(afterMount).toBe(2)
 
-    // Mirror rosterStore.updatePresence: a NEW contacts array where only bob's object is
-    // replaced (alice & carol keep their refs); bob stays "online-ish" (away ≠ offline) so
-    // group membership is unchanged — only his row's data differs.
-    const bobAway = makeContact('bob@example.com', { presence: 'away' })
-    mockContacts = [alice, bobAway, carol]
+    // Each row gets a stable jid + stable handlers, so a parent re-render must NOT
+    // cascade into the memoized rows (in production only the row whose own contact
+    // changed re-renders, via its per-jid store subscription).
     rerender(<ContactList onSelectContact={onSelectContact} />)
-
-    const delta = avatarRenders.count - afterMount
-    // Only bob's row should re-render — one row's worth, NOT all three.
-    expect(delta).toBeGreaterThan(0)
-    expect(delta).toBeLessThanOrEqual(perRowCost)
+    expect(avatarRenders.count).toBe(afterMount)
   })
 })

--- a/apps/fluux/src/components/sidebar-components/ContactList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useShallow } from 'zustand/react/shallow'
 import { useContextMenu, useTypeToFocus, useListKeyboardNav } from '@/hooks'
-import { useRoster, useAdminPermissions, type Contact } from '@fluux/sdk'
-import { useConnectionStore } from '@fluux/sdk/react'
+import { useContactIdentities, useRosterActions, useAdminPermissions, rosterStore, type Contact } from '@fluux/sdk'
+import { useConnectionStore, useRosterStore } from '@fluux/sdk/react'
 import { Avatar } from '../Avatar'
 import { RenameContactModal } from '../RenameContactModal'
 import { Tooltip } from '../Tooltip'
@@ -22,7 +23,13 @@ interface ContactListProps {
 export function ContactList({ onStartChat, onSelectContact, onManageUser, activeContactJid }: ContactListProps) {
   detectRenderLoop('ContactList')
   const { t } = useTranslation()
-  const { sortedContacts, removeContact, renameContact } = useRoster()
+  // Subscribe to the group-encoded, sidebar-ordered contact entries (presence-stable
+  // under useShallow: a flap that stays in the same group does NOT re-render the list)
+  // and to identity-only data for search (also presence-stable). Each ContactItem
+  // self-subscribes to its own contact by jid. (Mirrors RoomsList / ConversationList.)
+  const entries = useRosterStore(useShallow((s) => s.contactSidebarEntries()))
+  const identities = useContactIdentities()
+  const { removeContact, renameContact } = useRosterActions()
   const connectionStatus = useConnectionStore((s) => s.status)
   const forceOffline = connectionStatus !== 'online'
   const [searchQuery, setSearchQuery] = useState('')
@@ -33,33 +40,38 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
   // Type-to-focus: focus search input when user starts typing anywhere
   useTypeToFocus(searchInputRef)
 
-  // Filter contacts based on search query
-  const filteredContacts = (() => {
-    if (!searchQuery.trim()) {
-      return sortedContacts
-    }
-    const query = searchQuery.toLowerCase()
-    return sortedContacts.filter(contact => {
-      const username = contact.jid.split('@')[0].toLowerCase()
-      return contact.name.toLowerCase().includes(query) || username.includes(query)
-    })
-  })()
+  // Search matches name (from identity-only data, presence-stable) or the local part.
+  const query = searchQuery.trim().toLowerCase()
+  const matchesQuery = (jid: string) => {
+    if (!query) return true
+    const name = identities.get(jid)?.name.toLowerCase() ?? ''
+    return name.includes(query) || jid.split('@')[0].toLowerCase().includes(query)
+  }
 
-  const getDisplayPresence = (contact: Contact) => (forceOffline ? 'offline' : contact.presence)
-
-  // Flat list of contacts in display order (online, offline, errored)
-  const errored = filteredContacts.filter(c => c.presenceError)
-  const online = filteredContacts.filter(c => !c.presenceError && getDisplayPresence(c) !== 'offline')
-  const offline = filteredContacts.filter(c => !c.presenceError && getDisplayPresence(c) === 'offline')
-  const flatContactList = [...online, ...offline, ...errored]
-
-  // Map from jid to flat index for quick lookup
-  const jidToIndex = new Map(flatContactList.map((c, i) => [c.jid, i]))
+  // Decode entries into display sections (jids). When disconnected (forceOffline),
+  // every non-errored contact shows in the offline section. flatJids is the flat
+  // top-to-bottom order used for keyboard navigation.
+  const online: string[] = []
+  const offline: string[] = []
+  const errored: string[] = []
+  const flatJids: string[] = []
+  for (const entry of entries) {
+    const sep = entry.indexOf(' ')
+    const group = entry.slice(0, sep)
+    const jid = entry.slice(sep + 1)
+    if (!matchesQuery(jid)) continue
+    flatJids.push(jid)
+    if (group === 'errored') errored.push(jid)
+    else if (forceOffline || group === 'offline') offline.push(jid)
+    else online.push(jid)
+  }
+  const jidToIndex = new Map(flatJids.map((jid, i) => [jid, i]))
 
   // Reference-STABLE row callbacks for the memoized ContactItem. Their identity must stay
-  // fixed across re-renders or the memo no-ops and the WHOLE roster re-renders row by row
-  // on every presence stanza (rosterStore replaces the contacts Map each time). Same
-  // lazy-init + "latest" ref pattern as RoomsList (compiler-proof; useCallback is stripped).
+  // fixed across re-renders or the memo no-ops and the WHOLE roster re-renders row by row.
+  // Same lazy-init + "latest" ref pattern as RoomsList (compiler-proof; useCallback is
+  // stripped). onSelect / onStartChat take the Contact (ContactItem self-subscribes and
+  // passes its own); the rest take a jid.
   const latestRef = useRef({ onSelectContact, onStartChat, removeContact, renameContact, onManageUser })
   latestRef.current = { onSelectContact, onStartChat, removeContact, renameContact, onManageUser }
   const rowHandlersRef = useRef<{
@@ -79,19 +91,22 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
     }
   }
   const rowHandlers = rowHandlersRef.current
-  // Manage handler is exposed only when the capability exists (parent passed onManageUser);
-  // ContactItem keys its "Manage" menu item off this being defined. `onManageUser` is a
-  // stable prop so this derived value stays referentially stable across renders.
   const onManageUserStable = onManageUser ? rowHandlers.onManageUser : undefined
 
-  // Keyboard navigation using the hook
-  // Plain arrows: just highlight, Alt+arrows: navigate AND open contact profile
-  const { selectedIndex, isKeyboardNav, getItemProps, getContainerProps } = useListKeyboardNav({
-    items: flatContactList,
-    onSelect: rowHandlers.onSelect,
+  // Keyboard navigation works over the flat jid list; onSelect resolves jid -> contact.
+  const selectByJidRef = useRef<((jid: string) => void) | null>(null)
+  if (!selectByJidRef.current) {
+    selectByJidRef.current = (jid: string) => {
+      const c = rosterStore.getState().contacts.get(jid)
+      if (c) rowHandlers.onSelect(c)
+    }
+  }
+  const { selectedIndex, isKeyboardNav, getItemProps, getContainerProps } = useListKeyboardNav<string>({
+    items: flatJids,
+    onSelect: selectByJidRef.current,
     listRef,
     searchInputRef,
-    getItemId: (contact) => contact.jid,
+    getItemId: (jid) => jid,
     itemAttribute: 'data-contact-jid',
     zoneRef,
     enableBounce: true,
@@ -101,7 +116,7 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
   // Active contact gets the marker-bar treatment (parity with Messages/Rooms).
   // Keyboard-nav highlight is a separate, transient state that can coexist with active.
   const activeJid = activeContactJid ?? null
-  const selectedJid = selectedIndex >= 0 ? (flatContactList[selectedIndex]?.jid ?? null) : null
+  const selectedJid = selectedIndex >= 0 ? (flatJids[selectedIndex] ?? null) : null
 
   return (
     <div className="flex flex-col h-full">
@@ -126,11 +141,11 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
 
       {/* Contact list */}
       <div ref={listRef} className="flex-1 overflow-y-auto px-2 pb-2" {...getContainerProps()}>
-        {sortedContacts.length === 0 ? (
+        {entries.length === 0 ? (
           <div className="px-1 py-4 text-fluux-muted text-sm text-center">
             {t('contacts.noContacts')}
           </div>
-        ) : filteredContacts.length === 0 ? (
+        ) : flatJids.length === 0 ? (
           <div className="px-1 py-4 text-fluux-muted text-sm text-center">
             {t('contacts.noContactsFound')}
           </div>
@@ -139,7 +154,7 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
             {online.length > 0 && (
               <ContactGroup
                 title={`${t('contacts.online')} — ${online.length}`}
-                contacts={online}
+                jids={online}
                 activeJid={activeJid}
                 selectedJid={selectedJid}
                 isKeyboardNav={isKeyboardNav}
@@ -156,7 +171,7 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
             {offline.length > 0 && (
               <ContactGroup
                 title={`${t('contacts.offline')} — ${offline.length}`}
-                contacts={offline}
+                jids={offline}
                 activeJid={activeJid}
                 selectedJid={selectedJid}
                 isKeyboardNav={isKeyboardNav}
@@ -173,7 +188,7 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
             {errored.length > 0 && (
               <ContactGroup
                 title={`${t('contacts.error')} — ${errored.length}`}
-                contacts={errored}
+                jids={errored}
                 activeJid={activeJid}
                 selectedJid={selectedJid}
                 isKeyboardNav={isKeyboardNav}
@@ -196,7 +211,7 @@ export function ContactList({ onStartChat, onSelectContact, onManageUser, active
 
 interface ContactGroupProps {
   title: string
-  contacts: Contact[]
+  jids: string[]
   activeJid: string | null
   selectedJid: string | null
   isKeyboardNav: boolean
@@ -216,7 +231,7 @@ interface ContactGroupProps {
 
 function ContactGroup({
   title,
-  contacts,
+  jids,
   activeJid,
   selectedJid,
   isKeyboardNav,
@@ -235,15 +250,15 @@ function ContactGroup({
         {title}
       </h3>
       <div className="space-y-0.5">
-        {contacts.map((contact) => {
-          const flatIndex = jidToIndex.get(contact.jid) ?? -1
+        {jids.map((jid) => {
+          const flatIndex = jidToIndex.get(jid) ?? -1
           const itemProps = getItemProps(flatIndex)
           return (
             <ContactItem
-              key={contact.jid}
-              contact={contact}
-              isActive={contact.jid === activeJid}
-              isSelected={contact.jid === selectedJid}
+              key={jid}
+              jid={jid}
+              isActive={jid === activeJid}
+              isSelected={jid === selectedJid}
               isKeyboardNav={isKeyboardNav}
               onSelect={onSelect}
               onStartChat={onStartChat}
@@ -262,7 +277,7 @@ function ContactGroup({
 }
 
 interface ContactItemProps {
-  contact: Contact
+  jid: string
   isActive?: boolean
   isSelected?: boolean
   isKeyboardNav?: boolean
@@ -277,7 +292,7 @@ interface ContactItemProps {
 }
 
 const ContactItem = memo(function ContactItem({
-  contact,
+  jid,
   isActive,
   isSelected,
   isKeyboardNav,
@@ -298,9 +313,14 @@ const ContactItem = memo(function ContactItem({
   // gets its own subscription, so narrower selectors mean fewer rows
   // re-render on unrelated admin store updates.
   const { isAdmin, hasUserCommands, canManageUser } = useAdminPermissions()
+  // Per-row subscription: this row re-renders only when ITS contact changes
+  // (presence, avatar, name), not when any other contact's presence flaps.
+  const contact = useRosterStore((s) => s.contacts.get(jid))
+
+  if (!contact) return null
 
   // Check if admin can manage this specific user (based on vhost rights)
-  const showManageOption = isAdmin && hasUserCommands && onManageUser && canManageUser(contact.jid)
+  const showManageOption = isAdmin && hasUserCommands && onManageUser && canManageUser(jid)
 
   // Handle single-click to select contact (shows profile view)
   const handleClick = () => {
@@ -315,7 +335,7 @@ const ContactItem = memo(function ContactItem({
 
   const handleRemove = () => {
     menu.close()
-    onRemove(contact.jid)
+    onRemove(jid)
   }
 
   const handleRename = () => {
@@ -325,7 +345,7 @@ const ContactItem = memo(function ContactItem({
 
   const handleManage = () => {
     menu.close()
-    onManageUser?.(contact.jid)
+    onManageUser?.(jid)
   }
 
   return (

--- a/apps/fluux/src/components/sidebar-components/ConversationList.badge.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.badge.test.tsx
@@ -41,11 +41,27 @@ vi.mock('@/stores/settingsStore', () => ({
     selector({ timeFormat: '24h' }),
 }))
 
+// ConversationItem self-subscribes to its conversation / contact / room by id, so
+// the mock returns the conversation under test via conversations.get(id).
+const h = vi.hoisted(() => ({ conversation: null as Conversation | null }))
+
 vi.mock('@fluux/sdk/react', () => ({
   useConnectionStore: (selector: (s: { status: string }) => unknown) =>
     selector({ status: 'online' }),
-  useChatStore: (selector: (s: { typingStates: Map<string, Set<string>>; drafts: Map<string, string> }) => unknown) =>
-    selector({ typingStates: new Map(), drafts: new Map() }),
+  useChatStore: (selector: (s: {
+    conversations: Map<string, Conversation>
+    typingStates: Map<string, Set<string>>
+    drafts: Map<string, string>
+  }) => unknown) =>
+    selector({
+      conversations: new Map(h.conversation ? [[h.conversation.id, h.conversation]] : []),
+      typingStates: new Map(),
+      drafts: new Map(),
+    }),
+  useRosterStore: (selector: (s: { contacts: Map<string, unknown> }) => unknown) =>
+    selector({ contacts: new Map() }),
+  useRoomStore: (selector: (s: { getRoom: (jid: string) => undefined }) => unknown) =>
+    selector({ getRoom: () => undefined }),
 }))
 
 const makeConversation = (over: Partial<Conversation> = {}): Conversation => ({
@@ -62,14 +78,16 @@ const makeConversation = (over: Partial<Conversation> = {}): Conversation => ({
   ...over,
 }) as Conversation
 
-const renderItem = (conversation: Conversation) =>
-  render(
+const renderItem = (conversation: Conversation) => {
+  h.conversation = conversation
+  return render(
     <ConversationItem
-      conversation={conversation}
+      conversationId={conversation.id}
       isActive={false}
       onClick={() => {}}
     />
   )
+}
 
 describe('ConversationItem unread badge placement', () => {
   it('anchors the unread badge to the avatar as an absolute overlay', () => {

--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -1,20 +1,17 @@
-import React, { useState, useRef, useEffect, memo, useCallback } from 'react'
+import React, { useState, useRef, useEffect, memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useShallow } from 'zustand/react/shallow'
 import { useListKeyboardNav, useRouteSync } from '@/hooks'
 import { detectRenderLoop, trackSelectorChange } from '@/utils/renderLoopDetector'
 import {
-  useChat,
-  useRoster,
   chatStore,
   roomStore,
   generateConsistentColorHexSync,
   isPreviewableMessage,
   type Conversation,
-  type Contact,
-  type Room,
 } from '@fluux/sdk'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
-import { useChatStore, useConnectionStore } from '@fluux/sdk/react'
+import { useChatStore, useConnectionStore, useRosterStore, useRoomStore } from '@fluux/sdk/react'
 import { Avatar, TypingIndicator } from '../Avatar'
 import { Tooltip } from '../Tooltip'
 import { useSidebarZone, ContactTooltipContent } from './types'
@@ -40,51 +37,33 @@ import {
 export function ConversationList() {
   detectRenderLoop('ConversationList')
   const { t } = useTranslation()
-  const {
-    conversations,
-    activeConversationId,
-    setActiveConversation,
-    deleteConversation,
-    archiveConversation,
-  } = useChat()
-  // Direct store access — avoids subscribing to all room state (activeRoom, activeMessages,
-  // allRooms, roomsWithUnreadCount, etc.) that useRoom() would pull in. During sync,
-  // rapid room updates would cause 500+ renders/second through useRoom().
-  const setActiveRoom = useCallback(async (roomJid: string | null) => {
-    await roomStore.getState().activateRoom(roomJid)
-  }, [])
-  const getRoom = useCallback(
-    (roomJid: string) => roomStore.getState().rooms.get(roomJid),
-    []
-  )
-  const { contacts } = useRoster()
+  // Subscribe ONLY to the sidebar-ordered conversation ids. This re-renders the
+  // list on reorder / membership change, NOT on per-conversation metadata churn
+  // (unread, last message) or presence churn — each ConversationItem subscribes to
+  // its OWN conversation / contact / room by id. (Mirrors RoomsList.)
+  const conversationIds = useChatStore(useShallow((s) => s.conversationSidebarIds()))
+  const activeConversationId = useChatStore((s) => s.activeConversationId)
+  const deleteConversation = useChatStore((s) => s.deleteConversation)
+  const archiveConversation = useChatStore((s) => s.archiveConversation)
   const { navigateToMessages } = useRouteSync()
   const listRef = useRef<HTMLDivElement>(null)
   const zoneRef = useSidebarZone()
 
-  // Diagnostic: track every selector-derived value per render. Dev-only.
-  // Note: typingStates / drafts are NOT subscribed at the list level — each
-  // ConversationItem subscribes to its own entry to avoid re-rendering the
-  // full list on every typing / draft change during background sync.
-  trackSelectorChange('ConversationList', 'conversations', conversations)
+  trackSelectorChange('ConversationList', 'conversationIds', conversationIds)
   trackSelectorChange('ConversationList', 'activeConversationId', activeConversationId)
-  trackSelectorChange('ConversationList', 'contacts', contacts)
-
-  // Create maps for quick lookup
-  const contactMap = new Map(contacts.map(c => [c.jid, c]))
 
   // Identity-stable click handler. useCallback is unreliable here: the React
   // Compiler leaves JSX-only callbacks as fresh closures, which breaks
   // ConversationItem's React.memo and re-renders the whole list on every update.
   // A lazy-init ref + "latest" ref keeps the handler stable for the list's life.
-  const latestNavRef = useRef({ setActiveRoom, setActiveConversation, navigateToMessages })
-  latestNavRef.current = { setActiveRoom, setActiveConversation, navigateToMessages }
+  const latestNavRef = useRef({ navigateToMessages })
+  latestNavRef.current = { navigateToMessages }
   const clickRef = useRef<((convId: string) => void) | null>(null)
   if (!clickRef.current) {
     clickRef.current = (convId: string) => {
       const L = latestNavRef.current
       const hasActive = !!chatStore.getState().activeConversationId
-      void L.setActiveRoom(null)
+      void roomStore.getState().activateRoom(null)
       void chatStore.getState().activateConversation(convId)
       L.navigateToMessages(convId, { replace: hasActive })
     }
@@ -95,18 +74,18 @@ export function ConversationList() {
   // Alt+Arrow navigation is owned by the global handler in useKeyboardShortcuts
   // (goToPreviousItem / goToNextItem). The list reacts via `activeItemId` so the
   // active conversation is scrolled into view regardless of where focus lives.
-  const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav({
-    items: conversations,
-    onSelect: (conv) => handleConversationClick(conv.id),
+  const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav<string>({
+    items: conversationIds,
+    onSelect: (id) => handleConversationClick(id),
     listRef,
-    getItemId: (conv) => conv.id,
+    getItemId: (id) => id,
     itemAttribute: 'data-conv-id',
     zoneRef,
     enableBounce: true,
     activeItemId: activeConversationId,
   })
 
-  if (conversations.length === 0) {
+  if (conversationIds.length === 0) {
     return (
       <div className="px-3 py-4 text-fluux-muted text-sm text-center">
         {t('conversations.noConversations')}
@@ -117,13 +96,11 @@ export function ConversationList() {
   return (
     <SidebarListMenuProvider<Conversation>>
       <div ref={listRef} className="px-2 space-y-0.5" {...getContainerProps()}>
-        {conversations.map((conv, index) => (
+        {conversationIds.map((id, index) => (
           <ConversationItem
-            key={conv.id}
-            conversation={conv}
-            contact={conv.type === 'chat' ? contactMap.get(conv.id) : undefined}
-            room={conv.type === 'groupchat' ? getRoom(conv.id) : undefined}
-            isActive={conv.id === activeConversationId}
+            key={id}
+            conversationId={id}
+            isActive={id === activeConversationId}
             isSelected={index === selectedIndex}
             isKeyboardNav={isKeyboardNav}
             onClick={handleConversationClick}
@@ -146,54 +123,41 @@ export function ConversationList() {
 
 export function ArchiveList() {
   const { t } = useTranslation()
-  const {
-    archivedConversations,
-    activeConversationId,
-    setActiveConversation,
-    deleteConversation,
-    unarchiveConversation,
-  } = useChat()
-  const setActiveRoom = useCallback(async (roomJid: string | null) => {
-    await roomStore.getState().activateRoom(roomJid)
-  }, [])
-  const getRoom = useCallback(
-    (roomJid: string) => roomStore.getState().rooms.get(roomJid),
-    []
-  )
-  const { contacts } = useRoster()
+  const archivedIds = useChatStore(useShallow((s) => s.archivedConversationSidebarIds()))
+  const activeConversationId = useChatStore((s) => s.activeConversationId)
+  const deleteConversation = useChatStore((s) => s.deleteConversation)
+  const unarchiveConversation = useChatStore((s) => s.unarchiveConversation)
   const { navigateToArchive } = useRouteSync()
   const listRef = useRef<HTMLDivElement>(null)
   const zoneRef = useSidebarZone()
 
-  const contactMap = new Map(contacts.map(c => [c.jid, c]))
-
   // Identity-stable click handler (see ConversationList for rationale).
-  const latestNavRef = useRef({ setActiveRoom, setActiveConversation, navigateToArchive })
-  latestNavRef.current = { setActiveRoom, setActiveConversation, navigateToArchive }
+  const latestNavRef = useRef({ navigateToArchive })
+  latestNavRef.current = { navigateToArchive }
   const clickRef = useRef<((convId: string) => void) | null>(null)
   if (!clickRef.current) {
     clickRef.current = (convId: string) => {
       const L = latestNavRef.current
       const hasActive = !!chatStore.getState().activeConversationId
-      void L.setActiveRoom(null)
+      void roomStore.getState().activateRoom(null)
       void chatStore.getState().activateConversation(convId)
       L.navigateToArchive(convId, { replace: hasActive })
     }
   }
   const handleConversationClick = clickRef.current
 
-  const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav({
-    items: archivedConversations,
-    onSelect: (conv) => handleConversationClick(conv.id),
+  const { selectedIndex, isKeyboardNav, getItemProps, getItemAttribute, getContainerProps } = useListKeyboardNav<string>({
+    items: archivedIds,
+    onSelect: (id) => handleConversationClick(id),
     listRef,
-    getItemId: (conv) => conv.id,
+    getItemId: (id) => id,
     itemAttribute: 'data-conv-id',
     zoneRef,
     enableBounce: true,
     activeItemId: activeConversationId,
   })
 
-  if (archivedConversations.length === 0) {
+  if (archivedIds.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-fluux-muted px-4 text-center">
         <Archive className="size-12 mb-3 opacity-50" />
@@ -205,13 +169,11 @@ export function ArchiveList() {
   return (
     <SidebarListMenuProvider<Conversation>>
       <div ref={listRef} className="px-2 space-y-0.5" {...getContainerProps()}>
-        {archivedConversations.map((conv, index) => (
+        {archivedIds.map((id, index) => (
           <ConversationItem
-            key={conv.id}
-            conversation={conv}
-            contact={conv.type === 'chat' ? contactMap.get(conv.id) : undefined}
-            room={conv.type === 'groupchat' ? getRoom(conv.id) : undefined}
-            isActive={conv.id === activeConversationId}
+            key={id}
+            conversationId={id}
+            isActive={id === activeConversationId}
             isSelected={index === selectedIndex}
             isKeyboardNav={isKeyboardNav}
             onClick={handleConversationClick}
@@ -235,9 +197,7 @@ export function ArchiveList() {
 // ============================================================================
 
 interface ConversationItemProps {
-  conversation: Conversation
-  contact?: Contact
-  room?: Room
+  conversationId: string
   isActive: boolean
   isSelected?: boolean
   isKeyboardNav?: boolean
@@ -249,9 +209,7 @@ interface ConversationItemProps {
 }
 
 export const ConversationItem = memo(function ConversationItem({
-  conversation,
-  contact,
-  room,
+  conversationId,
   isActive,
   isSelected,
   isKeyboardNav,
@@ -268,26 +226,35 @@ export const ConversationItem = memo(function ConversationItem({
   const currentLang = i18n.language.split('-')[0]
   const timeFormat = useSettingsStore((s) => s.timeFormat)
 
-  // Per-item subscriptions: each item only re-renders when ITS typing/draft
-  // changes, not when any conversation's state changes.
-  const typingCount = useChatStore((s) => s.typingStates.get(conversation.id)?.size ?? 0)
+  // Per-item subscriptions: each row re-renders only when ITS conversation /
+  // contact / room / typing / draft changes — not when any OTHER conversation
+  // updates or any contact's presence changes. The combined `conversations` map is
+  // updated incrementally, so get(id) is a stable reference until THIS conversation
+  // changes; contacts.get / getRoom are likewise stable per entry. (For a 1:1 the
+  // room lookup is undefined; for a group chat the contact lookup is undefined.)
+  const conversation = useChatStore((s) => s.conversations.get(conversationId))
+  const contact = useRosterStore((s) => s.contacts.get(conversationId))
+  const room = useRoomStore((s) => s.getRoom(conversationId))
+  const typingCount = useChatStore((s) => s.typingStates.get(conversationId)?.size ?? 0)
   const isTyping = typingCount > 0
-  const draft = useChatStore((s) => s.drafts.get(conversation.id))
+  const draft = useChatStore((s) => s.drafts.get(conversationId))
 
-  const isGroupChat = conversation.type === 'groupchat'
   // Room avatars render as a raw <img> (no Avatar fallback). A dead blob: URL
   // (WebKit reclaim across sleep) would otherwise show a broken-image glyph;
   // fall back to the Hash icon instead. Reset when the URL changes.
   const [roomAvatarBroken, setRoomAvatarBroken] = useState(false)
   useEffect(() => { setRoomAvatarBroken(false) }, [room?.avatar])
+
+  if (!conversation) return null
+  const isGroupChat = conversation.type === 'groupchat'
   const menuProps = getItemMenuProps(conversation)
   // While the long-press / context menu is open, highlight the targeted cell so
   // the user can clearly see which conversation the action will apply to.
-  const isMenuTarget = isOpen && targetItem?.id === conversation.id
+  const isMenuTarget = isOpen && targetItem?.id === conversationId
 
   const handleClick = () => {
     if (isOpen || longPressTriggered.current) return
-    onClick(conversation.id)
+    onClick(conversationId)
   }
 
   return (

--- a/packages/fluux-sdk/src/stores/chatStore.sidebar.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.sidebar.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { chatStore } from './chatStore'
+import type { Conversation } from '../core/types/chat'
+
+// Minimal conversation for the sidebar-id selectors, which read only id +
+// lastMessage.timestamp (+ the archived set).
+const conv = (id: string, lastMessageTime?: number): Conversation =>
+  ({
+    id,
+    name: id.split('@')[0],
+    type: 'chat',
+    unreadCount: 0,
+    lastMessage: lastMessageTime != null ? ({ timestamp: new Date(lastMessageTime) } as Conversation['lastMessage']) : undefined,
+  }) as Conversation
+
+describe('chatStore conversation sidebar id selectors', () => {
+  beforeEach(() => {
+    chatStore.setState({ conversations: new Map(), archivedConversations: new Set() })
+  })
+
+  it('conversationSidebarIds returns active ids sorted by last activity (most recent first)', () => {
+    chatStore.setState({
+      conversations: new Map([
+        ['a@x', conv('a@x', 1000)],
+        ['b@x', conv('b@x', 3000)],
+        ['c@x', conv('c@x', 2000)],
+      ]),
+    })
+    expect(chatStore.getState().conversationSidebarIds()).toEqual(['b@x', 'c@x', 'a@x'])
+  })
+
+  it('conversationSidebarIds excludes archived conversations', () => {
+    chatStore.setState({
+      conversations: new Map([
+        ['a@x', conv('a@x', 1000)],
+        ['b@x', conv('b@x', 2000)],
+      ]),
+      archivedConversations: new Set(['b@x']),
+    })
+    expect(chatStore.getState().conversationSidebarIds()).toEqual(['a@x'])
+  })
+
+  it('archivedConversationSidebarIds returns only archived ids, sorted', () => {
+    chatStore.setState({
+      conversations: new Map([
+        ['a@x', conv('a@x', 1000)],
+        ['b@x', conv('b@x', 2000)],
+        ['c@x', conv('c@x', 3000)],
+      ]),
+      archivedConversations: new Set(['a@x', 'c@x']),
+    })
+    expect(chatStore.getState().archivedConversationSidebarIds()).toEqual(['c@x', 'a@x'])
+  })
+
+  it('returns a referentially-stable empty array when there are no conversations', () => {
+    const a = chatStore.getState().conversationSidebarIds()
+    const b = chatStore.getState().conversationSidebarIds()
+    expect(a).toEqual([])
+    expect(a).toBe(b) // stable identity so useShallow consumers never re-render
+  })
+
+  it('content is equal across a non-reordering change (so useShallow bails)', () => {
+    chatStore.setState({
+      conversations: new Map([
+        ['a@x', conv('a@x', 5000)],
+        ['b@x', conv('b@x', 1000)],
+      ]),
+    })
+    const before = chatStore.getState().conversationSidebarIds()
+    // A new message to `a` (already newest) bumps its timestamp but does not reorder.
+    chatStore.setState({
+      conversations: new Map([
+        ['a@x', conv('a@x', 6000)],
+        ['b@x', conv('b@x', 1000)],
+      ]),
+    })
+    expect(chatStore.getState().conversationSidebarIds()).toEqual(before)
+  })
+})

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -33,6 +33,30 @@ const STORAGE_KEY_BASE = 'xmpp-chat-storage'
  * constant instead of creating a new [] instances each time.
  */
 const EMPTY_MESSAGE_ARRAY: Message[] = []
+const EMPTY_CONVERSATION_IDS: string[] = []
+
+/**
+ * Conversation ids (active or archived) sorted by last activity, most recent
+ * first. Powers the sidebar's id-only subscription: the list re-renders only on
+ * reorder/membership change, not on per-conversation metadata churn. Returns a
+ * referentially-stable empty array so useShallow consumers never re-render when
+ * the list is empty.
+ */
+function conversationIdsByActivity(
+  conversations: Map<string, Conversation>,
+  archivedConversations: Set<string>,
+  archived: boolean,
+): string[] {
+  const entries: Array<[string, number]> = []
+  for (const [id, c] of conversations) {
+    if (archivedConversations.has(id) !== archived) continue
+    const ts = c.lastMessage?.timestamp
+    entries.push([id, ts instanceof Date ? ts.getTime() : ts ? new Date(ts).getTime() : 0])
+  }
+  if (entries.length === 0) return EMPTY_CONVERSATION_IDS
+  entries.sort((a, b) => b[1] - a[1])
+  return entries.map((e) => e[0])
+}
 
 // Monotonic token so a slow cache read from a superseded activateConversation
 // call can't overwrite a newer activation when it finally resolves
@@ -127,6 +151,16 @@ interface ChatState {
   isArchived: (id: string) => boolean
   /** Get all non-archived conversations (visible in sidebar) */
   activeConversations: () => Conversation[]
+  /**
+   * Active (non-archived) conversation ids, sorted by last activity (most recent
+   * first). Referentially stable under useShallow when order/membership is
+   * unchanged — the sidebar subscribes to this instead of the full conversation
+   * objects, so presence churn and per-conversation metadata updates don't
+   * re-render the whole list (each row self-subscribes by id).
+   */
+  conversationSidebarIds: () => string[]
+  /** Archived conversation ids, sorted by last activity (most recent first). */
+  archivedConversationSidebarIds: () => string[]
 
   // Actions
   setActiveConversation: (id: string | null) => void
@@ -515,6 +549,15 @@ export const chatStore = createStore<ChatState>()(
           }
         }
         return result
+      },
+
+      conversationSidebarIds: () => {
+        const { conversations, archivedConversations } = get()
+        return conversationIdsByActivity(conversations, archivedConversations, false)
+      },
+      archivedConversationSidebarIds: () => {
+        const { conversations, archivedConversations } = get()
+        return conversationIdsByActivity(conversations, archivedConversations, true)
       },
 
       setActiveConversation: (id) => {

--- a/packages/fluux-sdk/src/stores/rosterSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/rosterSelectors.test.ts
@@ -25,6 +25,7 @@ function createMockState(overrides: Partial<RosterState> = {}): RosterState {
     reset: () => {},
     onlineContacts: () => [],
     sortedContacts: () => [],
+    contactSidebarEntries: () => [],
     ...overrides,
   }
 }

--- a/packages/fluux-sdk/src/stores/rosterStore.contactSidebar.test.ts
+++ b/packages/fluux-sdk/src/stores/rosterStore.contactSidebar.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { rosterStore } from './rosterStore'
+import type { Contact } from '../core/types'
+
+const c = (jid: string, over: Partial<Contact> = {}): Contact =>
+  ({ jid, name: jid.split('@')[0], presence: 'online', subscription: 'both', ...over }) as Contact
+
+describe('rosterStore.contactSidebarEntries', () => {
+  beforeEach(() => rosterStore.setState({ contacts: new Map() }))
+
+  it('groups online (non-offline) / offline / errored, each sorted by name, encoded as `group jid`', () => {
+    rosterStore.setState({
+      contacts: new Map([
+        ['b@x', c('b@x', { name: 'Bob', presence: 'online' })],
+        ['a@x', c('a@x', { name: 'Alice', presence: 'away' })], // away is non-offline -> online group
+        ['z@x', c('z@x', { name: 'Zoe', presence: 'offline' })],
+        ['e@x', c('e@x', { name: 'Err', presenceError: 'forbidden' })],
+      ]),
+    })
+    expect(rosterStore.getState().contactSidebarEntries()).toEqual([
+      'online a@x', // Alice (away) sorts before Bob (online) by NAME within the group
+      'online b@x',
+      'offline z@x',
+      'errored e@x',
+    ])
+  })
+
+  it('a non-offline presence flap (online<->away) does NOT reorder — same group, name-stable', () => {
+    rosterStore.setState({
+      contacts: new Map([
+        ['a@x', c('a@x', { name: 'Alice', presence: 'online' })],
+        ['b@x', c('b@x', { name: 'Bob', presence: 'online' })],
+      ]),
+    })
+    const before = rosterStore.getState().contactSidebarEntries()
+    rosterStore.setState({
+      contacts: new Map([
+        ['a@x', c('a@x', { name: 'Alice', presence: 'away' })], // still non-offline
+        ['b@x', c('b@x', { name: 'Bob', presence: 'online' })],
+      ]),
+    })
+    expect(rosterStore.getState().contactSidebarEntries()).toEqual(before)
+  })
+
+  it('online -> offline moves the contact to the offline group (a real reorder)', () => {
+    rosterStore.setState({ contacts: new Map([['a@x', c('a@x', { name: 'Alice', presence: 'online' })]]) })
+    expect(rosterStore.getState().contactSidebarEntries()).toEqual(['online a@x'])
+    rosterStore.setState({ contacts: new Map([['a@x', c('a@x', { name: 'Alice', presence: 'offline' })]]) })
+    expect(rosterStore.getState().contactSidebarEntries()).toEqual(['offline a@x'])
+  })
+
+  it('returns a referentially-stable empty array when there are no contacts', () => {
+    const a = rosterStore.getState().contactSidebarEntries()
+    expect(a).toEqual([])
+    expect(rosterStore.getState().contactSidebarEntries()).toBe(a)
+  })
+})

--- a/packages/fluux-sdk/src/stores/rosterStore.ts
+++ b/packages/fluux-sdk/src/stores/rosterStore.ts
@@ -25,6 +25,7 @@ function calculateContactColors(jid: string): { colorLight: string; colorDark: s
  * constant instead of creating a new [] instance each time.
  */
 const EMPTY_CONTACT_ARRAY: Contact[] = []
+const EMPTY_CONTACT_ENTRIES: string[] = []
 
 // Selector memoization caches.
 // sortedContacts() and onlineContacts() are called on every Zustand subscription check.
@@ -97,6 +98,15 @@ interface RosterState {
   // Computed
   onlineContacts: () => Contact[]
   sortedContacts: () => Contact[]
+  /**
+   * Sidebar-ordered contact entries, each encoded as `<group> <jid>` where group is
+   * `online` (any non-offline presence) | `offline` | `errored`, sorted by name within
+   * each group. Referentially stable under useShallow when grouping/order is unchanged,
+   * so ContactList subscribes to this instead of the full Contact objects: a presence
+   * flap that stays in the same group (e.g. online<->away) does NOT re-render the list,
+   * and each ContactItem self-subscribes to its own contact by jid.
+   */
+  contactSidebarEntries: () => string[]
 }
 
 /**
@@ -353,6 +363,28 @@ export const rosterStore = createStore<RosterState>((set, get) => ({
       })
     _cachedSortedContacts = result.length > 0 ? result : EMPTY_CONTACT_ARRAY
     return _cachedSortedContacts
+  },
+
+  contactSidebarEntries: () => {
+    const contacts = get().contacts
+    if (contacts.size === 0) return EMPTY_CONTACT_ENTRIES
+    const online: Contact[] = []
+    const offline: Contact[] = []
+    const errored: Contact[] = []
+    for (const c of contacts.values()) {
+      if (c.presenceError) errored.push(c)
+      else if (c.presence !== 'offline') online.push(c)
+      else offline.push(c)
+    }
+    const byName = (a: Contact, b: Contact) => a.name.localeCompare(b.name)
+    online.sort(byName)
+    offline.sort(byName)
+    errored.sort(byName)
+    return [
+      ...online.map((c) => `online ${c.jid}`),
+      ...offline.map((c) => `offline ${c.jid}`),
+      ...errored.map((c) => `errored ${c.jid}`),
+    ]
   },
 }))
 


### PR DESCRIPTION
## Summary

Completes the non-virtualization sidebar render-perf plan by porting the proven RoomsList id-only pattern to the last two list views. In both, the parent subscribed to the full objects (`useChat` / `useRoster`), so any conversation update or presence stanza re-rendered the whole list and every row. Now the parent subscribes to a referentially-stable ordered id list and each row self-subscribes by id, so churn re-renders only the affected row.

### Phase 3 — ConversationList
- New `chatStore` selectors `conversationSidebarIds()` / `archivedConversationSidebarIds()` return the sorted conversation ids, stable under `useShallow` (re-render only on reorder / membership change).
- `ConversationList` and `ArchiveList` subscribe to the id list (no `useChat` / `useRoster`); each `ConversationItem` self-subscribes to its own conversation / contact / room / typing / draft by id. The combined `conversations` map is maintained incrementally, so `get(id)` isolates a row.

Measured (demo harness): ConversationList re-renders on a single contact's presence flap **30 → 0**, on a 100-presence roster sync **100 → 0**, and on messages to an inactive conversation **20 → 0**.

### Phase 4 — ContactList
- New `rosterStore` selector `contactSidebarEntries()` returns the sidebar contacts encoded as `<group> <jid>` (online | offline | errored), sorted by name within each group, stable under `useShallow`.
- `ContactList` subscribes to those entries + `useContactIdentities` (presence-stable search) + `useRosterActions` (no list subscription); each `ContactItem` takes a jid and self-subscribes to its own contact.
- Behaviour note: within a group, contacts are now ordered by name rather than by exact presence sub-state (online > away > dnd), so the list no longer jumps when a contact goes away/online. That stability is what lets the parent skip re-rendering on intra-group presence churn.

Measured (demo harness, Contacts tab): ContactList re-renders on a single contact's presence flap **31 → 0**.