### PR TITLE
fix(chat): persist reactions to durable cache when conversation is inactive

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -27,6 +27,7 @@ vi.mock('../utils/messageCache', () => ({
   getMessage: vi.fn().mockResolvedValue(null),
   getMessageByStanzaId: vi.fn().mockResolvedValue(null),
   updateMessage: vi.fn().mockResolvedValue(undefined),
+  updateMessageReactions: vi.fn().mockResolvedValue(false),
   deleteMessage: vi.fn().mockResolvedValue(undefined),
   deleteConversationMessages: vi.fn().mockResolvedValue(undefined),
   clearAllMessages: vi.fn().mockResolvedValue(undefined),

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -40,6 +40,7 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     getMessages: vi.fn().mockResolvedValue([]),
     getMessagesAround: vi.fn().mockResolvedValue([]),
     updateMessage: vi.fn().mockResolvedValue(undefined),
+    updateMessageReactions: vi.fn().mockResolvedValue(true),
   }
 })
 
@@ -1515,6 +1516,28 @@ describe('chatStore', () => {
 
       const messages = chatStore.getState().messages.get('nonexistent@example.com')
       expect(messages).toBeUndefined()
+    })
+
+    it('should fall back to the durable cache when the conversation is not active (messages evicted from RAM)', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com'))
+      chatStore.getState().addConversation(createConversation('carol@example.com'))
+      const msg = createMessage('alice@example.com', 'Hello!')
+      chatStore.getState().addMessage(msg)
+
+      // Switch away from alice's conversation — deactivation evicts her
+      // resident messages array, mirroring what happens when a reaction
+      // arrives for a conversation that isn't the active one.
+      chatStore.getState().setActiveConversation('alice@example.com')
+      chatStore.getState().setActiveConversation('carol@example.com')
+      expect(chatStore.getState().messages.get('alice@example.com')).toBeUndefined()
+
+      vi.mocked(messageCache.updateMessageReactions).mockClear()
+      chatStore.getState().updateReactions('alice@example.com', msg.id, 'bob@example.com', ['👍'])
+
+      expect(messageCache.updateMessageReactions).toHaveBeenCalledWith(msg.id, 'bob@example.com', ['👍'])
+      // No resident array to update — the reaction lands in the cache only,
+      // to be picked up next time the conversation is activated.
+      expect(chatStore.getState().messages.get('alice@example.com')).toBeUndefined()
     })
 
     it('should not modify state if message does not exist', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -3,6 +3,7 @@ import { persist, subscribeWithSelector } from 'zustand/middleware'
 import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState, RSMResponse } from '../core'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
