### PR TITLE
feat(pwa): user-triggered update button in the rail (web + desktop)

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -8,6 +8,7 @@ import { attemptCachedUnlockOrPrompt } from '@/e2ee/silentRestore'
 import { probeRemoteIdentityState } from './e2ee/secretKeyProbe'
 import { isOpenpgpEnabled } from './stores/encryptionSettingsStore'
 import { useToastStore } from './stores/toastStore'
+import { useAppUpdateStore } from './stores/appUpdateStore'
 import { UnlockEncryptionDialog } from './components/UnlockEncryptionDialog'
 import { IdentityChoiceDialog } from './components/IdentityChoiceDialog'
 import { RestorePassphraseDialog } from './components/RestorePassphraseDialog'
@@ -140,10 +141,22 @@ function App() {
     }
   }, [update.available, updateDismissed, showUpdateModal])
 
+  // Mirror desktop (Tauri) update availability into the shared app-update store so
+  // the sidebar rail button can surface it and reopen this modal on click. The
+  // platform action is registered here so the store stays free of Tauri specifics.
+  useEffect(() => {
+    useAppUpdateStore.getState().setDesktopUpdateAvailable(
+      update.available && update.updaterEnabled,
+      () => setShowUpdateModal(true),
+    )
+  }, [update.available, update.updaterEnabled])
+
   const handleUpdateDismiss = () => {
+    // Only close the modal and stop it auto-reshowing this session — deliberately
+    // do NOT wipe the update state, so the persistent rail button can reopen this
+    // modal later (it renders only while `update.available` is true).
     setShowUpdateModal(false)
     setUpdateDismissed(true)
-    update.dismissUpdate()
   }
 
   // Track if we're attempting auto-reconnect from saved session on page load

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { detectRenderLoop, trackSelectorChange } from '@/utils/renderLoopDetector'
 import { useClickOutside, useWindowDrag, useRouteSync } from '@/hooks'
 import { useModalStore } from '@/stores/modalStore'
