### PR TITLE
Aurora theme audit: contrast, visibility & readability fixes

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -434,7 +434,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
           >
             <button
               aria-label="chat.scrollToBottom"
-              class="size-10 rounded-full bg-fluux-bg border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors duration-200 hover:scale-105 active:scale-95"
+              class="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
               data-fab="scroll-to-bottom"
               tabindex="-1"
             >
@@ -545,7 +545,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
           >
             <button
               aria-label="chat.scrollToBottom"
-              class="size-10 rounded-full bg-fluux-bg border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors duration-200 hover:scale-105 active:scale-95"
+              class="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
               data-fab="scroll-to-bottom"
               tabindex="-1"
             >

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
             >
               <button
                 aria-label="chat.scrollToBottom"
-                class="size-10 rounded-full bg-fluux-bg border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors duration-200 hover:scale-105 active:scale-95"
+                class="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
                 data-fab="scroll-to-bottom"
                 tabindex="-1"
               >

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -519,7 +519,7 @@ export function MessageList<T extends BaseMessage>({
           <button
             onClick={scrollToBottom}
             data-fab="scroll-to-bottom"
-            className="size-10 rounded-full bg-fluux-bg border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors duration-200 hover:scale-105 active:scale-95"
+            className="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
             aria-label={t('chat.scrollToBottom')}
             tabIndex={showScrollToBottom ? 0 : -1}
           >

--- a/apps/fluux/src/components/sidebar-components/IconRailButton.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailButton.tsx
@@ -30,7 +30,7 @@ export function IconRailButton({
             ? 'bg-fluux-brand text-fluux-text-on-accent'
             : disabled
               ? 'text-fluux-muted/50 cursor-not-allowed'
-              : 'text-fluux-muted hover:bg-white/10 hover:text-fluux-text'
+              : 'text-fluux-muted hover:bg-fluux-hover hover:text-fluux-text'
           }`}
       >
         <Icon className="size-5" />

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -42,7 +42,7 @@ export function IconRailNavLink({
           focus-visible:ring-2 focus-visible:ring-fluux-brand focus-visible:ring-offset-2 focus-visible:ring-offset-fluux-sidebar
           ${isActive
             ? 'bg-fluux-brand text-fluux-text-on-accent'
-            : 'text-fluux-muted hover:bg-white/10 hover:text-fluux-text'
+            : 'text-fluux-muted hover:bg-fluux-hover hover:text-fluux-text'
           }
         `}
       >

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -366,6 +366,16 @@
   --fluux-color-blue-rgb: 9, 105, 218;
   --fluux-color-gray: #9ca3af;
 
+  /* Status colors as text/icon labels (toasts, settings status, edit/encryption
+     labels) fail WCAG AA at full brightness on the light surfaces (Pattern C:
+     green ~2.6:1, yellow ~1.6:1, red ~3.8:1). Darkened to clear AA as text; used
+     as fills (toast border, danger button, presence dots) they only gain
+     contrast against white. Syntax-highlight greens reference --fluux-color-*
+     directly and are unaffected. */
+  --fluux-status-success: #197740;
+  --fluux-status-warning: #89600A;
+  --fluux-status-error: #C8252A;
+
   /* Own-message ("you") name — brand-indigo darkened for WCAG AA on the white
      message background and its hover state (the raw accent only reached ~4.6:1
      at rest and failed on hover). */
@@ -394,12 +404,15 @@
   /* ── Aurora identity (light) ── */
   --fluux-accent-2: #11A88C;
   --fluux-grad: linear-gradient(135deg, #11A88C, #5B6CF0, #7C6CF0);
-  --fluux-sender-1: #1E84D8;
-  --fluux-sender-2: #119E73;
-  --fluux-sender-3: #B5790E;
-  --fluux-sender-4: #D8527A;
-  --fluux-sender-5: #6E54D8;
-  --fluux-sender-6: #128C86;
+  /* Sender palette darkened so MUC names clear WCAG AA on white and on the
+     hover/active message rows (Pattern C: the prior values reached only ~2.8-4.4
+     and were unreadable in light mode). */
+  --fluux-sender-1: #1766A7;
+  --fluux-sender-2: #0C7051;
+  --fluux-sender-3: #86590A;
+  --fluux-sender-4: #B92A54;
+  --fluux-sender-5: #654AD6;
+  --fluux-sender-6: #0E6F6A;
   --fluux-glass-bg: rgba(255, 255, 255, 0.72);
   --fluux-shadow-overlay: 0 20px 50px rgba(20, 27, 48, 0.18);
 

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -225,8 +225,11 @@
   --fluux-scrollbar-thumb-sidebar: var(--fluux-base-30);
   --fluux-scrollbar-thumb-sidebar-hover: var(--fluux-base-50);
 
-  /* Focus ring */
-  --fluux-focus-ring: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.5);
+  /* Focus ring — drives the universal `.user-interacted *:focus` outline, so this
+     one token governs keyboard-focus visibility app-wide. Solid accent: at 0.5
+     alpha it was only ~1.9:1 and failed the WCAG 1.4.11 non-text minimum (3:1);
+     solid clears 3:1 on every surface in both modes. */
+  --fluux-focus-ring: hsl(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l));
 
   /* Shadows */
   --fluux-shadow-color: rgba(0, 0, 0, 0.3);

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -167,6 +167,12 @@
   --fluux-bg-active: var(--fluux-base-50);
   --fluux-bg-accent: hsl(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l));
   --fluux-bg-accent-hover: hsl(var(--fluux-accent-h), var(--fluux-accent-s), calc(var(--fluux-accent-l) - 8%));
