### PR TITLE
Center the start-of-conversation marker

### DIFF
--- a/apps/fluux/src/components/conversation/HistoryStartMarker.test.tsx
+++ b/apps/fluux/src/components/conversation/HistoryStartMarker.test.tsx
@@ -22,20 +22,21 @@ describe('HistoryStartMarker', () => {
     expect(screen.getByText('Beginning of conversation')).toBeInTheDocument()
   })
 
-  it('should render a single trailing rule after the label', () => {
+  it('should flank the label with a rule on each side', () => {
     const { container } = render(<HistoryStartMarker />)
 
     const lines = container.querySelectorAll('.h-px.bg-fluux-hover')
-    expect(lines).toHaveLength(1)
+    expect(lines).toHaveLength(2)
   })
 
-  it('should render the label before the rule so it sits on the reading-start edge', () => {
+  it('should center the label between two symmetric rules', () => {
     const { container } = render(<HistoryStartMarker />)
 
     const wrapper = container.firstChild as HTMLElement
-    const [first, second] = Array.from(wrapper.children)
-    expect(first).toHaveTextContent('Beginning of conversation')
-    expect(second).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
+    const [first, second, third] = Array.from(wrapper.children)
+    expect(first).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
+    expect(second).toHaveTextContent('Beginning of conversation')
+    expect(third).toHaveClass('flex-1', 'h-px', 'bg-fluux-hover')
   })
 
   it('should render a clock icon', () => {

--- a/apps/fluux/src/components/conversation/HistoryStartMarker.tsx
+++ b/apps/fluux/src/components/conversation/HistoryStartMarker.tsx
@@ -5,15 +5,16 @@ import { Clock } from 'lucide-react'
  * Displays a marker indicating the beginning of conversation history.
  * Shown when all server-side message history has been loaded (MAM complete).
  *
- * Mirrors the leading-aligned DateSeparator layout: the label sits on the
- * reading-start edge and the rule trails toward the end edge. Relies on flex
- * flow + logical spacing so it mirrors correctly under RTL.
+ * Mirrors the centered DateSeparator layout: the label is flanked by symmetric
+ * rules so it shares the same horizontal anchor as the date markers and the
+ * floating date reminder. Relies on flex flow so it mirrors correctly under RTL.
  */
 export function HistoryStartMarker() {
   const { t } = useTranslation()
 
   return (
     <div className="flex items-center gap-3 py-4 px-2">
+      <div className="flex-1 h-px bg-fluux-hover" />
       <div className="flex items-center gap-2 text-xs text-fluux-muted whitespace-nowrap">
         <Clock className="size-3.5" />
         <span>{t('chat.historyStart')}</span>


### PR DESCRIPTION
Centers the "Début de la conversation" / history-start marker between two symmetric rules, matching the now-centered date separators and floating date reminder. Previously it was leading-aligned (clock + label, then a trailing rule).

Follow-up to #775. Test updated to assert the centered, two-rule layout.