### PR TITLE
feat(theme): auto-hide scrollbars, thinner and subtler

### DIFF
--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -29,6 +29,10 @@ import { installDemoLoadOlder, seedStressConversation } from './demo/demoLoadOld
 import App from './App'
 import i18n from './i18n'
 import './index.css'
+import { installScrollbarAutohide } from './utils/scrollbarAutohide'
+
+// Auto-hide scrollbars: paint the thumb only while hovering / scrolling.
+installScrollbarAutohide()
 
 // Parse URL parameters
 const params = new URLSearchParams(window.location.search)

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -505,10 +505,16 @@ em-emoji-picker {
   line-height: inherit;
 }
 
-/* Custom scrollbar styling */
+/* Custom scrollbar styling — thin gutter, auto-hiding thumb.
+   The thumb is transparent at rest and only painted while the container is
+   hovered or actively scrolling (the `[data-scrolling]` stamp comes from
+   scrollbarAutohide.ts). The 6px gutter is always reserved when a container
+   overflows, so revealing the thumb causes no layout shift (important for the
+   virtualized message list). transition is a progressive enhancement — WebKit
+   ignores it on older builds and simply toggles instantly. */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
@@ -516,11 +522,18 @@ em-emoji-picker {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
-  border-radius: 4px;
+  background: transparent;
+  border-radius: 3px;
+  transition: background-color 0.2s ease;
 }
 
-::-webkit-scrollbar-thumb:hover {
+:hover::-webkit-scrollbar-thumb,
+[data-scrolling]::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+}
+
+:hover::-webkit-scrollbar-thumb:hover,
+[data-scrolling]::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
 
