### PR TITLE
fix(e2ee): proactively purge expired web passphrase cache on boot

### DIFF
--- a/apps/fluux/src/e2ee/webPassphraseCache.test.ts
+++ b/apps/fluux/src/e2ee/webPassphraseCache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
 import {
@@ -96,12 +96,14 @@ describe('sweepExpiredPassphrases', () => {
 
   it('never throws when indexedDB is unavailable', async () => {
     const original = globalThis.indexedDB
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     // @ts-expect-error force the failure path
     globalThis.indexedDB = undefined
     try {
       await expect(sweepExpiredPassphrases()).resolves.toBeUndefined()
     } finally {
       globalThis.indexedDB = original
+      warnSpy.mockRestore()
     }
   })
 })

--- a/apps/fluux/src/e2ee/webPassphraseCache.test.ts
+++ b/apps/fluux/src/e2ee/webPassphraseCache.test.ts
@@ -8,6 +8,7 @@ import {
   clearAllCachedPassphrases,
   getRememberPassphrasePreference,
   setRememberPassphrasePreference,
+  sweepExpiredPassphrases,
 } from './webPassphraseCache'
 
 // Fresh in-memory IndexedDB per test so records don't leak across tests.
@@ -73,6 +74,35 @@ describe('webPassphraseCache', () => {
     expect(getRememberPassphrasePreference()).toBe(true)
     setRememberPassphrasePreference(false)
     expect(getRememberPassphrasePreference()).toBe(false)
+  })
+})
+
+describe('sweepExpiredPassphrases', () => {
+  it('deletes expired records and keeps fresh ones', async () => {
+    // Fresh record: 24h default TTL.
+    await cachePassphrase('alice@example.com', 'fresh-secret')
+    // Expired record: negative TTL puts expiresAt in the past.
+    await cachePassphrase('bob@example.com', 'stale-secret', -1000)
+
+    await sweepExpiredPassphrases()
+
+    expect(await loadCachedPassphrase('alice@example.com')).toBe('fresh-secret')
+    expect(await loadCachedPassphrase('bob@example.com')).toBeNull()
+  })
+
+  it('is a safe no-op on an empty database', async () => {
+    await expect(sweepExpiredPassphrases()).resolves.toBeUndefined()
+  })
+
+  it('never throws when indexedDB is unavailable', async () => {
+    const original = globalThis.indexedDB
+    // @ts-expect-error force the failure path
+    globalThis.indexedDB = undefined
+    try {
+      await expect(sweepExpiredPassphrases()).resolves.toBeUndefined()
+    } finally {
+      globalThis.indexedDB = original
+    }
   })
 })
 

--- a/apps/fluux/src/e2ee/webPassphraseCache.test.ts
+++ b/apps/fluux/src/e2ee/webPassphraseCache.test.ts
@@ -86,6 +86,13 @@ describe('sweepExpiredPassphrases', () => {
 
     await sweepExpiredPassphrases()
 
+    // Verify the sweep PHYSICALLY removed the expired record (rawRecord bypasses
+    // lazy-delete in loadCachedPassphrase, so this proves the sweep did the work).
+    expect(await rawRecord('bob@example.com')).toBeNull()
+    // Fresh record must still be stored in IndexedDB.
+    expect(await rawRecord('alice@example.com')).not.toBeNull()
+
+    // Behavioral assertions: fresh passphrase still loads; expired one does not.
     expect(await loadCachedPassphrase('alice@example.com')).toBe('fresh-secret')
     expect(await loadCachedPassphrase('bob@example.com')).toBeNull()
   })

--- a/apps/fluux/src/e2ee/webPassphraseCache.ts
+++ b/apps/fluux/src/e2ee/webPassphraseCache.ts
@@ -142,6 +142,34 @@ export async function clearCachedPassphrase(jid: string): Promise<void> {
   }
 }
 
