### PR TITLE
fix(scroll): restore deep-scrolled position on return by reloading the anchor's cache slice

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -47,7 +47,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, firstNewMessageId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, firstNewMessageId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, loadMessagesAround, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -488,6 +488,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
             onMessageSeen={handleMessageSeen}
             isDarkMode={resolvedMode === 'dark'}
           onScrollToTop={fetchOlderHistory}
+          onLoadAround={loadMessagesAround}
           isLoadingOlder={activeMAMState?.isLoading ?? false}
           isHistoryComplete={activeMAMState?.isHistoryComplete ?? false}
           forwardGapTimestamp={activeMAMState?.forwardGapTimestamp}
@@ -586,6 +587,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   onMessageSeen,
   isDarkMode,
   onScrollToTop,
+  onLoadAround,
   isLoadingOlder,
   isHistoryComplete,
   isInitialLoading,
@@ -625,6 +627,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   onMessageSeen?: (messageId: string) => void
   isDarkMode?: boolean
   onScrollToTop?: () => void
+  onLoadAround?: (anchorMessageId: string) => Promise<unknown> | void
   isLoadingOlder?: boolean
   isHistoryComplete?: boolean
   isInitialLoading?: boolean
@@ -728,6 +731,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       formatMessageForCopy={formatMessageForCopy}
       lastSentMessageId={lastSentMessageId}
       onScrollToTop={onScrollToTop}
+      onLoadAround={onLoadAround}
       isLoadingOlder={isLoadingOlder}
       isHistoryComplete={isHistoryComplete}
       forwardGapTimestamp={forwardGapTimestamp}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -81,7 +81,7 @@ const EMPTY_OCCUPANTS: Map<string, RoomOccupant> = new Map()
 export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = false, onShowOccupantsChange, onStartChat, onShowProfile, findOnPageRef, onSearchInConversation }: RoomViewProps) {
   detectRenderLoop('RoomView')
   const { t } = useTranslation()
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, sendWhisperChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId, firstNewMessageId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendPoll, votePoll, closePoll, sendCorrection, retractMessage, moderateMessage, sendChatState, sendWhisperChatState, setRoomNotifyAll, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, setRoomAvatar, clearRoomAvatar, fetchOlderHistory, loadMessagesAround, continueRoomCatchUp, activeMAMState, submitRoomConfig, setSubject, destroyRoom, setAffiliation, setRole, targetMessageId, clearTargetMessageId, firstNewMessageId } = useRoomActive()
   const mediaPolicy = useSettingsStore((s) => s.mediaAutoDownload)
 
   // NOTE: Use focused selectors instead of useConnection() hook to avoid
@@ -549,6 +549,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             isDarkMode={resolvedMode === 'dark'}
             onMediaLoad={handleMediaLoad}
             onScrollToTop={fetchOlderHistory}
+            onLoadAround={loadMessagesAround}
             isLoadingOlder={activeMAMState?.isLoading}
             isHistoryComplete={activeRoom.supportsMAM === false || activeMAMState?.isHistoryComplete}
             onNickContextMenu={handleNickContextMenu}
