### PR TITLE
fix(rooms): show loading indicator during first MAM catch-up on room entry

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -10,6 +10,7 @@ import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar } from './Avatar'
 import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './conversation/roomSenderResolution'
+import { selectRoomInitialLoading } from './conversation/roomLoadingState'
 import { format } from 'date-fns'
 import type { CopyMessageMeta } from '@/utils/buildCopyText'
 import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, Users, MessageCircle, EyeOff, User, Settings, Ear, X } from 'lucide-react'
@@ -931,13 +932,22 @@ export const RoomMessageList = memo(function RoomMessageList({
     [room.occupants, room.nickname],
   )
 
-  // Loading state: only show when joining room (SDK auto-loads cache in background)
-  // No "loading messages" spinner - cache loads instantly, messages appear immediately
-  const isInitialLoading = room.isJoining && !room.joined
+  // Loading state covers two phases: joining (waiting for self-presence) and the
+  // first MAM catch-up after join when nothing is cached yet. Without the second
+  // phase the spinner vanished on join and the view showed "No messages" while
+  // history was still loading (see selectRoomInitialLoading).
+  const isInitialLoading = selectRoomInitialLoading({
+    isJoining: room.isJoining ?? false,
+    joined: room.joined ?? false,
+    isCatchingUp: isCatchingUp ?? false,
+    messageCount: messages.length,
+  })
+  // Label matches the phase: still joining vs. joined and loading history.
+  const isJoiningPhase = (room.isJoining ?? false) && !(room.joined ?? false)
   const loadingState = isInitialLoading ? (
     <div className="flex-1 flex flex-col items-center justify-center gap-3 text-fluux-muted">
       <Loader2 className="size-8 animate-spin text-fluux-brand" />
-      <p>{t('rooms.joining')}</p>
+      <p>{isJoiningPhase ? t('rooms.joining') : t('chat.loadingMessages')}</p>
     </div>
   ) : null
 

--- a/apps/fluux/src/components/conversation/roomLoadingState.test.ts
+++ b/apps/fluux/src/components/conversation/roomLoadingState.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { selectRoomInitialLoading } from './roomLoadingState'
+
+describe('selectRoomInitialLoading', () => {
+  it('shows loading while joining (waiting for self-presence)', () => {
+    expect(
+      selectRoomInitialLoading({ isJoining: true, joined: false, isCatchingUp: false, messageCount: 0 }),
+    ).toBe(true)
+  })
+
+  it('shows loading after join while first MAM catch-up runs with nothing cached', () => {
+    // The gap the user reported: joined === true (spinner gone), but history is
+    // still being fetched and there is nothing to render yet.
+    expect(
+      selectRoomInitialLoading({ isJoining: false, joined: true, isCatchingUp: true, messageCount: 0 }),
+    ).toBe(true)
+  })
+
+  it('does NOT show the full-view loader when cached messages are already visible', () => {
+    // Catch-up may run in the background, but content is on screen — the gap marker
+    // / inline spinner handles that, not the full-view loader.
+    expect(
+      selectRoomInitialLoading({ isJoining: false, joined: true, isCatchingUp: true, messageCount: 12 }),
+    ).toBe(false)
+  })
+
+  it('does NOT show loading for a genuinely empty room once catch-up finished', () => {
+    expect(
+      selectRoomInitialLoading({ isJoining: false, joined: true, isCatchingUp: false, messageCount: 0 }),
+    ).toBe(false)
+  })
+
+  it('does NOT show loading for a not-yet-joined bookmarked room idling', () => {
+    // Not joining, not joined (viewing cached history of a bookmarked room) — the
+    // join prompt / cached-history banner owns this state, not the loader.
+    expect(
+      selectRoomInitialLoading({ isJoining: false, joined: false, isCatchingUp: false, messageCount: 0 }),
+    ).toBe(false)
+  })
+})

--- a/apps/fluux/src/components/conversation/roomLoadingState.ts
+++ b/apps/fluux/src/components/conversation/roomLoadingState.ts
@@ -1,0 +1,33 @@
+/**
+ * Decides whether the room message area should show its full-view loading
+ * indicator (the centered spinner) rather than message content or an empty state.
+ *
+ * There are two distinct "still loading" phases when entering a room, and only
+ * the first one used to be covered:
+ *
+ *   1. Joining — presence sent, waiting for the server's self-presence (status
+ *      110). `isJoining` is true, `joined` is false.
+ *   2. First catch-up — the room is joined (the "Joining…" spinner is gone), but
+ *      MAM history is still being fetched and there is nothing cached to render.
+ *      Without this, the view fell through to the "No messages" empty state while
+ *      messages were actively loading, reading as a silent, animation-less wait.
+ *
+ * Once any message is on screen (cache hit), the inline gap marker / older-history
+ * spinner owns the catch-up affordance, so the full-view loader steps aside.
+ */
+export function selectRoomInitialLoading(args: {
+  isJoining: boolean
+  joined: boolean
+  isCatchingUp: boolean
+  messageCount: number
+}): boolean {
+  const { isJoining, joined, isCatchingUp, messageCount } = args
+
+  // Phase 1: still joining.
+  if (isJoining && !joined) return true
+
+  // Phase 2: joined, first history fetch in flight, nothing to show yet.
+  if (joined && isCatchingUp && messageCount === 0) return true
+
+  return false
+}


### PR DESCRIPTION
## Summary

Fixes user feedback (0.16.2): "when I first go in a room everything is taking time to load with no load animation."

Entering a room has two loading phases, but only the first had a spinner:

1. **Joining** — presence sent, waiting for the server's self-presence (status 110). `isJoining` true, `joined` false. ✅ had a spinner.
2. **First MAM catch-up** — room is joined (the "Joining…" spinner is already gone) but history is still being fetched. With an empty cache the view fell through to the **"No messages"** empty state while messages were actively loading, which reads as a silent, animation-less wait. ❌ no spinner.

This is a missing loading affordance, not a render-perf problem, so the recent render-performance work did not touch it.

## Change

- New pure helper `selectRoomInitialLoading()` (`apps/fluux/src/components/conversation/roomLoadingState.ts`) that treats both phases as loading, and steps aside as soon as any cached message is on screen so the inline gap-marker spinner owns background catch-up (cached rooms still render instantly).
- `RoomView` now derives `isInitialLoading` from the helper and shows a phase-aware label: `rooms.joining` while joining, `chat.loadingMessages` while loading history. Both i18n keys already exist and are translated in every locale, so no new translation work.