### PR TITLE
fix(shortcuts): map Alt+3 to Search after contacts relocation

### DIFF
--- a/apps/fluux/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/fluux/src/hooks/useKeyboardShortcuts.test.tsx
@@ -900,7 +900,7 @@ describe('useKeyboardShortcuts', () => {
     })
   })
 
-  describe('Search View (Cmd+Shift+F / Alt+6)', () => {
+  describe('Search View (Cmd+Shift+F / Alt+3)', () => {
     it('should include Cmd+Shift+F shortcut for search view', () => {
       const options = createDefaultOptions()
       const { result } = renderHook(() => useKeyboardShortcuts(options))
@@ -923,26 +923,60 @@ describe('useKeyboardShortcuts', () => {
       expect(options.onSidebarViewChange).toHaveBeenCalledWith('search')
     })
 
-    it('should include Alt+6 shortcut for search view', () => {
+    it('should include Alt+3 shortcut for search view', () => {
       const options = createDefaultOptions()
       const { result } = renderHook(() => useKeyboardShortcuts(options))
 
-      const alt6 = result.current.find(
-        s => s.key === '6' && s.modifiers?.includes('alt')
+      const alt3 = result.current.find(
+        s => s.key === '3' && s.modifiers?.includes('alt')
       )
-      expect(alt6).toBeDefined()
-      expect(alt6!.description).toBe('shortcuts.searchView')
+      expect(alt3).toBeDefined()
+      expect(alt3!.description).toBe('shortcuts.searchView')
     })
 
-    it('should switch to search sidebar view via Alt+6', () => {
+    it('should switch to search sidebar view via Alt+3', () => {
+      const options = createDefaultOptions()
+      const { result } = renderHook(() => useKeyboardShortcuts(options))
+
+      const alt3 = result.current.find(
+        s => s.key === '3' && s.modifiers?.includes('alt')
+      )
+      alt3!.action()
+      expect(options.onSidebarViewChange).toHaveBeenCalledWith('search')
+    })
+
+    it('should no longer bind Alt+6 to any shortcut', () => {
       const options = createDefaultOptions()
       const { result } = renderHook(() => useKeyboardShortcuts(options))
 
       const alt6 = result.current.find(
         s => s.key === '6' && s.modifiers?.includes('alt')
       )
-      alt6!.action()
-      expect(options.onSidebarViewChange).toHaveBeenCalledWith('search')
+      expect(alt6).toBeUndefined()
+    })
+  })
+
+  describe('Contacts View (Alt+9)', () => {
+    it('should include Alt+9 shortcut for the contacts (directory) view', () => {
+      const options = createDefaultOptions()
+      const { result } = renderHook(() => useKeyboardShortcuts(options))
+
+      const alt9 = result.current.find(
+        s => s.key === '9' && s.modifiers?.includes('alt')
+      )
+      expect(alt9).toBeDefined()
+      expect(alt9!.description).toBe('shortcuts.connectionsView')
+    })
+
+    it('should switch to the directory sidebar view via Alt+9', () => {
+      const options = createDefaultOptions()
+      const { result } = renderHook(() => useKeyboardShortcuts(options))
+
+      const alt9 = result.current.find(
+        s => s.key === '9' && s.modifiers?.includes('alt')
+      )
+      alt9!.action()
+      expect(options.onSidebarViewChange).toHaveBeenCalledWith('directory')
     })
   })
 

--- a/apps/fluux/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/fluux/src/hooks/useKeyboardShortcuts.ts
@@ -392,6 +392,13 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions): Shor
     {
       key: '3',
       modifiers: ['alt'],
+      description: 'shortcuts.searchView',
+      category: 'navigation',
+      action: () => onSidebarViewChange('search'),
+    },
+    {
+      key: '9',
+      modifiers: ['alt'],
       description: 'shortcuts.connectionsView',
       category: 'navigation',
       action: () => onSidebarViewChange('directory'),
@@ -427,13 +434,6 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions): Shor
     {
       key: 'f',
       modifiers: ['meta', 'shift'],
-      description: 'shortcuts.searchView',
-      category: 'navigation',
-      action: () => onSidebarViewChange('search'),
-    },
-    {
-      key: '6',
-      modifiers: ['alt'],
       description: 'shortcuts.searchView',
       category: 'navigation',
       action: () => onSidebarViewChange('search'),


### PR DESCRIPTION
Aligns the `Alt+<number>` navigation shortcuts with the icon-rail order changed in the conversation-first relocation (#789), where Search became the 3rd rail item and Contacts moved to the bottom cluster.

- `Alt+3` now opens **Search** (was Contacts/`directory`)
- `Alt+9` now opens **Contacts** (`directory`), grouped near Admin (`Alt+0`)
- Removed the redundant `Alt+6` (Search is reachable via `Alt+3` and `⌘⇧F`)

Final mapping: Messages `Alt+1`, Rooms `Alt+2`, Search `Alt+3`, Contacts `Alt+9`, Admin `Alt+0`.

The shortcut-help overlay and command palette pick these up from the definitions automatically.