### PR TITLE
fix(app): stack clickable admin overview cards on Chromium

### DIFF
--- a/apps/fluux/src/components/ServerOverview.tsx
+++ b/apps/fluux/src/components/ServerOverview.tsx
@@ -93,7 +93,7 @@ export function ServerOverview() {
                   key={String(card.key)}
                   type="button"
                   onClick={() => adminStore.getState().setActiveCategory(target)}
-                  className="p-4 rounded-xl bg-fluux-surface border border-fluux-border text-start hover:bg-fluux-hover hover:border-fluux-brand/40 transition-colors tap-target"
+                  className="flex flex-col p-4 rounded-xl bg-fluux-surface border border-fluux-border text-start hover:bg-fluux-hover hover:border-fluux-brand/40 transition-colors tap-target"
                 >
                   {inner}
                 </button>


### PR DESCRIPTION
The **Utilisateurs** and **Salons actifs** cards on the server admin overview render as `<button>` (they navigate to their section on click), while the other overview cards are plain `<div>`. Chromium wraps a button's children in an anonymous centered flex box that can't be styled directly, so the block-level label / value / sub-line `<div>`s shrink-wrapped and centered instead of stacking left-aligned like the `<div>` cards. On mobile this produced a broken inline layout (e.g. "Utilisateurs › 14  3 en ligne" on one centered line).

Adding `flex flex-col` makes the button an explicit flex-column container, so its children stretch full-width and stack vertically, matching the non-clickable cards exactly. CSS-only, no behavior change.