### PR TITLE
fix(mds): correct XEP-0490 divider when the read-sync seed lands after first open

### DIFF
--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1863,6 +1863,41 @@ export function useMessageListScroll({
 
   }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, isAtBottomRef, staticMode, pinVirtualizedBottom, reassertBottom, restoreSavedPosition])
 
+  // XEP-0490 settle window: the fresh-session read-sync seed can land just AFTER a
+  // conversation is opened. The SDK's entry fold races the async PEP fetch, so at
+  // activation the divider was derived from the STALE local read position and the
+  // conversation-switch effect above already positioned the view (and armed a re-assert
+  // loop) against it. When the seed lands, the SDK advances lastSeenMessageId and
+  // recomputes the divider live for the ACTIVE conversation (chatStore/roomStore
+  // applyRemoteDisplayed); when the synced read caught the conversation up, the divider
+  // clears. Settle the view to the bottom so the FIRST open lands where a later re-open
+  // would — otherwise it stays stranded at the stale marker and appears to "jump to the
+  // end" only on re-open.
+  //
+  // Tightly gated so it never fights the user or a genuine unread marker:
+  //  - only a live divider CLEAR (a defined marker -> undefined) on the SAME conversation
+  //    already open (a real conversation switch is owned by the effect above; we detect it
+  //    via our OWN previous-conversation ref, since that effect updates prevConversationRef
+  //    before this one runs),
+  //  - only while the settle window is open (the user hasn't scrolled since entry),
+  //  - never in static/preview mode.
+  // reassertBottom() supersedes the stale marker re-assert loop (single-flight).
+  const prevSettleRef = useRef({ conv: conversationId, divider: firstNewMessageId })
+  useLayoutEffect(() => {
+    const prev = prevSettleRef.current
+    prevSettleRef.current = { conv: conversationId, divider: firstNewMessageId }
+    if (staticMode) return
+    if (prev.conv !== conversationId) return
+    if (prev.divider === undefined || firstNewMessageId !== undefined) return
+    if (userHasScrolledSinceEntryRef.current) return
+    debugLog('MDS SETTLE: divider cleared by late read-sync → settle to bottom', {
+      conversationId,
+      prevMarker: prev.divider,
+    })
+    isAtBottomRef.current = true
+    reassertBottom()
+  }, [conversationId, firstNewMessageId, staticMode, isAtBottomRef, reassertBottom])
+
   // Retry a saved-position restore that entered before any rows were mounted.
   // This is common for rooms: the MessageList mounts in a loading state, then
   // cache/MAM rows arrive in the same conversation id. Until the restore lands,

--- a/docs/superpowers/specs/2026-06-29-mds-sync-marker-first-open-design.md
+++ b/docs/superpowers/specs/2026-06-29-mds-sync-marker-first-open-design.md
@@ -68,3 +68,40 @@ the desktop build:
 - e2e (`scripts/scroll-invariants.ts`): the "new message while away → divider visible on re-entry"
   invariant passes (chromium verified locally; webkit via CI).
 - App scroll unit suite unchanged behavior (the scroll-layer marker branch is not gated).
