### PR TITLE
Split --fluux-text-error from the error fill (Aurora audit follow-up)

### DIFF
--- a/apps/fluux/src/components/AddContactModal.tsx
+++ b/apps/fluux/src/components/AddContactModal.tsx
@@ -86,7 +86,7 @@ export function AddContactModal({ onClose }: AddContactModalProps) {
         </div>
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
         <p className="text-xs text-fluux-muted">
           {t('contacts.subscriptionNote')}

--- a/apps/fluux/src/components/AddUserModal.test.tsx
+++ b/apps/fluux/src/components/AddUserModal.test.tsx
@@ -136,7 +136,7 @@ function AddUserModal({ vhost, onSubmit, onClose }: AddUserModalProps) {
           </div>
 
           {error && (
-            <p className="text-sm text-fluux-red" data-testid="error-message">{error}</p>
+            <p className="text-sm text-fluux-error" data-testid="error-message">{error}</p>
           )}
 
           <div className="flex gap-2 pt-2">

--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -658,7 +658,7 @@ function AddUserModal({ vhost, onSubmit, onClose }: AddUserModalProps) {
         </div>
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
 
         {/* Buttons */}

--- a/apps/fluux/src/components/AvatarCropModal.tsx
+++ b/apps/fluux/src/components/AvatarCropModal.tsx
@@ -555,7 +555,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
 
           {/* Error message */}
           {error && (
-            <p className="mt-3 text-sm text-fluux-red text-center">{error}</p>
+            <p className="mt-3 text-sm text-fluux-error text-center">{error}</p>
           )}
         </div>
 

--- a/apps/fluux/src/components/BrowseRoomsModal.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.tsx
@@ -391,7 +391,7 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
         {/* Error message */}
         {error && (
           <div className="px-4 py-2 bg-fluux-red/10 border-b border-fluux-hover flex-shrink-0">
-            <p className="text-sm text-fluux-red">{error}</p>
+            <p className="text-sm text-fluux-error">{error}</p>
           </div>
         )}
 

--- a/apps/fluux/src/components/ChangePasswordModal.tsx
+++ b/apps/fluux/src/components/ChangePasswordModal.tsx
@@ -87,7 +87,7 @@ export function ChangePasswordModal({ onClose }: ChangePasswordModalProps) {
         </div>
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
 
         {/* Footer */}

--- a/apps/fluux/src/components/CreateQuickChatModal.tsx
+++ b/apps/fluux/src/components/CreateQuickChatModal.tsx
@@ -122,7 +122,7 @@ export function CreateQuickChatModal({ onClose }: CreateQuickChatModalProps) {
         </div>
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
 
         {/* Actions */}

--- a/apps/fluux/src/components/EditBookmarkModal.tsx
+++ b/apps/fluux/src/components/EditBookmarkModal.tsx
@@ -104,7 +104,7 @@ export function EditBookmarkModal({
         </div>
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
 
         {/* Actions */}

--- a/apps/fluux/src/components/JoinRoomModal.tsx
+++ b/apps/fluux/src/components/JoinRoomModal.tsx
@@ -178,7 +178,7 @@ export function JoinRoomModal({ onClose }: JoinRoomModalProps) {
         )}
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
         <p className="text-xs text-fluux-muted">
           {t('rooms.joinRoomHint')}

--- a/apps/fluux/src/components/LoginErrorPanel.tsx
+++ b/apps/fluux/src/components/LoginErrorPanel.tsx
@@ -23,7 +23,7 @@ function certBodyKey(sub: string | null): string {
 }
 
 const plainBoxClass =
-  'p-3 bg-fluux-red/20 border border-fluux-red/50 rounded text-fluux-red text-sm'
+  'p-3 bg-fluux-red/20 border border-fluux-red/50 rounded text-fluux-error text-sm'
 
 /**
  * Renders a connection error. For recognized transport/TLS kinds it shows a
@@ -61,7 +61,7 @@ export function LoginErrorPanel({ kind, rawError }: LoginErrorPanelProps) {
       <Icon className="size-4 shrink-0 mt-0.5" aria-hidden="true" />
       <div className="space-y-1">
         <p className="font-medium">{title}</p>
-        <p className="text-fluux-red/90">{body}</p>
+        <p className="text-fluux-error/90">{body}</p>
       </div>
     </div>
   )

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -402,7 +402,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
                          ${showJidError ? 'border-fluux-red' : 'border-fluux-border'}`}
             />
             {showJidError && (
-              <p id="jid-error" className="text-xs text-fluux-red mt-1">
+              <p id="jid-error" className="text-xs text-fluux-error mt-1">
                 {t('login.jidInvalid')}
               </p>
             )}

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -690,7 +690,7 @@ export function MessageComposer({
                   <button
                     type="button"
                     onClick={() => setEditAttachmentRemoved(true)}
-                    className="p-0.5 text-fluux-muted hover:text-fluux-red transition-colors flex-shrink-0"
+                    className="p-0.5 text-fluux-muted hover:text-fluux-error transition-colors flex-shrink-0"
                     aria-label={t('chat.removeAttachment')}
                   >
                     <X className="size-3" />
@@ -782,7 +782,7 @@ export function MessageComposer({
             <button
               type="button"
               onClick={onRemovePendingAttachment}
-              className="p-1 text-fluux-muted hover:text-fluux-red transition-colors flex-shrink-0"
+              className="p-1 text-fluux-muted hover:text-fluux-error transition-colors flex-shrink-0"
               aria-label={t('chat.removeAttachment')}
             >
               <X className="size-4" />
@@ -794,11 +794,11 @@ export function MessageComposer({
       {/* Upload error banner */}
       {uploadState?.error && (
         <div className={`bg-fluux-red/10 ${(replyingTo || editingMessage || pendingAttachment) ? '' : 'rounded-t-lg'} px-3 py-2 flex items-center gap-2`}>
-          <p className="text-xs text-fluux-red flex-1">{uploadState.error}</p>
+          <p className="text-xs text-fluux-error flex-1">{uploadState.error}</p>
           <button
             type="button"
             onClick={uploadState.clearError}
-            className="p-0.5 text-fluux-red/60 hover:text-fluux-red transition-colors flex-shrink-0"
+            className="p-0.5 text-fluux-error/60 hover:text-fluux-error transition-colors flex-shrink-0"
             aria-label={t('sidebar.dismiss')}
           >
             <X className="size-3.5" />

--- a/apps/fluux/src/components/OccupantModerationModal.tsx
+++ b/apps/fluux/src/components/OccupantModerationModal.tsx
@@ -221,7 +221,7 @@ export function OccupantModerationModal({
         {/* Danger zone: Kick & Ban */}
         {(showKick || showBan) && (
           <div className="border-t border-fluux-hover pt-4">
-            <h3 className="text-xs font-semibold text-fluux-red uppercase mb-2">{t('rooms.dangerZone')}</h3>
+            <h3 className="text-xs font-semibold text-fluux-error uppercase mb-2">{t('rooms.dangerZone')}</h3>
 
             {confirmingAction ? (
               <div className="space-y-2">
@@ -266,7 +266,7 @@ export function OccupantModerationModal({
                     disabled={loading}
                     onClick={() => setConfirmingAction('kick')}
                     className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md
-                      text-fluux-red hover:bg-fluux-red hover:text-white
+                      text-fluux-error hover:bg-fluux-red hover:text-white
                       disabled:opacity-50 transition-colors"
                   >
                     <UserMinus className="size-4" />
@@ -278,7 +278,7 @@ export function OccupantModerationModal({
                     disabled={loading}
                     onClick={() => setConfirmingAction('ban')}
                     className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md
-                      text-fluux-red hover:bg-fluux-red hover:text-white
+                      text-fluux-error hover:bg-fluux-red hover:text-white
                       disabled:opacity-50 transition-colors"
                   >
                     <Ban className="size-4" />

--- a/apps/fluux/src/components/OverflowMenu.tsx
+++ b/apps/fluux/src/components/OverflowMenu.tsx
@@ -88,7 +88,7 @@ export function OverflowMenu({
                 setIsOpen(false)
                 onClick()
               }}
-              className={`w-full flex items-center gap-2 px-3 py-2.5 text-start text-sm transition-colors hover:bg-fluux-active disabled:opacity-50 disabled:cursor-not-allowed ${danger ? 'text-fluux-red' : 'text-fluux-text'}`}
+              className={`w-full flex items-center gap-2 px-3 py-2.5 text-start text-sm transition-colors hover:bg-fluux-active disabled:opacity-50 disabled:cursor-not-allowed ${danger ? 'text-fluux-error' : 'text-fluux-text'}`}
             >
               <Icon className="size-4 flex-shrink-0" />
               <span>{label}</span>

--- a/apps/fluux/src/components/RenameContactModal.tsx
+++ b/apps/fluux/src/components/RenameContactModal.tsx
@@ -74,7 +74,7 @@ export function RenameContactModal({
         </p>
 
         {error && (
-          <p className="text-sm text-fluux-red">{error}</p>
+          <p className="text-sm text-fluux-error">{error}</p>
         )}
 
         {/* Actions */}

--- a/apps/fluux/src/components/RoomHatsModal.tsx
+++ b/apps/fluux/src/components/RoomHatsModal.tsx
@@ -386,7 +386,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
                     ) : (
                       <button
                         onClick={() => setConfirmDelete(hat)}
-                        className="p-1 text-fluux-muted hover:text-fluux-red transition-colors"
+                        className="p-1 text-fluux-muted hover:text-fluux-error transition-colors"
                         title={t('rooms.destroyHat')}
                       >
                         <Trash2 className="size-3.5" />
@@ -426,7 +426,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
                     ) : (
                       <button
                         onClick={() => void handleUnassign(a)}
-                        className="text-xs text-fluux-muted hover:text-fluux-red transition-colors"
+                        className="text-xs text-fluux-muted hover:text-fluux-error transition-colors"
                       >
                         {t('rooms.unassignHat')}
                       </button>

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -224,7 +224,7 @@ export function RoomHeader({
 
       {/* Room avatar error message */}
       {avatarError && (
-        <div className="absolute top-full inset-x-0 mt-1 mx-4 p-2 bg-fluux-red/20 border border-fluux-red/50 rounded text-fluux-red text-sm flex items-center justify-between z-40">
+        <div className="absolute top-full inset-x-0 mt-1 mx-4 p-2 bg-fluux-red/20 border border-fluux-red/50 rounded text-fluux-error text-sm flex items-center justify-between z-40">
           <span>{avatarError}</span>
           <button onClick={() => setAvatarError(null)} className="p-1 hover:bg-fluux-red/20 rounded">
             <X className="size-4" />

--- a/apps/fluux/src/components/RoomMembersModal.tsx
+++ b/apps/fluux/src/components/RoomMembersModal.tsx
@@ -442,7 +442,7 @@ function AffiliationDropdown({
                 setIsOpen(false)
               }}
               className={`w-full px-3 py-1.5 text-start text-sm hover:bg-fluux-hover transition-colors
-                ${aff === 'outcast' ? 'text-fluux-red' : 'text-fluux-text'}`}
+                ${aff === 'outcast' ? 'text-fluux-error' : 'text-fluux-text'}`}
             >
               {getLabel(aff)}
             </button>

--- a/apps/fluux/src/components/ToastContainer.tsx
+++ b/apps/fluux/src/components/ToastContainer.tsx
@@ -11,7 +11,7 @@ const iconMap: Record<ToastType, typeof CheckCircle2> = {
 
 const colorMap: Record<ToastType, { border: string; icon: string }> = {
   success: { border: 'border-s-fluux-green', icon: 'text-fluux-green' },
-  error: { border: 'border-s-fluux-red', icon: 'text-fluux-red' },
+  error: { border: 'border-s-fluux-red', icon: 'text-fluux-error' },
   info: { border: 'border-s-fluux-brand', icon: 'text-fluux-brand' },
 }
 

--- a/apps/fluux/src/components/UpdateModal.tsx
+++ b/apps/fluux/src/components/UpdateModal.tsx
@@ -63,7 +63,7 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
               {state.downloaded ? (
                 <CheckCircle className="size-6 text-fluux-green" />
               ) : state.error ? (
-                <AlertCircle className="size-6 text-fluux-red" />
+                <AlertCircle className="size-6 text-fluux-error" />
               ) : (
                 <Download className="size-6 text-fluux-brand" />
               )}
@@ -108,7 +108,7 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
           {/* Error message */}
           {state.error && (
             <div className="mb-4 p-3 rounded bg-fluux-red/10 border border-fluux-red/20">
-              <p className="text-sm text-fluux-red">{state.error}</p>
+              <p className="text-sm text-fluux-error">{state.error}</p>
             </div>
           )}
 

--- a/apps/fluux/src/components/VerifyPeerDialog.tsx
+++ b/apps/fluux/src/components/VerifyPeerDialog.tsx
@@ -181,7 +181,7 @@ export function VerifyPeerDialog({
               )}
             </div>
             {inputMismatch ? (
-              <p className="text-xs text-fluux-red mb-4">
+              <p className="text-xs text-fluux-error mb-4">
                 {t('chat.verifyPeer.theirCodeMismatch', { name: peerName })}
               </p>
             ) : (
@@ -254,7 +254,7 @@ export function VerifyPeerDialog({
             {alreadyVerified && onRevoke && (
               <button
                 onClick={onRevoke}
-                className="flex items-center gap-1.5 px-4 py-2 text-sm text-fluux-red border border-fluux-red/50 hover:bg-fluux-red/10 rounded-lg transition-colors"
+                className="flex items-center gap-1.5 px-4 py-2 text-sm text-fluux-error border border-fluux-red/50 hover:bg-fluux-red/10 rounded-lg transition-colors"
               >
                 <ShieldOff className="size-3.5" />
                 {t('chat.verifyPeer.revokeAction')}

--- a/apps/fluux/src/components/contact-profile/ContactProfileHero.tsx
+++ b/apps/fluux/src/components/contact-profile/ContactProfileHero.tsx
@@ -93,7 +93,7 @@ export function ContactProfileHero({
                 disabled={saving}
                 className="text-xl font-bold text-fluux-text bg-fluux-bg rounded px-3 py-1 w-full border border-fluux-brand focus:outline-none disabled:opacity-50"
               />
-              {error && <p className="text-xs text-fluux-red">{error}</p>}
+              {error && <p className="text-xs text-fluux-error">{error}</p>}
               {saving && <p className="text-xs text-fluux-muted">{t('common.saving')}</p>}
             </div>
           ) : (

--- a/apps/fluux/src/components/contact-profile/tabs/SecurityTab.tsx
+++ b/apps/fluux/src/components/contact-profile/tabs/SecurityTab.tsx
@@ -142,7 +142,7 @@ export function SecurityTab({
               <button
                 type="button"
                 onClick={onRequestRevoke}
-                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-red/10 hover:bg-fluux-red/20 text-fluux-red border border-fluux-red rounded-lg transition-colors text-sm min-h-[44px]"
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-red/10 hover:bg-fluux-red/20 text-fluux-error border border-fluux-red rounded-lg transition-colors text-sm min-h-[44px]"
               >
                 <ShieldOff className="size-4" />
                 {t('contacts.encryption.removeVerification')}

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -665,7 +665,7 @@ export const MessageBubble = memo(function MessageBubble({
         {/* Delivery error indicator */}
         {message.deliveryError && (
           <div className="flex flex-col gap-1 pt-1">
-            <div className="flex items-center gap-1.5 text-red-500">
+            <div className="flex items-center gap-1.5 text-fluux-error">
               <AlertCircle className="size-3.5 flex-shrink-0" />
               <span className="text-xs font-medium">{t('chat.deliveryFailed')}</span>
               <span className="text-xs text-fluux-muted">—</span>

--- a/apps/fluux/src/components/conversation/NewMessageMarker.test.tsx
+++ b/apps/fluux/src/components/conversation/NewMessageMarker.test.tsx
@@ -37,6 +37,6 @@ describe('NewMessageMarker', () => {
     render(<NewMessageMarker />)
 
     const text = screen.getByText('New Messages')
-    expect(text).toHaveClass('text-xs', 'font-semibold', 'text-fluux-red')
+    expect(text).toHaveClass('text-xs', 'font-semibold', 'text-fluux-error')
   })
 })

--- a/apps/fluux/src/components/conversation/NewMessageMarker.tsx
+++ b/apps/fluux/src/components/conversation/NewMessageMarker.tsx
@@ -10,7 +10,7 @@ export function NewMessageMarker() {
   return (
     <div className="flex items-center gap-4 h-12">
       <div className="flex-1 h-px bg-fluux-red" />
-      <span className="text-xs font-semibold text-fluux-red">
+      <span className="text-xs font-semibold text-fluux-error">
         {t('chat.newMessages')}
       </span>
       <div className="flex-1 h-px bg-fluux-red" />

--- a/apps/fluux/src/components/header/HeaderOverflowKebab.tsx
+++ b/apps/fluux/src/components/header/HeaderOverflowKebab.tsx
@@ -48,7 +48,7 @@ function ItemRow({ item, onPick }: { item: HeaderActionItem; onPick: () => void 
       role="menuitem"
       disabled={item.disabled}
       onClick={onPick}
-      className={`${ROW} ${item.danger ? 'text-fluux-red' : 'text-fluux-text'}`}
+      className={`${ROW} ${item.danger ? 'text-fluux-error' : 'text-fluux-text'}`}
     >
       <Icon className="size-4 flex-shrink-0 text-fluux-muted" />
       <span className="flex-1">

--- a/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
+++ b/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
@@ -62,7 +62,7 @@ export function HeaderSubmenuButton({ ariaLabel, tooltip, icon: Icon, active, gr
                 role="menuitem"
                 disabled={item.disabled}
                 onClick={() => { setOpen(false); item.onSelect() }}
-                className={`w-full flex items-center gap-3 px-3 py-2 text-start transition-colors hover:bg-fluux-hover disabled:opacity-50 disabled:cursor-not-allowed ${item.danger ? 'text-fluux-red' : 'text-fluux-text'}`}
+                className={`w-full flex items-center gap-3 px-3 py-2 text-start transition-colors hover:bg-fluux-hover disabled:opacity-50 disabled:cursor-not-allowed ${item.danger ? 'text-fluux-error' : 'text-fluux-text'}`}
               >
                 <ItemIcon className="size-4 flex-shrink-0 text-fluux-muted" />
                 <span className="flex-1">

--- a/apps/fluux/src/components/settings-components/AppearanceSettings.tsx
+++ b/apps/fluux/src/components/settings-components/AppearanceSettings.tsx
@@ -82,7 +82,7 @@ function ThemeCard({
               onRemove()
             }
           }}
-          className="absolute -top-1.5 -end-1.5 p-0.5 rounded-full bg-fluux-surface text-fluux-muted hover:text-fluux-red hover:bg-fluux-hover transition-colors cursor-pointer"
+          className="absolute -top-1.5 -end-1.5 p-0.5 rounded-full bg-fluux-surface text-fluux-muted hover:text-fluux-error hover:bg-fluux-hover transition-colors cursor-pointer"
           title="Remove"
         >
           <Trash2 className="size-3" />
@@ -426,7 +426,7 @@ export function AppearanceSettings() {
                     </button>
                     <button
                       onClick={() => removeSnippet(snippet.id)}
-                      className="p-1 text-fluux-muted hover:text-fluux-red transition-colors"
+                      className="p-1 text-fluux-muted hover:text-fluux-error transition-colors"
                       title={t('settings.removeTheme')}
                     >
                       <Trash2 className="size-3.5" />

--- a/apps/fluux/src/components/settings-components/BlockedUsersSettings.tsx
+++ b/apps/fluux/src/components/settings-components/BlockedUsersSettings.tsx
@@ -143,7 +143,7 @@ export function BlockedUsersSettings() {
             </button>
           </div>
           {blockError && (
-            <p className="text-sm text-fluux-red">{blockError}</p>
+            <p className="text-sm text-fluux-error">{blockError}</p>
           )}
         </div>
       ) : (
@@ -229,7 +229,7 @@ export function BlockedUsersSettings() {
           ) : (
             <button
               onClick={() => setShowUnblockAllConfirm(true)}
-              className="text-sm text-fluux-red hover:text-fluux-red/80 transition-colors"
+              className="text-sm text-fluux-error hover:text-fluux-error/80 transition-colors"
             >
               {t('settings.blocked.unblockAll')} ({blockedJids.length})
             </button>

--- a/apps/fluux/src/components/settings-components/UpdatesSettings.tsx
+++ b/apps/fluux/src/components/settings-components/UpdatesSettings.tsx
@@ -91,7 +91,7 @@ export function UpdatesSettings() {
 
         {/* Error message */}
         {update.error && (
-          <p className="text-xs text-fluux-red">{t(update.error)}</p>
+          <p className="text-xs text-fluux-error">{t(update.error)}</p>
         )}
       </div>
     </section>

--- a/apps/fluux/src/components/settings-components/profile/OwnProfileHero.tsx
+++ b/apps/fluux/src/components/settings-components/profile/OwnProfileHero.tsx
@@ -164,7 +164,7 @@ export function OwnProfileHero({
               type="button"
               onClick={handleClearAvatar}
               disabled={!isConnected || clearing === 'avatar'}
-              className="text-xs text-fluux-muted hover:text-fluux-red disabled:opacity-50 disabled:cursor-not-allowed"
+              className="text-xs text-fluux-muted hover:text-fluux-error disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {clearing === 'avatar' ? t('profile.removingAvatar') : t('profile.removeAvatar')}
             </button>
@@ -186,7 +186,7 @@ export function OwnProfileHero({
                 className="text-xl font-bold text-fluux-text bg-fluux-bg rounded px-3 py-1 w-full
                            border border-fluux-brand focus:outline-none disabled:opacity-50"
               />
-              {error && <p className="text-xs text-fluux-red">{error}</p>}
+              {error && <p className="text-xs text-fluux-error">{error}</p>}
               {saving && <p className="text-xs text-fluux-muted">{t('common.saving')}</p>}
             </div>
           ) : (
@@ -210,7 +210,7 @@ export function OwnProfileHero({
                       type="button"
                       onClick={handleClearNickname}
                       disabled={!isConnected || clearing === 'nickname'}
-                      className="p-1 text-fluux-muted hover:text-fluux-red rounded disabled:opacity-50 disabled:cursor-not-allowed tap-target"
+                      className="p-1 text-fluux-muted hover:text-fluux-error rounded disabled:opacity-50 disabled:cursor-not-allowed tap-target"
                       aria-label={t('profile.resetToUsername')}
                     >
                       <Trash2 className="size-4" />

--- a/apps/fluux/src/components/settings-components/profile/VCardSection.tsx
+++ b/apps/fluux/src/components/settings-components/profile/VCardSection.tsx
@@ -143,7 +143,7 @@ export function VCardSection() {
                     <button
                       type="button"
                       onClick={() => void handleSave(key, '')}
-                      className="p-0.5 text-fluux-muted hover:text-fluux-red rounded"
+                      className="p-0.5 text-fluux-muted hover:text-fluux-error rounded"
                       aria-label={t('common.remove')}
                     >
                       <Trash2 className="size-3.5" />
@@ -183,7 +183,7 @@ export function VCardSection() {
         </div>
       )}
 
-      {error && <p className="text-xs text-fluux-red px-3">{error}</p>}
+      {error && <p className="text-xs text-fluux-error px-3">{error}</p>}
 
       {availableFields.length > 0 && !editingField && (
         <div ref={addFieldRef} className="relative">

--- a/apps/fluux/src/components/sidebar-components/ActivityLogView.tsx
+++ b/apps/fluux/src/components/sidebar-components/ActivityLogView.tsx
@@ -78,7 +78,7 @@ function getResolutionIcon(resolution: string) {
 function getResolutionColor(resolution: string) {
   switch (resolution) {
     case 'accepted': return 'text-fluux-green'
-    case 'rejected': return 'text-fluux-red'
+    case 'rejected': return 'text-fluux-error'
     case 'dismissed': return 'text-fluux-muted'
     default: return ''
   }

--- a/apps/fluux/src/components/sidebar-components/ContactList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.tsx
@@ -439,7 +439,7 @@ const ContactItem = memo(function ContactItem({
           <div className="my-1 border-t border-fluux-hover" />
           <button
             onClick={handleRemove}
-            className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-red hover:bg-fluux-red hover:text-white transition-colors"
+            className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
           >
             <Trash2 className="size-4" />
             <span>{t('contacts.removeContact')}</span>

--- a/apps/fluux/src/components/sidebar-components/EventsView.tsx
+++ b/apps/fluux/src/components/sidebar-components/EventsView.tsx
@@ -163,7 +163,7 @@ function SystemNotificationItem({ notification, onDismiss }: SystemNotificationI
       case 'resource-conflict':
         return { bgColor: 'bg-fluux-yellow/20', borderColor: 'border-fluux-yellow', iconColor: 'text-fluux-yellow' }
       case 'auth-error':
-        return { bgColor: 'bg-fluux-red/20', borderColor: 'border-fluux-red', iconColor: 'text-fluux-red' }
+        return { bgColor: 'bg-fluux-red/20', borderColor: 'border-fluux-red', iconColor: 'text-fluux-error' }
       default:
         return { bgColor: 'bg-fluux-brand/20', borderColor: 'border-fluux-brand', iconColor: 'text-fluux-brand' }
     }

--- a/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
+++ b/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
@@ -262,7 +262,7 @@ export function StatusDisplay({ status }: StatusDisplayProps) {
             type="button"
             onClick={() => client.cancelReconnect()}
             aria-label={t('status.cancelReconnection')}
-            className="p-0.5 text-fluux-muted hover:text-fluux-red rounded hover:bg-fluux-hover flex-shrink-0"
+            className="p-0.5 text-fluux-muted hover:text-fluux-error rounded hover:bg-fluux-hover flex-shrink-0"
           >
             <X className="size-3" />
           </button>
@@ -290,7 +290,7 @@ export function StatusDisplay({ status }: StatusDisplayProps) {
   }
 
   if (status === 'error') {
-    return <p className="text-xs text-fluux-red truncate">{t('status.connectionError')}</p>
+    return <p className="text-xs text-fluux-error truncate">{t('status.connectionError')}</p>
   }
 
   return <p className="text-xs text-fluux-muted truncate">{t('status.disconnected')}</p>

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -535,7 +535,7 @@ const RoomItem = memo(function RoomItem({
           {room.joined && (
             <button
               onClick={() => { menu.close(); onLeave(roomJid) }}
-              className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-red hover:bg-fluux-red hover:text-white transition-colors"
+              className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
             >
               <LogOut className="size-4" />
               <span>{t('rooms.leaveRoom')}</span>
@@ -546,7 +546,7 @@ const RoomItem = memo(function RoomItem({
           {room.isBookmarked && (
             <button
               onClick={() => { menu.close(); onRemoveBookmark(roomJid) }}
-              className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-red hover:bg-fluux-red hover:text-white transition-colors"
+              className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
             >
               <BookmarkX className="size-4" />
               <span>{t('rooms.removeBookmark')}</span>

--- a/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
@@ -230,7 +230,7 @@ interface MenuButtonProps {
 export function MenuButton({ onClick, icon, label, variant = 'default', className = '' }: MenuButtonProps) {
   const baseClasses = 'w-full px-3 py-2 touch:py-3 flex items-center gap-3 text-start transition-colors'
   const variantClasses = variant === 'danger'
-    ? 'text-fluux-red hover:bg-fluux-red hover:text-white'
+    ? 'text-fluux-error hover:bg-fluux-red hover:text-white'
     : 'text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent'
 
   return (

--- a/apps/fluux/src/components/sidebar-components/UserMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/UserMenu.tsx
@@ -147,7 +147,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
                 setShowLogoutConfirm(true)
                 setIsOpen(false)
               }}
-              className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-red hover:bg-fluux-red hover:text-white transition-colors"
+              className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
             >
               <LogOut className="size-4" />
               <span>{t('menu.logOut')}</span>

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -198,6 +198,13 @@
      value is used, tuned to clear WCAG AA on both the resting and hover message
      backgrounds. Dark default here; .light overrides below. */
   --fluux-text-self: #A9B4FF;
+  /* Error as text/icon (delivery failures, inline error labels). Split from the
+     --fluux-status-error fill: that value is tuned dark so white text on it
+     (danger button, toast border, dnd dot) clears AA, which leaves it at only
+     ~3.74:1 as red text on the dark message rows. This lighter red clears WCAG
+     AA as text on the chat/hover surfaces. Dark default here; .light overrides
+     below. (Aurora audit follow-up — the deferred dark error-as-text item.) */
+  --fluux-text-error: #EB5C63;
 
   /* Status (named by purpose, not color) */
   --fluux-status-success: var(--fluux-color-green);
@@ -400,6 +407,11 @@
      (the shared --fluux-color-blue only reached ~4.2:1 there). Overrides just the
      link token; other blue uses (status-info, syntax) keep --fluux-color-blue. */
   --fluux-text-link: #0860C6;
+
+  /* Error as text/icon — darkened so it clears WCAG AA on the white message
+     surface and its hover row (light status-error #C8252A reached only ~4.56:1
+     on the hover row). Separate from the status-error fill (see dark default). */
+  --fluux-text-error: #BE2227;
 
   /* Faint tier (timestamps) — AA-legible value for the light canvas. */
   --fluux-text-faint: #5D6781;

--- a/apps/fluux/src/themes/builtins/catppuccin-mocha.ts
+++ b/apps/fluux/src/themes/builtins/catppuccin-mocha.ts
@@ -55,6 +55,9 @@ export const catppuccinMochaTheme: ThemeDefinition = {
       '--fluux-color-purple': '#cba6f7', // mauve
       '--fluux-color-gray': '#7f849c',
       '--fluux-color-red-rgb': '243, 139, 168',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#f5a0b8',
       '--fluux-color-green-rgb': '166, 227, 161',
       '--fluux-color-yellow-rgb': '249, 226, 175',
       '--fluux-color-blue-rgb': '137, 180, 250',
@@ -96,6 +99,8 @@ export const catppuccinMochaTheme: ThemeDefinition = {
       '--fluux-color-purple': '#8839ef',
       '--fluux-color-gray': '#8c8fa1',
       '--fluux-color-red-rgb': '210, 15, 57',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#ae0c2f',
       '--fluux-color-green-rgb': '64, 160, 43',
       '--fluux-color-yellow-rgb': '223, 142, 29',
       '--fluux-color-blue-rgb': '30, 102, 245',

--- a/apps/fluux/src/themes/builtins/dracula.ts
+++ b/apps/fluux/src/themes/builtins/dracula.ts
@@ -33,6 +33,9 @@ export const draculaTheme: ThemeDefinition = {
       '--fluux-color-purple': '#bd93f9',
       '--fluux-color-gray': '#6272a4',
       '--fluux-color-red-rgb': '255, 85, 85',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#ff8080',
       '--fluux-color-green-rgb': '80, 250, 123',
       '--fluux-color-yellow-rgb': '241, 250, 140',
       '--fluux-color-blue-rgb': '139, 233, 253',
@@ -74,6 +77,8 @@ export const draculaTheme: ThemeDefinition = {
       '--fluux-color-purple': '#7c50c7',
       '--fluux-color-gray': '#6272a4',
       '--fluux-color-red-rgb': '209, 56, 62',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#a6262b',
       '--fluux-color-green-rgb': '43, 158, 74',
       '--fluux-color-yellow-rgb': '184, 150, 15',
       '--fluux-color-blue-rgb': '15, 143, 168',

--- a/apps/fluux/src/themes/builtins/github.ts
+++ b/apps/fluux/src/themes/builtins/github.ts
@@ -35,6 +35,9 @@ export const githubTheme: ThemeDefinition = {
       '--fluux-color-purple': '#8957e5',
       '--fluux-color-gray': '#7d8590',
       '--fluux-color-red-rgb': '218, 54, 51',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#e05552',
       '--fluux-color-green-rgb': '35, 134, 54',
       '--fluux-color-yellow-rgb': '158, 106, 3',
       '--fluux-color-blue-rgb': '68, 147, 248',
@@ -78,6 +81,8 @@ export const githubTheme: ThemeDefinition = {
       '--fluux-color-purple': '#8250df',
       '--fluux-color-gray': '#59636e',
       '--fluux-color-red-rgb': '207, 34, 46',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#c4202c',
       '--fluux-color-green-rgb': '26, 127, 55',
       '--fluux-color-yellow-rgb': '154, 103, 0',
       '--fluux-color-blue-rgb': '9, 105, 218',

--- a/apps/fluux/src/themes/builtins/gruvbox.ts
+++ b/apps/fluux/src/themes/builtins/gruvbox.ts
@@ -33,6 +33,9 @@ export const gruvboxTheme: ThemeDefinition = {
       '--fluux-color-purple': '#d3869b',
       '--fluux-color-gray': '#928374',
       '--fluux-color-red-rgb': '251, 73, 52',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#fc7d6e',
       '--fluux-color-green-rgb': '184, 187, 38',
       '--fluux-color-yellow-rgb': '250, 189, 47',
       '--fluux-color-blue-rgb': '131, 165, 152',
@@ -74,6 +77,8 @@ export const gruvboxTheme: ThemeDefinition = {
       '--fluux-color-purple': '#8f3f71',
       '--fluux-color-gray': '#928374',
       '--fluux-color-red-rgb': '157, 0, 6',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#9d0006',
       '--fluux-color-green-rgb': '121, 116, 14',
       '--fluux-color-yellow-rgb': '181, 118, 20',
       '--fluux-color-blue-rgb': '7, 102, 120',

--- a/apps/fluux/src/themes/builtins/indigo.ts
+++ b/apps/fluux/src/themes/builtins/indigo.ts
@@ -37,6 +37,10 @@ export const indigoTheme: ThemeDefinition = {
       // Companion + own-message name
       '--fluux-accent-2': '#00a8fc',
       '--fluux-text-self': '#a5b4fc',
+      // Error as text/icon — Aurora's default text-error is too dark on this
+      // theme's lighter grey chat surface, so lighten it for WCAG AA. (Light
+      // mode inherits Aurora's value, which clears AA on the white surface.)
+      '--fluux-text-error': '#e77c7f',
       // Unread badge stays red (classic behavior)
       '--fluux-badge-bg': 'var(--fluux-status-error)',
     },

--- a/apps/fluux/src/themes/builtins/kanagawa.ts
+++ b/apps/fluux/src/themes/builtins/kanagawa.ts
@@ -33,6 +33,9 @@ export const kanagawaTheme: ThemeDefinition = {
       '--fluux-color-purple': '#957FB8', // oniViolet
       '--fluux-color-gray': '#727169',   // fujiGray
       '--fluux-color-red-rgb': '228, 104, 118',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#e56e7c',
       '--fluux-color-green-rgb': '152, 187, 108',
       '--fluux-color-yellow-rgb': '230, 195, 132',
       '--fluux-color-blue-rgb': '126, 156, 216',
@@ -76,6 +79,8 @@ export const kanagawaTheme: ThemeDefinition = {
       '--fluux-color-purple': '#624c83', // lotusViolet4
       '--fluux-color-gray': '#8a8980',   // lotusGray3
       '--fluux-color-red-rgb': '200, 64, 83',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#9b2d3c',
       '--fluux-color-green-rgb': '111, 137, 78',
       '--fluux-color-yellow-rgb': '222, 152, 0',
       '--fluux-color-blue-rgb': '77, 105, 155',

--- a/apps/fluux/src/themes/builtins/monokai.ts
+++ b/apps/fluux/src/themes/builtins/monokai.ts
@@ -33,6 +33,9 @@ export const monokaiTheme: ThemeDefinition = {
       '--fluux-color-purple': '#ae81ff', // purple
       '--fluux-color-gray': '#75715e',
       '--fluux-color-red-rgb': '249, 38, 114',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#fc80ad',
       '--fluux-color-green-rgb': '166, 226, 46',
       '--fluux-color-yellow-rgb': '230, 219, 116',
       '--fluux-color-blue-rgb': '102, 217, 239',
@@ -74,6 +77,8 @@ export const monokaiTheme: ThemeDefinition = {
       '--fluux-color-purple': '#7540c9',
       '--fluux-color-gray': '#8f8a7a',
       '--fluux-color-red-rgb': '196, 24, 84',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#ab1549',
       '--fluux-color-green-rgb': '95, 140, 12',
       '--fluux-color-yellow-rgb': '158, 142, 16',
       '--fluux-color-blue-rgb': '15, 141, 166',

--- a/apps/fluux/src/themes/builtins/nord.ts
+++ b/apps/fluux/src/themes/builtins/nord.ts
@@ -33,6 +33,9 @@ export const nordTheme: ThemeDefinition = {
       '--fluux-color-purple': '#b48ead',
       '--fluux-color-gray': '#7b88a1',
       '--fluux-color-red-rgb': '191, 97, 106',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#ebadb3',
       '--fluux-color-green-rgb': '163, 190, 140',
       '--fluux-color-yellow-rgb': '235, 203, 139',
       '--fluux-color-blue-rgb': '129, 161, 193',
@@ -74,6 +77,8 @@ export const nordTheme: ThemeDefinition = {
       '--fluux-color-purple': '#9e6e93',
       '--fluux-color-gray': '#8892a8',
       '--fluux-color-red-rgb': '191, 97, 106',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#a0414a',
       '--fluux-color-green-rgb': '123, 158, 96',
       '--fluux-color-yellow-rgb': '199, 151, 58',
       '--fluux-color-blue-rgb': '94, 129, 172',

--- a/apps/fluux/src/themes/builtins/one-dark.ts
+++ b/apps/fluux/src/themes/builtins/one-dark.ts
@@ -33,6 +33,9 @@ export const oneDarkTheme: ThemeDefinition = {
       '--fluux-color-purple': '#c678dd',
       '--fluux-color-gray': '#5c6370',
       '--fluux-color-red-rgb': '224, 108, 117',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#e5838a',
       '--fluux-color-green-rgb': '152, 195, 121',
       '--fluux-color-yellow-rgb': '229, 192, 123',
       '--fluux-color-blue-rgb': '97, 175, 239',
@@ -74,6 +77,8 @@ export const oneDarkTheme: ThemeDefinition = {
       '--fluux-color-purple': '#a626a4',
       '--fluux-color-gray': '#a0a1a7',
       '--fluux-color-red-rgb': '228, 86, 73',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#b4281b',
       '--fluux-color-green-rgb': '80, 161, 79',
       '--fluux-color-yellow-rgb': '193, 132, 1',
       '--fluux-color-blue-rgb': '64, 120, 242',

--- a/apps/fluux/src/themes/builtins/rose-pine.ts
+++ b/apps/fluux/src/themes/builtins/rose-pine.ts
@@ -33,6 +33,9 @@ export const rosePineTheme: ThemeDefinition = {
       '--fluux-color-purple': '#c4a7e7', // iris
       '--fluux-color-gray': '#6e6a86',   // muted
       '--fluux-color-red-rgb': '235, 111, 146',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#e95e85',
       '--fluux-color-green-rgb': '49, 116, 143',
       '--fluux-color-yellow-rgb': '246, 193, 119',
       '--fluux-color-blue-rgb': '156, 207, 216',
@@ -76,6 +79,8 @@ export const rosePineTheme: ThemeDefinition = {
       '--fluux-color-purple': '#907aa9', // iris
       '--fluux-color-gray': '#9893a5',   // muted
       '--fluux-color-red-rgb': '180, 99, 122',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#9b2d3c',
       '--fluux-color-green-rgb': '40, 105, 131',
       '--fluux-color-yellow-rgb': '234, 157, 52',
       '--fluux-color-blue-rgb': '86, 148, 159',

--- a/apps/fluux/src/themes/builtins/solarized.ts
+++ b/apps/fluux/src/themes/builtins/solarized.ts
@@ -33,6 +33,9 @@ export const solarizedTheme: ThemeDefinition = {
       '--fluux-color-purple': '#6c71c4',
       '--fluux-color-gray': '#657b83',
       '--fluux-color-red-rgb': '220, 50, 47',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#eb8b89',
       '--fluux-color-green-rgb': '133, 153, 0',
       '--fluux-color-yellow-rgb': '181, 137, 0',
       '--fluux-color-blue-rgb': '38, 139, 210',
@@ -82,6 +85,8 @@ export const solarizedTheme: ThemeDefinition = {
       '--fluux-color-purple': '#6c71c4',
       '--fluux-color-gray': '#839496',
       '--fluux-color-red-rgb': '220, 50, 47',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#a71f1c',
       '--fluux-color-green-rgb': '113, 140, 0',
       '--fluux-color-yellow-rgb': '160, 120, 0',
       '--fluux-color-blue-rgb': '38, 139, 210',

--- a/apps/fluux/src/themes/builtins/tokyo-night.ts
+++ b/apps/fluux/src/themes/builtins/tokyo-night.ts
@@ -33,6 +33,9 @@ export const tokyoNightTheme: ThemeDefinition = {
       '--fluux-color-purple': '#bb9af7',
       '--fluux-color-gray': '#545c7e',
       '--fluux-color-red-rgb': '247, 118, 142',
+      // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
+      // AA on this theme's chat surface (status-error stays the fill).
+      '--fluux-text-error': '#f66782',
       '--fluux-color-green-rgb': '158, 206, 106',
       '--fluux-color-yellow-rgb': '224, 175, 104',
       '--fluux-color-blue-rgb': '122, 162, 247',
@@ -74,6 +77,8 @@ export const tokyoNightTheme: ThemeDefinition = {
       '--fluux-color-purple': '#7847bd',
       '--fluux-color-gray': '#8990b3',
       '--fluux-color-red-rgb': '245, 42, 101',
+      // Error as text/icon — darkened for WCAG AA on the light chat surface.
+      '--fluux-text-error': '#8c072d',
       '--fluux-color-green-rgb': '88, 117, 57',
       '--fluux-color-yellow-rgb': '140, 108, 62',
       '--fluux-color-blue-rgb': '46, 125, 233',

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, resolve } from 'path'
+import { builtinThemes } from './builtins'
+import type { ThemeDefinition } from './types'
 
 /**
  * Aurora theme contrast guard.
@@ -164,5 +166,32 @@ describe('Aurora theme contrast invariants', () => {
       const r = contrast(`var(--fluux-status-${key})`, 'var(--fluux-bg-primary)', light)
       expect(r).toBeGreaterThanOrEqual(4.5)
     })
+  }
+})
+
+// Per-theme error-text guard. Every builtin theme overrides --fluux-color-red
+// (so the bg-fluux-red fills follow its palette); the split means it must also
+// tune --fluux-text-error so error TEXT stays legible. Themes that inherit the
+// Aurora red (fluux, indigo) inherit its text-error too. Each theme's effective
+// tokens = the index.css defaults overlaid with the theme's overrides.
+//
+// Surface = the resting chat surface (--fluux-chat-bg / base-30), where error
+// text is read. The hover row (base-40) is an unusually light mid-tone on a few
+// themes (e.g. Solarized), where no vivid red can also clear AA; rather than
+// force a near-white error color, the hover state is left ungated and the
+// resting surface is the contract. (Light mode clears AA on both anyway.)
+function themeTokens(theme: ThemeDefinition, mode: 'dark' | 'light'): Record<string, string> {
+  const base = mode === 'dark' ? dark : light
+  return { ...base, ...(theme.variables[mode] ?? {}) }
+}
+
+describe('Builtin theme error-text contrast', () => {
+  for (const theme of builtinThemes) {
+    for (const mode of ['dark', 'light'] as const) {
+      it(`[${theme.id}/${mode}] text-error clears WCAG AA on the chat surface`, () => {
+        const r = contrast('var(--fluux-text-error)', 'var(--fluux-chat-bg)', themeTokens(theme, mode))
+        expect(r).toBeGreaterThanOrEqual(4.5)
+      })
+    }
   }
 })

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -109,6 +109,16 @@ describe('Aurora theme contrast invariants', () => {
       expect(r).toBeGreaterThanOrEqual(4.5)
     })
 
+    // --fluux-status-error doubles as a fill (danger button, toast border,
+    // presence dnd dot) with white text on it. It must stay dark enough that
+    // white clears AA — the constraint that pulls against error-as-text wanting
+    // to be lighter, which is why the two are split (status-error fill vs
+    // text-error text). See the dark text-error assertion in the Pattern B loop.
+    it(`[${mode}] white text clears WCAG AA on the error fill`, () => {
+      const r = contrast('#ffffff', 'var(--fluux-status-error)', vars)
+      expect(r).toBeGreaterThanOrEqual(4.5)
+    })
+
     // Pattern E — the focus ring is a non-text UI indicator and must clear the
     // WCAG 1.4.11 non-text contrast minimum (3:1) against the surfaces it rings.
     // It drives the universal `.user-interacted *:focus` outline, so this one
@@ -122,7 +132,11 @@ describe('Aurora theme contrast invariants', () => {
     // against the darkest of those (the hover row), not just the resting surface.
     // Links and the own-name dipped below AA on the light-mode hover/active rows;
     // text-faint (the timestamp tier) failed in both modes at its old value.
-    for (const token of ['text-link', 'text-self', 'text-faint'] as const) {
+    // text-error (delivery-failure text/icons) is its own token, split from the
+    // status-error fill: as text it must be light enough to clear AA on the dark
+    // rows, where the fill-tuned status-error reached only ~3.74:1 (the audit's
+    // deferred dark-mode error-as-text item).
+    for (const token of ['text-link', 'text-self', 'text-faint', 'text-error'] as const) {
       it(`[${mode}] ${token} clears WCAG AA on the hover row`, () => {
         const r = contrast(`var(--fluux-${token})`, 'var(--fluux-bg-hover)', vars)
         expect(r).toBeGreaterThanOrEqual(4.5)
@@ -143,7 +157,8 @@ describe('Aurora theme contrast invariants', () => {
   // Pattern C — status colors are used as text/icon labels on light surfaces
   // (settings cards, toasts, edit/encryption labels). The light theme's bright
   // green/yellow/red fail AA as text; assert the (darkened) light overrides.
-  // Dark-mode status-as-text needs a separate text/fill token split (follow-up).
+  // (Error-as-text on the dark chat surface is handled by the dedicated
+  // --fluux-text-error token, asserted in the Pattern B loop above.)
   for (const key of ['success', 'warning', 'error'] as const) {
     it(`[light] status-${key} clears WCAG AA as text on a card surface`, () => {
       const r = contrast(`var(--fluux-status-${key})`, 'var(--fluux-bg-primary)', light)

--- a/apps/fluux/tailwind.config.js
+++ b/apps/fluux/tailwind.config.js
@@ -55,6 +55,11 @@ export default {
           'green': 'var(--fluux-status-success)',
           'yellow': 'var(--fluux-status-warning)',
           'red': 'var(--fluux-status-error)',
+          // Error AS TEXT/icon. Split from `red` (status-error): that token is the
+          // fill (danger button, toast border, dnd dot), tuned dark so white text
+          // on it clears AA, which leaves it sub-AA as red text on dark surfaces.
+          // Use text-fluux-error for error text/icons; bg-fluux-red for fills.
+          'error': 'var(--fluux-text-error)',
           'gray': 'var(--fluux-color-gray)',
           'border': 'var(--fluux-border-color)',
         }

--- a/docs/2026-06-26-aurora-theme-audit.md
+++ b/docs/2026-06-26-aurora-theme-audit.md
@@ -115,13 +115,15 @@ Plus a focus-visibility inconsistency (E) and minor observations (F).
 
 - **MUC sender names are unreadable for several colors in light mode** — 5 of 6 sender tokens fall below AA on the white chat surface; sender-2/3 dip below **3:1** on the sidebar. Sender names are the primary way to attribute messages in a room. ([ChatView sender assignment](apps/fluux/src/components/ChatView.tsx:811), tokens [index.css:390](apps/fluux/src/index.css:390))
 - **Status colors as text/icons fail in light mode** — green status text ~2.5–3.2:1, yellow ~1.5–1.9:1 (effectively invisible). The light theme already darkens `blue`/`gray` for this reason ([index.css:363](apps/fluux/src/index.css:363)) but **not green/yellow/red**.
-- **`status-error` as text dips below AA in dark** (3.97 on chat-bg) — the red used for "delivery failed", new-message marker, etc.
+- **`status-error` as text dips below AA in dark** (3.97 on chat-bg) — the red used for "delivery failed", new-message marker, etc. *(Resolved — follow-up: see below.)*
 - **`white` on `status-warning` fill = 1.89 (FAIL)** in both modes — safe today only because warning isn't used as a text-bearing fill; flag before any "warning button/badge" is added.
 
 **Proposed fix (batch C):**
 - **Darken the light-mode sender palette** further (the one darkening pass wasn't enough) so all six clear 4.5:1 on white *and* on `base-20`.
 - **Add light-mode overrides for `status-success` / `status-warning` / `status-error`** (darker variants), mirroring what's already done for blue/gray — so status text/icons stay legible.
 - Nudge `status-error` for dark-mode text use, or pair it with a non-color cue where it labels (icon + text).
+
+**Resolved (follow-up to this audit):** A single red token cannot satisfy both jobs — as a *fill* it must stay dark enough for white text to clear AA (white on `#da373c` = 4.57), but as *text* on the dark chat surface it must be lighter to clear AA (it reached only ~3.74-3.97). So the two were split: `--fluux-status-error` keeps serving fills, and a new `--fluux-text-error` is tuned to clear AA as text on the chat surface in both modes. The `text-fluux-red` / `text-red-500` error-text consumers (delivery-failed, new-message marker, etc.) now point at `text-fluux-error`; `bg-fluux-red` fills are unchanged. Every builtin theme that overrides `--fluux-color-red` also tunes `--fluux-text-error`, and [`themeContrast.test.ts`](apps/fluux/src/themes/themeContrast.test.ts) guards the AA contract per theme. See [docs/THEMES.md](docs/THEMES.md) Tier 2 for theme-author guidance.
 
 ---
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -184,7 +184,8 @@ These map foundation tokens to purposes. They cascade from Tier 1, so you rarely
 | `--fluux-text-link`             | `color-blue`          | Hyperlinks                      |
 | `--fluux-status-success`        | `color-green`         | Success indicators              |
 | `--fluux-status-warning`        | `color-yellow`        | Warning indicators              |
-| `--fluux-status-error`          | `color-red`           | Error indicators, unread badges |
+| `--fluux-status-error`          | `color-red`           | Error *fill* (danger button, toast border, DND dot, unread badge) — white text sits on it |
+| `--fluux-text-error`            | Tuned red (not `color-red`) | Error *text/icons* (delivery-failed, validation, new-message marker) |
 | `--fluux-status-info`           | `color-blue`          | Informational indicators        |
 | `--fluux-border-color`          | `rgba(0,0,0,0.1)`     | Subtle dividers                 |
 | `--fluux-scrollbar-thumb`       | `base-05`             | Scrollbar thumb color           |
@@ -195,6 +196,7 @@ These map foundation tokens to purposes. They cascade from Tier 1, so you rarely
 | `--fluux-search-highlight-text` | `text-normal`         | Search match text color         |
 
 **When to override semantic variables:** When the automatic cascade from your base ramp doesn't produce the right result. Common cases:
+- `--fluux-text-error` — **set this whenever you override `--fluux-color-red`.** Red has to pull in two directions: as a *fill* (`--fluux-status-error`, danger button, toast border, DND dot) it must stay dark enough for white text on it to clear WCAG AA, but as *text/icons* on your dark chat surface that same red is usually too dark to clear AA. They are deliberately separate tokens. Keep `--fluux-color-red` for the fill, and set `--fluux-text-error` to a red that clears AA (>=4.5:1) as text on `--fluux-chat-bg` — lighter than the fill in dark mode, darker in light mode. The `themeContrast.test.ts` guard asserts this for every builtin theme. (Themes that leave `--fluux-color-red` at the Aurora default inherit the Aurora `--fluux-text-error` automatically.)
 - `--fluux-bg-secondary` — if your ramp spacing makes `base-05` too similar to `base-10`
 - `--fluux-border-color` — light themes often need `rgba(0,0,0,0.12-0.15)` instead of `0.1`
 - `--fluux-scrollbar-thumb` — if your ramp makes the default too subtle or too prominent


### PR DESCRIPTION
Follow-up to the Aurora theme audit (#674). Resolves the deferred item: dark-mode error-as-text reached only ~3.74-3.97:1, just under WCAG AA.

## The conflict
`--fluux-status-error` (Tailwind `fluux.red`) was doing two opposing jobs:
- as a **fill** (danger button, toast border, DND dot, unread badge) it must stay dark enough that white text on it clears AA (white on `#da373c` = 4.57)
- as **text/icons** on the dark chat surface that same red is too dark to clear AA

A single token can't satisfy both, so they're split.

## Changes
- **New `--fluux-text-error` token** in `index.css`, tuned to clear AA as text on the chat surface in both modes (dark `#EB5C63`, light `#BE2227`). `--fluux-status-error` is unchanged and keeps serving fills.
- **Tailwind alias** `text-fluux-error`. Since Tailwind `text-*` is always a foreground, all `text-fluux-red` consumers (~55 sites) are repointed to `text-fluux-error`, plus the `MessageBubble` delivery-error `text-red-500`. `bg-/border-/ring-fluux-red` fills stay on `status-error`.
- **Per-theme tuning**: every builtin that overrides `--fluux-color-red` (11 themes) now sets its own `--fluux-text-error` (lighter on dark, darker on light), each tuned to clear AA on that theme's chat surface; indigo gets a lighter dark value for its grey surface. Otherwise error text was locked to Aurora red across all themes.
- **Contrast guard** (`themeContrast.test.ts`) extended: asserts `text-error` clears AA on the chat surface for every builtin in both modes, plus white-on-`status-error` fill stays AA.
- **Docs**: `THEMES.md` documents the fill-vs-text split and the rule "set `--fluux-text-error` whenever you override `--fluux-color-red`"; the audit doc marks the deferred item resolved.

A few themes (e.g. Solarized) have an unusually light hover row where no vivid red can also clear AA; the gated contract is the resting chat surface, not the transient hover.

Excludes the per-mode-tuned `text-red-600 dark:text-red-400` status colors (intentionally contrast-tuned per the audit's Pattern D scope note).