### PR TITLE
fix(mam): catch up not-caught-up rooms on SM resume

### DIFF
--- a/docs/superpowers/specs/2026-07-01-room-mam-catchup-sm-resume-design.md
+++ b/docs/superpowers/specs/2026-07-01-room-mam-catchup-sm-resume-design.md
@@ -1,0 +1,163 @@
+# Room MAM catch-up on SM resume
+
+**Date:** 2026-07-01
+**Status:** Approved (design) — pending implementation plan
+**Base:** `main` at `6d26e373` (includes #783, the update-available button)
+
+## Problem
+
+The background room catch-up that seeds sidebar previews and fills history gaps
+(`MAM.catchUpAllRooms`, driven from `backgroundSync.ts`) runs **only on a fresh
+`'online'` session**, on a 10s delayed timer. The `'resumed'` (stream-management
+resume) handler does nothing but log.
+
+So on an SM resume, a joined MAM room that was never caught up **this session** —
+an autojoined room the user never opened, or a room whose fresh-session catch-up
+was interrupted — keeps `isCaughtUpToLive: false`, shows no preview, and sorts
+stale. SM replay only redelivers queued undelivered stanzas; it carries no history
+for a room the client never subscribed history for.
+
+This is the deferred follow-up to #783. That PR made page reloads user-triggered
+(removing the most common mobile trigger), but the underlying class remains: any
+SM resume — a mobile network change (wifi/cellular), an app foregrounding, or the
+now-rare user reload — skips the catch-up.
+
+## Existing infrastructure (grounding)
+
+The signal this design needs already exists; no new flag or persistence is
+required.
+
+- **`MAMQueryState.isCaughtUpToLive`** (`packages/fluux-sdk/src/core/types/pagination.ts`):
+  `true` when a forward catch-up completes with no gap, or after an initial
+  `before:''` fetch-latest. This is precisely "successfully updated to live."
+- **`mamQueryStates` is NOT persisted.** `roomStore` uses `subscribeWithSelector`
+  only (no `persist` middleware); `createEmptyRoomState` initializes
+  `mamQueryStates: new Map()` on every load. So `isCaughtUpToLive` is
+  **session-scoped**: `false` on each app start, flipped `true` as each room
+  catches up during the running session. That is the correct semantics for "did
+  we catch this room up this run."
+- **`roomGaps` IS persisted** (`packages/fluux-sdk/src/stores/roomStore.ts`,
+  `serializeGaps`/`deserializeGaps` to localStorage). An unfilled forward gap
+  survives a reload, so `catchUpRoom` forward-fills from the right boundary even
+  after the JS context resets.
+- **`MAM.catchUpRoom(jid, sessionStartTime)`** (`packages/fluux-sdk/src/core/modules/MAM.ts`):
+  cache-aware forward catch-up. `selectCatchUpQuery` returns `{ before: '' }` when
+  there is no cursor, so a never-fetched room gets its latest page (seeds the
+  preview) and a gap room forward-fills.
+- **`MAM.catchUpAllRooms({ concurrency, exclude, sessionStartTime })`**
+  (`MAM.ts:1052`) already filters `r.supportsMAM && !r.isQuickChat && exclude` and
+  fans out through `executeWithConcurrency(..., 2)`.
+- **Vestigial:** `needsCatchUp` / `markAllRoomsNeedsCatchUp` /
+  `clearRoomNeedsCatchUp` are defined and bound in `defaultStoreBindings.ts`, but
+  for rooms they are never called and never consumed. Dead scaffolding; this
+  design ignores it (an optional separate tidy could delete the room bindings).
+
+## Goal / non-goals
+
+**Goal:** on SM resume, seed previews and fill gaps for joined MAM-capable rooms
+that are not caught up to live this session, without re-fetching what SM already
+replays.
+
+**Non-goals:**
+- Unifying the fresh-`'online'` and `'resumed'` paths into a single "ensure caught
+  up" driver. Possible later; out of scope here to keep the change focused and low
+  risk.
+- Removing the vestigial `needsCatchUp` room scaffolding (optional separate tidy).
+
+## Design
+
+### Trigger — `backgroundSync.ts` `'resumed'` handler
+
+The handler (currently `backgroundSync.ts:286`, log-only) gains:
+
+1. Set a resume `sessionStartTime = Date.now()` (mirrors the `'online'` handler)
+   so any forward-from-cursor query is bounded consistently.
+2. Schedule a resume catch-up pass on a short settle delay
+   (`MAM_ROOM_RESUME_CATCHUP_DELAY_MS`, added to `mamCatchUpUtils.ts`, ~3000ms —
+   shorter than the fresh 10s because rooms are already joined from persist/SM, but
+   non-zero so SM's stanza replay lands first and genuinely-caught-up rooms are
+   correctly skipped).
+3. Store the timer in a `resumeCatchUpTimer` and clear it on disconnect — extend
+   the existing connection-status subscription that already clears
+   `roomCatchUpTimer` (`backgroundSync.ts:295`). Also clear on cleanup/unsubscribe.
+4. Guard the pass body with `client.isConnected()`.
+
+### Target selection — extend `catchUpAllRooms`
+
+Add an optional `onlyNotCaughtUp?: boolean` to `catchUpAllRooms`. When set, the
+filter also requires
+`!stores.room.getRoomMAMQueryState(r.jid).isCaughtUpToLive`. This avoids a
+near-duplicate method (per the repo's "avoid duplicate code" guidance). The
+`'resumed'` pass calls:
+
+```
+await client.mam.catchUpAllRooms({
+  concurrency: 2,
+  exclude: activeRoomJid,       // roomSideEffects owns the active room
+  sessionStartTime,             // resume time
+  onlyNotCaughtUp: true,
+})
+```
+
+The fresh `'online'` path is unchanged (no flag → catches up all rooms; on a fresh
+session they all start `isCaughtUpToLive: false` anyway, so the two are
+equivalent there — noted for a future unification).
+
+The resulting target set on resume is exactly:
+- never-fetched rooms (autojoined, never opened) → `{ before: '' }` seeds preview;
+- rooms with an unfilled forward gap → forward-fill from persisted `roomGaps`.
+Rooms already caught up this session are skipped, so the pass does not duplicate
+SM replay or fight stream management.
+
+### Cost
+
+Bounded: `executeWithConcurrency(2)`; a no-gap room's forward query returns
+`complete` immediately (cheap). Worst case is right after a reload, when
+`mamQueryStates` reset makes all rooms `isCaughtUpToLive: false` and the pass
+touches every joined room — but reloads are now user-triggered (post-#783), so
+this is rare; ordinary network-blip resumes touch only the small un-caught-up
+subset.
+
+### Interaction guards
+
+- Active room excluded (the `roomSideEffects` active-room path handles it).
+- `catchUpRoom` merges via `mergeRoomMAMMessages`, which dedups, so any overlap
+  with an on-open fetch is harmless (same as today's fresh-session behavior).
+- No `supportsMAM` late-disco race on resume: rooms rehydrate `supportsMAM: true`
+  from persist and are not re-disco'd, so the fresh-session late-MAM watcher is not
+  needed here.
+
+## Files touched
+
+- `packages/fluux-sdk/src/core/backgroundSync.ts` — implement the `'resumed'`
+  catch-up pass (set resume `sessionStartTime`, schedule + cancel
+  `resumeCatchUpTimer`, connected guard).
+- `packages/fluux-sdk/src/core/modules/MAM.ts` — add `onlyNotCaughtUp?: boolean`
+  to `catchUpAllRooms` (filter on `!isCaughtUpToLive`).
+- `packages/fluux-sdk/src/utils/mamCatchUpUtils.ts` — add
+  `MAM_ROOM_RESUME_CATCHUP_DELAY_MS`.
+- Tests (below).
+
+## Testing
+
+- **`MAM` unit test:** `catchUpAllRooms({ onlyNotCaughtUp: true })` drives
+  `catchUpRoom` only for rooms with `isCaughtUpToLive === false`; caught-up rooms
+  and the excluded active room are skipped; QuickChat/non-MAM rooms excluded.
+- **`backgroundSync` resume test** (reuse `sideEffects.testHelpers.ts`): simulate
+  `'resumed'` → after the delay, `catchUpAllRooms` is called with
+  `onlyNotCaughtUp: true` and `exclude` set to the active room; a disconnect before
+  the delay cancels the pass (no call). The mock client needs `on()` and a way to
+  emit `'resumed'`.
+- Run SDK vitest, then `npm run build:sdk` before app typecheck (SDK type surface
+  unchanged, but the option is new), plus lint. All green, no stderr.
+
+## Risks / edge cases
+
+- **Do not fight SM:** only `!isCaughtUpToLive` rooms are driven, so SM-replayed
+  rooms are never re-fetched.
+- **`sessionStartTime` on resume:** set to resume time; for the target set
+  (`{ before: '' }` or gap forward-fill) it does not affect correctness.
+- **Post-reload cost:** bounded (concurrency 2, cheap no-gap completes, rare
+  reloads). If it ever proves heavy for very large room counts, a follow-up can
+  cap or stagger; log the count so silent truncation never hides.
+- **Active room:** excluded; the on-open path is unaffected.

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -48,7 +48,7 @@ import { connectionStore } from '../stores/connectionStore'
 import { chatStore } from '../stores/chatStore'
 import { roomStore } from '../stores/roomStore'
 import { NS_MAM } from './namespaces'
-import { createMockClient, simulateFreshSession } from './sideEffects.testHelpers'
+import { createMockClient, simulateFreshSession, simulateSmResumption } from './sideEffects.testHelpers'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
 
 describe('setupBackgroundSyncSideEffects', () => {
@@ -401,6 +401,49 @@ describe('setupBackgroundSyncSideEffects', () => {
       expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledWith(
         expect.objectContaining({ concurrency: 2, sessionStartTime: expect.any(Number) })
       )
+    })
+
+    it('catches up not-caught-up rooms after an SM resume', async () => {
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+
+      // Nothing before the settle delay (lets SM replay land first).
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(mockClient.mam.catchUpAllRooms).not.toHaveBeenCalled()
+
+      // Then a pass scoped to rooms not caught up to live this session.
+      await vi.advanceTimersByTimeAsync(3_000)
+      expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(1)
+      expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledWith(
+        expect.objectContaining({ concurrency: 2, onlyNotCaughtUp: true, sessionStartTime: expect.any(Number) })
+      )
+    })
+
+    it('excludes the active room from the SM-resume catch-up', async () => {
+      roomStore.getState().setActiveRoom('room@conference.example.com')
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+      await vi.advanceTimersByTimeAsync(3_000)
+
+      expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledWith(
+        expect.objectContaining({ exclude: 'room@conference.example.com', onlyNotCaughtUp: true })
+      )
+    })
+
+    it('cancels the SM-resume catch-up if the connection drops before the delay', async () => {
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+      // Drop the connection before the settle delay elapses.
+      connectionStore.getState().setStatus('disconnected')
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(mockClient.mam.catchUpAllRooms).not.toHaveBeenCalled()
     })
 
     it('retries pending decrypts after conversation catch-up completes (catch-up-tail race)', async () => {

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -20,7 +20,7 @@ import { connectionStore, chatStore, roomStore } from '../stores'
 import { NS_MAM } from './namespaces'
 import { logInfo } from './logger'
 import { buildScopedStorageKey } from '../utils/storageScope'
-import { MAM_ROOM_CATCHUP_DELAY_MS } from '../utils/mamCatchUpUtils'
+import { MAM_ROOM_CATCHUP_DELAY_MS, MAM_ROOM_RESUME_CATCHUP_DELAY_MS } from '../utils/mamCatchUpUtils'
 
 /**
  * Sets up background sync side effects that run after a fresh session.
@@ -36,8 +36,10 @@ import { MAM_ROOM_CATCHUP_DELAY_MS } from '../utils/mamCatchUpUtils'
  * 4. **Room catch-up** (delayed): After a delay to let rooms finish joining,
  *    populate full message history for all MAM-enabled rooms (concurrency=2).
  *
- * On SM resumption (`'resumed'` event), no MAM queries are needed because the
- * server replays all undelivered stanzas automatically.
+ * On SM resumption (`'resumed'` event), the server replays undelivered stanzas, so
+ * rooms already caught up to live need nothing. A short-delayed pass then catches up
+ * only the joined MAM rooms NOT caught up this session (`onlyNotCaughtUp`) — the ones
+ * SM can't cover, e.g. an autojoined room the user never opened.
  *
  * @param client - The XMPPClient instance
  * @param options - Configuration options
@@ -55,6 +57,8 @@ export function setupBackgroundSyncSideEffects(
   let isFreshSession = false
   // Timer for delayed room catch-up (cleared on cleanup or disconnect)
   let roomCatchUpTimer: ReturnType<typeof setTimeout> | undefined
+  // Timer for the delayed SM-resume room catch-up (cleared on cleanup or disconnect)
+  let resumeCatchUpTimer: ReturnType<typeof setTimeout> | undefined
   // Epoch ms of the current fresh session's connection. Used as the forward
   // catch-up cursor boundary so live messages arriving during the 10s room
   // catch-up window can't poison the cursor and silently skip the offline gap.
@@ -282,10 +286,36 @@ export function setupBackgroundSyncSideEffects(
     // If MAM not yet known, the serverInfo subscription below will catch it
   })
 
-  // SM resumption: no MAM queries needed, just log
+  // SM resumption: the server replays undelivered stanzas, so rooms already caught
+  // up to live this session need nothing. But a room never caught up THIS session —
+  // an autojoined room the user never opened, or an interrupted fresh-session
+  // catch-up — has no preview and nothing in the SM queue (SM carries no history for
+  // a room whose archive we never subscribed to). After a short settle (so replay
+  // lands first and genuinely caught-up rooms are correctly skipped), drive a catch-up
+  // for joined MAM rooms that aren't caught up to live. Session-scoped
+  // `isCaughtUpToLive` is the signal; `catchUpAllRooms({ onlyNotCaughtUp: true })`
+  // filters on it, so this never re-fetches what stream management already replays.
   const unsubscribeResumed = client.on('resumed', () => {
     isFreshSession = false
-    logInfo('Background sync: SM resumption — skipping')
+    sessionStartTime = Date.now()
+    logInfo('Background sync: SM resumption — scheduling catch-up for not-caught-up rooms')
+
+    if (resumeCatchUpTimer) clearTimeout(resumeCatchUpTimer)
+    resumeCatchUpTimer = setTimeout(() => {
+      resumeCatchUpTimer = undefined
+      if (!client.isConnected()) return
+      const activeRoomJid = roomStore.getState().activeRoomJid
+      void (async () => {
+        try {
+          await client.mam.catchUpAllRooms({ concurrency: 2, exclude: activeRoomJid, sessionStartTime, onlyNotCaughtUp: true })
+        } catch {
+          // Silently ignore — best-effort resume catch-up.
+        }
+        // Re-decrypt anything stashed during the pass (parity with the fresh-session
+        // room catch-up); coalesced and a no-op when nothing is pending.
+        void client.retryPendingDecrypts()
+      })()
+    }, MAM_ROOM_RESUME_CATCHUP_DELAY_MS)
   })
 
   // When going offline, cancel any pending room catch-up timer.
@@ -301,6 +331,10 @@ export function setupBackgroundSyncSideEffects(
         if (roomCatchUpTimer) {
           clearTimeout(roomCatchUpTimer)
           roomCatchUpTimer = undefined
+        }
+        if (resumeCatchUpTimer) {
+          clearTimeout(resumeCatchUpTimer)
+          resumeCatchUpTimer = undefined
         }
       }
       previousStatus = status
@@ -385,6 +419,10 @@ export function setupBackgroundSyncSideEffects(
     if (roomCatchUpTimer) {
       clearTimeout(roomCatchUpTimer)
       roomCatchUpTimer = undefined
+    }
+    if (resumeCatchUpTimer) {
+      clearTimeout(resumeCatchUpTimer)
+      resumeCatchUpTimer = undefined
     }
   }
 }

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -35,6 +35,7 @@ import { executeWithConcurrency } from '../../utils/concurrencyUtils'
 import { parseRSMResponse } from '../../utils/rsm'
 import {
   selectCatchUpQuery,
+  selectRoomsToCatchUp,
   isConnectionError,
   MAM_CATCHUP_FORWARD_MAX,
   MAM_CATCHUP_BACKWARD_MAX,
@@ -1048,13 +1049,21 @@ export class MAM extends BaseModule {
    *   provided, the forward cursor is the newest message *before* this time, so a live
    *   message arriving during the catch-up window can't poison the cursor and silently
    *   skip the offline gap. Omit to fall back to the global newest message.
+   * @param options.onlyNotCaughtUp - When true, skip rooms already caught up to live this
+   *   session (`isCaughtUpToLive`). Used by the SM-resume pass so it only re-drives rooms
+   *   the resume didn't cover, and never re-fetches what stream-management already replays.
    */
-  async catchUpAllRooms(options: { concurrency?: number; exclude?: string | null; sessionStartTime?: number } = {}): Promise<void> {
-    const { concurrency = 2, exclude, sessionStartTime } = options
+  async catchUpAllRooms(options: { concurrency?: number; exclude?: string | null; sessionStartTime?: number; onlyNotCaughtUp?: boolean } = {}): Promise<void> {
+    const { concurrency = 2, exclude, sessionStartTime, onlyNotCaughtUp } = options
     const joinedRooms = this.deps.stores?.room.joinedRooms() || []
 
-    // Filter for MAM-enabled, non-Quick Chat rooms (and exclude active room if specified)
-    const mamRooms = joinedRooms.filter((r) => r.supportsMAM && !r.isQuickChat && (!exclude || r.jid !== exclude))
+    // Filter for MAM-enabled, non-Quick Chat rooms (excluding the active room, and — for
+    // the SM-resume pass — rooms already caught up to live this session).
+    const mamRooms = selectRoomsToCatchUp(
+      joinedRooms,
+      { exclude, onlyNotCaughtUp },
+      (jid) => this.deps.stores?.room.getRoomMAMQueryState(jid).isCaughtUpToLive ?? false,
+    )
     if (mamRooms.length === 0) return
 
     logInfo(`Background catch-up for ${mamRooms.length} room(s)`)

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -6,14 +6,66 @@ import {
   selectCatchUpQuery,
   buildCatchUpStartTime,
   isConnectionError,
+  selectRoomsToCatchUp,
   MAM_ROOM_FORWARD_MAX_PAGES_MANUAL,
   MAM_CATCHUP_FORWARD_MAX,
   MAM_CATCHUP_BACKWARD_MAX,
   MAM_BACKGROUND_CONCURRENCY,
   MAM_CACHE_LOAD_LIMIT,
   MAM_ROOM_CATCHUP_DELAY_MS,
+  MAM_ROOM_RESUME_CATCHUP_DELAY_MS,
   MAM_ROOM_FORWARD_MAX_PAGES,
 } from './mamCatchUpUtils'
+
+// ============================================================================
+// selectRoomsToCatchUp
+// ============================================================================
+
+describe('selectRoomsToCatchUp', () => {
+  const rooms = [
+    { jid: 'a@muc', supportsMAM: true, isQuickChat: false },
+    { jid: 'b@muc', supportsMAM: true, isQuickChat: false },
+    { jid: 'nomam@muc', supportsMAM: false, isQuickChat: false },
+    { jid: 'quick@muc', supportsMAM: true, isQuickChat: true },
+  ]
+
+  it('keeps only MAM-capable, non-Quick-Chat rooms', () => {
+    const result = selectRoomsToCatchUp(rooms, {}, () => false)
+    expect(result.map((r) => r.jid)).toEqual(['a@muc', 'b@muc'])
+  })
+
+  it('excludes the given room jid', () => {
+    const result = selectRoomsToCatchUp(rooms, { exclude: 'a@muc' }, () => false)
+    expect(result.map((r) => r.jid)).toEqual(['b@muc'])
+  })
+
+  it('with onlyNotCaughtUp, keeps only rooms that are not caught up to live', () => {
+    const caughtUp = new Set(['a@muc'])
+    const result = selectRoomsToCatchUp(rooms, { onlyNotCaughtUp: true }, (jid) => caughtUp.has(jid))
+    expect(result.map((r) => r.jid)).toEqual(['b@muc'])
+  })
+
+  it('with onlyNotCaughtUp, drops every room already caught up to live', () => {
+    const result = selectRoomsToCatchUp(rooms, { onlyNotCaughtUp: true }, () => true)
+    expect(result).toEqual([])
+  })
+
+  it('without onlyNotCaughtUp, keeps rooms regardless of caught-up state', () => {
+    const result = selectRoomsToCatchUp(rooms, { onlyNotCaughtUp: false }, () => true)
+    expect(result.map((r) => r.jid)).toEqual(['a@muc', 'b@muc'])
+  })
+})
+
+// ============================================================================
+// MAM_ROOM_RESUME_CATCHUP_DELAY_MS
+// ============================================================================
+
+describe('MAM_ROOM_RESUME_CATCHUP_DELAY_MS', () => {
+  it('is a positive settle delay, shorter than the fresh-session room catch-up', () => {
+    expect(MAM_ROOM_RESUME_CATCHUP_DELAY_MS).toBeGreaterThan(0)
+    expect(MAM_ROOM_RESUME_CATCHUP_DELAY_MS).toBeLessThan(MAM_ROOM_CATCHUP_DELAY_MS)
+  })
+})
 
 // ============================================================================
 // findNewestMessage

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -27,6 +27,12 @@ export const MAM_CACHE_LOAD_LIMIT = 100
 /** Delay (ms) before room catch-up starts, to let rooms finish joining. */
 export const MAM_ROOM_CATCHUP_DELAY_MS = 10_000
 
+/** Delay (ms) before the SM-resume room catch-up runs. Lets stream-management
+ *  replay land first so genuinely caught-up rooms are skipped. Shorter than the
+ *  fresh-session delay because rooms are already joined (from persist/SM) on
+ *  resume — there is nothing to wait for them to join. */
+export const MAM_ROOM_RESUME_CATCHUP_DELAY_MS = 3_000
+
 /** Max auto-pagination pages for forward room MAM catch-up.
  *  Room traffic is typically higher than 1:1, so we allow many more pages
  *  (50 × 100 = 5 000 stanzas) to close the gap after long offline periods.
@@ -187,6 +193,33 @@ export function findContinueCatchUpCursor(
 ): { timestamp: Date } | undefined {
   if (forwardGapTimestamp !== undefined) return { timestamp: new Date(forwardGapTimestamp) }
   return findNewestMessage(messages)
+}
+
+/**
+ * Select the joined rooms a background catch-up pass should process.
+ *
+ * Keeps MAM-capable, non-Quick-Chat rooms; drops the excluded room (the active
+ * room is handled by roomSideEffects); and — when `onlyNotCaughtUp` is set (the
+ * SM-resume pass) — drops rooms already caught up to live this session, so the
+ * pass never re-fetches what stream-management already replays.
+ *
+ * Pure over the passed rooms plus an `isCaughtUpToLive` lookup, so it is
+ * trivially unit-testable without instantiating the MAM module. Generic so it
+ * returns the caller's own room type.
+ */
+export function selectRoomsToCatchUp<T extends { jid: string; supportsMAM?: boolean; isQuickChat?: boolean }>(
+  rooms: T[],
+  options: { exclude?: string | null; onlyNotCaughtUp?: boolean },
+  isCaughtUpToLive: (jid: string) => boolean,
+): T[] {
+  const { exclude, onlyNotCaughtUp } = options
+  return rooms.filter(
+    (r) =>
+      r.supportsMAM &&
+      !r.isQuickChat &&
+      (!exclude || r.jid !== exclude) &&
+      (!onlyNotCaughtUp || !isCaughtUpToLive(r.jid)),
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #783. Fixes the underlying class behind "autojoined rooms show no sidebar preview": on an SM resume, rooms never caught up this session stayed preview-less because the background room catch-up ran only on a fresh `'online'` session.

- The `'resumed'` handler (previously log-only) now schedules a short-delayed pass (~3s, cancelled on disconnect) that catches up joined MAM rooms where `isCaughtUpToLive` is `false` (the never-fetched and gap-open ones).
- `catchUpAllRooms` gains an `onlyNotCaughtUp` option so the resume pass skips rooms already caught up to live, and therefore never re-fetches what stream management already replays.
- No new flag or persistence: `isCaughtUpToLive` already exists and is session-scoped (false on each app load, true as each room catches up this session), and `roomGaps` already persists holes across reloads.

## Why

`catchUpAllRooms` (the pass that seeds previews and fills gaps) fired only on fresh `'online'` via the 10s timer; the `'resumed'` handler did nothing. So a joined MAM room never caught up this session, an autojoined room the user never opened or an interrupted fresh-session catch-up, kept `isCaughtUpToLive: false`, showed no preview, and sorted stale. SM replay redelivers queued stanzas but carries no history for a room whose archive was never subscribed.