### PR TITLE
fix(command-palette): give the keyboard-selected row a visible fill

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -632,6 +632,14 @@ em-emoji-picker {
  * Comfortable matches the previous static py-2 / gap-3. */
 .command-row { padding-block: 8px; column-gap: 12px; }
 [data-density="compact"] .command-row { padding-block: 4px; column-gap: 8px; }
+/* Keyboard-selected row fill. A soft accent tint (NOT the Tailwind `/opacity`
+   modifier, which no-ops on our hsl()-string accent token and renders fully
+   transparent). Kept a touch stronger than `hover:bg-fluux-hover` so the active
+   selection reads as more prominent than a hovered row, while the 2px accent
+   left border + medium weight carry the rest of the emphasis. */
+.command-row[data-selected="true"] {
+  background: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.15);
+}
 .command-group-label { padding-block: 6px; }
 [data-density="compact"] .command-group-label { padding-block: 3px; }
 


### PR DESCRIPTION
## Summary

The Cmd-K command palette's keyboard-selected row had no visible background fill — only a thin left accent border and slightly bolder text marked the selection. A *hovered* row (`hover:bg-fluux-hover`) actually read as more highlighted than the keyboard-selected one.

## Root cause

The selected row used `bg-fluux-brand/50`, but `--fluux-brand` resolves to a complete `hsl(...)` string. Tailwind's `/opacity` modifier cannot inject an alpha value into such a token, so the whole `background-color` declaration was silently dropped — the computed background was `rgba(0, 0, 0, 0)` (fully transparent). This is the same no-op gotcha already documented around the search-field styling in this component. It went unnoticed because the surrounding tests only assert on the `data-selected` attribute and `toHaveClass` (the class string is present regardless of whether it renders).

## Fix

Replace the broken utility with a deterministic CSS rule keyed on `data-selected`, using the `hsla(var(--fluux-accent-h)...)` accent-alpha pattern already used for the focus-zone ring. This renders a soft accent tint correctly across all themes (light/dark), kept a touch stronger than the hover fill so the keyboard selection stays the most prominent state. The 2px accent left border and medium weight carry the rest of the emphasis.