### PR TITLE
Aurora motion language: token vocabulary + modal enter/exit

### DIFF
--- a/apps/fluux/src/components/AddContactModal.test.tsx
+++ b/apps/fluux/src/components/AddContactModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { AddContactModal } from './AddContactModal'
 
@@ -240,6 +240,13 @@ describe('AddContactModal', () => {
   })
 
   describe('modal closing', () => {
+    beforeEach(() => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
+    })
+    afterEach(() => {
+      document.documentElement.removeAttribute('data-motion')
+    })
+
     it('should call onClose when Cancel button is clicked', () => {
       render(<AddContactModal onClose={mockOnClose} />)
 

--- a/apps/fluux/src/components/AdminRoomView.test.tsx
+++ b/apps/fluux/src/components/AdminRoomView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AdminRoomView } from './AdminRoomView'
 import type { AdminRoom } from '@fluux/sdk'
@@ -147,6 +147,13 @@ describe('AdminRoomView', () => {
   })
 
   describe('destroy room', () => {
+    beforeEach(() => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
+    })
+    afterEach(() => {
+      document.documentElement.removeAttribute('data-motion')
+    })
+
     it('should show confirmation dialog when destroy button clicked', () => {
       render(
         <AdminRoomView

--- a/apps/fluux/src/components/AvatarCropModal.test.tsx
+++ b/apps/fluux/src/components/AvatarCropModal.test.tsx
@@ -73,12 +73,14 @@ describe('AvatarCropModal', () => {
     })
 
     it('should call onClose when Cancel button is clicked', () => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
       render(
         <AvatarCropModal isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />
       )
 
       fireEvent.click(screen.getAllByText('common.cancel')[0])
       expect(mockOnClose).toHaveBeenCalled()
+      document.documentElement.removeAttribute('data-motion')
     })
 
     it('should have disabled Save button when no image is selected', () => {

--- a/apps/fluux/src/components/AvatarCropModal.tsx
+++ b/apps/fluux/src/components/AvatarCropModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { X, Upload, ZoomIn, ZoomOut, RotateCcw, Camera, Video, VideoOff } from 'lucide-react'
 import { Tooltip } from './Tooltip'
+import { useModalTransition } from '@/hooks/useModalTransition'
 
 interface AvatarCropModalProps {
   isOpen: boolean
@@ -15,6 +16,8 @@ const MAX_ZOOM = 3
 
 export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProps) {
   const { t } = useTranslation()
+  const { panelClass, scrimClass, requestClose } = useModalTransition()
+  const close = useCallback(() => requestClose(onClose), [requestClose, onClose])
   const [, setSelectedFile] = useState<File | null>(null)
   const [imageUrl, setImageUrl] = useState<string | null>(null)
   const [zoom, setZoom] = useState(1)
@@ -358,14 +361,14 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
-      <div className="fluux-glass rounded-lg w-full max-w-md mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden">
+    <div className={`fixed inset-0 z-50 flex items-center justify-center bg-black/70 ${scrimClass}`}>
+      <div className={`fluux-glass rounded-lg w-full max-w-md mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden ${panelClass}`}>
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-fluux-bg">
           <h2 className="text-lg font-semibold text-fluux-text">{t('avatar.uploadTitle')}</h2>
           <Tooltip content={t('common.close')}>
             <button
-              onClick={onClose}
+              onClick={close}
               className="p-1 text-fluux-muted hover:text-fluux-text rounded"
             >
               <X className="size-5" />
@@ -562,7 +565,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
         {/* Footer */}
         <div className="flex justify-end gap-3 p-4 border-t border-fluux-bg">
           <button
-            onClick={onClose}
+            onClick={close}
             className="px-4 py-2 text-fluux-text hover:bg-fluux-hover rounded transition-colors"
           >
             {t('common.cancel')}

--- a/apps/fluux/src/components/BackupPassphraseDialog.tsx
+++ b/apps/fluux/src/components/BackupPassphraseDialog.tsx
@@ -4,6 +4,7 @@ import { Copy, Check, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { generateBackupPassphrase, generateBackupCode, USE_V6_KEYS } from '@/e2ee/passphraseGenerator'
 import { SaveToPasswordManagerButton } from './SaveToPasswordManagerButton'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useModalTransition } from '@/hooks/useModalTransition'
 
 // Draw a fresh passphrase in the user's UI language. 8 words ×
 // 11 bits (BIP-39) = 88 bits, which matches the acceptability gate
@@ -52,6 +53,9 @@ export function BackupPassphraseDialog({
   // Keep keyboard focus inside the dialog across OS window blur/refocus.
   useRestoreFocus(panelRef)
 
+  const { panelClass, scrimClass, requestClose } = useModalTransition()
+  const cancel = useCallback(() => requestClose(onCancel), [requestClose, onCancel])
+
   // Regenerate on every open rather than keeping a stable value — a
   // user who cancelled and reopened should get a fresh passphrase so
   // a shoulder-surfing observer of the first attempt can't reuse it.
@@ -86,11 +90,11 @@ export function BackupPassphraseDialog({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isPublishing) onCancel()
+      if (e.key === 'Escape' && !isPublishing) cancel()
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onCancel, isPublishing])
+  }, [cancel, isPublishing])
 
   const handleRegenerate = useCallback(async () => {
     if (isPublishing) return
@@ -143,17 +147,17 @@ export function BackupPassphraseDialog({
   return (
     <div
       data-modal="true"
-      className="fixed inset-0 modal-scrim flex items-center justify-center z-50"
+      className={`fixed inset-0 modal-scrim flex items-center justify-center z-50 ${scrimClass}`}
     >
       <button
         type="button"
         aria-hidden="true"
         tabIndex={-1}
         disabled={isPublishing}
-        onClick={onCancel}
+        onClick={cancel}
         className="absolute inset-0 cursor-default"
       />
-      <div ref={panelRef} className="relative z-10 fluux-glass rounded-lg max-w-md w-full mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden">
+      <div ref={panelRef} className={`relative z-10 fluux-glass rounded-lg max-w-md w-full mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden ${panelClass}`}>
         <form
           onSubmit={(e) => { e.preventDefault(); void handleConfirm() }}
           className="contents"
@@ -264,7 +268,7 @@ export function BackupPassphraseDialog({
           <div className="flex gap-2 justify-end">
             <button
               type="button"
-              onClick={onCancel}
+              onClick={cancel}
               disabled={isPublishing}
               className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors disabled:opacity-50"
             >

--- a/apps/fluux/src/components/BrowseRoomsModal.test.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.test.tsx
@@ -137,6 +137,7 @@ describe('BrowseRoomsModal', () => {
     })
 
     it('should call onClose when close button is clicked', async () => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
       render(<BrowseRoomsModal onClose={mockOnClose} />)
       await act(async () => {})
 
@@ -144,9 +145,11 @@ describe('BrowseRoomsModal', () => {
       fireEvent.click(closeButton)
 
       expect(mockOnClose).toHaveBeenCalled()
+      document.documentElement.removeAttribute('data-motion')
     })
 
     it('should call onClose when clicking backdrop', async () => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
       render(<BrowseRoomsModal onClose={mockOnClose} />)
       await act(async () => {})
 
@@ -156,6 +159,7 @@ describe('BrowseRoomsModal', () => {
       fireEvent.click(backdrop.querySelector('button')!)
 
       expect(mockOnClose).toHaveBeenCalled()
+      document.documentElement.removeAttribute('data-motion')
     })
 
     it('should show loading spinner while fetching rooms', async () => {

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -435,12 +435,14 @@ describe('CommandPalette', () => {
     })
 
     it('should close on Escape', () => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
       render(<CommandPalette {...defaultProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
       fireEvent.keyDown(container!, { key: 'Escape' })
 
       expect(defaultProps.onClose).toHaveBeenCalled()
+      document.documentElement.removeAttribute('data-motion')
     })
 
     it('should close on Cmd+K (toggle)', () => {
@@ -516,6 +518,7 @@ describe('CommandPalette', () => {
     })
 
     it('should close on backdrop click', () => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
       render(<CommandPalette {...defaultProps} />)
 
       // Click on the backdrop (the outer div)
@@ -524,6 +527,7 @@ describe('CommandPalette', () => {
       fireEvent.click(backdrop.querySelector('button')!)
 
       expect(defaultProps.onClose).toHaveBeenCalled()
+      document.documentElement.removeAttribute('data-motion')
     })
 
     it('should not close when clicking inside the palette', () => {

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import { TextInput } from './ui/TextInput'
 import { useTranslation } from 'react-i18next'
 import {
@@ -23,6 +23,7 @@ import { Avatar } from './Avatar'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { isAdvancedMode } from '@/stores/advancedModeStore'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useModalTransition } from '@/hooks/useModalTransition'
 
 // =============================================================================
 // Types
@@ -178,6 +179,8 @@ function CommandPaletteContent({
 }: CommandPaletteProps) {
   detectRenderLoop('CommandPalette')
   const { t } = useTranslation()
+  const { panelClass, scrimClass, requestClose } = useModalTransition({ panelInClass: 'command-palette-in' })
+  const close = useCallback(() => requestClose(onClose), [requestClose, onClose])
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
   const selectedIndexRef = useRef(0) // Ref for synchronous access in event handlers
@@ -499,7 +502,7 @@ function CommandPaletteContent({
       case 'Escape':
         e.preventDefault()
         e.stopPropagation() // Prevent global shortcuts from firing
-        onClose()
+        close()
         break
     }
   }
@@ -523,20 +526,20 @@ function CommandPaletteContent({
 
   return (
     <div
-      className="fixed inset-0 modal-scrim flex items-start justify-center pt-[15vh] z-50"
+      className={`fixed inset-0 modal-scrim flex items-start justify-center pt-[15vh] z-50 ${scrimClass}`}
     >
       <button
         type="button"
         aria-hidden="true"
         tabIndex={-1}
-        onClick={onClose}
+        onClick={close}
         className="absolute inset-0 cursor-default"
       />
       <div
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        className="relative z-10 fluux-glass rounded-lg w-full max-w-lg mx-4 overflow-hidden"
+        className={`relative z-10 fluux-glass rounded-lg w-full max-w-lg mx-4 overflow-hidden ${panelClass}`}
         onKeyDown={handleKeyDown}
       >
         {/* Search Input — contained, rounded field with a soft accent focus ring

--- a/apps/fluux/src/components/ConfirmDialog.tsx
+++ b/apps/fluux/src/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useModalTransition } from '@/hooks/useModalTransition'
 
 interface ConfirmDialogProps {
   title: string
@@ -25,13 +26,16 @@ export function ConfirmDialog({
   // Keep keyboard focus inside the dialog across OS window blur/refocus.
   useRestoreFocus(panelRef)
 
+  const { panelClass, scrimClass, requestClose } = useModalTransition()
+  const cancel = useCallback(() => requestClose(onCancel), [requestClose, onCancel])
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel()
+      if (e.key === 'Escape') cancel()
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onCancel])
+  }, [cancel])
 
   const confirmColors = variant === 'warning'
     ? 'bg-orange-500 hover:bg-orange-600'
@@ -40,21 +44,21 @@ export function ConfirmDialog({
   return (
     <div
       data-modal="true"
-      className="fixed inset-0 modal-scrim flex items-center justify-center z-50"
+      className={`fixed inset-0 modal-scrim flex items-center justify-center z-50 ${scrimClass}`}
     >
       <button
         type="button"
         aria-hidden="true"
         tabIndex={-1}
-        onClick={onCancel}
+        onClick={cancel}
         className="absolute inset-0 cursor-default"
       />
-      <div ref={panelRef} className="relative z-10 fluux-glass rounded-lg p-4 max-w-sm w-full mx-4">
+      <div ref={panelRef} className={`relative z-10 fluux-glass rounded-lg p-4 max-w-sm w-full mx-4 ${panelClass}`}>
         <h3 className="text-lg font-semibold text-fluux-text mb-2">{title}</h3>
         <p className="text-sm text-fluux-muted mb-4">{message}</p>
         <div className="flex gap-2 justify-end">
           <button
-            onClick={onCancel}
+            onClick={cancel}
             className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active
                        rounded-lg transition-colors"
           >

--- a/apps/fluux/src/components/InviteToRoomModal.test.tsx
+++ b/apps/fluux/src/components/InviteToRoomModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { InviteToRoomModal } from './InviteToRoomModal'
 import { useToastStore } from '@/stores/toastStore'
@@ -223,6 +223,13 @@ describe('InviteToRoomModal', () => {
   })
 
   describe('close behavior', () => {
+    beforeEach(() => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
+    })
+    afterEach(() => {
+      document.documentElement.removeAttribute('data-motion')
+    })
+
     it('should call onClose when close button is clicked', () => {
       render(
         <InviteToRoomModal

--- a/apps/fluux/src/components/JoinRoomModal.test.tsx
+++ b/apps/fluux/src/components/JoinRoomModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { JoinRoomModal } from './JoinRoomModal'
 
@@ -400,6 +400,13 @@ describe('JoinRoomModal', () => {
   })
 
   describe('modal closing', () => {
+    beforeEach(() => {
+      document.documentElement.setAttribute('data-motion', 'reduced')
+    })
+    afterEach(() => {
+      document.documentElement.removeAttribute('data-motion')
+    })
+
     it('should call onClose when Cancel button is clicked', () => {
       render(<JoinRoomModal onClose={mockOnClose} />)
 

--- a/apps/fluux/src/components/ModalShell.test.tsx
+++ b/apps/fluux/src/components/ModalShell.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
 import { ModalShell } from './ModalShell'
 
 vi.mock('react-i18next', () => ({
@@ -49,5 +49,38 @@ describe('ModalShell glass surface', () => {
     window.dispatchEvent(new Event('focus'))
 
     expect(document.activeElement).toBe(field)
+  })
+})
+
+function setMotion(value: 'full' | 'reduced') {
+  document.documentElement.setAttribute('data-motion', value)
+}
+
+describe('ModalShell motion', () => {
+  beforeEach(() => { vi.useFakeTimers(); setMotion('full') })
+  afterEach(() => { vi.useRealTimers(); document.documentElement.removeAttribute('data-motion') })
+
+  it('renders the enter classes on mount', () => {
+    const { container } = render(<ModalShell title="T" onClose={() => {}}>body</ModalShell>)
+    expect(container.querySelector('.scrim-in')).toBeTruthy()
+    expect(container.querySelector('.modal-panel-in')).toBeTruthy()
+  })
+
+  it('plays the exit then calls onClose after the delay (motion full)', () => {
+    const onClose = vi.fn()
+    const { container } = render(<ModalShell title="T" onClose={onClose}>body</ModalShell>)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(container.querySelector('.modal-panel-out')).toBeTruthy()
+    vi.advanceTimersByTime(150)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes immediately when motion is reduced', () => {
+    setMotion('reduced')
+    const onClose = vi.fn()
+    render(<ModalShell title="T" onClose={onClose}>body</ModalShell>)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/fluux/src/components/ModalShell.tsx
+++ b/apps/fluux/src/components/ModalShell.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { X } from 'lucide-react'
 import { Tooltip } from './Tooltip'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useModalTransition } from '@/hooks/useModalTransition'
 
 interface ModalShellProps {
   title: React.ReactNode
@@ -23,6 +24,8 @@ export function ModalShell({
 }: ModalShellProps) {
   const { t } = useTranslation()
   const panelRef = useRef<HTMLDivElement>(null)
+  const { panelClass, scrimClass, requestClose } = useModalTransition()
+  const close = useCallback(() => requestClose(onClose), [requestClose, onClose])
 
   // Keep keyboard focus inside the modal across OS window blur/refocus, so
   // global shortcuts don't reclaim arrow/Tab keys when the user switches away
@@ -31,31 +34,31 @@ export function ModalShell({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') close()
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  }, [close])
 
   return (
     <div
       data-modal="true"
-      className="fixed inset-0 modal-scrim flex items-center justify-center z-50"
+      className={`fixed inset-0 modal-scrim flex items-center justify-center z-50 ${scrimClass}`}
     >
       <button
         type="button"
         aria-hidden="true"
         tabIndex={-1}
-        onClick={onClose}
+        onClick={close}
         className="absolute inset-0 cursor-default"
       />
-      <div ref={panelRef} className={`relative z-10 fluux-glass rounded-lg w-full ${width} mx-4 ${panelClassName ?? ''}`}>
+      <div ref={panelRef} className={`relative z-10 fluux-glass rounded-lg w-full ${width} mx-4 ${panelClass} ${panelClassName ?? ''}`}>
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-fluux-hover flex-shrink-0">
           <h2 className="text-lg font-semibold text-fluux-text">{title}</h2>
           <Tooltip content={t('common.close')}>
             <button
-              onClick={onClose}
+              onClick={close}
               aria-label={t('common.close')}
               className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover tap-target"
             >

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -416,7 +416,7 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
         >
           <div className="sidebar-scroll h-full overflow-y-auto rounded-sm py-0.5 px-0.5">
             <SidebarZoneContext.Provider value={sidebarListRef}>
-              <div key={sidebarView} className="h-full md:h-auto" style={{ animation: 'sidebar-view-enter 150ms ease-out' }}>
+              <div key={sidebarView} className="h-full md:h-auto" style={{ animation: 'sidebar-view-enter var(--fluux-duration-fast) var(--fluux-ease-standard)' }}>
               {sidebarView === 'messages' ? (
                 <ConversationList />
               ) : sidebarView === 'directory' ? (

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -533,7 +533,7 @@ export function MessageList<T extends BaseMessage>({
             data-message-id={msg.id}
             data-stanza-id={msg.stanzaId}
             data-origin-id={msg.originId}
-            style={msg.id === lastSentMessageId ? { animation: 'message-send 300ms ease-out' } : undefined}
+            style={msg.id === lastSentMessageId ? { animation: 'message-send var(--fluux-duration-slow) var(--fluux-ease-standard)' } : undefined}
           >
             {msg.id === gapMarkerMessageId && onCatchUpHistory && (
               <HistoryGapMarker onLoadMore={onCatchUpHistory} isLoading={isCatchingUp ?? false} />
@@ -665,7 +665,7 @@ export function MessageList<T extends BaseMessage>({
                     data-message-id={msg.id}
                     data-stanza-id={msg.stanzaId}
                     data-origin-id={msg.originId}
-                    style={msg.id === lastSentMessageId ? { animation: 'message-send 300ms ease-out' } : undefined}
+                    style={msg.id === lastSentMessageId ? { animation: 'message-send var(--fluux-duration-slow) var(--fluux-ease-standard)' } : undefined}
                   >
                     {showGapMarker && <HistoryGapMarker onLoadMore={onCatchUpHistory} isLoading={isCatchingUp ?? false} />}
                     {showNewMarker && <NewMessageMarker />}
@@ -698,7 +698,7 @@ export function MessageList<T extends BaseMessage>({
       <div
         className={`absolute bottom-4 end-4 z-40 ${
           showScrollToBottom
-            ? 'animate-[fab-spring-in_0.4s_cubic-bezier(0.34,1.56,0.64,1)_forwards]'
+            ? 'animate-[fab-spring-in_0.4s_var(--fluux-ease-spring)_forwards]'
             : 'animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none'
         }`}
         inert={!showScrollToBottom}

--- a/apps/fluux/src/components/conversation/ReactionBurst.tsx
+++ b/apps/fluux/src/components/conversation/ReactionBurst.tsx
@@ -44,7 +44,7 @@ export function ReactionBurst({ x, y, onDone }: ReactionBurstProps) {
             style={{
               '--angle': `${angle}deg`,
               '--distance': `-${distance}px`,
-              animation: `reaction-burst ${DURATION_MS}ms ease-out forwards`,
+              animation: `reaction-burst ${DURATION_MS}ms var(--fluux-ease-standard) forwards`,
               animationDelay: `${i * 15}ms`,
             } as React.CSSProperties}
           />

--- a/apps/fluux/src/hooks/useModalTransition.test.ts
+++ b/apps/fluux/src/hooks/useModalTransition.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useModalTransition, MODAL_EXIT_MS } from './useModalTransition'
+
+function setMotion(value: 'full' | 'reduced') {
+  document.documentElement.setAttribute('data-motion', value)
+}
+
+describe('useModalTransition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setMotion('full')
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    document.documentElement.removeAttribute('data-motion')
+  })
+
+  it('starts with the enter classes and not closing', () => {
+    const { result } = renderHook(() => useModalTransition())
+    expect(result.current.panelClass).toBe('modal-panel-in')
+    expect(result.current.scrimClass).toBe('scrim-in')
+    expect(result.current.isClosing).toBe(false)
+  })
+
+  it('honors a custom enter class', () => {
+    const { result } = renderHook(() => useModalTransition({ panelInClass: 'command-palette-in' }))
+    expect(result.current.panelClass).toBe('command-palette-in')
+  })
+
+  it('plays the exit then calls onClose after the exit duration (motion full)', () => {
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useModalTransition())
+    act(() => result.current.requestClose(onClose))
+    expect(result.current.panelClass).toBe('modal-panel-out')
+    expect(result.current.scrimClass).toBe('scrim-out')
+    expect(onClose).not.toHaveBeenCalled()
+    act(() => { vi.advanceTimersByTime(MODAL_EXIT_MS) })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes immediately with no exit when motion is reduced', () => {
+    setMotion('reduced')
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useModalTransition())
+    act(() => result.current.requestClose(onClose))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(result.current.isClosing).toBe(false)
+  })
+
+  it('guards against a double close', () => {
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useModalTransition())
+    act(() => {
+      result.current.requestClose(onClose)
+      result.current.requestClose(onClose)
+    })
+    act(() => { vi.advanceTimersByTime(MODAL_EXIT_MS) })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/fluux/src/hooks/useModalTransition.ts
+++ b/apps/fluux/src/hooks/useModalTransition.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef, useState } from 'react'
+
+/** Exit animation duration. Matches --fluux-duration-fast in index.css. */
+export const MODAL_EXIT_MS = 150
+
+/** Whether motion should be suppressed: explicit data-motion wins, else the OS query. */
+function isReducedMotion(): boolean {
+  const attr = document.documentElement.getAttribute('data-motion')
+  if (attr === 'reduced') return true
+  if (attr === 'full') return false
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+interface ModalTransitionOptions {
+  /** Override the enter animation class (e.g. the command palette's drop). */
+  panelInClass?: string
+}
+
+/**
+ * Drives a modal's enter and exit animation. The panel and scrim get enter
+ * classes on mount; `requestClose` swaps to the exit classes, then calls the
+ * caller's `onClose` after the exit animation (so the parent unmounts on
+ * schedule). When motion is reduced the exit is skipped and onClose fires at
+ * once. A double close fires onClose only once.
+ */
+export function useModalTransition(options?: ModalTransitionOptions) {
+  const [isClosing, setIsClosing] = useState(false)
+  const closingRef = useRef(false)
+
+  const requestClose = useCallback((onClose: () => void) => {
+    if (closingRef.current) return
+    closingRef.current = true
+    if (isReducedMotion()) {
+      onClose()
+      return
+    }
+    setIsClosing(true)
+    setTimeout(onClose, MODAL_EXIT_MS)
+  }, [])
+
+  const panelClass = isClosing ? 'modal-panel-out' : (options?.panelInClass ?? 'modal-panel-in')
+  const scrimClass = isClosing ? 'scrim-out' : 'scrim-in'
+
+  return { panelClass, scrimClass, isClosing, requestClose }
+}

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -134,6 +134,18 @@
   --fluux-accent-2: #38E0C4;
   --fluux-grad: linear-gradient(135deg, #38E0C4, #7C8CFF, #A78BFA);
   --fluux-glass-blur: 12px;
+
+  /* ── Motion language: duration + easing tokens (global, never themed) ──
+     Three durations and three easings form the app's motion vocabulary.
+     Migrated animations reference these; new modal motion uses them natively.
+     The reduced-motion gate ([data-motion="reduced"]) collapses all of it. */
+  --fluux-duration-fast: 150ms;
+  --fluux-duration-base: 200ms;
+  --fluux-duration-slow: 300ms;
+  --fluux-ease-standard: ease-out;
+  --fluux-ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
+  --fluux-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
   /* Backdrop blur applied to the modal scrim itself, so the whole background
      behind a modal/palette frosts (the strongest "glass" cue in dark themes). */
   --fluux-scrim-blur: 10px;
@@ -793,8 +805,8 @@ html, body {
 @keyframes drawer-in-end { from { transform: translateX(100%); } to { transform: translateX(0); } }
 @keyframes drawer-in-end-rtl { from { transform: translateX(-100%); } to { transform: translateX(0); } }
 @media (max-width: 1023px) {
-  .animate-drawer-in { animation: drawer-in-end 220ms cubic-bezier(0.32, 0.72, 0, 1); }
-  [dir="rtl"] .animate-drawer-in { animation: drawer-in-end-rtl 220ms cubic-bezier(0.32, 0.72, 0, 1); }
+  .animate-drawer-in { animation: drawer-in-end 220ms var(--fluux-ease-emphasized); }
+  [dir="rtl"] .animate-drawer-in { animation: drawer-in-end-rtl 220ms var(--fluux-ease-emphasized); }
 }
 
 /* Allow native rubber band effect within scrollable elements (macOS) */
@@ -984,7 +996,7 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .message-highlight {
-  animation: message-highlight 1.5s ease-out;
+  animation: message-highlight 1.5s var(--fluux-ease-standard);
   border-radius: 0.5rem;
 }
 
@@ -1070,11 +1082,11 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .bounce-top {
-  animation: bounce-top 0.3s ease-out;
+  animation: bounce-top var(--fluux-duration-slow) var(--fluux-ease-standard);
 }
 
 .bounce-bottom {
-  animation: bounce-bottom 0.3s ease-out;
+  animation: bounce-bottom var(--fluux-duration-slow) var(--fluux-ease-standard);
 }
 
 /* Christmas animation - falling particles with sway */

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1208,6 +1208,22 @@ input[type="range"]::-moz-range-thumb {
   }
 }
 
+/* Modal / dialog / command-palette enter + exit (Aurora motion language).
+   The scrim layer fades (opacity); the panel scales (transform) so the two
+   compose without double-fading the panel. Exits use `forwards` to hold the
+   end frame for the ~150ms before the component unmounts. */
+@keyframes modal-panel-in  { from { transform: scale(0.97); } to { transform: scale(1); } }
+@keyframes modal-panel-out { from { transform: scale(1); }    to { transform: scale(0.98); } }
+@keyframes command-palette-in { from { transform: translateY(-8px) scale(0.98); } to { transform: translateY(0) scale(1); } }
+@keyframes scrim-in  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes scrim-out { from { opacity: 1; } to { opacity: 0; } }
+
+.modal-panel-in     { animation: modal-panel-in var(--fluux-duration-base) var(--fluux-ease-emphasized); }
+.modal-panel-out    { animation: modal-panel-out var(--fluux-duration-fast) var(--fluux-ease-standard) forwards; }
+.command-palette-in { animation: command-palette-in var(--fluux-duration-base) var(--fluux-ease-emphasized); }
+.scrim-in  { animation: scrim-in var(--fluux-duration-base) var(--fluux-ease-standard); }
+.scrim-out { animation: scrim-out var(--fluux-duration-fast) var(--fluux-ease-standard) forwards; }
+
 /* Bulk-copy selection highlight. Decoupled from native text selection (which cannot span
    virtualized/unmounted rows); driven by the `copy-selected` class on `.message-row`
    (MessageList). Uses the Aurora selection token so it adapts across themes. */

--- a/apps/fluux/src/themes/motionTokens.test.ts
+++ b/apps/fluux/src/themes/motionTokens.test.ts
@@ -33,3 +33,21 @@ describe('motion tokens', () => {
     expect(css).not.toMatch(/animation:\s*drawer-in-end 220ms cubic-bezier/)
   })
 })
+
+describe('component animations reference motion tokens', () => {
+  const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8')
+
+  it('MessageList send + FAB animations use tokens', () => {
+    const f = read('src/components/conversation/MessageList.tsx')
+    expect(f).toMatch(/message-send var\(--fluux-duration-slow\) var\(--fluux-ease-standard\)/)
+    expect(f).toMatch(/fab-spring-in_0\.4s_var\(--fluux-ease-spring\)_forwards/)
+  })
+
+  it('Sidebar view-enter uses tokens', () => {
+    expect(read('src/components/Sidebar.tsx')).toMatch(/sidebar-view-enter var\(--fluux-duration-fast\) var\(--fluux-ease-standard\)/)
+  })
+
+  it('ReactionBurst uses the standard easing token', () => {
+    expect(read('src/components/conversation/ReactionBurst.tsx')).toMatch(/reaction-burst \$\{DURATION_MS\}ms var\(--fluux-ease-standard\)/)
+  })
+})

--- a/apps/fluux/src/themes/motionTokens.test.ts
+++ b/apps/fluux/src/themes/motionTokens.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const css = readFileSync(join(process.cwd(), 'src/index.css'), 'utf-8')
+const tw = readFileSync(join(process.cwd(), 'tailwind.config.js'), 'utf-8')
+
+describe('motion tokens', () => {
+  it('defines the duration and easing tokens in :root', () => {
+    expect(css).toMatch(/--fluux-duration-fast:\s*150ms/)
+    expect(css).toMatch(/--fluux-duration-base:\s*200ms/)
+    expect(css).toMatch(/--fluux-duration-slow:\s*300ms/)
+    expect(css).toMatch(/--fluux-ease-standard:\s*ease-out/)
+    expect(css).toMatch(/--fluux-ease-emphasized:\s*cubic-bezier\(0\.32, 0\.72, 0, 1\)/)
+    expect(css).toMatch(/--fluux-ease-spring:\s*cubic-bezier\(0\.34, 1\.56, 0\.64, 1\)/)
+  })
+
+  it('exposes the tokens as Tailwind utilities', () => {
+    expect(tw).toMatch(/fast:\s*'var\(--fluux-duration-fast\)'/)
+    expect(tw).toMatch(/base:\s*'var\(--fluux-duration-base\)'/)
+    expect(tw).toMatch(/slow:\s*'var\(--fluux-duration-slow\)'/)
+    expect(tw).toMatch(/standard:\s*'var\(--fluux-ease-standard\)'/)
+    expect(tw).toMatch(/emphasized:\s*'var\(--fluux-ease-emphasized\)'/)
+    expect(tw).toMatch(/spring:\s*'var\(--fluux-ease-spring\)'/)
+  })
+
+  it('migrates the drawer and bounce animations onto the easing/duration tokens', () => {
+    // drawer keeps 220ms, adopts the emphasized easing token
+    expect(css).toMatch(/\.animate-drawer-in\s*\{\s*animation:\s*drawer-in-end 220ms var\(--fluux-ease-emphasized\)/)
+    // bounce migrates fully (0.3s = slow) onto tokens
+    expect(css).toMatch(/\.bounce-top\s*\{\s*animation:\s*bounce-top var\(--fluux-duration-slow\) var\(--fluux-ease-standard\)/)
+    // no bespoke bezier literal remains on the drawer shorthand
+    expect(css).not.toMatch(/animation:\s*drawer-in-end 220ms cubic-bezier/)
+  })
+})

--- a/apps/fluux/tailwind.config.js
+++ b/apps/fluux/tailwind.config.js
@@ -66,6 +66,16 @@ export default {
         mono: ['var(--fluux-font-mono)'],
         display: ['var(--fluux-font-display)'],
       },
+      transitionDuration: {
+        fast: 'var(--fluux-duration-fast)',
+        base: 'var(--fluux-duration-base)',
+        slow: 'var(--fluux-duration-slow)',
+      },
+      transitionTimingFunction: {
+        standard: 'var(--fluux-ease-standard)',
+        emphasized: 'var(--fluux-ease-emphasized)',
+        spring: 'var(--fluux-ease-spring)',
+      },
       keyframes: {
         'tooltip-in': {
           '0%': { opacity: '0', transform: 'scale(0.96)' },
@@ -81,9 +91,9 @@ export default {
         },
       },
       animation: {
-        'tooltip-in': 'tooltip-in 150ms ease-out',
-        'toast-in': 'toast-in 200ms ease-out',
-        'sheet-up': 'sheet-up 220ms cubic-bezier(0.32, 0.72, 0, 1)',
+        'tooltip-in': 'tooltip-in var(--fluux-duration-fast) var(--fluux-ease-standard)',
+        'toast-in': 'toast-in var(--fluux-duration-base) var(--fluux-ease-standard)',
+        'sheet-up': 'sheet-up 220ms var(--fluux-ease-emphasized)',
       },
     },
   },

--- a/docs/superpowers/plans/2026-06-29-aurora-motion-language.md
+++ b/docs/superpowers/plans/2026-06-29-aurora-motion-language.md
@@ -1,0 +1,669 @@
+# Aurora Motion Language Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the app a small named motion vocabulary (duration and easing tokens), migrate the existing animations onto it without changing their feel, and add graceful enter and exit animation to modals, dialogs, and the command palette.
+
+**Architecture:** Two pieces. (1) A token layer: CSS custom properties in `index.css` `:root` plus matching Tailwind utilities, with existing animations rewritten to reference the named easings. (2) A modal motion layer: a shared `useModalTransition` hook that supplies enter and exit classes plus a `requestClose` wrapper that delays the real `onClose` so the exit animation can play, applied to the shared `ModalShell` and the four standalone dialog surfaces. New CSS keyframes drive the enter and exit. Everything is pure CSS gated by the existing `data-motion` switch; no animation library.
+
+**Tech Stack:** React + TypeScript, Tailwind + CSS custom properties, Vitest + Testing Library (`renderHook`). No SDK changes.
+
+## Global Constraints
+
+- **Pure CSS only, no animation library.** All motion is CSS `@keyframes` / transitions plus the existing global `data-motion` gate. No new dependency. No SDK changes (no `build:sdk`).
+- **Token values (exact):** `--fluux-duration-fast: 150ms`, `--fluux-duration-base: 200ms`, `--fluux-duration-slow: 300ms`, `--fluux-ease-standard: ease-out`, `--fluux-ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1)`, `--fluux-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1)`. Defined in `:root` only (motion is global, never theme-overridden).
+- **Feel-preserving migration.** Durations are NOT changed. Generic animations whose value already equals a token adopt that token; bespoke animations (drawer 220ms, FAB 0.4s/0.25s, reaction burst 450ms, highlight 1.5s, typing 1.2s, fall) keep their literal duration and only adopt the named easing token where one matches. `typing-dot` (ease-in-out) and `fall` (linear) have no token and are left untouched.
+- **Modal exit = 150ms** (the `fast` duration); reduced motion skips the delay and closes instantly; a double-close must fire `onClose` only once.
+- **No em-dashes or en-dashes** in any user-facing string (this slice adds no UI copy, but keep comments clean too per project convention).
+- **Tests are unit-only.** Motion is transient and does not screenshot reliably. Proof is a static token guard plus hook and `ModalShell` behavior tests. Run app tests from `apps/fluux` (the repo-root vitest config lacks the `@` alias).
+
+## File Structure
+
+- Modify `apps/fluux/src/index.css`: add the six tokens to `:root`; migrate existing `animation:` shorthands onto the easing tokens; add the new modal keyframes and classes.
+- Modify `apps/fluux/tailwind.config.js`: add `transitionDuration` and `transitionTimingFunction` named entries; rewrite the three existing `animation` shorthands to reference the vars.
+- Create `apps/fluux/src/themes/motionTokens.test.ts`: static guard over `index.css` and `tailwind.config.js`.
+- Modify `apps/fluux/src/components/conversation/MessageList.tsx`, `apps/fluux/src/components/Sidebar.tsx`, `apps/fluux/src/components/conversation/ReactionBurst.tsx`: migrate the component-level inline animations onto the tokens.
+- Create `apps/fluux/src/hooks/useModalTransition.ts` + `apps/fluux/src/hooks/useModalTransition.test.ts`: the shared transition hook.
+- Modify `apps/fluux/src/components/ModalShell.tsx` + `apps/fluux/src/components/ModalShell.test.tsx`: apply the hook (covers ~18 dialogs).
+- Modify `apps/fluux/src/components/CommandPalette.tsx`, `apps/fluux/src/components/ConfirmDialog.tsx`, `apps/fluux/src/components/BackupPassphraseDialog.tsx`, `apps/fluux/src/components/AvatarCropModal.tsx`: apply the hook to the standalone surfaces.
+
+---
+
+### Task 1: Motion token vocabulary + CSS-layer migration
+
+**Files:**
+- Modify: `apps/fluux/src/index.css` (`:root` near line 133; `animation:` shorthands at lines 796, 797, 987, 1073, 1077)
+- Modify: `apps/fluux/tailwind.config.js` (lines 69-87)
+- Test: `apps/fluux/src/themes/motionTokens.test.ts`
+
+**Interfaces:**
+- Produces: CSS vars `--fluux-duration-fast|base|slow`, `--fluux-ease-standard|emphasized|spring`; Tailwind utilities `duration-fast|base|slow` and `ease-standard|emphasized|spring`.
+
+- [ ] **Step 1: Write the failing guard test**
+
+Create `apps/fluux/src/themes/motionTokens.test.ts`. It reads the source files from `process.cwd()` (the app runs vitest from `apps/fluux`; `import.meta.url` is not a `file://` path under vitest, so use the cwd-relative path):
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const css = readFileSync(join(process.cwd(), 'src/index.css'), 'utf-8')
+const tw = readFileSync(join(process.cwd(), 'tailwind.config.js'), 'utf-8')
+
+describe('motion tokens', () => {
+  it('defines the duration and easing tokens in :root', () => {
+    expect(css).toMatch(/--fluux-duration-fast:\s*150ms/)
+    expect(css).toMatch(/--fluux-duration-base:\s*200ms/)
+    expect(css).toMatch(/--fluux-duration-slow:\s*300ms/)
+    expect(css).toMatch(/--fluux-ease-standard:\s*ease-out/)
+    expect(css).toMatch(/--fluux-ease-emphasized:\s*cubic-bezier\(0\.32, 0\.72, 0, 1\)/)
+    expect(css).toMatch(/--fluux-ease-spring:\s*cubic-bezier\(0\.34, 1\.56, 0\.64, 1\)/)
+  })
+
+  it('exposes the tokens as Tailwind utilities', () => {
+    expect(tw).toMatch(/fast:\s*'var\(--fluux-duration-fast\)'/)
+    expect(tw).toMatch(/base:\s*'var\(--fluux-duration-base\)'/)
+    expect(tw).toMatch(/slow:\s*'var\(--fluux-duration-slow\)'/)
+    expect(tw).toMatch(/standard:\s*'var\(--fluux-ease-standard\)'/)
+    expect(tw).toMatch(/emphasized:\s*'var\(--fluux-ease-emphasized\)'/)
+    expect(tw).toMatch(/spring:\s*'var\(--fluux-ease-spring\)'/)
+  })
+
+  it('migrates the drawer and bounce animations onto the easing/duration tokens', () => {
+    // drawer keeps 220ms, adopts the emphasized easing token
+    expect(css).toMatch(/\.animate-drawer-in\s*\{\s*animation:\s*drawer-in-end 220ms var\(--fluux-ease-emphasized\)/)
+    // bounce migrates fully (0.3s = slow) onto tokens
+    expect(css).toMatch(/\.bounce-top\s*\{\s*animation:\s*bounce-top var\(--fluux-duration-slow\) var\(--fluux-ease-standard\)/)
+    // no bespoke bezier literal remains on the drawer shorthand
+    expect(css).not.toMatch(/animation:\s*drawer-in-end 220ms cubic-bezier/)
+  })
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/themes/motionTokens.test.ts`
+Expected: FAIL (tokens not defined yet, drawer still uses the literal bezier).
+
+- [ ] **Step 3: Add the tokens to `:root`**
+
+In `apps/fluux/src/index.css`, immediately after the Aurora identity block (after `--fluux-glass-blur: 12px;` at line 136), add:
+
+```css
+
+  /* ── Motion language: duration + easing tokens (global, never themed) ──
+     Three durations and three easings form the app's motion vocabulary.
+     Migrated animations reference these; new modal motion uses them natively.
+     The reduced-motion gate ([data-motion="reduced"]) collapses all of it. */
+  --fluux-duration-fast: 150ms;
+  --fluux-duration-base: 200ms;
+  --fluux-duration-slow: 300ms;
+  --fluux-ease-standard: ease-out;
+  --fluux-ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
+  --fluux-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+```
+
+- [ ] **Step 4: Wire the tokens into Tailwind**
+
+In `apps/fluux/tailwind.config.js`, add `transitionDuration` and `transitionTimingFunction` inside `theme.extend` (after the `fontFamily` block at line 68, before `keyframes`):
+
+```js
+      transitionDuration: {
+        fast: 'var(--fluux-duration-fast)',
+        base: 'var(--fluux-duration-base)',
+        slow: 'var(--fluux-duration-slow)',
+      },
+      transitionTimingFunction: {
+        standard: 'var(--fluux-ease-standard)',
+        emphasized: 'var(--fluux-ease-emphasized)',
+        spring: 'var(--fluux-ease-spring)',
+      },
+```
+
+Then rewrite the three `animation` shorthands (lines 84-86) to reference the tokens (durations unchanged; `sheet-up` keeps its bespoke 220ms and adopts the emphasized easing):
+
+```js
+      animation: {
+        'tooltip-in': 'tooltip-in var(--fluux-duration-fast) var(--fluux-ease-standard)',
+        'toast-in': 'toast-in var(--fluux-duration-base) var(--fluux-ease-standard)',
+        'sheet-up': 'sheet-up 220ms var(--fluux-ease-emphasized)',
+      },
+```
+
+- [ ] **Step 5: Migrate the index.css animation shorthands**
+
+In `apps/fluux/src/index.css`, edit these shorthands (durations unchanged, easing or duration swapped to tokens):
+
+Lines 796-797 (drawer, keep 220ms, adopt emphasized easing):
+```css
+  .animate-drawer-in { animation: drawer-in-end 220ms var(--fluux-ease-emphasized); }
+  [dir="rtl"] .animate-drawer-in { animation: drawer-in-end-rtl 220ms var(--fluux-ease-emphasized); }
+```
+
+Line 987 (message-highlight, keep 1.5s, adopt standard easing):
+```css
+  animation: message-highlight 1.5s var(--fluux-ease-standard);
+```
+
+Lines 1073 and 1077 (bounce, 0.3s = slow, full token migration):
+```css
+.bounce-top {
+  animation: bounce-top var(--fluux-duration-slow) var(--fluux-ease-standard);
+}
+```
+```css
+.bounce-bottom {
+  animation: bounce-bottom var(--fluux-duration-slow) var(--fluux-ease-standard);
+}
+```
+
+Leave `typing-dot` (1.2s ease-in-out infinite, lines 1119/1124/1129) and `fall` (linear, line 1102) untouched: neither value maps to a token.
+
+- [ ] **Step 6: Run the guard + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/themes/motionTokens.test.ts` (expect PASS), then from repo root `npm run typecheck` (expect clean). Tailwind config changes need no build to typecheck.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/index.css apps/fluux/tailwind.config.js apps/fluux/src/themes/motionTokens.test.ts
+git -c commit.gpgsign=false commit -m "feat(motion): duration + easing token vocabulary + migrate CSS animations"
+```
+
+---
+
+### Task 2: Migrate component inline animations onto tokens
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/MessageList.tsx:668` (message-send) and `:701-702` (FAB spring)
+- Modify: `apps/fluux/src/components/Sidebar.tsx:419` (sidebar-view-enter)
+- Modify: `apps/fluux/src/components/conversation/ReactionBurst.tsx:47` (reaction-burst)
+- Test: `apps/fluux/src/themes/motionTokens.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: the CSS vars from Task 1.
+
+- [ ] **Step 1: Extend the guard test**
+
+Append to `apps/fluux/src/themes/motionTokens.test.ts`:
+
+```ts
+describe('component animations reference motion tokens', () => {
+  const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8')
+
+  it('MessageList send + FAB animations use tokens', () => {
+    const f = read('src/components/conversation/MessageList.tsx')
+    expect(f).toMatch(/message-send var\(--fluux-duration-slow\) var\(--fluux-ease-standard\)/)
+    expect(f).toMatch(/fab-spring-in_0\.4s_var\(--fluux-ease-spring\)_forwards/)
+  })
+
+  it('Sidebar view-enter uses tokens', () => {
+    expect(read('src/components/Sidebar.tsx')).toMatch(/sidebar-view-enter var\(--fluux-duration-fast\) var\(--fluux-ease-standard\)/)
+  })
+
+  it('ReactionBurst uses the standard easing token', () => {
+    expect(read('src/components/conversation/ReactionBurst.tsx')).toMatch(/reaction-burst \$\{DURATION_MS\}ms var\(--fluux-ease-standard\)/)
+  })
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/themes/motionTokens.test.ts -t "component animations"`
+Expected: FAIL (components still use literals).
+
+- [ ] **Step 3: Migrate MessageList**
+
+In `apps/fluux/src/components/conversation/MessageList.tsx`, line 668, change the message-send inline style:
+```tsx
+                    style={msg.id === lastSentMessageId ? { animation: 'message-send var(--fluux-duration-slow) var(--fluux-ease-standard)' } : undefined}
+```
+Lines 701-702, change the FAB enter easing to the spring token (durations 0.4s/0.25s and the exit `ease-in` stay literal; only the spring easing tokenizes):
+```tsx
+            ? 'animate-[fab-spring-in_0.4s_var(--fluux-ease-spring)_forwards]'
+            : 'animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none'
+```
+
+- [ ] **Step 4: Migrate Sidebar**
+
+In `apps/fluux/src/components/Sidebar.tsx`, line 419:
+```tsx
+              <div key={sidebarView} className="h-full md:h-auto" style={{ animation: 'sidebar-view-enter var(--fluux-duration-fast) var(--fluux-ease-standard)' }}>
+```
+
+- [ ] **Step 5: Migrate ReactionBurst**
+
+In `apps/fluux/src/components/conversation/ReactionBurst.tsx`, line 47 (keep the `DURATION_MS` template, swap `ease-out` to the token):
+```tsx
+              animation: `reaction-burst ${DURATION_MS}ms var(--fluux-ease-standard) forwards`,
+```
+
+- [ ] **Step 6: Run the guard + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/themes/motionTokens.test.ts` (expect PASS), then `npm run typecheck` from repo root (expect clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/components/conversation/MessageList.tsx apps/fluux/src/components/Sidebar.tsx apps/fluux/src/components/conversation/ReactionBurst.tsx apps/fluux/src/themes/motionTokens.test.ts
+git -c commit.gpgsign=false commit -m "refactor(motion): migrate component inline animations onto motion tokens"
+```
+
+---
+
+### Task 3: `useModalTransition` hook
+
+**Files:**
+- Create: `apps/fluux/src/hooks/useModalTransition.ts`
+- Test: `apps/fluux/src/hooks/useModalTransition.test.ts`
+
+**Interfaces:**
+- Produces: `useModalTransition(options?: { panelInClass?: string }): { panelClass: string; scrimClass: string; isClosing: boolean; requestClose: (onClose: () => void) => void }` and `MODAL_EXIT_MS = 150`.
+- Reduced motion is detected from `document.documentElement`'s `data-motion` attribute (`'reduced'` / `'full'`), falling back to `matchMedia('(prefers-reduced-motion: reduce)')`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/fluux/src/hooks/useModalTransition.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useModalTransition, MODAL_EXIT_MS } from './useModalTransition'
+
+function setMotion(value: 'full' | 'reduced') {
+  document.documentElement.setAttribute('data-motion', value)
+}
+
+describe('useModalTransition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setMotion('full')
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    document.documentElement.removeAttribute('data-motion')
+  })
+
+  it('starts with the enter classes and not closing', () => {
+    const { result } = renderHook(() => useModalTransition())
+    expect(result.current.panelClass).toBe('modal-panel-in')
+    expect(result.current.scrimClass).toBe('scrim-in')
+    expect(result.current.isClosing).toBe(false)
+  })
+
+  it('honors a custom enter class', () => {
+    const { result } = renderHook(() => useModalTransition({ panelInClass: 'command-palette-in' }))
+    expect(result.current.panelClass).toBe('command-palette-in')
+  })
+
+  it('plays the exit then calls onClose after the exit duration (motion full)', () => {
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useModalTransition())
+    act(() => result.current.requestClose(onClose))
+    expect(result.current.panelClass).toBe('modal-panel-out')
+    expect(result.current.scrimClass).toBe('scrim-out')
+    expect(onClose).not.toHaveBeenCalled()
+    act(() => { vi.advanceTimersByTime(MODAL_EXIT_MS) })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes immediately with no exit when motion is reduced', () => {
+    setMotion('reduced')
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useModalTransition())
+    act(() => result.current.requestClose(onClose))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(result.current.isClosing).toBe(false)
+  })
+
+  it('guards against a double close', () => {
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useModalTransition())
+    act(() => {
+      result.current.requestClose(onClose)
+      result.current.requestClose(onClose)
+    })
+    act(() => { vi.advanceTimersByTime(MODAL_EXIT_MS) })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useModalTransition.test.ts`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Implement the hook**
+
+Create `apps/fluux/src/hooks/useModalTransition.ts`:
+
+```ts
+import { useCallback, useRef, useState } from 'react'
+
+/** Exit animation duration. Matches --fluux-duration-fast in index.css. */
+export const MODAL_EXIT_MS = 150
+
+/** Whether motion should be suppressed: explicit data-motion wins, else the OS query. */
+function isReducedMotion(): boolean {
+  const attr = document.documentElement.getAttribute('data-motion')
+  if (attr === 'reduced') return true
+  if (attr === 'full') return false
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+interface ModalTransitionOptions {
+  /** Override the enter animation class (e.g. the command palette's drop). */
+  panelInClass?: string
+}
+
+/**
+ * Drives a modal's enter and exit animation. The panel and scrim get enter
+ * classes on mount; `requestClose` swaps to the exit classes, then calls the
+ * caller's `onClose` after the exit animation (so the parent unmounts on
+ * schedule). When motion is reduced the exit is skipped and onClose fires at
+ * once. A double close fires onClose only once.
+ */
+export function useModalTransition(options?: ModalTransitionOptions) {
+  const [isClosing, setIsClosing] = useState(false)
+  const closingRef = useRef(false)
+
+  const requestClose = useCallback((onClose: () => void) => {
+    if (closingRef.current) return
+    closingRef.current = true
+    if (isReducedMotion()) {
+      onClose()
+      return
+    }
+    setIsClosing(true)
+    setTimeout(onClose, MODAL_EXIT_MS)
+  }, [])
+
+  const panelClass = isClosing ? 'modal-panel-out' : (options?.panelInClass ?? 'modal-panel-in')
+  const scrimClass = isClosing ? 'scrim-out' : 'scrim-in'
+
+  return { panelClass, scrimClass, isClosing, requestClose }
+}
+```
+
+- [ ] **Step 4: Run the tests + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useModalTransition.test.ts` (expect PASS), then `npm run typecheck` from repo root (expect clean).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/hooks/useModalTransition.ts apps/fluux/src/hooks/useModalTransition.test.ts
+git -c commit.gpgsign=false commit -m "feat(motion): useModalTransition hook (enter/exit + delayed close)"
+```
+
+---
+
+### Task 4: Modal keyframes + apply to ModalShell
+
+**Files:**
+- Modify: `apps/fluux/src/index.css` (add modal keyframes after the FAB block, around line 1197)
+- Modify: `apps/fluux/src/components/ModalShell.tsx`
+- Test: `apps/fluux/src/components/ModalShell.test.tsx`
+
+**Interfaces:**
+- Consumes: `useModalTransition` (Task 3); the duration/easing tokens (Task 1).
+- Produces: CSS classes `modal-panel-in`, `modal-panel-out`, `scrim-in`, `scrim-out`, `command-palette-in` (the last consumed in Task 5).
+
+- [ ] **Step 1: Add the modal keyframes to index.css**
+
+In `apps/fluux/src/index.css`, after the `fab-spring-out` block (after line 1197), add. The panel animates transform only (scale); the scrim layer carries the fade, so the panel is not double-faded. `forwards` on the exits holds the final frame during the brief unmount delay.
+
+```css
+
+/* Modal / dialog / command-palette enter + exit (Aurora motion language).
+   The scrim layer fades (opacity); the panel scales (transform) so the two
+   compose without double-fading the panel. Exits use `forwards` to hold the
+   end frame for the ~150ms before the component unmounts. */
+@keyframes modal-panel-in  { from { transform: scale(0.97); } to { transform: scale(1); } }
+@keyframes modal-panel-out { from { transform: scale(1); }    to { transform: scale(0.98); } }
+@keyframes command-palette-in { from { transform: translateY(-8px) scale(0.98); } to { transform: translateY(0) scale(1); } }
+@keyframes scrim-in  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes scrim-out { from { opacity: 1; } to { opacity: 0; } }
+
+.modal-panel-in     { animation: modal-panel-in var(--fluux-duration-base) var(--fluux-ease-emphasized); }
+.modal-panel-out    { animation: modal-panel-out var(--fluux-duration-fast) var(--fluux-ease-standard) forwards; }
+.command-palette-in { animation: command-palette-in var(--fluux-duration-base) var(--fluux-ease-emphasized); }
+.scrim-in  { animation: scrim-in var(--fluux-duration-base) var(--fluux-ease-standard); }
+.scrim-out { animation: scrim-out var(--fluux-duration-fast) var(--fluux-ease-standard) forwards; }
+```
+
+- [ ] **Step 2: Write the failing ModalShell tests**
+
+Replace the body of the existing test file or add a new `describe` to `apps/fluux/src/components/ModalShell.test.tsx`. (Read the existing file first to reuse its render setup and i18n mock.) Add:
+
+```tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ModalShell } from './ModalShell'
+
+function setMotion(value: 'full' | 'reduced') {
+  document.documentElement.setAttribute('data-motion', value)
+}
+
+describe('ModalShell motion', () => {
+  beforeEach(() => { vi.useFakeTimers(); setMotion('full') })
+  afterEach(() => { vi.useRealTimers(); document.documentElement.removeAttribute('data-motion') })
+
+  it('renders the enter classes on mount', () => {
+    const { container } = render(<ModalShell title="T" onClose={() => {}}>body</ModalShell>)
+    expect(container.querySelector('.scrim-in')).toBeTruthy()
+    expect(container.querySelector('.modal-panel-in')).toBeTruthy()
+  })
+
+  it('plays the exit then calls onClose after the delay (motion full)', () => {
+    const onClose = vi.fn()
+    const { container } = render(<ModalShell title="T" onClose={onClose}>body</ModalShell>)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+    expect(container.querySelector('.modal-panel-out')).toBeTruthy()
+    vi.advanceTimersByTime(150)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes immediately when motion is reduced', () => {
+    setMotion('reduced')
+    const onClose = vi.fn()
+    render(<ModalShell title="T" onClose={onClose}>body</ModalShell>)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 3: Run them, verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/components/ModalShell.test.tsx`
+Expected: FAIL (no enter classes; Escape calls onClose synchronously).
+
+- [ ] **Step 4: Apply the hook in ModalShell**
+
+In `apps/fluux/src/components/ModalShell.tsx`, import the hook and route close through it. Full updated component body (the render and Escape handler change; the scrim div gets `scrimClass`, the panel div gets `panelClass`, and every close path calls `close`):
+
+```tsx
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
+import { Tooltip } from './Tooltip'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useModalTransition } from '@/hooks/useModalTransition'
+
+interface ModalShellProps {
+  title: React.ReactNode
+  onClose: () => void
+  /** Tailwind width class for the panel, e.g. 'max-w-sm' (default), 'max-w-md', 'w-80' */
+  width?: string
+  /** Extra classes on the panel div, e.g. 'max-h-[80vh]' */
+  panelClassName?: string
+  children: React.ReactNode
+}
+
+export function ModalShell({
+  title,
+  onClose,
+  width = 'max-w-sm',
+  panelClassName,
+  children,
+}: ModalShellProps) {
+  const { t } = useTranslation()
+  const panelRef = useRef<HTMLDivElement>(null)
+  const { panelClass, scrimClass, requestClose } = useModalTransition()
+  const close = () => requestClose(onClose)
+
+  useRestoreFocus(panelRef)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div
+      data-modal="true"
+      className={`fixed inset-0 modal-scrim flex items-center justify-center z-50 ${scrimClass}`}
+    >
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        onClick={close}
+        className="absolute inset-0 cursor-default"
+      />
+      <div ref={panelRef} className={`relative z-10 fluux-glass rounded-lg w-full ${width} mx-4 ${panelClass} ${panelClassName ?? ''}`}>
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-fluux-hover flex-shrink-0">
+          <h2 className="text-lg font-semibold text-fluux-text">{title}</h2>
+          <Tooltip content={t('common.close')}>
+            <button
+              onClick={close}
+              aria-label={t('common.close')}
+              className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover tap-target"
+            >
+              <X className="size-4" />
+            </button>
+          </Tooltip>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  )
+}
+```
+
+Note: the Escape effect now depends on a fresh `close` each render but uses an empty dep array with the eslint-disable so the listener is bound once; `requestClose` is stable (`useCallback`) and `onClose` is captured per render, which is correct because the close path reads the latest `onClose` through the closure at call time. If the existing lint config forbids the disable comment, instead wrap `close` in `useCallback(() => requestClose(onClose), [requestClose, onClose])` and depend on it.
+
+- [ ] **Step 5: Run the tests + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/components/ModalShell.test.tsx` (expect PASS), then `npm run typecheck` from repo root (expect clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/index.css apps/fluux/src/components/ModalShell.tsx apps/fluux/src/components/ModalShell.test.tsx
+git -c commit.gpgsign=false commit -m "feat(motion): modal enter/exit keyframes + apply to ModalShell"
+```
+
+---
+
+### Task 5: Apply enter-exit to the four standalone dialogs
+
+**Files:**
+- Modify: `apps/fluux/src/components/ConfirmDialog.tsx`, `apps/fluux/src/components/CommandPalette.tsx`, `apps/fluux/src/components/BackupPassphraseDialog.tsx`, `apps/fluux/src/components/AvatarCropModal.tsx`
+
+**Interfaces:**
+- Consumes: `useModalTransition` (Task 3); the keyframe classes incl. `command-palette-in` (Task 4).
+
+Each dialog has its own scrim container and panel and calls `onClose`/`onCancel` from multiple places (Escape handler, backdrop button, close button, action handlers). The change is uniform: add the hook, put `scrimClass` on the scrim container and `panelClass` on the panel, and route every close path through `requestClose`.
+
+- [ ] **Step 1: ConfirmDialog (the worked example)**
+
+In `apps/fluux/src/components/ConfirmDialog.tsx`: import the hook; derive `cancel`; apply classes; route Escape and the backdrop/cancel buttons through `cancel`. (The Confirm button still calls `onConfirm` directly: confirming is the caller's action, which unmounts the dialog itself.)
+
+```tsx
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import { useModalTransition } from '@/hooks/useModalTransition'
+```
+Inside the component, after `const panelRef = useRef...`:
+```tsx
+  const { panelClass, scrimClass, requestClose } = useModalTransition()
+  const cancel = () => requestClose(onCancel)
+```
+Change the Escape handler (line 30) to `if (e.key === 'Escape') cancel()` and drop `onCancel` from the dep array (use `[]` with an eslint-disable, mirroring ModalShell). Change the scrim container (line 43) to append `${scrimClass}`, the backdrop button `onClick` (line 49) to `cancel`, the panel div (line 52) to append `${panelClass}`, and the footer Cancel button `onClick` (line 57) to `cancel`.
+
+- [ ] **Step 2: CommandPalette (uses the drop variant)**
+
+In `apps/fluux/src/components/CommandPalette.tsx`: import the hook; `const { panelClass, scrimClass, requestClose } = useModalTransition({ panelInClass: 'command-palette-in' })`. Add `const close = () => requestClose(onClose)`.
+
+The palette calls `onClose()` from many action handlers (lines 219, 291, 352-358, 474, 502). Those are post-action dismissals where the panel unmounts anyway; route the user-driven dismissals (the Escape handler and the backdrop click at line 532) through `close`, and leave the action-completion `onClose()` calls as-is (an action that navigates away does not need the 150ms exit). Concretely: find the Escape `onClose()` and the backdrop button `onClick={onClose}` (line 532) and change them to `close`. Apply `${scrimClass}` to the scrim container (line 526) and `${panelClass}` to the panel (line 539).
+
+- [ ] **Step 3: BackupPassphraseDialog**
+
+In `apps/fluux/src/components/BackupPassphraseDialog.tsx`: import the hook; `const { panelClass, scrimClass, requestClose } = useModalTransition()`; `const cancel = () => requestClose(onCancel)`. The Escape handler (line 89) keeps its `!isPublishing` guard: `if (e.key === 'Escape' && !isPublishing) cancel()`. Apply `${scrimClass}` to the scrim container (line 146), `${panelClass}` to the panel (line 156), and route the backdrop button (line 153) and the footer cancel button (line 267) `onClick` through `cancel`. Leave the publish/confirm path calling its own handler.
+
+- [ ] **Step 4: AvatarCropModal**
+
+In `apps/fluux/src/components/AvatarCropModal.tsx`: import the hook; `const { panelClass, scrimClass, requestClose } = useModalTransition()`; `const close = () => requestClose(onClose)`. It early-returns `null` when `!isOpen` (line 358), so it follows the same pattern: `requestClose` delays `onClose`, and the component stays mounted (still `isOpen`) through the exit. The scrim is `bg-black/70` (kept for image contrast); append `${scrimClass}` to it (line 361) so the backdrop fades, and `${panelClass}` to the panel (line 362). Route the header close button (line 368) and the footer cancel button (line 565) through `close`. Leave the Save path (line 350 region) calling `onClose()` after a successful save (it is an action completion).
+
+- [ ] **Step 5: Typecheck + run the affected suites**
+
+Run from repo root: `npm run typecheck` (expect clean). Then `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx src/components/AvatarCropModal.test.tsx 2>/dev/null` if those tests exist (some may not); they must stay green. Any test asserting a synchronous `onClose` on Escape/backdrop is updated to advance timers by 150ms first (motion full) or set `data-motion="reduced"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/components/ConfirmDialog.tsx apps/fluux/src/components/CommandPalette.tsx apps/fluux/src/components/BackupPassphraseDialog.tsx apps/fluux/src/components/AvatarCropModal.tsx
+git -c commit.gpgsign=false commit -m "feat(motion): enter/exit animation for the standalone dialogs"
+```
+
+---
+
+### Task 6: Verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full gate**
+
+Run from repo root: `npm run typecheck` (clean), `npm run lint` (0 errors), `npm test` (all pass, no new failures). Confirm `motionTokens.test.ts`, `useModalTransition.test.ts`, and `ModalShell.test.tsx` are green, and that the existing animation/modal tests still pass.
+
+- [ ] **Step 2: Confirm the onClose-timing risk is clear**
+
+Grep the `onClose`/`onCancel` callers of the touched dialogs for any that rely on a synchronous side effect at close time (a save, a navigation, a store write that must happen before the 150ms). Expected: none; every caller just flips an `isOpen`/visibility state. Record the finding (the spec flagged this as the one behavior change to verify).
+
+```bash
+grep -rn "onClose=\|onCancel=" apps/fluux/src/components | grep -iE "ConfirmDialog|BackupPassphrase|AvatarCrop|CommandPalette|ModalShell" | head -40
+```
+
+- [ ] **Step 3: No screenshot scene**
+
+Motion does not screenshot reliably (a modal mid-enter is not a stable capture; the resting state is unchanged from today). Do NOT add a screenshot scene. The unit tests carry the proof. Note this in the report.
+
+- [ ] **Step 4: Commit (if anything was adjusted)**
+
+If Step 2 surfaced a caller needing a synchronous close (unexpected), fix it and commit; otherwise nothing to commit (verification only).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** token vocabulary (Task 1) · Tailwind wiring (Task 1) · feel-preserving CSS migration (Task 1) · component-inline migration (Task 2) · `useModalTransition` hook with reduced-motion + double-close guards (Task 3) · ModalShell enter/exit covering ~18 dialogs (Task 4) · the 4 standalone dialogs incl. the command-palette drop (Task 5) · risk verification + unit-test-only proof + no screenshot (Task 6). All spec sections covered.
+- **Type consistency:** `useModalTransition(options?: { panelInClass?: string })` returns `{ panelClass, scrimClass, isClosing, requestClose }` and `MODAL_EXIT_MS` (150) consistently across Tasks 3, 4, 5. Class names `modal-panel-in/out`, `scrim-in/out`, `command-palette-in` defined in Task 4, consumed in Tasks 4 and 5.
+- **Token value consistency:** the same six token values appear in the Global Constraints, the Task 1 `:root` block, the Task 1 guard test, and the Tailwind wiring. `MODAL_EXIT_MS` (150) equals `--fluux-duration-fast` and the exit keyframe duration.
+- **Known risk flagged:** `ModalShell.onClose` now fires 150ms later; Task 6 Step 2 verifies no caller depends on a synchronous close.
+- **No SDK change** so no `build:sdk`.

--- a/docs/superpowers/specs/2026-06-29-aurora-motion-language-design.md
+++ b/docs/superpowers/specs/2026-06-29-aurora-motion-language-design.md
@@ -1,0 +1,93 @@
+# Aurora Motion Language: Design Spec
+
+- Status: Approved (design), pending spec review
+- Date: 2026-06-29
+- Scope: `apps/fluux`. A motion-token vocabulary plus modal / dialog / command-palette enter-exit animation. Effort S to M.
+- Builds on: the existing pure-CSS motion system (no animation library).
+
+## Goal
+
+The app already has a mature, motion-preference-compliant animation system: send animation, reaction burst, a spring scroll-to-bottom button, typing dots, occupant drawer, toasts, all gated by a global `data-motion` switch. Two things are missing. First, the durations and easings are ad-hoc one-offs with no shared vocabulary. Second, modal dialogs and the command palette pop in and out with no animation, which reads as unfinished next to the frosted-glass surfaces shipped in the glass slice. This slice defines a small named motion vocabulary (the "language"), migrates the existing animations onto it without changing how they feel, and gives modals and the palette a graceful enter and exit.
+
+## Background: current state (recon-confirmed)
+
+No external animation library. Pure CSS `@keyframes` plus Tailwind utilities. Motion is gated globally: `motionPreference` (`system` / `full` / `reduced`, persisted as `fluux-motion`) resolves to a `data-motion` attribute on `<html>` (set in `useTheme.ts`), and a rule in `index.css` collapses every animation and transition to near-zero when reduced, with a `prefers-reduced-motion` fallback for the pre-JS window.
+
+Durations today are scattered: 150ms (sidebar view fade), 200ms (toast, collapsible, color transitions), 220ms (occupant drawer), 250ms (button exit), 300ms (message send, keyboard-nav bounce), 400ms (button enter), 450ms (reaction burst), 1500ms (reply-highlight flash). Easings vary: `ease-out` (most), `ease-in` (button exit), `ease-in-out` (typing), `cubic-bezier(0.32, 0.72, 0, 1)` (drawer), `cubic-bezier(0.34, 1.56, 0.64, 1)` (button spring).
+
+Modals use a shared `ModalShell` (about 18 dialogs) plus four standalone surfaces (`CommandPalette`, `ConfirmDialog`, `BackupPassphraseDialog`, `AvatarCropModal`). `ModalShell` is conditionally mounted by its parent (`{isOpen && <Modal/>}`) and renders both the scrim (`.modal-scrim`) and the glass panel (`.fluux-glass`). None of these animate in or out. `BottomSheet` already animates (`sheet-up`) and is left alone.
+
+## Design
+
+### 1. Motion token vocabulary
+
+A small named scale, global (motion is not themed, so the tokens live in `:root` only with no per-theme overrides), defined in two coordinated layers.
+
+CSS custom properties in `index.css` `:root`:
+
+- `--fluux-duration-fast: 150ms`
+- `--fluux-duration-base: 200ms`
+- `--fluux-duration-slow: 300ms`
+- `--fluux-ease-standard: ease-out` (the decelerating default that most animations already use; kept as `ease-out` so migration does not change feel)
+- `--fluux-ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1)` (the drawer's snappy decelerate, reused for modal panels)
+- `--fluux-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1)` (the scroll-button overshoot)
+
+Tailwind config (`tailwind.config.js`) extension so the same vocabulary is usable as utilities:
+
+- `transitionDuration`: `{ fast: 'var(--fluux-duration-fast)', base: 'var(--fluux-duration-base)', slow: 'var(--fluux-duration-slow)' }` yields `duration-fast` / `duration-base` / `duration-slow`.
+- `transitionTimingFunction`: `{ standard: 'var(--fluux-ease-standard)', emphasized: 'var(--fluux-ease-emphasized)', spring: 'var(--fluux-ease-spring)' }` yields `ease-standard` / `ease-emphasized` / `ease-spring`.
+- The existing custom `animation` shorthands (`tooltip-in`, `toast-in`, `sheet-up`) are rewritten to reference the duration and easing vars instead of literals.
+
+### Migration map (feel-preserving)
+
+The migration changes no durations. Every generic value already equals a token, and every bespoke animation keeps its tuned duration and only adopts the named easing token.
+
+- Generic, maps fully onto tokens at the same value: `sidebar-view-enter` (150 to `fast` + `standard`), `toast-in` and collapsible height (200 to `base` + `standard`), `message-send` and keyboard bounce (300 to `slow` + `standard`), and the app-wide Tailwind `transition-colors` / `transition-opacity` usages (adopt `duration-base ease-standard` where a class is already being touched, not a blanket sweep).
+- Bespoke, keeps its literal duration, adopts the easing token: occupant drawer (220ms, easing to `var(--fluux-ease-emphasized)`), scroll-button spring pair (400 / 250ms, enter easing to `var(--fluux-ease-spring)`), reaction burst (450ms, to `var(--fluux-ease-standard)`), reply-highlight flash (1500ms, unchanged, a deliberate one-off).
+
+The result: three generic durations plus three easings form the vocabulary, used by generic transitions and the new modal work; bespoke animations share the easing names while keeping their tuned timing. Feel is identical to today.
+
+### 2. Modal / dialog / command-palette enter-exit
+
+Enter, centralized in `ModalShell` (covers all ~18 dialogs at once): the scrim fades in (opacity 0 to 1, `base`, `standard`); the panel scales and fades in (scale 0.97 to 1, opacity 0 to 1, `base`, `emphasized`). Pure CSS animation on mount.
+
+Exit, symmetric: `ModalShell` gains a `closing` state. Any close trigger (Escape, the X button, a scrim click) sets `closing`, which swaps the panel and scrim to exit animations (panel scale 1 to 0.98 plus fade, scrim fade, `fast` duration), and then calls the real `onClose` after the exit duration so the parent unmounts on schedule. Two guards: a ref prevents a double-close from firing `onClose` twice, and when motion is reduced (`data-motion="reduced"` or `prefers-reduced-motion`) the delay is skipped and `onClose` fires immediately.
+
+Shared hook: a small `useModalTransition` hook (in `apps/fluux/src/hooks/`) encapsulates the enter and exit class state, the `requestClose(onClose)` wrapper, the reduced-motion check, and the timing. `ModalShell` uses it, and the four standalone surfaces use it for identical behavior. `CommandPalette` adds a small downward `translateY` on enter (the familiar palette drop).
+
+New keyframes (`modal-panel-in`, `modal-panel-out`, `scrim-in`, `scrim-out`) live in `index.css` and reference the duration and easing tokens. All of this respects the global `data-motion` gate automatically (CSS), and the JS exit delay respects it through the hook.
+
+Interfaces (produced for the plan):
+
+- `useModalTransition(): { panelClass: string; scrimClass: string; isClosing: boolean; requestClose: (onClose: () => void) => void }` (exact shape finalized in the plan).
+- `ModalShell` keeps its existing props (`title`, `onClose`, `width`, `panelClassName`, `children`). The only behavior change is internal: `onClose` is invoked after the exit animation rather than synchronously.
+
+### 3. Preserve
+
+- The global `data-motion` and `motionPreference` system is unchanged; the new motion plugs into it.
+- Existing animations keep their current feel: durations are unchanged, only easing references become tokens. Reaction burst, send animation, the spring button, drawer, typing dots, toast, and the highlight flash all look identical.
+- `BottomSheet`'s `sheet-up` is left as-is.
+- Modal behavior is preserved: the focus trap (`useRestoreFocus`), Escape-to-close, and scrim-click-to-close all still work. The exit only defers the unmount by the animation duration; focus restoration still fires because the panel stays mounted through the brief exit and then unmounts.
+
+### 4. Risk to verify
+
+`ModalShell` now calls `onClose` after the exit animation (the `fast` duration, 150ms) instead of synchronously. Almost every caller's `onClose` simply flips an `isOpen` state to unmount, which is fine deferred. The plan's verification checks the `onClose` callers for any that rely on a synchronous side effect (for example a save or navigation that must happen instantly); none is expected, but it is confirmed rather than assumed.
+
+## Out of scope (deferred)
+
+Presence-change pulses, skeleton and shimmer loaders, cross-view and route transitions, and list-item stagger (the remaining "not found" gaps). No animation library. No SDK changes. No retuning of existing durations or easings: feel is preserved, not redesigned.
+
+## Theme-robustness
+
+Motion tokens are global (`:root` only, no theme overrides). The modal enter and exit use transform and opacity, which are theme-independent; the panel and scrim colors come from the existing `.fluux-glass` and `.modal-scrim` tokens, which are already theme-correct. There is no per-theme motion work and no contrast implication, because motion here is transform and opacity, not color.
+
+## Testing
+
+Motion is transient and does not screenshot reliably, so the proof is unit tests.
+
+- Token guard: `--fluux-duration-fast` / `-base` / `-slow` and `--fluux-ease-standard` / `-emphasized` / `-spring` are defined in `:root`, and the Tailwind config exposes the matching `duration-*` and `ease-*` utilities. A static assertion over `index.css` and `tailwind.config.js`.
+- `ModalShell`: renders the enter classes on mount; a close action (Escape, X, scrim) routes through the delayed-exit path (`onClose` fires after the exit duration, not synchronously) when motion is full; fires `onClose` synchronously when motion is reduced; and never fires `onClose` twice on a double-close.
+- `useModalTransition`: enter and exit class state, the `requestClose` timing (fake timers), the reduced-motion instant-close, and the double-close guard.
+- Existing animation and modal tests stay green; any test that assumed a synchronous `ModalShell` `onClose` is updated.
+
+Screenshots are optional. A modal mid-enter is not a stable capture, so the unit tests carry the proof; a resting-state (post-enter) screenshot is unchanged from today and adds nothing.


### PR DESCRIPTION
A small named motion vocabulary plus graceful enter/exit animation for modals, dialogs, and the command palette. Builds on the existing pure-CSS, motion-preference-gated animation system; no animation library, no SDK changes.

## Token vocabulary
- `--fluux-duration-fast/base/slow` (150/200/300ms) and `--fluux-ease-standard/emphasized/spring` defined in `:root`, wired into Tailwind as `duration-*` / `ease-*` utilities (one source of truth).
- Existing animations migrated onto the tokens feel-preserving: durations unchanged, only the easings tokenized (drawer, FAB spring, reaction burst, message send, bounce, reply highlight, toast, sheet).

## Modal enter/exit
- A shared `useModalTransition` hook: enter/exit class state plus a `requestClose` that defers the real `onClose` by 150ms so the exit animation can play. Reduced motion skips the delay (instant close); a double close fires `onClose` only once.
- Applied to `ModalShell` (covers ~18 dialogs) and the four standalone surfaces (CommandPalette with a drop-in, ConfirmDialog, BackupPassphraseDialog, AvatarCropModal). The scrim fades, the panel scales; user-driven dismissals (Escape, backdrop, X, Cancel) animate out, while action completions (save, command execute, publish) stay instant.
- New `modal-panel-*` / `scrim-*` / `command-palette-in` keyframes reference the tokens and are gated by the existing `data-motion` reduce-motion switch.