### PR TITLE
fix(scroll): position message jumps 1/3 down and window off-screen targets in

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -33,6 +33,11 @@ import { buildMessageListItems, type RenderItem } from './messageListItems'
 import { FloatingDateHeader } from './FloatingDateHeader'
 import { getTopVisibleDate } from './getTopVisibleDate'
 import { useTanstackMessageVirtualizer } from './tanstackMessageVirtualizer'
+import {
+  setActiveMessageListController,
+  getActiveMessageListController,
+  type ActiveMessageListController,
+} from './activeMessageListController'
 import { useRowMetrics } from './useRowMetrics'
 import { estimateRowHeight } from './rowHeightEstimator'
 import { isEstimateDebugEnabled, estimateDebugLog } from '@/utils/scrollDebug'
@@ -364,6 +369,23 @@ export function MessageList<T extends BaseMessage>({
     return getTopVisibleDate(v.getVirtualItems(), virtualItems, scroller.scrollTop)
   }
   const getTopDate = useCallback(() => getTopVisibleDateRef.current(), [])
+
+  // Register this (virtualized) list so scrollToMessage — reply-quote taps, find-on-page, poll and
+  // reaction jumps — can window an off-screen target row in before its DOM read. Non-virtualized
+  // lists keep every row mounted, so they register nothing and scrollToMessage's plain DOM path
+  // works unchanged. Identity-checked cleanup so a fast conversation switch can't clear the newly
+  // mounted list's registration.
+  useEffect(() => {
+    if (!activeVirtualizer) return
+    const controller: ActiveMessageListController = {
+      hasMessage: (id) => activeVirtualizer.getIndexForMessageId(id) !== null,
+      ensureMessageMounted: (id) => { void activeVirtualizer.ensureMessageMounted(id) },
+    }
+    setActiveMessageListController(controller)
+    return () => {
+      if (getActiveMessageListController() === controller) setActiveMessageListController(null)
+    }
+  }, [activeVirtualizer])
 
   // Dev-only: expose virtualizer offset lookup for Playwright test assertions (invariant-1).
   // Allows tests to check anchor position without requiring the row to be in the DOM window.

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -146,21 +146,30 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     expect(ensureMessageMounted).toHaveBeenCalledWith('msg-40')
   })
 
