### PR TITLE
Admin: drop offline presence dot, cap user/room list width

### DIFF
--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -367,7 +367,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
     // Show entity lists based on active category
     if (activeCategory === 'users') {
       return (
-        <div className="flex-1 flex flex-col min-h-0">
+        <div className="flex-1 flex flex-col min-h-0 w-full max-w-2xl mx-auto">
           {/* Vhost selector - only show when multiple vhosts available */}
           {vhosts.length > 1 && (
             <div className="mb-3">
@@ -453,24 +453,26 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
       }
 
       return (
-        <EntityListView
-          title={t('admin.roomList.title')}
-          items={filteredRooms}
-          isLoading={roomList.isLoading}
-          hasMore={hasMoreRooms && !roomSearchQuery}
-          searchValue={roomSearchQuery}
-          totalCount={serverStats?.onlineRooms}
-          onSearchChange={setRoomSearchQuery}
-          onLoadMore={loadMoreRooms}
-          emptyMessage={t('admin.roomList.noRooms')}
-          keyExtractor={(room) => room.jid}
-          renderItem={(room) => (
-            <RoomListItem
-              room={room}
-              onSelect={setSelectedRoom}
-            />
-          )}
-        />
+        <div className="flex-1 flex flex-col min-h-0 w-full max-w-2xl mx-auto">
+          <EntityListView
+            title={t('admin.roomList.title')}
+            items={filteredRooms}
+            isLoading={roomList.isLoading}
+            hasMore={hasMoreRooms && !roomSearchQuery}
+            searchValue={roomSearchQuery}
+            totalCount={serverStats?.onlineRooms}
+            onSearchChange={setRoomSearchQuery}
+            onLoadMore={loadMoreRooms}
+            emptyMessage={t('admin.roomList.noRooms')}
+            keyExtractor={(room) => room.jid}
+            renderItem={(room) => (
+              <RoomListItem
+                room={room}
+                onSelect={setSelectedRoom}
+              />
+            )}
+          />
+        </div>
       )
     }
 

--- a/apps/fluux/src/components/UserListItem.tsx
+++ b/apps/fluux/src/components/UserListItem.tsx
@@ -69,12 +69,16 @@ function UserListItemImpl({ user, onSelect, requestLastActivity }: UserListItemP
       className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-fluux-hover
                  transition-colors text-start"
     >
-      {showDot && (
-        <span
-          className={`size-2 rounded-full shrink-0 ${isOnline ? 'bg-fluux-green' : 'bg-fluux-muted'}`}
-          aria-label={isOnline ? t('admin.users.online') : t('admin.users.offline')}
-        />
-      )}
+      {showDot &&
+        (isOnline ? (
+          <span
+            className="size-2 rounded-full shrink-0 bg-fluux-green"
+            aria-label={t('admin.users.online')}
+          />
+        ) : (
+          // Offline is implicit: no grey dot, just a spacer to keep JIDs aligned.
+          <span className="size-2 shrink-0" aria-hidden="true" />
+        ))}
       <div className="flex-1 min-w-0">
         <p className="text-sm text-fluux-text truncate">{user.jid}</p>
       </div>


### PR DESCRIPTION
Two small refinements to the admin user/room lists.

- **Offline presence dot removed.** Offline users no longer show a grey dot in the user list — offline is now implicit (the last-seen time already conveys it), so only online users get the green dot. A same-size spacer keeps the JIDs aligned across rows.
- **List width capped.** The user and room lists were stretching edge-to-edge, leaving a large empty gap between the JID and its status on wide windows. They're now capped to `max-w-2xl` and centered.