### PR TITLE
Unify menu/popover surfaces on an elevated .fluux-popover style

### DIFF
--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -322,7 +322,7 @@ function EncryptionIcon({
           <div
             ref={menu.menuRef}
             style={{ left: menu.position.x, top: menu.position.y }}
-            className="fixed w-72 max-w-[calc(100vw-1rem)] rounded-lg border border-fluux-hover bg-fluux-bg shadow-lg z-50 py-2 px-3 overflow-hidden">
+            className="fixed w-72 max-w-[calc(100vw-1rem)] rounded-lg fluux-popover z-50 py-2 px-3 overflow-hidden">
             <div className="text-sm font-medium text-red-600 dark:text-red-400 mb-1.5">
               {t('chat.encryption.rejectedTitle')}
             </div>
@@ -366,7 +366,7 @@ function EncryptionIcon({
           <div
             ref={menu.menuRef}
             style={{ left: menu.position.x, top: menu.position.y }}
-            className="fixed w-56 max-w-[calc(100vw-1rem)] rounded-lg border border-fluux-hover bg-fluux-bg shadow-lg z-50 py-1 overflow-hidden">
+            className="fixed w-56 max-w-[calc(100vw-1rem)] rounded-lg fluux-popover z-50 py-1 overflow-hidden">
             {onEnableClick && (
               <button
                 type="button"
@@ -457,7 +457,7 @@ function EncryptionIcon({
         <div
           ref={menu.menuRef}
           style={{ left: menu.position.x, top: menu.position.y }}
-          className="fixed w-56 max-w-[calc(100vw-1rem)] rounded-lg border border-fluux-hover bg-fluux-bg shadow-lg z-50 py-1 overflow-hidden">
+          className="fixed w-56 max-w-[calc(100vw-1rem)] rounded-lg fluux-popover z-50 py-1 overflow-hidden">
           {onVerifyClick && (
             <button
               type="button"

--- a/apps/fluux/src/components/ContactSelector.tsx
+++ b/apps/fluux/src/components/ContactSelector.tsx
@@ -327,7 +327,7 @@ export function ContactSelector({
 
         {/* Dropdown with keyboard-highlighted contacts - flips up when near bottom */}
         {isFocused && filteredContacts.length > 0 && (
-          <div className={`absolute inset-x-0 max-h-40 overflow-y-auto bg-fluux-bg rounded border border-fluux-hover shadow-lg z-10 ${
+          <div className={`absolute inset-x-0 max-h-40 overflow-y-auto fluux-popover rounded z-10 ${
             flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
           }`}>
             {filteredContacts.map((contact, index) => {
@@ -366,7 +366,7 @@ export function ContactSelector({
 
         {/* Hint when input is a valid JID but no contacts match */}
         {isFocused && filteredContacts.length === 0 && canAddAsJid && (
-          <div className={`absolute inset-x-0 bg-fluux-bg rounded border border-fluux-hover shadow-lg z-10 ${
+          <div className={`absolute inset-x-0 fluux-popover rounded z-10 ${
             flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
           }`}>
             <div
@@ -386,7 +386,7 @@ export function ContactSelector({
 
         {/* No contacts found hint */}
         {isFocused && filteredContacts.length === 0 && search && !canAddAsJid && (
-          <div className={`absolute inset-x-0 bg-fluux-bg rounded border border-fluux-hover shadow-lg z-10 px-3 py-2 text-sm text-fluux-muted ${
+          <div className={`absolute inset-x-0 fluux-popover rounded z-10 px-3 py-2 text-sm text-fluux-muted ${
             flipUp ? 'bottom-full mb-1' : 'top-full mt-1'
           }`}>
             {t('contacts.noContactsFound')}

--- a/apps/fluux/src/components/ImageContextMenu.tsx
+++ b/apps/fluux/src/components/ImageContextMenu.tsx
@@ -47,7 +47,7 @@ export function ImageContextMenu({ originalUrl, proxiedUrl, filename, menu }: Im
   return (
     <div
       ref={menu.menuRef}
-      className="fixed z-50 min-w-[180px] py-1 rounded-lg bg-fluux-bg border border-fluux-border shadow-lg"
+      className="fixed z-50 min-w-[180px] py-1 rounded-lg fluux-popover"
       style={{ left: menu.position.x, top: menu.position.y }}
     >
       <MenuButton

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -889,7 +889,7 @@ export function MessageComposer({
           )}
 
           {showAttachMenu && (
-            <div className="absolute bottom-full start-0 mb-2 z-50 bg-fluux-bg border border-fluux-hover rounded-lg shadow-lg py-1 min-w-[180px]">
+            <div className="absolute bottom-full start-0 mb-2 z-50 fluux-popover rounded-lg py-1 min-w-[180px]">
               <button
                 type="button"
                 onClick={() => {

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -720,7 +720,7 @@ export function OccupantPanel({
       {menu.isOpen && menuTarget && (
         <div
           ref={menu.menuRef}
-          className="fixed bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 min-w-40"
+          className="fixed fluux-popover rounded-lg py-1 z-50 min-w-40"
           style={{ left: menu.position.x, top: menu.position.y }}
         >
           {/* Private message */}

--- a/apps/fluux/src/components/OverflowMenu.tsx
+++ b/apps/fluux/src/components/OverflowMenu.tsx
@@ -32,7 +32,7 @@ interface OverflowMenuProps {
 const DEFAULT_BUTTON_CLASS =
   'p-2 rounded-lg text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center'
 const DEFAULT_MENU_CLASS =
-  'absolute end-0 mt-1 z-50 w-56 bg-fluux-sidebar border border-fluux-hover rounded-lg shadow-lg py-1'
+  'absolute end-0 mt-1 z-50 w-56 fluux-popover rounded-lg py-1'
 
 /**
  * Generic kebab (overflow) menu: a `MoreVertical` trigger that opens a

--- a/apps/fluux/src/components/RoomMembersModal.tsx
+++ b/apps/fluux/src/components/RoomMembersModal.tsx
@@ -433,7 +433,7 @@ function AffiliationDropdown({
         <ChevronDown className="size-3" />
       </button>
       {isOpen && (
-        <div className="absolute end-0 top-full mt-1 bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 min-w-36">
+        <div className="absolute end-0 top-full mt-1 fluux-popover rounded-lg py-1 z-50 min-w-36">
           {availableAffiliations.map(aff => (
             <button
               key={aff}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -679,7 +679,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
         return (
           <div
             ref={nickMenu.menuRef}
-            className="fixed bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 min-w-40"
+            className="fixed fluux-popover rounded-lg py-1 z-50 min-w-40"
             style={{ left: nickMenu.position.x, top: nickMenu.position.y }}
           >
             {bareJid && onStartChat && (
@@ -1906,7 +1906,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
   const mentionDropdown = mentionState.isActive && mentionState.matches.length > 0 ? (
     <div
       className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto
-                 bg-fluux-bg border border-fluux-hover rounded-lg shadow-lg z-30"
+                 fluux-popover rounded-lg z-30"
     >
       {mentionState.matches.map((match, idx) => (
         <button

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -331,7 +331,7 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
                 </button>
               </Tooltip>
               {showContactDropdown && (
-                <div className="absolute end-0 mt-1 w-52 bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50">
+                <div className="absolute end-0 mt-1 w-52 fluux-popover rounded-lg py-1 z-50">
                   <button
                     onClick={() => { setShowContactDropdown(false); modalOpen('addContact') }}
                     className="w-full px-3 py-2 text-start text-sm hover:bg-fluux-hover flex items-center gap-2"
@@ -363,7 +363,7 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
                 </button>
               </Tooltip>
               {showRoomDropdown && (
-                <div className="absolute end-0 mt-1 w-52 bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50">
+                <div className="absolute end-0 mt-1 w-52 fluux-popover rounded-lg py-1 z-50">
                   <button
                     onClick={() => { setShowRoomDropdown(false); modalOpen('quickChat') }}
                     className="w-full px-3 py-2 text-start text-sm hover:bg-fluux-hover flex items-center gap-2"

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -131,7 +131,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       data-message-toolbar="true"
                     >
                       <div
-                        class="flex items-center bg-fluux-bg rounded-md shadow-lg border border-fluux-hover "
+                        class="flex items-center fluux-popover rounded-md "
                       >
                         <button
                           aria-label="chat.reactWith"
@@ -291,7 +291,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       data-message-toolbar="true"
                     >
                       <div
-                        class="flex items-center bg-fluux-bg rounded-md shadow-lg border border-fluux-hover "
+                        class="flex items-center fluux-popover rounded-md "
                       >
                         <button
                           aria-label="chat.reactWith"

--- a/apps/fluux/src/components/conversation/MessageToolbar.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.tsx
@@ -151,7 +151,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       {/* Visible toolbar */}
       <div
         ref={toolbarRef}
-        className={`flex items-center bg-fluux-bg rounded-md shadow-lg border border-fluux-hover ${interactivityClass}`}
+        className={`flex items-center fluux-popover rounded-md ${interactivityClass}`}
         onMouseEnter={onToolbarMouseEnter}
       >
       {/* Quick reaction emojis (hidden when reactions are disabled) */}
@@ -272,7 +272,7 @@ export const MessageToolbar = memo(function MessageToolbar({
 
         {/* More options dropdown menu */}
         {showMoreMenu && canDelete && (
-          <div className={`absolute end-0 min-w-[160px] bg-fluux-bg rounded-lg shadow-lg border border-fluux-hover z-30 overflow-hidden ${moreMenuDropUpRef.current ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
+          <div className={`absolute end-0 min-w-[160px] fluux-popover rounded-lg z-30 overflow-hidden ${moreMenuDropUpRef.current ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
             <button
               onClick={handleDelete}
               className="w-full px-3 py-2 text-sm text-start text-red-500 hover:bg-fluux-hover transition-colors flex items-center gap-2"

--- a/apps/fluux/src/components/conversation/UserInfoPopover.tsx
+++ b/apps/fluux/src/components/conversation/UserInfoPopover.tsx
@@ -197,7 +197,7 @@ export function UserInfoPopover({ contact, jid, occupantJid, role, affiliation, 
       {isOpen && createPortal(
         <div
           ref={popoverRef}
-          className="fixed bg-fluux-sidebar rounded-lg shadow-xl border border-fluux-hover p-3 z-50 min-w-[200px] max-w-[280px]"
+          className="fixed fluux-popover rounded-lg p-3 z-50 min-w-[200px] max-w-[280px]"
           style={{ left: position.x, top: position.top, bottom: position.bottom }}
         >
           {/* JID */}

--- a/apps/fluux/src/components/header/HeaderOverflowKebab.tsx
+++ b/apps/fluux/src/components/header/HeaderOverflowKebab.tsx
@@ -107,7 +107,7 @@ export function HeaderOverflowKebab({ ariaLabel, entries, triggerClassName }: He
             ref={menu.menuRef}
             role="menu"
             style={{ left: menu.position.x, top: menu.position.y }}
-            className="fixed w-64 max-w-[calc(100vw-1rem)] bg-fluux-bg border border-fluux-hover rounded-lg shadow-lg z-50 py-1"
+            className="fixed w-64 max-w-[calc(100vw-1rem)] fluux-popover rounded-lg z-50 py-1"
           >
             {entries.map((e) =>
               e.kind === 'action' ? (

--- a/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
+++ b/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
@@ -51,7 +51,7 @@ export function HeaderSubmenuButton({ ariaLabel, tooltip, icon: Icon, active, gr
           ref={menu.menuRef}
           role="menu"
           style={{ left: menu.position.x, top: menu.position.y }}
-          className="fixed w-64 max-w-[calc(100vw-1rem)] bg-fluux-bg border border-fluux-hover rounded-lg shadow-lg z-30 py-1"
+          className="fixed w-64 max-w-[calc(100vw-1rem)] fluux-popover rounded-lg z-30 py-1"
         >
           {group.items.map((item) => {
             const ItemIcon = item.icon

--- a/apps/fluux/src/components/settings-components/profile/VCardSection.tsx
+++ b/apps/fluux/src/components/settings-components/profile/VCardSection.tsx
@@ -196,7 +196,7 @@ export function VCardSection() {
             {t('profile.addField')}
           </button>
           {showAddField && (
-            <div className="absolute top-full mt-1 start-0 bg-fluux-sidebar border border-fluux-hover rounded-lg shadow-lg py-1 z-10">
+            <div className="absolute top-full mt-1 start-0 fluux-popover rounded-lg py-1 z-10">
               {availableFields.map(({ key, label, icon: Icon }) => (
                 <button
                   key={key}

--- a/apps/fluux/src/components/sidebar-components/ActivityLogView.tsx
+++ b/apps/fluux/src/components/sidebar-components/ActivityLogView.tsx
@@ -333,7 +333,7 @@ function ReactionMuteDropdown({
       </button>
 
       {isOpen && (
-        <div className="absolute end-0 top-full mt-1 z-50 bg-fluux-bg border border-fluux-hover rounded-md shadow-lg py-1 min-w-[200px]">
+        <div className="absolute end-0 top-full mt-1 z-50 fluux-popover rounded-md py-1 min-w-[200px]">
           <button
             className="w-full text-start px-3 py-1.5 text-xs text-fluux-text hover:bg-fluux-hover transition-colors"
             onClick={(e) => {

--- a/apps/fluux/src/components/sidebar-components/ContactList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.tsx
@@ -407,7 +407,7 @@ const ContactItem = memo(function ContactItem({
       {menu.isOpen && (
         <div
           ref={menu.menuRef}
-          className="fixed bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 min-w-40"
+          className="fixed fluux-popover rounded-lg py-1 z-50 min-w-40"
           style={{ left: menu.position.x, top: menu.position.y }}
         >
           <button

--- a/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
+++ b/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
@@ -143,7 +143,7 @@ export function PresenceSelector({ isOpen: isOpenProp, onOpenChange }: PresenceS
           ref={menu.menuRef}
           tabIndex={-1}
           style={{ left: menu.position.x, top: menu.position.y }}
-          className="fixed w-56 max-w-[calc(100vw-1rem)] bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 overflow-hidden outline-none"
+          className="fixed w-56 max-w-[calc(100vw-1rem)] fluux-popover rounded-lg py-1 z-50 overflow-hidden outline-none"
         >
           {/* Presence options */}
           {presenceOptions.map((option, index) => (

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -481,7 +481,7 @@ const RoomItem = memo(function RoomItem({
       {menu.isOpen && (
         <div
           ref={menu.menuRef}
-          className="fixed bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 min-w-48"
+          className="fixed fluux-popover rounded-lg py-1 z-50 min-w-48"
           style={{ left: menu.position.x, top: menu.position.y }}
         >
           {/* Join (only for non-joined rooms) */}

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -141,7 +141,7 @@ export function SearchView() {
 
           {/* in: prefix autocomplete dropdown */}
           {isInPrefixActive && inPrefixSuggestions.length > 0 && (
-            <div className="absolute inset-x-0 top-full mt-1 bg-fluux-bg border border-fluux-hover rounded-md shadow-lg z-50 max-h-48 overflow-y-auto">
+            <div className="absolute inset-x-0 top-full mt-1 fluux-popover rounded-md z-50 max-h-48 overflow-y-auto">
               {inPrefixSuggestions.map((s, i) => (
                 <button
                   key={s.id}

--- a/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
@@ -206,7 +206,7 @@ export function SidebarListMenuPortal({ children }: SidebarListMenuPortalProps) 
   return (
     <div
       ref={menuRef}
-      className="fixed bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50 min-w-40"
+      className="fixed fluux-popover rounded-lg py-1 z-50 min-w-40"
       style={{ left: position.x, top: position.y }}
     >
       {children}

--- a/apps/fluux/src/components/sidebar-components/UserMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/UserMenu.tsx
@@ -73,7 +73,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
           <div
             ref={menu.menuRef}
             style={{ left: menu.position.x, top: menu.position.y }}
-            className="fixed w-48 max-w-[calc(100vw-1rem)] bg-fluux-bg rounded-lg shadow-xl border border-fluux-hover py-1 z-50">
+            className="fixed w-48 max-w-[calc(100vw-1rem)] fluux-popover rounded-lg py-1 z-50">
             {/* Console toggle - hidden on mobile */}
             {!isMobile && (
               <button

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -457,6 +457,21 @@
   --em-color-border-over: var(--fluux-bg-active);
 }
 
+/* Elevated floating surface shared by every menu, dropdown, context menu and
+   popover. Uses the lifted float background (lighter than the canvas in dark,
+   white in light), the visible hairline border and the overlay drop shadow, so
+   the panel reads as a distinct floating card rather than a recessed hole. The
+   previous bg-primary surface was *darker* than the sidebar/chat it floated
+   over (Aurora dark), which is what made these menus look wrong. Pair with
+   positioning, width, padding and radius utilities at the call site. */
+@layer components {
+  .fluux-popover {
+    background-color: var(--fluux-bg-float);
+    border: 1px solid var(--fluux-border-color);
+    box-shadow: var(--fluux-shadow-overlay);
+  }
+}
+
 /* Text selection styling - uses brand color for consistent look */
 ::selection {
   background-color: var(--fluux-selection);


### PR DESCRIPTION
## Summary

Every popover, dropdown and context menu in the app shared one class string: `bg-fluux-bg … border border-fluux-hover shadow-xl`. In the Aurora **dark** theme that surface resolved to `--fluux-bg-primary` (`#0B1020`), which is *darker* than the sidebar (`#0E1326`) and chat (`#0F1528`) it floats over, so menus read as a recessed hole rather than a lifted card, with a near-invisible `border-fluux-hover` edge. This was most visible on the MUC occupant context menu.

The design system already had the right elevation tokens; the menus just weren't using them. This change:

- Adds a shared `.fluux-popover` utility in `index.css` (`@layer components`) that sets the lifted float surface (`--fluux-bg-float` — lighter than the canvas in dark, white in light), the visible hairline border (`--fluux-border-color`) and the overlay drop shadow (`--fluux-shadow-overlay`).
- Replaces the duplicated surface classes with `fluux-popover` across ~21 components (28 call sites) — every menu, dropdown, context menu and popover — keeping each site's positioning, width, radius and z-index utilities. This also removes the long-standing duplication of the class string.

Intentionally left untouched: modals (UpdateModal, the UserMenu settings card — they sit on a dimmed backdrop and use the modal border token) and the already-correct floating bars (FindOnPageBar, MessageSelectionBar, the scroll-to-bottom button, which already use `bg-fluux-float`/`border-fluux-border`). In-menu dividers are left as-is.

This continues the Aurora theme audit's "invisible borders/elevation" structural pattern.