### PR TITLE
Blockquote: drop serif glyph so quotes don't double their own cue

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -848,26 +848,17 @@ html, body {
   -webkit-overflow-scrolling: touch;
 }
 
-/* First-level quote — a recessed card with an accent edge and a single opening
-   mark (Aurora). Nested levels use a plain accent line (.blockquote-nested). */
+/* First-level quote — a recessed card with a single accent edge (Aurora). The
+   card + bar is the sole "quote" cue; no quotation glyph, so short quotes don't
+   float beside an empty gutter and the block never doubles its own signal.
+   Nested levels use a plain accent line (.blockquote-nested). */
 .blockquote-decorated {
   position: relative;
   border-left: 2px solid var(--fluux-brand);
   background: var(--fluux-bg-secondary);
   border-radius: 0 var(--fluux-radius-m) var(--fluux-radius-m) 0;
-  padding: 0.4rem 0.7rem 0.45rem 2.1rem;
+  padding: 0.4rem 0.75rem 0.45rem;
   margin-block: 0.25rem;
-}
-.blockquote-decorated::before {
-  content: '\201C';
-  position: absolute;
-  left: 0.55rem;
-  top: 0.15rem;
-  font-size: 1.4rem;
-  line-height: 1;
-  color: var(--fluux-brand);
-  opacity: 0.55;
-  font-family: Georgia, 'Times New Roman', serif;
 }
 /* Nested blockquote level — indented with a thin left border, no extra quote marks */
 .blockquote-nested {


### PR DESCRIPTION
The first-level markdown quote stacked three quote signals at once — a recessed card, an accent bar, and a large serif opening mark — so short quotes floated beside an empty ~2rem gutter and read as visually doubled.

This removes the `::before` glyph and switches to symmetric padding. The card + accent bar is now the sole quote cue. Nested quote levels are unchanged (flat brand bar-only rail), which also keeps markdown quotes visually distinct from sender-coloured reply chips.

CSS-only change; existing `messageStyles` tests pass and the result was verified in demo mode.