### PR TITLE
Rooms header: Quick Chat bolt button + single kebab menu

### DIFF
--- a/apps/fluux/src/components/OverflowMenu.test.tsx
+++ b/apps/fluux/src/components/OverflowMenu.test.tsx
@@ -156,4 +156,19 @@ describe('OverflowMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close it' }))
     expect(screen.queryByText('View profile')).not.toBeInTheDocument()
   })
+
+  it('renders a separator above an item marked dividerBefore', () => {
+    render(
+      <OverflowMenu
+        ariaLabel="More actions"
+        items={[
+          { key: 'a', label: 'First', icon: User, onClick: vi.fn() },
+          { key: 'b', label: 'Second', icon: Archive, onClick: vi.fn(), dividerBefore: true },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+  })
 })

--- a/apps/fluux/src/components/OverflowMenu.tsx
+++ b/apps/fluux/src/components/OverflowMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react'
 import { MoreVertical, Check, type LucideIcon } from 'lucide-react'
 import { useClickOutside } from '@/hooks/useClickOutside'
 
@@ -20,6 +20,8 @@ export interface OverflowMenuItem {
    * trailing check mark when `true`. Leave undefined for a plain action item.
    */
   active?: boolean
+  /** Renders a separator line above this item, to group menu sections. */
+  dividerBefore?: boolean
 }
 
 interface OverflowMenuProps {
@@ -99,23 +101,25 @@ export function OverflowMenu({
 
       {isOpen && (
         <div role="menu" className={menuClassName}>
-          {items.map(({ key, label, icon: Icon, onClick, danger, disabled, active }) => (
-            <button
-              key={key}
-              role={active === undefined ? 'menuitem' : 'menuitemcheckbox'}
-              aria-checked={active === undefined ? undefined : active}
-              type="button"
-              disabled={disabled}
-              onClick={() => {
-                setIsOpen(false)
-                onClick()
-              }}
-              className={`w-full flex items-center gap-2 px-3 py-2.5 text-start text-sm transition-colors hover:bg-fluux-active disabled:opacity-50 disabled:cursor-not-allowed ${danger ? 'text-fluux-error' : 'text-fluux-text'}`}
-            >
-              <Icon className="size-4 flex-shrink-0" />
-              <span>{label}</span>
-              {active && <Check className="size-4 flex-shrink-0 ms-auto" aria-hidden="true" />}
-            </button>
+          {items.map(({ key, label, icon: Icon, onClick, danger, disabled, active, dividerBefore }) => (
+            <Fragment key={key}>
+              {dividerBefore && <div role="separator" className="my-1 border-t border-fluux-hover" />}
+              <button
+                role={active === undefined ? 'menuitem' : 'menuitemcheckbox'}
+                aria-checked={active === undefined ? undefined : active}
+                type="button"
+                disabled={disabled}
+                onClick={() => {
+                  setIsOpen(false)
+                  onClick()
+                }}
+                className={`w-full flex items-center gap-2 px-3 py-2.5 text-start text-sm transition-colors hover:bg-fluux-active disabled:opacity-50 disabled:cursor-not-allowed ${danger ? 'text-fluux-error' : 'text-fluux-text'}`}
+              >
+                <Icon className="size-4 flex-shrink-0" />
+                <span>{label}</span>
+                {active && <Check className="size-4 flex-shrink-0 ms-auto" aria-hidden="true" />}
+              </button>
+            </Fragment>
           ))}
         </div>
       )}

--- a/apps/fluux/src/components/sidebar-components/RoomsHeaderActions.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsHeaderActions.test.tsx
@@ -15,32 +15,40 @@ const baseProps = () => ({
 })
 
 describe('RoomsHeaderActions', () => {
-  it('fires onQuickChat directly from the + button', () => {
+  it('fires onQuickChat directly from the bolt button', () => {
     const props = baseProps()
     render(<RoomsHeaderActions {...props} />)
     fireEvent.click(screen.getByRole('button', { name: 'Create Quick Chat' }))
     expect(props.onQuickChat).toHaveBeenCalledTimes(1)
   })
 
-  it('opens the create-menu from the chevron with all four paths', () => {
+  it('groups the other room actions in the overflow menu (Quick Chat is not duplicated there)', () => {
     render(<RoomsHeaderActions {...baseProps()} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Create Room' }))
-    expect(screen.getByRole('menuitem', { name: 'Quick Chat' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }))
     expect(screen.getByRole('menuitem', { name: 'Permanent Room' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Join room' })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: 'Browse Rooms' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Catch up all rooms' })).toBeInTheDocument()
+    // Quick Chat lives on the bolt button only, not repeated as a menu item.
+    expect(screen.queryByRole('menuitem', { name: 'Quick Chat' })).not.toBeInTheDocument()
   })
 
-  it('fires onPermanentRoom from the create-menu and closes it', () => {
+  it('separates the maintenance action from the create actions', () => {
+    render(<RoomsHeaderActions {...baseProps()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }))
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+  })
+
+  it('fires onPermanentRoom from the overflow menu and closes it', () => {
     const props = baseProps()
     render(<RoomsHeaderActions {...props} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Create Room' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }))
     fireEvent.click(screen.getByRole('menuitem', { name: 'Permanent Room' }))
     expect(props.onPermanentRoom).toHaveBeenCalledTimes(1)
     expect(screen.queryByRole('menuitem', { name: 'Permanent Room' })).not.toBeInTheDocument()
   })
 
-  it('exposes Catch up all in the overflow menu and fires it', () => {
+  it('fires onCatchUpAll from the overflow menu', () => {
     const props = baseProps()
     render(<RoomsHeaderActions {...props} />)
     fireEvent.click(screen.getByRole('button', { name: 'Options' }))

--- a/apps/fluux/src/components/sidebar-components/RoomsHeaderActions.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsHeaderActions.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from 'react-i18next'
-import { Plus, ChevronDown, Zap, Hash, LogIn, Search, RefreshCw } from 'lucide-react'
+import { Zap, Hash, LogIn, Search, RefreshCw } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 import { OverflowMenu, type OverflowMenuItem } from '../OverflowMenu'
 import { SIDEBAR_HEADER_ICON_BTN } from './types'
 
 interface RoomsHeaderActionsProps {
-  /** Create a Quick Chat (the + primary action). */
+  /** Create a Quick Chat — the prominent bolt button. */
   onQuickChat: () => void
   /** Open the Create (permanent) Room modal. */
   onPermanentRoom: () => void
@@ -20,9 +20,9 @@ interface RoomsHeaderActionsProps {
 }
 
 /**
- * Rooms tab header actions: a split create button (`+` = Quick Chat, `▾` opens a
- * create-menu of all four create/join paths) plus a `⋮` overflow menu for the
- * Catch-up maintenance action.
+ * Rooms tab header actions: a Quick Chat bolt button (the fast, casual path)
+ * beside a `⋮` overflow menu that groups the remaining room actions — the other
+ * create/join paths, then the Catch-up maintenance action below a separator.
  */
 export function RoomsHeaderActions({
   onQuickChat,
@@ -33,84 +33,29 @@ export function RoomsHeaderActions({
   isCatchingUp,
 }: RoomsHeaderActionsProps) {
   const { t } = useTranslation()
-  const overflowItems: OverflowMenuItem[] = [
-    { key: 'catchup', label: t('rooms.catchUpAll'), icon: RefreshCw, onClick: onCatchUpAll, disabled: isCatchingUp },
-  ]
-  return (
-    <div className="flex items-center gap-0.5">
-      <RoomsCreateSplitButton
-        onQuickChat={onQuickChat}
-        onPermanentRoom={onPermanentRoom}
-        onJoinRoom={onJoinRoom}
-        onBrowseRooms={onBrowseRooms}
-      />
-      <OverflowMenu
-        ariaLabel={t('common.options')}
-        items={overflowItems}
-        buttonClassName={`${SIDEBAR_HEADER_ICON_BTN} text-fluux-muted hover:text-fluux-text`}
-      />
-    </div>
-  )
-}
-
-interface RoomsCreateSplitButtonProps {
-  onQuickChat: () => void
-  onPermanentRoom: () => void
-  onJoinRoom: () => void
-  onBrowseRooms: () => void
-}
-
-/**
- * `+` fires Quick Chat directly; the adjacent `▾` opens a create-menu (built on
- * OverflowMenu via renderTrigger) listing all four create/join paths — Quick
- * Chat included, so the `+` shortcut is discoverable.
- */
-function RoomsCreateSplitButton({ onQuickChat, onPermanentRoom, onJoinRoom, onBrowseRooms }: RoomsCreateSplitButtonProps) {
-  const { t } = useTranslation()
   const items: OverflowMenuItem[] = [
-    { key: 'quickChat', label: t('rooms.quickChat'), icon: Zap, onClick: onQuickChat },
     { key: 'permanentRoom', label: t('rooms.permanentRoom'), icon: Hash, onClick: onPermanentRoom },
     { key: 'joinRoom', label: t('rooms.joinRoom'), icon: LogIn, onClick: onJoinRoom },
     { key: 'browseRooms', label: t('rooms.browseRooms'), icon: Search, onClick: onBrowseRooms },
+    { key: 'catchup', label: t('rooms.catchUpAll'), icon: RefreshCw, onClick: onCatchUpAll, disabled: isCatchingUp, dividerBefore: true },
   ]
   return (
-    <OverflowMenu
-      ariaLabel={t('rooms.createRoom')}
-      items={items}
-      renderTrigger={({ isOpen, toggle, close }) => (
-        <div className="flex items-center">
-          <Tooltip content={t('rooms.createQuickChat')} position="bottom">
-            <button
-              type="button"
-              onClick={() => {
-                close()
-                onQuickChat()
-              }}
-              aria-label={t('rooms.createQuickChat')}
-              className={`${SIDEBAR_HEADER_ICON_BTN} text-fluux-muted hover:text-fluux-text`}
-            >
-              <Plus className="size-5" />
-            </button>
-          </Tooltip>
-          <Tooltip content={t('rooms.createRoom')} position="bottom">
-            {/* Narrow secondary affordance of the split button — intentionally
-                NOT the 44px SIDEBAR_HEADER_ICON_BTN. A full-size chevron glued to
-                the 44px primary would form an ~88px control dominating the 56px
-                header; the primary "+" (the common path) already meets the touch
-                target. */}
-            <button
-              type="button"
-              onClick={toggle}
-              aria-label={t('rooms.createRoom')}
-              aria-haspopup="menu"
-              aria-expanded={isOpen}
-              className="-ms-1 p-2 rounded-lg hover:bg-fluux-hover transition-colors text-fluux-muted hover:text-fluux-text flex items-center"
-            >
-              <ChevronDown className="size-4" />
-            </button>
-          </Tooltip>
-        </div>
-      )}
-    />
+    <div className="flex items-center gap-0.5">
+      <Tooltip content={t('rooms.createQuickChat')} position="bottom">
+        <button
+          type="button"
+          onClick={onQuickChat}
+          aria-label={t('rooms.createQuickChat')}
+          className={`${SIDEBAR_HEADER_ICON_BTN} text-fluux-muted hover:text-fluux-text`}
+        >
+          <Zap className="size-5" />
+        </button>
+      </Tooltip>
+      <OverflowMenu
+        ariaLabel={t('common.options')}
+        items={items}
+        buttonClassName={`${SIDEBAR_HEADER_ICON_BTN} text-fluux-muted hover:text-fluux-text`}
+      />
+    </div>
   )
 }


### PR DESCRIPTION
Follow-up to the unified sidebar header (#799). The Rooms header showed three controls (`+`, `▾` create-menu, `⋮` overflow), which read as confusing.

## Change
- Quick Chat is now a prominent **Zap/bolt** button (self-explanatory, replacing the generic `+`).
- The `▾` create-dropdown is gone; its items fold into the single `⋮` kebab: **Permanent Room · Join Room · Browse Rooms**, then **Catch up all** below a separator.
- Adds an optional `dividerBefore` flag to `OverflowMenu` for grouping menu sections.

Result: two controls (`⚡` + `⋮`) instead of three. Quick Chat is not duplicated in the kebab.