+
+## Addendum (2026-07-02): the seed lands AFTER first open (race)
+
+Approach B assumes the pending `pendingRemoteDisplayedStanzaId` is present when
+`activateConversation`/`activateRoom` runs, so the entry fold can consume it before the
+divider is derived. But the fresh-session seed (`mdsSideEffects` `online` handler →
+`client.mds.fetchAllDisplayed()`) is a fire-and-forget async PEP fetch that is NOT awaited by
+activation. If the user opens a conversation before that IQ round-trips back, `pending` is
+undefined at the fold, so:
+
+1. the divider is derived from the STALE local read position (first open lands at the last
+   *local* place, not the synced read), and
+2. the seed lands moments later and advances `lastSeenMessageId` **live** — but the old code only
+   updated the badge, never the divider, so the corrected position only surfaced on the NEXT open
+   ("jumps to the end only on re-open").
+
+### Fix (two layers, provenance stays in the SDK)
+
+- **SDK — `applyRemoteDisplayed` recomputes the divider for the ACTIVE conversation.** When a
+  marker advances `lastSeenMessageId` and `activeConversationId`/`activeRoomJid` matches, re-derive
+  `firstNewMessageMarkers[id]` via `notifState.onActivate` (chat: `treatDelayedAsNew:true`; rooms:
+  default). Inactive entities are left untouched (recomputed on their next activation). This extends
+  the doc's existing "applied live" path from the badge to the divider. Tests:
+  `chatStore.mds.test.ts` / `roomStore.mds.test.ts` — "recomputes … when a late marker advances the
+  ACTIVE conversation/room past the divider" + a non-active gate (RED → GREEN).
+- **App — settle-window re-scroll (`useMessageListScroll`).** The conversation-switch effect captures
+  the marker id at entry and its re-assert loop chases that stale target, so the SDK divider clear
+  needs a companion `useLayoutEffect`: on a live divider CLEAR (defined → undefined) for the SAME
+  conversation, while the user has NOT scrolled since entry (`userHasScrolledSinceEntryRef`), call
+  `reassertBottom()` (single-flight → supersedes the stale marker loop). Self-contained prev-conv ref
+  so a genuine switch is excluded. Not verifiable in jsdom/preview (rAF gated); verify on device /
+  via `scripts/scroll-invariants.ts`.
+
+Note: the divider recompute is deliberately NOT gated by `mdsConsumedThisSession` — that gate is only
+about re-*folding* a stale marker at ENTRY. A genuine forward read-sync arriving live SHOULD move the
+divider (that is what "keep loaded conversations current" means); the settle-window/user-scroll gate
+in the app is what prevents yanking a user who has taken over the scroll.

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -258,6 +258,68 @@ describe('chatStore — new-message divider is session-only', () => {
   })
 })
 
+describe('chatStore.applyRemoteDisplayed — late marker corrects the ACTIVE divider', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  // Reproduces the fresh-session seed race: the conversation is activated (divider
+  // derived from the STALE local read position) BEFORE the async MDS seed lands, so
+  // the marker arrives via applyRemoteDisplayed while the conversation is already
+  // active. The divider must be recomputed to reflect the synced read position, not
+  // left frozen at the stale local one (which is what made the view open at the last
+  // local place and only jump to the synced place on the next open).
+  it('recomputes firstNewMessageMarkers when a late marker advances the active conversation past the divider', () => {
+    const cid = 'juliet@capulet.example'
+    const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3'), msg('m4', 's4')]
+    seedMessages(cid, messages)
+
+    // Post-activation state: local read stale at m2, divider parked at m3 (first unread),
+    // conversation is the active one. No pending marker yet (seed hasn't landed).
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2' })
+      const newMarkers = new Map(state.firstNewMessageMarkers)
+      newMarkers.set(cid, 'm3')
+      return { conversationMeta: newMeta, conversations: newConvs, firstNewMessageMarkers: newMarkers, activeConversationId: cid }
+    })
+
+    // The MDS seed lands late: the other device had read to s4 (the last message).
+    chatStore.getState().applyRemoteDisplayed(cid, 's4')
+
+    // Read position advanced to m4 …
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
+    // … and because m4 is the last message, there is nothing new: the divider clears
+    // (the UI then settles to the bottom instead of holding the stale m3 marker).
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
+  })
+
+  it('does NOT recompute the divider for a non-active conversation (it is derived fresh on activation)', () => {
+    const cid = 'juliet@capulet.example'
+    const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3'), msg('m4', 's4')]
+    seedMessages(cid, messages)
+
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2' })
+      const newMarkers = new Map(state.firstNewMessageMarkers)
+      newMarkers.set(cid, 'm3')
+      // Some OTHER conversation is active, not cid.
+      return { conversationMeta: newMeta, conversations: newConvs, firstNewMessageMarkers: newMarkers, activeConversationId: 'romeo@montague.example' }
+    })
+
+    chatStore.getState().applyRemoteDisplayed(cid, 's4')
+
+    // Read position still advances (forward-only sync is unconditional) …
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
+    // … but the session divider for the inactive conversation is left untouched;
+    // it is recomputed the next time the conversation is activated.
+    expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m3')
+  })
+})
+
 describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
   beforeEach(() => chatStore.getState().reset())
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1116,6 +1116,33 @@ export const chatStore = createStore<ChatState>()(
             pendingRemoteDisplayedStanzaId: undefined,
           })
 
