### PR TITLE
fix(ui): tighten interior gaps of a merged own-message group

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -854,6 +854,57 @@ describe('Own-message tint', () => {
     expect(tint.className).not.toContain('message-own-tint-start')
     expect(tint.className).not.toContain('message-own-tint-end')
   })
+
+  // Interior junctions of an own group are tightened so the merged surface reads
+  // as one block: the row pulls toward neighbouring own messages, but the
+  // group's outer top (group-start separation) and bottom are left alone.
+  it('tightens an own group-start row only at the bottom (toward the continuation)', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: true,
+      isGroupEnd: false,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const row = container.firstChild as HTMLElement
+    expect(row.className).toContain('message-own-cont-bottom')
+    expect(row.className).not.toContain('message-own-cont-top')
+  })
+
+  it('tightens an interior own continuation row on both edges', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: false,
+      isGroupEnd: false,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const row = container.firstChild as HTMLElement
+    expect(row.className).toContain('message-own-cont-top')
+    expect(row.className).toContain('message-own-cont-bottom')
+  })
+
+  it('tightens an own group-end row only at the top (toward the previous message)', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: false,
+      isGroupEnd: true,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const row = container.firstChild as HTMLElement
+    expect(row.className).toContain('message-own-cont-top')
+    expect(row.className).not.toContain('message-own-cont-bottom')
+  })
+
+  it('leaves a solo own message untightened (keeps normal outer spacing)', () => {
+    const props = createDefaultProps({
+      message: createTestMessage({ isOutgoing: true }),
+      showAvatar: true,
+      isGroupEnd: true,
+    })
+    const { container } = render(<MessageBubble {...props} />)
+    const row = container.firstChild as HTMLElement
+    expect(row.className).not.toContain('message-own-cont-top')
+    expect(row.className).not.toContain('message-own-cont-bottom')
+  })
 })
 
 describe('Density spacing', () => {

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -437,6 +437,13 @@ export const MessageBubble = memo(function MessageBubble({
   const ownTintClass = ownTint
     ? `message-own-tint${showAvatar ? ' message-own-tint-start' : ''}${isGroupEnd ? ' message-own-tint-end' : ''}`
     : ''
+  // Tighten the interior junctions of an own-message group so the merged surface
+  // reads as one block rather than messages separated by a blank line: a
+  // continuation row (no avatar) pulls up toward the message above; a row that a
+  // continuation follows (not the group end) pulls down toward the one below.
+  const ownRowClass = ownTint
+    ? `${!showAvatar ? ' message-own-cont-top' : ''}${!isGroupEnd ? ' message-own-cont-bottom' : ''}`
+    : ''
 
   const { canReply, canEdit, canDelete } = actions
   const canCopyBody = !!message.body && !message.isRetracted && !message.encryptedPayload && !message.unsupportedEncryption
@@ -473,7 +480,7 @@ export const MessageBubble = memo(function MessageBubble({
       data-message-from={senderName}
       data-message-time={formatTime(message.timestamp)}
       data-message-body={message.body || ''}
-      className={outerRowClass}
+      className={`${outerRowClass}${ownRowClass}`}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -997,12 +997,26 @@ input[type="range"]::-moz-range-thumb {
   background: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.08);
   padding-inline: 0.5rem;
   margin-inline: -0.5rem;
-  /* Bridge the outer row's py-0.5 (2px) gap so a run of consecutive own
-     messages renders as one continuous surface: each tint grows 2px into its
-     row's vertical padding and meets the next at the row boundary, seamlessly. */
-  padding-block: 0.125rem;
-  margin-block: -0.125rem;
+  /* Render a run of consecutive own messages as one continuous surface. At an
+     interior group junction both rows are tightened to 1px (message-own-cont-*
+     below), so `padding-block`/`margin-block` are set to 1px/-1px: the negative
+     margin cancels that 1px row padding so adjacent tints abut flush (no seam,
+     no overlap that would darken the translucent wash). The resulting gap
+     between two grouped messages is 2px — tight enough to read as one block
+     rather than a blank line. At the group's outer top/bottom the row keeps its
+     normal py-0.5, so the tint sits a hair inside the separation gap there. */
+  padding-block: 0.0625rem;
+  margin-block: -0.0625rem;
 }
+
+/* Tighten only the INTERIOR junctions of an own-message group so the run reads
+   as one block: a continuation row pulls up toward the message above it, and a
+   row followed by a continuation pulls down toward the message below. The
+   group's first-row top (message-group-start separation) and last-row bottom
+   are left untouched. Single-class selectors override Tailwind's py-0.5 (which
+   lives in @layer utilities). */
+.message-own-cont-top { padding-top: 0.0625rem; }
+.message-own-cont-bottom { padding-bottom: 0.0625rem; }
 
 /* Corner rounding is carried only at the group edges so interior rows stay
    square and the run reads as a single panel. A solo own message gets both


### PR DESCRIPTION
Follow-up to #748. Now that a run of own messages shares one tinted surface, the normal 4px inter-message gap read as a blank line *inside* the merged block.

This tightens only the interior junctions of an own-message group (continuation rows pull toward their neighbours) to a 2px gap, leaving the group's outer top (group-start separation) and bottom untouched. The tint's `margin-block` is matched to the tightened 1px row padding so adjacent backgrounds stay flush — no seam, no overlap that would darken the translucent wash. Solo messages are unchanged.