### PR TITLE
fix(app): route PWA notification clicks to the conversation

### DIFF
--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -33,6 +33,7 @@ import { useChatStore, useRoomStore, useRosterStore, useConnectionStore, useCons
 import { useNotificationBadge } from '@/hooks/useNotificationBadge'
 import { useDesktopNotifications } from '@/hooks/useDesktopNotifications'
 import { useWebPush } from '@/hooks/useWebPush'
+import { useServiceWorkerNavigation } from '@/hooks/useServiceWorkerNavigation'
 import { useSoundNotification } from '@/hooks/useSoundNotification'
 import { useEventsSoundNotification } from '@/hooks/useEventsSoundNotification'
 import { useEventsDesktopNotifications } from '@/hooks/useEventsDesktopNotifications'
@@ -81,6 +82,10 @@ function GlobalEffects() {
 
   // Register for web push notifications (browser only, skipped in Tauri)
   useWebPush()
+
+  // Route to the conversation when a web-push notification is clicked while the
+  // app is already running (service worker posts a navigate message).
+  useServiceWorkerNavigation()
 
   // Track window visibility for new message markers
   useWindowVisibility()

--- a/apps/fluux/src/hooks/useServiceWorkerNavigation.test.tsx
+++ b/apps/fluux/src/hooks/useServiceWorkerNavigation.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { NOTIFICATION_NAVIGATE } from '@/utils/notificationNavigation'
+
+const navigateToConversation = vi.fn()
+const navigateToRoom = vi.fn()
+
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({
+    navigateToConversation,
+    navigateToRoom,
+    navigateToContact: vi.fn(),
+  }),
+}))
+
+import { useServiceWorkerNavigation } from './useServiceWorkerNavigation'
+
+// Minimal EventTarget stand-in for navigator.serviceWorker in jsdom.
+function installFakeServiceWorker(): EventTarget {
+  const target = new EventTarget()
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: target,
+    configurable: true,
+  })
+  return target
+}
+
+describe('useServiceWorkerNavigation', () => {
+  let sw: EventTarget
+
+  beforeEach(() => {
+    navigateToConversation.mockClear()
+    navigateToRoom.mockClear()
+    sw = installFakeServiceWorker()
+  })
+
+  afterEach(() => {
+    delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker
+  })
+
+  it('routes a conversation navigate message to navigateToConversation', () => {
+    renderHook(() => useServiceWorkerNavigation())
+
+    sw.dispatchEvent(
+      Object.assign(new MessageEvent('message'), {
+        data: { type: NOTIFICATION_NAVIGATE, navType: 'conversation', target: 'alice@example.com' },
+      }),
+    )
+
+    expect(navigateToConversation).toHaveBeenCalledWith('alice@example.com')
+    expect(navigateToRoom).not.toHaveBeenCalled()
+  })
+
+  it('routes a room navigate message to navigateToRoom', () => {
+    renderHook(() => useServiceWorkerNavigation())
+
+    sw.dispatchEvent(
+      Object.assign(new MessageEvent('message'), {
+        data: { type: NOTIFICATION_NAVIGATE, navType: 'room', target: 'lobby@conf.example.com' },
+      }),
+    )
+
+    expect(navigateToRoom).toHaveBeenCalledWith('lobby@conf.example.com')
+    expect(navigateToConversation).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated service-worker messages', () => {
+    renderHook(() => useServiceWorkerNavigation())
+
+    sw.dispatchEvent(
+      Object.assign(new MessageEvent('message'), { data: { type: 'SKIP_WAITING' } }),
+    )
+
+    expect(navigateToConversation).not.toHaveBeenCalled()
+    expect(navigateToRoom).not.toHaveBeenCalled()
+  })
+
+  it('removes its listener on unmount', () => {
+    const { unmount } = renderHook(() => useServiceWorkerNavigation())
+    unmount()
+
+    sw.dispatchEvent(
+      Object.assign(new MessageEvent('message'), {
+        data: { type: NOTIFICATION_NAVIGATE, navType: 'conversation', target: 'alice@example.com' },
+      }),
+    )
+
+    expect(navigateToConversation).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/hooks/useServiceWorkerNavigation.ts
+++ b/apps/fluux/src/hooks/useServiceWorkerNavigation.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+import { useNavigateToTarget } from './useNavigateToTarget'
+import { handleNotificationNavigateMessage } from '@/utils/notificationNavigation'
+
+/**
+ * Route the app when the user clicks a web-push notification while the app is
+ * already running (warm or backgrounded/frozen).
+ *
+ * The service worker (`sw.ts`) posts a `notification-navigate` message to the
+ * focused client; this hook forwards it to `useNavigateToTarget`, which routes
+ * via React Router AND hydrates the message cache so the target view never
+ * renders empty. Going through the app's own router is reliable on Android,
+ * where `WindowClient.navigate()` to a hash route is not.
+ *
+ * The cold-start case (app was killed, no live client) is handled separately by
+ * the URL the service worker opens via `clients.openWindow()`.
+ */
+export function useServiceWorkerNavigation(): void {
+  const nav = useNavigateToTarget()
+
+  // Keep the latest navigation functions in a ref so the message listener is
+  // attached once (they are new identities each render).
+  const navRef = useRef(nav)
+  useEffect(() => {
+    navRef.current = nav
+  })
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return
+    const container = navigator.serviceWorker
+    const onMessage = (event: MessageEvent) => {
+      handleNotificationNavigateMessage(event.data, {
+        navigateToConversation: (jid) => navRef.current.navigateToConversation(jid),
+        navigateToRoom: (jid) => navRef.current.navigateToRoom(jid),
+      })
+    }
+    container.addEventListener('message', onMessage)
+    return () => container.removeEventListener('message', onMessage)
+  }, [])
+}

--- a/apps/fluux/src/sw.ts
+++ b/apps/fluux/src/sw.ts
@@ -17,6 +17,10 @@
 /// <reference lib="webworker" />
 
 import { precacheAndRoute } from 'workbox-precaching'
+import {
+  resolveNotificationTarget,
+  notificationNavigateMessage,
+} from './utils/notificationNavigation'
 
 declare const self: ServiceWorkerGlobalScope
 
@@ -65,27 +69,37 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close()
 
-  // Build a hash-router deep link from notification data
-  const data = event.notification.data as { from?: string; type?: string } | undefined
-  let deepLink = './'
-  if (data?.from) {
-    const jid = encodeURIComponent(data.from)
-    const route = data.type === 'room' ? 'rooms' : 'messages'
-    deepLink = `./#/${route}/${jid}`
-  }
+  // Resolve the target conversation/room from the notification's routing data
+  // (attached by showWebNotification, or by the push handler above from the
+  // server payload). Null when the payload carried no `from` — then we just
+  // focus/open the app at its default view instead of deep-linking nowhere.
+  const target = resolveNotificationTarget(
+    event.notification.data as { from?: string; type?: string } | undefined,
+  )
+  const deepLink = target?.deepLink ?? './'
+
+  console.log('[SW Click] notification data:', event.notification.data, '-> deepLink:', deepLink)
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
-      // Focus existing window and navigate to the conversation
       for (const client of clients) {
-        if (client.url.includes(self.location.origin) && 'focus' in client) {
-          if (data?.from) {
-            void (client as WindowClient).navigate(deepLink)
+        if (client.url.startsWith(self.location.origin) && 'focus' in client) {
+          if (target) {
+            // Primary path for a live document: hand the route to the running
+            // SPA so it navigates through its OWN router (see
+            // useServiceWorkerNavigation). This is reliable on Android, where
+            // WindowClient.navigate() to a hash route is not.
+            client.postMessage(notificationNavigateMessage(target))
+            // Fallback for a discarded/frozen document that focus() reloads: set
+            // the URL so it boots straight at the deep link. Ignored (harmless
+            // fragment nav) when the document is alive.
+            void (client as WindowClient).navigate(deepLink).catch(() => {})
           }
-          return client.focus()
+          return (client as WindowClient).focus()
         }
       }
-      // Open new window at the deep link URL
+      // No live client (app was killed): open a fresh window at the deep link;
+      // HashRouter routes to the conversation on boot.
       return self.clients.openWindow(deepLink)
     })
   )

--- a/apps/fluux/src/utils/notificationNavigation.test.ts
+++ b/apps/fluux/src/utils/notificationNavigation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  NOTIFICATION_NAVIGATE,
+  resolveNotificationTarget,
+  notificationNavigateMessage,
+  handleNotificationNavigateMessage,
+} from './notificationNavigation'
+
+describe('resolveNotificationTarget', () => {
+  it('builds a 1:1 conversation target with an encoded hash route', () => {
+    const target = resolveNotificationTarget({ from: 'alice@example.com', type: 'conversation' })
+    expect(target).toEqual({
+      navType: 'conversation',
+      target: 'alice@example.com',
+      hashPath: '#/messages/alice%40example.com',
+      deepLink: './#/messages/alice%40example.com',
+    })
+  })
+
+  it('builds a room target on the /rooms route', () => {
+    const target = resolveNotificationTarget({ from: 'lobby@conference.example.com', type: 'room' })
+    expect(target).toMatchObject({
+      navType: 'room',
+      target: 'lobby@conference.example.com',
+      hashPath: '#/rooms/lobby%40conference.example.com',
+      deepLink: './#/rooms/lobby%40conference.example.com',
+    })
+  })
+
+  it('treats any non-"room" type (or missing type) as a conversation', () => {
+    expect(resolveNotificationTarget({ from: 'a@b.com' })?.navType).toBe('conversation')
+    expect(resolveNotificationTarget({ from: 'a@b.com', type: 'chat' })?.navType).toBe('conversation')
+  })
+
+  it('returns null when there is no target JID (e.g. push payload missing `from`)', () => {
+    expect(resolveNotificationTarget({ type: 'conversation' })).toBeNull()
+    expect(resolveNotificationTarget({})).toBeNull()
+    expect(resolveNotificationTarget(undefined)).toBeNull()
+    expect(resolveNotificationTarget(null)).toBeNull()
+  })
+})
+
+describe('notificationNavigateMessage', () => {
+  it('carries the type discriminator, navType and target', () => {
+    const target = resolveNotificationTarget({ from: 'a@b.com', type: 'room' })!
+    expect(notificationNavigateMessage(target)).toEqual({
+      type: NOTIFICATION_NAVIGATE,
+      navType: 'room',
+      target: 'a@b.com',
+    })
+  })
+})
+
+describe('handleNotificationNavigateMessage', () => {
+  it('dispatches a conversation message to navigateToConversation', () => {
+    const navigateToConversation = vi.fn()
+    const navigateToRoom = vi.fn()
+    const handled = handleNotificationNavigateMessage(
+      { type: NOTIFICATION_NAVIGATE, navType: 'conversation', target: 'alice@example.com' },
+      { navigateToConversation, navigateToRoom },
+    )
+    expect(handled).toBe(true)
+    expect(navigateToConversation).toHaveBeenCalledWith('alice@example.com')
+    expect(navigateToRoom).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a room message to navigateToRoom', () => {
+    const navigateToConversation = vi.fn()
+    const navigateToRoom = vi.fn()
+    handleNotificationNavigateMessage(
+      { type: NOTIFICATION_NAVIGATE, navType: 'room', target: 'lobby@conference.example.com' },
+      { navigateToConversation, navigateToRoom },
+    )
+    expect(navigateToRoom).toHaveBeenCalledWith('lobby@conference.example.com')
+    expect(navigateToConversation).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated or malformed messages', () => {
+    const navigateToConversation = vi.fn()
+    const navigateToRoom = vi.fn()
+    const handlers = { navigateToConversation, navigateToRoom }
+    expect(handleNotificationNavigateMessage({ type: 'SKIP_WAITING' }, handlers)).toBe(false)
+    expect(handleNotificationNavigateMessage({ type: NOTIFICATION_NAVIGATE }, handlers)).toBe(false)
+    expect(handleNotificationNavigateMessage('nope', handlers)).toBe(false)
+    expect(handleNotificationNavigateMessage(null, handlers)).toBe(false)
+    expect(navigateToConversation).not.toHaveBeenCalled()
+    expect(navigateToRoom).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/utils/notificationNavigation.ts
+++ b/apps/fluux/src/utils/notificationNavigation.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared, platform-agnostic helpers for turning a Web Push / Notification
+ * `data` payload into an in-app navigation target.
+ *
+ * Imported by BOTH the service worker (`sw.ts`, `notificationclick` handler) and
+ * the in-page listener (`useServiceWorkerNavigation`) so the two always agree on
+ * the exact route format and the SW->client message shape. Keeping the logic in
+ * one pure module lets us unit-test it without a service-worker runtime.
+ */
+
+/** Routing data attached to a notification (by `showWebNotification` or the push payload). */
+export interface NotificationNavData {
+  /** Bare JID (1:1 contact) or room JID (MUC). */
+  from?: string
+  /** 'room' for MUC; any other value (or absent) is treated as a 1:1 conversation. */
+  type?: string
+}
+
+/** Discriminator for the message the service worker posts to a live client. */
+export const NOTIFICATION_NAVIGATE = 'notification-navigate' as const
+
+/** Message posted from the service worker to a focused client to route it. */
+export interface NotificationNavigateMessage {
+  type: typeof NOTIFICATION_NAVIGATE
+  navType: 'room' | 'conversation'
+  target: string
+}
+
+export interface NotificationTarget {
+  navType: 'room' | 'conversation'
+  /** Bare JID (1:1) or room JID (MUC). */
+  target: string
+  /** Hash-router path, e.g. `#/messages/user%40example.com`. */
+  hashPath: string
+  /** Scope-relative deep link for `openWindow`/`navigate`, e.g. `./#/messages/...`. */
+  deepLink: string
+}
+
+/**
+ * Resolve a notification's routing data into a concrete navigation target.
+ *
+ * Returns `null` when there is no target JID (e.g. a push payload that omitted
+ * `from`), in which case callers should just focus/open the app at its default
+ * view rather than deep-linking nowhere.
+ */
+export function resolveNotificationTarget(
+  data: NotificationNavData | undefined | null,
+): NotificationTarget | null {
+  const from = data?.from
+  if (!from) return null
+  const navType = data?.type === 'room' ? 'room' : 'conversation'
+  const route = navType === 'room' ? 'rooms' : 'messages'
+  const hashPath = `#/${route}/${encodeURIComponent(from)}`
+  return {
+    navType,
+    target: from,
+    hashPath,
+    deepLink: `./${hashPath}`,
+  }
+}
+
+/** Build the SW->client message for a resolved target. */
+export function notificationNavigateMessage(
+  target: NotificationTarget,
+): NotificationNavigateMessage {
+  return { type: NOTIFICATION_NAVIGATE, navType: target.navType, target: target.target }
+}
+
+/**
+ * Apply a service-worker message to the app router. Returns `true` when the
+ * message was a recognised navigation request and was dispatched, `false`
+ * otherwise (unrelated messages such as SKIP_WAITING are ignored).
+ */
+export function handleNotificationNavigateMessage(
+  data: unknown,
+  handlers: {
+    navigateToConversation: (jid: string) => void
+    navigateToRoom: (jid: string) => void
+  },
+): boolean {
+  if (!data || typeof data !== 'object') return false
+  const msg = data as Partial<NotificationNavigateMessage>
+  if (msg.type !== NOTIFICATION_NAVIGATE || typeof msg.target !== 'string') return false
+  if (msg.navType === 'room') {
+    handlers.navigateToRoom(msg.target)
+  } else {
+    handlers.navigateToConversation(msg.target)
+  }
+  return true
+}


### PR DESCRIPTION
## Problem

Clicking a web-push notification on **Android PWA** opened a blank page instead of the relevant conversation.

## Root cause

The service worker's `notificationclick` handler built a hash deep link and relied on fire-and-forget `WindowClient.navigate('./#/messages/<jid>')` + `focus()`. On Android this is unreliable — backgrounded PWA documents get frozen/discarded, and there was no `postMessage` channel or app-side listener to route through the app's own React Router. The window focused/reloaded but never landed on the conversation.

## Fix

- **`utils/notificationNavigation.ts`** (new): shared pure helper (`resolveNotificationTarget`, `notificationNavigateMessage`, `handleNotificationNavigateMessage`) imported by *both* the service worker and the app so route format and message shape can never drift. Fully unit-tested.
- **`sw.ts`**: `notificationclick` now posts a `notification-navigate` message to a live client (primary), keeps `WindowClient.navigate()` as the reload path for a discarded document, and uses `clients.openWindow()` for the cold (app-killed) case. Adds a `[SW Click]` diagnostic log.
- **`useServiceWorkerNavigation.ts`** (new): listens for the SW message and forwards to `useNavigateToTarget`, which routes via React Router **and** hydrates the message cache (`activateConversation`/`activateRoom`) so the target view never renders empty. Mounted in `ChatLayout` alongside the other notification hooks.

## Follow-up (server-side, not in this PR)

For the app-killed case the notification is built by the SW `push` handler from the ejabberd / web-push gateway payload, which must include `from` (bare/room JID) and `type` (`"room"` else conversation). If the gateway omits them the deep link degrades to `./`. Verifying/aligning the gateway payload is tracked separately.