### PR TITLE
fix(nav): reaction toast opens the wrong room/conversation

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -21,6 +21,7 @@ const {
     activationPending: false,
     isArchivedResult: false,
     conversations: new Map<string, { id: string }>(),
+    rooms: new Map<string, { jid: string; joined: boolean }>(),
   }
 
   const mockContact: Contact = {
@@ -214,6 +215,8 @@ vi.mock('@fluux/sdk', () => ({
       clearFirstNewMessageId: vi.fn(),
       setActiveRoom: mockSetActiveRoom,
       activateRoom: mockActivateRoom,
+      rooms: getMockState().rooms,
+      allRooms: () => Array.from(getMockState().rooms.values()),
     }),
   },
   connectionStore: {
@@ -285,7 +288,7 @@ vi.mock('@fluux/sdk/react', () => ({
         activeRoomJid: getMockState().activeRoomJid,
         setActiveRoom: mockSetActiveRoom,
         activateRoom: mockActivateRoom,
-        rooms: new Map(),
+        rooms: getMockState().rooms,
       }
       return selector(state)
     },
@@ -529,6 +532,7 @@ describe('ChatLayout - Tab Memory', () => {
       activeRoomJid: null,
       isArchivedResult: false,
       conversations: new Map(),
+      rooms: new Map(),
     })
   })
 
@@ -555,6 +559,51 @@ describe('ChatLayout - Tab Memory', () => {
 
       // With replace there is nothing behind the auto-selected conversation.
       expect(path()).toBe('/messages/bob@example.com')
+    })
+  })
+
+  describe('deep-link / programmatic navigation to a specific target', () => {
+    // Regression: clicking a reaction toast (or any deep link) that targets a
+    // specific conversation/room must not be hijacked by the "auto-select first
+    // item" effect. activateConversation/activateRoom are async (they await a
+    // cache load before setting the active id), so on the navigation commit the
+    // store's active id is still null — the auto-select effect must instead defer
+    // to the URL's target (activeJid) and not pick the first item.
+    it('does not auto-select the first conversation when the URL targets another one', async () => {
+      // Store's first (only) conversation is bob, but the URL points at alice.
+      setMockState({
+        activeConversationId: null,
+        conversations: new Map([['bob@example.com', { id: 'bob@example.com' }]]),
+      })
+
+      render(<ChatLayoutWithProbe initialRoute="/messages/alice@example.com" />)
+
+      const path = () => decodeURIComponent(screen.getByTestId('probe-path').textContent ?? '')
+
+      // Give the auto-select effect a chance to (wrongly) fire, then assert the
+      // URL still targets alice — auto-select must not override it with bob.
+      await waitFor(() => {
+        expect(path()).toBe('/messages/alice@example.com')
+      })
+      expect(mockActivateConversation).not.toHaveBeenCalledWith('bob@example.com')
+    })
+
+    it('does not auto-select the first room when the URL targets another one', async () => {
+      // Store's first joined room is room1, but the URL points at room2 — the
+      // exact reaction-toast case: navigating to a room that isn't the first.
+      setMockState({
+        activeRoomJid: null,
+        rooms: new Map([['room1@conf.example.com', { jid: 'room1@conf.example.com', joined: true }]]),
+      })
+
+      render(<ChatLayoutWithProbe initialRoute="/rooms/room2@conf.example.com" />)
+
+      const path = () => decodeURIComponent(screen.getByTestId('probe-path').textContent ?? '')
+
+      await waitFor(() => {
+        expect(path()).toBe('/rooms/room2@conf.example.com')
+      })
+      expect(mockActivateRoom).not.toHaveBeenCalledWith('room1@conf.example.com')
     })
   })
 

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -462,6 +462,11 @@ function ChatLayoutContent() {
     // Only run once when we're online, on messages view, with conversations available
     if (status !== 'online' || hasAutoSelectedRef.current) return
     if (sidebarView !== 'messages') return
+    // The URL already names a conversation (deep link, session restore, or a
+    // reaction-toast click): let the URL→store sync activate it. activateConversation
+    // is async — activeConversationId is still null on this commit — so without this
+    // guard auto-select would hijack the URL to the first conversation.
+    if (activeJid) return
     // Only check the value owned by this tab — cross-tab clearing is handled by
     // useViewNavigation. A stale activeRoomJid/selectedContactJid from another tab
     // shouldn't block Messages auto-select.
@@ -498,7 +503,7 @@ function ChatLayoutContent() {
       // doesn't leave a back-able "empty list" entry behind the conversation.
       navigateToMessages(firstConversation.id, { replace: true })
     }
-  }, [status, sidebarView, activeConversationId, conversationCount, activateConversation, navigateToMessages])
+  }, [status, sidebarView, activeJid, activeConversationId, conversationCount, activateConversation, navigateToMessages])
 
   // Auto-select first joined room on initial connection if none selected.
   // Mirrors the messages auto-select above. Required because navigateToView('rooms')
@@ -511,6 +516,11 @@ function ChatLayoutContent() {
   useEffect(() => {
     if (status !== 'online' || hasAutoSelectedRoomRef.current) return
     if (sidebarView !== 'rooms') return
+    // The URL already names a room (deep link, session restore, or a reaction-toast
+    // click): let the URL→store sync activate it. activateRoom is async — activeRoomJid
+    // is still null on this commit — so without this guard auto-select would hijack the
+    // URL to the first joined room, landing on the wrong room.
+    if (activeJid) return
     if (activeRoomJid) return
     if (roomCount === 0) return
 
@@ -530,7 +540,7 @@ function ChatLayoutContent() {
       // (mirrors the messages auto-select above).
       navigateToRooms(firstRoom.jid, { replace: true })
     }
-  }, [status, sidebarView, activeRoomJid, roomCount, activateRoom, navigateToRooms])
+  }, [status, sidebarView, activeJid, activeRoomJid, roomCount, activateRoom, navigateToRooms])
 
   // Ensure container has focus for keyboard shortcuts on mount and when window becomes visible
   useEffect(() => {


### PR DESCRIPTION
## Summary

Clicking a reaction toast opened the rooms tab on the **wrong** room (and so never scrolled to the reacted message).

The toast handler calls `navigateToRooms(roomJid)`, but on that same render commit two effects run:

1. The URL→store sync calls `activateRoom(roomJid)` — which `await`s a message-cache load **before** setting `activeRoomJid`, so it's asynchronous.
2. The "auto-select first room" effect guarded only on `if (activeRoomJid) return`. On that commit `activeRoomJid` is still `null`, so the guard doesn't trip — it picks the first joined room and `navigateToRooms(firstRoom, {replace})`, hijacking the target URL.

Only bit the first entry into the rooms tab per session (`hasAutoSelectedRoomRef`). The messages tab had the identical latent bug.

## Fix

Both auto-select-first effects now bail when the URL already names a target (`if (activeJid) return`). Auto-select-first is only for landing on `/rooms` or `/messages` with no selection; when the URL carries a JID (reaction toast, deep link, session restore), the URL→store sync owns activation.