### PR TITLE
fix(app): mobile back button exits the admin dashboard

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -22,6 +22,9 @@ const {
     isArchivedResult: false,
     conversations: new Map<string, { id: string }>(),
     rooms: new Map<string, { jid: string; joined: boolean }>(),
+    adminCategory: null as string | null,
+    adminSession: null as unknown,
+    adminIsAdmin: false,
   }
 
   const mockContact: Contact = {
@@ -235,9 +238,9 @@ vi.mock('@fluux/sdk', () => ({
   },
   adminStore: {
     getState: () => ({
-      setCurrentSession: vi.fn(),
+      setCurrentSession: (v: unknown) => setMockState({ adminSession: v }),
       setTargetJid: vi.fn(),
-      setActiveCategory: vi.fn(),
+      setActiveCategory: (v: string | null) => setMockState({ adminCategory: v }),
       vhosts: [],
       setSelectedVhost: vi.fn(),
       setPendingSelectedUserJid: vi.fn(),
@@ -328,8 +331,12 @@ vi.mock('@fluux/sdk/react', () => ({
     }
   ),
   useAdminStore: Object.assign(
-    (selector: (state: { currentSession: null; activeCategory: null }) => unknown) => {
-      return selector({ currentSession: null, activeCategory: null })
+    (selector: (state: { currentSession: unknown; activeCategory: string | null; isAdmin: boolean }) => unknown) => {
+      return selector({
+        currentSession: getMockState().adminSession ?? null,
+        activeCategory: getMockState().adminCategory ?? null,
+        isAdmin: getMockState().adminIsAdmin ?? false,
+      })
     },
     {
       getState: () => ({
@@ -492,7 +499,12 @@ vi.mock('./SettingsView', () => ({
 }))
 
 vi.mock('./AdminView', () => ({
-  AdminView: () => <div data-testid="admin-view">Admin</div>,
+  AdminView: ({ onBack }: { onBack?: () => void }) => (
+    <div data-testid="admin-view">
+      Admin
+      <button data-testid="admin-back" onClick={() => onBack?.()}>back</button>
+    </div>
+  ),
 }))
 
 vi.mock('./MemberList', () => ({
@@ -1264,5 +1276,54 @@ describe('ChatLayout - activation gap (no empty-state flash)', () => {
     render(<ChatLayoutWithRouter initialRoute="/messages" />)
 
     expect(screen.getByText('Start a conversation')).toBeInTheDocument()
+  })
+})
+
+describe('ChatLayout - admin back navigation (mobile)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setMockState({
+      activeConversationId: null,
+      activeRoomJid: null,
+      activationPending: false,
+      isArchivedResult: false,
+      conversations: new Map(),
+      rooms: new Map(),
+      adminIsAdmin: true,
+      adminCategory: 'stats',
+      adminSession: null,
+    })
+  })
+
+  afterEach(() => {
+    setMockState({ adminIsAdmin: false, adminCategory: null, adminSession: null })
+  })
+
+  it('renders the admin view when the URL is /admin', async () => {
+    render(<ChatLayoutWithRouter initialRoute="/admin" />)
+    // AdminView is lazy-loaded behind Suspense.
+    expect(await screen.findByTestId('admin-view')).toBeInTheDocument()
+  })
+
+  // System/browser back pops the URL off /admin, but the admin store state can
+  // still hold a category (nothing clears it on popstate). The admin panel must
+  // NOT render over the route we backed into — it is gated on the admin route.
+  it('does not render the admin view when the URL left /admin, even with a stale category', async () => {
+    render(<ChatLayoutWithRouter initialRoute="/messages" />)
+    // The page underneath (messages home) is visible instead. With the bug the
+    // stale category renders AdminView's Suspense fallback and this never shows.
+    expect(await screen.findByText('Start a conversation')).toBeInTheDocument()
+    expect(screen.queryByTestId('admin-view')).not.toBeInTheDocument()
+  })
+
+  // In-app header back arrow from the admin overview must leave admin entirely
+  // and return to the home screen, not bounce back to the overview.
+  it('mobile back from the admin overview navigates home (messages)', async () => {
+    render(<ChatLayoutWithProbe initialRoute="/admin" />)
+    fireEvent.click(await screen.findByTestId('admin-back'))
+
+    expect(await screen.findByText('Start a conversation')).toBeInTheDocument()
+    expect(screen.getByTestId('probe-path').textContent).toBe('/messages')
+    expect(screen.queryByTestId('admin-view')).not.toBeInTheDocument()
   })
 })

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -581,7 +581,11 @@ function ChatLayoutContent() {
   // For admin: 'users', 'rooms', and 'stats' categories have main view content
   // ('stats' renders the ServerOverview dashboard); 'announcements' just expands
   // to show commands in the sidebar
-  const adminHasMainContent = adminSession || adminCategory === 'users' || adminCategory === 'rooms' || adminCategory === 'stats'
+  // Gate on the admin route: after backing out of admin (popstate), the admin
+  // store may still hold a stale category. Without this guard that stale value
+  // would keep the mobile layout in "content" mode and hide the sidebar on the
+  // page we backed into.
+  const adminHasMainContent = sidebarView === 'admin' && (adminSession || adminCategory === 'users' || adminCategory === 'rooms' || adminCategory === 'stats')
   // Settings: only show content when a category is explicitly selected (on mobile, let user choose from sidebar first)
   const settingsHasContent = sidebarView === 'settings' && !!settingsCategory
   const hasActiveContent = !!(activeConversationId || activeRoomJid || selectedContact || adminHasMainContent || settingsHasContent || searchPreviewResult || previewJid)
@@ -654,11 +658,15 @@ function ChatLayoutContent() {
     navigateToContacts(undefined, { replace: true })
   }
 
-  // Handle mobile back from admin view - clear category to show sidebar
+  // Handle mobile back from the admin overview (the top of the admin stack).
+  // Leave admin entirely and return to the home screen. Navigating back to
+  // /admin here would be re-trapped by the "admin home" layout effect below,
+  // which re-selects the stats overview whenever we sit on /admin with no
+  // category — so the user could never step out of the dashboard.
   const handleAdminBack = () => {
     clearAdminSession()
     setAdminCategory(null)
-    navigateToAdmin(undefined, { replace: true })
+    navigateToMessages(undefined, { replace: true })
   }
 
   // Handle mobile back from settings view - go back to settings sidebar (no category selected)
@@ -947,7 +955,7 @@ function ChatLayoutContent() {
                 onBack={handleContactBack}
               />
             </Suspense>
-          ) : (adminSession || adminCategory) ? (
+          ) : (sidebarView === 'admin' && (adminSession || adminCategory)) ? (
             <Suspense fallback={<ViewLoadingFallback />}>
               <AdminView activeCategory={adminCategory} onBack={handleAdminBack} />
             </Suspense>


### PR DESCRIPTION
## Summary

On mobile, pressing back in the admin dashboard did not return to the previous page or home screen — the user was stuck in the admin panel.

Root cause: the admin dashboard keeps all of its navigation state (which category, selected user/room, open command session) in the admin store, never reflected in the URL. So browser history and the on-screen view drift apart. Two failures fell out of this:

- **System / browser back** popped the URL off `/admin`, but nothing cleared the admin store and the render gate checked only `(adminSession || adminCategory)` — not the current route. A stale category kept `AdminView` rendering *over* the page you backed into, and on mobile kept the sidebar hidden. Fixed by gating both the `AdminView` render and `adminHasMainContent` on `sidebarView === 'admin'`, so a stale category becomes inert the moment the URL leaves admin.

- **In-app header back arrow from the overview** navigated back to `/admin`, where the "admin home" layout effect immediately re-selected the `stats` overview — re-trapping the user. `handleAdminBack` now returns to the home screen (`/messages`) instead.