### PR TITLE
fix(console): stop content peeking above the list's top focus ring

### DIFF
--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -628,7 +628,10 @@ export function XmppConsole() {
         <div
           ref={packetsContainerRef}
           tabIndex={0}
-          className="xmpp-console-log absolute inset-0 overflow-y-auto overflow-x-hidden"
+          // border-transparent insets the scroll clip by 1px so it lines up with
+          // the focus ring (outline-offset: -1px). Without it, rows scroll in the
+          // 1px band above the ring and a sliver of content peeks over the top edge.
+          className="xmpp-console-log absolute inset-0 overflow-y-auto overflow-x-hidden border border-transparent"
           onScroll={handleScroll}
           onKeyDown={handleLogKeyDown}
         >


### PR DESCRIPTION
## Summary

Follow-up to #749. When the console log is scrolled and keyboard-focused, a ~1px sliver of the topmost row peeked **above** the container's focus-ring line.

The container's focus ring is an `outline` at `outline-offset: -1px` (drawn 1px inside the panel so it stays within the bounds), but the scroll content was clipped at the true top edge — so scrolled rows rendered in the 1px band above the ring. It can't simply move to `outline-offset: 0` without rendering outside the panel, over the toolbar.

Fix: a 1px transparent border on the scroll container insets the content clip by 1px so it lines up exactly with the ring. Verified in WebKit (Playwright): the content clip and ring now coincide, so no content paints above the ring line.