### PR TITLE
fix(ui): merge consecutive own messages into one tinted surface

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -677,6 +677,7 @@ export const ChatMessageList = memo(function ChatMessageList({
     <ChatMessageBubble
       message={msg}
       showAvatar={shouldShowAvatar(groupMessages, idx)}
+      isGroupEnd={idx === groupMessages.length - 1 || shouldShowAvatar(groupMessages, idx + 1)}
       avatar={msg.isOutgoing ? ownAvatar ?? undefined : contactsByJid.get(msg.from)?.avatar}
       ownAvatar={ownAvatar}
       ownNickname={ownNickname}
@@ -753,6 +754,7 @@ export const ChatMessageList = memo(function ChatMessageList({
 interface ChatMessageBubbleProps {
   message: Message
   showAvatar: boolean
+  isGroupEnd: boolean
   avatar?: string
   ownAvatar?: string | null
   ownNickname?: string | null
@@ -796,6 +798,7 @@ interface ChatMessageBubbleProps {
 const ChatMessageBubble = memo(function ChatMessageBubble({
   message,
   showAvatar,
+  isGroupEnd,
   avatar,
   ownAvatar,
   ownNickname,
@@ -914,6 +917,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       <MessageBubble
         message={message}
         showAvatar={showAvatar}
+        isGroupEnd={isGroupEnd}
         isSelected={isSelected}
         hasKeyboardSelection={hasKeyboardSelection}
         showToolbarForSelection={showToolbarForSelection}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1027,6 +1027,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       <RoomMessageBubbleWrapper
         message={msg}
         showAvatar={shouldShowAvatar(groupMessages, idx)}
+        isGroupEnd={idx === groupMessages.length - 1 || shouldShowAvatar(groupMessages, idx + 1)}
         whisperThread={whisperThreadPosition(groupMessages, idx)}
         roomJid={room.jid}
         myNick={room.nickname}
@@ -1119,6 +1120,7 @@ export const RoomMessageList = memo(function RoomMessageList({
 interface RoomMessageBubbleWrapperProps {
   message: RoomMessage
   showAvatar: boolean
+  isGroupEnd: boolean
   whisperThread: WhisperThreadPosition | null
   // Per-row resolved sender data (resolved in the list layer from cheap Map lookups).
   // `occupant` is the live, reference-stable occupant record (roomStore.addOccupant
@@ -1197,6 +1199,7 @@ interface RoomMessageBubbleWrapperProps {
 const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   message,
   showAvatar,
+  isGroupEnd,
   whisperThread,
   roomJid,
   myNick,
@@ -1424,6 +1427,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
       <MessageBubble
         message={message}
         showAvatar={showAvatar}
+        isGroupEnd={isGroupEnd}
         isSelected={isSelected}
         hasKeyboardSelection={hasKeyboardSelection}
         showToolbarForSelection={showToolbarForSelection}

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -479,6 +479,7 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
         <MessageBubble
           message={msg}
           showAvatar={shouldShowAvatar(groupMessages, idx)}
+          isGroupEnd={idx === groupMessages.length - 1 || shouldShowAvatar(groupMessages, idx + 1)}
           isLastOutgoing={false}
           isLastMessage={false}
           hideToolbar

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -286,7 +286,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     </div>
                   </div>
                   <div
-                    class="relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  message-own-tint"
+                    class="relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  message-own-tint message-own-tint-start message-own-tint-end"
                     data-msg-chrome="header"
                   >
                     <div

--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -802,6 +802,58 @@ describe('Own-message tint', () => {
     const { container } = render(<MessageBubble {...props} />)
     expect(container.querySelector('.message-own-tint')).not.toBeInTheDocument()
   })
+
+  // The tint renders a run of own messages as one continuous surface: the group
+  // start (showAvatar) rounds the top, the group end (isGroupEnd) rounds the
+  // bottom, interior rows stay square so the run reads as a single panel under
+  // the group's lock indicator.
+  it('rounds both corners of a solo own message (group start and end)', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: true,
+      isGroupEnd: true,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const tint = container.querySelector('.message-own-tint')!
+    expect(tint.className).toContain('message-own-tint-start')
+    expect(tint.className).toContain('message-own-tint-end')
+  })
+
+  it('rounds only the top of an own group-start row that continues below', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: true,
+      isGroupEnd: false,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const tint = container.querySelector('.message-own-tint')!
+    expect(tint.className).toContain('message-own-tint-start')
+    expect(tint.className).not.toContain('message-own-tint-end')
+  })
+
+  it('rounds only the bottom of an own group-end continuation row', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: false,
+      isGroupEnd: true,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const tint = container.querySelector('.message-own-tint')!
+    expect(tint.className).not.toContain('message-own-tint-start')
+    expect(tint.className).toContain('message-own-tint-end')
+  })
+
+  it('leaves an interior own continuation row square (neither corner rounded)', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: false,
+      isGroupEnd: false,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const tint = container.querySelector('.message-own-tint')!
+    expect(tint.className).not.toContain('message-own-tint-start')
+    expect(tint.className).not.toContain('message-own-tint-end')
+  })
 })
 
 describe('Density spacing', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -42,6 +42,15 @@ export interface MessageBubbleProps {
   hideToolbar?: boolean
   isLastOutgoing: boolean
   isLastMessage: boolean
+  /**
+   * Whether this row is the LAST in its avatar-group (the next message starts a
+   * new group, or this is the last message). Combined with `showAvatar` (group
+   * start), it lets the own-message tint render a run of outgoing messages as one
+   * continuous surface — rounded at the top of the first and bottom of the last —
+   * so the group's lock/trust indicator visually covers every message under it.
+   * Defaults to true so a standalone bubble renders a fully-rounded solo surface.
+   */
+  isGroupEnd?: boolean
   isDarkMode?: boolean
 
   // Hover state (controlled by parent for stable toolbar interaction)
@@ -204,6 +213,7 @@ function arePropsEqual(prev: MessageBubbleProps, next: MessageBubbleProps): bool
   if (prev.hideToolbar !== next.hideToolbar) return false
   if (prev.isLastOutgoing !== next.isLastOutgoing) return false
   if (prev.isLastMessage !== next.isLastMessage) return false
+  if (prev.isGroupEnd !== next.isGroupEnd) return false
   if (prev.isHovered !== next.isHovered) return false
 
   // Sender info
@@ -267,6 +277,7 @@ export const MessageBubble = memo(function MessageBubble({
   hideToolbar,
   isLastOutgoing,
   isLastMessage,
+  isGroupEnd = true,
   isDarkMode,
   isHovered,
   onMouseEnter,
@@ -417,6 +428,16 @@ export const MessageBubble = memo(function MessageBubble({
 
   // Action capabilities — shared by the hover toolbar (MessageToolbar) and the
   // touch action sheet (MessageActionSheet) so the two surfaces stay in lock-step.
+  // Own-message tint as a continuous surface across an avatar-group: `showAvatar`
+  // marks the group start (round the top), `isGroupEnd` the last row (round the
+  // bottom); interior rows stay square and the tint bridges the inter-row gap so
+  // the run reads as one panel under the group's lock indicator. Suppressed in a
+  // whisper thread (the bounded "private with X" card owns the fill there).
+  const ownTint = message.isOutgoing && !inThread
+  const ownTintClass = ownTint
+    ? `message-own-tint${showAvatar ? ' message-own-tint-start' : ''}${isGroupEnd ? ' message-own-tint-end' : ''}`
+    : ''
+
   const { canReply, canEdit, canDelete } = actions
   const canCopyBody = !!message.body && !message.isRetracted && !message.encryptedPayload && !message.unsupportedEncryption
   const hasMessageActions = !message.isRetracted && (actions.canReact || canReply || canEdit || canDelete || canCopyBody)
@@ -498,7 +519,7 @@ export const MessageBubble = memo(function MessageBubble({
           the incoming rows — shattering the single "private with X" card. The
           name header already carries the own-vs-counterpart distinction. */}
       <div
-        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${message.isOutgoing && !inThread ? 'message-own-tint' : ''}`}
+        className={`relative flex-1 min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${ownTintClass}`}
         data-msg-chrome={showAvatar ? 'header' : 'cont'}
         onTouchStart={handleContentTouchStart}
         onTouchEnd={cancelLongPress}

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -981,9 +981,25 @@ input[type="range"]::-moz-range-thumb {
    kept subtle so body text AA holds. */
 .message-own-tint {
   background: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.08);
-  border-radius: var(--fluux-radius-m);
   padding-inline: 0.5rem;
   margin-inline: -0.5rem;
+  /* Bridge the outer row's py-0.5 (2px) gap so a run of consecutive own
+     messages renders as one continuous surface: each tint grows 2px into its
+     row's vertical padding and meets the next at the row boundary, seamlessly. */
+  padding-block: 0.125rem;
+  margin-block: -0.125rem;
+}
+
+/* Corner rounding is carried only at the group edges so interior rows stay
+   square and the run reads as a single panel. A solo own message gets both
+   (full radius); the default isGroupEnd=true keeps standalone bubbles rounded. */
+.message-own-tint-start {
+  border-top-left-radius: var(--fluux-radius-m);
+  border-top-right-radius: var(--fluux-radius-m);
+}
+.message-own-tint-end {
+  border-bottom-left-radius: var(--fluux-radius-m);
+  border-bottom-right-radius: var(--fluux-radius-m);
 }
 
 /* Persistent highlight for search context view */


### PR DESCRIPTION
A run of outgoing messages in the same avatar-group now renders as a single continuous tinted surface — rounded only at the top of the first row and the bottom of the last — instead of separate rounded pills. This makes it obvious that the group's lock/trust indicator (shown on the header row) applies to every message in the run.

The group boundary reuses the existing `shouldShowAvatar` logic (sender / 5-min gap / security-context / whisper change); a new `isGroupEnd` flag marks the last row of the run. The tint bridges the inter-row gap so adjacent surfaces meet seamlessly (verified: 0px gap, 8px radius only at the run's outer corners). Suppressed inside whisper threads as before.