### PR TITLE
Login screen: scroll-safe centering for short viewports

### DIFF
--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -360,10 +360,14 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
   }
 
   return (
-    <div className="h-full bg-fluux-bg flex items-center justify-center p-4 relative">
+    <div className="h-full bg-fluux-bg overflow-y-auto relative">
       {/* Window drag region - covers top area for title bar */}
       <div className="absolute top-0 inset-x-0 h-8" {...dragRegionProps} />
-      <div className="w-full max-w-md">
+      {/* min-h-full + centering keeps the card centered when there is room, but
+          lets the container scroll to every field on short viewports (e.g. a
+          phone in landscape with the keyboard open). */}
+      <div className="min-h-full flex items-center justify-center p-4">
+        <div className="w-full max-w-md">
         {/* Logo / Header */}
         <div className="text-center mb-8">
           <img
@@ -598,6 +602,7 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
               XMPP
             </a>
           </p>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

On a short viewport (a phone in landscape with the on-screen keyboard open, or a small device), the login screen clipped its content with no way to scroll. The form card was vertically centered on a fixed-height, non-scrollable container, so the **Se connecter** button fell below the fold and could not be reached.

This wraps the card in the canonical scroll-safe centering pattern: an outer `overflow-y-auto` container plus an inner `min-h-full flex items-center justify-center` wrapper. When there is room the card stays exactly centered as before; when the viewport is short the container scrolls so every field and the submit button are reachable.

## Verification (375px wide)

| Viewport height | Before | After |
| --- | --- | --- |
| 812px (no keyboard) | centered | Still centered, symmetric spacing, no scrollbar |
| 300px (landscape + keyboard) | Submit button cut off, no scroll | Container scrolls, button fully reachable |
| Top of form at 300px | Top clipped | Logo and JID field reachable, padding preserved |