### PR TITLE
fix(scroll): restore search go-to-message highlight flash in virtualized list

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -841,3 +841,91 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     expect(scrollToIndexCalls).not.toContain('end')       // ...and did not jump to the bottom
   })
 })
+
+/**
+ * Target-message HIGHLIGHT (the "go to message" flash) must land on the row even though consuming
+ * the target synchronously clears targetMessageId in the same tick. Regression: search "go to
+ * message" stopped flashing the arrived row. In the virtualized path the highlight was scheduled in
+ * a requestAnimationFrame, but consuming the target (onTargetMessageConsumed -> clearTargetMessageId)
+ * nulls targetMessageId, which re-runs the scroll effect and fires its cleanup BEFORE that rAF —
+ * cancelling the pending highlight so it never painted.
+ *
+ * This harness mocks requestAnimationFrame/cancelAnimationFrame with an id->cb map (the shared
+ * bottom-stick mock above does not model cancellation, which is exactly the mechanism under test)
+ * and drives the target clear through real component state, flushing ONE frame per act() so the
+ * clear's re-render + effect cleanup interleave between frames the way the production microtask does.
+ */
+describe('MessageList — target-message highlight survives the target clear (virtualized)', () => {
+  let realRaf: typeof requestAnimationFrame
+  let realCaf: typeof cancelAnimationFrame
+  let rafCbs: Map<number, FrameRequestCallback>
+  let nextRafId: number
+  const flush = () => {
+    const entries = [...rafCbs.entries()]
+    rafCbs.clear()
+    entries.forEach(([, cb]) => cb(0))
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    scrollStateManager.reset()
+    scrollToIndexCalls.length = 0
+    scrollToOffsetCalls.length = 0
+    scrollToIndexStartOffsets.length = 0
+    rafCbs = new Map()
+    nextRafId = 0
+    realRaf = globalThis.requestAnimationFrame
+    realCaf = globalThis.cancelAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = ++nextRafId
+      rafCbs.set(id, cb)
+      return id
+    }) as typeof requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((id: number) => { rafCbs.delete(id) }) as typeof cancelAnimationFrame
+  })
+  afterEach(() => {
+    globalThis.requestAnimationFrame = realRaf
+    globalThis.cancelAnimationFrame = realCaf
+    localStorage.clear()
+  })
+
+  function Harness() {
+    // Mirrors the real wiring: onTargetMessageConsumed = clearTargetMessageId, which nulls the
+    // store's targetMessageId, so the prop transitions to undefined the instant the jump is consumed.
+    const [target, setTarget] = React.useState<string | undefined>('msg-30')
+    const onConsumed = React.useCallback(() => setTarget(undefined), [])
+    return (
+      <MessageList
+        messages={makeMessages(50)}
+        conversationId="conv-highlight"
+        targetMessageId={target}
+        onTargetMessageConsumed={onConsumed}
+        renderMessage={(m: BaseMessage) => <div>{m.body}</div>}
+      />
+    )
+  }
+
+  it('applies .message-highlight to the target row even though consuming it clears the target', () => {
+    // Hold scrollTop steady so the reassert loop reaches TARGET_STABLE_FRAMES and consumes.
+    scrollToIndexStartOffsets.push(1200, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400)
+    const { container } = render(<Harness />)
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    let top = 5000
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => 8000, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { value: 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => top,
+      set: (v: number) => { top = v },
+      configurable: true,
+    })
+
+    // One frame per act() so the target-clear re-render + effect cleanup land between frames — the
+    // window in which the buggy cleanup cancels the not-yet-fired highlight rAF.
+    for (let i = 0; i < 10; i++) act(() => flush())
+
+    const targetRow = container.querySelector('[data-message-id="msg-30"]')
+    expect(targetRow).not.toBeNull()
+    expect(targetRow?.classList.contains('message-highlight')).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1937,7 +1937,6 @@ export function useMessageListScroll({
 
     const virt = latestRef.current.virtualizer
     const escapedId = CSS.escape(targetMessageId)
-    let highlightRafId: number | null = null
 
     const highlight = (el: Element) => {
       el.classList.add('message-highlight')
@@ -1988,10 +1987,13 @@ export function useMessageListScroll({
       const consumeAndHighlight = () => {
         if (consumed) return
         consumed = true
-        highlightRafId = requestAnimationFrame(() => {
-          const el = scrollerRef.current?.querySelector(`[data-message-id="${escapedId}"]`)
-          if (el) highlight(el)
-        })
+        // Apply the highlight synchronously BEFORE clearing the target (mirrors the non-virtualized
+        // branch below). onTargetMessageConsumed clears targetMessageId, which re-runs this effect and
+        // fires its cleanup in the same tick; a deferred (rAF) highlight got cancelled by that cleanup
+        // before it could paint, so the "go to message" flash silently vanished. The reassert loop has
+        // already settled the target row into the window, so it is mounted and queryable now.
+        const el = scrollerRef.current?.querySelector(`[data-message-id="${escapedId}"]`)
+        if (el) highlight(el)
         onTargetMessageConsumed?.()
       }
 
@@ -2060,7 +2062,6 @@ export function useMessageListScroll({
 
       return () => {
         finishTarget()
-        if (highlightRafId !== null) cancelAnimationFrame(highlightRafId)
       }
     } else {
       // Non-virtualized: all rows are always in the DOM.
@@ -2084,8 +2085,6 @@ export function useMessageListScroll({
       debugLog('TARGET MESSAGE: scrolled to target (center)', { targetMessageId })
       onTargetMessageConsumed?.()
     }
-
-    return () => { if (highlightRafId !== null) cancelAnimationFrame(highlightRafId) }
 
     // messageCount is in deps so this re-fires when messages load from async sources
     // (e.g., IndexedDB in search context view)


### PR DESCRIPTION
The target message no longer blinks when clicking "go to message" from search.

## Cause
In the virtualized message-list scroll path, the highlight flash was scheduled in a `requestAnimationFrame`, and `targetMessageId` was cleared synchronously right after. Clearing the target re-runs the scroll effect, whose cleanup cancelled the not-yet-fired highlight frame — so the flash silently vanished. The non-virtualized path was unaffected because it highlights synchronously.

Introduced by `1ecbb227` ("Harden message list scroll edge cases"), which moved the highlight into a deferred rAF plus a cleanup that cancels it. Virtualization is the normal production case for any conversation with enough messages, so the highlight appeared to "just stop."

## Fix
Apply the highlight synchronously before consuming the target, mirroring the non-virtualized branch. By consume time the reassert loop has already settled the target row into the window, so it is mounted and queryable. Removes the dead `highlightRafId` plumbing.