### PR TITLE
fix(command-palette): restore soft accent focus ring around the whole search field

### DIFF
--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -539,11 +539,18 @@ function CommandPaletteContent({
         className="relative z-10 fluux-glass rounded-lg w-full max-w-lg mx-4 overflow-hidden"
         onKeyDown={handleKeyDown}
       >
-        {/* Search Input — contained, rounded field with a neutral hairline.
-            The palette auto-focuses the input, so the field is the obvious
-            "type here" affordance without needing an accent ring. */}
+        {/* Search Input — contained, rounded field with a soft accent focus ring
+            that wraps the whole field (icon + input + esc), matching the
+            composer card's `:focus-within` treatment. The palette auto-focuses
+            the input, so the ring is effectively always on while open, giving a
+            clear "type here" affordance. The ring lives on the wrapper via the
+            `command-search-field` class (Tailwind's `/opacity` modifiers no-op
+            on our `hsl()`-string accent token, so a plain CSS rule is used). The
+            inner input carries `no-focus-ring` so the global 2px outline doesn't
+            draw a second, tighter box around just the text field. */}
         <div className="p-3 border-b border-fluux-hover">
-          <div className="flex items-center gap-3 px-3 py-2 rounded-lg border border-fluux-hover bg-fluux-bg/40">
+          <div className="command-search-field flex items-center gap-3 px-3 py-2 rounded-lg border border-fluux-hover bg-fluux-bg/40
+            transition-[box-shadow,border-color] duration-150">
             <Search className="size-5 text-fluux-muted flex-shrink-0" />
             <TextInput
               ref={inputRef}
@@ -551,7 +558,7 @@ function CommandPaletteContent({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={t('commandPalette.placeholder')}
-              className="flex-1 bg-transparent text-fluux-text placeholder:text-fluux-muted outline-none text-base"
+              className="flex-1 bg-transparent text-fluux-text placeholder:text-fluux-muted outline-none no-focus-ring text-base"
             />
             <kbd className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 text-xs text-fluux-muted bg-fluux-bg rounded border border-fluux-hover">
               esc

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -892,6 +892,16 @@ html, body {
   box-shadow: 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22);
 }
 
+/* Command palette (⌘K) search field — same soft accent focus ring as the
+ * composer card, wrapping the whole field (icon + input + esc). The palette
+ * auto-focuses its input, so this reads as an always-on "type here" affordance
+ * while the panel is open. The dialog's header padding keeps the 3px outset
+ * glow from being clipped by its overflow-hidden. */
+.command-search-field:focus-within {
+  border-color: var(--fluux-brand);
+  box-shadow: 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22);
+}
+
 /*
  * Hide the per-message floating hover toolbars while the user is composing.
  * Driven by the `composer-active` class toggled on the message area (ChatView),


### PR DESCRIPTION
## Summary

Restores the soft accent focus ring that wraps the **whole** ⌘K command-palette search field (magnifier + input + `esc`), instead of the tight 2px outline that was sitting around just the bare `<input>`.

## Changes

- `CommandPalette.tsx`: wrapper gets a `command-search-field` class; the input gets `no-focus-ring` to suppress the global center outline.
- `index.css`: a `.command-search-field:focus-within` rule mirroring `.composer-card:focus-within` (accent border + `0 0 0 3px hsla(var(--fluux-accent-h/s/l), 0.22)` glow), so the ring uses the real app accent rather than Tailwind's fallback blue.