### PR TITLE
feat(composer): focus-reveal toolbar on narrow widths

### DIFF
--- a/apps/fluux/src/components/MessageComposer.layout.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.layout.test.tsx
@@ -34,4 +34,35 @@ describe('MessageComposer responsive layout', () => {
     const row = screen.getByPlaceholderText('Type a message').closest('.composer-actions')
     expect(row!.innerHTML).toContain('grid-area:lock')
   })
+
+  it('marks the +/emoji controls as collapsible drawer items', () => {
+    render(<MessageComposer placeholder="Type a message" onSend={onSend} />)
+
+    const row = screen.getByPlaceholderText('Type a message').closest('.composer-actions')!
+
+    // No encryption → only the + and emoji wrappers are drawer items.
+    const drawerItems = row.querySelectorAll('.composer-drawer-item')
+    expect(drawerItems.length).toBe(2)
+
+    const add = row.querySelector('[class*="grid-area:add"]')
+    const emoji = row.querySelector('[class*="grid-area:emoji"]')
+    expect(add?.classList.contains('composer-drawer-item')).toBe(true)
+    expect(emoji?.classList.contains('composer-drawer-item')).toBe(true)
+  })
+
+  it('marks the encryption lock as a drawer item when encrypted', () => {
+    render(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={onSend}
+        encryptionState={{ kind: 'encrypted', fingerprint: 'ABCD1234', trust: 'unverified' }}
+      />
+    )
+
+    const row = screen.getByPlaceholderText('Type a message').closest('.composer-actions')!
+    const lock = row.querySelector('[class*="grid-area:lock"]')
+    expect(lock?.classList.contains('composer-drawer-item')).toBe(true)
+    // + / lock / emoji are all drawer items now.
+    expect(row.querySelectorAll('.composer-drawer-item').length).toBe(3)
+  })
 })

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -866,7 +866,7 @@ export function MessageComposer({
         />
 
         {/* Attach menu — combines attachment + poll into a single "+" button */}
-        <div className="relative [grid-area:add]" ref={attachMenuRef}>
+        <div className="relative [grid-area:add] composer-drawer-item" ref={attachMenuRef}>
           {uploadState?.isUploading ? (
             /* During upload, show spinner directly instead of the menu toggle */
             <button type="button" disabled className="p-3 text-fluux-brand">
@@ -931,12 +931,12 @@ export function MessageComposer({
               data-encryption-lock
               onClick={onEncryptionClick}
               aria-label={lockInfo.label}
-              className="p-1.5 flex-shrink-0 rounded-lg hover:bg-fluux-bg transition-colors [grid-area:lock]"
+              className="p-1.5 flex-shrink-0 rounded-lg hover:bg-fluux-bg transition-colors [grid-area:lock] composer-drawer-item"
             >
               <lockInfo.Icon className="size-4" style={{ color: lockInfo.color }} />
             </button>
           ) : (
-            <span data-encryption-lock aria-label={lockInfo.label} className="p-1.5 flex-shrink-0 [grid-area:lock]">
+            <span data-encryption-lock aria-label={lockInfo.label} className="p-1.5 flex-shrink-0 [grid-area:lock] composer-drawer-item">
               <lockInfo.Icon className="size-4" style={{ color: lockInfo.color }} />
             </span>
           )
@@ -961,7 +961,7 @@ export function MessageComposer({
         )}
 
         {/* Emoji button */}
-        <div className="relative [grid-area:emoji]" ref={emojiPickerRef}>
+        <div className="relative [grid-area:emoji] composer-drawer-item" ref={emojiPickerRef}>
           <button
             type="button"
             onClick={() => setShowEmojiPicker(!showEmojiPicker)}

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -950,23 +950,52 @@ html, body {
   box-shadow: 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22);
 }
 
-/* Composer action row. One row when the card is wide enough; on narrow widths
- * (phone, narrowed pane) the text field takes the full first line and the
- * controls drop to a toolbar row below — `add`/`lock` at the inline-start,
- * `emoji`/`send` grouped at the inline-end (same order as the wide row).
- * Container-query driven off `.composer-card`; no JS. RTL mirrors automatically
- * because grid-template-areas follows the inline axis. */
+/* Composer action row. On narrow widths (phone, narrowed pane) the input + send
+ * sit on a top row and the secondary controls (+ / lock / emoji) form a drawer
+ * beneath it that is collapsed while idle and extends on focus. On wide widths
+ * it is the single comfortable row. Container-query + :focus-within driven off
+ * `.composer-card`; no JS. RTL mirrors automatically (areas follow the inline
+ * axis). */
 .composer-actions {
   display: grid;
   align-items: center;
-  grid-template-columns: auto auto 1fr auto auto;
+  grid-template-columns: auto 1fr auto;
   grid-template-areas:
-    "input input input input input"
-    "add   lock  .     emoji send";
+    "input input send"
+    "add   lock  emoji";
 }
+
+/* The drawer controls. Expanded height by default; collapsed to zero while the
+ * card is idle. `overflow: hidden` is applied ONLY in the collapsed state so it
+ * clips the shrinking icons without ever clipping the (focus-only) attach/emoji
+ * popovers, which open upward out of these wrappers. */
+.composer-drawer-item {
+  max-height: 3.5rem;
+  opacity: 1;
+  transition: max-height 160ms ease, opacity 160ms ease;
+}
+.composer-card:not(:focus-within) .composer-drawer-item {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+}
+
 @container (min-width: 420px) {
   .composer-actions {
+    grid-template-columns: auto auto 1fr auto auto;
     grid-template-areas: "add lock input emoji send";
+  }
+  /* Wide is a comfortable single row — the drawer is never collapsed. */
+  .composer-card:not(:focus-within) .composer-drawer-item {
+    max-height: none;
+    opacity: 1;
+    overflow: visible;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-drawer-item {
+    transition: none;
   }
 }
 

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -966,18 +966,27 @@ html, body {
 }
 
 /* The drawer controls. Expanded height by default; collapsed to zero while the
- * card is idle. `overflow: hidden` is applied ONLY in the collapsed state so it
- * clips the shrinking icons without ever clipping the (focus-only) attach/emoji
- * popovers, which open upward out of these wrappers. */
+ * card is idle. `overflow: hidden` and `visibility: hidden` apply ONLY in the
+ * collapsed state: overflow clips the shrinking icons without ever clipping the
+ * (focus-only) attach/emoji popovers, and visibility removes the collapsed
+ * controls from the tab order / a11y tree so the first Tab into the idle
+ * composer lands on the input (matching the single-row look), not an invisible
+ * `+`. Focusing the input or the always-visible send button reveals the drawer.
+ * 3.5rem must exceed the tallest drawer-row control (an icon button). */
 .composer-drawer-item {
   max-height: 3.5rem;
   opacity: 1;
+  visibility: visible;
   transition: max-height 160ms ease, opacity 160ms ease;
 }
 .composer-card:not(:focus-within) .composer-drawer-item {
   max-height: 0;
   opacity: 0;
   overflow: hidden;
+  pointer-events: none;
+  /* visibility flips to hidden only after the 160ms fade-out completes */
+  visibility: hidden;
+  transition: max-height 160ms ease, opacity 160ms ease, visibility 0s linear 160ms;
 }
 
 @container (min-width: 420px) {
@@ -990,11 +999,15 @@ html, body {
     max-height: none;
     opacity: 1;
     overflow: visible;
+    pointer-events: auto;
+    visibility: visible;
+    transition: max-height 160ms ease, opacity 160ms ease;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .composer-drawer-item {
+  .composer-drawer-item,
+  .composer-card:not(:focus-within) .composer-drawer-item {
     transition: none;
   }
 }

--- a/docs/superpowers/plans/2026-07-02-composer-focus-reveal-toolbar.md
+++ b/docs/superpowers/plans/2026-07-02-composer-focus-reveal-toolbar.md
@@ -1,0 +1,246 @@
+# Composer Focus-Reveal Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On narrow widths, collapse the composer to a slim `input + send` row when idle and extend the `+`/lock/emoji controls into a drawer only when the field is engaged (`:focus-within`).
+
+**Architecture:** Pure CSS on top of #815's grid. The narrow `.composer-actions` template becomes a fixed two-row grid (`input input send` / `add lock emoji`); the three drawer items collapse to zero height by default and expand on `.composer-card:focus-within`. Send stays anchored to the top row so it never reflows. No JS, no component state. The only TSX change is adding a shared marker class to the three drawer wrappers.
+
+**Tech Stack:** React 19, Tailwind (arbitrary `[grid-area:*]` utilities), CSS container queries + `:focus-within`, Vitest + Testing Library (jsdom).
+
+## Global Constraints
+
+- **Pure CSS, no JS/state** — reveal is `:focus-within` on `.composer-card`; no new React state, effects, or props.
+- **Wide layout (`≥ 420px` container) unchanged** — single `"add lock input emoji send"` row, drawer never collapsed.
+- **Send never reflows** between idle and focused (stays top-row inline-end).
+- **Collapse on blur even with a draft** — no "keep open if draft" special-casing.
+- **Respect `prefers-reduced-motion: reduce`** — no transition.
+- **Do not put `overflow: hidden` on the drawer wrappers in the expanded state** — it would clip the absolutely-positioned attach/emoji popovers. `overflow: hidden` applies only in the collapsed (`:not(:focus-within)`) state, where popovers are never open.
+- **Breakpoint stays `420px`**, matching #815.
+- Work happens in the worktree at `.claude/worktrees/eloquent-mcclintock-6bb18a/`. Verify edited paths start with that prefix (never the main checkout).
+
+---
+
+### Task 1: Mark the drawer wrappers (`+` / lock / emoji)
+
+Add a shared `composer-drawer-item` class to the three secondary-control wrappers so CSS can collapse them as a group. This is the only markup change; it is inert until Task 2 adds the CSS.
+
+**Files:**
+- Modify: `apps/fluux/src/components/MessageComposer.tsx` (the `+` wrapper ~line 869, the two encryption-lock variants ~lines 934 & 939, the emoji wrapper ~line 964)
+- Test: `apps/fluux/src/components/MessageComposer.layout.test.tsx`
+
+**Interfaces:**
+- Consumes: existing grid areas `add`, `lock`, `emoji`, `input`, `send` from #815.
+- Produces: a `composer-drawer-item` class present on exactly the `add` and `emoji` wrappers always, and on the `lock` wrapper when `encryptionState.kind === 'encrypted'`. Task 2's CSS selects `.composer-drawer-item`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two tests to `apps/fluux/src/components/MessageComposer.layout.test.tsx` (inside the existing `describe`):
+
+```tsx
+  it('marks the +/emoji controls as collapsible drawer items', () => {
+    render(<MessageComposer placeholder="Type a message" onSend={onSend} />)
+
+    const row = screen.getByPlaceholderText('Type a message').closest('.composer-actions')!
+
+    // No encryption → only the + and emoji wrappers are drawer items.
+    const drawerItems = row.querySelectorAll('.composer-drawer-item')
+    expect(drawerItems.length).toBe(2)
+
+    const add = row.querySelector('[class*="grid-area:add"]')
+    const emoji = row.querySelector('[class*="grid-area:emoji"]')
+    expect(add?.classList.contains('composer-drawer-item')).toBe(true)
+    expect(emoji?.classList.contains('composer-drawer-item')).toBe(true)
+  })
+
+  it('marks the encryption lock as a drawer item when encrypted', () => {
+    render(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={onSend}
+        encryptionState={{ kind: 'encrypted', fingerprint: 'ABCD1234', trust: 'unverified' }}
+      />
+    )
+
+    const row = screen.getByPlaceholderText('Type a message').closest('.composer-actions')!
+    const lock = row.querySelector('[class*="grid-area:lock"]')
+    expect(lock?.classList.contains('composer-drawer-item')).toBe(true)
+    // + / lock / emoji are all drawer items now.
+    expect(row.querySelectorAll('.composer-drawer-item').length).toBe(3)
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/components/MessageComposer.layout.test.tsx`
+Expected: the two new tests FAIL (`expect(received).toBe(true)` / length `0` or `1`, class not yet present). The two existing tests still PASS.
+
+- [ ] **Step 3: Add the marker class in `MessageComposer.tsx`**
+
+Append ` composer-drawer-item` to each of these four `className` strings (do not change anything else on the elements):
+
+The `+` attach-menu wrapper:
+```tsx
+        <div className="relative [grid-area:add] composer-drawer-item" ref={attachMenuRef}>
+```
+
+The interactive encryption-lock button:
+```tsx
+            <button
+              type="button"
+              data-encryption-lock
+              onClick={onEncryptionClick}
+              aria-label={lockInfo.label}
+              className="p-1.5 flex-shrink-0 rounded-lg hover:bg-fluux-bg transition-colors [grid-area:lock] composer-drawer-item"
+            >
+```
+
+The non-interactive encryption-lock span:
+```tsx
+            <span data-encryption-lock aria-label={lockInfo.label} className="p-1.5 flex-shrink-0 [grid-area:lock] composer-drawer-item">
+```
+
+The emoji wrapper:
+```tsx
+        <div className="relative [grid-area:emoji] composer-drawer-item" ref={emojiPickerRef}>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/components/MessageComposer.layout.test.tsx`
+Expected: all four tests PASS, no stderr.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: passes (no new type errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/components/MessageComposer.tsx apps/fluux/src/components/MessageComposer.layout.test.tsx
+git commit -m "feat(composer): mark +/lock/emoji as drawer items"
+```
+
+---
+
+### Task 2: Collapse/reveal the drawer in CSS
+
+Rewrite the narrow `.composer-actions` template to a fixed two-row grid with send anchored top-right, collapse the drawer items by default, and expand them on `.composer-card:focus-within`. Keep the wide single-row layout and its `420px` breakpoint intact.
+
+**Files:**
+- Modify: `apps/fluux/src/index.css` (the `.composer-actions` block + `@container (min-width: 420px)` override, currently ~lines 953–971)
+
+**Interfaces:**
+- Consumes: `.composer-drawer-item` (Task 1), `.composer-card` (has `container-type: inline-size` and is the `:focus-within` host, ~lines 943–951), grid areas `input`/`send`/`add`/`lock`/`emoji`.
+- Produces: no new selectors consumed by other tasks.
+
+- [ ] **Step 1: Replace the `.composer-actions` rules**
+
+Replace the existing block (from the comment above `.composer-actions` through the closing `}` of the `@container (min-width: 420px)` rule — currently lines 953–971) with:
+
+```css
+/* Composer action row. On narrow widths (phone, narrowed pane) the input + send
+ * sit on a top row and the secondary controls (+ / lock / emoji) form a drawer
+ * beneath it that is collapsed while idle and extends on focus. On wide widths
+ * it is the single comfortable row. Container-query + :focus-within driven off
+ * `.composer-card`; no JS. RTL mirrors automatically (areas follow the inline
+ * axis). */
+.composer-actions {
+  display: grid;
+  align-items: center;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas:
+    "input input send"
+    "add   lock  emoji";
+}
+
+/* The drawer controls. Expanded height by default; collapsed to zero while the
+ * card is idle. `overflow: hidden` is applied ONLY in the collapsed state so it
+ * clips the shrinking icons without ever clipping the (focus-only) attach/emoji
+ * popovers, which open upward out of these wrappers. */
+.composer-drawer-item {
+  max-height: 3.5rem;
+  opacity: 1;
+  transition: max-height 160ms ease, opacity 160ms ease;
+}
+.composer-card:not(:focus-within) .composer-drawer-item {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+}
+
+@container (min-width: 420px) {
+  .composer-actions {
+    grid-template-columns: auto auto 1fr auto auto;
+    grid-template-areas: "add lock input emoji send";
+  }
+  /* Wide is a comfortable single row — the drawer is never collapsed. */
+  .composer-card:not(:focus-within) .composer-drawer-item {
+    max-height: none;
+    opacity: 1;
+    overflow: visible;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-drawer-item {
+    transition: none;
+  }
+}
+```
+
+- [ ] **Step 2: Re-run the layout unit tests (guard against markup regressions)**
+
+Run: `cd apps/fluux && npx vitest run src/components/MessageComposer.layout.test.tsx`
+Expected: all four tests PASS (jsdom does not evaluate container queries or `:focus-within`, so this only confirms the markup contract from Task 1 is intact).
+
+- [ ] **Step 3: Verify in the preview (demo mode, narrow)**
+
+Start the dev server and open demo mode; narrow the chat pane (or the window) so the `.composer-card` container is below `420px`.
+
+Confirm:
+1. **Idle, empty:** single row — `input` + `send` only; `+`/lock/emoji are not visible and take no vertical space.
+2. **Focus the field:** the `+`/(lock)/emoji drawer extends below; **`send` does not move** (stays top inline-end).
+3. **Type then blur:** drawer collapses; `send` stays visible and the typed draft is preserved.
+4. **Open the emoji picker / attach menu:** popovers are not clipped (drawer is expanded because focus is within the card).
+5. **Wide (`≥ 420px`):** unchanged single row `+ lock input emoji send`.
+6. **Reduced motion** (`preview_resize` cannot set this; use `preview_eval` to add a `<style>` forcing `prefers-reduced-motion` is unreliable — instead verify the class carries `transition: none` under the media query by reading the rule, or note it as visual-only): the extend snaps without animating.
+7. **RTL:** switch language/dir to RTL and confirm `+`/lock hug the inline-start and emoji/send the inline-end (mirrored).
+
+Capture a screenshot of the idle (collapsed) and focused (extended) narrow states for the summary.
+
+- [ ] **Step 4: Full app test suite + typecheck + lint**
+
+Run: `cd apps/fluux && npx vitest run`
+Expected: green, no stderr.
+
+Run: `npm run typecheck`
+Expected: passes.
+
+Run the linter as configured for the repo (e.g. `npm run lint` if present); expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/index.css
+git commit -m "feat(composer): focus-reveal drawer on narrow widths"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Idle narrow = `input + send` only → Task 2 narrow template + default-collapsed drawer. ✓
+- Focused narrow = drawer extends, send stays put → Task 2 fixed two-row template + `:focus-within` expand. ✓
+- Pure CSS, no state → Task 1 (class only) + Task 2 (CSS only). ✓
+- Collapse on blur incl. draft → `.composer-card:not(:focus-within)` with no draft exception. ✓
+- Motion + reduced-motion → Task 2 transition + media query. ✓
+- Wide unchanged, `420px` breakpoint → Task 2 `@container (min-width: 420px)`. ✓
+- Popover clipping avoided → `overflow: hidden` only in collapsed state (constraint + Task 2). ✓
+- RTL, tap targets, autosize width observer → covered by unchanged #815 behavior; RTL verified in Task 2 Step 3. ✓
+
+**Placeholder scan:** none — all code and commands are literal.
+
+**Type consistency:** the only shared symbol across tasks is the CSS class `composer-drawer-item`, spelled identically in Task 1 (markup + tests) and Task 2 (selectors).

--- a/docs/superpowers/specs/2026-07-02-composer-focus-reveal-toolbar-design.md
+++ b/docs/superpowers/specs/2026-07-02-composer-focus-reveal-toolbar-design.md
@@ -1,0 +1,151 @@
+# Composer: focus-reveal toolbar on narrow widths
+
+## Problem
+
+The narrow-width composer (#815) always renders two rows once the
+`.composer-card` container drops below 420px: the text field on the first line
+and a toolbar row (`+` / lock / emoji / send) beneath it
+([`index.css` `.composer-actions`](../../../apps/fluux/src/index.css)).
+
+```
+┌────────────────────────┐
+│ [ Message…           ]  │   ← input, full width
+│  +   🛡         😊  ➤   │   ← toolbar, always present
+└────────────────────────┘
+```
+
+That toolbar row costs a permanent strip of vertical space even when the
+composer is idle — the moment it matters most, on a phone-height viewport where
+the message list is already tight.
+
+## Goal
+
+On narrow widths, collapse the composer to a slim single row when idle and
+"extend" the secondary controls into a drawer only when the user engages the
+field. Keep it pure CSS — no JS, no component state — matching #815.
+
+Non-goals: no change to which controls exist, no change to the wide (`≥ 420px`)
+single-row layout, no change to the emoji/attach popovers, no JS-driven
+measurement or focus state.
+
+## Approach
+
+Anchor the **send button to the top row with the input** so the collapsed state
+is a usable single row (input + send). The secondary controls (`+`, lock, emoji)
+live in a **second row that is a collapsible drawer**, revealed on
+`:focus-within`.
+
+Reuse the existing mechanisms:
+
+- The `.composer-card` already declares `container-type: inline-size` and already
+  uses `:focus-within` for its accent focus-edge
+  ([`index.css` `.composer-card:focus-within`](../../../apps/fluux/src/index.css)).
+  The drawer gates on the **same** `:focus-within`.
+- The narrow/wide split stays a `@container (min-width: 420px)` query.
+
+### Layout
+
+Grid areas are unchanged from #815 (`add`, `lock`, `input`, `emoji`, `send`).
+Only the narrow template and its focus variant change.
+
+**Narrow, idle (default — not `:focus-within`) — single row:**
+
+```
+grid-template-areas: "input send";
+grid-template-columns: 1fr auto;
+```
+
+`add`, `lock`, `emoji` are placed in a drawer row that is collapsed to zero
+height (see below). Send stays beside the input; when there is no text it is the
+existing disabled/transparent send affordance.
+
+**Narrow, focused (`:focus-within`) — input + send on top, drawer below:**
+
+```
+grid-template-areas:
+  "input input send"
+  "add   lock  emoji";
+grid-template-columns: auto auto 1fr;   /* drawer row: +/lock at inline-start, emoji at inline-end under send */
+```
+
+Row 1: `input` (spanning) + `send` at the inline-end corner — unchanged from
+idle, so send does **not** move when the drawer opens.
+Row 2 (drawer): `add` and `lock` at the inline-start, `emoji` at the inline-end
+(sitting under `send`).
+
+**Wide (`@container (min-width: 420px)`) — single row, untouched:**
+
+```
+grid-template-areas: "add lock input emoji send";
+```
+
+Exactly today's result.
+
+### Drawer collapse / reveal
+
+The drawer must animate as an "extend," so it can't rely on a grid-template swap
+alone (grid reflow doesn't transition). Approach:
+
+- Wrap the drawer controls' row so its **height/opacity** transition. Idle:
+  `max-height: 0; opacity: 0; overflow: hidden; pointer-events: none`.
+  `:focus-within`: `max-height` to a value covering one toolbar row, `opacity: 1`.
+- Gate the whole behavior inside the narrow branch only. Wide is never collapsed.
+- `prefers-reduced-motion: reduce` → no transition (snap open/closed).
+
+Exact CSS structuring (whether the drawer is a nested element vs. the grid rows
+collapsing) is an implementation detail for the plan; the constraint is:
+send never reflows between idle and focused, and the reveal is CSS-only.
+
+### Behavior
+
+- **Reveal trigger:** `:focus-within`. Tabbing to the field — or to any control —
+  opens the drawer; opening the emoji/attach popovers keeps it open (they are
+  DOM children of the card). CSS applies synchronously with focus, so a control
+  that receives focus is visible in the same frame (no flash).
+- **Collapse on blur, even with a draft.** Send lives on the top row, so a typed
+  but unsent draft stays sendable; attach/emoji are one tap away again. This
+  avoids any "keep open while draft present" special-casing and keeps it pure CSS.
+- **Wide layout is never collapsed** — the drawer logic lives entirely under the
+  narrow container query.
+
+### Edge cases
+
+- **`input` cell must shrink**: keep `min-width: 0` on the input area (as today).
+- **Autosize width observer**: the input width changes when the layout switches
+  and when the drawer opens/closes if it affects input width — it does not here
+  (input width is the same in idle and focused narrow states, both `1fr` on the
+  top row). The existing width `ResizeObserver` (`resizeToContent(true)`) covers
+  the narrow⇄wide switch regardless.
+- **Tap targets**: drawer buttons keep `p-3` / `tap-target`; the collapsed drawer
+  must not leave them focusable while hidden — `:focus-within` reveals before
+  interaction, but confirm keyboard tab order lands on the input first (DOM order
+  is `add, lock, input, emoji, send`; focusing a hidden `add`/`lock` still
+  triggers `:focus-within` and reveals synchronously, so no dead tab stop).
+- **RTL**: `grid-template-areas` follows the inline axis; groups mirror
+  automatically. Verify.
+- **Escalation banner / edit / reply / attachment previews**: sibling rows above
+  the action row, unaffected.
+
+## Testing
+
+- Unit: extend `MessageComposer.layout.test.tsx` — assert the `.composer-actions`
+  markup/classes for the drawer (jsdom does not evaluate container queries or
+  `:focus-within`, so assert the class strings / structure, mirroring #815's test).
+- Manual/preview (demo mode, narrowed pane below 420px):
+  - Idle: single row, input + send only; `+`/lock/emoji hidden.
+  - Focus the field: drawer extends below with `+`/lock/emoji; send does not move.
+  - Blur: drawer collapses; a typed draft keeps send visible.
+  - `prefers-reduced-motion`: snaps without animating.
+  - Wide (`≥ 420px`): unchanged single row.
+  - RTL mirrors the groups.
+
+## Files
+
+- [`apps/fluux/src/index.css`](../../../apps/fluux/src/index.css) — `.composer-actions`
+  narrow template, `:focus-within` drawer variant, and the collapse/reveal
+  transition.
+- [`apps/fluux/src/components/MessageComposer.tsx`](../../../apps/fluux/src/components/MessageComposer.tsx)
+  — only if the drawer needs a wrapper element around `add`/`lock`/`emoji`;
+  prefer a CSS-only change if the existing grid children suffice.
+- [`apps/fluux/src/components/MessageComposer.layout.test.tsx`](../../../apps/fluux/src/components/MessageComposer.layout.test.tsx)
+  — drawer structure assertions.


### PR DESCRIPTION
On narrow widths (phone, or a narrowed chat pane) the composer's two-row layout from #815 kept the `+`/lock/emoji toolbar row permanently visible, spending vertical space even when the composer was idle.

This collapses the composer to a slim single row (input + send) when idle and extends the secondary controls into a drawer beneath it only on `:focus-within`. Send stays anchored to the top row, so it never reflows when the drawer opens. Pure CSS on top of #815's grid — no JS, no component state:

- Narrow, idle: `input + send` only; `+`/lock/emoji collapsed to zero height and removed from the tab order/a11y tree (`visibility:hidden` + `pointer-events:none`), so the first Tab lands on the input.
- Narrow, focused: the drawer extends below (`+`/lock at inline-start, emoji under send); collapses again on blur, keeping any typed draft sendable.
- Wide (`≥ 420px`): unchanged single row.
- Honors `prefers-reduced-motion`.