### PR TITLE
Make all scroll re-assert loops single-flight

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Single-flight invariant for the message-list rAF scroll re-assert loops.
+ *
+ * The list keeps the virtualized view pinned by re-asserting a scroll target across ~1s of
+ * frames (`pinVirtualizedBottom` → bottom; the MAM-prepend `runMeasureAssert` → a history
+ * anchor). When two of these run at once they fight over scrollTop — the `[ScrollReassertLoop]`
+ * overlap the reassert monitor warns about, observed in the wild as `(pin-bottom, pin-bottom)`.
+ * pin-bottom was made single-flight against itself; this suite pins the FULL invariant: across
+ * any rapid multi-trigger sequence, at most ONE re-assert loop is ever active — including the
+ * still-open cases (`prepend` vs `prepend`, and `pin-bottom` vs `prepend`, whose targets
+ * contradict each other).
+ *
+ * Mechanism: the reassert monitor is mocked to track the peak number of concurrently-active
+ * loops via begin()/end(). jsdom has no layout, so this is a structural (loop-lifecycle)
+ * guard, not a pixel one.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import type { BaseMessage } from '@fluux/sdk'
+
+// Peak-concurrency tracker injected via the mocked monitor. begin() bumps the active count and
+// records the high-water mark; end() releases. The fix must keep the peak at 1.
+const loopTracker = { active: 0, peak: 0, begins: [] as string[] }
+
+vi.mock('./reassertLoopMonitor', () => ({
+  createReassertLoopMonitor: () => ({
+    begin: (label: string) => {
+      loopTracker.begins.push(label)
+      loopTracker.active += 1
+      loopTracker.peak = Math.max(loopTracker.peak, loopTracker.active)
+      let ended = false
+      return {
+        frame: () => null,
+        end: () => {
+          if (ended) return
+          ended = true
+          loopTracker.active -= 1
+        },
+      }
+    },
+    activeLabels: () => [],
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(),
+    selectionCount: 0,
+    isSelecting: false,
+    selectAll: vi.fn(),
+    extendTo: vi.fn(),
+    clearSelection: vi.fn(),
+    copySelected: vi.fn(),
+  })),
+}))
+
+const getOffsetForMessageId = vi.fn((_id: string): number | null => 0)
+vi.mock('./tanstackMessageVirtualizer', () => ({
+  useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
+    getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
+    getTotalSize: () => args.items.length * 40,
+    itemCount: args.items.length,
+    getOffsetForMessageId,
+    ensureMessageMounted: vi.fn(() => Promise.resolve()),
+    measureElement: () => {},
+    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    scrollToIndex: (index: number, opts?: { align?: string }) => {
+      const el = args.scrollRef.current
+      if (!el) return
+      el.scrollTop = opts?.align === 'end' ? el.scrollHeight : index * 40
+    },
+  }),
+}))
+
+function makeMessages(count: number, prefix = 'msg'): BaseMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    from: 'user@example.com',
+    body: `Body ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i % 60),
+    isOutgoing: false,
+    type: 'chat' as const,
+  }))
+}
+
+describe('MessageList — re-assert loops are single-flight (at most one active)', () => {
+  let realRaf: typeof requestAnimationFrame
+  let rafQueue: FrameRequestCallback[]
+  const flush = (frames: number) => {
+    for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0))
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafQueue.push(cb)
+      return rafQueue.length
+    }) as typeof requestAnimationFrame
+    loopTracker.active = 0
+    loopTracker.peak = 0
+    loopTracker.begins = []
+    getOffsetForMessageId.mockClear()
+    getOffsetForMessageId.mockImplementation(() => 0)
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = realRaf
+    localStorage.clear()
+  })
+
+  function instrumentScroller(scroller: HTMLElement, height: number) {
+    let scrollTopVal = 0
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => height, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { value: 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => scrollTopVal,
+      set: (v: number) => { scrollTopVal = v },
+      configurable: true,
+    })
+  }
+
+  const props = {
+    renderMessage: (m: BaseMessage) => <div>{m.body}</div>,
+    onScrollToTop: vi.fn(),
+    isHistoryComplete: false,
+  }
+
+  it('does not start a second prepend re-assert loop while the first is still running', () => {
+    const { container, getByText, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-pp" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    // First load-older -> older messages prepended -> prepend restore begins runMeasureAssert.
+    fireEvent.click(getByText('chat.loadEarlierMessages'))
+    rerender(<MessageList messages={[...makeMessages(10, 'older1'), ...makeMessages(50)]} conversationId="conv-pp" {...props} />)
+    flush(2) // a couple of frames pass; the first loop still has ~58 frames left
+
+    // Second load-older BEFORE the first settles -> a second prepend restore. It must supersede
+    // the first, not run alongside it (the documented prime suspect: runMeasureAssert had no
+    // cleanup and no early-stable exit).
+    fireEvent.click(getByText('chat.loadEarlierMessages'))
+    rerender(<MessageList messages={[...makeMessages(10, 'older2'), ...makeMessages(10, 'older1'), ...makeMessages(50)]} conversationId="conv-pp" {...props} />)
+
+    expect(loopTracker.begins.filter((l) => l === 'prepend').length).toBeGreaterThanOrEqual(2)
+    expect(loopTracker.peak).toBeLessThanOrEqual(1)
+  })
+
+  it('does not run a pin-bottom loop concurrently with an in-flight prepend loop', () => {
+    const { container, getByText, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-mix" {...props} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    // Load older -> prepend restore begins runMeasureAssert (the 'prepend' loop).
+    fireEvent.click(getByText('chat.loadEarlierMessages'))
+    rerender(<MessageList messages={[...makeMessages(10, 'older1'), ...makeMessages(50)]} conversationId="conv-mix" {...props} />)
+    flush(2) // prepend loop in-flight
+
+    // A SENT (outgoing) message arrives while the prepend loop is still running -> the outgoing
+    // path forces a scroll-to-bottom (pinVirtualizedBottom). pin-bottom and prepend target
+    // opposite positions, so they must not coexist.
+    const sent: BaseMessage = {
+      id: 'sent-1', from: 'me@example.com', body: 'my reply',
+      timestamp: new Date(2024, 0, 1, 13, 0), isOutgoing: true, type: 'chat',
+    }
+    rerender(<MessageList messages={[...makeMessages(10, 'older1'), ...makeMessages(50), sent]} conversationId="conv-mix" {...props} />)
+
+    expect(loopTracker.begins).toContain('pin-bottom')
+    expect(loopTracker.peak).toBeLessThanOrEqual(1)
+  })
+})

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -254,10 +254,21 @@ export function useMessageListScroll({
   // surfaces a non-converging loop or two overlapping loops fighting over scrollTop on WebKit
   // (frame-coupled, so invisible to the headless harness and the other monitors). Never cancels.
   const reassertMonitorRef = useRef<ReturnType<typeof createReassertLoopMonitor> | null>(null)
-  // In-flight pin-bottom loop (rAF id + monitor handle), so a fresh pin can supersede it instead
-  // of running a second loop that fights the first over scrollTop (the overlap the monitor warns
-  // about). Single-flight: latest call wins with a fresh settle window.
-  const pinLoopRef = useRef<{ raf: number; handle: ReassertLoopHandle } | null>(null)
+  // In-flight scroll re-assert loop (rAF id + monitor handle), SHARED across pin-bottom and the
+  // MAM-prepend re-assert. Starting any re-assert loop supersedes whatever is in-flight, so only
+  // one ever runs: two loops fight over scrollTop (the overlap the monitor warns about), and
+  // pin-bottom vs prepend target opposite positions (bottom vs a history anchor). Single-flight:
+  // latest call wins with a fresh settle window.
+  const reassertLoopRef = useRef<{ raf: number; handle: ReassertLoopHandle } | null>(null)
+  // Supersede any in-flight re-assert loop. Held in a ref (read as `.current()`) so callers in
+  // useCallback / useLayoutEffect don't need it as a dependency — react-hooks treats refs as stable.
+  const supersedeReassertLoopRef = useRef(() => {
+    if (reassertLoopRef.current) {
+      cancelAnimationFrame(reassertLoopRef.current.raf)
+      reassertLoopRef.current.handle.end()
+      reassertLoopRef.current = null
+    }
+  })
 
   // Track scroll position - always create internal ref to follow rules of hooks
   const internalIsAtBottomRef = useRef(true)
@@ -617,18 +628,13 @@ export function useMessageListScroll({
     const scroller = scrollerRef.current
     if (!virt || !scroller || virt.itemCount === 0) return
 
-    // Single-flight: supersede any pin-bottom loop still running from a previous call so two never
-    // run at once and fight over scrollTop (the overlap the reassert monitor warns about, and the
-    // suspected cause of a just-sent message not sticking to the bottom on WebKit). Cancel the
-    // in-flight loop's next frame and end its monitor handle; this call restarts with a fresh
-    // settle window. reassertBottom fires from several sites (new-message, typing, composer/viewport
-    // resize, media load) that can land within the ~1s window, so re-entry is routine.
-    if (pinLoopRef.current) {
-      cancelAnimationFrame(pinLoopRef.current.raf)
-      pinLoopRef.current.handle.end()
-      pinLoopRef.current = null
-      debugLog('PIN superseded in-flight loop')
-    }
+    // Single-flight: supersede any re-assert loop still running (pin-bottom OR prepend) so two
+    // never run at once and fight over scrollTop (the overlap the reassert monitor warns about,
+    // and the suspected cause of a just-sent message not sticking to the bottom on WebKit). This
+    // call restarts with a fresh settle window. reassertBottom fires from several sites
+    // (new-message, typing, composer/viewport resize, media load) that can land within the ~1s
+    // window — and a send can land mid-prepend — so re-entry is routine.
+    supersedeReassertLoopRef.current()
 
     // Immediate pin (pre-paint when called from a layout effect).
     virt.scrollToIndex(virt.itemCount - 1, { align: 'end' })
@@ -643,7 +649,7 @@ export function useMessageListScroll({
     let lastHeight = scroller.scrollHeight
     const finish = () => {
       loop.end()
-      pinLoopRef.current = null
+      reassertLoopRef.current = null
     }
     const step = () => {
       const s = scrollerRef.current
@@ -692,9 +698,9 @@ export function useMessageListScroll({
       }
       const warning = loop.frame(performance.now(), wrote)
       if (warning) console.warn(warning)
-      pinLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
+      reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
     }
-    pinLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
+    reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
   }, [isAtBottomRef])
 
   // Re-pin the list to the bottom after a layout change that grows the content or shrinks the
@@ -1181,7 +1187,14 @@ export function useMessageListScroll({
         // and re-applying each frame lands at the marker once the region mounts. Mirrors
         // pinVirtualizedBottom's re-assert loop; bails on user scroll or a conversation switch.
         const startedAt = Date.now()
+        // Single-flight (shared with pin-bottom / prepend): the marker positioning loop owns
+        // scrollTop while it runs, so it supersedes any in-flight re-assert and registers itself.
+        supersedeReassertLoopRef.current()
         const markerLoop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('marker', performance.now())
+        const finishMarker = () => {
+          markerLoop.end()
+          reassertLoopRef.current = null
+        }
         let framesLeft = MARKER_REASSERT_FRAMES
         let stableFrames = 0
         let landedTarget = -1
@@ -1191,18 +1204,18 @@ export function useMessageListScroll({
             // Marker never resolved at all (e.g. trimmed from the loaded set) — don't strand the
             // view at the top; fall back to the bottom. End first so the handoff to reassertBottom
             // (which begins a pin-bottom loop) is not miscounted as an overlap.
-            markerLoop.end()
+            finishMarker()
             if (!resolved) reassertBottom()
             return
           }
           const s = scrollerRef.current
-          if (!s) { markerLoop.end(); return }
+          if (!s) { finishMarker(); return }
           // Conversation switched away while this loop was still running → stop (a stale loop must
           // never scroll the new conversation). prevConversationRef is set synchronously below.
-          if (prevConversationRef.current !== markerConvId) { markerLoop.end(); return }
+          if (prevConversationRef.current !== markerConvId) { finishMarker(); return }
           // User took over (FAB/wheel) or scrolled away from where we landed → stop fighting them.
-          if (userScrollIntentAtRef.current > startedAt) { markerLoop.end(); return }
-          if (landedTarget >= 0 && Math.abs(s.scrollTop - landedTarget) > FAB_THRESHOLD) { markerLoop.end(); return }
+          if (userScrollIntentAtRef.current > startedAt) { finishMarker(); return }
+          if (landedTarget >= 0 && Math.abs(s.scrollTop - landedTarget) > FAB_THRESHOLD) { finishMarker(); return }
 
           const viewportHeight = s.clientHeight
           const v = latestRef.current.virtualizer
@@ -1225,7 +1238,7 @@ export function useMessageListScroll({
             // unread case; fall back to the bottom (the prior behavior) rather than paginating.
             if (target <= 0) {
               isAtBottomRef.current = true
-              markerLoop.end()
+              finishMarker()
               reassertBottom()
               return
             }
@@ -1244,15 +1257,15 @@ export function useMessageListScroll({
               })
             } else if (landedTarget >= 0 && ++stableFrames >= MARKER_STABLE_FRAMES) {
               // Landed and the target has held steady — stop re-asserting.
-              markerLoop.end()
+              finishMarker()
               return
             }
           }
           const warning = markerLoop.frame(performance.now(), wrote)
           if (warning) console.warn(warning)
-          requestAnimationFrame(stepToMarker)
+          reassertLoopRef.current = { raf: requestAnimationFrame(stepToMarker), handle: markerLoop }
         }
-        requestAnimationFrame(stepToMarker)
+        reassertLoopRef.current = { raf: requestAnimationFrame(stepToMarker), handle: markerLoop }
       } else if (targetMessageId) {
         // Has a target message to scroll to — skip scroll-to-bottom.
         // The targetMessageId effect will handle scrolling.
@@ -1635,18 +1648,24 @@ export function useMessageListScroll({
     // the user took over → yield. A content-shrink clamp records no intent, so the loop keeps
     // re-pinning the anchor through it (clamp recovery — the "jump to bottom" fix).
     const assertStartedAt = Date.now()
-    // Diagnostic: this loop has no cleanup and no early-stable exit, so a second MAM prepend
-    // (fast scroll-up through history) can start a second 'prepend' loop against a different
-    // anchor while this one is still running — they then fight over scrollTop. The monitor
-    // surfaces that overlap (and a single loop that never settles) in fluux.log on WebKit.
+    // Single-flight (shared with pin-bottom): supersede any re-assert loop still in-flight so two
+    // never run at once. This loop has no early-stable exit, so a second MAM prepend (fast
+    // scroll-up through history) would otherwise start a second 'prepend' loop against a different
+    // anchor while this one runs; and a pin-bottom from a send can land mid-prepend. Both fight
+    // over scrollTop. The latest re-assert wins.
+    supersedeReassertLoopRef.current()
     const assertLoop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('prepend', performance.now())
+    const finishAssert = () => {
+      assertLoop.end()
+      reassertLoopRef.current = null
+    }
     const runMeasureAssert = () => {
-      if (framesLeft-- <= 0) { assertLoop.end(); return }
+      if (framesLeft-- <= 0) { finishAssert(); return }
       // Deliberate user scroll (FAB / wheel) since the loop started → the user took over;
       // stop re-pinning and yield. A content-shrink clamp does NOT set this, so we keep going.
       if (userScrollIntentAtRef.current > assertStartedAt) {
         debugLog('PREPEND ASSERT CANCELLED (user scroll intent)', { scrollTop: scrollerRef.current?.scrollTop })
-        assertLoop.end()
+        finishAssert()
         return
       }
       let wrote = false
@@ -1676,9 +1695,9 @@ export function useMessageListScroll({
       }
       const warning = assertLoop.frame(performance.now(), wrote)
       if (warning) console.warn(warning)
-      requestAnimationFrame(runMeasureAssert)
+      reassertLoopRef.current = { raf: requestAnimationFrame(runMeasureAssert), handle: assertLoop }
     }
-    requestAnimationFrame(runMeasureAssert)
+    reassertLoopRef.current = { raf: requestAnimationFrame(runMeasureAssert), handle: assertLoop }
 
     // Clear after cooldown
     setTimeout(() => {


### PR DESCRIPTION
Follow-up to #703.

## Summary

#703 made the pin-bottom re-assert loop single-flight against itself, fixing the `(pin-bottom, pin-bottom)` overlap observed in the wild. But the reassert monitor warns on overlap across **all** the rAF re-assert loops, and two cases remained open:

- **`prepend` vs `prepend`** — `runMeasureAssert` (the MAM-prepend restore) had no cleanup and no early-stable exit, so a second prepend from a fast scroll-up through history started a second ~1s loop against a different anchor while the first was still running. (The originally documented prime suspect.)
- **`pin-bottom` vs `prepend`** — reachable when a send lands mid-prepend: the outgoing path forces a scroll-to-bottom while `runMeasureAssert` is still re-pinning a history anchor. Their targets contradict (bottom vs a history anchor), so they actively fight over `scrollTop`.

This generalises #703's pin-specific in-flight ref into a single shared `reassertLoopRef` used by all three re-assert loops (pin-bottom, the conversation-switch marker loop, and the prepend restore). Starting any loop supersedes whatever is in-flight, via a ref-stable supersede helper, so at most one re-assert loop ever owns `scrollTop`. This closes the monitor's whole overlap class rather than just the pin-bottom-vs-itself case.

## Regression test

`MessageList.reassertSingleFlight.test.tsx` drives the two previously-unfixed overlaps with a controllable rAF queue and a mocked monitor that tracks the peak number of concurrently-active loops, asserting it never exceeds one. Both tests fail on #703's code (peak 2-3) and pass with this change.