### PR TITLE
fix(scroll): stop the entry-at-bottom blink under virtualization

### DIFF
--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -516,10 +516,22 @@ export function useMessageListScroll({
       const element = contentRef.current
       if (!scroller || !element || contentObserverRef.current) return
 
-      const { staticMode, isAtBottomRef } = latestRef.current
+      const { staticMode, isAtBottomRef, virtualizer } = latestRef.current
 
-      // On mount: if we should be at bottom, scroll there immediately
-      if (isAtBottomRef.current && !staticMode) {
+      // On mount: if we should be at bottom, scroll there immediately.
+      //
+      // NON-VIRTUALIZED ONLY. Under virtualization the conversation-switch layout effect (which
+      // also runs on this same fresh mount — MessageList is keyed by conversation id, so every
+      // entry remounts and prevConversationRef starts null) owns the initial bottom positioning
+      // via pinVirtualizedBottom() → scrollToIndex(last,'end'). That target is MEASUREMENT-AWARE;
+      // this legacy raw `scrollTop = scrollHeight` predates virtualization and lands on the
+      // @tanstack spacer's ESTIMATED total instead — a different pixel. Running both on entry (the
+      // raw write here, plus its one-frame-later rAF, against the pin's scrollToIndex) positions
+      // the view twice at two slightly different bottoms, so it visibly nudges up/down before it
+      // settles. Gating on !virtualizer leaves the non-virtualized path byte-identical while
+      // letting the (virtualization-aware) switch effect be the single source of bottom positioning
+      // — the same migration already applied to the switch effect's own else branch.
+      if (isAtBottomRef.current && !staticMode && !virtualizer) {
         void scroller.offsetHeight // Force reflow
         scroller.scrollTop = scroller.scrollHeight
         requestAnimationFrame(() => {


### PR DESCRIPTION
Loading a conversation that's already at the bottom visibly nudged up/down for a frame or two before settling.

`MessageList` is keyed by conversation id (`ChatView` / `RoomView`), so **every** entry remounts it. On that fresh mount two mechanisms both scroll to the bottom, computing it differently:

1. `trySetupContentObserver` does a raw `scroller.scrollTop = scroller.scrollHeight` (plus a one-frame-later `requestAnimationFrame` that repeats it). Under virtualization `scrollHeight` is the @tanstack spacer's **estimated** total.
2. The conversation-switch layout effect calls `pinVirtualizedBottom()` → `scrollToIndex(last, 'end')`, which is **measurement-aware** (real row heights).

The two targets differ by the bottom rows' estimate-vs-measured delta, and #1's rAF fires a frame after #2, so the view is positioned twice at two slightly different bottoms — the blink.

The raw mount scroll (#1) is legacy code that predates virtualization and was never gated on the virtualizer, even though the conversation-switch path's own else branch already was. This gates it on `!virtualizer`, making the virtualization-aware pin the single source of initial bottom positioning. The non-virtualized path is byte-identical.

The existing scroll tests switch conversations via `rerender` (no remount), so they never exercised the fresh-mount raw-scroll overlapping the pin — which is why this slipped past the suite.