### PR TITLE
fix(app): no spurious composer scrollbar on mobile (Blink)

### DIFF
--- a/apps/fluux/src/components/MessageComposer.autosize.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.autosize.test.tsx
@@ -132,6 +132,44 @@ describe('MessageComposer autosize', () => {
     expect(roDisconnected).toBeGreaterThan(0)
   })
 
+  // --- Scrollbar only past the 8-line cap -----------------------------------
+  // With overflow-y:auto always on, Blink (mobile Brave) paints a scrollbar for
+  // a single line because the integer height we write can round under the
+  // fractional content height. Keep overflow-y hidden until content genuinely
+  // exceeds the 8-line cap (192px), where a scrollbar is actually needed.
+  it('keeps overflow-y hidden below the max height', () => {
+    mockScrollHeight = 48 // one line
+    const { container } = renderComposer('Hello world test')
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.style.overflowY).toBe('hidden')
+  })
+
+  it('switches overflow-y to auto once content exceeds the 8-line cap', () => {
+    mockScrollHeight = 240 // taller than the 192px cap
+    const { container } = renderComposer('Nine\nlines\nof\ntext\nthat\noverflow\nthe\ncomposer\ncap')
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.style.height).toBe('192px')
+    expect(textarea.style.overflowY).toBe('auto')
+  })
+
+  it('restores overflow-y hidden when a tall draft shrinks back under the cap', () => {
+    mockScrollHeight = 240
+    const { container, rerender } = renderComposer('a\nb\nc\nd\ne\nf\ng\nh\ni')
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.style.overflowY).toBe('auto')
+
+    mockScrollHeight = 48 // deleted back to one line
+    rerender(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value="a"
+        onValueChange={() => {}}
+      />
+    )
+    expect(textarea.style.overflowY).toBe('hidden')
+  })
+
   // --- Per-keystroke forced-layout avoidance --------------------------------
   // resizeToContent ran on every keystroke and unconditionally (a) reset the
   // textarea to height:auto and (b) called onInputResize. The auto-reset

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -38,7 +38,12 @@ const COMPOSING_UI_TIMEOUT_MS = 1500
 // outline (index.css): the composer card's own `:focus-within` accent edge is the
 // focus affordance now, so the textarea's inner outline would be a doubled ring.
 // The action buttons keep their outlines for keyboard navigation.
-export const MESSAGE_INPUT_BASE_CLASSES = 'message-input no-focus-ring flex-1 px-2 py-3 bg-transparent resize-none overflow-y-auto'
+// Default to overflow-y-hidden: a scrollbar is only meaningful once the content
+// reaches the 8-line cap. resizeToContent() flips overflow-y to `auto` at max
+// height. Starting at `auto` makes Blink (mobile Brave) paint a scrollbar track
+// for even a single line, since the integer height we write can round below the
+// fractional content height. Desktop WebKit hides this behind overlay scrollbars.
+export const MESSAGE_INPUT_BASE_CLASSES = 'message-input no-focus-ring flex-1 px-2 py-3 bg-transparent resize-none overflow-y-hidden'
 export const MESSAGE_INPUT_TEXT_CLASSES = 'text-fluux-text placeholder:text-fluux-muted'
 // For overlay-based inputs (e.g., mention highlighting) - text is transparent, caret visible via style
 export const MESSAGE_INPUT_OVERLAY_CLASSES = 'text-transparent placeholder:text-fluux-muted'
@@ -358,9 +363,10 @@ export function MessageComposer({
     const mayShrink = forceRemeasure || (couldShrink && lastSetHeightRef.current > minHeight)
 
     const savedScrollTop = textarea.scrollTop
-    // Only collapse to `auto` when a shrink is possible. With overflow-y:auto,
-    // scrollHeight reflects the full content height even without the reset, so
-    // growth is still detected — without dirtying the surrounding layout.
+    // Only collapse to `auto` when a shrink is possible. Even with overflow-y
+    // hidden, scrollHeight still reflects the full content height without the
+    // reset, so growth is still detected — without dirtying the surrounding
+    // layout.
     if (mayShrink) textarea.style.height = 'auto'
     const scrollHeight = textarea.scrollHeight
     const newHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight)
@@ -368,9 +374,15 @@ export function MessageComposer({
     // Fast path: a non-shrinking edit that leaves the height unchanged touched
     // nothing, so there is no height to write, no scroll to restore, and no
     // listener to notify. This is what keeps continuous typing off the
-    // message-list reflow path.
+    // message-list reflow path. Overflow only flips at the max-height boundary,
+    // which always changes newHeight, so it never needs updating on this path.
     if (!mayShrink && newHeight === lastSetHeightRef.current) return
 
+    // Only allow scrolling once content reaches the cap. Below the cap the
+    // textarea grows to fit, so a scrollbar is spurious (and Blink/mobile Brave
+    // paints one for a single line when the integer height rounds under the real
+    // content height). At the cap the content genuinely overflows → auto.
+    textarea.style.overflowY = scrollHeight > maxHeight ? 'auto' : 'hidden'
     textarea.style.height = `${newHeight}px`
     lastSetHeightRef.current = newHeight
 


### PR DESCRIPTION
On mobile Brave (Blink), the message composer showed a vertical scrollbar even when empty or holding less than one line of text.

## Cause

The composer textarea was hardwired to `overflow-y: auto`. Desktop WebKit hides this behind overlay/auto-hiding scrollbars, so it was never visible there. Blink paints a scrollbar track the moment `scrollHeight` exceeds the element height by any amount — and the integer pixel height the autosize code writes can round just below the fractional content height, so a single line marginally overflows.

## Fix

A scrollbar is only meaningful once content reaches the 8-line cap, so:

- Default the textarea to `overflow-y: hidden` in the shared base classes.
- In `resizeToContent`, flip `overflow-y` to `auto` only when `scrollHeight > maxHeight`, else `hidden`. It sits below the fast-path guard, so continuous typing still touches nothing (overflow only flips at the cap boundary, which always changes the height anyway).

This covers both the 1:1 and MUC composers, since both reuse `MESSAGE_INPUT_BASE_CLASSES` and the same `resizeToContent`.