### PR TITLE
Own-message tint only: drop the edge bar that read as a reply

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -287,7 +287,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     </div>
                   </div>
                   <div
-                    class="relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  message-own-edge"
+                    class="relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  message-own-tint"
                   >
                     <div
                       class="absolute -top-7 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -755,16 +755,16 @@ describe('buildReplyContext', () => {
   })
 })
 
-describe('Own-message edge', () => {
-  it('applies the own-edge class to outgoing messages', () => {
+describe('Own-message tint', () => {
+  it('applies the own-tint class to outgoing messages', () => {
     const props = createDefaultProps({ message: createTestMessage({ isOutgoing: true }) })
     const { container } = render(<MessageBubble {...props} />)
-    expect(container.querySelector('.message-own-edge')).toBeInTheDocument()
+    expect(container.querySelector('.message-own-tint')).toBeInTheDocument()
   })
 
-  it('does not apply the own-edge class to incoming messages', () => {
+  it('does not apply the own-tint class to incoming messages', () => {
     const props = createDefaultProps({ message: createTestMessage({ isOutgoing: false }) })
     const { container } = render(<MessageBubble {...props} />)
-    expect(container.querySelector('.message-own-edge')).not.toBeInTheDocument()
+    expect(container.querySelector('.message-own-tint')).not.toBeInTheDocument()
   })
 })

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -483,7 +483,7 @@ export const MessageBubble = memo(function MessageBubble({
 
       {/* Content */}
       <div
-        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${message.isOutgoing ? 'message-own-edge' : ''}`}
+        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${message.isOutgoing ? 'message-own-tint' : ''}`}
         onTouchStart={handleContentTouchStart}
         onTouchEnd={cancelLongPress}
         onTouchMove={cancelLongPress}

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -756,15 +756,16 @@ input[type="range"]::-moz-range-thumb {
   border-radius: 0.5rem;
 }
 
-/* Own-message accent edge — a quiet luminous spine on outgoing messages
-   (Aurora). Decorative; the own-name color (--fluux-text-self) carries identity,
-   so this isn't contrast-bound. Tint kept subtle so body text AA holds. */
-.message-own-edge {
-  border-inline-start: 2px solid var(--fluux-bg-accent);
+/* Own-message tint — a quiet luminous wash on outgoing messages (Aurora).
+   No edge bar: a leading-edge bar reads as "quoted reply" elsewhere, so the
+   tint carries the distinction on its own. Decorative; the own-name color
+   (--fluux-text-self) carries identity, so this isn't contrast-bound. Tint
+   kept subtle so body text AA holds. */
+.message-own-tint {
   background: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.08);
-  border-radius: 0 var(--fluux-radius-m) var(--fluux-radius-m) 0;
+  border-radius: var(--fluux-radius-m);
   padding-inline: 0.5rem;
-  margin-inline-start: -0.5rem;
+  margin-inline: -0.5rem;
 }
 
 /* Persistent highlight for search context view */


### PR DESCRIPTION
## Summary

The Aurora own-message accent (#677) used a 2px inline-start bar plus a faint tint on outgoing messages. The problem: a leading-edge bar is *already* the visual grammar for "quoted reply" in the message list (reply chips use `border-s-2`), so the same bar on own messages read as a reply affordance.

This drops the bar entirely and keeps only the subtle accent **tint** to distinguish own messages. The own-name color (`--fluux-text-self`) continues to carry identity, so nothing contrast-bound is lost. Verified in both light and dark mode, with quoted replies in view — the reply's left bar is now the sole bar-grammar element, so it reads unambiguously.

## Changes

- `index.css`: `.message-own-edge` reduced from `border-inline-start` + tint to tint + rounded corners only. Renamed to `.message-own-tint` to match the new treatment.
- `MessageBubble.tsx`: apply the renamed class.
- Tests/snapshot updated for the new class name (assertions unchanged in intent).