+import { useUpdateAffordance } from '@/stores/appUpdateStore'
 import {
   useXMPP,
   type Contact,
@@ -34,6 +35,7 @@ import {
   Ban,
   UserPlus,
   RefreshCw,
+  CircleArrowUp,
 } from 'lucide-react'
 import { performLogout } from '@/utils/performLogout'
 
@@ -46,6 +48,7 @@ import {
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_WIDTH_KEY,
   IconRailNavLink,
+  IconRailButton,
   StatusOrPresence,
   ConversationList,
   ArchiveList,
@@ -126,6 +129,10 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
   const showPresenceMenu = useModalStore((s) => s.presenceMenu)
   const modalOpen = useModalStore((s) => s.open)
   const modalClose = useModalStore((s) => s.close)
+
+  // Cross-platform "an update is available" affordance (web PWA reload / desktop
+  // update modal). Hidden unless an update is actually ready.
+  const { visible: updateAvailable, activate: activateUpdate } = useUpdateAffordance()
 
   // Local UI state (not shared)
   const [showCreateRoom, setShowCreateRoom] = useState(false)
@@ -278,6 +285,16 @@ export function Sidebar({ onSelectContact, onStartChat, onManageUser, adminCateg
           onNavigate={onViewChange}
         />
         <div className="flex-1" />
+        {/* Update available — user-triggered (web reload / desktop update modal) */}
+        {updateAvailable && (
+          <IconRailButton
+            icon={CircleArrowUp}
+            label={t('sidebar.updateAvailable')}
+            active={false}
+            accent
+            onClick={activateUpdate}
+          />
+        )}
         {/* Admin - only visible for server administrators */}
         {isAdmin && (
           <IconRailNavLink

--- a/apps/fluux/src/components/sidebar-components/IconRailButton.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailButton.tsx
@@ -8,6 +8,12 @@ interface IconRailButtonProps {
   onClick: () => void
   disabled?: boolean
   showBadge?: boolean
+  /**
+   * Calm brand-tinted resting state (brand-colored icon, subtle hover), for a
+   * gentle attention-drawing action like "update available" — distinct from the
+   * loud filled `active` state and without an alarm badge.
+   */
+  accent?: boolean
 }
 
 export function IconRailButton({
@@ -16,7 +22,8 @@ export function IconRailButton({
   active,
   onClick,
   disabled,
-  showBadge
+  showBadge,
+  accent
 }: IconRailButtonProps) {
   return (
     <Tooltip content={label} position="right" delay={500}>
@@ -30,7 +37,9 @@ export function IconRailButton({
             ? 'bg-fluux-brand text-fluux-text-on-accent'
             : disabled
               ? 'text-fluux-muted/50 cursor-not-allowed'
-              : 'text-fluux-muted hover:bg-fluux-hover hover:text-fluux-text'
+              : accent
+                ? 'text-fluux-brand hover:bg-fluux-hover'
+                : 'text-fluux-muted hover:bg-fluux-hover hover:text-fluux-text'
           }`}
       >
         <Icon className="size-5" />

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -60,6 +60,7 @@
         "advancedMode": "الوضع المتقدم"
     },
     "sidebar": {
+        "updateAvailable": "تحديث متوفر",
         "messages": "الرسائل",
         "rooms": "الغرف",
         "connections": "جهات الاتصال",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -60,6 +60,7 @@
         "advancedMode": "Пашыраны рэжым"
     },
     "sidebar": {
+        "updateAvailable": "Даступнае абнаўленне",
         "messages": "Паведамленні",
         "rooms": "Пакоі",
         "connections": "Кантакты",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -60,6 +60,7 @@
         "advancedMode": "Разширен режим"
     },
     "sidebar": {
+        "updateAvailable": "Налична актуализация",
         "messages": "Съобщения",
         "rooms": "Стаи",
         "connections": "Връзки",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -60,6 +60,7 @@
         "advancedMode": "Mode avançat"
     },
     "sidebar": {
+        "updateAvailable": "Actualització disponible",
         "messages": "Missatges",
         "rooms": "Sales",
         "connections": "Connexions",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -60,6 +60,7 @@
         "advancedMode": "Pokročilý režim"
     },
     "sidebar": {
+        "updateAvailable": "Aktualizace k dispozici",
         "messages": "Zprávy",
         "rooms": "Místnosti",
         "connections": "Kontakty",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -60,6 +60,7 @@
         "advancedMode": "Avanceret tilstand"
     },
     "sidebar": {
+        "updateAvailable": "Opdatering tilgængelig",
         "messages": "Beskeder",
         "rooms": "Rum",
         "connections": "Forbindelser",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -60,6 +60,7 @@
         "advancedMode": "Erweiterter Modus"
     },
     "sidebar": {
+        "updateAvailable": "Update verfügbar",
         "messages": "Nachrichten",
         "rooms": "Räume",
         "connections": "Kontakte",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -60,6 +60,7 @@
         "advancedMode": "Σύνθετη λειτουργία"
     },
     "sidebar": {
+        "updateAvailable": "Διαθέσιμη ενημέρωση",
         "messages": "Μηνύματα",
         "rooms": "Δωμάτια",
         "connections": "Επαφές",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -60,6 +60,7 @@
         }
     },
     "sidebar": {
+        "updateAvailable": "Update available",
         "messages": "Messages",
         "rooms": "Rooms",
         "connections": "Connections",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -60,6 +60,7 @@
         "advancedMode": "Modo avanzado"
     },
     "sidebar": {
+        "updateAvailable": "Actualización disponible",
         "messages": "Mensajes",
         "rooms": "Salas",
         "connections": "Conexiones",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -60,6 +60,7 @@
         "advancedMode": "Täpsem režiim"
     },
     "sidebar": {
+        "updateAvailable": "Uuendus saadaval",
         "messages": "Sõnumid",
         "rooms": "Toad",
         "connections": "Ühendused",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -60,6 +60,7 @@
         "advancedMode": "Edistynyt tila"
     },
     "sidebar": {
+        "updateAvailable": "Päivitys saatavilla",
         "messages": "Viestit",
         "rooms": "Huoneet",
         "connections": "Yhteydet",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -60,6 +60,7 @@
         }
     },
     "sidebar": {
+        "updateAvailable": "Mise à jour disponible",
         "messages": "Messages",
         "rooms": "Salons",
         "connections": "Contacts",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -60,6 +60,7 @@
         "advancedMode": "Mód ardleibhéil"
     },
     "sidebar": {
+        "updateAvailable": "Nuashonrú ar fáil",
         "messages": "Teachtaireachtaí",
         "rooms": "Seomraí",
         "connections": "Ceangail",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -60,6 +60,7 @@
         "advancedMode": "מצב מתקדם"
     },
     "sidebar": {
+        "updateAvailable": "עדכון זמין",
         "messages": "הודעות",
         "rooms": "חדרים",
         "connections": "אנשי קשר",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -60,6 +60,7 @@
         "advancedMode": "Napredni način"
     },
     "sidebar": {
+        "updateAvailable": "Ažuriranje dostupno",
         "messages": "Poruke",
         "rooms": "Sobe",
         "connections": "Veze",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -60,6 +60,7 @@
         "advancedMode": "Speciális mód"
     },
     "sidebar": {
+        "updateAvailable": "Frissítés érhető el",
         "messages": "Üzenetek",
         "rooms": "Szobák",
         "connections": "Kapcsolatok",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -60,6 +60,7 @@
         "advancedMode": "Ítarlegur hamur"
     },
     "sidebar": {
+        "updateAvailable": "Uppfærsla í boði",
         "messages": "Skilaboð",
         "rooms": "Herbergi",
         "connections": "Tengingar",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -60,6 +60,7 @@
         "advancedMode": "Modalità avanzata"
     },
     "sidebar": {
+        "updateAvailable": "Aggiornamento disponibile",
         "messages": "Messaggi",
         "rooms": "Stanze",
         "connections": "Contatti",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -60,6 +60,7 @@
         "advancedMode": "Išplėstinis režimas"
     },
     "sidebar": {
+        "updateAvailable": "Yra atnaujinimas",
         "messages": "Žinutės",
         "rooms": "Kambariai",
         "connections": "Ryšiai",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -60,6 +60,7 @@
         "advancedMode": "Papildu režīms"
     },
     "sidebar": {
+        "updateAvailable": "Pieejams atjauninājums",
         "messages": "Ziņojumi",
         "rooms": "Istabas",
         "connections": "Savienojumi",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -60,6 +60,7 @@
         "advancedMode": "Modalità avvanzata"
     },
     "sidebar": {
+        "updateAvailable": "Aġġornament disponibbli",
         "messages": "Messaġġi",
         "rooms": "Kmamar",
         "connections": "Konnessjonijiet",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -60,6 +60,7 @@
         "advancedMode": "Avansert modus"
     },
     "sidebar": {
+        "updateAvailable": "Oppdatering tilgjengelig",
         "messages": "Meldinger",
         "rooms": "Rom",
         "connections": "Tilkoblinger",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -60,6 +60,7 @@
         "advancedMode": "Geavanceerde modus"
     },
     "sidebar": {
+        "updateAvailable": "Update beschikbaar",
         "messages": "Berichten",
         "rooms": "Groepen",
         "connections": "Contacten",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -60,6 +60,7 @@
         "advancedMode": "Tryb zaawansowany"
     },
     "sidebar": {
+        "updateAvailable": "Dostępna aktualizacja",
         "messages": "Wiadomości",
         "rooms": "Pokoje",
         "connections": "Kontakty",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -60,6 +60,7 @@
         "advancedMode": "Modo avançado"
     },
     "sidebar": {
+        "updateAvailable": "Atualização disponível",
         "messages": "Mensagens",
         "rooms": "Salas",
         "connections": "Ligações",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -60,6 +60,7 @@
         "advancedMode": "Mod avansat"
     },
     "sidebar": {
+        "updateAvailable": "Actualizare disponibilă",
         "messages": "Mesaje",
         "rooms": "Camere",
         "connections": "Conexiuni",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -60,6 +60,7 @@
         "advancedMode": "Расширенный режим"
     },
     "sidebar": {
+        "updateAvailable": "Доступно обновление",
         "messages": "Сообщения",
         "rooms": "Конференции",
         "connections": "Контакты",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -60,6 +60,7 @@
         "advancedMode": "Pokročilý režim"
     },
     "sidebar": {
+        "updateAvailable": "Aktualizácia k dispozícii",
         "messages": "Správy",
         "rooms": "Miestnosti",
         "connections": "Pripojenia",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -60,6 +60,7 @@
         "advancedMode": "Napredni način"
     },
     "sidebar": {
+        "updateAvailable": "Posodobitev je na voljo",
         "messages": "Sporočila",
         "rooms": "Sobe",
         "connections": "Povezave",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -60,6 +60,7 @@
         "advancedMode": "Avancerat läge"
     },
     "sidebar": {
+        "updateAvailable": "Uppdatering tillgänglig",
         "messages": "Meddelanden",
         "rooms": "Rum",
         "connections": "Anslutningar",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -60,6 +60,7 @@
         "advancedMode": "Розширений режим"
     },
     "sidebar": {
+        "updateAvailable": "Доступне оновлення",
         "messages": "Повідомлення",
         "rooms": "Кімнати",
         "connections": "Контакти",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -60,6 +60,7 @@
         "advancedMode": "高级模式"
     },
     "sidebar": {
+        "updateAvailable": "有可用更新",
         "messages": "消息",
         "rooms": "房间",
         "connections": "连接",

--- a/apps/fluux/src/stores/appUpdateStore.test.ts
+++ b/apps/fluux/src/stores/appUpdateStore.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useAppUpdateStore, activateUpdate } from './appUpdateStore'
+
+const reset = () =>
+  useAppUpdateStore.setState({
+    webUpdateReady: false,
+    desktopUpdateAvailable: false,
+    applyWebUpdate: null,
+    openDesktopUpdate: null,
+  })
+
+describe('appUpdateStore', () => {
+  beforeEach(reset)
+
+  it('starts with no update available and no actions registered', () => {
+    const s = useAppUpdateStore.getState()
+    expect(s.webUpdateReady).toBe(false)
+    expect(s.desktopUpdateAvailable).toBe(false)
+    expect(s.applyWebUpdate).toBeNull()
+    expect(s.openDesktopUpdate).toBeNull()
+  })
+
+  it('setWebUpdateReady(true, fn) marks web ready and registers the apply action', () => {
+    const apply = vi.fn()
+    useAppUpdateStore.getState().setWebUpdateReady(true, apply)
+    const s = useAppUpdateStore.getState()
+    expect(s.webUpdateReady).toBe(true)
+    expect(s.applyWebUpdate).toBe(apply)
+  })
+
+  it('setWebUpdateReady(false) clears ready and the apply action', () => {
+    useAppUpdateStore.getState().setWebUpdateReady(true, vi.fn())
+    useAppUpdateStore.getState().setWebUpdateReady(false)
+    const s = useAppUpdateStore.getState()
+    expect(s.webUpdateReady).toBe(false)
+    expect(s.applyWebUpdate).toBeNull()
+  })
+
+  it('setDesktopUpdateAvailable(true, fn) marks desktop available and registers the open action', () => {
+    const open = vi.fn()
+    useAppUpdateStore.getState().setDesktopUpdateAvailable(true, open)
+    const s = useAppUpdateStore.getState()
+    expect(s.desktopUpdateAvailable).toBe(true)
+    expect(s.openDesktopUpdate).toBe(open)
+  })
+
+  it('setDesktopUpdateAvailable(false) clears available and the open action', () => {
+    useAppUpdateStore.getState().setDesktopUpdateAvailable(true, vi.fn())
+    useAppUpdateStore.getState().setDesktopUpdateAvailable(false)
+    const s = useAppUpdateStore.getState()
+    expect(s.desktopUpdateAvailable).toBe(false)
+    expect(s.openDesktopUpdate).toBeNull()
+  })
+
+  it('activateUpdate runs the web apply action when a web update is ready', () => {
+    const apply = vi.fn()
+    const open = vi.fn()
+    useAppUpdateStore.getState().setWebUpdateReady(true, apply)
+    activateUpdate(useAppUpdateStore.getState())
+    expect(apply).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('activateUpdate runs the desktop open action when only a desktop update is available', () => {
+    const open = vi.fn()
+    useAppUpdateStore.getState().setDesktopUpdateAvailable(true, open)
+    activateUpdate(useAppUpdateStore.getState())
+    expect(open).toHaveBeenCalledTimes(1)
+  })
+
+  it('activateUpdate prioritizes the web reload when both channels signal', () => {
+    const apply = vi.fn()
+    const open = vi.fn()
+    useAppUpdateStore.getState().setWebUpdateReady(true, apply)
+    useAppUpdateStore.getState().setDesktopUpdateAvailable(true, open)
+    activateUpdate(useAppUpdateStore.getState())
+    expect(apply).toHaveBeenCalledTimes(1)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('activateUpdate is a no-op when nothing is available', () => {
+    expect(() => activateUpdate(useAppUpdateStore.getState())).not.toThrow()
+  })
+})

--- a/apps/fluux/src/stores/appUpdateStore.ts
+++ b/apps/fluux/src/stores/appUpdateStore.ts
@@ -1,0 +1,66 @@
+import { create } from 'zustand'
+import { useCallback } from 'react'
+
+/**
+ * Cross-platform "an update is available" state.
+ *
+ * Two mutually-exclusive channels feed one rail affordance:
+ *  - **web** (`webUpdateReady`): a new PWA service worker is waiting to activate.
+ *    Applying it reloads the page into the new build.
+ *  - **desktop** (`desktopUpdateAvailable`): the Tauri updater found a release.
+ *    Applying it reopens the in-app UpdateModal.
+ *
+ * A build only ever exposes one channel (web registers a service worker but has
+ * no Tauri updater; desktop has the updater but registers no service worker), so
+ * the two booleans are never both true in practice — `activateUpdate` still
+ * prioritizes web defensively.
+ *
+ * The action closures are registered by their platform owners
+ * (`registerServiceWorker` for web, `App` for desktop) rather than living here,
+ * so this store stays free of platform imports.
+ */
+export interface AppUpdateState {
+  webUpdateReady: boolean
+  desktopUpdateAvailable: boolean
+  applyWebUpdate: (() => void) | null
+  openDesktopUpdate: (() => void) | null
+  /** Mark (or clear) a waiting web update, registering the reload action. */
+  setWebUpdateReady: (ready: boolean, apply?: (() => void) | null) => void
+  /** Mark (or clear) an available desktop update, registering the open action. */
+  setDesktopUpdateAvailable: (available: boolean, open?: (() => void) | null) => void
+}
+
+export const useAppUpdateStore = create<AppUpdateState>((set) => ({
+  webUpdateReady: false,
+  desktopUpdateAvailable: false,
+  applyWebUpdate: null,
+  openDesktopUpdate: null,
+  setWebUpdateReady: (ready, apply = null) =>
+    set({ webUpdateReady: ready, applyWebUpdate: ready ? apply : null }),
+  setDesktopUpdateAvailable: (available, open = null) =>
+    set({ desktopUpdateAvailable: available, openDesktopUpdate: available ? open : null }),
+}))
+
+/**
+ * Run the platform-appropriate update action. Web takes priority over desktop
+ * (they are mutually exclusive by build, but web wins if both ever signal).
+ * Pure over the passed state so it is trivially unit-testable.
+ */
+export function activateUpdate(
+  state: Pick<AppUpdateState, 'webUpdateReady' | 'desktopUpdateAvailable' | 'applyWebUpdate' | 'openDesktopUpdate'>,
+): void {
+  if (state.webUpdateReady) state.applyWebUpdate?.()
+  else if (state.desktopUpdateAvailable) state.openDesktopUpdate?.()
+}
+
+/**
+ * The single affordance the rail button consumes: whether to show, and what to
+ * do on click. Subscribes only to the two booleans; the action closures are
+ * read lazily at click time so registering them never re-renders the button.
+ */
+export function useUpdateAffordance(): { visible: boolean; activate: () => void } {
+  const webUpdateReady = useAppUpdateStore((s) => s.webUpdateReady)
+  const desktopUpdateAvailable = useAppUpdateStore((s) => s.desktopUpdateAvailable)
+  const activate = useCallback(() => activateUpdate(useAppUpdateStore.getState()), [])
+  return { visible: webUpdateReady || desktopUpdateAvailable, activate }
+}

--- a/apps/fluux/src/sw.ts
+++ b/apps/fluux/src/sw.ts
@@ -95,12 +95,22 @@ self.addEventListener('notificationclick', (event) => {
 // Lifecycle
 // ============================================================================
 
-// Skip waiting on install for immediate activation
-self.addEventListener('install', (event) => {
-  event.waitUntil(self.skipWaiting())
+// Do NOT skipWaiting on install. A freshly deployed build installs and then
+// parks in the `waiting` state instead of seizing control, so the running page
+// stays on its current (matching) build until the user opts in. The app detects
+// the waiting worker and shows an "update available" button (see
+// serviceWorkerUpdate.ts); clicking it posts SKIP_WAITING below.
+//
+// A first install still activates immediately (there is no active worker to wait
+// behind), so offline precaching works on first visit without any prompt.
+self.addEventListener('message', (event) => {
+  if ((event.data as { type?: string })?.type === 'SKIP_WAITING') {
+    void self.skipWaiting()
+  }
 })
 
-// Claim all clients immediately
+// Claim all clients immediately on activation (first install, and after a
+// user-approved SKIP_WAITING).
 self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim())
 })

--- a/apps/fluux/src/utils/serviceWorkerUpdate.test.ts
+++ b/apps/fluux/src/utils/serviceWorkerUpdate.test.ts
@@ -1,15 +1,51 @@
 import { describe, it, expect, vi } from 'vitest'
-import { installServiceWorkerAutoReload, createFocusUpdateChecker } from './serviceWorkerUpdate'
+import {
+  installUpdateReadyDetection,
+  applyWaitingUpdate,
+  createFocusUpdateChecker,
+} from './serviceWorkerUpdate'
 
 /**
- * Minimal stand-in for the browser's ServiceWorkerContainer: captures the
- * `controllerchange` listener so the test can fire it, and lets us set the
- * initial `controller` to model "fresh install" (null) vs "already controlled".
+ * Minimal stand-in for a ServiceWorker: exposes a mutable `state`, records the
+ * `statechange` listener, and spies `postMessage`.
  */
-function createFakeContainer(initialController: object | null) {
+function createFakeWorker(initialState: string) {
+  let stateChange: (() => void) | null = null
+  return {
+    state: initialState,
+    postMessage: vi.fn(),
+    addEventListener(type: string, cb: () => void) {
+      if (type === 'statechange') stateChange = cb
+    },
+    setState(next: string) {
+      this.state = next
+      stateChange?.()
+    },
+  }
+}
+
+/**
+ * Minimal stand-in for a ServiceWorkerRegistration: `waiting`/`installing`
+ * workers plus a fireable `updatefound` event.
+ */
+function createFakeRegistration() {
+  let updateFound: (() => void) | null = null
+  return {
+    waiting: null as ReturnType<typeof createFakeWorker> | null,
+    installing: null as ReturnType<typeof createFakeWorker> | null,
+    addEventListener(type: string, cb: () => void) {
+      if (type === 'updatefound') updateFound = cb
+    },
+    fireUpdateFound() {
+      updateFound?.()
+    },
+  }
+}
+
+/** Minimal stand-in for ServiceWorkerContainer's controllerchange event. */
+function createFakeContainer() {
   let listener: (() => void) | null = null
   return {
-    controller: initialController,
     addEventListener(type: string, cb: () => void) {
       if (type === 'controllerchange') listener = cb
     },
@@ -19,48 +55,115 @@ function createFakeContainer(initialController: object | null) {
   }
 }
 
-describe('installServiceWorkerAutoReload', () => {
-  it('reloads when an updated worker takes control of an already-controlled page', () => {
-    const reload = vi.fn()
-    const container = createFakeContainer({})
-    installServiceWorkerAutoReload(container as unknown as ServiceWorkerContainer, reload)
+describe('installUpdateReadyDetection', () => {
+  it('reports ready immediately when a worker is already waiting', () => {
+    const onReady = vi.fn()
+    const reg = createFakeRegistration()
+    reg.waiting = createFakeWorker('installed')
 
+    installUpdateReadyDetection(reg as unknown as ServiceWorkerRegistration, () => true, onReady)
+
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports ready when an installing worker finishes while a controller exists (an update)', () => {
+    const onReady = vi.fn()
+    const reg = createFakeRegistration()
+    installUpdateReadyDetection(reg as unknown as ServiceWorkerRegistration, () => true, onReady)
+
+    reg.installing = createFakeWorker('installing')
+    reg.fireUpdateFound()
+    reg.installing.setState('installed')
+
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not report ready on a first install (installed with no controller)', () => {
+    const onReady = vi.fn()
+    const reg = createFakeRegistration()
+    installUpdateReadyDetection(reg as unknown as ServiceWorkerRegistration, () => false, onReady)
+
+    reg.installing = createFakeWorker('installing')
+    reg.fireUpdateFound()
+    reg.installing.setState('installed')
+
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-installed state transitions', () => {
+    const onReady = vi.fn()
+    const reg = createFakeRegistration()
+    installUpdateReadyDetection(reg as unknown as ServiceWorkerRegistration, () => true, onReady)
+
+    reg.installing = createFakeWorker('installing')
+    reg.fireUpdateFound()
+    reg.installing.setState('redundant')
+
+    expect(onReady).not.toHaveBeenCalled()
+  })
+})
+
+describe('applyWaitingUpdate', () => {
+  it('posts SKIP_WAITING to the waiting worker', () => {
+    const reg = createFakeRegistration()
+    reg.waiting = createFakeWorker('installed')
+    const container = createFakeContainer()
+
+    applyWaitingUpdate(
+      reg as unknown as ServiceWorkerRegistration,
+      container as unknown as ServiceWorkerContainer,
+      vi.fn(),
+    )
+
+    expect(reg.waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+  })
+
+  it('reloads once when the new worker takes control', () => {
+    const reload = vi.fn()
+    const reg = createFakeRegistration()
+    reg.waiting = createFakeWorker('installed')
+    const container = createFakeContainer()
+
+    applyWaitingUpdate(
+      reg as unknown as ServiceWorkerRegistration,
+      container as unknown as ServiceWorkerContainer,
+      reload,
+    )
     container.fireControllerChange()
-
-    expect(reload).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not reload on the initial install (first controllerchange with no prior controller)', () => {
-    const reload = vi.fn()
-    const container = createFakeContainer(null)
-    installServiceWorkerAutoReload(container as unknown as ServiceWorkerContainer, reload)
-
-    container.fireControllerChange() // initial clients.claim()
-
-    expect(reload).not.toHaveBeenCalled()
-  })
-
-  it('reloads on an update that follows a fresh install', () => {
-    const reload = vi.fn()
-    const container = createFakeContainer(null)
-    installServiceWorkerAutoReload(container as unknown as ServiceWorkerContainer, reload)
-
-    container.fireControllerChange() // initial install — adopt the controller, no reload
-    container.fireControllerChange() // later update — reload
 
     expect(reload).toHaveBeenCalledTimes(1)
   })
 
   it('reloads at most once across repeated controllerchange events', () => {
     const reload = vi.fn()
-    const container = createFakeContainer({})
-    installServiceWorkerAutoReload(container as unknown as ServiceWorkerContainer, reload)
+    const reg = createFakeRegistration()
+    reg.waiting = createFakeWorker('installed')
+    const container = createFakeContainer()
 
-    container.fireControllerChange()
+    applyWaitingUpdate(
+      reg as unknown as ServiceWorkerRegistration,
+      container as unknown as ServiceWorkerContainer,
+      reload,
+    )
     container.fireControllerChange()
     container.fireControllerChange()
 
     expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when there is no waiting worker (no reload on unrelated controllerchange)', () => {
+    const reload = vi.fn()
+    const reg = createFakeRegistration()
+    const container = createFakeContainer()
+
+    applyWaitingUpdate(
+      reg as unknown as ServiceWorkerRegistration,
+      container as unknown as ServiceWorkerContainer,
+      reload,
+    )
+    container.fireControllerChange()
+
+    expect(reload).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/fluux/src/utils/serviceWorkerUpdate.ts
+++ b/apps/fluux/src/utils/serviceWorkerUpdate.ts
@@ -1,68 +1,84 @@
 /**
- * Service worker registration + auto-reload-on-update (browser/PWA only).
+ * Service worker registration + user-triggered update (browser/PWA only).
  *
- * The custom service worker (`sw.ts`) calls `skipWaiting()` on install and
- * `clients.claim()` on activate, so a freshly deployed build activates and
- * caches its assets immediately. But activating a new SW does NOT reload the
- * page that is already running — it only changes what future fetches return.
- * On a desktop tab you eventually get a fresh navigation (close/reopen), so the
- * gap is invisible; on an installed Android PWA the activity persists and even
- * a cold tap is served the old precached `index.html` by the still-current SW,
- * so the app stays pinned to a stale version until the user uninstalls and
- * reinstalls it.
+ * The custom service worker (`sw.ts`) no longer calls `skipWaiting()` on install:
+ * a freshly deployed build installs and then PARKS in the `waiting` state instead
+ * of seizing control. That keeps the running page on its current (matching) build
+ * — no mixed old/new assets, no surprise reload — until the user opts in.
  *
- * vite-plugin-pwa's `autoUpdate` registration normally closes this gap by
- * reloading the page once the new SW takes control. We register manually
- * (`injectRegister: false`) so we can skip the SW entirely under Tauri, which
- * means we also have to wire that reload ourselves — that is what
- * `installServiceWorkerAutoReload` does.
+ * Previously we reloaded the page automatically as soon as the new worker took
+ * control. On an installed PWA that fires on nearly every foreground-after-deploy
+ * (see the focus update check below), so the app reloaded out from under the user
+ * mid-session. Now, when a waiting worker is detected we flag
+ * `appUpdateStore.webUpdateReady` so the sidebar surfaces an "update available"
+ * button; clicking it runs `applyWaitingUpdate`, which tells the waiting worker to
+ * `skipWaiting()` and reloads once it takes control.
  *
- * Reloading on activation only helps once a new SW is *detected*, though. The
- * browser only checks for an updated `sw.js` on the initial `register()` call,
- * on navigations within scope, and on its own ~24h timer — none of which fire
- * for a backgrounded, installed PWA that is merely brought back to the
- * foreground. So we also force an update check (`registration.update()`) when
- * the document becomes visible again, throttled by `createFocusUpdateChecker`.
- * A check that finds a new build flows straight into the activation reload
- * above, so the app refreshes to the latest version shortly after refocus.
+ * The browser only checks for an updated `sw.js` on `register()`, on navigations
+ * within scope, and on its own ~24h timer — none of which fire for a backgrounded,
+ * installed PWA merely brought back to the foreground. So we also force an update
+ * check (`registration.update()`) when the document becomes visible again,
+ * throttled by `createFocusUpdateChecker`. A found update now flows into the
+ * button, not a reload.
  */
+
+import { useAppUpdateStore } from '@/stores/appUpdateStore'
 
 /** Minimum gap between focus-triggered update checks (one short network probe). */
 export const FOCUS_UPDATE_MIN_INTERVAL_MS = 60_000
 
 /**
- * Reload the page once an updated service worker takes control.
+ * Watch a registration for an update that is ready to activate, and invoke
+ * `onReady` when one is.
  *
- * `controllerchange` fires whenever the active SW changes. There are two
- * cases we must distinguish:
- *
- *  - **Fresh install** (no prior controller): the very first `controllerchange`
- *    is just the new SW's initial `clients.claim()`. The page was already
- *    loaded from the network, so reloading here would be a pointless refresh on
- *    first visit. We adopt the controller silently and arm for later updates.
- *  - **Update** (page was already controlled, or a second change after install):
- *    a new build has taken over — reload so the running page picks it up.
- *
- * Reload is guarded so repeated `controllerchange` events can only ever trigger
- * a single reload.
+ * "Ready" means a worker is `waiting` — either already (from a check on a prior
+ * page load) or after a fresh `updatefound` reaches the `installed` state while a
+ * controller exists. The controller check is what distinguishes a genuine update
+ * from the very first install (which has no prior controller and must not prompt).
  */
-export function installServiceWorkerAutoReload(
-  container: ServiceWorkerContainer,
-  reload: () => void
+export function installUpdateReadyDetection(
+  registration: ServiceWorkerRegistration,
+  hasController: () => boolean,
+  onReady: () => void,
 ): void {
-  let hasController = container.controller !== null
-  let reloading = false
+  if (registration.waiting) {
+    onReady()
+    return
+  }
+  registration.addEventListener('updatefound', () => {
+    const installing = registration.installing
+    if (!installing) return
+    installing.addEventListener('statechange', () => {
+      if (installing.state === 'installed' && hasController()) {
+        onReady()
+      }
+    })
+  })
+}
 
+/**
+ * Activate a waiting service worker and reload once it takes control.
+ *
+ * Posts `SKIP_WAITING` to the waiting worker (which triggers `self.skipWaiting()`
+ * in `sw.ts`); the resulting `controllerchange` reloads the page into the new
+ * build. The reload listener is attached only here (never at registration), so a
+ * first-install `clients.claim()` can never trigger a reload, and it fires at
+ * most once. No-op when nothing is waiting.
+ */
+export function applyWaitingUpdate(
+  registration: ServiceWorkerRegistration,
+  container: ServiceWorkerContainer,
+  reload: () => void,
+): void {
+  const waiting = registration.waiting
+  if (!waiting) return
+  let reloaded = false
   container.addEventListener('controllerchange', () => {
-    if (!hasController) {
-      // Initial install's clients.claim() — adopt the controller, don't reload.
-      hasController = true
-      return
-    }
-    if (reloading) return
-    reloading = true
+    if (reloaded) return
+    reloaded = true
     reload()
   })
+  waiting.postMessage({ type: 'SKIP_WAITING' })
 }
 
 /** Decides whether a focus-triggered update check should run right now. */
@@ -93,24 +109,34 @@ export function createFocusUpdateChecker(options: { minIntervalMs: number }): Fo
 }
 
 /**
- * Register the service worker and wire auto-reload-on-update plus a
+ * Register the service worker and wire user-triggered update detection plus a
  * focus-triggered update check. No-op when the runtime has no service worker
  * support (e.g. the Tauri webview, which serves the app over a custom protocol
- * that doesn't support service workers).
+ * that doesn't support service workers) — so `webUpdateReady` stays false there.
  */
 export function registerServiceWorker(): void {
   if (!('serviceWorker' in navigator)) return
-
-  installServiceWorkerAutoReload(navigator.serviceWorker, () => window.location.reload())
 
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('./sw.js')
       .then((registration) => {
+        // A waiting worker means a new build is ready. Surface the button and
+        // register the apply action (skipWaiting + one reload) for it.
+        installUpdateReadyDetection(
+          registration,
+          () => navigator.serviceWorker.controller !== null,
+          () => {
+            useAppUpdateStore.getState().setWebUpdateReady(true, () =>
+              applyWaitingUpdate(registration, navigator.serviceWorker, () => window.location.reload()),
+            )
+          },
+        )
+
         const checker = createFocusUpdateChecker({ minIntervalMs: FOCUS_UPDATE_MIN_INTERVAL_MS })
         // Re-check for a new build whenever the app is brought back to the
         // foreground — the only reliable signal for an installed PWA that never
-        // navigates. A found update activates and reloads via the listener above.
+        // navigates. A found update surfaces the button via the detection above.
         document.addEventListener('visibilitychange', () => {
           if (checker.shouldCheck(document.visibilityState, Date.now())) {
             registration.update().catch(() => {

--- a/docs/superpowers/specs/2026-07-01-update-available-rail-button-design.md
+++ b/docs/superpowers/specs/2026-07-01-update-available-rail-button-design.md
@@ -1,0 +1,265 @@
+# Update-available rail button (web PWA + desktop Tauri)
+
+**Date:** 2026-07-01
+**Status:** Approved (design) — pending implementation plan
+
+## Problem
+
+Two symptoms, one root:
+
+1. **Web/PWA auto-reloads on service-worker update.** `serviceWorkerUpdate.ts`
+   wires `window.location.reload()` to fire on `controllerchange` whenever a new
+   build takes control, and forces an update check (`registration.update()`) on
+   every foreground (`visibilitychange`). On mobile, where the app is
+   foregrounded constantly and deploys are frequent, this produces a
+   "connect then reload" sequence: open app → connect (fresh XMPP session) → a
+   newer build is found → reload → reconnect via **SM resume**.
+
+2. **The reload throws away in-flight work.** A never-opened autojoined MUC
+   room's sidebar preview (`lastMessage`) is seeded *only* by the fresh-session
+   background room catch-up (a 10s-delayed timer in `backgroundSync.ts`). The
+   surprise reload discards that timer/queries mid-flight, and the post-reload
+   **SM resume skips the background catch-up entirely** — so joined rooms show
+   no preview and stale ordering. This is the reported bug's mobile trigger.
+
+3. **Desktop has no persistent "update available" affordance.** The Tauri
+   updater (`useAutoUpdate`) auto-shows `UpdateModal` once per launch; after the
+   user dismisses it, `updateDismissed` blocks re-show and the only remaining
+   path is the manual Settings ▸ Updates screen. There is no badge or indicator
+   today (verified).
+
+## Goal
+
+- Replace the disruptive web auto-reload with a **user-triggered** update.
+- Give **one consistent rail affordance** on both platforms that appears when an
+  update is available and lets the user apply it deliberately.
+
+## Non-goals (explicitly deferred)
+
+- **Room preview catch-up resilience on SM resume.** Removing the surprise
+  reload removes the *primary* mobile trigger, but SM resume also happens for
+  ordinary reasons (network change, backgrounding), and the room catch-up is
+  skipped on all SM resumes. Making previews seed on SM resume is tracked as a
+  separate follow-up. This spec does not address it.
+
+## Decisions (resolved during brainstorming)
+
+| Question | Decision |
+| --- | --- |
+| Scope | Update-button only (no catch-up hardening this round). |
+| Button placement | Bottom of the icon rail, with Admin/Settings. |
+| Web SW mechanism | Canonical "waiting" prompt: do not auto-`skipWaiting`; skip on user action. |
+| Desktop click action | Reopen the existing `UpdateModal`. |
+
+## Design
+
+### Shared state — `apps/fluux/src/stores/appUpdateStore.ts` (new)
+
+A tiny Zustand store, mirroring the existing `toastStore`/`modalStore` pattern
+(`create<State>((set, get) => …)`; the returned hook also exposes
+`.getState()`/`.setState()` for non-React callers like `registerServiceWorker`).
+
+```ts
+interface AppUpdateState {
+  // Web PWA: a new service worker is waiting to activate.
+  webUpdateReady: boolean
+  // Desktop Tauri: the updater found an available update.
+  desktopUpdateAvailable: boolean
+  // Platform-specific action registrations (null until wired).
+  applyWebUpdate: (() => void) | null      // post SKIP_WAITING + reload once
+  openDesktopUpdate: (() => void) | null    // reopen UpdateModal
+  setWebUpdateReady: (ready: boolean) => void
+  setDesktopUpdateAvailable: (available: boolean) => void
+  setApplyWebUpdate: (fn: (() => void) | null) => void
+  setOpenDesktopUpdate: (fn: (() => void) | null) => void
+}
+```
+
+A small selector hook keeps the consuming component dumb:
+
+```ts
+// Returns the single affordance the rail button needs.
+export function useUpdateAffordance(): { visible: boolean; activate: () => void }
+// visible  = webUpdateReady || desktopUpdateAvailable
+// activate = webUpdateReady ? applyWebUpdate?.() : openDesktopUpdate?.()
+//            (web prioritized defensively; the two are mutually exclusive by build)
+```
+
+Rationale for a store over context: three unrelated owners must touch this
+state — `registerServiceWorker()` (module scope, non-React, web), `App.tsx`
+(desktop owner of `useAutoUpdate`), and `Sidebar.tsx` (the button). A store
+avoids prop-drilling and matches existing app conventions.
+
+### Web: service worker — `apps/fluux/src/sw.ts`
+
+- **`install`:** remove `event.waitUntil(self.skipWaiting())`. A first install
+  still activates immediately (nothing to wait behind); an *update* now parks in
+  `waiting` instead of seizing control.
+- **`activate`:** keep `event.waitUntil(self.clients.claim())` (first-install
+  control, and control after a user-approved `skipWaiting`).
+- **Add a message handler:**
+  ```ts
+  self.addEventListener('message', (event) => {
+    if ((event.data as { type?: string })?.type === 'SKIP_WAITING') {
+      void self.skipWaiting()
+    }
+  })
+  ```
+- Push, `notificationclick`, and `precacheAndRoute` are unchanged.
+
+### Web: registration — `apps/fluux/src/utils/serviceWorkerUpdate.ts`
+
+Replace `installServiceWorkerAutoReload` (which reloads) with update **detection**
+plus an **apply** action. Keep the existing testable-factory style (inject
+`reload` and the "update ready" callback so `serviceWorkerUpdate.test.ts` can
+drive it without a real `ServiceWorkerContainer`).
+
+- **Detect "update ready":**
+  - After `register()`, if `registration.waiting` exists → ready.
+  - On `registration` `updatefound` → track `registration.installing`; when its
+    `state` becomes `installed` **and** `navigator.serviceWorker.controller`
+    exists → ready. (Controller-exists is what distinguishes an update from a
+    first install, replacing the old `hasController` guard.)
+  - "Ready" invokes a callback that sets `webUpdateReady=true` and registers
+    `applyWebUpdate`.
+- **`applyWebUpdate()`:** `registration.waiting?.postMessage({ type: 'SKIP_WAITING' })`,
+  then attach a **one-shot, guarded** `controllerchange` listener that calls
+  `window.location.reload()`. The listener is attached only inside
+  `applyWebUpdate`, so a fresh-install `clients.claim()` can never trigger a
+  reload.
+- **Keep** `createFocusUpdateChecker` + the `visibilitychange` →
+  `registration.update()` probe. It still discovers new builds for an installed
+  PWA; it now feeds the button instead of reloading.
+- `registerServiceWorker()` wires detection → `appUpdateStore`. It remains a
+  no-op when `serviceWorker` is unsupported (the Tauri webview), so
+  `webUpdateReady` stays `false` on desktop.
+
+This removes the only SW-driven auto-reload. The `vite:preloadError` reload in
+`main.tsx` stays — it is a separate recovery path for a genuinely missing
+dynamic-import chunk (404). With the waiting pattern the running page keeps being
+served by its own (old) service worker, so its content-hashed chunks remain
+available and it should not hit `preloadError` from an update mid-session.
+
+### Desktop: wiring — `apps/fluux/src/App.tsx`
+
+`App` already owns `const update = useAutoUpdate({ autoCheck: true })`, the
+`showUpdateModal` / `updateDismissed` state, and the `UpdateModal` render. All of
+that stays. Add two effects to mirror into the store:
+
+- `setDesktopUpdateAvailable(update.available && update.updaterEnabled)`.
+- `setOpenDesktopUpdate(() => setShowUpdateModal(true))` — the rail button can
+  reopen the modal even after it was dismissed (user-initiated, so the
+  auto-show-once launch guard does not apply).
+
+The existing "auto-show once on first detection" effect is untouched, so launch
+behavior does not regress.
+
+### UI: rail button — `apps/fluux/src/components/Sidebar.tsx`
+
+- Read `const { visible: updateVisible, activate } = useUpdateAffordance()`.
+- Render in the bottom rail cluster (after the `flex-1` spacer at
+  `Sidebar.tsx:280`, adjacent to Admin/Settings — placed just above Settings),
+  only when `updateVisible`:
+  ```tsx
+  {updateVisible && (
+    <IconRailButton
+      icon={CircleArrowUp}
+      label={t('sidebar.updateAvailable')}
+      active={false}
+      accent            // calm brand tint (see note)
+      onClick={activate}
+    />
+  )}
+  ```
+- Icon: `CircleArrowUp` from `lucide-react` (confirmed exported in 1.16.0).
+- **Calm styling:** do not use the loud `active` brand fill and do not use the
+  red `showBadge` dot (reads as an alert). Add a small, optional `accent?: boolean`
+  prop to `IconRailButton` that applies a subtle brand tint to the resting icon.
+  This is a backward-compatible extension; all existing call sites keep their
+  current look. Aligns with the app's calm-by-default iconography ethos.
+- Tooltip + `aria-label` come from `label`.
+
+### i18n
+
+Add one key, `sidebar.updateAvailable` = `"Update available"` (no dashes, per the
+no-em-dash rule), with genuine translations in every locale file. `i18n.test.ts`
+enforces presence across all 33 locales. The label is platform-agnostic (it
+announces availability; the action differs by platform).
+
+## Data flow
+
+**Web:**
+```
+new build deployed
+  → focus/nav → registration.update()
+  → new SW installs → parks in `waiting`  (no auto-skipWaiting)
+  → detection callback → appUpdateStore.setWebUpdateReady(true) + setApplyWebUpdate(fn)
+  → rail button appears
+  → user clicks → activate() → applyWebUpdate()
+      → waiting.postMessage(SKIP_WAITING) → SW skipWaiting → controllerchange
+      → (one-shot, guarded) window.location.reload() → new build
+```
+
+**Desktop (Tauri, macOS/Windows):**
+```
+launch → useAutoUpdate autoCheck (2s) → update.available
+  → App effect → appUpdateStore.setDesktopUpdateAvailable(true) + setOpenDesktopUpdate(fn)
+  → (existing) UpdateModal auto-shows once
+  → rail button appears (persists after modal dismiss)
+  → user clicks → activate() → openDesktopUpdate() → setShowUpdateModal(true)
+      → UpdateModal → download → relaunch (existing flow)
+```
+
+## Platform matrix
+
+| Platform | Source of "available" | Button action | Notes |
+| --- | --- | --- | --- |
+| Web / PWA | `webUpdateReady` (SW waiting) | reload into new build | SW registered; Tauri updater absent. |
+| Desktop macOS/Windows | `desktopUpdateAvailable` (Tauri) | reopen `UpdateModal` | `updaterEnabled=true`; SW not registered. |
+| Desktop Linux | — | — | `updaterEnabled=false`; SW not registered → button never shows (distro updates). |
+| Demo mode | — | — | No update source → hidden. |
+
+## Testing
+
+- **`serviceWorkerUpdate.test.ts` (extend):**
+  - `registration.waiting` present at register → "ready" callback fires.
+  - `updatefound` → `installed` **with** controller → ready; **without** controller
+    (first install) → not ready.
+  - `applyWebUpdate()` posts `SKIP_WAITING` to the waiting worker and reloads
+    exactly once on `controllerchange` (injected `reload` spy).
+  - `createFocusUpdateChecker` throttle unchanged.
+- **`appUpdateStore.test.ts` (new):** `useUpdateAffordance` visibility and
+  activate-dispatch (web vs desktop); setters; both-false → hidden.
+- **Sidebar (optional, follow existing patterns):** button renders only when
+  `visible` and calls `activate` on click.
+- Full suite + `typecheck` + lint green before commit (repo policy). SDK
+  untouched, so no `build:sdk` needed for app typecheck here.
+
+## Files touched
+
+- **New:** `apps/fluux/src/stores/appUpdateStore.ts` (+ `appUpdateStore.test.ts`)
+- **Modify:** `apps/fluux/src/sw.ts`
+- **Modify:** `apps/fluux/src/utils/serviceWorkerUpdate.ts` (+ extend test)
+- **Modify:** `apps/fluux/src/App.tsx` (mirror desktop state into store)
+- **Modify:** `apps/fluux/src/components/Sidebar.tsx` (rail button)
+- **Modify:** `apps/fluux/src/components/sidebar-components/IconRailButton.tsx`
+  (optional `accent` prop)
+- **Modify:** i18n locale files (new `sidebar.updateAvailable` key, all locales)
+
+`main.tsx` already calls `registerServiceWorker()`; the store wiring lives inside
+that function, so `main.tsx` itself likely needs no change.
+
+## Risks / edge cases
+
+- **Never auto-reload on first install** — guaranteed by attaching the
+  `controllerchange` → reload listener only inside `applyWebUpdate`, plus the
+  controller-exists check in detection.
+- **Exactly one reload** — the apply listener is guarded against repeat
+  `controllerchange` events.
+- **User ignores the button** — web keeps running the old build until they click
+  or naturally navigate/reload; desktop keeps running until they install.
+  Acceptable and intentional (no forced interruption).
+- **Do not regress the desktop launch modal** — the auto-show-once effect stays;
+  the store only adds a second, user-initiated way to open it.
+- **Deferred**: previews can still be stale after non-reload SM resumes (network
+  change, backgrounding). Out of scope; separate follow-up.


### PR DESCRIPTION
## Summary

Replaces the automatic service-worker reload with a calm, user-triggered "update available" button at the bottom of the icon rail, unified across web and desktop.

- **Web/PWA:** the service worker no longer calls `skipWaiting()` on install. A new build parks in the `waiting` state; the rail button appears and only the user's click triggers `skipWaiting` (via `postMessage`) and a single reload. This removes the automatic reload that fired on nearly every foreground-after-deploy on installed PWAs.
- **Desktop/Tauri:** the same button surfaces the existing Tauri updater state and reopens the `UpdateModal`. Dismissing the launch modal no longer wipes the update, so the button stays reachable.
- Both channels are fronted by a small `appUpdateStore`; they are mutually exclusive by platform.

## Why

On mobile the old flow was: open app, connect (fresh XMPP session), a newer build is found, the page auto-reloads, and the reconnect resumes via stream management. The fresh-session background room catch-up (a 10s delayed pass) is what seeds the sidebar preview for never-opened autojoined rooms, and it is skipped on SM resume, so the reload left joined MUC rooms with no preview and stale ordering. Making the update user-triggered removes that surprise reload.