### PR TITLE
feat(cmdk): prioritize unread in the command palette

### DIFF
--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -14,9 +14,10 @@ const mockConversations: Array<{ id: string; name: string; unreadCount: number; 
   { id: 'bob@example.com', name: 'Bob Jones', unreadCount: 2, type: 'chat', lastMessage: { body: 'The exponential backoff is working now' } },
 ]
 
-const mockRooms: Array<{ jid: string; name: string; joined: boolean; lastMessage?: { body: string } }> = [
-  { jid: 'dev@conference.example.com', name: 'Development', joined: true, lastMessage: { body: 'PR merged successfully' } },
-  { jid: 'general@conference.example.com', name: 'General Chat', joined: true },
+const mockRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; lastMessage?: { body: string } }> = [
+  { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully' } },
+  { jid: 'general@conference.example.com', name: 'General Chat', joined: true, unreadCount: 3, mentionsCount: 0 },
+  { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1 },
 ]
 
 const mockBookmarkedRooms = [
@@ -774,14 +775,14 @@ describe('CommandPalette', () => {
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'ArrowUp' })
 
-      // Third item in the list should be a room (Development)
-      // Order: Bob (Unread), Alice (Messages), Development (Rooms), General Chat...
-      const devRoom = screen.getByText('Development').closest('button')
-      expect(devRoom).toHaveAttribute('data-selected', 'true')
+      // Third item in the list should be a room (Announcements — tier 0, has mention)
+      // Order: Bob (Unread), Alice (Messages), Announcements (Rooms tier 0), General Chat (tier 1), Development (tier 2)...
+      const announceRoom = screen.getByText('Announcements').closest('button')
+      expect(announceRoom).toHaveAttribute('data-selected', 'true')
 
       fireEvent.keyDown(container!, { key: 'Enter' })
 
-      expect(mockSetActiveRoom).toHaveBeenCalledWith('dev@conference.example.com')
+      expect(mockSetActiveRoom).toHaveBeenCalledWith('announce@conference.example.com')
     })
 
     it('should work correctly with rapid consecutive selections', () => {
@@ -1242,6 +1243,21 @@ describe('CommandPalette', () => {
       const bob = screen.getByText('Bob Jones')
       const alice = screen.getByText('Alice Smith')
       expect(bob.compareDocumentPosition(alice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
+  describe('Room ordering', () => {
+    it('orders rooms mentions-first, then unread, then read', () => {
+      render(<CommandPalette {...defaultProps} />)
+
+      const announce = screen.getByText('Announcements') // mention (tier 0)
+      const general = screen.getByText('General Chat')    // unread (tier 1)
+      const dev = screen.getByText('Development')          // read (tier 2)
+
+      // Announcements before General Chat
+      expect(announce.compareDocumentPosition(general) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      // General Chat before Development
+      expect(general.compareDocumentPosition(dev) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     })
   })
 

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -1246,6 +1246,22 @@ describe('CommandPalette', () => {
     })
   })
 
+  describe('Unread badge', () => {
+    it('shows a count badge for unread DMs in the default view', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // Bob Jones has unreadCount 2
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+
+    it('does not show unread badges once the user types a query', () => {
+      render(<CommandPalette {...defaultProps} />)
+      fireEvent.change(screen.getByPlaceholderText('Go to...'), { target: { value: 'Bob' } })
+      // Bob still listed, but no "2" badge in search results
+      expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+      expect(screen.queryByText('2')).not.toBeInTheDocument()
+    })
+  })
+
   describe('Room ordering', () => {
     it('orders rooms mentions-first, then unread, then read', () => {
       render(<CommandPalette {...defaultProps} />)

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -92,6 +92,7 @@ vi.mock('react-i18next', () => ({
         'commandPalette.filteringRooms': 'Filtering rooms...',
         'commandPalette.filteringCommands': 'Filtering commands...',
         'commandPalette.searchMessages': 'Search messages for "{{query}}"',
+        'commandPalette.unread': 'Unread',
         'sidebar.messages': 'Messages',
         'sidebar.rooms': 'Rooms',
         'sidebar.connections': 'Connections',
@@ -375,8 +376,8 @@ describe('CommandPalette', () => {
     it('should select first item by default', () => {
       render(<CommandPalette {...defaultProps} />)
 
-      // First item should have data-selected="true"
-      const firstItem = screen.getByText('Alice Smith').closest('button')
+      // Bob (unreadCount 2) is in the Unread section, which comes first
+      const firstItem = screen.getByText('Bob Jones').closest('button')
       expect(firstItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -386,8 +387,8 @@ describe('CommandPalette', () => {
 
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
 
-      // Second item should now be selected
-      const secondItem = screen.getByText('Bob Jones').closest('button')
+      // Second item is Alice (in the Messages section, after the Unread section)
+      const secondItem = screen.getByText('Alice Smith').closest('button')
       expect(secondItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -402,7 +403,8 @@ describe('CommandPalette', () => {
       // Then move up
       fireEvent.keyDown(container!, { key: 'ArrowUp' })
 
-      const secondItem = screen.getByText('Bob Jones').closest('button')
+      // Back to index 1 = Alice (Messages section)
+      const secondItem = screen.getByText('Alice Smith').closest('button')
       expect(secondItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -429,8 +431,8 @@ describe('CommandPalette', () => {
         fireEvent.keyDown(container!, { key: 'ArrowUp' })
       }
 
-      // First item should still be selected
-      const firstItem = screen.getByText('Alice Smith').closest('button')
+      // First item should still be selected (Bob, in the Unread section)
+      const firstItem = screen.getByText('Bob Jones').closest('button')
       expect(firstItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -469,8 +471,8 @@ describe('CommandPalette', () => {
 
       fireEvent.keyDown(container!, { key: 'Enter' })
 
-      // First item is a conversation, should set active conversation
-      expect(mockSetActiveConversation).toHaveBeenCalledWith('alice@example.com')
+      // First item is Bob (unread, in the Unread section), should set active conversation
+      expect(mockSetActiveConversation).toHaveBeenCalledWith('bob@example.com')
       expect(defaultProps.onClose).toHaveBeenCalled()
     })
 
@@ -653,8 +655,8 @@ describe('CommandPalette', () => {
       rerender(<CommandPalette {...defaultProps} isOpen={false} />)
       rerender(<CommandPalette {...defaultProps} isOpen={true} />)
 
-      // First item should be selected again
-      const firstItem = screen.getByText('Alice Smith').closest('button')
+      // First item should be selected again (Bob, in the Unread section)
+      const firstItem = screen.getByText('Bob Jones').closest('button')
       expect(firstItem).toHaveAttribute('data-selected', 'true')
     })
   })
@@ -684,27 +686,27 @@ describe('CommandPalette', () => {
       render(<CommandPalette {...defaultProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Navigate to Bob Jones (second item)
+      // Navigate to Alice Smith (second item — Bob is first in Unread section)
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
 
-      // Verify Bob is selected
-      const bobItem = screen.getByText('Bob Jones').closest('button')
-      expect(bobItem).toHaveAttribute('data-selected', 'true')
+      // Verify Alice is selected
+      const aliceItem = screen.getByText('Alice Smith').closest('button')
+      expect(aliceItem).toHaveAttribute('data-selected', 'true')
 
-      // Press Enter - should select Bob, not Alice
+      // Press Enter - should select Alice, not Bob
       fireEvent.keyDown(container!, { key: 'Enter' })
 
-      expect(mockSetActiveConversation).toHaveBeenCalledWith('bob@example.com')
-      expect(mockSetActiveConversation).not.toHaveBeenCalledWith('alice@example.com')
+      expect(mockSetActiveConversation).toHaveBeenCalledWith('alice@example.com')
+      expect(mockSetActiveConversation).not.toHaveBeenCalledWith('bob@example.com')
     })
 
     it('should work correctly on consecutive selections after reopening', () => {
       const { rerender } = render(<CommandPalette {...defaultProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // First selection: Alice (first item)
+      // First selection: Bob (first item, in Unread section)
       fireEvent.keyDown(container!, { key: 'Enter' })
-      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('alice@example.com')
+      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('bob@example.com')
 
       vi.clearAllMocks()
 
@@ -714,11 +716,11 @@ describe('CommandPalette', () => {
 
       const container2 = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Navigate to Bob and select
+      // Navigate to Alice (index 1) and select
       fireEvent.keyDown(container2!, { key: 'ArrowDown' })
       fireEvent.keyDown(container2!, { key: 'Enter' })
 
-      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('bob@example.com')
+      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('alice@example.com')
     })
 
     it('should select correct item after filtering and navigating', () => {
@@ -773,7 +775,7 @@ describe('CommandPalette', () => {
       fireEvent.keyDown(container!, { key: 'ArrowUp' })
 
       // Third item in the list should be a room (Development)
-      // Order: Alice, Bob, Development, General Chat...
+      // Order: Bob (Unread), Alice (Messages), Development (Rooms), General Chat...
       const devRoom = screen.getByText('Development').closest('button')
       expect(devRoom).toHaveAttribute('data-selected', 'true')
 
@@ -791,8 +793,7 @@ describe('CommandPalette', () => {
 
         const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-        // Navigate to second item and select
-        fireEvent.keyDown(container!, { key: 'ArrowDown' })
+        // Select first item (Bob, in the Unread section) without navigating
         fireEvent.keyDown(container!, { key: 'Enter' })
 
         expect(mockSetActiveConversation).toHaveBeenCalledWith('bob@example.com')
@@ -1226,6 +1227,24 @@ describe('CommandPalette', () => {
     })
   })
 
+  describe('Unread section', () => {
+    it('shows unread DMs under an Unread header, read DMs under Messages, no duplication', () => {
+      render(<CommandPalette {...defaultProps} />)
+
+      // The Unread section header is present
+      expect(screen.getByText('Unread')).toBeInTheDocument()
+
+      // Bob (unreadCount 2) appears exactly once, Alice (unreadCount 0) appears exactly once
+      expect(screen.getAllByText('Bob Jones')).toHaveLength(1)
+      expect(screen.getAllByText('Alice Smith')).toHaveLength(1)
+
+      // Bob's row is above Alice's row (Unread section precedes Messages section)
+      const bob = screen.getByText('Bob Jones')
+      const alice = screen.getByText('Alice Smith')
+      expect(bob.compareDocumentPosition(alice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
   describe('Archived conversations', () => {
     it('should navigate to archive view when selecting an archived conversation', () => {
       // Make Bob's conversation archived
@@ -1275,7 +1294,8 @@ describe('CommandPalette', () => {
       render(<CommandPalette {...trackingProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Alice is first in the list, press Enter
+      // Bob is first (Unread section), Alice is second (Messages section). Navigate to Alice.
+      fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'Enter' })
 
       expect(trackingProps.onSidebarViewChange).toHaveBeenCalledWith('archive')

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -33,6 +33,8 @@ const mockSetActiveConversation = vi.fn()
 const mockSetActiveRoom = vi.fn()
 const mockIsArchived = vi.fn((_jid: string) => false)
 let mockArchivedConversations: typeof mockConversations = []
+let mockActiveConversationId: string | null = null
+let mockActiveRoomJid: string | null = null
 
 // Mock SDK hooks
 const mockSearchFn = vi.fn()
@@ -66,14 +68,24 @@ vi.mock('@fluux/sdk', () => ({
 }))
 
 // Mock React store hooks (from @fluux/sdk/react)
-vi.mock('@fluux/sdk/react', () => ({
-  useChatStore: () => ({
+vi.mock('@fluux/sdk/react', () => {
+  // Selector-aware: called bare (`useChatStore()`) returns the state object;
+  // called with a selector returns the selected slice.
+  const chatState = () => ({
     setActiveConversation: mockSetActiveConversation,
-  }),
-  useConnectionStore: (selector: (state: { status: string }) => unknown) =>
-    selector({ status: 'online' }),
-  useContactTime: () => null, useLastActivity: vi.fn(),
-}))
+    activeConversationId: mockActiveConversationId,
+  })
+  const roomState = () => ({ activeRoomJid: mockActiveRoomJid })
+  return {
+    useChatStore: (selector?: (s: ReturnType<typeof chatState>) => unknown) =>
+      selector ? selector(chatState()) : chatState(),
+    useRoomStore: (selector?: (s: ReturnType<typeof roomState>) => unknown) =>
+      selector ? selector(roomState()) : roomState(),
+    useConnectionStore: (selector: (state: { status: string }) => unknown) =>
+      selector({ status: 'online' }),
+    useContactTime: () => null, useLastActivity: vi.fn(),
+  }
+})
 
 // Mock i18n
 vi.mock('react-i18next', () => ({
@@ -135,6 +147,8 @@ describe('CommandPalette', () => {
     vi.clearAllMocks()
     mockIsArchived.mockReturnValue(false)
     mockArchivedConversations = []
+    mockActiveConversationId = null
+    mockActiveRoomJid = null
     useAdvancedModeStore.setState({ advancedMode: false })
   })
 
@@ -1274,6 +1288,32 @@ describe('CommandPalette', () => {
       expect(announce.compareDocumentPosition(general) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
       // General Chat before Development
       expect(general.compareDocumentPosition(dev) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
+  describe('Active entity hidden', () => {
+    it('does not propose the currently-open conversation', () => {
+      mockActiveConversationId = 'bob@example.com'
+      render(<CommandPalette {...defaultProps} />)
+      // Bob is the open conversation — hidden everywhere, including the Unread section
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+      // Other conversations still listed
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+
+    it('does not propose the open conversation even when the user searches for it', () => {
+      mockActiveConversationId = 'bob@example.com'
+      render(<CommandPalette {...defaultProps} />)
+      fireEvent.change(screen.getByPlaceholderText('Go to...'), { target: { value: 'Bob' } })
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    })
+
+    it('does not propose the currently-open room', () => {
+      mockActiveRoomJid = 'dev@conference.example.com'
+      render(<CommandPalette {...defaultProps} />)
+      // Development is the open room — hidden; other joined rooms still listed
+      expect(screen.queryByText('Development')).not.toBeInTheDocument()
+      expect(screen.getByText('General Chat')).toBeInTheDocument()
     })
   })
 

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -16,7 +16,7 @@ import {
 import { useChat, useRoom, useRoster, matchNameOrJid, getLocalPart, searchStore } from '@fluux/sdk'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useChatStore, useConnectionStore } from '@fluux/sdk/react'
+import { useChatStore, useConnectionStore, useRoomStore } from '@fluux/sdk/react'
 import type { PresenceStatus } from '@fluux/sdk'
 import type { SidebarView } from './Sidebar'
 import { Avatar } from './Avatar'
@@ -258,6 +258,11 @@ function CommandPaletteContent({
   const connectionStatus = useConnectionStore((s) => s.status)
   const forceOffline = connectionStatus !== 'online'
   const { setActiveConversation } = useChatStore()
+  // The entity currently open in the main pane — never propose "go to where you
+  // already are". Read as narrow selectors (change only on navigation, which
+  // closes the palette anyway).
+  const activeConversationId = useChatStore((s) => s.activeConversationId)
+  const activeRoomJid = useRoomStore((s) => s.activeRoomJid)
   // Narrow read: only re-render on a density change. Drives the entity avatar
   // size and the action/view icon box; row padding + gap come from CSS keyed on
   // `[data-density]` (the `.command-row` class) so a flip needs no row work.
@@ -302,6 +307,7 @@ function CommandPaletteContent({
     // 1. Conversations (contacts with active chats, sorted by recency)
     for (const conv of conversations) {
       if (conv.type !== 'chat') continue
+      if (conv.id === activeConversationId) continue // don't propose the open conversation
       const contact = contacts.find((c) => c.jid === conv.id)
       const preview = conv.lastMessage ? formatLocalizedPreview(conv.lastMessage, t) : undefined
       items.push({
@@ -353,6 +359,7 @@ function CommandPaletteContent({
 
     // 3. Joined rooms
     for (const room of joinedRooms) {
+      if (room.jid === activeRoomJid) continue // don't propose the open room
       const preview = room.lastMessage ? formatLocalizedPreview(room.lastMessage, t) : undefined
       items.push({
         id: `room-${room.jid}`,

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -155,6 +155,13 @@ function groupItemsByType(items: CommandItem[], t: (key: string) => string): Ite
   return groups
 }
 
+// Unread ranking tier for a room row: mentions outrank plain unread, which outrank read.
+function roomTier(item: CommandItem): number {
+  if ((item.mentionsCount ?? 0) > 0) return 0
+  if ((item.unreadCount ?? 0) > 0) return 1
+  return 2
+}
+
 // =============================================================================
 // Helper: Build groups for the empty-query default view (unread-first)
 // =============================================================================
@@ -172,7 +179,10 @@ function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): I
     groups.push({ key: 'conversation', type: 'conversation', label: t('sidebar.messages'), items: readConvs })
   }
 
-  const rooms = items.filter((i) => i.type === 'room').slice(0, 4)
+  const rooms = items
+    .filter((i) => i.type === 'room')
+    .sort((a, b) => roomTier(a) - roomTier(b))
+    .slice(0, 4)
   if (rooms.length > 0) {
     groups.push({ key: 'room', type: 'room', label: t('sidebar.rooms'), items: rooms })
   }

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -44,12 +44,17 @@ interface CommandItem {
   avatarIdentifier?: string
   /** Avatar image URL for an entity row (contact or room avatar), when available. */
   avatarUrl?: string
+  /** Unread message count for conversation/room rows (drives the Unread section + badge). */
+  unreadCount?: number
+  /** Mention count for room rows (ranks a mentioned room above merely-unread ones). */
+  mentionsCount?: number
   action: () => void
   keywords?: string[]
   presence?: PresenceStatus
 }
 
 interface ItemGroup {
+  key: string
   type: ItemType
   label: string
   items: CommandItem[]
@@ -143,8 +148,48 @@ function groupItemsByType(items: CommandItem[], t: (key: string) => string): Ite
   for (const { type, labelKey } of typeOrder) {
     const typeItems = items.filter((i) => i.type === type)
     if (typeItems.length > 0) {
-      groups.push({ type, label: t(labelKey), items: typeItems })
+      groups.push({ key: type, type, label: t(labelKey), items: typeItems })
     }
+  }
+
+  return groups
+}
+
+// =============================================================================
+// Helper: Build groups for the empty-query default view (unread-first)
+// =============================================================================
+
+function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): ItemGroup[] {
+  const groups: ItemGroup[] = []
+
+  const conversations = items.filter((i) => i.type === 'conversation')
+  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0).slice(0, 5)
+  const readConvs = conversations.filter((i) => (i.unreadCount ?? 0) === 0).slice(0, 5)
+  if (unreadConvs.length > 0) {
+    groups.push({ key: 'unread', type: 'conversation', label: t('commandPalette.unread'), items: unreadConvs })
+  }
+  if (readConvs.length > 0) {
+    groups.push({ key: 'conversation', type: 'conversation', label: t('sidebar.messages'), items: readConvs })
+  }
+
+  const rooms = items.filter((i) => i.type === 'room').slice(0, 4)
+  if (rooms.length > 0) {
+    groups.push({ key: 'room', type: 'room', label: t('sidebar.rooms'), items: rooms })
+  }
+
+  const contacts = items.filter((i) => i.type === 'contact').slice(0, 3)
+  if (contacts.length > 0) {
+    groups.push({ key: 'contact', type: 'contact', label: t('sidebar.connections'), items: contacts })
+  }
+
+  const views = items.filter((i) => i.type === 'view').slice(0, 3)
+  if (views.length > 0) {
+    groups.push({ key: 'view', type: 'view', label: t('commandPalette.views'), items: views })
+  }
+
+  const actions = items.filter((i) => i.type === 'action').slice(0, 3)
+  if (actions.length > 0) {
+    groups.push({ key: 'action', type: 'action', label: t('commandPalette.actions'), items: actions })
   }
 
   return groups
@@ -256,6 +301,7 @@ function CommandPaletteContent({
         sublabel: conv.id,
         lastMessagePreview: preview,
         lastMessageBody: conv.lastMessage?.body,
+        unreadCount: conv.unreadCount,
         avatarIdentifier: conv.id,
         avatarUrl: contact?.avatar,
         action: () => selectConversation(conv.id),
@@ -305,6 +351,8 @@ function CommandPaletteContent({
         sublabel: room.jid,
         lastMessagePreview: preview,
         lastMessageBody: room.lastMessage?.body,
+        unreadCount: room.unreadCount,
+        mentionsCount: room.mentionsCount,
         avatarIdentifier: room.jid,
         avatarUrl: room.avatar,
         action: () => selectRoom(room.jid),
@@ -375,31 +423,27 @@ function CommandPaletteContent({
   // Filter and group items (combined into single memo for simplicity)
   // =============================================================================
 
-  const { flatItems, groupedItems, filterMode } = (() => {
+  const { flatItems, groupedItems, filterMode, isDefaultView: _isDefaultView } = (() => {
     const { filterMode, searchQuery } = parseQuery(query)
     const allowedTypes = getTypesForMode(filterMode)
+    const isDefaultView = !searchQuery && filterMode === 'all'
 
-    let filtered: CommandItem[]
-
-    if (!searchQuery && filterMode === 'all') {
-      // Default view: show a balanced mix from each category
-      const convs = allItems.filter((i) => i.type === 'conversation').slice(0, 5)
-      const conts = allItems.filter((i) => i.type === 'contact').slice(0, 3)
-      const rooms = allItems.filter((i) => i.type === 'room').slice(0, 4)
-      const views = allItems.filter((i) => i.type === 'view').slice(0, 3)
-      const actions = allItems.filter((i) => i.type === 'action').slice(0, 3)
-      filtered = [...convs, ...conts, ...rooms, ...views, ...actions]
+    let grouped: ItemGroup[]
+    if (isDefaultView) {
+      // Default view: unread-first grouping (Unread DMs on top, then the rest)
+      grouped = buildDefaultGroups(allItems, t)
     } else if (!searchQuery) {
       // Filter mode without search: show all items of matching types
-      filtered = allItems.filter((i) => allowedTypes.includes(i.type))
+      grouped = groupItemsByType(allItems.filter((i) => allowedTypes.includes(i.type)), t)
     } else {
       // Search mode: filter by type and query
-      filtered = allItems
-        .filter((i) => allowedTypes.includes(i.type))
-        .filter((i) => itemMatchesQuery(i, searchQuery))
+      grouped = groupItemsByType(
+        allItems
+          .filter((i) => allowedTypes.includes(i.type))
+          .filter((i) => itemMatchesQuery(i, searchQuery)),
+        t,
+      )
     }
-
-    const grouped = groupItemsByType(filtered, t)
 
     // Append "Search messages" gateway when user has typed a query
     if (searchQuery && filterMode !== 'commands') {
@@ -419,13 +463,13 @@ function CommandPaletteContent({
       if (actionsGroup) {
         actionsGroup.items.push(gatewayItem)
       } else {
-        grouped.push({ type: 'action', label: t('commandPalette.actions'), items: [gatewayItem] })
+        grouped.push({ key: 'action', type: 'action', label: t('commandPalette.actions'), items: [gatewayItem] })
       }
     }
 
     const flat = grouped.flatMap((g) => g.items)
 
-    return { flatItems: flat, groupedItems: grouped, filterMode }
+    return { flatItems: flat, groupedItems: grouped, filterMode, isDefaultView }
   })()
 
   // Clamp selected index to valid range
@@ -562,7 +606,7 @@ function CommandPaletteContent({
             </div>
           ) : (
             groupedItems.map((group) => (
-              <div key={group.type}>
+              <div key={group.key}>
                 <div className="px-4 command-group-label text-xs font-semibold text-fluux-muted uppercase tracking-wide font-display">
                   {group.label}
                 </div>

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -433,7 +433,7 @@ function CommandPaletteContent({
   // Filter and group items (combined into single memo for simplicity)
   // =============================================================================
 
-  const { flatItems, groupedItems, filterMode, isDefaultView: _isDefaultView } = (() => {
+  const { flatItems, groupedItems, filterMode, isDefaultView } = (() => {
     const { filterMode, searchQuery } = parseQuery(query)
     const allowedTypes = getTypesForMode(filterMode)
     const isDefaultView = !searchQuery && filterMode === 'all'
@@ -673,6 +673,17 @@ function CommandPaletteContent({
                           </div>
                         )}
                       </div>
+                      {isDefaultView && (item.unreadCount ?? 0) > 0 && (
+                        <span
+                          className={`ms-2 flex-shrink-0 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-semibold ${
+                            (item.mentionsCount ?? 0) > 0
+                              ? 'bg-fluux-brand text-white'
+                              : 'bg-fluux-hover text-fluux-text'
+                          }`}
+                        >
+                          {item.unreadCount}
+                        </span>
+                      )}
                       {isSelected && (
                         <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-xs text-fluux-muted bg-fluux-bg rounded border border-fluux-hover">
                           ↵

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "تصفية جهات الاتصال...",
         "filteringRooms": "تصفية الغرف...",
         "filteringCommands": "تصفية الأوامر...",
-        "searchMessages": "البحث في الرسائل عن \"{{query}}\""
+        "searchMessages": "البحث في الرسائل عن \"{{query}}\"",
+        "unread": "غير مقروءة"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "الاسم المعروض في قوائم الغرف والعنوان.",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Фільтрацыя кантактаў...",
         "filteringRooms": "Фільтрацыя пакояў...",
         "filteringCommands": "Фільтрацыя каманд...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Непрачытаныя"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Імя, якое адлюстроўваецца ў спісе пакояў і ў загалоўку.",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Филтриране на контакти...",
         "filteringRooms": "Филтриране на стаи...",
         "filteringCommands": "Филтриране на команди...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Непрочетени"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Показваното име в списъка със стаи и в заглавието.",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Filtrant contactes...",
         "filteringRooms": "Filtrant sales...",
         "filteringCommands": "Filtrant comandes...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "No llegits"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "El nom visible que es mostra a la llista de sales i a la capçalera.",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Filtrování kontaktů...",
         "filteringRooms": "Filtrování místností...",
         "filteringCommands": "Filtrování příkazů...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Nepřečtené"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Zobrazovaný název v seznamu místností a v záhlaví.",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Filtrerer kontakter...",
         "filteringRooms": "Filtrerer rum...",
         "filteringCommands": "Filtrerer kommandoer...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Ulæste"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Det viste navn i rumlister og overskriften.",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Kontakte werden gefiltert...",
         "filteringRooms": "Räume werden gefiltert...",
         "filteringCommands": "Befehle werden gefiltert...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Ungelesen"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Der Anzeigename in der Raumliste und der Kopfzeile.",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -1225,7 +1225,8 @@
         "filteringContacts": "Φιλτράρισμα επαφών...",
         "filteringRooms": "Φιλτράρισμα δωματίων...",
         "filteringCommands": "Φιλτράρισμα εντολών...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Μη αναγνωσμένα"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Το εμφανιζόμενο όνομα στη λίστα δωματίων και στην κεφαλίδα.",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Filtering contacts...",
         "filteringRooms": "Filtering rooms...",
         "filteringCommands": "Filtering commands...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Unread"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "The display name shown in room listings and the header.",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Filtrando contactos...",
         "filteringRooms": "Filtrando salas...",
         "filteringCommands": "Filtrando comandos...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "No leídos"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "El nombre mostrado en la lista de salas y en el encabezado.",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Kontaktide filtreerimine...",
         "filteringRooms": "Tubade filtreerimine...",
         "filteringCommands": "Käskude filtreerimine...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Lugemata"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Kuvatav nimi ruumide loendis ja päises.",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Suodatetaan yhteystietoja...",
         "filteringRooms": "Suodatetaan huoneita...",
         "filteringCommands": "Suodatetaan komentoja...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Lukematta"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Huoneluettelossa ja otsikossa näkyvä nimi.",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -1225,7 +1225,8 @@
         "filteringContacts": "Filtrage des contacts...",
         "filteringRooms": "Filtrage des salons...",
         "filteringCommands": "Filtrage des commandes...",
-        "searchMessages": "Rechercher dans les messages \"{{query}}\""
+        "searchMessages": "Rechercher dans les messages \"{{query}}\"",
+        "unread": "Non lus"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Le nom affiché dans les listes de salons et l'en-tête.",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Ag scagadh teagmhálacha...",
         "filteringRooms": "Ag scagadh seomraí...",
         "filteringCommands": "Ag scagadh orduithe...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Neamhléite"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "An t-ainm taispeána a thaispeántar i liostaí seomraí agus sa cheanntásc.",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "מסנן אנשי קשר...",
         "filteringRooms": "מסנן חדרים...",
         "filteringCommands": "מסנן פקודות...",
-        "searchMessages": "חיפוש הודעות עבור \"{{query}}\""
+        "searchMessages": "חיפוש הודעות עבור \"{{query}}\"",
+        "unread": "לא נקראו"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "שם התצוגה המוצג ברשימות החדרים ובכותרת.",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Filtriranje kontakata...",
         "filteringRooms": "Filtriranje soba...",
         "filteringCommands": "Filtriranje naredbi...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Nepročitano"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Prikazano ime na popisu soba i u zaglavlju.",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Névjegyek szűrése...",
         "filteringRooms": "Szobák szűrése...",
         "filteringCommands": "Parancsok szűrése...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Olvasatlan"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "A szobalistákban és a fejlécben megjelenő megjelenítési név.",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Sía tengiliði...",
         "filteringRooms": "Sía herbergi...",
         "filteringCommands": "Sía skipanir...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Ólesin"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Birtingarnafnið sem birtist í herbergjalista og haus.",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Filtraggio contatti...",
         "filteringRooms": "Filtraggio stanze...",
         "filteringCommands": "Filtraggio comandi...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Non letti"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Il nome visualizzato nell'elenco delle stanze e nell'intestazione.",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Filtruojami kontaktai...",
         "filteringRooms": "Filtruojami kambariai...",
         "filteringCommands": "Filtruojamos komandos...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Neperskaityti"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Rodomas pavadinimas kambarių sąraše ir antraštėje.",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -1225,7 +1225,8 @@
         "filteringContacts": "Filtrē kontaktus...",
         "filteringRooms": "Filtrē istabas...",
         "filteringCommands": "Filtrē komandas...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Nelasīti"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Attēlojamais nosaukums istabu sarakstā un galvenē.",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Qed jiffiltra kuntatti...",
         "filteringRooms": "Qed jiffiltra kmamar...",
         "filteringCommands": "Qed jiffiltra kmandi...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Mhux moqrija"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "L-isem tal-wiri muri fil-lista tal-kmamar u fl-header.",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Filtrerer kontakter...",
         "filteringRooms": "Filtrerer rom...",
         "filteringCommands": "Filtrerer kommandoer...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Uleste"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Visningsnavnet som vises i romlister og overskriften.",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Contacten filteren...",
         "filteringRooms": "Groepen filteren...",
         "filteringCommands": "Commando's filteren...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Ongelezen"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "De weergavenaam in de kamerlijst en de koptekst.",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Filtrowanie kontaktów...",
         "filteringRooms": "Filtrowanie pokoi...",
         "filteringCommands": "Filtrowanie poleceń...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Nieprzeczytane"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Wyświetlana nazwa na liście pokojów i w nagłówku.",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "A filtrar contactos...",
         "filteringRooms": "A filtrar salas...",
         "filteringCommands": "A filtrar comandos...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Não lidas"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "O nome exibido na lista de salas e no cabeçalho.",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Se filtrează contactele...",
         "filteringRooms": "Se filtrează camerele...",
         "filteringCommands": "Se filtrează comenzile...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Necitite"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Numele afișat în lista camerelor și în antet.",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Фильтр контактов...",
         "filteringRooms": "Фильтр конференций...",
         "filteringCommands": "Фильтр команд...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Непрочитанные"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Отображаемое имя в списке комнат и в заголовке.",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -1225,7 +1225,8 @@
         "filteringContacts": "Filtrujú sa kontakty...",
         "filteringRooms": "Filtrujú sa miestnosti...",
         "filteringCommands": "Filtrujú sa príkazy...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Neprečítané"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Zobrazovaný názov v zozname miestností a v hlavičke.",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -1226,7 +1226,8 @@
         "filteringContacts": "Filtriranje stikov...",
         "filteringRooms": "Filtriranje sob...",
         "filteringCommands": "Filtriranje ukazov...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Neprebrano"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Prikazano ime na seznamu sob in v glavi.",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Filtrerar kontakter...",
         "filteringRooms": "Filtrerar rum...",
         "filteringCommands": "Filtrerar kommandon...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Olästa"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Visningsnamnet som visas i rumslistor och rubriken.",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "Фільтрація контактів...",
         "filteringRooms": "Фільтрація кімнат...",
         "filteringCommands": "Фільтрація команд...",
-        "searchMessages": "Search messages for \"{{query}}\""
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Непрочитані"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Ім'я, що відображається у списку кімнат та в заголовку.",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -1224,7 +1224,8 @@
         "filteringContacts": "正在筛选联系人…",
         "filteringRooms": "正在筛选房间…",
         "filteringCommands": "正在筛选命令…",
-        "searchMessages": "搜索包含“{{query}}”的消息"
+        "searchMessages": "搜索包含“{{query}}”的消息",
+        "unread": "未读"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "在房间列表和标题栏中显示的名称。",

--- a/docs/superpowers/plans/2026-07-01-cmdk-prioritize-unread.md
+++ b/docs/superpowers/plans/2026-07-01-cmdk-prioritize-unread.md
@@ -1,0 +1,558 @@
+# Cmd-K Prioritize Unread — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the Cmd-K command palette's empty-query view, surface unread chats first — a top "Unread" section for 1:1 DMs, unread-first ordering for rooms, and count badges.
+
+**Architecture:** All changes live in `apps/fluux/src/components/CommandPalette.tsx`. The empty-query ("default") branch of the filter/group IIFE is redirected to a new `buildDefaultGroups()` helper that partitions conversations into unread/read groups and sorts rooms by an unread tier. Unread counts already exist on the SDK `Conversation` (`unreadCount`) and `Room` (`unreadCount`, `mentionsCount`) objects the palette already consumes — no SDK changes. Badges render only in the default view.
+
+**Tech Stack:** React + TypeScript, Vitest + @testing-library/react (jsdom), react-i18next.
+
+## Global Constraints
+
+- All changes confined to `apps/fluux/src/components/CommandPalette.tsx` and its test file, plus one i18n key across 33 locale files. No SDK changes.
+- Behavior change applies ONLY to the empty-query default view (`!searchQuery && filterMode === 'all'`). Typed-search and prefix-filter (`@`/`#`/`>`) paths must remain byte-for-byte unchanged in output.
+- New i18n key `commandPalette.unread` must be added and translated in ALL 33 locale files under `apps/fluux/src/i18n/locales/` — real translations, no English placeholders, no em-dash/en-dash connectors.
+- Group display order in default view: **Unread, Messages, Rooms, Connections, Views, Actions** (Unread is new-on-top; the rest preserve today's order).
+- Run app tests per-workspace, not from repo root. Verify with `npm run typecheck` before committing.
+
+---
+
+## File Structure
+
+- **Modify:** `apps/fluux/src/components/CommandPalette.tsx`
+  - `CommandItem` interface — add `unreadCount?`, `mentionsCount?`.
+  - `ItemGroup` interface — add `key: string` (unique render key; `type` alone is no longer unique now that two groups can be `conversation`).
+  - `groupItemsByType()` — set `key: type` on emitted groups.
+  - New `roomTier()` helper and new `buildDefaultGroups()` helper.
+  - Filter/group IIFE — route default view through `buildDefaultGroups`, expose `isDefaultView`.
+  - `allItems` builder — populate `unreadCount`/`mentionsCount` on conversation and room items.
+  - Render — key groups by `group.key`; render unread badge gated on `isDefaultView`.
+- **Modify:** `apps/fluux/src/components/CommandPalette.test.tsx` — extend mocks, add `commandPalette.unread` to the i18n mock, add tests.
+- **Modify:** all 33 files in `apps/fluux/src/i18n/locales/*.json` — add `commandPalette.unread`.
+
+---
+
+## Task 1: Unread DM section + dedup from Messages
+
+Introduces the data fields, the `buildDefaultGroups` helper, the group `key`, the i18n key, and routes the default view. Rooms are NOT yet unread-sorted (Task 2) and badges are NOT yet rendered (Task 3).
+
+**Files:**
+- Modify: `apps/fluux/src/components/CommandPalette.tsx`
+- Modify: `apps/fluux/src/components/CommandPalette.test.tsx`
+- Modify: `apps/fluux/src/i18n/locales/*.json` (33 files)
+- Test: `apps/fluux/src/components/CommandPalette.test.tsx`
+
+**Interfaces:**
+- Consumes: SDK `Conversation.unreadCount: number`, `Room.unreadCount: number`, `Room.mentionsCount: number` (already present on objects returned by `useChat()`/`useRoom()`).
+- Produces:
+  - `CommandItem` gains `unreadCount?: number` and `mentionsCount?: number`.
+  - `ItemGroup` gains `key: string`.
+  - `buildDefaultGroups(items: CommandItem[], t: (key: string) => string): ItemGroup[]` — returns groups in order Unread, Messages, Rooms, Connections, Views, Actions, skipping empty groups.
+  - The filter/group IIFE returns an added field `isDefaultView: boolean`.
+
+- [ ] **Step 1: Add the i18n key to the English locale**
+
+In `apps/fluux/src/i18n/locales/en.json`, the `commandPalette` block currently ends:
+
+```json
+        "searchMessages": "Search messages for \"{{query}}\""
+    },
+```
+
+Change it to add the new key (note the added comma):
+
+```json
+        "searchMessages": "Search messages for \"{{query}}\"",
+        "unread": "Unread"
+    },
+```
+
+- [ ] **Step 2: Add the i18n key to the other 32 locales**
+
+In each remaining locale file, add `"unread": "<translation>"` as the last key of the `commandPalette` object (adding a comma after the previous last key, exactly as in Step 1). Use these translations:
+
+| File | Value |
+|------|-------|
+| ar.json | `غير مقروءة` |
+| be.json | `Непрачытаныя` |
+| bg.json | `Непрочетени` |
+| ca.json | `No llegits` |
+| cs.json | `Nepřečtené` |
+| da.json | `Ulæste` |
+| de.json | `Ungelesen` |
+| el.json | `Μη αναγνωσμένα` |
+| es.json | `No leídos` |
+| et.json | `Lugemata` |
+| fi.json | `Lukematta` |
+| fr.json | `Non lus` |
+| ga.json | `Neamhléite` |
+| he.json | `לא נקראו` |
+| hr.json | `Nepročitano` |
+| hu.json | `Olvasatlan` |
+| is.json | `Ólesin` |
+| it.json | `Non letti` |
+| lt.json | `Neperskaityti` |
+| lv.json | `Nelasīti` |
+| mt.json | `Mhux moqrija` |
+| nb.json | `Uleste` |
+| nl.json | `Ongelezen` |
+| pl.json | `Nieprzeczytane` |
+| pt.json | `Não lidas` |
+| ro.json | `Necitite` |
+| ru.json | `Непрочитанные` |
+| sk.json | `Neprečítané` |
+| sl.json | `Neprebrano` |
+| sv.json | `Olästa` |
+| uk.json | `Непрочитані` |
+| zh-CN.json | `未读` |
+
+- [ ] **Step 3: Write the failing test**
+
+In `apps/fluux/src/components/CommandPalette.test.tsx`, first add the new key to the i18n mock's `translations` map (inside the `vi.mock('react-i18next', ...)` block, alongside the other `commandPalette.*` entries):
+
+```ts
+        'commandPalette.unread': 'Unread',
+```
+
+Then add this test inside `describe('CommandPalette', ...)` (the existing mock has `Alice Smith` with `unreadCount: 0` and `Bob Jones` with `unreadCount: 2`):
+
+```ts
+  describe('Unread section', () => {
+    it('shows unread DMs under an Unread header, read DMs under Messages, no duplication', () => {
+      render(<CommandPalette {...defaultProps} />)
+
+      // The Unread section header is present
+      expect(screen.getByText('Unread')).toBeInTheDocument()
+
+      // Bob (unreadCount 2) appears exactly once, Alice (unreadCount 0) appears exactly once
+      expect(screen.getAllByText('Bob Jones')).toHaveLength(1)
+      expect(screen.getAllByText('Alice Smith')).toHaveLength(1)
+
+      // Bob's row is above Alice's row (Unread section precedes Messages section)
+      const bob = screen.getByText('Bob Jones')
+      const alice = screen.getByText('Alice Smith')
+      expect(bob.compareDocumentPosition(alice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Unread section"`
+Expected: FAIL — `Unable to find an element with the text: Unread` (the section does not exist yet).
+
+- [ ] **Step 5: Add the new fields to `CommandItem` and `ItemGroup`**
+
+In `CommandPalette.tsx`, update the `CommandItem` interface — add these two lines before `action: () => void`:
+
+```ts
+  /** Unread message count for conversation/room rows (drives the Unread section + badge). */
+  unreadCount?: number
+  /** Mention count for room rows (ranks a mentioned room above merely-unread ones). */
+  mentionsCount?: number
+```
+
+Update the `ItemGroup` interface to add a unique render key:
+
+```ts
+interface ItemGroup {
+  key: string
+  type: ItemType
+  label: string
+  items: CommandItem[]
+}
+```
+
+- [ ] **Step 6: Set `key` in `groupItemsByType`**
+
+In `groupItemsByType`, change the `groups.push` call to include `key`:
+
+```ts
+    if (typeItems.length > 0) {
+      groups.push({ key: type, type, label: t(labelKey), items: typeItems })
+    }
+```
+
+- [ ] **Step 7: Populate `unreadCount`/`mentionsCount` in the `allItems` builder**
+
+In the conversations loop (`for (const conv of conversations)`), add to the pushed object (e.g. right after `lastMessageBody: conv.lastMessage?.body,`):
+
+```ts
+        unreadCount: conv.unreadCount,
+```
+
+In the joined-rooms loop (`for (const room of joinedRooms)`), add after `lastMessageBody: room.lastMessage?.body,`:
+
+```ts
+        unreadCount: room.unreadCount,
+        mentionsCount: room.mentionsCount,
+```
+
+(Leave the bookmarked-rooms loop and contacts loop unchanged — they have no unread counts.)
+
+- [ ] **Step 8: Add the `buildDefaultGroups` helper**
+
+Add this function immediately after `groupItemsByType` (before the Component section). Rooms are sliced by recency here; Task 2 adds the unread-tier sort.
+
+```ts
+// =============================================================================
+// Helper: Build groups for the empty-query default view (unread-first)
+// =============================================================================
+
+function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): ItemGroup[] {
+  const groups: ItemGroup[] = []
+
+  const conversations = items.filter((i) => i.type === 'conversation')
+  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0).slice(0, 5)
+  const readConvs = conversations.filter((i) => (i.unreadCount ?? 0) === 0).slice(0, 5)
+  if (unreadConvs.length > 0) {
+    groups.push({ key: 'unread', type: 'conversation', label: t('commandPalette.unread'), items: unreadConvs })
+  }
+  if (readConvs.length > 0) {
+    groups.push({ key: 'conversation', type: 'conversation', label: t('sidebar.messages'), items: readConvs })
+  }
+
+  const rooms = items.filter((i) => i.type === 'room').slice(0, 4)
+  if (rooms.length > 0) {
+    groups.push({ key: 'room', type: 'room', label: t('sidebar.rooms'), items: rooms })
+  }
+
+  const contacts = items.filter((i) => i.type === 'contact').slice(0, 3)
+  if (contacts.length > 0) {
+    groups.push({ key: 'contact', type: 'contact', label: t('sidebar.connections'), items: contacts })
+  }
+
+  const views = items.filter((i) => i.type === 'view').slice(0, 3)
+  if (views.length > 0) {
+    groups.push({ key: 'view', type: 'view', label: t('commandPalette.views'), items: views })
+  }
+
+  const actions = items.filter((i) => i.type === 'action').slice(0, 3)
+  if (actions.length > 0) {
+    groups.push({ key: 'action', type: 'action', label: t('commandPalette.actions'), items: actions })
+  }
+
+  return groups
+}
+```
+
+- [ ] **Step 9: Route the default view through `buildDefaultGroups`**
+
+Replace the body of the filter/group IIFE. The current code is:
+
+```ts
+  const { flatItems, groupedItems, filterMode } = (() => {
+    const { filterMode, searchQuery } = parseQuery(query)
+    const allowedTypes = getTypesForMode(filterMode)
+
+    let filtered: CommandItem[]
+
+    if (!searchQuery && filterMode === 'all') {
+      // Default view: show a balanced mix from each category
+      const convs = allItems.filter((i) => i.type === 'conversation').slice(0, 5)
+      const conts = allItems.filter((i) => i.type === 'contact').slice(0, 3)
+      const rooms = allItems.filter((i) => i.type === 'room').slice(0, 4)
+      const views = allItems.filter((i) => i.type === 'view').slice(0, 3)
+      const actions = allItems.filter((i) => i.type === 'action').slice(0, 3)
+      filtered = [...convs, ...conts, ...rooms, ...views, ...actions]
+    } else if (!searchQuery) {
+      // Filter mode without search: show all items of matching types
+      filtered = allItems.filter((i) => allowedTypes.includes(i.type))
+    } else {
+      // Search mode: filter by type and query
+      filtered = allItems
+        .filter((i) => allowedTypes.includes(i.type))
+        .filter((i) => itemMatchesQuery(i, searchQuery))
+    }
+
+    const grouped = groupItemsByType(filtered, t)
+```
+
+Replace everything from `const { flatItems, groupedItems, filterMode } = (() => {` down to `const grouped = groupItemsByType(filtered, t)` (inclusive) with:
+
+```ts
+  const { flatItems, groupedItems, filterMode, isDefaultView } = (() => {
+    const { filterMode, searchQuery } = parseQuery(query)
+    const allowedTypes = getTypesForMode(filterMode)
+    const isDefaultView = !searchQuery && filterMode === 'all'
+
+    let grouped: ItemGroup[]
+    if (isDefaultView) {
+      // Default view: unread-first grouping (Unread DMs on top, then the rest)
+      grouped = buildDefaultGroups(allItems, t)
+    } else if (!searchQuery) {
+      // Filter mode without search: show all items of matching types
+      grouped = groupItemsByType(allItems.filter((i) => allowedTypes.includes(i.type)), t)
+    } else {
+      // Search mode: filter by type and query
+      grouped = groupItemsByType(
+        allItems
+          .filter((i) => allowedTypes.includes(i.type))
+          .filter((i) => itemMatchesQuery(i, searchQuery)),
+        t,
+      )
+    }
+```
+
+Then update the IIFE's return statement (a few lines below, after the gateway-append block) from:
+
+```ts
+    return { flatItems: flat, groupedItems: grouped, filterMode }
+```
+
+to:
+
+```ts
+    return { flatItems: flat, groupedItems: grouped, filterMode, isDefaultView }
+```
+
+- [ ] **Step 10: Add `key` to the search-gateway group literal**
+
+The gateway-append block (a few lines below, runs only for typed search) constructs an `ItemGroup` without a key. Since `ItemGroup` now requires `key`, update that fallback `push`. Change:
+
+```ts
+        grouped.push({ type: 'action', label: t('commandPalette.actions'), items: [gatewayItem] })
+```
+
+to:
+
+```ts
+        grouped.push({ key: 'action', type: 'action', label: t('commandPalette.actions'), items: [gatewayItem] })
+```
+
+- [ ] **Step 11: Key groups by `group.key` in render**
+
+In the render, change the group wrapper key from `group.type` to `group.key`:
+
+```tsx
+            groupedItems.map((group) => (
+              <div key={group.key}>
+```
+
+- [ ] **Step 12: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Unread section"`
+Expected: PASS.
+
+- [ ] **Step 13: Run the full palette test file + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+Expected: PASS, no stderr.
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add apps/fluux/src/components/CommandPalette.tsx apps/fluux/src/components/CommandPalette.test.tsx apps/fluux/src/i18n/locales
+git commit -m "feat(cmdk): add Unread section for DMs in command palette"
+```
+
+---
+
+## Task 2: Rooms unread-first ordering
+
+Sort the Rooms group so mentioned rooms come first, then unread, then read — recency preserved within each tier.
+
+**Files:**
+- Modify: `apps/fluux/src/components/CommandPalette.tsx`
+- Modify: `apps/fluux/src/components/CommandPalette.test.tsx`
+- Test: `apps/fluux/src/components/CommandPalette.test.tsx`
+
+**Interfaces:**
+- Consumes: `CommandItem.unreadCount`, `CommandItem.mentionsCount` (from Task 1).
+- Produces: `roomTier(item: CommandItem): number` — `0` for mentions, `1` for unread, `2` otherwise.
+
+- [ ] **Step 1: Extend the room mocks with unread/mention counts**
+
+In `CommandPalette.test.tsx`, update the `mockRooms` declaration so ordering is testable. Replace:
+
+```ts
+const mockRooms: Array<{ jid: string; name: string; joined: boolean; lastMessage?: { body: string } }> = [
+  { jid: 'dev@conference.example.com', name: 'Development', joined: true, lastMessage: { body: 'PR merged successfully' } },
+  { jid: 'general@conference.example.com', name: 'General Chat', joined: true },
+]
+```
+
+with (note: `Development` is listed first / more-recent but has no unread; `General Chat` has unread; a new `Announcements` room has a mention — so a correct tier sort must reorder them):
+
+```ts
+const mockRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; lastMessage?: { body: string } }> = [
+  { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully' } },
+  { jid: 'general@conference.example.com', name: 'General Chat', joined: true, unreadCount: 3, mentionsCount: 0 },
+  { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1 },
+]
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add inside `describe('CommandPalette', ...)`:
+
+```ts
+  describe('Room ordering', () => {
+    it('orders rooms mentions-first, then unread, then read', () => {
+      render(<CommandPalette {...defaultProps} />)
+
+      const announce = screen.getByText('Announcements') // mention (tier 0)
+      const general = screen.getByText('General Chat')    // unread (tier 1)
+      const dev = screen.getByText('Development')          // read (tier 2)
+
+      // Announcements before General Chat
+      expect(announce.compareDocumentPosition(general) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      // General Chat before Development
+      expect(general.compareDocumentPosition(dev) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Room ordering"`
+Expected: FAIL — rooms are still in mock/recency order (`Development` first), so the position assertions fail.
+
+- [ ] **Step 4: Add the `roomTier` helper**
+
+In `CommandPalette.tsx`, add above `buildDefaultGroups`:
+
+```ts
+// Unread ranking tier for a room row: mentions outrank plain unread, which outrank read.
+function roomTier(item: CommandItem): number {
+  if ((item.mentionsCount ?? 0) > 0) return 0
+  if ((item.unreadCount ?? 0) > 0) return 1
+  return 2
+}
+```
+
+- [ ] **Step 5: Sort rooms by tier in `buildDefaultGroups`**
+
+In `buildDefaultGroups`, replace:
+
+```ts
+  const rooms = items.filter((i) => i.type === 'room').slice(0, 4)
+```
+
+with (`.filter` returns a fresh array, so `.sort` does not mutate `allItems`; `Array.prototype.sort` is stable, preserving recency within a tier):
+
+```ts
+  const rooms = items
+    .filter((i) => i.type === 'room')
+    .sort((a, b) => roomTier(a) - roomTier(b))
+    .slice(0, 4)
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Room ordering"`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full palette test file + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+Expected: PASS, no stderr.
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/fluux/src/components/CommandPalette.tsx apps/fluux/src/components/CommandPalette.test.tsx
+git commit -m "feat(cmdk): order rooms unread-first in command palette default view"
+```
+
+---
+
+## Task 3: Unread count badge
+
+Render a count badge on unread items (default view only). Mentioned rooms get an accent-styled badge.
+
+**Files:**
+- Modify: `apps/fluux/src/components/CommandPalette.tsx`
+- Modify: `apps/fluux/src/components/CommandPalette.test.tsx`
+- Test: `apps/fluux/src/components/CommandPalette.test.tsx`
+
+**Interfaces:**
+- Consumes: `CommandItem.unreadCount`, `CommandItem.mentionsCount`, and the `isDefaultView` flag from the filter/group IIFE (Task 1).
+- Produces: no new exported symbols (render-only change).
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside `describe('CommandPalette', ...)`:
+
+```ts
+  describe('Unread badge', () => {
+    it('shows a count badge for unread DMs in the default view', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // Bob Jones has unreadCount 2
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+
+    it('does not show unread badges once the user types a query', () => {
+      render(<CommandPalette {...defaultProps} />)
+      fireEvent.change(screen.getByPlaceholderText('Go to...'), { target: { value: 'Bob' } })
+      // Bob still listed, but no "2" badge in search results
+      expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+      expect(screen.queryByText('2')).not.toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Unread badge"`
+Expected: FAIL — first test cannot find text `2` (no badge rendered yet).
+
+- [ ] **Step 3: Render the badge**
+
+In `CommandPalette.tsx`, in the row `<button>`, insert the badge just before the existing selected-row `↵` kbd block:
+
+```tsx
+                      {isSelected && (
+                        <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-xs text-fluux-muted bg-fluux-bg rounded border border-fluux-hover">
+                          ↵
+                        </kbd>
+                      )}
+```
+
+Add, immediately BEFORE that block:
+
+```tsx
+                      {isDefaultView && (item.unreadCount ?? 0) > 0 && (
+                        <span
+                          className={`ms-2 flex-shrink-0 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-semibold ${
+                            (item.mentionsCount ?? 0) > 0
+                              ? 'bg-fluux-brand text-white'
+                              : 'bg-fluux-hover text-fluux-text'
+                          }`}
+                        >
+                          {item.unreadCount}
+                        </span>
+                      )}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Unread badge"`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the full palette test file + typecheck**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+Expected: PASS, no stderr.
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/components/CommandPalette.tsx apps/fluux/src/components/CommandPalette.test.tsx
+git commit -m "feat(cmdk): show unread count badges in command palette default view"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the full app test suite for the affected area: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+- [ ] `npm run typecheck` clean.
+- [ ] Manual/demo check (optional but recommended): `npm run dev`, open `http://localhost:5173/demo.html`, press Cmd-K — confirm an "Unread" section appears on top when DMs have unread, rooms with unread/mentions sort first, and count badges show. Clearing the query returns to today's layout when nothing is unread.

--- a/docs/superpowers/specs/2026-07-01-cmdk-prioritize-unread-design.md
+++ b/docs/superpowers/specs/2026-07-01-cmdk-prioritize-unread-design.md
@@ -1,0 +1,83 @@
+# Cmd-K: Prioritize Unread Conversations — Design
+
+**Date:** 2026-07-01
+**Status:** Approved (brainstorming), pending implementation plan
+
+## Problem
+
+The command palette (Cmd-K / Ctrl-K) is the primary "where do I go?" jump target.
+On open with an empty query it lists up to 5 recent 1:1 conversations sorted purely
+by recency, plus contacts, rooms, views, and actions. Unread state is invisible:
+`conversation.unreadCount`, `room.unreadCount`, and `room.mentionsCount` are already
+present in the data the palette consumes, but the palette neither displays nor sorts
+by them. The most likely reason a user opens Cmd-K — jump to a chat with something
+new in it — is unsupported.
+
+## Goal
+
+Surface unread state in the empty-query default view so unread chats are the fastest
+thing to reach, without disrupting search or the rest of the palette.
+
+## Scope
+
+- **In scope:** empty-query default view of `CommandPalette.tsx` only.
+- **Out of scope:** typed-search results (unchanged — type-grouped as today), SDK
+  changes (none needed), contacts/views/actions sections (unchanged).
+
+As soon as the user types a query, behavior reverts to the current type-grouped
+results. Rationale: a search match should not be reordered by unread; an empty
+palette is the moment where unread is the strongest signal.
+
+## Behavior
+
+### 1. New "Unread" section (DMs only), pinned at top
+
+- A new section renders **above all existing sections**, listing only 1:1
+  conversations with `unreadCount > 0`.
+- Sorted by recency (most recent unread first).
+- Capped at 5 (matching the current conversations cap); the rest remain reachable
+  by typing.
+- Conversations shown here are **removed from the regular recent-conversations
+  section** — no duplication. Dedup key: conversation JID.
+
+### 2. Rooms section: unread-first ordering
+
+- Keep the single Rooms section (no separate room-unread section).
+- Sort so unread rooms come first, then recency within each tier.
+- Tiebreak tiers, highest first: **mentions (`mentionsCount > 0`) > unread
+  (`unreadCount > 0`) > read**, then recency within each tier. A room where the
+  user was @-mentioned outranks a room with only unread traffic.
+
+### 3. Unread badge
+
+- Show a small count badge on items that carry unread — in the new Unread section
+  and on unread rooms — so the count is visible, not only implied by order.
+- Uses counts already present on the data objects (`unreadCount`; rooms may also
+  reflect `mentionsCount`). No new data source.
+
+### 4. Empty state
+
+- When there are zero unread DMs, the Unread section does not render (no empty
+  header). With no unread anywhere, the palette looks exactly as it does today.
+
+## Implementation Notes
+
+- All changes live in
+  `apps/fluux/src/components/CommandPalette.tsx` — the `allItems` builder plus the
+  grouping/render path. The recency sort for conversations/rooms already exists in
+  the SDK (`useChat`), so this layer only partitions and reorders what it receives.
+- One new i18n key for the "Unread" section header, translated across all 33
+  locales per project convention (no English placeholders).
+- The new section participates in the existing keyboard navigation (arrow keys /
+  enter) since it flows through the same grouped-items list the palette already
+  renders and indexes.
+
+## Testing
+
+- Unit coverage in the palette's test file for the empty-query builder:
+  - Unread DMs appear in the Unread section and are absent from the recent section.
+  - Zero unread DMs → no Unread section rendered.
+  - Rooms ordering: mention-room before unread-room before read-room, recency
+    within tier.
+  - Typed query → no Unread section; existing type-grouped behavior intact.
+- Badge rendering assertions (count present on unread items, absent on read items).


### PR DESCRIPTION
Makes Cmd-K surface what you most likely want to jump to.

In the empty-query view:
- New **Unread** section at the top listing 1:1 conversations with unread messages (deduped from the recent Messages section).
- Rooms are ordered **mentions > unread > read**, recency within each tier.
- Unread **count badges** on unread items (mentioned rooms get an accent badge; plain unread uses a softer treatment than the sidebar's red, and distinguishes mentions from unread).

Everywhere (default list and typed search):
- The currently-open conversation and room are no longer proposed — no point navigating to where you already are.

Scope is limited to the empty-query view for the section/ordering changes; typed-search and prefix-filter results are otherwise unchanged. No SDK changes. New `commandPalette.unread` key translated across all 33 locales.

Note: the empty-query view also moves Connections below Rooms (previously between Messages and Rooms), matching the new unread-first ordering.