### PR TITLE
fix(conversation): give day markers asymmetric spacing for hierarchy

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 data-date-separator="10:00"
               >
                 <div
-                  class="flex items-center gap-3 h-12"
+                  class="flex items-center gap-3 pt-6 pb-2"
                 >
                   <span
                     class="text-xs font-semibold text-fluux-muted whitespace-nowrap"

--- a/apps/fluux/src/components/conversation/DateSeparator.test.tsx
+++ b/apps/fluux/src/components/conversation/DateSeparator.test.tsx
@@ -43,7 +43,7 @@ describe('DateSeparator', () => {
     const { container } = render(<DateSeparator date="2024-01-15" />)
 
     const wrapper = container.firstChild as HTMLElement
-    expect(wrapper).toHaveClass('flex', 'items-center', 'gap-3', 'h-12')
+    expect(wrapper).toHaveClass('flex', 'items-center', 'gap-3', 'pt-6', 'pb-2')
   })
 
   it('should style the date text correctly', () => {

--- a/apps/fluux/src/components/conversation/DateSeparator.tsx
+++ b/apps/fluux/src/components/conversation/DateSeparator.tsx
@@ -19,7 +19,7 @@ export function DateSeparator({ date }: DateSeparatorProps) {
   const currentLang = i18n.language.split('-')[0]
 
   return (
-    <div className="flex items-center gap-3 h-12">
+    <div className="flex items-center gap-3 pt-6 pb-2">
       <span className="text-xs font-semibold text-fluux-muted whitespace-nowrap">
         {formatDateHeader(date, t, currentLang)}
       </span>


### PR DESCRIPTION
Day separators (`Aujourd'hui`, `Hier`, etc.) used a fixed `h-12` container with `items-center`, which split the vertical space evenly above and below the label. Visually it read as a free-floating divider sitting equidistant between two days, rather than a heading that belongs to the messages it introduces.

This switches to asymmetric padding (`pt-6 pb-2`): 24px before, 8px after. Each day marker now groups tightly with the messages below it, conveying the intended hierarchy.

The `DateSeparator` styling test is updated to match the new classes.