### PR TITLE
fix(reactions): keep the emoji picker mounted across re-renders

### DIFF
--- a/apps/fluux/src/components/EmojiPicker.test.tsx
+++ b/apps/fluux/src/components/EmojiPicker.test.tsx
@@ -4,6 +4,9 @@ import { EmojiPicker } from './EmojiPicker'
 
 // Capture the config emoji-mart's Picker is constructed with.
 let lastPickerConfig: Record<string, unknown> | null = null
+// Every config the Picker is constructed with, in order — lets us assert how
+// many times the (expensive) web component was instantiated across re-renders.
+const pickerConfigs: Record<string, unknown>[] = []
 
 vi.mock('emoji-mart', () => ({
   // `new Picker(config)` returns a real DOM node so the component can
@@ -11,6 +14,7 @@ vi.mock('emoji-mart', () => ({
   Picker: class {
     constructor(config: Record<string, unknown>) {
       lastPickerConfig = config
+      pickerConfigs.push(config)
       return document.createElement('em-emoji-picker') as unknown as object
     }
   },
@@ -36,6 +40,7 @@ vi.mock('@/hooks', () => ({
 describe('EmojiPicker autoFocus gating', () => {
   beforeEach(() => {
     lastPickerConfig = null
+    pickerConfigs.length = 0
     cleanup()
   })
 
@@ -49,5 +54,42 @@ describe('EmojiPicker autoFocus gating', () => {
     mockHasHover.mockReturnValue(false)
     render(<EmojiPicker onSelect={vi.fn()} onClose={vi.fn()} />)
     expect(lastPickerConfig?.autoFocus).toBe(false)
+  })
+})
+
+describe('EmojiPicker stability across re-renders', () => {
+  beforeEach(() => {
+    lastPickerConfig = null
+    pickerConfigs.length = 0
+    mockHasHover.mockReturnValue(true)
+    cleanup()
+  })
+
+  // Regression: callers pass fresh inline onSelect/onClose closures every
+  // render. When the message bubble re-renders while the picker is open
+  // (background presence/typing/MAM churn), the picker must NOT be torn down
+  // and rebuilt — that is the "menu disappears and reappears" flicker and it
+  // swallows the in-flight emoji click.
+  it('does not recreate the picker when callback props change identity', () => {
+    const { rerender } = render(<EmojiPicker onSelect={vi.fn()} onClose={vi.fn()} />)
+    expect(pickerConfigs).toHaveLength(1)
+
+    rerender(<EmojiPicker onSelect={vi.fn()} onClose={vi.fn()} />)
+    expect(pickerConfigs).toHaveLength(1)
+  })
+
+  // The picker must still call the *latest* onSelect after a re-render, so the
+  // ref indirection that keeps it stable doesn't introduce a stale closure.
+  it('routes emoji selection to the latest onSelect after a re-render', () => {
+    const firstSelect = vi.fn()
+    const secondSelect = vi.fn()
+    const { rerender } = render(<EmojiPicker onSelect={firstSelect} onClose={vi.fn()} />)
+    rerender(<EmojiPicker onSelect={secondSelect} onClose={vi.fn()} />)
+
+    const onEmojiSelect = pickerConfigs[0].onEmojiSelect as (e: { native: string }) => void
+    onEmojiSelect({ native: '🎉' })
+
+    expect(secondSelect).toHaveBeenCalledWith('🎉')
+    expect(firstSelect).not.toHaveBeenCalled()
   })
 })

--- a/apps/fluux/src/components/EmojiPicker.tsx
+++ b/apps/fluux/src/components/EmojiPicker.tsx
@@ -28,6 +28,19 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
   // the emoji grid (especially inside the mobile reaction bottom sheet).
   const hasHover = useHasHover()
 
+  // Callers pass fresh inline onSelect/onClose closures every render. Read them
+  // through refs so the mount effect below does NOT depend on their identity —
+  // otherwise a parent re-render while the picker is open (background presence/
+  // typing/MAM churn re-rendering the message bubble) would tear down and
+  // rebuild the emoji-mart web component, which reads as a flicker ("menu
+  // disappears and reappears") and swallows the in-flight emoji click.
+  const onSelectRef = useRef(onSelect)
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onSelectRef.current = onSelect
+    onCloseRef.current = onClose
+  })
+
   useEffect(() => {
     if (!containerRef.current) return
 
@@ -35,7 +48,7 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
     const picker = new Picker({
       data,
       theme,
-      onEmojiSelect: (emoji: { native: string }) => onSelect(emoji.native),
+      onEmojiSelect: (emoji: { native: string }) => onSelectRef.current(emoji.native),
       searchPosition: 'sticky',
       previewPosition: 'none',
       skinTonePosition: 'search',
@@ -54,20 +67,21 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
       // Clean up: remove the picker element
       container.replaceChildren()
     }
-    // Re-create picker when theme, locale, or hover capability changes
-  }, [theme, i18n.language, onSelect, hasHover])
+    // Re-create picker only when theme, locale, or hover capability changes —
+    // never on callback identity (see the ref indirection above).
+  }, [theme, i18n.language, hasHover])
 
   // Close on Escape key
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.stopPropagation()
-        onClose()
+        onCloseRef.current()
       }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  }, [])
 
   return <div ref={containerRef} />
 }


### PR DESCRIPTION
## Summary

Clicking an emoji in the message reaction menu intermittently did nothing — the picker would just disappear and reappear.

**Root cause:** `EmojiPicker` mounts the emoji-mart web component imperatively in an effect that depended on the caller's `onSelect` identity. Every caller (message toolbar, composer, action sheet, poll creator) passes a fresh inline `onSelect`/`onClose` closure on each render, so whenever the open picker's parent re-rendered — the pointer entering the picker flipping hover state, presence/typing churn, MAM sync — the effect got a new dependency, re-ran, and tore down the picker via `container.replaceChildren()` before building a new one. That teardown/rebuild is the visible flicker, and a click landing during the swap was lost. It was intermittent because it only fired when something re-rendered the bubble mid-interaction.

**Fix:** read `onSelect`/`onClose` through refs kept current each render, and depend the mount effect only on `theme`, locale, and hover capability — the things that actually require rebuilding the picker. It now stays mounted across re-renders and always calls the latest callback. The fix lives in the shared `EmojiPicker`, so all four consumers benefit.

A regression test asserts the picker is constructed once across a re-render and still routes selection to the latest `onSelect`.