### PR TITLE
fix(messages): drop messages that strip to an empty body instead of storing blank bubbles

### DIFF
--- a/docs/2026-06-25-empty-message-guard-and-chat-marker-display.md
+++ b/docs/2026-06-25-empty-message-guard-and-chat-marker-display.md
@@ -1,0 +1,81 @@
+# Empty-message guard + chat-marker display follow-up
+
+**Date:** 2026-06-25
+**Status:** Part 1 (empty-message guard) — DONE this branch. Part 2 (display markers) — PLANNED, separate code run.
+
+---
+
+## Background — the "empty Cynthia row"
+
+In the XSF room (`xsf@muc.xmpp.org`) a message attributed to *Cynthia* rendered as a
+blank bubble. Investigation of an XMPP trace showed:
+
+- Cynthia sent **no message body** to the room in the captured session — only presence
+  flapping (repeated `status code="333"` "recipient unavailable" kicks + rejoins as her
+  server connection dropped).
+- The blank row was a **pre-existing cached message**: the room's MAM catch-up `start`
+  (`2026-06-25T17:15:14.214Z`) matched the row's timestamp exactly, and the catch-up
+  cursor is derived from the newest cached message (`selectCatchUpQuery`).
+- The only body-less *message-shaped* stanzas the room delivers are **XEP-0333 `<displayed>`
+  chat markers** (singpolyma's, captured live). These were always correctly dropped.
+
+### Root cause (Part 1)
+
+The store-write gates accepted a message when its **raw `<body>`** was non-empty, but the
+message was then stored with **`processedBody`** — the body *after* XEP-0428 fallback
+stripping. A message whose body is entirely a fallback (e.g. a XEP-0461 reply quote with no
+new text, or a whole-body `<fallback><body/></fallback>`) strips to `''` and was stored as a
+blank row. Nothing guarded `processedBody` emptiness.
+
+### Fix shipped (Part 1)
+
+- `hasRenderableContent()` in `core/modules/messagingUtils.ts` — post-parse gate: a message
+  with empty `processedBody` and no attachment / poll / poll-closed / encrypted payload is
+  **dropped** instead of stored. Wired into all four store-write paths: `parseRoomArchiveMessage`,
+  `parseArchiveMessage` (MAM), `processRoomMessage`, `processChatMessage` (live).
+- `isRenderableStoredMessage()` in `utils/messageRenderability.ts` — read-side complement:
+  `messageCache.getMessages` / `getRoomMessages` skip legacy blank rows already on disk, so the
+  existing stale artifact disappears and can no longer seed a catch-up cursor as the newest row.
+  Retraction tombstones, polls, attachments and encrypted placeholders are explicitly kept.
+
+Tests: `messagingUtils.test.ts` (`hasRenderableContent`), `MAM.e2ee.test.ts` (room + 1:1
+archive drop + positive control), `Chat.test.ts` (live 1:1 drop), `messageRenderability.test.ts`
++ `messageCache.test.ts` (read-side prune + tombstone kept).
+
+---
+
+## Part 2 — Display chat markers as read indicators (FUTURE, separate run)
+
+Today incoming XEP-0333 `<displayed>` markers from **other** participants are *dropped* (they
+carry no body, so the gate filters them). The only marker plumbing that exists is
+`mdsSideEffects.ts`, which publishes **our own** read position via XEP-0490 (MDS) — it does not
+surface anyone else's read state.
+
+We may want to **consume** those markers and display read indicators the way Conversations /
+monocles do — e.g. "seen by" / read avatars at the last-read message — rather than silently
+discarding them.
+
+### Why it's deferred
+
+It is a feature, not a correctness fix. It needs its own design pass (UI + data model + perf),
+and Part 1 must land first so markers are cleanly separated from renderable messages.
+
+### Design sketch / open questions for the next run
+
+- **Capture point.** Add an explicit `<displayed>` (and optionally `<received>`) handler in
+  `Chat.handleMessageInternal` *before* the body-presence gate, so markers become first-class
+  read-state signals instead of being dropped. Mirror it on the MAM archive path so read state
+  survives catch-up.
+- **Data model.** Per-conversation read state keyed by occupant. For rooms map the marker's
+  XEP-0421 `occupant-id` → display name; for 1:1 it's just the peer. Store the highest
+  acknowledged stanza-id per reader; never move it backwards.
+- **UI.** 1:1: a single "seen" tick / timestamp on the last outgoing read message. Rooms:
+  aggregated "seen by N" with an avatar row at the last-read message (don't render a marker per
+  occupant inline).
+- **Scale & privacy.** Large public rooms (XSF ≈ 169 occupants) can emit a high volume of
+  markers — coalesce, cap the displayed set, and consider not tracking read state for very large
+  rooms. Respect that some users disable read receipts.
+- **Reuse.** The read-position resolution in `mdsSideEffects.ts` (stanza-id mapping, room-vs-1:1
+  routing, seed-time stash/self-heal) is a good reference for resolving inbound markers too.
+- **Guard interaction.** Whatever consumes markers must `return { handled: true }` so they never
+  fall through to the renderable-message path that Part 1 now also guards.

--- a/packages/fluux-sdk/src/core/modules/Chat.routing.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.routing.test.ts
@@ -317,6 +317,71 @@ describe('Message Routing', () => {
         })
       }))
     })
