### PR TITLE
fix(messages): virtualized scroll — bottom re-pin + WebKit momentum windowing

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -216,12 +216,12 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
   const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div> }
 
-  // TODO: The ResizeObserver bottom-stick correction is intentionally disabled when the
-  // virtualizer is active (to prevent oscillation from spacer-height churn). A follow-up
-  // needs to implement a totalSize-change → scrollToIndex(last,'end') re-pin so that rows
-  // measuring taller than the estimate after an initial scroll-to-bottom don't leave the
-  // last message partially clipped. Tracked: post-0.16.0 virtualizer bottom-stick gap.
-  it.skip('re-pins to the bottom as scrollHeight grows after a fresh-conversation scroll-to-bottom', () => {
+  // The ResizeObserver bottom-stick correction is intentionally disabled when the virtualizer
+  // is active (to prevent oscillation from spacer-height churn). Instead the scroll hook runs a
+  // measurement-aware rAF re-assert loop: as rows mount and measure taller/shorter than the
+  // fixed estimate, scrollHeight changes, and the loop re-calls scrollToIndex(last,'end') so the
+  // last message isn't left clipped (taller) or floating above empty space (shorter).
+  it('re-pins to the bottom as scrollHeight grows after a fresh-conversation scroll-to-bottom', () => {
     const { container, rerender } = render(
       <MessageList messages={makeMessages(50)} conversationId="conv-A" {...props} />,
     )
@@ -241,7 +241,7 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     expect(scrollTopSets).toContain(3000)
   })
 
-  it.skip('re-pins to the bottom as a new message row measures taller than the estimate', () => {
+  it('re-pins to the bottom as a new message row measures taller than the estimate', () => {
     const { container, rerender } = render(
       <MessageList messages={makeMessages(50)} conversationId="conv-1" {...props} />,
     )

--- a/apps/fluux/src/components/conversation/observeElementOffsetWithRaf.test.ts
+++ b/apps/fluux/src/components/conversation/observeElementOffsetWithRaf.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit coverage for observeElementOffsetWithRaf — the rAF scroll-offset poller that keeps the
+ * @tanstack virtualizer re-windowing during WebKit inertial ("kinetic") momentum, when the
+ * desktop webview withholds `scroll` events and the default scroll-event-only observer freezes
+ * the mounted window (the "looping images" report on the Tauri build).
+ *
+ * jsdom/happy-dom can't produce real momentum, so we drive the exact failure deterministically:
+ * change scrollTop WITHOUT firing a `scroll` event and assert the offset is still re-emitted.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { observeElementOffsetWithRaf } from './tanstackMessageVirtualizer'
+
+describe('observeElementOffsetWithRaf', () => {
+  let rafQueue: Array<FrameRequestCallback | undefined>
+  let realRaf: typeof requestAnimationFrame
+  let realCaf: typeof cancelAnimationFrame
+
+  beforeEach(() => {
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    realCaf = globalThis.cancelAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafQueue.push(cb)
+      return rafQueue.length
+    }) as typeof requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      rafQueue[id - 1] = undefined
+    }) as typeof cancelAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = realRaf
+    globalThis.cancelAnimationFrame = realCaf
+  })
+
+  const flush = (frames: number) => {
+    for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb && cb(0))
+  }
+
+  function makeEl(initial = 0) {
+    let top = initial
+    const listeners: Record<string, Array<() => void>> = {}
+    return {
+      get scrollTop() { return top },
+      set scrollTop(v: number) { top = v },
+      addEventListener: (t: string, h: () => void) => { (listeners[t] = listeners[t] || []).push(h) },
+      removeEventListener: (t: string, h: () => void) => { listeners[t] = (listeners[t] || []).filter((x) => x !== h) },
+      _fire: (t: string) => { (listeners[t] || []).forEach((h) => h()) },
+      _count: (t: string) => (listeners[t] || []).length,
+    }
+  }
+
+  it('re-emits the offset when scrollTop changes WITHOUT a scroll event (WebKit momentum)', () => {
+    const el = makeEl(0)
+    const cb = vi.fn()
+    observeElementOffsetWithRaf({ scrollElement: el as unknown as HTMLElement }, cb)
+    cb.mockClear()
+
+    // A wheel kicks off momentum; the inertial phase moves scrollTop but fires NO scroll event.
+    el._fire('wheel')
+    el.scrollTop = 500
+    flush(1)
+    expect(cb).toHaveBeenCalledWith(500, true)
+
+    el.scrollTop = 900
+    flush(1)
+    expect(cb).toHaveBeenCalledWith(900, true)
+  })
+
+  it('stops polling and emits isScrolling=false once the offset is stable', () => {
+    const el = makeEl(0)
+    const cb = vi.fn()
+    observeElementOffsetWithRaf({ scrollElement: el as unknown as HTMLElement }, cb)
+    cb.mockClear()
+
+    el._fire('scroll')
+    el.scrollTop = 300
+    flush(1)
+    cb.mockClear()
+
+    // No further movement → after the idle window the poll emits false and stops rescheduling.
+    flush(12)
+    expect(cb).toHaveBeenCalledWith(300, false)
+
+    cb.mockClear()
+    flush(5)
+    expect(cb).not.toHaveBeenCalled() // poll is no longer running
+  })
+
+  it('still re-windows on a normal scroll event (Chromium path unchanged)', () => {
+    const el = makeEl(0)
+    const cb = vi.fn()
+    observeElementOffsetWithRaf({ scrollElement: el as unknown as HTMLElement }, cb)
+    cb.mockClear()
+
+    el.scrollTop = 250
+    el._fire('scroll')
+    expect(cb).toHaveBeenCalledWith(250, true)
+  })
+
+  it('detaches all listeners and cancels the poll on cleanup', () => {
+    const el = makeEl(0)
+    const cb = vi.fn()
+    const cleanup = observeElementOffsetWithRaf({ scrollElement: el as unknown as HTMLElement }, cb)
+    el._fire('wheel')
+    el.scrollTop = 100
+    cleanup?.()
+    cb.mockClear()
+    flush(5)
+    expect(cb).not.toHaveBeenCalled()
+    expect(el._count('scroll')).toBe(0)
+    expect(el._count('wheel')).toBe(0)
+  })
+
+  it('is inert when there is no scroll element', () => {
+    const cb = vi.fn()
+    const cleanup = observeElementOffsetWithRaf({ scrollElement: null }, cb)
+    flush(3)
+    expect(cb).not.toHaveBeenCalled()
+    expect(cleanup).toBeUndefined()
+  })
+})

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -2,6 +2,80 @@ import { useCallback } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { MessageVirtualizer } from './messageVirtualizer'
 
+// Frames the offset must hold steady before we declare scrolling settled and stop polling
+// (~100ms at 60fps — close to @tanstack's default 150ms isScrollingResetDelay).
+const OFFSET_POLL_IDLE_FRAMES = 6
+
+/**
+ * Drop-in replacement for @tanstack/react-virtual's `observeElementOffset` that re-windows from a
+ * requestAnimationFrame poll of `scrollTop`, not only from the element's `scroll` event.
+ *
+ * WHY: the default observer updates the virtualizer's offset (and thus the mounted window) ONLY
+ * when the scroll element fires a `scroll` event. WebKit — the Tauri desktop webview — coalesces
+ * or withholds `scroll` events during INERTIAL ("kinetic") momentum scrolling: the layer scrolls
+ * on the compositor while JS sees no event. With the default observer the mounted window then
+ * freezes mid-fling, so the same rows render as the user scrolls (the "looping images" report).
+ * Chromium fires `scroll` promptly during inertia, so it never shows the bug — and the headless
+ * preview/Playwright harness can't reproduce momentum at all.
+ *
+ * HOW: keep the `scroll` listener (so the Chromium path is unchanged) but, once a gesture starts
+ * (scroll / wheel / touch), poll `scrollTop` every frame and push each change into the virtualizer.
+ * The poll stops after the offset is stable for OFFSET_POLL_IDLE_FRAMES, so it runs only during an
+ * active scroll. It is strictly READ-ONLY (never writes scrollTop) so it cannot feed back into the
+ * scroll-correction loops. Same `(instance, cb) => cleanup` contract as the @tanstack default.
+ */
+export function observeElementOffsetWithRaf(
+  instance: { scrollElement: HTMLElement | null },
+  cb: (offset: number, isScrolling: boolean) => void,
+): void | (() => void) {
+  const el = instance.scrollElement
+  if (!el) return
+
+  let rafId: number | null = null
+  let lastOffset = el.scrollTop
+  let idleFrames = 0
+
+  const tick = () => {
+    const offset = el.scrollTop
+    if (offset !== lastOffset) {
+      lastOffset = offset
+      idleFrames = 0
+      cb(offset, true)
+    } else if (++idleFrames >= OFFSET_POLL_IDLE_FRAMES) {
+      rafId = null
+      cb(offset, false) // scrolling settled — resume measurement adjustments
+      return
+    }
+    rafId = requestAnimationFrame(tick)
+  }
+
+  const startPolling = () => {
+    if (rafId === null) {
+      idleFrames = 0
+      rafId = requestAnimationFrame(tick)
+    }
+  }
+
+  const onScroll = () => {
+    lastOffset = el.scrollTop
+    cb(lastOffset, true)
+    startPolling()
+  }
+
+  el.addEventListener('scroll', onScroll, { passive: true })
+  // Momentum initiators: WebKit may suppress the `scroll` event during the inertial phase, so
+  // begin polling the moment the gesture starts rather than waiting for a `scroll` that won't come.
+  el.addEventListener('wheel', startPolling, { passive: true })
+  el.addEventListener('touchmove', startPolling, { passive: true })
+
+  return () => {
+    el.removeEventListener('scroll', onScroll)
+    el.removeEventListener('wheel', startPolling)
+    el.removeEventListener('touchmove', startPolling)
+    if (rafId !== null) cancelAnimationFrame(rafId)
+  }
+}
+
 interface Args {
   /** Only the stable `key` per row is needed — the adapter is agnostic to item kind
    *  (date/message/header/footer all window uniformly). The caller renders by kind. */
@@ -35,6 +109,9 @@ export function useTanstackMessageVirtualizer({
     estimateSize: () => estimateSize,
     getItemKey: (index) => items[index].key,
     overscan: 12,
+    // rAF-polled offset observer so the window keeps advancing during WebKit inertial momentum,
+    // when the desktop webview withholds `scroll` events (the "looping rows" bug). See the fn doc.
+    observeElementOffset: observeElementOffsetWithRaf,
   })
 
   const getOffsetForMessageId = useCallback((id: string): number | null => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -48,6 +48,11 @@ const LOAD_COOLDOWN_MS = 500 // minimum time between load triggers
 const SAVE_THROTTLE_MS = 100 // minimum time between position saves
 const PREPEND_COOLDOWN_MS = 500 // time to keep prepend flag after restore (prevents re-trigger)
 const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
+// Frames to keep re-pinning a virtualized list to the bottom after a scroll-to-bottom. Rows
+// start at the fixed estimateSize and re-measure asynchronously over several frames (taller →
+// scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
+// one-shot scrollToIndex isn't enough. ~1s at 60fps comfortably covers the measurement settle.
+const BOTTOM_REASSERT_FRAMES = 60
 
 // ============================================================================
 // KINETIC SCROLL
@@ -538,6 +543,49 @@ export function useMessageListScroll({
     scrollerRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
 
+  // Pin a VIRTUALIZED list to the bottom and keep it pinned as rows measure.
+  //
+  // scrollToIndex(last, 'end') uses the virtualizer's current (estimated) layout. Rows then
+  // mount and re-measure over the next several frames; scrollHeight grows (rows taller than the
+  // estimate → last message clipped below the fold) or shrinks (shorter → empty space below the
+  // content). The content ResizeObserver that re-pins for the non-virtualized path is disabled
+  // under virtualization (its feedback loops with the @tanstack spacer churn — PR #646), so we
+  // re-assert across frames here instead.
+  //
+  // Runs entirely in rAF (NOT useLayoutEffect) to avoid the scroll→rerender→scrollTop-override
+  // oscillation. Re-pins only when scrollHeight actually changed since the previous frame, and
+  // yields the moment the user takes over (deliberate scroll intent, or simply scrolling away
+  // from the bottom). No-op for the non-virtualized path — callers keep their direct scrollTop.
+  const pinVirtualizedBottom = useCallback(() => {
+    const virt = virtualizerRef.current
+    const scroller = scrollerRef.current
+    if (!virt || !scroller || virt.itemCount === 0) return
+
+    // Immediate pin (pre-paint when called from a layout effect).
+    virt.scrollToIndex(virt.itemCount - 1, { align: 'end' })
+
+    const startedAt = Date.now()
+    let framesLeft = BOTTOM_REASSERT_FRAMES
+    let lastHeight = scroller.scrollHeight
+    const step = () => {
+      if (framesLeft-- <= 0) return
+      const s = scrollerRef.current
+      const v = virtualizerRef.current
+      if (!s || !v || v.itemCount === 0) return
+      // User took over (FAB/wheel intent recorded after we started, or they scrolled away from
+      // the bottom) → stop fighting them. Programmatic growth doesn't move scrollTop, so it never
+      // flips isAtBottom; only a genuine user scroll up does.
+      if (userScrollIntentAtRef.current > startedAt || !isAtBottomRef.current) return
+      const h = s.scrollHeight
+      if (h !== lastHeight) {
+        lastHeight = h
+        v.scrollToIndex(v.itemCount - 1, { align: 'end' })
+      }
+      requestAnimationFrame(step)
+    }
+    requestAnimationFrame(step)
+  }, [isAtBottomRef])
+
   // ==========================================================================
   // LOAD OLDER MESSAGES
   // ==========================================================================
@@ -1014,9 +1062,9 @@ export function useMessageListScroll({
           // Virtualizer-native bottom: uses actual measured heights, not the estimated
           // spacer height. This is the root cause of the "blank FAB" bug — estimated
           // scrollHeight undershoots when bottom rows are taller than estimateSize.
-          if (virtSwitch.itemCount > 0) {
-            virtSwitch.scrollToIndex(virtSwitch.itemCount - 1, { align: 'end' })
-          }
+          // pinVirtualizedBottom re-asserts across frames as those rows measure, so the
+          // last message isn't left clipped (taller) or floating above empty space (shorter).
+          pinVirtualizedBottom()
         } else {
           void scroller.offsetHeight  // Force layout calculation
           scroller.scrollTop = scroller.scrollHeight
@@ -1050,7 +1098,7 @@ export function useMessageListScroll({
         }
       }
     }
-  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, isAtBottomRef, staticMode])
+  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, isAtBottomRef, staticMode, pinVirtualizedBottom])
 
   // ==========================================================================
   // EFFECT: Scroll to target message (from activity log click, etc.)
@@ -1452,7 +1500,7 @@ export function useMessageListScroll({
       isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
       const virtNewMsg = latestRef.current.virtualizer
       if (virtNewMsg) {
-        if (virtNewMsg.itemCount > 0) virtNewMsg.scrollToIndex(virtNewMsg.itemCount - 1, { align: 'end' })
+        pinVirtualizedBottom()
       } else {
         scroller.scrollTop = scroller.scrollHeight
       }
@@ -1465,7 +1513,7 @@ export function useMessageListScroll({
     }
 
     prevMessageCountRef.current = messageCount
-  }, [messageCount, isAtBottomRef, staticMode, lastMessageIsOutgoing])
+  }, [messageCount, isAtBottomRef, staticMode, lastMessageIsOutgoing, pinVirtualizedBottom])
 
   // ==========================================================================
   // EFFECT: Reset marker scroll tracking when firstNewMessageId changes
@@ -1493,22 +1541,22 @@ export function useMessageListScroll({
     const virtTyping = latestRef.current.virtualizer
     const s = scrollerRef.current
     if (virtTyping) {
-      if (virtTyping.itemCount > 0) virtTyping.scrollToIndex(virtTyping.itemCount - 1, { align: 'end' })
+      pinVirtualizedBottom()
     } else if (s) {
       s.scrollTop = s.scrollHeight
     }
-  }, [typingUsersCount, isAtBottomRef])
+  }, [typingUsersCount, isAtBottomRef, pinVirtualizedBottom])
 
   useLayoutEffect(() => {
     if (!isAtBottomRef.current) return
     const virtReaction = latestRef.current.virtualizer
     const s = scrollerRef.current
     if (virtReaction) {
-      if (virtReaction.itemCount > 0) virtReaction.scrollToIndex(virtReaction.itemCount - 1, { align: 'end' })
+      pinVirtualizedBottom()
     } else if (s) {
       s.scrollTop = s.scrollHeight
     }
-  }, [lastMessageReactionsKey, isAtBottomRef])
+  }, [lastMessageReactionsKey, isAtBottomRef, pinVirtualizedBottom])
 
   // ==========================================================================
   // EFFECT: Container resize (composer grows/shrinks)


