### PR TITLE
Aurora login: gradient brand mark + display heading + elevated card (#8)

### DIFF
--- a/apps/fluux/src/components/LoginErrorPanel.tsx
+++ b/apps/fluux/src/components/LoginErrorPanel.tsx
@@ -23,7 +23,7 @@ function certBodyKey(sub: string | null): string {
 }
 
 const plainBoxClass =
-  'p-3 bg-fluux-red/20 border border-fluux-red/50 rounded text-fluux-error text-sm'
+  'p-3 bg-fluux-red/20 border border-fluux-red/50 rounded-lg text-fluux-error text-sm'
 
 /**
  * Renders a connection error. For recognized transport/TLS kinds it shows a

--- a/apps/fluux/src/components/LoginScreen.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.test.tsx
@@ -498,6 +498,22 @@ describe('LoginScreen prefill', () => {
     })
 })
 
+describe('LoginScreen — Aurora branding', () => {
+  beforeEach(() => {
+    useAdvancedModeStore.setState({ advancedMode: false })
+    mockUseConnection.mockReturnValue({ status: 'offline', error: null, connect: mockConnect })
+  })
+
+  it('renders the Aurora gradient mark + display-font heading (no flat logo img)', () => {
+    render(<LoginScreen />)
+    // display-font heading
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading.className).toMatch(/font-display/)
+    // the flat logo <img> is replaced by the gradient mark (no <img> for the brand)
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+})
+
 describe('LoginScreen — advanced-mode kebab', () => {
   beforeEach(() => {
     useAdvancedModeStore.setState({ advancedMode: false })

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -3,7 +3,7 @@ import { TextInput } from './ui/TextInput'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { useConnectionStatus, useConnectionActions, deleteFastToken, classifyConnectionError } from '@fluux/sdk'
-import { Loader2, KeyRound, Eye, EyeOff, Wrench } from 'lucide-react'
+import { Loader2, KeyRound, Eye, EyeOff, Wrench, MessageCircle } from 'lucide-react'
 import { saveSession } from '@/hooks/useSessionPersistence'
 import { getResource } from '@/utils/xmppResource'
 import { hasSavedCredentials, getCredentials, saveCredentials, deleteCredentials } from '@/utils/keychain'
@@ -417,10 +417,16 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     <div className="h-full bg-fluux-bg overflow-y-auto relative">
       {/* Window drag region - covers top area for title bar */}
       <div className="absolute top-0 inset-x-0 h-8" {...dragRegionProps} />
