### PR TITLE
Admin: pre-fill user/host fields (not just accountjid) from targetJid

### DIFF
--- a/apps/fluux/src/components/AdminCommandForm.test.tsx
+++ b/apps/fluux/src/components/AdminCommandForm.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AdminCommandForm } from './AdminCommandForm'
+import type { DataForm } from '@fluux/sdk'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('AdminCommandForm', () => {
+  describe('accountjid pre-fill (XEP-0133 single-field commands)', () => {
+    const form: DataForm = {
+      type: 'form',
+      title: 'Delete User',
+      fields: [
+        { var: 'accountjid', type: 'jid-single', label: 'JID' },
+      ],
+    }
+
+    it('pre-fills and hides accountjid when targetJid is set', () => {
+      const onSubmit = vi.fn()
+      const { container } = render(
+        <AdminCommandForm
+          form={form}
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          targetJid="alice@example.com"
+        />
+      )
+
+      // Field is hidden (shown via the target-user banner instead).
+      expect(screen.queryByRole('textbox', { name: /jid/i })).not.toBeInTheDocument()
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+
+      fireEvent.submit(container.querySelector('form')!)
+      expect(onSubmit).toHaveBeenCalledWith({ accountjid: 'alice@example.com' })
+    })
+  })
+
+  describe('user/host pre-fill (ejabberd api-commands split-JID commands)', () => {
+    const form: DataForm = {
+      type: 'form',
+      title: 'Ban Account',
+      fields: [
+        { var: 'user', type: 'text-single', label: 'user' },
+        { var: 'host', type: 'text-single', label: 'host' },
+        { var: 'reason', type: 'text-single', label: 'reason' },
+      ],
+    }
+
+    it('pre-fills user and host from targetJid and hides both behind the target banner', () => {
+      const onSubmit = vi.fn()
+      const { container } = render(
+        <AdminCommandForm
+          form={form}
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          targetJid="emma@fluux.chat"
+        />
+      )
+
+      expect(container.querySelector('input[name="user"]')).not.toBeInTheDocument()
+      expect(container.querySelector('input[name="host"]')).not.toBeInTheDocument()
+      expect(screen.getByText('emma@fluux.chat')).toBeInTheDocument()
+      // The unrelated field still renders normally.
+      expect(container.querySelector('input[name="reason"]')).toBeInTheDocument()
+    })
+
+    it('submits the derived user/host from targetJid alongside other field values', () => {
+      const onSubmit = vi.fn()
+      const { container } = render(
+        <AdminCommandForm
+          form={form}
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          targetJid="emma@fluux.chat"
+        />
+      )
+
+      fireEvent.change(container.querySelector('input[name="reason"]')!, {
+        target: { value: 'Spamming' },
+      })
+      fireEvent.submit(container.querySelector('form')!)
+
+      expect(onSubmit).toHaveBeenCalledWith({
+        user: 'emma',
+        host: 'fluux.chat',
+        reason: 'Spamming',
+      })
+    })
+
+    it('does not auto-fill a lone user field when there is no matching host field', () => {
+      const lonelyForm: DataForm = {
+        type: 'form',
+        title: 'Unrelated command',
+        fields: [{ var: 'user', type: 'text-single', label: 'user' }],
+      }
+      const { container } = render(
+        <AdminCommandForm
+          form={lonelyForm}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+          targetJid="emma@fluux.chat"
+        />
+      )
+
+      const input = container.querySelector('input[name="user"]') as HTMLInputElement
+      expect(input).toBeInTheDocument()
+      expect(input.value).toBe('')
+    })
+  })
+
+  describe('no targetJid', () => {
+    it('renders user/host fields normally, using server-supplied defaults', () => {
+      const form: DataForm = {
+        type: 'form',
+        title: 'Ban Account',
+        fields: [
+          { var: 'user', type: 'text-single', label: 'user' },
+          { var: 'host', type: 'text-single', label: 'host', value: 'fluux.chat' },
+        ],
+      }
+      const { container } = render(
+        <AdminCommandForm form={form} onSubmit={vi.fn()} onCancel={vi.fn()} />
+      )
+
+      expect(container.querySelector('input[name="user"]')).toBeInTheDocument()
+      expect((container.querySelector('input[name="host"]') as HTMLInputElement).value).toBe('fluux.chat')
+    })
+  })
+})

