### PR TITLE
Match the emoji picker to the Aurora elevated popover surface

### DIFF
--- a/apps/fluux/src/hooks/useTheme.ts
+++ b/apps/fluux/src/hooks/useTheme.ts
@@ -120,6 +120,42 @@ function applyAccentOverride(accent: AccentPreset | null, resolved: 'light' | 'd
   }
 }
 
+/**
+ * emoji-mart (the web-component emoji picker) reads its colors as RGB *triples*
+ * — `rgb(var(--rgb-background))` etc. Fluux tokens are hex/hsl and themes only
+ * ship RGB triples for the named status colors, so we derive the few triples the
+ * picker needs from the *resolved* theme tokens at apply-time. This keeps the
+ * picker on the active theme's elevated surface (and works for custom/plugin
+ * themes) without every theme having to declare emoji-mart vars. The structural
+ * look (border/shadow/radius) is handled in index.css via the --fluux-* tokens.
+ */
+const EMOJI_PICKER_COLOR_MAP: ReadonlyArray<readonly [emojiVar: string, sourceVar: string]> = [
+  ['--rgb-background', '--fluux-bg-float'], // picker surface (lifted, matches .fluux-popover)
+  ['--rgb-input', '--fluux-input-bg'],      // search field
+  ['--rgb-color', '--fluux-text-normal'],   // text
+  ['--rgb-accent', '--fluux-bg-accent'],    // accent (selected category, focus ring)
+]
+
+function applyEmojiPickerColors() {
+  const root = document.documentElement
+  // Resolve each source token to an "r, g, b" triple via the browser's own color
+  // parser (handles hex/hsl/rgb uniformly), then expose it under emoji-mart's
+  // public --rgb-* hook. One hidden probe is reused for all reads. These are
+  // always overwritten on every theme/mode change, so no cleanup is needed.
+  const probe = document.createElement('span')
+  probe.style.cssText = 'position:absolute;width:0;height:0;visibility:hidden;pointer-events:none'
+  document.body.appendChild(probe)
+  try {
+    for (const [emojiVar, sourceVar] of EMOJI_PICKER_COLOR_MAP) {
+      probe.style.color = `var(${sourceVar})`
+      const m = getComputedStyle(probe).color.match(/(\d+)[,\s]+(\d+)[,\s]+(\d+)/)
+      if (m) root.style.setProperty(emojiVar, `${m[1]}, ${m[2]}, ${m[3]}`)
+    }
+  } finally {
+    probe.remove()
+  }
+}
+
 /** Snippet <style> element data attribute */
 const SNIPPET_ATTR = 'data-fluux-snippet'
 
@@ -195,6 +231,9 @@ export function useTheme() {
       root.style.setProperty('--fluux-text-on-accent', contrastColorForHsl(effectiveHsl.h, effectiveHsl.s, effectiveHsl.l))
     }
 
+    // 3c. Derive emoji-picker RGB triples from the now-resolved theme tokens
+    applyEmojiPickerColors()
+
     // 4. Sync status bar color
     updateThemeColorMeta(resolved)
 
@@ -233,6 +272,8 @@ export function useTheme() {
         const effectiveHsl = getEffectiveAccentHsl(null, resolved, modeVars)
         document.documentElement.style.setProperty('--fluux-text-on-accent', contrastColorForHsl(effectiveHsl.h, effectiveHsl.s, effectiveHsl.l))
       }
+
+      applyEmojiPickerColors()
 
       updateThemeColorMeta(resolved)
     }

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -370,12 +370,9 @@
   --scrollbar-thumb: var(--fluux-scrollbar-thumb);
   --scrollbar-thumb-hover: var(--fluux-scrollbar-thumb-hover);
 
-  /* emoji-mart theming */
-  --em-rgb-background: 30, 31, 34;
-  --em-rgb-input: 53, 55, 60;
-  --em-rgb-color: 219, 222, 225;
-  --em-color-border: var(--fluux-bg-hover);
-  --em-color-border-over: var(--fluux-bg-active);
+  /* emoji-mart theming lives on the em-emoji-picker host rule below (not here):
+     emoji-mart's own per-theme :host rules would override these if set on :root,
+     so they must target the host element directly. */
 }
 
 /* Light mode — overrides foundation + select semantic vars */
