### PR TITLE
Focus ring consistency across surfaces (composer, zones, console)

### DIFF
--- a/apps/fluux/src/components/MessageComposer.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.test.tsx
@@ -1095,6 +1095,15 @@ describe('MessageComposer', () => {
       // The textarea also lives inside the same card.
       expect(card!.querySelector('textarea')).not.toBeNull()
     })
+
+    it('opts the textarea out of the global focus outline (card edge is the sole affordance)', () => {
+      render(
+        <MessageComposer placeholder="Type a message" onSend={vi.fn().mockResolvedValue(true)} />
+      )
+      // `no-focus-ring` suppresses the universal `.user-interacted *:focus` outline so
+      // the `.composer-card:focus-within` edge is not doubled by an inner textarea ring.
+      expect(screen.getByPlaceholderText('Type a message').className).toContain('no-focus-ring')
+    })
   })
 
   describe('clipboard paste image handling', () => {

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -33,8 +33,12 @@ const COMPOSING_THROTTLE_MS = 2000
 const PAUSED_TIMEOUT_MS = 5000
 const COMPOSING_UI_TIMEOUT_MS = 1500
 
-// Base textarea classes - exported for custom renderInput implementations to reuse
-export const MESSAGE_INPUT_BASE_CLASSES = 'message-input flex-1 px-2 py-3 bg-transparent resize-none overflow-y-auto'
+// Base textarea classes - exported for custom renderInput implementations to reuse.
+// `no-focus-ring` opts the textarea out of the global `.user-interacted *:focus`
+// outline (index.css): the composer card's own `:focus-within` accent edge is the
+// focus affordance now, so the textarea's inner outline would be a doubled ring.
+// The action buttons keep their outlines for keyboard navigation.
+export const MESSAGE_INPUT_BASE_CLASSES = 'message-input no-focus-ring flex-1 px-2 py-3 bg-transparent resize-none overflow-y-auto'
 export const MESSAGE_INPUT_TEXT_CLASSES = 'text-fluux-text placeholder:text-fluux-muted'
 // For overlay-based inputs (e.g., mention highlighting) - text is transparent, caret visible via style
 export const MESSAGE_INPUT_OVERLAY_CLASSES = 'text-transparent placeholder:text-fluux-muted'

--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -628,7 +628,7 @@ export function XmppConsole() {
         <div
           ref={packetsContainerRef}
           tabIndex={0}
-          className="xmpp-console-log absolute inset-0 overflow-y-auto overflow-x-hidden focus:outline-none focus:ring-2 focus:ring-inset focus:ring-fluux-brand/50"
+          className="xmpp-console-log absolute inset-0 overflow-y-auto overflow-x-hidden"
           onScroll={handleScroll}
           onKeyDown={handleLogKeyDown}
         >

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -691,10 +691,17 @@ html, body {
   outline-offset: -2px;
 }
 
-/* Focus zone styling - only show after user interaction */
+/* Focus zone styling - only show after user interaction.
+ * Matches the composer card's focus treatment (1px accent line + soft glow) so
+ * the sidebar / message / room focus rings read at the same weight as the
+ * composer instead of a heavier 2px solid outline. Inset because these zones are
+ * flush panels (no room for an outset glow); the solid 1px line keeps the
+ * keyboard-focus indicator visible for accessibility. */
 .user-interacted .focus-zone:focus {
-  outline: 2px solid var(--fluux-focus-ring) !important;
-  outline-offset: -2px !important;
+  outline: none !important;
+  box-shadow:
+    inset 0 0 0 1px var(--fluux-brand),
+    inset 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22) !important;
 }
 
 /*

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -704,6 +704,15 @@ html, body {
     inset 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22) !important;
 }
 
+/* XMPP console log: the focus ring is an outline (not an inset box-shadow) so it
+ * sits ABOVE the scrolling entries. An inset ring would be painted under the
+ * rows (the content scrolls on top of it), which is the overlap we want to avoid.
+ * Same 1px accent weight as the focus zones, inset so it stays within the panel. */
+.user-interacted .xmpp-console-log:focus {
+  outline: 1px solid var(--fluux-brand) !important;
+  outline-offset: -1px !important;
+}
+
 /*
  * Aurora composer card. The bar that wraps the context sections + input row.
  * Background is applied as a utility (bg-fluux-hover) on the element; this class


### PR DESCRIPTION
Focus-ring consistency pass across surfaces, following the Aurora composer work (#684).

## Doubled textarea focus ring (composer)
The composer card's accent `:focus-within` edge was being doubled by the textarea's own focus outline (the global `.user-interacted *:focus` ring). The textarea now opts out via the existing `no-focus-ring` hatch, leaving the card edge as the single focus affordance. Covers both 1:1 and rooms (shared `MESSAGE_INPUT_BASE_CLASSES`); the action buttons keep their own outlines for keyboard navigation.

## Align the zone focus rings to the composer
The sidebar, message view, and room view focus zones used a heavier 2px solid outline, inconsistent with the composer's 1px accent line + soft glow. They now use the same treatment (inset, since they are flush panels), so every focusable surface shares one focus weight. The solid 1px line preserves keyboard-focus visibility for accessibility.

## XMPP console log focus ring
The console log used a 2px inset `ring` on the scrollable element, so the entries painted on top of it (a visible overlap) and it was heavier than the rest. It is now a 1px accent outline: an outline renders above the content (no overlap), at the same weight as the other surfaces.
