### PR TITLE
Left-align day and history-start markers

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -85,11 +85,8 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 data-date-separator="10:00"
               >
                 <div
-                  class="flex items-center gap-4 h-12"
+                  class="flex items-center gap-3 h-12"
                 >
-                  <div
-                    class="flex-1 h-px bg-fluux-hover"
-                  />
                   <span
                     class="text-xs font-semibold text-fluux-muted whitespace-nowrap"
                   >

--- a/apps/fluux/src/components/conversation/DateSeparator.test.tsx
+++ b/apps/fluux/src/components/conversation/DateSeparator.test.tsx
@@ -22,18 +22,28 @@ describe('DateSeparator', () => {
     expect(screen.getByText('Formatted: 2024-01-15')).toBeInTheDocument()
   })
 
-  it('should render horizontal lines', () => {
+  it('should render a single trailing rule after the label', () => {
     const { container } = render(<DateSeparator date="2024-01-15" />)
 
     const lines = container.querySelectorAll('.h-px.bg-fluux-hover')
-    expect(lines).toHaveLength(2)
+    expect(lines).toHaveLength(1)
+  })
+
+  it('should render the label before the rule so it sits on the reading-start edge', () => {
+    const { container } = render(<DateSeparator date="2024-01-15" />)
+
+    const wrapper = container.firstChild as HTMLElement
+    const [first, second] = Array.from(wrapper.children)
+    expect(first.tagName).toBe('SPAN')
+    expect(first).toHaveTextContent('Formatted: 2024-01-15')
+    expect(second).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
   })
 
   it('should have correct styling classes', () => {
     const { container } = render(<DateSeparator date="2024-01-15" />)
 
     const wrapper = container.firstChild as HTMLElement
-    expect(wrapper).toHaveClass('flex', 'items-center', 'gap-4', 'h-12')
+    expect(wrapper).toHaveClass('flex', 'items-center', 'gap-3', 'h-12')
   })
 
   it('should style the date text correctly', () => {

--- a/apps/fluux/src/components/conversation/DateSeparator.tsx
+++ b/apps/fluux/src/components/conversation/DateSeparator.tsx
@@ -7,16 +7,19 @@ export interface DateSeparatorProps {
 }
 
 /**
- * Displays a horizontal line with a centered date label.
+ * Displays a leading-aligned date label followed by a horizontal rule.
  * Used to separate messages by day in conversation views.
+ *
+ * Layout leans on flex flow + logical properties so it mirrors correctly
+ * under RTL: the label always sits on the reading-start edge and the rule
+ * extends toward the trailing edge.
  */
 export function DateSeparator({ date }: DateSeparatorProps) {
   const { t, i18n } = useTranslation()
   const currentLang = i18n.language.split('-')[0]
 
   return (
-    <div className="flex items-center gap-4 h-12">
-      <div className="flex-1 h-px bg-fluux-hover" />
+    <div className="flex items-center gap-3 h-12">
       <span className="text-xs font-semibold text-fluux-muted whitespace-nowrap">
         {formatDateHeader(date, t, currentLang)}
       </span>

--- a/apps/fluux/src/components/conversation/HistoryStartMarker.test.tsx
+++ b/apps/fluux/src/components/conversation/HistoryStartMarker.test.tsx
@@ -22,11 +22,20 @@ describe('HistoryStartMarker', () => {
     expect(screen.getByText('Beginning of conversation')).toBeInTheDocument()
   })
 
-  it('should render horizontal lines', () => {
+  it('should render a single trailing rule after the label', () => {
     const { container } = render(<HistoryStartMarker />)
 
     const lines = container.querySelectorAll('.h-px.bg-fluux-hover')
-    expect(lines).toHaveLength(2)
+    expect(lines).toHaveLength(1)
+  })
+
+  it('should render the label before the rule so it sits on the reading-start edge', () => {
+    const { container } = render(<HistoryStartMarker />)
+
+    const wrapper = container.firstChild as HTMLElement
+    const [first, second] = Array.from(wrapper.children)
+    expect(first).toHaveTextContent('Beginning of conversation')
+    expect(second).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
   })
 
   it('should render a clock icon', () => {

--- a/apps/fluux/src/components/conversation/HistoryStartMarker.tsx
+++ b/apps/fluux/src/components/conversation/HistoryStartMarker.tsx
@@ -4,14 +4,17 @@ import { Clock } from 'lucide-react'
 /**
  * Displays a marker indicating the beginning of conversation history.
  * Shown when all server-side message history has been loaded (MAM complete).
+ *
+ * Mirrors the leading-aligned DateSeparator layout: the label sits on the
+ * reading-start edge and the rule trails toward the end edge. Relies on flex
+ * flow + logical spacing so it mirrors correctly under RTL.
  */
 export function HistoryStartMarker() {
   const { t } = useTranslation()
 
   return (
     <div className="flex items-center gap-3 py-4 px-2">
-      <div className="flex-1 h-px bg-fluux-hover" />
-      <div className="flex items-center gap-2 text-xs text-fluux-muted">
+      <div className="flex items-center gap-2 text-xs text-fluux-muted whitespace-nowrap">
         <Clock className="size-3.5" />
         <span>{t('chat.historyStart')}</span>
       </div>


### PR DESCRIPTION
Switches the day separator and the start-of-conversation marker from a centered `rule-label-rule` layout to a leading-aligned label followed by a single trailing rule. The markers now line up with the message column's left edge instead of being the only horizontally-centered elements in the stream, reading as section headings rather than decorative bands.

## RTL

The layout leans on flex flow plus logical spacing, so it mirrors automatically under RTL: the label always sits on the reading-start edge and the rule extends toward the trailing edge, with no direction-specific code. Verified live in demo mode under both LTR (fr) and RTL (ar) — in `ar` the label sits flush at the right edge with the rule trailing left.

## Scope

- `DateSeparator` — day markers (Today / Yesterday / date).
- `HistoryStartMarker` — start-of-conversation marker, kept its Clock icon.
- `HistoryGapMarker` is intentionally left centered: it is an interactive warning with a centered "load missing messages" action, not a passive boundary.

Snapshot and unit tests updated to reflect the single-rule, label-before-rule structure.