### PR TITLE
fix(avatar): freeze animated GIFs across virtualized remounts

### DIFF
--- a/apps/fluux/src/components/Avatar.test.tsx
+++ b/apps/fluux/src/components/Avatar.test.tsx
@@ -5,8 +5,8 @@
  * differs between DOM environments (jsdom normalizes #hex to rgb(); happy-dom, the
  * default env, keeps the literal). These assertions/snapshots only hold under jsdom.
  */
-import { describe, it, expect, vi, test } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, test, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Avatar, getConsistentTextColor } from './Avatar'
 
 // Mock the SDK color generation
@@ -204,6 +204,93 @@ describe('Avatar', () => {
       expect(root.className).toContain('rounded-xl')
       expect(root.className).not.toContain('rounded-full')
     })
+  })
+})
+
+describe('Avatar — animated GIF freeze-on-hover', () => {
+  const STATIC_DATA_URL = 'data:image/png;base64,FROZEN'
+  let fetchSpy: ReturnType<typeof vi.fn>
+  let OriginalImage: typeof Image
+
+  // Minimal Image stub: fires onload asynchronously once `src` is assigned,
+  // so the extraction effect (which sets onload *before* src) runs to completion.
+  class MockImage {
+    onload: (() => void) | null = null
+    naturalWidth = 48
+    naturalHeight = 48
+    set src(_v: string) {
+      queueMicrotask(() => this.onload?.())
+    }
+  }
+
+  // The extraction only branches on blob.type, so a bare { type } suffices.
+  const respondWith = (type: string) =>
+    fetchSpy.mockResolvedValue({ blob: () => Promise.resolve({ type }) })
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    respondWith('image/gif')
+    global.fetch = fetchSpy as unknown as typeof fetch
+    OriginalImage = global.Image
+    global.Image = MockImage as unknown as typeof Image
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(STATIC_DATA_URL)
+  })
+
+  afterEach(() => {
+    global.Image = OriginalImage
+    vi.restoreAllMocks()
+  })
+
+  it('freezes an animated GIF to its first frame after extraction', async () => {
+    const url = 'blob:gif-freeze'
+    render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    // The live (animated) URL shows while the first frame is being extracted.
+    expect(screen.getByRole('img')).toHaveAttribute('src', url)
+    await waitFor(() =>
+      expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    )
+  })
+
+  it('shows the cached static frame synchronously on remount (no replay)', async () => {
+    // Regression: virtualized message rows unmount/remount on scroll. The frozen
+    // frame must be applied on the first render of the new instance, without a
+    // fresh fetch/decode — otherwise the GIF replays every time it scrolls in.
+    const url = 'blob:gif-remount'
+    const { unmount } = render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    await waitFor(() =>
+      expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    unmount()
+
+    render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('plays the GIF on hover and re-freezes on mouse leave', async () => {
+    const url = 'blob:gif-hover'
+    const { container } = render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    await waitFor(() =>
+      expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    )
+    fireEvent.mouseEnter(container.firstChild as Element)
+    expect(screen.getByRole('img')).toHaveAttribute('src', url)
+    fireEvent.mouseLeave(container.firstChild as Element)
+    expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+  })
+
+  it('never freezes a non-GIF image', async () => {
+    respondWith('image/png')
+    const url = 'blob:png-static'
+    render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', url)
+    // Let any extraction microtasks flush; the src must stay the live URL.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.getByRole('img')).toHaveAttribute('src', url)
   })
 })
 

--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -117,14 +117,39 @@ function getPresenceStatusFromShow(show: PresenceShow | undefined): PresenceStat
 }
 
 /**
+ * Module-level cache of extracted first frames, keyed by avatar URL. It outlives
+ * any single Avatar mount so a frozen frame is reused instantly when the same URL
+ * mounts again — e.g. a virtualized message row scrolling back into view. Without
+ * it, each remount restarts the async extraction and the GIF replays its opening
+ * frames every time it re-enters the viewport. Bounded so churning blob: URLs
+ * (re-minted on every reconnect) can't grow it without limit.
+ */
+const STATIC_FRAME_CACHE_CAP = 256
+const staticFrameCache = new Map<string, string>()
+
+function cacheStaticFrame(url: string, dataUrl: string): void {
+  if (staticFrameCache.size >= STATIC_FRAME_CACHE_CAP) {
+    const oldest = staticFrameCache.keys().next().value
+    if (oldest !== undefined) staticFrameCache.delete(oldest)
+  }
+  staticFrameCache.set(url, dataUrl)
+}
+
+/**
  * For animated GIF avatars, extract the first frame as a static PNG data URL.
- * Returns null for non-GIF images or while loading.
+ * Returns null for non-GIF images or while loading. A cached frame for the same
+ * URL is applied synchronously on mount (no re-fetch, no replay).
  */
 function useStaticFrame(url: string | undefined): string | null {
-  const [frame, setFrame] = useState<string | null>(null)
+  const [frame, setFrame] = useState<string | null>(() =>
+    url ? staticFrameCache.get(url) ?? null : null
+  )
 
   useEffect(() => {
     if (!url) { setFrame(null); return }
+    const cached = staticFrameCache.get(url)
+    if (cached) { setFrame(cached); return }
+    setFrame(null)
     let cancelled = false
 
     fetch(url)
@@ -138,7 +163,9 @@ function useStaticFrame(url: string | undefined): string | null {
           c.width = img.naturalWidth
           c.height = img.naturalHeight
           c.getContext('2d')?.drawImage(img, 0, 0)
-          setFrame(c.toDataURL('image/png'))
+          const dataUrl = c.toDataURL('image/png')
+          cacheStaticFrame(url, dataUrl)
+          setFrame(dataUrl)
         }
         img.src = url
       })


### PR DESCRIPTION
## Summary

Animated GIF avatars used to be frozen to their first frame and only play on hover. That stopped working once message-list virtualization became default-on (#650): the freeze code was still present but never took effect during scrolling.

**Cause.** `useStaticFrame` extracts a GIF's first frame asynchronously and shows the live (animated) URL until extraction finishes. Virtualized message rows unmount and remount as they scroll in and out of view, and the hook reset its state to `null` on every mount, restarting extraction from scratch. The GIF replayed its opening frames each time it re-entered the viewport, so animated avatars appeared to always animate.

**Fix.** A bounded (256-entry, FIFO) module-level cache of extracted first frames, keyed by avatar URL. The hook seeds its state lazily from the cache, so a remount applies the frozen frame on the very first render with no re-fetch and no replay. The hover-to-play handlers and `src` toggle are unchanged.

This is also cheaper than the previous behavior: the old code re-ran `fetch -> blob -> canvas -> toDataURL` on every remount (i.e. every scroll-in); each GIF is now decoded at most once per session.