### PR TITLE
fix(rooms): match room-list activity dot to the icon-rail indicator

### DIFF
--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -6,6 +6,7 @@ import { detectRenderLoop, trackSelectorChange } from '@/utils/renderLoopDetecto
 import {
   useRoomActions,
   roomStore,
+  roomActivityTone,
   generateConsistentColorHexSync,
 } from '@fluux/sdk'
 import { useChatStore, useRoomStore } from '@fluux/sdk/react'
@@ -428,10 +429,15 @@ const RoomItem = memo(function RoomItem({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <p dir="auto" className={`truncate ${room.unreadCount > 0 ? 'font-semibold text-fluux-text' : 'font-medium'}`}>{room.name}</p>
-            {/* Activity dot for unread (non-mention) activity */}
+            {/* Activity dot for unread (non-mention) activity. Blue for a
+                notify-all room (matches the icon-rail indicator), grey otherwise. */}
             {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
               <Tooltip content={`${room.unreadCount} unread`} position="top">
-                <div className="size-2.5 rounded-full bg-fluux-gray flex-shrink-0" />
+                <div
+                  className={`size-2.5 rounded-full flex-shrink-0 ${
+                    roomActivityTone(room) === 'accent' ? 'bg-fluux-brand' : 'bg-fluux-gray'
+                  }`}
+                />
               </Tooltip>
             )}
             {/* Mentions count badge */}

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -192,6 +192,10 @@ export {
 // Granular selectors for reduced re-renders (use with shallow comparison)
 export { chatSelectors, roomSelectors, rosterSelectors } from './stores'
 
+// Per-room sidebar activity tone (shared by the icon-rail indicator and the room list)
+export { roomActivityTone } from './stores'
+export type { RoomActivityTone } from './stores'
+
 // Admin dashboard types
 export type { AdminStats } from './stores/adminStore'
 

--- a/packages/fluux-sdk/src/stores/index.ts
+++ b/packages/fluux-sdk/src/stores/index.ts
@@ -58,7 +58,8 @@ export type { SubscriptionRequest, StrangerMessage, MucInvitation } from '../cor
 
 export { roomStore } from './roomStore'
 export type { RoomState } from './roomStore'
-export { roomSelectors } from './roomSelectors'
+export { roomSelectors, roomActivityTone } from './roomSelectors'
+export type { RoomActivityTone } from './roomSelectors'
 
 export { adminStore } from './adminStore'
 export type { AdminState, AdminCommand, AdminSession, DataForm, DataFormField, AdminNote } from './adminStore'

--- a/packages/fluux-sdk/src/stores/roomSelectors.test.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { roomSelectors } from './roomSelectors'
+import { roomSelectors, roomActivityTone } from './roomSelectors'
 import type { RoomState } from './roomStore'
 import type { Room, RoomEntity, RoomMetadata, RoomRuntime, RoomOccupant, RoomMessage, MAMQueryState } from '../core/types'
 
@@ -702,5 +702,45 @@ describe('roomSelectors', () => {
       const state = createMockState({ roomRuntime: new Map() })
       expect(roomSelectors.runtimeOccupantCountFor('missing@conference.example.com')(state)).toBe(0)
     })
+  })
+})
+
+describe('roomActivityTone', () => {
+  const base = { joined: true, muted: false, unreadCount: 0, mentionsCount: 0 }
+
+  it("returns 'none' for a joined room with no unread", () => {
+    expect(roomActivityTone({ ...base })).toBe('none')
+  })
+
+  it("returns 'neutral' for plain unread (no mention, no notifyAll)", () => {
+    expect(roomActivityTone({ ...base, unreadCount: 3 })).toBe('neutral')
+  })
+
+  it("returns 'accent' for a mention", () => {
+    expect(roomActivityTone({ ...base, unreadCount: 3, mentionsCount: 1 })).toBe('accent')
+  })
+
+  it("returns 'accent' for unread in a notifyAll (session) room", () => {
+    expect(roomActivityTone({ ...base, unreadCount: 2, notifyAll: true })).toBe('accent')
+  })
+
+  it("returns 'accent' for unread in a notifyAllPersistent room", () => {
+    expect(roomActivityTone({ ...base, unreadCount: 2, notifyAllPersistent: true })).toBe('accent')
+  })
+
+  it("returns 'none' for a notifyAll room with zero unread", () => {
+    expect(roomActivityTone({ ...base, notifyAllPersistent: true, unreadCount: 0 })).toBe('none')
+  })
+
+  it("returns 'none' for a muted room even with a mention", () => {
+    expect(roomActivityTone({ ...base, unreadCount: 4, mentionsCount: 2, muted: true })).toBe('none')
+  })
+
+  it("returns 'none' for a muted notifyAll room with unread", () => {
+    expect(roomActivityTone({ ...base, unreadCount: 4, notifyAllPersistent: true, muted: true })).toBe('none')
+  })
+
+  it("returns 'none' for a non-joined room", () => {
+    expect(roomActivityTone({ ...base, joined: false, unreadCount: 9, mentionsCount: 3 })).toBe('none')
   })
 })

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -39,6 +39,38 @@ const EMPTY_TYPING_SET: Set<string> = new Set()
  *
  * @category Selectors
  */
