### PR TITLE
fix(app): unify rail and room-list unread badges to a two-tier red/grey model

### DIFF
--- a/apps/fluux/src/components/Sidebar.tsx
+++ b/apps/fluux/src/components/Sidebar.tsx
@@ -245,7 +245,9 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
           pathPrefix="/rooms"
           onNavigate={onViewChange}
           showBadge={roomTabTone !== 'none'}
-          tone={roomTabTone === 'accent' ? 'accent' : 'neutral'}
+          // A room mention/highlight ('accent' from the SDK) is the loud tier, so
+          // it shows red — same as DMs and contact requests. Plain unread stays grey.
+          tone={roomTabTone === 'accent' ? 'strong' : 'neutral'}
         />
         {/* Search */}
         <IconRailNavLink
@@ -273,7 +275,8 @@ export function Sidebar({ onSelectContact, onStartChat, onStartChatWithJid, onMa
           view="contacts"
           pathPrefix="/contacts"
           onNavigate={onViewChange}
-          badgeCount={pendingRequestCount}
+          showBadge={pendingRequestCount > 0}
+          tone="strong"
           badgeLabel={pendingRequestCount > 0 ? `${t('sidebar.contacts')} (${pendingRequestCount})` : undefined}
         />
         {/* Admin - only visible for server administrators */}

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
@@ -166,24 +166,6 @@ describe('IconRailNavLink', () => {
       expect(container.querySelector('.bg-fluux-gray')).toBeInTheDocument()
       expect(container.querySelector('.bg-fluux-badge-strong')).toBeNull()
     })
-
-    it('renders an accent (blue) dot when tone="accent"', () => {
-      const Wrapper = createWrapper('/')
-      const { container } = render(
-        <IconRailNavLink
-          icon={Hash}
-          label="Rooms"
-          view="rooms"
-          pathPrefix="/rooms"
-          onNavigate={vi.fn()}
-          showBadge={true}
-          tone="accent"
-        />,
-        { wrapper: Wrapper }
-      )
-      const dot = container.querySelector('span.bg-fluux-brand')
-      expect(dot).toBeInTheDocument()
-    })
   })
 
   describe('active state from URL', () => {
@@ -344,45 +326,12 @@ describe('IconRailNavLink', () => {
     })
   })
 
