### PR TITLE
fix(search): stop focus ring stacking on the search input

### DIFF
--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -128,7 +128,7 @@ export function SearchView() {
             placeholder={t('search.placeholder', 'Search messages…')}
             className="w-full ps-8 pe-8 py-1.5 text-sm bg-fluux-bg border border-fluux-border rounded-md
                        text-fluux-text placeholder-fluux-muted
-                       focus:outline-none focus:ring-1 focus:ring-fluux-brand focus:border-fluux-brand"
+                       focus:border-fluux-brand"
           />
           {query && (
             <button


### PR DESCRIPTION
The Search view input rendered a noticeably thicker focus ring than other controls.

## Cause

The input set `focus:outline-none focus:ring-1 focus:ring-fluux-brand focus:border-fluux-brand`. The global focus rule in `index.css` (`.user-interacted *:focus:not(html):not(body):not(#root):not(.no-focus-ring)`) carries id-level specificity via `:not(#root)`, so it overrides the input's own `focus:outline-none`. The result was three brand-blue layers stacking on focus:

- `outline: 2px solid` (global rule, inset)
- `box-shadow: 0 0 0 1px` (the input's own `focus:ring-1`, outset)
- `border: 1px` recolored to brand

Measured live in the running app, that reads as a ~3px band, while controls relying on the global system show only the single 2px outline.

## Fix

Drop the redundant per-element ring so the input uses the same global 2px focus outline as the rest of the app, keeping the subtle brand border recolor (matching JoinRoomModal).