### PR TITLE
fix(e2ee): show own outgoing messages with their real trust, not a grey lock

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -340,7 +340,7 @@ export const MessageBubble = memo(function MessageBubble({
   const verifiedFingerprint = useVerifiedPeerKeysStore(
     (s) => s.verifiedFingerprintByJid[getBareJid(message.from)],
   )
-  const displayTrust = resolveDisplayTrust(message.securityContext, verifiedFingerprint)
+  const displayTrust = resolveDisplayTrust(message.securityContext, verifiedFingerprint, message.isOutgoing)
 
   // Density-aware avatar: reads only `densityMode` (narrow selector) so this row
   // only re-renders on a density change, NOT on message append or composing toggle.

--- a/apps/fluux/src/components/conversation/messageTrust.test.ts
+++ b/apps/fluux/src/components/conversation/messageTrust.test.ts
@@ -71,4 +71,29 @@ describe('resolveDisplayTrust', () => {
   it('downgrades a baked verified to tofu when a DIFFERENT key is now verified', () => {
     expect(resolveDisplayTrust(ctx({ trust: 'verified', fingerprint: FP_B }), FP_A)).toBe('tofu')
   })
+
+  // Own outgoing messages are signed by OUR OWN key and the plugin already
+  // baked the correct trust against our own bundle (verified iff the signature
+  // verified and matched our fingerprint). Our own JID is never an entry in the
+  // verified-PEER store, so the peer-verification downgrade must be skipped —
+  // otherwise every own message renders a grey "unverified peer" lock. This is
+  // the bug seen after reload, when MAM-decrypted own messages carry the own
+  // signing fingerprint.
+  describe('own outgoing messages (isOwn)', () => {
+    it('keeps a baked verified own message verified even with no verified-peer entry (MAM reload path)', () => {
+      expect(resolveDisplayTrust(ctx({ trust: 'verified', fingerprint: FP_A }), undefined, true)).toBe('verified')
+    })
+
+    it('keeps a fingerprint-less baked verified own message verified (live send path)', () => {
+      expect(resolveDisplayTrust(ctx({ trust: 'verified' }), undefined, true)).toBe('verified')
+    })
+
+    it('preserves an untrusted own message (own signature did not verify) without greening it', () => {
+      expect(resolveDisplayTrust(ctx({ trust: 'untrusted', fingerprint: FP_A }), undefined, true)).toBe('untrusted')
+    })
+
+    it('still returns undefined for a cleartext own message', () => {
+      expect(resolveDisplayTrust(undefined, undefined, true)).toBeUndefined()
+    })
+  })
 })

--- a/apps/fluux/src/components/conversation/messageTrust.ts
+++ b/apps/fluux/src/components/conversation/messageTrust.ts
@@ -21,15 +21,27 @@ import { fingerprintsEqual } from '@/e2ee/fingerprintCompare'
  * whose signature did not verify (`untrusted` / `rejected`), or a web-of-trust
  * `introduced`, passes through untouched.
  *
+ * Own outgoing messages (`isOwn`) are a special case: they are signed by OUR
+ * OWN key, and the plugin already baked the correct trust against our own
+ * bundle (`verified` iff the signature verified and matched our fingerprint,
+ * `untrusted` otherwise). There is no peer to verify out of band, and our own
+ * JID is never an entry in the verified-PEER store, so running the
+ * peer-verification downgrade below would force every own message to grey
+ * `tofu` — the "unverified peer" lock. For own messages we therefore trust the
+ * baked value verbatim.
+ *
  * @param securityContext - the message's baked security context, if encrypted
  * @param verifiedFingerprint - the fingerprint the user verified for this peer
+ * @param isOwn - whether this is the user's own outgoing message
  * @returns the trust level to render, or `undefined` for cleartext messages
  */
 export function resolveDisplayTrust(
   securityContext: MessageSecurityContext | undefined,
   verifiedFingerprint: string | undefined,
+  isOwn = false,
 ): MessageSecurityContext['trust'] | undefined {
   if (!securityContext) return undefined
+  if (isOwn) return securityContext.trust
   const baked = securityContext.trust
   if (baked === 'tofu' || baked === 'verified') {
     // Legacy fallback: messages decrypted before the signing fingerprint was


### PR DESCRIPTION
## Summary

Own outgoing OpenPGP/OX messages rendered a **grey "tofu" (unverified-peer) lock** instead of their real verified state. This was most visible after a reload — with the 24h passphrase cache (#717), the whole encrypted history re-decrypts from MAM and every own message painted grey at once.

The OX plugin's `buildSelfOutgoingSecurityContext` already bakes the correct trust by verifying the signature against the user's **own** key bundle (`verified` iff the signature verifies and matches our fingerprint, `untrusted` otherwise). But `resolveDisplayTrust` then re-derived trust through **peer** verification for every message: it looks up `verifiedFingerprintByJid[message.from]`. For an own message, `message.from` is the user's own JID, which is never an entry in the verified-*peer* store, so the lookup returns `undefined` and the baked `verified` is downgraded to grey `tofu`.

An own message has no peer to verify out-of-band, so that downgrade is meaningless for it.

## Fix

`resolveDisplayTrust` now takes an `isOwn` flag and returns the baked trust verbatim for own messages, skipping the peer-verification downgrade. `MessageBubble` passes `message.isOutgoing`.

- Verified own message → teal lock (correct).
- Own message whose own signature did not verify (own-key trouble) → still `untrusted` (yellow), so a genuine problem is still flagged.
- Applies to both paths that were affected: live send (`{ trust: 'verified' }`, no fingerprint) and MAM-decrypt (`{ trust: 'verified', fingerprint: ownFP }`).