### PR TITLE
Fix flaky scroll-invariant-2 (wait for the real load-older batch)

### DIFF
--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -321,11 +321,16 @@ test.describe('Virtualization scroll invariants', () => {
     // Trigger load-older by scrolling to top (handleScroll at scrollTop=0 calls triggerLoadOlder)
     await scrollToTopAndLoad(page)
 
-    // Wait for 80ms mock network delay + store update + React re-render + useLayoutEffect restore.
-    // The spacer must grow before we check scrollTop.
+    // Wait for the load-older batch to actually land: 80ms mock network delay + store update +
+    // React re-render + useLayoutEffect restore. The threshold must be well ABOVE the spacer
+    // jitter caused by rows re-measuring as they mount on scroll-to-top (~300px) — otherwise the
+    // wait resolves on that jitter BEFORE the batch merges (the 80ms delay lands after), and the
+    // sample below sees only a partial gain (the flake: "spacer grew by only ~300px"). A real BATCH
+    // is ~3200px (50 × 64px estimate); 1500px cleanly clears the jitter while staying below one
+    // batch, so it fires only once the batch is in.
     await page.waitForFunction((spacer) => {
       const sp = document.querySelector('[data-virtualizer-spacer]') as HTMLElement | null
-      return sp ? sp.offsetHeight > spacer + 100 : false
+      return sp ? sp.offsetHeight > spacer + 1500 : false
     }, spacerBefore, { timeout: 5_000 })
 
     const debugAfter = await getDebugState(page)


### PR DESCRIPTION
## Summary

The "Scroll invariants (e2e)" job is intermittently failing (`invariant-2: spacer grew by only ~300px`, plus cascading timeouts in invariant-1/4). Root-caused as a wait-too-early race in the test, **not** an app regression.

`invariant-2` triggers load-older and waits for the virtualizer spacer to grow before sampling the gain. The wait threshold was `+100px` — but scrolling to the top mounts new rows that **re-measure**, which alone moves the spacer by ~300px. So the wait resolved on that measurement **jitter**, *before* the 80ms-delayed load-older batch had merged, and the sample then saw only the partial growth (~300px) — under the `>1500px` assertion.

Confirmed with instrumentation: at the eager trigger the spacer was `9048` (before `8748`, i.e. +300 jitter); 1.5s later it was `12896` (+4148 — the batch had landed). So the batch always arrives; the test just looked too early.

When it flaked in CI, the resulting Playwright **retries + trace capture** slowed the shared runner enough to time out the other invariants (invariant-1 demo-load, invariant-4 new-message-visible) — explaining why a whole run would go red.

## Fix

Raise the wait threshold to `+1500px`. A real batch is ~3200px (50 rows × 64px estimate) and jitter is ~300px, so 1500px cleanly separates them: the wait now fires only once the batch is actually in. The existing 5s timeout comfortably covers the 80ms mock network delay.

Verified locally: full suite (14 tests, chromium + webkit) green in one pass, no retries.

Pre-existing flake on `main` — surfaced (not caused) by the load-older fix in #708.