### PR TITLE
fix(e2ee): decrypt MAM entries before building sidebar preview

### DIFF
--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -1041,3 +1041,100 @@ describe('MAM forward catch-up — cross-page modification resolution (1:1)', ()
     expect(target!.reactions!['👍']).toContain(PEER)
   })
 })
+
+describe('MAM preview refresh E2EE (sidebar preview)', () => {
+  const ME = 'me@example.com'
+  const PEER = 'bob@example.com'
+
+  /**
+   * Drive {@link MAM.refreshConversationPreviews} for a single conversation,
+   * feed it one archive entry, and return the message handed to
+   * `updateLastMessagePreview` (the sidebar preview), or null if none was set.
+   */
+  async function runPreviewWithEntry(
+    manager: E2EEManager,
+    conversationId: string,
+    archiveEntry: Element,
+  ): Promise<{ body: string; from: string; encryptedPayload?: string } | null> {
+    const collectors = new Map<string, (stanza: Element) => void>()
+    let pendingResolve: ((v: Element) => void) | null = null
+    let pendingReady: (() => void) | null = null
+    const ready = new Promise<void>((r) => {
+      pendingReady = r
+    })
+    let captured: { body: string; from: string; encryptedPayload?: string } | null = null
+
+    const deps: ModuleDependencies = {
+      stores: {
+        chat: {
+          getAllConversations: () => [{ id: conversationId }],
+          updateLastMessagePreview: (_id: string, message: { body: string; from: string; encryptedPayload?: string }) => {
+            captured = {
+              body: message.body,
+              from: message.from,
+              ...(message.encryptedPayload && { encryptedPayload: message.encryptedPayload }),
+            }
+          },
+        },
+      } as unknown as ModuleDependencies['stores'],
+      sendStanza: async () => {},
+      sendIQ: () =>
+        new Promise<Element>((resolve) => {
+          pendingResolve = resolve
+          pendingReady?.()
+        }),
+      getCurrentJid: () => ME,
+      emit: () => {},
+      emitSDK: (() => {}) as ModuleDependencies['emitSDK'],
+      getXmpp: () => null,
+      getE2EEManager: () => manager,
+      registerMAMCollector: (queryId, collector) => {
+        collectors.set(queryId, collector)
+        return () => collectors.delete(queryId)
+      },
+    }
+
+    const mam = new MAM(deps)
+    const done = mam.refreshConversationPreviews()
+    await ready
+    const [queryId, collector] = [...collectors.entries()][0]
+    archiveEntry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+    collector(archiveEntry)
+    pendingResolve!(xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })))
+    await done
+    return captured
+  }
+
+  it('decrypts a self-outgoing encrypted entry before setting the sidebar preview', async () => {
+    // Regression: the sidebar preview for our OWN sent message showed the
+    // sender's cleartext fallback ("[OpenPGP-encrypted message]") until the
+    // conversation was opened, because the preview-refresh path parsed the
+    // archive entry WITHOUT decrypting it (unlike the catch-up path).
+    const manager = await makeManagerWithDummyPlugin(ME)
+    const payload = await manager.encryptOutbound(
+      { kind: 'direct', peer: PEER },
+      new TextEncoder().encode('my own secret message'),
+    )
+    if (!payload) throw new Error('Test setup: encryptOutbound returned null')
+
+    const forwardedMessage = xml(
+      'message',
+      { from: ME + '/res', to: PEER, type: 'chat', id: 'mam-self-preview' },
+      xml('body', {}, payload.payload.fallbackBody ?? '[encrypted]'),
+      xml(
+        payload.payload.stanzaElement.name,
+        payload.payload.stanzaElement.attrs,
+        ...(payload.payload.stanzaElement.children as (string | Element)[]),
+      ),
+    )
+    const archiveEntry = buildMAMResult({ archiveId: 'arch-self-preview', forwardedMessage })
+
+    const preview = await runPreviewWithEntry(manager, PEER, archiveEntry)
+
+    expect(preview).not.toBeNull()
+    // The sidebar preview text is derived from the message body, so it must be
+    // the decrypted plaintext — never the sender's cleartext fallback.
+    expect(preview!.body).toBe('my own secret message')
+    expect(preview!.body).not.toContain('payload')
+  })
+})

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1198,11 +1198,16 @@ export class MAM extends BaseModule {
       // This handles the case where recent messages are modifications that can't be previewed
       const iq = this.buildMAMQuery(queryId, formFields, 5, '')
 
-      let latestMessage: Message | null = null
-
-      const collectMessage = this.createMessageCollector(queryId, (forwarded, _messageEl, archiveId) => {
-        const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
-        if (msg) latestMessage = msg
+      // Buffer raw entries and decrypt each BEFORE parsing (mirrors the
+      // catch-up drain loop). Parsing an encrypted entry without decrypting
+      // first surfaces the sender's cleartext XEP-0380/0428 fallback body
+      // (e.g. "[OpenPGP-encrypted message]") as the sidebar preview — and for
+      // our own sent messages that never self-heals via the deferred-decrypt
+      // path (the local echo carries no stashed encryptedPayload), so the
+      // preview stayed stuck on the fallback until the conversation was opened.
+      const rawEntries: RawArchiveEntry[] = []
+      const collectMessage = this.createMessageCollector(queryId, (forwarded, messageEl, archiveId) => {
+        rawEntries.push({ forwarded, messageEl, archiveId })
       })
 
       // Use the collector registry if available, otherwise fall back to direct listeners
@@ -1217,8 +1222,16 @@ export class MAM extends BaseModule {
 
       try {
         const response = await this.deps.sendIQ(iq)
-        // latestMessage is mutated by the collector callback; TS CFA can't track this
-        const message = latestMessage as Message | null
+
+        let latestMessage: Message | null = null
+        for (const { forwarded, messageEl, archiveId } of rawEntries) {
+          const forwardedTimestamp = this.extractForwardedTimestamp(forwarded)
+          await this.decryptArchiveEntryIfNeeded(messageEl, conversationId, forwardedTimestamp)
+          const msg = this.parseArchiveMessage(forwarded, conversationId, archiveId)
+          if (msg) latestMessage = msg
+        }
+
+        const message = latestMessage
         if (response && message) {
           // For archived conversations: check if we should unarchive BEFORE updating preview
           // (updateLastMessagePreview uses shouldUpdateLastMessage internally)


### PR DESCRIPTION
## Summary

The sidebar preview for an **own-sent** encrypted message showed the cleartext fallback `[OpenPGP-encrypted message]` until the conversation was opened.

`MAM.fetchPreviewForConversation` built the preview by calling `parseArchiveMessage` directly, without first running `decryptArchiveEntryIfNeeded` (unlike the catch-up drain loop). So an encrypted archive entry surfaced its raw `<body>` — the sender's XEP-0380/0428 fallback string — as `lastMessage.body`, which is what the sidebar renders.

For own-sent messages this could never self-heal: the stale preview carries no `encryptedPayload`, so neither `retryPendingDecrypts` (durable path) nor `isResolvedSamePreview` can repair it — only opening the conversation (full decrypting catch-up) does.

## Fix

Buffer the raw archive entries and decrypt each (`decryptArchiveEntryIfNeeded`, which derives `isSelfOutgoing` for encrypt-to-self) before parsing, mirroring the catch-up path. Cleartext entries are a no-op; the room preview path is untouched (MUC has no E2EE).

Adds a regression test that drives the preview refresh with a self-outgoing encrypted entry and asserts the preview body is the decrypted plaintext.