### PR TITLE
fix(scroll): stop conversations drifting back in time on re-open

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -1144,8 +1144,10 @@ describe('MessageList scroll behavior', () => {
           configurable: true,
         })
 
-        // Trigger scroll event to save the scrolled-up position
+        // Trigger scroll event to save the scrolled-up position. A genuine user scroll fires a
+        // wheel first — the save gate only persists user-driven positions (see the hook).
         act(() => {
+          container.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
           container.dispatchEvent(new Event('scroll'))
         })
 
@@ -1213,8 +1215,9 @@ describe('MessageList scroll behavior', () => {
           configurable: true,
         })
 
-        // Trigger scroll to mark as scrolled up and save position
+        // Trigger scroll to mark as scrolled up and save position (wheel = genuine user scroll).
         act(() => {
+          container.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
           container.dispatchEvent(new Event('scroll'))
         })
         scrollSpy.mockClear()
@@ -1524,8 +1527,9 @@ describe('MessageList scroll behavior', () => {
           configurable: true,
         })
 
-        // Trigger a scroll event to ensure the hook has the scroll data
+        // Trigger a scroll event to ensure the hook has the scroll data (wheel = genuine user scroll).
         act(() => {
+          container.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
           container.dispatchEvent(new Event('scroll'))
         })
 
@@ -1584,8 +1588,9 @@ describe('MessageList scroll behavior', () => {
           configurable: true,
         })
 
-        // Scroll to position 100 - this gets captured
+        // Scroll to position 100 - this gets captured (wheel = genuine user scroll).
         act(() => {
+          container.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
           container.dispatchEvent(new Event('scroll'))
         })
 
@@ -2110,8 +2115,9 @@ describe('MessageList scroll behavior', () => {
         })
         scrollContainer.scrollTo = vi.fn()
 
-        // Trigger scroll to save position
+        // Trigger scroll to save position (wheel = genuine user scroll).
         act(() => {
+          scrollContainer.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
           scrollContainer.dispatchEvent(new Event('scroll'))
         })
         scrollSpy.mockClear()

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -428,6 +428,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     // User is reading history, then clicks the bottom FAB.
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
     scrollTopSets.length = 0
     fireEvent.click(container.querySelector('[data-fab="scroll-to-bottom"]') as HTMLButtonElement)
@@ -538,6 +541,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     // Scroll up to 200 and let the scroll handler record the position + anchor.
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
 
     // Switch away (saves conv-r1's position) then back (should restore it).
@@ -561,6 +567,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     rafQueue.length = 0
 
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
 
     rerender(<MessageList messages={makeMessages(50)} conversationId="room-repeat-2" {...props} />)
@@ -590,6 +599,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     // First visit: user scrolled up, so the room should restore this once.
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
     rerender(<MessageList messages={makeMessages(50)} conversationId="conv-other" {...props} />)
     rerender(<MessageList messages={makeMessages(50)} conversationId="conv-return-bottom" {...props} />)
@@ -631,6 +643,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     // Scroll up to 200 and let the scroll handler record the position + anchor.
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
 
     // Switch away (saves conv-rw1's position) then back (should restore it).
@@ -659,6 +674,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     // User scrolls up and the hook captures the anchor + saved position.
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
 
     // Switch away (saves conv-vi1's position and anchor).
@@ -702,6 +720,9 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
 
     // Scroll up to 200 in the conversation and record the position + anchor.
     scroller.scrollTop = 200
+    // A genuine user scroll fires a wheel (the save gate only persists user-driven positions, not
+    // media/measurement-induced shifts); a bare scroll event alone no longer counts.
+    scroller.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
     scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
 
     // Switch away (conversation is now hidden / unmounted from the user's view).

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -358,4 +358,43 @@ describe('useMessageListScroll saved-position restore', () => {
 
     expect(onLoadAround).not.toHaveBeenCalled()
   })
