### PR TITLE
fix(muc): widen SM-resume catch-up to rooms not caught up to live

### DIFF
--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -644,6 +644,14 @@ describe('setupBackgroundSyncSideEffects', () => {
         timestamp: new Date(), isOutgoing: false,
       } as RoomMessage)
 
+    const markCaughtUp = (jid: string) =>
+      roomStore.setState((s) => ({
+        mamQueryStates: new Map(s.mamQueryStates).set(jid, {
+          isLoading: false, error: null, hasQueried: true,
+          isHistoryComplete: false, isCaughtUpToLive: true,
+        }),
+      }))
+
     it('catches up a joined MAM room with no preview on SM resumption', async () => {
       addRoom('unseeded@conference.example.com')
       connectionStore.getState().setStatus('disconnected')
@@ -659,9 +667,9 @@ describe('setupBackgroundSyncSideEffects', () => {
       ).toBe('unseeded@conference.example.com')
     })
 
-    it('does not catch up a room that already has a sidebar preview', async () => {
-      addRoom('seeded@conference.example.com')
-      seedPreview('seeded@conference.example.com')
+    it('does not catch up a room already caught up to live', async () => {
+      addRoom('live@conference.example.com')
+      markCaughtUp('live@conference.example.com')
       connectionStore.getState().setStatus('disconnected')
       cleanup = setupBackgroundSyncSideEffects(mockClient)
 
@@ -669,6 +677,24 @@ describe('setupBackgroundSyncSideEffects', () => {
       await vi.advanceTimersByTimeAsync(100)
 
       expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+    })
+
+    it('catches up a previewed room that is not caught up to live (open gap)', async () => {
+      // Widened scope: a room with a preview but an unfilled forward gap
+      // (isCaughtUpToLive false) is refreshed on resume, not left stale until opened.
+      addRoom('gap@conference.example.com')
+      seedPreview('gap@conference.example.com')
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+      })
+      expect(
+        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      ).toBe('gap@conference.example.com')
     })
 
     it('does not catch up QuickChat rooms', async () => {

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -282,14 +282,15 @@ export function setupBackgroundSyncSideEffects(
     // If MAM not yet known, the serverInfo subscription below will catch it
   })
 
-  // SM resumption: the server replays undelivered stanzas, so no bulk MAM sync
-  // is needed. But the fresh-session room catch-up (`catchUpAllRooms`) never runs
-  // here, so an autojoined room that never completed catch-up keeps an empty
-  // sidebar preview until opened manually (e.g. after a mobile network change, or
-  // when a flaky connection dropped before the 10s fresh-session room pass fired).
-  // Seed exactly those rooms — no preview AND no completed MAM query — reusing
-  // catchUpRoom (its no-cursor path is a `{ before: '' }` fetch-latest that both
-  // populates the archive and sets the preview). Rooms we already hold history for
+  // SM resumption: the server replays undelivered stanzas, so no bulk MAM sync is
+  // needed for rooms already caught up to live. But the fresh-session room catch-up
+  // (`catchUpAllRooms`) never runs here, so a room NOT caught up to live this
+  // session — an autojoined room the user never opened, or one whose forward
+  // catch-up left an open gap (e.g. a flaky connection dropped before the 10s
+  // fresh-session pass fired) — keeps an empty or stale sidebar preview until opened
+  // manually. Catch up exactly those rooms, reusing catchUpRoom (its no-cursor path
+  // is a `{ before: '' }` fetch-latest that populates the archive and sets the
+  // preview; a gap-open room forward-fills from its recorded gap). Caught-up rooms
   // are skipped, so this stays out of SM's "server replays, no MAM" path.
   const unsubscribeResumed = client.on('resumed', () => {
     isFreshSession = false
@@ -297,15 +298,15 @@ export function setupBackgroundSyncSideEffects(
     const state = roomStore.getState()
     const eligible = selectRoomsNeedingResumeSeed(
       state.joinedRooms(),
-      (jid) => state.getRoomMAMQueryState(jid).hasQueried,
+      (jid) => state.getRoomMAMQueryState(jid).isCaughtUpToLive,
       state.activeRoomJid,
     )
     if (eligible.length === 0) {
-      logInfo('Background sync: SM resumption — no rooms need seeding')
+      logInfo('Background sync: SM resumption — all rooms caught up')
       return
     }
 
-    logInfo(`Background sync: SM resumption — seeding ${eligible.length} room(s) without preview`)
+    logInfo(`Background sync: SM resumption — catching up ${eligible.length} not-caught-up room(s)`)
     void (async () => {
       for (const room of eligible) {
         if (!client.isConnected()) break

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.test.ts
@@ -307,7 +307,7 @@ describe('isConnectionError', () => {
 // ============================================================================
 
 describe('selectRoomsNeedingResumeSeed', () => {
-  const neverQueried = () => false
+  const notCaughtUp = () => false
 
   const room = (
     over: Partial<{
@@ -326,52 +326,56 @@ describe('selectRoomsNeedingResumeSeed', () => {
     ...over,
   })
 
-  it('includes a joined MAM room with no preview that was never queried', () => {
+  it('includes a joined MAM room that is not caught up to live', () => {
     const r = room({ jid: 'unseeded@conf.example.com' })
-    expect(selectRoomsNeedingResumeSeed([r], neverQueried, null)).toEqual([r])
+    expect(selectRoomsNeedingResumeSeed([r], notCaughtUp, null)).toEqual([r])
   })
 
-  it('excludes a room that already has a preview (lastMessage set)', () => {
-    const r = room({ jid: 'seeded@conf.example.com', lastMessage: { id: 'm1' } })
-    expect(selectRoomsNeedingResumeSeed([r], neverQueried, null)).toEqual([])
+  it('includes a previewed room with an open gap (has lastMessage but not caught up to live)', () => {
+    // The widened scope: a previously-seeded room whose forward catch-up never
+    // completed (isCaughtUpToLive false) is refreshed on resume, not left stale
+    // until the user opens it. #784 excluded it because it had a preview.
+    const r = room({ jid: 'gap@conf.example.com', lastMessage: { id: 'm1' } })
+    expect(selectRoomsNeedingResumeSeed([r], notCaughtUp, null)).toEqual([r])
   })
 
-  it('excludes a room already queried this session (known-empty)', () => {
-    const r = room({ jid: 'queried@conf.example.com' })
-    const hasQueried = (jid: string) => jid === 'queried@conf.example.com'
-    expect(selectRoomsNeedingResumeSeed([r], hasQueried, null)).toEqual([])
+  it('excludes a room already caught up to live', () => {
+    const r = room({ jid: 'live@conf.example.com' })
+    const isCaughtUpToLive = (jid: string) => jid === 'live@conf.example.com'
+    expect(selectRoomsNeedingResumeSeed([r], isCaughtUpToLive, null)).toEqual([])
   })
 
   it('excludes QuickChat rooms', () => {
     const r = room({ jid: 'quick@conf.example.com', isQuickChat: true })
-    expect(selectRoomsNeedingResumeSeed([r], neverQueried, null)).toEqual([])
+    expect(selectRoomsNeedingResumeSeed([r], notCaughtUp, null)).toEqual([])
   })
 
   it('excludes rooms that do not support MAM', () => {
     const r = room({ jid: 'nomam@conf.example.com', supportsMAM: false })
-    expect(selectRoomsNeedingResumeSeed([r], neverQueried, null)).toEqual([])
+    expect(selectRoomsNeedingResumeSeed([r], notCaughtUp, null)).toEqual([])
   })
 
   it('excludes rooms that are not joined', () => {
     const r = room({ jid: 'left@conf.example.com', joined: false })
-    expect(selectRoomsNeedingResumeSeed([r], neverQueried, null)).toEqual([])
+    expect(selectRoomsNeedingResumeSeed([r], notCaughtUp, null)).toEqual([])
   })
 
   it('excludes the active room (handled by roomSideEffects)', () => {
     const r = room({ jid: 'active@conf.example.com' })
     expect(
-      selectRoomsNeedingResumeSeed([r], neverQueried, 'active@conf.example.com'),
+      selectRoomsNeedingResumeSeed([r], notCaughtUp, 'active@conf.example.com'),
     ).toEqual([])
   })
 
   it('returns only the eligible rooms from a mixed set', () => {
     const eligible = room({ jid: 'a@conf.example.com' })
-    const previewed = room({ jid: 'b@conf.example.com', lastMessage: { id: 'm' } })
+    const live = room({ jid: 'b@conf.example.com' })
     const quick = room({ jid: 'c@conf.example.com', isQuickChat: true })
     const active = room({ jid: 'd@conf.example.com' })
+    const isCaughtUpToLive = (jid: string) => jid === 'b@conf.example.com'
     const result = selectRoomsNeedingResumeSeed(
-      [eligible, previewed, quick, active],
-      neverQueried,
+      [eligible, live, quick, active],
+      isCaughtUpToLive,
       'd@conf.example.com',
     )
     expect(result).toEqual([eligible])

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -168,28 +168,29 @@ export function selectCatchUpQuery(
 }
 
 /**
- * Pick the joined rooms that need a preview/catch-up seed on SM resumption.
+ * Pick the joined rooms that need a MAM catch-up on SM resumption.
  *
  * The fresh-session background room catch-up (`catchUpAllRooms`) runs only on a
- * fresh `'online'` event, never on an SM `'resumed'` one. So an autojoined room
- * that never completed catch-up keeps an empty sidebar preview (and stale
- * ordering) until the user opens it manually. This picks exactly those rooms so
- * a resume handler can seed them.
+ * fresh `'online'` event, never on an SM `'resumed'` one. So a room not caught up
+ * to live this session — an autojoined room the user never opened, or a room whose
+ * forward catch-up left an open gap — keeps an empty or stale sidebar preview (and
+ * stale ordering) until the user opens it manually. This picks exactly those rooms
+ * so a resume handler can catch them up.
  *
- * Stays out of Stream Management's way: it targets ONLY rooms with no preview
- * AND no completed MAM query, so a room already seeded (`lastMessage` present)
- * or already known-empty (queried, no messages) is skipped — SM already replays
- * undelivered stanzas for any room we hold history for, and a seeded/empty room
- * must not be re-queried on every resume.
+ * Stays out of Stream Management's way: it targets ONLY rooms NOT caught up to live
+ * (`isCaughtUpToLive` false). A room already synced to the live edge is skipped — SM
+ * replays undelivered stanzas for it — so a caught-up room is never re-queried on
+ * every resume. Both a never-fetched room and a gap-open room qualify; a
+ * genuinely-empty room caught up via a completed `before:''` query has
+ * `isCaughtUpToLive` true and is skipped.
  *
  * @param rooms - Candidate rooms (typically `roomStore.joinedRooms()`)
- * @param hasQueried - Predicate: has this room a completed MAM query this session
- *   (`getRoomMAMQueryState(jid).hasQueried`)? `hasQueried` flips true on any
- *   completed query (even an empty result), so a genuinely-empty room seeds at
- *   most once per session.
+ * @param isCaughtUpToLive - Predicate: is this room synced to the live edge with no
+ *   open forward gap (`getRoomMAMQueryState(jid).isCaughtUpToLive`)? Session-scoped,
+ *   so it resets false on each app load and a reload correctly re-catches-up.
  * @param activeRoomJid - The active room, skipped here because roomSideEffects
  *   drives its own catch-up.
- * @returns The subset of `rooms` needing a seed, preserving element type.
+ * @returns The subset of `rooms` needing catch-up, preserving element type.
  */
 export function selectRoomsNeedingResumeSeed<
   R extends {
@@ -197,11 +198,10 @@ export function selectRoomsNeedingResumeSeed<
     joined?: boolean
     supportsMAM?: boolean
     isQuickChat?: boolean
-    lastMessage?: unknown
   },
 >(
   rooms: R[],
-  hasQueried: (jid: string) => boolean,
+  isCaughtUpToLive: (jid: string) => boolean,
   activeRoomJid: string | null | undefined,
 ): R[] {
   return rooms.filter((r) => {
@@ -209,8 +209,7 @@ export function selectRoomsNeedingResumeSeed<
     if (!r.supportsMAM) return false
     if (r.isQuickChat) return false
     if (r.jid === activeRoomJid) return false
-    if (r.lastMessage) return false
-    if (hasQueried(r.jid)) return false
+    if (isCaughtUpToLive(r.jid)) return false
     return true
   })
 }


### PR DESCRIPTION
## Summary

Follow-up to #784. #784 seeded only rooms with **no preview AND no completed MAM query** on SM resume. This widens that to the scope agreed during design: catch up any joined MAM room **not caught up to live**.

The one behavioral gap #784 left: a previously-seeded room whose forward catch-up never completed (an open forward gap, `isCaughtUpToLive` false, but `lastMessage` present) was skipped on resume and stayed stale until the user opened it. Now it is refreshed on resume.