@@ -460,13 +457,6 @@
   --fluux-grad: linear-gradient(135deg, #11A88C, #5B6CF0, #7C6CF0);
   --fluux-glass-bg: rgba(255, 255, 255, 0.72);
   --fluux-shadow-overlay: 0 20px 50px rgba(20, 27, 48, 0.18);
-
-  /* emoji-mart theming */
-  --em-rgb-background: 227, 229, 232;
-  --em-rgb-input: 220, 222, 227;
-  --em-rgb-color: 46, 51, 56;
-  --em-color-border: var(--fluux-bg-hover);
-  --em-color-border-over: var(--fluux-bg-active);
 }
 
 /* Elevated floating surface shared by every menu, dropdown, context menu and
@@ -482,6 +472,35 @@
     border: 1px solid var(--fluux-border-color);
     box-shadow: var(--fluux-shadow-overlay);
   }
+}
+
+/* Emoji picker (emoji-mart web component) — give it the same elevated treatment
+   as .fluux-popover: the float surface, a hairline border and the overlay drop
+   shadow. emoji-mart's PUBLIC theming hooks are the un-prefixed --rgb-* (RGB
+   triples) and --color-border / --shadow / --border-radius; internally it maps
+   them to --em-rgb-* per theme (--em-rgb-background: var(--rgb-background, …)),
+   so the --em-* names are emoji-mart's and must NOT be set by us. These are set
+   on the host element and inherit into the picker's shadow tree. Dark values
+   here; the .light override follows. Structural vars use the Aurora tokens,
+   which already adapt per theme. */
+em-emoji-picker {
+  --rgb-background: 26, 34, 56;   /* --fluux-bg-float #1A2238 (lifted) */
+  --rgb-input: 11, 16, 32;        /* --fluux-base-10 #0B1020 (inset search) */
+  --rgb-color: 233, 237, 247;     /* --fluux-base-90 #E9EDF7 (text) */
+  --rgb-accent: 71, 99, 255;      /* brand periwinkle */
+  --border-radius: var(--fluux-radius-l);
+  --color-border: var(--fluux-border-color);
+  --color-border-over: var(--fluux-border-color-strong);
+  --shadow: var(--fluux-shadow-overlay);
+  /* emoji-mart draws no outer border on :host; add the popover hairline so the
+     edge matches the menus (the shadow alone carries the lift otherwise). */
+  border: 1px solid var(--fluux-border-color);
+}
+.light em-emoji-picker {
+  --rgb-background: 255, 255, 255; /* --fluux-bg-float (white, lifted) */
+  --rgb-input: 238, 240, 248;      /* --fluux-base-20 #EEF0F8 (subtle search) */
+  --rgb-color: 27, 34, 51;         /* --fluux-base-90 #1B2233 (text) */
+  --rgb-accent: 51, 82, 255;       /* brand periwinkle (light) */
 }
 
 /* Text selection styling - uses brand color for consistent look */

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -476,18 +476,13 @@
 
 /* Emoji picker (emoji-mart web component) — give it the same elevated treatment
    as .fluux-popover: the float surface, a hairline border and the overlay drop
-   shadow. emoji-mart's PUBLIC theming hooks are the un-prefixed --rgb-* (RGB
-   triples) and --color-border / --shadow / --border-radius; internally it maps
-   them to --em-rgb-* per theme (--em-rgb-background: var(--rgb-background, …)),
-   so the --em-* names are emoji-mart's and must NOT be set by us. These are set
-   on the host element and inherit into the picker's shadow tree. Dark values
-   here; the .light override follows. Structural vars use the Aurora tokens,
-   which already adapt per theme. */
+   shadow. The COLOR hooks (--rgb-background/input/color/accent, RGB triples that
+   emoji-mart reads as rgb(var(--rgb-*))) are derived per-theme at runtime in
+   useTheme.ts (applyEmojiPickerColors) from --fluux-bg-float / --fluux-input-bg
+   / --fluux-text-normal / --fluux-bg-accent, so the picker tracks the active
+   theme. Only the structural vars live here — they reference the --fluux-*
+   tokens, which already adapt per theme and mode. */
 em-emoji-picker {
-  --rgb-background: 26, 34, 56;   /* --fluux-bg-float #1A2238 (lifted) */
-  --rgb-input: 11, 16, 32;        /* --fluux-base-10 #0B1020 (inset search) */
-  --rgb-color: 233, 237, 247;     /* --fluux-base-90 #E9EDF7 (text) */
-  --rgb-accent: 71, 99, 255;      /* brand periwinkle */
   --border-radius: var(--fluux-radius-l);
   --color-border: var(--fluux-border-color);
   --color-border-over: var(--fluux-border-color-strong);
@@ -495,12 +490,6 @@ em-emoji-picker {
   /* emoji-mart draws no outer border on :host; add the popover hairline so the
      edge matches the menus (the shadow alone carries the lift otherwise). */
   border: 1px solid var(--fluux-border-color);
-}
-.light em-emoji-picker {
-  --rgb-background: 255, 255, 255; /* --fluux-bg-float (white, lifted) */
-  --rgb-input: 238, 240, 248;      /* --fluux-base-20 #EEF0F8 (subtle search) */
-  --rgb-color: 27, 34, 51;         /* --fluux-base-90 #1B2233 (text) */
-  --rgb-accent: 51, 82, 255;       /* brand periwinkle (light) */
 }
 
 /* Text selection styling - uses brand color for consistent look */


### PR DESCRIPTION
## Summary

Follow-up to the popover unification (#693). The emoji-mart picker rendered on its own generic dark-gray surface with a faint default border and no real drop shadow, so it clashed with the rest of the app and didn't read as a lifted card. This gives it the same elevated treatment as `.fluux-popover`, and makes it track the **active theme** (not just Aurora).

### How

emoji-mart consumes colors as RGB **triples** (`rgb(var(--rgb-background))`), and Fluux only ships RGB-triple tokens for the named status colors — none for surfaces/text. Rather than declaring four triples (× light/dark) in all 13 theme files, the triples are derived once at theme-apply time:

- `apps/fluux/src/hooks/useTheme.ts` → `applyEmojiPickerColors()` resolves `--fluux-bg-float` / `--fluux-input-bg` / `--fluux-text-normal` / `--fluux-bg-accent` through the browser's own color parser and exposes them under emoji-mart's public `--rgb-background` / `--rgb-input` / `--rgb-color` / `--rgb-accent` hooks. Runs on every theme/mode/accent change (both the main apply path and the system-preference handler).
- `index.css` keeps only the **structural** emoji-mart vars on the `em-emoji-picker` host (`--border-radius`, `--color-border`, `--shadow`, plus an explicit hairline `border`), all referencing the theme-adaptive `--fluux-*` tokens.

This means the picker matches the theme's elevated surface for **every built-in theme and any future custom/plugin theme**, with no per-theme tokens to maintain.

The old `--em-rgb-*` vars on `:root` were removed: `--em-*` are emoji-mart's *internal* names (reset by its own per-theme rules), so they never took effect. The public hook is the un-prefixed `--rgb-*`.