### PR TITLE
fix(app): move advanced-mode disable button to top of Advanced settings

### DIFF
--- a/apps/fluux/src/components/settings-components/AdvancedSettings.tsx
+++ b/apps/fluux/src/components/settings-components/AdvancedSettings.tsx
@@ -34,19 +34,9 @@ export function AdvancedSettings() {
           </button>
         </div>
       ) : (
-        /* ON: warning + options placeholder + turn back off. */
+        /* ON: turn back off (kept at top for visibility) + warning + options placeholder. */
         <>
-          <div className="flex items-start gap-3 rounded-lg border border-fluux-border bg-fluux-bg p-4 mb-6">
-            <AlertTriangle className="size-5 text-fluux-yellow shrink-0 mt-0.5" />
-            <p className="text-sm text-fluux-text">{t('settings.advanced.warning')}</p>
-          </div>
-
-          <div className="flex flex-col items-center text-center gap-2 rounded-lg border border-dashed border-fluux-border p-6 mb-6">
-            <Wrench className="size-6 text-fluux-muted" />
-            <p className="text-sm text-fluux-muted">{t('settings.advanced.empty')}</p>
-          </div>
-
-          <div className="space-y-3">
+          <div className="space-y-3 mb-6">
             <p className="text-sm text-fluux-text">{t('settings.advanced.disableDescription')}</p>
             <button
               type="button"
@@ -56,6 +46,16 @@ export function AdvancedSettings() {
             >
               {t('settings.advanced.disable')}
             </button>
+          </div>
+
+          <div className="flex items-start gap-3 rounded-lg border border-fluux-border bg-fluux-bg p-4 mb-6">
+            <AlertTriangle className="size-5 text-fluux-yellow shrink-0 mt-0.5" />
+            <p className="text-sm text-fluux-text">{t('settings.advanced.warning')}</p>
+          </div>
+
+          <div className="flex flex-col items-center text-center gap-2 rounded-lg border border-dashed border-fluux-border p-6">
+            <Wrench className="size-6 text-fluux-muted" />
+            <p className="text-sm text-fluux-muted">{t('settings.advanced.empty')}</p>
           </div>
         </>
       )}


### PR DESCRIPTION
The "Disable advanced mode" control sat at the bottom of the Advanced settings section — below the warning callout and the options placeholder — making it hard to spot. This reorders the section so the disable description and button lead, with the warning and placeholder following.