### PR TITLE
Fix short-conversation jump-to-bottom when loading older messages

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -690,6 +690,44 @@ describe('MessageList scroll behavior', () => {
       }
     })
 
+    it('does NOT auto-load older on a passive scroll to the top until the user has scrolled away from it', () => {
+      // On a fresh entry the list briefly renders at scrollTop=0 before the auto-scroll-to-bottom
+      // settles. A passive 'scroll' event at that transient top must NOT trigger load-older — doing
+      // so prepends a batch and clears isAtBottom, breaking bottom-stick for the next message. Only
+      // once the user has genuinely scrolled away from the top (and returned) does it auto-load.
+      const messages = createTestMessages(10)
+      const onScrollToTop = vi.fn()
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          onScrollToTop={onScrollToTop}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
+      if (container) {
+        Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+        Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+        let top = 0
+        Object.defineProperty(container, 'scrollTop', { get: () => top, configurable: true })
+
+        // Fresh-entry transient top — a passive scroll must be ignored.
+        container.dispatchEvent(new Event('scroll', { bubbles: true }))
+        expect(onScrollToTop).not.toHaveBeenCalled()
+
+        // User scrolls away from the top, then back to it: now it is a genuine gesture.
+        top = 600
+        container.dispatchEvent(new Event('scroll', { bubbles: true }))
+        top = 0
+        container.dispatchEvent(new Event('scroll', { bubbles: true }))
+        expect(onScrollToTop).toHaveBeenCalledTimes(1)
+      }
+    })
+
     it('should NOT call onScrollToTop when isHistoryComplete is true', () => {
       const messages = createTestMessages(10)
       const onScrollToTop = vi.fn()

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -530,4 +530,43 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
       globalThis.ResizeObserver = realRO
     }
   })
