### PR TITLE
Admin: align Add User modal's domain suffix with the input

### DIFF
--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -646,7 +646,8 @@ function AddUserModal({ vhost, onSubmit, onClose }: AddUserModalProps) {
           <label htmlFor="add-user-username" className="block text-xs font-semibold text-fluux-muted uppercase mb-2">
             {t('admin.addUser.username')}
           </label>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 px-3 py-2 bg-fluux-bg text-fluux-text rounded
+                          border border-transparent focus-within:border-fluux-brand">
             <TextInput
               ref={inputRef}
               id="add-user-username"
@@ -655,11 +656,10 @@ function AddUserModal({ vhost, onSubmit, onClose }: AddUserModalProps) {
               onChange={(e) => setUsername(e.target.value)}
               placeholder={t('admin.addUser.usernamePlaceholder')}
               disabled={isSubmitting}
-              className="flex-1 px-3 py-2 bg-fluux-bg text-fluux-text rounded
-                         border border-transparent focus:border-fluux-brand
-                         placeholder:text-fluux-muted disabled:opacity-50"
+              className="flex-1 min-w-0 bg-transparent
+                         placeholder:text-fluux-muted disabled:opacity-50 focus:outline-none"
             />
-            <span className="text-fluux-muted">@{vhost}</span>
+            <span className="text-fluux-muted whitespace-nowrap flex-shrink-0">@{vhost}</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Follow-up pushed after #819 had already merged, so it never made it into a PR — same situation as #819 itself. Rebased onto current `main`.

The Add User modal's `@vhost` domain suffix was a separate flex sibling next to a full-width input, so it floated far to the right with an awkward gap, and wrapped onto a second line entirely for longer vhosts (e.g. `process-one.net`). Moved the border/background onto the row and made the input transparent inside it, so `username` + `@vhost` read as one cohesive field.

## Test plan
- Typecheck (root), lint, and full app suite (315 files / 4415 tests) green.
- Verified in the demo preview with a long vhost (`process-one.net`): the domain now sits directly after the typed text inside one bordered field instead of floating/wrapping, no console errors.