### PR TITLE
fix(sidebar): order rooms by cached last-message at launch

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -2433,6 +2433,12 @@ export class XMPPClient {
     const { roomsToAutojoin } = await this.muc.fetchBookmarks(iqTimeout)
     if (this.isSessionSuperseded(gen, 'Fresh session aborted after fetchBookmarks')) return
 
+    // Order the sidebar from the durable cache immediately (network-free, single
+    // batched write). Without this, freshly-added bookmarked rooms all sort at
+    // epoch-0 until each room's preview lands on join / the delayed catch-up, so
+    // the active room visibly "jumps" to the top once opened.
+    this.stores?.room.hydratePreviewsFromCache().catch(() => {})
+
     // Fetch and merge server-side conversation list (XEP-0223)
     try {
       const serverConversations = await this.conversationSync.fetchConversations(iqTimeout)

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -224,6 +224,7 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       updateLastMessagePreview: roomStore.getState().updateLastMessagePreview,
       loadMessagesFromCache: roomStore.getState().loadMessagesFromCache,
       loadPreviewFromCache: roomStore.getState().loadPreviewFromCache,
+      hydratePreviewsFromCache: roomStore.getState().hydratePreviewsFromCache,
       mergeRoomMembers: roomStore.getState().mergeRoomMembers,
       updateMemberAffiliation: roomStore.getState().updateMemberAffiliation,
     },

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -734,6 +734,7 @@ export const createMockStores = (): MockStoreBindings => ({
     updateLastMessagePreview: vi.fn(),
     loadMessagesFromCache: vi.fn().mockResolvedValue([]),
     loadPreviewFromCache: vi.fn().mockResolvedValue(null),
+    hydratePreviewsFromCache: vi.fn().mockResolvedValue(undefined),
     mergeRoomMembers: vi.fn(),
     updateMemberAffiliation: vi.fn(),
   },

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -208,6 +208,10 @@ export interface StoreBindings {
     loadMessagesFromCache: (roomJid: string, options?: { limit?: number; before?: Date; after?: Date; peek?: boolean }) => Promise<RoomMessage[]>
     // Load preview from cache for non-MAM rooms (only updates lastMessage, not messages array)
     loadPreviewFromCache: (roomJid: string) => Promise<RoomMessage | null>
+    // Batched launch-time preview hydration: populate lastMessage for all bookmarked/joined
+    // rooms from the durable cache in a single store write so the sidebar orders correctly
+    // immediately, instead of each room sitting at epoch-0 order until its preview lands.
+    hydratePreviewsFromCache: () => Promise<void>
     // XEP-0045: Merge affiliated members (for offline member display, avatar resolution, mentions)
     mergeRoomMembers: (roomJid: string, members: RoomMember[], contactAvatarLookup?: (jid: string) => string | null) => void
     // XEP-0045: Apply a single affiliation change to the cached member list (none/outcast remove, owner/admin/member upsert)

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3491,6 +3491,113 @@ describe('roomStore', () => {
     })
   })
 
+  describe('hydratePreviewsFromCache', () => {
+    const roomA = 'a@conference.example.com'
+    const roomB = 'b@conference.example.com'
+
+    function makeMsg(roomJid: string, iso: string, body: string): RoomMessage {
+      return {
+        type: 'groupchat',
+        id: `${roomJid}-${iso}`,
+        roomJid,
+        from: `${roomJid}/alice`,
+        nick: 'alice',
+        body,
+        timestamp: new Date(iso),
+        isOutgoing: false,
+      }
+    }
+
+    function addBookmarkedRoom(jid: string): void {
+      roomStore.getState().addRoom({
+        jid,
+        name: jid,
+        nickname: 'me',
+        joined: false,
+        isJoining: false,
+        isBookmarked: true,
+        supportsMAM: true,
+        occupants: new Map(),
+        messages: [],
+        unreadCount: 0,
+        mentionsCount: 0,
+        typingUsers: new Set(),
+      })
+    }
+
+    beforeEach(() => {
+      roomStore.getState().reset()
+      vi.mocked(messageCache.getRoomMessages).mockReset()
+      vi.mocked(messageCache.isMessageCacheAvailable).mockReturnValue(true)
+    })
+
+    // Restore the shared cache mocks so overrides here don't leak into later blocks.
+    afterEach(() => {
+      vi.mocked(messageCache.getRoomMessages).mockReset()
+      vi.mocked(messageCache.getRoomMessages).mockResolvedValue([])
+      vi.mocked(messageCache.isMessageCacheAvailable).mockReturnValue(true)
+    })
+
+    it('orders the sidebar from cache at launch and only writes the store ONCE', async () => {
+      // Added in A-then-B order with no lastMessage -> both would sort at epoch 0.
+      addBookmarkedRoom(roomA)
+      addBookmarkedRoom(roomB)
+      expect(roomStore.getState().rooms.get(roomA)?.lastMessage).toBeUndefined()
+      expect(roomStore.getState().rooms.get(roomB)?.lastMessage).toBeUndefined()
+
+      // B's newest cached message is more recent than A's.
+      vi.mocked(messageCache.getRoomMessages).mockImplementation((jid) =>
+        Promise.resolve(
+          jid === roomB
+            ? [makeMsg(roomB, '2024-01-15T12:00:00Z', 'newer')]
+            : [makeMsg(roomA, '2024-01-15T09:00:00Z', 'older')],
+        ),
+      )
+
+      let writes = 0
+      const unsub = roomStore.subscribe(() => { writes++ })
+      await roomStore.getState().hydratePreviewsFromCache()
+      unsub()
+
+      // Both previews populated from cache...
+      expect(roomStore.getState().rooms.get(roomA)?.lastMessage?.body).toBe('older')
+      expect(roomStore.getState().rooms.get(roomB)?.lastMessage?.body).toBe('newer')
+      // ...and B (most recent) now sorts above A, without ever opening a room.
+      expect(roomStore.getState().allRooms().map((r) => r.jid)).toEqual([roomB, roomA])
+      // Batched: a single store write regardless of room count (one sidebar re-sort).
+      expect(writes).toBe(1)
+    })
+
+    it('never downgrades a fresher preview already set by join/catch-up', async () => {
+      addBookmarkedRoom(roomA)
+      const fresh = makeMsg(roomA, '2024-01-15T15:00:00Z', 'fresh from join')
+      roomStore.getState().updateLastMessagePreview(roomA, fresh)
+
+      // Cache only has an older message.
+      vi.mocked(messageCache.getRoomMessages).mockResolvedValue([
+        makeMsg(roomA, '2024-01-15T08:00:00Z', 'stale cache'),
+      ])
+
+      let writes = 0
+      const unsub = roomStore.subscribe(() => { writes++ })
+      await roomStore.getState().hydratePreviewsFromCache()
+      unsub()
+
+      expect(roomStore.getState().rooms.get(roomA)?.lastMessage?.body).toBe('fresh from join')
+      // Nothing to update -> no store write at all.
+      expect(writes).toBe(0)
+    })
+
+    it('is a no-op when the message cache is unavailable', async () => {
+      addBookmarkedRoom(roomA)
+      vi.mocked(messageCache.isMessageCacheAvailable).mockReturnValue(false)
+
+      await roomStore.getState().hydratePreviewsFromCache()
+
+      expect(messageCache.getRoomMessages).not.toHaveBeenCalled()
+    })
+  })
+
   describe('loadMessagesAroundFromCache', () => {
     const roomJid = 'room@conference.example.com'
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -506,6 +506,19 @@ export interface RoomState {
   loadOlderMessagesFromCache: (roomJid: string, limit?: number) => Promise<RoomMessage[]>
   /** Load only the latest message from cache for sidebar preview (doesn't modify messages array) */
   loadPreviewFromCache: (roomJid: string) => Promise<RoomMessage | null>
+  /**
+   * Populate sidebar-ordering previews for all bookmarked/joined rooms from the
+   * durable IndexedDB cache in a SINGLE batched store write.
+   *
+   * At launch the room list is rebuilt from bookmarks with no `lastMessage`, so
+   * every room sorts at epoch 0 until its per-room preview lands (on join, or the
+   * delayed catch-up) - leaving the sidebar mis-ordered and making the active room
+   * "jump" to the top once opened. This reads each room's newest cached message in
+   * parallel (network-free) and applies all previews at once, so the sidebar
+   * re-sorts a single time instead of once per room. Never downgrades a fresher
+   * preview, so it is safe alongside the join / catch-up preview paths.
+   */
+  hydratePreviewsFromCache: () => Promise<void>
 
   // MAM state management (XEP-0313 for MUC rooms)
   setRoomMAMLoading: (roomJid: string, isLoading: boolean) => void
@@ -2184,6 +2197,54 @@ export const roomStore = createStore<RoomState>()(
       console.error('Failed to load room preview from IndexedDB:', error)
       return null
     }
+  },
+
+  // Batched sidebar-preview hydration from the durable cache (see interface doc).
+  // Reads every bookmarked/joined room's newest cached message in parallel, then
+  // applies all previews in ONE set() so the sidebar re-sorts exactly once.
+  hydratePreviewsFromCache: async () => {
+    if (!messageCache.isMessageCacheAvailable()) return
+
+    // Snapshot the rooms the sidebar actually orders (bookmarked or joined).
+    const rooms = Array.from(get().rooms.values()).filter((r) => r.isBookmarked || r.joined)
+    if (rooms.length === 0) return
+
+    // Read caches in parallel (IndexedDB reads are cheap and non-blocking).
+    const previews = await Promise.all(
+      rooms.map(async (room) => {
+        try {
+          const cachedMessages = await messageCache.getRoomMessages(room.jid, { limit: 10, latest: true })
+          if (cachedMessages.length === 0) return null
+          const latest = findLastNonIgnoredMessage(cachedMessages, room.jid, room.nickToJidCache)
+          return latest ? { roomJid: room.jid, latest } : null
+        } catch {
+          // Best-effort per room - one room's cache failure shouldn't block others.
+          return null
+        }
+      })
+    )
+
+    const updates = previews.filter((p): p is { roomJid: string; latest: RoomMessage } => p !== null)
+    if (updates.length === 0) return
+
+    // Apply every preview in a single write. shouldUpdateLastMessage guards against
+    // clobbering a fresher preview that a join/catch-up may have set in the meantime.
+    set((state) => {
+      const newMeta = new Map(state.roomMeta)
+      const newRooms = new Map(state.rooms)
+      let changed = false
+      for (const { roomJid, latest } of updates) {
+        const room = state.rooms.get(roomJid)
+        const meta = state.roomMeta.get(roomJid)
+        if (!room || !meta) continue
+        if (!shouldUpdateLastMessage(meta.lastMessage, latest)) continue
+        newMeta.set(roomJid, { ...meta, lastMessage: latest })
+        newRooms.set(roomJid, { ...room, lastMessage: latest })
+        changed = true
+      }
+      if (!changed) return state
+      return { roomMeta: newMeta, rooms: newRooms }
+    })
   },
 
   // MAM state management (XEP-0313 for MUC rooms)


### PR DESCRIPTION
## Summary

MUC rooms were mis-ordered in the sidebar on launch: the room with the most recent message only jumped to its correct position once the user opened it.

**Root cause:** room data is ephemeral (rebuilt from bookmarks + MAM each launch), so freshly-added rooms have no `lastMessage`/`lastInteractedAt` and all tie at epoch `0` in the sort — holding bookmark/join order. The sort key was only populated lazily: per-room `fetchPreviewForRoom` on `mucJoined` (async, skipped on SM resume) or the 10s-delayed `catchUpAllRooms`. Opening a room forced its timestamp via `setActiveRoom`, so it visibly jumped to the top.

**Fix:** add a batched `roomStore.hydratePreviewsFromCache()` that reads every bookmarked/joined room's newest cached message from IndexedDB in parallel (network-free) and applies all previews in a **single** store write — the sidebar re-sorts exactly once instead of once per room. It never downgrades a fresher preview, so it is safe alongside the join/catch-up paths. Wired once after `fetchBookmarks` in the fresh-session sequence.

1:1 conversations need no equivalent: `chatStore` persists `conversationMeta` (incl. `lastMessage`) to localStorage and restores it on launch, so DM ordering is already correct at cold start.