+
+  // Regression: after a restore, the view can shift on its own as rows below the fold load media /
+  // re-measure. Those non-user scroll events must NOT overwrite the saved position — otherwise the
+  // (drifted, older) position is persisted and the next open starts from there, compounding into
+  // "goes back in time on every switch". Only a genuine user scroll updates the saved position.
+  describe('save gating after restore', () => {
+    const scrollAndFire = (handle: HarnessHandle, top: number) => {
+      handle.scroller.scrollTop = top
+      handle.api.handleScroll({ currentTarget: handle.scroller } as unknown as React.UIEvent<HTMLDivElement>)
+    }
+
+    it('does not overwrite the saved position from a non-user (media/measurement) scroll', () => {
+      seedSavedScrollPosition('gate-nonuser', 200)
+      let handle: HarnessHandle | undefined
+      render(
+        <HookHarness conversationId="gate-nonuser" ids={['m0', 'm1', 'm2']} onReady={(n) => { handle = n }} />,
+      )
+
+      // A spontaneous (non-user) scroll to a different, not-at-bottom position.
+      act(() => scrollAndFire(handle!, 320))
+
+      expect(scrollStateManager.getSavedScrollTop('gate-nonuser')).toBe(200)
+    })
+
+    it('saves the new position once the user genuinely scrolls (wheel)', () => {
+      seedSavedScrollPosition('gate-user', 200)
+      let handle: HarnessHandle | undefined
+      render(
+        <HookHarness conversationId="gate-user" ids={['m0', 'm1', 'm2']} onReady={(n) => { handle = n }} />,
+      )
+
+      act(() => {
+        handle!.api.handleWheel({ currentTarget: handle!.scroller, deltaY: -10 } as unknown as React.WheelEvent<HTMLDivElement>)
+        scrollAndFire(handle!, 320)
+      })
+
+      expect(scrollStateManager.getSavedScrollTop('gate-user')).toBe(320)
+    })
+  })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -92,6 +92,16 @@ const MARKER_DRIFT_PX = 16
 const TARGET_REASSERT_FRAMES = 30
 const TARGET_STABLE_FRAMES = 4
 const TARGET_DRIFT_PX = 16
+// Saved-position (content-anchor) restore needs the SAME measurement-aware re-assert as the marker
+// path. A one-shot scrollToIndex(anchor,'end') lands on the rows' ESTIMATED sizes; those rows then
+// measure TALLER over the next frames (media, wrapping), the content above the anchor grows, and the
+// anchor slides below the fold — the view drifts OLDER. handleScroll then saves that drifted position
+// and the (now older) bottom-visible message becomes the next anchor, so each re-open drifts further
+// back ("goes back in time on every open"). Re-pinning the anchor across frames lands it on settled
+// measurements, and registering the loop gates the save so the transient can't compound.
+const RESTORE_REASSERT_FRAMES = 90
+const RESTORE_STABLE_FRAMES = 8
+const RESTORE_DRIFT_PX = 8
 // While re-pinning, treat the list as not-yet-pinned whenever it sits more than this many pixels
 // above the true bottom. The change-detection guard (re-pin only when scrollHeight moved) can miss
 // the frame where the last row's measurement settles — coalesced height deltas, or a height delta
@@ -736,6 +746,87 @@ export function useMessageListScroll({
     rememberBottomIntent()
   }, [pinVirtualizedBottom, rememberBottomIntent])
 
