### PR TITLE
fix(admin): detect server admin via XEP-0133 namespace, not any ad-hoc command

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Admin.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Admin.test.ts
@@ -442,6 +442,45 @@ describe('XMPPClient Admin', () => {
       expect(commands.map(c => c.node)).toContain('api-commands/status')
     })
 
+    it('should NOT flag user as admin when only ejabberd api-commands are available (no XEP-0133 admin namespace)', async () => {
+      await connectClient()
+
+      // Mirrors what a NON-admin (e.g. mrtest@process-one.net) receives: ejabberd
+      // advertises a broad api-commands/ catalog in disco#items regardless of whether
+      // the user may execute them (authorization is enforced at execution time). A
+      // genuine server admin additionally sees the XEP-0133 http://jabber.org/protocol/admin#
+      // namespace, which is the only reliable signal. None of those appear here.
+      const items = [
+        { name: 'item', attrs: { jid: 'example.com', node: 'api-commands/get_vcard', name: 'Get Vcard' } },
+        { name: 'item', attrs: { jid: 'example.com', node: 'api-commands/get_presence', name: 'Get Presence' } },
+        { name: 'item', attrs: { jid: 'example.com', node: 'api-commands/user_info', name: 'User Info' } },
+        // Even destructive-looking api-commands can be listed to a non-admin; presence != executability
+        { name: 'item', attrs: { jid: 'example.com', node: 'api-commands/delete_account', name: 'Delete Account' } },
+        { name: 'item', attrs: { jid: 'example.com', node: 'ping', name: 'Ping' } },
+      ]
+
+      const discoItemsResponse = {
+        name: 'iq',
+        attrs: { type: 'result' },
+        getChild: (name: string, xmlns?: string) => {
+          if (name === 'query' && xmlns === 'http://jabber.org/protocol/disco#items') {
+            return {
+              name: 'query',
+              attrs: { xmlns: 'http://jabber.org/protocol/disco#items' },
+              getChildren: (childName: string) => childName === 'item' ? items : [],
+            }
+          }
+          return undefined
+        },
+      }
+
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(discoItemsResponse)
+
+      await xmppClient.admin.discoverAdminCommands()
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('admin:is-admin', { isAdmin: false })
+    })
+
     it('should categorize ejabberd api-commands user commands correctly', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/Admin.ts
+++ b/packages/fluux-sdk/src/core/modules/Admin.ts
@@ -111,7 +111,14 @@ export class Admin extends BaseModule {
           return { node, name, category }
         })
 
-      const isAdmin = adminCommands.length > 0
+      // Admin status is signalled ONLY by the XEP-0133 service-administration
+      // namespace (http://jabber.org/protocol/admin#...). ejabberd advertises its
+      // broad api-commands/ catalog in disco#items to every authenticated user
+      // regardless of execution rights, so the mere presence of api-commands does
+      // NOT imply admin privileges. mod_configure (ejabberd) and mod_admin_adhoc
+      // (Prosody) gate the whole admin# namespace behind the admin ACL at disco
+      // time, making it the reliable, portable discriminator.
+      const isAdmin = adminCommands.some((cmd) => cmd.node.startsWith(`${NS_ADMIN}#`))
       this.deps.emitSDK('admin:is-admin', { isAdmin })
       this.deps.emitSDK('admin:commands', { commands: adminCommands })
 


### PR DESCRIPTION
## Problem

A non-admin user saw the server-admin icon in the sidebar. `isAdmin` was computed as `adminCommands.length > 0` in `Admin.discoverAdminCommands()`, treating the presence of *any* ad-hoc command under `http://jabber.org/protocol/admin#` **or** `api-commands/` as proof of admin privileges.

That heuristic is unsound against ejabberd: the server advertises its **entire `api-commands/` catalog in `disco#items` to every authenticated user** regardless of execution rights, because authorization is enforced at *execution* time, not discovery. Comparing two real `disco#items` responses on the same server confirmed it:

| Catalog slice | non-admin | admin |
|---|---|---|
| XEP-0133 `http://jabber.org/protocol/admin#...` | **0** | **31** |
| ejabberd `api-commands/...` | 68 | 96 |

The non-admin's `api-commands/` list even included destructive entries (`delete_account`, `create_account`, `destroy_room`, `kick_user`), so it carries no information about admin status. The XEP-0133 `admin#` namespace is the clean discriminator: `mod_configure` (ejabberd) and `mod_admin_adhoc` (Prosody) gate that whole namespace behind the admin ACL at disco time.

## Fix

Gate `isAdmin` on the presence of an XEP-0133 `http://jabber.org/protocol/admin#` command:

```js
const isAdmin = adminCommands.some((cmd) => cmd.node.startsWith(`${NS_ADMIN}#`))
```

Standards-aligned and portable (ejabberd + Prosody), no extra round-trip. The `commands` list emission is unchanged, since all admin UI is already `isAdmin`-gated.