### PR TITLE
fix(theme): use chat background for admin main area

### DIFF
--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -528,7 +528,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
   }
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-fluux-sidebar">
+    <div className="flex-1 flex flex-col min-h-0 bg-fluux-chat">
       {/* Header */}
       <div className="h-14 flex items-center px-4 border-b border-fluux-bg">
         {/* Back button - mobile only */}


### PR DESCRIPTION
The admin section's main content area used `bg-fluux-sidebar` on its root container, overriding the `<main>` element's `bg-fluux-chat` with the darker sidebar shade. This collapsed the normal sidebar↔main contrast, making the admin section read as a flat, off-theme tone unlike every other view.

The admin sidebar itself was already correct — it renders inside the shared sidebar container. Only the main pane was affected.

Fix: swap the AdminView root to `bg-fluux-chat`, the same token the chat area and Settings view use. Verified in demo mode — the admin content root now resolves to the chat background and matches `<main>`.