### PR TITLE
Calm two-tone notification badges on the nav tabs

### DIFF
--- a/apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
+++ b/apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
@@ -64,8 +64,7 @@ vi.mock('@fluux/sdk/react', () => ({
     }),
   useRoomStore: (sel: (s: Record<string, unknown>) => unknown) =>
     sel({
-      totalMentionsCount: () => 0,
-      totalNotifiableUnreadCount: () => 0,
+      roomTabIndicator: () => 'none',
     }),
   useEventsStore: (sel: (s: Record<string, unknown>) => unknown) =>
     sel({ subscriptionRequests: [] }),

--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -100,8 +100,7 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
     return sum
   })
   const pendingRequestCount = useEventsStore((s) => s.subscriptionRequests.length)
-  const totalMentionsCount = useRoomStore((s) => s.totalMentionsCount())
-  const totalNotifiableUnreadCount = useRoomStore((s) => s.totalNotifiableUnreadCount())
+  const roomTabTone = useRoomStore((s) => s.roomTabIndicator())
 
   // Diagnostic: track every selector value per render. Dev-only (guarded inside
   // trackSelectorChange). Helps pinpoint unstable selectors causing render loops.
@@ -110,8 +109,7 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
   trackSelectorChange('Sidebar', 'ownNickname', ownNickname)
   trackSelectorChange('Sidebar', 'isAdmin', isAdmin)
   trackSelectorChange('Sidebar', 'totalUnread', totalUnread)
-  trackSelectorChange('Sidebar', 'totalMentionsCount', totalMentionsCount)
-  trackSelectorChange('Sidebar', 'totalNotifiableUnreadCount', totalNotifiableUnreadCount)
+  trackSelectorChange('Sidebar', 'roomTabTone', roomTabTone)
   const { dragRegionProps } = useWindowDrag()
 
   // Per-modal subscriptions: the Sidebar owns these three modals and re-renders
@@ -243,6 +241,7 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
           pathPrefix="/messages"
           onNavigate={onViewChange}
           showBadge={totalUnread > 0}
+          tone="strong"
         />
         <IconRailNavLink
           icon={Hash}
@@ -250,7 +249,8 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
           view="rooms"
           pathPrefix="/rooms"
           onNavigate={onViewChange}
-          showBadge={totalMentionsCount > 0 || totalNotifiableUnreadCount > 0}
+          showBadge={roomTabTone !== 'none'}
+          tone={roomTabTone === 'accent' ? 'accent' : 'neutral'}
         />
         {/* Search */}
         <IconRailNavLink

--- a/apps/fluux/src/components/sidebar-components/ConversationList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ConversationList.tsx
@@ -312,7 +312,7 @@ export const ConversationItem = memo(function ConversationItem({
             />
           )}
           {conversation.unreadCount > 0 && (
-            <span className="absolute -top-1 -end-1 z-10 min-w-4 h-4 px-1 bg-fluux-badge text-fluux-badge-text text-[10px] font-bold rounded-full flex items-center justify-center">
+            <span className="absolute -top-1 -end-1 z-10 min-w-4 h-4 px-1 bg-fluux-badge-strong text-white text-[10px] font-bold rounded-full flex items-center justify-center">
               {conversation.unreadCount}
             </span>
           )}

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
@@ -111,7 +111,7 @@ describe('IconRailNavLink', () => {
       )
 
       // Badge should be visible (small red dot)
-      const badge = container.querySelector('.bg-fluux-red')
+      const badge = container.querySelector('.bg-fluux-badge-strong')
       expect(badge).toBeInTheDocument()
     })
 
