### PR TITLE
fix(sidebar): rail badges render as full circles

### DIFF
--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -64,11 +64,11 @@ export function IconRailNavLink({
       >
         <Icon className="size-5" />
         {hasCount ? (
-          <span className="absolute -top-0.5 -end-0.5 min-w-4 h-4 px-1 flex items-center justify-center bg-fluux-red text-white text-[10px] leading-none font-semibold rounded-full border-2 border-fluux-sidebar">
+          <span className="absolute -top-0.5 -end-0.5 min-w-4 h-4 px-1 flex items-center justify-center bg-fluux-red text-white text-[10px] leading-none font-semibold rounded-full ring-2 ring-fluux-sidebar">
             {badgeCount > 99 ? '99+' : badgeCount}
           </span>
         ) : showBadge ? (
-          <span className={`absolute top-0 end-0 size-3 ${dotToneClass} rounded-full border-2 border-fluux-sidebar`} />
+          <span className={`absolute top-0.5 end-0.5 size-2.5 ${dotToneClass} rounded-full ring-2 ring-fluux-sidebar`} />
         ) : null}
       </button>
     </Tooltip>

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -40,12 +40,24 @@ export function IconRailNavLink({
   const location = useLocation()
   const isActive = location.pathname === pathPrefix || location.pathname.startsWith(pathPrefix + '/')
   const hasCount = typeof badgeCount === 'number' && badgeCount > 0
-  const dotToneClass =
-    tone === 'neutral'
+  // The badge is "cut out" from the button surface with a ring the same colour
+  // as that surface — accent when the tab is selected, the rail otherwise.
+  const ringClass = isActive ? 'ring-fluux-brand' : 'ring-fluux-sidebar'
+  // On a selected tab the surface is the accent colour. Tone colours are only
+  // guaranteed to contrast against the rail, not the accent surface (an accent
+  // dot would even be invisible). The only token guaranteed readable on accent
+  // in every theme is on-accent, so use it — and its inverse (accent-on-on-accent)
+  // for the numeric badge — while the tab is selected.
+  const dotFillClass = isActive
+    ? 'bg-fluux-text-on-accent'
+    : tone === 'neutral'
       ? 'bg-fluux-gray'
       : tone === 'accent'
         ? 'bg-fluux-brand'
         : 'bg-fluux-badge-strong'
+  const countBadgeClass = isActive
+    ? 'bg-fluux-text-on-accent text-fluux-brand'
+    : 'bg-fluux-red text-white'
 
   return (
     <Tooltip content={label} position="right" delay={500}>
@@ -64,11 +76,11 @@ export function IconRailNavLink({
       >
         <Icon className="size-5" />
         {hasCount ? (
-          <span className="absolute -top-0.5 -end-0.5 min-w-4 h-4 px-1 flex items-center justify-center bg-fluux-red text-white text-[10px] leading-none font-semibold rounded-full ring-2 ring-fluux-sidebar">
+          <span className={`absolute -top-0.5 -end-0.5 min-w-4 h-4 px-1 flex items-center justify-center ${countBadgeClass} text-[10px] leading-none font-semibold rounded-full ring-2 ${ringClass}`}>
             {badgeCount > 99 ? '99+' : badgeCount}
           </span>
         ) : showBadge ? (
-          <span className={`absolute top-0.5 end-0.5 size-2.5 ${dotToneClass} rounded-full ring-2 ring-fluux-sidebar`} />
+          <span className={`absolute top-0.5 end-0.5 size-2.5 ${dotFillClass} rounded-full ring-2 ${ringClass}`} />
         ) : null}
       </button>
     </Tooltip>


### PR DESCRIPTION
Two fixes for the icon-rail unread indicators.

**1. Badges render as full circles.** The unread dot and numeric badge used a 2px *inside* border for separation, which shrank the 12px dot to only 8px of painted color so it read as a thin, lumpy ring. Switched to an outer `ring-2` (box-shadow) so the whole disc is filled and the count badge no longer clips its own edge.

**2. Badge stays visible on a selected tab, in every theme.** A selected tab's surface is the accent color, and the accent-tone dot is also the accent color, so it vanished (blue on blue). Tone colors are only guaranteed to contrast against the rail, not the accent surface. On a selected tab the dot now uses the on-accent token (the only color the theme system guarantees readable on accent — what the active icon already uses), the numeric badge uses its inverse, and the cutout ring matches the accent surface. Non-selected tabs keep their tone colors and rail-colored ring.

Pure styling change.