### PR TITLE
fix(composer): optically center the send icon in its button

### DIFF
--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -990,7 +990,7 @@ export function MessageComposer({
                      disabled:bg-transparent disabled:text-fluux-muted disabled:cursor-not-allowed
                      transition-colors"
         >
-          <Send className="rtl-mirror size-5" />
+          <Send className="rtl-mirror icon-optical-send size-5" />
           {sendBadge}
         </button>
       </div>

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -7,6 +7,18 @@
   transform: scaleX(-1);
 }
 
+/* Optical centering for the paper-plane send icon. Its bounding box is centered,
+   but the stroke mass leans up-and-right, so it reads as off-center. Nudge it
+   down-and-left via the `translate` property, which composes with the
+   `rtl-mirror` `transform` instead of overriding it. The horizontal nudge flips
+   in RTL because the glyph itself is mirrored there. */
+.icon-optical-send {
+  translate: -1px 1px;
+}
+[dir="rtl"] .icon-optical-send {
+  translate: 1px 1px;
+}
+
 /* Restore pointer cursor on interactive elements (Tailwind Preflight resets to default) */
 @layer base {
   button:not(:disabled),


### PR DESCRIPTION
The paper-plane send icon in the message composer reads as off-center, floating toward the top-right of its button.

## Cause

The layout centering is already correct: the 20x20 icon sits with an exact 10px gap on all four sides of the 40x40 button, and the glyph's bounding box is symmetric within its viewBox. The imbalance is optical, not geometric. lucide's `Send` glyph concentrates its stroke mass up-and-to-the-right: sampling the stroke puts its center of mass at ~(14.9, 9.1) versus the geometric center (12, 12) in the 24-unit viewBox. The eye reads that as the plane floating high-right with empty space in the lower-left.

## Fix

A small optical nudge of the icon down-and-left (`translate: -1px 1px`), recovering ~1px of the ~2.4px imbalance — measured as the point where the visual mass straddles the button center without over-correcting.

It uses the CSS `translate` property rather than `transform`, so it composes with the existing `rtl-mirror` `transform: scaleX(-1)` instead of overriding it. The horizontal nudge flips in RTL (`translate: 1px 1px`) because the glyph itself is mirrored there.