+      {/* Faint aurora backdrop glow — decorative, behind the content */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-80 z-0"
+        style={{ background: 'radial-gradient(60% 100% at 50% 0%, color-mix(in srgb, var(--fluux-bg-accent), transparent 88%), transparent 70%)' }}
+        aria-hidden="true"
+      />
       {/* min-h-full + centering keeps the card centered when there is room, but
           lets the container scroll to every field on short viewports (e.g. a
           phone in landscape with the keyboard open). */}
-      <div className="min-h-full flex items-center justify-center p-4">
+      <div className="min-h-full flex items-center justify-center p-4 relative z-10">
         <div className="relative w-full max-w-md">
         {/* Advanced-mode kebab — quiet, top-right. The toggle reveals the
             custom-server field below and unlocks the app's expert surfaces. */}
@@ -438,17 +444,26 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
         </div>
         {/* Logo / Header */}
         <div className="text-center mb-8">
-          <img
-            src="/logo.png"
-            alt={t('login.title')}
-            className="size-16 mx-auto mb-4"
-          />
-          <h1 className="text-2xl font-bold text-fluux-text">{t('login.title')}</h1>
+          {/* Aurora gradient brand mark: the --fluux-grad tile + a soft glow */}
+          <div className="relative size-16 mx-auto mb-4">
+            <div
+              className="absolute -inset-1.5 rounded-2xl blur-xl opacity-60"
+              style={{ background: 'var(--fluux-grad)' }}
+              aria-hidden="true"
+            />
+            <div
+              className="absolute inset-0 rounded-2xl flex items-center justify-center"
+              style={{ background: 'var(--fluux-grad)' }}
+            >
+              <MessageCircle className="size-8 text-white" aria-hidden="true" />
+            </div>
+          </div>
+          <h1 className="text-3xl font-semibold font-display tracking-tight text-fluux-text">{t('login.title')}</h1>
           <p className="text-fluux-muted mt-2">{t('login.subtitle')}</p>
         </div>
 
         {/* Login Form */}
-        <form onSubmit={handleSubmit} name="login" className="bg-fluux-sidebar rounded-lg p-6 space-y-4">
+        <form onSubmit={handleSubmit} name="login" className="bg-fluux-sidebar rounded-lg p-6 space-y-4 border border-[color:var(--fluux-surface-divider)] shadow-[var(--fluux-shadow-overlay)]">
           {/* JID Field */}
           <div>
             <label htmlFor="jid" className="block text-xs font-semibold text-fluux-muted uppercase mb-2">

--- a/docs/superpowers/plans/2026-06-28-aurora-auth-login.md
+++ b/docs/superpowers/plans/2026-06-28-aurora-auth-login.md
@@ -1,0 +1,151 @@
+# Aurora Auth / Login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the login screen an Aurora-branded first impression — a gradient app-tile mark, a display-font heading, an elevated card, and a faint aurora backdrop — without touching the auth flow.
+
+**Architecture:** Purely visual changes in `LoginScreen.tsx` (the header mark + heading, the form-card elevation, a decorative backdrop glow) plus a one-line radius touch in `LoginErrorPanel.tsx`. Token-based; the gradient mark uses `--fluux-grad` (the brand signature), surfaces inherit the active theme. No new components, no behavior change.
+
+**Tech Stack:** React + TypeScript, Tailwind + CSS custom properties, lucide-react, Vitest + Testing Library. No SDK changes.
+
+## Global Constraints
+
+- **Purely visual — preserve ALL behavior.** No auth/connection flow, field, validation, prefill, remember-me, or persistence changes. The **advanced-mode kebab** (`OverflowMenu`, `LoginScreen.tsx:427-438`, toggles `useAdvancedModeStore`, reveals the server field) is KEPT exactly, and must stay clickable above the new backdrop glow + clear of the centered mark.
+- **No copy rewrites.** Reuse all existing `login.*` i18n keys. The footer keeps its two lines: "Made by ProcessOne, the company behind ejabberd" and "**Powered by XMPP**" (links `XMPP` -> `xmpp.org`, already correct — do NOT change to ejabberd).
+- **Gradient mark = `--fluux-grad`** (the Fluux brand signature, theme-overridden light/dark; intentionally stays the Aurora gradient on other themes). The backdrop glow uses the theme ACCENT faintly (theme-aware). Surfaces (`bg-fluux-bg`, `bg-fluux-sidebar`) inherit the theme.
+- **Decorative layers must NOT reduce text/field contrast** (the backdrop glow is very faint + behind the card). The white glyph on the gradient tile is decorative (3:1 floor).
+- **No em-dashes/en-dashes** in any user-facing string. No SDK changes (-> no `build:sdk`).
+
+## File Structure
+
+- Modify: `apps/fluux/src/components/LoginScreen.tsx` — the brand mark + heading (header block ~440-448), the form-card elevation (form ~451), the backdrop glow (root container ~417). Preserve the kebab + server field + footer.
+- Modify: `apps/fluux/src/components/LoginErrorPanel.tsx` — radius touch only.
+- Test: `apps/fluux/src/components/LoginScreen.test.tsx`.
+- Modify: `scripts/screenshots.ts` (best-effort login scene).
+
+---
+
+### Task 1: LoginScreen Aurora branding
+
+**Files:**
+- Modify: `apps/fluux/src/components/LoginScreen.tsx`, `apps/fluux/src/components/LoginErrorPanel.tsx`
+- Test: `apps/fluux/src/components/LoginScreen.test.tsx`
+
+**Interfaces:** Consumes `MessageCircle` from `lucide-react` (add to the existing lucide import). Uses CSS vars `--fluux-grad`, `--fluux-surface-divider`, `--fluux-shadow-overlay`, `--fluux-bg-accent`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `LoginScreen.test.tsx` (follow the file's existing mock setup — it mocks `react-i18next` with `t` returning the key, plus the connection/prefill/window hooks):
+```tsx
+it('renders the Aurora gradient mark + display-font heading (no flat logo img)', () => {
+  renderLogin() // the file's existing render helper / <LoginScreen /> with its mocks
+  // display-font heading
+  const heading = screen.getByRole('heading', { level: 1 })
+  expect(heading.className).toMatch(/font-display/)
+  // the flat logo <img> is replaced by the gradient mark (no <img> for the brand)
+  expect(screen.queryByRole('img')).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/LoginScreen.test.tsx -t "gradient mark"`
+Expected: FAIL — the heading has no `font-display`, and the `<img src="/logo.png">` still renders.
+
+- [ ] **Step 3: Replace the header block with the gradient mark + display heading**
+
+In `LoginScreen.tsx`, add `MessageCircle` to the `lucide-react` import. Replace the header block (~lines 440-448):
+```tsx
+        {/* Logo / Header */}
+        <div className="text-center mb-8">
+          {/* Aurora gradient brand mark: the --fluux-grad tile + a soft glow */}
+          <div className="relative size-16 mx-auto mb-4">
+            <div
+              className="absolute -inset-1.5 rounded-2xl blur-xl opacity-60"
+              style={{ background: 'var(--fluux-grad)' }}
+              aria-hidden="true"
+            />
+            <div
+              className="absolute inset-0 rounded-2xl flex items-center justify-center"
+              style={{ background: 'var(--fluux-grad)' }}
+            >
+              <MessageCircle className="size-8 text-white" aria-hidden="true" />
+            </div>
+          </div>
+          <h1 className="text-3xl font-semibold font-display tracking-tight text-fluux-text">{t('login.title')}</h1>
+          <p className="text-fluux-muted mt-2">{t('login.subtitle')}</p>
+        </div>
+```
+
+- [ ] **Step 4: Elevate the form card**
+
+Update the `<form>` className (~line 451) to add a hairline border + the overlay shadow:
+```tsx
+        <form onSubmit={handleSubmit} name="login" className="bg-fluux-sidebar rounded-lg p-6 space-y-4 border border-[color:var(--fluux-surface-divider)] shadow-[var(--fluux-shadow-overlay)]">
+```
+
+- [ ] **Step 5: Add the faint aurora backdrop glow**
+
+In the root container (~line 417, `<div className="h-full bg-fluux-bg overflow-y-auto relative">`), add the glow as the FIRST child with `z-0`, and give the centering wrapper a `relative z-10` so the content paints above the glow (an absolute element otherwise paints ABOVE its static siblings, so the content needs an explicit higher z):
+```tsx
+      {/* Faint aurora backdrop glow — decorative, behind the content */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-80 z-0"
+        style={{ background: 'radial-gradient(60% 100% at 50% 0%, color-mix(in srgb, var(--fluux-bg-accent), transparent 88%), transparent 70%)' }}
+        aria-hidden="true"
+      />
+```
+Then on the centering wrapper (~line 423, `<div className="min-h-full flex items-center justify-center p-4">`) add `relative z-10`:
+```tsx
+        <div className="min-h-full flex items-center justify-center p-4 relative z-10">
+```
+The card is opaque `bg-fluux-sidebar` (covers the glow where they overlap) and the advanced-mode kebab keeps its `z-10` within the now-z-10 content (stays above the glow + clickable). Do NOT change the kebab, the server field, remember-me, or the footer.
+
+- [ ] **Step 6: LoginErrorPanel radius touch**
+
+In `LoginErrorPanel.tsx`, change the `plainBoxClass` `rounded` -> `rounded-lg` so the error box matches the card radius. No other change.
+
+- [ ] **Step 7: Run the tests + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/components/LoginScreen.test.tsx src/components/LoginErrorPanel.test.tsx 2>/dev/null` ; then from repo root `npm run typecheck`.
+Expected: PASS / clean. (The connection/field/kebab behavior is unchanged, so the existing LoginScreen tests stay green; update any test that asserted the old `<img>`/`text-2xl` heading.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/fluux/src/components/LoginScreen.tsx apps/fluux/src/components/LoginErrorPanel.tsx apps/fluux/src/components/LoginScreen.test.tsx
+git -c commit.gpgsign=false commit -m "feat(login): Aurora gradient brand mark + display heading + elevated card + backdrop"
+```
+
+---
+
+### Task 2: Verification + screenshots
+
+**Files:** Modify `scripts/screenshots.ts`; verify the slice.
+
+- [ ] **Step 1: Full verification**
+
+Run from repo root: `npm run typecheck` (clean), `npm run lint` (0 errors), `npm test` (all pass, no stderr; incl. `LoginScreen.test`). Confirm the login text contrast is already covered (the surfaces are `bg-fluux-sidebar` + `bg-fluux-bg`; `text-muted` on the sidebar surface is guarded by `emptyStateContrast.test.ts`). No new contrast guard expected; if a NEW token/surface was introduced, extend the guard.
+
+- [ ] **Step 2: Add a login screenshot scene (best-effort)**
+
+The demo (`demo.html`) auto-connects and bypasses login, so the login screen may not be reachable from the existing demo harness. In `scripts/screenshots.ts`, attempt a login scene: load the app so the LOGIN renders (e.g. the non-demo entry, or a demo URL param / store state that forces the logged-out LoginScreen). If reachable, capture it in Aurora dark + light + gruvbox (`setTheme`), naming `8x-login-<theme>`. If the harness cannot reach a logged-out state cleanly, SKIP the scene and note why in the report (the LoginScreen unit test + the verification carry the proof); do NOT hack the demo auto-connect.
+
+- [ ] **Step 3: Regenerate + eyeball (if a scene was added)**
+
+If a login scene was added: `npm run screenshots`, then confirm the gradient mark + display heading + elevated card render, the backdrop glow is subtle (fields readable), and the advanced-mode kebab is visible top-right, in dark + light + gruvbox.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/screenshots.ts screenshots/ 2>/dev/null; git -c commit.gpgsign=false commit -m "test(login): verification + login screenshot scene" || echo "nothing to commit (no scene reachable)"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** gradient app-tile mark (Task 1 Step 3) · display heading (Step 3) · elevated card (Step 4) · aurora backdrop (Step 5) · error-panel light touch (Step 6) · preserve advanced-mode kebab + server field + footer "Powered by XMPP" (Global Constraints + untouched in the edits) · theme-robust + contrast covered (Task 2 Step 1). All covered.
+- **Type consistency:** `MessageCircle` (lucide), the CSS vars (`--fluux-grad`, `--fluux-surface-divider`, `--fluux-shadow-overlay`, `--fluux-bg-accent`) — consistent.
+- **No SDK change** -> no `build:sdk`.
+- **Known risk flagged:** the login screenshot may be unreachable in the demo harness (demo auto-connects) — Task 2 makes it best-effort and falls back to the unit test, rather than hacking the demo.

--- a/docs/superpowers/specs/2026-06-28-aurora-auth-login-design.md
+++ b/docs/superpowers/specs/2026-06-28-aurora-auth-login-design.md
@@ -1,0 +1,61 @@
+# Aurora Auth / Login — Design Spec
+
+- Status: Approved (design + brand-mark choice), pending spec review
+- Date: 2026-06-28
+- Screen: #8 in `2026-06-26-aurora-screen-inventory.md` ("Auth surfaces — LoginScreen / LoginErrorPanel") — the LAST roadmap screen
+- Scope: `apps/fluux` — `LoginScreen` branding pass (+ a light `LoginErrorPanel` touch). Effort S.
+
+## Goal
+
+The login is the first screen a new user sees, and today it is plain: the Aurora gradient and display font are defined but unused, the heading is a generic `text-2xl`, and the logo is a flat 64px image. Give it a branded Aurora first impression — a luminous gradient mark, display typography, an elevated card, and a faint aurora backdrop — without touching the auth flow.
+
+## Background — current state (recon-confirmed)
+
+`LoginScreen.tsx` is functional + already token-based (no hardcoded colors): full-height `bg-fluux-bg` container, centered `max-w-md` card on `bg-fluux-sidebar rounded-lg p-6`, a `/logo.png` (`size-16`) + `h1 text-2xl font-bold` + muted subtitle, JID/password/server fields (JID + server use `ui/TextInput`), a remember-me checkbox, and a `bg-fluux-brand` Connect button with a connecting spinner. `LoginErrorPanel.tsx` is already Aurora-appropriate (tokenized `bg-fluux-red/20` + `text-fluux-error`, `ShieldAlert`/`AlertTriangle` icons, calm). The login renders INSIDE an already-themed `<html>` (ThemeProvider runs in `main.tsx` before routes), so it inherits the active theme. **Unused on login:** `--fluux-grad`, an intentional `--fluux-font-display` heading, `--fluux-shadow-overlay`, `--fluux-surface-divider`.
+
+## Design
+
+### 1. Gradient app-tile brand mark (the brand moment)
+
+Replace the flat `<img src="/logo.png">` with a bold Aurora mark: a ~64px rounded-square tile filled with `--fluux-grad` (the signature teal -> periwinkle -> violet), a clean white lucide glyph centered on it (a message glyph, e.g. `MessageCircle` / `MessagesSquare` — the implementer picks the cleanest), and a soft gradient glow behind it (a blurred, lower-opacity `--fluux-grad` layer) so it reads as luminous. Centered above the heading. The white glyph on the mid-tone gradient is decorative (non-text, the 3:1 floor); confirm it stays legible.
+
+### 2. Display-font heading
+
+"Fluux Messenger" (the existing `login.title` key) set intentionally in the display font (`font-display`), larger (`text-3xl`), `tracking-tight`, `text-fluux-text`. Subtitle (`login.subtitle`) stays `text-fluux-muted`. Copy unchanged.
+
+### 3. Elevated card
+
+The form card keeps `bg-fluux-sidebar` but gains a hairline border (`--fluux-surface-divider`) + the overlay shadow (`--fluux-shadow-overlay`) so it reads as a clean elevated panel (deep-ink in dark, cool-white in light). Radius/padding unchanged.
+
+### 4. Faint aurora backdrop
+
+A subtle, low-opacity radial `--fluux-grad` glow on the full-screen `bg-fluux-bg` container (behind/above the card) for atmosphere — decorative, very faint, must NOT reduce text or field contrast. Sits behind the card; the Tauri drag region + scroll behavior are preserved.
+
+### 5. Error panel — light touch only
+
+`LoginErrorPanel` is already tokenized + iconed + calm. Keep it; at most align its box radius/spacing to the card. No restructure, no new states.
+
+## Preserve (existing functionality the redesign MUST keep)
+
+- **Advanced-mode toggle (the top-right kebab).** `LoginScreen.tsx:427-438` renders a quiet `OverflowMenu` (`absolute top-0 end-0 z-10`) with the single item `login.advancedMode` (Wrench icon, `active={advancedMode}`, toggling `useAdvancedModeStore`). Toggling it reveals the custom-server field (`{(showServerField || advancedMode) && ...}`, line ~535) and unlocks the app's expert surfaces (XMPP console, Advanced settings). The redesign KEEPS this kebab and its behavior unchanged. Watch the layering: it must stay clickable and visible above the new aurora backdrop glow (`z-10` over the decorative glow) and not be overlapped by the centered gradient mark (the mark is centered, the kebab is the top-right corner — no overlap, but verify after adding the backdrop). The mock omitted it for simplicity; it stays.
+- **The custom-server field** (revealed by advanced mode / auto-reveal) keeps its `ui/TextInput` + the calm link-server note, restyled only to match the card (consistent field treatment), no behavior change.
+- **Remember-me, prefill/deep-link, keychain/FAST persistence, auto-connect** — all unchanged.
+- **Footer copy is unchanged** — keep the existing two lines: "Made by [ProcessOne], the company behind [ejabberd]" and "**Powered by [XMPP]**" (the second line already links `XMPP` to `xmpp.org` — NOT ejabberd). Restyle only (it already uses `text-fluux-brand` links). The mock incorrectly showed "Powered by ejabberd"; the real/kept copy is "Powered by XMPP".
+
+## Theme-robustness
+
+- The **gradient mark uses `--fluux-grad`** — the Fluux brand signature, which IS overridden for light vs dark (`#38E0C4,#7C8CFF,#A78BFA` dark / `#11A88C,#5B6CF0,#7C6CF0` light). No theme overrides `--fluux-grad`, so on non-Aurora themes the mark stays the Aurora gradient — intentional, since it is the PRODUCT brand mark (not theme chrome).
+- The **surfaces inherit the active theme** (`bg-fluux-bg`, `bg-fluux-sidebar`), so the login tones to the user's theme.
+- **Text contrast:** the heading (`text-fluux-text`) + subtitle (`text-fluux-muted`) render on `bg-fluux-sidebar` / `bg-fluux-bg`; `text-muted` on the sidebar surface is already AA-guarded by `emptyStateContrast.test.ts` (the settings/empty-states fix). The Connect button is `bg-fluux-brand` + `text-fluux-text-on-accent` (the white-on-accent AA invariant). No new contrast risk expected; confirm during implementation.
+
+## Out of scope
+
+- No auth/connection flow, field, validation, remember-me, prefill, or persistence changes — purely visual.
+- No copy rewrites (reuse all existing `login.*` i18n keys).
+- No `LoginErrorPanel` restructure. No SDK changes.
+
+## Testing
+
+- `LoginScreen.test.tsx` stays green (the mark/heading/card are presentational; fields + handlers unchanged). Add/extend a render check that the gradient mark + display heading render.
+- Confirm the login text is AA on its surfaces across themes (reuse the existing contrast coverage; the surfaces are the already-guarded sidebar/bg).
+- Screenshots: the login screen in Aurora dark + light + 1-2 accent themes (e.g. gruvbox), to confirm the gradient mark + display heading + elevated card render and the backdrop glow is subtle, with readable fields.


### PR DESCRIPTION
Aurora-branded first impression for the login screen, the last screen in the Aurora screen-by-screen rollout. Purely visual; no auth flow, field, or behavior change.

What changed:
- Gradient \`--fluux-grad\` app-tile brand mark with a soft glow and a \`MessageCircle\` glyph, replacing the flat \`logo.png\`
- Display-font heading (\`font-display\`, \`text-3xl\`, \`tracking-tight\`)
- Elevated form card: hairline \`--fluux-surface-divider\` border plus \`--fluux-shadow-overlay\`
- Faint aurora backdrop glow (decorative, behind the card; z-layered so the advanced-mode kebab and the fields stay above it)
- \`LoginErrorPanel\`: box radius aligned to the card (\`rounded\` to \`rounded-lg\`)

Preserved unchanged: the advanced-mode kebab and custom-server field, remember-me, deep-link prefill, keychain/FAST persistence, and the footer ("Powered by XMPP"). Surfaces inherit the active theme across all 13 built-ins; login text contrast is covered by the existing \`emptyStateContrast\` guard (both surfaces, 13x2).