+
+/**
+ * Sidebar activity tone for a single room.
+ *
+ * Shared by the icon-rail indicator ({@link roomStore.roomTabIndicator}) and
+ * the room-list activity dot so the two can never disagree on when a room is
+ * "blue" vs "grey":
+ * - `'accent'`  → a mention, or a notify-all room with unread ("blue pill")
+ * - `'neutral'` → other unread ("grey pill")
+ * - `'none'`    → nothing to signal
+ *
+ * Muted and non-joined rooms contribute no tone, matching the rail indicator.
+ *
+ * @category Selectors
+ */
+export type RoomActivityTone = 'accent' | 'neutral' | 'none'
+
+export function roomActivityTone(room: {
+  joined?: boolean
+  muted?: boolean
+  unreadCount: number
+  mentionsCount: number
+  notifyAll?: boolean
+  notifyAllPersistent?: boolean
+}): RoomActivityTone {
+  if (!room.joined || room.muted) return 'none'
+  const notifyAll = room.notifyAll || room.notifyAllPersistent
+  if (room.mentionsCount > 0 || (notifyAll && room.unreadCount > 0)) return 'accent'
+  if (room.unreadCount > 0) return 'neutral'
+  return 'none'
+}
+
 export const roomSelectors = {
   /**
    * Get all room JIDs.

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -26,6 +26,7 @@ import * as draftState from './shared/draftState'
 import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, prependOlderMessages, mergeAndProcessMessages } from './shared/messageArrayUtils'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
+import { roomActivityTone } from './roomSelectors'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
@@ -2489,15 +2490,12 @@ export const roomStore = createStore<RoomState>()(
   roomTabIndicator: () => {
     let hasNeutral = false
     for (const [jid, entity] of get().roomEntities) {
-      if (!entity.joined) continue
-      if (entity.muted) continue
       const meta = get().roomMeta.get(jid)
       if (!meta) continue
-      const notifyAll = meta.notifyAll || meta.notifyAllPersistent
-      if (meta.mentionsCount > 0 || (notifyAll && meta.unreadCount > 0)) {
-        return 'accent'
-      }
-      if (meta.unreadCount > 0) hasNeutral = true
+      // Same per-room predicate the room list uses, so rail and list agree.
+      const tone = roomActivityTone({ ...entity, ...meta })
+      if (tone === 'accent') return 'accent'
+      if (tone === 'neutral') hasNeutral = true
     }
     return hasNeutral ? 'neutral' : 'none'
   },


### PR DESCRIPTION
The icon-rail Rooms indicator turns blue for a notify-all room with unread messages, but the room list only showed a blue badge for @-mentions. A notify-all room with plain unread rendered a grey dot, so the rail and the list disagreed.

Extracts the per-room tone into a shared `roomActivityTone()` helper in the SDK and drives both the rail's `roomTabIndicator` and the room-list activity dot from it, so the two can no longer drift. The list dot reuses the same `bg-fluux-brand` accent token as the rail, so it tracks every theme.
