### PR TITLE
feat(sdk): live cross-device sync for conversation archive/unarchive

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -790,6 +790,14 @@ export class XMPPClient {
       this.on('rosterLoaded', () => {
         this.profile.restoreAllContactAvatarHashes().catch(() => {})
       })
+
+      // Live conversation-list sync: another of our own devices archived/
+      // unarchived (or added) a 1:1 conversation and the server pushed the
+      // updated PEP list. Reconcile it into the local store immediately,
+      // reusing the same merge path as the fresh-session fetch.
+      this.subscribe('conversation:list-synced', ({ conversations }) => {
+        this.mergeServerConversations(conversations)
+      })
     }
 
     // Start the snapshot subscriber so SM-resumable state (rooms, roster,

--- a/packages/fluux-sdk/src/core/caps.test.ts
+++ b/packages/fluux-sdk/src/core/caps.test.ts
@@ -6,7 +6,7 @@ import {
   getClientIdentity,
   getCapsNode,
 } from './caps'
-import { NS_MDS_NOTIFY } from './namespaces'
+import { NS_MDS_NOTIFY, NS_CONVERSATIONS_NOTIFY } from './namespaces'
 
 describe('caps (XEP-0115)', () => {
   describe('CLIENT_FEATURES', () => {
@@ -59,6 +59,14 @@ describe('caps (XEP-0115)', () => {
       expect(CLIENT_FEATURES).toContain(NS_MDS_NOTIFY)
       // feature appears in the (sorted) XEP-0115 verification string
       expect(calculateVerificationString()).toContain(`${NS_MDS_NOTIFY}<`)
+    })
+
+    it('includes the Fluux conversation-list +notify so the server pushes archive/unarchive changes', () => {
+      // Without this, ejabberd will not push PEP headlines when another
+      // device of the same account archives/unarchives a conversation —
+      // the change would only surface on the next fresh-session fetch.
+      expect(CLIENT_FEATURES).toContain(NS_CONVERSATIONS_NOTIFY)
+      expect(calculateVerificationString()).toContain(`${NS_CONVERSATIONS_NOTIFY}<`)
     })
 
     it('should include XEP-0374 OX-IM discovery feature', () => {

--- a/packages/fluux-sdk/src/core/caps.ts
+++ b/packages/fluux-sdk/src/core/caps.ts
@@ -12,6 +12,7 @@ import {
   NS_BOOKMARKS_NOTIFY,
   NS_CARBONS,
   NS_FLUUX_VERIFICATIONS_NOTIFY,
+  NS_CONVERSATIONS_NOTIFY,
   NS_IDLE,
   NS_MDS_NOTIFY,
   NS_OPENPGP_IM,
@@ -67,6 +68,7 @@ export const CLIENT_FEATURES = [
   NS_CARBONS,               // XEP-0280 Message Carbons
   NS_IDLE,                  // XEP-0319 Last User Interaction
   NS_FLUUX_VERIFICATIONS_NOTIFY, // Fluux private PEP notify (cross-device verification sync)
+  NS_CONVERSATIONS_NOTIFY,   // Fluux private PEP notify (conversation archive/unarchive sync)
   NS_MDS_NOTIFY,             // XEP-0490 PEP notify (read-position sync)
   NS_OPENPGP_IM,            // XEP-0374 OpenPGP for XMPP Instant Messaging (OX-IM)
   NS_OPENPGP_PUBLIC_KEYS_NOTIFY, // XEP-0373 PEP notify (OpenPGP public keys)

--- a/packages/fluux-sdk/src/core/modules/ConversationSync.ts
+++ b/packages/fluux-sdk/src/core/modules/ConversationSync.ts
@@ -1,4 +1,5 @@
 import { xml } from '@xmpp/client'
+import type { Element } from '@xmpp/client'
 import { getBareJid } from '../jid'
 import { generateUUID } from '../../utils/uuid'
 import { NS_PUBSUB, NS_CONVERSATIONS } from '../namespaces'
@@ -11,6 +12,28 @@ import type { ModuleDependencies } from './BaseModule'
 export interface SyncedConversation {
   jid: string
   archived: boolean
+}
+
+/**
+ * Parse a PEP `<item>` (id="current") holding the conversation list into
+ * {@link SyncedConversation} entries. Shared by the IQ fetch path and the
+ * live PEP-notify handler so both interpret the wire format identically.
+ * Returns an empty array if the item has no `<conversations>` container.
+ */
+export function parseConversationsItem(item: Element | undefined): SyncedConversation[] {
+  const container = item?.getChild('conversations', NS_CONVERSATIONS)
+  if (!container) return []
+
+  const conversations: SyncedConversation[] = []
+  for (const convEl of container.getChildren('conversation')) {
+    const jid = convEl.attrs.jid
+    if (!jid) continue
+    conversations.push({
+      jid,
+      archived: convEl.attrs.archived === 'true',
+    })
+  }
+  return conversations
 }
 
 /**
@@ -50,19 +73,7 @@ export class ConversationSync {
     try {
       const result = await this.deps.sendIQ(iq, timeoutMs)
       const item = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')?.getChild('item')
-      const container = item?.getChild('conversations', NS_CONVERSATIONS)
-      if (!container) return []
-
-      const conversations: SyncedConversation[] = []
-      for (const convEl of container.getChildren('conversation')) {
-        const jid = convEl.attrs.jid
-        if (!jid) continue
-        conversations.push({
-          jid,
-          archived: convEl.attrs.archived === 'true',
-        })
-      }
-      return conversations
+      return parseConversationsItem(item)
     } catch {
       // Node may not exist yet, or item not found
       return []

--- a/packages/fluux-sdk/src/core/modules/PubSub.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.test.ts
@@ -331,6 +331,86 @@ describe('PubSub Module', () => {
     })
   })
 
+  describe('conversation list incoming notify (Fluux private PEP live sync)', () => {
+    const convEvent = (from: string, convChildren: Array<Record<string, unknown>>) =>
+      createMockElement('message', { from, to: 'user@example.com' }, [
+        {
+          name: 'event',
+          attrs: { xmlns: 'http://jabber.org/protocol/pubsub#event' },
+          children: [
+            {
+              name: 'items',
+              attrs: { node: 'urn:xmpp:fluux:conversations:0' },
+              children: [
+                {
+                  name: 'item',
+                  attrs: { id: 'current' },
+                  children: [
+                    {
+                      name: 'conversations',
+                      attrs: { xmlns: 'urn:xmpp:fluux:conversations:0' },
+                      children: convChildren,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+    it('emits conversation:list-synced for own conversations node notifications', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit('stanza', convEvent('user@example.com', [
+        { name: 'conversation', attrs: { jid: 'alice@example.com' } },
+        { name: 'conversation', attrs: { jid: 'bob@example.com', archived: 'true' } },
+      ]))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('conversation:list-synced', {
+        conversations: [
+          { jid: 'alice@example.com', archived: false },
+          { jid: 'bob@example.com', archived: true },
+        ],
+      })
+    })
+
+    it('ignores conversations notifications that are not from our own bare JID', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit('stanza', convEvent('attacker@evil.example', [
+        { name: 'conversation', attrs: { jid: 'bob@example.com', archived: 'true' } },
+      ]))
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('conversation:list-synced', expect.anything())
+    })
+
+    it('returns true (handled) for conversations PubSub event messages', async () => {
+      await connectClient()
+
+      const result = xmppClient.pubsub.handle(convEvent('user@example.com', [
+        { name: 'conversation', attrs: { jid: 'alice@example.com' } },
+      ]))
+
+      expect(result).toBe(true)
+    })
+
+    it('applies an incoming archived conversation to the chat store live', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit('stanza', convEvent('user@example.com', [
+        { name: 'conversation', attrs: { jid: 'bob@example.com', archived: 'true' } },
+      ]))
+
+      // hasConversation() is mocked false → merge takes the "new conversation"
+      // branch: add it, then archive it, matching the remote device's state.
+      expect(mockStores.chat.addConversation).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'bob@example.com' })
+      )
+      expect(mockStores.chat.archiveConversation).toHaveBeenCalledWith('bob@example.com')
+    })
+  })
+
   describe('stanza handling', () => {
     it('should return true (handled) for PubSub event messages', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/modules/PubSub.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.ts
@@ -21,8 +21,9 @@ import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
 import { getBareJid } from '../jid'
-import { NS_PUBSUB, NS_NICK, NS_OPENPGP_PUBLIC_KEYS, NS_BOOKMARKS, NS_MDS } from '../namespaces'
+import { NS_PUBSUB, NS_NICK, NS_OPENPGP_PUBLIC_KEYS, NS_BOOKMARKS, NS_MDS, NS_CONVERSATIONS } from '../namespaces'
 import { parseMdsItems } from './Mds'
+import { parseConversationsItem } from './ConversationSync'
 import { generateUUID } from '../../utils/uuid'
 import { dataToElement, elementToData } from '../e2ee/stanzaAdapter'
 import type { PEPItem, Subscription, XMLElementData } from '../e2ee'
@@ -146,6 +147,13 @@ export class PubSub extends BaseModule {
     // conversation — sync the read position across devices.
     if (node === NS_MDS) {
       this.handleMdsUpdate(bareFrom, items)
+    }
+
+    // Fluux private conversation list. A headline here means another of our
+    // own clients archived/unarchived (or added) a 1:1 conversation — keep
+    // the list in sync live instead of only on the next reconnect's fetch.
+    if (node === NS_CONVERSATIONS) {
+      this.handleConversationsUpdate(bareFrom, items)
     }
 
     // Dispatch to any user-registered subscribers for (bareFrom, node).
@@ -374,6 +382,24 @@ export class PubSub extends BaseModule {
         stanzaId,
       })
     }
+  }
+
+  /**
+   * Fluux private PEP: apply an incoming conversation-list notification from
+   * our own node. Other entities' nodes are ignored (own-account PEP only).
+   * The list is published as a single item (id="current") holding the full
+   * set, so we emit the whole parsed list for the consumer to reconcile.
+   */
+  private handleConversationsUpdate(bareFrom: string, items: Element): void {
+    const ownBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
+    if (!ownBareJid || bareFrom !== ownBareJid) return
+
+    const item = items.getChild('item')
+    if (!item) return
+
+    this.deps.emitSDK('conversation:list-synced', {
+      conversations: parseConversationsItem(item),
+    })
   }
 
   private dispatchToSubscribers(bareFrom: string, node: string, items: Element): void {

--- a/packages/fluux-sdk/src/core/namespaces.ts
+++ b/packages/fluux-sdk/src/core/namespaces.ts
@@ -121,8 +121,11 @@ export const NS_APPEARANCE = 'urn:xmpp:fluux:appearance:0'
 // Custom: Fluux ignored users per-room (XEP-0223 private storage)
 export const NS_IGNORED_USERS = 'urn:xmpp:fluux:ignored-users:0'
 
-// Custom: Fluux conversation list sync (XEP-0223 private storage)
+// Custom: Fluux conversation list sync (XEP-0223 private storage).
+// The +notify variant is advertised in caps so the server pushes headlines
+// when another device of the same account archives/unarchives a conversation.
 export const NS_CONVERSATIONS = 'urn:xmpp:fluux:conversations:0'
+export const NS_CONVERSATIONS_NOTIFY = 'urn:xmpp:fluux:conversations:0+notify'
 
 // XEP-0334: Message Processing Hints
 export const NS_HINTS = 'urn:xmpp:hints'

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -155,6 +155,15 @@ export interface ChatEvents {
     stanzaId: string
   }
 
+  /**
+   * Fluux private PEP: another device of the same account published an
+   * updated conversation list (archive/unarchive/add). Carries the full
+   * list; consumers reconcile local archive state against it.
+   */
+  'conversation:list-synced': {
+    conversations: Array<{ jid: string; archived: boolean }>
+  }
+
   /** Message delivery error received from server */
   'chat:message-error': {
     conversationId: string


### PR DESCRIPTION
## Summary

Archiving/unarchiving a 1:1 conversation was already persisted to the private PEP node `urn:xmpp:fluux:conversations:0` (XEP-0223), but nothing subscribed to that node. A change made on one device only surfaced on another device's **next fresh session** (full reconnect/login) — not on SM resume, and not live.

This wires the live path so another device's archive/unarchive is applied immediately, mirroring the existing bookmarks (XEP-0402) and MDS (XEP-0490) live-sync handlers.

## What changed

- **Advertise `urn:xmpp:fluux:conversations:0+notify` in caps** so the server pushes PEP headlines to the account's other resources (`namespaces.ts`, `caps.ts`).
- **Handle the incoming event** in the PubSub module: `handlePubSubEvent` routes the node to `handleConversationsUpdate`, which is gated to our own bare JID and emits a new `conversation:list-synced` SDK event (`PubSub.ts`, `sdk-events.ts`).
- **Reconcile into the store**: `XMPPClient` subscribes to `conversation:list-synced` and applies it through the existing `mergeServerConversations` path used by the fresh-session fetch (`XMPPClient.ts`).
- **Share the parser**: extracted `parseConversationsItem()` so the IQ fetch and the live handler interpret the wire format identically (`ConversationSync.ts`).

## Semantics / scope

- The node stores the full list as a single item (`id="current"`), so a headline carries the whole list; the handler reconciles archive state and adds unknown conversations.
- Merge semantics match the fresh-session fetch: add + archive-state reconcile. Deletes are not propagated (unchanged behavior). Self-echo converges within at most one redundant publish thanks to the snapshot-equality guard in the debounced publisher — no loop.