### PR TITLE
fix(chat): show new-message marker when switching into an unread conversation

### DIFF
--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1050,7 +1050,14 @@ export function useMessageListScroll({
             const viewportHeight = markerScroller.clientHeight
             const targetScrollTop = Math.max(0, elementTop - viewportHeight / 3)
 
-            markerScroller.scrollTop = targetScrollTop
+            // Route through the virtualizer (scrollToOffset) so @tanstack's reactive
+            // scrollOffset is updated. A raw `scrollTop` write is reverted to the top when
+            // the virtualizer re-windows as rows measure (it re-applies its stale offset),
+            // which left the marker stranded below the fold — the same fix the
+            // restore-position and bottom-pin paths already use.
+            const v = latestRef.current.virtualizer
+            if (v) v.scrollToOffset(targetScrollTop)
+            else markerScroller.scrollTop = targetScrollTop
 
             // Update isAtBottom based on actual position after scrolling
             const distFromBottom = markerScroller.scrollHeight - targetScrollTop - viewportHeight


### PR DESCRIPTION
## Problem

Opening a conversation that has unread messages landed the view at the **top of the conversation** (oldest messages) instead of at the new-message marker / most recent messages, so the "New messages" (Nouveaux messages) divider was effectively never seen.

## Root cause

In the conversation-switch effect of `useMessageListScroll.ts`, the scroll-to-marker branch positioned the marker with a raw `markerScroller.scrollTop = …` write. With the @tanstack virtualizer (default-on) a raw `scrollTop` write leaves the virtualizer's reactive `scrollOffset` stale, so the next re-window (as rows measure) re-applies the old offset and snaps the view back to the top — stranding the marker below the fold. The restore-position and bottom-pin paths were already fixed to route through the virtualizer; the marker branch was missed.

## Fix

Route that one write through `scrollToOffset`, which keeps @tanstack's reactive `scrollOffset` in sync (the same approach the restore-position and bottom-pin paths already use). The surrounding structure — including the DOM-query guard and `ensureMessageMounted` — is unchanged, so behaviour is identical when the marker row is not mounted (e.g. the all-unread stress-room case). Net change: +8 / -1 lines.

With the fix, switching into a conversation with a few unread messages lands at the marker / most recent messages (you see the new content) instead of at the oldest messages.

## Verification

- All 14 Playwright scroll invariants pass locally on **chromium and webkit** (no test changes).
- `npm run typecheck` clean; lint clean (no new warnings); 436 conversation unit tests pass.
- Manually verified in demo mode (switch into an unread conversation no longer lands at the top showing old messages).

## Known follow-up (not in this PR)

For a conversation whose unread tail is very short or contains tall media (e.g. a video) directly below the marker, landing at/near the bottom can trip the existing marker-clear-on-scroll handler so the divider itself is cleared once the new messages are visible. That is a separate behaviour in the clear logic and is better addressed on its own.