### PR TITLE
fix(messages): stick-to-bottom on WebKit — re-window virtualizer after scrollToIndex

### DIFF
--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.test.tsx
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.test.tsx
@@ -31,7 +31,13 @@ vi.mock('@tanstack/react-virtual', () => ({
       getTotalSize: () => opts.count * 40,
       getOffsetForIndex: (index: number) => [index * 40, 'start'] as const,
       measureElement: () => {},
-      scrollToIndex: () => {},
+      // Mirror real @tanstack: scrollToIndex resolves an offset and sets the DOM scrollTop
+      // (via _scrollToOffset → scrollToFn) but does NOT update its reactive scrollOffset. The
+      // adapter must read the landed scrollTop back and re-window through the offset callback.
+      scrollToIndex: (index: number) => {
+        const el = opts.getScrollElement()
+        if (el) el.scrollTop = index * 40
+      },
       scrollToOffset: scrollToOffsetSpy,
     }
   },
@@ -93,6 +99,42 @@ describe('useTanstackMessageVirtualizer', () => {
     expect(
       scrollEvents.length,
       'scrollToOffset must NOT dispatch a synthetic scroll event (flushSync-in-commit risk)',
+    ).toBe(0)
+  })
+
+  it('scrollToIndex re-windows via @tanstack\'s offset callback with isScrolling=false (bottom-stick on WebKit)', () => {
+    // Same scrollOffset-desync as scrollToOffset, on the stick-to-bottom path. @tanstack's
+    // scrollToIndex (used by pinVirtualizedBottom for both send and receive, the FAB, and
+    // ensureMessageMounted) sets the DOM scrollTop via _scrollToOffset but leaves its reactive
+    // scrollOffset stale until the native 'scroll' event fires. On Tauri WebKit that event is
+    // withheld/coalesced for a programmatic scroll, so the mounted window never re-syncs and a
+    // just-appended bottom row (the new message) is never windowed in → the view does NOT stick
+    // to the bottom. The adapter must read the landed scrollTop and push it straight into the
+    // offset callback (isScrolling=false, non-sync), exactly as scrollToOffset does. Not
+    // reproducible in Playwright (chromium/webkit fire the native event), so this is the guard.
+    offsetNotifySpy.mockClear()
+    const el = document.createElement('div')
+    const dispatchSpy = vi.spyOn(el, 'dispatchEvent')
+    const { items, indexById } = makeItems(['a', 'b', 'c'])
+    const { result } = renderHook(() => {
+      const scrollRef = useRef<HTMLElement | null>(el)
+      return useTanstackMessageVirtualizer({ items, indexById, scrollRef })
+    })
+
+    result.current.scrollToIndex(2, { align: 'end' })
+
+    // 1. @tanstack's scrollToIndex set the DOM scrollTop (mock: index * 40 = 80).
+    expect(el.scrollTop).toBe(80)
+    // 2. The window is re-synced through the offset callback with isScrolling=false (non-sync).
+    expect(
+      offsetNotifySpy,
+      'scrollToIndex must re-window via the offset callback with isScrolling=false',
+    ).toHaveBeenCalledWith(80, false)
+    // 3. It must NOT dispatch a synthetic scroll event (flushSync-in-commit risk).
+    const scrollEvents = dispatchSpy.mock.calls.filter(([e]) => (e as Event).type === 'scroll')
+    expect(
+      scrollEvents.length,
+      'scrollToIndex must NOT dispatch a synthetic scroll event (flushSync-in-commit risk)',
     ).toBe(0)
   })
 })

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -173,6 +173,20 @@ export function useTanstackMessageVirtualizer({
       // inside a lifecycle method" + a render-loop storm when called during the layout-effect commit.
       offsetCbRef.current?.(offset, false)
     },
-    scrollToIndex: (index, opts) => virtualizer.scrollToIndex(index, opts),
+    scrollToIndex: (index, opts) => {
+      virtualizer.scrollToIndex(index, opts)
+      // Same scrollOffset-desync guard as scrollToOffset above, on the stick-to-bottom path.
+      // @tanstack's scrollToIndex sets the DOM scrollTop (via _scrollToOffset → scrollToFn) but
+      // leaves its reactive scrollOffset stale until the scroll element's native 'scroll' event
+      // fires. On Tauri WebKit that event is withheld/coalesced for a programmatic scroll, so the
+      // mounted window never re-windows and a just-appended bottom row (new message — send OR
+      // receive, via pinVirtualizedBottom) is never windowed in: the view fails to stick to the
+      // bottom. Push the landed scrollTop straight into @tanstack's offset callback with
+      // isScrolling=false (non-sync, plain rerender — NOT a synthetic scroll event, which would
+      // flushSync mid-commit) to re-window before paint. Chromium fires the native event promptly
+      // so this is a redundant no-op there; the bug is WebKit-only (not reproducible in Playwright).
+      const el = scrollRef.current
+      if (el) offsetCbRef.current?.(el.scrollTop, false)
+    },
   }
 }


### PR DESCRIPTION
## Problem

On the Tauri desktop app (WebKit), the message list did **not** stick to the bottom when sending or receiving a message — at any conversation length, in both 1:1 chats and MUC rooms. The sent/received message would not be scrolled into view. It worked fine in Chromium (web/dev) and in the Playwright WebKit suite, so it never surfaced in automated checks.

## Root cause

Stick-to-bottom is driven by `pinVirtualizedBottom()` → the virtualizer's `scrollToIndex(last, 'end')`. In the @tanstack adapter, `scrollToIndex` was a bare pass-through.

@tanstack's `scrollToIndex` sets the DOM `scrollTop` (via `_scrollToOffset` → `scrollToFn`) but leaves its **reactive `scrollOffset` stale** — that value, which drives the mounted window (`calculateRange`), only updates from the scroll element's native `scroll` event. On Tauri WebKit that event is withheld/coalesced for a programmatic scroll, so the window never re-windows and the just-appended bottom row is never mounted. Chromium fires `scroll` promptly, which is why it's invisible there and in Playwright.

This is the **same `scrollOffset`-desync that `scrollToOffset` was already patched for** (the MAM-prepend blank); `scrollToIndex` simply never got the matching fix.

## Fix

After `virtualizer.scrollToIndex(...)`, read the landed `scrollTop` back and push it into @tanstack's offset callback with `isScrolling=false` — a non-sync, plain rerender (not a synthetic `scroll` event, which would `flushSync` mid-commit and storm). This re-windows before paint on WebKit and is a redundant no-op on Chromium. It mirrors the existing `scrollToOffset` guard.