### PR TITLE
fix(avatar): keep the GIF freeze-frame cache filling during virtualized scroll

### DIFF
--- a/apps/fluux/src/components/Avatar.test.tsx
+++ b/apps/fluux/src/components/Avatar.test.tsx
@@ -319,6 +319,29 @@ describe('Avatar — animated GIF freeze-on-hover', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('caches the frozen frame even when the row unmounts mid-extraction (fast scroll)', async () => {
+    // The whole point of the module-level cache is virtualized scrolling, where
+    // rows mount and unmount in quick succession. Extraction (fetch -> decode ->
+    // canvas) is async and takes longer than a fast scroll-past, so the row
+    // unmounts *before* it finishes. The cache must still be populated by that
+    // in-flight extraction — otherwise it never fills during scrolling and every
+    // scroll-in replays the GIF, defeating the fix entirely.
+    const url = 'blob:gif-fastscroll'
+    const { unmount } = render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    // Scroll past: unmount immediately, before the extraction microtasks resolve.
+    unmount()
+
+    // Let the background extraction run to completion despite the unmount.
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Scroll back into view: the frozen frame is applied on the first render with
+    // no second fetch, because the earlier extraction populated the shared cache.
+    render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('plays the GIF on hover and re-freezes on mouse leave', async () => {
     const url = 'blob:gif-hover'
     const { container } = render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)

--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -150,6 +150,56 @@ function cacheStaticFrame(url: string, dataUrl: string): void {
 }
 
 /**
+ * In-flight first-frame extractions, keyed by avatar URL. Dedupes concurrent
+ * decodes of the same avatar (it can be mounted in several visible rows at once)
+ * and, crucially, lets an extraction outlive the component that started it. A
+ * virtualized row routinely unmounts mid-decode while the user scrolls past;
+ * tying the decode to that component's lifetime meant the frozen frame never
+ * reached the cache during scrolling, so every scroll-in replayed the GIF.
+ */
+const inFlightFrames = new Map<string, Promise<string | null>>()
+
+/**
+ * Extract an animated GIF's first frame as a static PNG data URL and populate the
+ * module-level cache on success. Resolves to null for non-GIF images or on any
+ * decode failure. Deliberately decoupled from React: it is NOT cancelled when the
+ * requesting component unmounts, so the cache fills even during fast scrolling.
+ */
+function extractFirstFrame(url: string): Promise<string | null> {
+  const cached = staticFrameCache.get(url)
+  if (cached) return Promise.resolve(cached)
+  const pending = inFlightFrames.get(url)
+  if (pending) return pending
+
+  const extraction = fetch(url)
+    .then(r => r.blob())
+    .then(blob => {
+      if (blob.type !== 'image/gif') return null
+      return new Promise<string | null>((resolve) => {
+        const img = new Image()
+        img.onload = () => {
+          const c = document.createElement('canvas')
+          c.width = img.naturalWidth
+          c.height = img.naturalHeight
+          const ctx = c.getContext('2d')
+          if (!ctx) { resolve(null); return }
+          ctx.drawImage(img, 0, 0)
+          const dataUrl = c.toDataURL('image/png')
+          cacheStaticFrame(url, dataUrl)
+          resolve(dataUrl)
+        }
+        img.onerror = () => resolve(null)
+        img.src = url
+      })
+    })
+    .catch(() => null)
+    .finally(() => { inFlightFrames.delete(url) })
+
+  inFlightFrames.set(url, extraction)
+  return extraction
+}
+
+/**
  * For animated GIF avatars, extract the first frame as a static PNG data URL.
  * Returns null for non-GIF images or while loading. A cached frame for the same
  * URL is applied synchronously on mount (no re-fetch, no replay).
@@ -165,25 +215,12 @@ function useStaticFrame(url: string | undefined): string | null {
     if (cached) { setFrame(cached); return }
     setFrame(null)
     let cancelled = false
-
-    fetch(url)
-      .then(r => r.blob())
-      .then(blob => {
-        if (cancelled || blob.type !== 'image/gif') return
-        const img = new Image()
-        img.onload = () => {
-          if (cancelled) return
-          const c = document.createElement('canvas')
-          c.width = img.naturalWidth
-          c.height = img.naturalHeight
-          c.getContext('2d')?.drawImage(img, 0, 0)
-          const dataUrl = c.toDataURL('image/png')
-          cacheStaticFrame(url, dataUrl)
-          setFrame(dataUrl)
-        }
-        img.src = url
-      })
-      .catch(() => {})
+    // Extraction runs to completion regardless of unmount (it feeds the shared
+    // cache for the next mount); only the state update is guarded so we never
+    // setState on an unmounted row.
+    void extractFirstFrame(url).then(dataUrl => {
+      if (!cancelled && dataUrl) setFrame(dataUrl)
+    })
 
     return () => { cancelled = true }
   }, [url])


### PR DESCRIPTION
## Summary

Animated GIF avatars are meant to show a frozen first frame and only play on hover. After message-list virtualization went default-on, they replayed their opening frames on every scroll-in. #711 added a shared first-frame cache to fix this, but the cache never actually filled during scrolling.

The first-frame extraction (fetch, decode, canvas) ran inside the Avatar component's effect and was cancelled on unmount. A virtualized row routinely unmounts mid-decode as it scrolls past, so `cacheStaticFrame()` was never reached and the shared cache stayed empty during scrolling, the one scenario it was built for. The cache only filled for avatars that happened to sit still long enough.

This moves extraction into a module-level `extractFirstFrame()` that runs to completion regardless of whether the requesting row unmounted, populating the shared cache from there. The hook now only guards the React state update, so it never sets state on an unmounted row. The function also dedupes concurrent decodes of the same avatar (it can be mounted in several visible rows at once) and resolves cleanly via `img.onerror` if a blob URL is revoked mid-decode instead of hanging.

A regression test covers the race the previous tests missed: a row that unmounts mid-extraction and then remounts must show the frozen frame with no re-fetch.

### Known limitation

The very first decode of a given GIF in a session still animates briefly (tens of ms) until its first frame is extracted, which is inherent to client-side extraction. After that one-time decode, every subsequent mount and scroll-in is frozen. Eliminating that first flash would require eagerly warming the cache when avatars are received, tracked separately.
