### PR TITLE
fix(ui): center macOS traffic lights by matching bar height to decorum's fixed inset

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1390,8 +1390,11 @@ fn main() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        // Repositions the macOS traffic lights (see set_traffic_lights_inset in
-        // the macOS setup block). Cross-platform-safe to register everywhere.
+        // On macOS, decorum's on_window_ready hook repositions the traffic
+        // lights at a fixed inset (dot centre ~20px from top) and keeps them
+        // there across resize. The AppBar height is matched to that. We do NOT
+        // call decorum's per-window APIs — see the note in the macOS setup
+        // block. Cross-platform-safe to register everywhere.
         .plugin(tauri_plugin_decorum::init())
         .invoke_handler(tauri::generate_handler![
             get_idle_time,
@@ -1696,21 +1699,16 @@ fn main() {
 
                 let main_window = app.get_webview_window("main").unwrap();
 
-                // Vertically center the traffic lights inside the 44px app bar
-                // (h-11 in components/AppBar.tsx). decorum must take over the
-                // overlay titlebar first (create_overlay_titlebar) for the inset
-                // to apply; it then re-positions across resize / fullscreen.
-                // The buttons are ~16px, so y ≈ (44-16)/2 ≈ 14 centers them —
-                // tune the y value here if the bar height changes.
-                {
-                    use tauri_plugin_decorum::WebviewWindowExt;
-                    if let Err(e) = main_window.create_overlay_titlebar() {
-                        eprintln!("[decorum] create_overlay_titlebar failed: {e}");
-                    }
-                    if let Err(e) = main_window.set_traffic_lights_inset(16.0, 14.0) {
-                        eprintln!("[decorum] set_traffic_lights_inset failed: {e}");
-                    }
-                }
+                // NOTE: the macOS traffic lights are positioned by the decorum
+                // plugin's own `on_window_ready` hook at its FIXED inset (dot
+                // centre ~20px from the window top), kept in place across resize
+                // by a native delegate. We intentionally do NOT call
+                // set_traffic_lights_inset / create_overlay_titlebar: decorum
+                // hardcodes the inset and overrides any per-call value, and
+                // create_overlay_titlebar injects its own titlebar HTML that
+                // clashes with our AppBar. Instead the AppBar height (h-10 /
+                // 40px, see components/AppBar.tsx) is chosen so that fixed dot
+                // centre lands in the middle of the bar.
 
                 let window = main_window.clone();
                 let app_handle = app.handle().clone();

--- a/apps/fluux/src/components/AppBar.tsx
+++ b/apps/fluux/src/components/AppBar.tsx
@@ -32,7 +32,9 @@ const TRAFFIC_LIGHT_INSET = 84
  * Platform behaviour:
  *  - macOS (Tauri): the native traffic lights overlay the bar's start; the bar
  *    background drags the window. `TRAFFIC_LIGHT_INSET` keeps controls clear of
- *    the dots, and decorum centres the dots vertically (see src-tauri).
+ *    the dots. The decorum plugin parks the dots at a FIXED inset (~20px dot
+ *    centre); the bar height (h-10/40px) is chosen so that centre is vertically
+ *    centred. Changing the height means re-checking the dot alignment.
  *  - Windows / Linux (Tauri): the OS keeps its native title bar above; this bar
  *    renders below it as a normal toolbar (left edge free) and is also draggable.
  *  - Web desktop: a plain toolbar (no window dragging).
@@ -118,7 +120,7 @@ export const AppBar = memo(function AppBar() {
     <div
       onMouseDown={handleDragMouseDown}
       onDoubleClick={handleDragDoubleClick}
-      className="flex items-center gap-2 h-11 flex-shrink-0 bg-fluux-sidebar border-b border-fluux-bg shadow-sm pe-2 select-none"
+      className="flex items-center gap-2 h-10 flex-shrink-0 bg-fluux-sidebar border-b border-fluux-bg shadow-sm pe-2 select-none"
       style={{ paddingInlineStart: needsTrafficLightInset ? TRAFFIC_LIGHT_INSET : 8 }}
     >
       {/* History back / forward — mirror the webview history the keyboard drives */}

--- a/docs/APP_BAR.md
+++ b/docs/APP_BAR.md
@@ -32,6 +32,15 @@ it to the bar would strand it on mobile, where the bar doesn't render.
 On macOS the bar reserves `TRAFFIC_LIGHT_INSET` (84px) at its start so the back
 arrow never overlaps the native traffic lights.
 
+**Vertical centring of the traffic lights** is handled by registering
+`tauri-plugin-decorum`, whose `on_window_ready` hook parks the dots at a *fixed*
+inset (dot centre ~20px from the window top) and keeps them there across resize.
+decorum hardcodes that inset — `set_traffic_lights_inset(x, y)` is overridden by
+the on-ready hook and `create_overlay_titlebar()` injects a conflicting titlebar
+— so we call neither. Instead the bar height (`h-10` / 40px) is chosen so the
+fixed ~20px dot centre lands in the bar's middle. **Changing the bar height
+means re-checking the dot alignment** on a real macOS build.
+
 ## Platform behaviour (Path 1 — current)
 
 | Platform           | Window controls            | App bar |


### PR DESCRIPTION
Follow-up to #744. The traffic lights still weren't centering.

Root cause (found by reading decorum's source): decorum **hardcodes** the traffic-light position. Its `on_window_ready` hook positions the dots at a fixed inset (`WINDOW_CONTROL_PAD_X/Y = 12/16`, dot centre ~20px from the window top) and installs a resize delegate that re-applies those exact values. So:
- `set_traffic_lights_inset(x, y)` is overridden by the on-ready hook — our value never wins.
- `create_overlay_titlebar()` injects decorum's own titlebar HTML, which conflicts with our app bar.

Fix: stop fighting it. Drop both per-window calls (keep only the plugin registration, which gives the fixed positioner + free resize/fullscreen persistence) and size the bar to `h-10` (40px) so decorum's fixed ~20px dot centre is the bar's vertical centre.