### PR TITLE
fix(desktop): keep window app bar on narrow desktop-app windows

### DIFF
--- a/apps/fluux/src/components/AppBar.test.tsx
+++ b/apps/fluux/src/components/AppBar.test.tsx
@@ -42,11 +42,13 @@ describe('AppBar', () => {
     mockHasHover = true
     navigateSpy.mockClear()
     toggleSpy.mockClear()
+    // Default to the web build; the desktop-app tests opt in explicitly.
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
     // Reset history position so each test starts at index 0 (start = end).
     window.history.replaceState(null, '')
   })
 
-  it('renders nothing on mobile (below the desktop breakpoint)', () => {
+  it('renders nothing on mobile web (below the desktop breakpoint)', () => {
     mockIsDesktop = false
     const { container } = renderAppBar()
     expect(container).toBeEmptyDOMElement()
@@ -57,6 +59,15 @@ describe('AppBar', () => {
     mockHasHover = false
     const { container } = renderAppBar()
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('still renders on the desktop app in a narrow window (Tauri, below the breakpoint)', () => {
+    ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+    mockIsDesktop = false
+    mockHasHover = false
+    renderAppBar()
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open command palette' })).toBeInTheDocument()
   })
 
   it('renders back, forward and command-palette controls on desktop', () => {

--- a/apps/fluux/src/components/AppBar.tsx
+++ b/apps/fluux/src/components/AppBar.tsx
@@ -10,9 +10,9 @@ import { useModalStore } from '@/stores/modalStore'
 // Minimal shape of the Tauri window methods we drive for window dragging.
 type DraggableWindow = { startDragging: () => Promise<void>; toggleMaximize: () => Promise<void> }
 
-// Tauri / macOS detection — only macOS overlays native traffic lights onto the
-// webview, so only there does the bar need to reserve space at its start.
-const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+// macOS detection — only macOS overlays native traffic lights onto the webview,
+// so only there does the bar need to reserve space at its start. Tauri detection
+// is read at render time (see component body) so tests can toggle it.
 const isMacOS = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform)
 
 // Width reserved at the bar's start for the macOS traffic lights so the first
@@ -38,7 +38,11 @@ const TRAFFIC_LIGHT_INSET = 84
  *  - Windows / Linux (Tauri): the OS keeps its native title bar above; this bar
  *    renders below it as a normal toolbar (left edge free) and is also draggable.
  *  - Web desktop: a plain toolbar (no window dragging).
- *  - Mobile (< md): not rendered — the single-pane layout owns navigation.
+ *  - Web mobile (< md): not rendered — the single-pane layout owns navigation.
+ *
+ * On the native desktop app (Tauri) the bar always renders, even in a narrow
+ * window, so it keeps hosting the macOS traffic lights (off the rail seam) and
+ * the window stays draggable. The width gate below applies only on the web.
  *
  * Dragging calls Tauri's startDragging() on mousedown rather than using
  * `-webkit-app-region: drag` (data-tauri-drag-region), whose macOS WebKit
@@ -57,6 +61,9 @@ export const AppBar = memo(function AppBar() {
   const { t } = useTranslation()
   const toggleModal = useModalStore((s) => s.toggle)
 
+  // Read at render time (not module scope) so tests can toggle it per case.
+  const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+
   // Pre-resolve the Tauri window so the mousedown drag handler stays synchronous
   // (an async import there would miss the gesture). Null in the browser.
   const dragWindowRef = useRef<DraggableWindow | null>(null)
@@ -69,7 +76,7 @@ export const AppBar = memo(function AppBar() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [isTauri])
 
   // React Router stores a numeric index in history state; re-read it on every
   // navigation (useLocation re-renders us). `currentIdx` is the position in the
@@ -88,12 +95,14 @@ export const AppBar = memo(function AppBar() {
     setMaxIdx((prev) => (navigationType === 'PUSH' ? currentIdx : Math.max(prev, currentIdx)))
   }, [location, navigationType, currentIdx])
 
-  // App bar is desktop window chrome: render only on a wide viewport AND a
-  // hovering, fine pointer (mouse/trackpad). The hover gate keeps it hidden on
-  // touch devices even when they're wide — e.g. a phone in landscape (>768px)
-  // or a tablet — where its mouse-sized controls would be hard to tap and the
-  // single-pane touch affordances own navigation.
-  if (!isDesktop || !hasHover) return null
+  // App bar is desktop window chrome. On the native desktop app (Tauri) it always
+  // renders — even in a narrow window — so the macOS traffic lights keep a surface
+  // to sit on and the window stays draggable. On the web it's gated to a wide
+  // viewport AND a hovering, fine pointer (mouse/trackpad): the hover gate keeps it
+  // hidden on touch devices even when they're wide — e.g. a phone in landscape
+  // (>768px) or a tablet — where its mouse-sized controls would be hard to tap and
+  // the single-pane touch affordances own navigation.
+  if (!isTauri && (!isDesktop || !hasHover)) return null
 
   const needsTrafficLightInset = isTauri && isMacOS && !isFullscreen
 

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -902,7 +902,8 @@ function ChatLayoutContent() {
       <GlobalEffects />
 
       {/* Desktop window app bar — hosts macOS traffic lights + nav/search/settings.
-          Renders null on mobile; the single-pane layout owns navigation there. */}
+          On the desktop app it always renders (even in a narrow window); on the
+          web it renders null on mobile, where the single-pane layout owns nav. */}
       <AppBar />
 
       {/* Main content area */}


### PR DESCRIPTION
The `AppBar` (desktop window chrome hosting the macOS traffic lights, back/forward, and ⌘K) was gated on a >=768px viewport. Resizing the native desktop app below that width hid it entirely, leaving the macOS traffic lights straddling the rail seam with no surface to sit on.

Render the bar unconditionally on the desktop app (Tauri, any window width); keep the wide-viewport + hover gate for the web build so the mobile single-pane layout still owns navigation there.