### PR TITLE
Chat: re-pin to bottom when the keyboard deploys

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -578,6 +578,84 @@ describe('MessageList scroll behavior', () => {
     })
   })
 
+  describe('viewport resize (keyboard deploy)', () => {
+    // The on-screen keyboard shrinks the SCROLLER viewport without changing content
+    // height, so the content ResizeObserver never fires. A window/visualViewport
+    // resize listener must re-pin to the bottom when the user was following along —
+    // otherwise the latest message slides behind the keyboard/composer.
+    function mountAtBottom(scrollSpy: ReturnType<typeof vi.fn<(v: number) => void>>) {
+      const messages = createTestMessages(5)
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+      const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
+      let scrollTopValue = 500 // at bottom: scrollHeight 1000 - clientHeight 500
+      Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+      Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+      Object.defineProperty(container, 'scrollTop', {
+        get: () => scrollTopValue,
+        set: (v) => { scrollTopValue = v; scrollSpy(v) },
+        configurable: true,
+      })
+      return { container, setScrollTop: (v: number) => { scrollTopValue = v } }
+    }
+
+    it('re-pins to the bottom on window resize when the user is at the bottom', () => {
+      const scrollSpy = vi.fn()
+      const { container } = mountAtBottom(scrollSpy)
+
+      // Confirm at-bottom state from a scroll event
+      act(() => { container.dispatchEvent(new Event('scroll')) })
+      scrollSpy.mockClear()
+
+      // Keyboard deploys: viewport shrinks -> window resize fires
+      act(() => { window.dispatchEvent(new Event('resize')) })
+
+      expect(scrollSpy).toHaveBeenCalledWith(1000)
+    })
+
+    it('re-pins to the bottom on visualViewport resize when the user is at the bottom', () => {
+      const realVV = window.visualViewport
+      const listeners = new Set<EventListener>()
+      const fakeVV = {
+        addEventListener: (_t: string, cb: EventListener) => listeners.add(cb),
+        removeEventListener: (_t: string, cb: EventListener) => listeners.delete(cb),
+      }
+      Object.defineProperty(window, 'visualViewport', { value: fakeVV, configurable: true })
+      try {
+        const scrollSpy = vi.fn()
+        const { container } = mountAtBottom(scrollSpy)
+        act(() => { container.dispatchEvent(new Event('scroll')) })
+        scrollSpy.mockClear()
+
+        act(() => { listeners.forEach((cb) => cb(new Event('resize'))) })
+
+        expect(scrollSpy).toHaveBeenCalledWith(1000)
+      } finally {
+        Object.defineProperty(window, 'visualViewport', { value: realVV, configurable: true })
+      }
+    })
+
+    it('does NOT re-pin on window resize when the user has scrolled up', () => {
+      const scrollSpy = vi.fn()
+      const { container, setScrollTop } = mountAtBottom(scrollSpy)
+
+      // User scrolled up (distance from bottom > threshold)
+      setScrollTop(200)
+      act(() => { container.dispatchEvent(new Event('scroll')) })
+      scrollSpy.mockClear()
+
+      act(() => { window.dispatchEvent(new Event('resize')) })
+
+      expect(scrollSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe('scroll-to-top lazy loading', () => {
     it('should call onScrollToTop when scrolling up while at top (wheel event)', () => {
       const messages = createTestMessages(10)

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -632,6 +632,31 @@ export function useMessageListScroll({
     }
   }, [pinVirtualizedBottom])
 
+  // Re-pin to the bottom when the VIEWPORT itself shrinks (or grows) under a list
+  // that is following along — most importantly when the mobile on-screen keyboard
+  // deploys. The keyboard shrinks the scroller's clientHeight WITHOUT changing the
+  // content height, so the content ResizeObserver above never fires and the latest
+  // message slides out of view behind the composer/keyboard. window 'resize' fires
+  // when the layout viewport resizes (Android, resizing webviews); visualViewport
+  // 'resize' covers the overlay-keyboard case (iOS). Reasserts directly (no rAF
+  // coalescing) to match the new-message / typing re-pin sites — a window 'resize'
+  // handler is not a ResizeObserver callback, so a synchronous scroll write here is
+  // safe. Gated on isAtBottomRef so a reader who scrolled up to history is not
+  // yanked back down.
+  useEffect(() => {
+    if (staticMode) return
+    const onViewportResize = () => {
+      if (isAtBottomRef.current) reassertBottom()
+    }
+    window.addEventListener('resize', onViewportResize)
+    const vv = window.visualViewport
+    vv?.addEventListener('resize', onViewportResize)
+    return () => {
+      window.removeEventListener('resize', onViewportResize)
+      vv?.removeEventListener('resize', onViewportResize)
+    }
+  }, [staticMode, isAtBottomRef, reassertBottom])
+
   // ==========================================================================
   // LOAD OLDER MESSAGES
   // ==========================================================================


### PR DESCRIPTION
## Summary

When the on-screen keyboard deploys in a conversation, the message list did not stay stuck to the bottom: the keyboard shrinks the scroller's viewport without changing the content height, so the existing content `ResizeObserver` (which only re-pins on content growth) never fires. The result is that the latest message slides behind the composer/keyboard and a "N new" badge appears, forcing a manual scroll down.

This adds a `window` `resize` + `visualViewport` `resize` listener in `useMessageListScroll` that calls the existing `reassertBottom()` when the user is following along. `window resize` covers the layout-viewport case (Android, resizing webviews); `visualViewport resize` covers the overlay-keyboard case (iOS). It is gated on `isAtBottom`, so a reader who scrolled up into history is never yanked back down. It reasserts directly (no rAF), matching the new-message and typing re-pin sites.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| At bottom, keyboard deploys | Latest message hidden, "N new" badge, must scroll manually | List re-pins to bottom |
| Scrolled up reading history, keyboard deploys | Stays put | Stays put (not yanked down) |
| Typing a multi-line message (composer grows) | Already worked | Still works |