### PR TITLE
feat(focus): trap keyboard focus in modals, Cmd-K, and overlays

### DIFF
--- a/apps/fluux/src/components/ImageContextMenu.tsx
+++ b/apps/fluux/src/components/ImageContextMenu.tsx
@@ -5,6 +5,7 @@ import { copyToClipboard } from '@/utils/clipboard'
 import { isTauri } from '@/utils/tauri'
 import { downloadFile } from '@/utils/download'
 import type { ContextMenuState } from '@/hooks/useContextMenu'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 
 interface ImageContextMenuProps {
   originalUrl: string
@@ -24,6 +25,8 @@ async function openInBrowser(url: string): Promise<void> {
 
 export function ImageContextMenu({ originalUrl, proxiedUrl, filename, menu }: ImageContextMenuProps) {
   const { t } = useTranslation()
+
+  useFocusTrap(menu.menuRef, { active: menu.isOpen })
 
   if (!menu.isOpen) return null
 

--- a/apps/fluux/src/components/ImageContextMenu.tsx
+++ b/apps/fluux/src/components/ImageContextMenu.tsx
@@ -26,6 +26,9 @@ async function openInBrowser(url: string): Promise<void> {
 export function ImageContextMenu({ originalUrl, proxiedUrl, filename, menu }: ImageContextMenuProps) {
   const { t } = useTranslation()
 
+  // This menu can render inside an already-trapped overlay (e.g. ImageLightbox). A Tab keydown
+  // bubbles through both container listeners; this is safe because the inner handler moves focus
+  // first and the outer handler then no-ops (active element is still inside its container).
   useFocusTrap(menu.menuRef, { active: menu.isOpen })
 
   if (!menu.isOpen) return null

--- a/apps/fluux/src/components/ImageLightbox.tsx
+++ b/apps/fluux/src/components/ImageLightbox.tsx
@@ -2,8 +2,9 @@
  * Full-screen lightbox overlay for viewing image attachments.
  * Triggered by clicking on an image attachment in chat/room views.
  */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 import { X, Download, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { FileEncryption } from '@fluux/sdk'
@@ -37,6 +38,8 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
   const { url: proxiedSrc, isLoading } = useAttachmentUrl(src, encryption, allowFetch)
   const { cachedUrl: cachedFullRes } = useCachedMediaUrl(src, encryption, !allowFetch)
   const imageMenu = useContextMenu()
+  const overlayRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(overlayRef)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -50,6 +53,7 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
 
   return createPortal(
     <div
+      ref={overlayRef}
       className="fixed inset-0 bg-black/90 flex flex-col items-center justify-center z-50"
     >
       {/* Click-outside-to-close backdrop (Escape also closes; see effect above) */}

--- a/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { ModalOverlay } from './ModalOverlay'
+
+afterEach(cleanup)
+
+describe('ModalOverlay focus trap', () => {
+  it('wraps Tab within the panel', () => {
+    const { getByText } = render(
+      <ModalOverlay onClose={vi.fn()}>
+        <button>alpha</button>
+        <button>omega</button>
+      </ModalOverlay>,
+    )
+    const omega = getByText('omega')
+    omega.focus()
+    fireEvent.keyDown(omega, { key: 'Tab' })
+    expect(document.activeElement).toBe(getByText('alpha'))
+  })
+})

--- a/apps/fluux/src/components/ModalOverlay.tsx
+++ b/apps/fluux/src/components/ModalOverlay.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 import { useModalTransition } from '@/hooks/useModalTransition'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 
 /** A panel keyboard handler that also receives the transition-aware `close`. */
 type PanelKeyDown = (
@@ -96,6 +97,8 @@ export function ModalOverlay({
   // the implicit backdrop-click and Escape affordances below, not this.
   const close = useCallback(() => requestClose(onClose), [requestClose, onClose])
 
+  // Trap Tab focus inside the panel and return focus to the opener on close.
+  useFocusTrap(panelRef, { initialFocusRef: focusRef })
   // Keep keyboard focus inside the modal across OS window blur/refocus.
   useRestoreFocus(panelRef, focusRef)
 

--- a/apps/fluux/src/components/conversation/UserInfoPopover.tsx
+++ b/apps/fluux/src/components/conversation/UserInfoPopover.tsx
@@ -10,6 +10,7 @@ import type { Contact, ContactIdentity, RoomAffiliation, RoomRole, VCardInfo } f
 import { useXMPP } from '@fluux/sdk'
 import { useConnectionStore, useContactTime, useLastActivity } from '@fluux/sdk/react'
 import { useClickOutside } from '@/hooks'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 import { getTranslatedShowText } from '@/utils/presence'
 import { Monitor, Smartphone, Tablet, Globe, HelpCircle, Shield, Crown, UserCheck, Building2, Mail, MapPin, Clock, Loader2 } from 'lucide-react'
 
@@ -88,6 +89,7 @@ export function UserInfoPopover({ contact, jid, occupantJid, role, affiliation, 
 
   // Close on click outside
   useClickOutside(popoverRef, () => setIsOpen(false), isOpen)
+  useFocusTrap(popoverRef, { active: isOpen })
 
   // Close on scroll (message list or any parent)
   useEffect(() => {

--- a/apps/fluux/src/components/ui/BottomSheet.tsx
+++ b/apps/fluux/src/components/ui/BottomSheet.tsx
@@ -12,8 +12,9 @@
  * Used for touch action menus (e.g. per-message actions) where a centered modal
  * or a hover toolbar doesn't fit thumb ergonomics.
  */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
 
 interface BottomSheetProps {
   /** Whether the sheet is open. Renders nothing when false. */
@@ -37,6 +38,9 @@ export function BottomSheet({
   panelClassName,
   children,
 }: BottomSheetProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(panelRef, { active: open })
+
   useEffect(() => {
     if (!open) return
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -61,6 +65,7 @@ export function BottomSheet({
         className="absolute inset-0 cursor-default"
       />
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}

--- a/apps/fluux/src/hooks/focusable.test.ts
+++ b/apps/fluux/src/hooks/focusable.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { getFocusableElements } from './focusable'
+
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  document.body.appendChild(root)
+  return root
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('getFocusableElements', () => {
+  it('returns focusable descendants in DOM order', () => {
+    const root = mount(
+      '<button>a</button><input /><a href="#">l</a>',
+    )
+    const els = getFocusableElements(root)
+    expect(els.map((e) => e.tagName)).toEqual(['BUTTON', 'INPUT', 'A'])
+  })
+
+  it('excludes disabled and tabindex="-1" elements', () => {
+    const root = mount(
+      '<button disabled>a</button><button tabindex="-1">b</button><button>c</button>',
+    )
+    const els = getFocusableElements(root)
+    expect(els).toHaveLength(1)
+    expect(els[0].textContent).toBe('c')
+  })
+})

--- a/apps/fluux/src/hooks/focusable.ts
+++ b/apps/fluux/src/hooks/focusable.ts
@@ -5,6 +5,8 @@ export const FOCUSABLE_SELECTOR =
 
 /** Focusable descendants of `container`, in DOM (tab) order. */
 export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  // The selector's `button`/`a[href]` clauses still match elements with tabindex="-1",
+  // so this filter is required to exclude them from the focusable set.
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
     (el) => el.getAttribute('tabindex') !== '-1'
   )

--- a/apps/fluux/src/hooks/focusable.ts
+++ b/apps/fluux/src/hooks/focusable.ts
@@ -1,0 +1,11 @@
+// Tab-order focusable elements, excluding programmatically-removed ones.
+export const FOCUSABLE_SELECTOR =
+  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), ' +
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/** Focusable descendants of `container`, in DOM (tab) order. */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => el.getAttribute('tabindex') !== '-1'
+  )
+}

--- a/apps/fluux/src/hooks/useFocusTrap.test.tsx
+++ b/apps/fluux/src/hooks/useFocusTrap.test.tsx
@@ -69,4 +69,21 @@ describe('useFocusTrap', () => {
     expect(document.activeElement).toBe(opener)
     opener.remove()
   })
+
+  it('focuses initialFocusRef element instead of the first focusable', () => {
+    function TrapWithInitial() {
+      const containerRef = useRef<HTMLDivElement>(null)
+      const initialRef = useRef<HTMLButtonElement>(null)
+      useFocusTrap(containerRef, { initialFocusRef: initialRef })
+      return (
+        <div ref={containerRef}>
+          <button>first</button>
+          <button ref={initialRef}>second</button>
+          <button>third</button>
+        </div>
+      )
+    }
+    const { getByText } = render(<TrapWithInitial />)
+    expect(document.activeElement).toBe(getByText('second'))
+  })
 })

--- a/apps/fluux/src/hooks/useFocusTrap.test.tsx
+++ b/apps/fluux/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { useRef } from 'react'
+import { useFocusTrap } from './useFocusTrap'
+
+afterEach(cleanup)
+
+function Trap({ active = true }: { active?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useFocusTrap(ref, { active })
+  return (
+    <div ref={ref}>
+      <button>first</button>
+      <button>middle</button>
+      <button>last</button>
+    </div>
+  )
+}
+
+describe('useFocusTrap', () => {
+  it('moves focus into the container on mount', () => {
+    const { getByText } = render(<Trap />)
+    expect(document.activeElement).toBe(getByText('first'))
+  })
+
+  it('wraps Tab from the last element to the first', () => {
+    const { getByText } = render(<Trap />)
+    const last = getByText('last')
+    last.focus()
+    fireEvent.keyDown(last, { key: 'Tab' })
+    expect(document.activeElement).toBe(getByText('first'))
+  })
+
+  it('wraps Shift+Tab from the first element to the last', () => {
+    const { getByText } = render(<Trap />)
+    const first = getByText('first')
+    first.focus()
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(getByText('last'))
+  })
+
+  it('focuses the container itself when it has no focusable children', () => {
+    function Empty() {
+      const ref = useRef<HTMLDivElement>(null)
+      useFocusTrap(ref)
+      return <div ref={ref} data-testid="empty" />
+    }
+    const { getByTestId } = render(<Empty />)
+    expect(document.activeElement).toBe(getByTestId('empty'))
+  })
+
+  it('restores focus to the opener on unmount', () => {
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+    const { unmount } = render(<Trap />)
+    expect(document.activeElement).not.toBe(opener)
+    unmount()
+    expect(document.activeElement).toBe(opener)
+    opener.remove()
+  })
+
+  it('does nothing while inactive', () => {
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+    render(<Trap active={false} />)
+    expect(document.activeElement).toBe(opener)
+    opener.remove()
+  })
+})

--- a/apps/fluux/src/hooks/useFocusTrap.ts
+++ b/apps/fluux/src/hooks/useFocusTrap.ts
@@ -1,0 +1,80 @@
+import { useLayoutEffect, type RefObject } from 'react'
+import { getFocusableElements } from './focusable'
+
+interface FocusTrapOptions {
+  /** Preferred element to focus on open; falls back to the first focusable
+   *  element, then the container itself. */
+  initialFocusRef?: RefObject<HTMLElement | null>
+  /** Gate the trap (e.g. an overlay's `open`/`isOpen` flag). Default true. */
+  active?: boolean
+}
+
+/**
+ * Hard focus trap for an open modal / overlay:
+ *
+ * - moves focus into the container when it opens,
+ * - cycles Tab / Shift+Tab within the container so focus never reaches the UI
+ *   beneath it,
+ * - returns focus to the element that was focused before it opened, on close.
+ *
+ * The keydown listener is attached to the container (not `document`), so a
+ * stacked overlay wins automatically: the lower overlay's container never
+ * receives the event because focus lives in the top one.
+ *
+ * Complements {@link useRestoreFocus}, which reclaims focus across OS window
+ * blur; this hook owns entering and leaving the trap.
+ */
+export function useFocusTrap<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  { initialFocusRef, active = true }: FocusTrapOptions = {},
+) {
+  useLayoutEffect(() => {
+    if (!active) return
+    const container = containerRef.current
+    if (!container) return
+
+    // Captured before we move focus, so we can restore the opener on close.
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement &&
+      !container.contains(document.activeElement)
+        ? document.activeElement
+        : null
+
+    // Let the container hold focus itself when it has no focusable children, so
+    // focus can never fall through to the page beneath.
+    if (!container.hasAttribute('tabindex')) container.tabIndex = -1
+
+    if (!container.contains(document.activeElement)) {
+      const target =
+        initialFocusRef?.current ?? getFocusableElements(container)[0] ?? container
+      target.focus()
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const focusables = getFocusableElements(container)
+      if (focusables.length === 0) {
+        e.preventDefault()
+        container.focus()
+        return
+      }
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const activeEl = document.activeElement
+      if (e.shiftKey && activeEl === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && activeEl === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown)
+      if (previouslyFocused?.isConnected) previouslyFocused.focus()
+    }
+  }, [containerRef, initialFocusRef, active])
+}

--- a/apps/fluux/src/hooks/useRestoreFocus.ts
+++ b/apps/fluux/src/hooks/useRestoreFocus.ts
@@ -1,9 +1,5 @@
 import { useEffect, useRef, type RefObject } from 'react'
-
-// Tab-order focusable elements, excluding programmatically-removed ones.
-const FOCUSABLE_SELECTOR =
-  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), ' +
-  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+import { FOCUSABLE_SELECTOR } from './focusable'
 
 /**
  * Keeps keyboard focus inside an open modal/overlay across OS window blur and

--- a/docs/superpowers/plans/2026-07-01-modal-focus-trap.md
+++ b/docs/superpowers/plans/2026-07-01-modal-focus-trap.md
@@ -1,0 +1,571 @@
+# Modal & Cmd-K Focus Trap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep keyboard focus inside a modal / command palette / overlay while it is open, cycling Tab within it and returning focus to the opener on close.
+
+**Architecture:** One small `useFocusTrap` hook applied centrally in `ModalOverlay` (covers all standard modals + Cmd-K) and in the four portaled overlays. A shared `focusable.ts` module supplies the focusable-element machinery to both `useFocusTrap` and the existing `useRestoreFocus`. `useFocusTrap` owns entering/leaving the trap (initial focus, Tab wrap, return focus); `useRestoreFocus` continues to own window-blur restoration.
+
+**Tech Stack:** React 18, TypeScript, Vitest + Testing Library (jsdom), Tailwind.
+
+## Global Constraints
+
+- App code lives under `apps/fluux/src`. Run app tests per-workspace, not bare `vitest` from root.
+- DOM/focus tests MUST pin `@vitest-environment jsdom` (the app default is happy-dom).
+- No new dependencies — the codebase deliberately carries no focus-trap library.
+- `ModalOverlay` is the single source of truth for modal chrome; do not duplicate its behaviour elsewhere.
+
+---
+
+### Task 1: Extract shared `focusable` helper
+
+**Files:**
+- Create: `apps/fluux/src/hooks/focusable.ts`
+- Create: `apps/fluux/src/hooks/focusable.test.ts`
+- Modify: `apps/fluux/src/hooks/useRestoreFocus.ts` (replace inlined selector with the import)
+
+**Interfaces:**
+- Produces: `FOCUSABLE_SELECTOR: string`, `getFocusableElements(container: HTMLElement): HTMLElement[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/hooks/focusable.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { getFocusableElements } from './focusable'
+
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  document.body.appendChild(root)
+  return root
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('getFocusableElements', () => {
+  it('returns focusable descendants in DOM order', () => {
+    const root = mount(
+      '<button>a</button><input /><a href="#">l</a>',
+    )
+    const els = getFocusableElements(root)
+    expect(els.map((e) => e.tagName)).toEqual(['BUTTON', 'INPUT', 'A'])
+  })
+
+  it('excludes disabled and tabindex="-1" elements', () => {
+    const root = mount(
+      '<button disabled>a</button><button tabindex="-1">b</button><button>c</button>',
+    )
+    const els = getFocusableElements(root)
+    expect(els).toHaveLength(1)
+    expect(els[0].textContent).toBe('c')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/focusable.test.ts`
+Expected: FAIL — cannot resolve `./focusable`.
+
+- [ ] **Step 3: Create the helper**
+
+Create `apps/fluux/src/hooks/focusable.ts`:
+
+```ts
+// Tab-order focusable elements, excluding programmatically-removed ones.
+export const FOCUSABLE_SELECTOR =
+  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), ' +
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/** Focusable descendants of `container`, in DOM (tab) order. */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+```
+
+- [ ] **Step 4: Point `useRestoreFocus` at the shared helper**
+
+In `apps/fluux/src/hooks/useRestoreFocus.ts`, delete the local `FOCUSABLE_SELECTOR` const (lines 3-6) and add the import at the top:
+
+```ts
+import { FOCUSABLE_SELECTOR } from './focusable'
+```
+
+Leave the rest of the file unchanged (it references `FOCUSABLE_SELECTOR` at what is currently line 46).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/focusable.test.ts src/hooks/useRestoreFocus.test.ts`
+Expected: PASS. (If `useRestoreFocus.test.ts` does not exist, run only `focusable.test.ts`.)
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/hooks/focusable.ts apps/fluux/src/hooks/focusable.test.ts apps/fluux/src/hooks/useRestoreFocus.ts
+git commit -m "refactor(focus): extract shared focusable helper"
+```
+
+---
+
+### Task 2: `useFocusTrap` hook
+
+**Files:**
+- Create: `apps/fluux/src/hooks/useFocusTrap.ts`
+- Create: `apps/fluux/src/hooks/useFocusTrap.test.tsx`
+
+**Interfaces:**
+- Consumes: `getFocusableElements` from `./focusable` (Task 1).
+- Produces: `useFocusTrap<T extends HTMLElement>(containerRef: RefObject<T | null>, options?: { initialFocusRef?: RefObject<HTMLElement | null>; active?: boolean }): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/hooks/useFocusTrap.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { useRef } from 'react'
+import { useFocusTrap } from './useFocusTrap'
+
+afterEach(cleanup)
+
+function Trap({ active = true }: { active?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useFocusTrap(ref, { active })
+  return (
+    <div ref={ref}>
+      <button>first</button>
+      <button>middle</button>
+      <button>last</button>
+    </div>
+  )
+}
+
+describe('useFocusTrap', () => {
+  it('moves focus into the container on mount', () => {
+    const { getByText } = render(<Trap />)
+    expect(document.activeElement).toBe(getByText('first'))
+  })
+
+  it('wraps Tab from the last element to the first', () => {
+    const { getByText } = render(<Trap />)
+    const last = getByText('last')
+    last.focus()
+    fireEvent.keyDown(last, { key: 'Tab' })
+    expect(document.activeElement).toBe(getByText('first'))
+  })
+
+  it('wraps Shift+Tab from the first element to the last', () => {
+    const { getByText } = render(<Trap />)
+    const first = getByText('first')
+    first.focus()
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(getByText('last'))
+  })
+
+  it('focuses the container itself when it has no focusable children', () => {
+    function Empty() {
+      const ref = useRef<HTMLDivElement>(null)
+      useFocusTrap(ref)
+      return <div ref={ref} data-testid="empty" />
+    }
+    const { getByTestId } = render(<Empty />)
+    expect(document.activeElement).toBe(getByTestId('empty'))
+  })
+
+  it('restores focus to the opener on unmount', () => {
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+    const { unmount } = render(<Trap />)
+    expect(document.activeElement).not.toBe(opener)
+    unmount()
+    expect(document.activeElement).toBe(opener)
+    opener.remove()
+  })
+
+  it('does nothing while inactive', () => {
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+    render(<Trap active={false} />)
+    expect(document.activeElement).toBe(opener)
+    opener.remove()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useFocusTrap.test.tsx`
+Expected: FAIL — cannot resolve `./useFocusTrap`.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `apps/fluux/src/hooks/useFocusTrap.ts`:
+
+```ts
+import { useLayoutEffect, type RefObject } from 'react'
+import { getFocusableElements } from './focusable'
+
+interface FocusTrapOptions {
+  /** Preferred element to focus on open; falls back to the first focusable
+   *  element, then the container itself. */
+  initialFocusRef?: RefObject<HTMLElement | null>
+  /** Gate the trap (e.g. an overlay's `open`/`isOpen` flag). Default true. */
+  active?: boolean
+}
+
+/**
+ * Hard focus trap for an open modal / overlay:
+ *
+ * - moves focus into the container when it opens,
+ * - cycles Tab / Shift+Tab within the container so focus never reaches the UI
+ *   beneath it,
+ * - returns focus to the element that was focused before it opened, on close.
+ *
+ * The keydown listener is attached to the container (not `document`), so a
+ * stacked overlay wins automatically: the lower overlay's container never
+ * receives the event because focus lives in the top one.
+ *
+ * Complements {@link useRestoreFocus}, which reclaims focus across OS window
+ * blur; this hook owns entering and leaving the trap.
+ */
+export function useFocusTrap<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  { initialFocusRef, active = true }: FocusTrapOptions = {},
+) {
+  useLayoutEffect(() => {
+    if (!active) return
+    const container = containerRef.current
+    if (!container) return
+
+    // Captured before we move focus, so we can restore the opener on close.
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement &&
+      !container.contains(document.activeElement)
+        ? document.activeElement
+        : null
+
+    // Let the container hold focus itself when it has no focusable children, so
+    // focus can never fall through to the page beneath.
+    if (!container.hasAttribute('tabindex')) container.tabIndex = -1
+
+    if (!container.contains(document.activeElement)) {
+      const target =
+        initialFocusRef?.current ?? getFocusableElements(container)[0] ?? container
+      target.focus()
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const focusables = getFocusableElements(container)
+      if (focusables.length === 0) {
+        e.preventDefault()
+        container.focus()
+        return
+      }
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const activeEl = document.activeElement
+      if (e.shiftKey && activeEl === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && activeEl === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown)
+      if (previouslyFocused?.isConnected) previouslyFocused.focus()
+    }
+  }, [containerRef, initialFocusRef, active])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useFocusTrap.test.tsx`
+Expected: PASS (all 6 cases).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/hooks/useFocusTrap.ts apps/fluux/src/hooks/useFocusTrap.test.tsx
+git commit -m "feat(focus): add useFocusTrap hook"
+```
+
+---
+
+### Task 3: Wire the trap into `ModalOverlay`
+
+This covers every standard modal, dialog, and the command palette (all built on `ModalOverlay`).
+
+**Files:**
+- Modify: `apps/fluux/src/components/ModalOverlay.tsx`
+- Create: `apps/fluux/src/components/ModalOverlay.focustrap.test.tsx`
+
+**Interfaces:**
+- Consumes: `useFocusTrap` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/components/ModalOverlay.focustrap.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { ModalOverlay } from './ModalOverlay'
+
+afterEach(cleanup)
+
+describe('ModalOverlay focus trap', () => {
+  it('wraps Tab within the panel', () => {
+    const { getByText } = render(
+      <ModalOverlay onClose={vi.fn()}>
+        <button>alpha</button>
+        <button>omega</button>
+      </ModalOverlay>,
+    )
+    const omega = getByText('omega')
+    omega.focus()
+    fireEvent.keyDown(omega, { key: 'Tab' })
+    expect(document.activeElement).toBe(getByText('alpha'))
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/ModalOverlay.focustrap.test.tsx`
+Expected: FAIL — Tab does not wrap (focus stays on `omega`).
+
+- [ ] **Step 3: Add the hook**
+
+In `apps/fluux/src/components/ModalOverlay.tsx`:
+
+Add the import next to the other hook imports (near current line 9):
+
+```ts
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+```
+
+Add the hook call immediately before the existing `useRestoreFocus(panelRef, focusRef)` (current line 100):
+
+```ts
+  // Trap Tab focus inside the panel and return focus to the opener on close.
+  useFocusTrap(panelRef, { initialFocusRef: focusRef })
+  // Keep keyboard focus inside the modal across OS window blur/refocus.
+  useRestoreFocus(panelRef, focusRef)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/components/ModalOverlay.focustrap.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Guard against regressions in existing modal tests**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette src/components/ModalOverlay`
+Expected: PASS (no regression from the added hook). Vitest skips any pattern with no matching test file, so this is safe even if one suite doesn't exist.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/components/ModalOverlay.tsx apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
+git commit -m "feat(focus): trap focus in ModalOverlay (all modals + Cmd-K)"
+```
+
+---
+
+### Task 4: Wire the trap into the portaled overlays
+
+These bypass `ModalOverlay`. Each gets a `useFocusTrap` call gated on its open flag.
+
+**Files:**
+- Modify: `apps/fluux/src/components/ui/BottomSheet.tsx`
+- Modify: `apps/fluux/src/components/ImageLightbox.tsx`
+- Modify: `apps/fluux/src/components/ImageContextMenu.tsx`
+- Modify: `apps/fluux/src/components/conversation/UserInfoPopover.tsx`
+
+**Interfaces:**
+- Consumes: `useFocusTrap` (Task 2).
+
+- [ ] **Step 1: BottomSheet**
+
+The panel `<div role="dialog">` currently has no ref. Add one and trap on `open`.
+
+Add imports (BottomSheet currently imports `createPortal` from `react-dom`; it needs `useRef` from react and the hook):
+
+```ts
+import { useEffect, useRef } from 'react'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+```
+
+(If `useEffect` is already imported from `'react'`, just add `useRef` to that import.)
+
+Inside the component, before the `if (!open ...) return null` early return, add:
+
+```ts
+  const panelRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(panelRef, { active: open })
+```
+
+Attach the ref to the dialog panel (the `<div role="dialog" aria-modal="true" ...>`):
+
+```tsx
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+```
+
+- [ ] **Step 2: ImageLightbox**
+
+The overlay is mounted only while shown, so `active` defaults to true. Trap the whole overlay container so the download/close buttons are inside.
+
+Add imports:
+
+```ts
+import { useRef } from 'react'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+```
+
+(Merge `useRef` into any existing `'react'` import.)
+
+Inside the component (near the top, after the existing hooks), add:
+
+```ts
+  const overlayRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(overlayRef)
+```
+
+Attach the ref to the outer `createPortal` container div (`<div className="fixed inset-0 bg-black/90 ...">`):
+
+```tsx
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 bg-black/90 flex flex-col items-center justify-center z-50"
+    >
+```
+
+- [ ] **Step 3: ImageContextMenu**
+
+It already has `menu.menuRef` and early-returns when closed. Trap on `menu.isOpen`, calling the hook before the early return.
+
+Add import:
+
+```ts
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+```
+
+Inside the component, before `if (!menu.isOpen) return null`, add:
+
+```ts
+  useFocusTrap(menu.menuRef, { active: menu.isOpen })
+```
+
+(No JSX change — the ref is already on the menu `<div ref={menu.menuRef}>`.)
+
+- [ ] **Step 4: UserInfoPopover**
+
+It already has `popoverRef` and renders the portal on `isOpen`. Trap on `isOpen`.
+
+Add import:
+
+```ts
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+```
+
+Inside the component, after the existing `useClickOutside(popoverRef, ...)` call, add:
+
+```ts
+  useFocusTrap(popoverRef, { active: isOpen })
+```
+
+(No JSX change — the ref is already on the popover `<div ref={popoverRef}>`.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `cd apps/fluux && npx vitest run src/components/ui/BottomSheet src/components/ImageLightbox src/components/ImageContextMenu src/components/conversation/UserInfoPopover`
+Expected: PASS for any suites that exist; missing suites are simply skipped by vitest (no matching files). No new failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/components/ui/BottomSheet.tsx apps/fluux/src/components/ImageLightbox.tsx apps/fluux/src/components/ImageContextMenu.tsx apps/fluux/src/components/conversation/UserInfoPopover.tsx
+git commit -m "feat(focus): trap focus in portaled overlays"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: no errors, no stderr.
+
+- [ ] **Step 3: Run the new + focus-related tests**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/focusable.test.ts src/hooks/useFocusTrap.test.tsx src/components/ModalOverlay.focustrap.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Run the app test suite**
+
+Run: `cd apps/fluux && npx vitest run`
+Expected: PASS, no stderr regressions.
+
+- [ ] **Step 5: Manual/preview verification (demo mode)**
+
+Start the dev server (`npm run dev`, open `http://localhost:5173/demo.html`) and confirm:
+  1. Open the command palette (Cmd-K): focus is on the search input; Tab / Shift+Tab cycle only within the palette; Escape closes and focus returns to where it was.
+  2. Open a standard modal (e.g. Add Contact): Tab cannot reach the sidebar/composer; closing returns focus to the opener.
+  3. Open the image lightbox: Tab cycles between the download and close buttons only.
+
+- [ ] **Step 6: Final commit (if any verification fixups were needed)**
+
+Only if Steps 1-5 required changes:
+
+```bash
+git add -A
+git commit -m "fix(focus): verification fixups for focus trap"
+```

--- a/docs/superpowers/specs/2026-07-01-modal-focus-trap-design.md
+++ b/docs/superpowers/specs/2026-07-01-modal-focus-trap-design.md
@@ -1,0 +1,138 @@
+# Modal & Cmd-K focus trap — design
+
+**Date:** 2026-07-01
+**Status:** Approved, pending implementation
+
+## Problem
+
+When a modal or the Cmd-K command palette is open, keyboard focus can leave the
+panel and land on the interface underneath it. `Tab` / `Shift+Tab` walk out of
+the open overlay into the sidebar, composer, or main content, which is both an
+accessibility defect and a UX surprise: the visible layer is the modal, but the
+keyboard is driving the layer beneath it.
+
+The existing [`useRestoreFocus`](../../../apps/fluux/src/hooks/useRestoreFocus.ts)
+hook only reclaims focus when the OS window regains focus (WebKit/Tauri resets
+`document.activeElement` to `<body>` on window blur). It does **not** intercept
+Tab, so intra-window tabbing escapes the panel.
+
+## Goal
+
+While any modal, dialog, command palette, or overlay is open:
+
+1. Focus is placed **on the panel** when it opens.
+2. `Tab` / `Shift+Tab` cycle **only** through the panel's focusable elements —
+   focus can never reach the interface beneath.
+3. When the panel closes, focus **returns** to the element that was focused
+   before it opened.
+
+## Approach
+
+A single small hook, `useFocusTrap`, applied centrally.
+
+Rejected alternatives:
+
+- **Add `focus-trap-react` / Radix / HeadlessUI** — the codebase deliberately
+  carries no focus-trap dependency; the logic is ~40 lines.
+- **Fold trapping into `useRestoreFocus`** — conflates window-blur restoration
+  with Tab-trapping, and would not reach the portaled overlays that don't use
+  that hook.
+
+## Components
+
+### `apps/fluux/src/hooks/focusable.ts` (new)
+
+Extract the tab-order focusable machinery currently inlined in
+`useRestoreFocus`:
+
+```ts
+export const FOCUSABLE_SELECTOR =
+  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), ' +
+  'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/** Focusable descendants of `container`, in DOM (tab) order. */
+export function getFocusableElements(container: HTMLElement): HTMLElement[]
+```
+
+`useRestoreFocus` is updated to import from here (no behaviour change).
+
+### `apps/fluux/src/hooks/useFocusTrap.ts` (new)
+
+```ts
+useFocusTrap<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  options?: {
+    initialFocusRef?: RefObject<HTMLElement | null>
+    active?: boolean // default true; lets a caller gate the trap
+  },
+)
+```
+
+Behaviour, all inside a single `useEffect` keyed on the container and `active`:
+
+- **On activate:** capture `document.activeElement` as the return target. If
+  focus is not already inside the container, move it to
+  `initialFocusRef` → first focusable → the container itself (which is given
+  `tabindex="-1"` when it has no focusable children).
+- **Tab wrap:** a `keydown` listener attached **to the container element** (not
+  `document`). This scoping means a stacked modal wins automatically — the lower
+  modal's container never receives the event because focus lives in the top one.
+  - `Tab` while the last focusable is active → `preventDefault`, focus first.
+  - `Shift+Tab` while the first focusable is active → `preventDefault`, focus
+    last.
+  - No focusable children → `preventDefault`, keep focus on the container.
+- **On deactivate / unmount:** restore focus to the captured return target, but
+  only if it is still connected to the DOM and focusable (guard with
+  `document.contains` / `isConnected`). Fires after the exit transition, since
+  `ModalOverlay` unmounts the panel only after `useModalTransition` completes.
+
+This hook owns *entering and leaving* the trap (initial focus in, Tab cycling,
+return focus out). `useRestoreFocus` continues to own *staying in* across OS
+window blur. The two compose without overlap.
+
+### `apps/fluux/src/components/ModalOverlay.tsx`
+
+Add one call next to the existing `useRestoreFocus`:
+
+```ts
+useFocusTrap(panelRef, { initialFocusRef: focusRef })
+useRestoreFocus(panelRef, focusRef)
+```
+
+This single change covers every standard modal and dialog (all ~28 components
+built on `ModalOverlay` / `ModalShell`) plus the command palette.
+
+### Portaled overlays
+
+These bypass `ModalOverlay`; add `useFocusTrap(ref)` to each:
+
+- `apps/fluux/src/components/ui/BottomSheet.tsx`
+- `apps/fluux/src/components/ImageLightbox.tsx`
+- `apps/fluux/src/components/ImageContextMenu.tsx`
+- `apps/fluux/src/components/conversation/UserInfoPopover.tsx`
+
+Note on `UserInfoPopover` and `ImageContextMenu`: these are non-modal (they
+dismiss on click-outside). A hard Tab-trap is slightly unconventional for a
+popover, but full coverage was requested. They already close on Escape /
+outside-click, so the trap only keeps Tab cycling while open.
+
+## Testing
+
+Unit test `apps/fluux/src/hooks/useFocusTrap.test.tsx` (jsdom — pin
+`@vitest-environment jsdom`):
+
+- On mount, focus lands inside the container (first focusable, or the
+  `initialFocusRef` when provided).
+- `Tab` keydown while the last focusable is active moves focus to the first.
+- `Shift+Tab` keydown while the first focusable is active moves focus to the
+  last.
+- A container with no focusable children receives focus itself.
+- On unmount, focus returns to the element focused before mount.
+
+jsdom does not perform native tabbing, so tests drive focus with `.focus()` and
+dispatch `Tab` `keydown` events, asserting the wrap our handler performs.
+
+## Out of scope
+
+- Reworking `useRestoreFocus`'s window-blur behaviour (unchanged).
+- Any visual / animation changes to modals.


### PR DESCRIPTION
When a modal, the command palette, or an overlay is open, keyboard focus could Tab out into the interface underneath it. This adds a hard focus trap so the open layer keeps keyboard control.

While a modal / Cmd-K palette / overlay is open:
- focus is placed on the panel when it opens,
- Tab / Shift+Tab cycle only within the panel — never reaching the sidebar, composer, or main content beneath,
- focus returns to the element that opened it, on close.

Implemented as a reusable `useFocusTrap` hook wired centrally in `ModalOverlay` (covers all modals + Cmd-K) and in the four portaled overlays (BottomSheet, ImageLightbox, ImageContextMenu, UserInfoPopover). A shared `focusable.ts` helper is now used by both `useFocusTrap` and the existing `useRestoreFocus`; the latter continues to own focus restoration across OS window blur. The keydown listener is container-scoped so stacked overlays behave correctly.