### PR TITLE
refactor(ui): remove dead titleBarClass from useWindowDrag and headers

### DIFF
--- a/apps/fluux/src/components/ActivityContextView.tsx
+++ b/apps/fluux/src/components/ActivityContextView.tsx
@@ -31,7 +31,7 @@ export function ActivityContextView({ onBack }: { onBack?: () => void }) {
   const { t } = useTranslation()
   const { previewEvent, setPreviewEvent } = useActivityLog()
   const { navigateToConversation, navigateToRoom } = useNavigateToTarget()
-  const { titleBarClass, dragRegionProps } = useWindowDrag()
+  const { dragRegionProps } = useWindowDrag()
   const { resolvedMode } = useMode()
   const isDarkMode = resolvedMode === 'dark'
   const hasRoom = useCallback((jid: string) => roomStore.getState().rooms.has(jid), [])
@@ -255,7 +255,7 @@ export function ActivityContextView({ onBack }: { onBack?: () => void }) {
   return (
     <div className="flex flex-col h-full bg-fluux-surface/50">
       {/* Header */}
-      <header className={`h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3`} {...dragRegionProps}>
+      <header className="h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
         {/* Back button - mobile */}
         {onBack && (
           <button

--- a/apps/fluux/src/components/AdminView.test.tsx
+++ b/apps/fluux/src/components/AdminView.test.tsx
@@ -8,7 +8,7 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('@/hooks', () => ({
-  useWindowDrag: () => ({ titleBarClass: '' }),
+  useWindowDrag: () => ({ dragRegionProps: { 'data-tauri-drag-region': true } }),
   useModalInput: () => ({ current: null }),
 }))
 

--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Server, Plus, ArrowLeft, Menu } from 'lucide-react'
 import { useAdmin, useXMPP, adminStore, type AdminCategory, type AdminUser, type AdminRoom } from '@fluux/sdk'
 import { useAdminStore } from '@fluux/sdk/react'
-import { useWindowDrag, useModalInput } from '@/hooks'
+import { useModalInput } from '@/hooks'
 import { useWindowedList } from '../hooks/useWindowedList'
 import { Tooltip } from './Tooltip'
 import { ModalShell } from './ModalShell'
@@ -27,7 +27,6 @@ interface AdminViewProps {
 
 export function AdminView({ activeCategory, onBack }: AdminViewProps) {
   const { t } = useTranslation()
-  const { titleBarClass } = useWindowDrag()
   const { client } = useXMPP()
   const {
     currentSession,
@@ -531,7 +530,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
   return (
     <div className="flex-1 flex flex-col min-h-0 bg-fluux-sidebar">
       {/* Header */}
-      <div className={`h-14 flex items-center px-4 ${titleBarClass} border-b border-fluux-bg`}>
+      <div className="h-14 flex items-center px-4 border-b border-fluux-bg">
         {/* Back button - mobile only */}
         {onBack && (
           <button

--- a/apps/fluux/src/components/ChatHeader.test.tsx
+++ b/apps/fluux/src/components/ChatHeader.test.tsx
@@ -14,7 +14,6 @@ vi.mock('react-i18next', () => ({
 // Mock useWindowDrag hook and other hooks used by ChatHeader and HeaderOverflowKebab
 vi.mock('@/hooks', () => ({
   useWindowDrag: () => ({
-    titleBarClass: 'mt-5',
     dragRegionProps: { 'data-tauri-drag-region': true },
   }),
   useAnchoredMenu: () => ({
@@ -297,19 +296,6 @@ describe('ChatHeader', () => {
   })
 
   describe('Title Bar', () => {
-    it('applies title bar class from useWindowDrag', () => {
-      const { container } = render(
-        <ChatHeader
-          name="Alice"
-          type="chat"
-          jid="alice@example.com"
-        />
-      )
-
-      const header = container.querySelector('header')
-      expect(header).toHaveClass('mt-5')
-    })
-
     it('applies drag region props for Tauri', () => {
       const { container } = render(
         <ChatHeader

--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -57,7 +57,7 @@ export function ChatHeader({
 }: ChatHeaderProps) {
   const { t } = useTranslation()
   const isGroupChat = type === 'groupchat'
-  const { titleBarClass, dragRegionProps } = useWindowDrag()
+  const { dragRegionProps } = useWindowDrag()
 
   // Subscribe to this specific contact's full data from the roster store
   // for presence display. This is a focused selector — only re-renders when
@@ -92,7 +92,7 @@ export function ChatHeader({
   const kebabWrapperClass = hasAlwaysShownEntry ? undefined : kebabClass('search')
 
   return (
-    <header className={`@container h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3`} {...dragRegionProps}>
+    <header className="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
       {/* Back button - mobile only */}
       {onBack && (
         <button

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -39,7 +39,6 @@ import { useFocusZones, useViewNavigation, isMobileWeb, isSmallScreen, useWindow
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useDeepLink } from '@/hooks/useDeepLink'
 import { saveViewState, getSavedViewState, type ViewStateData } from '@/hooks/useSessionPersistence'
-import { useWindowDrag } from '@/hooks'
 import { useModalStore } from '@/stores/modalStore'
 import { Server, ShieldOff, MessageCircle, Hash, Users, Archive, Bell, Search, Settings, Plus, type LucideIcon } from 'lucide-react'
 
@@ -1077,13 +1076,12 @@ function EmptyState({ sidebarView, primaryAction }: { sidebarView: SidebarView; 
  */
 function AdminEmptyState() {
   const { t } = useTranslation()
-  const { titleBarClass } = useWindowDrag()
   const isAdmin = useAdminStore((s) => s.isAdmin)
 
   return (
     <div className="flex-1 flex flex-col bg-fluux-sidebar">
       {/* Header - no close button on root admin screen */}
-      <div className={`flex items-center px-4 py-3 ${titleBarClass} border-b border-fluux-bg`}>
+      <div className="flex items-center px-4 py-3 border-b border-fluux-bg">
         <div className="flex items-center gap-2">
           <Server className="size-5 text-fluux-muted" />
           <h2 className="font-semibold text-fluux-text">{t('admin.title')}</h2>

--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -195,7 +195,7 @@ vi.mock('@/hooks', () => ({
     menuRef: { current: null },
     position: { x: 0, y: 0 },
   }),
-  useWindowDrag: () => ({ titleBarClass: '', dragRegionProps: {} }),
+  useWindowDrag: () => ({ dragRegionProps: {} }),
   useFileUpload: () => ({
     uploadFile: vi.fn(),
     isUploading: false,

--- a/apps/fluux/src/components/ContactProfileView.tsx
+++ b/apps/fluux/src/components/ContactProfileView.tsx
@@ -47,7 +47,7 @@ export function ContactProfileView({
   const connectionStatus = useConnectionStore((s) => s.status)
   const ownJid = useConnectionStore((s) => s.jid)
   const forceOffline = connectionStatus !== 'online'
-  const { titleBarClass, dragRegionProps } = useWindowDrag()
+  const { dragRegionProps } = useWindowDrag()
 
   const [activeTab, setActiveTab] = useState<ContactProfileTab>('profile')
   const [isEditing, setIsEditing] = useState(false)
@@ -202,7 +202,7 @@ export function ContactProfileView({
       <div className="h-full flex flex-col bg-fluux-chat">
         {/* Header */}
         <div
-          className={`h-14 ${titleBarClass} px-4 flex items-center gap-2 border-b border-fluux-bg shadow-sm`}
+          className="h-14 px-4 flex items-center gap-2 border-b border-fluux-bg shadow-sm"
           {...dragRegionProps}
         >
           {onBack && (

--- a/apps/fluux/src/components/OccupantPanel.memo.test.tsx
+++ b/apps/fluux/src/components/OccupantPanel.memo.test.tsx
@@ -15,7 +15,7 @@ vi.mock('react-i18next', () => ({
 const themeMock = { isDark: true }
 
 vi.mock('@/hooks', () => ({
-  useWindowDrag: () => ({ titleBarClass: '', dragRegionProps: {} }),
+  useWindowDrag: () => ({ dragRegionProps: {} }),
   useContextMenu: () => ({
     isOpen: false, position: { x: 0, y: 0 }, open: vi.fn(), close: vi.fn(),
     menuRef: { current: null }, triggerHandlers: {},

--- a/apps/fluux/src/components/OccupantPanel.test.tsx
+++ b/apps/fluux/src/components/OccupantPanel.test.tsx
@@ -17,7 +17,6 @@ vi.mock('react-i18next', () => ({
 // Mock hooks
 vi.mock('@/hooks', () => ({
   useWindowDrag: () => ({
-    titleBarClass: 'mt-5',
     dragRegionProps: { 'data-tauri-drag-region': true },
   }),
   useContextMenu: () => ({
@@ -196,20 +195,6 @@ describe('OccupantPanel', () => {
       )
 
       expect(screen.getByText('rooms.noMembersInRoom')).toBeInTheDocument()
-    })
-
-    it('applies title bar class from useWindowDrag', () => {
-      const room = createRoom()
-      const { container } = render(
-        <OccupantPanel
-          room={room}
-          contactsByJid={new Map()}
-          onClose={() => {}}
-        />
-      )
-
-      const header = container.querySelector('.h-14')
-      expect(header).toHaveClass('mt-5')
     })
   })
 

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -20,7 +20,7 @@ import { ignoreStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { Avatar } from './Avatar'
 import { Tooltip } from './Tooltip'
 import { MenuButton, MenuDivider } from './sidebar-components/SidebarListMenu'
-import { useContextMenu, useWindowDrag, useTheme } from '@/hooks'
+import { useContextMenu, useTheme } from '@/hooks'
 import { auroraSenderColor } from '@/utils/senderColor'
 import { bestTextColor } from '@/utils/contrastColor'
 import { useToastStore } from '@/stores/toastStore'
@@ -292,7 +292,6 @@ export function OccupantPanel({
   const { isDark } = useTheme()
   const connectionStatus = useConnectionStore((s) => s.status)
   const forceOffline = connectionStatus !== 'online'
-  const { titleBarClass } = useWindowDrag()
   const ignoredForRoom = useIgnoreStore((s) => s.ignoredUsers[room.jid] ?? EMPTY_IGNORED_ARRAY)
 
   // Context menu state
@@ -663,7 +662,7 @@ export function OccupantPanel({
   return (
     <div className={`${fullScreen ? 'w-full h-full' : 'w-64 border-s border-fluux-bg'} flex flex-col bg-fluux-chat`}>
       {/* Panel header */}
-      <div className={`h-14 ${titleBarClass} px-4 flex items-center justify-between border-b border-fluux-bg`}>
+      <div className="h-14 px-4 flex items-center justify-between border-b border-fluux-bg">
         {fullScreen ? (
           <div className="flex items-center gap-2">
             <button

--- a/apps/fluux/src/components/RoomHeader.test.tsx
+++ b/apps/fluux/src/components/RoomHeader.test.tsx
@@ -40,7 +40,6 @@ vi.mock('react-i18next', () => ({
 // Mock useWindowDrag hook
 vi.mock('@/hooks', () => ({
   useWindowDrag: () => ({
-    titleBarClass: 'mt-5',
     dragRegionProps: { 'data-tauri-drag-region': true },
   }),
   useClickOutside: vi.fn(),
@@ -749,26 +748,6 @@ describe('RoomHeader', () => {
     })
   })
 
-  describe('Title Bar', () => {
-    it('applies title bar class from useWindowDrag', () => {
-      const { container } = render(
-        <RoomHeader
-          room={createRoom()}
-          showOccupants={false}
-          onToggleOccupants={mockOnToggleOccupants}
-          setRoomNotifyAll={mockSetRoomNotifyAll}
-          setRoomAvatar={mockSetRoomAvatar}
-          clearRoomAvatar={mockClearRoomAvatar}
-          submitRoomConfig={mockSubmitRoomConfig}
-          setSubject={mockSetSubject}
-          destroyRoom={mockDestroyRoom}
-        />
-      )
-
-      const header = container.querySelector('header')
-      expect(header).toHaveClass('mt-5')
-    })
-  })
 
   describe('Manage Hats', () => {
     it('shows "Manage Hats" only for owners', () => {

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -71,7 +71,7 @@ export function RoomHeader({
   const [showMembersModal, setShowMembersModal] = useState(false)
   const [showHatsModal, setShowHatsModal] = useState(false)
   const [avatarError, setAvatarError] = useState<string | null>(null)
-  const { titleBarClass, dragRegionProps } = useWindowDrag()
+  const { dragRegionProps } = useWindowDrag()
 
   // Get self occupant to check affiliation
   const selfOccupant = room.nickname ? room.occupants.get(room.nickname) : undefined
@@ -97,7 +97,7 @@ export function RoomHeader({
   })
 
   return (
-    <header className={`@container h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3`} {...dragRegionProps}>
+    <header className="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
       {/* Back button - mobile only */}
       {onBack && (
         <button

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -312,7 +312,7 @@ vi.mock('@/hooks', () => ({
     moveSelection: vi.fn(),
     dismiss: vi.fn(),
   }),
-  useWindowDrag: () => ({ titleBarClass: '', dragRegionProps: {} }),
+  useWindowDrag: () => ({ dragRegionProps: {} }),
   useFileUpload: () => ({
     uploadFile: vi.fn(),
     isUploading: false,

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -40,7 +40,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
   const { t } = useTranslation()
   const { query, previewResult, setPreviewResult } = useSearch()
   const { navigateToConversation, navigateToRoom } = useNavigateToTarget()
-  const { titleBarClass, dragRegionProps } = useWindowDrag()
+  const { dragRegionProps } = useWindowDrag()
   const { resolvedMode } = useMode()
   const isDarkMode = resolvedMode === 'dark'
 
@@ -274,7 +274,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
   return (
     <div className="flex flex-col h-full bg-fluux-surface/50">
       {/* Header */}
-      <header className={`h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3`} {...dragRegionProps}>
+      <header className="h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
         {/* Back button - mobile */}
         {onBack && (
           <button

--- a/apps/fluux/src/components/SettingsView.tsx
+++ b/apps/fluux/src/components/SettingsView.tsx
@@ -32,7 +32,7 @@ interface SettingsViewProps {
 export function SettingsView({ onBack }: SettingsViewProps) {
   detectRenderLoop('SettingsView')
   const { t } = useTranslation()
-  const { titleBarClass, dragRegionProps } = useWindowDrag()
+  const { dragRegionProps } = useWindowDrag()
   const { settingsCategory } = useRouteSync()
 
   // Current category (default to profile if none specified)
@@ -77,7 +77,7 @@ export function SettingsView({ onBack }: SettingsViewProps) {
   return (
     <div className="h-full flex flex-col bg-fluux-chat">
       {/* Header */}
-      <div className={`h-14 ${titleBarClass} px-4 flex items-center border-b border-fluux-bg shadow-sm`} {...dragRegionProps}>
+      <div className="h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm" {...dragRegionProps}>
         {/* Back button - mobile only */}
         {onBack && (
           <button

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
     class="flex flex-col h-full min-h-0 relative"
   >
     <header
-      class="@container h-14  px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+      class="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
     >
       <div
         data-testid="avatar"
@@ -472,7 +472,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
     class="flex flex-col h-full min-h-0 relative"
   >
     <header
-      class="@container h-14  px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+      class="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
     >
       <div
         data-testid="avatar"

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
       class="flex flex-col flex-1 min-w-0"
     >
       <header
-        class="@container h-14  px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+        class="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
       >
         <div
           class="size-9 rounded-xl flex items-center justify-center flex-shrink-0"

--- a/apps/fluux/src/hooks/useWindowDrag.ts
+++ b/apps/fluux/src/hooks/useWindowDrag.ts
@@ -10,16 +10,12 @@ export interface DragRegionProps {
  * Hook that returns props to make an element a window drag region.
  * Uses data-tauri-drag-region for Tauri native dragging.
  *
- * `titleBarClass` used to add a macOS top margin so column headers cleared the
- * overlaid traffic lights. The desktop AppBar (see components/AppBar.tsx) now
- * hosts the traffic lights on a full-width strip above the whole layout, so no
- * header needs that clearance anymore. The field is kept (as an empty string)
- * so existing consumers compile unchanged; the inert interpolation can be
- * dropped from each header in a follow-up cleanup.
+ * The desktop AppBar (see components/AppBar.tsx) hosts the macOS traffic lights
+ * on a full-width strip above the whole layout, so no header needs top-margin
+ * clearance for them anymore.
  */
 export function useWindowDrag() {
   return {
-    titleBarClass: '',
     // Drag region props to spread on elements (harmless in web, enables dragging in Tauri)
     dragRegionProps: {
       'data-tauri-drag-region': true,


### PR DESCRIPTION
The desktop AppBar now hosts the macOS traffic lights, so the old per-header top-margin clearance is obsolete. `useWindowDrag()` already returned an empty `titleBarClass`.

This removes the field entirely and cleans up the inert `${titleBarClass}` className interpolations in every consumer (ChatHeader, RoomHeader, OccupantPanel, SettingsView, AdminView, ContactProfileView, ActivityContextView, SearchContextView, ChatLayout). The leftover single-interpolation template literals are collapsed to plain strings, which also drops the stray double-space. Where the hook was used only for `titleBarClass` (OccupantPanel, AdminView, ChatLayout), the now-unused import and call are removed.

Stale `mt-5` test mocks and their assertions are dropped, and two component snapshots regenerated (whitespace only). typecheck, eslint and the affected vitest suites pass.