### PR TITLE
fix(theme): darken popover surface in 4 dark themes so menu text clears AA

### DIFF
--- a/apps/fluux/src/themes/builtins/catppuccin-mocha.ts
+++ b/apps/fluux/src/themes/builtins/catppuccin-mocha.ts
@@ -62,6 +62,13 @@ export const catppuccinMochaTheme: ThemeDefinition = {
       // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
       // AA on this theme's chat surface (status-error stays the fill).
       '--fluux-text-error': '#f5a0b8',
+      // Floating surface (menus, dropdowns, context menus via .fluux-popover).
+      // Default dark maps this to base-50, but Catppuccin base-50 (#6c7086/overlay0)
+      // is a light overlay tone, so menu text dropped to ~3.4:1 (sub-AA). Use a
+      // mid-surface lifted above the chat (#45475a/surface1) that clears AA
+      // (5.45:1) for menu text; border + shadow carry the elevation.
+      '--fluux-bg-float': '#4e5066',
+      '--fluux-bg-float-hover': '#585b70',
       '--fluux-color-green-rgb': '166, 227, 161',
       '--fluux-color-yellow-rgb': '249, 226, 175',
       '--fluux-color-blue-rgb': '137, 180, 250',

--- a/apps/fluux/src/themes/builtins/nord.ts
+++ b/apps/fluux/src/themes/builtins/nord.ts
@@ -40,6 +40,13 @@ export const nordTheme: ThemeDefinition = {
       // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
       // AA on this theme's chat surface (status-error stays the fill).
       '--fluux-text-error': '#ebadb3',
+      // Floating surface (menus, dropdowns, context menus via .fluux-popover).
+      // Default dark maps this to base-50, but Nord base-50 (#59657d) is a light
+      // polar tone, so menu text dropped to ~4.3:1 (sub-AA). Use nord3 (#4c566a),
+      // the authentic polar-night surface lifted above the chat (#434c5e); it
+      // clears AA (5.46:1) for menu text, with border + shadow carrying the lift.
+      '--fluux-bg-float': '#4c566a',
+      '--fluux-bg-float-hover': '#59657d',
       '--fluux-color-green-rgb': '163, 190, 140',
       '--fluux-color-yellow-rgb': '235, 203, 139',
       '--fluux-color-blue-rgb': '129, 161, 193',

--- a/apps/fluux/src/themes/builtins/one-dark.ts
+++ b/apps/fluux/src/themes/builtins/one-dark.ts
@@ -40,6 +40,13 @@ export const oneDarkTheme: ThemeDefinition = {
       // Error as text/icon — lightened from --fluux-color-red so it clears WCAG
       // AA on this theme's chat surface (status-error stays the fill).
       '--fluux-text-error': '#e5838a',
+      // Floating surface (menus, dropdowns, context menus via .fluux-popover).
+      // Default dark maps this to base-50, but One Dark base-50 (#4b5263) is a
+      // light-ish gray, so menu text dropped to ~3.7:1 (sub-AA). Use a surface
+      // lifted just above the chat (#313640) that clears AA (5.04:1) for menu
+      // text; border + shadow carry the elevation.
+      '--fluux-bg-float': '#383e4a',
+      '--fluux-bg-float-hover': '#3e4451',
       '--fluux-color-green-rgb': '152, 195, 121',
       '--fluux-color-yellow-rgb': '229, 192, 123',
       '--fluux-color-blue-rgb': '97, 175, 239',

--- a/apps/fluux/src/themes/builtins/solarized.ts
+++ b/apps/fluux/src/themes/builtins/solarized.ts
@@ -47,6 +47,14 @@ export const solarizedTheme: ThemeDefinition = {
       // Semantic overrides — base-40/50 are content colors, too bright for backgrounds
       '--fluux-bg-hover': 'rgba(7, 54, 66, 0.6)',
       '--fluux-bg-active': '#073642',
+      // Floating surface (menus, dropdowns, context menus via .fluux-popover).
+      // Default dark maps this to base-50, but Solarized base-50 (#657b83/base00)
+      // is a body-TEXT color, so the popover rendered as a washed-out light slab
+      // over the dark chat and dropped menu text to ~3.6:1 (sub-AA). Use a deep
+      // teal lifted above the chat surface (#0a4050): #0f4c5d clears AAA (7.75:1)
+      // for menu text while still reading as a raised panel via border + shadow.
+      '--fluux-bg-float': '#0f4c5d',
+      '--fluux-bg-float-hover': '#14596d',
       '--fluux-selection-bg': 'hsla(205, 69%, 49%, 0.2)',
       '--fluux-scrollbar-thumb': '#073642',
       '--fluux-scrollbar-thumb-hover': '#0a4050',

--- a/apps/fluux/src/themes/themeContrast.test.ts
+++ b/apps/fluux/src/themes/themeContrast.test.ts
@@ -279,6 +279,26 @@ describe('Builtin theme unread-badge contrast', () => {
   }
 })
 
+// Per-theme popover-surface text contrast guard. Every menu, dropdown and
+// context menu renders through .fluux-popover, whose surface is --fluux-bg-float
+// and whose label text is --fluux-text-normal. In dark mode index.css maps
+// bg-float to base-50, but several palettes use a light "content/overlay" tone
+// for base-50 (Solarized base00, Catppuccin overlay0, Nord/One Dark mid-grays);
+// that pushed menu text below AA and made the panel read as a washed-out light
+// slab over the dark chat (audit 2026-06-27). Each theme overrides bg-float to a
+// surface tone where menu text clears AA, in both modes. (Light mode maps
+// bg-float to base-00 — near-white everywhere — and already clears AA.)
+describe('Builtin theme popover-surface text contrast', () => {
+  for (const theme of builtinThemes) {
+    for (const mode of ['dark', 'light'] as const) {
+      it(`[${theme.id}/${mode}] normal text clears WCAG AA on the popover (float) surface`, () => {
+        const r = contrast('var(--fluux-text-normal)', 'var(--fluux-bg-float)', themeTokens(theme, mode))
+        expect(r).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+  }
+})
+
 // Encryption lock/shield icon contrast guard.
 // The composer card uses --fluux-base-40 as its background. The global
 // --fluux-accent-2 fails the 3:1 non-text contrast floor (WCAG 1.4.11) in light


### PR DESCRIPTION
## Summary

In **Solarized dark** the context-menu surface read as a washed-out light slab over the dark UI. Root cause: every menu / dropdown / context menu renders through the shared `.fluux-popover` class, whose surface is `--fluux-bg-float`. In dark mode `index.css` maps that to `base-50`, but several palettes use `base-50` as a body-text/overlay tone rather than a deep surface, so the popover panel was too light **and** its menu text fell below WCAG AA:

| theme (dark) | old float | menu text |
|---|---|---|
| solarized | `#657b83` (base00 = body text) | 3.64:1 |
| catppuccin-mocha | `#6c7086` (overlay0) | 3.38:1 |
| one-dark | `#4b5263` | 3.67:1 |
| nord | `#59657d` | 4.34:1 |

Solarized's file already overrode `--fluux-bg-hover` / `--fluux-bg-active` for exactly this reason ("base-40/50 are content colors, too bright for backgrounds") — it just missed `--fluux-bg-float`. Light mode was unaffected (`.light` maps the float surface to `base-00` ≈ near-white).

## Change

Per-theme dark `--fluux-bg-float` / `--fluux-bg-float-hover` overrides to a surface tone lifted just above the chat surface (`base-30`), so menu text clears AA while the hairline border and overlay shadow carry the elevation (same principle as the glass and occupant-panel slices: anchor text-bearing surfaces to a contrast-safe tone instead of chasing a lighter "lifted" tone):

| theme (dark) | new float | menu text |
|---|---|---|
| solarized | `#0f4c5d` | 7.75:1 (AAA) |
| catppuccin-mocha | `#4e5066` | 5.45:1 |
| one-dark | `#383e4a` | 5.04:1 |
| nord | `#4c566a` (nord3) | 5.46:1 |

A new guard in `themeContrast.test.ts` ("Builtin theme popover-surface text contrast") asserts `--fluux-text-normal` clears WCAG AA on `--fluux-bg-float` for every builtin theme in both modes, so this can't silently regress.

## Verification

- New guard confirmed to fail `solarized/dark` without the fix.
- All theme tests pass; `npm run typecheck` clean; `npm run lint` 0 errors.
- Visually confirmed in demo mode (Solarized and catppuccin dark): the presence/context popovers now render as legible lifted surfaces instead of light slabs.