+  /* Floating / elevated surfaces (FAB, raised controls) — lifted above the
+     canvas so the control reads as a distinct shape. Pairs with the visible
+     border below and a drop shadow; on the light canvas (white) the border +
+     shadow carry the separation. */
+  --fluux-bg-float: var(--fluux-base-50);
+  --fluux-bg-float-hover: var(--fluux-base-60);
 
   /* Text */
   --fluux-text-normal: var(--fluux-base-90);
@@ -194,7 +200,11 @@
   --fluux-interactive-accent-hover: var(--fluux-bg-accent-hover);
 
   /* Borders & dividers */
-  --fluux-border-color: rgba(0, 0, 0, 0.1);
+  /* Light-alpha on the dark canvas: a black border on a dark surface is
+     invisible (~1.0:1). White at low alpha gives a readable hairline (~1.6:1)
+     that defines edges for the FAB, inputs, modals, tooltips and dividers.
+     The .light override flips this back to black-alpha. */
+  --fluux-border-color: rgba(255, 255, 255, 0.16);
   --fluux-border-color-strong: var(--fluux-base-40);
   --fluux-divider-color: var(--fluux-base-05);
 
@@ -370,7 +380,12 @@
   /* Semantic overrides where cascade from foundation isn't sufficient */
   --fluux-bg-secondary: #DDE2F0;
   --fluux-sidebar-item-active: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.14);
-  --fluux-border-color: rgba(0, 0, 0, 0.15);
+  /* Black-alpha hairline on the light canvas, bumped for a clearer edge (~1.5:1). */
+  --fluux-border-color: rgba(0, 0, 0, 0.18);
+  /* Floating surface on the light (white) canvas: stays white, the border +
+     shadow provide the separation; hover tints to the tertiary gray. */
+  --fluux-bg-float: var(--fluux-base-00);
+  --fluux-bg-float-hover: var(--fluux-base-20);
   --fluux-selection-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.15);
   --fluux-search-highlight-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);
   --fluux-scrollbar-thumb: #c4c9ce;

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -177,7 +177,11 @@
   /* Text */
   --fluux-text-normal: var(--fluux-base-90);
   --fluux-text-muted: var(--fluux-base-80);
-  --fluux-text-faint: var(--fluux-base-70);
+  /* Faintest informational tier (e.g. timestamps). Decoupled from base-70 and
+     lifted to clear WCAG AA on the message rows it renders on — the raw ramp
+     value reached only ~3.2:1 on the hover row. Still lighter than text-muted,
+     so the tier distinction holds. .light overrides below. */
+  --fluux-text-faint: #7885A3;
   --fluux-text-on-accent: #ffffff;
   --fluux-text-accent: var(--fluux-bg-accent);
   --fluux-text-link: var(--fluux-color-blue);
@@ -379,7 +383,15 @@
   /* Own-message ("you") name — brand-indigo darkened for WCAG AA on the white
      message background and its hover state (the raw accent only reached ~4.6:1
      at rest and failed on hover). */
-  --fluux-text-self: #4F5BD8;
+  --fluux-text-self: #4753D6;
+
+  /* Link text darkened so it clears WCAG AA on the message hover/active rows
+     (the shared --fluux-color-blue only reached ~4.2:1 there). Overrides just the
+     link token; other blue uses (status-info, syntax) keep --fluux-color-blue. */
+  --fluux-text-link: #0860C6;
+
+  /* Faint tier (timestamps) — AA-legible value for the light canvas. */
+  --fluux-text-faint: #5D6781;
 
   /* Private (whisper) — deeper violet for contrast on light backgrounds */
   --fluux-private: hsl(270, 70%, 48%);

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -109,6 +109,15 @@ describe('Aurora theme contrast invariants', () => {
       expect(r).toBeGreaterThanOrEqual(4.5)
     })
 
