### PR TITLE
fix(contacts): restore visible card borders in dark mode

### DIFF
--- a/apps/fluux/src/components/AdminCommandForm.tsx
+++ b/apps/fluux/src/components/AdminCommandForm.tsx
@@ -91,7 +91,7 @@ export function AdminCommandForm({
 
       {/* Target user display (when pre-filled) */}
       {targetJid && (
-        <div className="flex items-center gap-2 p-3 rounded-lg bg-fluux-bg border border-fluux-hover mb-4">
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-fluux-bg border border-fluux-border mb-4">
           <User className="size-5 text-fluux-muted flex-shrink-0" />
           <div className="flex-1 min-w-0">
             <p className="text-xs text-fluux-muted">{t('admin.targetUser')}</p>

--- a/apps/fluux/src/components/BackupPassphraseDialog.tsx
+++ b/apps/fluux/src/components/BackupPassphraseDialog.tsx
@@ -166,7 +166,7 @@ export function BackupPassphraseDialog({
         </div>
 
         {/* Passphrase display */}
-        <div className="rounded-lg border border-fluux-hover bg-fluux-bg p-3 mb-2 min-h-[3.5rem] flex items-center justify-center">
+        <div className="rounded-lg border border-fluux-border bg-fluux-bg p-3 mb-2 min-h-[3.5rem] flex items-center justify-center">
           {passphrase ? (
             isBackupCode ? (
               <code className="text-base font-mono text-fluux-text tracking-wider select-all">

--- a/apps/fluux/src/components/IdentityChoiceDialog.tsx
+++ b/apps/fluux/src/components/IdentityChoiceDialog.tsx
@@ -155,7 +155,7 @@ export function IdentityChoiceDialog({
 
         <div className="flex-1 overflow-y-auto min-h-0 px-5">
           {publishedFingerprints.length > 0 && (
-            <div className="mb-4 p-3 rounded-lg bg-fluux-bg/50 border border-fluux-hover">
+            <div className="mb-4 p-3 rounded-lg bg-fluux-bg/50 border border-fluux-border">
               <p className="text-xs text-fluux-muted mb-1">
                 {t('settings.encryption.identityChoice.publishedFingerprintLabel')}
               </p>
@@ -317,10 +317,10 @@ function ChoiceButton({ icon, title, description, onClick, disabled, danger }: C
       disabled={disabled}
       className={`flex items-start gap-3 text-left px-3 py-3 rounded-lg border transition-colors ${
         disabled
-          ? 'opacity-50 cursor-not-allowed border-fluux-hover'
+          ? 'opacity-50 cursor-not-allowed border-fluux-border'
           : danger
           ? 'border-yellow-500/30 hover:bg-yellow-500/5'
-          : 'border-fluux-hover hover:bg-fluux-hover/50'
+          : 'border-fluux-border hover:bg-fluux-hover/50'
       }`}
     >
       <span className="flex-shrink-0 mt-0.5 text-fluux-text">{icon}</span>

--- a/apps/fluux/src/components/KeyPickerDialog.tsx
+++ b/apps/fluux/src/components/KeyPickerDialog.tsx
@@ -70,7 +70,7 @@ export function KeyPickerDialog({ candidates, onConfirm, onCancel }: KeyPickerDi
                 className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
                   selected === bundle.fingerprint
                     ? 'border-fluux-brand bg-fluux-brand/10'
-                    : 'border-fluux-hover bg-fluux-bg hover:border-fluux-active'
+                    : 'border-fluux-border bg-fluux-bg hover:border-fluux-active'
                 } ${isInstalling ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 <input

--- a/apps/fluux/src/components/ServerOverview.tsx
+++ b/apps/fluux/src/components/ServerOverview.tsx
@@ -93,14 +93,14 @@ export function ServerOverview() {
                   key={String(card.key)}
                   type="button"
                   onClick={() => adminStore.getState().setActiveCategory(target)}
-                  className="p-4 rounded-xl bg-fluux-bg border border-fluux-hover text-start hover:bg-fluux-hover hover:border-fluux-brand/40 transition-colors tap-target"
+                  className="p-4 rounded-xl bg-fluux-surface border border-fluux-border text-start hover:bg-fluux-hover hover:border-fluux-brand/40 transition-colors tap-target"
                 >
                   {inner}
                 </button>
               )
             }
             return (
-              <div key={String(card.key)} className="p-4 rounded-xl bg-fluux-bg border border-fluux-hover">
+              <div key={String(card.key)} className="p-4 rounded-xl bg-fluux-surface border border-fluux-border">
                 {inner}
               </div>
             )

--- a/apps/fluux/src/components/UpdateModal.tsx
+++ b/apps/fluux/src/components/UpdateModal.tsx
@@ -116,7 +116,7 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
               <>
                 <button
                   onClick={close}
-                  className="flex-1 px-4 py-2 text-fluux-muted hover:text-fluux-text border border-fluux-hover rounded-lg hover:bg-fluux-hover transition-colors"
+                  className="flex-1 px-4 py-2 text-fluux-muted hover:text-fluux-text border border-fluux-border rounded-lg hover:bg-fluux-hover transition-colors"
                 >
                   {t('update.later')}
                 </button>

--- a/apps/fluux/src/components/VerifyPeerDialog.tsx
+++ b/apps/fluux/src/components/VerifyPeerDialog.tsx
@@ -129,7 +129,7 @@ export function VerifyPeerDialog({
             <label className="block text-sm font-medium text-fluux-text mb-1">
               {t('chat.verifyPeer.myCodeLabel', { name: peerName })}
             </label>
-            <div className="rounded-lg border border-fluux-hover bg-fluux-bg p-3 mb-1 text-center">
+            <div className="rounded-lg border border-fluux-border bg-fluux-bg p-3 mb-1 text-center">
               <code className="text-2xl font-mono font-semibold text-fluux-text tracking-widest">
                 {sas.mine}
               </code>
@@ -175,7 +175,7 @@ export function VerifyPeerDialog({
             )}
           </>
         ) : (
-          <div className="rounded-lg border border-fluux-hover bg-fluux-bg p-3 mb-4">
+          <div className="rounded-lg border border-fluux-border bg-fluux-bg p-3 mb-4">
             <p className="text-xs text-fluux-muted italic">
               {t('chat.verifyPeer.codeUnavailable')}
             </p>
@@ -202,7 +202,7 @@ export function VerifyPeerDialog({
             <label className="block text-sm font-medium text-fluux-text mb-1">
               {t('chat.verifyPeer.peerFingerprintLabel', { name: peerName })}
             </label>
-            <div className="rounded-lg border border-fluux-hover bg-fluux-bg p-2 mb-3">
+            <div className="rounded-lg border border-fluux-border bg-fluux-bg p-2 mb-3">
               <code className="block text-xs font-mono text-fluux-text break-all leading-relaxed">
                 {formatFingerprint(peerFingerprint)}
               </code>
@@ -211,7 +211,7 @@ export function VerifyPeerDialog({
             <label className="block text-sm font-medium text-fluux-text mb-1">
               {t('chat.verifyPeer.ownFingerprintLabel')}
             </label>
-            <div className="rounded-lg border border-fluux-hover bg-fluux-bg p-2 mb-3">
+            <div className="rounded-lg border border-fluux-border bg-fluux-bg p-2 mb-3">
               {ownFingerprint ? (
                 <code className="block text-xs font-mono text-fluux-text break-all leading-relaxed">
                   {formatFingerprint(ownFingerprint)}
@@ -225,7 +225,7 @@ export function VerifyPeerDialog({
 
             <button
               onClick={() => onConfirm(peerFingerprint)}
-              className="w-full flex items-center justify-center gap-1.5 px-4 py-2 text-sm text-fluux-text border border-fluux-hover hover:bg-fluux-hover rounded-lg transition-colors"
+              className="w-full flex items-center justify-center gap-1.5 px-4 py-2 text-sm text-fluux-text border border-fluux-border hover:bg-fluux-hover rounded-lg transition-colors"
             >
               <ShieldCheck className="size-3.5" />
               {t('chat.verifyPeer.confirmByFingerprint')}

--- a/apps/fluux/src/components/contact-profile/cards/AboutCard.tsx
+++ b/apps/fluux/src/components/contact-profile/cards/AboutCard.tsx
@@ -13,7 +13,7 @@ export function AboutCard({ vcard }: AboutCardProps) {
   if (!hasVcard || !vcard) return null
 
   return (
-    <section className="rounded-xl border border-fluux-hover bg-fluux-surface p-3">
+    <section className="rounded-xl border border-fluux-border bg-fluux-surface p-3">
       <h3 className="text-xs font-semibold text-fluux-muted uppercase tracking-wide mb-1 px-1">
         {t('contacts.about')}
       </h3>

--- a/apps/fluux/src/components/contact-profile/cards/DevicesCard.tsx
+++ b/apps/fluux/src/components/contact-profile/cards/DevicesCard.tsx
@@ -13,7 +13,7 @@ export function DevicesCard({ contact, forceOffline }: DevicesCardProps) {
   if (!hasResources || !contact.resources) return null
 
   return (
-    <section className="rounded-xl border border-fluux-hover bg-fluux-surface p-3">
+    <section className="rounded-xl border border-fluux-border bg-fluux-surface p-3">
       <h3 className="text-xs font-semibold text-fluux-muted uppercase tracking-wide mb-2 px-1">
         {t('contacts.connectedDevices')}
       </h3>

--- a/apps/fluux/src/components/contact-profile/cards/GroupsCard.tsx
+++ b/apps/fluux/src/components/contact-profile/cards/GroupsCard.tsx
@@ -10,7 +10,7 @@ export function GroupsCard({ groups, isInRoster }: GroupsCardProps) {
   if (!isInRoster || !groups || groups.length === 0) return null
 
   return (
-    <section className="rounded-xl border border-fluux-hover bg-fluux-surface p-3">
+    <section className="rounded-xl border border-fluux-border bg-fluux-surface p-3">
       <h3 className="text-xs font-semibold text-fluux-muted uppercase tracking-wide mb-2 px-1">
         {t('contacts.groups')}
       </h3>

--- a/apps/fluux/src/components/contact-profile/cards/SecurityGlanceCard.tsx
+++ b/apps/fluux/src/components/contact-profile/cards/SecurityGlanceCard.tsx
@@ -59,7 +59,7 @@ export function SecurityGlanceCard({ state, onOpen }: SecurityGlanceCardProps) {
     <button
       type="button"
       onClick={onOpen}
-      className="w-full flex items-center gap-2 rounded-xl border border-fluux-hover bg-fluux-surface p-3 text-start hover:bg-fluux-hover transition-colors min-h-[44px]"
+      className="w-full flex items-center gap-2 rounded-xl border border-fluux-border bg-fluux-surface p-3 text-start hover:bg-fluux-hover transition-colors min-h-[44px]"
     >
       <Icon className={`size-5 flex-shrink-0 ${TONE_CLASS[glance.tone]} ${spin ? 'animate-spin' : ''}`} aria-hidden />
       <span className="text-sm text-fluux-text flex-1 min-w-0">{glance.label}</span>

--- a/apps/fluux/src/components/contact-profile/tabs/SecurityTab.tsx
+++ b/apps/fluux/src/components/contact-profile/tabs/SecurityTab.tsx
@@ -82,7 +82,7 @@ export function SecurityTab({
             <button
               type="button"
               onClick={onEnableEncryption}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-bg hover:bg-fluux-hover text-fluux-text border border-fluux-hover rounded-lg transition-colors text-sm min-h-[44px]"
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-bg hover:bg-fluux-hover text-fluux-text border border-fluux-border rounded-lg transition-colors text-sm min-h-[44px]"
             >
               <Lock className="size-4" />
               {t('chat.encryption.enableEncryption')}
@@ -132,7 +132,7 @@ export function SecurityTab({
               <button
                 type="button"
                 onClick={onVerify}
-                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-bg hover:bg-fluux-hover text-fluux-text border border-fluux-hover rounded-lg transition-colors text-sm min-h-[44px]"
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-bg hover:bg-fluux-hover text-fluux-text border border-fluux-border rounded-lg transition-colors text-sm min-h-[44px]"
               >
                 <ShieldCheck className="size-4" />
                 {t('contacts.encryption.verifyButton')}
@@ -153,7 +153,7 @@ export function SecurityTab({
             <button
               type="button"
               onClick={onDisableEncryption}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-bg hover:bg-fluux-hover text-fluux-muted border border-fluux-hover rounded-lg transition-colors text-sm min-h-[44px]"
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-fluux-bg hover:bg-fluux-hover text-fluux-muted border border-fluux-border rounded-lg transition-colors text-sm min-h-[44px]"
             >
               <ShieldOff className="size-4" />
               {t('contacts.encryption.disableForContact')}

--- a/apps/fluux/src/components/settings-components/AccessibilitySettings.tsx
+++ b/apps/fluux/src/components/settings-components/AccessibilitySettings.tsx
@@ -48,7 +48,7 @@ export function AccessibilitySettings() {
                   className={`flex min-h-24 min-w-0 flex-col items-center justify-center gap-2 rounded-lg border-2 p-4 text-center transition-all
                     ${isSelected
                       ? 'border-fluux-brand bg-fluux-brand/10'
-                      : 'border-fluux-hover bg-fluux-bg hover:border-fluux-muted'
+                      : 'border-fluux-border bg-fluux-bg hover:border-fluux-muted'
                     }`}
                 >
                   <Icon className={`size-6 ${isSelected ? 'text-fluux-brand' : 'text-fluux-muted'}`} />
@@ -80,7 +80,7 @@ export function AccessibilitySettings() {
                   className={`flex min-h-24 min-w-0 flex-col items-center justify-center gap-2 rounded-lg border-2 p-4 text-center transition-all
                     ${isSelected
                       ? 'border-fluux-brand bg-fluux-brand/10'
-                      : 'border-fluux-hover bg-fluux-bg hover:border-fluux-muted'
+                      : 'border-fluux-border bg-fluux-bg hover:border-fluux-muted'
                     }`}
                 >
                   <Icon className={`size-6 ${isSelected ? 'text-fluux-brand' : 'text-fluux-muted'}`} />

--- a/apps/fluux/src/components/settings-components/AppearanceSettings.tsx
+++ b/apps/fluux/src/components/settings-components/AppearanceSettings.tsx
@@ -59,7 +59,7 @@ function ThemeCard({
       className={`relative flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all text-start
         ${isActive
           ? 'border-fluux-brand bg-fluux-brand/10'
-          : 'border-fluux-hover bg-fluux-bg hover:border-fluux-muted'
+          : 'border-fluux-border bg-fluux-bg hover:border-fluux-muted'
         }`}
     >
       <ThemeSwatches colors={swatches} />
@@ -259,7 +259,7 @@ export function AppearanceSettings() {
                     className={`flex min-h-24 min-w-0 flex-col items-center justify-center gap-2 rounded-lg border-2 p-4 text-center transition-all
                       ${isSelected
                         ? 'border-fluux-brand bg-fluux-brand/10'
-                        : 'border-fluux-hover bg-fluux-bg hover:border-fluux-muted'
+                        : 'border-fluux-border bg-fluux-bg hover:border-fluux-muted'
                       }`}
                   >
                     <Icon className={`size-6 ${isSelected ? 'text-fluux-brand' : 'text-fluux-muted'}`} />
@@ -288,7 +288,7 @@ export function AppearanceSettings() {
                     onClick={() => setDensityMode(option.value)}
                     aria-pressed={isSelected}
                     className={`flex min-h-16 min-w-0 flex-col items-center justify-center gap-2 rounded-lg border-2 p-4 text-center transition-all
-                      ${isSelected ? 'border-fluux-brand bg-fluux-brand/10' : 'border-fluux-hover bg-fluux-bg hover:border-fluux-muted'}`}
+                      ${isSelected ? 'border-fluux-brand bg-fluux-brand/10' : 'border-fluux-border bg-fluux-bg hover:border-fluux-muted'}`}
                   >
                     <span className={`min-w-0 text-sm font-medium leading-tight ${isSelected ? 'text-fluux-text' : 'text-fluux-muted'}`}>
                       {t(option.labelKey)}

--- a/apps/fluux/src/components/settings-components/BlockedUsersSettings.tsx
+++ b/apps/fluux/src/components/settings-components/BlockedUsersSettings.tsx
@@ -95,7 +95,7 @@ export function BlockedUsersSettings() {
 
       {/* Add block form */}
       {showAddForm ? (
-        <div className="mb-4 p-3 rounded-lg border border-fluux-hover bg-fluux-bg">
+        <div className="mb-4 p-3 rounded-lg border border-fluux-border bg-fluux-bg">
           <div className="flex items-center gap-2 mb-2">
             <TextInput
               type="text"
@@ -247,7 +247,7 @@ function BlockedUserItem({ jid, isUnblocking, onUnblock }: BlockedUserItemProps)
   const displayName = getLocalPart(jid)
 
   return (
-    <div className="flex items-center gap-3 p-3 rounded-lg border border-fluux-hover bg-fluux-bg hover:bg-fluux-hover transition-colors">
+    <div className="flex items-center gap-3 p-3 rounded-lg border border-fluux-border bg-fluux-bg hover:bg-fluux-hover transition-colors">
       <Avatar
         identifier={jid}
         name={displayName}

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -923,7 +923,7 @@ export function EncryptionSettings() {
 
         {/* Web locked banner — shown when key exists but no session passphrase */}
         {webLocked && (
-          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-fluux-bg border border-fluux-hover">
+          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-fluux-bg border border-fluux-border">
             <p className="text-xs text-fluux-text leading-snug flex-1">
               {t('settings.encryption.lockedBannerBody')}
             </p>
@@ -946,7 +946,7 @@ export function EncryptionSettings() {
               className={`rounded-lg border-2 p-3 space-y-2 ${
                 pluginStatus === 'generation-failed' || pluginStatus === 'registration-failed'
                   ? 'border-fluux-red/40 bg-fluux-red/5'
-                  : 'border-fluux-hover bg-fluux-bg'
+                  : 'border-fluux-border bg-fluux-bg'
               }`}
             >
               <div

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -148,7 +148,7 @@ export function NotificationsSettings() {
     <section className="w-full max-w-md">
       <SettingsSection title={t('settings.notifications')}>
       <div className="space-y-3">
-        <div className="flex items-center justify-between p-4 rounded-lg border-2 border-fluux-hover bg-fluux-bg">
+        <div className="flex items-center justify-between p-4 rounded-lg border-2 border-fluux-border bg-fluux-bg">
           <div className="flex items-center gap-3">
             {notificationStatus === 'granted' ? (
               <Bell className="size-5 text-fluux-green" />
@@ -223,7 +223,7 @@ export function NotificationsSettings() {
 
         {/* Web Push registration (browser only, when connected) */}
         {isWebPushSupported && isConnected && (
-          <div className="flex items-center justify-between p-4 rounded-lg border-2 border-fluux-hover bg-fluux-bg">
+          <div className="flex items-center justify-between p-4 rounded-lg border-2 border-fluux-border bg-fluux-bg">
             <div className="flex items-center gap-3">
               <Send className={`size-5 ${
                 webPushStatus === 'registered' ? 'text-fluux-green'

--- a/apps/fluux/src/components/settings-components/PrivacySettings.tsx
+++ b/apps/fluux/src/components/settings-components/PrivacySettings.tsx
@@ -31,7 +31,7 @@ export function PrivacySettings() {
                 className={`w-full text-start px-4 py-2.5 rounded-lg border-2 transition-all
                   ${isSelected
                     ? 'border-fluux-brand bg-fluux-brand/10'
-                    : 'border-fluux-hover bg-fluux-bg hover:border-fluux-muted'
+                    : 'border-fluux-border bg-fluux-bg hover:border-fluux-muted'
                   }`}
               >
                 <span className={`text-sm font-medium ${isSelected ? 'text-fluux-text' : 'text-fluux-muted'}`}>

--- a/apps/fluux/src/components/settings-components/UpdatesSettings.tsx
+++ b/apps/fluux/src/components/settings-components/UpdatesSettings.tsx
@@ -11,7 +11,7 @@ export function UpdatesSettings() {
     <section className="w-full max-w-md">
       <SettingsSection title={t('settings.updates')}>
         <div className="space-y-3">
-        <div className="flex items-center justify-between p-4 rounded-lg border-2 border-fluux-hover bg-fluux-bg">
+        <div className="flex items-center justify-between p-4 rounded-lg border-2 border-fluux-border bg-fluux-bg">
           <div className="flex items-center gap-3">
             {update.downloaded ? (
               <CheckCircle className="size-5 text-fluux-green" />


### PR DESCRIPTION
## Summary
- Contact detail cards (About, Devices, Groups, Security) used `border-fluux-hover`, a token tuned for interactive hover states, which reads at only ~1.06:1 contrast against the dark panel background — effectively invisible in dark mode.
- The admin overview stat cards had the same issue, plus `bg-fluux-bg` (darker than the panel background) for the fill.
- Both switched to `bg-fluux-surface` + `border-fluux-border`, the tokens already used elsewhere in the app (`PollCard`, `PollClosedCard`, `.fluux-popover`) for exactly this purpose (~1.6:1 border contrast in dark, with a proper light-mode override).