### PR TITLE
fix(navigation): hold a neutral surface during the tab-switch activation gap

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ChatLayout } from './ChatLayout'
@@ -18,6 +18,7 @@ const {
   const state = {
     activeConversationId: null as string | null,
     activeRoomJid: null as string | null,
+    activationPending: false,
     isArchivedResult: false,
   }
 
@@ -223,6 +224,7 @@ vi.mock('@fluux/sdk/react', () => ({
   useChatStore: Object.assign(
     (selector: (state: {
       activeConversationId: string | null;
+      activationPending: boolean;
       setActiveConversation: typeof mockSetActiveConversation;
       activateConversation: typeof mockActivateConversation;
       addConversation: ReturnType<typeof vi.fn>;
@@ -233,6 +235,7 @@ vi.mock('@fluux/sdk/react', () => ({
     }) => unknown) => {
       const state = {
         activeConversationId: getMockState().activeConversationId,
+        activationPending: getMockState().activationPending,
         setActiveConversation: mockSetActiveConversation,
         activateConversation: mockActivateConversation,
         addConversation: vi.fn(),
@@ -1150,5 +1153,39 @@ describe('ChatLayout - EmptyState primary actions', () => {
     await waitFor(() => {
       expect(screen.getByTestId('create-room-modal')).toBeInTheDocument()
     })
+  })
+})
+
+describe('ChatLayout - activation gap (no empty-state flash)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setMockState({
+      activeConversationId: null,
+      activeRoomJid: null,
+      activationPending: false,
+      isArchivedResult: false,
+    })
+  })
+
+  afterEach(() => {
+    setMockState({ activationPending: false })
+  })
+
+  // Regression for the empty-screen flash on rail tab switch: while a hydrating
+  // activation is in flight (cache load before the active id lands) both active
+  // ids are null, so the render cascade would otherwise fall through to the
+  // empty-state hero. It must hold a neutral surface instead.
+  it('does not flash the empty-state hero while an activation is pending', () => {
+    setMockState({ activationPending: true })
+    render(<ChatLayoutWithRouter initialRoute="/messages" />)
+
+    expect(screen.queryByText('Start a conversation')).toBeNull()
+  })
+
+  it('shows the empty-state hero once no activation is pending', () => {
+    setMockState({ activationPending: false })
+    render(<ChatLayoutWithRouter initialRoute="/messages" />)
+
+    expect(screen.getByText('Start a conversation')).toBeInTheDocument()
   })
 })

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -184,6 +184,12 @@ function ChatLayoutContent() {
   const activeRoomJid = useRoomStore((s) => s.activeRoomJid)
   const setActiveRoom = useRoomStore((s) => s.setActiveRoom)
   const activateRoom = useRoomStore((s) => s.activateRoom)
+  // True while a hydrating activation is in flight (cache read before the active
+  // id lands). During this gap both active ids are null, so without it the main
+  // pane would flash the empty-state hero on every content-tab switch.
+  const chatActivationPending = useChatStore((s) => s.activationPending)
+  const roomActivationPending = useRoomStore((s) => s.activationPending)
+  const activationPending = chatActivationPending || roomActivationPending
   const searchPreviewResult = useSearchStore((s) => s.previewResult)
   const activityPreviewEvent = useActivityLogStore((s) => s.previewEvent)
 
@@ -898,6 +904,11 @@ function ChatLayoutContent() {
             <Suspense fallback={<ViewLoadingFallback />}>
               <ActivityContextView onBack={() => activityLogStore.getState().setPreviewEvent(null)} />
             </Suspense>
+          ) : activationPending ? (
+            // A hydrating activation is in flight (cache load before the active id
+            // lands). Hold the neutral loading surface — matching the lazy views
+            // above — so switching content tabs doesn't flash the empty-state hero.
+            <ViewLoadingFallback />
           ) : (
             <EmptyState
               sidebarView={sidebarView}

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -369,6 +369,42 @@ describe('chatStore', () => {
 
       expect(chatStore.getState().activeConversationId).toBe('bob@example.com')
     })
+
+    it('flags activationPending while the cache read is in flight, then clears it', async () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+
+      // Hold the cache read open so we can observe the in-flight window — this is
+      // the gap during which ChatLayout would otherwise flash the empty state.
+      let resolveRead: (value: Message[]) => void = () => {}
+      vi.mocked(messageCache.getMessages).mockReturnValue(
+        new Promise((resolve) => { resolveRead = resolve })
+      )
+
+      expect(chatStore.getState().activationPending).toBe(false)
+
+      const activation = chatStore.getState().activateConversation('alice@example.com')
+
+      // Synchronously after the call: read is in flight, active id not set yet
+      expect(chatStore.getState().activationPending).toBe(true)
+      expect(chatStore.getState().activeConversationId).toBeNull()
+
+      resolveRead([])
+      await activation
+
+      // Once the active id lands the flag clears, atomically with activation
+      expect(chatStore.getState().activationPending).toBe(false)
+      expect(chatStore.getState().activeConversationId).toBe('alice@example.com')
+    })
+
+    it('does not flag activationPending when deactivating with null', async () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      chatStore.getState().setActiveConversation('alice@example.com')
+
+      await chatStore.getState().activateConversation(null)
+
+      expect(chatStore.getState().activationPending).toBe(false)
+      expect(chatStore.getState().activeConversationId).toBeNull()
+    })
   })
 
   describe('loadMessagesAroundFromCache', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -186,6 +186,10 @@ interface ChatState {
   conversations: Map<string, Conversation>
   messages: Map<string, Message[]>
   activeConversationId: string | null
+  // True while activateConversation() is hydrating a conversation's cache before
+  // it becomes active. Lets the UI hold a neutral loading surface during the async
+  // gap instead of flashing the "nothing selected" empty state on tab switch.
+  activationPending: boolean
   // Archived conversation IDs - hidden from main list but reappear on new activity
   archivedConversations: Set<string>
   // Typing indicators: conversationId -> Set of JIDs currently typing (ephemeral, not persisted)
@@ -492,13 +496,14 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
   }
 }
 
-function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId' | 'firstNewMessageMarkers'> {
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'targetMessageId' | 'firstNewMessageMarkers'> {
   return {
     conversationEntities: new Map(),
     conversationMeta: new Map(),
     conversations: new Map(),
     messages: new Map(),
     activeConversationId: null,
+    activationPending: false,
     archivedConversations: new Set(),
     typingStates: new Map(),
     activeAnimation: null,
@@ -706,8 +711,12 @@ export const chatStore = createStore<ChatState>()(
       activateConversation: async (id) => {
         const token = ++activationToken
         if (id) {
+          // Signal the hydration window so the UI can hold a neutral surface
+          // instead of flashing the empty state while the cache read is in flight.
+          set({ activationPending: true })
           await get().loadMessagesFromCache(id, { limit: 100 })
-          // A newer activation started while the cache read was in flight
+          // A newer activation started while the cache read was in flight: it owns
+          // the pending flag now, so bail without clearing it.
           if (token !== activationToken) return
           // XEP-0490: fold any pending remote read position into lastSeenMessageId
           // BEFORE setActiveConversation derives the new-message divider. The fresh
@@ -740,7 +749,10 @@ export const chatStore = createStore<ChatState>()(
             })
           }
         }
+        // Set active and clear pending atomically (same React commit) so the view
+        // swaps straight from loading surface to content with no empty-state frame.
         get().setActiveConversation(id)
+        set({ activationPending: false })
       },
 
       addConversation: (conv) => {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1799,6 +1799,42 @@ describe('roomStore', () => {
 
       expect(roomStore.getState().activeRoomJid).toBe('fast@conference.example.com')
     })
+
+    it('flags activationPending while the cache read is in flight, then clears it', async () => {
+      const roomJid = 'test@conference.example.com'
+      roomStore.getState().addRoom(createRoom(roomJid))
+
+      // Hold the cache read open so we can observe the in-flight window — this is
+      // the gap during which ChatLayout would otherwise flash the empty state.
+      let resolveRead: (value: RoomMessage[]) => void = () => {}
+      vi.mocked(messageCache.getRoomMessages).mockReturnValue(
+        new Promise((resolve) => { resolveRead = resolve })
+      )
+
+      expect(roomStore.getState().activationPending).toBe(false)
+
+      const activation = roomStore.getState().activateRoom(roomJid)
+
+      // Synchronously after the call: read is in flight, active room not set yet
+      expect(roomStore.getState().activationPending).toBe(true)
+      expect(roomStore.getState().activeRoomJid).toBeNull()
+
+      resolveRead([])
+      await activation
+
+      // Once the active room lands the flag clears, atomically with activation
+      expect(roomStore.getState().activationPending).toBe(false)
+      expect(roomStore.getState().activeRoomJid).toBe(roomJid)
+    })
+
+    it('does not flag activationPending when deactivating with null', async () => {
+      roomStore.setState({ activeRoomJid: 'test@conference.example.com' })
+
+      await roomStore.getState().activateRoom(null)
+
+      expect(roomStore.getState().activationPending).toBe(false)
+      expect(roomStore.getState().activeRoomJid).toBeNull()
+    })
   })
 
   describe('activeRoom', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -373,6 +373,10 @@ export interface RoomState {
   /** Runtime room data - occupants, messages (rebuilt on join) */
   roomRuntime: Map<string, RoomRuntime>
   activeRoomJid: string | null
+  // True while activateRoom() is hydrating a room's cache before it becomes active.
+  // Lets the UI hold a neutral loading surface during the async gap instead of
+  // flashing the "nothing selected" empty state on tab switch.
+  activationPending: boolean
   // Easter egg animation state (ephemeral)
   activeAnimation: { roomJid: string; animation: string } | null
   // Message drafts per room (persisted to localStorage separately)
@@ -550,13 +554,14 @@ function createEmptyRoomState(
   dismissedPollIds: Map<string, Set<string>> = new Map(),
   roomGaps: Map<string, GapInterval> = new Map(),
   acknowledgedNonAnonymousRooms: Set<string> = new Set(),
-): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'acknowledgedNonAnonymousRooms' | 'targetMessageId' | 'firstNewMessageMarkers'> {
+): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'acknowledgedNonAnonymousRooms' | 'targetMessageId' | 'firstNewMessageMarkers'> {
   return {
     rooms: new Map(),
     roomEntities: new Map(),
     roomMeta: new Map(),
     roomRuntime: new Map(),
     activeRoomJid: null,
+    activationPending: false,
     activeAnimation: null,
     drafts,
     votedPollIds,
@@ -1549,8 +1554,12 @@ export const roomStore = createStore<RoomState>()(
   activateRoom: async (roomJid) => {
     const token = ++activationToken
     if (roomJid) {
+      // Signal the hydration window so the UI can hold a neutral surface
+      // instead of flashing the empty state while the cache read is in flight.
+      set({ activationPending: true })
       await get().loadMessagesFromCache(roomJid, { limit: 100 })
-      // A newer activation started while the cache read was in flight
+      // A newer activation started while the cache read was in flight: it owns
+      // the pending flag now, so bail without clearing it.
       if (token !== activationToken) return
       // XEP-0490: fold any pending remote read position into lastSeenMessageId
       // BEFORE setActiveRoom derives the new-message divider (parity with
@@ -1579,7 +1588,10 @@ export const roomStore = createStore<RoomState>()(
         })
       }
     }
+    // Set active and clear pending atomically (same React commit) so the view
+    // swaps straight from loading surface to content with no empty-state frame.
     get().setActiveRoom(roomJid)
+    set({ activationPending: false })
   },
 
   getActiveRoomJid: () => get().activeRoomJid,


### PR DESCRIPTION
## Summary

Switching content tabs (Messages / Rooms / Archive) via the rail icons briefly flashed the empty-state hero before the conversation or room rendered.

`navigateToView()` synchronously flips `sidebarView` and clears the opposite store, then fires the hydrating `activateConversation` / `activateRoom` action. Those `await` an IndexedDB cache read *before* setting the active id — by design, so the view never renders with an empty message list and the unread-divider is computed against loaded messages. That await is a real macrotask, so React commits and paints the in-between frame where both `activeConversationId` and `activeRoomJid` are null while `sidebarView` is already a content view, and the render cascade falls through to the `EmptyState` hero. The lazy tabs (Settings / Admin / Search) never showed this because they sit behind a `Suspense` skeleton; the content tabs had nothing covering the gap.

This adds a token-correct `activationPending` flag to `chatStore` and `roomStore` — set synchronously before the cache-read await and cleared atomically when the active id lands (the existing monotonic activation token means a superseded activation leaves the flag for the winner to clear). ChatLayout renders the existing `ViewLoadingFallback` skeleton instead of the `EmptyState` hero while it is true, so content-tab switches now match the lazy tabs and the hero no longer pops in and out.

`activationPending` is also a useful signal for any client built on the SDK, which hits the same flash.
