### PR TITLE
fix(scroll): content-anchor restore independent of rendering

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -644,13 +644,12 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     expect(scrollToOffsetCalls).toContain(200)
   })
 
-  it('restores via virtualizer scrollToIndex when the anchor row is windowed out of the DOM', () => {
+  it('re-windows to the saved offset even when the anchor row is windowed out of the DOM', () => {
     // Real-browser case: the virtualizer's initial window covers only the top rows; the saved
-    // anchor (the bottom-most message the user was reading) is NOT in the DOM. restoreToAnchor()
-    // returns false, so the hook falls through to the new virtualizer-index path:
-    // getIndexForMessageId + scrollToIndex('end') + scrollToOffset(bottomGap adjustment).
-    // Previously both DOM paths failed and the hook fell back to pinVirtualizedBottom(),
-    // which cleared the saved state and left the conversation stuck at bottom on every return.
+    // anchor row is NOT in the DOM, so the DOM anchor lookup fails. Because the content height is
+    // unchanged since save (same-session return), restore takes the layout-unchanged path and
+    // re-windows to the EXACT saved offset via scrollToOffset — it must NOT go blank or fall back
+    // to pinVirtualizedBottom() (which cleared the saved state and stuck the convo at the bottom).
     const { container, rerender } = render(
       <MessageList messages={makeMessages(50)} conversationId="conv-vi1" {...props} />,
     )
@@ -682,12 +681,8 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     scroller.querySelector = origQS as typeof scroller.querySelector
 
-    // The virtualizer-index path called scrollToIndex('end') to place the anchor at the
-    // viewport bottom, then scrollToOffset for the bottomGap adjustment.
-    // pinVirtualizedBottom also calls scrollToIndex('end') but never calls scrollToOffset,
-    // so scrollToOffsetCalls.length > 0 proves the restore path ran, not the bottom fallback.
-    expect(scrollToIndexCalls).toContain('end')
-    expect(scrollToOffsetCalls.length).toBeGreaterThan(0)
+    // Re-windowed to the exact saved offset (200) rather than going blank or to the bottom.
+    expect(scrollToOffsetCalls).toContain(200)
   })
 
   it('restores (re-windowed) when a message arrived in the conversation while it was hidden', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -126,47 +126,52 @@ export function cancelKineticScroll(el: HTMLElement): void {
 // ANCHOR HELPERS (content-stable scroll restoration)
 // ============================================================================
 
+const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
+
 /**
- * Find the bottom-most visible message row and the gap between its bottom edge
- * and the viewport bottom. This anchor survives a change in the loaded message
- * set (memory eviction + cache re-hydration), unlike a raw scrollTop.
+ * Capture a CONTENT anchor: the bottom-most visible message and the FRACTION (0..1) of its
+ * height at which the viewport bottom sits. fraction=1 → the message's bottom edge is at the
+ * window bottom; 0.5 → the window bottom cuts its middle.
+ *
+ * Storing a fraction (not a pixel gap) makes the position INDEPENDENT OF RENDERING: on return we
+ * re-derive pixels from the message's CURRENT measured height, so a re-measure, a width change, or
+ * a virtualization re-window can't corrupt it. The previous implementation stored a pixel gap found
+ * via a BINARY SEARCH over `offsetTop` assuming rows were in sorted document order — false under
+ * virtualization (the DOM holds an unsorted/stale window), which produced a wildly wrong gap and
+ * flung the view to the bottom on return. This is a linear max-scan over the (small) rendered
+ * window using each row's own `offsetTop`/`offsetHeight`, so DOM order no longer matters.
  */
 function findBottomAnchor(scroller: HTMLElement): ScrollAnchor | null {
   const rows = scroller.querySelectorAll('.message-row[data-message-id]')
   if (rows.length === 0) return null
   const viewportBottom = scroller.scrollTop + scroller.clientHeight
-  // Binary search (rows are in ascending offsetTop order) for the bottom-most row
-  // whose top is above the viewport bottom — the last visible row. O(log n), so
-  // it's cheap to run on every scroll event (keeps the anchor at the latest pos).
-  let lo = 0
-  let hi = rows.length - 1
-  let found = 0
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1
-    if ((rows[mid] as HTMLElement).offsetTop < viewportBottom) {
-      found = mid
-      lo = mid + 1
-    } else {
-      hi = mid - 1
+  // Bottom-most row that STARTS above the viewport bottom (greatest offsetTop < viewportBottom).
+  let best: HTMLElement | null = null
+  for (const node of rows) {
+    const el = node as HTMLElement
+    if (el.offsetHeight <= 0) continue
+    if (el.offsetTop < viewportBottom && (best === null || el.offsetTop > best.offsetTop)) {
+      best = el
     }
   }
-  const el = rows[found] as HTMLElement
-  const messageId = el.dataset.messageId
+  if (best === null) best = rows[rows.length - 1] as HTMLElement
+  const messageId = best.dataset.messageId
   if (!messageId) return null
-  return { messageId, bottomGap: viewportBottom - (el.offsetTop + el.offsetHeight) }
+  const height = best.offsetHeight || 1
+  return { messageId, fraction: clamp01((viewportBottom - best.offsetTop) / height) }
 }
 
 /**
- * Restore scroll so the anchor message's bottom sits at its saved offset from the
- * viewport bottom. Returns false if the anchor message isn't currently loaded
- * (scrolled up beyond the re-hydrated window) so the caller can fall back.
+ * Restore scroll so the viewport bottom sits at the saved FRACTION through the anchor message,
+ * using the message's CURRENT measured height. Returns false if the anchor message isn't currently
+ * mounted (scrolled up beyond the re-hydrated/virtualized window) so the caller can fall back.
  */
 function restoreToAnchor(scroller: HTMLElement, anchor: ScrollAnchor): boolean {
   const el = scroller.querySelector(
     `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`
   ) as HTMLElement | null
-  if (!el) return false
-  scroller.scrollTop = el.offsetTop + el.offsetHeight + anchor.bottomGap - scroller.clientHeight
+  if (!el || el.offsetHeight <= 0) return false
+  scroller.scrollTop = el.offsetTop + anchor.fraction * el.offsetHeight - scroller.clientHeight
   return true
 }
 
@@ -744,6 +749,19 @@ export function useMessageListScroll({
       return 'restored'
     }
 
+    // Exact restore when the layout is UNCHANGED since save (same-session navigate-back, including
+    // eviction+rehydrate that reproduces identical content): the saved scrollTop is exact and
+    // layout-independent precisely because the content is the same, so the ratio-based anchor isn't
+    // needed — and a corrupt/degenerate anchor can't override a perfectly good saved position (the
+    // "jump to bottom on return" report). The fraction anchor below is for a CHANGED height (MAM
+    // prepend, width change). Tolerance covers sub-pixel measurement noise only.
+    const savedHeight = scrollStateManager.getSavedScrollHeight(conversationId)
+    if (savedPos !== null && savedHeight !== null && Math.abs(scroller.scrollHeight - savedHeight) <= 4) {
+      if (virtRestore) virtRestore.scrollToOffset(savedPos)
+      else scroller.scrollTop = savedPos
+      return finishRestore('RESTORE via savedPos (layout unchanged)', { savedPos, savedHeight })
+    }
+
     if (savedAnchor && restoreToAnchor(scroller, savedAnchor)) {
       if (virtRestore) virtRestore.scrollToOffset(scroller.scrollTop)
       return finishRestore('RESTORE via anchor', { savedAnchor })
@@ -752,12 +770,19 @@ export function useMessageListScroll({
     if (virtRestore && savedAnchor) {
       const anchorIndex = virtRestore.getIndexForMessageId(savedAnchor.messageId)
       if (anchorIndex !== null) {
-        // Place the anchor row's bottom at the viewport bottom (align:'end'), then
-        // shift by bottomGap so its bottom edge sits the same distance from the
-        // viewport bottom as when the user left.
+        // Baseline: place the anchor message's bottom at the viewport bottom (align:'end').
+        // This both windows the (possibly off-screen) row in and covers the common fraction=1
+        // case. scrollToIndex re-windows synchronously in the adapter, so its measured size is
+        // available right after for the sub-message refine below.
         virtRestore.scrollToIndex(anchorIndex, { align: 'end' })
-        if (savedAnchor.bottomGap !== 0) {
-          virtRestore.scrollToOffset(scroller.scrollTop + savedAnchor.bottomGap)
+        // Refine to the saved fraction using the message's CURRENT measured height (rendering-
+        // independent — re-derived from measurements, never a stored pixel gap).
+        if (savedAnchor.fraction < 1) {
+          const start = virtRestore.getOffsetForMessageId(savedAnchor.messageId)
+          const size = virtRestore.getVirtualItems().find((v) => v.index === anchorIndex)?.size
+          if (start !== null && size) {
+            virtRestore.scrollToOffset(Math.max(0, start + savedAnchor.fraction * size - scroller.clientHeight))
+          }
         }
         return finishRestore('RESTORE via virtualizer index', { savedAnchor, anchorIndex })
       }
@@ -1533,7 +1558,7 @@ export function useMessageListScroll({
             top, height, client,
             distFromBottom: height - top - client,
             anchorMessageId: lastAnchorRef.current?.messageId,
-            anchorBottomGap: lastAnchorRef.current?.bottomGap,
+            anchorFraction: lastAnchorRef.current?.fraction,
           })
           scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined)
         } else {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -337,7 +337,7 @@ export function useMessageListScroll({
   const mediaLoadDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Last scroll data (for saving on conversation switch)
-  const lastScrollDataRef = useRef<{ top: number; height: number; client: number } | null>(null)
+  const lastScrollDataRef = useRef<{ top: number; height: number; client: number; width: number } | null>(null)
   // Bottom-most-visible message anchor, captured (throttled) during scroll so it
   // survives the conversation switch (at switch time the DOM is already the new
   // conversation). Used for content-stable position restoration on return.
@@ -369,6 +369,7 @@ export function useMessageListScroll({
       top: scroller.scrollTop,
       height: scroller.scrollHeight,
       client: scroller.clientHeight,
+      width: scroller.clientWidth,
     }
     lastAnchorRef.current = findBottomAnchor(scroller)
   }, [])
@@ -382,6 +383,7 @@ export function useMessageListScroll({
       top: bottomTop,
       height: scroller.scrollHeight,
       client: scroller.clientHeight,
+      width: scroller.clientWidth,
     }
     lastAnchorRef.current = findBottomAnchor(scroller)
     isAtBottomRef.current = true
@@ -756,10 +758,20 @@ export function useMessageListScroll({
     // "jump to bottom on return" report). The fraction anchor below is for a CHANGED height (MAM
     // prepend, width change). Tolerance covers sub-pixel measurement noise only.
     const savedHeight = scrollStateManager.getSavedScrollHeight(conversationId)
-    if (savedPos !== null && savedHeight !== null && Math.abs(scroller.scrollHeight - savedHeight) <= 4) {
+    const savedWidth = scrollStateManager.getSavedClientWidth(conversationId)
+    // A width change rewraps bubbles, so the absolute scrollTop is meaningless even if the total
+    // height coincidentally matches — only take the exact fast-path when the width is unchanged (or
+    // unknown, for legacy saves). Otherwise fall through to the rendering-independent fraction anchor.
+    const widthUnchanged = savedWidth === null || scroller.clientWidth === savedWidth
+    if (
+      savedPos !== null &&
+      savedHeight !== null &&
+      widthUnchanged &&
+      Math.abs(scroller.scrollHeight - savedHeight) <= 4
+    ) {
       if (virtRestore) virtRestore.scrollToOffset(savedPos)
       else scroller.scrollTop = savedPos
-      return finishRestore('RESTORE via savedPos (layout unchanged)', { savedPos, savedHeight })
+      return finishRestore('RESTORE via savedPos (layout unchanged)', { savedPos, savedHeight, savedWidth })
     }
 
     if (savedAnchor && restoreToAnchor(scroller, savedAnchor)) {
@@ -1181,11 +1193,11 @@ export function useMessageListScroll({
     notifyUserInput()
 
     const el = e.currentTarget
-    const { scrollTop, scrollHeight, clientHeight } = el
+    const { scrollTop, scrollHeight, clientHeight, clientWidth } = el
     const distFromBottom = scrollHeight - scrollTop - clientHeight
 
     // Update refs (NO React state updates here except FAB)
-    lastScrollDataRef.current = { top: scrollTop, height: scrollHeight, client: clientHeight }
+    lastScrollDataRef.current = { top: scrollTop, height: scrollHeight, client: clientHeight, width: clientWidth }
     // Capture the bottom-most-visible anchor on every scroll event (binary search,
     // cheap) so it reflects the latest position — at switch time the DOM is already
     // the new conversation, so this must be captured live during scroll.
@@ -1254,7 +1266,7 @@ export function useMessageListScroll({
     const now = Date.now()
     if (!programmaticScroll && now - lastSaveTimeRef.current > SAVE_THROTTLE_MS) {
       lastSaveTimeRef.current = now
-      scrollStateManager.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, lastAnchorRef.current ?? undefined)
+      scrollStateManager.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, lastAnchorRef.current ?? undefined, clientWidth)
     }
 
     // Track if user scrolled away from top (allows re-trigger of load)
@@ -1309,8 +1321,8 @@ export function useMessageListScroll({
 
     // LEAVING old conversation - save position
     if (prevConversationRef.current && lastScrollDataRef.current) {
-      const { top, height, client } = lastScrollDataRef.current
-      scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined)
+      const { top, height, client, width } = lastScrollDataRef.current
+      scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined, width)
     }
 
     // ENTERING new conversation - reset state
@@ -1547,7 +1559,7 @@ export function useMessageListScroll({
     return () => {
       if (prevConversationRef.current) {
         if (lastScrollDataRef.current) {
-          const { top, height, client } = lastScrollDataRef.current
+          const { top, height, client, width } = lastScrollDataRef.current
           // UNMOUNT save: this is the leave path for navigations that DESTROY the message view —
           // opening Settings, switching DM↔Room, going back to the list. (DM↔DM keeps the view
           // mounted and saves via the conversation-switch effect instead.) If `top`/anchor here are
@@ -1560,7 +1572,7 @@ export function useMessageListScroll({
             anchorMessageId: lastAnchorRef.current?.messageId,
             anchorFraction: lastAnchorRef.current?.fraction,
           })
-          scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined)
+          scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined, width)
         } else {
           // No scroll data captured before unmount → nothing to restore TO on return. A user who
           // never scrolled (or unmounted before the first throttled save) lands at the bottom next

--- a/apps/fluux/src/utils/scrollStateManager.test.ts
+++ b/apps/fluux/src/utils/scrollStateManager.test.ts
@@ -145,6 +145,18 @@ describe('ScrollStateManager', () => {
     })
   })
 
+  describe('getSavedClientWidth', () => {
+    it('round-trips the saved viewport width (used to gate the exact-scrollTop restore)', () => {
+      manager.leaveConversation('conv1', 200, 1000, 100, { messageId: 'm', fraction: 0.5 }, 800)
+      expect(manager.getSavedClientWidth('conv1')).toBe(800)
+    })
+
+    it('returns null for a legacy save that did not capture width', () => {
+      manager.leaveConversation('conv1', 200, 1000, 100, { messageId: 'm', fraction: 0.5 })
+      expect(manager.getSavedClientWidth('conv1')).toBeNull()
+    })
+  })
+
   describe('updateMessageCount', () => {
     it('returns false for first update (no previous count)', () => {
       manager.enterConversation('conv1', 0)

--- a/apps/fluux/src/utils/scrollStateManager.test.ts
+++ b/apps/fluux/src/utils/scrollStateManager.test.ts
@@ -128,13 +128,13 @@ describe('ScrollStateManager', () => {
     })
 
     it('returns the anchor when the user left scrolled-up', () => {
-      const anchor = { messageId: 'msg-42', bottomGap: 12 }
+      const anchor = { messageId: 'msg-42', fraction: 0.5 }
       manager.leaveConversation('conv1', 200, 1000, 100, anchor)
       expect(manager.getSavedAnchor('conv1')).toEqual(anchor)
     })
 
     it('returns null when the user was at the bottom (no restore needed)', () => {
-      const anchor = { messageId: 'msg-42', bottomGap: 0 }
+      const anchor = { messageId: 'msg-42', fraction: 1 }
       manager.leaveConversation('conv1', 900, 1000, 100, anchor)
       expect(manager.getSavedAnchor('conv1')).toBeNull()
     })

--- a/apps/fluux/src/utils/scrollStateManager.ts
+++ b/apps/fluux/src/utils/scrollStateManager.ts
@@ -53,6 +53,11 @@ interface ScrollState {
   savedAt: number
   /** Total scroll height when saved (for validation) */
   scrollHeight: number
+  /** Viewport width (clientWidth) when saved. The exact-scrollTop fast-path on restore is valid
+   *  ONLY when BOTH height and width are unchanged — a width change rewraps bubbles (heights
+   *  change), so the absolute scrollTop points at different content even if the total height
+   *  coincidentally matches. On a width change the (rendering-independent) anchor governs instead. */
+  clientWidth?: number
   /** Content-stable anchor (preferred over scrollTop for restoration). */
   anchor?: ScrollAnchor
 }
@@ -161,7 +166,8 @@ class ScrollStateManager {
     scrollTop: number,
     scrollHeight: number,
     clientHeight: number,
-    anchor?: ScrollAnchor
+    anchor?: ScrollAnchor,
+    clientWidth?: number
   ): void {
     const state = this.getState(conversationId)
     const distanceFromBottom = scrollHeight - scrollTop - clientHeight
@@ -187,6 +193,7 @@ class ScrollStateManager {
         wasAtBottom,
         savedAt: Date.now(),
         scrollHeight,
+        clientWidth,
         anchor,
       }
     }
@@ -201,10 +208,11 @@ class ScrollStateManager {
     scrollTop: number,
     scrollHeight: number,
     clientHeight: number,
-    anchor?: ScrollAnchor
+    anchor?: ScrollAnchor,
+    clientWidth?: number
   ): void {
     // Save position first
-    this.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, anchor)
+    this.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, anchor, clientWidth)
 
     const state = this.getState(conversationId)
     this.log('leaveConversation', {
@@ -268,6 +276,22 @@ class ScrollStateManager {
       return null
     }
     return state.scrollState.scrollHeight
+  }
+
+  /**
+   * Get the viewport width captured at save time, or null when none/stale/legacy save.
+   * Used together with {@link getSavedScrollHeight} to confirm the layout is truly unchanged
+   * before taking the exact-scrollTop restore fast-path.
+   */
+  getSavedClientWidth(conversationId: string): number | null {
+    const state = this.states.get(conversationId)
+    if (!state?.scrollState || state.scrollState.wasAtBottom) {
+      return null
+    }
+    if (Date.now() - state.scrollState.savedAt > this.staleThresholdMs) {
+      return null
+    }
+    return state.scrollState.clientWidth ?? null
   }
 
   /**

--- a/apps/fluux/src/utils/scrollStateManager.ts
+++ b/apps/fluux/src/utils/scrollStateManager.ts
@@ -33,14 +33,15 @@ function isDebugEnabled(): boolean {
 export const AT_BOTTOM_THRESHOLD = 150
 
 /**
- * A content-stable scroll anchor: the bottom-most visible message and the gap
- * (px) between its bottom edge and the viewport bottom. Survives a change in the
- * loaded message set (e.g. after memory eviction + re-hydration from cache),
- * unlike a raw pixel scrollTop whose meaning depends on the total content height.
+ * A content-stable scroll anchor: the bottom-most visible message and the FRACTION
+ * (0..1) of that message's height at which the viewport bottom sits (1 = message bottom
+ * at the window bottom). Survives a change in the loaded message set (memory eviction +
+ * re-hydration) AND a re-measure/width change, because the position is re-derived from the
+ * message's CURRENT height on restore — independent of rendering — rather than a stored pixel gap.
  */
 export interface ScrollAnchor {
   messageId: string
-  bottomGap: number
+  fraction: number
 }
 
 interface ScrollState {
@@ -250,6 +251,23 @@ class ScrollStateManager {
     }
 
     return state.scrollState.scrollTop
+  }
+
+  /**
+   * Get the scrollHeight captured at save time, or null when no restorable state.
+   * Lets the restore prefer the exact saved scrollTop when the content height is unchanged
+   * since save (same-session navigate-back): the pixel is then exact and layout-independent,
+   * so the (ratio-based) anchor is only needed when the height actually changed.
+   */
+  getSavedScrollHeight(conversationId: string): number | null {
+    const state = this.states.get(conversationId)
+    if (!state?.scrollState || state.scrollState.wasAtBottom) {
+      return null
+    }
+    if (Date.now() - state.scrollState.savedAt > this.staleThresholdMs) {
+      return null
+    }
+    return state.scrollState.scrollHeight
   }
 
   /**


### PR DESCRIPTION
## Summary

Returning to a conversation could jump to the bottom (reported for "Adrien"). The `[Scroll]`/`[ScrollStateManager]` trace showed `restore-position` ran with a correct saved `scrollTop` (7565) but a corrupt saved anchor (`bottomGap: 8130`) flung the view to the bottom.

**Root cause:** `findBottomAnchor` used a binary search over `.message-row` `offsetTop` assuming sorted document order — false under virtualization (the DOM holds an unsorted/stale window) — producing a garbage pixel gap that restore then applied.

## Change

Make the anchor a **content anchor, independent of rendering**:
- `ScrollAnchor` is now `{ messageId, fraction }` — the bottom-most visible message and the 0..1 fraction of its height at which the viewport bottom sits (1 = message bottom at window bottom). On restore the pixels are re-derived from the message's **current measured height**, so a re-measure / width change / virtualization re-window can't corrupt it.
- `findBottomAnchor` is a linear max-scan by `offsetTop` (no sorted assumption); `restoreToAnchor` and the virtualizer-index branch apply the fraction.

**Restore precedence:** when the content height is **unchanged** since save (same-session navigate-back, incl. eviction+rehydrate of identical content) restore the exact saved `scrollTop` — it's exact and layout-independent because the content is the same, so a degenerate/corrupt anchor can't override a good saved position. The fraction anchor is used when the height actually changed (MAM prepend, width change). Adds `scrollStateManager.getSavedScrollHeight`.