+/** Delete every cached passphrase whose expiry has passed (best-effort sweep). */
+export async function sweepExpiredPassphrases(): Promise<void> {
+  try {
+    const db = await openDb()
+    try {
+      const now = Date.now()
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite')
+        const req = tx.objectStore(STORE_NAME).openCursor()
+        req.onsuccess = () => {
+          const cursor = req.result
+          if (!cursor) return
+          const record = cursor.value as CacheRecord
+          if (now > record.expiresAt) cursor.delete()
+          cursor.continue()
+        }
+        req.onerror = () => reject(req.error)
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+      })
+    } finally {
+      db.close()
+    }
+  } catch (err) {
+    console.warn('[Fluux] webPassphraseCache: sweep failed', err)
+  }
+}
+
 /** Remove all cached passphrases (full local-data wipe). */
 export async function clearAllCachedPassphrases(): Promise<void> {
   try {

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -15,6 +15,7 @@ import { installBeforeInputGuard } from './utils/tauriInputFix'
 import { logStartupCapabilities } from './utils/startupDiagnostics'
 import { startStallSentinel } from './utils/stallSentinel'
 import { registerServiceWorker } from './utils/serviceWorkerUpdate'
+import { sweepExpiredPassphrases } from './e2ee/webPassphraseCache'
 import { getReconnectIntent } from './utils/reconnectIntent'
 import { captureWebLoginPrefill } from './utils/loginPrefillSources'
 import { useLoginPrefillStore } from './stores/loginPrefillStore'
@@ -32,6 +33,9 @@ const proxyAdapter = isTauri && !disableTcpProxy ? tauriProxyAdapter : undefined
 // land without needing to reinstall an installed PWA (see serviceWorkerUpdate.ts).
 if (!isTauri) {
   registerServiceWorker()
+  // Purge any cached passphrases past their 24h expiry as early as possible
+  // (covers reopen-after-24h and stale cross-account records).
+  void sweepExpiredPassphrases()
 }
 
 // Web: capture any login-prefill params from the launch URL (e.g. a shared

--- a/docs/superpowers/plans/2026-06-27-web-passphrase-expired-sweep.md
+++ b/docs/superpowers/plans/2026-06-27-web-passphrase-expired-sweep.md
@@ -1,0 +1,210 @@
+# Web Passphrase Cache — Proactive Expired-Record Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete outdated web OpenPGP passphrase cache records as soon as the app boots, instead of only lazily on next access for the matching JID.
+
+**Architecture:** Add one best-effort function `sweepExpiredPassphrases()` to the existing `webPassphraseCache.ts` module that walks all IndexedDB records and deletes any past their `expiresAt`. Call it once, fire-and-forget, in the web-only boot block of `main.tsx`. The existing lazy on-access deletion stays as additive defense-in-depth.
+
+**Tech Stack:** TypeScript, IndexedDB (raw `idb` request API as already used in the module), Vitest + `fake-indexeddb`.
+
+## Global Constraints
+
+- Web-only feature. Tauri uses the OS keychain and must be unaffected — the boot call lives inside the existing `if (!isTauri) { … }` block in `main.tsx`.
+- Every cache operation is **best-effort**: wrap in `try/catch`, log via `console.warn('[Fluux] webPassphraseCache: …', err)`, never throw, never block login/logout/startup.
+- Do not change the happy path or the existing lazy deletion in `loadCachedPassphrase`. This change is additive.
+- No new dependencies. No live timer / `setInterval` (explicitly out of scope).
+- Before committing: `npm run typecheck` and the cache test file must pass with no errors or stderr.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-27-web-passphrase-expired-sweep-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `apps/fluux/src/e2ee/webPassphraseCache.ts` — add the exported `sweepExpiredPassphrases()` function alongside the existing record helpers.
+- **Modify** `apps/fluux/src/e2ee/webPassphraseCache.test.ts` — add sweep tests.
+- **Modify** `apps/fluux/src/main.tsx` — call the sweep once at web boot.
+
+---
+
+### Task 1: `sweepExpiredPassphrases()` in the cache module
+
+**Files:**
+- Modify: `apps/fluux/src/e2ee/webPassphraseCache.ts` (add function near the other DB helpers / exported ops; reuse the existing `openDb`, `STORE_NAME`, `CacheRecord`)
+- Test: `apps/fluux/src/e2ee/webPassphraseCache.test.ts`
+
+**Interfaces:**
+- Consumes (already in the module): `openDb(): Promise<IDBDatabase>`, `STORE_NAME` constant, `CacheRecord` interface with `{ jid: string; expiresAt: number; … }`, and existing exports `cachePassphrase(jid, passphrase, ttlMs?)`, `loadCachedPassphrase(jid): Promise<string|null>`.
+- Produces (for Task 2): `export async function sweepExpiredPassphrases(): Promise<void>` — deletes every record whose `expiresAt < Date.now()`; resolves on completion; never rejects.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/fluux/src/e2ee/webPassphraseCache.test.ts`. The file already imports `'fake-indexeddb/auto'`, `{ IDBFactory }` from `'fake-indexeddb'`, and resets `globalThis.indexedDB` between tests. Add `sweepExpiredPassphrases` to the existing import from `'./webPassphraseCache'`.
+
+```ts
+describe('sweepExpiredPassphrases', () => {
+  it('deletes expired records and keeps fresh ones', async () => {
+    // Fresh record: 24h default TTL.
+    await cachePassphrase('alice@example.com', 'fresh-secret')
+    // Expired record: negative TTL puts expiresAt in the past.
+    await cachePassphrase('bob@example.com', 'stale-secret', -1000)
+
+    await sweepExpiredPassphrases()
+
+    expect(await loadCachedPassphrase('alice@example.com')).toBe('fresh-secret')
+    expect(await loadCachedPassphrase('bob@example.com')).toBeNull()
+  })
+
+  it('is a safe no-op on an empty database', async () => {
+    await expect(sweepExpiredPassphrases()).resolves.toBeUndefined()
+  })
+
+  it('never throws when indexedDB is unavailable', async () => {
+    const original = globalThis.indexedDB
+    // @ts-expect-error force the failure path
+    globalThis.indexedDB = undefined
+    try {
+      await expect(sweepExpiredPassphrases()).resolves.toBeUndefined()
+    } finally {
+      globalThis.indexedDB = original
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `apps/fluux`:
+```bash
+cd apps/fluux && npx vitest run src/e2ee/webPassphraseCache.test.ts -t sweepExpiredPassphrases
+```
+Expected: FAIL — `sweepExpiredPassphrases is not a function` / import is `undefined`.
+
+- [ ] **Step 3: Implement `sweepExpiredPassphrases`**
+
+Add to `apps/fluux/src/e2ee/webPassphraseCache.ts` (e.g. directly after `clearAllCachedPassphrases`). Use a readwrite cursor so the scan + deletes happen in one transaction:
+
+```ts
+/** Delete every cached passphrase whose expiry has passed (best-effort sweep). */
+export async function sweepExpiredPassphrases(): Promise<void> {
+  try {
+    const db = await openDb()
+    try {
+      const now = Date.now()
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite')
+        const req = tx.objectStore(STORE_NAME).openCursor()
+        req.onsuccess = () => {
+          const cursor = req.result
+          if (!cursor) return
+          const record = cursor.value as CacheRecord
+          if (now > record.expiresAt) cursor.delete()
+          cursor.continue()
+        }
+        req.onerror = () => reject(req.error)
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+      })
+    } finally {
+      db.close()
+    }
+  } catch (err) {
+    console.warn('[Fluux] webPassphraseCache: sweep failed', err)
+  }
+}
+```
+
+Note: resolution is driven by `tx.oncomplete` (fires once the cursor walk and all `cursor.delete()` calls finish), so the promise resolves only after deletions commit.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run from `apps/fluux`:
+```bash
+cd apps/fluux && npx vitest run src/e2ee/webPassphraseCache.test.ts
+```
+Expected: PASS — the new `sweepExpiredPassphrases` block plus all pre-existing cache tests.
+
+- [ ] **Step 5: Typecheck**
+
+Run from repo root:
+```bash
+npm run typecheck
+```
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/e2ee/webPassphraseCache.ts apps/fluux/src/e2ee/webPassphraseCache.test.ts
+git commit -m "feat(e2ee): sweep expired web passphrase cache records"
+```
+
+---
+
+### Task 2: Run the sweep at web boot
+
+**Files:**
+- Modify: `apps/fluux/src/main.tsx`
+
+**Interfaces:**
+- Consumes (from Task 1): `sweepExpiredPassphrases(): Promise<void>` from `'@/e2ee/webPassphraseCache'` (or the relative path that matches sibling imports in `main.tsx`).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the import**
+
+In `apps/fluux/src/main.tsx`, add to the existing import group near the other `./utils` / `./e2ee` imports:
+```ts
+import { sweepExpiredPassphrases } from '@/e2ee/webPassphraseCache'
+```
+Match the import-path style already used in the file (alias `@/…` vs relative). If `main.tsx` uses relative paths, use `'./e2ee/webPassphraseCache'`.
+
+- [ ] **Step 2: Call it inside the existing web-only boot block**
+
+`main.tsx` already has `const isTauri = '__TAURI_INTERNALS__' in window` and at least one `if (!isTauri) { … }` block at boot. Add the fire-and-forget sweep inside such a block (e.g. next to `registerServiceWorker()`):
+```ts
+if (!isTauri) {
+  // Purge any cached passphrases that have passed their 24h expiry, as early
+  // as possible (covers reopen-after-24h and stale cross-account records).
+  void sweepExpiredPassphrases()
+}
+```
+It must remain `void`-ed / not awaited so it never delays startup.
+
+- [ ] **Step 3: Typecheck**
+
+Run from repo root:
+```bash
+npm run typecheck
+```
+Expected: no errors.
+
+- [ ] **Step 4: Build the app to confirm boot wiring compiles**
+
+Run from repo root:
+```bash
+npm run build
+```
+Expected: build succeeds (SDK + app), no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/main.tsx
+git commit -m "feat(e2ee): sweep expired passphrase cache on web boot"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §Design.1 `sweepExpiredPassphrases()` → Task 1. ✓
+- Spec §Design.2 call once at boot in `main.tsx` web-only block → Task 2. ✓
+- Spec §Design.3 keep existing lazy deletion → enforced by Global Constraints ("do not change … existing lazy deletion"); no task modifies `loadCachedPassphrase`. ✓
+- Spec §Out of scope (no timer/interval) → Global Constraints. ✓
+- Spec §Testing (expired+fresh, empty-DB no-op, never throws) → Task 1 Step 1. ✓
+
+**Placeholder scan:** No TBD/TODO; all code shown in full; commands and expected outputs given. ✓
+
+**Type consistency:** `sweepExpiredPassphrases(): Promise<void>` named identically in Task 1 (definition), Task 1 Interfaces (Produces), and Task 2 (Consumes/import/call). Reuses existing `openDb`, `STORE_NAME`, `CacheRecord`, `cachePassphrase`, `loadCachedPassphrase` with their current signatures. ✓

--- a/docs/superpowers/specs/2026-06-27-web-passphrase-expired-sweep-design.md
+++ b/docs/superpowers/specs/2026-06-27-web-passphrase-expired-sweep-design.md
@@ -1,0 +1,83 @@
+# Web passphrase cache — proactive expired-record sweep
+
+**Date:** 2026-06-27
+**Status:** Approved (design)
+**Builds on:** [`2026-06-27-web-passphrase-24h-cache-design.md`](2026-06-27-web-passphrase-24h-cache-design.md)
+
+## Problem
+
+The web-only OpenPGP passphrase cache (`apps/fluux/src/e2ee/webPassphraseCache.ts`)
+stores the encrypted passphrase in IndexedDB with a fixed 24h `expiresAt`. Today an
+expired record is only removed **lazily**: `loadCachedPassphrase(jid)` checks
+`Date.now() > expiresAt` and deletes — but only for the one JID being loaded, and only
+when that load path actually runs (on connect).
+
+This leaves outdated material at rest in two cases:
+
+1. **Reopen-after-24h** — the user returns but the connect/unlock path never calls
+   `loadCachedPassphrase` for that exact JID, so the expired ciphertext + its
+   non-extractable `CryptoKey` linger in IndexedDB indefinitely.
+2. **Cross-account leftovers** — account A's record is never cleared when the user later
+   signs in as account B.
+
+### Why it matters
+
+The 24h expiry is the mechanism that bounds exposure. The non-extractable AES-GCM key
+blocks a passive storage dump, but a live-JS (XSS) attacker arriving **after** the 24h
+window could still call `subtle.decrypt` against the lingering key. Eagerly deleting the
+record once it is stale is what actually closes that window.
+
+## Goal
+
+Delete outdated cached passphrases as soon as the app can — not only on next access for
+the matching JID.
+
+## Design
+
+Additive, web-only, best-effort. No behavior change to the happy path.
+
+### 1. `sweepExpiredPassphrases()` in `webPassphraseCache.ts`
+
+```ts
+export async function sweepExpiredPassphrases(): Promise<void>
+```
+
+Opens the cache DB and walks **all** records with a single readwrite cursor, calling
+`cursor.delete()` on any record where `Date.now() > expiresAt`. This clears both the
+reopen-after-24h ciphertext and stale cross-account leftovers in one pass.
+
+Best-effort, consistent with every other op in the module: wrap in `try/catch`, log a
+`console.warn` on failure, never throw, never block.
+
+### 2. Call once at boot in `main.tsx`
+
+Inside the existing `if (!isTauri) { … }` boot block (web-only, runs before React mounts,
+does not wait for a connect):
+
+```ts
+void sweepExpiredPassphrases()
+```
+
+Fire-and-forget so it cannot delay startup. Tauri is unaffected (it uses the OS keychain,
+not this cache).
+
+### 3. Keep existing lazy deletion
+
+The `Date.now() > record.expiresAt` check and `deleteRecord` in `loadCachedPassphrase`
+stay as-is. The startup sweep is additive defense-in-depth, not a replacement.
+
+## Out of scope
+
+No live timer / `setInterval` for a tab left continuously open past 24h. That case still
+purges on the tab's next reload or connect. (Explicit choice: startup sweep only.)
+
+## Testing
+
+Add to the existing `apps/fluux/src/e2ee/webPassphraseCache.test.ts` (already uses
+`fake-indexeddb`):
+
+- Seed one expired record (`expiresAt` in the past) and one fresh record → run
+  `sweepExpiredPassphrases()` → assert the expired record is gone and the fresh one
+  survives (e.g. `loadCachedPassphrase` still returns the fresh passphrase, returns null
+  for the expired JID).
+- `sweepExpiredPassphrases()` on an empty DB is a safe no-op and does not throw.


### PR DESCRIPTION
## Summary

The web-only opt-in 24h OpenPGP passphrase cache only removed expired records **lazily** — `loadCachedPassphrase(jid)` checked the expiry and deleted, but only for the one JID being loaded on connect. Outdated material could therefore linger in IndexedDB past its 24h window in two cases: when the user reopens the app but the connect/unlock path never loads that exact JID, and for stale cross-account records (account A is never cleared after signing in as account B).

This matters because the 24h expiry is the mechanism that bounds exposure. The ciphertext is encrypted under a non-extractable WebCrypto key (a passive storage dump is useless), but a live-JS (XSS) attacker arriving **after** the window could still call `subtle.decrypt` against a lingering key. Eagerly deleting stale records is what actually closes that window.

## Changes

- Add `sweepExpiredPassphrases()` to `webPassphraseCache.ts` — best-effort, walks **all** records with a single readwrite cursor and deletes any past their `expiresAt` (clears both reopen-after-24h ciphertext and stale cross-account leftovers). Resolves only after `tx.oncomplete`, so deletions are committed before the promise settles. Same swallow-and-warn error discipline and `db.close()` in `finally` as the rest of the module.
- Call it once, fire-and-forget, inside the existing web-only (`!isTauri`) boot block in `main.tsx`, so purging happens as early as possible without delaying startup.
- The existing lazy deletion in `loadCachedPassphrase` is left untouched; the sweep is additive defense-in-depth.

Desktop (Tauri) is unaffected — it uses the OS keychain, and the boot call lives inside the `!isTauri` guard.

## Out of scope

No live timer/`setInterval` for a tab left continuously open past 24h (deliberate choice: startup sweep only). That case still purges on the tab's next reload or connect.