+import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
@@ -1293,7 +1294,15 @@ export const chatStore = createStore<ChatState>()(
       updateReactions: (conversationId, messageId, reactorJid, emojis) => {
         set((state) => {
           const convMessages = state.messages.get(conversationId)
-          if (!convMessages) return state
+          if (!convMessages) {
+            // Conversation isn't active — its messages aren't resident in RAM
+            // (evicted on deactivation). Update reactions directly in the
+            // durable cache so the correct state loads when the conversation
+            // is reactivated, instead of silently dropping the reaction.
+            logInfo(`Reaction for message ${messageId} not in memory — updating in cache`)
+            void messageCache.updateMessageReactions(messageId, reactorJid, emojis)
+            return state
+          }
 
           // Resolve by id/stanzaId first, origin-id only as fallback (reactions
           // may reference any tier; origin-id must not shadow a real id).

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -295,6 +295,58 @@ describe('messageCache', () => {
       })
     })
 
+    describe('updateMessageReactions', () => {
+      it('should add reactions to a message found by id', async () => {
+        const message = createMockMessage(conversationId, { id: 'react-1' })
+        await messageCache.saveMessage(message)
+
+        const found = await messageCache.updateMessageReactions('react-1', 'bob@example.com', ['👍'])
+
+        expect(found).toBe(true)
+        const retrieved = await messageCache.getMessage('react-1')
+        expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
+      })
+
+      it('should find the message by stanzaId when the reaction references the server-assigned id', async () => {
+        const message = createMockMessage(conversationId, { id: 'react-2', stanzaId: 'server-stanza-id-1' })
+        await messageCache.saveMessage(message)
+
+        const found = await messageCache.updateMessageReactions('server-stanza-id-1', 'bob@example.com', ['👍'])
+
+        expect(found).toBe(true)
+        const retrieved = await messageCache.getMessage('react-2')
+        expect(retrieved?.reactions).toEqual({ '👍': ['bob@example.com'] })
+      })
+
+      it('should replace reactions from the same reactor', async () => {
+        const message = createMockMessage(conversationId, { id: 'react-3', reactions: { '👍': ['bob@example.com'] } })
+        await messageCache.saveMessage(message)
+
+        await messageCache.updateMessageReactions('react-3', 'bob@example.com', ['❤️'])
+
+        const retrieved = await messageCache.getMessage('react-3')
+        expect(retrieved?.reactions).toEqual({ '❤️': ['bob@example.com'] })
+      })
+
+      it('should remove all reactions from the reactor when an empty array is passed', async () => {
+        const message = createMockMessage(conversationId, {
+          id: 'react-4',
+          reactions: { '👍': ['bob@example.com', 'carol@example.com'] },
+        })
+        await messageCache.saveMessage(message)
+
+        await messageCache.updateMessageReactions('react-4', 'bob@example.com', [])
+
+        const retrieved = await messageCache.getMessage('react-4')
+        expect(retrieved?.reactions).toEqual({ '👍': ['carol@example.com'] })
+      })
+
+      it('should return false when the message is not found', async () => {
+        const found = await messageCache.updateMessageReactions('nonexistent', 'bob@example.com', ['👍'])
+        expect(found).toBe(false)
+      })
+    })
+
     describe('deleteMessage', () => {
       it('should delete a message', async () => {
         const message = createMockMessage(conversationId, { id: 'delete-1' })

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -633,6 +633,60 @@ export async function updateMessage(
 }
 
 /**
+ * Update reactions for a chat message in IndexedDB.
+ * Used as a fallback when the message is not currently loaded in memory
+ * (e.g. a reaction arrives for a conversation that isn't the active one).
+ * Looks up by client ID or stanza-id (reactions may reference either).
+ *
+ * @returns true if the message was found and updated, false otherwise.
+ */
+export async function updateMessageReactions(
+  messageId: string,
+  reactorJid: string,
+  emojis: string[],
+): Promise<boolean> {
+  try {
+    const db = await getDB(getStorageScopeJid())
+
+    let existing = await db.get(MESSAGES_STORE, messageId)
+    if (!existing) {
+      existing = await db.getFromIndex(MESSAGES_STORE, 'stanzaId', messageId)
+    }
+    if (!existing) return false
+
+    // Build new reactions map: remove reactor from all, then add to new emojis
+    const newReactions: Record<string, string[]> = {}
+    if (existing.reactions) {
+      for (const [emoji, reactors] of Object.entries(existing.reactions)) {
+        const filtered = (reactors as string[]).filter((jid: string) => jid !== reactorJid)
+        if (filtered.length > 0) {
+          newReactions[emoji] = filtered
+        }
+      }
+    }
+    for (const emoji of emojis) {
+      if (!newReactions[emoji]) {
+        newReactions[emoji] = []
+      }
+      newReactions[emoji].push(reactorJid)
+    }
+
+    const updated = {
+      ...existing,
+      reactions: Object.keys(newReactions).length > 0 ? newReactions : undefined,
+    }
+
+    await db.put(MESSAGES_STORE, updated)
+    return true
+  } catch (error) {
+    if (isIndexedDBAvailable()) {
+      console.warn('Failed to update message reactions in cache:', error)
+    }
+    return false
+  }
+}
+
+/**
  * Delete a message by ID.
  */
 export async function deleteMessage(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- A 1:1 reaction received while the conversation was inactive was silently dropped: `chatStore.updateReactions` bailed out entirely when the conversation's messages weren't resident in RAM (evicted on deactivation), never writing to the durable cache. The reaction toast fired, but the reaction never appeared after switching to the conversation.
- `roomStore.updateReactions` already had a fallback for this (rooms stay keyed in state even when inactive); ported the same pattern to chat via a new `messageCache.updateMessageReactions` cache-only lookup/patch.