### PR TITLE
fix(perf): arm render-loop grace on scroll so virtualizer windowing stops tripping the warning

### DIFF
--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -20,6 +20,7 @@ import { scrollStateManager, type ScrollAnchor } from '@/utils/scrollStateManage
 import { createResizeLoopMonitor } from './resizeLoopMonitor'
 import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
 import type { MessageVirtualizer } from './messageVirtualizer'
+import { notifyUserInput } from '@/utils/renderLoopDetector'
 
 // ============================================================================
 // DEBUG
@@ -845,6 +846,12 @@ export function useMessageListScroll({
   // ==========================================================================
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    // Arm the render-loop interaction grace: a fast scroll legitimately re-windows the
+    // virtualized MessageList ~once per frame, which would otherwise trip the loop
+    // *warning*. The rolling window expires shortly after scrolling stops, so a genuine
+    // post-scroll loop is still reported; the hard throw threshold is unaffected.
+    notifyUserInput()
+
     const el = e.currentTarget
     const { scrollTop, scrollHeight, clientHeight } = el
     const distFromBottom = scrollHeight - scrollTop - clientHeight

--- a/apps/fluux/src/utils/renderLoopDetector.test.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.test.ts
@@ -37,6 +37,26 @@ describe('renderLoopDetector — interaction grace', () => {
       for (let i = 0; i < 250; i++) detectRenderLoop('LoopComp')
     }).toThrow(/Render loop detected/)
   })
+
+  // Scroll arms the SAME interaction grace as keystrokes (a fast scroll re-windows the
+  // virtualized MessageList ~once per frame — legitimate input-driven churn). The grace
+  // is a rolling window: once the user stops scrolling it expires, so a genuine
+  // post-scroll loop is still reported.
+  it('suppresses warnings during a scroll burst but resumes after the grace window expires', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let t = 5_000_000
+    __setClock(() => t)
+
+    notifyUserInput() // a scroll event just happened — arms the interaction grace
+    for (let i = 0; i < 30; i++) detectRenderLoop('ScrollComp') // burst within the grace window
+    expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(WARNING_RE))
+
+    // Scrolling stopped: advance past the grace window (and the 1s render window so the
+    // per-component counter resets). A sustained loop now keeps rendering on its own.
+    t += 1600
+    for (let i = 0; i < 30; i++) detectRenderLoop('ScrollComp')
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(WARNING_RE))
+  })
 })
 
 const SUSTAINED_RE = /Sustained render rate/

--- a/apps/fluux/src/utils/renderLoopDetector.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.ts
@@ -379,11 +379,14 @@ export function resetRenderLoopDetector(): void {
 }
 
 /**
- * Signal that a user-input event just occurred (e.g. a keystroke in the message
- * composer). Suppresses render-loop *warnings* for a short rolling window so that
- * legitimate per-keystroke re-renders of a controlled input don't read as a loop.
- * The error/throw threshold is NOT affected — a genuine loop triggered while
- * typing still trips the hard break.
+ * Signal that a user-input event just occurred — a keystroke in the message
+ * composer, or a scroll in the message list. Suppresses render-loop *warnings* for
+ * a short rolling window so that legitimate input-driven re-renders don't read as a
+ * loop: a controlled input re-renders ~1-2× per keystroke, and a fast scroll
+ * re-windows the virtualized list ~once per frame. The error/throw threshold is NOT
+ * affected — a genuine loop triggered while typing or scrolling still trips the hard
+ * break, and the rolling window expires once the interaction stops so a sustained
+ * post-interaction loop is still reported.
  */
 export function notifyUserInput(): void {
   interactionGraceUntil = nowFn() + INTERACTION_GRACE_MS


### PR DESCRIPTION
## Summary

Scrolling fast in a conversation logged `[RenderLoopDetector] Warning: MessageList has rendered 30 times in 1000ms`. This is **expected behavior, not a render loop**: with message-list virtualization now ON by default (#650), `@tanstack/react-virtual` re-renders `MessageList` on every scroll offset change to re-window the visible rows (~once per animation frame during a fast scroll). Each render only mounts the visible window, so it's cheap and bounded — but a fast fling crosses the detector's 30-renders/1000ms warning threshold.

`handleScroll` now calls `notifyUserInput()`, arming the **same rolling interaction grace** that keystrokes already use. Warnings are suppressed while the user is actively scrolling and resume once scrolling stops — so a genuine self-sustaining post-scroll loop is still reported. The EWMA sustained-rate detector and the hard 200-render throw threshold are untouched.

Chosen over raising `WARNING_THRESHOLD`, which would globally desensitize every instrumented component to every cause, and would still leave the independent sustained-rate detector (40/sec) firing on a long scroll.

## Changes
- `useMessageListScroll.ts` — `handleScroll` arms the interaction grace via `notifyUserInput()`.
- `renderLoopDetector.ts` — broaden the `notifyUserInput` doc to cover scroll (no logic change; the primitive already did exactly this for keystrokes).
- `renderLoopDetector.test.ts` — scroll grace-expiry guard: a burst during scroll does not warn, a synthetic post-scroll loop still does.