--- a/apps/fluux/src/components/AdminCommandForm.tsx
+++ b/apps/fluux/src/components/AdminCommandForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { DataForm } from '@fluux/sdk'
+import { getLocalPart, getDomain, type DataForm } from '@fluux/sdk'
 import { AlertCircle, Info, AlertTriangle, User, X } from 'lucide-react'
 import { Tooltip } from './Tooltip'
 import { FormField } from './DataFormFields'
@@ -34,14 +34,24 @@ export function AdminCommandForm({
 }: AdminCommandFormProps) {
   const { t } = useTranslation()
 
-  // Initialize form state from field values, pre-filling accountjid if targetJid is set
+  // Some commands (XEP-0133) take a single `accountjid` field; ejabberd's own
+  // api-commands (ban_account, unban_account, kick_session, ...) instead take
+  // separate `user`/`host` fields. Only treat user/host as JID-derived when
+  // both are present — a lone `user` field on some other command shouldn't be
+  // guessed at.
+  const hasSplitJidFields = form.fields.some(f => f.var === 'user') && form.fields.some(f => f.var === 'host')
+
+  // Initialize form state from field values, pre-filling target-JID fields if targetJid is set
   const [formData, setFormData] = useState<Record<string, string | string[]>>(() => {
     const initial: Record<string, string | string[]> = {}
     for (const field of form.fields) {
       if (field.type === 'hidden' || field.type === 'fixed') continue
-      // Pre-fill accountjid with targetJid
       if (field.var === 'accountjid' && targetJid) {
         initial[field.var] = targetJid
+      } else if (field.var === 'user' && targetJid && hasSplitJidFields) {
+        initial[field.var] = getLocalPart(targetJid)
+      } else if (field.var === 'host' && targetJid && hasSplitJidFields) {
+        initial[field.var] = getDomain(targetJid)
       } else {
         initial[field.var] = field.value ?? (field.type === 'list-multi' || field.type === 'jid-multi' || field.type === 'text-multi' ? [] : '')
       }
@@ -67,11 +77,13 @@ export function AdminCommandForm({
     onSubmit(submitData)
   }
 
-  // Filter out hidden fields for display
-  // Also filter out accountjid when targetJid is set (shown separately at top)
+  // Filter out hidden fields for display. Also filter out the target-JID
+  // field(s) — accountjid, or user+host together — when targetJid is set
+  // (shown separately at top instead).
   const visibleFields = form.fields.filter(f => {
     if (f.type === 'hidden') return false
     if (f.var === 'accountjid' && targetJid) return false
+    if ((f.var === 'user' || f.var === 'host') && targetJid && hasSplitJidFields) return false
     return true
   })
 


### PR DESCRIPTION
## Summary

Verified against live process-one.net traffic (`ban_account` execute response): ejabberd's own api-commands (`ban_account`, `unban_account`, `kick_session`, and others) take separate `user`/`host` string fields, not a single `accountjid` field the way XEP-0133 commands (delete-user, change-user-password, end-user-session) do.

`AdminCommandForm`'s pre-fill only recognized `accountjid`, so opening Ban Account from a user's detail screen showed an empty form requiring the admin to manually type both `user` and `host` instead of the one-click pre-filled flow every other user action already gets.

Fix: when a form has both a `user` and a `host` field (guarding against misfiring on some other command with an unrelated lone `user` field), derive both from `targetJid` via the SDK's `getLocalPart`/`getDomain`, and hide them behind the existing target-user banner — same treatment `accountjid` already gets.