### PR TITLE
fix(scroll): make composer-resize bottom-stick virtualizer-aware

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -27,6 +27,10 @@ const getOffsetForMessageId = vi.fn((_id: string): number | null => 0)
 // path). A direct scrollTop write does NOT go through here, so this distinguishes a
 // virtualizer-aware restore (re-windows before paint) from a raw scrollTop write (blank).
 const scrollToOffsetCalls: number[] = []
+// Records the align of every scrollToIndex. A bottom re-pin goes through
+// scrollToIndex(last,'end') (re-windows the virtualizer); a raw scrollTop write does not.
+// Lets a test prove the composer-resize correction routes through the virtualizer.
+const scrollToIndexCalls: Array<string | undefined> = []
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
@@ -64,6 +68,7 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
       if (el) el.scrollTop = offset
     },
     scrollToIndex: (_index: number, opts?: { align?: string }) => {
+      scrollToIndexCalls.push(opts?.align)
       const el = args.scrollRef.current
       if (!el) return
       if (opts?.align === 'end') {
@@ -431,5 +436,60 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     // Restored (and re-windowed) to the saved offset, not yanked to the new message at bottom.
     expect(scrollToOffsetCalls).toContain(200)
     expect(scrollTopSets).not.toContain(5000)
+  })
+
+  it('re-windows the virtualizer when the composer grows (attachment / whisper / reply banner) while at bottom', () => {
+    // A composer banner appearing (file attachment preview, whisper marker, reply/edit
+    // preview) shrinks the message scroller. The composer-resize correction must re-pin to
+    // the bottom THROUGH the virtualizer (scrollToIndex(last,'end')) so the mounted window
+    // re-windows — a raw `scrollTop = scrollHeight` write leaves @tanstack's offset stale and
+    // the newly-revealed region blank, the same class of bug fixed for conversation-switch and
+    // MAM-prepend restores. jsdom has no layout, so this pins the re-window CONTRACT.
+    const realRO = globalThis.ResizeObserver
+    const observers: Array<{ targets: Element[]; fire: (height: number) => void }> = []
+    globalThis.ResizeObserver = class {
+      private cb: ResizeObserverCallback
+      targets: Element[] = []
+      constructor(cb: ResizeObserverCallback) {
+        this.cb = cb
+        observers.push({ targets: this.targets, fire: (height: number) =>
+          this.cb([{ contentRect: { height } } as ResizeObserverEntry], this as unknown as ResizeObserver) })
+      }
+      observe(t: Element) { this.targets.push(t) }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver
+
+    try {
+      const { container } = render(
+        <MessageList messages={makeMessages(50)} conversationId="conv-grow" {...props} />,
+      )
+      const scroller = container.querySelector('[data-message-list]') as HTMLElement
+      const { grow } = instrumentScroller(scroller, 5000)
+      void grow
+
+      // Sit at the bottom and let the scroll handler record isAtBottom = true.
+      scroller.scrollTop = 4500 // scrollHeight 5000 - clientHeight 500
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+      flush(2)
+
+      // The correction observer is the LAST one watching the scroller (MessageWidthProvider's
+      // width observer is created first; the scroll-correction observer last).
+      const correction = [...observers].reverse().find((o) => o.targets.includes(scroller))
+      expect(correction).toBeTruthy()
+
+      scrollToIndexCalls.length = 0
+
+      // Establish the baseline height, then shrink it (composer banner appeared).
+      correction!.fire(500)
+      flush(1)
+      correction!.fire(400)
+      flush(1)
+
+      // The correction re-pinned through the virtualizer (re-window), not a raw scrollTop write.
+      expect(scrollToIndexCalls).toContain('end')
+    } finally {
+      globalThis.ResizeObserver = realRO
+    }
   })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -587,6 +587,21 @@ export function useMessageListScroll({
     requestAnimationFrame(step)
   }, [isAtBottomRef])
 
+  // Re-pin the list to the bottom after a layout change that grows the content or shrinks the
+  // scroller while the user is following along: typing indicator, reactions on the last message,
+  // or a composer banner appearing/disappearing (attachment preview, whisper marker, reply/edit
+  // preview). Routes through the virtualizer when active so the mounted window re-windows before
+  // paint (a raw scrollTop write leaves @tanstack's offset stale → blank/clipped); otherwise a
+  // direct scrollTop write. Callers must have already confirmed the user is at/near the bottom.
+  const reassertBottom = useCallback(() => {
+    if (virtualizerRef.current) {
+      pinVirtualizedBottom()
+    } else {
+      const s = scrollerRef.current
+      if (s) s.scrollTop = s.scrollHeight
+    }
+  }, [pinVirtualizedBottom])
+
   // ==========================================================================
   // LOAD OLDER MESSAGES
   // ==========================================================================
@@ -1555,25 +1570,13 @@ export function useMessageListScroll({
   // on conversation switch (stale "not at bottom" state gets persisted).
   useLayoutEffect(() => {
     if (!isAtBottomRef.current) return
-    const virtTyping = latestRef.current.virtualizer
-    const s = scrollerRef.current
-    if (virtTyping) {
-      pinVirtualizedBottom()
-    } else if (s) {
-      s.scrollTop = s.scrollHeight
-    }
-  }, [typingUsersCount, isAtBottomRef, pinVirtualizedBottom])
+    reassertBottom()
+  }, [typingUsersCount, isAtBottomRef, reassertBottom])
 
   useLayoutEffect(() => {
     if (!isAtBottomRef.current) return
-    const virtReaction = latestRef.current.virtualizer
-    const s = scrollerRef.current
-    if (virtReaction) {
-      pinVirtualizedBottom()
-    } else if (s) {
-      s.scrollTop = s.scrollHeight
-    }
-  }, [lastMessageReactionsKey, isAtBottomRef, pinVirtualizedBottom])
+    reassertBottom()
+  }, [lastMessageReactionsKey, isAtBottomRef, reassertBottom])
 
   // ==========================================================================
   // EFFECT: Container resize (composer grows/shrinks)
