### PR TITLE
fix(scroll-debug): split the [Estimate] flood onto its own flag

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -35,7 +35,7 @@ import { getTopVisibleDate } from './getTopVisibleDate'
 import { useTanstackMessageVirtualizer } from './tanstackMessageVirtualizer'
 import { useRowMetrics } from './useRowMetrics'
 import { estimateRowHeight } from './rowHeightEstimator'
-import { isScrollDebugEnabled, estimateDebugLog } from '@/utils/scrollDebug'
+import { isEstimateDebugEnabled, estimateDebugLog } from '@/utils/scrollDebug'
 import {
   getCachedHeights,
   recordMeasuredHeight,
@@ -332,9 +332,9 @@ export function MessageList<T extends BaseMessage>({
             const widthBucketPx = Math.round(metricsRef.current.contentWidthPx / 20) * 20
             recordMeasuredHeight(cid, heightCacheKey(key, widthBucketPx, scale), size)
             noteConversationWidthBucket(cid, widthBucketPx)
-            // Estimate-accuracy trace (scroll-debug only): predicted vs first-measured per row.
+            // Estimate-accuracy trace (estimate-debug only): predicted vs first-measured per row.
             // Gated up front so the predict (which may call pretext) is skipped when debug is off.
-            if (isScrollDebugEnabled()) {
+            if (isEstimateDebugEnabled()) {
               const idx = idMap.get(key)
               const item = idx != null ? items[idx] : undefined
               const predicted = item ? estimateRowHeight(item, metricsRef.current) : undefined

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -50,6 +50,14 @@ if (typeof window !== 'undefined') {
     ;(window as Window & { __fluuxScrollDebugOn?: boolean }).__fluuxScrollDebugOn = on
     console.warn(`[Scroll] debug ${on ? 'ENABLED' : 'disabled'}`)
   }
+  // SEPARATE toggle for the high-volume per-row `[Estimate]` trace, so the scroll-decision trace
+  // above stays readable. Enable only when auditing estimate accuracy.
+  ;(window as Window & { __fluuxEstimateDebug?: (on?: boolean) => void }).__fluuxEstimateDebug = (
+    on = true
+  ) => {
+    ;(window as Window & { __fluuxEstimateDebugOn?: boolean }).__fluuxEstimateDebugOn = on
+    console.warn(`[Estimate] debug ${on ? 'ENABLED' : 'disabled'}`)
+  }
 }
 
 function debugLog(action: string, data?: Record<string, unknown>) {

--- a/apps/fluux/src/utils/scrollDebug.ts
+++ b/apps/fluux/src/utils/scrollDebug.ts
@@ -15,12 +15,28 @@ export function isScrollDebugEnabled(): boolean {
 }
 
 /**
- * Console log gated on the scroll-debug flag, tagged `[Estimate]` so the estimator/sampler/cache
- * lines are filterable within the shared scroll trace. No-op (and zero arg cost at call sites that
- * pre-check {@link isScrollDebugEnabled}) when the flag is off.
+ * The `[Estimate]` trace is on its OWN flag — it logs per-row, per-measure (hundreds of lines per
+ * scroll), which buries the `[Scroll]`/`[ScrollStateManager]` decision trace. So `__fluuxScrollDebug`
+ * (or `fluux:scroll-debug`) gives a clean decision trace; enable this separately only when actually
+ * auditing estimate accuracy: `__fluuxEstimateDebug(true)`, or `localStorage 'fluux:estimate-debug'`.
+ */
+export function isEstimateDebugEnabled(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    if ((window as Window & { __fluuxEstimateDebugOn?: boolean }).__fluuxEstimateDebugOn) return true
+    return window.localStorage?.getItem('fluux:estimate-debug') === '1'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Console log tagged `[Estimate]`, gated on the SEPARATE estimate-debug flag (see
+ * {@link isEstimateDebugEnabled}) so it doesn't flood the scroll-decision trace. No-op (and zero arg
+ * cost at call sites that pre-check the flag) when off.
  */
 export function estimateDebugLog(...args: unknown[]): void {
-  if (!isScrollDebugEnabled()) return
+  if (!isEstimateDebugEnabled()) return
   console.log('[Estimate]', ...args)
 }
 


### PR DESCRIPTION
The per-row, per-measure `[Estimate]` trace (hundreds of lines per scroll) shared the scroll-debug flag, burying the `[Scroll]`/`[ScrollStateManager]` decision trace it's meant to sit beside — making the scroll trace unusable for debugging.

Move `[Estimate]` to its own flag:
- `__fluuxScrollDebug(true)` (or `fluux:scroll-debug`) → clean `[Scroll]`/`[ScrollStateManager]`/`[Nav]` decision trace.
- `__fluuxEstimateDebug(true)` (or `fluux:estimate-debug`) → opt in to the high-volume estimate trace only when auditing estimate accuracy.

The expensive predict at the `[Estimate]` call site is now gated on the estimate flag too, so scroll-debug no longer pays for it.

Verified live (chromium + webkit): under scroll-debug the estimate trace is silent (0 lines) while the scroll/state-manager trace is present (42 / ~15 lines).