### PR TITLE
fix(muc): hide reactions left by ignored users

### DIFF
--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -127,6 +127,23 @@ function _isReplyToIgnoredUser(
   return _isMessageFromIgnoredUser(ignoredUsers, { nick }, nickToJidCache)
 }
 
+function _filterIgnoredReactions(
+  reactions: Record<string, string[]> | undefined,
+  ignoredUsers: { identifier: string; jid?: string }[],
+  nickToJidCache?: Map<string, string>,
+): Record<string, string[]> | undefined {
+  if (!reactions || ignoredUsers.length === 0) return reactions
+  let changed = false
+  const result: Record<string, string[]> = {}
+  for (const [emoji, reactors] of Object.entries(reactions)) {
+    const kept = reactors.filter(nick => !_isMessageFromIgnoredUser(ignoredUsers, { nick }, nickToJidCache))
+    if (kept.length !== reactors.length) changed = true
+    if (kept.length > 0) result[emoji] = kept
+  }
+  if (!changed) return reactions
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
 // Mock SDK hooks and pure functions
 vi.mock('@fluux/sdk', () => ({
   useReferencedMessage: () => undefined,
@@ -218,6 +235,7 @@ vi.mock('@fluux/sdk', () => ({
   },
   isMessageFromIgnoredUser: _isMessageFromIgnoredUser,
   isReplyToIgnoredUser: _isReplyToIgnoredUser,
+  filterIgnoredReactions: _filterIgnoredReactions,
   canKick: () => false,
   canBan: () => false,
   canModerate: () => false,
@@ -1146,6 +1164,49 @@ describe('RoomView', () => {
       expect(screen.queryByText('Alice text')).not.toBeInTheDocument()
       expect(screen.getByText('Bob text')).toBeInTheDocument()
       expect(screen.queryByText('Charlie text')).not.toBeInTheDocument()
+    })
+
+    it('should hide a reaction left by an ignored user on a visible message', () => {
+      // Bob (not ignored) posts a message that Mallory (ignored) and Bob both
+      // react to. Mallory's emoji must not leak through even though the target
+      // message stays visible.
+      mockActiveMessages = [
+        createRoomMessage({
+          id: 'msg-1',
+          nick: 'Bob',
+          body: 'Bob says hello',
+          occupantId: 'occ-bob',
+          // Emojis are chosen outside TOOLBAR_REACTIONS so the quick-react
+          // picker buttons don't collide with the rendered reaction pills.
+          reactions: { '🔥': ['Mallory'], '🎉': ['Bob'] },
+        }),
+      ]
+      mockIgnoredUsers = {
+        [ROOM_JID]: [{ identifier: 'Mallory', displayName: 'Mallory' }],
+      }
+
+      render(<RoomView />)
+
+      expect(screen.getByText('Bob says hello')).toBeInTheDocument()
+      // Bob's reaction survives, Mallory's is stripped.
+      expect(screen.getByText('🎉')).toBeInTheDocument()
+      expect(screen.queryByText('🔥')).not.toBeInTheDocument()
+    })
+
+    it('should keep reactions from ignored users when no one is ignored', () => {
+      mockActiveMessages = [
+        createRoomMessage({
+          id: 'msg-1',
+          nick: 'Bob',
+          body: 'Bob says hello',
+          reactions: { '🔥': ['Mallory'] },
+        }),
+      ]
+      mockIgnoredUsers = {}
+
+      render(<RoomView />)
+
+      expect(screen.getByText('🔥')).toBeInTheDocument()
     })
 
     it('should prioritize occupantId match over nick match', () => {

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useRoomActive, useRoomEntity, useRoomOccupantCount, useContactIdentities, getBareJid, generateConsistentColorHexSync, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, WhisperCounterpartGoneError, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
+import { useRoomActive, useRoomEntity, useRoomOccupantCount, useContactIdentities, getBareJid, generateConsistentColorHexSync, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, WhisperCounterpartGoneError, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useMessageHoverState, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, isSmallScreen } from '@/hooks'
@@ -113,10 +113,19 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   const displayMessages = useMemo(() => {
     if (ignoredForRoom.length === 0) return activeMessages
     const cache = activeRoom?.nickToJidCache
-    return activeMessages.filter(msg =>
-      !isMessageFromIgnoredUser(ignoredForRoom, msg, cache) &&
-      !isReplyToIgnoredUser(ignoredForRoom, msg.replyTo, cache)
-    )
+    return activeMessages
+      .filter(msg =>
+        !isMessageFromIgnoredUser(ignoredForRoom, msg, cache) &&
+        !isReplyToIgnoredUser(ignoredForRoom, msg.replyTo, cache)
+      )
+      // Also strip reactions left by ignored users on surviving messages. The
+      // helper returns the same reference when nothing is removed, so we only
+      // clone the rare message that actually carried an ignored reaction —
+      // keeping the memo bailout intact for everything else.
+      .map(msg => {
+        const reactions = filterIgnoredReactions(msg.reactions, ignoredForRoom, cache)
+        return reactions === msg.reactions ? msg : { ...msg, reactions }
+      })
   }, [activeMessages, ignoredForRoom, activeRoom?.nickToJidCache])
 
   // Filter typing indicators from ignored users

--- a/docs/ROADMAP_2026.md
+++ b/docs/ROADMAP_2026.md
@@ -131,6 +131,16 @@ Engage with the XMPP MLS XEP effort. Implement once the wire format stabilises.
 
 ---
 
+## Polish & Backlog
+
+- **Filter muted users from search results** — the per-room ignore (mute) list is
+  applied in the room view (messages, mentions, typing indicators and reactions are
+  hidden) but not in cross-room search. Messages, mentions and reactions from muted
+  users still surface in `SearchContextView`. Apply the same ignore filter to search
+  results so muted users stay hidden everywhere.
+
+---
+
 ## Already Shipped
 
 - Message editing, reactions, emoji, GIFs

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -202,7 +202,7 @@ export type { IgnoredUser } from './stores/ignoreStore'
 
 // Conversation sync types
 export type { SyncedConversation } from './core/modules/ConversationSync'
-export { isMessageFromIgnoredUser, isReplyToIgnoredUser } from './stores/ignoreStore'
+export { isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions } from './stores/ignoreStore'
 
 // Notification state utilities (pure functions for badge computation, etc.)
 export { computeBadgeCount, shouldNotifyConversation, shouldNotifyRoom } from './stores/shared/notificationState'

--- a/packages/fluux-sdk/src/stores/ignoreStore.test.ts
+++ b/packages/fluux-sdk/src/stores/ignoreStore.test.ts
@@ -27,7 +27,7 @@ vi.mock('zustand/middleware', () => ({
   persist: (fn: unknown) => fn,
 }))
 
-import { ignoreStore, isMessageFromIgnoredUser, isReplyToIgnoredUser } from './ignoreStore'
+import { ignoreStore, isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions } from './ignoreStore'
 
 const ROOM_JID = 'room@conference.example.com'
 const ROOM_JID_2 = 'room2@conference.example.com'
@@ -329,6 +329,56 @@ describe('ignoreStore', () => {
       const ignored = [{ identifier: 'occ-alice', displayName: 'Alice' }]
 
       expect(isReplyToIgnoredUser(ignored, { to: `${ROOM}/Alice` })).toBe(false)
+    })
+  })
+
+  describe('filterIgnoredReactions', () => {
+    it('removes an ignored reactor matched by nick identifier', () => {
+      const ignored = [{ identifier: 'Mallory', displayName: 'Mallory' }]
+      const reactions = { '👍': ['Mallory', 'Bob'] }
+
+      expect(filterIgnoredReactions(reactions, ignored)).toEqual({ '👍': ['Bob'] })
+    })
+
+    it('removes an ignored reactor matched by JID via nickToJidCache', () => {
+      const ignored = [{ identifier: 'mallory@example.com', displayName: 'Mallory', jid: 'mallory@example.com' }]
+      const reactions = { '🎉': ['Mallory', 'Bob'] }
+      const cache = new Map([['Mallory', 'mallory@example.com']])
+
+      expect(filterIgnoredReactions(reactions, ignored, cache)).toEqual({ '🎉': ['Bob'] })
+    })
+
+    it('drops an emoji entirely when the ignored user was its only reactor', () => {
+      const ignored = [{ identifier: 'Mallory', displayName: 'Mallory' }]
+      const reactions = { '👍': ['Bob'], '😡': ['Mallory'] }
+
+      expect(filterIgnoredReactions(reactions, ignored)).toEqual({ '👍': ['Bob'] })
+    })
+
+    it('returns undefined when every reaction came from ignored users', () => {
+      const ignored = [{ identifier: 'Mallory', displayName: 'Mallory' }]
+      const reactions = { '😡': ['Mallory'] }
+
+      expect(filterIgnoredReactions(reactions, ignored)).toBeUndefined()
+    })
+
+    it('returns the same reference when nothing is removed (referential stability)', () => {
+      const ignored = [{ identifier: 'Mallory', displayName: 'Mallory' }]
+      const reactions = { '👍': ['Bob', 'Alice'] }
+
+      expect(filterIgnoredReactions(reactions, ignored)).toBe(reactions)
+    })
+
+    it('returns the same reference for an empty ignored list', () => {
+      const reactions = { '👍': ['Mallory'] }
+
+      expect(filterIgnoredReactions(reactions, [])).toBe(reactions)
+    })
+
+    it('returns undefined when reactions are undefined', () => {
+      const ignored = [{ identifier: 'Mallory', displayName: 'Mallory' }]
+
+      expect(filterIgnoredReactions(undefined, ignored)).toBeUndefined()
     })
   })
 

--- a/packages/fluux-sdk/src/stores/ignoreStore.ts
+++ b/packages/fluux-sdk/src/stores/ignoreStore.ts
@@ -209,4 +209,38 @@ export function isReplyToIgnoredUser(
   return isMessageFromIgnoredUser(ignoredUsers, { nick }, nickToJidCache)
 }
 
+/**
+ * Strip reactions (XEP-0444) contributed by ignored users from a reactions map.
+ *
+ * Reactions are stored on the *target* message keyed by reactor nick. Because
+ * the target is usually authored by a non-ignored user, the message survives
+ * the message-level ignore filter — so an ignored user's emoji would still be
+ * shown unless its reactor entry is removed here. Reactors are matched by nick
+ * with the same logic used for messages (nick > JID via nickToJidCache).
+ *
+ * Returns the original `reactions` reference when nothing is removed, so
+ * callers can rely on referential equality to skip re-renders. Returns
+ * `undefined` when every reaction came from ignored users.
+ */
+export function filterIgnoredReactions(
+  reactions: Record<string, string[]> | undefined,
+  ignoredUsers: IgnoredUser[],
+  nickToJidCache?: Map<string, string>,
+): Record<string, string[]> | undefined {
+  if (!reactions || ignoredUsers.length === 0) return reactions
+
+  let changed = false
+  const result: Record<string, string[]> = {}
+  for (const [emoji, reactors] of Object.entries(reactions)) {
+    const kept = reactors.filter(
+      nick => !isMessageFromIgnoredUser(ignoredUsers, { nick }, nickToJidCache),
+    )
+    if (kept.length !== reactors.length) changed = true
+    if (kept.length > 0) result[emoji] = kept
+  }
+
+  if (!changed) return reactions
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
 export type { IgnoreState }


### PR DESCRIPTION
Ignoring (muting) a user in a room hid their messages, mentions and typing indicators, but not their XEP-0444 reactions. Reactions are stored on the *target* message — usually authored by a non-ignored user — so they survived the message-level ignore filter and still showed on screen (emoji count + reactor name in the tooltip).

Adds a pure `filterIgnoredReactions()` helper in the SDK and strips ignored reactors from surviving messages at render time in `RoomView`, consistent with the existing message/typing ignore filtering. The helper returns the same reference when nothing is removed, preserving the row memo bailout. Data stays intact in the store, so un-muting restores reactions instantly.

Also adds a roadmap backlog item to extend the same ignore filter to cross-room search results (`SearchContextView`), where muted users' content still surfaces.