### PR TITLE
fix(tooltip): dismiss lingering tooltips when a modal opens

### DIFF
--- a/apps/fluux/src/components/Tooltip.test.tsx
+++ b/apps/fluux/src/components/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { Tooltip, SimpleTooltip } from './Tooltip'
+import { dismissAllTooltips } from '../utils/tooltipBus'
 
 describe('Tooltip', () => {
   afterEach(() => {
@@ -80,6 +81,59 @@ describe('Tooltip', () => {
       fireEvent.mouseLeave(trigger)
 
       // Complete the delay
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250)
+      })
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('global dismiss (tooltip bus)', () => {
+    it('hides a visible tooltip when dismissAllTooltips() fires', async () => {
+      vi.useFakeTimers()
+      render(
+        <Tooltip content="Test tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      )
+
+      const trigger = screen.getByText('Hover me').parentElement!
+      fireEvent.mouseEnter(trigger)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(screen.getByRole('tooltip')).toBeInTheDocument()
+
+      act(() => {
+        dismissAllTooltips()
+      })
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
+    it('cancels a pending tooltip so it never appears over a modal', async () => {
+      vi.useFakeTimers()
+      render(
+        <Tooltip content="Test tooltip" delay={500}>
+          <button>Hover me</button>
+        </Tooltip>
+      )
+
+      const trigger = screen.getByText('Hover me').parentElement!
+      fireEvent.mouseEnter(trigger)
+
+      // Delay still counting down — a modal opens and dismisses tooltips.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250)
+      })
+      act(() => {
+        dismissAllTooltips()
+      })
+
+      // Complete the original delay: the tooltip must NOT pop up afterwards.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(250)
       })

--- a/apps/fluux/src/components/Tooltip.tsx
+++ b/apps/fluux/src/components/Tooltip.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { useIsMobileWeb } from '../hooks/useIsMobileWeb'
+import { onDismissAllTooltips } from '../utils/tooltipBus'
 
 export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right'
 
@@ -89,6 +90,13 @@ export function Tooltip({
     if (effectiveDisabled) return
     setIsVisible(v => !v)
   }
+
+  // Dismiss on the global tooltip-bus signal (fired when a modal such as the
+  // Cmd-K command palette opens). hideTooltip also cancels a pending show, so a
+  // tooltip whose delay is still counting down won't pop up over the modal.
+  // Always mounted (not gated on isVisible) so pending-but-not-yet-visible
+  // tooltips are caught too.
+  useEffect(() => onDismissAllTooltips(hideTooltip), [hideTooltip])
 
   // Hide tooltip on scroll, window blur, or any pointer down — these events
   // can cause the trigger to move or disappear without firing mouseLeave.

--- a/apps/fluux/src/stores/modalStore.test.ts
+++ b/apps/fluux/src/stores/modalStore.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useModalStore, MODAL_ESCAPE_PRIORITY } from './modalStore'
+import * as tooltipBus from '../utils/tooltipBus'
 
 const reset = () =>
   useModalStore.setState({
@@ -57,6 +58,35 @@ describe('modalStore', () => {
 
   it('closeTopmost() returns false when no modal is open', () => {
     expect(useModalStore.getState().closeTopmost()).toBe(false)
+  })
+
+  describe('tooltip dismissal on open', () => {
+    it('open() dismisses any lingering tooltips so they cannot float over the modal', () => {
+      const spy = vi.spyOn(tooltipBus, 'dismissAllTooltips')
+      useModalStore.getState().open('commandPalette')
+      expect(spy).toHaveBeenCalledTimes(1)
+      spy.mockRestore()
+    })
+
+    it('toggle() dismisses tooltips when opening, but not when closing', () => {
+      const spy = vi.spyOn(tooltipBus, 'dismissAllTooltips')
+      const { toggle } = useModalStore.getState()
+
+      toggle('shortcutHelp') // closed -> open
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      toggle('shortcutHelp') // open -> closed
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      spy.mockRestore()
+    })
+
+    it('close() does not dismiss tooltips', () => {
+      const spy = vi.spyOn(tooltipBus, 'dismissAllTooltips')
+      useModalStore.getState().close('quickChat')
+      expect(spy).not.toHaveBeenCalled()
+      spy.mockRestore()
+    })
   })
 
   it('action identities are stable across state changes (so action-only consumers never re-render)', () => {

--- a/apps/fluux/src/stores/modalStore.ts
+++ b/apps/fluux/src/stores/modalStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { dismissAllTooltips } from '../utils/tooltipBus'
 
 /**
  * App-level modal state.
@@ -64,9 +65,19 @@ const ALL_CLOSED = {
 
 export const useModalStore = create<ModalStoreState>((set, get) => ({
   ...ALL_CLOSED,
-  open: (modal) => set({ [modal]: true } as Pick<ModalStoreState, ModalName>),
+  open: (modal) => {
+    // A modal floats above the UI, but hover tooltips portal even higher and
+    // are never dismissed by a keyboard-opened modal — clear them on open so
+    // none linger over the command palette etc.
+    dismissAllTooltips()
+    set({ [modal]: true } as Pick<ModalStoreState, ModalName>)
+  },
   close: (modal) => set({ [modal]: false } as Pick<ModalStoreState, ModalName>),
-  toggle: (modal) => set((s) => ({ [modal]: !s[modal] } as Pick<ModalStoreState, ModalName>)),
+  toggle: (modal) =>
+    set((s) => {
+      if (!s[modal]) dismissAllTooltips()
+      return { [modal]: !s[modal] } as Pick<ModalStoreState, ModalName>
+    }),
   closeAll: () => set({ ...ALL_CLOSED }),
   closeTopmost: () => {
     const s = get()

--- a/apps/fluux/src/utils/tooltipBus.test.ts
+++ b/apps/fluux/src/utils/tooltipBus.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { dismissAllTooltips, onDismissAllTooltips } from './tooltipBus'
+
+describe('tooltipBus', () => {
+  it('notifies subscribers when dismissAllTooltips() is called', () => {
+    const handler = vi.fn()
+    const unsubscribe = onDismissAllTooltips(handler)
+
+    dismissAllTooltips()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    dismissAllTooltips()
+    expect(handler).toHaveBeenCalledTimes(2)
+
+    unsubscribe()
+  })
+
+  it('stops notifying after unsubscribe', () => {
+    const handler = vi.fn()
+    const unsubscribe = onDismissAllTooltips(handler)
+    unsubscribe()
+
+    dismissAllTooltips()
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('fans out to every subscriber', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const unA = onDismissAllTooltips(a)
+    const unB = onDismissAllTooltips(b)
+
+    dismissAllTooltips()
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+
+    unA()
+    unB()
+  })
+})

--- a/apps/fluux/src/utils/tooltipBus.ts
+++ b/apps/fluux/src/utils/tooltipBus.ts
@@ -1,0 +1,26 @@
+/**
+ * Tiny global bus to dismiss every visible (or pending) tooltip at once.
+ *
+ * Tooltips portal to `document.body` at a very high z-index (see Tooltip.tsx),
+ * so a tooltip left hovering over the UI floats ABOVE modals like the Cmd-K
+ * command palette. Keyboard-opened modals never fire the pointerdown/blur that
+ * would otherwise dismiss a tooltip, so we dismiss them explicitly the moment a
+ * modal opens (see modalStore.ts).
+ *
+ * A DOM CustomEvent keeps the contract decoupled: the modal store dispatches,
+ * each Tooltip instance listens — neither imports the other.
+ */
+const DISMISS_TOOLTIPS_EVENT = 'fluux:dismiss-tooltips'
+
+/** Ask every mounted Tooltip to hide itself (and cancel any pending show). */
+export function dismissAllTooltips(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(DISMISS_TOOLTIPS_EVENT))
+}
+
+/** Subscribe to the dismiss signal. Returns an unsubscribe function. */
+export function onDismissAllTooltips(handler: () => void): () => void {
+  if (typeof window === 'undefined') return () => {}
+  window.addEventListener(DISMISS_TOOLTIPS_EVENT, handler)
+  return () => window.removeEventListener(DISMISS_TOOLTIPS_EVENT, handler)
+}


### PR DESCRIPTION
## Summary

Opening the Cmd-K command palette could leave a hover tooltip floating on top of the panel.

Tooltips portal to `document.body` at `z-index: 9999`, while the command palette renders at `z-50`. A tooltip hovering over the UI sits *above* the palette, and because modals open from a keyboard shortcut, none of the events that normally dismiss a tooltip (`pointerdown` / `blur` / `scroll`) ever fire. The stale tooltip lingers over the panel.

This dismisses tooltips when a modal opens (the better UX than a z-index bump), generalized to every modal rather than just the command palette.

## Changes

- **`apps/fluux/src/utils/tooltipBus.ts`** (new): tiny decoupled bus over a DOM `CustomEvent` (`dismissAllTooltips()` / `onDismissAllTooltips()`), so the store and the Tooltip component don't import each other.
- **`Tooltip.tsx`**: an always-mounted effect subscribes to the bus and calls `hideTooltip()`. Since `hideTooltip` also clears the pending show-timer, a tooltip whose delay is still counting down won't pop up over the modal after it opens.
- **`modalStore.ts`**: `open()` and `toggle()` (only when transitioning to open) fire `dismissAllTooltips()` — the single chokepoint every modal-open path already flows through.

Once the palette is open, its full-screen scrim blocks pointer events to the buttons underneath, so no new tooltip can spawn from below; dismissing on open is sufficient and no z-index change is needed.