### PR DESCRIPTION
Two message-list virtualization scroll fixes (virtualization is on by default since #650).

**1. Re-pin to bottom as rows measure.** Switching conversations could leave the view not at the bottom — empty space below the last message (rows shorter than the 64px estimate) or clipped last lines (taller). The one-shot `scrollToIndex(last,'end')` lands on the estimated layout before rows measure, and the ResizeObserver bottom-stick correction is disabled under virtualization. Adds `pinVirtualizedBottom()`: an immediate scroll-to-bottom plus a measurement-aware rAF re-pin loop (mirrors the MAM-prepend loop) that re-pins as `scrollHeight` settles and yields on user scroll. Wired into the switch, new-message, typing and reactions paths. Un-skips the two known-gap tests.

**2. Keep the window advancing during WebKit momentum.** On the Tauri (WebKit) desktop build, a strong kinetic mouse-wheel fling scrolls smoothly but the rows don't advance — the same rows repeat ("looping"). `@tanstack/react-virtual` re-windows only from the `scroll` event, which WebKit coalesces/withholds during inertial momentum, freezing the mounted window. Adds `observeElementOffsetWithRaf` (passed as the virtualizer's `observeElementOffset`): keeps the `scroll` listener and additionally polls `scrollTop` per animation frame while scrolling, so the window advances even when WebKit withholds events. Read-only; Chromium path unchanged.

Verification: 5 new unit tests + the 2 un-skipped gap tests; full app suite green; typecheck/lint clean. The looping bug only manifests on WebKit, which headless Chromium/Playwright can't reproduce — so fix #2 still needs a final confirmation on the desktop build.
