### PR TITLE
fix(theme): visible, auto-hiding, thinner scrollbars (Aurora dark)

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -228,11 +228,15 @@
   --fluux-search-highlight-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.35);
   --fluux-search-highlight-text: var(--fluux-text-normal);
 
-  /* Scrollbar */
-  --fluux-scrollbar-thumb: var(--fluux-base-05);
-  --fluux-scrollbar-thumb-hover: var(--fluux-base-20);
-  --fluux-scrollbar-thumb-sidebar: var(--fluux-base-30);
-  --fluux-scrollbar-thumb-sidebar-hover: var(--fluux-base-50);
+  /* Scrollbar — the thumb sits over a transparent track on the dark chat
+     (base-30) and sidebar (base-20) surfaces. base-05 was darker than both, so
+     the thumb read as invisible (~1.05:1). These mid-ramp blues clear ~3:1
+     resting and brighten on hover, matching the visible thumbs the other dark
+     themes ship. .light overrides below. */
+  --fluux-scrollbar-thumb: var(--fluux-base-70);
+  --fluux-scrollbar-thumb-hover: var(--fluux-base-80);
+  --fluux-scrollbar-thumb-sidebar: var(--fluux-base-70);
+  --fluux-scrollbar-thumb-sidebar-hover: var(--fluux-base-80);
 
   /* Focus ring — drives the universal `.user-interacted *:focus` outline, so this
      one token governs keyboard-focus visibility app-wide. Solid accent: at 0.5


### PR DESCRIPTION
The Aurora dark-mode scrollbar was effectively invisible: the thumb used `--fluux-base-05` (`#0A0F1E`), darker than the surfaces it sits on (chat `#0F1528`, sidebar `#0E1326`), giving ~1.05:1 contrast. Every other dark theme ships a visible thumb; Aurora was the lone outlier.

This PR fixes the visibility and then makes the scrollbars feel lighter and less obtrusive.

### 1. Visible dark thumb
Move the four dark-mode scrollbar tokens to mid-ramp blues that stay within Aurora's palette:

| Token | Before | After |
|---|---|---|
| thumb | `base-05` | `base-70` (`#5E6B8A`) |
| thumb-hover | `base-20` | `base-80` (`#97A4C4`) |
| thumb-sidebar | `base-30` | `base-70` |
| thumb-sidebar-hover | `base-50` | `base-80` |

Contrast vs the chat surface goes from **1.05:1 → 3.41:1** (3.46:1 sidebar, 7.27:1 hover), clearing the WCAG 3:1 non-text minimum.

### 2. Auto-hide + thinner / subtler
- Thinner gutter: **8px → 6px** (radius 4 → 3).
- The thumb is **transparent at rest** and only painted while the container is **hovered** or **actively scrolling**.
- `scrollbarAutohide.ts` installs a single capture-phase scroll listener that stamps the scrolled element with a `data-scrolling` attribute and clears it **700ms** after scrolling stops. A data attribute (not a class) is used so React's reconciler never strips it across re-renders (e.g. the virtualized message list).
- The 6px gutter stays reserved while a container overflows, so revealing the thumb causes **no layout shift**.
- The sidebar keeps its theme-specific thumb color when revealed.

Light mode keeps its existing override; the 12 named themes set their own thumb tokens and are unaffected.

Verified live in the dark preview: gutter `6px`, thumb `rgba(0,0,0,0)` at rest, `rgb(94,107,138)` while scrolling; a real scroll event stamps `data-scrolling` and it clears after the idle delay. `themeContrast.test.ts` (49) + `scrollbarAutohide.test.ts` (5), typecheck, and lint all pass.