+
+    it('should NOT store a live groupchat reply whose body is entirely a fallback', async () => {
+      await connectClient()
+
+      const mockRoom = createMockRoom('room@conference.example.com', {
+        joined: true,
+        nickname: 'myname',
+      })
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(mockRoom)
+
+      // XEP-0461 reply quoting an earlier message with no new text: the whole-body
+      // XEP-0428 fallback strips processedBody to '' — nothing to render. The
+      // live room path must drop it, not store a blank bubble (the reported bug).
+      const messageStanza = createMockElement('message', {
+        from: 'room@conference.example.com/otherperson',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'room-empty-reply',
+      }, [
+        { name: 'body', text: '> quoted line' },
+        { name: 'reply', attrs: { xmlns: 'urn:xmpp:reply:0', id: 'orig-r', to: 'room@conference.example.com/bob' } },
+        {
+          name: 'fallback',
+          attrs: { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+          // <body/> with no start/end → entire body is fallback.
+          children: [{ name: 'body', attrs: { xmlns: 'urn:xmpp:fallback:0' } }],
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message', expect.objectContaining({
+        message: expect.objectContaining({ id: 'room-empty-reply' }),
+      }))
+    })
+
+    it('still stores a live groupchat message that has no body but carries an OOB attachment', async () => {
+      // Guard must not over-drop: a media-only share (empty body + attachment)
+      // has something to render and must survive.
+      await connectClient()
+
+      const mockRoom = createMockRoom('room@conference.example.com', {
+        joined: true,
+        nickname: 'myname',
+      })
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(mockRoom)
+
+      const messageStanza = createMockElement('message', {
+        from: 'room@conference.example.com/otherperson',
+        to: 'user@example.com',
+        type: 'groupchat',
+        id: 'room-file-only',
+      }, [
+        { name: 'x', attrs: { xmlns: 'jabber:x:oob' }, children: [{ name: 'url', text: 'https://upload.example.com/pic.png' }] },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:message', expect.objectContaining({
+        message: expect.objectContaining({
+          id: 'room-file-only',
+          attachment: expect.objectContaining({ url: 'https://upload.example.com/pic.png' }),
+        }),
+      }))
+    })
   })
 
   describe('Message type discrimination', () => {

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -935,6 +935,37 @@ describe('XMPPClient Message', () => {
       })
     })
 
