### PR TITLE
Hold Aurora contrast standards across all built-in themes

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       >
                         <span
                           class="font-medium"
-                          style="color: rgb(74, 144, 217);"
+                          style="color: rgb(161, 197, 235);"
                         >
                           Alice Smith
                         </span>

--- a/apps/fluux/src/hooks/useTheme.ts
+++ b/apps/fluux/src/hooks/useTheme.ts
@@ -24,7 +24,12 @@ function contrastColorForHsl(h: number, s: number, l: number): '#ffffff' | '#000
     return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
   }
   const luminance = 0.2126 * f(0) + 0.7152 * f(8) + 0.0722 * f(4)
-  return luminance > 0.36 ? '#000000' : '#ffffff'
+  // Pick whichever of black/white yields the higher WCAG contrast on this fill.
+  // (A fixed luminance threshold mispicks mid-luminance accents — e.g. a frost
+  // blue where black actually beats white — leaving on-accent text below AA.)
+  const contrastWhite = 1.05 / (luminance + 0.05)
+  const contrastBlack = (luminance + 0.05) / 0.05
+  return contrastBlack > contrastWhite ? '#000000' : '#ffffff'
 }
 
 /**

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -326,9 +326,12 @@
   --fluux-tooltip-bg: var(--fluux-bg-primary);
   --fluux-tooltip-text: var(--fluux-text-normal);
 
-  /* Badge (unread count) */
+  /* Badge (unread count). badge-text tracks the auto on-accent color so it stays
+     readable on light AND dark accents (white badge text was unreadable on the
+     brighter dark-mode accents). A theme overriding --fluux-badge-bg should also
+     set --fluux-badge-text to a color that clears AA on its chosen fill. */
   --fluux-badge-bg: var(--fluux-bg-accent);
-  --fluux-badge-text: #ffffff;
+  --fluux-badge-text: var(--fluux-text-on-accent);
 
   /* Avatar presence */
   --fluux-presence-online: var(--fluux-status-success);

