### PR TITLE
fix(scroll): keep the at-bottom pin alive until the DOM spacer commits

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomSpacerLag.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomSpacerLag.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Cold-open send-stick: the bottom pin must not settle at a FALSE distFromBottom=0.
+ *
+ * The reported bug (Tauri/WebKit, 1:1 chat, first open of a conversation this session): you open a
+ * conversation, it lands at the bottom, you send a message — and the just-sent message stays a row
+ * below the fold. Leaving and re-opening the same conversation fixes it.
+ *
+ * Root cause (confirmed by an on-device [Scroll] trace): on a COLD first open the tail row measures
+ * TALLER than its estimate only AFTER the pin scrolls. The virtualizer's getTotalSize() grows
+ * immediately (measureElement's ResizeObserver, forced by flushTailLayout), but the DOM spacer that
+ * backs `scroller.scrollHeight` only catches up on the next React commit — and scrollTop is clamped
+ * to the still-short spacer. So `pinVirtualizedBottom` read `scrollHeight - scrollTop - clientHeight`
+ * as 0 and settled ("PIN settled distFromBottom: 0"), while the real gap was ~121px ("saveScroll…
+ * distanceFromBottom: 121") and nothing re-pinned once the spacer grew. On a WARM re-open the heights
+ * are seeded, getTotalSize() never leads scrollHeight, and the same 0 is truthful.
+ *
+ * The fix keys the pin's settle on the AUTHORITATIVE height (max of the DOM spacer and the
+ * virtualizer's getTotalSize()) and keeps the loop ALIVE while that gap exceeds tolerance — but it does
+ * NOT re-pin every frame: each scrollToIndex re-windows @tanstack and forces a re-render (see the
+ * adapter), so while merely waiting for the spacer to commit it idle-polls (read-only flushTailLayout)
+ * and writes only when the reachable bottom moves. When the spacer finally commits it lands the true
+ * bottom with a single write.
+ *
+ * jsdom has no layout, so this drives the divergence explicitly: getTotalSize() is held ABOVE the
+ * instrumented scrollHeight, and scrollToIndex('end') clamps scrollTop to the DOM spacer.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import type { BaseMessage } from '@fluux/sdk'
+
+// Live-mutable virtualizer state the test controls: `totalSize` is the virtualizer's authoritative
+// content height (leads the DOM spacer on a cold measure). `endCalls` counts scrollToIndex('end')
+// re-pins so a test can prove the pin does NOT re-pin (re-window + re-render) every frame while it
+// merely waits for the spacer to commit.
+const virt = { totalSize: 2000 }
+const endCalls = { count: 0 }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(),
+    selectionCount: 0,
+    isSelecting: false,
+    selectAll: vi.fn(),
+    extendTo: vi.fn(),
+    clearSelection: vi.fn(),
+    copySelected: vi.fn(),
+  })),
+}))
+
+vi.mock('./tanstackMessageVirtualizer', () => ({
+  useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
+    getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
+    // Authoritative height, driven by the test — held ABOVE scrollHeight to model the cold-open lag.
+    getTotalSize: () => virt.totalSize,
+    itemCount: args.items.length,
+    getOffsetForMessageId: () => 0,
+    getIndexForMessageId: (id: string) => {
+      const i = args.items.findIndex((it) => it.key === id)
+      return i >= 0 ? i : null
+    },
+    ensureMessageMounted: vi.fn(() => Promise.resolve()),
+    measureElement: () => {},
+    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    // Real browsers clamp scrollTop to the DOM element's scrollHeight (the spacer), NOT to the
+    // virtualizer's getTotalSize. So 'end' can only reach the CURRENT (possibly stale-short) spacer.
+    scrollToIndex: (_index: number, opts?: { align?: string }) => {
+      const el = args.scrollRef.current
+      if (!el) return
+      if (opts?.align === 'end') {
+        endCalls.count += 1
+        el.scrollTop = el.scrollHeight // clamped by the scrollTop setter below
+      } else {
+        el.scrollTop = _index * 40
+      }
+    },
+  }),
+}))
+
+function makeMessages(count: number, prefix = 'msg'): BaseMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    from: 'user@example.com',
+    body: `Body ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i % 60),
+    isOutgoing: false,
+    type: 'chat' as const,
+  }))
+}
+
+describe('MessageList — bottom pin keys on the authoritative height, not the lagged DOM spacer', () => {
+  let realRaf: typeof requestAnimationFrame
+  let rafQueue: FrameRequestCallback[]
+  const flush = (frames: number) => {
+    for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0))
+  }
+
+  // A scroller whose scrollHeight is a mutable "DOM spacer" the test can grow to model the React
+  // commit catching up. scrollTop is clamped to [0, scrollHeight - clientHeight] like a browser.
+  function instrumentScroller(scroller: HTMLElement, initialHeight: number) {
+    const state = { height: initialHeight, top: 0 }
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => state.height, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { value: 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => state.top,
+      set: (v: number) => { state.top = Math.max(0, Math.min(v, state.height - 500)) },
+      configurable: true,
+    })
+    return {
+      setSpacerHeight: (h: number) => { state.height = h },
+      get distFromBottom() { return state.height - state.top - 500 },
+    }
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafQueue.push(cb)
+      return rafQueue.length
+    }) as typeof requestAnimationFrame
+    virt.totalSize = 2000
+    endCalls.count = 0
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = realRaf
+    localStorage.clear()
+  })
+
+  const baseProps = {
+    renderMessage: (m: BaseMessage) => <div>{m.body}</div>,
+    onScrollToTop: vi.fn(),
+    isHistoryComplete: false,
+  }
+
+  it('stays alive past the normal budget and lands the true bottom when the spacer commits late', () => {
+    // CORRECTNESS (the bug fix). RED on the old loop: it exited after 60 frames, so a spacer that
+    // committed later left the just-sent row stranded. GREEN now: the loop stays alive on the
+    // authoritative gap and re-pins the instant the spacer grows.
+    const isAtBottomRef = { current: true }
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-late" isAtBottomRef={isAtBottomRef} {...baseProps} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const probe = instrumentScroller(scroller, 2000)
+
+    // Let the entry pin settle at a matched height (spacer == getTotalSize), then start clean.
+    flush(70)
+    endCalls.count = 0
+
+    // COLD SEND: the just-sent row measures taller — the virtualizer knows (getTotalSize jumps to
+    // 2300) but the DOM spacer is still the pre-commit 2000, and scrollTop clamps to it (dist 0).
+    virt.totalSize = 2300
+    const sent: BaseMessage = {
+      id: 'sent-1', from: 'me@example.com', body: 'hello', isOutgoing: true, type: 'chat',
+      timestamp: new Date(2024, 0, 1, 13, 0),
+    }
+    rerender(
+      <MessageList messages={[...makeMessages(50), sent]} conversationId="conv-late" isAtBottomRef={isAtBottomRef} {...baseProps} />,
+    )
+
+    // The spacer commits LATE — well past the old 60-frame budget, as a cold open can.
+    flush(100)
+    probe.setSpacerHeight(2300)
+    flush(40)
+
+    // The still-running pin scrolls to the real bottom: scrollTop = 1800, dist 0 against the TRUE
+    // height — the just-sent message is fully in view.
+    expect(scroller.scrollTop).toBe(1800)
+    expect(probe.distFromBottom).toBe(0)
+    expect(isAtBottomRef.current).toBe(true)
+  })
+
+  it('does not re-pin every frame while the spacer lags (no per-frame re-window / re-render)', () => {
+    // PERFORMANCE. Each scrollToIndex('end') re-windows @tanstack and forces a re-render (the adapter
+    // pushes the offset back in), so re-pinning on every frame of the wait would be a re-render storm.
+    // While the spacer is stale-short, scrollTop is already clamped to its bottom, so the pin has
+    // nothing to write — it must idle-poll (read-only flushTailLayout) and leave scrollToIndex alone.
+    const isAtBottomRef = { current: true }
+    const { container, rerender } = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-nothrash" isAtBottomRef={isAtBottomRef} {...baseProps} />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller, 2000)
+    flush(70)
+    endCalls.count = 0
+
+    virt.totalSize = 2300 // getTotalSize leads; the DOM spacer never commits in this test
+    const sent: BaseMessage = {
+      id: 'sent-1', from: 'me@example.com', body: 'hello', isOutgoing: true, type: 'chat',
+      timestamp: new Date(2024, 0, 1, 13, 0),
+    }
+    rerender(
+      <MessageList messages={[...makeMessages(50), sent]} conversationId="conv-nothrash" isAtBottomRef={isAtBottomRef} {...baseProps} />,
+    )
+
+    // 100 frames of lag. The pin stays alive (see the previous test) but must NOT issue a
+    // scrollToIndex('end') each frame — only the initial pin(s). A thrashing loop would be ~100 here.
+    flush(100)
+    expect(endCalls.count).toBeLessThan(10)
+  })
+})

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -84,6 +84,13 @@ const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load even
 // scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
 // one-shot scrollToIndex isn't enough. ~1s at 60fps comfortably covers the measurement settle.
 const BOTTOM_REASSERT_FRAMES = 60
+// Hard wall-clock cap (frames) for the bottom pin, independent of the settle window above. While the
+// AUTHORITATIVE content height (max of the DOM spacer and the virtualizer's getTotalSize) still shows
+// content below the fold, the pin keeps its settle window from expiring so it survives until the DOM
+// spacer commits the grown height (which, on a COLD first open, can land after the ~1s settle — the
+// just-sent row was stranded because the loop exited first). This cap bounds the pathological case
+// where the spacer never commits. ~3s at 60fps, comfortably longer than a cold measure + React commit.
+const BOTTOM_REASSERT_HARD_CAP_FRAMES = 180
 // Frames to keep re-resolving the unread-marker offset after a conversation switch. On entry the
 // conversation's messages were evicted on leave and rehydrate from cache asynchronously, then the
 // rows measure over several frames, so the marker offset is unresolved at first and sharpens as it
@@ -756,6 +763,9 @@ export function useMessageListScroll({
     const startedAt = Date.now()
     const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('pin-bottom', performance.now())
     let framesLeft = BOTTOM_REASSERT_FRAMES
+    // Independent hard cap (see BOTTOM_REASSERT_HARD_CAP_FRAMES): the settle window above is held open
+    // while content is still below the fold, so this bounds the pathological never-commit case.
+    let hardFramesLeft = BOTTOM_REASSERT_HARD_CAP_FRAMES
     let lastHeight = scroller.scrollHeight
     const finish = () => {
       loop.end()
@@ -763,51 +773,64 @@ export function useMessageListScroll({
     }
     const step = () => {
       const s = scrollerRef.current
-      if (framesLeft-- <= 0) {
-        // Loop ran its full budget. Re-derive isAtBottom from REAL geometry so downstream consumers
-        // (FAB, auto-follow on the next message, position save) are left accurate even if WebKit
-        // withheld the final settle scroll event — the pin no longer trusts the position-derived flag
-        // mid-loop (see the removed bail above), so it must leave a correct one behind here. If dist
-        // is still > tolerance the pin never converged (the just-sent message ended up below the fold).
-        if (s) {
-          flushTailLayout()
-          const dist = s.scrollHeight - s.scrollTop - s.clientHeight
-          isAtBottomRef.current = dist < AT_BOTTOM_THRESHOLD
-          debugLog('PIN settled (frames exhausted)', { distFromBottom: dist })
-        }
-        finish()
-        return
-      }
       const v = virtualizerRef.current
       if (!s || !v || v.itemCount === 0) { finish(); return }
-      // The ONLY reason to stop pinning is a genuine user takeover — a FAB tap or a wheel scroll,
-      // both of which stamp userScrollIntentAtRef AFTER we started. We deliberately do NOT also bail
-      // on a position-derived `!isAtBottomRef.current`: on WebKit a tall bottom row's post-paint
-      // growth fires extra `scroll` events that transiently report a large distFromBottom, and the
+      // The ONLY reason to stop pinning early is a genuine user takeover — a FAB tap or a wheel scroll,
+      // both of which stamp userScrollIntentAtRef AFTER we started. We deliberately do NOT also bail on
+      // a position-derived `!isAtBottomRef.current`: on WebKit a tall bottom row's post-paint growth
+      // fires extra `scroll` events that transiently report a large distFromBottom, and the
       // height-unchanged discriminator in handleScroll cannot catch every one — a growth that settles
       // across TWO scroll events (the second at the now-unchanged height) slips it, flips isAtBottom
       // false, and used to strand the just-sent message below the fold (the recurring send-stick bug).
-      // The pin instead keeps converging on REAL geometry (the dist check below) and yields only to
-      // real input intent. See scroll-invariants "...growth that settles across TWO scroll events".
+      // The pin instead keeps converging on the AUTHORITATIVE geometry (below) and yields only to real
+      // input intent. See scroll-invariants "...growth that settles across TWO scroll events".
       if (userScrollIntentAtRef.current > startedAt) {
         debugLog('PIN bail (user scroll intent)', {
-          distFromBottom: s.scrollHeight - s.scrollTop - s.clientHeight,
+          distFromBottom: Math.max(s.scrollHeight, v.getTotalSize()) - s.scrollTop - s.clientHeight,
         })
         finish()
         return
       }
       // Force the tail rows to lay out this frame (the field-proven flush) so WebKit's late
-      // ResizeObserver delivers and getTotalSize/scrollHeight grow to include the just-added row,
-      // BEFORE we read scrollHeight below.
+      // ResizeObserver delivers and getTotalSize() grows to include the just-added row BEFORE we read
+      // the height below.
       flushTailLayout()
       const h = s.scrollHeight
-      // Re-pin when the layout grew/shrank (the common case) OR when we're still measurably short of
-      // the true bottom. The flush above makes the at-bottom growth show up here within a frame or
-      // two, so the send no longer settles a row low on WebKit. Idempotent at the bottom.
-      const dist = h - s.scrollTop - s.clientHeight
+      // Two distances. domDist is measured against the DOM spacer — the bottom the scroll can actually
+      // REACH this frame (scrollTop is clamped to the spacer). trueDist also folds in the virtualizer's
+      // getTotalSize(), which reflects a just-measured tail row the instant measureElement's
+      // ResizeObserver delivers (the flush above forces it) and so LEADS the DOM spacer — the spacer
+      // only catches up on the next React commit. Keying settle on domDist alone let the pin read a
+      // false distFromBottom 0 and exit with the just-sent row still a line below the fold on a COLD
+      // first open (warm re-opens seed the heights, so getTotalSize never leads and the 0 is truthful).
+      const domDist = h - s.scrollTop - s.clientHeight
+      const trueDist = Math.max(h, v.getTotalSize()) - s.scrollTop - s.clientHeight
+      const converged = trueDist <= BOTTOM_PIN_TOLERANCE
+      // Settle only once genuinely at the bottom (trueDist within tolerance) AND the settle window has
+      // elapsed — or the hard cap is reached. While trueDist still shows content below the fold, RESET
+      // the settle window and keep the loop ALIVE: on a cold open the commit that reveals the grown
+      // height can land after the normal ~1s budget, and exiting early is exactly what stranded the row.
+      // isAtBottom is re-derived from geometry on exit so downstream consumers (FAB, next-message
+      // auto-follow, position save) stay accurate even if WebKit withheld the final settle scroll.
+      if (converged) framesLeft--
+      else framesLeft = BOTTOM_REASSERT_FRAMES
+      if (hardFramesLeft-- <= 0 || (converged && framesLeft <= 0)) {
+        isAtBottomRef.current = trueDist < AT_BOTTOM_THRESHOLD
+        debugLog('PIN settled', { distFromBottom: trueDist, converged })
+        finish()
+        return
+      }
+      // Re-pin (a WRITE — the adapter re-windows @tanstack + forces a re-render on every scrollToIndex)
+      // ONLY when it can make progress: the reachable bottom moved (height changed) or scrollTop drifted
+      // off it (domDist). We deliberately do NOT write each frame while merely WAITING for the spacer to
+      // commit — scrollTop is already clamped to the current spacer, so a re-pin would be a no-op
+      // position-wise yet still cost a re-window + re-render every frame. The loop instead stays alive on
+      // trueDist above (a cheap read-only flushTailLayout poll) and re-pins the instant the spacer grows
+      // (h changes), landing the true bottom with a single write. So the write/re-render profile stays
+      // identical to the original loop — only its lifetime changed.
       let wrote = false
-      if (h !== lastHeight || dist > BOTTOM_PIN_TOLERANCE) {
-        debugLog('PIN re-assert', { distFromBottom: dist, heightChanged: h !== lastHeight })
+      if (h !== lastHeight || domDist > BOTTOM_PIN_TOLERANCE) {
+        debugLog('PIN re-assert', { distFromBottom: trueDist, domDist, heightChanged: h !== lastHeight })
         lastHeight = h
         v.scrollToIndex(v.itemCount - 1, { align: 'end' })
         wrote = true


### PR DESCRIPTION
## Summary

Sending a message the **first time you open a conversation this session** (Tauri/WebKit, 1:1 chat) left the just-sent message a line below the fold. Leaving and re-opening the same conversation fixed it. This makes a cold-open send stick like a warm one.

## Root cause

On a cold first open, the just-sent tail row measures taller than its estimate only *after* the pin scrolls. The virtualizer's `getTotalSize()` grows immediately (the row's `measureElement` ResizeObserver, forced by `flushTailLayout`), but the DOM spacer behind `scroller.scrollHeight` only catches up on the next React commit — and `scrollTop` is clamped to the still-short spacer.

So `pinVirtualizedBottom` read `scrollHeight - scrollTop - clientHeight` as **0**, settled at a false "at bottom", and nothing re-pinned once the spacer grew. A device trace confirmed it: `PIN settled distFromBottom: 0` immediately followed by `saveScrollPosition … distanceFromBottom: 121`. Warm re-opens seed the row heights from a persistent cache, so `getTotalSize()` never leads `scrollHeight` and the `0` is truthful — which is exactly why the round-trip "fixed" it.

## Fix

Key the pin's settle and `isAtBottom` on the **authoritative height** — `max(scrollHeight, getTotalSize())` — and hold the settle window open while that gap exceeds tolerance, bounded by a new `~3s` hard cap so a spacer that never commits cannot spin forever.

The **write condition is unchanged**, so the loop only issues a `scrollToIndex` (which re-windows @tanstack and forces a re-render) when the *reachable* bottom actually moves. While waiting for the commit it idle-polls read-only (`flushTailLayout`) and then lands the true bottom with a single write. The write/re-render profile is identical to the original loop; only its lifetime changed — so this does not add per-frame re-renders to the app's hottest loop.