### PR TITLE
fix(muc): sync occupant list when a member's affiliation is removed

### DIFF
--- a/packages/fluux-sdk/src/bindings/storeBindings.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.test.ts
@@ -440,6 +440,20 @@ describe('createStoreBindings', () => {
       expect(avatarLookup('alice@example.com')).toBe('blob:avatar-data')
       expect(avatarLookup('unknown@example.com')).toBeNull()
     })
+
+    it('should handle room:affiliation-changed by updating the cached member list', () => {
+      mockClient.emit('room:affiliation-changed', {
+        roomJid: 'room@conference.example.com',
+        userJid: 'xram@zinid.ru',
+        affiliation: 'none',
+      })
+
+      expect(mockStores.room.updateMemberAffiliation).toHaveBeenCalledWith(
+        'room@conference.example.com',
+        'xram@zinid.ru',
+        'none'
+      )
+    })
   })
 
   describe('roster events', () => {

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -407,6 +407,11 @@ export function createStoreBindings(
     })
   })
 
+  on('room:affiliation-changed', ({ roomJid, userJid, affiliation }) => {
+    const stores = getStores()
+    stores.room.updateMemberAffiliation(roomJid, userJid, affiliation)
+  })
+
   // ============================================================================
   // Roster Events
   // ============================================================================

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -225,6 +225,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       loadMessagesFromCache: roomStore.getState().loadMessagesFromCache,
       loadPreviewFromCache: roomStore.getState().loadPreviewFromCache,
       mergeRoomMembers: roomStore.getState().mergeRoomMembers,