+          // XEP-0490: if this marker advances the CURRENTLY ACTIVE conversation, the
+          // new-message divider was already derived at activation from the (now stale)
+          // local read position — e.g. the fresh-session seed landed just after the
+          // conversation opened, so the fold at activation missed it. Recompute the
+          // divider from the advanced position so it reflects the synced read instead
+          // of freezing at the local one (the view otherwise stays at the last local
+          // place and only jumps to the synced place on the next open). Reuse
+          // onActivate's forward-scan derivation. For a non-active conversation the
+          // divider is recomputed on its next activation, so leave the map untouched.
+          let newMarkers = state.firstNewMessageMarkers
+          if (state.activeConversationId === conversationId) {
+            const divider = notifState.onActivate(
+              {
+                unreadCount: 0,
+                mentionsCount: 0,
+                lastReadAt: meta.lastReadAt,
+                lastSeenMessageId: updated.lastSeenMessageId,
+                firstNewMessageId: undefined,
+              },
+              messages,
+              { treatDelayedAsNew: true }
+            ).firstNewMessageId
+            newMarkers = new Map(state.firstNewMessageMarkers)
+            if (divider) newMarkers.set(conversationId, divider)
+            else newMarkers.delete(conversationId)
+          }
+
           if (conv) {
             const newConversations = new Map(state.conversations)
             newConversations.set(conversationId, {
@@ -1124,10 +1151,10 @@ export const chatStore = createStore<ChatState>()(
               // Keep the combined map coherent with conversationMeta.
               pendingRemoteDisplayedStanzaId: undefined,
             })
-            return { conversationMeta: newMeta, conversations: newConversations }
+            return { conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
           }
 
-          return { conversationMeta: newMeta }
+          return { conversationMeta: newMeta, firstNewMessageMarkers: newMarkers }
         })
       },
 

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -139,6 +139,38 @@ describe('roomStore.applyRemoteDisplayed', () => {
     expect(after?.lastSeenMessageId).toBe('m2')
   })
 
