### PR TITLE
feat(aurora): tokenize EncryptionSettings security iconography + Toggle loading prop

### DIFF
--- a/apps/fluux/src/components/settings-components/EncryptionSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.test.tsx
@@ -10,6 +10,7 @@
  *   immediately (specific text for `pep-unsupported`, generic for other
  *   codes) instead of spinning on "Generating your key…" for 60s.
  */
+import { readFileSync } from 'node:fs'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { EncryptionSettings } from './EncryptionSettings'
@@ -247,6 +248,23 @@ describe('EncryptionSettings PEP support', () => {
         expect(document.querySelector('input[name="backup-code"]')).not.toBeNull()
         expect(document.querySelector('input[name="passphrase"]')).toBeNull()
       })
+    })
+  })
+
+  // Aurora security-iconography pass: every status color routes through the
+  // theme-aware Aurora tokens (fluux-red/green/yellow + text-fluux-error for
+  // red text) so it adapts across all 13 themes x light/dark. This guards
+  // against a regression reintroducing raw Tailwind palette literals like
+  // `bg-yellow-500/10`, `text-red-400`, or `text-green-600`.
+  describe('Aurora color tokenization', () => {
+    it('uses fluux- design tokens, not hardcoded Tailwind palette colors', () => {
+      // Resolved from cwd: the app suite always runs from apps/fluux.
+      const source = readFileSync(
+        'src/components/settings-components/EncryptionSettings.tsx',
+        'utf8',
+      )
+      const hardcoded = source.match(/(?:red|green|yellow)-\d{2,3}/g) ?? []
+      expect(hardcoded).toEqual([])
     })
   })
 })

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -898,6 +898,7 @@ export function EncryptionSettings() {
               checked={openpgpEnabled}
               onChange={handleToggle}
               disabled={toggleDisabled}
+              loading={isToggling}
               aria-label={t('settings.encryption.openpgpLabel')}
             />
           </div>
@@ -907,8 +908,8 @@ export function EncryptionSettings() {
             so OpenPGP (XEP-0373) can never work on this account. Shown from
             the proactive probe, before the user even tries the toggle. */}
         {pepSupported === false && (
-          <div className="flex gap-2 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-xs leading-snug">
-            <AlertTriangle className="size-4 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" />
+          <div className="flex gap-2 p-3 rounded-lg bg-fluux-yellow/10 border border-fluux-yellow/20 text-xs leading-snug">
+            <AlertTriangle className="size-4 text-fluux-yellow flex-shrink-0 mt-0.5" />
             <p className="flex-1 text-fluux-text">
               {t('settings.encryption.pepUnsupportedBanner')}
             </p>
@@ -922,7 +923,7 @@ export function EncryptionSettings() {
 
         {/* Web locked banner — shown when key exists but no session passphrase */}
         {webLocked && (
-          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-fluux-bg border border-fluux-hover">
             <p className="text-xs text-fluux-text leading-snug flex-1">
               {t('settings.encryption.lockedBannerBody')}
             </p>
@@ -944,14 +945,14 @@ export function EncryptionSettings() {
             <div
               className={`rounded-lg border-2 p-3 space-y-2 ${
                 pluginStatus === 'generation-failed' || pluginStatus === 'registration-failed'
-                  ? 'border-red-500/40 bg-red-500/5'
+                  ? 'border-fluux-red/40 bg-fluux-red/5'
                   : 'border-fluux-hover bg-fluux-bg'
               }`}
             >
               <div
                 className={`text-xs ${
                   pluginStatus === 'generation-failed' || pluginStatus === 'registration-failed'
-                    ? 'text-red-500 dark:text-red-400'
+                    ? 'text-fluux-error'
                     : 'text-fluux-muted'
                 }`}
               >
@@ -983,7 +984,7 @@ export function EncryptionSettings() {
                     aria-label={t('settings.encryption.copyFingerprint')}
                   >
                     {isCopied ? (
-                      <Check className="size-3.5 text-green-500" />
+                      <Check className="size-3.5 text-fluux-green" />
                     ) : (
                       <Copy className="size-3.5" />
                     )}
@@ -1000,7 +1001,7 @@ export function EncryptionSettings() {
         {keychainBacked === false && (
           <div
             role="alert"
-            className="flex gap-2 p-3 rounded-lg bg-red-500/10 text-xs text-red-600 dark:text-red-400 leading-snug"
+            className="flex gap-2 p-3 rounded-lg bg-fluux-red/10 text-xs text-fluux-error leading-snug"
           >
             <AlertTriangle className="size-4 flex-shrink-0 mt-0.5" />
             <p className="flex-1">{t('settings.encryption.notProtectedAtRest')}</p>
@@ -1009,8 +1010,8 @@ export function EncryptionSettings() {
 
         {/* Limitations callout — dismissible */}
         {!limitationsDismissed && (
-          <div className="flex gap-2 p-3 rounded-lg bg-yellow-500/10 text-xs text-fluux-muted leading-snug">
-            <AlertTriangle className="size-4 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" />
+          <div className="flex gap-2 p-3 rounded-lg bg-fluux-yellow/10 text-xs text-fluux-muted leading-snug">
+            <AlertTriangle className="size-4 text-fluux-yellow flex-shrink-0 mt-0.5" />
             <div className="flex-1">
               <p className="font-medium text-fluux-text">
                 {t('settings.encryption.limitationsTitle')}
@@ -1071,7 +1072,7 @@ export function EncryptionSettings() {
                       </span>
                     )}
                     {!checking && inSync && (
-                      <span className="text-green-600 dark:text-green-400">
+                      <span className="text-fluux-green">
                         {t('settings.encryption.backupStatusInSync')}
                       </span>
                     )}
@@ -1081,7 +1082,7 @@ export function EncryptionSettings() {
                       </span>
                     )}
                     {!checking && !inSync && remoteBackupExists === true && (
-                      <span className="text-yellow-600 dark:text-yellow-400">
+                      <span className="text-fluux-yellow">
                         {t('settings.encryption.backupStatusMismatch')}
                       </span>
                     )}
@@ -1194,7 +1195,7 @@ export function EncryptionSettings() {
                 <button
                   onClick={() => setShowDeleteConfirm(true)}
                   disabled={isDeleting}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-red-500/10 hover:bg-red-500/20 text-red-500 dark:text-red-400 rounded transition-colors disabled:opacity-50 disabled:cursor-wait"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-red/10 hover:bg-fluux-red/20 text-fluux-error rounded transition-colors disabled:opacity-50 disabled:cursor-wait"
                 >
                   <Trash2 className="size-3.5" />
                   {t('settings.encryption.deleteKey')}

--- a/apps/fluux/src/components/ui/Toggle.test.tsx
+++ b/apps/fluux/src/components/ui/Toggle.test.tsx
@@ -17,4 +17,23 @@ describe('Toggle', () => {
     fireEvent.click(screen.getByRole('switch'))
     expect(onChange).not.toHaveBeenCalled()
   })
+
+  it('shows cursor-wait (not cursor-not-allowed) while loading, even when also disabled', () => {
+    // The async-pending affordance: a toggle mid-operation reads as "busy",
+    // not "blocked". EncryptionSettings drives both at once (disabled covers
+    // isToggling AND the PEP gate), so cursor-wait must win over the
+    // disabled cursor-not-allowed.
+    const onChange = vi.fn()
+    render(<Toggle checked onChange={onChange} disabled loading aria-label="Sounds" />)
+    const sw = screen.getByRole('switch', { name: 'Sounds' })
+    expect(sw.className).toContain('cursor-wait')
+    expect(sw.className).not.toContain('cursor-not-allowed')
+  })
+
+  it('does not fire onChange while loading', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} loading aria-label="Sounds" />)
+    fireEvent.click(screen.getByRole('switch'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })

--- a/apps/fluux/src/components/ui/Toggle.tsx
+++ b/apps/fluux/src/components/ui/Toggle.tsx
@@ -2,11 +2,20 @@ interface ToggleProps {
   checked: boolean
   onChange: (next: boolean) => void
   disabled?: boolean
+  /**
+   * Async-pending affordance: while true the toggle reads as "busy" rather
+   * than "blocked" — it renders `cursor-wait` (taking precedence over the
+   * `disabled` `cursor-not-allowed`) and ignores clicks. Mirrors the
+   * isToggling state the inline EncryptionSettings toggle used to show.
+   */
+  loading?: boolean
   id?: string
   'aria-label'?: string
 }
 
-export function Toggle({ checked, onChange, disabled = false, id, 'aria-label': ariaLabel }: ToggleProps) {
+export function Toggle({ checked, onChange, disabled = false, loading = false, id, 'aria-label': ariaLabel }: ToggleProps) {
+  // `loading` implies non-interactive too: never fire onChange mid-operation.
+  const inactive = disabled || loading
   return (
     <button
       type="button"
@@ -14,11 +23,13 @@ export function Toggle({ checked, onChange, disabled = false, id, 'aria-label': 
       id={id}
       aria-checked={checked}
       aria-label={ariaLabel}
-      disabled={disabled}
-      onClick={() => !disabled && onChange(!checked)}
+      disabled={inactive}
+      onClick={() => !inactive && onChange(!checked)}
       className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${
         checked ? 'bg-fluux-brand' : 'bg-fluux-hover'
-      } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      } ${inactive ? 'opacity-50' : ''} ${
+        loading ? 'cursor-wait' : inactive ? 'cursor-not-allowed' : 'cursor-pointer'
+      }`}
     >
       <span
         className={`absolute top-0.5 start-0.5 size-4 rounded-full bg-white transition-transform ${


### PR DESCRIPTION
## Summary

- Replaces ~12 hardcoded Tailwind palette literals (`yellow-500`, `red-500`, `green-500/600`) in the OpenPGP key-management UI with Aurora `fluux-` design tokens — deliberate security-iconography pass, not a blind swap
- Token split applied: red text/icons → `text-fluux-error` (AA-safe), red fills → `bg-fluux-red`/`border-fluux-red` (fill-tuned); `fluux-yellow`/`fluux-green` have no text/fill split
- Web-locked "unlock" banner **neutralized** to `bg-fluux-bg border-fluux-hover` (calm/routine post-reload prompt, not an alarm); all other yellow/red spots are genuine warnings or errors and keep their alarm semantics
- Adds optional `loading?: boolean` to `ui/Toggle`: renders `cursor-wait` (wins over `cursor-not-allowed`) and blocks `onChange` while busy; `EncryptionSettings` passes `loading={isToggling}` to restore the async affordance the old inline toggle had before #731

## Verification

Static guard in `EncryptionSettings.test.tsx` asserts no `red/green/yellow-NNN` literals remain. Two new `Toggle.test.tsx` tests cover cursor-wait precedence and onChange suppression. 4191/4191 app tests pass, typecheck and lint clean.