### PR TITLE
fix(attachments): render DjVu as a document, not a broken image

### DIFF
--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -8,7 +8,7 @@ import { formatBytes, useAttachmentUrl, useCachedMediaUrl } from '@/hooks'
 import { DeferredMediaPlaceholder } from './DeferredMediaPlaceholder'
 import { useDeferredMedia } from '@/hooks/useDeferredMedia'
 import { useContextMenu } from '@/hooks/useContextMenu'
-import { isPdfMimeType, isDocumentMimeType, isArchiveMimeType, isEbookMimeType, getFileTypeLabel } from '@/utils/thumbnail'
+import { isPdfMimeType, isDocumentMimeType, isArchiveMimeType, isEbookMimeType, getFileTypeLabel, isRenderableImageMime } from '@/utils/thumbnail'
 import type { FileAttachment } from '@fluux/sdk'
 
 /**
@@ -37,7 +37,7 @@ interface AttachmentProps {
  */
 export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoad, isOwnMessage }: AttachmentProps) {
   const { t } = useTranslation()
-  const isImage = attachment.mediaType?.startsWith('image/') ?? false
+  const isImage = isRenderableImageMime(attachment.mediaType)
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const imageMenu = useContextMenu()
 
@@ -534,7 +534,7 @@ export function FileAttachmentCard({ attachment }: AttachmentProps) {
  */
 export function shouldShowFileCard(attachment: FileAttachment | undefined, canPreviewAsText: boolean): boolean {
   if (!attachment) return false
-  if (attachment.mediaType?.startsWith('image/')) return false
+  if (isRenderableImageMime(attachment.mediaType)) return false
   if (attachment.mediaType?.startsWith('video/')) return false
   if (attachment.mediaType?.startsWith('audio/')) return false
   if (canPreviewAsText) return false

--- a/apps/fluux/src/utils/thumbnail.test.ts
+++ b/apps/fluux/src/utils/thumbnail.test.ts
@@ -11,6 +11,8 @@ import {
   getVideoDimensions,
   getAudioDuration,
   getEffectiveMimeType,
+  effectiveMediaType,
+  isRenderableImageMime,
   isPdfFile,
   isPdfMimeType,
   isDocumentMimeType,
@@ -144,6 +146,39 @@ describe('isImageFile', () => {
   it('should return false for files without type', () => {
     const file = new File([''], 'unknown')
     expect(isImageFile(file)).toBe(false)
+  })
+})
+
+describe('isRenderableImageMime', () => {
+  it('returns true for real image types', () => {
+    expect(isRenderableImageMime('image/jpeg')).toBe(true)
+    expect(isRenderableImageMime('image/png')).toBe(true)
+    expect(isRenderableImageMime('image/webp')).toBe(true)
+  })
+
+  it('returns false for DjVu even though it is registered under image/*', () => {
+    // Old messages carry the IANA type verbatim; the browser cannot render it.
+    expect(isRenderableImageMime('image/vnd.djvu')).toBe(false)
+    expect(isRenderableImageMime('image/x-djvu')).toBe(false)
+  })
+
+  it('returns false for non-image and missing types', () => {
+    expect(isRenderableImageMime('application/pdf')).toBe(false)
+    expect(isRenderableImageMime('application/x-djvu')).toBe(false)
+    expect(isRenderableImageMime(undefined)).toBe(false)
+  })
+})
+
+describe('effectiveMediaType', () => {
+  it('remaps non-renderable image types to their application/ equivalent', () => {
+    expect(effectiveMediaType('image/vnd.djvu')).toBe('application/x-djvu')
+    expect(effectiveMediaType('image/x-djvu')).toBe('application/x-djvu')
+  })
+
+  it('passes through renderable and unrelated types unchanged', () => {
+    expect(effectiveMediaType('image/png')).toBe('image/png')
+    expect(effectiveMediaType('application/pdf')).toBe('application/pdf')
+    expect(effectiveMediaType(undefined)).toBeUndefined()
   })
 })
 
@@ -813,6 +848,10 @@ describe('isDocumentMimeType', () => {
     expect(isDocumentMimeType('text/plain')).toBe(true)
   })
 
+  it('should return true for DjVu', () => {
+    expect(isDocumentMimeType('application/x-djvu')).toBe(true)
+  })
+
   it('should return false for images', () => {
     expect(isDocumentMimeType('image/png')).toBe(false)
   })
@@ -899,6 +938,10 @@ describe('getFileTypeLabel', () => {
 
   it('should return "RTF" for RTF files', () => {
     expect(getFileTypeLabel('application/rtf')).toBe('RTF')
+  })
+
+  it('should return "DjVu" for DjVu files', () => {
+    expect(getFileTypeLabel('application/x-djvu')).toBe('DjVu')
   })
 
   it('should return "ZIP" for ZIP archives', () => {

--- a/apps/fluux/src/utils/thumbnail.ts
+++ b/apps/fluux/src/utils/thumbnail.ts
@@ -110,6 +110,28 @@ const NON_RENDERABLE_IMAGE_TYPES: Record<string, string> = {
 }
 
 /**
+ * Remap a MIME type string that is registered under image/* but which browsers
+ * cannot render (e.g. DjVu) to its application/ equivalent. Returns the input
+ * unchanged for everything else.
+ *
+ * Unlike getEffectiveMimeType this works on a bare MIME string, so it applies to
+ * received attachments — not just files being uploaded — and makes the DjVu fix
+ * retroactive for messages that were sent before it existed.
+ */
+export function effectiveMediaType(mediaType: string | undefined): string | undefined {
+  if (!mediaType) return mediaType
+  return NON_RENDERABLE_IMAGE_TYPES[mediaType] ?? mediaType
+}
+
+/**
+ * Whether a MIME type should render as an inline <img>. False for image/* types
+ * the browser cannot actually decode (DjVu), so they fall through to a file card.
+ */
+export function isRenderableImageMime(mediaType: string | undefined): boolean {
+  return effectiveMediaType(mediaType)?.startsWith('image/') ?? false
+}
+
+/**
  * Get effective MIME type for a file.
  * Uses browser-detected type if valid, otherwise falls back to extension lookup.
  */
@@ -471,6 +493,7 @@ export function isDocumentMimeType(mimeType: string | undefined): boolean {
     mimeType === 'application/msword' ||
     mimeType.includes('officedocument') ||
     mimeType === 'application/rtf' ||
+    mimeType === 'application/x-djvu' ||
     mimeType === 'text/plain'
 }
 
@@ -511,6 +534,7 @@ export function getFileTypeLabel(mimeType: string | undefined): string {
   if (mimeType === 'application/x-7z-compressed') return '7Z'
   if (mimeType === 'application/x-tar' || mimeType === 'application/gzip') return 'Archive'
   if (mimeType === 'application/epub+zip') return 'EPUB'
+  if (mimeType === 'application/x-djvu') return 'DjVu'
 
   return 'File'
 }

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
@@ -227,6 +227,23 @@ describe('messagingUtils', () => {
       expect(result?.mediaType).toBeUndefined()
     })
 
+    it('should map .djvu extension to application/x-djvu (not a renderable image)', () => {
+      const stanza = createMockElement('message', { id: 'msg-1' }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'jabber:x:oob' },
+          children: [
+            { name: 'url', text: 'https://example.com/uploads/scan.djvu' },
+          ],
+        },
+      ])
+
+      const result = parseOobData(stanza)
+
+      expect(result?.name).toBe('scan.djvu')
+      expect(result?.mediaType).toBe('application/x-djvu')
+    })
+
     it('should return undefined when no OOB element', () => {
       const stanza = createMockElement('message', { id: 'msg-1' }, [
         { name: 'body', text: 'No attachment' },

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.ts
@@ -212,6 +212,9 @@ export function parseOobData(stanza: Element): FileAttachment | undefined {
       'wmv': 'video/x-ms-wmv', '3gp': 'video/3gpp', 'ogv': 'video/ogg',
       // Documents
       'pdf': 'application/pdf',
+      // DjVu: registered under image/* by IANA but browsers cannot render it,
+      // so map straight to the application/ type used for the file card.
+      'djvu': 'application/x-djvu', 'djv': 'application/x-djvu',
     }
     mediaType = ext ? mimeMap[ext] : undefined
   }


### PR DESCRIPTION
The DjVu remap previously ran only on the upload path, so received messages — old ones sent before the fix and any incoming from other clients — still tried to render `image/vnd.djvu` as an `<img>` and showed a broken-image tile.

This moves the remap to the render-decision layer so it applies retroactively (no data migration): the image-vs-file choice is derived at render time from the attachment's MIME type.

- Add `effectiveMediaType()` / `isRenderableImageMime()` and use them in `ImageAttachment` and `shouldShowFileCard`, reusing the existing `NON_RENDERABLE_IMAGE_TYPES` map.
- Classify `application/x-djvu` as a document (blue doc icon, "DjVu" label).
- Add `.djvu`/`.djv` to the receive-side extension fallback for senders that omit `<media-type>`.