### PR TITLE
fix(scroll): keep message list pinned to bottom when occupant sidebar toggles

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -93,10 +93,11 @@ class MockResizeObserver {
     if (index > -1) MockResizeObserver.instances.splice(index, 1)
   }
 
-  // Helper to trigger resize
-  triggerResize(height: number) {
+  // Helper to trigger resize. Width is optional so existing height-only callers
+  // are unaffected (contentRect.width stays undefined → the width branch is inert).
+  triggerResize(height: number, width?: number) {
     this.callback(
-      [{ contentRect: { height } } as ResizeObserverEntry],
+      [{ contentRect: { height, width } } as ResizeObserverEntry],
       this
     )
   }
@@ -461,6 +462,97 @@ describe('MessageList scroll behavior', () => {
         }
 
         // Should NOT have scrolled
+        expect(scrollSpy).not.toHaveBeenCalled()
+      }
+    })
+
+    it('should scroll to bottom when only the WIDTH changes (occupant sidebar toggle) and user is at bottom', () => {
+      // Toggling the occupant sidebar at lg+ narrows the message column (width change,
+      // same height) which re-wraps text and grows content height, but fires no window
+      // 'resize' event — so only the container observer can re-pin. Regression guard for
+      // the list drifting off the bottom on sidebar expand.
+      const messages = createTestMessages(5)
+      const scrollSpy = vi.fn()
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
+      if (container) {
+        let scrollTopValue = 500 // at bottom
+        Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+        Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+        Object.defineProperty(container, 'scrollTop', {
+          get: () => scrollTopValue,
+          set: (v) => {
+            scrollTopValue = v
+            scrollSpy(v)
+          },
+          configurable: true,
+        })
+
+        const observer = MockResizeObserver.observing(container)
+        if (observer) {
+          act(() => { observer.triggerResize(500, 800) }) // baseline: width 800, height 500
+        }
+
+        scrollSpy.mockClear()
+
+        // Width shrinks (sidebar appears) but height is unchanged.
+        if (observer) {
+          act(() => { observer.triggerResize(500, 600) })
+        }
+
+        expect(scrollSpy).toHaveBeenCalledWith(1000)
+      }
+    })
+
+    it('should NOT scroll on a WIDTH change when the user is scrolled up', () => {
+      const messages = createTestMessages(5)
+      const scrollSpy = vi.fn()
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
+      if (container) {
+        let scrollTopValue = 200 // scrolled up
+        Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+        Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+        Object.defineProperty(container, 'scrollTop', {
+          get: () => scrollTopValue,
+          set: (v) => {
+            scrollTopValue = v
+            scrollSpy(v)
+          },
+          configurable: true,
+        })
+
+        act(() => { container.dispatchEvent(new Event('scroll')) })
+
+        const observer = MockResizeObserver.observing(container)
+        if (observer) {
+          act(() => { observer.triggerResize(500, 800) }) // baseline
+        }
+
+        scrollSpy.mockClear()
+
+        if (observer) {
+          act(() => { observer.triggerResize(500, 600) }) // width change while scrolled up
+        }
+
         expect(scrollSpy).not.toHaveBeenCalled()
       }
     })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -2508,6 +2508,8 @@ export function useMessageListScroll({
 
     let lastHeight: number | null = null
     let pendingHeight: number | null = null
+    let lastWidth: number | null = null
+    let pendingWidth: number | null = null
     let scheduled = false
     let rafId: number | null = null
     let monitor: ReturnType<typeof createResizeLoopMonitor> | null = null
@@ -2521,10 +2523,12 @@ export function useMessageListScroll({
       scheduled = false
       rafId = null
       const newHeight = pendingHeight
+      const newWidth = pendingWidth
       pendingHeight = null
+      pendingWidth = null
       if (newHeight === null) return
 
-      if (lastHeight === null) { lastHeight = newHeight; return }
+      if (lastHeight === null) { lastHeight = newHeight; lastWidth = newWidth; return }
 
       const shrunk = lastHeight - newHeight
       if (shrunk > 0 && scrollerRef.current) {
@@ -2532,9 +2536,23 @@ export function useMessageListScroll({
         // Route through reassertBottom so the virtualized path re-windows (scrollToIndex) rather
         // than a raw scrollTop write that would leave the mounted window stale → blank/clipped.
         if (wasNear) reassertBottom()
+      } else if (
+        newWidth !== null && lastWidth !== null && newWidth !== lastWidth &&
+        scrollerRef.current && isAtBottomRef.current
+      ) {
+        // A WIDTH change with no height shrink — most notably the occupant sidebar toggling
+        // in/out at lg+, where the message column narrows/widens as the panel becomes an
+        // in-flow flex sibling. That re-wraps message text and grows/shrinks row heights, but
+        // fires no window 'resize' event (so the viewport-resize handler never runs) and does
+        // not shrink the scroller's height (so the branch above never runs) — leaving the list
+        // drifted off the bottom. Re-assert while the user is following along, mirroring the
+        // window-resize handler. The scroller's own width only changes on real layout changes,
+        // not on row measurement, so this cannot feed back into the @tanstack spacer churn.
+        reassertBottom()
       }
 
       lastHeight = newHeight
+      lastWidth = newWidth
     }
 
     const observer = new ResizeObserver((entries) => {
@@ -2551,6 +2569,7 @@ export function useMessageListScroll({
       // double-scheduling: it stays correct even when rAF runs the callback
       // synchronously and reentrantly.
       pendingHeight = entries[0].contentRect.height
+      pendingWidth = entries[0].contentRect.width
       if (!scheduled) {
         scheduled = true
         rafId = requestAnimationFrame(runCorrection)
@@ -2564,7 +2583,9 @@ export function useMessageListScroll({
     }
     // reassertBottom is stable (depends only on the stable pinVirtualizedBottom), so listing it
     // re-creates the observer only on conversation change, same as conversationId alone.
-  }, [conversationId, reassertBottom])
+    // isAtBottomRef is stable unless the caller passes a new externalIsAtBottomRef (same
+    // rationale as the viewport-resize effect above).
+  }, [conversationId, reassertBottom, isAtBottomRef])
 
   // ==========================================================================
   // EFFECT: Keyboard shortcuts


### PR DESCRIPTION
Expanding the occupant sidebar in a room let the message list drift off the bottom, while a plain window resize kept it stuck.

**Cause:** two separate re-pin paths in \`useMessageListScroll.ts\` were asymmetric. Window resize re-pins via the \`window\`/\`visualViewport\` \`resize\` handler; the container-resize observer only re-pinned when the scroller's *height* shrank. Toggling the sidebar at \`lg+\` narrows the message column (a *width* change, no window \`resize\` event), so text re-wrapped taller and nothing re-pinned. The content ResizeObserver is disabled under virtualization (#646), so it couldn't cover this either.

**Fix:** track \`contentRect.width\` in the container-resize observer and re-assert to the bottom on a width change with no height shrink while the user is at the bottom. Loop-safe because the scroller's own width only changes on real layout changes, not row measurement.