### PR TITLE
Round focus-zone ring corners

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -699,6 +699,10 @@ html, body {
  * keyboard-focus indicator visible for accessibility. */
 .user-interacted .focus-zone:focus {
   outline: none !important;
+  /* A small radius softens the inset ring's corners (box-shadow follows the
+     element's border-radius) so the zone focus edge reads as gently rounded
+     rather than a hard square. */
+  border-radius: 4px;
   box-shadow:
     inset 0 0 0 1px var(--fluux-brand),
     inset 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22) !important;


### PR DESCRIPTION
Add a small 4px `border-radius` to the `.focus-zone:focus` state so the focus ring reads as gently rounded instead of a hard square.

The sidebar, message view, and room view share the `.focus-zone` class and use an inset `box-shadow` for their keyboard-focus ring. An inset shadow follows the element's `border-radius`, so with square zones the ring was square. A 4px radius softens the four corners while preserving the 1px accent line + soft glow weight (consistent with the composer focus treatment from #687).

Affects all three focus surfaces; no layout change.