-  describe('numeric count badge', () => {
-    it('renders a numeric badge with the count when badgeCount > 0', () => {
-      const Wrapper = createWrapper('/messages')
-      render(
-        <IconRailNavLink
-          icon={Hash}
-          label="Contacts"
-          view="contacts"
-          pathPrefix="/contacts"
-          onNavigate={vi.fn()}
-          badgeCount={2}
-          badgeLabel="Contacts (2)"
-        />,
-        { wrapper: Wrapper }
-      )
-      expect(screen.getByText('2')).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Contacts (2)' })).toBeInTheDocument()
-    })
-
-    it('clamps a large badge count to 99+', () => {
-      const Wrapper = createWrapper('/messages')
-      render(
-        <IconRailNavLink
-          icon={Hash}
-          label="Contacts"
-          view="contacts"
-          pathPrefix="/contacts"
-          onNavigate={vi.fn()}
-          badgeCount={150}
-        />,
-        { wrapper: Wrapper }
-      )
-      expect(screen.getByText('99+')).toBeInTheDocument()
-      // No badgeLabel passed → aria-label falls back to label.
-      expect(screen.getByRole('button', { name: 'Contacts' })).toBeInTheDocument()
-    })
-
-    it('renders no badge when badgeCount is 0 and showBadge is false', () => {
-      const Wrapper = createWrapper('/messages')
+  describe('dot colour on the selected tab', () => {
+    // On the selected tab the surface is the accent colour. Both tones read fine
+    // on it, so the dot keeps its colour — a red badge that stays red when
+    // selected is more consistent than flipping it to white.
+    it('keeps the red (strong) dot red when the tab is selected', () => {
+      const Wrapper = createWrapper('/contacts')
       const { container } = render(
         <IconRailNavLink
           icon={Hash}
@@ -390,11 +339,30 @@ describe('IconRailNavLink', () => {
           view="contacts"
           pathPrefix="/contacts"
           onNavigate={vi.fn()}
-          badgeCount={0}
+          showBadge={true}
+          tone="strong"
         />,
         { wrapper: Wrapper }
       )
-      expect(container.querySelector('span.bg-fluux-red')).toBeNull()
+      expect(container.querySelector('span.bg-fluux-badge-strong')).toBeInTheDocument()
+      expect(container.querySelector('span.bg-fluux-text-on-accent')).toBeNull()
+    })
+
+    it('keeps the neutral (grey) dot grey when the tab is selected', () => {
+      const Wrapper = createWrapper('/rooms')
+      const { container } = render(
+        <IconRailNavLink
+          icon={Hash}
+          label="Rooms"
+          view="rooms"
+          pathPrefix="/rooms"
+          onNavigate={vi.fn()}
+          showBadge={true}
+          tone="neutral"
+        />,
+        { wrapper: Wrapper }
+      )
+      expect(container.querySelector('span.bg-fluux-gray')).toBeInTheDocument()
     })
   })
 })

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -11,10 +11,9 @@ interface IconRailNavLinkProps {
   /** Path prefix to match for active state (e.g., '/messages', '/rooms') */
   pathPrefix: string
   showBadge?: boolean
-  /** Dot colour when showBadge is true. Defaults to 'strong' (red) to preserve prior behaviour. */
-  tone?: 'neutral' | 'accent' | 'strong'
-  /** When > 0, renders a red numeric badge (clamped to 99+). Takes precedence over showBadge. */
-  badgeCount?: number
+  /** Dot colour when showBadge is true. 'strong' (red) is the attention tier (DMs,
+   *  mentions, contact requests); 'neutral' (grey) is ambient unread. Defaults to 'strong'. */
+  tone?: 'neutral' | 'strong'
   /** Overrides the button aria-label (the tooltip still shows `label`). */
   badgeLabel?: string
   /** Handler called when clicked - should handle navigation */
@@ -33,31 +32,18 @@ export function IconRailNavLink({
   pathPrefix,
   showBadge,
   tone = 'strong',
-  badgeCount,
   badgeLabel,
   onNavigate,
 }: IconRailNavLinkProps) {
   const location = useLocation()
   const isActive = location.pathname === pathPrefix || location.pathname.startsWith(pathPrefix + '/')
-  const hasCount = typeof badgeCount === 'number' && badgeCount > 0
   // The badge is "cut out" from the button surface with a ring the same colour
   // as that surface — accent when the tab is selected, the rail otherwise.
   const ringClass = isActive ? 'ring-fluux-brand' : 'ring-fluux-sidebar'
-  // On a selected tab the surface is the accent colour. Tone colours are only
-  // guaranteed to contrast against the rail, not the accent surface (an accent
-  // dot would even be invisible). The only token guaranteed readable on accent
-  // in every theme is on-accent, so use it — and its inverse (accent-on-on-accent)
-  // for the numeric badge — while the tab is selected.
-  const dotFillClass = isActive
-    ? 'bg-fluux-text-on-accent'
-    : tone === 'neutral'
-      ? 'bg-fluux-gray'
-      : tone === 'accent'
-        ? 'bg-fluux-brand'
-        : 'bg-fluux-badge-strong'
-  const countBadgeClass = isActive
-    ? 'bg-fluux-text-on-accent text-fluux-brand'
-    : 'bg-fluux-red text-white'
+  // Both tones read fine on the accent surface of a selected tab, so the dot
+  // keeps its colour regardless of selection — a red badge that stays red when
+  // selected is more consistent than flipping it to white.
+  const dotFillClass = tone === 'neutral' ? 'bg-fluux-gray' : 'bg-fluux-badge-strong'
 
   return (
     <Tooltip content={label} position="right" delay={500}>
@@ -75,11 +61,7 @@ export function IconRailNavLink({
         `}
       >
         <Icon className="size-5" />
-        {hasCount ? (
-          <span className={`absolute -top-0.5 -end-0.5 min-w-4 h-4 px-1 flex items-center justify-center ${countBadgeClass} text-[10px] leading-none font-semibold rounded-full ring-2 ${ringClass}`}>
-            {badgeCount > 99 ? '99+' : badgeCount}
-          </span>
-        ) : showBadge ? (
+        {showBadge ? (
           <span className={`absolute top-0.5 end-0.5 size-2.5 ${dotFillClass} rounded-full ring-2 ${ringClass}`} />
         ) : null}
       </button>

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -429,20 +429,21 @@ const RoomItem = memo(function RoomItem({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <p dir="auto" className={`truncate ${room.unreadCount > 0 ? 'font-semibold text-fluux-text' : 'font-medium'}`}>{room.name}</p>
-            {/* Activity dot for unread (non-mention) activity. Blue for a
-                notify-all room (matches the icon-rail indicator), grey otherwise. */}
+            {/* Activity dot for unread (non-mention) activity. Red for a
+                notify-all room — the attention tier, matching the icon-rail
+                indicator and mention badge — grey for plain unread. */}
             {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
               <Tooltip content={`${room.unreadCount} unread`} position="top">
                 <div
                   className={`size-2.5 rounded-full flex-shrink-0 ${
-                    roomActivityTone(room) === 'accent' ? 'bg-fluux-brand' : 'bg-fluux-gray'
+                    roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
                   }`}
                 />
               </Tooltip>
             )}
-            {/* Mentions count badge */}
+            {/* Mentions count badge — red, the loud "wants your attention" tier. */}
             {room.mentionsCount > 0 && (
-              <span className="min-w-5 h-5 px-1.5 bg-fluux-badge text-fluux-badge-text text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
+              <span className="min-w-5 h-5 px-1.5 bg-fluux-badge-strong text-white text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
                 @{room.mentionsCount}
               </span>
             )}


### PR DESCRIPTION
Unifies the rail and room-list unread indicators around a two-tier urgency model:

- **Red** = attention tier — DMs, room mentions, and contact requests.
- **Grey** = ambient room unread (no mention).

Changes:
- Room mentions render red instead of blue, both on the rooms rail dot and the room-list `@N` pill / notify-all dot.
- Retire the blue `accent` badge tone and the selected-tab white-swap. That swap existed only because an accent dot on a selected (accent) tab was invisible; with red it's unnecessary, and a badge that keeps its colour when the tab is selected is more consistent.
- The contacts rail icon shows a red dot instead of a numeric count, making the whole rail dot-based. The aria-label still announces the pending-request count.

SDK semantics are untouched — `roomActivityTone` still returns `accent | neutral | none`; the mapping to red happens at the app boundary.