### PR TITLE
fix(muc): keep whisper thread as one bounded card by suppressing own-tint

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -783,6 +783,25 @@ describe('Own-message tint', () => {
     const { container } = render(<MessageBubble {...props} />)
     expect(container.querySelector('.message-own-tint')).not.toBeInTheDocument()
   })
+
+  // Inside a whisper thread the rows already share one bounded "private with X"
+  // container (bg-fluux-private-soft + border-x). The own-tint sets its own
+  // `background` (overriding the purple fill) and widens the row via
+  // margin-inline: -0.5rem, so an outgoing whisper row would render with a
+  // mismatched blue fill and side-borders 8px out of alignment with the
+  // incoming rows — visually shattering the single card. The name header
+  // ("You" vs the counterpart) already carries the sender identity, so the
+  // tint must be suppressed in-thread.
+  it('does not apply the own-tint class to an outgoing whisper-thread row', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      whisperThread: 'start',
+      whisperWith: 'Emma',
+      counterpartPresent: true,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    expect(container.querySelector('.message-own-tint')).not.toBeInTheDocument()
+  })
 })
 
 describe('Density spacing', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -491,9 +491,14 @@ export const MessageBubble = memo(function MessageBubble({
         )}
       </div>
 
-      {/* Content */}
+      {/* Content. The own-message tint is suppressed inside a whisper thread
+          (`!inThread`): it sets its own `background` (overriding the bounded
+          card's purple fill) and widens the row via margin-inline, which would
+          mismatch the fill and knock the side borders 8px out of alignment with
+          the incoming rows — shattering the single "private with X" card. The
+          name header already carries the own-vs-counterpart distinction. */}
       <div
-        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${message.isOutgoing ? 'message-own-tint' : ''}`}
+        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${message.isOutgoing && !inThread ? 'message-own-tint' : ''}`}
         onTouchStart={handleContentTouchStart}
         onTouchEnd={cancelLongPress}
         onTouchMove={cancelLongPress}


### PR DESCRIPTION
## Summary

The private whisper area continuation looked broken: inside a "Private with X" thread, the outgoing ("You") rows rendered with a different (blue) fill and their side borders sat ~8px out of alignment with the incoming rows, so the single bounded card looked striped and jagged.

A whisper thread renders a same-counterpart private run as one bounded card — each row's content box shares `bg-fluux-private-soft` + `border-x`, with rounded corners only on the first/last rows. The own-message tint (#680) was applied to every outgoing row via `message.isOutgoing`, and inside a whisper thread it fought that card:

- its `background` repainted the outgoing rows the blue accent instead of the card's purple (striping the fill);
- its `margin-inline: -0.5rem` widened those rows so their `border-x` no longer lined up with the incoming rows (jagging the edges).

## Fix

Gate the tint on `message.isOutgoing && !inThread` in `MessageBubble`. The name header already distinguishes own vs counterpart inside the card, so the three rows now share one uniform fill and aligned borders, forming a single cohesive container. Added a guard test asserting an outgoing whisper-thread row gets no `.message-own-tint`.

Before: outgoing rows blue, left=356/right=1262; incoming purple, left=364/right=1254.
After: all rows purple `bg-fluux-private-soft`, left=364/right=1254, with rounded-top start, square middle, rounded-bottom end.