### PR TITLE
fix(rooms): skip redundant cache reload + MAM on re-entry of a joined room

### DIFF
--- a/packages/fluux-sdk/src/core/roomSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.test.ts
@@ -280,6 +280,62 @@ describe('setupRoomSideEffects', () => {
     })
   })
 
+  describe('re-entry of a caught-up resident room', () => {
+    // Re-entering a room you're still joined to (no reconnect) should be a no-op for
+    // side effects: the messages are already resident (activateRoom's own cache load
+    // ran on the way in) and MAM was already caught up this session. Reloading the
+    // cache here churns the message array AFTER the list has mounted and scrolled,
+    // which knocks the restored scroll position off (lands mid-list). See the
+    // activeRoomJid subscriber guard in roomSideEffects.ts.
+    it('does not reload cache or query MAM when activating a joined, resident, caught-up room', async () => {
+      // Distinct jid + jid-scoped assertions: sibling tests leave their Step-2
+      // fetchMAMForRoom async in flight (they only await the Step-1 load), which can
+      // fire loadMessagesFromCache/queryRoomMAM on the shared store during this test.
+      const ROOM = 'reentry@conference.example.com'
+      const liveMessage = {
+        type: 'groupchat' as const,
+        id: 'live-1',
+        roomJid: ROOM,
+        from: `${ROOM}/alice`,
+        nick: 'alice',
+        body: 'hi',
+        timestamp: new Date('2026-02-04T12:00:00Z'),
+        isOutgoing: false,
+      }
+      // Joined room with messages already resident (as activateRoom leaves it on the
+      // way in). SM resumption marks every joined room caught up for the session
+      // without a reconnect — exactly the "joined, did not reconnect" case.
+      roomStore.getState().addRoom({
+        jid: ROOM,
+        name: 'Test Room',
+        nickname: 'me',
+        joined: true,
+        supportsMAM: true,
+        occupants: new Map(),
+        messages: [liveMessage],
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set(),
+        isBookmarked: true,
+      })
+
+      cleanup = setupRoomSideEffects(mockClient)
+      simulateSmResumption(mockClient) // seeds fetchInitiated for joined rooms; no MAM
+
+      const loadSpy = vi.spyOn(roomStore.getState(), 'loadMessagesFromCache')
+
+      // Activating it now is a no-op: caught up this session AND still resident.
+      roomStore.getState().setActiveRoom(ROOM)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(loadSpy).not.toHaveBeenCalledWith(ROOM, expect.anything())
+      expect(mockClient.chat.queryRoomMAM).not.toHaveBeenCalledWith(
+        expect.objectContaining({ roomJid: ROOM })
+      )
+      loadSpy.mockRestore()
+    })
+  })
+
   describe('reconnection', () => {
     it('should trigger MAM catchup on reconnection for active room', async () => {
       roomStore.getState().addRoom({

--- a/packages/fluux-sdk/src/core/roomSideEffects.ts
+++ b/packages/fluux-sdk/src/core/roomSideEffects.ts
@@ -171,8 +171,22 @@ export function setupRoomSideEffects(
 
       // Run async operations outside the synchronous subscriber
       void (async () => {
-        // Step 1: Always load from IndexedDB cache (deduplication is handled by loadMessagesFromCache).
-        // This is a fallback for cases where the hook's cache load didn't run (e.g., reconnection).
+        // Re-entry of a room we're still joined to (no reconnect): nothing to do.
+        // It was already caught up this session (fetchInitiated) AND its messages are
+        // still resident (activateRoom's own cache load ran before this subscriber
+        // fired on the way back in). Reloading the cache here would rebuild the
+        // message array AFTER the list mounted and scrolled, knocking the restored
+        // scroll position off (lands mid-list). Live delivery keeps the resident set
+        // current, so there is genuinely nothing to fetch.
+        const residentCount = roomStore.getState().rooms.get(activeRoomJid)?.messages.length ?? 0
+        if (fetchInitiated.has(activeRoomJid) && residentCount > 0) {
+          if (debug) console.log('[SideEffects] Room: re-entry of caught-up resident room, skipping cache reload + MAM', activeRoomJid)
+          return
+        }
+
+        // Step 1: Load from IndexedDB cache (deduplication is handled by loadMessagesFromCache).
+        // Covers paths that set the active room WITHOUT a cache load (e.g. CommandPalette's
+        // setActiveRoom, session restore) and the first activation / post-reconnect catch-up.
         if (debug) console.log('[SideEffects] Room: Loading from cache')
         await roomStore.getState().loadMessagesFromCache(activeRoomJid, { limit: MAM_CACHE_LOAD_LIMIT })
 


### PR DESCRIPTION
## Problem

Switching into a MUC room you are still joined to (same session, no reconnect) restored the scroll position incorrectly — it landed **mid-list** instead of at the bottom, even when you had left the room at the bottom. 1:1 conversations were unaffected.

## Root cause

The active-room side effect (`roomSideEffects.ts`, the `activeRoomJid` subscriber) **always** reloaded the IndexedDB cache on every room switch (Step 1), as a fallback for activation paths that don't hydrate. But the normal path — `activateRoom` — already hydrates the room from cache *before* flipping `activeRoomJid`. So on a plain re-entry the subscriber's reload was pure redundancy: it rebuilt the room's message array (`loadMessagesFromCache` merges/sorts/trims into a fresh array) **after** the `MessageList` had already mounted and run its scroll-to-bottom. That post-mount array churn knocked the just-restored scroll position off, leaving the view stranded mid-list.

The MAM catch-up was likewise unnecessary on such a re-entry (already caught up this session, kept current by live delivery). 1:1 chat doesn't exhibit it in practice; this was room-specific.

## Fix

Guard the subscriber's async work: if the room is **already caught up this session** (`fetchInitiated`) **and** its messages are **still resident**, do nothing. The cache load + catch-up still run for:
- paths that set the active room without hydrating it (`CommandPalette.setActiveRoom`, session restore — these leave messages empty, so the guard doesn't trip),
- first activation of a room this session,
- post-reconnect MAM catch-up (`fetchInitiated` is cleared on disconnect).