### PR TITLE
Dismiss a conversation's notification when it is read

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1429,7 +1429,9 @@ fn main() {
             #[cfg(target_os = "macos")]
             notifications::take_pending_notification_target,
             #[cfg(target_os = "macos")]
-            notifications::set_notification_listener_ready
+            notifications::set_notification_listener_ready,
+            #[cfg(target_os = "macos")]
+            notifications::remove_delivered_notifications
         ])
         .on_page_load(move |webview, payload| {
             // Always inject console-forwarding script so SDK diagnostic logs

--- a/apps/fluux/src-tauri/src/notifications/macos.rs
+++ b/apps/fluux/src-tauri/src/notifications/macos.rs
@@ -237,6 +237,23 @@ pub fn post(n: NativeNotification) -> Result<(), String> {
     Ok(())
 }
 
+/// Remove already-delivered notifications from Notification Center by their
+/// identifiers (see `encode_identifier`). Called when a conversation/room is
+/// read so its stale entry disappears. Best-effort: no-op when the process is
+/// not app-bundled (`current_center()` returns `None`) or when an identifier
+/// has no matching delivered notification.
+pub fn remove_delivered(identifiers: Vec<String>) {
+    let Some(center) = current_center() else {
+        return;
+    };
+    use objc2_foundation::NSArray;
+    // Keep the NSStrings alive in `ids` while `refs` borrows them for the call.
+    let ids: Vec<Retained<NSString>> = identifiers.iter().map(|s| NSString::from_str(s)).collect();
+    let refs: Vec<&NSString> = ids.iter().map(|s| &**s).collect();
+    let array = NSArray::from_slice(&refs);
+    center.removeDeliveredNotificationsWithIdentifiers(&array);
+}
+
 fn map_status(status: UNAuthorizationStatus) -> AuthState {
     // Provisional/Ephemeral both permit delivery, so treat them as granted.
     if status == UNAuthorizationStatus::Authorized

--- a/apps/fluux/src-tauri/src/notifications/mod.rs
+++ b/apps/fluux/src-tauri/src/notifications/mod.rs
@@ -70,3 +70,9 @@ pub fn take_pending_notification_target() -> Option<NavTarget> {
 pub fn set_notification_listener_ready(ready: bool) {
     macos::set_listener_ready(ready);
 }
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn remove_delivered_notifications(identifiers: Vec<String>) {
+    macos::remove_delivered(identifiers);
+}

--- a/apps/fluux/src/hooks/useDeepLink.test.tsx
+++ b/apps/fluux/src/hooks/useDeepLink.test.tsx
@@ -122,10 +122,8 @@ vi.mock('@tauri-apps/plugin-deep-link', () => ({
   getCurrent: () => mockGetCurrent(),
 }))
 
-// Mock the notification plugin to prevent errors from clearAllNotifications
-vi.mock('@tauri-apps/plugin-notification', () => ({
-  removeAllActive: vi.fn().mockResolvedValue(undefined),
-}))
+// Mock the dismissal helper (useNavigateToTarget calls it on navigation)
+vi.mock('@/utils/dismissNotification', () => ({ dismissNotification: vi.fn() }))
 
 // Track location changes
 const currentLocation = { current: { pathname: '/', search: '' } }
@@ -153,9 +151,6 @@ function createWrapper(initialPath = '/') {
 describe('useDeepLink', () => {
   let useDeepLink: typeof import('./useDeepLink').useDeepLink
 
-  // Suppress expected console.warn from clearAllNotifications in test environment
-  const originalWarn = console.warn
-
   beforeEach(() => {
     vi.clearAllMocks()
     mockHasConversation.mockReturnValue(false)
@@ -163,13 +158,10 @@ describe('useDeepLink', () => {
     mockJoinRoom.mockResolvedValue(undefined)
     mockJoinResult.mockResolvedValue(undefined)
     currentLocation.current = { pathname: '/', search: '' }
-    // Suppress "[Navigation] Failed to clear notifications" warnings in tests
-    console.warn = vi.fn()
   })
 
   afterEach(() => {
     vi.resetModules()
-    console.warn = originalWarn
   })
 
   describe('in non-Tauri environment', () => {

--- a/apps/fluux/src/hooks/useNavigateToTarget.test.tsx
+++ b/apps/fluux/src/hooks/useNavigateToTarget.test.tsx
@@ -36,10 +36,9 @@ vi.mock('@fluux/sdk/react', () => ({
   useContactTime: () => null, useLastActivity: vi.fn(),
 }))
 
-// Mock Tauri notification plugin (avoid import errors)
-vi.mock('@tauri-apps/plugin-notification', () => ({
-  removeAllActive: vi.fn(),
-}))
+// Mock the per-conversation dismissal helper
+const { dismissNotification } = vi.hoisted(() => ({ dismissNotification: vi.fn() }))
+vi.mock('@/utils/dismissNotification', () => ({ dismissNotification }))
 
 // Track location changes
 const currentLocation = { current: { pathname: '/', search: '' } }
@@ -114,6 +113,16 @@ describe('useNavigateToTarget', () => {
       expect(currentLocation.current.pathname).toContain('/messages/')
       expect(mockState.activateConversation).toHaveBeenCalledWith('user+tag@example.com/resource')
     })
+
+    it('dismisses the conversation notification', () => {
+      const { result } = renderHook(() => useNavigateToTarget(), {
+        wrapper: createWrapper('/messages'),
+      })
+      act(() => {
+        result.current.navigateToConversation('alice@example.com')
+      })
+      expect(dismissNotification).toHaveBeenCalledWith('conversation', 'alice@example.com')
+    })
   })
 
   describe('navigateToRoom', () => {
@@ -167,6 +176,16 @@ describe('useNavigateToTarget', () => {
 
       expect(mockState.setRoomTargetMessageId).not.toHaveBeenCalled()
     })
+
+    it('dismisses the room notification', () => {
+      const { result } = renderHook(() => useNavigateToTarget(), {
+        wrapper: createWrapper('/rooms'),
+      })
+      act(() => {
+        result.current.navigateToRoom('general@conference.example.com')
+      })
+      expect(dismissNotification).toHaveBeenCalledWith('room', 'general@conference.example.com')
+    })
   })
 
   describe('navigateToContact', () => {
@@ -194,6 +213,16 @@ describe('useNavigateToTarget', () => {
       expect(mockState.activateConversation).toHaveBeenCalledWith(null)
       expect(mockState.activateRoom).toHaveBeenCalledWith(null)
       expect(currentLocation.current.pathname).toBe('/contacts/bob%40example.com')
+    })
+
+    it('does not dismiss any notification (not a conversation read)', () => {
+      const { result } = renderHook(() => useNavigateToTarget(), {
+        wrapper: createWrapper('/messages'),
+      })
+      act(() => {
+        result.current.navigateToContact('bob@example.com')
+      })
+      expect(dismissNotification).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/fluux/src/hooks/useNavigateToTarget.ts
+++ b/apps/fluux/src/hooks/useNavigateToTarget.ts
@@ -10,27 +10,7 @@
 import { useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useChatStore, useRoomStore } from '@fluux/sdk/react'
-
-// Check if we're running in Tauri
-const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
-
-/**
- * Clear all active notifications from the notification center.
- * Called when navigating to a conversation/room so stale notifications are dismissed.
- *
- * Note: removeAllActive() is not available on all platforms (e.g., may not work on macOS).
- * We silently ignore errors since this is a "nice to have" feature.
- */
-async function clearAllNotifications(): Promise<void> {
-  if (!isTauri) return
-
-  try {
-    const { removeAllActive } = await import('@tauri-apps/plugin-notification')
-    await removeAllActive()
-  } catch {
-    // Silently ignore - removeAllActive is not available on all platforms
-  }
-}
+import { dismissNotification } from '@/utils/dismissNotification'
 
 /**
  * Hook that provides navigation functions for switching to conversations and rooms.
@@ -67,7 +47,7 @@ export function useNavigateToTarget() {
    * Navigate to a 1:1 conversation.
    * Uses URL-based navigation (/messages/:jid) and sets active conversation.
    * Optionally scrolls to a specific message.
-   * Clears all active notifications.
+   * Dismisses this conversation's notification.
    */
   const navigateToConversation = (conversationId: string, messageId?: string) => {
     if (messageId) {
@@ -77,26 +57,24 @@ export function useNavigateToTarget() {
     void navigateRef.current(`/messages/${encodeURIComponent(conversationId)}`)
     // Also set active conversation in state
     void activateConversationRef.current(conversationId)
-    void clearAllNotifications()
+    void dismissNotification('conversation', conversationId)
   }
 
   /**
    * Navigate to a contact's profile.
    * Uses URL-based navigation (/contacts/:jid) and clears active conversation/room.
-   * Clears all active notifications.
    */
   const navigateToContact = (jid: string) => {
     void activateConversationRef.current(null)
     void activateRoomRef.current(null)
     void navigateRef.current(`/contacts/${encodeURIComponent(jid)}`)
-    void clearAllNotifications()
   }
 
   /**
    * Navigate to a MUC room.
    * Uses URL-based navigation (/rooms/:jid) and sets active room.
    * Optionally scrolls to a specific message.
-   * Clears all active notifications.
+   * Dismisses this room's notification.
    */
   const navigateToRoom = (roomJid: string, messageId?: string) => {
     if (messageId) {
@@ -106,7 +84,7 @@ export function useNavigateToTarget() {
     void navigateRef.current(`/rooms/${encodeURIComponent(roomJid)}`)
     // Also set active room in state
     void activateRoomRef.current(roomJid)
-    void clearAllNotifications()
+    void dismissNotification('room', roomJid)
   }
 
   return { navigateToConversation, navigateToContact, navigateToRoom }

--- a/apps/fluux/src/hooks/useWindowVisibility.test.tsx
+++ b/apps/fluux/src/hooks/useWindowVisibility.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const state = vi.hoisted(() => ({
+  windowVisible: false,
+  activeConversationId: null as string | null,
+  activeRoomJid: null as string | null,
+}))
+const { setWindowVisible, markConvRead, markRoomRead, dismissNotification } = vi.hoisted(() => ({
+  setWindowVisible: vi.fn(),
+  markConvRead: vi.fn(),
+  markRoomRead: vi.fn(),
+  dismissNotification: vi.fn(),
+}))
+
+vi.mock('@fluux/sdk', () => ({
+  connectionStore: { getState: () => ({ windowVisible: state.windowVisible, setWindowVisible }) },
+  chatStore: { getState: () => ({ activeConversationId: state.activeConversationId, markAsRead: markConvRead }) },
+  roomStore: { getState: () => ({ activeRoomJid: state.activeRoomJid, markAsRead: markRoomRead }) },
+}))
+vi.mock('@/utils/dismissNotification', () => ({ dismissNotification }))
+
+import { useWindowVisibility } from './useWindowVisibility'
+
+describe('useWindowVisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.windowVisible = false
+    state.activeConversationId = null
+    state.activeRoomJid = null
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+  })
+
+  it('dismisses the active conversation notification on focus regain', () => {
+    state.activeConversationId = 'alice@example.com'
+    renderHook(() => useWindowVisibility())
+    expect(markConvRead).toHaveBeenCalledWith('alice@example.com')
+    expect(dismissNotification).toHaveBeenCalledWith('conversation', 'alice@example.com')
+  })
+
+  it('dismisses the active room notification on focus regain', () => {
+    state.activeRoomJid = 'team@conf.example.com'
+    renderHook(() => useWindowVisibility())
+    expect(markRoomRead).toHaveBeenCalledWith('team@conf.example.com')
+    expect(dismissNotification).toHaveBeenCalledWith('room', 'team@conf.example.com')
+  })
+
+  it('does nothing when there is no active conversation or room', () => {
+    renderHook(() => useWindowVisibility())
+    expect(dismissNotification).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/hooks/useWindowVisibility.ts
+++ b/apps/fluux/src/hooks/useWindowVisibility.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { connectionStore, chatStore, roomStore } from '@fluux/sdk'
+import { dismissNotification } from '@/utils/dismissNotification'
 
 /**
  * Hook to track window focus and update the SDK store.
@@ -28,10 +29,12 @@ export function useWindowVisibility(): void {
         const activeConversationId = chatStore.getState().activeConversationId
         if (activeConversationId) {
           chatStore.getState().markAsRead(activeConversationId)
+          void dismissNotification('conversation', activeConversationId)
         }
         const activeRoomJid = roomStore.getState().activeRoomJid
         if (activeRoomJid) {
           roomStore.getState().markAsRead(activeRoomJid)
+          void dismissNotification('room', activeRoomJid)
         }
       }
     }

--- a/apps/fluux/src/utils/dismissNotification.test.ts
+++ b/apps/fluux/src/utils/dismissNotification.test.ts
@@ -1,15 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-const { isMacOSDesktop, invoke, active, removeActive } = vi.hoisted(() => ({
+const { isMacOSDesktop, invoke } = vi.hoisted(() => ({
   isMacOSDesktop: vi.fn(),
   invoke: vi.fn().mockResolvedValue(undefined),
-  active: vi.fn().mockResolvedValue([]),
-  removeActive: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/utils/tauriPlatform', () => ({ isMacOSDesktop }))
 vi.mock('@tauri-apps/api/core', () => ({ invoke }))
-vi.mock('@tauri-apps/plugin-notification', () => ({ active, removeActive }))
 
 import { dismissNotification } from './dismissNotification'
 
@@ -21,7 +18,6 @@ function setTauri(on: boolean) {
 describe('dismissNotification', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    active.mockResolvedValue([])
   })
   afterEach(() => setTauri(false))
 
@@ -43,34 +39,14 @@ describe('dismissNotification', () => {
     })
   })
 
-  it('Windows/Linux Tauri: removes plugin notifications matching the tag', async () => {
+  it('Windows/Linux Tauri: no-op (no native command, no throw)', async () => {
     isMacOSDesktop.mockResolvedValue(false)
     setTauri(true)
-    const match = { id: 1, tag: 'alice@example.com' }
-    active.mockResolvedValue([match, { id: 2, tag: 'room-other@conf' }])
-    await dismissNotification('conversation', 'alice@example.com')
+    await expect(dismissNotification('conversation', 'alice@example.com')).resolves.toBeUndefined()
     expect(invoke).not.toHaveBeenCalled()
-    expect(removeActive).toHaveBeenCalledWith([match])
   })
 
-  it('Windows/Linux Tauri: maps rooms to the room-<jid> tag', async () => {
-    isMacOSDesktop.mockResolvedValue(false)
-    setTauri(true)
-    const match = { id: 3, tag: 'room-team@conf.example.com' }
-    active.mockResolvedValue([match, { id: 4, tag: 'alice@example.com' }])
-    await dismissNotification('room', 'team@conf.example.com')
-    expect(removeActive).toHaveBeenCalledWith([match])
-  })
-
-  it('Windows/Linux Tauri: no-op when no notification matches the tag', async () => {
-    isMacOSDesktop.mockResolvedValue(false)
-    setTauri(true)
-    active.mockResolvedValue([{ id: 9, tag: 'bob@example.com' }])
-    await dismissNotification('conversation', 'alice@example.com')
-    expect(removeActive).not.toHaveBeenCalled()
-  })
-
-  it('Web: closes service-worker notifications matching the tag', async () => {
+  it('Web: closes service-worker notifications matching the conversation tag', async () => {
     isMacOSDesktop.mockResolvedValue(false)
     setTauri(false)
     const close = vi.fn()
@@ -82,6 +58,20 @@ describe('dismissNotification', () => {
     await dismissNotification('conversation', 'alice@example.com')
     expect(getNotifications).toHaveBeenCalledWith({ tag: 'alice@example.com' })
     expect(close).toHaveBeenCalledTimes(2)
+    delete (navigator as unknown as Record<string, unknown>).serviceWorker
+  })
+
+  it('Web: uses the room- tag for rooms', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(false)
+    const close = vi.fn()
+    const getNotifications = vi.fn().mockResolvedValue([{ close }])
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { ready: Promise.resolve({ getNotifications }) },
+    })
+    await dismissNotification('room', 'team@conf.example.com')
+    expect(getNotifications).toHaveBeenCalledWith({ tag: 'room-team@conf.example.com' })
     delete (navigator as unknown as Record<string, unknown>).serviceWorker
   })
 

--- a/apps/fluux/src/utils/dismissNotification.test.ts
+++ b/apps/fluux/src/utils/dismissNotification.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { isMacOSDesktop, invoke, active, removeActive } = vi.hoisted(() => ({
+  isMacOSDesktop: vi.fn(),
+  invoke: vi.fn().mockResolvedValue(undefined),
+  active: vi.fn().mockResolvedValue([]),
+  removeActive: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/utils/tauriPlatform', () => ({ isMacOSDesktop }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke }))
+vi.mock('@tauri-apps/plugin-notification', () => ({ active, removeActive }))
+
+import { dismissNotification } from './dismissNotification'
+
+function setTauri(on: boolean) {
+  if (on) (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+  else delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+}
+
+describe('dismissNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    active.mockResolvedValue([])
+  })
+  afterEach(() => setTauri(false))
+
+  it('macOS: invokes the native command with the conversation identifier', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    setTauri(true)
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(invoke).toHaveBeenCalledWith('remove_delivered_notifications', {
+      identifiers: ['conversation:alice@example.com'],
+    })
+  })
+
+  it('macOS: uses the room identifier for rooms', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    setTauri(true)
+    await dismissNotification('room', 'team@conf.example.com')
+    expect(invoke).toHaveBeenCalledWith('remove_delivered_notifications', {
+      identifiers: ['room:team@conf.example.com'],
+    })
+  })
+
+  it('Windows/Linux Tauri: removes plugin notifications matching the tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(true)
+    const match = { id: 1, tag: 'alice@example.com' }
+    active.mockResolvedValue([match, { id: 2, tag: 'room-other@conf' }])
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(invoke).not.toHaveBeenCalled()
+    expect(removeActive).toHaveBeenCalledWith([match])
+  })
+
+  it('Windows/Linux Tauri: maps rooms to the room-<jid> tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(true)
+    const match = { id: 3, tag: 'room-team@conf.example.com' }
+    active.mockResolvedValue([match, { id: 4, tag: 'alice@example.com' }])
+    await dismissNotification('room', 'team@conf.example.com')
+    expect(removeActive).toHaveBeenCalledWith([match])
+  })
+
+  it('Windows/Linux Tauri: no-op when no notification matches the tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(true)
+    active.mockResolvedValue([{ id: 9, tag: 'bob@example.com' }])
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(removeActive).not.toHaveBeenCalled()
+  })
+
+  it('Web: closes service-worker notifications matching the tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(false)
+    const close = vi.fn()
+    const getNotifications = vi.fn().mockResolvedValue([{ close }, { close }])
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { ready: Promise.resolve({ getNotifications }) },
+    })
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(getNotifications).toHaveBeenCalledWith({ tag: 'alice@example.com' })
+    expect(close).toHaveBeenCalledTimes(2)
+    delete (navigator as unknown as Record<string, unknown>).serviceWorker
+  })
+
+  it('swallows errors from the platform call', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    setTauri(true)
+    invoke.mockRejectedValueOnce(new Error('boom'))
+    await expect(dismissNotification('conversation', 'alice@example.com')).resolves.toBeUndefined()
+  })
+})

--- a/apps/fluux/src/utils/dismissNotification.ts
+++ b/apps/fluux/src/utils/dismissNotification.ts
@@ -1,0 +1,55 @@
+import { isMacOSDesktop } from '@/utils/tauriPlatform'
+
+export type NavType = 'conversation' | 'room'
+
+/** Running inside the Tauri desktop app. Checked at call time (not module load)
+ *  so tests can toggle it. */
+function inTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+}
+
+/** Tag used by the Tauri notification plugin and the web Notification API
+ *  (see useDesktopNotifications.ts). Differs from the macOS native identifier. */
+function pluginTag(navType: NavType, navTarget: string): string {
+  return navType === 'room' ? `room-${navTarget}` : navTarget
+}
+
+/**
+ * Remove the delivered notification(s) for a single conversation/room when it
+ * is read, leaving other conversations' notifications untouched. Best-effort
+ * and platform-specific:
+ * - macOS Tauri: native UNUserNotificationCenter command, keyed by identifier
+ *   `"<navType>:<navTarget>"`.
+ * - Windows/Linux Tauri: notification plugin, keyed by tag.
+ * - Web (PWA): service worker registration, keyed by tag.
+ */
+export async function dismissNotification(navType: NavType, navTarget: string): Promise<void> {
+  try {
+    if (await isMacOSDesktop()) {
+      const { invoke } = await import('@tauri-apps/api/core')
+      await invoke('remove_delivered_notifications', {
+        identifiers: [`${navType}:${navTarget}`],
+      })
+      return
+    }
+
+    const tag = pluginTag(navType, navTarget)
+
+    if (inTauri()) {
+      const { active, removeActive } = await import('@tauri-apps/plugin-notification')
+      const delivered = await active()
+      const matches = delivered.filter((n) => n.tag === tag)
+      if (matches.length > 0) await removeActive(matches)
+      return
+    }
+
+    // Web PWA: notifications were posted via ServiceWorkerRegistration.showNotification.
+    if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+      const registration = await navigator.serviceWorker.ready
+      const notifications = await registration.getNotifications({ tag })
+      notifications.forEach((n) => n.close())
+    }
+  } catch {
+    // Best-effort: dismissing a read notification is a nice-to-have.
+  }
+}

--- a/apps/fluux/src/utils/dismissNotification.ts
+++ b/apps/fluux/src/utils/dismissNotification.ts
@@ -8,9 +8,9 @@ function inTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 }
 
-/** Tag used by the Tauri notification plugin and the web Notification API
- *  (see useDesktopNotifications.ts). Differs from the macOS native identifier. */
-function pluginTag(navType: NavType, navTarget: string): string {
+/** Tag used by the web Notification API (see useDesktopNotifications.ts's
+ *  showWebNotification branch). Differs from the macOS native identifier. */
+function webTag(navType: NavType, navTarget: string): string {
   return navType === 'room' ? `room-${navTarget}` : navTarget
 }
 
@@ -20,7 +20,10 @@ function pluginTag(navType: NavType, navTarget: string): string {
  * and platform-specific:
  * - macOS Tauri: native UNUserNotificationCenter command, keyed by identifier
  *   `"<navType>:<navTarget>"`.
- * - Windows/Linux Tauri: notification plugin, keyed by tag.
+ * - Windows/Linux Tauri: no-op. The notification plugin can only reference a
+ *   sent notification by a 32-bit integer id, not by our JID-based tag, so
+ *   there is no reliable way to remove a single conversation's notification;
+ *   it is left to auto-expire.
  * - Web (PWA): service worker registration, keyed by tag.
  */
 export async function dismissNotification(navType: NavType, navTarget: string): Promise<void> {
@@ -33,18 +36,14 @@ export async function dismissNotification(navType: NavType, navTarget: string): 
       return
     }
 
-    const tag = pluginTag(navType, navTarget)
-
     if (inTauri()) {
-      const { active, removeActive } = await import('@tauri-apps/plugin-notification')
-      const delivered = await active()
-      const matches = delivered.filter((n) => n.tag === tag)
-      if (matches.length > 0) await removeActive(matches)
+      // Windows/Linux Tauri: no per-conversation removal available (see above).
       return
     }
 
     // Web PWA: notifications were posted via ServiceWorkerRegistration.showNotification.
     if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+      const tag = webTag(navType, navTarget)
       const registration = await navigator.serviceWorker.ready
       const notifications = await registration.getNotifications({ tag })
       notifications.forEach((n) => n.close())

--- a/docs/superpowers/plans/2026-07-02-dismiss-read-notifications.md
+++ b/docs/superpowers/plans/2026-07-02-dismiss-read-notifications.md
@@ -1,0 +1,585 @@
+# Dismiss Read Conversation Notifications — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a conversation or room is read, remove *only that conversation's* delivered notification from the OS notification center; leave other conversations' notifications in place.
+
+**Architecture:** Add a macOS-native Tauri command that removes delivered notifications by identifier (macOS posts via a custom `UNUserNotificationCenter` path the notification plugin can't touch). Add a cross-platform JS helper `dismissNotification(navType, navTarget)` that routes to the native command (macOS), the notification plugin by tag (Windows/Linux), or the service worker by tag (web) — mirroring the existing *posting* branch. Delete the broken all-or-nothing `clearAllNotifications()` and call the scoped helper from the two read paths (open/navigate + window-focus).
+
+**Tech Stack:** Rust (Tauri v2, `objc2` / `objc2-user-notifications`), TypeScript/React, Vitest, `@tauri-apps/plugin-notification`, `@tauri-apps/plugin-os`.
+
+**Design spec:** [docs/superpowers/specs/2026-07-02-dismiss-read-notifications-design.md](../specs/2026-07-02-dismiss-read-notifications-design.md)
+
+## Global Constraints
+
+- **Worktree path:** all edits go under `/Users/mremond/AIProjects/fluux-messenger/.claude/worktrees/bold-torvalds-ed4819/`. Tool-reported absolute paths may point at the protected MAIN repo — verify the path contains `.claude/worktrees/bold-torvalds-ed4819/` before editing.
+- **macOS notification identifier scheme:** `` `${navType}:${navTarget}` `` — e.g. `conversation:alice@example.com`, `room:team@conf.example.com` (from `macos.rs::encode_identifier`; `navType` never contains `:`).
+- **Plugin / web tag scheme:** conversation → `navTarget` (the conversation id); room → `` `room-${navTarget}` `` (from `useDesktopNotifications.ts:182,238`).
+- **`navType` values:** the string literals `'conversation'` and `'room'` only.
+- **Best-effort posture:** all removal is a nice-to-have; swallow errors, never surface them to the user (matches the code being replaced).
+- **Rust command is macOS-only:** gate every new Rust item with `#[cfg(target_os = "macos")]`, matching the sibling notification commands. Non-macOS builds compile with `-D warnings`.
+- **Run tests per-workspace** (never bare `vitest` from root): `cd apps/fluux && npx vitest run <path>` for app tests.
+- **Commits:** SSH-signed. If a commit fails on signing, ask the user to run `ssh-add ~/.ssh/id_ed25519`. No Claude footer in commit messages.
+
+---
+
+## File Structure
+
+- **Create** `apps/fluux/src/utils/dismissNotification.ts` — the cross-platform per-conversation dismissal helper.
+- **Create** `apps/fluux/src/utils/dismissNotification.test.ts` — unit tests for the three platform branches.
+- **Create** `apps/fluux/src/hooks/useWindowVisibility.test.tsx` — tests the focus-path wiring (no test exists today).
+- **Modify** `apps/fluux/src-tauri/src/notifications/macos.rs` — add `remove_delivered(identifiers)`.
+- **Modify** `apps/fluux/src-tauri/src/notifications/mod.rs` — add `#[tauri::command] remove_delivered_notifications`.
+- **Modify** `apps/fluux/src-tauri/src/main.rs:1424-1432` — register the command in `generate_handler!`.
+- **Modify** `apps/fluux/src/hooks/useNavigateToTarget.ts` — delete `clearAllNotifications`, call `dismissNotification` from `navigateToConversation`/`navigateToRoom`, drop the clear from `navigateToContact`.
+- **Modify** `apps/fluux/src/hooks/useNavigateToTarget.test.tsx` — mock `dismissNotification`, assert calls.
+- **Modify** `apps/fluux/src/hooks/useDeepLink.test.tsx` — swap the `plugin-notification` mock for a `dismissNotification` mock.
+- **Modify** `apps/fluux/src/hooks/useWindowVisibility.ts` — dismiss the active entity's notification on focus regain.
+
+---
+
+## Task 1: Native macOS `remove_delivered_notifications` command
+
+**Files:**
+- Modify: `apps/fluux/src-tauri/src/notifications/macos.rs` (add `remove_delivered`)
+- Modify: `apps/fluux/src-tauri/src/notifications/mod.rs` (add command)
+- Modify: `apps/fluux/src-tauri/src/main.rs:1424-1432` (register)
+
+**Interfaces:**
+- Produces (Rust): `pub fn remove_delivered(identifiers: Vec<String>)` in `macos.rs`; `#[tauri::command] pub fn remove_delivered_notifications(identifiers: Vec<String>)` in `mod.rs`.
+- Produces (JS-facing): Tauri command name `remove_delivered_notifications`, arg key `identifiers: string[]`, returns `void`.
+
+- [ ] **Step 1: Add `remove_delivered` to `macos.rs`**
+
+Add this function directly after `post` (which ends at line 238):
+
+```rust
+/// Remove already-delivered notifications from Notification Center by their
+/// identifiers (see `encode_identifier`). Called when a conversation/room is
+/// read so its stale entry disappears. Best-effort: no-op when the process is
+/// not app-bundled (`current_center()` returns `None`) or when an identifier
+/// has no matching delivered notification.
+pub fn remove_delivered(identifiers: Vec<String>) {
+    let Some(center) = current_center() else {
+        return;
+    };
+    use objc2_foundation::NSArray;
+    // Keep the NSStrings alive in `ids` while `refs` borrows them for the call.
+    let ids: Vec<Retained<NSString>> = identifiers.iter().map(|s| NSString::from_str(s)).collect();
+    let refs: Vec<&NSString> = ids.iter().map(|s| &**s).collect();
+    let array = NSArray::from_slice(&refs);
+    center.removeDeliveredNotificationsWithIdentifiers(&array);
+}
+```
+
+- [ ] **Step 2: Add the Tauri command to `mod.rs`**
+
+After `set_notification_listener_ready` (ends at line 72), add:
+
+```rust
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn remove_delivered_notifications(identifiers: Vec<String>) {
+    macos::remove_delivered(identifiers);
+}
+```
+
+- [ ] **Step 3: Register the command in `main.rs`**
+
+In the `tauri::generate_handler![...]` block, the current last notification entry (`main.rs:1432`) is `notifications::set_notification_listener_ready` with **no trailing comma**. Add a comma to it and append the new command:
+
+```rust
+            #[cfg(target_os = "macos")]
+            notifications::set_notification_listener_ready,
+            #[cfg(target_os = "macos")]
+            notifications::remove_delivered_notifications
+```
+
+- [ ] **Step 4: Verify it compiles (macOS)**
+
+Run: `cd apps/fluux/src-tauri && cargo check`
+Expected: compiles with no errors and no new warnings. (This is a thin FFI wrapper over a system API; there is no meaningful Rust unit test — behaviour is verified end-to-end in Task 5.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src-tauri/src/notifications/macos.rs apps/fluux/src-tauri/src/notifications/mod.rs apps/fluux/src-tauri/src/main.rs
+git commit -m "feat(notifications): native macOS command to remove delivered notifications by identifier"
+```
+
+---
+
+## Task 2: `dismissNotification` cross-platform helper
+
+**Files:**
+- Create: `apps/fluux/src/utils/dismissNotification.ts`
+- Test: `apps/fluux/src/utils/dismissNotification.test.ts`
+
+**Interfaces:**
+- Consumes: `isMacOSDesktop()` from `@/utils/tauriPlatform`; `invoke` from `@tauri-apps/api/core`; `active`/`removeActive` from `@tauri-apps/plugin-notification`; Tauri command `remove_delivered_notifications` (Task 1).
+- Produces: `export type NavType = 'conversation' | 'room'` and `export async function dismissNotification(navType: NavType, navTarget: string): Promise<void>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/fluux/src/utils/dismissNotification.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { isMacOSDesktop, invoke, active, removeActive } = vi.hoisted(() => ({
+  isMacOSDesktop: vi.fn(),
+  invoke: vi.fn().mockResolvedValue(undefined),
+  active: vi.fn().mockResolvedValue([]),
+  removeActive: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/utils/tauriPlatform', () => ({ isMacOSDesktop }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke }))
+vi.mock('@tauri-apps/plugin-notification', () => ({ active, removeActive }))
+
+import { dismissNotification } from './dismissNotification'
+
+function setTauri(on: boolean) {
+  if (on) (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+  else delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+}
+
+describe('dismissNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    active.mockResolvedValue([])
+  })
+  afterEach(() => setTauri(false))
+
+  it('macOS: invokes the native command with the conversation identifier', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    setTauri(true)
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(invoke).toHaveBeenCalledWith('remove_delivered_notifications', {
+      identifiers: ['conversation:alice@example.com'],
+    })
+  })
+
+  it('macOS: uses the room identifier for rooms', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    setTauri(true)
+    await dismissNotification('room', 'team@conf.example.com')
+    expect(invoke).toHaveBeenCalledWith('remove_delivered_notifications', {
+      identifiers: ['room:team@conf.example.com'],
+    })
+  })
+
+  it('Windows/Linux Tauri: removes plugin notifications matching the tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(true)
+    const match = { id: 1, tag: 'alice@example.com' }
+    active.mockResolvedValue([match, { id: 2, tag: 'room-other@conf' }])
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(invoke).not.toHaveBeenCalled()
+    expect(removeActive).toHaveBeenCalledWith([match])
+  })
+
+  it('Windows/Linux Tauri: maps rooms to the room-<jid> tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(true)
+    const match = { id: 3, tag: 'room-team@conf.example.com' }
+    active.mockResolvedValue([match, { id: 4, tag: 'alice@example.com' }])
+    await dismissNotification('room', 'team@conf.example.com')
+    expect(removeActive).toHaveBeenCalledWith([match])
+  })
+
+  it('Windows/Linux Tauri: no-op when no notification matches the tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(true)
+    active.mockResolvedValue([{ id: 9, tag: 'bob@example.com' }])
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(removeActive).not.toHaveBeenCalled()
+  })
+
+  it('Web: closes service-worker notifications matching the tag', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(false)
+    const close = vi.fn()
+    const getNotifications = vi.fn().mockResolvedValue([{ close }, { close }])
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { ready: Promise.resolve({ getNotifications }) },
+    })
+    await dismissNotification('conversation', 'alice@example.com')
+    expect(getNotifications).toHaveBeenCalledWith({ tag: 'alice@example.com' })
+    expect(close).toHaveBeenCalledTimes(2)
+    delete (navigator as unknown as Record<string, unknown>).serviceWorker
+  })
+
+  it('swallows errors from the platform call', async () => {
+    isMacOSDesktop.mockResolvedValue(true)
+    setTauri(true)
+    invoke.mockRejectedValueOnce(new Error('boom'))
+    await expect(dismissNotification('conversation', 'alice@example.com')).resolves.toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/utils/dismissNotification.test.ts`
+Expected: FAIL — `Failed to resolve import './dismissNotification'` (module does not exist yet).
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/fluux/src/utils/dismissNotification.ts`:
+
+```ts
+import { isMacOSDesktop } from '@/utils/tauriPlatform'
+
+export type NavType = 'conversation' | 'room'
+
+/** Running inside the Tauri desktop app. Checked at call time (not module load)
+ *  so tests can toggle it. */
+function inTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+}
+
+/** Tag used by the Tauri notification plugin and the web Notification API
+ *  (see useDesktopNotifications.ts). Differs from the macOS native identifier. */
+function pluginTag(navType: NavType, navTarget: string): string {
+  return navType === 'room' ? `room-${navTarget}` : navTarget
+}
+
+/**
+ * Remove the delivered notification(s) for a single conversation/room when it
+ * is read, leaving other conversations' notifications untouched. Best-effort
+ * and platform-specific:
+ * - macOS Tauri: native UNUserNotificationCenter command, keyed by identifier
+ *   `"<navType>:<navTarget>"`.
+ * - Windows/Linux Tauri: notification plugin, keyed by tag.
+ * - Web (PWA): service worker registration, keyed by tag.
+ */
+export async function dismissNotification(navType: NavType, navTarget: string): Promise<void> {
+  try {
+    if (await isMacOSDesktop()) {
+      const { invoke } = await import('@tauri-apps/api/core')
+      await invoke('remove_delivered_notifications', {
+        identifiers: [`${navType}:${navTarget}`],
+      })
+      return
+    }
+
+    const tag = pluginTag(navType, navTarget)
+
+    if (inTauri()) {
+      const { active, removeActive } = await import('@tauri-apps/plugin-notification')
+      const delivered = await active()
+      const matches = delivered.filter((n) => n.tag === tag)
+      if (matches.length > 0) await removeActive(matches)
+      return
+    }
+
+    // Web PWA: notifications were posted via ServiceWorkerRegistration.showNotification.
+    if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+      const registration = await navigator.serviceWorker.ready
+      const notifications = await registration.getNotifications({ tag })
+      notifications.forEach((n) => n.close())
+    }
+  } catch {
+    // Best-effort: dismissing a read notification is a nice-to-have.
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/utils/dismissNotification.test.ts`
+Expected: PASS — all 7 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/utils/dismissNotification.ts apps/fluux/src/utils/dismissNotification.test.ts
+git commit -m "feat(notifications): add per-conversation dismissNotification helper"
+```
+
+---
+
+## Task 3: Wire the open/navigate path + delete `clearAllNotifications`
+
+**Files:**
+- Modify: `apps/fluux/src/hooks/useNavigateToTarget.ts`
+- Modify: `apps/fluux/src/hooks/useNavigateToTarget.test.tsx`
+- Modify: `apps/fluux/src/hooks/useDeepLink.test.tsx`
+
+**Interfaces:**
+- Consumes: `dismissNotification` from `@/utils/dismissNotification` (Task 2).
+- Produces: unchanged public API of `useNavigateToTarget` — `{ navigateToConversation, navigateToContact, navigateToRoom }`.
+
+- [ ] **Step 1: Update `useNavigateToTarget.test.tsx` (failing assertions first)**
+
+Replace the plugin mock at lines 39-42:
+
+```ts
+// Mock the per-conversation dismissal helper
+const dismissNotification = vi.fn()
+vi.mock('@/utils/dismissNotification', () => ({ dismissNotification }))
+```
+
+Then add these assertions inside the existing `describe` blocks:
+
+In `describe('navigateToConversation', ...)`, add:
+
+```ts
+it('dismisses the conversation notification', () => {
+  const { result } = renderHook(() => useNavigateToTarget(), {
+    wrapper: createWrapper('/messages'),
+  })
+  act(() => {
+    result.current.navigateToConversation('alice@example.com')
+  })
+  expect(dismissNotification).toHaveBeenCalledWith('conversation', 'alice@example.com')
+})
+```
+
+In `describe('navigateToRoom', ...)`, add:
+
+```ts
+it('dismisses the room notification', () => {
+  const { result } = renderHook(() => useNavigateToTarget(), {
+    wrapper: createWrapper('/rooms'),
+  })
+  act(() => {
+    result.current.navigateToRoom('general@conference.example.com')
+  })
+  expect(dismissNotification).toHaveBeenCalledWith('room', 'general@conference.example.com')
+})
+```
+
+In `describe('navigateToContact', ...)`, add:
+
+```ts
+it('does not dismiss any notification (not a conversation read)', () => {
+  const { result } = renderHook(() => useNavigateToTarget(), {
+    wrapper: createWrapper('/messages'),
+  })
+  act(() => {
+    result.current.navigateToContact('bob@example.com')
+  })
+  expect(dismissNotification).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useNavigateToTarget.test.tsx`
+Expected: FAIL — `dismissNotification` is never called (production code still calls the old `clearAllNotifications`).
+
+- [ ] **Step 3: Update `useNavigateToTarget.ts`**
+
+Delete the `clearAllNotifications` helper (lines 17-33) and its comment block. Add an import near the top (after line 12):
+
+```ts
+import { dismissNotification } from '@/utils/dismissNotification'
+```
+
+In `navigateToConversation`, replace `void clearAllNotifications()` (line 80) with:
+
+```ts
+    void dismissNotification('conversation', conversationId)
+```
+
+In `navigateToRoom`, replace `void clearAllNotifications()` (line 109) with:
+
+```ts
+    void dismissNotification('room', roomJid)
+```
+
+In `navigateToContact`, delete the `void clearAllNotifications()` line (line 92) entirely, and update its doc comment: remove the "Clears all active notifications." sentence.
+
+Also update the `navigateToConversation` / `navigateToRoom` doc comments: replace "Clears all active notifications." with "Dismisses this conversation's/room's notification."
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useNavigateToTarget.test.tsx`
+Expected: PASS — all existing tests plus the 3 new ones.
+
+- [ ] **Step 5: Fix the `useDeepLink.test.tsx` mock**
+
+`useDeepLink` navigates via `useNavigateToTarget`, which no longer imports `@tauri-apps/plugin-notification`. Replace the mock at `useDeepLink.test.tsx:126-127`:
+
+```ts
+// Mock the dismissal helper (useNavigateToTarget calls it on navigation)
+vi.mock('@/utils/dismissNotification', () => ({ dismissNotification: vi.fn() }))
+```
+
+Remove the now-obsolete comment at line 156 about suppressing `clearAllNotifications` console warnings if the corresponding `console.warn` suppression is no longer needed (the helper no longer warns).
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useDeepLink.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/hooks/useNavigateToTarget.ts apps/fluux/src/hooks/useNavigateToTarget.test.tsx apps/fluux/src/hooks/useDeepLink.test.tsx
+git commit -m "feat(notifications): dismiss per-conversation notification on open, drop broken clear-all"
+```
+
+---
+
+## Task 4: Wire the window-focus read path
+
+**Files:**
+- Modify: `apps/fluux/src/hooks/useWindowVisibility.ts`
+- Test: `apps/fluux/src/hooks/useWindowVisibility.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `dismissNotification` from `@/utils/dismissNotification` (Task 2); `connectionStore`, `chatStore`, `roomStore` from `@fluux/sdk`.
+- Produces: no API change (`useWindowVisibility(): void`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/hooks/useWindowVisibility.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const state = {
+  windowVisible: false,
+  activeConversationId: null as string | null,
+  activeRoomJid: null as string | null,
+}
+const setWindowVisible = vi.fn()
+const markConvRead = vi.fn()
+const markRoomRead = vi.fn()
+const dismissNotification = vi.fn()
+
+vi.mock('@fluux/sdk', () => ({
+  connectionStore: { getState: () => ({ windowVisible: state.windowVisible, setWindowVisible }) },
+  chatStore: { getState: () => ({ activeConversationId: state.activeConversationId, markAsRead: markConvRead }) },
+  roomStore: { getState: () => ({ activeRoomJid: state.activeRoomJid, markAsRead: markRoomRead }) },
+}))
+vi.mock('@/utils/dismissNotification', () => ({ dismissNotification }))
+
+import { useWindowVisibility } from './useWindowVisibility'
+
+describe('useWindowVisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.windowVisible = false
+    state.activeConversationId = null
+    state.activeRoomJid = null
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+  })
+
+  it('dismisses the active conversation notification on focus regain', () => {
+    state.activeConversationId = 'alice@example.com'
+    renderHook(() => useWindowVisibility())
+    expect(markConvRead).toHaveBeenCalledWith('alice@example.com')
+    expect(dismissNotification).toHaveBeenCalledWith('conversation', 'alice@example.com')
+  })
+
+  it('dismisses the active room notification on focus regain', () => {
+    state.activeRoomJid = 'team@conf.example.com'
+    renderHook(() => useWindowVisibility())
+    expect(markRoomRead).toHaveBeenCalledWith('team@conf.example.com')
+    expect(dismissNotification).toHaveBeenCalledWith('room', 'team@conf.example.com')
+  })
+
+  it('does nothing when there is no active conversation or room', () => {
+    renderHook(() => useWindowVisibility())
+    expect(dismissNotification).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useWindowVisibility.test.tsx`
+Expected: FAIL — `dismissNotification` is not called (hook only marks read today).
+
+- [ ] **Step 3: Update `useWindowVisibility.ts`**
+
+Add the import after line 2:
+
+```ts
+import { dismissNotification } from '@/utils/dismissNotification'
+```
+
+In the `if (!wasFocused && isFocused)` block (lines 27-36), add a dismissal after each `markAsRead`:
+
+```ts
+      if (!wasFocused && isFocused) {
+        const activeConversationId = chatStore.getState().activeConversationId
+        if (activeConversationId) {
+          chatStore.getState().markAsRead(activeConversationId)
+          void dismissNotification('conversation', activeConversationId)
+        }
+        const activeRoomJid = roomStore.getState().activeRoomJid
+        if (activeRoomJid) {
+          roomStore.getState().markAsRead(activeRoomJid)
+          void dismissNotification('room', activeRoomJid)
+        }
+      }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/hooks/useWindowVisibility.test.tsx`
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/hooks/useWindowVisibility.ts apps/fluux/src/hooks/useWindowVisibility.test.tsx
+git commit -m "feat(notifications): dismiss active conversation notification on window focus"
+```
+
+---
+
+## Task 5: Full verification (typecheck, lint, affected tests, manual macOS)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors. (If the SDK types were touched — they were not here — run `npm run build:sdk` first.)
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: no errors on the touched files.
+
+- [ ] **Step 3: Run all affected app tests**
+
+Run: `cd apps/fluux && npx vitest run src/utils/dismissNotification.test.ts src/hooks/useNavigateToTarget.test.tsx src/hooks/useDeepLink.test.tsx src/hooks/useWindowVisibility.test.tsx`
+Expected: all PASS, no stderr.
+
+- [ ] **Step 4: Rust build**
+
+Run: `cd apps/fluux/src-tauri && cargo build`
+Expected: builds clean, no new warnings.
+
+- [ ] **Step 5: Manual end-to-end on macOS**
+
+Run: `npm run tauri:dev`
+
+Verify (requires a bundled build for native notifications — see spec; under `tauri:dev` the process may be unbundled, in which case `current_center()` is `None` and native dismissal no-ops. If so, verify against a `npm run tauri:build` bundle instead):
+1. With the app backgrounded, receive messages from two different conversations (A and B). Confirm two entries in Notification Center.
+2. Open conversation A. Confirm A's entry disappears from Notification Center and B's remains.
+3. With conversation A already open, background the app, receive a new message from A (entry reappears), then bring the app to the foreground (Cmd-Tab / dock). Confirm A's entry disappears on refocus.
+
+- [ ] **Step 6: Final commit (if any doc/cleanup changes)**
+
+```bash
+git add -A
+git commit -m "chore(notifications): finalize read-dismissal wiring"
+```
+
+(Skip if there is nothing to commit.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Rust command (Task 1) ↔ spec §Components.1; JS helper + deletion of `clearAllNotifications` (Task 2, Task 3) ↔ §Components.2; open/navigate wiring (Task 3) ↔ §Components.3.1; focus wiring (Task 4) ↔ §Components.3.2; three-platform matrix ↔ Task 2 tests; manual macOS verification (Task 5) ↔ §Testing.
+- **Type consistency:** `dismissNotification(navType: NavType, navTarget: string)` used identically in Tasks 2/3/4; `NavType = 'conversation' | 'room'`; Tauri command `remove_delivered_notifications` with `{ identifiers: string[] }` used identically in Task 1 (Rust) and Task 2 (JS).
+- **No placeholders:** every code and test step contains full content.

--- a/docs/superpowers/plans/2026-07-02-dismiss-read-notifications.md
+++ b/docs/superpowers/plans/2026-07-02-dismiss-read-notifications.md
@@ -14,7 +14,8 @@
 
 - **Worktree path:** all edits go under `/Users/mremond/AIProjects/fluux-messenger/.claude/worktrees/bold-torvalds-ed4819/`. Tool-reported absolute paths may point at the protected MAIN repo — verify the path contains `.claude/worktrees/bold-torvalds-ed4819/` before editing.
 - **macOS notification identifier scheme:** `` `${navType}:${navTarget}` `` — e.g. `conversation:alice@example.com`, `room:team@conf.example.com` (from `macos.rs::encode_identifier`; `navType` never contains `:`).
-- **Plugin / web tag scheme:** conversation → `navTarget` (the conversation id); room → `` `room-${navTarget}` `` (from `useDesktopNotifications.ts:182,238`).
+- **Web tag scheme:** conversation → `navTarget` (the conversation id); room → `` `room-${navTarget}` `` (from `useDesktopNotifications.ts:182,238` — the web `showWebNotification` branch).
+- **Windows/Linux Tauri dismissal is a no-op.** The notification plugin can only reference a sent notification by a 32-bit integer `id` (its send `Options` has no `tag`), so per-conversation removal is not possible there; the notification auto-expires. Only macOS (native) and web (service worker) dismiss.
 - **`navType` values:** the string literals `'conversation'` and `'room'` only.
 - **Best-effort posture:** all removal is a nice-to-have; swallow errors, never surface them to the user (matches the code being replaced).
 - **Rust command is macOS-only:** gate every new Rust item with `#[cfg(target_os = "macos")]`, matching the sibling notification commands. Non-macOS builds compile with `-D warnings`.
@@ -126,16 +127,13 @@ Create `apps/fluux/src/utils/dismissNotification.test.ts`:
 ```ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-const { isMacOSDesktop, invoke, active, removeActive } = vi.hoisted(() => ({
+const { isMacOSDesktop, invoke } = vi.hoisted(() => ({
   isMacOSDesktop: vi.fn(),
   invoke: vi.fn().mockResolvedValue(undefined),
-  active: vi.fn().mockResolvedValue([]),
-  removeActive: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/utils/tauriPlatform', () => ({ isMacOSDesktop }))
 vi.mock('@tauri-apps/api/core', () => ({ invoke }))
-vi.mock('@tauri-apps/plugin-notification', () => ({ active, removeActive }))
 
 import { dismissNotification } from './dismissNotification'
 
@@ -147,7 +145,6 @@ function setTauri(on: boolean) {
 describe('dismissNotification', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    active.mockResolvedValue([])
   })
   afterEach(() => setTauri(false))
 
@@ -169,34 +166,14 @@ describe('dismissNotification', () => {
     })
   })
 
-  it('Windows/Linux Tauri: removes plugin notifications matching the tag', async () => {
+  it('Windows/Linux Tauri: no-op (no native command, no throw)', async () => {
     isMacOSDesktop.mockResolvedValue(false)
     setTauri(true)
-    const match = { id: 1, tag: 'alice@example.com' }
-    active.mockResolvedValue([match, { id: 2, tag: 'room-other@conf' }])
-    await dismissNotification('conversation', 'alice@example.com')
+    await expect(dismissNotification('conversation', 'alice@example.com')).resolves.toBeUndefined()
     expect(invoke).not.toHaveBeenCalled()
-    expect(removeActive).toHaveBeenCalledWith([match])
   })
 
-  it('Windows/Linux Tauri: maps rooms to the room-<jid> tag', async () => {
-    isMacOSDesktop.mockResolvedValue(false)
-    setTauri(true)
-    const match = { id: 3, tag: 'room-team@conf.example.com' }
-    active.mockResolvedValue([match, { id: 4, tag: 'alice@example.com' }])
-    await dismissNotification('room', 'team@conf.example.com')
-    expect(removeActive).toHaveBeenCalledWith([match])
-  })
-
-  it('Windows/Linux Tauri: no-op when no notification matches the tag', async () => {
-    isMacOSDesktop.mockResolvedValue(false)
-    setTauri(true)
-    active.mockResolvedValue([{ id: 9, tag: 'bob@example.com' }])
-    await dismissNotification('conversation', 'alice@example.com')
-    expect(removeActive).not.toHaveBeenCalled()
-  })
-
-  it('Web: closes service-worker notifications matching the tag', async () => {
+  it('Web: closes service-worker notifications matching the conversation tag', async () => {
     isMacOSDesktop.mockResolvedValue(false)
     setTauri(false)
     const close = vi.fn()
@@ -208,6 +185,20 @@ describe('dismissNotification', () => {
     await dismissNotification('conversation', 'alice@example.com')
     expect(getNotifications).toHaveBeenCalledWith({ tag: 'alice@example.com' })
     expect(close).toHaveBeenCalledTimes(2)
+    delete (navigator as unknown as Record<string, unknown>).serviceWorker
+  })
+
+  it('Web: uses the room- tag for rooms', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    setTauri(false)
+    const close = vi.fn()
+    const getNotifications = vi.fn().mockResolvedValue([{ close }])
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { ready: Promise.resolve({ getNotifications }) },
+    })
+    await dismissNotification('room', 'team@conf.example.com')
+    expect(getNotifications).toHaveBeenCalledWith({ tag: 'room-team@conf.example.com' })
     delete (navigator as unknown as Record<string, unknown>).serviceWorker
   })
 
@@ -240,9 +231,9 @@ function inTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 }
 
-/** Tag used by the Tauri notification plugin and the web Notification API
- *  (see useDesktopNotifications.ts). Differs from the macOS native identifier. */
-function pluginTag(navType: NavType, navTarget: string): string {
+/** Tag used by the web Notification API (see useDesktopNotifications.ts's
+ *  showWebNotification branch). Differs from the macOS native identifier. */
+function webTag(navType: NavType, navTarget: string): string {
   return navType === 'room' ? `room-${navTarget}` : navTarget
 }
 
@@ -252,7 +243,10 @@ function pluginTag(navType: NavType, navTarget: string): string {
  * and platform-specific:
  * - macOS Tauri: native UNUserNotificationCenter command, keyed by identifier
  *   `"<navType>:<navTarget>"`.
- * - Windows/Linux Tauri: notification plugin, keyed by tag.
+ * - Windows/Linux Tauri: no-op. The notification plugin can only reference a
+ *   sent notification by a 32-bit integer id, not by our JID-based tag, so
+ *   there is no reliable way to remove a single conversation's notification;
+ *   it is left to auto-expire.
  * - Web (PWA): service worker registration, keyed by tag.
  */
 export async function dismissNotification(navType: NavType, navTarget: string): Promise<void> {
@@ -265,18 +259,14 @@ export async function dismissNotification(navType: NavType, navTarget: string): 
       return
     }
 
-    const tag = pluginTag(navType, navTarget)
-
     if (inTauri()) {
-      const { active, removeActive } = await import('@tauri-apps/plugin-notification')
-      const delivered = await active()
-      const matches = delivered.filter((n) => n.tag === tag)
-      if (matches.length > 0) await removeActive(matches)
+      // Windows/Linux Tauri: no per-conversation removal available (see above).
       return
     }
 
     // Web PWA: notifications were posted via ServiceWorkerRegistration.showNotification.
     if (typeof navigator !== 'undefined' && navigator.serviceWorker) {
+      const tag = webTag(navType, navTarget)
       const registration = await navigator.serviceWorker.ready
       const notifications = await registration.getNotifications({ tag })
       notifications.forEach((n) => n.close())
@@ -290,7 +280,7 @@ export async function dismissNotification(navType: NavType, navTarget: string): 
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `cd apps/fluux && npx vitest run src/utils/dismissNotification.test.ts`
-Expected: PASS — all 7 tests green.
+Expected: PASS — all 6 tests green.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-07-02-dismiss-read-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-02-dismiss-read-notifications-design.md
@@ -76,23 +76,27 @@ notification. `clearAllNotifications()` and its `removeAllActive()` call are
 **deleted entirely** (it is the only `removeAllActive` caller in the app) and
 replaced by the scoped, per-platform helper below. No remove-all call remains.
 
-The helper mirrors the **posting** path, which already branches per platform
-(`isMacOSDesktop()` → native command; else plugin; web → service worker). The
+The helper branches per platform, mirroring the **posting** path. The
 `(navType, navTarget)` pair maps to a different token per mechanism:
 
 | Platform / mechanism | Removal token | Source of the scheme |
 | --- | --- | --- |
 | macOS Tauri — native | identifier `` `${navType}:${navTarget}` `` — e.g. `conversation:alice@x`, `room:team@x` | `macos.rs::encode_identifier` |
-| Windows/Linux Tauri — plugin | tag: `navTarget` (conversation) / `` `room-${navTarget}` `` (room) | `useDesktopNotifications.ts:182,238` |
-| Web (PWA) — service worker | same tag as the plugin row | `useDesktopNotifications.ts:182,238` |
+| Windows/Linux Tauri | **no-op** (see note) | — |
+| Web (PWA) — service worker | tag: `navTarget` (conversation) / `` `room-${navTarget}` `` (room) | `useDesktopNotifications.ts:182,238` |
 
-Behaviour — three branches matching the posting logic (reuse the existing
-`isMacOSDesktop()` from `@/utils/tauriPlatform` and the module-local `isTauri`):
+**Why Windows/Linux is a no-op:** the Tauri notification plugin can only
+reference a sent notification by a 32-bit integer `id` (its send `Options` has
+no `tag` field, and the app's `sendNotification` calls set neither). There is no
+reliable way to map a JID to a stable id and remove a single conversation's
+notification, so on Windows/Linux the read simply leaves the OS notification to
+auto-expire. macOS (the primary target) and web PWA both dismiss precisely.
+
+Behaviour — three branches (reuse the existing `isMacOSDesktop()` from
+`@/utils/tauriPlatform`; check Tauri at call time via a local `inTauri()`):
 - **macOS Tauri:** `invoke('remove_delivered_notifications', { identifiers: [\`${navType}:${navTarget}\`] })`.
-- **Windows/Linux Tauri:** plugin — `active()` → filter to entries whose `tag`
-  matches the mapped tag → `removeActive(matches)`. (`removeActive` takes
-  `{ id, tag }[]`; the entries from `active()` carry real ids. No-op if none match.)
-- **Web (`!isTauri`):** `navigator.serviceWorker.ready` →
+- **Windows/Linux Tauri (`inTauri()` && !macOS):** return — no-op.
+- **Web (`!inTauri()`):** `navigator.serviceWorker.ready` →
   `registration.getNotifications({ tag }).then(ns => ns.forEach(n => n.close()))`.
 
 Wrapped in try/catch, best-effort — matching the "silently ignore, nice-to-have"
@@ -130,7 +134,7 @@ user reads conversation
        → dismissNotification('conversation', <jid>)
             ├─ macOS Tauri → invoke remove_delivered_notifications([conversation:<jid>])
             │                  → center.removeDeliveredNotificationsWithIdentifiers([...])
-            ├─ Win/Linux   → plugin active() → filter tag=<jid> → removeActive(matches)
+            ├─ Win/Linux   → no-op (plugin cannot remove by JID; auto-expires)
             └─ web         → registration.getNotifications({tag:<jid>}) → n.close()
   → only that conversation's entry is removed; others remain
 ```
@@ -150,12 +154,11 @@ user reads conversation
   - macOS Tauri branch: mock `isMacOSDesktop → true` + `invoke`, assert it is
     called with `{ identifiers: ['conversation:alice@x'] }` for a conversation
     and `['room:team@x']` for a room.
-  - Win/Linux Tauri branch: mock `isMacOSDesktop → false` + `isTauri` + plugin
-    `active`/`removeActive`; assert it filters by the correct tag
-    (`conv.id` vs `room-<jid>`) and passes the matching entries to `removeActive`.
+  - Win/Linux Tauri branch: mock `isMacOSDesktop → false` + `inTauri → true`;
+    assert it resolves without calling `invoke` (no-op).
   - Web branch: mock `navigator.serviceWorker.ready` / `getNotifications`,
-    assert it queries the correct tag and calls `close()` on the returned
-    notifications.
+    assert it queries the correct tag (`navTarget` vs `room-<jid>`) and calls
+    `close()` on the returned notifications.
   - Assert errors from any branch are swallowed.
 - **Call sites:** assert `navigateToConversation`/`navigateToRoom` invoke the
   helper with the right `(navType, navTarget)`; assert `navigateToContact` no

--- a/docs/superpowers/specs/2026-07-02-dismiss-read-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-02-dismiss-read-notifications-design.md
@@ -1,0 +1,173 @@
+# Dismiss a conversation's notification when it is read (macOS)
+
+**Date:** 2026-07-02
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+When a message arrives while the app is backgrounded, macOS shows a banner and
+keeps an entry in Notification Center. When the user later reads that
+conversation, the entry should disappear. Today it does not.
+
+### Why it's broken today
+
+- macOS notifications are posted through a **custom Rust path**
+  (`UNUserNotificationCenter` in `notifications/macos.rs::post`), keyed by an
+  identifier `"<navType>:<navTarget>"` — e.g. `conversation:alice@example.com`
+  or `room:team@conf.example.com`. Because every message for a conversation
+  reuses the same identifier, macOS coalesces them into **one** delivered entry
+  per conversation (latest message wins).
+- The existing "clear on read" logic, `clearAllNotifications()` in
+  `apps/fluux/src/hooks/useNavigateToTarget.ts`, calls the **Tauri notification
+  plugin's** `removeAllActive()`. The plugin never posted the macOS
+  notifications, so it cannot see or remove them. The Notification Center entry
+  survives the read.
+
+## Goal
+
+Reading a conversation removes **only that conversation's** delivered
+notification from Notification Center; other conversations' unread
+notifications remain. "Read" fires on two paths:
+
+1. **Open/navigate** — user opens/activates a conversation or room.
+2. **Window focus** — the window regains focus while a conversation/room is
+   already the active one (the app already marks it read here).
+
+## Approach (chosen: A)
+
+Add a native macOS command to remove *delivered* notifications by identifier,
+plus a small cross-platform JS helper that dismisses a single conversation's
+notification. Wire it into both read paths.
+
+Rejected alternatives:
+- **B — pure JS via plugin `removeActive({ tag })`:** the plugin cannot see the
+  natively-posted macOS notifications. This is the current bug.
+- **C — "remove all delivered" on any read:** reading one conversation would
+  wipe every other conversation's unread notification. Defeats the purpose.
+
+## Components
+
+### 1. Rust: `remove_delivered_notifications` command (macOS only)
+
+- **`notifications/mod.rs`** — new `#[tauri::command]`
+  `remove_delivered_notifications(identifiers: Vec<String>)`, gated
+  `#[cfg(target_os = "macos")]`, delegating to `macos::remove_delivered`.
+- **`notifications/macos.rs`** — new `remove_delivered(identifiers: Vec<String>)`:
+  - Resolve the notification center via the existing `current_center()`
+    (returns `None` when the process is not app-bundled — degrade to no-op).
+  - Build an `NSArray<NSString>` from the identifiers and call
+    `center.removeDeliveredNotificationsWithIdentifiers(&array)`.
+  - No return value needed beyond `()`; removal is best-effort.
+- **`main.rs`** — register the command in the existing
+  `tauri::generate_handler![...]` block (next to `notifications::post_notification`
+  at ~line 1424).
+- Non-macOS builds do not get this command; the JS helper's plugin/web branches
+  handle those platforms.
+
+### 2. JS: `dismissNotification` helper — and removal of the broken plugin call
+
+**The bug this also fixes:** `clearAllNotifications()` in
+`apps/fluux/src/hooks/useNavigateToTarget.ts` calls the Tauri plugin's
+`removeAllActive()`. This is wrong on two counts: (a) on macOS it targets the
+plugin, which never posted the native `UNUserNotificationCenter` notifications,
+so it removes nothing; (b) even where it works (Windows/Linux/web) it is
+all-or-nothing — reading one conversation clears every conversation's
+notification. `clearAllNotifications()` and its `removeAllActive()` call are
+**deleted entirely** (it is the only `removeAllActive` caller in the app) and
+replaced by the scoped, per-platform helper below. No remove-all call remains.
+
+The helper mirrors the **posting** path, which already branches per platform
+(`isMacOSDesktop()` → native command; else plugin; web → service worker). The
+`(navType, navTarget)` pair maps to a different token per mechanism:
+
+| Platform / mechanism | Removal token | Source of the scheme |
+| --- | --- | --- |
+| macOS Tauri — native | identifier `` `${navType}:${navTarget}` `` — e.g. `conversation:alice@x`, `room:team@x` | `macos.rs::encode_identifier` |
+| Windows/Linux Tauri — plugin | tag: `navTarget` (conversation) / `` `room-${navTarget}` `` (room) | `useDesktopNotifications.ts:182,238` |
+| Web (PWA) — service worker | same tag as the plugin row | `useDesktopNotifications.ts:182,238` |
+
+Behaviour — three branches matching the posting logic (reuse the existing
+`isMacOSDesktop()` from `@/utils/tauriPlatform` and the module-local `isTauri`):
+- **macOS Tauri:** `invoke('remove_delivered_notifications', { identifiers: [\`${navType}:${navTarget}\`] })`.
+- **Windows/Linux Tauri:** plugin — `active()` → filter to entries whose `tag`
+  matches the mapped tag → `removeActive(matches)`. (`removeActive` takes
+  `{ id, tag }[]`; the entries from `active()` carry real ids. No-op if none match.)
+- **Web (`!isTauri`):** `navigator.serviceWorker.ready` →
+  `registration.getNotifications({ tag }).then(ns => ns.forEach(n => n.close()))`.
+
+Wrapped in try/catch, best-effort — matching the "silently ignore, nice-to-have"
+posture of the code it replaces.
+
+Signature: `dismissNotification(navType: 'conversation' | 'room', navTarget: string): Promise<void>`.
+
+### 3. Call sites (the two read paths)
+
+1. **Open/navigate — `useNavigateToTarget.ts`:**
+   - `navigateToConversation` → `void dismissNotification('conversation', conversationId)`
+     (replaces `clearAllNotifications()`).
+   - `navigateToRoom` → `void dismissNotification('room', roomJid)` (replaces
+     `clearAllNotifications()`).
+   - `navigateToContact` → **drop** the `clearAllNotifications()` call. Opening a
+     contact profile is not a conversation read, so there is no specific
+     notification to dismiss. (Decision: do not invent behaviour here.)
+   - `clearAllNotifications()` is removed once it has no callers.
+
+2. **Window focus — `useWindowVisibility.ts`:** in the `!wasFocused && isFocused`
+   branch, after each `markAsRead(...)`, also dismiss that entity's
+   notification:
+   - active conversation → `void dismissNotification('conversation', activeConversationId)`
+   - active room → `void dismissNotification('room', activeRoomJid)`
+
+## Data flow
+
+```
+message arrives (backgrounded)
+  → post_notification  → UNUserNotificationCenter entry  [id: conversation:<jid>]
+
+user reads conversation
+  ├─ opens it            (useNavigateToTarget.navigateToConversation)
+  └─ or refocuses window (useWindowVisibility, active conversation)
+       → dismissNotification('conversation', <jid>)
+            ├─ macOS Tauri → invoke remove_delivered_notifications([conversation:<jid>])
+            │                  → center.removeDeliveredNotificationsWithIdentifiers([...])
+            ├─ Win/Linux   → plugin active() → filter tag=<jid> → removeActive(matches)
+            └─ web         → registration.getNotifications({tag:<jid>}) → n.close()
+  → only that conversation's entry is removed; others remain
+```
+
+## Error handling
+
+- Native removal is best-effort: unbundled process (`current_center() == None`)
+  or a non-macOS Tauri target → no-op, no error surfaced.
+- JS helper wraps platform calls in try/catch and swallows errors (consistent
+  with the removed `clearAllNotifications`, which was explicitly "nice to have").
+- Passing an identifier that has no delivered notification is a harmless no-op
+  on both platforms.
+
+## Testing
+
+- **JS helper (unit, vitest):**
+  - macOS Tauri branch: mock `isMacOSDesktop → true` + `invoke`, assert it is
+    called with `{ identifiers: ['conversation:alice@x'] }` for a conversation
+    and `['room:team@x']` for a room.
+  - Win/Linux Tauri branch: mock `isMacOSDesktop → false` + `isTauri` + plugin
+    `active`/`removeActive`; assert it filters by the correct tag
+    (`conv.id` vs `room-<jid>`) and passes the matching entries to `removeActive`.
+  - Web branch: mock `navigator.serviceWorker.ready` / `getNotifications`,
+    assert it queries the correct tag and calls `close()` on the returned
+    notifications.
+  - Assert errors from any branch are swallowed.
+- **Call sites:** assert `navigateToConversation`/`navigateToRoom` invoke the
+  helper with the right `(navType, navTarget)`; assert `navigateToContact` no
+  longer clears notifications.
+- **Rust command:** thin FFI over a system API — not unit tested. Verified
+  manually via `npm run tauri:dev` on macOS: post a notification for two
+  conversations, open one, confirm its Notification Center entry disappears and
+  the other remains; repeat for the refocus path.
+
+## Out of scope
+
+- Server-initiated push notifications (local notifications only).
+- Windows / Linux native removal beyond what the web/service-worker path and the
+  Tauri plugin already provide.
+- Changing the identifier/tag schemes themselves.


### PR DESCRIPTION
Dismiss a conversation's OS notification from the notification center when the conversation is read, leaving other conversations' notifications intact.

## Why
On macOS, notifications are posted through a custom `UNUserNotificationCenter` path, but the previous dismissal called the Tauri plugin's `removeAllActive()` — which never posted those notifications, so it removed nothing. It was also all-or-nothing (reading one chat cleared every notification). This replaces it with precise, per-conversation removal.

## What
- **Rust (macOS):** new `remove_delivered_notifications(identifiers)` command using `removeDeliveredNotificationsWithIdentifiers:`, keyed by the existing `"<navType>:<navTarget>"` identifier.
- **JS:** new `dismissNotification(navType, navTarget)` helper — macOS → native command; web PWA → service worker by tag; Windows/Linux Tauri → no-op (the plugin can't reference a notification by JID, only an integer id).
- Wired into both read paths: open/navigate (`useNavigateToTarget`) and window focus (`useWindowVisibility`). The broken `clearAllNotifications()` is removed.