+  // Re-pin a VIRTUALIZED list to a saved CONTENT ANCHOR and keep it pinned as rows measure — the
+  // restore counterpart of pinVirtualizedBottom. A one-shot scrollToIndex(anchor,'end') lands on the
+  // rows' estimated sizes; they then measure taller and the anchor drifts below the fold (see the
+  // RESTORE_* constants). Re-deriving the anchor's pixel target each frame (align:'end' + the saved
+  // fraction, both from CURRENT measurements) lands it on settled layout. Registering the loop in
+  // reassertLoopRef makes handleScroll treat these scrolls as programmatic — so the drifting
+  // transient is NOT saved (which is what made the drift compound across re-opens). Bails on a user
+  // scroll or a conversation switch; converges (and stops early) once the landing position is stable.
+  const pinVirtualizedAnchor = useCallback((anchor: ScrollAnchor, anchorConvId: string) => {
+    const scroller = scrollerRef.current
+    if (!virtualizerRef.current || !scroller) return
+
+    supersedeReassertLoopRef.current()
+
+    // Re-derive and apply the anchor's pixel position from the CURRENT measured layout. Returns the
+    // resulting scrollTop, or null when the anchor row is no longer resolvable.
+    const applyAnchor = (): number | null => {
+      const v = virtualizerRef.current
+      const s = scrollerRef.current
+      if (!v || !s) return null
+      const idx = v.getIndexForMessageId(anchor.messageId)
+      if (idx === null) return null
+      v.scrollToIndex(idx, { align: 'end' })
+      if (anchor.fraction < 1) {
+        const start = v.getOffsetForMessageId(anchor.messageId)
+        const size = v.getVirtualItems().find((vi) => vi.index === idx)?.size
+        if (start !== null && size) {
+          v.scrollToOffset(Math.max(0, start + anchor.fraction * size - s.clientHeight))
+        }
+      }
+      return s.scrollTop
+    }
+
+    // Immediate pin (pre-paint when called from the restore path's layout effect).
+    applyAnchor()
+
+    const startedAt = Date.now()
+    const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('restore-anchor', performance.now())
+    let framesLeft = RESTORE_REASSERT_FRAMES
+    let stableFrames = 0
+    let landed = -1
+    const finish = () => {
+      loop.end()
+      reassertLoopRef.current = null
+      // Capture the settled position so a leave right after restore saves the anchor we LANDED on,
+      // not a mid-settle transient.
+      const s = scrollerRef.current
+      if (s) {
+        isAtBottomRef.current = (s.scrollHeight - s.scrollTop - s.clientHeight) < AT_BOTTOM_THRESHOLD
+        rememberCurrentScrollSnapshot()
+      }
+    }
+    const step = () => {
+      const s = scrollerRef.current
+      if (!s) { finish(); return }
+      if (framesLeft-- <= 0) { finish(); return }
+      // Stale loop must never scroll the new conversation (prevConversationRef is set synchronously
+      // at the end of the conversation-switch effect).
+      if (prevConversationRef.current !== anchorConvId) { finish(); return }
+      // User took over → stop fighting them.
+      if (userScrollIntentAtRef.current > startedAt) { finish(); return }
+
+      const st = applyAnchor()
+      if (st === null) { finish(); return }
+
+      let wrote = false
+      if (landed >= 0 && Math.abs(st - landed) <= RESTORE_DRIFT_PX) {
+        if (++stableFrames >= RESTORE_STABLE_FRAMES) { finish(); return }
+      } else {
+        wrote = true
+        stableFrames = 0
+      }
+      landed = st
+
+      const warning = loop.frame(performance.now(), wrote)
+      if (warning) console.warn(warning)
+      reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
+    }
+    reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
+  }, [isAtBottomRef, rememberCurrentScrollSnapshot])
+
   const restoreSavedPosition = useCallback((source: 'entry' | 'retry'): RestoreSavedPositionResult => {
     const scroller = scrollerRef.current
     if (!scroller) return 'pending'
@@ -836,20 +927,11 @@ export function useMessageListScroll({
     if (virtRestore && savedAnchor) {
       const anchorIndex = virtRestore.getIndexForMessageId(savedAnchor.messageId)
       if (anchorIndex !== null) {
-        // Baseline: place the anchor message's bottom at the viewport bottom (align:'end').
-        // This both windows the (possibly off-screen) row in and covers the common fraction=1
-        // case. scrollToIndex re-windows synchronously in the adapter, so its measured size is
-        // available right after for the sub-message refine below.
-        virtRestore.scrollToIndex(anchorIndex, { align: 'end' })
-        // Refine to the saved fraction using the message's CURRENT measured height (rendering-
-        // independent — re-derived from measurements, never a stored pixel gap).
-        if (savedAnchor.fraction < 1) {
-          const start = virtRestore.getOffsetForMessageId(savedAnchor.messageId)
-          const size = virtRestore.getVirtualItems().find((v) => v.index === anchorIndex)?.size
-          if (start !== null && size) {
-            virtRestore.scrollToOffset(Math.max(0, start + savedAnchor.fraction * size - scroller.clientHeight))
-          }
-        }
+        // Position the anchor's bottom at the viewport bottom (align:'end') refined to the saved
+        // fraction, and KEEP it pinned across frames as the just-windowed rows measure taller. A
+        // one-shot landing here drifts older (and compounds across re-opens) because it lands on
+        // estimated sizes — see pinVirtualizedAnchor / the RESTORE_* constants.
+        pinVirtualizedAnchor(savedAnchor, conversationId)
         return finishRestore('RESTORE via virtualizer index', { savedAnchor, anchorIndex })
       }
 
@@ -896,6 +978,7 @@ export function useMessageListScroll({
     firstMessageId,
     isAtBottomRef,
     messageCount,
+    pinVirtualizedAnchor,
     reassertBottom,
     rememberCurrentScrollSnapshot,
   ])

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -323,6 +323,20 @@ export function useMessageListScroll({
   const prevLastMessageIdRef = useRef<string | undefined>(lastMessageId)
   const hasInitializedRef = useRef(false)
   const pendingRestoreConversationRef = useRef<string | null>(null)
+  // Whether the user has GENUINELY scrolled since entering this conversation (wheel / touch /
+  // keyboard / FAB). Reset on every conversation switch. The saved scroll position is only
+  // overwritten once this is true: a restore can drift on its own as rows below the fold load media
+  // and re-measure, and persisting that spontaneous shift made the position creep older on every
+  // re-open ("goes back in time on switch"). Gating the save on real user intent keeps the saved
+  // anchor at the user's actual reading position, so re-opens are stable regardless of media timing.
+  const userHasScrolledSinceEntryRef = useRef(false)
+  // scrollHeight at the previous scroll event, to tell a genuine user scroll (content height
+  // unchanged) from a media/measurement-driven shift (height changed). Complements the input-event
+  // listeners below so scrollbar-drag — which fires no wheel/touch — still counts. Reset per entry.
+  const prevScrollHeightRef = useRef<number | null>(null)
+  // Teardown for the native user-input listeners attached to the scroller (set them via addEventListener
+  // so touch/keyboard scrolls — which don't go through the React onWheel handler — also count).
+  const userInputCleanupRef = useRef<(() => void) | null>(null)
   // Per-anchor status for the on-demand "load the cache slice around the anchor" request used when
   // a saved content anchor (or navigation target) is older than the latest-N slice loaded on
   // activation. 'loading' → request in flight (stay pending); 'done' → attempted (resolved by the
@@ -624,7 +638,24 @@ export function useMessageListScroll({
         if (externalScrollerRef) {
           (externalScrollerRef as React.MutableRefObject<HTMLElement | null>).current = el
         }
-        if (el) trySetupContentObserver()
+        // Native user-input listeners: mark a GENUINE user scroll so the save gate (see
+        // userHasScrolledSinceEntryRef) opens. wheel covers mouse/trackpad, touchstart covers
+        // mobile, keydown covers PageUp/Down/arrows/Space when the list is focused. These are
+        // distinct from media/measurement-driven scroll events, which must NOT open the gate.
+        userInputCleanupRef.current?.()
+        userInputCleanupRef.current = null
+        if (el) {
+          const markUserScrolled = () => { userHasScrolledSinceEntryRef.current = true }
+          el.addEventListener('wheel', markUserScrolled, { passive: true })
+          el.addEventListener('touchstart', markUserScrolled, { passive: true })
+          el.addEventListener('keydown', markUserScrolled)
+          userInputCleanupRef.current = () => {
+            el.removeEventListener('wheel', markUserScrolled)
+            el.removeEventListener('touchstart', markUserScrolled)
+            el.removeEventListener('keydown', markUserScrolled)
+          }
+          trySetupContentObserver()
+        }
       },
       setContentRef: (element: HTMLDivElement | null) => {
         if (element === contentRef.current) return
@@ -999,6 +1030,8 @@ export function useMessageListScroll({
     // loop yields instead of fighting it back to the anchor (it can fire while the loop runs:
     // entering at the top triggers a load-older, then the user clicks the FAB).
     userScrollIntentAtRef.current = Date.now()
+    // Deliberate user action → open the save gate so the resulting position persists.
+    userHasScrolledSinceEntryRef.current = true
 
     // Two-step behavior: scroll to the new message marker only when it exists AND
     // is still further down than the current viewport (not yet visible). Otherwise —
@@ -1374,6 +1407,15 @@ export function useMessageListScroll({
     // marker entirely). Gate both on a genuine user scroll.
     const programmaticScroll = reassertLoopRef.current !== null
 
+    // Open the save gate when this is a genuine user scroll: content height UNCHANGED from the
+    // previous scroll event (a media/measurement-driven shift changes the height; a wheel / touch /
+    // scrollbar-drag does not). Complements the input-event listeners so scrollbar-drag — which
+    // fires no wheel/touch — also counts. Programmatic loop scrolls are excluded.
+    if (!programmaticScroll && prevScrollHeightRef.current === scrollHeight) {
+      userHasScrolledSinceEntryRef.current = true
+    }
+    prevScrollHeightRef.current = scrollHeight
+
     // Clear new message marker when user scrolls past it or reaches the bottom.
     // Skip on the very first scroll events after marker setup to avoid clearing
     // the marker before the user has a chance to see it.
@@ -1415,8 +1457,11 @@ export function useMessageListScroll({
     // and during scroll because at switch time the DOM is already the new room.
     // Skipped while a programmatic loop is positioning the list (see programmaticScroll above):
     // saving the transient entry position would poison the next re-entry's restore decision.
+    // Also skipped until the user has GENUINELY scrolled this entry: a post-restore scroll caused
+    // by media/measurement settling must not overwrite the saved anchor (that drift compounded
+    // across re-opens — see userHasScrolledSinceEntryRef).
     const now = Date.now()
-    if (!programmaticScroll && now - lastSaveTimeRef.current > SAVE_THROTTLE_MS) {
+    if (!programmaticScroll && userHasScrolledSinceEntryRef.current && now - lastSaveTimeRef.current > SAVE_THROTTLE_MS) {
       lastSaveTimeRef.current = now
       scrollStateManager.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, lastAnchorRef.current ?? undefined, clientWidth)
     }
@@ -1439,6 +1484,9 @@ export function useMessageListScroll({
     // the user keeps scrolling after a load (rather than fighting a content-shrink clamp). The
     // wheel that triggers the load itself is recorded BEFORE the loop starts, so it won't bail.
     userScrollIntentAtRef.current = Date.now()
+    // Genuine user scroll → open the save gate (see userHasScrolledSinceEntryRef). Mirrors the
+    // native wheel listener; kept here so it fires even when wheel arrives via the React handler.
+    userHasScrolledSinceEntryRef.current = true
     const { scrollTop } = e.currentTarget
     if (scrollTop === 0 && e.deltaY < 0 && !staticMode) triggerLoadOlder()
     if (scrollTop === 0 && e.deltaY > 0) scrolledAwayFromTopRef.current = true
@@ -1471,10 +1519,15 @@ export function useMessageListScroll({
       messageCount,
     })
 
-    // LEAVING old conversation - save position
-    if (prevConversationRef.current && lastScrollDataRef.current) {
+    // LEAVING old conversation - save position, but ONLY if the user genuinely scrolled it this
+    // visit. Otherwise keep its existing saved anchor untouched (markAsLeft): the live scroll data
+    // may have drifted from media/measurement after the restore, and persisting it would make the
+    // position creep older on the next open (see userHasScrolledSinceEntryRef).
+    if (prevConversationRef.current && lastScrollDataRef.current && userHasScrolledSinceEntryRef.current) {
       const { top, height, client, width } = lastScrollDataRef.current
       scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined, width)
+    } else if (prevConversationRef.current) {
+      scrollStateManager.markAsLeft(prevConversationRef.current)
     }
 
     // ENTERING new conversation - reset state
@@ -1487,6 +1540,9 @@ export function useMessageListScroll({
     pendingRestoreConversationRef.current = null
     // Returning to this conversation later must be free to re-request its anchor slice.
     aroundLoadStatusRef.current.clear()
+    // Fresh entry: the saved position is locked until the user genuinely scrolls (see the ref).
+    userHasScrolledSinceEntryRef.current = false
+    prevScrollHeightRef.current = null
     setShowScrollToBottom(false)
 
     // Clear any pending media load batch
@@ -1712,7 +1768,10 @@ export function useMessageListScroll({
   useLayoutEffect(() => {
     return () => {
       if (prevConversationRef.current) {
-        if (lastScrollDataRef.current) {
+        // Same gate as the conversation-switch leave: only persist the live scroll data when the
+        // user genuinely scrolled this visit; otherwise keep the existing saved anchor (markAsLeft)
+        // so a media/measurement-induced post-restore drift can't be saved (see the ref).
+        if (lastScrollDataRef.current && userHasScrolledSinceEntryRef.current) {
           const { top, height, client, width } = lastScrollDataRef.current
           // UNMOUNT save: this is the leave path for navigations that DESTROY the message view —
           // opening Settings, switching DM↔Room, going back to the list. (DM↔DM keeps the view
@@ -1728,13 +1787,14 @@ export function useMessageListScroll({
           })
           scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined, width)
         } else {
-          // No scroll data captured before unmount → nothing to restore TO on return. A user who
-          // never scrolled (or unmounted before the first throttled save) lands at the bottom next
-          // time, by design — but if this fires after the user DID scroll up, the save side is the bug.
-          debugLog('UNMOUNT markAsLeft (no scroll data)', { conversationId: prevConversationRef.current })
+          // No scroll data, or the user never scrolled this visit → don't overwrite the saved
+          // position; just mark the conversation left so a return is detected as a switch.
+          debugLog('UNMOUNT markAsLeft (no user scroll / no scroll data)', { conversationId: prevConversationRef.current })
           scrollStateManager.markAsLeft(prevConversationRef.current)
         }
       }
+      userInputCleanupRef.current?.()
+      userInputCleanupRef.current = null
     }
   }, [])
 

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -701,6 +701,69 @@ test.describe('Virtualization scroll invariants', () => {
     expect(placed!.distFromBottom, 'view snapped to the bottom instead of restoring the deep reading position').toBeGreaterThan(1500)
   })
 
+  // ── 9: Re-opening a scrolled-up conversation must not drift older each time ──
+  //
+  // Reported (real data): opening a conversation that isn't at the bottom restores a position that
+  // creeps further back in time on every re-open. Cause: the one-shot anchor restore landed on
+  // ESTIMATED row sizes; rows then measured taller, the anchor slid below the fold, and handleScroll
+  // SAVED the drifted (older) position — so the next open started from there and compounded. The
+  // measurement-aware re-assert (pinVirtualizedAnchor) lands on settled sizes and gates the save.
+  //
+  // CAVEAT: the demo's stress room is text-only, so its rows measure synchronously on mount and the
+  // one-shot restore does NOT visibly compound here — the real-world drift needs rows that measure
+  // taller AFTER paint (images / link previews). So this asserts the general "stable restore across
+  // re-opens" contract (a regression guard) rather than isolating the media-induced compounding; the
+  // specific fix is pinned by the trace diagnosis + by mirroring the marker/target re-assert loops.
+  test('invariant-9: re-opening a scrolled-up conversation restores a stable position (no backward drift)', async ({ page }) => {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+
+    const distFromBottom = () => page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      return s ? Math.round(s.scrollHeight - s.scrollTop - s.clientHeight) : -1
+    })
+
+    // Scroll UP into the loaded window (real wheel so the virtualizer re-windows), away from the
+    // bottom but not so far it needs an on-demand slice — this exercises the anchor-restore path.
+    const box = await page.locator('[data-message-list]').first().boundingBox()
+    if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.wheel(0, -2500)
+    await page.waitForTimeout(700)
+
+    expect(await distFromBottom(), 'precondition: must be scrolled up off the bottom').toBeGreaterThan(AT_BOTTOM_OK_PX)
+
+    // Re-open the conversation several times; after each restore record the content anchor (the
+    // bottom-most visible message — the same thing the restore persists/targets) and the restored
+    // distance-from-bottom. "Goes back in time" = the anchor message changes / the distance grows
+    // each open. We compare RESTORED opens to each other (not to the live pre-leave scroll, whose
+    // distFromBottom legitimately differs once rows below the fold finish measuring).
+    const anchors: (string | null)[] = []
+    const dists: number[] = []
+    for (let i = 0; i < 4; i++) {
+      await page.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        void (window as any).__roomStore?.getState?.()?.activateRoom(null)
+      })
+      await page.waitForTimeout(300)
+      await navigateToStressRoom(page)
+      await page.waitForTimeout(900) // activation + anchor re-assert settle
+      anchors.push((await findBottomVisibleMessage(page))?.id ?? null)
+      dists.push(await distFromBottom())
+    }
+
+    // The bug made each re-open land on an OLDER anchor message; the fix keeps it identical.
+    expect(
+      anchors.every((a) => a !== null && a === anchors[0]),
+      `restored anchor drifted older across re-opens (bottom-visible per open: ${JSON.stringify(anchors)}) — anchor not re-pinned`,
+    ).toBe(true)
+    // …and the restored distance-from-bottom is stable open-to-open (the bug grew it ~1000–2000px
+    // each time). 200px covers media/measurement settle between opens.
+    expect(
+      Math.max(...dists) - Math.min(...dists),
+      `restored position drifted across re-opens (distFromBottom: ${JSON.stringify(dists)})`,
+    ).toBeLessThan(200)
+  })
+
 })
 
 // ── DIAGNOSTIC: new-message marker on re-entry (the user-reported bug) ──────────


### PR DESCRIPTION
Follow-up to #746. Returning to a conversation that was scrolled up drifted further back in time on every switch.

Two causes, two fixes:

- **Restore not re-pinned as rows measure.** The virtualized restore landed on the estimated row offset, then rows below the fold measured and the anchor shifted. `pinVirtualizedAnchor` re-asserts the anchor's pixel position each frame until it stabilises (bails on a real user scroll or a conversation switch).
- **Spontaneous shifts were persisted.** As media/measurement settled after a restore, scrollTop was nudged older and the throttled/leave save wrote that drifted position, so the next open started from there and the drift compounded. The save is now gated on genuine user intent: the saved position is overwritten only after the user has actually scrolled this visit (wheel / touch / keyboard / FAB native listeners, plus a content-height-unchanged scroll so scrollbar-drag still counts). Leaving without a user scroll keeps the existing saved anchor.