### PR TITLE
fix(modals): restore keyboard focus when the window regains focus

### DIFF
--- a/apps/fluux/src/components/BackupPassphraseDialog.tsx
+++ b/apps/fluux/src/components/BackupPassphraseDialog.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Copy, Check, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { generateBackupPassphrase, generateBackupCode, USE_V6_KEYS } from '@/e2ee/passphraseGenerator'
 import { SaveToPasswordManagerButton } from './SaveToPasswordManagerButton'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 
 // Draw a fresh passphrase in the user's UI language. 8 words ×
 // 11 bits (BIP-39) = 88 bits, which matches the acceptability gate
@@ -46,6 +47,10 @@ export function BackupPassphraseDialog({
   confirmLabel,
 }: BackupPassphraseDialogProps) {
   const { t, i18n } = useTranslation()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Keep keyboard focus inside the dialog across OS window blur/refocus.
+  useRestoreFocus(panelRef)
 
   // Regenerate on every open rather than keeping a stable value — a
   // user who cancelled and reopened should get a fresh passphrase so
@@ -148,7 +153,7 @@ export function BackupPassphraseDialog({
         onClick={onCancel}
         className="absolute inset-0 cursor-default"
       />
-      <div className="relative z-10 fluux-glass rounded-lg max-w-md w-full mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden">
+      <div ref={panelRef} className="relative z-10 fluux-glass rounded-lg max-w-md w-full mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden">
         <form
           onSubmit={(e) => { e.preventDefault(); void handleConfirm() }}
           className="contents"

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -22,6 +22,7 @@ import type { SidebarView } from './Sidebar'
 import { Avatar } from './Avatar'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { isAdvancedMode } from '@/stores/advancedModeStore'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 
 // =============================================================================
 // Types
@@ -182,6 +183,7 @@ function CommandPaletteContent({
   const selectedIndexRef = useRef(0) // Ref for synchronous access in event handlers
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
   const ignoreMouseRef = useRef(true) // start true; cleared after first paint to avoid stale-hover index changes
   const [isKeyboardNav, setIsKeyboardNav] = useState(false) // Track keyboard navigation mode
   const lastMousePosRef = useRef<{ x: number; y: number } | null>(null) // Track mouse position to detect real movement
@@ -444,6 +446,11 @@ function CommandPaletteContent({
     })
   }, [])
 
+  // Restore focus to the search input when the app window regains focus.
+  // Without this, switching away and back leaves focus on <body>, so arrow keys
+  // leak to the sidebar instead of moving the palette selection.
+  useRestoreFocus(dialogRef, inputRef)
+
   // Reset selection synchronously when query changes
   useLayoutEffect(() => {
     setSelectedIndex(0)
@@ -526,6 +533,7 @@ function CommandPaletteContent({
         className="absolute inset-0 cursor-default"
       />
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         className="relative z-10 fluux-glass rounded-lg w-full max-w-lg mx-4 overflow-hidden"

--- a/apps/fluux/src/components/ConfirmDialog.tsx
+++ b/apps/fluux/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 
 interface ConfirmDialogProps {
   title: string
@@ -19,6 +20,10 @@ export function ConfirmDialog({
   variant = 'danger',
 }: ConfirmDialogProps) {
   const { t } = useTranslation()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Keep keyboard focus inside the dialog across OS window blur/refocus.
+  useRestoreFocus(panelRef)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -44,7 +49,7 @@ export function ConfirmDialog({
         onClick={onCancel}
         className="absolute inset-0 cursor-default"
       />
-      <div className="relative z-10 fluux-glass rounded-lg p-4 max-w-sm w-full mx-4">
+      <div ref={panelRef} className="relative z-10 fluux-glass rounded-lg p-4 max-w-sm w-full mx-4">
         <h3 className="text-lg font-semibold text-fluux-text mb-2">{title}</h3>
         <p className="text-sm text-fluux-muted mb-4">{message}</p>
         <div className="flex gap-2 justify-end">

--- a/apps/fluux/src/components/ModalShell.test.tsx
+++ b/apps/fluux/src/components/ModalShell.test.tsx
@@ -27,4 +27,27 @@ describe('ModalShell glass surface', () => {
     expect(scrim?.classList.contains('modal-scrim')).toBe(true)
     expect(scrim?.classList.contains('bg-black/50')).toBe(false)
   })
+
+  it('restores focus to its input when the window regains focus', () => {
+    const { container } = render(
+      <>
+        <button data-testid="outside">outside</button>
+        <ModalShell title="X" onClose={() => {}}>
+          <input data-testid="field" autoFocus />
+        </ModalShell>
+      </>
+    )
+    const field = container.querySelector('[data-testid="field"]') as HTMLInputElement
+    const outside = container.querySelector('[data-testid="outside"]') as HTMLButtonElement
+
+    // The input is focused on open; the user types, then the OS window blurs and
+    // focus collapses to an element outside the modal.
+    field.focus()
+    outside.focus()
+    expect(document.activeElement).toBe(outside)
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(document.activeElement).toBe(field)
+  })
 })

--- a/apps/fluux/src/components/ModalShell.tsx
+++ b/apps/fluux/src/components/ModalShell.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { X } from 'lucide-react'
 import { Tooltip } from './Tooltip'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 
 interface ModalShellProps {
   title: React.ReactNode
@@ -21,6 +22,12 @@ export function ModalShell({
   children,
 }: ModalShellProps) {
   const { t } = useTranslation()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Keep keyboard focus inside the modal across OS window blur/refocus, so
+  // global shortcuts don't reclaim arrow/Tab keys when the user switches away
+  // and back. See useRestoreFocus for the full rationale.
+  useRestoreFocus(panelRef)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -42,7 +49,7 @@ export function ModalShell({
         onClick={onClose}
         className="absolute inset-0 cursor-default"
       />
-      <div className={`relative z-10 fluux-glass rounded-lg w-full ${width} mx-4 ${panelClassName ?? ''}`}>
+      <div ref={panelRef} className={`relative z-10 fluux-glass rounded-lg w-full ${width} mx-4 ${panelClassName ?? ''}`}>
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-fluux-hover flex-shrink-0">
           <h2 className="text-lg font-semibold text-fluux-text">{title}</h2>

--- a/apps/fluux/src/components/UnlockEncryptionDialog.tsx
+++ b/apps/fluux/src/components/UnlockEncryptionDialog.tsx
@@ -7,6 +7,7 @@ import { KeyPickerDialog } from './KeyPickerDialog'
 import { KeyPickerRequiredError, NoRecoveryAvailableError } from '@/e2ee/recoveryErrors'
 import type { KeyBundle } from '@/e2ee/OpenPGPPluginBase'
 import { isTauri } from '@/utils/tauri'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 import {
   cachePassphrase,
   clearCachedPassphrase,
@@ -37,6 +38,11 @@ interface UnlockEncryptionDialogProps {
 export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDialogProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Keep keyboard focus inside the dialog (or its nested key picker) across OS
+  // window blur/refocus, falling back to the passphrase field.
+  useRestoreFocus(dialogRef, inputRef)
 
   const [passphrase, setPassphrase] = useState('')
   const [confirmPassphrase, setConfirmPassphrase] = useState('')
@@ -203,6 +209,7 @@ export function UnlockEncryptionDialog({ client, onClose }: UnlockEncryptionDial
 
   return (
     <div
+      ref={dialogRef}
       data-modal="true"
       role="dialog"
       aria-modal="true"

--- a/apps/fluux/src/hooks/useRestoreFocus.test.tsx
+++ b/apps/fluux/src/hooks/useRestoreFocus.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { useRef } from 'react'
+import { useRestoreFocus } from './useRestoreFocus'
+
+/**
+ * Test harness: an "outside" control (the app behind the modal) plus a
+ * modal container holding an input and a button. The hook should keep
+ * keyboard focus inside the container across window blur/refocus.
+ */
+function Harness() {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  useRestoreFocus(containerRef, inputRef)
+  return (
+    <div>
+      <button data-testid="outside">outside</button>
+      <div ref={containerRef} data-testid="modal">
+        <input ref={inputRef} data-testid="field" />
+        <button data-testid="inside-btn">inside</button>
+      </div>
+    </div>
+  )
+}
+
+afterEach(cleanup)
+
+describe('useRestoreFocus', () => {
+  it('restores focus to the initial element when the window regains focus after focus escaped the modal', () => {
+    const { getByTestId } = render(<Harness />)
+    const outside = getByTestId('outside') as HTMLButtonElement
+    const field = getByTestId('field') as HTMLInputElement
+
+    // Simulate the OS window blur resetting focus outside the modal.
+    outside.focus()
+    expect(document.activeElement).toBe(outside)
+
+    // Window regains focus.
+    window.dispatchEvent(new Event('focus'))
+
+    expect(document.activeElement).toBe(field)
+  })
+
+  it('does not steal focus when focus is still inside the modal', () => {
+    const { getByTestId } = render(<Harness />)
+    const insideBtn = getByTestId('inside-btn') as HTMLButtonElement
+
+    insideBtn.focus()
+    expect(document.activeElement).toBe(insideBtn)
+
+    window.dispatchEvent(new Event('focus'))
+
+    // Focus was already inside the modal, so it must be left untouched.
+    expect(document.activeElement).toBe(insideBtn)
+  })
+
+  it('restores focus to the element last focused inside the modal, not just the initial one', () => {
+    const { getByTestId } = render(<Harness />)
+    const outside = getByTestId('outside') as HTMLButtonElement
+    const insideBtn = getByTestId('inside-btn') as HTMLButtonElement
+
+    // User moves to a different control inside the modal, then leaves the window.
+    insideBtn.focus()
+    outside.focus()
+
+    window.dispatchEvent(new Event('focus'))
+
+    expect(document.activeElement).toBe(insideBtn)
+  })
+
+  it('restores focus when the document becomes visible again', () => {
+    const { getByTestId } = render(<Harness />)
+    const outside = getByTestId('outside') as HTMLButtonElement
+    const field = getByTestId('field') as HTMLInputElement
+
+    outside.focus()
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(document.activeElement).toBe(field)
+  })
+
+  it('stops restoring focus after unmount', () => {
+    const { getByTestId, unmount } = render(<Harness />)
+    const outside = getByTestId('outside') as HTMLButtonElement
+    const field = getByTestId('field') as HTMLInputElement
+
+    unmount()
+    // The detached field must not be re-focused by a lingering listener.
+    outside.focus()
+    window.dispatchEvent(new Event('focus'))
+
+    expect(document.activeElement).not.toBe(field)
+  })
+})

--- a/apps/fluux/src/hooks/useRestoreFocus.ts
+++ b/apps/fluux/src/hooks/useRestoreFocus.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, type RefObject } from 'react'
+
+// Tab-order focusable elements, excluding programmatically-removed ones.
+const FOCUSABLE_SELECTOR =
+  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), ' +
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/**
+ * Keeps keyboard focus inside an open modal/overlay across OS window blur and
+ * refocus.
+ *
+ * WebKit (Tauri) and browser tab-switching reset `document.activeElement` to
+ * `<body>` when the app window loses and regains focus. With focus outside the
+ * modal, the global keyboard handlers (`useFocusZones`, `useKeyboardShortcuts`)
+ * no longer recognise that a modal is open and treat keys as app-level
+ * shortcuts again - e.g. ArrowUp/Down move the sidebar selection instead of the
+ * command-palette selection. This hook restores focus into the container when
+ * the window regains focus, so the modal keeps keyboard control.
+ *
+ * @param containerRef   The modal/overlay root element.
+ * @param initialFocusRef Preferred element to focus when nothing else inside the
+ *   modal was focused (e.g. a search input). Falls back to the first focusable
+ *   element in the container.
+ */
+export function useRestoreFocus<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  initialFocusRef?: RefObject<HTMLElement | null>,
+) {
+  // The most-recently focused element inside the container, so we restore the
+  // user to exactly where they were rather than always jumping to the first field.
+  const lastFocusedRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    // Seed from whatever the modal focused on mount (e.g. via useModalInput).
+    if (container.contains(document.activeElement)) {
+      lastFocusedRef.current = document.activeElement as HTMLElement
+    }
+
+    const focusTarget = (): HTMLElement | null => {
+      const last = lastFocusedRef.current
+      if (last && container.contains(last)) return last
+      if (initialFocusRef?.current) return initialFocusRef.current
+      return container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+    }
+
+    const handleFocusIn = (e: FocusEvent) => {
+      const target = e.target as HTMLElement | null
+      if (target && container.contains(target)) lastFocusedRef.current = target
+    }
+
+    const restore = () => {
+      // Only reclaim focus if it has escaped the modal; never yank it from an
+      // element the user deliberately focused inside.
+      if (!container.contains(document.activeElement)) {
+        focusTarget()?.focus()
+      }
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') restore()
+    }
+
+    container.addEventListener('focusin', handleFocusIn)
+    window.addEventListener('focus', restore)
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    return () => {
+      container.removeEventListener('focusin', handleFocusIn)
+      window.removeEventListener('focus', restore)
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [containerRef, initialFocusRef])
+}


### PR DESCRIPTION
## Summary

Switching away from the app window while a modal is open and switching back left keyboard focus on `<body>` instead of the modal. Most visibly, the Cmd-K command palette stopped responding to the keyboard and ArrowUp/Down moved the **sidebar** selection instead of the palette selection. The same focus loss affected every modal.

Root cause: modals focus their input only once on mount, and nothing re-focuses on window return. WebKit/Tauri (and browser tab-switch) reset `document.activeElement` to `<body>` on window blur→refocus, and the global keyboard handlers (`useFocusZones`, `useKeyboardShortcuts`) decide whether a modal is open from focus location rather than modal-open state — so with focus on `<body>` they reclaim the arrow keys.

## Changes

- New shared hook `useRestoreFocus` — on `window 'focus'` / `document 'visibilitychange'` it re-focuses the modal when focus has escaped the container (last-focused-inside element, else a preferred input, else first focusable). It is a no-op while focus is still inside, so it never yanks focus mid-interaction.
- Wired into every modal surface:
  - `ModalShell` — covers the form modals
  - `CommandPalette` — restores to the search input
  - The custom-scrim dialogs that bypass `ModalShell`: `ConfirmDialog`, `BackupPassphraseDialog`, `UnlockEncryptionDialog` (ref on the outer container so its nested `KeyPickerDialog` is covered)
- Unit tests for the hook (window focus, visibilitychange, no-steal-when-inside, restore-to-last-focused, unmount cleanup) plus a `ModalShell` integration test.