### PR TITLE
fix(login): soften the brand-mark glow in dark mode

### DIFF
--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -433,8 +433,8 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
           {/* Aurora gradient brand mark: the --fluux-grad tile + a soft glow */}
           <div className="relative size-16 mx-auto mb-4">
             <div
-              className="absolute -inset-1.5 rounded-2xl blur-xl opacity-60"
-              style={{ background: 'var(--fluux-grad)' }}
+              className="absolute -inset-1.5 rounded-2xl blur-xl"
+              style={{ background: 'var(--fluux-grad)', opacity: 'var(--fluux-brand-glow-opacity)' }}
               aria-hidden="true"
             />
             <div

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -133,6 +133,10 @@
   /* ── Aurora identity additions ── */
   --fluux-accent-2: #38E0C4;
   --fluux-grad: linear-gradient(135deg, #38E0C4, #7C8CFF, #A78BFA);
+  /* Opacity of the soft brand-mark glow (login). The bright gradient bloom reads
+     much stronger against the dark canvas than the light one, so it is themed:
+     calmer here, fuller under .light (which keeps its current, subtler look). */
+  --fluux-brand-glow-opacity: 0.35;
   --fluux-glass-blur: 12px;
 
   /* ── Motion language: duration + easing tokens (global, never themed) ──
@@ -481,6 +485,8 @@
      this darker teal clears 3.58:1 (non-text floor is 3:1, target 3.5+). */
   --fluux-text-encryption: #0D8872;
   --fluux-grad: linear-gradient(135deg, #11A88C, #5B6CF0, #7C6CF0);
+  /* Light canvas absorbs the bloom, so it can stay fuller without reading strong. */
+  --fluux-brand-glow-opacity: 0.6;
   /* 0.12 (not 0.10) so the hairline clears the >=1.25:1 perceptibility floor on
      the lightest theme glass surfaces (tokyo-night/kanagawa light were near-miss
      at 0.10); guarded by glass.test.ts. */


### PR DESCRIPTION
The login brand mark's glow used a flat `opacity-60` across every theme. Because it's a bright aurora gradient, that intensity reads strong against the dark canvas (the reported issue) while staying subtle on the light one.

This makes the glow opacity theme-aware via a new `--fluux-brand-glow-opacity` token:

- **Dark** (`:root`): `0.6 → 0.35` — calmer, while still a soft glow that keeps the aurora identity.
- **Light** (`.light`): unchanged at `0.6` — it was never too strong on the light canvas, which absorbs the bloom.

The brand mark now reads the token instead of a hardcoded opacity class, so each theme gets the appropriate intensity.