+  // Fresh-session seed race (MUC): the room is activated (divider derived from the
+  // stale local read) BEFORE the async MDS seed lands, so the marker arrives while the
+  // room is already active. The divider must be recomputed from the advanced position,
+  // not frozen at the stale local one.
+  it('recomputes firstNewMessageMarkers when a late marker advances the ACTIVE room past the divider', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)], 'm2')
+    roomStore.setState((s) => {
+      const markers = new Map(s.firstNewMessageMarkers)
+      markers.set(ROOM, 'm3')
+      return { firstNewMessageMarkers: markers, activeRoomJid: ROOM }
+    })
+
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's4')
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m4')
+    expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBeUndefined()
+  })
+
+  it('does NOT recompute the divider for a non-active room', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)], 'm2')
+    roomStore.setState((s) => {
+      const markers = new Map(s.firstNewMessageMarkers)
+      markers.set(ROOM, 'm3')
+      return { firstNewMessageMarkers: markers, activeRoomJid: 'other@conference.example' }
+    })
+
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's4')
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m4')
+    expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('m3')
+  })
+
   it('resolves a pending room marker once the message arrives via room MAM merge', () => {
     seedRoom(ROOM, [rmsg('m1', 's1', 1)], 'm1')
     roomStore.getState().applyRemoteDisplayed(ROOM, 's5') // not loaded → pending

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1693,6 +1693,31 @@ export const roomStore = createStore<RoomState>()(
         lastSeenMessageId: updated.lastSeenMessageId,
         pendingRemoteDisplayedStanzaId: undefined,
       })
+
+      // XEP-0490: if this marker advances the CURRENTLY ACTIVE room, its new-message
+      // divider was already derived at activation from the (now stale) local read
+      // position — the fresh-session seed can land just after the room opens, so the
+      // fold at activation missed it. Recompute the divider from the advanced position
+      // (rooms treat delayed messages as history replay, so no treatDelayedAsNew) so it
+      // reflects the synced read instead of freezing at the local one. Inactive rooms
+      // recompute on their next activation, so leave the map untouched.
+      let newMarkers = state.firstNewMessageMarkers
+      if (state.activeRoomJid === roomJid) {
+        const divider = notifState.onActivate(
+          {
+            unreadCount: 0,
+            mentionsCount: 0,
+            lastReadAt: meta.lastReadAt,
+            lastSeenMessageId: updated.lastSeenMessageId,
+            firstNewMessageId: undefined,
+          },
+          messages
+        ).firstNewMessageId
+        newMarkers = new Map(state.firstNewMessageMarkers)
+        if (divider) newMarkers.set(roomJid, divider)
+        else newMarkers.delete(roomJid)
+      }
+
       if (existing) {
         const newRooms = new Map(state.rooms)
         newRooms.set(roomJid, {
@@ -1700,9 +1725,9 @@ export const roomStore = createStore<RoomState>()(
           lastSeenMessageId: updated.lastSeenMessageId,
           pendingRemoteDisplayedStanzaId: undefined,
         })
-        return { roomMeta: newMeta, rooms: newRooms }
+        return { roomMeta: newMeta, rooms: newRooms, firstNewMessageMarkers: newMarkers }
       }
-      return { roomMeta: newMeta }
+      return { roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
     })
   },
 


### PR DESCRIPTION
## Problem

XEP-0490 (Message Displayed Synchronization) was not reliably skipping messages already read on another device. On the **first** open of a conversation the view landed at the last place read on *this* device, and only on a **re-open** did it jump to the synced read position.

## Root cause

The fresh-session read-sync seed (`mdsSideEffects` `online` handler → `client.mds.fetchAllDisplayed()`) is fire-and-forget and is **not awaited** by `activateConversation` / `activateRoom`. The entry fold only works if `pendingRemoteDisplayedStanzaId` is already stashed. If the user opens a conversation before that PEP fetch returns:

1. the new-message divider is derived from the **stale local** read position → the view opens at the last place read on this device;
2. the seed lands a moment later and advances `lastSeenMessageId` **live**, but the old `applyRemoteDisplayed` only updated the unread **badge**, never the divider — so the synced position only surfaced on the next open ("jumps to the end on re-open").

The 2026-06-29 design doc assumed the marker is present at activation; the race defeats that assumption.

## Fix

Provenance stays in the SDK (the design doc's chosen approach), extending the existing "applied live" path from the badge to the divider.

- **SDK** — `applyRemoteDisplayed` (chatStore + roomStore) recomputes `firstNewMessageMarkers` for the **active** conversation/room when a marker advances the read position, reusing `notifState.onActivate`. Inactive entities are untouched (recomputed on next activation). Deliberately **not** gated by `mdsConsumedThisSession`: that gate only governs re-*folding* a stale marker at entry, whereas a live forward read-sync should move the divider.
- **App** — `useMessageListScroll` gains a settle-window effect: on a live divider clear (defined → undefined) for the same conversation, while the user has not scrolled since entry, it `reassertBottom()`s (single-flight; supersedes the stale marker re-assert loop). Tightly gated so it never yanks a scrolling user or fights a genuine unread marker.