### PR TITLE
Apply the display font to admin stat figures

### DIFF
--- a/apps/fluux/src/components/ServerOverview.tsx
+++ b/apps/fluux/src/components/ServerOverview.tsx
@@ -76,7 +76,7 @@ export function ServerOverview() {
                   <span className="text-xs font-medium">{t(card.labelKey)}</span>
                   {card.target && <ChevronRight className="size-4 ms-auto rtl-mirror" />}
                 </div>
-                <div className="text-2xl font-semibold text-fluux-text break-words" title={String(value)}>
+                <div className="text-2xl font-semibold text-fluux-text break-words font-display" title={String(value)}>
                   {card.format(value, durationUnits)}
                 </div>
                 {card.secondaryLabelKey && secondary != null && (


### PR DESCRIPTION
Small follow-up to the display-font work. The base `h1–h6` rule doesn't reach the ServerOverview stat values (a `<div>`, not a heading), so the big metric figures (uptime, users, rooms, version) were still on Inter. Tight numerals suit large figures — apply `font-display` to the values; the small labels stay on the body font. Uses the 600 cut already on main, so it's self-sufficient.