@@ -538,12 +551,14 @@ em-emoji-picker {
 [data-density="compact"] .icon-rail-btn { width: 36px; height: 36px; }
 [data-density="compact"] .icon-rail-btn svg { width: 18px; height: 18px; }
 
-/* Sidebar scrollbar — more visible on dark sidebar background */
-.sidebar-scroll::-webkit-scrollbar-thumb {
+/* Sidebar scrollbar — keeps its own (theme-specific) thumb color when revealed. */
+.sidebar-scroll:hover::-webkit-scrollbar-thumb,
+.sidebar-scroll[data-scrolling]::-webkit-scrollbar-thumb {
   background: var(--fluux-scrollbar-thumb-sidebar);
 }
 
-.sidebar-scroll::-webkit-scrollbar-thumb:hover {
+.sidebar-scroll:hover::-webkit-scrollbar-thumb:hover,
+.sidebar-scroll[data-scrolling]::-webkit-scrollbar-thumb:hover {
   background: var(--fluux-scrollbar-thumb-sidebar-hover);
 }
 

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -16,6 +16,10 @@ import { logStartupCapabilities } from './utils/startupDiagnostics'
 import { startStallSentinel } from './utils/stallSentinel'
 import { registerServiceWorker } from './utils/serviceWorkerUpdate'
 import { getReconnectIntent } from './utils/reconnectIntent'
+import { installScrollbarAutohide } from './utils/scrollbarAutohide'
+
+// Auto-hide scrollbars: paint the thumb only while hovering / scrolling.
+installScrollbarAutohide()
 
 // Check if running in Tauri
 const isTauri = '__TAURI_INTERNALS__' in window

--- a/apps/fluux/src/utils/scrollbarAutohide.test.ts
+++ b/apps/fluux/src/utils/scrollbarAutohide.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SCROLL_IDLE_MS,
+  installScrollbarAutohide,
+  __resetScrollbarAutohideForTests,
+} from './scrollbarAutohide'
+
+describe('scrollbarAutohide', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    installScrollbarAutohide()
+  })
+
+  afterEach(() => {
+    __resetScrollbarAutohideForTests()
+    vi.useRealTimers()
+    document.body.replaceChildren()
+  })
+
+  function scrollableDiv(): HTMLDivElement {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    return el
+  }
+
+  it('stamps data-scrolling on the scrolled element', () => {
+    const el = scrollableDiv()
+    el.dispatchEvent(new Event('scroll'))
+    expect(el.hasAttribute('data-scrolling')).toBe(true)
+  })
+
+  it('clears data-scrolling after the idle delay', () => {
+    const el = scrollableDiv()
+    el.dispatchEvent(new Event('scroll'))
+    vi.advanceTimersByTime(SCROLL_IDLE_MS - 1)
+    expect(el.hasAttribute('data-scrolling')).toBe(true)
+    vi.advanceTimersByTime(1)
+    expect(el.hasAttribute('data-scrolling')).toBe(false)
+  })
+
+  it('debounces: a fresh scroll resets the idle countdown', () => {
+    const el = scrollableDiv()
+    el.dispatchEvent(new Event('scroll'))
+    vi.advanceTimersByTime(SCROLL_IDLE_MS - 100)
+    el.dispatchEvent(new Event('scroll')) // restart the timer
+    vi.advanceTimersByTime(200) // past the original deadline, before the new one
+    expect(el.hasAttribute('data-scrolling')).toBe(true)
+    vi.advanceTimersByTime(SCROLL_IDLE_MS)
+    expect(el.hasAttribute('data-scrolling')).toBe(false)
+  })
+
+  it('tracks elements independently', () => {
+    const a = scrollableDiv()
+    const b = scrollableDiv()
+    a.dispatchEvent(new Event('scroll'))
+    expect(a.hasAttribute('data-scrolling')).toBe(true)
+    expect(b.hasAttribute('data-scrolling')).toBe(false)
+  })
+
+  it('installs only once', () => {
+    const el = scrollableDiv()
+    installScrollbarAutohide() // second call should be a no-op
+    const addSpy = vi.spyOn(el, 'setAttribute')
+    el.dispatchEvent(new Event('scroll'))
+    // A duplicate listener would stamp twice; one listener = one setAttribute.
+    expect(addSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/fluux/src/utils/scrollbarAutohide.ts
+++ b/apps/fluux/src/utils/scrollbarAutohide.ts
@@ -21,7 +21,13 @@
 /** How long the thumb lingers after the last scroll event, in milliseconds. */
 export const SCROLL_IDLE_MS = 700
 
-const SCROLLING_ATTR = 'data-scrolling'
+/**
+ * Attribute stamped on the actively-scrolling element. The reveal rules in
+ * index.css key off `[data-scrolling]`; this constant is the single source of
+ * truth for that contract and is asserted against the CSS in
+ * scrollbarStyles.test.ts.
+ */
+export const SCROLLING_ATTR = 'data-scrolling'
 
 const idleTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>()
 

--- a/apps/fluux/src/utils/scrollbarAutohide.ts
+++ b/apps/fluux/src/utils/scrollbarAutohide.ts
@@ -1,0 +1,65 @@
+/**
+ * Auto-hide scrollbars.
+ *
+ * The thumb is transparent at rest (see index.css) and only painted while the
+ * user is hovering a scrollable container or actively scrolling it. This module
+ * supplies the "actively scrolling" signal so the thumb also appears for wheel /
+ * keyboard / programmatic scrolls where the pointer may not be over the area,
+ * then fades out shortly after scrolling stops.
+ *
+ * A single capture-phase listener on `document` catches every scrollable
+ * element (scroll events don't bubble, but they do propagate in the capture
+ * phase). The scrolled element is stamped with a `data-scrolling` attribute that
+ * CSS keys off; the attribute is cleared after a short idle delay.
+ *
+ * Why a data attribute and not a class: no component renders `data-scrolling`,
+ * so React's reconciler never touches it — the stamp survives re-renders. A
+ * className toggle could be clobbered when the owning component re-renders with
+ * a changed `className` prop (e.g. the virtualized message list).
+ */
+
+/** How long the thumb lingers after the last scroll event, in milliseconds. */
+export const SCROLL_IDLE_MS = 700
+
+const SCROLLING_ATTR = 'data-scrolling'
+
+const idleTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>()
+
+function handleScroll(event: Event): void {
+  const el = event.target
+  // Document/window scroll targets aren't Elements that can hold the attribute.
+  if (!(el instanceof Element)) return
+
+  el.setAttribute(SCROLLING_ATTR, '')
+
+  const pending = idleTimers.get(el)
+  if (pending !== undefined) clearTimeout(pending)
+
+  idleTimers.set(
+    el,
+    setTimeout(() => {
+      el.removeAttribute(SCROLLING_ATTR)
+      idleTimers.delete(el)
+    }, SCROLL_IDLE_MS),
+  )
+}
+
+let installed = false
+
+/**
+ * Install the global scroll listener. Idempotent and safe to call from multiple
+ * entry points (the app and the demo). No-op outside a DOM environment.
+ */
+export function installScrollbarAutohide(): void {
+  if (installed || typeof document === 'undefined') return
+  installed = true
+  document.addEventListener('scroll', handleScroll, { capture: true, passive: true })
+}
+
+/** Test-only: reset module state so the listener can be reinstalled. */
+export function __resetScrollbarAutohideForTests(): void {
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('scroll', handleScroll, { capture: true })
+  }
+  installed = false
+}

--- a/apps/fluux/src/utils/scrollbarStyles.test.ts
+++ b/apps/fluux/src/utils/scrollbarStyles.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+import { SCROLLING_ATTR } from './scrollbarAutohide'
+
+/**
+ * Scrollbar styling guard (index.css).
+ *
+ * The auto-hide behaviour is a CSS contract that no visual diff in review would
+ * catch if it regressed: making the resting thumb opaque turns the scrollbar
+ * always-on again, fattening the gutter undoes the "subtle" intent, and the
+ * reveal rules are coupled to the `data-scrolling` attribute written by
+ * scrollbarAutohide.ts — rename one side and the thumb silently never appears.
+ * These assertions lock the contract:
+ *
+ *  - thin gutter (<= 6px)
+ *  - thumb transparent at rest (hidden)
+ *  - revealed on hover AND on [data-scrolling]
+ *  - the CSS selector matches the JS attribute constant
+ */
+
+const cssPath = resolve(dirname(fileURLToPath(import.meta.url)), '../index.css')
+const css = readFileSync(cssPath, 'utf8')
+
+// --- minimal CSS rule parser (comments stripped, no nesting in this file) ---
+type Rule = { selectors: string[]; decls: Record<string, string> }
+
+const rules: Rule[] = [...css.replace(/\/\*[\s\S]*?\*\//g, '').matchAll(/([^{}]+)\{([^{}]+)\}/g)].map(
+  m => {
+    const decls: Record<string, string> = {}
+    for (const d of m[2].split(';')) {
+      const i = d.indexOf(':')
+      if (i === -1) continue
+      decls[d.slice(0, i).trim()] = d.slice(i + 1).trim()
+    }
+    return { selectors: m[1].split(',').map(s => s.trim()).filter(Boolean), decls }
+  },
+)
+
+/** The rule whose selector list contains exactly `selector`. */
+function ruleFor(selector: string): Rule {
+  const found = rules.find(r => r.selectors.includes(selector))
+  if (!found) throw new Error(`no CSS rule for selector "${selector}"`)
+  return found
+}
+
+describe('scrollbar styles (index.css)', () => {
+  it('uses a thin gutter (<= 6px)', () => {
+    const bar = ruleFor('::-webkit-scrollbar')
+    expect(parseInt(bar.decls.width, 10)).toBeLessThanOrEqual(6)
+    expect(parseInt(bar.decls.height, 10)).toBeLessThanOrEqual(6)
+  })
+
+  it('hides the thumb at rest (transparent background)', () => {
+    expect(ruleFor('::-webkit-scrollbar-thumb').decls.background).toBe('transparent')
+  })
+
+  it('reveals the thumb while actively scrolling', () => {
+    const rule = ruleFor(`[${SCROLLING_ATTR}]::-webkit-scrollbar-thumb`)
+    expect(rule.decls.background).toBe('var(--scrollbar-thumb)')
+    expect(rule.decls.background).not.toBe('transparent')
+  })
+
+  it('reveals the thumb on hover', () => {
+    const rule = ruleFor(':hover::-webkit-scrollbar-thumb')
+    expect(rule.decls.background).toBe('var(--scrollbar-thumb)')
+  })
+
+  it('couples the reveal selector to the JS data-scrolling attribute', () => {
+    // If scrollbarAutohide.ts renames the attribute, the CSS selector keyed on
+    // the old name would no longer match and the thumb would never reveal.
+    expect(css).toContain(`[${SCROLLING_ATTR}]::-webkit-scrollbar-thumb`)
+  })
+
+  it('reveals the sidebar thumb with its own theme color', () => {
+    const rule = ruleFor(`.sidebar-scroll[${SCROLLING_ATTR}]::-webkit-scrollbar-thumb`)
+    expect(rule.decls.background).toBe('var(--fluux-scrollbar-thumb-sidebar)')
+  })
+})


### PR DESCRIPTION
Follow-up to #685 (the dark-thumb visibility fix, already merged). That commit made the Aurora dark scrollbar visible; this makes scrollbars feel lighter and less obtrusive across the app.

> Note: the auto-hide commit was originally pushed to #685's branch just after it was squash-merged, so it never reached `main`. This PR re-lands it cleanly on top of current `main`.

### What changes
- **Thinner gutter:** 8px → 6px (radius 4 → 3).
- **Auto-hide:** the thumb is transparent at rest and only painted while the container is **hovered** or **actively scrolling**. A single capture-phase scroll listener (`scrollbarAutohide.ts`) stamps the scrolled element with a `data-scrolling` attribute and clears it **700ms** after scrolling stops.
- **Data attribute, not a class:** no component renders `data-scrolling`, so React's reconciler never strips it across re-renders (matters for the virtualized message list, whose scroll container re-renders constantly).
- **No layout shift:** the 6px gutter stays reserved whenever a container overflows, so revealing the thumb doesn't reflow content.
- The sidebar keeps its theme-specific thumb color when revealed; the 12 named themes set their own thumb tokens and are unaffected.

Wired into both `main.tsx` and `demo.tsx`.