### PR TITLE
fix(theme): align sidebar scrollbar color with main across themes

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -272,8 +272,13 @@
      themes ship. .light overrides below. */
   --fluux-scrollbar-thumb: var(--fluux-base-70);
   --fluux-scrollbar-thumb-hover: var(--fluux-base-80);
-  --fluux-scrollbar-thumb-sidebar: var(--fluux-base-70);
-  --fluux-scrollbar-thumb-sidebar-hover: var(--fluux-base-80);
+  /* Sidebar thumb tracks the main thumb by default so a single per-theme override
+     of --fluux-scrollbar-thumb reskins both surfaces. In dark mode the light thumb
+     already clears contrast on the darker sidebar, so they stay equal here; the
+     light block below nudges the sidebar one step more prominent (matching the
+     builtin light themes), since a gray thumb on the grayer sidebar needs it. */
+  --fluux-scrollbar-thumb-sidebar: var(--fluux-scrollbar-thumb);
+  --fluux-scrollbar-thumb-sidebar-hover: var(--fluux-scrollbar-thumb-hover);
 
   /* Focus ring — drives the universal `.user-interacted *:focus` outline, so this
      one token governs keyboard-focus visibility app-wide. Solid accent: at 0.5
@@ -478,6 +483,11 @@
   --fluux-search-highlight-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);
   --fluux-scrollbar-thumb: #c4c9ce;
   --fluux-scrollbar-thumb-hover: #a8adb3;
+  /* Sidebar sits on a grayer surface than the white content area, so its thumb is
+     nudged one step more prominent (the main thumb's hover shade) to keep equal
+     visual weight — the convention the builtin light themes follow. */
+  --fluux-scrollbar-thumb-sidebar: var(--fluux-scrollbar-thumb-hover);
+  --fluux-scrollbar-thumb-sidebar-hover: #8f949b;
 
   /* ── Aurora identity (light) ── */
   --fluux-accent-2: #11A88C;

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -188,9 +188,10 @@ These map foundation tokens to purposes. They cascade from Tier 1, so you rarely
 | `--fluux-text-error`            | Tuned red (not `color-red`) | Error *text/icons* (delivery-failed, validation, new-message marker) |
 | `--fluux-status-info`           | `color-blue`          | Informational indicators        |
 | `--fluux-border-color`          | `rgba(0,0,0,0.1)`     | Subtle dividers                 |
-| `--fluux-scrollbar-thumb`       | `base-05`             | Scrollbar thumb color           |
-| `--fluux-scrollbar-thumb-sidebar` | `base-30`           | Sidebar scrollbar thumb color   |
-| `--fluux-scrollbar-thumb-sidebar-hover` | `base-50`     | Sidebar scrollbar thumb hover   |
+| `--fluux-scrollbar-thumb`       | `base-70`             | Scrollbar thumb (main content)  |
+| `--fluux-scrollbar-thumb-hover` | `base-80`             | Scrollbar thumb hover (main content) |
+| `--fluux-scrollbar-thumb-sidebar` | `= scrollbar-thumb` | Sidebar scrollbar thumb (tracks the main thumb by default) |
+| `--fluux-scrollbar-thumb-sidebar-hover` | `= scrollbar-thumb-hover` | Sidebar scrollbar thumb hover (tracks the main hover by default) |
 | `--fluux-selection-bg`          | Accent at 25% opacity | Text selection highlight        |
 | `--fluux-search-highlight-bg`   | Accent at 35% opacity | Search match background         |
 | `--fluux-search-highlight-text` | `text-normal`         | Search match text color         |
@@ -199,8 +200,8 @@ These map foundation tokens to purposes. They cascade from Tier 1, so you rarely
 - `--fluux-text-error` — **set this whenever you override `--fluux-color-red`.** Red has to pull in two directions: as a *fill* (`--fluux-status-error`, danger button, toast border, DND dot) it must stay dark enough for white text on it to clear WCAG AA, but as *text/icons* on your dark chat surface that same red is usually too dark to clear AA. They are deliberately separate tokens. Keep `--fluux-color-red` for the fill, and set `--fluux-text-error` to a red that clears AA (>=4.5:1) as text on `--fluux-chat-bg` — lighter than the fill in dark mode, darker in light mode. The `themeContrast.test.ts` guard asserts this for every builtin theme. (Themes that leave `--fluux-color-red` at the Aurora default inherit the Aurora `--fluux-text-error` automatically.)
 - `--fluux-bg-secondary` — if your ramp spacing makes `base-05` too similar to `base-10`
 - `--fluux-border-color` — light themes often need `rgba(0,0,0,0.12-0.15)` instead of `0.1`
-- `--fluux-scrollbar-thumb` — if your ramp makes the default too subtle or too prominent
-- `--fluux-scrollbar-thumb-sidebar` / `--fluux-scrollbar-thumb-sidebar-hover` — the sidebar has a darker background than the main content area, so the default `base-30`/`base-50` may not provide enough contrast. Light themes almost always need explicit overrides here since `base-30` is often near-white
+- `--fluux-scrollbar-thumb` / `--fluux-scrollbar-thumb-hover` — if your ramp makes the default (`base-70`/`base-80`) too subtle or too prominent on your chat surface
+- `--fluux-scrollbar-thumb-sidebar` / `--fluux-scrollbar-thumb-sidebar-hover` — these track the main thumb by default, so overriding `--fluux-scrollbar-thumb` reskins both surfaces at once. Override the sidebar pair only when the sidebar's (usually grayer) surface needs a different thumb for equal visual weight. The builtin light themes nudge the sidebar one step more prominent: set `--fluux-scrollbar-thumb-sidebar` to the main thumb's hover shade, with `--fluux-scrollbar-thumb-sidebar-hover` one step darker again. Dark variants generally leave them tracking the main thumb.
 
 ## Tier 3: Component Variables (Rarely Needed)
 


### PR DESCRIPTION
The Aurora light theme overrode the main scrollbar thumb tokens but not the `-sidebar` ones, so the sidebar thumb fell back to `base-70` (a blue-gray) while the main thumb was a neutral gray — the two scrollbars visibly clashed.

The sidebar tokens now track the main thumb by default, so a single `--fluux-scrollbar-thumb` override reskins both surfaces. The light block applies the same per-surface offset the builtin light themes already use: sidebar = the main thumb's hover shade (one step more prominent, to match the grayer sidebar surface). Dark mode keeps both equal, matching the builtin dark variants. Builtin themes are unchanged.

Also refreshed `docs/THEMES.md`, whose documented scrollbar defaults were stale (`base-05`/`base-30`/`base-50`) and omitted the main-hover token.