### PR TITLE
Center the date separator to match the floating date reminder

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -87,6 +87,9 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 <div
                   class="flex items-center gap-3 pt-6 pb-2"
                 >
+                  <div
+                    class="flex-1 h-px bg-fluux-hover"
+                  />
                   <span
                     class="text-xs font-semibold text-fluux-muted whitespace-nowrap"
                   >

--- a/apps/fluux/src/components/conversation/DateSeparator.test.tsx
+++ b/apps/fluux/src/components/conversation/DateSeparator.test.tsx
@@ -22,21 +22,22 @@ describe('DateSeparator', () => {
     expect(screen.getByText('Formatted: 2024-01-15')).toBeInTheDocument()
   })
 
-  it('should render a single trailing rule after the label', () => {
+  it('should flank the label with a rule on each side', () => {
     const { container } = render(<DateSeparator date="2024-01-15" />)
 
     const lines = container.querySelectorAll('.h-px.bg-fluux-hover')
-    expect(lines).toHaveLength(1)
+    expect(lines).toHaveLength(2)
   })
 
-  it('should render the label before the rule so it sits on the reading-start edge', () => {
+  it('should center the label between two symmetric rules', () => {
     const { container } = render(<DateSeparator date="2024-01-15" />)
 
     const wrapper = container.firstChild as HTMLElement
-    const [first, second] = Array.from(wrapper.children)
-    expect(first.tagName).toBe('SPAN')
-    expect(first).toHaveTextContent('Formatted: 2024-01-15')
-    expect(second).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
+    const [first, second, third] = Array.from(wrapper.children)
+    expect(first).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
+    expect(second.tagName).toBe('SPAN')
+    expect(second).toHaveTextContent('Formatted: 2024-01-15')
+    expect(third).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
   })
 
   it('should have correct styling classes', () => {

--- a/apps/fluux/src/components/conversation/DateSeparator.tsx
+++ b/apps/fluux/src/components/conversation/DateSeparator.tsx
@@ -7,12 +7,12 @@ export interface DateSeparatorProps {
 }
 
 /**
- * Displays a leading-aligned date label followed by a horizontal rule.
+ * Displays a centered date label flanked by horizontal rules.
  * Used to separate messages by day in conversation views.
  *
- * Layout leans on flex flow + logical properties so it mirrors correctly
- * under RTL: the label always sits on the reading-start edge and the rule
- * extends toward the trailing edge.
+ * Centering mirrors the floating date reminder shown during scroll, so the
+ * static marker and the transient pill share the same horizontal anchor. The
+ * symmetric rules stay RTL-safe with no directional assumptions.
  */
 export function DateSeparator({ date }: DateSeparatorProps) {
   const { t, i18n } = useTranslation()
@@ -20,6 +20,7 @@ export function DateSeparator({ date }: DateSeparatorProps) {
 
   return (
     <div className="flex items-center gap-3 pt-6 pb-2">
+      <div className="flex-1 h-px bg-fluux-hover" />
       <span className="text-xs font-semibold text-fluux-muted whitespace-nowrap">
         {formatDateHeader(date, t, currentLang)}
       </span>

--- a/apps/fluux/src/components/conversation/FloatingDateHeader.test.tsx
+++ b/apps/fluux/src/components/conversation/FloatingDateHeader.test.tsx
@@ -27,18 +27,28 @@ function Host({ getTopDate, fadeDelayMs }: { getTopDate: () => string | null; fa
 }
 
 describe('FloatingDateHeader', () => {
-  beforeEach(() => vi.useFakeTimers())
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Run the scroll-coalescing rAF synchronously. Whether fake timers also fake
+    // rAF is environment-dependent under jsdom, which made the rAF-flush flaky;
+    // a synchronous frame keeps the scroll compute deterministic. The fade-out
+    // still rides the faked setTimeout below.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+  })
   afterEach(() => {
     vi.runOnlyPendingTimers()
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   function scroll(container: HTMLElement) {
     const scroller = container.querySelector('[data-scroller]') as HTMLElement
-    fireEvent.scroll(scroller)
-    // flush the rAF-coalesced compute (vitest fake timers shim rAF as a ~16ms macrotask)
     act(() => {
-      vi.advanceTimersByTime(20)
+      fireEvent.scroll(scroller)
     })
   }
 


### PR DESCRIPTION
Centers the inline date marker between two symmetric rules so it shares the same horizontal anchor as the transient floating date reminder shown during scroll. Previously the marker was leading-aligned (label + trailing rule).

Updated unit tests to assert the centered, two-rule layout.