### PR TITLE
fix: virtualizer render-loop + deferred OpenPGP decrypt after catch-up

### DIFF
--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.test.tsx
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.test.tsx
@@ -3,20 +3,38 @@ import { renderHook } from '@testing-library/react'
 import { useRef } from 'react'
 import { useTanstackMessageVirtualizer } from './tanstackMessageVirtualizer'
 
+// @tanstack's internal offset callback (the one it hands to `observeElementOffset` on mount). The
+// adapter stashes it so a programmatic scrollToOffset can re-window through it directly.
+const offsetNotifySpy = vi.fn<(offset: number, isScrolling: boolean) => void>()
+const scrollToOffsetSpy = vi.fn()
+
 // Mock the real @tanstack/react-virtual surface the adapter uses (jsdom has no layout):
-// a fixed 40px row height exposes deterministic offsets for every index.
+// a fixed 40px row height exposes deterministic offsets for every index. The mock also invokes
+// `observeElementOffset(instance, internalCb)` exactly as the real adapter does on mount, so the
+// adapter's cb-stashing path runs and `offsetNotifySpy` becomes the captured callback.
 vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: (opts: { count: number; getItemKey: (i: number) => string }) => ({
-    getVirtualItems: () =>
-      Array.from({ length: opts.count }, (_, index) => ({
-        index, key: opts.getItemKey(index), start: index * 40, end: index * 40 + 40, size: 40, lane: 0,
-      })),
-    getTotalSize: () => opts.count * 40,
-    getOffsetForIndex: (index: number) => [index * 40, 'start'] as const,
-    measureElement: () => {},
-    scrollToIndex: () => {},
-    scrollToOffset: () => {},
-  }),
+  useVirtualizer: (opts: {
+    count: number
+    getItemKey: (i: number) => string
+    getScrollElement: () => HTMLElement | null
+    observeElementOffset?: (
+      instance: { scrollElement: HTMLElement | null },
+      cb: (offset: number, isScrolling: boolean) => void,
+    ) => void | (() => void)
+  }) => {
+    opts.observeElementOffset?.({ scrollElement: opts.getScrollElement() }, offsetNotifySpy)
+    return {
+      getVirtualItems: () =>
+        Array.from({ length: opts.count }, (_, index) => ({
+          index, key: opts.getItemKey(index), start: index * 40, end: index * 40 + 40, size: 40, lane: 0,
+        })),
+      getTotalSize: () => opts.count * 40,
+      getOffsetForIndex: (index: number) => [index * 40, 'start'] as const,
+      measureElement: () => {},
+      scrollToIndex: () => {},
+      scrollToOffset: scrollToOffsetSpy,
+    }
+  },
 }))
 
 function makeItems(ids: string[]): { items: { key: string }[]; indexById: Map<string, number> } {
@@ -36,16 +54,23 @@ describe('useTanstackMessageVirtualizer', () => {
     expect(result.current.getOffsetForMessageId('missing')).toBeNull()
   })
 
-  it('scrollToOffset dispatches a scroll event so @tanstack re-syncs its window to scrollTop', () => {
-    // @tanstack updates its reactive scrollOffset ONLY from the scroll element's 'scroll'
-    // DOM event (observeElementOffset). scrollToOffset sets the DOM scrollTop but leaves
-    // scrollOffset stale until that event fires. The MAM-prepend restore calls scrollToOffset
-    // from a useLayoutEffect right after a count change; on engines that don't fire the native
-    // scroll event promptly (Tauri WebKitGTK + the headless preview browser) the virtualizer
-    // keeps the old top rows mounted while scrollTop sits at the restored offset → the viewport
-    // renders BLANK. The adapter dispatches the event itself to force a re-window. This bug does
-    // NOT reproduce in Playwright (chromium/webkit fire the native event), so this unit test is
-    // the deterministic guard for the fix.
+  it('scrollToOffset re-windows via @tanstack\'s offset callback with isScrolling=false (no synthetic scroll)', () => {
+    // @tanstack updates its reactive scrollOffset ONLY from the scroll element's 'scroll' DOM event
+    // (observeElementOffset). scrollToOffset sets the DOM scrollTop but leaves scrollOffset stale
+    // until that event fires. The MAM-prepend restore calls scrollToOffset from a useLayoutEffect
+    // right after a count change; on engines that don't fire the native scroll event promptly (Tauri
+    // WebKitGTK + the headless preview browser) the virtualizer keeps the old top rows mounted while
+    // scrollTop sits at the restored offset → the viewport renders BLANK.
+    //
+    // The adapter MUST force a re-window — but NOT by dispatching a synthetic 'scroll' event. That
+    // event routes through our observer's onScroll with isScrolling=true, and react-virtual's
+    // onChange does flushSync(rerender) whenever sync===true. Inside the layout-effect commit that
+    // throws "flushSync was called from inside a lifecycle method" and triggers a render-loop storm.
+    // Instead it pushes the offset straight into @tanstack's offset callback with isScrolling=false,
+    // a non-sync notify (plain rerender, legal mid-commit). This bug does NOT reproduce in Playwright
+    // (chromium/webkit fire the native event), so this unit test is the deterministic guard.
+    offsetNotifySpy.mockClear()
+    scrollToOffsetSpy.mockClear()
     const el = document.createElement('div')
     const dispatchSpy = vi.spyOn(el, 'dispatchEvent')
     const { items, indexById } = makeItems(['a', 'b'])
@@ -56,10 +81,18 @@ describe('useTanstackMessageVirtualizer', () => {
 
     result.current.scrollToOffset(1000)
 
+    // 1. @tanstack's own scrollToOffset still sets the DOM scrollTop.
+    expect(scrollToOffsetSpy).toHaveBeenCalledWith(1000, undefined)
+    // 2. The window is re-synced through the offset callback with isScrolling=false (non-sync).
+    expect(
+      offsetNotifySpy,
+      'scrollToOffset must re-window via the offset callback with isScrolling=false',
+    ).toHaveBeenCalledWith(1000, false)
+    // 3. It must NOT dispatch a synthetic scroll event (that path → flushSync-in-commit → render loop).
     const scrollEvents = dispatchSpy.mock.calls.filter(([e]) => (e as Event).type === 'scroll')
     expect(
       scrollEvents.length,
-      'scrollToOffset must dispatch a scroll event to keep the virtualizer window synced to scrollTop',
-    ).toBeGreaterThan(0)
+      'scrollToOffset must NOT dispatch a synthetic scroll event (flushSync-in-commit risk)',
+    ).toBe(0)
   })
 })

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type { MessageVirtualizer } from './messageVirtualizer'
 
@@ -103,6 +103,25 @@ export function useTanstackMessageVirtualizer({
   // of the conversation. A constant estimate keeps getTotalSize stable; the prepend restore
   // stays accurate via getOffsetForMessageId + the scroll hook's per-frame re-assert, which
   // re-reads the offset as the prepended rows measure.
+  // @tanstack hands its offset callback to `observeElementOffset` on (re)mount; we stash it so a
+  // PROGRAMMATIC scroll (scrollToOffset) can re-window by pushing the new offset straight into it
+  // with isScrolling=false — a non-sync notify that routes through the adapter's plain rerender()
+  // instead of flushSync. A synthetic `scroll` DOM event would instead drive isScrolling=true →
+  // flushSync, which explodes ("flushSync from inside a lifecycle method") when scrollToOffset is
+  // called from the MAM-prepend restore useLayoutEffect, spamming a render-loop storm. See scrollToOffset.
+  const offsetCbRef = useRef<((offset: number, isScrolling: boolean) => void) | null>(null)
+  const observeOffset = useCallback(
+    (instance: { scrollElement: HTMLElement | null }, cb: (offset: number, isScrolling: boolean) => void) => {
+      offsetCbRef.current = cb
+      const cleanup = observeElementOffsetWithRaf(instance, cb)
+      return () => {
+        offsetCbRef.current = null
+        cleanup?.()
+      }
+    },
+    [],
+  )
+
   const virtualizer = useVirtualizer<HTMLElement, Element>({
     count: items.length,
     getScrollElement: () => scrollRef.current,
@@ -111,7 +130,7 @@ export function useTanstackMessageVirtualizer({
     overscan: 12,
     // rAF-polled offset observer so the window keeps advancing during WebKit inertial momentum,
     // when the desktop webview withholds `scroll` events (the "looping rows" bug). See the fn doc.
-    observeElementOffset: observeElementOffsetWithRaf,
+    observeElementOffset: observeOffset,
   })
 
   const getOffsetForMessageId = useCallback((id: string): number | null => {
@@ -141,16 +160,18 @@ export function useTanstackMessageVirtualizer({
     measureElement: virtualizer.measureElement,
     scrollToOffset: (offset, opts) => {
       virtualizer.scrollToOffset(offset, opts)
-      // @tanstack updates its reactive scrollOffset ONLY from the scroll element's
-      // 'scroll' DOM event (observeElementOffset). scrollToOffset sets the DOM
-      // scrollTop (via _scrollToOffset) but leaves scrollOffset stale until that
-      // event fires. The MAM-prepend restore calls this from a useLayoutEffect
-      // right after a count change; the browser's pending scroll event does not
-      // re-window before paint, so the mounted window keeps the old (top) rows and
-      // the viewport renders BLANK until the user scrolls again. Dispatch the event
-      // synchronously so the virtualizer re-reads scrollTop and re-windows to match
-      // — the same sync a real user scroll performs.
-      scrollRef.current?.dispatchEvent(new Event('scroll'))
+      // @tanstack updates its reactive scrollOffset ONLY from the scroll element's 'scroll' DOM
+      // event (observeElementOffset). scrollToOffset sets the DOM scrollTop (via _scrollToOffset)
+      // but leaves scrollOffset stale until that event fires. The MAM-prepend restore calls this
+      // from a useLayoutEffect right after a count change; the browser's pending scroll event does
+      // not re-window before paint, so the mounted window keeps the old (top) rows and the viewport
+      // renders BLANK until the user scrolls again. Push the restored offset straight into
+      // @tanstack's offset callback with isScrolling=false: this updates scrollOffset and
+      // recalculates the window synchronously (re-windowed before paint, same as the old synthetic
+      // scroll dispatch) BUT routes through the adapter's plain rerender() rather than flushSync.
+      // A synthetic `scroll` event would hardcode isScrolling=true → flushSync → "flushSync from
+      // inside a lifecycle method" + a render-loop storm when called during the layout-effect commit.
+      offsetCbRef.current?.(offset, false)
     },
     scrollToIndex: (index, opts) => virtualizer.scrollToIndex(index, opts),
   }

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -403,6 +403,67 @@ describe('setupBackgroundSyncSideEffects', () => {
       )
     })
 
+    it('retries pending decrypts after conversation catch-up completes (catch-up-tail race)', async () => {
+      // A message fetched and stashed during the long catch-up TAIL — after the
+      // one-shot key-unlock retry already ran its snapshot — would otherwise stay
+      // "could not be decrypted" until the next launch. Re-running retryPendingDecrypts
+      // when catch-up settles decrypts it in the same session.
+      ;(mockClient.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+
+      connectionStore.getState().setServerInfo({
+        identities: [],
+        domain: 'example.com',
+        features: [NS_MAM],
+      })
+
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateFreshSession(mockClient)
+
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+      })
+      await vi.waitFor(() => {
+        expect(mockClient.retryPendingDecrypts).toHaveBeenCalled()
+      })
+    })
+
+    it('retries pending decrypts again after room catch-up completes', async () => {
+      connectionStore.getState().setServerInfo({
+        identities: [],
+        domain: 'example.com',
+        features: [NS_MAM],
+      })
+
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateFreshSession(mockClient)
+
+      // Conversation catch-up settles first and triggers its own retry.
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
+      })
+      await vi.waitFor(() => {
+        expect(mockClient.retryPendingDecrypts).toHaveBeenCalled()
+      })
+      const afterConversation =
+        (mockClient.retryPendingDecrypts as ReturnType<typeof vi.fn>).mock.calls.length
+
+      // Room catch-up runs after the 10s delay; its completion must trigger another
+      // retry so room messages stashed during that later pass also self-heal in-session.
+      await vi.advanceTimersByTimeAsync(10_000)
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(1)
+      })
+      await vi.waitFor(() => {
+        expect(
+          (mockClient.retryPendingDecrypts as ReturnType<typeof vi.fn>).mock.calls.length,
+        ).toBeGreaterThan(afterConversation)
+      })
+    })
+
     it('should cancel room catch-up timer on disconnect', async () => {
       connectionStore.getState().setServerInfo({
         identities: [],

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -203,6 +203,15 @@ export function setupBackgroundSyncSideEffects(
       } catch {
         // Silently ignore — best-effort sync
       }
+      // Re-decrypt anything stashed during this catch-up. retryPendingDecrypts is
+      // a one-shot snapshot driven by KEY-availability events (key-unlock / plugin
+      // registration). When the key is restored WHILE catch-up is still streaming,
+      // its single pass only covers what was stashed at that instant; messages
+      // fetched in the catch-up TAIL stay "could not be decrypted" until the next
+      // launch. Firing a (coalesced) retry once catch-up settles closes that window
+      // in-session. Cheap when nothing is pending (sparse encryptedPayload index)
+      // and a no-op without a registered plugin. Runs even if a stage above threw.
+      void client.retryPendingDecrypts()
     })()
 
     // Stage 4: Room catch-up + member discovery (delayed to let rooms finish joining and discover MAM)
@@ -215,6 +224,11 @@ export function setupBackgroundSyncSideEffects(
         } catch {
           // Silently ignore MAM catch-up errors
         }
+        // Same rationale as the 1:1 catch-up retry above: room messages stashed
+        // during this delayed pass (encrypted MUC history fetched after a mid-sync
+        // key unlock) would otherwise wait until the next launch. Re-run once room
+        // catch-up settles. Coalesced with any in-flight pass.
+        void client.retryPendingDecrypts()
         // Record every room covered by this pass (MAM-ready now, plus the active
         // room handled by roomSideEffects) so the late-MAM watcher only retries
         // rooms whose support resolves AFTER this point (issue D).


### PR DESCRIPTION
Two independent fixes surfaced from a new-client encryption restore session.

## 1. Virtualizer render loop / flushSync storm
`scrollToOffset` dispatched a synthetic `scroll` event to force @tanstack to re-window. That drives the offset callback with `isScrolling=true`, and react-virtual does `flushSync` whenever `sync===true`. The MAM-prepend restore calls `scrollToOffset` from a `useLayoutEffect` (commit phase), so `flushSync` throws "flushSync was called from inside a lifecycle method" and snowballs into a 30-renders/1000ms storm during backward MAM pagination.

Fix: re-window via @tanstack's stashed offset callback with `isScrolling=false` — a non-sync notify (plain rerender, legal mid-commit) that still updates the window synchronously before paint, no blank frame.

## 2. OpenPGP messages stay encrypted until next launch
`retryPendingDecrypts` is a one-shot snapshot triggered only by key-availability events. When the key is restored while background catch-up is still streaming (60s+), the single pass misses messages stashed in the catch-up tail — they stay "could not be decrypted" until the next launch.

Fix: fire a coalesced `retryPendingDecrypts` after conversation catch-up and after room catch-up settle, adding a content-settled trigger alongside the key-available ones. Also gives deferred reactions another attach attempt as targets load.