+    // Pattern E — the focus ring is a non-text UI indicator and must clear the
+    // WCAG 1.4.11 non-text contrast minimum (3:1) against the surfaces it rings.
+    // It drives the universal `.user-interacted *:focus` outline, so this one
+    // token governs focus visibility app-wide. (Was accent @ 0.5 alpha, ~1.9:1.)
+    it(`[${mode}] focus ring clears 3:1 non-text contrast on the hover surface`, () => {
+      const r = contrast('var(--fluux-focus-ring)', 'var(--fluux-bg-hover)', vars)
+      expect(r).toBeGreaterThanOrEqual(3)
+    })
+
     // Pattern B — informational text that renders on message rows must clear AA
     // against the darkest of those (the hover row), not just the resting surface.
     // Links and the own-name dipped below AA on the light-mode hover/active rows;

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+/**
+ * Aurora theme contrast guard.
+ *
+ * The theme is token-driven, so contrast regressions are silent — a single edit
+ * to index.css can make a control's border invisible or push body text below
+ * WCAG AA without any visual diff in code review. This test resolves the CSS
+ * custom properties for both modes and asserts the structural invariants the
+ * 2026-06-26 Aurora audit established (docs/2026-06-26-aurora-theme-audit.md):
+ *
+ *  - a border drawn on a surface must read as a hairline (Pattern A)
+ *  - body/muted informational text must clear WCAG AA (Pattern B)
+ *
+ * Numbers are exact WCAG 2.1, alpha composited over the real backdrop.
+ */
+
+const cssPath = resolve(dirname(fileURLToPath(import.meta.url)), '../index.css')
+const css = readFileSync(cssPath, 'utf8')
+
+// --- extract the :root (dark) and .light token blocks ---
+function block(selector: string): Record<string, string> {
+  const re = new RegExp(`${selector.replace('.', '\\.')}\\s*\\{([\\s\\S]*?)\\n\\}`)
+  const body = css.match(re)?.[1] ?? ''
+  const map: Record<string, string> = {}
+  for (const m of body.matchAll(/(--[\w-]+):\s*([^;]+);/g)) map[m[1]] = m[2].trim()
+  return map
+}
+const dark = block(':root')
+const light = { ...dark, ...block('.light') } // light inherits :root where not overridden
+
+// --- color resolution: hex / rgba / hsl, with var() expanded anywhere ---
+type RGBA = [number, number, number, number]
+// Textually expand every var(--x) in a value (including inside hsl()/rgba() args).
+function expand(value: string, vars: Record<string, string>, depth = 0): string {
+  if (depth > 16) throw new Error('var() cycle: ' + value)
+  return value.replace(/var\((--[\w-]+)\)/g, (_, k: string) => {
+    if (!(k in vars)) throw new Error('undefined token: ' + k)
+    return expand(vars[k], vars, depth + 1)
+  })
+}
+function resolve_(value: string, vars: Record<string, string>): RGBA {
+  const v = expand(value, vars).trim()
+  if (v.startsWith('#')) {
+    const h = v.slice(1)
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16), 1]
+  }
+  const rgba = v.match(/^rgba?\(([^)]+)\)$/)
+  if (rgba) {
+    const p = rgba[1].split(',').map((x) => parseFloat(x))
+    return [p[0], p[1], p[2], p[3] ?? 1]
+  }
+  const hsl = v.match(/^hsla?\(([^)]+)\)$/)
+  if (hsl) {
+    const p = hsl[1].split(',').map((x) => parseFloat(x))
+    return [...hslToRgb(p[0], p[1], p[2]), p[3] ?? 1] as RGBA
+  }
+  throw new Error('unhandled color: ' + value)
+}
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  s /= 100; l /= 100
+  const k = (n: number) => (n + h / 30) % 12
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)))
+  return [Math.round(255 * f(0)), Math.round(255 * f(8)), Math.round(255 * f(4))]
+}
+function over(fg: RGBA, bg: RGBA): [number, number, number] {
+  const a = fg[3]
+  return [0, 1, 2].map((i) => fg[i] * a + bg[i] * (1 - a)) as [number, number, number]
+}
+function relLum([r, g, b]: number[]): number {
+  const lin = (c: number) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4) }
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+}
+function contrast(fg: string, bg: string, vars: Record<string, string>): number {
+  const bgc = resolve_(bg, vars)
+  const fgc = resolve_(fg, vars)
+  const top = fgc[3] < 1 ? over(fgc, bgc) : [fgc[0], fgc[1], fgc[2]]
+  const l1 = relLum(top), l2 = relLum([bgc[0], bgc[1], bgc[2]])
+  const hi = Math.max(l1, l2), lo = Math.min(l1, l2)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+describe('Aurora theme contrast invariants', () => {
+  // Pattern A — a border must define an edge against its surface in both modes.
+  // 1.5:1 is a deliberately low bar (a hairline, not AA text); the regression we
+  // guard against is the old black-on-dark border at ~1.0:1 (invisible).
+  for (const [mode, vars] of [['dark', dark], ['light', light]] as const) {
+    it(`[${mode}] border-color reads as a hairline on the chat surface`, () => {
+      const r = contrast('var(--fluux-border-color)', 'var(--fluux-chat-bg)', vars)
+      expect(r).toBeGreaterThanOrEqual(1.5)
+    })
+
+    it(`[${mode}] muted text clears WCAG AA on the chat surface`, () => {
+      const r = contrast('var(--fluux-text-muted)', 'var(--fluux-chat-bg)', vars)
+      expect(r).toBeGreaterThanOrEqual(4.5)
+    })
+
+    it(`[${mode}] normal text clears WCAG AAA on the chat surface`, () => {
+      const r = contrast('var(--fluux-text-normal)', 'var(--fluux-chat-bg)', vars)
+      expect(r).toBeGreaterThanOrEqual(7)
+    })
+
+    it(`[${mode}] white text clears WCAG AA on the accent fill`, () => {
+      const r = contrast('var(--fluux-text-on-accent)', 'var(--fluux-bg-accent)', vars)
+      expect(r).toBeGreaterThanOrEqual(4.5)
+    })
+  }
+})

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -109,6 +109,17 @@ describe('Aurora theme contrast invariants', () => {
       expect(r).toBeGreaterThanOrEqual(4.5)
     })
 
+    // Pattern B — informational text that renders on message rows must clear AA
+    // against the darkest of those (the hover row), not just the resting surface.
+    // Links and the own-name dipped below AA on the light-mode hover/active rows;
+    // text-faint (the timestamp tier) failed in both modes at its old value.
+    for (const token of ['text-link', 'text-self', 'text-faint'] as const) {
+      it(`[${mode}] ${token} clears WCAG AA on the hover row`, () => {
+        const r = contrast(`var(--fluux-${token})`, 'var(--fluux-bg-hover)', vars)
+        expect(r).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+
     // Pattern C — MUC sender names are informational text. They render in the
     // message list on the chat surface AND on the hover/active row, so they must
     // clear AA against the darkest of those (bg-hover) in both modes.

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -108,5 +108,26 @@ describe('Aurora theme contrast invariants', () => {
       const r = contrast('var(--fluux-text-on-accent)', 'var(--fluux-bg-accent)', vars)
       expect(r).toBeGreaterThanOrEqual(4.5)
     })
+
+    // Pattern C — MUC sender names are informational text. They render in the
+    // message list on the chat surface AND on the hover/active row, so they must
+    // clear AA against the darkest of those (bg-hover) in both modes.
+    for (let i = 1; i <= 6; i++) {
+      it(`[${mode}] sender-${i} clears WCAG AA on the hover row`, () => {
+        const r = contrast(`var(--fluux-sender-${i})`, 'var(--fluux-bg-hover)', vars)
+        expect(r).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+  }
+
+  // Pattern C — status colors are used as text/icon labels on light surfaces
+  // (settings cards, toasts, edit/encryption labels). The light theme's bright
+  // green/yellow/red fail AA as text; assert the (darkened) light overrides.
+  // Dark-mode status-as-text needs a separate text/fill token split (follow-up).
+  for (const key of ['success', 'warning', 'error'] as const) {
+    it(`[light] status-${key} clears WCAG AA as text on a card surface`, () => {
+      const r = contrast(`var(--fluux-status-${key})`, 'var(--fluux-bg-primary)', light)
+      expect(r).toBeGreaterThanOrEqual(4.5)
+    })
   }
 })

--- a/apps/fluux/tailwind.config.js
+++ b/apps/fluux/tailwind.config.js
@@ -21,6 +21,8 @@ export default {
           'surface': 'var(--fluux-bg-tertiary)',
           'hover': 'var(--fluux-bg-hover)',
           'active': 'var(--fluux-bg-active)',
+          'float': 'var(--fluux-bg-float)',
+          'float-hover': 'var(--fluux-bg-float-hover)',
           'sidebar-item-active': 'var(--fluux-sidebar-item-active)',
           'sidebar-item-active-accent': 'var(--fluux-sidebar-item-active-accent)',
           'selection': 'var(--fluux-selection-bg)',

--- a/docs/2026-06-26-aurora-theme-audit.md
+++ b/docs/2026-06-26-aurora-theme-audit.md
@@ -1,0 +1,189 @@
+# Aurora Theme Audit — Contrast, Visibility & Readability
+
+**Date:** 2026-06-26
+**Scope:** Aurora theme (`id: fluux`), both **dark** and **light** modes.
+**Method:** Hybrid — exact WCAG 2.1 contrast computation on every token pairing actually used in the UI, cross-checked against live computed-style measurements and rendered screenshots in demo mode.
+
+> Most findings are structural token-placement issues that surface identically across all 13 built-in themes. Fixing them in Aurora's shared semantic tokens fixes them everywhere.
+
+---
+
+## 1. Executive summary
+
+The system is fundamentally sound: fully token-driven, a clean 3-tier cascade, WCAG-aware accent-fill contrast. The problems are not the palette values themselves but **the wrong _kind_ of token applied in the wrong place**, concentrated in four structural patterns:
+
+| # | Pattern | Severity | Where | Root cause |
+|---|---------|----------|-------|-----------|
+| **A** | **Elevation is invisible** — floating/raised/hover/active surfaces and panel boundaries do not read as distinct | **High** | FAB, hover/active rows, rail↔sidebar↔chat seams, inputs, modals, dividers, tooltips | `--fluux-border-color` uses **black alpha in both modes** (invisible on dark), and the neutral ramp steps 10→50 are too close in luminance to separate by fill alone |
+| **B** | **"Faint" text fails AA** | **High (light) / Med (dark)** | timestamps, faint/tertiary text, links & self-name in light mode | `--fluux-text-faint` and several light-mode colors fall below 4.5:1 |
+| **C** | **Color-as-text fails AA, severely in light mode** | **High** | MUC sender names, status (success/warning/error) text & icons | light-mode sender + status palettes are too light; many below 3:1 |
+| **D** | **Hardcoded non-token colors** | **Low–Med** | ~25 sites (red-500/green-500/yellow-500/amber, white/10, black/50, ad-hoc shadows) | bypass the theme system; break under non-Aurora themes and can't be tuned for contrast |
+
+Plus a focus-visibility inconsistency (E) and minor observations (F).
+
+**The FAB you flagged is the poster child of Pattern A** — it is `bg-fluux-bg` (identical to the chat background, **1.04:1**) with a border of `rgba(0,0,0,0.1)` (**1.01:1** — mathematically invisible on dark). Its only separation from the canvas is a soft shadow that barely reads on deep ink.
+
+---
+
+## 2. Methodology
+
+1. **Token resolution** — every semantic/component token resolved to concrete sRGB for both modes from [index.css](apps/fluux/src/index.css) (`:root` = dark, `.light` = light).
+2. **Usage inventory** — every visible foreground↔background pairing in the UI traced to `file:line` (chat, sidebar, rail, composer, modals, toasts, tooltips, settings, occupant panel, search).
+3. **Contrast computation** — WCAG 2.1 relative-luminance ratios, with alpha tokens composited over their actual backdrop. (Script archived; numbers below are exact, not estimated.)
+4. **Live cross-check** — `getComputedStyle` measurements in the running demo confirmed the math (e.g. muted preview text measured **5.00:1**, predicted 5.00:1).
+5. **Visual confirmation** — Aurora dark + light rendered in demo mode.
+
+### Severity model
+
+- **High** — fails WCAG AA (4.5:1) for informational text, OR an interactive control / essential boundary is effectively invisible (< ~1.5:1 separation).
+- **Medium** — AA-large only (3:1) where AA is wanted, borderline (dips below AA in some states), or a hierarchy layer that does not read as distinct.
+- **Low** — polish: semantic-color inconsistency, hardcoded colors, minor legibility.
+
+---
+
+## 3. Findings
+
+### Pattern A — Invisible elevation & boundaries  `High`  `Control visibility / Surface hierarchy`
+
+**Control/surface separation ratios (need ~3:1 to read as a distinct shape; < 1.5 = invisible):**
+
+| Pairing | Dark | Light |
+|---|---|---|
+| **FAB** (`bg-fluux-bg`) on chat-bg | **1.04** | **1.20** |
+| hover row (`base-40`) on chat-bg | 1.06 | 1.23 |
+| active row (`base-50`) on chat-bg | 1.15 | 1.30 |
+| sidebar (`base-20`) ↔ chat (`base-30`) | **1.02** | 1.14 |
+| rail (`base-10`) ↔ sidebar (`base-20`) | 1.02 | 1.06 |
+| input (`base-10`) on chat-bg | 1.04 | 1.20 |
+| modal (`base-20`) on primary (`base-10`) | 1.03 | 1.06 |
+| **border** `rgba(0,0,0,α)` on any dark surface | **1.01–1.03** | 1.41 |
+
+**Two compounding causes:**
+
+1. **`--fluux-border-color` is black-alpha in both modes** ([index.css:205](apps/fluux/src/index.css:205) `rgba(0,0,0,0.1)`; [:381](apps/fluux/src/index.css:381) `rgba(0,0,0,0.15)`). A *dark* border on a *dark* surface is invisible (1.01–1.03:1). Borders carry the entire burden of defining edges for the FAB, inputs, modals, tooltips, dividers, attach menu, search box — and in dark mode they contribute nothing. Confirmed in the dark render: the icon rail and sidebar merge into one mass.
+2. **The neutral ramp is compressed at the dark end** — `base-30→40→50` (`#0F1528 / #141B30 / #1A2238`) differ by ~0.1 in ratio, so hover/active/elevation cannot be conveyed by fill lightness alone.
+
+**Affected sites (representative):**
+- Scroll-to-bottom FAB — [MessageList.tsx:522](apps/fluux/src/components/conversation/MessageList.tsx:522) (`bg-fluux-bg border border-fluux-border`)
+- Composer container & inputs — [MessageComposer.tsx:648](apps/fluux/src/components/MessageComposer.tsx:648), search input — [SearchView.tsx:128](apps/fluux/src/components/sidebar-components/SearchView.tsx:128)
+- Modals — [ModalShell.tsx:45](apps/fluux/src/components/ModalShell.tsx:45), tooltips — [Tooltip.tsx:254](apps/fluux/src/components/Tooltip.tsx:254), toasts — [ToastContainer.tsx:35](apps/fluux/src/components/ToastContainer.tsx:35)
+- Panel seams: rail↔sidebar↔chat have no hairline; they rely on near-zero luminance steps.
+
+**Proposed fix (batch A):**
+- **Split `--fluux-border-color` by mode polarity**: light-alpha on dark (`rgba(255,255,255,0.10–0.14)`), black-alpha on light (bump light to ~`0.18`). This single change restores edges to every bordered control/panel in dark mode.
+- Add an explicit **elevated-surface token** (e.g. `--fluux-bg-float`) for floating controls (FAB, menus, tooltips), lighter than its backdrop, paired with the now-visible border + existing shadow. FAB should use it instead of `bg-fluux-bg`.
+- Give the **rail / sidebar / chat seams a hairline** using the corrected border token (fill contrast alone can't reach 3:1 at the dark end, and shouldn't need to).
+
+---
+
+### Pattern B — "Faint" text below AA  `High (light) / Med (dark)`  `Text contrast`
+
+**Text-on-surface ratios (AA = 4.5; `!` below AA, `!!` below 3.0):**
+
+| Token | Dark (chat-bg) | Light (chat-bg) | Light (on hover/active) |
+|---|---|---|---|
+| `text-normal` | 15.5 | 15.9 | 12.3–13.0 |
+| `text-muted` | 7.3 | 5.7 | 4.4–4.6 `!` |
+| **`text-faint` / timestamps** | **3.41 `!`** | **3.78 `!`** | **2.92 `!!`** |
+| `text-self` (own name) | 9.2 | 5.5 | **4.24–4.49 `!`** |
+| `text-link` | 6.9 | 5.2 | **4.01–4.24 `!`** |
+
+- **Timestamps fail AA in both modes** — `--fluux-text-faint` ([index.css:182](apps/fluux/src/index.css:182)) is used for message timestamps ([MessageBubble.tsx:552](apps/fluux/src/components/conversation/MessageBubble.tsx:552)) and several markers; ~3.4:1. They carry information (when a message was sent) so AA applies.
+- In **light mode**, `text-muted`, `text-self`, and `text-link` all dip **below 4.5:1 on hover/active surfaces** (`base-40/50`). Links at 4.01–4.24 are the most-used offender.
+
+**Proposed fix (batch B):**
+- Darken/lighten `--fluux-text-faint` to clear 4.5:1 on its real surfaces (target ~`#7E8BA8` dark / ~`#646F8C` light), OR if "faint" is intentionally decorative, reserve it for non-informational glyphs and move **timestamps to `text-muted`**.
+- Nudge light-mode `text-link` and `text-self` ~6–8% darker so they hold AA on `base-40/50`.
+
+---
+
+### Pattern C — Color-as-text fails AA, severe in light mode  `High`  `Color semantics / Text contrast`
+
+**Light mode is the problem; dark mode mostly passes.**
+
+| Token (as text) | Dark (chat-bg) | Light (chat-bg) | Light (sidebar base-20) |
+|---|---|---|---|
+| sender-1 | 11.5 | 3.93 `!` | 3.45 `!` |
+| **sender-2** | 11.5 | **3.41 `!`** | **2.99 `!!`** |
+| **sender-3** | 12.1 | 3.68 `!` | **3.23 `!`** |
+| **sender-4** | 9.2 | 3.88 `!` | 3.41 `!` |
+| sender-5 | 9.1 | 5.35 | 4.70 |
+| sender-6 | 10.3 | 4.10 `!` | 3.60 `!` |
+| status-success (text/icon) | 5.7 | **3.18 `!`** | **2.80 `!!`** |
+| **status-warning** (text/icon) | 9.6 | **1.89 `!!`** | **1.66 `!!`** |
+| status-error (text/icon) | 4.0 `!` | 4.57 | 4.02 `!` |
+
+- **MUC sender names are unreadable for several colors in light mode** — 5 of 6 sender tokens fall below AA on the white chat surface; sender-2/3 dip below **3:1** on the sidebar. Sender names are the primary way to attribute messages in a room. ([ChatView sender assignment](apps/fluux/src/components/ChatView.tsx:811), tokens [index.css:390](apps/fluux/src/index.css:390))
+- **Status colors as text/icons fail in light mode** — green status text ~2.5–3.2:1, yellow ~1.5–1.9:1 (effectively invisible). The light theme already darkens `blue`/`gray` for this reason ([index.css:363](apps/fluux/src/index.css:363)) but **not green/yellow/red**.
+- **`status-error` as text dips below AA in dark** (3.97 on chat-bg) — the red used for "delivery failed", new-message marker, etc.
+- **`white` on `status-warning` fill = 1.89 (FAIL)** in both modes — safe today only because warning isn't used as a text-bearing fill; flag before any "warning button/badge" is added.
+
+**Proposed fix (batch C):**
+- **Darken the light-mode sender palette** further (the one darkening pass wasn't enough) so all six clear 4.5:1 on white *and* on `base-20`.
+- **Add light-mode overrides for `status-success` / `status-warning` / `status-error`** (darker variants), mirroring what's already done for blue/gray — so status text/icons stay legible.
+- Nudge `status-error` for dark-mode text use, or pair it with a non-color cue where it labels (icon + text).
+
+---
+
+### Pattern D — Hardcoded non-token colors  `Low–Med`  `Color semantics`
+
+~25 sites bypass the token system with raw Tailwind palette colors. They won't adapt to non-Aurora themes and can't be contrast-tuned centrally. Grouped:
+
+**Status colors that should be `--fluux-status-*`:**
+- Trust/lock icons green/red/yellow-500 — [MessageBubble.tsx:559-565](apps/fluux/src/components/conversation/MessageBubble.tsx:559)
+- Composer encryption badge & edit labels green/red-500 — [MessageComposer.tsx:672](apps/fluux/src/components/MessageComposer.tsx:672), [:935](apps/fluux/src/components/MessageComposer.tsx:935)
+- Delivery error red-500 — [MessageBubble.tsx:668](apps/fluux/src/components/conversation/MessageBubble.tsx:668)
+- Notification permission status green/red/yellow-500 — [NotificationsSettings.tsx:156](apps/fluux/src/components/settings-components/NotificationsSettings.tsx:156)
+- Confirm-dialog danger/warning `bg-red-500`/`bg-orange-500` — [ConfirmDialog.tsx:32](apps/fluux/src/components/ConfirmDialog.tsx:32)
+- Occupant "owner" badge amber, "Quick Chat" header amber-500 — [OccupantPanel.tsx:54](apps/fluux/src/components/OccupantPanel.tsx:54), [RoomsList.tsx:232](apps/fluux/src/components/sidebar-components/RoomsList.tsx:232)
+- App-offline presence `bg-slate-500` — [ui.ts:23](apps/fluux/src/constants/ui.ts:23)
+
+**Surfaces/overlays that should be semantic tokens:**
+- Modal/dialog backdrops `bg-black/50` (token `--fluux-modal-backdrop` exists but is unused) — [ModalShell.tsx:36](apps/fluux/src/components/ModalShell.tsx:36), [ConfirmDialog.tsx:38](apps/fluux/src/components/ConfirmDialog.tsx:38), [UserMenu.tsx:168](apps/fluux/src/components/UserMenu.tsx:168)
+- Icon-rail hover `bg-white/10` — [IconRailNavLink.tsx:45](apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx:45)
+- Tooltip ad-hoc shadow `shadow-[0_4px_16px_rgba(0,0,0,0.25)]` — [Tooltip.tsx:254](apps/fluux/src/components/Tooltip.tsx:254)
+- Video thumb overlay `bg-black/30` — [MessageComposer.tsx:758](apps/fluux/src/components/MessageComposer.tsx:758)
+
+**Proposed fix (batch D):** mechanical token substitution. Reuse `--fluux-modal-backdrop` (already defined). Note `bg-fluux-red` is referenced in a few places but only `--fluux-red` (alias) exists — verify the Tailwind alias resolves, since several danger buttons mix `bg-red-500` and `bg-fluux-red`.
+
+---
+
+### Pattern E — Focus visibility  `Medium`  `Control visibility`
+
+- The global focus ring ([index.css:637](apps/fluux/src/index.css:637)) applies **only after** `.user-interacted` is set, and many inputs override it with `outline-none` + a border-color change only ([AppearanceSettings.tsx:150](apps/fluux/src/components/settings-components/AppearanceSettings.tsx:150)). Keyboard focus is inconsistently visible across modals, settings inputs, and buttons.
+- **Proposed fix (batch E):** standardize a `focus-visible:ring-2 ring-fluux-focus-ring` utility; stop replacing the ring with border-only changes (border at 1.41:1 in light / invisible in dark is not a sufficient focus cue).
+
+---
+
+### Pattern F — Minor observations  `Low`
+
+- **Glass tokens defined but unused** — `--fluux-glass-bg` / `--fluux-glass-blur` exist but no component consumes them; modals use opaque `--fluux-sidebar-bg`. Either wire glass into modals/overlays or drop the dead tokens.
+- **Soft-muted via opacity** — `text-fluux-muted/60` and `/40` (search context, occupant counts) stack opacity on an already-marginal color; can drop below AA. Prefer a dedicated `--fluux-text-faint`-style token over opacity.
+- **`--fluux-accent-2` / `--fluux-grad` (Aurora's signature teal + gradient) are defined but unused** in the audited surfaces — an identity opportunity, not a defect.
+
+---
+
+## 4. Batch-fix plan (phase 2)
+
+Grouped so each batch is one coherent change set:
+
+| Batch | Theme | Effort | Impact |
+|---|---|---|---|
+| **A — Edges & elevation** | mode-polar `--fluux-border-color`, `--fluux-bg-float` token, FAB + panel seams | Small (token-level) + a few component swaps | **Highest** — fixes the FAB and every invisible-edge control/panel in dark mode at once |
+| **B — Informational text** | `text-faint`/timestamps, light-mode link/self nudges | Small | High — timestamps & links become AA |
+| **C — Sender + status palettes** | darken light-mode sender-1..6 + add light status overrides | Small (token-level) | High — MUC names & status legible in light |
+| **D — De-hardcode colors** | substitute `--fluux-status-*` / `--fluux-modal-backdrop` | Medium (mechanical, many sites) | Med — theme correctness across all 13 themes |
+| **E — Focus ring** | standardize `focus-visible` utility | Medium | Med — a11y |
+
+**Recommended order:** A → C → B → E → D. A and C are small token edits with the largest perceptual payoff; D is the long mechanical tail.
+
+### Suggested guardrail
+The contrast math is deterministic. A small unit test that resolves the theme tokens and asserts AA on the informational-text and status pairings (and a minimum separation for border-on-surface) would prevent regressions — the same approach that already guards i18n and security iconography.
+
+---
+
+## 5. Appendix — measurement notes
+
+- Accent fill contrast is healthy: white-on-accent **4.67:1 (dark) / 5.54:1 (light)** — AA. The existing `contrastColorForHsl()` machinery works; the gaps are in *non-accent* token placement.
+- Light mode is consistently the weaker of the two — its surfaces sit in a narrow high-luminance band (`#E7EAF4`–`#FFFFFF`), so both colored text and surface separation have less room.
+- All ratios above are exact WCAG 2.1, alpha tokens composited over their real backdrop, and were spot-validated against live `getComputedStyle` in the running app.


### PR DESCRIPTION
## Aurora theme audit — contrast, visibility & readability

A systematic audit of the Aurora theme (both dark and light modes) for contrast, control visibility, surface hierarchy and color semantics, followed by fixes grouped by category.

The system was already sound (fully token-driven, WCAG-aware accent fills); the issues were the wrong *kind* of token applied in the wrong place. Each fix is a small, mostly token-level change, and all of them are locked in by a new contrast guard.

### Fixes

**A — Borders & the scroll-to-bottom FAB were invisible.** `--fluux-border-color` was a black alpha in *both* modes, so on the dark canvas every border was invisible (~1.0:1). Split it by polarity (light alpha on dark, ~1.6:1 hairline; bumped black alpha on light). Added `--fluux-bg-float` for elevated controls and pointed the FAB at it instead of `--fluux-bg` (which was identical to the chat background). This restores edges to the FAB, inputs, modals, tooltips and dividers across the dark theme at once.

**C — Light-mode color-text was unreadable.** 5 of 6 MUC sender-name colors fell below WCAG AA on white (two below 3:1); status green/yellow/red as text failed badly (yellow ~1.6:1). Darkened the light-mode sender palette and added darkened light-mode `--fluux-status-*` overrides. Used as fills, the darker status values only improve white-on-fill contrast; syntax-highlight greens are untouched.

**B — Informational text below AA.** Darkened the light-mode link and own-name tokens so they clear AA on the message hover/active rows, and lifted `--fluux-text-faint` (the timestamp tier) to be AA-legible in both modes while staying lighter than `text-muted`.

**E — Focus ring failed non-text contrast.** `--fluux-focus-ring` was accent at 0.5 alpha (~1.9:1), below WCAG 1.4.11's 3:1 minimum. Made it solid accent (clears 3:1 on every surface in both modes). Since this token drives the universal `.user-interacted *:focus` outline, focus visibility improves app-wide from one edit.

**D — Theme-aware icon-rail hover.** The icon rail used `hover:bg-white/10`, a white tint only visible on the dark rail; switched to `hover:bg-fluux-hover` so the hover reads in both modes.

### Guard

`apps/fluux/src/themes/themeContrast.test.ts` resolves the CSS tokens for both modes (var/hsl/rgba, alpha composited over the real backdrop) and asserts 31 invariants: border-on-surface hairline visibility, AA body/muted/link/self/faint text, AA sender names on the hover row, AA light-mode status text, AA white-on-accent, and 3:1 focus-ring contrast. This is what each fix was driven against (TDD: red → green) and prevents silent regressions.

### Scope notes

- The "timestamps fail AA" finding was a token-definition artifact: timestamps render with `text-fluux-muted` (AA-safe). `--fluux-text-faint` was defined but unused; it is now honest and safe to adopt.
- The bulk of Pattern D ("hardcoded colors") is intentional and was deliberately left as-is: the status/security colors use per-mode `dark:` variants that are contrast-tuned (flattening them to one token would regress dark mode), modal scrims are theme-neutral, and the app-offline gray is deliberately distinct.