### PR TITLE
Add runtime-toggleable scroll diagnostics for stick-to-bottom troubleshooting

### DIFF
--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -26,7 +26,27 @@ import { notifyUserInput } from '@/utils/renderLoopDetector'
 // DEBUG
 // ============================================================================
 
-const DEBUG = false
+// Off by default. Toggle at runtime from the devtools console without a rebuild:
+//   __fluuxScrollDebug(true)   → start logging
+//   __fluuxScrollDebug(false)  → stop
+// Or persist across reloads with: localStorage.setItem('fluux:scroll-debug', '1')
+let DEBUG = (() => {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage?.getItem('fluux:scroll-debug') === '1'
+  } catch {
+    return false
+  }
+})()
+
+if (typeof window !== 'undefined') {
+  ;(window as Window & { __fluuxScrollDebug?: (on?: boolean) => void }).__fluuxScrollDebug = (
+    on = true
+  ) => {
+    DEBUG = on
+    console.warn(`[Scroll] debug ${on ? 'ENABLED' : 'disabled'}`)
+  }
+}
 
 function debugLog(action: string, data?: Record<string, unknown>) {
   if (DEBUG) {
@@ -589,19 +609,43 @@ export function useMessageListScroll({
 
     // Immediate pin (pre-paint when called from a layout effect).
     virt.scrollToIndex(virt.itemCount - 1, { align: 'end' })
+    debugLog('PIN start', {
+      itemCount: virt.itemCount,
+      distFromBottom: scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
+    })
 
     const startedAt = Date.now()
     let framesLeft = BOTTOM_REASSERT_FRAMES
     let lastHeight = scroller.scrollHeight
     const step = () => {
-      if (framesLeft-- <= 0) return
       const s = scrollerRef.current
+      if (framesLeft-- <= 0) {
+        // Loop ran to completion without being interrupted. If distFromBottom is still > the
+        // tolerance here, the pin never converged (the just-sent message ended up below the fold).
+        if (s) {
+          debugLog('PIN settled (frames exhausted)', {
+            distFromBottom: s.scrollHeight - s.scrollTop - s.clientHeight,
+          })
+        }
+        return
+      }
       const v = virtualizerRef.current
       if (!s || !v || v.itemCount === 0) return
       // User took over (FAB/wheel intent recorded after we started, or they scrolled away from
       // the bottom) → stop fighting them. Programmatic growth doesn't move scrollTop, so it never
       // flips isAtBottom; only a genuine user scroll up does.
-      if (userScrollIntentAtRef.current > startedAt || !isAtBottomRef.current) return
+      if (userScrollIntentAtRef.current > startedAt) {
+        debugLog('PIN bail (user scroll intent)', {
+          distFromBottom: s.scrollHeight - s.scrollTop - s.clientHeight,
+        })
+        return
+      }
+      if (!isAtBottomRef.current) {
+        debugLog('PIN bail (not at bottom)', {
+          distFromBottom: s.scrollHeight - s.scrollTop - s.clientHeight,
+        })
+        return
+      }
       const h = s.scrollHeight
       // Re-pin when the layout grew/shrank (the common case) OR when we're still measurably short
       // of the true bottom. The latter catches the frame the change-detection guard alone misses —
@@ -609,6 +653,7 @@ export function useMessageListScroll({
       // is what left the just-sent message a row below the fold on WebKit. Idempotent at the bottom.
       const dist = h - s.scrollTop - s.clientHeight
       if (h !== lastHeight || dist > BOTTOM_PIN_TOLERANCE) {
+        debugLog('PIN re-assert', { distFromBottom: dist, heightChanged: h !== lastHeight })
         lastHeight = h
         v.scrollToIndex(v.itemCount - 1, { align: 'end' })
       }
@@ -1620,6 +1665,8 @@ export function useMessageListScroll({
         isAtBottom: isAtBottomRef.current,
         outgoing: lastMessageIsOutgoing,
         scrollTopBefore: scroller.scrollTop,
+        distFromBottomBefore:
+          scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
       })
       isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
       reassertBottom()
@@ -1628,6 +1675,18 @@ export function useMessageListScroll({
         messageCount,
         prevCount: prevMessageCountRef.current,
         isAtBottom: isAtBottomRef.current,
+      })
+    } else if (lastMessageIsOutgoing) {
+      // The last message is the user's own send but messageCount did NOT increase past the
+      // previous count, so this effect treats it as "not new" and never re-pins. Prime suspect
+      // for "I sent a message and the view didn't stick to bottom": the optimistic message was
+      // already counted on a prior render, or a reconciliation replaced a row in place. Logged
+      // so the troubleshooting phase can tell this apart from a failed pin.
+      debugLog('NEW MSG SKIPPED (outgoing but count did not grow)', {
+        messageCount,
+        prevCount: prevMessageCountRef.current,
+        isAtBottom: isAtBottomRef.current,
+        distFromBottom: scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
       })
     }
 


### PR DESCRIPTION
## Summary

When a just-sent message fails to pin the view to the bottom, the existing scroll instrumentation gives us nothing to go on: the `DEBUG` flag in `useMessageListScroll.ts` was compile-time only, and the pin path (`pinVirtualizedBottom`) was entirely unlogged. This change adds diagnostics so the troubleshooting phase can tell *which* failure mode is happening, without a rebuild.

## Changes

- **Runtime toggle.** `DEBUG` can now be flipped live from the devtools console with `__fluuxScrollDebug(true)` / `__fluuxScrollDebug(false)`, or persisted across reloads with `localStorage.setItem('fluux:scroll-debug', '1')`. Off by default.
- **Outgoing-send-not-counted-as-new log.** The new-message effect only re-pins when `messageCount` grows. If an own send does not grow the count (optimistic row already counted, or an in-place reconciliation), it was silently skipped. A `NEW MSG SKIPPED (outgoing but count did not grow)` log now surfaces that case.
- **Pin-loop visibility.** `pinVirtualizedBottom` now logs `PIN start`, `PIN re-assert`, the bail reasons (user scroll intent / not at bottom), and `PIN settled` with the final distance from bottom, so a pin that never converged is distinguishable from an effect that never fired.

These two diagnostic forks split the suspected root causes: an effect that never fired (app-side count/reconciliation) versus a pin that lost the race to virtualizer row measurement (WebKit settle).

## How to use

1. Run the desktop app (`npm run tauri:dev`) to reproduce on WebKit.
2. In the devtools console: `__fluuxScrollDebug(true)`.
3. Reproduce the send, then read the `[Scroll]` log sequence.