### PR TITLE
fix(scroll): remount message view per conversation to stop cross-conversation scroll bleed

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -684,6 +684,11 @@ export const ChatMessageList = memo(function ChatMessageList({
 
   return (
     <MessageListComponent
+      // Remount the message view (fresh virtualizer + scroll refs) per conversation so no
+      // imperative scroll state — the @tanstack virtualizer's measurement/offset cache above
+      // all — bleeds between conversations. Restoration survives via scrollStateManager (an
+      // external singleton keyed by conversation id).
+      key={conversationId}
       messages={messages}
       conversationId={conversationId}
       firstNewMessageId={firstNewMessageId}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1066,6 +1066,10 @@ export const RoomMessageList = memo(function RoomMessageList({
 
   return (
     <MessageList
+      // Remount the message view (fresh virtualizer + scroll refs) per room so no imperative
+      // scroll state — the @tanstack virtualizer's measurement/offset cache above all — bleeds
+      // between rooms. Restoration survives via scrollStateManager (keyed by room jid).
+      key={room.jid}
       messages={messages}
       conversationId={room.jid}
       firstNewMessageId={firstNewMessageId}

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -509,6 +509,11 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
 
   return (
     <MessageList
+      // Remount per previewed message so shared scroll-hook refs don't bleed between previews.
+      // Keyed on the preview identity (conversation + anchor message), not conversationId alone,
+      // since different results within one conversation must each get a fresh view. (staticMode
+      // here disables virtualization, so there is no virtualizer cache to leak.)
+      key={`${conversationId}:${highlightedMessageId}`}
       messages={messages}
       conversationId={conversationId}
       scrollerRef={scrollerRef}


### PR DESCRIPTION
## Summary

Switching between conversations gradually corrupted the scroll position in other conversations — the position got worse the more you switched around. Root cause is architectural: the message view is a single instance reused across conversation switches, so its imperative scroll state leaks between conversations.

`ChatView` and `RoomView` render `<MessageList>` **without a key**, so one instance (with one `@tanstack` virtualizer and one set of `useMessageListScroll` refs) serves every conversation of that type — only props change on switch. The conversation-switch effect scrubs the hook's own refs but **never resets the virtualizer**, whose measurement/offset cache is mutated continuously across all conversations. That accumulation is what degrades the restored position over time. It only became observable now because message-list virtualization became default-on (#650); the virtualizer is the heaviest piece of shared mutable state, and neither jsdom (no layout) nor the preview harness (no rAF) can exercise it.

## Fix

Key `<MessageList>` by conversation identity so each conversation/room/preview remounts with a fresh virtualizer and fresh scroll refs, eliminating cross-conversation state bleed by construction:

- `ChatView` — `key={conversationId}`
- `RoomView` — `key={room.jid}`
- `SearchContextView` — `key={`${conversationId}:${highlightedMessageId}`}` (per previewed message, since one conversation can have several previews)

Scroll restoration is unaffected: `scrollStateManager` is an external singleton keyed by conversation id that survives the remount. The search-context preview runs in `staticMode` (no virtualizer), so keying there just cleanly resets the shared hook refs.

Keeping the key on the `MessageList` subtree (not the whole `ChatView`/`RoomView`) targets exactly the leaky part without remounting the composer, drafts, or focus handling.