### PR TITLE
fix(e2ee): unify encryption affordance color across header, locks, composer

### DIFF
--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -394,7 +394,7 @@ function EncryptionIcon({
   // share an alarming icon.
   const Icon = verified ? ShieldCheck : Lock
   const colorClass = verified
-    ? 'text-green-500'
+    ? 'text-fluux-encryption'
     : 'text-fluux-muted hover:text-fluux-text'
   const hasActions = onVerifyClick || onDisableClick
 
@@ -464,7 +464,7 @@ function EncryptionIcon({
               className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-fluux-text hover:bg-fluux-hover transition-colors"
               onClick={() => { setOpen(false); onVerifyClick() }}
             >
-              <ShieldCheck className={`size-4 flex-shrink-0 ${verified ? 'text-green-500' : 'text-fluux-muted'}`} />
+              <ShieldCheck className={`size-4 flex-shrink-0 ${verified ? 'text-fluux-encryption' : 'text-fluux-muted'}`} />
               {verified
                 ? t('chat.verifyPeer.menuViewVerified', { name: peerName })
                 : t('chat.verifyPeer.dialogTitle', { name: peerName })}

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -557,7 +557,7 @@ export const MessageBubble = memo(function MessageBubble({
                 <span
                   className={`flex items-center ${
                     displayTrust === 'verified'
-                      ? 'text-green-500'
+                      ? 'text-fluux-encryption'
                       : displayTrust === 'rejected'
                       ? 'text-red-500'
                       : displayTrust === 'untrusted'

--- a/apps/fluux/tailwind.config.js
+++ b/apps/fluux/tailwind.config.js
@@ -45,6 +45,9 @@ export default {
           'badge-text': 'var(--fluux-badge-text)',
           // Aurora identity tokens
           'accent-2': 'var(--fluux-accent-2)',
+          // Encryption affordance (shields, locks) — single source of truth so
+          // the header shield, composer lock, and per-message lock match.
+          'encryption': 'var(--fluux-text-encryption)',
           // Status (semantic purpose, not color)
           'green': 'var(--fluux-status-success)',
           'yellow': 'var(--fluux-status-warning)',


### PR DESCRIPTION
## Summary

The e2ee encryption indicators used two different greens. The composer/toolbar shield rendered the theme's encryption teal (`var(--fluux-text-encryption)`), while the conversation **header verified shield** and the **per-message verified locks** used a hardcoded Tailwind `text-green-500`. This made the affordances visibly inconsistent.

This change introduces a single source of truth and points all three at it:

- **tailwind.config.js** — new `fluux-encryption` color token mapped to `var(--fluux-text-encryption)`.
- **ChatHeader.tsx** — verified header shield and its menu `ShieldCheck`: `text-green-500` → `text-fluux-encryption`.
- **MessageBubble.tsx** — verified per-message lock: `text-green-500` → `text-fluux-encryption`.

The unverified (neutral gray Lock), untrusted (yellow), and rejected (red) states are intentionally untouched.

## Result

All three encryption affordances now resolve to the same token in every theme:

| Affordance | Light (`#0D8872`) | Dark (`#38E0C4`) |
|---|---|---|
| Header verified shield | `rgb(13,136,114)` | `rgb(56,224,196)` |
| Verified message lock | `rgb(13,136,114)` | `rgb(56,224,196)` |
| Composer shield | (already this token) | (already this token) |

Verified in demo mode (light and dark). Typecheck and lint clean; 116 tests pass, including the `themeContrast` guard that confirms the teal clears the WCAG 3:1 non-text contrast floor (the previous hardcoded green was not covered by that guard).