--- a/apps/fluux/src/themes/builtins/catppuccin-mocha.ts
+++ b/apps/fluux/src/themes/builtins/catppuccin-mocha.ts
@@ -98,6 +98,13 @@ export const catppuccinMochaTheme: ThemeDefinition = {
       '--fluux-color-blue': '#1e66f5',
       '--fluux-color-purple': '#8839ef',
       '--fluux-color-gray': '#8c8fa1',
+      // Status as text/icon labels on cards (bg-primary). The vibrant palette
+      // colors above are tuned for fills/swatches and fail WCAG AA as text on
+      // this theme's light bg-primary; these darkened, hue-matched shades clear
+      // AA (white still clears AA on the error fill).
+      '--fluux-status-success': '#2c6d1d',
+      '--fluux-status-warning': '#865511',
+      '--fluux-status-error': '#c10e34',
       '--fluux-color-red-rgb': '210, 15, 57',
       // Error as text/icon — darkened for WCAG AA on the light chat surface.
       '--fluux-text-error': '#ae0c2f',
@@ -107,7 +114,7 @@ export const catppuccinMochaTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '136, 57, 239',
       // Semantic overrides
       '--fluux-bg-secondary': '#dce0e8',
-      '--fluux-border-color': 'rgba(76, 79, 105, 0.12)',
+      '--fluux-border-color': 'rgba(76, 79, 105, 0.29)',
       '--fluux-selection-bg': 'hsla(267, 83%, 58%, 0.15)',
       '--fluux-scrollbar-thumb': '#bcc0cc',
       '--fluux-scrollbar-thumb-hover': '#acb0be',

--- a/apps/fluux/src/themes/builtins/dracula.ts
+++ b/apps/fluux/src/themes/builtins/dracula.ts
@@ -84,7 +84,7 @@ export const draculaTheme: ThemeDefinition = {
       '--fluux-color-blue-rgb': '15, 143, 168',
       '--fluux-color-purple-rgb': '124, 80, 199',
       '--fluux-bg-secondary': '#ddddd7',
-      '--fluux-border-color': 'rgba(40, 42, 54, 0.12)',
+      '--fluux-border-color': 'rgba(40, 42, 54, 0.23)',
       '--fluux-selection-bg': 'hsla(265, 70%, 55%, 0.15)',
       '--fluux-scrollbar-thumb': '#c8c8c2',
       '--fluux-scrollbar-thumb-hover': '#b0b0aa',

--- a/apps/fluux/src/themes/builtins/github.ts
+++ b/apps/fluux/src/themes/builtins/github.ts
@@ -89,7 +89,7 @@ export const githubTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '130, 80, 223',
       // Semantic overrides
       '--fluux-bg-secondary': '#eff2f5',
-      '--fluux-border-color': 'rgba(31, 35, 40, 0.12)',
+      '--fluux-border-color': 'rgba(31, 35, 40, 0.22)',
       '--fluux-selection-bg': 'hsla(212, 92%, 45%, 0.15)',
       '--fluux-scrollbar-thumb': '#dae0e7',
       '--fluux-scrollbar-thumb-hover': '#c8ced5',

--- a/apps/fluux/src/themes/builtins/gruvbox.ts
+++ b/apps/fluux/src/themes/builtins/gruvbox.ts
@@ -76,6 +76,12 @@ export const gruvboxTheme: ThemeDefinition = {
       '--fluux-color-blue': '#076678',
       '--fluux-color-purple': '#8f3f71',
       '--fluux-color-gray': '#928374',
+      // Status as text/icon labels on cards (bg-primary). The palette colors are
+      // tuned for fills; these darkened, hue-matched shades clear WCAG AA as text
+      // on this theme's light bg-primary (white still clears AA on the error fill).
+      '--fluux-status-success': '#66610c',
+      '--fluux-status-warning': '#82550e',
+      '--fluux-status-error': '#9d0006',
       '--fluux-color-red-rgb': '157, 0, 6',
       // Error as text/icon — darkened for WCAG AA on the light chat surface.
       '--fluux-text-error': '#9d0006',
@@ -85,7 +91,7 @@ export const gruvboxTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '143, 63, 113',
       // Semantic overrides
       '--fluux-bg-secondary': '#e8d8a8',
-      '--fluux-border-color': 'rgba(60, 56, 54, 0.15)',
+      '--fluux-border-color': 'rgba(60, 56, 54, 0.25)',
       '--fluux-selection-bg': 'hsla(24, 88%, 35%, 0.15)',
       '--fluux-scrollbar-thumb': '#bdae93',
       '--fluux-scrollbar-thumb-hover': '#a89984',

--- a/apps/fluux/src/themes/builtins/indigo.ts
+++ b/apps/fluux/src/themes/builtins/indigo.ts
@@ -6,8 +6,8 @@ import type { ThemeDefinition } from '../types'
  * Neutral grey surfaces with an indigo/blurple accent. Preserved as a built-in
  * so anyone who preferred the original look can keep it. It overrides only what
  * Aurora changed in the defaults (the neutral ramp, the accent, own-message and
- * accent-2 colors, the unread-badge color, and the light secondary surface);
- * everything else cascades from the semantic/component tiers.
+ * accent-2 colors, the classic red unread badge, and the light secondary
+ * surface); everything else cascades from the semantic/component tiers.
  */
 export const indigoTheme: ThemeDefinition = {
   id: 'indigo',
@@ -41,8 +41,9 @@ export const indigoTheme: ThemeDefinition = {
       // theme's lighter grey chat surface, so lighten it for WCAG AA. (Light
       // mode inherits Aurora's value, which clears AA on the white surface.)
       '--fluux-text-error': '#e77c7f',
-      // Unread badge stays red (classic behavior)
+      // Classic red unread badge (white text clears AA on the red fill).
       '--fluux-badge-bg': 'var(--fluux-status-error)',
+      '--fluux-badge-text': '#ffffff',
     },
     light: {
       // Neutral ramp (00 = lightest, 100 = darkest)
@@ -67,8 +68,16 @@ export const indigoTheme: ThemeDefinition = {
       '--fluux-text-self': '#4f46e5',
       // Restore the original warm-grey secondary surface
       '--fluux-bg-secondary': '#d8dadf',
-      // Unread badge stays red (classic behavior)
+      // Status as text/icon labels on cards. This theme's light bg-primary
+      // (#e3e5e8) is darker than Aurora's, dropping the inherited status colors
+      // below WCAG AA as text; darkened, hue-matched shades restore AA (white
+      // still clears AA on the error fill).
+      '--fluux-status-success': '#18703d',
+      '--fluux-status-warning': '#7d5d1a',
+      '--fluux-status-error': '#b72e32',
+      // Classic red unread badge (white text clears AA on the red fill).
       '--fluux-badge-bg': 'var(--fluux-status-error)',
+      '--fluux-badge-text': '#ffffff',
     },
   },
   swatches: {

--- a/apps/fluux/src/themes/builtins/kanagawa.ts
+++ b/apps/fluux/src/themes/builtins/kanagawa.ts
@@ -87,7 +87,7 @@ export const kanagawaTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '98, 76, 131',
       // Semantic overrides
       '--fluux-bg-secondary': '#dcd5ac',
-      '--fluux-border-color': 'rgba(84, 84, 100, 0.12)',
+      '--fluux-border-color': 'rgba(84, 84, 100, 0.3)',
       '--fluux-selection-bg': 'hsla(219, 36%, 45%, 0.15)',
       '--fluux-scrollbar-thumb': '#d5cea3',
       '--fluux-scrollbar-thumb-hover': '#c9c297',

--- a/apps/fluux/src/themes/builtins/monokai.ts
+++ b/apps/fluux/src/themes/builtins/monokai.ts
@@ -85,7 +85,7 @@ export const monokaiTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '117, 64, 201',
       // Semantic overrides
       '--fluux-bg-secondary': '#e4dfd4',
-      '--fluux-border-color': 'rgba(39, 40, 34, 0.12)',
+      '--fluux-border-color': 'rgba(39, 40, 34, 0.23)',
       '--fluux-selection-bg': 'hsla(338, 75%, 42%, 0.15)',
       '--fluux-scrollbar-thumb': '#c8c4b8',
       '--fluux-scrollbar-thumb-hover': '#b0aca0',

--- a/apps/fluux/src/themes/builtins/nord.ts
+++ b/apps/fluux/src/themes/builtins/nord.ts
@@ -85,7 +85,7 @@ export const nordTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '158, 110, 147',
       // Semantic overrides
       '--fluux-bg-secondary': '#dde2ea',
-      '--fluux-border-color': 'rgba(59, 66, 82, 0.12)',
+      '--fluux-border-color': 'rgba(59, 66, 82, 0.27)',
       '--fluux-selection-bg': 'hsla(213, 32%, 42%, 0.15)',
       '--fluux-scrollbar-thumb': '#c8d0e0',
       '--fluux-scrollbar-thumb-hover': '#a5b1c7',

--- a/apps/fluux/src/themes/builtins/one-dark.ts
+++ b/apps/fluux/src/themes/builtins/one-dark.ts
@@ -85,7 +85,7 @@ export const oneDarkTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '166, 38, 164',
       // Semantic overrides
       '--fluux-bg-secondary': '#e8e8e9',
-      '--fluux-border-color': 'rgba(56, 58, 66, 0.10)',
+      '--fluux-border-color': 'rgba(56, 58, 66, 0.25)',
       '--fluux-selection-bg': 'hsla(224, 100%, 56%, 0.12)',
       '--fluux-scrollbar-thumb': '#c8c8c9',
       '--fluux-scrollbar-thumb-hover': '#b0b0b1',

--- a/apps/fluux/src/themes/builtins/rose-pine.ts
+++ b/apps/fluux/src/themes/builtins/rose-pine.ts
@@ -87,7 +87,7 @@ export const rosePineTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '144, 122, 169',
       // Semantic overrides
       '--fluux-bg-secondary': '#f4ede8',
-      '--fluux-border-color': 'rgba(87, 82, 121, 0.10)',
+      '--fluux-border-color': 'rgba(87, 82, 121, 0.29)',
       '--fluux-selection-bg': 'hsla(267, 22%, 57%, 0.15)',
       '--fluux-scrollbar-thumb': '#dfdad9',
       '--fluux-scrollbar-thumb-hover': '#cecacd',

--- a/apps/fluux/src/themes/builtins/solarized.ts
+++ b/apps/fluux/src/themes/builtins/solarized.ts
@@ -93,7 +93,7 @@ export const solarizedTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '108, 113, 196',
       // Semantic overrides
       '--fluux-bg-secondary': '#e8e1cd',
-      '--fluux-border-color': 'rgba(88, 110, 117, 0.15)',
+      '--fluux-border-color': 'rgba(88, 110, 117, 0.33)',
       '--fluux-selection-bg': 'hsla(205, 69%, 42%, 0.15)',
       '--fluux-scrollbar-thumb': '#c5bca6',
       '--fluux-scrollbar-thumb-hover': '#b3a992',

--- a/apps/fluux/src/themes/builtins/tokyo-night.ts
+++ b/apps/fluux/src/themes/builtins/tokyo-night.ts
@@ -76,6 +76,12 @@ export const tokyoNightTheme: ThemeDefinition = {
       '--fluux-color-blue': '#2e7de9',
       '--fluux-color-purple': '#7847bd',
       '--fluux-color-gray': '#8990b3',
+      // Status as text/icon labels on cards (bg-primary). The palette colors are
+      // tuned for fills; these darkened, hue-matched shades clear WCAG AA as text
+      // on this theme's light bg-primary (white still clears AA on the error fill).
+      '--fluux-status-success': '#4a6230',
+      '--fluux-status-warning': '#705632',
+      '--fluux-status-error': '#a71d45',
       '--fluux-color-red-rgb': '245, 42, 101',
       // Error as text/icon — darkened for WCAG AA on the light chat surface.
       '--fluux-text-error': '#8c072d',
@@ -85,7 +91,7 @@ export const tokyoNightTheme: ThemeDefinition = {
       '--fluux-color-purple-rgb': '120, 71, 189',
       // Semantic overrides
       '--fluux-bg-secondary': '#c4c8da',
-      '--fluux-border-color': 'rgba(55, 96, 191, 0.12)',
+      '--fluux-border-color': 'rgba(55, 96, 191, 0.34)',
       '--fluux-selection-bg': 'hsla(220, 72%, 52%, 0.15)',
       '--fluux-scrollbar-thumb': '#b4b5b9',
       '--fluux-scrollbar-thumb-hover': '#a0a1a5',

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, resolve } from 'path'
 import { builtinThemes } from './builtins'
+import { auroraSenderColor } from '@/utils/senderColor'
 import type { ThemeDefinition } from './types'
 
 /**
@@ -181,6 +182,97 @@ describe('Builtin theme error-text contrast', () => {
     for (const mode of ['dark', 'light'] as const) {
       it(`[${theme.id}/${mode}] text-error clears WCAG AA on the chat surface`, () => {
         const r = contrast('var(--fluux-text-error)', 'var(--fluux-chat-bg)', themeTokens(theme, mode))
+        expect(r).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+  }
+})
+
+// Per-theme sender-name contrast guard. Sender names are the primary message
+// attribution cue (especially in MUC). The palette (auroraSenderColor) is
+// generated deterministically per identifier and is theme-INDEPENDENT, so it
+// must stay legible on every theme's chat surface, not just Aurora's near-black.
+// The 2026-06-27 audit found nord/catppuccin (lighter dark surfaces) pushed the
+// worst-case sender below AA because the dark branch assumed a near-black bg.
+//
+// We sample a deterministic spread of identifiers (djb2 distributes hues evenly)
+// and assert the WORST-case sender clears AA on each theme's --fluux-chat-bg.
+const SENDER_SAMPLE_IDS = Array.from({ length: 2000 }, (_, i) => `user${i}@example.com`)
+
+describe('Builtin theme sender-name contrast', () => {
+  for (const theme of builtinThemes) {
+    for (const mode of ['dark', 'light'] as const) {
+      it(`[${theme.id}/${mode}] worst-case sender name clears WCAG AA on the chat surface`, () => {
+        const vars = themeTokens(theme, mode)
+        let worst = Infinity
+        for (const id of SENDER_SAMPLE_IDS) {
+          const hex = auroraSenderColor(id, mode === 'dark')
+          worst = Math.min(worst, contrast(hex, 'var(--fluux-chat-bg)', vars))
+        }
+        expect(worst).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+  }
+})
+
+// Per-theme light-mode status-as-text guard. status-{success,warning,error}
+// double as text/icon labels on cards & settings (bg-primary). The Aurora light
+// overrides clear AA on Aurora's bg-primary, but themes with a darker light
+// bg-primary (base-10) drop the inherited status colors below AA (audit
+// 2026-06-27: tokyo-night/gruvbox/catppuccin/indigo). Each theme must keep
+// status text legible on its own light bg-primary.
+describe('Builtin theme light status-as-text contrast', () => {
+  for (const theme of builtinThemes) {
+    for (const key of ['success', 'warning', 'error'] as const) {
+      it(`[${theme.id}/light] status-${key} clears WCAG AA as text on bg-primary`, () => {
+        const r = contrast(`var(--fluux-status-${key})`, 'var(--fluux-bg-primary)', themeTokens(theme, 'light'))
+        expect(r).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+  }
+})
+
+// Per-theme light-mode hairline guard. The border-color carries every control
+// and panel edge; on light surfaces it is a black-alpha hairline. Themes with a
+// tinted (non-pure-white) chat surface composited the inherited alpha down to
+// ~1.16-1.29:1 (audit 2026-06-27), below the 1.5 floor that the Aurora tokens
+// already satisfy. 1.5 is a deliberately low bar (a visible hairline, not AA).
+describe('Builtin theme light hairline visibility', () => {
+  for (const theme of builtinThemes) {
+    it(`[${theme.id}/light] border-color reads as a hairline on the chat surface`, () => {
+      const r = contrast('var(--fluux-border-color)', 'var(--fluux-chat-bg)', themeTokens(theme, 'light'))
+      expect(r).toBeGreaterThanOrEqual(1.5)
+    })
+  }
+})
+
+// Per-theme unread-badge contrast guard. The badge background is overridable
+// (--fluux-badge-bg, default the accent fill) and pairs with --fluux-badge-text.
+// When badge-text is left at the auto on-accent value, it tracks the accent so
+// it stays readable on light AND dark accents; a theme that overrides badge-bg
+// (e.g. indigo's classic red) must keep its badge-text readable on that fill.
+// Mirrors contrastColorForHsl() in hooks/useTheme.ts (higher-contrast of b/w).
+function autoOnAccent(h: number, s: number, l: number): '#ffffff' | '#000000' {
+  const lum = relLum(hslToRgb(h, s, l))
+  return (lum + 0.05) / 0.05 > 1.05 / (lum + 0.05) ? '#000000' : '#ffffff'
+}
+function accentHsl(vars: Record<string, string>): [number, number, number] {
+  return [
+    parseFloat(expand('var(--fluux-accent-h)', vars)),
+    parseFloat(expand('var(--fluux-accent-s)', vars)),
+    parseFloat(expand('var(--fluux-accent-l)', vars)),
+  ]
+}
+
+describe('Builtin theme unread-badge contrast', () => {
+  for (const theme of builtinThemes) {
+    for (const mode of ['dark', 'light'] as const) {
+      it(`[${theme.id}/${mode}] badge text clears WCAG AA on the badge background`, () => {
+        const vars = themeTokens(theme, mode)
+        const text = /text-on-accent/.test(vars['--fluux-badge-text'])
+          ? autoOnAccent(...accentHsl(vars))
+          : 'var(--fluux-badge-text)'
+        const r = contrast(text, 'var(--fluux-badge-bg)', vars)
         expect(r).toBeGreaterThanOrEqual(4.5)
       })
     }

--- a/apps/fluux/src/utils/contrastColor.ts
+++ b/apps/fluux/src/utils/contrastColor.ts
@@ -49,3 +49,23 @@ export function ensureContrast(hex: string, bgLuminance: number, ratio = 4.5): s
 export function ensureContrastWithWhite(hex: string): string {
   return ensureContrast(hex, 1.0, 4.5)
 }
+
+/**
+ * Lighten `hex` (blend toward white) until it reaches `ratio` contrast against a
+ * background of luminance `bgLuminance`. The dark-surface counterpart of
+ * `ensureContrast`: on a dark background a color clears AA by getting brighter,
+ * not darker. Returns the original if it already passes.
+ */
+export function ensureContrastOnDark(hex: string, bgLuminance: number, ratio = 4.5): string {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return hex
+  let factor = 0
+  let r = rgb.r, g = rgb.g, b = rgb.b
+  while (contrastRatio(getLuminance(r, g, b), bgLuminance) < ratio && factor < 0.92) {
+    factor += 0.08
+    r = Math.round(rgb.r + (255 - rgb.r) * factor)
+    g = Math.round(rgb.g + (255 - rgb.g) * factor)
+    b = Math.round(rgb.b + (255 - rgb.b) * factor)
+  }
+  return toHex(r, g, b)
+}

--- a/apps/fluux/src/utils/senderColor.ts
+++ b/apps/fluux/src/utils/senderColor.ts
@@ -1,11 +1,21 @@
 import { generateConsistentColorHexSync } from '@fluux/sdk'
-import { ensureContrast } from './contrastColor'
+import { ensureContrast, ensureContrastOnDark } from './contrastColor'
 
 /**
  * Representative light message-row luminance to AA-correct against. Covers the
  * white chat surface and the slightly darker hover row (the harder case).
  */
 const LIGHT_ROW_LUMINANCE = 0.80
+
+/**
+ * Conservative dark chat-surface luminance to AA-correct against. The palette is
+ * theme-independent, so it must clear AA on the LIGHTEST dark surface any theme
+ * ships, not just Aurora's near-black (lum ~0.008). The lightest dark chat-bg in
+ * the built-ins is Nord's #434c5e (lum ~0.072); 0.08 covers it with margin, so a
+ * sender corrected here clears AA on every darker surface too. Guarded per theme
+ * in themeContrast.test.ts.
+ */
+const DARK_ROW_LUMINANCE = 0.08
 
 /**
  * Aurora-tuned per-person sender color. Continuous XEP-0392 hue (deterministic
@@ -16,8 +26,11 @@ const LIGHT_ROW_LUMINANCE = 0.80
  */
 export function auroraSenderColor(identifier: string, isDarkMode: boolean): string {
   if (isDarkMode) {
-    // Luminous on near-black; AA on resting + hover rows by construction.
-    return generateConsistentColorHexSync(identifier, { saturation: 75, lightness: 72 })
+    // Luminous on near-black; lighten intrinsically-dark hues until they clear AA
+    // on the lightest dark surface a theme may use (Nord/Catppuccin run brighter
+    // than Aurora's deep ink).
+    const base = generateConsistentColorHexSync(identifier, { saturation: 75, lightness: 72 })
+    return ensureContrastOnDark(base, DARK_ROW_LUMINANCE, 4.5)
   }
   // Vibrant base, then darken intrinsically-light hues until AA on the light rows.
   const base = generateConsistentColorHexSync(identifier, { saturation: 65, lightness: 45 })

--- a/docs/2026-06-26-aurora-theme-audit.md
+++ b/docs/2026-06-26-aurora-theme-audit.md
@@ -189,3 +189,25 @@ The contrast math is deterministic. A small unit test that resolves the theme to
 - Accent fill contrast is healthy: white-on-accent **4.67:1 (dark) / 5.54:1 (light)** — AA. The existing `contrastColorForHsl()` machinery works; the gaps are in *non-accent* token placement.
 - Light mode is consistently the weaker of the two — its surfaces sit in a narrow high-luminance band (`#E7EAF4`–`#FFFFFF`), so both colored text and surface separation have less room.
 - All ratios above are exact WCAG 2.1, alpha tokens composited over their real backdrop, and were spot-validated against live `getComputedStyle` in the running app.
+
+---
+
+## 6. Cross-theme follow-up (2026-06-27, PR #700)
+
+This audit covered the Aurora default (`id: fluux`) only. A follow-up audit measured the **13 built-in themes** against the same standards (accent triplet, semantic/component tokens, sender palette, 5-level elevation, type scale, component specs). The standards held structurally, but four invariants that pass on Aurora's surfaces failed on themes whose surfaces differ — and only `--fluux-text-error` was guarded per theme, so the failures were silent.
+
+| # | Finding | Severity | Affected | Root cause |
+|---|---------|----------|----------|-----------|
+| 1 | **Sender names below AA** | High | nord (3.98), catppuccin (4.20) dark | `auroraSenderColor` tuned its dark hues to Aurora's near-black; lighter dark chat surfaces drop contrast |
+| 2 | **Light status-as-text below AA** | Med | tokyo-night (3.81), gruvbox, catppuccin, indigo | inherited Aurora light `--fluux-status-*` on a darker theme `bg-primary` |
+| 3 | **Light hairline below 1.5** | Low | 11 themes (1.16–1.29) | each theme's tinted light `--fluux-border-color` at low alpha composited too faint on its chat surface |
+| 4 | **Unread badge text unreadable** | High | 8 themes (bright dark accents) | `--fluux-badge-text` hardcoded white on the accent fill; `contrastColorForHsl` mispicked via a `lum > 0.36` threshold |
+
+**Fixes (all token-level + one util/hook):**
+
+1. **Surface-aware sender generator** — new `ensureContrastOnDark` (the dark-surface mirror of `ensureContrast`, lightening toward white); the dark branch AA-corrects against a conservative `DARK_ROW_LUMINANCE = 0.08` floor (covers the lightest built-in dark surface, Nord's, with margin). Theme-independent palette preserved; senders just run slightly more luminous.
+2. **Per-theme dark light-mode `--fluux-status-*`** for the four failing themes (the same text-vs-fill split as `--fluux-text-error`): hue-matched, AA on their `bg-primary`, white still AA on the error fill.
+3. **Raised each theme's light `--fluux-border-color` alpha** (0.10–0.15 → 0.22–0.34), tint preserved, hairline clears the floor.
+4. **Theme-overridable unread badge** — `--fluux-badge-bg` + `--fluux-badge-text`; the text default now follows the auto on-accent color, and `contrastColorForHsl` (in `useTheme.ts`) picks the higher-**contrast** of black/white instead of a luminance threshold. This also fixes unreadable on-accent **button** text (same `--fluux-text-on-accent` token). The built-in **Indigo** theme uses the override to keep its classic **red** badge.
+
+**Guards** (`themeContrast.test.ts`, per theme / per mode): worst-case sender ≥4.5 on chat-bg; light status-{success,warning,error} ≥4.5 on bg-primary; light border ≥1.5 on chat-bg; badge text ≥4.5 on badge fill (modelling the real auto on-accent pick). `docs/THEMES.md` documents the badge override and the corrected `--fluux-badge-bg` / `--fluux-badge-text` defaults.

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -220,7 +220,8 @@ Per-widget overrides for surgical changes. These default to semantic values.
 | `--fluux-modal-backdrop`     | `rgba(0,0,0,0.5)`    | Modal overlay                 |
 | `--fluux-toast-bg`           | `sidebar-bg`         | Toast notification background |
 | `--fluux-tooltip-bg`         | `bg-primary`         | Tooltip background            |
-| `--fluux-badge-bg`           | `status-error`       | Unread count badge            |
+| `--fluux-badge-bg`           | `bg-accent`          | Unread count badge fill       |
+| `--fluux-badge-text`         | `text-on-accent`     | Unread count badge text       |
 | `--fluux-presence-online`    | `status-success`     | Online indicator              |
 | `--fluux-presence-away`      | `status-warning`     | Away indicator                |
 | `--fluux-presence-dnd`       | `status-error`       | Do not disturb indicator      |
@@ -229,6 +230,15 @@ Per-widget overrides for surgical changes. These default to semantic values.
 | `--fluux-button-danger-bg`   | `status-error`       | Danger button                 |
 
 **When to override component variables:** When you want one specific widget to look different from the rest. For example, giving the sidebar a distinct tint while keeping other surfaces neutral.
+
+**Unread badge color.** The unread count badge defaults to the accent fill (`--fluux-badge-bg`) with auto-contrasting text (`--fluux-badge-text` follows `--fluux-text-on-accent`, so it stays readable on light or dark accents). To get a classic **red** badge instead, override the fill and pair it with a text color that clears WCAG AA on that fill — the built-in **Indigo** theme does exactly this:
+
+```json
+"--fluux-badge-bg": "var(--fluux-status-error)",
+"--fluux-badge-text": "#ffffff"
+```
+
+Always set `--fluux-badge-text` whenever you override `--fluux-badge-bg`: the default tracks the *accent*, not your chosen fill, so a custom fill needs its own readable text color. The `themeContrast.test.ts` guard asserts badge text clears AA on the badge fill for every built-in theme.
 
 ## Theme File Format
 


### PR DESCRIPTION
## Summary

An audit of the 13 built-in themes against the Aurora design standards found that several Aurora contrast guarantees held only on the **default** theme. The other themes inherited tokens (sender palette, status colors, hairline border, badge) that dropped below WCAG AA on their own surfaces — silently, because nothing guarded them per theme.

This PR extends the standards to every theme and adds a per-theme guard for each invariant so these regressions fail CI instead of shipping.

## Changes

**Sender names (High).** `auroraSenderColor` now AA-corrects dark hues against a conservative dark-surface luminance floor via a new `ensureContrastOnDark` helper, mirroring what the light branch already did. Names stay legible on lighter dark surfaces — nord 3.98 → 4.81, catppuccin 4.20 → 5.08. The palette stays theme-independent; the only visible effect is dark sender colors being a touch more luminous.

**Light status-as-text (Medium).** `catppuccin`, `gruvbox`, `tokyo-night`, and `indigo` have a darker light `bg-primary` than Aurora, so the inherited `status-{success,warning,error}` failed AA as text/icon labels (down to 3.81). Each now defines dedicated dark, hue-matched `--fluux-status-*` values — the text-vs-fill split, so white still clears AA on the error fill.

**Light hairline (Low).** Each theme's tinted light `--fluux-border-color` alpha was raised (0.10–0.15 → 0.22–0.34) so the hairline clears the visibility floor on tinted chat surfaces; the tints themselves are unchanged.

**Unread badge — now fully theme-overridable.** `--fluux-badge-bg` pairs with `--fluux-badge-text`. The text default now follows the auto on-accent color, and `contrastColorForHsl` picks the higher-contrast of black/white instead of a `luminance > 0.36` threshold that mispicked bright accents — which also fixes previously-unreadable white text on accent **buttons** (same token). **Indigo** keeps its classic **red** badge through the override.

## Guards (themeContrast.test.ts)

New per-theme/per-mode assertions: sender-name AA on the chat surface, light status-as-text AA on `bg-primary`, light hairline visibility, and badge-text AA on the badge fill (modelling the real auto on-accent pick). Each was written failing-first and confirmed RED on exactly the predicted themes before the fix.

`THEMES.md` is updated to document the badge override pattern and correct the stale component-token defaults.