+    it('should NOT store a reply whose body is entirely a fallback (no new text)', async () => {
+      await connectClient()
+
+      // "> Alice: Hello there!" is 21 chars and the fallback covers all of it,
+      // so processedBody strips to '' — there is no new text. With no attachment
+      // or other payload, the message has nothing to render and must be dropped
+      // rather than stored as a blank bubble.
+      const messageStanza = createMockElement('message', {
+        from: 'contact@example.com/resource',
+        to: 'user@example.com',
+        type: 'chat',
+        id: 'msg-empty-reply',
+      }, [
+        { name: 'body', text: '> Alice: Hello there!' },
+        { name: 'reply', attrs: { xmlns: 'urn:xmpp:reply:0', id: 'orig-empty', to: 'alice@example.com' } },
+        {
+          name: 'fallback',
+          attrs: { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+          children: [
+            { name: 'body', attrs: { xmlns: 'urn:xmpp:fallback:0', start: '0', end: '21' } },
+          ],
+        },
+      ])
+
+      mockXmppClientInstance._emit('stanza', messageStanza)
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('chat:message', expect.objectContaining({
+        message: expect.objectContaining({ id: 'msg-empty-reply' }),
+      }))
+    })
+
     it('should extract fallback body without author prefix', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -60,7 +60,7 @@ import type {
   RoomMAMResult,
   PollClosedData,
 } from '../types'
-import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, createOriginIdElement, parseStanzaId } from './messagingUtils'
+import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, createOriginIdElement, parseStanzaId, hasRenderableContent } from './messagingUtils'
 import { checkForMention } from '../mentionDetection'
 import { parsePollElement, parsePollClosedElement } from '../poll'
 import { logWarn } from '../logger'
