### PR TITLE
Quote & reply rework: recessed quotes, avatar-less reply chip

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -224,6 +224,8 @@ describe('MessageBubble', () => {
       const quote = screen.getByText('Original message').closest('button')!
       expect(quote).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' })
       expect(within(quote).getByText('Bob')).toHaveStyle({ color: 'rgb(0, 255, 0)' })
+      // the leading reply arrow also follows the sender hue
+      expect(quote.querySelector('svg')).toHaveStyle({ color: 'rgb(0, 255, 0)' })
     })
 
     it('re-renders the quote when only replyContext.senderColor changes', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -168,7 +168,7 @@ describe('MessageBubble', () => {
       expect(screen.getByText('Original message')).toBeInTheDocument()
     })
 
-    it('renders avatar in reply context when avatarUrl is provided', () => {
+    it('does not render an avatar in the reply context (avatar-less design)', () => {
       const props = createDefaultProps({
         replyContext: {
           senderName: 'Bob',
@@ -181,10 +181,11 @@ describe('MessageBubble', () => {
       })
       render(<MessageBubble {...props} />)
 
-      // When avatarUrl is provided, an img element with that src should be rendered
-      const avatarImg = screen.getByRole('img', { name: 'Bob' })
-      expect(avatarImg).toBeInTheDocument()
-      expect(avatarImg).toHaveAttribute('src', 'https://example.com/bob-avatar.jpg')
+      // The reply chip is avatar-less even when an avatar URL is available;
+      // identity is carried by the colored edge + nick text.
+      expect(screen.queryByRole('img', { name: 'Bob' })).not.toBeInTheDocument()
+      expect(screen.getByText('Bob')).toBeInTheDocument()
+      expect(screen.getByText('Original message')).toBeInTheDocument()
     })
 
     it('does not render avatar in reply context when avatarUrl is undefined', () => {
@@ -205,11 +206,10 @@ describe('MessageBubble', () => {
       expect(avatarImg).not.toBeInTheDocument()
     })
 
-    // Regression: the quote's letter avatar auto-generated its color from the
-    // identifier (nick hash) while the main message avatar followed senderColor
-    // (contact color) — same sender, two different hues. The quote avatar must
-    // follow replyContext.senderColor like the quote's border and nick text do.
-    it('uses replyContext.senderColor as the quote letter avatar background', () => {
+    // The reply chip is avatar-less: identity is carried by the colored edge and
+    // the nick text, both following replyContext.senderColor (the contact color),
+    // so the reply matches the sender's color in the thread.
+    it('uses replyContext.senderColor for the quote edge and name', () => {
       const props = createDefaultProps({
         replyContext: {
           senderName: 'Bob',
@@ -222,8 +222,8 @@ describe('MessageBubble', () => {
       render(<MessageBubble {...props} />)
 
       const quote = screen.getByText('Original message').closest('button')!
-      const letter = within(quote).getByText('B')
-      expect(letter.parentElement).toHaveStyle({ backgroundColor: 'rgb(0, 255, 0)' })
+      expect(quote).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' })
+      expect(within(quote).getByText('Bob')).toHaveStyle({ color: 'rgb(0, 255, 0)' })
     })
 
     it('re-renders the quote when only replyContext.senderColor changes', () => {
@@ -243,7 +243,7 @@ describe('MessageBubble', () => {
       rerender(<MessageBubble {...props} replyContext={{ ...base, senderColor: 'rgb(255, 0, 255)' }} />)
 
       const quote = screen.getByText('Original message').closest('button')!
-      expect(within(quote).getByText('B').parentElement).toHaveStyle({ backgroundColor: 'rgb(255, 0, 255)' })
+      expect(quote).toHaveStyle({ borderColor: 'rgb(255, 0, 255)' })
       expect(within(quote).getByText('Bob')).toHaveStyle({ color: 'rgb(255, 0, 255)' })
     })
 

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -579,19 +579,13 @@ export const MessageBubble = memo(function MessageBubble({
         {!message.isRetracted && replyContext && (
           <button
             onClick={() => scrollToMessage(replyContext.messageId)}
-            className="flex items-start gap-1.5 pb-1 ps-2 border-s-2 text-start min-w-0 hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
+            className="flex items-start gap-1.5 py-1 pe-2 ps-2 border-s-2 text-start min-w-0 bg-fluux-bg-secondary hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
             style={{ borderColor: replyContext.senderColor }}
           >
-            <div className="flex flex-col items-center flex-shrink-0 gap-0.5">
-              <Avatar
-                identifier={replyContext.avatarIdentifier}
-                name={replyContext.senderName}
-                avatarUrl={replyContext.avatarUrl}
-                fallbackColor={replyContext.senderColor}
-                size="xs"
-              />
-              <CornerUpRight className="rtl-mirror size-3 text-fluux-muted" />
-            </div>
+            <CornerUpRight
+              className="rtl-mirror size-3.5 flex-shrink-0 mt-0.5"
+              style={{ color: replyContext.senderColor }}
+            />
             <div className="text-sm text-fluux-muted min-w-0 flex-1">
               <span
                 className="font-medium"

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -550,35 +550,26 @@ html, body {
   -webkit-overflow-scrolling: touch;
 }
 
-/* Blockquote with decorative quotation marks — distinguishes quotes from reply indicators */
+/* First-level quote — a recessed card with an accent edge and a single opening
+   mark (Aurora). Nested levels use a plain accent line (.blockquote-nested). */
 .blockquote-decorated {
   position: relative;
-  padding-left: 1.25rem;
-  padding-right: 0.5rem;
-  padding-top: 0.2rem;
-  padding-bottom: 0.5rem;
-  margin-block: 0.125rem;
+  border-left: 2px solid var(--fluux-brand);
+  background: var(--fluux-bg-secondary);
+  border-radius: 0 var(--fluux-radius-m) var(--fluux-radius-m) 0;
+  padding: 0.4rem 0.7rem 0.45rem 2.1rem;
+  margin-block: 0.25rem;
 }
 .blockquote-decorated::before {
   content: '\201C';
   position: absolute;
-  left: 0;
-  top: -0.15rem;
-  font-size: 1.75rem;
+  left: 0.55rem;
+  top: 0.15rem;
+  font-size: 1.4rem;
   line-height: 1;
   color: var(--fluux-brand);
-  opacity: 0.6;
+  opacity: 0.55;
   font-family: Georgia, 'Times New Roman', serif;
-}
-.blockquote-decorated::after {
-  content: '\201D';
-  font-size: 1.75rem;
-  line-height: 0;
-  color: var(--fluux-brand);
-  opacity: 0.6;
-  font-family: Georgia, 'Times New Roman', serif;
-  vertical-align: -0.4rem;
-  margin-left: 0.1rem;
 }
 /* Nested blockquote level — indented with a thin left border, no extra quote marks */
 .blockquote-nested {

--- a/apps/fluux/src/utils/messageStyles.test.tsx
+++ b/apps/fluux/src/utils/messageStyles.test.tsx
@@ -247,6 +247,18 @@ describe('renderStyledMessage', () => {
       expect(quote?.classList.contains('blockquote-decorated')).toBe(true)
     })
 
+    it('renders quote text upright (not italic) and muted', () => {
+      const container = renderText('> Top level\n>> Nested level')
+      const outer = container.querySelector('blockquote.blockquote-decorated')!
+      const nested = container.querySelector('blockquote.blockquote-nested')!
+      // Community feedback: quotes must not be italic. Guard both levels.
+      expect(outer.classList.contains('italic')).toBe(false)
+      expect(nested.classList.contains('italic')).toBe(false)
+      // ...while keeping the muted treatment.
+      expect(outer.classList.contains('text-fluux-muted')).toBe(true)
+      expect(nested.classList.contains('text-fluux-muted')).toBe(true)
+    })
+
     it('treats spaced "> >" markers as nested depth (no raw > leaks)', () => {
       const container = renderText('> Top level\n> > Spaced nested')
       const outer = container.querySelector('blockquote.blockquote-decorated')

--- a/apps/fluux/src/utils/messageStyles.tsx
+++ b/apps/fluux/src/utils/messageStyles.tsx
@@ -519,7 +519,7 @@ function renderQuoteTree(
   return (
     <blockquote
       key={`quote-${baseIdx}`}
-      className={isDecorated ? 'blockquote-decorated text-fluux-muted italic' : 'blockquote-nested text-fluux-muted italic'}
+      className={isDecorated ? 'blockquote-decorated text-fluux-muted' : 'blockquote-nested text-fluux-muted'}
     >
       {children}
     </blockquote>


### PR DESCRIPTION
Reworks quote and reply rendering, driven by community feedback (the decorated quote style read heavy and the italics hurt readability) and the Aurora design language.

## Markdown quotes (`> …`)
- First level is now a **recessed card** with an accent edge and a **single** opening mark — instead of the large `❝ … ❞` pair bracketing the whole block.
- Nested levels keep a **plain accent line**.
- Quote text is **upright** (no longer italic), still muted.

## Reply chip
- **Avatar-less and recessed.** With the edge and nick both following the sender's thread color, the avatar was redundant for identity and cost readability (Telegram-style). A leading reply arrow in the sender hue replaces it.
- The edge, nick, and arrow all use `replyContext.senderColor` — the same color the sender's name uses in the thread — so the reply matches the sender, and will automatically follow the curated sender palette once that lands.
- Shared by 1:1 and rooms via `MessageBubble`.