### PR TITLE
fix(ci): never cancel in-flight GitHub Pages deploys

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
 
-#  cancels previous builds if another commit arrives
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pages: write
@@ -18,6 +13,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # Redundant builds from rapid pushes are safe to cancel.
+    concurrency:
+      group: pages-build
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -46,6 +46,14 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+
+    # Never interrupt an in-flight deployment: cancelling mid-deploy leaves
+    # GitHub Pages in a bad state and the next run fails with
+    # "Deployment failed, try again later." Queue deploys instead.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

The "Publish Live Demo to Github Pages" workflow was intermittently failing on the deploy step with:

```
Getting Pages deployment status...
##[error]Deployment failed, try again later.
```

The build and artifact upload always succeeded — the error came from GitHub's Pages backend a few seconds after the deployment was created, and only during bursts of rapid pushes to `main` (every failure sat next to `cancelled` runs).

## Cause

The workflow used a single workflow-level concurrency group:

```yaml
concurrency:
  group: pages
  cancel-in-progress: true
```

Because it applied to the whole run, a rapid follow-up push cancelled the `deploy` job mid-flight — after it had already told the Pages API to start deploying. That left the deployment half-committed, and the next run raced against the orphaned state and failed with `Deployment failed, try again later.` This is exactly why GitHub's own starter workflow and the `actions/deploy-pages` README warn to set `cancel-in-progress: false`: a deployment must never be interrupted.

## Fix

Split concurrency per job:

- `build` → group `pages-build`, `cancel-in-progress: true` — redundant builds from rapid pushes are still cancelled, saving CI minutes.
- `deploy` → group `pages-deploy`, `cancel-in-progress: false` — deployments queue and always run to completion, eliminating the corrupted-state failures.