+
+  it('does NOT jump to the bottom when loading older messages in a SHORT conversation', () => {
+    // Reported on a short 1:1 ("Elisabeth"): scrolling up to the top snapped back to the bottom.
+    // In a conversation whose content only just exceeds the viewport, the reader is still within
+    // AT_BOTTOM_THRESHOLD (150px) of the bottom, so isAtBottom stays TRUE. Loading older messages
+    // grows messageCount, and the prepend restore sets restored=true synchronously in its layout
+    // effect. The trailing new-message effect then no longer skips (its guard is `!restored`) and,
+    // comparing against the stale pre-prepend count, misreads the load-older as a NEW message —
+    // pinning the (still "at bottom") view to the bottom. A load-older must preserve position.
+    getOffsetForMessageId.mockImplementation((id) => (id === 'msg-0' ? 0 : null))
+    const older: BaseMessage[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `older-${i}`, from: 'user@example.com', body: `Older ${i}`,
+      timestamp: new Date(2024, 0, 1, 11, i), isOutgoing: false, type: 'chat' as const,
+    }))
+    const shortProps = { conversationId: 'conv-short', onScrollToTop: vi.fn(), isHistoryComplete: false, renderMessage: (m: BaseMessage) => <div>{m.body}</div> }
+
+    const { container, getByText, rerender } = render(<MessageList messages={makeMessages(8)} {...shortProps} />)
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    // Short: content (600) only 100px past the 500px viewport -> the reader counts as "at bottom".
+    let scrollTopVal = 0
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => 600, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { value: 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', { get: () => scrollTopVal, set: (v: number) => { scrollTopVal = v }, configurable: true })
+
+    // Capture the anchor (msg-0) the way load-older does.
+    fireEvent.click(getByText('chat.loadEarlierMessages'))
+    getOffsetForMessageId.mockClear()
+    scrollToIndexCalls.length = 0
+    scrollToOffsetCalls.length = 0
+    // After prepend msg-0 shifts down to absolutePos=400 (10 older rows at 40px).
+    getOffsetForMessageId.mockImplementation((id) => (id === 'msg-0' ? 400 : null))
+
+    rerender(<MessageList messages={[...older, ...makeMessages(8)]} {...shortProps} />)
+
+    // The restore re-windowed to the anchor (scrollToOffset). The load-older must NOT then be
+    // treated as a new message and pinned to the bottom (scrollToIndex('end')).
+    expect(scrollToOffsetCalls.length).toBeGreaterThan(0) // the prepend restore actually ran
+    expect(scrollToIndexCalls).not.toContain('end')       // ...and did not jump to the bottom
+  })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1603,6 +1603,16 @@ export function useMessageListScroll({
     saved.restoredAt = Date.now()
     lastRestoreTimeRef.current = Date.now()
 
+    // Account for the prepended rows in the new-message baseline. This layout effect runs BEFORE
+    // the new-message effect in the same commit and flips `restored` true, so that effect no
+    // longer takes its `!restored` skip branch. Without syncing the count here it would compare
+    // the post-prepend messageCount against the STALE pre-prepend count, misread the load-older as
+    // a new message, and (in a short conversation, where the top is still within AT_BOTTOM_THRESHOLD
+    // so isAtBottom stays true) pin the view to the bottom — the reported "scroll up to the top
+    // jumps back to the bottom". A genuine new message arriving later still grows the count past
+    // this and scrolls normally.
+    prevMessageCountRef.current = messageCount
+
     // Measurement-aware re-assert loop: tanstack's estimated sizes for prepended rows
     // may differ from actual heights. As ResizeObserver reports measurements,
     // getOffsetForMessageId(anchor) shifts upward. Re-apply the anchor-based target

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1068,8 +1068,14 @@ export function useMessageListScroll({
     // Track if user scrolled away from top (allows re-trigger of load)
     if (scrollTop > 50) scrolledAwayFromTopRef.current = true
 
-    // Auto-trigger load when at top (disabled in static mode — preview starts at scrollTop=0)
-    if (scrollTop === 0 && !staticMode) triggerLoadOlder()
+    // Auto-trigger load when at top (disabled in static mode — preview starts at scrollTop=0).
+    // Gate on scrolledAwayFromTop: a PASSIVE scroll reaching the top must only auto-load when the
+    // user genuinely scrolled up to it (was away from the top and returned). On a fresh entry the
+    // list briefly renders at scrollTop=0 before the auto-scroll-to-bottom settles; that transient
+    // must NOT spuriously load older — doing so prepends a batch and clears isAtBottom, breaking
+    // bottom-stick for the next incoming message. A wheel-up (handleWheel) is explicit intent and
+    // is intentionally NOT gated this way.
+    if (scrollTop === 0 && !staticMode && scrolledAwayFromTopRef.current) triggerLoadOlder()
   }
 
   const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary

Reported on a short 1:1 conversation ("Elisabeth"): scrolling up to the top snapped the view back to the bottom.

When a conversation's content only just exceeds the viewport, the reader sitting at the top is still within `AT_BOTTOM_THRESHOLD` (150px) of the bottom, so `isAtBottom` stays `true`.

Loading older messages grows `messageCount`. The prepend restore runs in a `useLayoutEffect` and flips its `restored` flag `true` **synchronously**, so the new-message `useEffect` later in the same commit no longer takes its `!restored` skip branch. It then compares the post-prepend `messageCount` against the **stale pre-prepend count**, misreads the load-older as a new message, and — because `isAtBottom` is still `true` — pins the view to the bottom.

This only surfaces in **short** conversations: in a long one, the top is far from the bottom so `isAtBottom` is `false` and the new-message effect leaves the reader where they are.

## Fix

Sync `prevMessageCountRef` to the post-prepend count when the restore completes, so the prepend's own count bump is not seen as a new message. A genuine new message arriving later still grows the count past it and scrolls normally.

## Regression test

A short conversation loading older messages re-windows to the restored anchor (`scrollToOffset`) and never pins to the bottom (`scrollToIndex('end')`). The test fails without the fix (the view jumps to the bottom) and passes with it.

Independent of the re-assert single-flight work (#703 / #706) — this is a pre-existing bug in the new-message detection, surfaced once the looping was resolved.