-  it('scrolls to the target row via virtualizer index when a targetMessageId is set (reply / search jump)', () => {
-    // targetMessageId (reply-to jump, search result open) previously used ensureMessageMounted
-    // + DOM querySelector + 4 retry timeouts to find the row. The new path uses
-    // getIndexForMessageId + scrollToIndex('start') which resolves unmounted rows directly —
-    // no DOM query, no async waits. ensureMessageMounted is no longer called for this path.
+  it('scrolls to the target row ~1/3 down (scrollToIndex windows it in, then scrollToOffset shifts) when a targetMessageId is set (reply / search jump)', () => {
+    // targetMessageId (reply-to jump, search result open) resolves the row through the virtualizer
+    // index (works for unmounted rows — no DOM query, no async waits). Two-step, like the anchor
+    // restore: scrollToIndex('start') FIRST to window + measure the (possibly far-out-of-window)
+    // row, then scrollToOffset(offset - clientHeight/3) to shift it ~1/3 down from the top so it
+    // does NOT sit flush against the top edge (under the sticky date header) where it reads as
+    // misaligned and the highlight flash is easy to miss. The scrollToOffset step is the proof the
+    // row isn't left at the raw top-align position. ensureMessageMounted is not used for this path.
+    // Exact clientHeight/3 pixel math is covered by the real-engine scroll-invariants e2e (jsdom
+    // has no layout → clientHeight 0, so the shifted offset equals the raw offset here).
+    getOffsetForMessageId.mockImplementation((id) => (id === 'msg-30' ? 1200 : 0))
     scrollToIndexCalls.length = 0
+    scrollToOffsetCalls.length = 0
     renderList({ targetMessageId: 'msg-30' })
-    expect(scrollToIndexCalls).toContain('start')
+    expect(scrollToIndexCalls).toContain('start') // windows the target row in
+    expect(scrollToOffsetCalls).toContain(1200) // then positions via the measured offset (not left at top-align)
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-30')
   })
 
-  it('scrolls to the marker row via scrollToIndex when FAB is clicked with an unread marker', () => {
+  it('scrolls the FAB to the unread marker ~1/3 down via scrollToOffset (not flush at the top edge)', () => {
     // FAB previously used ensureMessageMounted + querySelector + offsetTop (which fails when the
-    // marker is windowed out). New path: getIndexForMessageId + scrollToIndex('start', smooth),
-    // no DOM dependency. ensureMessageMounted is no longer called for the FAB.
+    // marker is windowed out). New path: getOffsetForMessageId + scrollToOffset(offset - vh/3,
+    // smooth), positioning the marker ~1/3 down (consistent with the entry marker and the
+    // reply/search jump), no DOM dependency. ensureMessageMounted is no longer called for the FAB.
     getOffsetForMessageId.mockImplementation((id) => (id === 'msg-40' ? 1600 : null))
     const { container, getByLabelText } = renderList({ firstNewMessageId: 'msg-40' })
     const scroller = container.querySelector('[data-message-list]') as HTMLElement
@@ -168,9 +177,11 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     Object.defineProperty(scroller, 'scrollTop', { value: 0, writable: true, configurable: true })
 
     scrollToIndexCalls.length = 0
+    scrollToOffsetCalls.length = 0 // clear the entry-marker mount scroll so we isolate the FAB click
     ensureMessageMounted.mockClear()
     fireEvent.click(getByLabelText('chat.scrollToBottom'))
-    expect(scrollToIndexCalls).toContain('start')
+    expect(scrollToOffsetCalls).toContain(1600 - 500 / 3) // marker offset minus a third of the viewport
+    expect(scrollToIndexCalls).not.toContain('start') // not tucked flush against the top edge
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-40')
   })
 

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -146,30 +146,27 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     expect(ensureMessageMounted).toHaveBeenCalledWith('msg-40')
   })
 
-  it('scrolls to the target row ~1/3 down (scrollToIndex windows it in, then scrollToOffset shifts) when a targetMessageId is set (reply / search jump)', () => {
+  it('centers the target row via scrollToIndex when a targetMessageId is set (reply / search jump)', () => {
     // targetMessageId (reply-to jump, search result open) resolves the row through the virtualizer
-    // index (works for unmounted rows — no DOM query, no async waits). Two-step, like the anchor
-    // restore: scrollToIndex('start') FIRST to window + measure the (possibly far-out-of-window)
-    // row, then scrollToOffset(offset - clientHeight/3) to shift it ~1/3 down from the top so it
-    // does NOT sit flush against the top edge (under the sticky date header) where it reads as
-    // misaligned and the highlight flash is easy to miss. The scrollToOffset step is the proof the
-    // row isn't left at the raw top-align position. ensureMessageMounted is not used for this path.
-    // Exact clientHeight/3 pixel math is covered by the real-engine scroll-invariants e2e (jsdom
-    // has no layout → clientHeight 0, so the shifted offset equals the raw offset here).
-    getOffsetForMessageId.mockImplementation((id) => (id === 'msg-30' ? 1200 : 0))
+    // index (works for unmounted rows — no DOM query, no async waits) and centers it via
+    // scrollToIndex('center'). Center — not align:'start' — so the row does NOT sit flush against
+    // the top edge (under the sticky date header) where it reads as misaligned and the highlight
+    // flash is easy to miss; scrollToIndex also windows + measures + clamps, so a near-bottom
+    // target stays visible instead of being scrolled past the fold. ensureMessageMounted is not
+    // used for this path.
     scrollToIndexCalls.length = 0
-    scrollToOffsetCalls.length = 0
     renderList({ targetMessageId: 'msg-30' })
-    expect(scrollToIndexCalls).toContain('start') // windows the target row in
-    expect(scrollToOffsetCalls).toContain(1200) // then positions via the measured offset (not left at top-align)
+    expect(scrollToIndexCalls).toContain('center')
+    expect(scrollToIndexCalls).not.toContain('start') // not tucked flush against the top edge
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-30')
   })
 
-  it('scrolls the FAB to the unread marker ~1/3 down via scrollToOffset (not flush at the top edge)', () => {
+  it('scrolls to the marker row via scrollToIndex when FAB is clicked with an unread marker', () => {
     // FAB previously used ensureMessageMounted + querySelector + offsetTop (which fails when the
-    // marker is windowed out). New path: getOffsetForMessageId + scrollToOffset(offset - vh/3,
-    // smooth), positioning the marker ~1/3 down (consistent with the entry marker and the
-    // reply/search jump), no DOM dependency. ensureMessageMounted is no longer called for the FAB.
+    // marker is windowed out). New path: getIndexForMessageId + scrollToIndex('start', smooth),
+    // no DOM dependency. align:'start' clamps to the bottom when the marker is the last message,
+    // keeping a just-arrived new message fully visible (do not shift up by vh/3 — see the marker
+    // loop). ensureMessageMounted is no longer called for the FAB.
     getOffsetForMessageId.mockImplementation((id) => (id === 'msg-40' ? 1600 : null))
     const { container, getByLabelText } = renderList({ firstNewMessageId: 'msg-40' })
     const scroller = container.querySelector('[data-message-list]') as HTMLElement
@@ -177,11 +174,9 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     Object.defineProperty(scroller, 'scrollTop', { value: 0, writable: true, configurable: true })
 
     scrollToIndexCalls.length = 0
-    scrollToOffsetCalls.length = 0 // clear the entry-marker mount scroll so we isolate the FAB click
     ensureMessageMounted.mockClear()
     fireEvent.click(getByLabelText('chat.scrollToBottom'))
-    expect(scrollToOffsetCalls).toContain(1600 - 500 / 3) // marker offset minus a third of the viewport
-    expect(scrollToIndexCalls).not.toContain('start') // not tucked flush against the top edge
+    expect(scrollToIndexCalls).toContain('start')
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-40')
   })
 
@@ -395,7 +390,7 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
   const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div> }
 
   it('reasserts target-message jumps while virtualized rows settle', () => {
-    // Reply/search/activity jumps used to call scrollToIndex('start') once. If rows above the
+    // Reply/search/activity jumps used to call scrollToIndex('center') once. If rows above the
     // target measured taller after that first landing, the target could drift. The target path now
     // reasserts for a short settle window, mirroring the unread-marker path.
     scrollToIndexStartOffsets.push(1200, 1400, 1400, 1400, 1400, 1400, 1400, 1400)
@@ -415,7 +410,7 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     scrollToIndexCalls.length = 0
     flush(8)
 
-    expect(scrollToIndexCalls.filter((align) => align === 'start').length).toBeGreaterThan(1)
+    expect(scrollToIndexCalls.filter((align) => align === 'center').length).toBeGreaterThan(1)
     expect(onConsumed).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/fluux/src/components/conversation/activeMessageListController.ts
+++ b/apps/fluux/src/components/conversation/activeMessageListController.ts
@@ -1,0 +1,33 @@
+/**
+ * Registry for the currently-mounted conversation message list, so DOM-based jump helpers
+ * (notably `scrollToMessage` in messageGrouping.ts — reply-quote taps, find-on-page, poll and
+ * reaction jumps) can reach the active virtualizer without threading it through every caller.
+ *
+ * Why this exists: under virtualization the target row of an in-conversation jump may be OUTSIDE
+ * the mounted DOM window, so a raw `querySelector('[data-message-id]')` finds nothing and the jump
+ * silently no-ops. The active list registers a tiny controller here; the helper asks it to window
+ * the row in first, then the DOM read + scrollIntoView succeed. Non-virtualized lists keep every
+ * row mounted, so they register no controller and the helper's plain DOM path works unchanged.
+ *
+ * There is a single active conversation list at a time (ChatView / RoomView render one), so a
+ * module-level singleton is sufficient. The list clears its registration on unmount (identity-
+ * checked, so a fast conversation switch can't clobber the newly mounted list's registration).
+ */
+export interface ActiveMessageListController {
+  /** True when `id` is in the loaded item set (resolvable by the virtualizer index), whether or
+   *  not its row is currently mounted. */
+  hasMessage(id: string): boolean
+  /** Window the (possibly unmounted) row for `id` into the virtualizer's mounted set so a
+   *  subsequent DOM query can find it. No-op when `id` isn't in the item set. */
+  ensureMessageMounted(id: string): void
+}
+
+let active: ActiveMessageListController | null = null
+
+export function setActiveMessageListController(controller: ActiveMessageListController | null): void {
+  active = controller
+}
+
+export function getActiveMessageListController(): ActiveMessageListController | null {
+  return active
+}

--- a/apps/fluux/src/components/conversation/messageGrouping.test.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { groupMessagesByDate, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage, canClosePoll } from './messageGrouping'
+import { setActiveMessageListController } from './activeMessageListController'
 
 // Mock CSS.escape since it's not available in JSDOM
 // This implementation matches the browser's CSS.escape behavior
@@ -452,14 +453,53 @@ describe('scrollToMessage', () => {
     expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="non-existent-id"]')
     expect(mockElement.scrollIntoView).not.toHaveBeenCalled()
 
-    // scrollToMessage retries 3 times via requestAnimationFrame before warning
-    // Flush all pending rAF callbacks (jsdom polyfills rAF as setTimeout)
-    vi.advanceTimersByTime(100)
+    // scrollToMessage retries several times via requestAnimationFrame before warning.
+    // Flush all pending rAF callbacks (jsdom polyfills rAF as setTimeout ~16ms/frame).
+    vi.advanceTimersByTime(300)
 
     // Should log warning for debugging after retries exhausted
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       '[scrollToMessage] Message not found in DOM: id="non-existent-id"'
     )
+  })
+
+  it('windows an off-screen (virtualized) target in via the active controller, then scrolls to it', () => {
+    // The target row is NOT in the DOM until the active list mounts it — the failure mode a plain
+    // querySelector retry can never recover from. scrollToMessage must ask the controller to window
+    // it in, then scroll once it mounts.
+    let mounted = false
+    querySelectorSpy.mockImplementation(() => (mounted ? (mockElement as unknown as Element) : null))
+    const ensureMessageMounted = vi.fn(() => { mounted = true })
+    setActiveMessageListController({ hasMessage: () => true, ensureMessageMounted })
+    try {
+      scrollToMessage('windowed-out-id')
+
+      // Not in the DOM on the first pass → controller asked to window it in (exactly once).
+      expect(ensureMessageMounted).toHaveBeenCalledTimes(1)
+      expect(ensureMessageMounted).toHaveBeenCalledWith('windowed-out-id')
+
+      // Next frame: the row is now mounted → scrolled + highlighted, no warning.
+      vi.advanceTimersByTime(50)
+      expect(mockElement.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+      expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    } finally {
+      setActiveMessageListController(null)
+    }
+  })
+
+  it('does not ask the controller to mount an id it does not have (no churn on a truly missing id)', () => {
+    querySelectorSpy.mockReturnValue(null)
+    const ensureMessageMounted = vi.fn()
+    setActiveMessageListController({ hasMessage: () => false, ensureMessageMounted })
+    try {
+      scrollToMessage('unknown-id')
+      vi.advanceTimersByTime(300)
+      expect(ensureMessageMounted).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).toHaveBeenCalled()
+    } finally {
+      setActiveMessageListController(null)
+    }
   })
 
   it('should handle special characters in message ID by escaping them', () => {

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns'
+import { getActiveMessageListController } from './activeMessageListController'
 
 /**
  * Check if message is a /me action message (IRC-style action).
@@ -255,14 +256,32 @@ export function scrollToMessage(messageId: string): void {
     )
   }
 
+  let requestedMount = false
+
   function tryScroll(retriesLeft: number) {
     const element = findElement()
     if (element) {
+      // scrollIntoView uses the real measured layout, so it lands precisely even when the row was
+      // just windowed in via an estimate-based scrollToIndex below (which self-corrects here).
       element.scrollIntoView({ behavior: 'smooth', block: 'center' })
       element.classList.add('message-highlight')
       setTimeout(() => element.classList.remove('message-highlight'), 1500)
-    } else if (retriesLeft > 0) {
-      // Element may not be in DOM yet (first render). Retry after next frame.
+      return
+    }
+    // Under virtualization the target row may be OUTSIDE the mounted window, so the DOM query above
+    // finds nothing (retrying alone never helps — the row is never rendered). Ask the active list to
+    // window it in once, then keep retrying across frames while it mounts and measures. No-op /
+    // absent for non-virtualized lists, where every row is already in the DOM.
+    if (!requestedMount) {
+      const controller = getActiveMessageListController()
+      if (controller?.hasMessage(messageId)) {
+        controller.ensureMessageMounted(messageId)
+        requestedMount = true
+      }
+    }
+    if (retriesLeft > 0) {
+      // Element may not be in the DOM yet (first render, or a row still being windowed in). Retry
+      // after the next frame.
       requestAnimationFrame(() => tryScroll(retriesLeft - 1))
     } else {
       // Debug: message not found in DOM, log to help diagnose issues
@@ -273,5 +292,7 @@ export function scrollToMessage(messageId: string): void {
     }
   }
 
-  tryScroll(3)
+  // A windowed-in row needs a few frames to mount + measure, so allow more retries than the
+  // original 3 (which only had to cover a first-render race, not a virtualizer re-window).
+  tryScroll(8)
 }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1148,15 +1148,8 @@ export function useMessageListScroll({
         if (markerIdx !== null) {
           const markerOffset = virt.getOffsetForMessageId(firstNewMessageId)
           const viewportBottom = scroller.scrollTop + scroller.clientHeight
-          if (markerOffset === null) {
-            // Offset unresolved — windowing scroll at top-align still brings the row in.
+          if (markerOffset === null || markerOffset > viewportBottom) {
             virt.scrollToIndex(markerIdx, { align: 'start', behavior: 'smooth' })
-            return
-          }
-          if (markerOffset > viewportBottom) {
-            // Position the marker ~1/3 down from the top, consistent with the non-virtualized path
-            // below and the entry-marker / reply-search jump — not flush against the top edge.
-            virt.scrollToOffset(Math.max(0, markerOffset - scroller.clientHeight / 3), { behavior: 'smooth' })
             return
           }
         }
@@ -1811,22 +1804,18 @@ export function useMessageListScroll({
               reassertBottom()
               return
             }
-            // Position the marker row ~1/3 down from the top (per this branch's intent, matching
-            // the non-virtualized path and the reply/search targetMessageId jump). Two-step:
-            // scrollToIndex('start') FIRST to window the marker region in (mount + measure) — a raw
-            // scrollToOffset to the ESTIMATED offset lands SHORT and never mounts the row, so its
-            // height never sharpens and the loop converges on a wrong target with the marker
-            // stranded below the fold (the bug). Then shift up by viewportHeight/3 using the now
-            // measurement-aware offset. Re-asserting each frame converges as rows settle. The
-            // offset <= viewportHeight/3 case already fell back to the bottom above, so the shift
-            // here is always positive (no scroll-to-0 load-older churn).
-            if (v) {
-              v.scrollToIndex(markerIndex!, { align: 'start' })
-              const markerStart = v.getOffsetForMessageId(markerId)
-              if (markerStart != null) v.scrollToOffset(Math.max(0, markerStart - viewportHeight / 3))
-            } else {
-              s.scrollTop = Math.max(0, offset - viewportHeight / 3)
-            }
+            // Position the marker row via the virtualizer's measurement-aware scrollToIndex.
+            // A raw scrollToOffset to the ESTIMATED offset lands SHORT and never windows the marker
+            // row in, so its height never measures and the offset estimate never sharpens — the loop
+            // then sees a "stable" (wrong) target and stops with the marker stranded below the fold
+            // (the bug). scrollToIndex windows the marker region in (mount + measure), so each frame
+            // lands closer and re-asserting converges, exactly like pinVirtualizedBottom. align:'start'
+            // puts the divider near the top to read forward, and clamps to the bottom when the marker
+            // is the last message (so a single new message lands at the bottom, fully visible — do NOT
+            // shift up by viewportHeight/3 here: getOffsetForMessageId clamps to the scrollable range
+            // for a near-bottom marker, so the shift would scroll past the new message and hide it).
+            if (v) v.scrollToIndex(markerIndex!, { align: 'start' })
+            else s.scrollTop = Math.max(0, offset - viewportHeight / 3)
 
             const st = s.scrollTop
             // Converged when the landing position stops moving (rows have finished measuring).
@@ -2057,22 +2046,14 @@ export function useMessageListScroll({
           return
         }
 
-        // Position the target ~1/3 down from the top rather than flush against the top edge
-        // (align:'start'), which tucks it under the sticky date header — where it reads as
-        // misaligned and the highlight flash is easy to miss. Matches the non-virtualized path,
-        // the search-context preview, and the pre-#734 behavior.
-        //
-        // Two-step, mirroring pinVirtualizedAnchor: scrollToIndex('start') FIRST to window the
-        // (possibly far-out-of-window) target row in and measure it — a raw scrollToOffset to the
-        // ESTIMATED offset would land short, never mount the row, so its height never sharpens and
-        // the loop would converge on a wrong target with the message stranded below the fold (see
-        // the marker loop's note). Then shift up by clientHeight/3 using the now-measurement-aware
-        // offset. Re-asserting each frame lands it as rows settle their real heights.
-        v.scrollToIndex(currentIdx, { align: 'start' })
-        const start = v.getOffsetForMessageId(targetMessageId)
-        if (start !== null) {
-          v.scrollToOffset(Math.max(0, start - s.clientHeight / 3))
-        }
+        // Center the target rather than pinning it to the top edge (align:'start'), which tucks it
+        // under the sticky date header where it reads as misaligned and the highlight flash is easy
+        // to miss. scrollToIndex('center') windows the (possibly far-out-of-window) row in, measures
+        // it, and clamps internally — so a near-bottom target stays visible instead of being scrolled
+        // past the fold (the failure mode of a manual getOffsetForMessageId − clientHeight/3 shift,
+        // since getOffsetForMessageId returns an offset already clamped to the scrollable range).
+        // Re-asserting each frame converges as rows settle. Matches the reply-scroll block:'center'.
+        v.scrollToIndex(currentIdx, { align: 'center' })
         const st = s.scrollTop
         const distFromBottom = s.scrollHeight - st - s.clientHeight
         isAtBottomRef.current = distFromBottom < AT_BOTTOM_THRESHOLD
@@ -2124,12 +2105,12 @@ export function useMessageListScroll({
         }
         return
       }
-      const elementTop = (el as HTMLElement).offsetTop
-      const targetScrollTop = Math.max(0, elementTop - scroller.clientHeight / 3)
-      scroller.scrollTop = targetScrollTop
-      isAtBottomRef.current = (scroller.scrollHeight - targetScrollTop - scroller.clientHeight) < AT_BOTTOM_THRESHOLD
+      // Center the target (matches the virtualized path above and the reply-scroll convention);
+      // the browser clamps scrollTop, so a near-bottom target stays fully visible.
+      ;(el as HTMLElement).scrollIntoView({ block: 'center' })
+      isAtBottomRef.current = (scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight) < AT_BOTTOM_THRESHOLD
       highlight(el)
-      debugLog('TARGET MESSAGE: scrolled to target', { targetMessageId, elementTop, targetScrollTop })
+      debugLog('TARGET MESSAGE: scrolled to target (center)', { targetMessageId })
       onTargetMessageConsumed?.()
     }
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1148,8 +1148,15 @@ export function useMessageListScroll({
         if (markerIdx !== null) {
           const markerOffset = virt.getOffsetForMessageId(firstNewMessageId)
           const viewportBottom = scroller.scrollTop + scroller.clientHeight
-          if (markerOffset === null || markerOffset > viewportBottom) {
+          if (markerOffset === null) {
+            // Offset unresolved — windowing scroll at top-align still brings the row in.
             virt.scrollToIndex(markerIdx, { align: 'start', behavior: 'smooth' })
+            return
+          }
+          if (markerOffset > viewportBottom) {
+            // Position the marker ~1/3 down from the top, consistent with the non-virtualized path
+            // below and the entry-marker / reply-search jump — not flush against the top edge.
+            virt.scrollToOffset(Math.max(0, markerOffset - scroller.clientHeight / 3), { behavior: 'smooth' })
             return
           }
         }
@@ -1804,16 +1811,22 @@ export function useMessageListScroll({
               reassertBottom()
               return
             }
-            // Position the marker row via the virtualizer's measurement-aware scrollToIndex.
-            // A raw scrollToOffset to the ESTIMATED offset lands SHORT and never windows the marker
-            // row in, so its height never measures and the offset estimate never sharpens — the loop
-            // then sees a "stable" (wrong) target and stops with the marker stranded below the fold
-            // (the bug). scrollToIndex windows the marker region in (mount + measure), so each frame
-            // lands closer and re-asserting converges, exactly like pinVirtualizedBottom. align:'start'
-            // puts the divider near the top to read forward, and clamps to the bottom when the marker
-            // is the last message (so a single new message lands at the bottom, fully visible).
-            if (v) v.scrollToIndex(markerIndex!, { align: 'start' })
-            else s.scrollTop = Math.max(0, offset - viewportHeight / 3)
+            // Position the marker row ~1/3 down from the top (per this branch's intent, matching
+            // the non-virtualized path and the reply/search targetMessageId jump). Two-step:
+            // scrollToIndex('start') FIRST to window the marker region in (mount + measure) — a raw
+            // scrollToOffset to the ESTIMATED offset lands SHORT and never mounts the row, so its
+            // height never sharpens and the loop converges on a wrong target with the marker
+            // stranded below the fold (the bug). Then shift up by viewportHeight/3 using the now
+            // measurement-aware offset. Re-asserting each frame converges as rows settle. The
+            // offset <= viewportHeight/3 case already fell back to the bottom above, so the shift
+            // here is always positive (no scroll-to-0 load-older churn).
+            if (v) {
+              v.scrollToIndex(markerIndex!, { align: 'start' })
+              const markerStart = v.getOffsetForMessageId(markerId)
+              if (markerStart != null) v.scrollToOffset(Math.max(0, markerStart - viewportHeight / 3))
+            } else {
+              s.scrollTop = Math.max(0, offset - viewportHeight / 3)
+            }
 
             const st = s.scrollTop
             // Converged when the landing position stops moving (rows have finished measuring).
@@ -2044,7 +2057,22 @@ export function useMessageListScroll({
           return
         }
 
+        // Position the target ~1/3 down from the top rather than flush against the top edge
+        // (align:'start'), which tucks it under the sticky date header — where it reads as
+        // misaligned and the highlight flash is easy to miss. Matches the non-virtualized path,
+        // the search-context preview, and the pre-#734 behavior.
+        //
+        // Two-step, mirroring pinVirtualizedAnchor: scrollToIndex('start') FIRST to window the
+        // (possibly far-out-of-window) target row in and measure it — a raw scrollToOffset to the
+        // ESTIMATED offset would land short, never mount the row, so its height never sharpens and
+        // the loop would converge on a wrong target with the message stranded below the fold (see
+        // the marker loop's note). Then shift up by clientHeight/3 using the now-measurement-aware
+        // offset. Re-asserting each frame lands it as rows settle their real heights.
         v.scrollToIndex(currentIdx, { align: 'start' })
+        const start = v.getOffsetForMessageId(targetMessageId)
+        if (start !== null) {
+          v.scrollToOffset(Math.max(0, start - s.clientHeight / 3))
+        }
         const st = s.scrollTop
         const distFromBottom = s.scrollHeight - st - s.clientHeight
         isAtBottomRef.current = distFromBottom < AT_BOTTOM_THRESHOLD


### PR DESCRIPTION
## Summary

Fixes the search-preview "go to message" jump landing flush at the top of the viewport (tucked under the floating date header) with its highlight flash hard to see — a regression from #734, which switched the virtualized target jump to `align:'start'`. Restores the ~1/3-down positioning used by the non-virtualized path and the search-context preview.

Audited the other jump sites and fixed the same class of issue:

- **Reply/search `targetMessageId` jump** — `getOffsetForMessageId` + `scrollToOffset(offset − clientHeight/3)`, windowing the row in first (via `scrollToIndex('start')`) so a far-out-of-window target isn't stranded on an estimate.
- **Entry unread-marker auto-scroll** and **scroll-to-bottom FAB two-step** — same top-edge → 1/3-down fix, matching each branch's own non-virtualized path and stated intent.
- **`scrollToMessage`** (reply-quote taps, find-on-page, poll/reaction jumps) — was DOM-query-only and silently no-op'd when the target row was outside the mounted virtualizer window. Added a small `activeMessageListController` registry so it can window the row in before scrolling; the DOM `scrollIntoView` then self-corrects the precise centering. Non-virtualized lists register nothing and behave as before.