### PR TITLE
fix(theme): scrollbar reveal silently fails in WebKit (un-group selectors)

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -509,12 +509,23 @@ em-emoji-picker {
 }
 
 /* Custom scrollbar styling — thin gutter, auto-hiding thumb.
-   The thumb is transparent at rest and only painted while the container is
-   hovered or actively scrolling (the `[data-scrolling]` stamp comes from
+   The thumb is transparent at rest and revealed while the container is hovered
+   or actively scrolling (the `[data-scrolling]` stamp comes from
    scrollbarAutohide.ts). The 6px gutter is always reserved when a container
    overflows, so revealing the thumb causes no layout shift (important for the
-   virtualized message list). transition is a progressive enhancement — WebKit
-   ignores it on older builds and simply toggles instantly. */
+   virtualized message list).
+
+   WebKit (the engine the desktop app actually runs — WKWebView / WebKitGTK)
+   needs each reveal selector as its OWN rule, never grouped:
+     1. WebKit drops the ENTIRE selector list if any ::-webkit-scrollbar
+        compound in it is one it won't apply — so a grouped
+        `:hover, [data-scrolling]` rule takes the `:hover` reveal down with it.
+     2. WebKit paints the scrollbar on the compositor and does not reliably
+        repaint it when JS toggles an attribute, so `[data-scrolling]` alone is
+        unreliable there. `:hover` IS a native scrollbar state WebKit repaints.
+   Keeping them separate lets the `:hover` reveal work in WebKit while
+   `[data-scrolling]` still adds keyboard/programmatic-scroll reveal in
+   Chromium / the web build. */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -527,18 +538,12 @@ em-emoji-picker {
 ::-webkit-scrollbar-thumb {
   background: transparent;
   border-radius: 3px;
-  transition: background-color 0.2s ease;
 }
 
-:hover::-webkit-scrollbar-thumb,
-[data-scrolling]::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
-}
-
-:hover::-webkit-scrollbar-thumb:hover,
-[data-scrolling]::-webkit-scrollbar-thumb:hover {
-  background: var(--scrollbar-thumb-hover);
-}
+/* Reveal — each selector is its own rule (see WebKit note above). */
+:hover::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); }
+[data-scrolling]::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
 /* Sidebar list rows. Horizontal padding stays a utility (px-2); the density-
  * varying vertical padding + gap live here so a [data-density] flip needs no
@@ -559,16 +564,11 @@ em-emoji-picker {
 [data-density="compact"] .icon-rail-btn { width: 36px; height: 36px; }
 [data-density="compact"] .icon-rail-btn svg { width: 18px; height: 18px; }
 
-/* Sidebar scrollbar — keeps its own (theme-specific) thumb color when revealed. */
-.sidebar-scroll:hover::-webkit-scrollbar-thumb,
-.sidebar-scroll[data-scrolling]::-webkit-scrollbar-thumb {
-  background: var(--fluux-scrollbar-thumb-sidebar);
-}
-
-.sidebar-scroll:hover::-webkit-scrollbar-thumb:hover,
-.sidebar-scroll[data-scrolling]::-webkit-scrollbar-thumb:hover {
-  background: var(--fluux-scrollbar-thumb-sidebar-hover);
-}
+/* Sidebar scrollbar — keeps its own (theme-specific) thumb color when revealed.
+   Un-grouped for the same WebKit reason as the global rules above. */
+.sidebar-scroll:hover::-webkit-scrollbar-thumb { background: var(--fluux-scrollbar-thumb-sidebar); }
+.sidebar-scroll[data-scrolling]::-webkit-scrollbar-thumb { background: var(--fluux-scrollbar-thumb-sidebar); }
+.sidebar-scroll::-webkit-scrollbar-thumb:hover { background: var(--fluux-scrollbar-thumb-sidebar-hover); }
 
 /* Smooth scrolling */
 html {

--- a/apps/fluux/src/utils/scrollbarStyles.test.ts
+++ b/apps/fluux/src/utils/scrollbarStyles.test.ts
@@ -18,6 +18,8 @@ import { SCROLLING_ATTR } from './scrollbarAutohide'
  *  - thumb transparent at rest (hidden)
  *  - revealed on hover AND on [data-scrolling]
  *  - the CSS selector matches the JS attribute constant
+ *  - ::-webkit-scrollbar selectors are never grouped (WebKit drops the whole
+ *    selector list if it dislikes any compound in it — see the index.css note)
  */
 
 const cssPath = resolve(dirname(fileURLToPath(import.meta.url)), '../index.css')
@@ -76,5 +78,15 @@ describe('scrollbar styles (index.css)', () => {
   it('reveals the sidebar thumb with its own theme color', () => {
     const rule = ruleFor(`.sidebar-scroll[${SCROLLING_ATTR}]::-webkit-scrollbar-thumb`)
     expect(rule.decls.background).toBe('var(--fluux-scrollbar-thumb-sidebar)')
+  })
+
+  it('never groups ::-webkit-scrollbar selectors (WebKit drops grouped lists)', () => {
+    // A comma-grouped list containing a ::-webkit-scrollbar compound is dropped
+    // wholesale by WebKit, taking the reliable `:hover` reveal down with the
+    // unreliable `[data-scrolling]` one. Each must be its own rule.
+    const grouped = rules
+      .filter(r => r.selectors.length > 1 && r.selectors.some(s => s.includes('::-webkit-scrollbar')))
+      .map(r => r.selectors.join(', '))
+    expect(grouped).toEqual([])
   })
 })


### PR DESCRIPTION
Follow-up to #698. The auto-hide scrollbar reveal works in Chromium (where the preview verified it) but **fails in the app's real engine — WebKit** (Tauri WKWebView on macOS, WebKitGTK on Linux). In the desktop app the message-list and sidebar thumbs stay transparent: the scrollbar shows briefly on room/chat entry then disappears and never returns on scroll.

### Root cause
The reveal rules grouped two selectors per rule:
```css
:hover::-webkit-scrollbar-thumb,
[data-scrolling]::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); }
```
Two WebKit specifics make this fail:
1. **Grouped selector lists are dropped wholesale.** WebKit discards the *entire* comma list if any `::-webkit-scrollbar` compound in it is one it won't apply — so the grouped rule takes the reliable `:hover` reveal down together with the `[data-scrolling]` one.
2. **No repaint on attribute toggle.** WebKit composites the scrollbar and does not reliably repaint it when JS toggles `data-scrolling`, so that path alone never reveals there. `:hover` *is* a native scrollbar state WebKit repaints.

### Fix
Un-group every `::-webkit-scrollbar` reveal selector into its own rule. `:hover` now works independently in WebKit (covers both the message list and the sidebar), while `[data-scrolling]` still adds keyboard/programmatic-scroll reveal in Chromium / the web build. No behaviour change in Chromium.