@@ -129,8 +129,60 @@ describe('IconRailNavLink', () => {
         { wrapper: Wrapper }
       )
 
-      const badge = container.querySelector('.bg-fluux-red')
+      const badge = container.querySelector('.bg-fluux-badge-strong')
       expect(badge).not.toBeInTheDocument()
+    })
+
+    it('renders a strong (red) dot by default', () => {
+      const Wrapper = createWrapper('/')
+      const { container } = render(
+        <IconRailNavLink
+          icon={MessageCircle}
+          label="Messages"
+          view="messages"
+          pathPrefix="/messages"
+          onNavigate={vi.fn()}
+          showBadge={true}
+        />,
+        { wrapper: Wrapper }
+      )
+      expect(container.querySelector('.bg-fluux-badge-strong')).toBeInTheDocument()
+    })
+
+    it('renders a neutral (grey) dot when tone="neutral"', () => {
+      const Wrapper = createWrapper('/')
+      const { container } = render(
+        <IconRailNavLink
+          icon={Hash}
+          label="Rooms"
+          view="rooms"
+          pathPrefix="/rooms"
+          onNavigate={vi.fn()}
+          showBadge={true}
+          tone="neutral"
+        />,
+        { wrapper: Wrapper }
+      )
+      expect(container.querySelector('.bg-fluux-gray')).toBeInTheDocument()
+      expect(container.querySelector('.bg-fluux-badge-strong')).toBeNull()
+    })
+
+    it('renders an accent (blue) dot when tone="accent"', () => {
+      const Wrapper = createWrapper('/')
+      const { container } = render(
+        <IconRailNavLink
+          icon={Hash}
+          label="Rooms"
+          view="rooms"
+          pathPrefix="/rooms"
+          onNavigate={vi.fn()}
+          showBadge={true}
+          tone="accent"
+        />,
+        { wrapper: Wrapper }
+      )
+      const dot = container.querySelector('span.bg-fluux-brand')
+      expect(dot).toBeInTheDocument()
     })
   })
 

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -11,6 +11,8 @@ interface IconRailNavLinkProps {
   /** Path prefix to match for active state (e.g., '/messages', '/rooms') */
   pathPrefix: string
   showBadge?: boolean
+  /** Dot colour when showBadge is true. Defaults to 'strong' (red) to preserve prior behaviour. */
+  tone?: 'neutral' | 'accent' | 'strong'
   /** When > 0, renders a red numeric badge (clamped to 99+). Takes precedence over showBadge. */
   badgeCount?: number
   /** Overrides the button aria-label (the tooltip still shows `label`). */
@@ -30,6 +32,7 @@ export function IconRailNavLink({
   view,
   pathPrefix,
   showBadge,
+  tone = 'strong',
   badgeCount,
   badgeLabel,
   onNavigate,
@@ -37,6 +40,12 @@ export function IconRailNavLink({
   const location = useLocation()
   const isActive = location.pathname === pathPrefix || location.pathname.startsWith(pathPrefix + '/')
   const hasCount = typeof badgeCount === 'number' && badgeCount > 0
+  const dotToneClass =
+    tone === 'neutral'
+      ? 'bg-fluux-gray'
+      : tone === 'accent'
+        ? 'bg-fluux-brand'
+        : 'bg-fluux-badge-strong'
 
   return (
     <Tooltip content={label} position="right" delay={500}>
@@ -59,7 +68,7 @@ export function IconRailNavLink({
             {badgeCount > 99 ? '99+' : badgeCount}
           </span>
         ) : showBadge ? (
-          <span className="absolute top-0 end-0 size-3 bg-fluux-red rounded-full border-2 border-fluux-sidebar" />
+          <span className={`absolute top-0 end-0 size-3 ${dotToneClass} rounded-full border-2 border-fluux-sidebar`} />
         ) : null}
       </button>
     </Tooltip>

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -429,12 +429,12 @@ const RoomItem = memo(function RoomItem({
             {/* Activity dot for unread (non-mention) activity */}
             {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
               <Tooltip content={`${room.unreadCount} unread`} position="top">
-                <div className="size-2.5 rounded-full bg-fluux-brand flex-shrink-0" />
+                <div className="size-2.5 rounded-full bg-fluux-gray flex-shrink-0" />
               </Tooltip>
             )}
             {/* Mentions count badge */}
             {room.mentionsCount > 0 && (
-              <span className="min-w-5 h-5 px-1.5 bg-fluux-red text-white text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
+              <span className="min-w-5 h-5 px-1.5 bg-fluux-badge text-fluux-badge-text text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
                 @{room.mentionsCount}
               </span>
             )}

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -359,6 +359,10 @@
      set --fluux-badge-text to a color that clears AA on its chosen fill. */
   --fluux-badge-bg: var(--fluux-bg-accent);
   --fluux-badge-text: var(--fluux-text-on-accent);
+  /* Strong badge (direct messages) — the loudest unread tone. Separate from the
+     error red so themes can retune notification urgency without touching danger
+     buttons/toasts. Defaults to the status-error red. */
+  --fluux-badge-strong: var(--fluux-status-error);
 
   /* Avatar presence */
   --fluux-presence-online: var(--fluux-status-success);

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -361,7 +361,10 @@
   --fluux-badge-text: var(--fluux-text-on-accent);
   /* Strong badge (direct messages) — the loudest unread tone. Separate from the
      error red so themes can retune notification urgency without touching danger
-     buttons/toasts. Defaults to the status-error red. */
+     buttons/toasts. Defaults to the status-error red. Consumers pair this fill
+     with white text, so a theme overriding --fluux-badge-strong must keep the
+     fill dark enough for white to clear AA (the default status-error red is
+     tuned that way). */
   --fluux-badge-strong: var(--fluux-status-error);
 
   /* Avatar presence */

--- a/apps/fluux/src/test-setup.ts
+++ b/apps/fluux/src/test-setup.ts
@@ -413,6 +413,7 @@ vi.mock('@fluux/sdk/react', () => ({
       getDraft: () => '',
       clearDraft: vi.fn(),
       roomsWithUnreadCount: () => 0,
+      roomTabIndicator: () => 'none',
       getMAMQueryState: () => ({ isLoading: false, hasMoreHistory: false }),
     }
     return selector ? selector(state) : state

--- a/apps/fluux/tailwind.config.js
+++ b/apps/fluux/tailwind.config.js
@@ -43,6 +43,7 @@ export default {
           // Badge
           'badge': 'var(--fluux-badge-bg)',
           'badge-text': 'var(--fluux-badge-text)',
+          'badge-strong': 'var(--fluux-badge-strong)',
           // Aurora identity tokens
           'accent-2': 'var(--fluux-accent-2)',
           // Encryption affordance (shields, locks) — single source of truth so

--- a/docs/superpowers/plans/2026-07-01-nav-tab-calm-badges.md
+++ b/docs/superpowers/plans/2026-07-01-nav-tab-calm-badges.md
@@ -1,0 +1,500 @@
+# Calm Two-Tone Nav-Tab Badges Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a calm grey "new messages" dot on the `#` rooms tab (accent-blue when mentioned or notify-all), keep the DM tab red via a themable token, and align the per-row badges to the same three-tone palette.
+
+**Architecture:** A new pure store selector `roomTabIndicator()` returns `'none' | 'neutral' | 'accent'` for the rooms tab. `IconRailNavLink` gains a `tone` prop mapping to dot colours. A new CSS token `--fluux-badge-strong` de-hardcodes the DM red. Per-row room/DM badges are recoloured to match.
+
+**Tech Stack:** React + TypeScript, Zustand vanilla stores, Tailwind (CSS-variable colour tokens), Vitest + Testing Library.
+
+## Global Constraints
+
+- Three tones, low → high urgency: `neutral` = `bg-fluux-gray` (ambient room unread); `accent` = `bg-fluux-brand` (room mention / notify-all); `strong` = `bg-fluux-badge-strong` (DMs).
+- Accent wins over neutral on the rooms tab. Muted rooms are fully silent — they contribute neither tone, even with a mention.
+- Tabs render plain dots only (no numeric counts); the existing numeric-badge path (`badgeCount`) is unchanged and keeps `bg-fluux-red`.
+- SDK type changes require `npm run build:sdk` before the app typechecks (worktree resolves `@fluux/sdk` to built dist).
+- Run tests per-workspace, not bare `vitest` from root.
+
+---
+
+### Task 1: Themable `badge-strong` token + `tone` prop on `IconRailNavLink`
+
+**Files:**
+- Modify: `apps/fluux/src/index.css` (after line 361)
+- Modify: `apps/fluux/tailwind.config.js` (after line 45)
+- Modify: `apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx`
+- Test: `apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx`
+
+**Interfaces:**
+- Produces: `IconRailNavLink` accepts `tone?: 'neutral' | 'accent' | 'strong'` (default `'strong'`). The dot `<span>` colour is `bg-fluux-gray` (neutral), `bg-fluux-brand` (accent), or `bg-fluux-badge-strong` (strong). Tailwind class `bg-fluux-badge-strong` resolves to `var(--fluux-badge-strong)` → `var(--fluux-status-error)`.
+
+- [ ] **Step 1: Add the CSS token.** In `apps/fluux/src/index.css`, immediately after line 361 (`  --fluux-badge-text: var(--fluux-text-on-accent);`), add:
+
+```css
+  /* Strong badge (direct messages) — the loudest unread tone. Separate from the
+     error red so themes can retune notification urgency without touching danger
+     buttons/toasts. Defaults to the status-error red. */
+  --fluux-badge-strong: var(--fluux-status-error);
+```
+
+- [ ] **Step 2: Expose the Tailwind colour.** In `apps/fluux/tailwind.config.js`, immediately after line 45 (`          'badge-text': 'var(--fluux-badge-text)',`), add:
+
+```js
+          'badge-strong': 'var(--fluux-badge-strong)',
+```
+
+- [ ] **Step 3: Update the failing tests first.** In `IconRailNavLink.test.tsx`, the two existing dot assertions expect the old red. Change line 114 from:
+
+```tsx
+      const badge = container.querySelector('.bg-fluux-red')
+```
+to:
+```tsx
+      const badge = container.querySelector('.bg-fluux-badge-strong')
+```
+
+And change line 132 the same way (the "should not render badge" test):
+
+```tsx
+      const badge = container.querySelector('.bg-fluux-badge-strong')
+```
+
+Leave line 345 (`span.bg-fluux-red`, the numeric-badge test) unchanged — the numeric path keeps its red.
+
+- [ ] **Step 4: Add tone tests.** Append this block inside the `describe('rendering', ...)` group in `IconRailNavLink.test.tsx`, after the "should not render badge when showBadge is false" test (after line 134):
+
+```tsx
+    it('renders a strong (red) dot by default', () => {
+      const Wrapper = createWrapper('/')
+      const { container } = render(
+        <IconRailNavLink
+          icon={MessageCircle}
+          label="Messages"
+          view="messages"
+          pathPrefix="/messages"
+          onNavigate={vi.fn()}
+          showBadge={true}
+        />,
+        { wrapper: Wrapper }
+      )
+      expect(container.querySelector('.bg-fluux-badge-strong')).toBeInTheDocument()
+    })
+
+    it('renders a neutral (grey) dot when tone="neutral"', () => {
+      const Wrapper = createWrapper('/')
+      const { container } = render(
+        <IconRailNavLink
+          icon={Hash}
+          label="Rooms"
+          view="rooms"
+          pathPrefix="/rooms"
+          onNavigate={vi.fn()}
+          showBadge={true}
+          tone="neutral"
+        />,
+        { wrapper: Wrapper }
+      )
+      expect(container.querySelector('.bg-fluux-gray')).toBeInTheDocument()
+      expect(container.querySelector('.bg-fluux-badge-strong')).toBeNull()
+    })
+
+    it('renders an accent (blue) dot when tone="accent"', () => {
+      const Wrapper = createWrapper('/')
+      const { container } = render(
+        <IconRailNavLink
+          icon={Hash}
+          label="Rooms"
+          view="rooms"
+          pathPrefix="/rooms"
+          onNavigate={vi.fn()}
+          showBadge={true}
+          tone="accent"
+        />,
+        { wrapper: Wrapper }
+      )
+      const dot = container.querySelector('span.bg-fluux-brand')
+      expect(dot).toBeInTheDocument()
+    })
+```
+
+- [ ] **Step 5: Run the tests to verify they fail.**
+
+Run: `cd apps/fluux && npx vitest run src/components/sidebar-components/IconRailNavLink.test.tsx`
+Expected: FAIL — the `tone` prop doesn't exist yet and the default dot still renders `bg-fluux-red`, so the new/updated assertions fail.
+
+- [ ] **Step 6: Implement the `tone` prop.** In `IconRailNavLink.tsx`, add the prop to the interface. Replace lines 13-15:
+
+```tsx
+  showBadge?: boolean
+  /** When > 0, renders a red numeric badge (clamped to 99+). Takes precedence over showBadge. */
+  badgeCount?: number
+```
+with:
+```tsx
+  showBadge?: boolean
+  /** Dot colour when showBadge is true. Defaults to 'strong' (red) to preserve prior behaviour. */
+  tone?: 'neutral' | 'accent' | 'strong'
+  /** When > 0, renders a red numeric badge (clamped to 99+). Takes precedence over showBadge. */
+  badgeCount?: number
+```
+
+Destructure it: change lines 32-33:
+
+```tsx
+  showBadge,
+  badgeCount,
+```
+to:
+```tsx
+  showBadge,
+  tone = 'strong',
+  badgeCount,
+```
+
+After line 39 (`  const hasCount = ...`), add the tone→class map:
+
+```tsx
+  const dotToneClass =
+    tone === 'neutral'
+      ? 'bg-fluux-gray'
+      : tone === 'accent'
+        ? 'bg-fluux-brand'
+        : 'bg-fluux-badge-strong'
+```
+
+Replace the dot span (line 62):
+
+```tsx
+          <span className="absolute top-0 end-0 size-3 bg-fluux-red rounded-full border-2 border-fluux-sidebar" />
+```
+with:
+```tsx
+          <span className={`absolute top-0 end-0 size-3 ${dotToneClass} rounded-full border-2 border-fluux-sidebar`} />
+```
+
+- [ ] **Step 7: Run the tests to verify they pass.**
+
+Run: `cd apps/fluux && npx vitest run src/components/sidebar-components/IconRailNavLink.test.tsx`
+Expected: PASS (all rendering, tone, and numeric-badge tests green).
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add apps/fluux/src/index.css apps/fluux/tailwind.config.js \
+  apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx \
+  apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
+git commit -m "feat(sidebar): add themable badge-strong token and tone prop to IconRailNavLink"
+```
+
+---
+
+### Task 2: `roomTabIndicator()` selector in the SDK room store
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/roomStore.ts` (interface near line 548; implementation near line 2487)
+- Test: `packages/fluux-sdk/src/stores/roomStore.test.ts`
+
+**Interfaces:**
+- Produces: `roomTabIndicator: () => 'none' | 'neutral' | 'accent'` on the room store. Returns `'accent'` if any joined, non-muted room has `mentionsCount > 0` or (`notifyAll || notifyAllPersistent`) with `unreadCount > 0`; else `'neutral'` if any joined, non-muted room has `unreadCount > 0`; else `'none'`. Muted rooms are skipped entirely. Return value is a primitive string (stable for Zustand subscriptions).
+
+- [ ] **Step 1: Write the failing tests.** In `roomStore.test.ts`, add this block immediately after the `describe('totalNotifiableUnreadCount', ...)` block closes (after line 1704):
+
+```tsx
+  describe('roomTabIndicator', () => {
+    it("returns 'none' when there are no rooms", () => {
+      expect(roomStore.getState().roomTabIndicator()).toBe('none')
+    })
+
+    it("returns 'neutral' for plain unread in a non-muted joined room", () => {
+      roomStore.getState().addRoom(createRoom('r1@conference.example.com', {
+        joined: true,
+        unreadCount: 3,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('neutral')
+    })
+
+    it("returns 'accent' when a room has a mention", () => {
+      roomStore.getState().addRoom(createRoom('r1@conference.example.com', {
+        joined: true,
+        unreadCount: 3,
+        mentionsCount: 1,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('accent')
+    })
+
+    it("returns 'accent' for unread in a notifyAll room (no mention)", () => {
+      roomStore.getState().addRoom(createRoom('r1@conference.example.com', {
+        joined: true,
+        unreadCount: 2,
+        notifyAllPersistent: true,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('accent')
+    })
+
+    it('lets accent win over neutral across rooms', () => {
+      roomStore.getState().addRoom(createRoom('plain@conference.example.com', {
+        joined: true,
+        unreadCount: 5,
+      }))
+      roomStore.getState().addRoom(createRoom('mention@conference.example.com', {
+        joined: true,
+        unreadCount: 1,
+        mentionsCount: 1,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('accent')
+    })
+
+    it("keeps muted rooms silent, even with a mention ('none')", () => {
+      roomStore.getState().addRoom(createRoom('muted@conference.example.com', {
+        joined: true,
+        unreadCount: 4,
+        mentionsCount: 2,
+        muted: true,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('none')
+    })
+
+    it('ignores non-joined rooms', () => {
+      roomStore.getState().addRoom(createRoom('bookmarked@conference.example.com', {
+        joined: false,
+        isBookmarked: true,
+        unreadCount: 9,
+        mentionsCount: 3,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('none')
+    })
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail.**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.test.ts -t roomTabIndicator`
+Expected: FAIL — `roomTabIndicator is not a function`.
+
+- [ ] **Step 3: Declare the method on the store interface.** In `roomStore.ts`, after line 548 (`  roomsWithUnreadCount: () => number ...`), add:
+
+```tsx
+  roomTabIndicator: () => 'none' | 'neutral' | 'accent' // Rooms tab dot tone
+```
+
+- [ ] **Step 4: Implement the selector.** In `roomStore.ts`, immediately after the `roomsWithUnreadCount: () => { ... }` implementation closes (after line 2487), add:
+
+```tsx
+  roomTabIndicator: () => {
+    let hasNeutral = false
+    for (const [jid, entity] of get().roomEntities) {
+      if (!entity.joined) continue
+      const meta = get().roomMeta.get(jid)
+      if (!meta || meta.muted) continue
+      const notifyAll = meta.notifyAll || meta.notifyAllPersistent
+      if (meta.mentionsCount > 0 || (notifyAll && meta.unreadCount > 0)) {
+        return 'accent'
+      }
+      if (meta.unreadCount > 0) hasNeutral = true
+    }
+    return hasNeutral ? 'neutral' : 'none'
+  },
+```
+
+- [ ] **Step 5: Run the tests to verify they pass.**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.test.ts -t roomTabIndicator`
+Expected: PASS (all seven cases green).
+
+- [ ] **Step 6: Rebuild the SDK so the app sees the new type.**
+
+Run: `npm run build:sdk`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add packages/fluux-sdk/src/stores/roomStore.ts packages/fluux-sdk/src/stores/roomStore.test.ts
+git commit -m "feat(sdk): add roomTabIndicator selector for the rooms tab tone"
+```
+
+---
+
+### Task 3: Wire the sidebar tabs to the new tones
+
+**Files:**
+- Modify: `apps/fluux/src/components/Sidebar.tsx` (lines 103-104, 113-114, 239-254)
+- Modify: `apps/fluux/src/test-setup.ts` (useRoomStore mock, after line 415)
+- Modify: `apps/fluux/src/components/Sidebar.archiveToggle.test.tsx` (useRoomStore override, lines 66-69)
+
+**Interfaces:**
+- Consumes: `roomTabIndicator()` from Task 2; `tone` prop from Task 1.
+- Produces: rooms tab shows a dot (`showBadge`) when the indicator isn't `'none'`, tinted `accent` or `neutral`; DM tab explicitly `tone="strong"`.
+
+- [ ] **Step 1: Add `roomTabIndicator` to the global test mock.** In `apps/fluux/src/test-setup.ts`, in the `useRoomStore` mock state object, after line 415 (`      roomsWithUnreadCount: () => 0,`), add:
+
+```tsx
+      roomTabIndicator: () => 'none',
+```
+
+- [ ] **Step 2: Update the archiveToggle test override.** In `apps/fluux/src/components/Sidebar.archiveToggle.test.tsx`, replace the `useRoomStore` override (lines 66-69):
+
+```tsx
+  useRoomStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      totalMentionsCount: () => 0,
+      totalNotifiableUnreadCount: () => 0,
+    }),
+```
+with:
+```tsx
+  useRoomStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      roomTabIndicator: () => 'none',
+    }),
+```
+
+- [ ] **Step 3: Replace the room selectors in `Sidebar.tsx`.** Change lines 103-104:
+
+```tsx
+  const totalMentionsCount = useRoomStore((s) => s.totalMentionsCount())
+  const totalNotifiableUnreadCount = useRoomStore((s) => s.totalNotifiableUnreadCount())
+```
+to:
+```tsx
+  const roomTabTone = useRoomStore((s) => s.roomTabIndicator())
+```
+
+- [ ] **Step 4: Update the diagnostic tracking.** Change lines 113-114:
+
+```tsx
+  trackSelectorChange('Sidebar', 'totalMentionsCount', totalMentionsCount)
+  trackSelectorChange('Sidebar', 'totalNotifiableUnreadCount', totalNotifiableUnreadCount)
+```
+to:
+```tsx
+  trackSelectorChange('Sidebar', 'roomTabTone', roomTabTone)
+```
+
+- [ ] **Step 5: Set the DM tab tone explicitly.** In the messages `IconRailNavLink` (lines 239-246), add a `tone` line after `showBadge={totalUnread > 0}` (line 245):
+
+```tsx
+          showBadge={totalUnread > 0}
+          tone="strong"
+```
+
+- [ ] **Step 6: Drive the rooms tab from the indicator.** In the rooms `IconRailNavLink` (lines 247-254), replace line 253:
+
+```tsx
+          showBadge={totalMentionsCount > 0 || totalNotifiableUnreadCount > 0}
+```
+with:
+```tsx
+          showBadge={roomTabTone !== 'none'}
+          tone={roomTabTone === 'accent' ? 'accent' : 'neutral'}
+```
+
+- [ ] **Step 7: Typecheck and run the sidebar test.**
+
+Run: `npm run typecheck && cd apps/fluux && npx vitest run src/components/Sidebar.archiveToggle.test.tsx`
+Expected: typecheck passes (no reference to the removed `totalMentionsCount`/`totalNotifiableUnreadCount` locals); Sidebar test PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add apps/fluux/src/components/Sidebar.tsx apps/fluux/src/test-setup.ts \
+  apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
+git commit -m "feat(sidebar): drive rooms tab dot from roomTabIndicator, DM tab uses strong tone"
+```
+
+---
+
+### Task 4: Recolour the per-row badges to match the palette
+
+**Files:**
+- Modify: `apps/fluux/src/components/sidebar-components/RoomsList.tsx` (lines 432, 437)
+- Modify: `apps/fluux/src/components/sidebar-components/ConversationList.tsx` (line 315)
+
+**Interfaces:**
+- Consumes: `bg-fluux-gray`, `bg-fluux-badge`/`bg-fluux-badge-text`, `bg-fluux-badge-strong` tokens (Task 1 for `badge-strong`).
+- Produces: room unread dot = grey; room mention pill = accent; DM count badge = strong red. No behavioural change — colours only.
+
+- [ ] **Step 1: Recolour the room unread dot.** In `RoomsList.tsx`, change line 432:
+
+```tsx
+                <div className="size-2.5 rounded-full bg-fluux-brand flex-shrink-0" />
+```
+to:
+```tsx
+                <div className="size-2.5 rounded-full bg-fluux-gray flex-shrink-0" />
+```
+
+- [ ] **Step 2: Recolour the room mention pill to accent.** In `RoomsList.tsx`, change line 437:
+
+```tsx
+              <span className="min-w-5 h-5 px-1.5 bg-fluux-red text-white text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
+```
+to:
+```tsx
+              <span className="min-w-5 h-5 px-1.5 bg-fluux-badge text-fluux-badge-text text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
+```
+
+(`bg-fluux-badge` resolves to the same accent fill as `bg-fluux-brand`; the paired `text-fluux-badge-text` guarantees readable text on both light and dark accents.)
+
+- [ ] **Step 3: Recolour the DM count badge to strong.** In `ConversationList.tsx`, change line 315:
+
+```tsx
+            <span className="absolute -top-1 -end-1 z-10 min-w-4 h-4 px-1 bg-fluux-badge text-fluux-badge-text text-[10px] font-bold rounded-full flex items-center justify-center">
+```
+to:
+```tsx
+            <span className="absolute -top-1 -end-1 z-10 min-w-4 h-4 px-1 bg-fluux-badge-strong text-white text-[10px] font-bold rounded-full flex items-center justify-center">
+```
+
+- [ ] **Step 4: Run the affected component tests + typecheck.**
+
+Run: `npm run typecheck && cd apps/fluux && npx vitest run src/components/sidebar-components/`
+Expected: PASS — no test asserts these specific colour classes, so existing tests stay green; typecheck clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add apps/fluux/src/components/sidebar-components/RoomsList.tsx \
+  apps/fluux/src/components/sidebar-components/ConversationList.tsx
+git commit -m "feat(sidebar): align per-row room/DM badges to the three-tone palette"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Typecheck the whole workspace.**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Run the SDK room-store tests.**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.test.ts`
+Expected: PASS, including the new `roomTabIndicator` block.
+
+- [ ] **Step 3: Run the affected app tests.**
+
+Run: `cd apps/fluux && npx vitest run src/components/sidebar-components/IconRailNavLink.test.tsx src/components/Sidebar.archiveToggle.test.tsx src/components/sidebar-components/`
+Expected: PASS with no stderr.
+
+- [ ] **Step 4: Manual demo check (optional but recommended).** Run `npm run dev`, open `http://localhost:5173/demo.html`, and confirm: the `#` tab shows a grey dot when rooms have plain unread, a blue dot when a room has a mention or notify-all unread, and nothing when all such rooms are muted/read; the DM tab dot is red; per-row room unread dots are grey, mention pills blue, DM counts red.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Palette (grey/accent/strong) → Task 1 (token + tone map), Task 4 (per-row).
+- New `--fluux-badge-strong` token → Task 1 Steps 1-2.
+- `#` rooms tab neutral/accent/none logic incl. muted-silent + notifyAll-accent + accent-wins → Task 2 selector + tests, Task 3 wiring.
+- DM tab keeps red via token → Task 3 Step 5 (`tone="strong"`) + Task 1 token.
+- Per-row room mention (red→blue), room unread (blue→grey), DM count (blue→strong) → Task 4.
+- Testing (SDK matrix + IconRailNavLink tones) → Task 2 Step 1, Task 1 Step 4.
+
+**Placeholder scan:** none — every code step shows the exact before/after.
+
+**Type consistency:** `roomTabIndicator()` returns `'none' | 'neutral' | 'accent'` in the interface (Task 2 Step 3), implementation (Step 4), mocks (Task 3 Steps 1-2), and consumer (Task 3 Step 6, which maps `'accent'`→`'accent'` else `'neutral'`). `tone` prop union `'neutral' | 'accent' | 'strong'` is identical in the interface (Task 1 Step 6) and every call site (Task 3 Steps 5-6).

--- a/docs/superpowers/specs/2026-07-01-room-tab-calm-badge-design.md
+++ b/docs/superpowers/specs/2026-07-01-room-tab-calm-badge-design.md
@@ -1,0 +1,94 @@
+# Calm two-tone badges on the nav tabs
+
+**Date:** 2026-07-01
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The `#` rooms icon tab only shows an indicator when you are **mentioned**, or
+when a room you explicitly set to *notify all* has unread messages. Ordinary
+room unread is invisible at the tab level. The result: you switch to the Rooms
+view and discover unread the tab never hinted at — which feels strange.
+
+The DM tab already shows a "calm" dot for any unread. We want to port that idea
+to the `#` tab, but with two tones so ambient activity reads differently from
+things that are actually addressed to you.
+
+## Palette
+
+Two tones, reused on tabs and per-row:
+
+- **Grey dot** — `bg-fluux-gray` (`--fluux-color-gray`): ambient "new messages".
+- **Accent dot** — `bg-fluux-brand` (`--fluux-bg-accent`, blue): priority — an
+  @-mention, or unread in a room set to *notify all*.
+
+**Accent always wins** over grey when both conditions are present.
+
+## Behaviour
+
+### `#` rooms tab (core change)
+
+A single derived indicator computed over **joined, non-muted** rooms:
+
+1. `accent` — if any qualifying room has `mentionsCount > 0`, **or**
+   (`notifyAll || notifyAllPersistent`) with `unreadCount > 0`.
+2. else `neutral` (grey) — if any qualifying room has `unreadCount > 0`.
+3. else nothing.
+
+**Muted rooms are fully silent**: they contribute neither grey nor accent, even
+when they contain an @-mention. This matches the "all joined rooms *minus muted*"
+scope chosen during design. (Single, well-isolated rule — easy to change later if
+we decide mentions should break through mute.)
+
+### DM tab
+
+Change its dot from red → **blue accent**. A 1:1 DM is inherently addressed to
+you, so the DM tab is always accent-tone. Trigger logic is unchanged: dot when
+`totalUnread > 0`.
+
+### Per-row (rooms list), for palette consistency
+
+- **`@N` mention badge**: red → **blue** (`bg-fluux-brand`).
+- **Unread dot**: currently blue brand → **grey** (`bg-fluux-gray`), so a room
+  row reads the same grey-ambient / blue-priority story as the tab. (Without
+  this, the unread dot and the mention badge would both be blue, distinguishable
+  only by shape.)
+
+DM per-row count badge already uses `bg-fluux-badge` (accent) and needs no change.
+
+## Components touched
+
+- **`packages/fluux-sdk/src/stores/roomStore.ts`** — add one derived selector
+  `roomTabIndicator(): 'none' | 'neutral' | 'accent'`. Returns a primitive, so
+  selector subscriptions don't churn. Reuses the existing per-room walk pattern
+  (`roomEntities` + `roomMeta`), honouring `entity.joined`, `meta.muted`,
+  `meta.mentionsCount`, `meta.unreadCount`, `meta.notifyAll`,
+  `meta.notifyAllPersistent`.
+- **`apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx`** — add a
+  `tone?: 'accent' | 'neutral'` prop (default `'accent'`). The dot colour stops
+  being hardcoded `bg-fluux-red`: `accent → bg-fluux-brand`,
+  `neutral → bg-fluux-gray`. Numeric-badge path is untouched (this design keeps
+  tabs as plain dots).
+- **`apps/fluux/src/components/Sidebar.tsx`** — feed `roomTabIndicator()` into
+  the rooms tab (`showBadge` when not `'none'`, `tone` from the value); set the
+  DM tab `tone='accent'`. Removes the ad-hoc
+  `totalMentionsCount > 0 || totalNotifiableUnreadCount > 0` expression at the
+  tab in favour of the selector.
+- **`apps/fluux/src/components/sidebar-components/RoomsList.tsx`** — recolour the
+  per-row mention badge (red → `bg-fluux-brand`) and unread dot
+  (`bg-fluux-brand` → `bg-fluux-gray`).
+
+## Testing
+
+- **SDK (vitest):** unit-test `roomTabIndicator()` across the matrix — muted vs
+  non-muted; mention vs plain unread vs notifyAll-unread vs nothing; joined vs
+  not-joined. Assert accent-wins-over-grey and muted-is-silent.
+- **App:** assert `IconRailNavLink` renders the correct dot class per `tone`, and
+  that `Sidebar` maps `'accent' | 'neutral' | 'none'` to the right tab state.
+
+## Out of scope
+
+- Numeric counts on the tabs (design keeps plain dots).
+- Changing when the DM tab lights up (unchanged).
+- Any change to notification sounds / native notifications / mute semantics
+  beyond reading the existing `muted` flag.

--- a/docs/superpowers/specs/2026-07-01-room-tab-calm-badge-design.md
+++ b/docs/superpowers/specs/2026-07-01-room-tab-calm-badge-design.md
@@ -16,13 +16,27 @@ things that are actually addressed to you.
 
 ## Palette
 
-Two tones, reused on tabs and per-row:
+Three tones, low → high urgency, reused on tabs and per-row:
 
-- **Grey dot** — `bg-fluux-gray` (`--fluux-color-gray`): ambient "new messages".
-- **Accent dot** — `bg-fluux-brand` (`--fluux-bg-accent`, blue): priority — an
-  @-mention, or unread in a room set to *notify all*.
+- **`neutral` — grey dot** — `bg-fluux-gray` (`--fluux-color-gray`): ambient
+  "new messages" in rooms.
+- **`accent` — blue dot** — `bg-fluux-brand` (`--fluux-bg-accent`): priority in
+  rooms — an @-mention, or unread in a room set to *notify all*.
+- **`strong` — red dot** — `bg-fluux-badge-strong` (**new themable token**, see
+  below): direct messages, the most important.
 
-**Accent always wins** over grey when both conditions are present.
+Within the rooms tab, **accent wins over neutral** when both apply. The DM tab is
+always `strong`.
+
+### New token
+
+Introduce a dedicated, themeable notification colour instead of hardcoding red:
+
+- `apps/fluux/src/index.css`: `--fluux-badge-strong: var(--fluux-status-error);`
+  (defaults to today's red; light/dark/custom themes can override it
+  independently of the error red).
+- `apps/fluux/tailwind.config.js`: expose `'badge-strong': 'var(--fluux-badge-strong)'`
+  so `bg-fluux-badge-strong` is available.
 
 ## Behaviour
 
@@ -42,49 +56,62 @@ we decide mentions should break through mute.)
 
 ### DM tab
 
-Change its dot from red → **blue accent**. A 1:1 DM is inherently addressed to
-you, so the DM tab is always accent-tone. Trigger logic is unchanged: dot when
-`totalUnread > 0`.
+Keep the red dot (DMs outrank room mentions), but drive it from the new
+`strong` tone / `bg-fluux-badge-strong` token instead of hardcoded
+`bg-fluux-red`. Trigger logic is unchanged: dot when `totalUnread > 0`.
 
 ### Per-row (rooms list), for palette consistency
 
-- **`@N` mention badge**: red → **blue** (`bg-fluux-brand`).
+- **`@N` mention badge**: red → **blue** (`bg-fluux-brand`) — room mentions are
+  `accent`, not `strong`.
 - **Unread dot**: currently blue brand → **grey** (`bg-fluux-gray`), so a room
   row reads the same grey-ambient / blue-priority story as the tab. (Without
   this, the unread dot and the mention badge would both be blue, distinguishable
   only by shape.)
 
-DM per-row count badge already uses `bg-fluux-badge` (accent) and needs no change.
+### Per-row (DM list)
+
+DM per-row count badge currently uses `bg-fluux-badge` (blue accent).
+**Recommended:** switch it to `bg-fluux-badge-strong` so DMs read red end-to-end
+(tab dot + row count). Flag if per-row DM counts should stay blue.
 
 ## Components touched
 
+- **`apps/fluux/src/index.css`** — add `--fluux-badge-strong: var(--fluux-status-error);`
+  (and any per-theme override blocks that already redefine status/badge colours).
+- **`apps/fluux/tailwind.config.js`** — expose `'badge-strong': 'var(--fluux-badge-strong)'`.
 - **`packages/fluux-sdk/src/stores/roomStore.ts`** — add one derived selector
-  `roomTabIndicator(): 'none' | 'neutral' | 'accent'`. Returns a primitive, so
-  selector subscriptions don't churn. Reuses the existing per-room walk pattern
-  (`roomEntities` + `roomMeta`), honouring `entity.joined`, `meta.muted`,
-  `meta.mentionsCount`, `meta.unreadCount`, `meta.notifyAll`,
-  `meta.notifyAllPersistent`.
+  `roomTabIndicator(): 'none' | 'neutral' | 'accent'` (rooms only ever use grey or
+  blue — never `strong`). Returns a primitive, so selector subscriptions don't
+  churn. Reuses the existing per-room walk pattern (`roomEntities` + `roomMeta`),
+  honouring `entity.joined`, `meta.muted`, `meta.mentionsCount`,
+  `meta.unreadCount`, `meta.notifyAll`, `meta.notifyAllPersistent`.
 - **`apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx`** — add a
-  `tone?: 'accent' | 'neutral'` prop (default `'accent'`). The dot colour stops
-  being hardcoded `bg-fluux-red`: `accent → bg-fluux-brand`,
-  `neutral → bg-fluux-gray`. Numeric-badge path is untouched (this design keeps
-  tabs as plain dots).
+  `tone?: 'neutral' | 'accent' | 'strong'` prop (default `'strong'`, preserving
+  today's red default). The dot colour stops being hardcoded `bg-fluux-red`:
+  `neutral → bg-fluux-gray`, `accent → bg-fluux-brand`,
+  `strong → bg-fluux-badge-strong`. Numeric-badge path is untouched (this design
+  keeps tabs as plain dots).
 - **`apps/fluux/src/components/Sidebar.tsx`** — feed `roomTabIndicator()` into
   the rooms tab (`showBadge` when not `'none'`, `tone` from the value); set the
-  DM tab `tone='accent'`. Removes the ad-hoc
+  DM tab `tone='strong'`. Removes the ad-hoc
   `totalMentionsCount > 0 || totalNotifiableUnreadCount > 0` expression at the
   tab in favour of the selector.
 - **`apps/fluux/src/components/sidebar-components/RoomsList.tsx`** — recolour the
   per-row mention badge (red → `bg-fluux-brand`) and unread dot
   (`bg-fluux-brand` → `bg-fluux-gray`).
+- **`apps/fluux/src/components/sidebar-components/ConversationList.tsx`**
+  (recommended) — switch the per-row DM count badge `bg-fluux-badge` →
+  `bg-fluux-badge-strong` so DMs read red end-to-end.
 
 ## Testing
 
 - **SDK (vitest):** unit-test `roomTabIndicator()` across the matrix — muted vs
   non-muted; mention vs plain unread vs notifyAll-unread vs nothing; joined vs
   not-joined. Assert accent-wins-over-grey and muted-is-silent.
-- **App:** assert `IconRailNavLink` renders the correct dot class per `tone`, and
-  that `Sidebar` maps `'accent' | 'neutral' | 'none'` to the right tab state.
+- **App:** assert `IconRailNavLink` renders the correct dot class per `tone`
+  (`neutral`/`accent`/`strong`), and that `Sidebar` maps the rooms indicator
+  (`'accent' | 'neutral' | 'none'`) and the `strong` DM tab to the right state.
 
 ## Out of scope
 

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1703,6 +1703,71 @@ describe('roomStore', () => {
     })
   })
 
+  describe('roomTabIndicator', () => {
+    it("returns 'none' when there are no rooms", () => {
+      expect(roomStore.getState().roomTabIndicator()).toBe('none')
+    })
+
+    it("returns 'neutral' for plain unread in a non-muted joined room", () => {
+      roomStore.getState().addRoom(createRoom('r1@conference.example.com', {
+        joined: true,
+        unreadCount: 3,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('neutral')
+    })
+
+    it("returns 'accent' when a room has a mention", () => {
+      roomStore.getState().addRoom(createRoom('r1@conference.example.com', {
+        joined: true,
+        unreadCount: 3,
+        mentionsCount: 1,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('accent')
+    })
+
+    it("returns 'accent' for unread in a notifyAll room (no mention)", () => {
+      roomStore.getState().addRoom(createRoom('r1@conference.example.com', {
+        joined: true,
+        unreadCount: 2,
+        notifyAllPersistent: true,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('accent')
+    })
+
+    it('lets accent win over neutral across rooms', () => {
+      roomStore.getState().addRoom(createRoom('plain@conference.example.com', {
+        joined: true,
+        unreadCount: 5,
+      }))
+      roomStore.getState().addRoom(createRoom('mention@conference.example.com', {
+        joined: true,
+        unreadCount: 1,
+        mentionsCount: 1,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('accent')
+    })
+
+    it("keeps muted rooms silent, even with a mention ('none')", () => {
+      roomStore.getState().addRoom(createRoom('muted@conference.example.com', {
+        joined: true,
+        unreadCount: 4,
+        mentionsCount: 2,
+        muted: true,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('none')
+    })
+
+    it('ignores non-joined rooms', () => {
+      roomStore.getState().addRoom(createRoom('bookmarked@conference.example.com', {
+        joined: false,
+        isBookmarked: true,
+        unreadCount: 9,
+        mentionsCount: 3,
+      }))
+      expect(roomStore.getState().roomTabIndicator()).toBe('none')
+    })
+  })
+
   describe('setActiveRoom', () => {
     it('should set the active room', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com'))

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -546,6 +546,7 @@ export interface RoomState {
   totalUnreadCount: () => number // Total unread messages across all joined rooms
   totalNotifiableUnreadCount: () => number // Total unread in rooms with notifyAll enabled
   roomsWithUnreadCount: () => number // Number of rooms with unread activity (for dock badge)
+  roomTabIndicator: () => 'none' | 'neutral' | 'accent' // Rooms tab dot tone
 }
 
 function createEmptyRoomState(
@@ -2484,6 +2485,21 @@ export const roomStore = createStore<RoomState>()(
       }
     }
     return count
+  },
+  roomTabIndicator: () => {
+    let hasNeutral = false
+    for (const [jid, entity] of get().roomEntities) {
+      if (!entity.joined) continue
+      if (entity.muted) continue
+      const meta = get().roomMeta.get(jid)
+      if (!meta) continue
+      const notifyAll = meta.notifyAll || meta.notifyAllPersistent
+      if (meta.mentionsCount > 0 || (notifyAll && meta.unreadCount > 0)) {
+        return 'accent'
+      }
+      if (meta.unreadCount > 0) hasNeutral = true
+    }
+    return hasNeutral ? 'neutral' : 'none'
   },
 }))
 )


### PR DESCRIPTION
Surfaces room unread at the nav-tab level so you're not surprised by unread messages when you open the Rooms view.

## What changed
- **`#` rooms tab** now shows a calm **grey** dot for ambient unread (any joined, non-muted room), and an **accent-blue** dot for priority (an @-mention, or unread in a *notify-all* room). Accent wins over grey; muted rooms stay fully silent. Previously the tab only lit up for mentions/notify-all, so ordinary unread was invisible there.
- **DM tab** keeps its **red** dot (DMs outrank room mentions), but now via a new themable `--fluux-badge-strong` token instead of a hardcoded red — themes can retune notification urgency without touching danger/error colors.
- **Per-row badges** align to the same grey → blue → red urgency scale (room unread dot grey, room mention pill accent, DM count badge strong).