### PR TITLE
fix(avatar): freeze APNG and animated WebP avatars, not just GIF

### DIFF
--- a/apps/fluux/src/components/Avatar.test.tsx
+++ b/apps/fluux/src/components/Avatar.test.tsx
@@ -271,13 +271,18 @@ describe('Avatar — animated GIF freeze-on-hover', () => {
     }
   }
 
-  // The extraction only branches on blob.type, so a bare { type } suffices.
-  const respondWith = (type: string) =>
-    fetchSpy.mockResolvedValue({ blob: () => Promise.resolve({ type }) })
+  // Extraction sniffs the image bytes (not the MIME type), so each response
+  // carries real magic bytes. Minimal but valid signatures per format:
+  const GIF89A = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0, 0, 0, 0, 0, 0]
+  const APNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x61, 0x63, 0x54, 0x4c] // PNG sig + acTL
+  const STATIC_PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x49, 0x44, 0x41, 0x54] // PNG sig + IDAT
+  const WEBP_ANIMATED = [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50, 0x41, 0x4e, 0x49, 0x4d] // RIFF/WEBP + ANIM
+  const respondWithBytes = (bytes: number[]) =>
+    fetchSpy.mockResolvedValue({ arrayBuffer: () => Promise.resolve(new Uint8Array(bytes).buffer) })
 
   beforeEach(() => {
     fetchSpy = vi.fn()
-    respondWith('image/gif')
+    respondWithBytes(GIF89A)
     global.fetch = fetchSpy as unknown as typeof fetch
     OriginalImage = global.Image
     global.Image = MockImage as unknown as typeof Image
@@ -297,6 +302,28 @@ describe('Avatar — animated GIF freeze-on-hover', () => {
     render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
     // The live (animated) URL shows while the first frame is being extracted.
     expect(screen.getByRole('img')).toHaveAttribute('src', url)
+    await waitFor(() =>
+      expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    )
+  })
+
+  it('freezes an animated avatar that is not a GIF (e.g. APNG delivered as image/png)', async () => {
+    // Real-world: the SDK occupant-avatar path hardcodes/defaults the stored
+    // type to image/png (Profile.ts), and many animated avatars are APNG or
+    // animated WebP, not GIF. Freezing must key off the actual image bytes, not
+    // the declared mime type, or these animate forever (kuyuhi in #XSF).
+    respondWithBytes(APNG)
+    const url = 'blob:apng-freeze'
+    render(<Avatar identifier="kuyuhi" name="kuyuhi" avatarUrl={url} />)
+    await waitFor(() =>
+      expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
+    )
+  })
+
+  it('freezes an animated WebP avatar', async () => {
+    respondWithBytes(WEBP_ANIMATED)
+    const url = 'blob:webp-freeze'
+    render(<Avatar identifier="dave" name="Dave" avatarUrl={url} />)
     await waitFor(() =>
       expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
     )
@@ -354,8 +381,8 @@ describe('Avatar — animated GIF freeze-on-hover', () => {
     expect(screen.getByRole('img')).toHaveAttribute('src', STATIC_DATA_URL)
   })
 
-  it('never freezes a non-GIF image', async () => {
-    respondWith('image/png')
+  it('never freezes a static image (PNG with no acTL chunk)', async () => {
+    respondWithBytes(STATIC_PNG)
     const url = 'blob:png-static'
     render(<Avatar identifier="alice" name="Alice" avatarUrl={url} />)
     expect(screen.getByRole('img')).toHaveAttribute('src', url)

--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -159,11 +159,55 @@ function cacheStaticFrame(url: string, dataUrl: string): void {
  */
 const inFlightFrames = new Map<string, Promise<string | null>>()
 
+// Control-chunk markers that only appear in animated files: 'acTL' (APNG) and
+// 'ANIM' (animated WebP).
+const APNG_ACTL = [0x61, 0x63, 0x54, 0x4c]
+const WEBP_ANIM = [0x41, 0x4e, 0x49, 0x4d]
+
+function containsMarker(bytes: Uint8Array, marker: number[], limit: number): boolean {
+  const end = Math.min(bytes.length - marker.length, limit)
+  for (let i = 0; i <= end; i++) {
+    let hit = true
+    for (let j = 0; j < marker.length; j++) {
+      if (bytes[i + j] !== marker[j]) { hit = false; break }
+    }
+    if (hit) return true
+  }
+  return false
+}
+
 /**
- * Extract an animated GIF's first frame as a static PNG data URL and populate the
- * module-level cache on success. Resolves to null for non-GIF images or on any
- * decode failure. Deliberately decoupled from React: it is NOT cancelled when the
- * requesting component unmounts, so the cache fills even during fast scrolling.
+ * Detect an animated raster image from its bytes, independent of the declared
+ * MIME type. The type cannot be trusted: the SDK occupant-avatar path stores
+ * avatars as image/png regardless of the real format (Profile.ts), and many
+ * animated avatars are APNG or animated WebP rather than GIF. Covers exactly the
+ * formats WebKit animates in an <img>. The marker scan is capped to the header
+ * region where the control chunks always sit.
+ */
+function isAnimatedImage(buffer: ArrayBuffer): boolean {
+  const b = new Uint8Array(buffer)
+  if (b.length < 12) return false
+  // GIF87a / GIF89a — a single-frame GIF frozen is identical, so freeze all GIFs.
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) return true
+  // APNG: PNG signature followed by an 'acTL' chunk (absent in static PNGs).
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    return containsMarker(b, APNG_ACTL, 4096)
+  }
+  // Animated WebP: RIFF....WEBP container with an 'ANIM' chunk.
+  if (b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+      b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50) {
+    return containsMarker(b, WEBP_ANIM, 4096)
+  }
+  return false
+}
+
+/**
+ * Extract an animated avatar's first frame as a static PNG data URL and populate
+ * the module-level cache on success. Resolves to null for static images or on any
+ * decode failure. Animation is decided from the image bytes (GIF / APNG /
+ * animated WebP), never the declared MIME type. Deliberately decoupled from
+ * React: it is NOT cancelled when the requesting component unmounts, so the cache
+ * fills even during fast scrolling.
  */
 function extractFirstFrame(url: string): Promise<string | null> {
   const cached = staticFrameCache.get(url)
@@ -172,9 +216,9 @@ function extractFirstFrame(url: string): Promise<string | null> {
   if (pending) return pending
 
   const extraction = fetch(url)
-    .then(r => r.blob())
-    .then(blob => {
-      if (blob.type !== 'image/gif') return null
+    .then(r => r.arrayBuffer())
+    .then(buffer => {
+      if (!isAnimatedImage(buffer)) return null
       return new Promise<string | null>((resolve) => {
         const img = new Image()
         img.onload = () => {
@@ -200,9 +244,10 @@ function extractFirstFrame(url: string): Promise<string | null> {
 }
 
 /**
- * For animated GIF avatars, extract the first frame as a static PNG data URL.
- * Returns null for non-GIF images or while loading. A cached frame for the same
- * URL is applied synchronously on mount (no re-fetch, no replay).
+ * For animated avatars (GIF, APNG, animated WebP), extract the first frame as a
+ * static PNG data URL. Returns null for static images or while loading. A cached
+ * frame for the same URL is applied synchronously on mount (no re-fetch, no
+ * replay).
  */
 function useStaticFrame(url: string | undefined): string | null {
   const [frame, setFrame] = useState<string | null>(() =>
@@ -237,7 +282,7 @@ function useStaticFrame(url: string | undefined): string | null {
  * - Supports presence indicators
  * - Multiple size presets
  * - Accessible with proper alt text
- * - Animated GIF avatars are frozen by default, play on hover
+ * - Animated avatars (GIF, APNG, animated WebP) are frozen by default, play on hover
  */
 export function Avatar({
   identifier,


### PR DESCRIPTION
## Summary

Follow-up to #770. Animated avatars are meant to show a frozen first frame and play only on hover. #770 fixed the freeze-frame cache for virtualized scrolling, but the freeze still only ever applied to literal GIFs.

The decision "is this animated?" was made from the declared MIME type (`blob.type === 'image/gif'`). That misses the common real-world cases:

- Many animated avatars are APNG or animated WebP, not GIF. WebKit animates all three in an `<img>`.
- The SDK occupant-avatar path stores avatars as `image/png` regardless of the real format (`Profile.ts` hardcodes it for PEP avatars and defaults to it for vCard avatars with no `<TYPE>`), so even a GIF can arrive mistyped.

So these avatars were never frozen and animated continuously (observed: kuyuhi in #XSF, an animated PNG).

This detects animation from the actual image bytes instead of the declared type: GIF header, APNG `acTL` control chunk, or animated-WebP `ANIM` chunk. The existing canvas first-frame extraction already handles any decodable raster format, so the freeze now covers all three. Static JPEG/PNG/WebP are left untouched (no signature match), so there is no extra work for the common case.

### Known gap

Animated AVIF/HEIF are not detected (rare as avatars, and WebKit animation support for them is limited). They would keep animating.