@@ -826,6 +827,7 @@ export const RoomMessageList = memo(function RoomMessageList({
   isDarkMode,
   onMediaLoad,
   onScrollToTop,
+  onLoadAround,
   isLoadingOlder,
   isHistoryComplete,
   onNickContextMenu,
@@ -869,6 +871,7 @@ export const RoomMessageList = memo(function RoomMessageList({
   isDarkMode?: boolean
   onMediaLoad?: () => void
   onScrollToTop?: () => void
+  onLoadAround?: (anchorMessageId: string) => Promise<unknown> | void
   isLoadingOlder?: boolean
   isHistoryComplete?: boolean
   onNickContextMenu?: (nick: string, e: React.MouseEvent) => void
@@ -1100,6 +1103,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       emptyState={emptyState}
       extraContent={extraContent}
       onScrollToTop={onScrollToTop}
+      onLoadAround={onLoadAround}
       isLoadingOlder={isLoadingOlder}
       isHistoryComplete={isHistoryComplete}
       renderMessage={renderMessage}

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -86,6 +86,12 @@ export interface MessageListProps<T extends BaseMessage> {
   isAtBottomRef?: React.MutableRefObject<boolean>
   /** Callback when user scrolls to top (for lazy loading older messages) */
   onScrollToTop?: () => void
+  /**
+   * Hydrate the resident message window with the cache slice CONTAINING a specific message.
+   * Used by scroll-position restore (and search/target navigation) when the saved anchor / target
+   * is older than the latest-N slice loaded on activation, so the existing anchor restore can land.
+   */
+  onLoadAround?: (anchorMessageId: string) => Promise<unknown> | void
   /** If true, show loading indicator at top while fetching older messages */
   isLoadingOlder?: boolean
   /** If true, all history has been fetched - disable scroll-to-top trigger */
@@ -134,6 +140,7 @@ export function MessageList<T extends BaseMessage>({
   scrollerRef: externalScrollerRef,
   isAtBottomRef: externalIsAtBottomRef,
   onScrollToTop,
+  onLoadAround,
   isLoadingOlder,
   isHistoryComplete,
   onMessageSeen,
@@ -391,6 +398,7 @@ export function MessageList<T extends BaseMessage>({
     externalScrollerRef,
     externalIsAtBottomRef,
     onScrollToTop,
+    onLoadAround,
     isLoadingOlder,
     isHistoryComplete,
     typingUsersCount: typingUsers.length,

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -32,6 +32,7 @@ interface HookHarnessProps {
   ids: string[]
   firstNewMessageId?: string
   clearFirstNewMessageId?: () => void
+  onLoadAround?: (anchorMessageId: string) => Promise<unknown> | void
   scrollHeight?: number
   clientHeight?: number
   initialScrollTop?: number
@@ -43,11 +44,23 @@ function seedSavedScrollPosition(conversationId: string, scrollTop = 200) {
   scrollStateManager.leaveConversation(conversationId, scrollTop, 1000, 500)
 }
 
+// Seed a saved CONTENT anchor whose scrollHeight differs from the harness scroller (1000) so the
+// exact-scrollTop fast-path is skipped and the anchor path runs — mirrors returning to a deeply
+// scrolled-back conversation whose tall window was evicted and rehydrated to a short latest slice.
+function seedSavedAnchor(conversationId: string, anchorMessageId: string, scrollTop = 200) {
+  scrollStateManager.enterConversation(conversationId, 10)
+  scrollStateManager.leaveConversation(conversationId, scrollTop, 5000, 500, {
+    messageId: anchorMessageId,
+    fraction: 1,
+  })
+}
+
 function HookHarness({
   conversationId,
   ids,
   firstNewMessageId,
   clearFirstNewMessageId,
+  onLoadAround,
   scrollHeight = 1000,
   clientHeight = 500,
   initialScrollTop = 0,
@@ -65,6 +78,7 @@ function HookHarness({
     firstMessageId: ids[0],
     firstNewMessageId,
     clearFirstNewMessageId,
+    onLoadAround,
     typingUsersCount: 0,
     lastMessageReactionsKey: '',
     lastMessageId: ids.at(-1),
@@ -307,5 +321,41 @@ describe('useMessageListScroll saved-position restore', () => {
 
     expect(handle?.getScrollTop()).toBe(1000)
     expect(scrollStateManager.getSavedScrollTop('room-bottom-intent')).toBeNull()
+  })
+
+  // Regression: returning to a conversation scrolled deep into history. The saved anchor points at
+  // an OLD message that the latest-N rehydration didn't load, so restore can't resolve it. It must
+  // request the cache slice AROUND the anchor (onLoadAround) rather than fall back to the saved
+  // scrollTop on the short list (which landed near the top at the load-more trigger — the bug).
+  it('requests the cache slice around a saved anchor that is not in the loaded set', () => {
+    seedSavedAnchor('around-missing', 'old-anchor')
+    const onLoadAround = vi.fn().mockResolvedValue([])
+
+    render(
+      <HookHarness
+        conversationId="around-missing"
+        ids={['msg-0', 'msg-1', 'msg-2']}
+        onLoadAround={onLoadAround}
+        onReady={() => {}}
+      />,
+    )
+
+    expect(onLoadAround).toHaveBeenCalledWith('old-anchor')
+  })
+
+  it('does not request a slice when the saved anchor is already in the loaded set', () => {
+    seedSavedAnchor('around-present', 'msg-1')
+    const onLoadAround = vi.fn().mockResolvedValue([])
+
+    render(
+      <HookHarness
+        conversationId="around-present"
+        ids={['msg-0', 'msg-1', 'msg-2']}
+        onLoadAround={onLoadAround}
+        onReady={() => {}}
+      />,
+    )
+
+    expect(onLoadAround).not.toHaveBeenCalled()
   })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -191,6 +191,15 @@ export interface UseMessageListScrollOptions {
   externalIsAtBottomRef?: React.MutableRefObject<boolean>
   clearFirstNewMessageId?: () => void  // Called when user scrolls past the new message marker
   onScrollToTop?: () => void
+  /**
+   * Hydrate the resident message window with the cache slice CONTAINING a specific message.
+   * Called by the restore path when a saved content anchor (or a navigation target) is older than
+   * the latest-N slice loaded on activation, so it isn't in the loaded set and the anchor restore
+   * can't resolve it. The resulting message-count growth re-runs the restore via the retry effect.
+   * Returns a promise that resolves once the slice has merged (or with an empty slice when the
+   * anchor isn't in the cache).
+   */
+  onLoadAround?: (anchorMessageId: string) => Promise<unknown> | void
   isLoadingOlder?: boolean
   isHistoryComplete?: boolean
   typingUsersCount: number
@@ -243,6 +252,7 @@ export function useMessageListScroll({
   externalScrollerRef,
   externalIsAtBottomRef,
   onScrollToTop,
+  onLoadAround,
   isLoadingOlder,
   isHistoryComplete,
   typingUsersCount,
@@ -303,6 +313,20 @@ export function useMessageListScroll({
   const prevLastMessageIdRef = useRef<string | undefined>(lastMessageId)
   const hasInitializedRef = useRef(false)
   const pendingRestoreConversationRef = useRef<string | null>(null)
+  // Per-anchor status for the on-demand "load the cache slice around the anchor" request used when
+  // a saved content anchor (or navigation target) is older than the latest-N slice loaded on
+  // activation. 'loading' → request in flight (stay pending); 'done' → attempted (resolved by the
+  // index path, or the anchor wasn't in the cache → fall through to the legacy fallback). Keyed by
+  // `${conversationId}:${anchorMessageId}` and cleared on conversation switch so returning to the
+  // same conversation re-requests. Prevents re-issuing the load on every retry frame.
+  const aroundLoadStatusRef = useRef<Map<string, 'loading' | 'done'>>(new Map())
+  // Last target message id we requested an around-load for (search / activity navigation to a
+  // message older than the loaded window). Prevents re-issuing the load while the target effect
+  // re-fires waiting for the slice to merge.
+  const targetAroundRequestedRef = useRef<string | null>(null)
+  // Stable indirection so the async around-load completion can re-run restore without making
+  // restoreSavedPosition a dependency of itself.
+  const restoreSavedPositionRef = useRef<((source: 'entry' | 'retry') => RestoreSavedPositionResult) | null>(null)
 
   // Track prepend (loading older messages)
   // When we load older messages, we save the anchor element position BEFORE the load,
@@ -415,9 +439,9 @@ export function useMessageListScroll({
   //    values they need are read through latestRef (updated each render via
   //    effect), never closed over.
 
-  const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer })
+  const latestRef = useRef({ staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer, onLoadAround })
   useEffect(() => {
-    latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer }
+    latestRef.current = { staticMode, externalScrollerRef, isAtBottomRef, conversationId, virtualizer, onLoadAround }
   })
 
   const stableSettersRef = useRef<{
@@ -751,6 +775,36 @@ export function useMessageListScroll({
       return 'restored'
     }
 
+    // The saved anchor message is not in the currently-loaded window (the user had scrolled deep
+    // into history, so it sits OLDER than the latest-N slice rehydrated on activation). Request the
+    // cache slice that CONTAINS it; the merge grows messageCount, which re-runs this restore via the
+    // retry effect, and the anchor then resolves through the virtualizer-index path below. Without
+    // this the restore fell through to the saved scrollTop on the short rehydrated list and landed
+    // near the top at the load-more trigger — the reported bug. Returns true while the load should
+    // hold the restore in 'pending'; false when there's no loader or the load already completed
+    // without recovering the anchor (then the legacy fallbacks run).
+    const requestAnchorAroundLoad = (anchorMessageId: string): boolean => {
+      const loader = latestRef.current.onLoadAround
+      if (!loader) return false
+      const key = `${conversationId}:${anchorMessageId}`
+      const status = aroundLoadStatusRef.current.get(key)
+      if (status === 'done') return false
+      if (status === 'loading') return true
+      aroundLoadStatusRef.current.set(key, 'loading')
+      isAtBottomRef.current = false
+      debugLog('RESTORE: anchor not loaded, requesting cache slice around it', { source, anchorMessageId, conversationId })
+      void Promise.resolve(loader(anchorMessageId)).finally(() => {
+        aroundLoadStatusRef.current.set(key, 'done')
+        // The merge bumps messageCount → the retry effect re-runs restore. Force one attempt too,
+        // covering the empty-slice case (anchor not in cache → no count change → no retry) so the
+        // restore can fall through to its bottom fallback instead of hanging in 'pending'.
+        if (pendingRestoreConversationRef.current === conversationId) {
+          restoreSavedPositionRef.current?.('retry')
+        }
+      })
+      return true
+    }
+
     // Exact restore when the layout is UNCHANGED since save (same-session navigate-back, including
     // eviction+rehydrate that reproduces identical content): the saved scrollTop is exact and
     // layout-independent precisely because the content is the same, so the ratio-based anchor isn't
@@ -799,6 +853,11 @@ export function useMessageListScroll({
         return finishRestore('RESTORE via virtualizer index', { savedAnchor, anchorIndex })
       }
 
+      // Anchor is older than the loaded window — pull in the slice that contains it, then retry.
+      if (requestAnchorAroundLoad(savedAnchor.messageId)) {
+        return 'pending'
+      }
+
       if (savedPos !== null) {
         virtRestore.scrollToOffset(savedPos)
         return finishRestore('RESTORE via savedPos (virt, anchor not indexed)', { savedPos })
@@ -807,6 +866,12 @@ export function useMessageListScroll({
       debugLog('RESTORE: anchor not indexed, no savedPos, scrolling to bottom', { source, savedAnchor })
       reassertBottom()
       return 'bottom'
+    }
+
+    // Non-virtualized: all loaded rows are in the DOM, so a missing anchor row means the anchor
+    // isn't loaded. Pull in its slice and retry before falling back to the saved scrollTop.
+    if (!virtRestore && savedAnchor && requestAnchorAroundLoad(savedAnchor.messageId)) {
+      return 'pending'
     }
 
     if (virtRestore && savedPos !== null) {
@@ -834,6 +899,10 @@ export function useMessageListScroll({
     reassertBottom,
     rememberCurrentScrollSnapshot,
   ])
+
+  // Stable handle so the async around-load completion can re-run restore (see
+  // requestAnchorAroundLoad) without restoreSavedPosition depending on itself. Updated each render.
+  restoreSavedPositionRef.current = restoreSavedPosition
 
   // ==========================================================================
   // SCROLL ACTIONS
@@ -1333,6 +1402,8 @@ export function useMessageListScroll({
     lastAnchorRef.current = null
     prependRef.current = null
     pendingRestoreConversationRef.current = null
+    // Returning to this conversation later must be free to re-request its anchor slice.
+    aroundLoadStatusRef.current.clear()
     setShowScrollToBottom(false)
 
     // Clear any pending media load batch
@@ -1593,7 +1664,12 @@ export function useMessageListScroll({
   // as the unread marker scroll. Clears the target after consumption.
 
   useEffect(() => {
-    if (!targetMessageId || staticMode) return
+    if (!targetMessageId || staticMode) {
+      // Target cleared (consumed or navigated away): allow a future jump to the same id to
+      // re-request its slice (it may have been evicted again in the meantime).
+      if (!targetMessageId) targetAroundRequestedRef.current = null
+      return
+    }
     const scroller = scrollerRef.current
     if (!scroller) return
 
@@ -1613,7 +1689,17 @@ export function useMessageListScroll({
       // yet (e.g., search opens a conversation before messages finish loading from cache).
       const idx = virt.getIndexForMessageId(targetMessageId)
       if (idx === null) {
-        debugLog('TARGET MESSAGE: not in item set yet, waiting for load', { targetMessageId })
+        // The target isn't in the loaded window — pull in the cache slice that contains it (search /
+        // activity jump to a message older than the latest-N slice). The merge grows messageCount,
+        // re-firing this effect with the target now resolvable. Request once per target.
+        const loader = latestRef.current.onLoadAround
+        if (loader && targetAroundRequestedRef.current !== targetMessageId) {
+          targetAroundRequestedRef.current = targetMessageId
+          debugLog('TARGET MESSAGE: not loaded, requesting cache slice around it', { targetMessageId })
+          void Promise.resolve(loader(targetMessageId))
+        } else {
+          debugLog('TARGET MESSAGE: not in item set yet, waiting for load', { targetMessageId })
+        }
         return
       }
       const targetConvId = conversationId
@@ -1711,7 +1797,14 @@ export function useMessageListScroll({
       // Non-virtualized: all rows are always in the DOM.
       const el = scroller.querySelector(`[data-message-id="${escapedId}"]`)
       if (!el) {
-        debugLog('TARGET MESSAGE: element not found (non-virtualized), waiting for load', { targetMessageId })
+        const loader = latestRef.current.onLoadAround
+        if (loader && targetAroundRequestedRef.current !== targetMessageId) {
+          targetAroundRequestedRef.current = targetMessageId
+          debugLog('TARGET MESSAGE: not loaded (non-virtualized), requesting cache slice around it', { targetMessageId })
+          void Promise.resolve(loader(targetMessageId))
+        } else {
+          debugLog('TARGET MESSAGE: element not found (non-virtualized), waiting for load', { targetMessageId })
+        }
         return
       }
       const elementTop = (el as HTMLElement).offsetTop

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -373,6 +373,18 @@ export function useChatActive() {
     }
   }, [client])
 
+  // Hydrate the resident array with the cache slice CONTAINING a specific message, used by scroll
+  // restore / search navigation when the target/anchor isn't in the latest-N slice. Bound to the
+  // currently-active conversation (the one being viewed when restore runs).
+  const loadMessagesAround = useCallback(
+    (anchorMessageId: string) => {
+      const id = chatStore.getState().activeConversationId
+      if (!id) return Promise.resolve([])
+      return chatStore.getState().loadMessagesAroundFromCache(id, anchorMessageId)
+    },
+    []
+  )
+
   // --- Return ---
 
   const actions = useMemo(
@@ -400,6 +412,7 @@ export function useChatActive() {
       updateLastSeenMessageId,
       fetchHistory,
       fetchOlderHistory,
+      loadMessagesAround,
       continueChatCatchUp,
     }),
     [
@@ -408,7 +421,7 @@ export function useChatActive() {
       sendChatState, sendReaction, sendCorrection, retractMessage, retryMessage,
       sendEasterEgg, clearAnimation, clearTargetMessageId, setDraft, getDraft, clearDraft,
       clearFirstNewMessageId, updateLastSeenMessageId, fetchHistory, fetchOlderHistory,
-      continueChatCatchUp,
+      loadMessagesAround, continueChatCatchUp,
     ]
   )
 

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -432,6 +432,18 @@ export function useRoomActive() {
     }
   }, [client])
 
+  // Hydrate the resident array with the cache slice CONTAINING a specific message, used by scroll
+  // restore / search navigation when the target/anchor isn't in the latest-N slice. Bound to the
+  // currently-active room (the one being viewed when restore runs).
+  const loadMessagesAround = useCallback(
+    (anchorMessageId: string) => {
+      const id = roomStore.getState().activeRoomJid
+      if (!id) return Promise.resolve([])
+      return roomStore.getState().loadMessagesAroundFromCache(id, anchorMessageId)
+    },
+    []
+  )
+
   // --- Return ---
 
   // Memoize actions object to prevent re-renders when only state changes
@@ -467,6 +479,7 @@ export function useRoomActive() {
       clearFirstNewMessageId,
       updateLastSeenMessageId,
       fetchOlderHistory,
+      loadMessagesAround,
       continueRoomCatchUp,
       submitRoomConfig,
       setSubject,
@@ -505,6 +518,7 @@ export function useRoomActive() {
       clearFirstNewMessageId,
       updateLastSeenMessageId,
       fetchOlderHistory,
+      loadMessagesAround,
       continueRoomCatchUp,
       submitRoomConfig,
       setSubject,

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -38,6 +38,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     saveMessage: vi.fn().mockResolvedValue(undefined),
     saveMessages: vi.fn().mockResolvedValue(undefined),
     getMessages: vi.fn().mockResolvedValue([]),
+    getMessagesAround: vi.fn().mockResolvedValue([]),
     updateMessage: vi.fn().mockResolvedValue(undefined),
   }
 })
@@ -367,6 +368,66 @@ describe('chatStore', () => {
       await stale
 
       expect(chatStore.getState().activeConversationId).toBe('bob@example.com')
+    })
+  })
+
+  describe('loadMessagesAroundFromCache', () => {
+    afterEach(() => {
+      vi.mocked(messageCache.getMessagesAround).mockReset()
+      vi.mocked(messageCache.getMessagesAround).mockResolvedValue([])
+    })
+
+    function msgAt(conversationId: string, id: string, minute: number): Message {
+      return {
+        type: 'chat',
+        id,
+        conversationId,
+        from: conversationId,
+        body: id,
+        timestamp: new Date(`2024-03-01T10:0${minute}:00Z`),
+        isOutgoing: false,
+      }
+    }
+
+    it('hydrates the resident array with the cache slice that contains the anchor', async () => {
+      const A = 'alice@example.com'
+      chatStore.getState().addConversation(createConversation(A))
+      chatStore.setState({ activeConversationId: A })
+
+      const slice = [
+        msgAt(A, 'old-3', 3),
+        msgAt(A, 'anchor', 4),
+        msgAt(A, 'newer-5', 5),
+        msgAt(A, 'newer-6', 6),
+      ]
+      vi.mocked(messageCache.getMessagesAround).mockResolvedValue(slice)
+
+      const returned = await chatStore.getState().loadMessagesAroundFromCache(A, 'anchor')
+
+      expect(messageCache.getMessagesAround).toHaveBeenCalledWith(A, 'anchor', expect.any(Object))
+      const resident = chatStore.getState().messages.get(A)
+      expect(resident?.map((m) => m.id)).toEqual(['old-3', 'anchor', 'newer-5', 'newer-6'])
+      expect(returned.map((m) => m.id)).toEqual(['old-3', 'anchor', 'newer-5', 'newer-6'])
+    })
+
+    it('merges the slice with any already-resident messages, deduped and sorted', async () => {
+      const A = 'alice@example.com'
+      chatStore.getState().addConversation(createConversation(A))
+      chatStore.setState({
+        activeConversationId: A,
+        messages: new Map([[A, [msgAt(A, 'newer-6', 6), msgAt(A, 'newer-7', 7)]]]),
+      })
+
+      vi.mocked(messageCache.getMessagesAround).mockResolvedValue([
+        msgAt(A, 'anchor', 4),
+        msgAt(A, 'newer-5', 5),
+        msgAt(A, 'newer-6', 6), // duplicate of a resident message
+      ])
+
+      await chatStore.getState().loadMessagesAroundFromCache(A, 'anchor')
+
+      const resident = chatStore.getState().messages.get(A)
+      expect(resident?.map((m) => m.id)).toEqual(['anchor', 'newer-5', 'newer-6', 'newer-7'])
     })
   })
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -76,6 +76,56 @@ function getScopedStorageKey(jid?: string | null): string {
   return buildScopedStorageKey(STORAGE_KEY_BASE, jid)
 }
 
+/**
+ * Merge a batch of cached messages into a conversation's resident array, returning the partial
+ * state update (or `null` when every cached message is already resident). Shared by
+ * {@link ChatState.loadMessagesFromCache} and {@link ChatState.loadMessagesAroundFromCache}: both
+ * filter duplicates, merge/sort/trim, and refresh the sidebar preview to the newest previewable
+ * message (healing a stuck encrypted-fallback placeholder). The only difference between the two
+ * callers is WHICH cache slice they fetch (latest-N vs the slice around an anchor).
+ */
+function mergeCachedChatMessages(
+  state: ChatState,
+  conversationId: string,
+  cachedMessages: Message[]
+): Pick<ChatState, 'messages' | 'conversationMeta' | 'conversations'> | { messages: ChatState['messages'] } | null {
+  const existingMessages = state.messages.get(conversationId) || []
+
+  const existingKeySet = buildMessageKeySet(existingMessages, getChatMessageKeys)
+  const newMessages = cachedMessages.filter(
+    (m) => !isMessageDuplicate(m, existingKeySet, getChatMessageKeys)
+  )
+
+  if (newMessages.length === 0) return null
+
+  const merged = sortMessagesByTimestamp([...existingMessages, ...newMessages])
+  const trimmed = trimMessages(merged, MAX_MESSAGES_PER_CONVERSATION)
+
+  const newMessagesMap = new Map(state.messages)
+  newMessagesMap.set(conversationId, trimmed)
+
+  // Update lastMessage with the newest previewable message after merge/sort, skipping bodiless
+  // signal placeholders. Opening a conversation whose stored preview is a stuck placeholder heals
+  // it here: a real cached message supersedes the placeholder even though the placeholder's
+  // timestamp is newer.
+  const lastMessage = findLastPreviewableMessage(trimmed)
+  const meta = state.conversationMeta.get(conversationId)
+  const conv = state.conversations.get(conversationId)
+  if (
+    meta && conv && lastMessage &&
+    (shouldReplaceLastMessage(meta.lastMessage, lastMessage) ||
+      isResolvedSamePreview(meta.lastMessage, lastMessage))
+  ) {
+    const newMeta = new Map(state.conversationMeta)
+    newMeta.set(conversationId, { ...meta, lastMessage })
+    const newConversations = new Map(state.conversations)
+    newConversations.set(conversationId, { ...conv, lastMessage })
+    return { messages: newMessagesMap, conversationMeta: newMeta, conversations: newConversations }
+  }
+
+  return { messages: newMessagesMap }
+}
+
 function getLegacyStorageKey(): string {
   return STORAGE_KEY_BASE
 }
@@ -271,6 +321,16 @@ interface ChatState {
   refreshLastMessageContent: (conversationId: string, messageId: string, updates: Partial<Message>) => void
   // IndexedDB message loading
   loadMessagesFromCache: (conversationId: string, options?: { limit?: number; before?: Date; peek?: boolean }) => Promise<Message[]>
+  /**
+   * Hydrate the resident array with the contiguous cache slice that CONTAINS a specific message
+   * (the anchor), rather than the latest-N slice. Used by scroll-position restore on return to a
+   * conversation the user had scrolled deep into: the saved content anchor points at an old message
+   * absent from the latest-100 rehydration, so restore can't resolve it. Loading the slice around
+   * the anchor (older context + the tail through the latest message) makes the existing anchor
+   * restore land correctly. Also serves search/activity navigation to a message not in the recent
+   * slice. Returns the loaded slice (empty if the anchor is not in the cache).
+   */
+  loadMessagesAroundFromCache: (conversationId: string, anchorMessageId: string, options?: { before?: number; after?: number }) => Promise<Message[]>
   loadOlderMessagesFromCache: (conversationId: string, limit?: number) => Promise<Message[]>
   setTargetMessageId: (id: string | null) => void
   switchAccount: (jid: string | null) => void
@@ -1633,62 +1693,25 @@ export const chatStore = createStore<ChatState>()(
           // used to compute a catch-up cursor for a non-active conversation without
           // pulling its history into RAM (only the active conversation is resident).
           if (!peek && cachedMessages.length > 0) {
-            set((state) => {
-              const existingMessages = state.messages.get(conversationId) || []
-
-              // Build key set and filter duplicates using shared utilities
-              const existingKeySet = buildMessageKeySet(existingMessages, getChatMessageKeys)
-              const newMessages = cachedMessages.filter(
-                (m) => !isMessageDuplicate(m, existingKeySet, getChatMessageKeys)
-              )
-
-              if (newMessages.length === 0) {
-                return state
-              }
-
-              // Merge, sort, and trim using shared utilities
-              const merged = sortMessagesByTimestamp([...existingMessages, ...newMessages])
-              const trimmed = trimMessages(merged, MAX_MESSAGES_PER_CONVERSATION)
-
-              const newMessagesMap = new Map(state.messages)
-              newMessagesMap.set(conversationId, trimmed)
-
-              // Update lastMessage with the newest previewable message after
-              // merge/sort, skipping bodiless signal placeholders. Opening a
-              // conversation whose stored preview is a stuck placeholder heals
-              // it here: a real cached message supersedes the placeholder even
-              // though the placeholder's timestamp is newer.
-              const lastMessage = findLastPreviewableMessage(trimmed)
-              const meta = state.conversationMeta.get(conversationId)
-              const conv = state.conversations.get(conversationId)
-              // Replace when newer/a stuck placeholder, OR when this is the same
-              // message resolved in the cache (deferred decrypt) while the preview
-              // kept the encrypted fallback — shouldReplaceLastMessage's
-              // strictly-newer gate would otherwise leave the sidebar stuck on
-              // "[OpenPGP-encrypted message]".
-              if (
-                meta && conv && lastMessage &&
-                (shouldReplaceLastMessage(meta.lastMessage, lastMessage) ||
-                  isResolvedSamePreview(meta.lastMessage, lastMessage))
-              ) {
-                // Update metadata map
-                const newMeta = new Map(state.conversationMeta)
-                newMeta.set(conversationId, { ...meta, lastMessage })
-
-                // Update combined map
-                const newConversations = new Map(state.conversations)
-                newConversations.set(conversationId, { ...conv, lastMessage })
-
-                return { messages: newMessagesMap, conversationMeta: newMeta, conversations: newConversations }
-              }
-
-              return { messages: newMessagesMap }
-            })
+            set((state) => mergeCachedChatMessages(state, conversationId, cachedMessages) ?? state)
           }
 
           return cachedMessages
         } catch (error) {
           console.warn('Failed to load messages from cache:', error)
+          return []
+        }
+      },
+
+      loadMessagesAroundFromCache: async (conversationId, anchorMessageId, options = {}) => {
+        try {
+          const slice = await messageCache.getMessagesAround(conversationId, anchorMessageId, options)
+          if (slice.length > 0) {
+            set((state) => mergeCachedChatMessages(state, conversationId, slice) ?? state)
+          }
+          return slice
+        } catch (error) {
+          console.warn('Failed to load messages around anchor from cache:', error)
           return []
         }
       },

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -38,6 +38,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     saveRoomMessage: vi.fn().mockResolvedValue(undefined),
     saveRoomMessages: vi.fn().mockResolvedValue(undefined),
     getRoomMessages: vi.fn().mockResolvedValue([]),
+    getRoomMessagesAround: vi.fn().mockResolvedValue([]),
     updateRoomMessage: vi.fn().mockResolvedValue(undefined),
     deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
   }
@@ -3386,6 +3387,55 @@ describe('roomStore', () => {
 
       expect(result).toBeNull()
       expect(messageCache.getRoomMessages).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('loadMessagesAroundFromCache', () => {
+    const roomJid = 'room@conference.example.com'
+
+    beforeEach(() => {
+      roomStore.getState().reset()
+      vi.mocked(messageCache.getRoomMessagesAround).mockReset()
+      vi.mocked(messageCache.getRoomMessagesAround).mockResolvedValue([])
+      roomStore.getState().addRoom({
+        jid: roomJid,
+        name: 'Test Room',
+        nickname: 'testuser',
+        joined: true,
+        isJoining: false,
+        isBookmarked: false,
+        supportsMAM: true,
+        occupants: new Map(),
+        messages: [],
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set(),
+      })
+    })
+
+    function roomMsgAt(id: string, minute: number): RoomMessage {
+      return {
+        type: 'groupchat',
+        id,
+        roomJid,
+        from: `${roomJid}/alice`,
+        nick: 'alice',
+        body: id,
+        timestamp: new Date(`2024-03-01T10:0${minute}:00Z`),
+        isOutgoing: false,
+      }
+    }
+
+    it('hydrates the resident array with the cache slice that contains the anchor', async () => {
+      const slice = [roomMsgAt('old-3', 3), roomMsgAt('anchor', 4), roomMsgAt('newer-5', 5)]
+      vi.mocked(messageCache.getRoomMessagesAround).mockResolvedValue(slice)
+
+      const returned = await roomStore.getState().loadMessagesAroundFromCache(roomJid, 'anchor')
+
+      expect(messageCache.getRoomMessagesAround).toHaveBeenCalledWith(roomJid, 'anchor', expect.any(Object))
+      const resident = roomStore.getState().rooms.get(roomJid)?.messages
+      expect(resident?.map((m) => m.id)).toEqual(['old-3', 'anchor', 'newer-5'])
+      expect(returned.map((m) => m.id)).toEqual(['old-3', 'anchor', 'newer-5'])
     })
   })
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -283,6 +283,57 @@ function getRoomMessageKeys(m: RoomMessage): string[] {
 }
 
 /**
+ * Merge a batch of cached room messages into a room's resident array (and runtime mirror),
+ * returning the partial state update (or `null` when the room is not present). Shared by
+ * {@link RoomState.loadMessagesFromCache} and {@link RoomState.loadMessagesAroundFromCache}: both
+ * dedupe, merge/sort/trim, and refresh the sidebar preview. The only difference between the two
+ * callers is WHICH cache slice they fetch (latest-N vs the slice around an anchor).
+ */
+function mergeCachedRoomMessages(
+  state: RoomState,
+  roomJid: string,
+  cachedMessages: RoomMessage[]
+): Pick<RoomState, 'rooms' | 'roomRuntime' | 'roomMeta'> | null {
+  const newRooms = new Map(state.rooms)
+  const existing = newRooms.get(roomJid)
+  if (!existing) return null
+
+  // Build key set from in-memory messages (they take precedence)
+  const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
+
+  // Filter out duplicates from cached messages
+  const newFromCache = cachedMessages.filter(
+    (msg) => !isMessageDuplicate(msg, existingKeys, getRoomMessageKeys)
+  )
+
+  // Merge, sort, and trim using shared utilities
+  const combined = [...newFromCache, ...existing.messages]
+  const sorted = sortMessagesByTimestamp(combined)
+  const merged = trimMessages(sorted, MAX_MESSAGES_PER_ROOM)
+
+  // Get last non-ignored message from merged messages for sidebar preview
+  const lastMessage = (merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, existing.nickToJidCache) : undefined) ?? existing.lastMessage
+
+  newRooms.set(roomJid, { ...existing, messages: merged, lastMessage })
+
+  // Update runtime
+  const newRuntime = new Map(state.roomRuntime)
+  const existingRuntime = newRuntime.get(roomJid)
+  if (existingRuntime) {
+    newRuntime.set(roomJid, { ...existingRuntime, messages: merged })
+  }
+
+  // Update metadata with lastMessage for sidebar
+  const newMeta = new Map(state.roomMeta)
+  const existingMeta = newMeta.get(roomJid)
+  if (existingMeta) {
+    newMeta.set(roomJid, { ...existingMeta, lastMessage })
+  }
+
+  return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta }
+}
+
+/**
  * Room state interface for Multi-User Chat (MUC) rooms.
  *
  * Manages group chat rooms, occupants, messages, bookmarks, typing indicators,
@@ -439,6 +490,14 @@ export interface RoomState {
 
   // IndexedDB cache loading
   loadMessagesFromCache: (roomJid: string, options?: GetMessagesOptions & { peek?: boolean }) => Promise<RoomMessage[]>
+  /**
+   * Hydrate the resident array with the contiguous cache slice that CONTAINS a specific message
+   * (the anchor), rather than the latest-N slice. Room counterpart of
+   * {@link ChatState.loadMessagesAroundFromCache} — used by scroll-position restore on return to a
+   * room the user had scrolled deep into, and by search/activity navigation. Returns the loaded
+   * slice (empty if the anchor is not in the cache).
+   */
+  loadMessagesAroundFromCache: (roomJid: string, anchorMessageId: string, options?: { before?: number; after?: number }) => Promise<RoomMessage[]>
   loadOlderMessagesFromCache: (roomJid: string, limit?: number) => Promise<RoomMessage[]>
   /** Load only the latest message from cache for sidebar preview (doesn't modify messages array) */
   loadPreviewFromCache: (roomJid: string) => Promise<RoomMessage | null>
@@ -1948,50 +2007,29 @@ export const roomStore = createStore<RoomState>()(
       // store. Used to compute a catch-up cursor for a non-active room without
       // breaking the invariant that only the active room is resident in RAM.
       if (!options.peek && cachedMessages.length > 0) {
-        // Merge with existing messages in memory using shared utilities
-        set((state) => {
-          const newRooms = new Map(state.rooms)
-          const existing = newRooms.get(roomJid)
-          if (!existing) return state
-
-          // Build key set from in-memory messages (they take precedence)
-          const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
-
-          // Filter out duplicates from cached messages
-          const newFromCache = cachedMessages.filter(
-            (msg) => !isMessageDuplicate(msg, existingKeys, getRoomMessageKeys)
-          )
-
-          // Merge, sort, and trim using shared utilities
-          const combined = [...newFromCache, ...existing.messages]
-          const sorted = sortMessagesByTimestamp(combined)
-          const merged = trimMessages(sorted, MAX_MESSAGES_PER_ROOM)
-
-          // Get last non-ignored message from merged messages for sidebar preview
-          const lastMessage = (merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, existing.nickToJidCache) : undefined) ?? existing.lastMessage
-
-          newRooms.set(roomJid, { ...existing, messages: merged, lastMessage })
-
-          // Update runtime
-          const newRuntime = new Map(state.roomRuntime)
-          const existingRuntime = newRuntime.get(roomJid)
-          if (existingRuntime) {
-            newRuntime.set(roomJid, { ...existingRuntime, messages: merged })
-          }
-
-          // Update metadata with lastMessage for sidebar
-          const newMeta = new Map(state.roomMeta)
-          const existingMeta = newMeta.get(roomJid)
-          if (existingMeta) {
-            newMeta.set(roomJid, { ...existingMeta, lastMessage })
-          }
-
-          return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta }
-        })
+        // Merge with existing messages in memory using the shared helper
+        set((state) => mergeCachedRoomMessages(state, roomJid, cachedMessages) ?? state)
       }
       return cachedMessages
     } catch (error) {
       console.error('Failed to load room messages from IndexedDB:', error)
+      return []
+    }
+  },
+
+  loadMessagesAroundFromCache: async (roomJid, anchorMessageId, options = {}) => {
+    if (!messageCache.isMessageCacheAvailable()) {
+      return []
+    }
+
+    try {
+      const slice = await messageCache.getRoomMessagesAround(roomJid, anchorMessageId, options)
+      if (slice.length > 0) {
+        set((state) => mergeCachedRoomMessages(state, roomJid, slice) ?? state)
+      }
+      return slice
+    } catch (error) {
+      console.error('Failed to load room messages around anchor from IndexedDB:', error)
       return []
     }
   },

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -370,6 +370,54 @@ describe('messageCache', () => {
         expect(timestamp).toBeNull()
       })
     })
+
+    describe('getMessagesAround', () => {
+      // Ten messages, one minute apart, ids a0..a9 in chronological order.
+      const around = (i: number) => new Date(`2024-03-01T10:0${i}:00Z`)
+      async function seedTen() {
+        await messageCache.saveMessages(
+          Array.from({ length: 10 }, (_, i) =>
+            createMockMessage(conversationId, { id: `a${i}`, timestamp: around(i) })
+          )
+        )
+      }
+
+      it('loads the anchor plus context above it AND the full tail through the latest', async () => {
+        await seedTen()
+        // Anchor a5, two messages of context above it, tail uncapped → reach a9.
+        const slice = await messageCache.getMessagesAround(conversationId, 'a5', { before: 2 })
+        expect(slice.map((m) => m.id)).toEqual(['a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9'])
+      })
+
+      it('honours an explicit forward cap (windowed load for search)', async () => {
+        await seedTen()
+        const slice = await messageCache.getMessagesAround(conversationId, 'a5', { before: 2, after: 2 })
+        expect(slice.map((m) => m.id)).toEqual(['a3', 'a4', 'a5', 'a6', 'a7'])
+      })
+
+      it('returns the anchor at the head when there is no older context', async () => {
+        await seedTen()
+        const slice = await messageCache.getMessagesAround(conversationId, 'a0', { before: 5 })
+        expect(slice[0].id).toBe('a0')
+        expect(slice.map((m) => m.id)).toEqual(['a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9'])
+      })
+
+      it('returns an empty array when the anchor id is not cached', async () => {
+        await seedTen()
+        const slice = await messageCache.getMessagesAround(conversationId, 'not-here', { before: 2 })
+        expect(slice).toEqual([])
+      })
+
+      it('resolves the anchor by stanzaId when the id is a server stanza id', async () => {
+        await messageCache.saveMessages([
+          createMockMessage(conversationId, { id: 'sa0', timestamp: around(0) }),
+          createMockMessage(conversationId, { id: 'sa1', stanzaId: 'stanza-anchor', timestamp: around(1) }),
+          createMockMessage(conversationId, { id: 'sa2', timestamp: around(2) }),
+        ])
+        const slice = await messageCache.getMessagesAround(conversationId, 'stanza-anchor', { before: 5 })
+        expect(slice.map((m) => m.id)).toEqual(['sa0', 'sa1', 'sa2'])
+      })
+    })
   })
 
   describe('Room Messages', () => {
@@ -535,6 +583,29 @@ describe('messageCache', () => {
 
         const timestamp = await messageCache.getOldestRoomMessageTimestamp(roomJid)
         expect(timestamp?.getTime()).toBe(oldest.getTime())
+      })
+    })
+
+    describe('getRoomMessagesAround', () => {
+      const around = (i: number) => new Date(`2024-03-01T10:0${i}:00Z`)
+      async function seedTen() {
+        await messageCache.saveRoomMessages(
+          Array.from({ length: 10 }, (_, i) =>
+            createMockRoomMessage(roomJid, { id: `r${i}`, timestamp: around(i) })
+          )
+        )
+      }
+
+      it('loads the anchor plus context above it AND the full tail through the latest', async () => {
+        await seedTen()
+        const slice = await messageCache.getRoomMessagesAround(roomJid, 'r5', { before: 2 })
+        expect(slice.map((m) => m.id)).toEqual(['r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9'])
+      })
+
+      it('returns an empty array when the anchor id is not cached', async () => {
+        await seedTen()
+        const slice = await messageCache.getRoomMessagesAround(roomJid, 'not-here', { before: 2 })
+        expect(slice).toEqual([])
       })
     })
   })

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -484,6 +484,76 @@ export async function getMessages(
 }
 
 /**
+ * Options for loading a contiguous window of cached messages centered on an anchor.
+ */
+export interface GetMessagesAroundOptions {
+  /** Messages of context to include immediately BEFORE (older than) the anchor. Default 50. */
+  before?: number
+  /**
+   * Optional cap on how many messages to include AFTER (newer than) the anchor. Omit to include
+   * EVERY newer message through the latest, so the rehydrated window stays contiguous to the
+   * present (required for scroll-position restore: the resident array must reach the tail so
+   * bottom-stick and "new message arrives" keep working). A finite value yields a bounded window
+   * on both sides (used for search/target navigation to an arbitrary point in history).
+   */
+  after?: number
+}
+
+/**
+ * Load a contiguous window of cached chat messages centered on a specific message.
+ *
+ * Returns the anchor message, up to `before` messages of older context above it, and the messages
+ * after it (capped by `after`, or all the way through the latest when `after` is omitted), in
+ * chronological order. Returns `[]` when the anchor id is not in the cache so the caller can fall
+ * back to a latest-slice load.
+ *
+ * This is what makes scroll restore independent of the latest-N rehydration: after deep scroll-back
+ * the saved anchor points at an OLD message absent from the newest-100 slice, so the restore can't
+ * resolve it. Loading the slice that CONTAINS the anchor (plus the tail to the present) lets the
+ * existing content-anchor restore land correctly. The same primitive serves search/activity jumps
+ * to a message that isn't in the recent slice.
+ *
+ * @param anchorMessageId - The anchor's client id (`message.id`, as carried by `data-message-id`).
+ *   Falls back to the stanza-id index so a server stanza id (e.g. a navigation target) also resolves.
+ */
+export async function getMessagesAround(
+  conversationId: string,
+  anchorMessageId: string,
+  options: GetMessagesAroundOptions = {}
+): Promise<Message[]> {
+  const { before = 50, after } = options
+
+  let anchor = await getMessage(anchorMessageId)
+  if (!anchor) anchor = await getMessageByStanzaId(anchorMessageId)
+  if (!anchor) return []
+
+  const t = anchor.timestamp.getTime()
+  // Context above + the anchor itself: the `before + 1` newest messages with timestamp <= t.
+  // (upperBound is exclusive, so `t + 1` includes the anchor sitting at exactly t.)
+  const olderAndAnchor = await getMessages(conversationId, {
+    before: new Date(t + 1),
+    limit: before + 1,
+  })
+  // Tail: messages strictly newer than the anchor. Capped by `after` (oldest-first from the
+  // anchor) for a bounded window, or uncapped to reach the latest message.
+  const newer = await getMessages(conversationId, {
+    after: new Date(t),
+    ...(after !== undefined ? { limit: after } : {}),
+  })
+
+  // Merge + dedupe by id, preserving chronological order (the two reads cannot overlap by
+  // timestamp, but a defensive id-dedupe keeps it robust against same-ms siblings).
+  const seen = new Set<string>()
+  const merged: Message[] = []
+  for (const m of [...olderAndAnchor, ...newer]) {
+    if (seen.has(m.id)) continue
+    seen.add(m.id)
+    merged.push(m)
+  }
+  return merged
+}
+
+/**
  * Get the count of messages for a conversation.
  */
 export async function getMessageCount(conversationId: string): Promise<number> {
@@ -734,6 +804,43 @@ export async function getRoomMessages(
     }
     return []
   }
+}
+
+/**
+ * Load a contiguous window of cached room messages centered on a specific message.
+ * Room counterpart of {@link getMessagesAround} — see it for semantics.
+ */
+export async function getRoomMessagesAround(
+  roomJid: string,
+  anchorMessageId: string,
+  options: GetMessagesAroundOptions = {}
+): Promise<RoomMessage[]> {
+  const { before = 50, after } = options
+
+  let anchor = await getRoomMessage(anchorMessageId)
+  if (!anchor) anchor = await getRoomMessageByStanzaId(anchorMessageId)
+  if (!anchor) return []
+
+  const t = anchor.timestamp.getTime()
+  const olderAndAnchor = await getRoomMessages(roomJid, {
+    before: new Date(t + 1),
+    limit: before + 1,
+  })
+  const newer = await getRoomMessages(roomJid, {
+    after: new Date(t),
+    ...(after !== undefined ? { limit: after } : {}),
+  })
+
+  // Dedupe by the same key the cache uses (room ids are not unique across senders).
+  const seen = new Set<string>()
+  const merged: RoomMessage[] = []
+  for (const m of [...olderAndAnchor, ...newer]) {
+    const key = getRoomMessageCacheKey(m)
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(m)
+  }
+  return merged
 }
 
 /**

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -167,6 +167,29 @@ async function findTopVisibleMessage(page: Page): Promise<{ id: string; offsetFr
   })
 }
 
+/**
+ * Find the BOTTOM-most message row whose top is above the viewport bottom — i.e. the row the
+ * content anchor is captured from (mirrors findBottomAnchor in useMessageListScroll). Returns
+ * {id, visible} or null.
+ */
+async function findBottomVisibleMessage(page: Page): Promise<{ id: string; topInView: number } | null> {
+  return page.evaluate(() => {
+    const scroller = document.querySelector('[data-message-list]') as HTMLElement | null
+    if (!scroller) return null
+    const sRect = scroller.getBoundingClientRect()
+    const viewportBottom = scroller.scrollTop + scroller.clientHeight
+    const rows = Array.from(scroller.querySelectorAll('.message-row[data-message-id]')) as HTMLElement[]
+    let best: HTMLElement | null = null
+    for (const el of rows) {
+      if (el.offsetHeight <= 0) continue
+      if (el.offsetTop < viewportBottom && (best === null || el.offsetTop > best.offsetTop)) best = el
+    }
+    if (!best && rows.length) best = rows[rows.length - 1]
+    if (!best) return null
+    return { id: best.dataset.messageId!, topInView: best.getBoundingClientRect().top - sRect.top }
+  })
+}
+
 /** Get a message row's current viewport offset-from-top (null if not mounted). */
 async function getMessageOffsetFromTop(page: Page, messageId: string): Promise<number | null> {
   return page.evaluate((id) => {
@@ -571,6 +594,111 @@ test.describe('Virtualization scroll invariants', () => {
       'viewport went BLANK on at least one frame after scroll-up load-older — virtualizer ' +
         'window desynced from scrollTop (mounted rows fell outside the visible band)',
     ).toBeGreaterThan(0)
+  })
+
+  // ── 8: Deep-history restore survives conversation-switch eviction ───────────
+  //
+  // The reported bug: scroll FAR back into history (load several older pages), switch to another
+  // conversation, switch back. On return the non-active room's resident window was evicted and
+  // rehydrated to the LATEST slice (~100), so the saved content anchor — an OLD message now absent
+  // from the loaded set — couldn't be resolved and the restore fell back near the TOP at the
+  // load-more trigger. The fix loads the cache slice AROUND the anchor on demand, so the anchor is
+  // resident before restore runs and the position is restored.
+  test('invariant-8: deep-history anchor is reloaded and repositioned after switching away and back', async ({ page }) => {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+
+    // Load several older pages so the loaded window extends WELL past the latest ~100 (each
+    // load-older synthesizes + persists a 50-message batch via the real MAM/cache path).
+    for (let i = 0; i < 5; i++) {
+      const spacerBefore = await getSpacerHeight(page)
+      await page.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const trigger = (window as any).__fluuxTriggerLoadOlder
+        if (typeof trigger === 'function') trigger()
+      })
+      await page.waitForFunction(
+        (before) => {
+          const sp = document.querySelector('[data-virtualizer-spacer]') as HTMLElement | null
+          return sp ? sp.offsetHeight > before + 1500 : false
+        },
+        spacerBefore,
+        { timeout: 6_000 },
+      ).catch(() => { /* history may complete; tolerate */ })
+      await page.waitForTimeout(200)
+    }
+
+    // The view is still at the bottom (load-older prepends above the fold). Scroll UP into deep
+    // history with real wheel events (the virtualizer re-windows on the native scroll event; a raw
+    // scrollTop write doesn't in headless). Stop well short of the top so we don't sit on the
+    // load-more trigger. This leaves a deep OLD message as the bottom-most-visible content anchor.
+    const box = await page.locator('[data-message-list]').first().boundingBox()
+    if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    for (let i = 0; i < 8; i++) {
+      await page.mouse.wheel(0, -1500)
+      await page.waitForTimeout(150)
+    }
+    await page.waitForTimeout(400)
+    const anchor = await findBottomVisibleMessage(page)
+    expect(anchor, 'must capture a deep-history anchor message').not.toBeNull()
+    const anchorId = anchor!.id
+    // Sanity: the anchor is a synthesized OLDER message, i.e. genuinely deep history (not a seed),
+    // so after eviction it is absent from the latest-~100 rehydration.
+    expect(anchorId, `anchor "${anchorId}" should be a deep older message, not the latest slice`).toContain('older-')
+
+    // SWITCH AWAY → the room's resident window is evicted from RAM.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void (window as any).__roomStore?.getState?.()?.activateRoom(null)
+    })
+    await page.waitForTimeout(400)
+    // Confirm the eviction actually happened (resident array dropped to the latest slice or empty).
+    const evicted = await page.evaluate((jid) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rs = (window as any).__roomStore.getState()
+      return (rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []).length
+    }, STRESS_ROOM_JID)
+    expect(evicted, 'resident window should be evicted (or trimmed) after switching away').toBeLessThan(150)
+
+    // SWITCH BACK → activation rehydrates the latest slice; the restore must pull in the anchor's
+    // slice on demand and reposition to it.
+    await navigateToStressRoom(page)
+    await page.waitForTimeout(2500) // activation + on-demand around-load + retry restore + re-assert
+
+    // CORE OF THE FIX: the deep anchor's cache slice was pulled back in. The resident window now
+    // spans far more than the latest-~100 rehydration (the buggy path stayed at ~100, never reloaded
+    // the anchor), and the captured deep-history anchor is resident again.
+    const reloaded = await page.evaluate(([jid, id]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rs = (window as any).__roomStore.getState()
+      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      return { residentLen: msgs.length, hasAnchor: msgs.some((m: { id: string }) => m.id === id) }
+    }, [STRESS_ROOM_JID, anchorId] as const)
+    expect(reloaded.residentLen, 'resident window did not grow past the latest slice — anchor slice not reloaded').toBeGreaterThan(150)
+    expect(reloaded.hasAnchor, `deep anchor "${anchorId}" was not reloaded into the resident window`).toBe(true)
+
+    // POSITIONED in deep history — NOT stranded near the top at the load-more trigger (the bug), and
+    // NOT snapped to the bottom (the latest seeds). The top-most visible row is a synthesized OLDER
+    // message and the view sits well off both the top and the bottom.
+    const placed = await page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return null
+      const sRect = s.getBoundingClientRect()
+      let topVisible: string | null = null
+      for (const el of Array.from(s.querySelectorAll('.message-row[data-message-id]')) as HTMLElement[]) {
+        const r = el.getBoundingClientRect()
+        if (r.bottom > sRect.top && r.top < sRect.bottom) { topVisible = el.dataset.messageId ?? null; break }
+      }
+      return {
+        topVisible,
+        scrollTop: Math.round(s.scrollTop),
+        distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+      }
+    })
+    expect(placed, 'message list not found after return').not.toBeNull()
+    expect(placed!.topVisible, `view did not restore to deep history (top-visible="${placed!.topVisible}") — likely snapped to bottom or stranded at top`).toContain('older-')
+    expect(placed!.scrollTop, 'view is stranded at the very top (load-more trigger) instead of the reading position').toBeGreaterThan(300)
+    expect(placed!.distFromBottom, 'view snapped to the bottom instead of restoring the deep reading position').toBeGreaterThan(1500)
   })
 
 })


### PR DESCRIPTION
## Summary

Returning to a conversation you'd scrolled far back into showed the message list near the **top at the "load more" trigger** instead of the position you were reading.

**Cause:** non-active conversations are evicted from RAM on switch-away. On return, activation rehydrates only the latest ~100 messages, so the saved content anchor (an older message) isn't in the loaded set — the restore can't resolve it and falls back to the saved `scrollTop` on the short list, landing near the top.

**Fix (content-anchored):** load the contiguous cache slice that *contains* the anchor on demand, then let the existing anchor restore land.

- SDK: `messageCache.getMessagesAround` / `getRoomMessagesAround` — older context + tail through the latest message (empty if the anchor isn't cached).
- SDK: `loadMessagesAroundFromCache` store actions (chat + room), merging via a helper shared with `loadMessagesFromCache`; exposed on `useChatActive`/`useRoomActive`.
- App: when the saved anchor isn't loaded, `restoreSavedPosition` requests the slice and stays `pending`; the existing retry effect re-runs once it merges. Wired through `MessageList` → `ChatView`/`RoomView` as `onLoadAround`.
- The same path also serves **search/activity navigation** to a message older than the latest slice.

Applies to both 1:1 chats and MUC rooms.