@@ -1606,7 +1609,9 @@ export function useMessageListScroll({
       const shrunk = lastHeight - newHeight
       if (shrunk > 0 && scrollerRef.current) {
         const wasNear = getDistanceFromBottom(scrollerRef.current) <= shrunk + AT_BOTTOM_THRESHOLD
-        if (wasNear) scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
+        // Route through reassertBottom so the virtualized path re-windows (scrollToIndex) rather
+        // than a raw scrollTop write that would leave the mounted window stale → blank/clipped.
+        if (wasNear) reassertBottom()
       }
 
       lastHeight = newHeight
@@ -1637,7 +1642,9 @@ export function useMessageListScroll({
       observer.disconnect()
       if (rafId !== null) cancelAnimationFrame(rafId)
     }
-  }, [conversationId])
+    // reassertBottom is stable (depends only on the stable pinVirtualizedBottom), so listing it
+    // re-creates the observer only on conversation change, same as conversationId alone.
+  }, [conversationId, reassertBottom])
 
   // ==========================================================================
   // EFFECT: Keyboard shortcuts

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -420,7 +420,11 @@ export function useMessageListScroll({
 
         const { staticMode, isAtBottomRef } = latestRef.current
 
-        // Content grew and we were at bottom -> stay at bottom
+        // Content grew and we were at bottom -> stay at bottom. Route through the shared
+        // reassertBottom (the same helper the new-message / typing / composer-resize sites use)
+        // so there is one place that decides how to land at the bottom. Virtualized is already
+        // excluded above, so this only ever takes the raw-scrollTop branch — but keeping it
+        // funnelled means a future change to the pin logic can't miss this site.
         if (newHeight > lastHeight && isAtBottomRef.current && !staticMode) {
           debugLog('RESIZE SCROLL TO BOTTOM', {
             newHeight,
@@ -428,7 +432,7 @@ export function useMessageListScroll({
             isAtBottom: isAtBottomRef.current,
             scrollTopBefore: currentScrollTop,
           })
-          currentScroller.scrollTop = newHeight
+          reassertBottom()
         } else if (newHeight !== lastHeight) {
           debugLog('RESIZE NO SCROLL', {
             newHeight,
@@ -1530,12 +1534,7 @@ export function useMessageListScroll({
         scrollTopBefore: scroller.scrollTop,
       })
       isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
-      const virtNewMsg = latestRef.current.virtualizer
-      if (virtNewMsg) {
-        pinVirtualizedBottom()
-      } else {
-        scroller.scrollTop = scroller.scrollHeight
-      }
+      reassertBottom()
     } else if (isNewMessage) {
       debugLog('NEW MSG NO SCROLL (not at bottom)', {
         messageCount,
@@ -1545,7 +1544,7 @@ export function useMessageListScroll({
     }
 
     prevMessageCountRef.current = messageCount
-  }, [messageCount, isAtBottomRef, staticMode, lastMessageIsOutgoing, pinVirtualizedBottom])
+  }, [messageCount, isAtBottomRef, staticMode, lastMessageIsOutgoing, reassertBottom])
 
   // ==========================================================================
   // EFFECT: Reset marker scroll tracking when firstNewMessageId changes
@@ -1563,20 +1562,17 @@ export function useMessageListScroll({
   // EFFECT: Typing indicator / reactions change
   // ==========================================================================
 
-  // useLayoutEffect ensures scroll adjustment happens BEFORE browser paint.
-  // With useEffect, the browser paints a frame with the gap visible, and scroll
-  // events can fire in between - potentially setting isAtBottomRef to false,
-  // which breaks auto-scroll for subsequent messages and causes blank screens
-  // on conversation switch (stale "not at bottom" state gets persisted).
+  // Content grew INSIDE the scroller (typing indicator toggled, reactions added to the last
+  // message): the scroller box is unchanged but scrollHeight grew, so a follower must re-pin.
+  // One effect keyed on both signals — the body is identical and both mean "footer/last-row
+  // height changed". useLayoutEffect runs BEFORE paint: with useEffect the browser paints a
+  // frame with the gap visible and a scroll event can fire in between, flipping isAtBottomRef
+  // false — which breaks auto-scroll for subsequent messages and strands a blank screen on
+  // conversation switch (the stale "not at bottom" state gets persisted).
   useLayoutEffect(() => {
     if (!isAtBottomRef.current) return
     reassertBottom()
-  }, [typingUsersCount, isAtBottomRef, reassertBottom])
-
-  useLayoutEffect(() => {
-    if (!isAtBottomRef.current) return
-    reassertBottom()
-  }, [lastMessageReactionsKey, isAtBottomRef, reassertBottom])
+  }, [typingUsersCount, lastMessageReactionsKey, isAtBottomRef, reassertBottom])
 
   // ==========================================================================
   // EFFECT: Container resize (composer grows/shrinks)


### PR DESCRIPTION
## Summary

Stick-to-bottom has three height-change handlers in `useMessageListScroll.ts`. The typing-indicator and reactions layout-effects correctly branch to `pinVirtualizedBottom()` when virtualization is active, but the **composer-resize correction** (the `ResizeObserver` on the scroller) still did a raw `scrollTop = scrollHeight` write even under virtualization.

That composer-resize path is the one that handles every banner that grows the composer and so shrinks the message list:

- file-attachment preview
- private whisper marker
- reply preview
- edit banner

Since message-list virtualization is default-on, a raw `scrollTop` write leaves the @tanstack window stale (the same blank/clipped class of bug already fixed for conversation-switch and MAM-prepend restores). So when one of those banners appeared while the user was at the bottom, the view could fail to re-pin and show a blank or clipped tail.

The typing indicator and reactions live *inside* the scroller (content grows, scroller box height unchanged), which is why they have their own effects and were already correct.

## Fix

Extract a shared `reassertBottom()` helper — `if (virtualizerRef.current) pinVirtualizedBottom() else scrollTop = scrollHeight` — and route all three height-change sites (typing, reactions, composer-resize) through it. This makes the composer-resize correction virtualizer-aware and removes the duplicated branch the other two effects already had.