### PR TITLE
fix(sidebar): match rail badge cutout ring to the rail surface

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -688,6 +688,15 @@ em-emoji-picker {
 }
 .icon-rail-btn { width: 40px; height: 40px; }
 .icon-rail-btn svg { width: 20px; height: 20px; }
+/* Status/count badges use a border as a "cutout" ring so they read as detached
+   from the icon. That ring must match the surface behind the badge — and rail
+   badges sit on the rail, which is darker than the sidebar (see the 14% overlay
+   above). Ringing them in the sidebar color leaves a faint lighter halo that
+   makes small dots look lumpy rather than perfectly round, so match the rail.
+   (Falls back to the utility's border-fluux-sidebar where color-mix is absent.) */
+.icon-rail button > span {
+  border-color: color-mix(in srgb, #000 14%, var(--fluux-sidebar-bg));
+}
 /* Divider between the sidebar column and the main message view. */
 .chrome-sidebar { border-inline-end: 1px solid var(--fluux-surface-divider); }
 


### PR DESCRIPTION
Rail status/count badges (the small dots on the Messages/Rooms/Contacts icons) use a border as a "cutout" ring so they read as detached from the icon. That ring was colored `border-fluux-sidebar`, but the rail is deliberately darker than the sidebar (a 14% black overlay). The lighter ring left a faint halo around each badge, which made the small status dots look lumpy rather than perfectly round.

Ring rail badges in the rail's own composited color (`color-mix(in srgb, #000 14%, var(--fluux-sidebar-bg))`) instead. Theme-agnostic, and falls back to the existing `border-fluux-sidebar` where `color-mix` is unavailable.