### PR TITLE
fix(admin): make sidebar title non-clickable like other views

### DIFF
--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -301,16 +301,7 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
         {/* Header - with drag region for window movement */}
         <div className={`h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm`} {...dragRegionProps}>
           <h1 className="flex-1 font-semibold text-fluux-text truncate">
-            {sidebarView === 'admin' && isAdmin ? (
-              // Clicking the title returns to the admin "home" (server overview)
-              <button
-                type="button"
-                onClick={() => onAdminCategoryChange?.('stats')}
-                className="text-start hover:text-fluux-brand transition-colors"
-              >
-                {t('sidebar.admin')}
-              </button>
-            ) : sidebarView === 'messages' ? t('sidebar.messages')
+            {sidebarView === 'messages' ? t('sidebar.messages')
               : sidebarView === 'rooms' ? t('sidebar.rooms')
               : sidebarView === 'directory' ? t('sidebar.connections')
               : sidebarView === 'archive' ? t('sidebar.archive')


### PR DESCRIPTION
The admin sidebar title was a special clickable shortcut back to the admin home (server overview). Now that the admin panel has a breadcrumb providing that navigation, this restores the title to a plain non-link label, consistent with the other sidebar views (Messages, Rooms, etc.).

No functionality is lost — the breadcrumb's "Admin" crumb still returns to the admin home.