### PR TITLE
fix(ui): center new-message marker between neighbouring messages

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -628,6 +628,13 @@ em-emoji-picker {
 .message-group-start { padding-top: 16px; }
 [data-density="compact"] .message-group-start { padding-top: 8px; }
 
+/* The "New messages" marker already provides the visual break before the first
+ * unread message, so collapse the sender-group top padding on the row right after
+ * it down to the normal inter-row gap (py-0.5). Without this the marker's label is
+ * pushed up against the previous message instead of sitting centred between its
+ * neighbours. */
+[data-new-message-marker] + .message-group-start { padding-top: 0.125rem; }
+
 /* Icon rail density. Width + button + icon shrink in compact. */
 /* Rail background: 14% black overlay composited over the sidebar color so the
    rail is always visually deeper than the sidebar, regardless of theme or mode. */


### PR DESCRIPTION
The "New messages" divider sat closer to the message above it than the one below. The first unread message's row carries `.message-group-start` (16px top padding), which landed below the marker line with no counterpart above, pushing the divider up against the previous message.

Collapse that group-start padding to the normal inter-row gap when the row directly follows the marker (`[data-new-message-marker] + .message-group-start`) — the marker already provides the visual break. The line is now centered (24px above / 24px below, verified live in demo mode). Adjacent-sibling scoped, so it only fires when the next row is actually a group start.