### PR TITLE
fix(sidebar): order rooms on SM-resumed reload too

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -904,6 +904,47 @@ describe('XMPPClient', () => {
       expect(bookmarksSpy).not.toHaveBeenCalled()
     })
 
+    it('should hydrate sidebar previews from the durable cache on SM resumption', async () => {
+      // On a reload that resumes via SM, the room list is rebuilt from persisted
+      // state whose non-active rooms had their messages evicted before save, so they
+      // carry no lastMessage and would sort at epoch-0 until opened. The resume path
+      // must repopulate previews from the cache, same as a fresh session does.
+      const mockClientWithSM = createMockXmppClientWithSM('sm-id-hydrate')
+      mockClientFactory._setInstance(mockClientWithSM)
+
+      const stores = createMockStores()
+      const newXmppClient = new XMPPClient({ debug: false })
+      newXmppClient.bindStores(stores)
+
+      // Short disconnect keeps the path minimal (no bookmark fetch / catch-up).
+      // (In this node env localStorage.getItem throws, so the cache-marker check is
+      // swallowed and execution continues down the real SM-resume path.)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(newXmppClient.connection as any).disconnectedAtTimestamp = Date.now() - 30_000
+
+      const connectPromise = newXmppClient.connect({
+        jid: 'user@example.com',
+        password: 'secret',
+        server: 'example.com',
+        smState: { id: 'sm-id-hydrate', inbound: 5, outbound: 0 },
+        skipDiscovery: true,
+        previouslyJoinedRooms: [
+          { jid: 'room1@conference.example.com', nickname: 'testuser' },
+        ],
+      })
+
+      const resumedNonza = createMockElement('resumed', {
+        xmlns: 'urn:xmpp:sm:3',
+        previd: 'sm-id-hydrate',
+        h: '5',
+      })
+      mockClientWithSM._emit('nonza', resumedNonza)
+
+      await connectPromise
+
+      expect(stores.room.hydratePreviewsFromCache).toHaveBeenCalled()
+    })
+
     it('should skip MAM catch-up but fetch bookmarks on SM resumption for long disconnects', async () => {
       const mockClientWithSM = createMockXmppClientWithSM('sm-id-long')
       mockClientFactory._setInstance(mockClientWithSM)

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -2273,6 +2273,14 @@ export class XMPPClient {
       }
     } catch { /* ignore storage errors (e.g., SSR environments) */ }
 
+    // Repopulate sidebar ordering from the durable cache. On a reload that resumes
+    // via SM, the room list is rebuilt from persisted state where every non-active
+    // room's messages were evicted before save, so it carries no lastMessage and
+    // would sort at epoch-0 until opened. This mirrors the fresh-session hydration;
+    // it is network-free, batched, and never downgrades a fresher preview, so it is
+    // a cheap no-op for in-process resumes whose store is still intact.
+    this.stores?.room.hydratePreviewsFromCache().catch(() => {})
+
     const SM_SHORT_DISCONNECT_MS = 120_000
     const isShortDisconnect = disconnectDurationMs != null
       && disconnectDurationMs < SM_SHORT_DISCONNECT_MS


### PR DESCRIPTION
## Summary

Follow-up to the fresh-session sidebar-ordering fix (merged). That fix populates room ordering from the durable cache on a fresh login, but not on the **SM-resumed reload** path.

**Root cause:** on a page reload that resumes via Stream Management, the room list is rebuilt from persisted state (`saveRooms`/`getSavedRooms` → `addRoom`). But `setActiveRoom` evicts the message array of every non-active room before save, and `saveRooms` doesn't persist `lastInteractedAt` — so on restore those rooms have no `lastMessage` and sort at epoch `0` until opened. `handleSmResumption` doesn't run the fresh-session hydration, and the `mucJoined` preview fetch is skipped on SM resume, so the previews never populate → the same "active room jumps to the top when opened" bug.

**Fix:** call `roomStore.hydratePreviewsFromCache()` in `handleSmResumption`, after the cache-marker check (the cache-cleared branch still routes through `handleFreshSession`, which already hydrates). It's network-free, batched, and never downgrades a fresher preview — so it's a cheap no-op for in-process resumes whose store is still intact, and only does real work on a reload-resume with a rebuilt store.