@@ -2067,6 +2067,18 @@ export class Chat extends BaseModule {
     const securityContext = this.readMessageSecurityContext(stanza)
     const encryptedPayload = readStashedEncryptedPayload(stanza)
     const unsupportedEncryption = readStashedUnsupportedEncryption(stanza)
+
+    // A non-empty <body> that XEP-0428 fallback stripping reduces to '' (e.g. a
+    // reply quote with no new text) would store a blank bubble. Drop it unless it
+    // carries an attachment or encrypted payload to render.
+    if (!hasRenderableContent({
+      processedBody: parsed.processedBody,
+      attachment: parsed.attachment,
+      hasEncryptedContent: !!encryptedPayload || !!unsupportedEncryption,
+    })) {
+      return null
+    }
+
     const message: Message = {
       type: 'chat',
       id: messageId,
@@ -2141,6 +2153,20 @@ export class Chat extends BaseModule {
     const securityContext = this.readMessageSecurityContext(stanza)
     const encryptedPayload = readStashedEncryptedPayload(stanza)
     const unsupportedEncryption = readStashedUnsupportedEncryption(stanza)
+
+    // A non-empty <body> that XEP-0428 fallback stripping reduces to '' (e.g. a
+    // reply quote with no new text) would store a blank bubble. Drop it unless it
+    // carries an attachment, poll, or encrypted payload to render.
+    if (!hasRenderableContent({
+      processedBody: parsed.processedBody,
+      attachment: parsed.attachment,
+      hasPoll: !!stanza.getChild('poll', NS_POLL),
+      hasPollClosed: !!stanza.getChild('poll-closed', NS_POLL),
+      hasEncryptedContent: !!encryptedPayload || !!unsupportedEncryption,
+    })) {
+      return null
+    }
+
     const message: RoomMessage = {
       type: 'groupchat',
       id: messageId,

--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -519,6 +519,94 @@ describe('MAM E2EE wiring', () => {
     expect(msg.body).toBe('')
   })
 
+  it('drops a room archive message whose body is entirely a fallback (no renderable content)', async () => {
+    // The mirror of the bodiless-OMEMO case above: a message that carries a
+    // non-empty raw <body> but whose body is ENTIRELY a XEP-0428 fallback
+    // (here a XEP-0461 reply quote with no new text) strips to processedBody=''.
+    // The raw-<body> gate let it through and stored a blank bubble — the
+    // "empty Cynthia row" reported from the XSF room. With no attachment, poll
+    // or encrypted content, it has nothing to render and must be dropped.
+    const ROOM = 'room@conference.example.com'
+    const forwardedMessage = xml(
+      'message',
+      { from: ROOM + '/cynthia', to: ME, type: 'groupchat', id: 'mam-room-empty-fallback' },
+      xml('body', {}, '> a quote with no new text'),
+      xml('reply', { xmlns: 'urn:xmpp:reply:0', id: 'orig-1', to: ROOM + '/bob' }),
+      // <body/> with no start/end → the entire body is fallback for the reply.
+      xml('fallback', { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+        xml('body', {}),
+      ),
+    )
+    const archiveEntry = buildMAMResult({ archiveId: 'arch-room-empty-fallback', forwardedMessage })
+
+    const resultPromise = harness.mam.queryRoomArchive({ roomJid: ROOM, max: 10 })
+    await harness.iqPending()
+    const entries = [...harness.collectors.entries()]
+    if (entries.length === 0) throw new Error('No collector registered')
+    const [queryId, collector] = entries[0]
+    archiveEntry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+    collector(archiveEntry)
+    harness.resolveNextIQ(
+      xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+    )
+    const result = await resultPromise
+
+    expect(result.messages).toHaveLength(0)
+  })
+
+  it('keeps a room archive reply that has real text after the fallback quote', async () => {
+    // Positive control for the guard above: a normal reply (quote fallback +
+    // new text) must still surface, with only the quoted prefix stripped.
+    const ROOM = 'room@conference.example.com'
+    const fullBody = '> earlier message\nthanks, that works!'
+    const quoteEnd = fullBody.indexOf('thanks')
+    const forwardedMessage = xml(
+      'message',
+      { from: ROOM + '/cynthia', to: ME, type: 'groupchat', id: 'mam-room-reply-with-text' },
+      xml('body', {}, fullBody),
+      xml('reply', { xmlns: 'urn:xmpp:reply:0', id: 'orig-2', to: ROOM + '/bob' }),
+      xml('fallback', { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+        xml('body', { start: '0', end: String(quoteEnd) }),
+      ),
+    )
+    const archiveEntry = buildMAMResult({ archiveId: 'arch-room-reply-with-text', forwardedMessage })
+
+    const resultPromise = harness.mam.queryRoomArchive({ roomJid: ROOM, max: 10 })
+    await harness.iqPending()
+    const entries = [...harness.collectors.entries()]
+    if (entries.length === 0) throw new Error('No collector registered')
+    const [queryId, collector] = entries[0]
+    archiveEntry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+    collector(archiveEntry)
+    harness.resolveNextIQ(
+      xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+    )
+    const result = await resultPromise
+
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages[0].body).toBe('thanks, that works!')
+    expect(result.messages[0].replyTo).toBeDefined()
+  })
+
+  it('drops a 1:1 archive message whose body is entirely a fallback (no renderable content)', async () => {
+    // Same gate as the room path, for 1:1 archive: a reply whose body is ALL
+    // fallback strips to processedBody='' and must not surface as a blank row.
+    const forwardedMessage = xml(
+      'message',
+      { from: PEER + '/res', to: ME, type: 'chat', id: 'mam-chat-empty-fallback' },
+      xml('body', {}, '> a quote with no new text'),
+      xml('reply', { xmlns: 'urn:xmpp:reply:0', id: 'orig-c1', to: PEER }),
+      xml('fallback', { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:reply:0' },
+        xml('body', {}),
+      ),
+    )
+    const archiveEntry = buildMAMResult({ archiveId: 'arch-chat-empty-fallback', forwardedMessage })
+
+    const messages = await runQueryWithEntry(harness, PEER, archiveEntry)
+
+    expect(messages).toHaveLength(0)
+  })
+
   describe('no E2EE manager (archive replayed before E2EE init)', () => {
     let noMgrHarness: TestHarness
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -69,7 +69,7 @@ import type {
   RoomMAMSearchOptions,
   MAMPagingSearchOptions,
 } from '../types'
-import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, parseStanzaId } from './messagingUtils'
+import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, parseStanzaId, hasRenderableContent } from './messagingUtils'
 import { getDomain } from '../jid'
 import { logInfo, logError as logErr } from '../logger'
 import {
@@ -1857,6 +1857,17 @@ export class MAM extends BaseModule {
       ...(authoredAt && { authoredAt }),
     })
 
+    // The raw-<body> gate above passes any non-empty body, but XEP-0428 fallback
+    // stripping can leave processedBody='' (e.g. a reply quote with no new text).
+    // Drop it rather than store a blank row.
+    if (!hasRenderableContent({
+      processedBody: parsed.processedBody,
+      attachment: parsed.attachment,
+      hasEncryptedContent,
+    })) {
+      return null
+    }
+
     // Use stanza-id from message element, or fall back to MAM archive ID (they're equivalent)
     const stanzaId = parsed.stanzaId || archiveId
 
@@ -1933,6 +1944,20 @@ export class MAM extends BaseModule {
       expectedStanzaIdBy: roomJid,
       ...(roomAuthoredAt && { authoredAt: roomAuthoredAt }),
     })
+
+    // The raw-<body> gate above passes any non-empty body, but XEP-0428 fallback
+    // stripping can leave processedBody='' (e.g. a reply quote with no new text).
+    // Such an entry has nothing to render — dropping it here keeps a blank row out
+    // of the archive (the "empty Cynthia row" reported from the XSF room).
+    if (!hasRenderableContent({
+      processedBody: parsed.processedBody,
+      attachment: parsed.attachment,
+      hasPoll,
+      hasPollClosed,
+      hasEncryptedContent,
+    })) {
+      return null
+    }
 
     // Use stanza-id from message element, or fall back to MAM archive ID (they're equivalent)
     const stanzaId = parsed.stanzaId || archiveId

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyRetraction, applyCorrection, parseOobData, parseMessageContent, parseOriginId, parseStanzaId, createOriginIdElement } from './messagingUtils'
+import { applyRetraction, applyCorrection, parseOobData, parseMessageContent, parseOriginId, parseStanzaId, createOriginIdElement, hasRenderableContent } from './messagingUtils'
 import { createMockElement } from '../test-utils'
 
 describe('messagingUtils', () => {
@@ -835,6 +835,36 @@ describe('messagingUtils', () => {
       const result = parseMessageContent({ messageEl, body })
 
       expect(result.processedBody).toBe('Check this video!')
+    })
+  })
+
+  describe('hasRenderableContent', () => {
+    it('returns true when processedBody has text', () => {
+      expect(hasRenderableContent({ processedBody: 'hello' })).toBe(true)
+    })
+
+    it('returns false when processedBody is empty and there is no other content', () => {
+      expect(hasRenderableContent({ processedBody: '' })).toBe(false)
+    })
+
+    it('returns false when processedBody is only whitespace', () => {
+      expect(hasRenderableContent({ processedBody: '   \n  ' })).toBe(false)
+    })
+
+    it('returns true for an empty body with an attachment (file-only message)', () => {
+      expect(hasRenderableContent({ processedBody: '', attachment: { url: 'https://x/y.png' } })).toBe(true)
+    })
+
+    it('returns true for an empty body that carries a poll', () => {
+      expect(hasRenderableContent({ processedBody: '', hasPoll: true })).toBe(true)
+    })
+
+    it('returns true for an empty body that carries a poll-closed result', () => {
+      expect(hasRenderableContent({ processedBody: '', hasPollClosed: true })).toBe(true)
+    })
+
+    it('returns true for an empty body that carries encrypted content (placeholder)', () => {
+      expect(hasRenderableContent({ processedBody: '', hasEncryptedContent: true })).toBe(true)
     })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.ts
@@ -430,6 +430,38 @@ export function parseMessageContent(options: ParseMessageContentOptions): Parsed
 }
 
 /**
+ * Whether a parsed message carries anything renderable.
+ *
+ * The upstream body-presence gates accept a message when its raw `<body>` is
+ * non-empty. But XEP-0428 fallback processing can strip that body to nothing —
+ * e.g. a XEP-0461 reply whose body is entirely the quoted fallback with no new
+ * text. Such a message has empty `processedBody` and, unless it also carries an
+ * attachment, poll, or encrypted payload, would render as a blank bubble. This
+ * is the post-parse complement to the raw-body gate: callers drop a message
+ * with no renderable content instead of storing an empty row.
+ *
+ * `processedBody` is checked after trimming so a whitespace-only remainder
+ * counts as empty. Encrypted-but-bodiless entries are kept on purpose — the UI
+ * renders a placeholder from `encryptedPayload`/`unsupportedEncryption`
+ * (see issue #135).
+ */
+export function hasRenderableContent(content: {
+  processedBody: string
+  attachment?: unknown
+  hasPoll?: boolean
+  hasPollClosed?: boolean
+  hasEncryptedContent?: boolean
+}): boolean {
+  return (
+    content.processedBody.trim().length > 0 ||
+    content.attachment != null ||
+    content.hasPoll === true ||
+    content.hasPollClosed === true ||
+    content.hasEncryptedContent === true
+  )
+}
+
+/**
  * Result of applying a retraction to a message.
  */
 export interface RetractionResult {

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -3,6 +3,7 @@ import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
 import type { Message, RoomMessage } from '../core/types'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
+import { selectCatchUpQuery } from './mamCatchUpUtils'
 
 // Must import after fake-indexeddb/auto
 import * as messageCache from './messageCache'
@@ -191,6 +192,26 @@ describe('messageCache', () => {
       it('should return empty array for non-existent conversation', async () => {
         const retrieved = await messageCache.getMessages('nonexistent@example.com')
         expect(retrieved).toEqual([])
+      })
+
+      it('skips legacy blank rows (empty body, no payload) left by older builds', async () => {
+        await messageCache.saveMessages([
+          createMockMessage(conversationId, { id: 'real-1', body: 'hello', timestamp: new Date('2024-02-01T10:00:00Z') }),
+          // The stale artifact: empty body, nothing renderable.
+          createMockMessage(conversationId, { id: 'blank-1', body: '', timestamp: new Date('2024-02-01T11:00:00Z') }),
+        ])
+
+        const retrieved = await messageCache.getMessages(conversationId)
+        expect(retrieved.map((m) => m.id)).toEqual(['real-1'])
+      })
+
+      it('keeps an empty-body retraction tombstone', async () => {
+        await messageCache.saveMessages([
+          createMockMessage(conversationId, { id: 'tomb-1', body: '', isRetracted: true, timestamp: new Date('2024-02-02T10:00:00Z') }),
+        ])
+
+        const retrieved = await messageCache.getMessages(conversationId)
+        expect(retrieved.map((m) => m.id)).toEqual(['tomb-1'])
       })
 
       it('should respect limit option', async () => {
@@ -422,6 +443,18 @@ describe('messageCache', () => {
         const retrieved = await messageCache.getRoomMessages(roomJid, { before: cutoff, limit: 1 })
         expect(retrieved.length).toBe(1)
         expect(retrieved[0].timestamp < cutoff).toBe(true)
+      })
+
+      it('skips a legacy blank room row so it cannot render or seed the catch-up cursor', async () => {
+        // Mirrors the reported XSF case: the newest cached row is an empty-body
+        // leftover. It must be filtered so the newest returned row is the real one.
+        await messageCache.saveRoomMessages([
+          createMockRoomMessage(roomJid, { id: 'room-real', body: 'real text', timestamp: new Date('2024-02-01T10:00:00Z') }),
+          createMockRoomMessage(roomJid, { id: 'room-blank', body: '', timestamp: new Date('2024-02-01T11:00:00Z') }),
+        ])
+
+        const retrieved = await messageCache.getRoomMessages(roomJid)
+        expect(retrieved.map((m) => m.id)).toEqual(['room-real'])
       })
     })
 
@@ -775,6 +808,36 @@ describe('messageCache', () => {
     it('should handle getMessage for non-existent ID', async () => {
       const message = await messageCache.getMessage('nonexistent-id')
       expect(message).toBeNull()
+    })
+  })
+
+  // The reported bug: the room's MAM catch-up `start` is derived from the newest
+  // cached message (selectCatchUpQuery). When the newest cached row was a blank
+  // leftover, the cursor anchored on it. This composes the two real units —
+  // getRoomMessages (read-side prune) feeding selectCatchUpQuery (cursor) — to
+  // prove the blank row can no longer poison the cursor.
+  describe('catch-up cursor composition (blank row must not anchor the cursor)', () => {
+    const cursorRoomJid = 'cursor-room@conference.example.com'
+    // The real value seen in the trace: blank row is the NEWEST by timestamp.
+    const realTs = new Date('2026-06-25T17:00:00.000Z')
+    const blankTs = new Date('2026-06-25T17:15:14.214Z')
+    // Session connected well after both, so both count as pre-session history.
+    const sessionStartTime = new Date('2026-06-25T22:00:00.000Z').getTime()
+
+    it('anchors the catch-up cursor on the newest renderable row, not the blank one', async () => {
+      await messageCache.saveRoomMessages([
+        createMockRoomMessage(cursorRoomJid, { id: 'cursor-real', body: 'real text', timestamp: realTs }),
+        createMockRoomMessage(cursorRoomJid, { id: 'cursor-blank', body: '', timestamp: blankTs }),
+      ])
+
+      const cached = await messageCache.getRoomMessages(cursorRoomJid)
+      const query = selectCatchUpQuery(cached, { sessionStartTime })
+
+      // Forward query, anchored exactly as if only the real row existed...
+      expect(query.before).toBeUndefined()
+      expect(query).toEqual(selectCatchUpQuery([{ timestamp: realTs }], { sessionStartTime }))
+      // ...and NOT on the blank row's (newer) timestamp.
+      expect(query).not.toEqual(selectCatchUpQuery([{ timestamp: blankTs }], { sessionStartTime }))
     })
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -10,6 +10,7 @@
 import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
 import { getStorageScopeJid } from './storageScope'
+import { isRenderableStoredMessage } from './messageRenderability'
 
 const DB_NAME = 'fluux-message-cache'
 // v3: add a SPARSE index on `encryptedPayload` so deferred decryption can list
@@ -456,7 +457,14 @@ export async function getMessages(
       const stored = cursor.value
       // Double-check conversationId matches (IDB compound index quirk)
       if (stored.conversationId === conversationId) {
-        results.push(deserializeMessage(stored))
+        const message = deserializeMessage(stored)
+        // Skip legacy blank rows (empty body, no attachment/poll/encryption/
+        // retraction) that older builds persisted before the parse-time guard.
+        // They have nothing to render and must not fill the limit or anchor a
+        // catch-up cursor as the newest message. See isRenderableStoredMessage.
+        if (isRenderableStoredMessage(message)) {
+          results.push(message)
+        }
       }
       cursor = await cursor.continue()
     }
@@ -705,7 +713,12 @@ export async function getRoomMessages(
     while (cursor && (!limit || results.length < limit)) {
       const stored = cursor.value
       if (stored.roomJid === roomJid) {
-        results.push(deserializeRoomMessage(stored))
+        const message = deserializeRoomMessage(stored)
+        // Skip legacy blank rows (see getMessages / isRenderableStoredMessage):
+        // the "empty Cynthia row" lived in a room archive exactly like this.
+        if (isRenderableStoredMessage(message)) {
+          results.push(message)
+        }
       }
       cursor = await cursor.continue()
     }

--- a/packages/fluux-sdk/src/utils/messageRenderability.test.ts
+++ b/packages/fluux-sdk/src/utils/messageRenderability.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { isRenderableStoredMessage } from './messageRenderability'
+import type { Message, RoomMessage } from '../core/types'
+
+function chat(overrides: Partial<Message>): Message {
+  return {
+    type: 'chat',
+    id: 'm1',
+    conversationId: 'peer@example.com',
+    from: 'peer@example.com',
+    body: '',
+    timestamp: new Date(),
+    isOutgoing: false,
+    ...overrides,
+  } as Message
+}
+
+function room(overrides: Partial<RoomMessage>): RoomMessage {
+  return {
+    type: 'groupchat',
+    id: 'r1',
+    roomJid: 'room@conference.example.com',
+    from: 'room@conference.example.com/alice',
+    nick: 'alice',
+    body: '',
+    timestamp: new Date(),
+    isOutgoing: false,
+    ...overrides,
+  } as RoomMessage
+}
+
+describe('isRenderableStoredMessage', () => {
+  it('keeps a message with body text', () => {
+    expect(isRenderableStoredMessage(chat({ body: 'hello' }))).toBe(true)
+  })
+
+  it('drops an empty-body message with no other content (the stale blank row)', () => {
+    expect(isRenderableStoredMessage(chat({ body: '' }))).toBe(false)
+    expect(isRenderableStoredMessage(room({ body: '' }))).toBe(false)
+  })
+
+  it('drops a whitespace-only body', () => {
+    expect(isRenderableStoredMessage(chat({ body: '   \n ' }))).toBe(false)
+  })
+
+  it('keeps a retraction tombstone (empty body but isRetracted)', () => {
+    expect(isRenderableStoredMessage(chat({ body: '', isRetracted: true }))).toBe(true)
+  })
+
+  it('keeps an empty-body message that carries an attachment', () => {
+    expect(isRenderableStoredMessage(chat({ body: '', attachment: { url: 'https://x/y.png', filename: 'y.png' } as unknown as Message['attachment'] }))).toBe(true)
+  })
+
+  it('keeps a poll message with empty body', () => {
+    expect(isRenderableStoredMessage(room({ body: '', poll: { title: 'Q?', options: [] } as unknown as RoomMessage['poll'] }))).toBe(true)
+  })
+
+  it('keeps a poll-closed announcement with empty body', () => {
+    expect(isRenderableStoredMessage(room({ body: '', pollClosed: { pollMessageId: 'p1', title: 'Q?', results: [] } as unknown as RoomMessage['pollClosed'] }))).toBe(true)
+  })
+
+  it('keeps an encrypted-but-bodiless placeholder', () => {
+    expect(isRenderableStoredMessage(chat({ body: '', encryptedPayload: '<encrypted/>' }))).toBe(true)
+    expect(isRenderableStoredMessage(chat({ body: '', unsupportedEncryption: { namespace: 'eu.siacs.conversations.axolotl' } as unknown as Message['unsupportedEncryption'] }))).toBe(true)
+  })
+})

--- a/packages/fluux-sdk/src/utils/messageRenderability.ts
+++ b/packages/fluux-sdk/src/utils/messageRenderability.ts
@@ -1,0 +1,28 @@
+import type { Message, RoomMessage } from '../core/types'
+
+/**
+ * Whether a persisted message has anything to display.
+ *
+ * Historically a body-less stanza (a stray XEP-0333 chat marker, or a message
+ * whose `<body>` was entirely a XEP-0428 fallback) could be stored with an
+ * empty body and no other payload — it then rendered as a blank bubble (the
+ * "empty Cynthia row" reported from the XSF room). New writes are blocked at
+ * parse time by `hasRenderableContent`; this predicate is the read-side
+ * complement: cache reads skip any such rows already on disk so the stale
+ * artifact disappears (and never seeds a catch-up cursor as the newest row).
+ *
+ * A message still renders with an empty body when it is a retraction tombstone,
+ * carries an attachment or poll, or holds encrypted content shown as a
+ * placeholder — those are all kept.
+ */
+export function isRenderableStoredMessage(message: Message | RoomMessage): boolean {
+  return (
+    (typeof message.body === 'string' && message.body.trim().length > 0) ||
+    message.attachment != null ||
+    message.poll != null ||
+    message.pollClosed != null ||
+    message.isRetracted === true ||
+    message.encryptedPayload != null ||
+    message.unsupportedEncryption != null
+  )
+}


### PR DESCRIPTION
## Summary

Fixes empty message bubbles (the blank row seen for a participant in the XSF room) caused by messages whose body is **entirely a XEP-0428 fallback**.

The store-write paths gated on the raw `<body>` but persisted `processedBody` — the body *after* fallback stripping. A message whose body is entirely a fallback (e.g. a XEP-0461 reply quote with no new text, or a whole-body `<fallback><body/></fallback>`) strips to `''` and was stored as a blank bubble. Nothing guarded `processedBody` emptiness, on the live or the MAM path.

The blank row also sat at the newest position in the room cache, so it seeded the MAM catch-up `start` cursor (`selectCatchUpQuery` derives the cursor from the newest cached message).

## Changes

- **`hasRenderableContent()`** (`messagingUtils.ts`) — post-parse gate wired into all four store-write paths (`processRoomMessage`, `processChatMessage`, `parseRoomArchiveMessage`, `parseArchiveMessage`). A message with empty `processedBody` and no attachment / poll / encrypted payload is dropped instead of stored.
- **`isRenderableStoredMessage()`** (`utils/messageRenderability.ts`) — read-side complement in `messageCache.getMessages` / `getRoomMessages`. Blank rows already on disk are skipped on load, so the stale row disappears and can no longer anchor the catch-up cursor. Retraction tombstones, polls, attachments and encrypted placeholders are explicitly kept.

## Notes

- Bodiless **encrypted** archive entries (issue #135) and **file-only** (OOB) messages are unaffected — they have renderable content and are kept.
- Each guard site, both predicates, the read-side prune, and the prune→catch-up-cursor composition have dedicated regression tests, each verified to fail without the fix.