### PR TITLE
fix(console): keep first line inside the per-row focus ring

### DIFF
--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -66,11 +66,11 @@ const ConsoleEntry = React.memo(function ConsoleEntry({ entry, isSelected, expan
       <div
         role="button"
         tabIndex={0}
-        className={`${selectedClass} cursor-pointer border-s-4 border-s-orange-500`}
+        className={`xmpp-console-entry ${selectedClass} cursor-pointer border-s-4 border-s-orange-500`}
         onClick={() => onSelect(entry.id)}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(entry.id) } }}
       >
-        <div className="flex items-start gap-2 px-3 py-1.5">
+        <div className="flex items-start gap-2 px-3 py-2">
           <span className="text-fluux-muted text-xs font-mono whitespace-nowrap">
             [{format(entry.timestamp, 'HH:mm:ss.SSS')}]
           </span>
@@ -112,7 +112,7 @@ const ConsoleEntry = React.memo(function ConsoleEntry({ entry, isSelected, expan
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
-        className="flex items-center gap-2 px-3 py-1.5 cursor-pointer select-none"
+        className="xmpp-console-entry flex items-center gap-2 px-3 py-2 cursor-pointer select-none"
         onClick={() => { onSelect(entry.id); onToggle(entry.id); }}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(entry.id); onToggle(entry.id); } }}
       >

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -875,6 +875,20 @@ html, body {
   outline-offset: -1px !important;
 }
 
+/* XMPP console entries: per-row keyboard-focus ring. The app-wide focus rule
+ * (.user-interacted *:focus) insets the outline 2px, which on these dense,
+ * square rows leaves only a hair of clearance above the first line — and WebKit
+ * strokes outlines on a rounded path, so on some platforms the top line's glyphs
+ * poke past the ring. Scope a calmer ring here: a defined corner radius (the
+ * outline now follows a known curve instead of WebKit's implicit one) and just a
+ * 1px inset so the ring hugs the row edge, keeping the full row padding as
+ * clearance between the ring and the content. */
+.user-interacted .xmpp-console-entry:focus {
+  outline: 2px solid var(--fluux-focus-ring) !important;
+  outline-offset: -1px !important;
+  border-radius: 6px;
+}
+
 /*
  * Aurora composer card. The bar that wraps the context sections + input row.
  * Background is applied as a utility (bg-fluux-hover) on the element; this class


### PR DESCRIPTION
## Summary

In the XMPP console, the first line of a selected/focused row could bleed past the top of its focus ring on macOS/WebKit builds.

The per-row focus indicator is the app-wide `*:focus` outline with `outline-offset: -2px`, which pulls the ring *into* the row. With only 6px of vertical padding that left ~4px of clearance, and WebKit strokes outlines on a rounded path — so the first line's glyphs poked past the ring on some font/DPI configurations.

The fix scopes a calmer ring to console entries (`xmpp-console-entry`): a defined 6px corner radius so the outline follows a known curve, a 1px inset so it hugs the row edge, and a touch more row padding for clearance. `!important` is needed because the app-wide rule's `:not(#root)` gives it ID-level specificity (same approach as the existing `.xmpp-console-log:focus` rule).