### PR TITLE
fix(ui): grey out app bar forward arrow at end of history

### DIFF
--- a/apps/fluux/src/components/AppBar.test.tsx
+++ b/apps/fluux/src/components/AppBar.test.tsx
@@ -42,6 +42,8 @@ describe('AppBar', () => {
     mockHasHover = true
     navigateSpy.mockClear()
     toggleSpy.mockClear()
+    // Reset history position so each test starts at index 0 (start = end).
+    window.history.replaceState(null, '')
   })
 
   it('renders nothing on mobile (below the desktop breakpoint)', () => {
@@ -69,16 +71,26 @@ describe('AppBar', () => {
     expect(screen.queryByRole('button', { name: 'Settings' })).not.toBeInTheDocument()
   })
 
-  it('navigates forward through history', () => {
-    renderAppBar()
-    fireEvent.click(screen.getByRole('button', { name: 'Forward' }))
-    expect(navigateSpy).toHaveBeenCalledWith(1)
-  })
-
   it('disables back at the first history entry', () => {
     renderAppBar()
     // Fresh history starts at index 0 → nowhere to go back.
     expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
+  })
+
+  it('disables forward at the end of history', () => {
+    renderAppBar()
+    // At the furthest index reached → nowhere to go forward.
+    expect(screen.getByRole('button', { name: 'Forward' })).toBeDisabled()
+  })
+
+  it('navigates back when not at the first history entry', () => {
+    // Simulate being one step into the history stack.
+    window.history.replaceState({ idx: 1 }, '')
+    renderAppBar()
+    const back = screen.getByRole('button', { name: 'Back' })
+    expect(back).toBeEnabled()
+    fireEvent.click(back)
+    expect(navigateSpy).toHaveBeenCalledWith(-1)
   })
 
   it('opens the command palette from the search control', () => {

--- a/apps/fluux/src/components/AppBar.tsx
+++ b/apps/fluux/src/components/AppBar.tsx
@@ -1,5 +1,5 @@
-import { memo } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { memo, useEffect, useState } from 'react'
+import { useNavigate, useLocation, useNavigationType } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react'
 import { useIsDesktop } from '@/hooks/useIsDesktop'
@@ -49,9 +49,22 @@ export const AppBar = memo(function AppBar() {
   const { dragRegionProps } = useWindowDrag()
   const toggleModal = useModalStore((s) => s.toggle)
 
-  // Re-render on every navigation so `canGoBack` reflects the current history
-  // position (React Router stores a numeric index in history state).
-  useLocation()
+  // React Router stores a numeric index in history state; re-read it on every
+  // navigation (useLocation re-renders us). `currentIdx` is the position in the
+  // stack; back is available when we're past the first entry.
+  const location = useLocation()
+  const navigationType = useNavigationType()
+  const currentIdx =
+    (typeof window !== 'undefined' ? (window.history.state?.idx as number | undefined) : undefined) ?? 0
+
+  // The History API exposes no "can go forward" flag, so derive it from the
+  // furthest index we've reached. A PUSH truncates any forward entries, so it
+  // resets the ceiling to the new index; POP/REPLACE keep the existing ceiling.
+  // Forward is available whenever we've stepped back below that ceiling.
+  const [maxIdx, setMaxIdx] = useState(currentIdx)
+  useEffect(() => {
+    setMaxIdx((prev) => (navigationType === 'PUSH' ? currentIdx : Math.max(prev, currentIdx)))
+  }, [location, navigationType, currentIdx])
 
   // App bar is desktop window chrome: render only on a wide viewport AND a
   // hovering, fine pointer (mouse/trackpad). The hover gate keeps it hidden on
@@ -62,12 +75,8 @@ export const AppBar = memo(function AppBar() {
 
   const needsTrafficLightInset = isTauri && isMacOS && !isFullscreen
 
-  // Back is unavailable at the first history entry. Forward availability isn't
-  // reliably exposed by the History API, so it stays enabled and safely no-ops
-  // at the end of history — identical to the keyboard navigation today.
-  const historyIdx =
-    (typeof window !== 'undefined' ? (window.history.state?.idx as number | undefined) : undefined) ?? 0
-  const canGoBack = historyIdx > 0
+  const canGoBack = currentIdx > 0
+  const canGoForward = currentIdx < maxIdx
 
   const shortcutMod = isMacOS ? '⌘' : 'Ctrl'
   const iconButton =
@@ -95,6 +104,7 @@ export const AppBar = memo(function AppBar() {
           type="button"
           aria-label={t('common.forward')}
           title={t('common.forward')}
+          disabled={!canGoForward}
           onClick={() => navigate(1)}
           className={iconButton}
         >


### PR DESCRIPTION
Follow-up to #738.

The app bar's back arrow was already disabled at the first history entry, but the forward arrow stayed always-enabled because the History API exposes no "can go forward" flag. This tracks the furthest history index reached — resetting it on a PUSH, which truncates any forward entries — so the forward arrow greys out at the end of the stack and re-enables after going back.