+      updateMemberAffiliation: roomStore.getState().updateMemberAffiliation,
     },
     admin: {
       setIsAdmin: adminStore.getState().setIsAdmin,

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -735,6 +735,7 @@ export const createMockStores = (): MockStoreBindings => ({
     loadMessagesFromCache: vi.fn().mockResolvedValue([]),
     loadPreviewFromCache: vi.fn().mockResolvedValue(null),
     mergeRoomMembers: vi.fn(),
+    updateMemberAffiliation: vi.fn(),
   },
   admin: {
     setIsAdmin: vi.fn(),
@@ -1005,6 +1006,7 @@ export const createMockStoreRefs = (): MockStoreRefs => ({
     removeBookmark: vi.fn(),
     triggerAnimation: vi.fn(),
     mergeRoomMembers: vi.fn(),
+    updateMemberAffiliation: vi.fn(),
     getRoom: vi.fn().mockReturnValue(undefined),
     rooms: new Map(),
     applyRemoteDisplayed: vi.fn(),

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -9,7 +9,7 @@ import type { Element } from '@xmpp/client'
 import type { ConnectionStatus, ConnectionMethod } from './connection'
 import type { Message, Conversation } from './chat'
 import type { PresenceStatus, PresenceShow, Contact, VCardInfo } from './roster'
-import type { Room, RoomOccupant, RoomMessage, RoomMember } from './room'
+import type { Room, RoomOccupant, RoomMessage, RoomMember, RoomAffiliation } from './room'
 import type { SystemNotificationType } from './events'
 import type { ServerInfo } from './discovery'
 import type { HttpUploadService } from './upload'
@@ -210,6 +210,8 @@ export interface StoreBindings {
     loadPreviewFromCache: (roomJid: string) => Promise<RoomMessage | null>
     // XEP-0045: Merge affiliated members (for offline member display, avatar resolution, mentions)
     mergeRoomMembers: (roomJid: string, members: RoomMember[], contactAvatarLookup?: (jid: string) => string | null) => void
+    // XEP-0045: Apply a single affiliation change to the cached member list (none/outcast remove, owner/admin/member upsert)
+    updateMemberAffiliation: (roomJid: string, userJid: string, affiliation: RoomAffiliation) => void
   }
   admin: {
     setIsAdmin: (isAdmin: boolean) => void

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3504,6 +3504,100 @@ describe('roomStore', () => {
     })
   })
 
+  describe('updateMemberAffiliation', () => {
+    const roomJid = 'room@conference.example.com'
+
+    beforeEach(() => {
+      roomStore.getState().addRoom(createRoom(roomJid, { joined: true }))
+    })
+
+    function seedMembers() {
+      roomStore.getState().mergeRoomMembers(roomJid, [
+        { jid: 'alice@example.com', nick: 'Alice', affiliation: 'owner' as const },
+        { jid: 'bob@example.com', nick: 'Bob', affiliation: 'member' as const },
+      ])
+    }
+
+    it("removes a member from affiliatedMembers when affiliation is set to 'none'", () => {
+      seedMembers()
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'bob@example.com', 'none')
+
+      const room = roomStore.getState().rooms.get(roomJid)
+      expect(room?.affiliatedMembers?.map((m) => m.jid)).toEqual(['alice@example.com'])
+    })
+
+    it('removes the last affiliated member (empty-list edge case)', () => {
+      roomStore.getState().mergeRoomMembers(roomJid, [
+        { jid: 'bob@example.com', nick: 'Bob', affiliation: 'member' as const },
+      ])
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'bob@example.com', 'none')
+
+      const room = roomStore.getState().rooms.get(roomJid)
+      expect(room?.affiliatedMembers).toEqual([])
+    })
+
+    it("removes a member when affiliation is set to 'outcast' (banned, not an offline member)", () => {
+      seedMembers()
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'alice@example.com', 'outcast')
+
+      const room = roomStore.getState().rooms.get(roomJid)
+      expect(room?.affiliatedMembers?.map((m) => m.jid)).toEqual(['bob@example.com'])
+    })
+
+    it('updates an existing member affiliation in place (member → admin)', () => {
+      seedMembers()
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'bob@example.com', 'admin')
+
+      const room = roomStore.getState().rooms.get(roomJid)
+      const bob = room?.affiliatedMembers?.find((m) => m.jid === 'bob@example.com')
+      expect(bob?.affiliation).toBe('admin')
+      expect(room?.affiliatedMembers).toHaveLength(2)
+    })
+
+    it('adds an offline user promoted to an affiliation when not already in the list', () => {
+      seedMembers()
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'carol@example.com', 'member')
+
+      const room = roomStore.getState().rooms.get(roomJid)
+      const carol = room?.affiliatedMembers?.find((m) => m.jid === 'carol@example.com')
+      expect(carol).toEqual({ jid: 'carol@example.com', affiliation: 'member' })
+      expect(room?.affiliatedMembers).toHaveLength(3)
+    })
+
+    it("is a no-op when removing a user not in the list", () => {
+      seedMembers()
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'dave@example.com', 'none')
+
+      const room = roomStore.getState().rooms.get(roomJid)
+      expect(room?.affiliatedMembers?.map((m) => m.jid)).toEqual([
+        'alice@example.com',
+        'bob@example.com',
+      ])
+    })
+
+    it('updates roomRuntime alongside the rooms map', () => {
+      seedMembers()
+
+      roomStore.getState().updateMemberAffiliation(roomJid, 'bob@example.com', 'none')
+
+      const runtime = roomStore.getState().roomRuntime.get(roomJid)
+      expect(runtime?.affiliatedMembers?.map((m) => m.jid)).toEqual(['alice@example.com'])
+    })
+
+    it('does nothing for a non-existent room', () => {
+      // Should not throw
+      roomStore
+        .getState()
+        .updateMemberAffiliation('nonexistent@conference.example.com', 'alice@example.com', 'none')
+    })
+  })
+
   describe('updateMessage', () => {
     it('should update message found by client id', () => {
       const roomJid = 'room@conference.example.com'

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -7,6 +7,7 @@ import type {
   RoomRuntime,
   RoomOccupant,
   RoomAffiliation,
+  RoomMember,
   RoomMessage,
   MAMQueryState,
   RSMResponse,
@@ -351,6 +352,12 @@ export interface RoomState {
   updateOccupantAvatars: (roomJid: string, updates: Array<{ nick: string; avatar: string | null; avatarHash: string | null }>) => void
   setSelfOccupant: (roomJid: string, occupant: RoomOccupant) => void
   mergeRoomMembers: (roomJid: string, members: Array<{ jid: string; nick?: string; affiliation: RoomAffiliation }>, contactAvatarLookup?: (jid: string) => string | null) => void
+  /**
+   * Apply a single affiliation change to the cached `affiliatedMembers` list (XEP-0045 admin set).
+   * owner/admin/member upsert the member; none/outcast remove them. Keeps the occupant
+   * sidebar's offline-member list in sync after a change without a full member re-query.
+   */
+  updateMemberAffiliation: (roomJid: string, userJid: string, affiliation: RoomAffiliation) => void
   getRoom: (roomJid: string) => Room | undefined
   switchAccount: (jid: string | null) => void
   reset: () => void
@@ -995,6 +1002,43 @@ export const roomStore = createStore<RoomState>()(
           affiliatedMembers: members,
           ...(cacheChanged && { nickToJidCache, nickToAvatarCache }),
         })
+      }
+
+      return { rooms: newRooms, roomRuntime: newRuntime }
+    })
+  },
+
+  updateMemberAffiliation: (roomJid, userJid, affiliation) => {
+    set((state) => {
+      const existing = state.rooms.get(roomJid)
+      if (!existing) return state
+
+      const current = existing.affiliatedMembers ?? []
+      // owner/admin/member are the tiers shown as offline members; none/outcast are not.
+      const isAffiliated =
+        affiliation === 'owner' || affiliation === 'admin' || affiliation === 'member'
+
+      let next: RoomMember[]
+      if (isAffiliated) {
+        const idx = current.findIndex((m) => m.jid === userJid)
+        if (idx >= 0) {
+          if (current[idx].affiliation === affiliation) return state // no change
+          next = current.map((m) => (m.jid === userJid ? { ...m, affiliation } : m))
+        } else {
+          next = [...current, { jid: userJid, affiliation }]
+        }
+      } else {
+        next = current.filter((m) => m.jid !== userJid)
+        if (next.length === current.length) return state // nothing to remove
+      }
+
+      const newRooms = new Map(state.rooms)
+      newRooms.set(roomJid, { ...existing, affiliatedMembers: next })
+
+      const newRuntime = new Map(state.roomRuntime)
+      const existingRuntime = newRuntime.get(roomJid)
+      if (existingRuntime) {
+        newRuntime.set(roomJid, { ...existingRuntime, affiliatedMembers: next })
       }
 
       return { rooms: newRooms, roomRuntime: newRuntime }


### PR DESCRIPTION
## Summary

Removing a member's affiliation in a MUC (via **Manage Membership** → set affiliation to *none*) did not update the occupant sidebar: the removed user stayed in the **OFFLINE** group with a stale affiliation badge. The membership dialog itself looked correct because it refreshes its own local state.

**Root cause:** `MUC.setAffiliation` emits a `room:affiliation-changed` SDK event, but no store binding ever listened for it, so the cached `affiliatedMembers` list (which feeds the sidebar's offline-member group) was never updated. Online occupants self-correct because the server broadcasts updated presence on an affiliation change; an **offline** member gets no presence broadcast, so the missing binding was the only thing that could have updated the list — making the bug structurally specific to offline affiliated members.

## Changes

- Add a dedicated `updateMemberAffiliation(roomJid, userJid, affiliation)` action to `roomStore`: removes the member on `none`/`outcast`, upserts on `owner`/`admin`/`member`, and updates both the `rooms` and `roomRuntime` maps (mirroring `mergeRoomMembers`).
- Bind `room:affiliation-changed` → `updateMemberAffiliation` in `storeBindings`.
- Thread the new action through the `StoreBindings` type and `defaultStoreBindings` wiring.

A dedicated action is used rather than reusing `mergeRoomMembers`, which early-returns on an empty array and therefore could never remove the *last* affiliated member.