### PR TITLE
fix(console): give type/subtype badges room so the keyword can't bleed

### DIFF
--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -124,12 +124,12 @@ const ConsoleEntry = React.memo(function ConsoleEntry({ entry, isSelected, expan
         {stanzaPreview ? (
           <>
             {/* Type badge */}
-            <span className={`px-1.5 py-0.5 text-xs font-bold rounded ${typeColors[stanzaPreview.type] || 'bg-gray-600'} text-white`}>
+            <span className={`px-1.5 py-1 text-xs font-bold rounded ${typeColors[stanzaPreview.type] || 'bg-gray-600'} text-white`}>
               {stanzaPreview.type}
             </span>
 
             {/* Subtype */}
-            <span className={`px-1.5 py-0.5 text-xs rounded ${subtypeColors[stanzaPreview.subtype] || 'bg-fluux-bg'} text-fluux-text`}>
+            <span className={`px-1.5 py-1 text-xs rounded ${subtypeColors[stanzaPreview.subtype] || 'bg-fluux-bg'} text-fluux-text`}>
               {stanzaPreview.subtype}
             </span>
 


### PR DESCRIPTION
## Summary

Follow-up to #749 / #750. The IQ/get/result pills in the XMPP console used `py-0.5` (2px) vertical padding, leaving the keyword only ~2.7px of clearance inside the pill — on some platforms the glyphs touched the pill edge and looked like they bled out.

Bump both badges to `py-1`. Clearance goes to ~4.7px and the row height is unchanged, since the direction arrow already sets the row's line height — the pills just breathe.

Verified in WebKit (Playwright): badge text clearance measured 2.7px → 4.7px, pills still balanced (not chunky).