### PR TITLE
fix(mds): publish the XEP-0490 spec payload and migrate legacy markers

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -395,6 +395,34 @@ describe('setupMdsSideEffects', () => {
     cleanup()
   })
 
+  it('a failed legacy migration does not break the seed or later publishing', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1', legacy: true }])
+    // The migration republish fails (e.g. transient IQ error)…
+    client.mds.publishDisplayed = vi.fn().mockRejectedValueOnce(new Error('timeout'))
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    addConversation(cid)
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1) // the failed migration
+
+    // …and a later local read advance still publishes normally.
+    client.mds.publishDisplayed = vi.fn().mockResolvedValue(undefined)
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    seedMeta(cid, 'm1')
+    chatStore.getState().updateLastSeenMessageId(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    cleanup()
+  })
+
   it('does NOT republish spec-format seed markers', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -148,7 +148,7 @@ describe('setupMdsSideEffects', () => {
   it('publishes the resolved stanza-id once, debounced, on a local read advance', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     const cleanup = setupMdsSideEffects(client as never)
 
     client._emit('online')
@@ -162,14 +162,15 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2')
+    // 1:1 → by is our own bare JID (the archive that assigned the stanza-id).
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 
   it('does not publish a marker with no stanza-id', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
@@ -186,7 +187,7 @@ describe('setupMdsSideEffects', () => {
   it('drops pending publishes on disconnect', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
@@ -204,7 +205,7 @@ describe('setupMdsSideEffects', () => {
   it('does not re-publish the echo of a live incoming remote marker', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     // Conversation already exists with a settled local read position at m1 before
     // the side effect starts, so the fresh-session seed snapshots m1 as the last
@@ -235,7 +236,7 @@ describe('setupMdsSideEffects', () => {
   it('publishes the room-archive stanza-id on a local room read advance, debounced', async () => {
     const ROOM = 'room@conference.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     // Seed the room (rooms + roomRuntime + roomMeta) so isRoom()/routing works.
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)], 'm1')
@@ -249,7 +250,8 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
-    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2')
+    // MUC → by is the room JID (the room's archive assigned the stanza-id).
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
     cleanup()
   })
 
@@ -259,7 +261,7 @@ describe('setupMdsSideEffects', () => {
     client.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's2' }])
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     // roomStore.rooms must contain ROOM with its messages so the seed routes to
     // the room and applyRemoteDisplayed can resolve the stanza-id to a local id.
@@ -281,7 +283,7 @@ describe('setupMdsSideEffects', () => {
     client.mds.fetchAllDisplayed = vi
       .fn()
       .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's2' }])
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
@@ -310,7 +312,7 @@ describe('setupMdsSideEffects', () => {
   it('does not re-publish the echo of a live incoming remote marker for a known room', async () => {
     const ROOM = 'room@conference.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     // Known room with a settled local read position at m1 before the side effect
     // starts, so the seed snapshots m1 as the last considered position.
@@ -337,7 +339,7 @@ describe('setupMdsSideEffects', () => {
   it('retracts the MDS marker when a conversation is deleted while online+synced', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.runOnlyPendingTimersAsync() // seed completes → syncEnabled true, baseline built
@@ -354,7 +356,7 @@ describe('setupMdsSideEffects', () => {
 
   it('does NOT retract on a wholesale clear (logout/reset)', async () => {
     const client = makeClient()
-    connectionStore.setState({ status: 'online' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
@@ -367,6 +369,77 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(client.mds.retractDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('migrates a legacy-format 1:1 seed marker by republishing it in spec format', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1', legacy: true }])
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    // Known 1:1 conversation entity → the seed can classify the JID and migrate.
+    addConversation(cid)
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+
+    // Migration is one-shot: nothing further is pending or debounced.
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('does NOT republish spec-format seed markers', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1' }])
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    addConversation(cid)
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('migrates a legacy room marker when the room becomes known after the seed', async () => {
+    const ROOM = 'room@conference.example'
+    const client = makeClient()
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's2', legacy: true }])
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // Unknown JID at seed time (bookmarks not loaded, no conversation entity):
+    // cannot classify → no migration yet.
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // The bookmark lands: the room appears, the stashed marker drains, and the
+    // legacy marker is republished in spec format with by = room JID.
+    seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m2')
+
+    // And no echo republish on top of the migration.
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -23,6 +23,7 @@
  */
 
 import type { XMPPClient } from './XMPPClient'
+import type { DisplayedMarker } from './modules/Mds'
 import type { SideEffectsOptions } from './chatSideEffects'
 import { chatStore, connectionStore, roomStore } from '../stores'
 import { createKeyedCoalescer } from '../utils/keyedCoalescer'
@@ -55,11 +56,12 @@ export function setupMdsSideEffects(
   const lastKnownNodeStanzaId = new Map<string, string>()
   // The lastSeenMessageId we last considered per JID, to detect advances.
   const lastConsideredSeenId = new Map<string, string | undefined>()
-  // Seed markers (jid → stanzaId) whose JID was NOT a known room at seed time.
+  // Seed markers (jid → marker) whose JID was NOT a known room at seed time.
   // The fresh-session seed runs before bookmarks load (roomStore.rooms is empty),
   // so a room's marker would otherwise route to chat and be dropped. We stash it
-  // here and re-apply it when roomStore.rooms gains the JID (self-heal).
-  const unroutedSeedMarkers = new Map<string, string>()
+  // here and re-apply it when roomStore.rooms gains the JID (self-heal). A stashed
+  // marker also remembers whether it still needs a legacy-format migration.
+  const unroutedSeedMarkers = new Map<string, { stanzaId: string; legacy: boolean }>()
   // Live conversation/room JIDs, to detect user deletes (retraction). Maintained
   // while disarmed; the removed delta is retracted only while armed (syncEnabled).
   let trackedJids = new Set<string>()
@@ -67,6 +69,33 @@ export function setupMdsSideEffects(
   /** Is this JID a known room (bookmarked or joined)? Routes accessors per-store. */
   function isRoom(jid: string): boolean {
     return roomStore.getState().rooms.has(jid)
+  }
+
+  /** Our own bare JID, or '' before the connection JID is known. */
+  function ownBareJid(): string {
+    const jid = connectionStore.getState().jid
+    return jid ? getBareJid(jid) : ''
+  }
+
+  /**
+   * XEP-0359 `by` for a conversation's stanza-ids: the archive that assigned
+   * them — the room itself for MUC, our own server (bare JID) for 1:1.
+   */
+  function stanzaIdBy(jid: string): string {
+    return isRoom(jid) ? jid : ownBareJid()
+  }
+
+  /**
+   * Republish a legacy-format marker (pre-0.18 payload) in XEP-0490 format so
+   * other clients can read it. Best-effort; the value is already correct
+   * locally and on the node, only its shape is wrong.
+   */
+  function migrateLegacyMarker(jid: string, stanzaId: string): void {
+    const by = stanzaIdBy(jid)
+    if (!by) return
+    client.mds.publishDisplayed(jid, stanzaId, by).catch(() => {
+      // Best-effort — an unconverted marker is republished on the next advance.
+    })
   }
 
   /** Index of a stanza-id in a conversation's/room's loaded messages, or -1. */
@@ -123,8 +152,10 @@ export function setupMdsSideEffects(
       // below) or a redundant re-enqueue. The local marker is forward-only, so
       // re-asserting a value the node already has is always pointless.
       if (lastKnownNodeStanzaId.get(jid) === stanzaId) continue
+      const by = stanzaIdBy(jid)
+      if (!by) continue // own JID unknown (should not happen while online) — retry next advance
       try {
-        await client.mds.publishDisplayed(jid, stanzaId)
+        await client.mds.publishDisplayed(jid, stanzaId, by)
         lastKnownNodeStanzaId.set(jid, stanzaId)
       } catch {
         // Best-effort — localStorage keeps the read position; reconnect re-publishes.
@@ -254,13 +285,15 @@ export function setupMdsSideEffects(
       // Collect-then-apply: applyRemoteDisplayed writes the combined `rooms` map,
       // which re-fires this subscription synchronously. Delete each entry from the
       // stash BEFORE applying so a re-entrant pass finds nothing to redo.
-      const drainable: Array<[string, string]> = []
-      for (const [jid, stanzaId] of unroutedSeedMarkers) {
-        if (rooms.has(jid)) drainable.push([jid, stanzaId])
+      const drainable: Array<[string, { stanzaId: string; legacy: boolean }]> = []
+      for (const [jid, marker] of unroutedSeedMarkers) {
+        if (rooms.has(jid)) drainable.push([jid, marker])
       }
       for (const [jid] of drainable) unroutedSeedMarkers.delete(jid)
-      for (const [jid, stanzaId] of drainable) {
+      for (const [jid, { stanzaId, legacy }] of drainable) {
         roomStore.getState().applyRemoteDisplayed(jid, stanzaId)
+        // The JID is now classified as a room → a legacy item can be migrated.
+        if (legacy) migrateLegacyMarker(jid, stanzaId)
       }
     }
   )
@@ -283,7 +316,7 @@ export function setupMdsSideEffects(
   const unsubscribeOnline = client.on('online', () => {
     syncEnabled = false
     void (async () => {
-      let markers: Array<{ conversationJid: string; stanzaId: string }> = []
+      let markers: DisplayedMarker[] = []
       try {
         markers = await client.mds.fetchAllDisplayed()
       } catch {
@@ -293,7 +326,7 @@ export function setupMdsSideEffects(
       // Reset the unrouted-marker stash for this seed (mirrors dirty.drop below).
       unroutedSeedMarkers.clear()
 
-      for (const { conversationJid, stanzaId } of markers) {
+      for (const { conversationJid, stanzaId, legacy } of markers) {
         const bare = getBareJid(conversationJid)
         lastKnownNodeStanzaId.set(bare, stanzaId)
         // Route the seed by membership. The fresh-session seed runs BEFORE
@@ -303,11 +336,21 @@ export function setupMdsSideEffects(
         // entity) AND is stashed so the rooms subscription below re-applies it
         // once the bookmark lands. A genuine 1:1 JID also lands in the else
         // branch and simply never drains — cleared on the next seed.
+        //
+        // Legacy-format items (pre-0.18 payload) are additionally republished
+        // in spec format once the JID can be classified (`by` differs for
+        // rooms vs 1:1): known rooms and known 1:1 entities migrate here;
+        // stashed room markers migrate when their bookmark drains below. A
+        // JID we can never classify keeps its legacy item until the next
+        // local read advance overwrites it.
         if (isRoom(bare)) {
           roomStore.getState().applyRemoteDisplayed(bare, stanzaId)
+          if (legacy) migrateLegacyMarker(bare, stanzaId)
         } else {
           chatStore.getState().applyRemoteDisplayed(bare, stanzaId)
-          unroutedSeedMarkers.set(bare, stanzaId)
+          const migrateNow = !!legacy && chatStore.getState().conversationEntities.has(bare)
+          if (migrateNow) migrateLegacyMarker(bare, stanzaId)
+          unroutedSeedMarkers.set(bare, { stanzaId, legacy: !!legacy && !migrateNow })
         }
       }
 

--- a/packages/fluux-sdk/src/core/modules/Mds.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { xml } from '@xmpp/client'
 import { Mds, parseMdsItems } from './Mds'
-import { NS_PUBSUB, NS_MDS, NS_CHAT_MARKERS } from '../namespaces'
+import { NS_PUBSUB, NS_MDS, NS_CHAT_MARKERS, NS_STANZA_ID } from '../namespaces'
 
 function makeDeps(sendIQ: ReturnType<typeof vi.fn>) {
   return {
@@ -16,11 +16,11 @@ function makeDeps(sendIQ: ReturnType<typeof vi.fn>) {
 }
 
 describe('Mds.publishDisplayed', () => {
-  it('publishes a <displayed/> marker keyed by the conversation bare JID with MDS publish-options', async () => {
+  it('publishes the XEP-0490 payload: mds <displayed/> wrapping a stanza-id with by', async () => {
     const sendIQ = vi.fn().mockResolvedValue(xml('iq', { type: 'result' }))
     const mds = new Mds(makeDeps(sendIQ))
 
-    await mds.publishDisplayed('juliet@capulet.example', 'stanza-42')
+    await mds.publishDisplayed('juliet@capulet.example', 'stanza-42', 'romeo@montague.example')
 
     const iq = sendIQ.mock.calls[0][0]
     expect(iq.attrs.type).toBe('set')
@@ -28,8 +28,10 @@ describe('Mds.publishDisplayed', () => {
     expect(publish?.attrs.node).toBe(NS_MDS)
     const item = publish?.getChild('item')
     expect(item?.attrs.id).toBe('juliet@capulet.example')
-    const displayed = item?.getChild('displayed', NS_CHAT_MARKERS)
-    expect(displayed?.attrs.id).toBe('stanza-42')
+    const displayed = item?.getChild('displayed', NS_MDS)
+    const stanzaId = displayed?.getChild('stanza-id', NS_STANZA_ID)
+    expect(stanzaId?.attrs.id).toBe('stanza-42')
+    expect(stanzaId?.attrs.by).toBe('romeo@montague.example')
 
     // publish-options: persist, max_items=max, send_last_published_item=never, whitelist
     const fields = iq
@@ -47,17 +49,41 @@ describe('Mds.publishDisplayed', () => {
 })
 
 describe('parseMdsItems', () => {
-  it('extracts conversationJid + stanzaId from each item', () => {
+  it('extracts conversationJid + stanzaId from spec-format items', () => {
     const items = xml('items', { node: NS_MDS },
       xml('item', { id: 'juliet@capulet.example' },
-        xml('displayed', { xmlns: NS_CHAT_MARKERS, id: 'stanza-42' })),
+        xml('displayed', { xmlns: NS_MDS },
+          xml('stanza-id', { xmlns: NS_STANZA_ID, id: 'stanza-42', by: 'romeo@montague.example' }))),
       xml('item', { id: 'mercutio@montague.example' },
-        xml('displayed', { xmlns: NS_CHAT_MARKERS, id: 'stanza-7' })),
+        xml('displayed', { xmlns: NS_MDS },
+          xml('stanza-id', { xmlns: NS_STANZA_ID, id: 'stanza-7', by: 'romeo@montague.example' }))),
       xml('item', { id: 'broken@example' }), // no <displayed/> → skipped
     )
     expect(parseMdsItems(items)).toEqual([
       { conversationJid: 'juliet@capulet.example', stanzaId: 'stanza-42' },
       { conversationJid: 'mercutio@montague.example', stanzaId: 'stanza-7' },
+    ])
+  })
+
+  it('parses legacy chat-markers-shaped items (pre-fix Fluux) and flags them for migration', () => {
+    const items = xml('items', { node: NS_MDS },
+      xml('item', { id: 'mercutio@montague.example' },
+        xml('displayed', { xmlns: NS_CHAT_MARKERS, id: 'stanza-7' })),
+    )
+    expect(parseMdsItems(items)).toEqual([
+      { conversationJid: 'mercutio@montague.example', stanzaId: 'stanza-7', legacy: true },
+    ])
+  })
+
+  it('prefers the spec payload when an item somehow carries both shapes', () => {
+    const items = xml('items', { node: NS_MDS },
+      xml('item', { id: 'juliet@capulet.example' },
+        xml('displayed', { xmlns: NS_CHAT_MARKERS, id: 'old-1' }),
+        xml('displayed', { xmlns: NS_MDS },
+          xml('stanza-id', { xmlns: NS_STANZA_ID, id: 'new-1', by: 'romeo@montague.example' }))),
+    )
+    expect(parseMdsItems(items)).toEqual([
+      { conversationJid: 'juliet@capulet.example', stanzaId: 'new-1' },
     ])
   })
 })
@@ -89,11 +115,15 @@ describe('Mds.fetchAllDisplayed', () => {
       xml('pubsub', { xmlns: NS_PUBSUB },
         xml('items', { node: NS_MDS },
           xml('item', { id: 'juliet@capulet.example' },
-            xml('displayed', { xmlns: NS_CHAT_MARKERS, id: 'stanza-42' })))))
+            xml('displayed', { xmlns: NS_MDS },
+              xml('stanza-id', { xmlns: NS_STANZA_ID, id: 'stanza-42', by: 'romeo@montague.example' }))),
+          xml('item', { id: 'mercutio@montague.example' },
+            xml('displayed', { xmlns: NS_CHAT_MARKERS, id: 'stanza-7' })))))
     const sendIQ = vi.fn().mockResolvedValue(result)
     const mds = new Mds(makeDeps(sendIQ))
     expect(await mds.fetchAllDisplayed()).toEqual([
       { conversationJid: 'juliet@capulet.example', stanzaId: 'stanza-42' },
+      { conversationJid: 'mercutio@montague.example', stanzaId: 'stanza-7', legacy: true },
     ])
 
     const sendIQErr = vi.fn().mockRejectedValue(new Error('item-not-found'))

--- a/packages/fluux-sdk/src/core/modules/Mds.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.ts
@@ -2,7 +2,7 @@ import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { getBareJid } from '../jid'
 import { generateUUID } from '../../utils/uuid'
-import { NS_PUBSUB, NS_MDS, NS_CHAT_MARKERS } from '../namespaces'
+import { NS_PUBSUB, NS_MDS, NS_CHAT_MARKERS, NS_STANZA_ID } from '../namespaces'
 import type { ModuleDependencies } from './BaseModule'
 
 /** A per-conversation last-displayed marker (XEP-0490). */
@@ -11,20 +11,37 @@ export interface DisplayedMarker {
   conversationJid: string
   /** XEP-0359 stanza-id of the last displayed message. */
   stanzaId: string
+  /**
+   * True when the item was published in the pre-0.18 Fluux payload (a bare
+   * XEP-0333 `<displayed/>` instead of the XEP-0490 wrapper). Other clients
+   * cannot read that shape — the consumer should republish it in spec format.
+   */
+  legacy?: boolean
 }
 
 /**
  * Parse the `<items/>` of an MDS node into markers.
- * Items without a `<displayed/>` child carrying an id are skipped.
+ * Accepts the XEP-0490 payload (`<displayed xmlns='urn:xmpp:mds:displayed:0'>`
+ * wrapping a XEP-0359 `<stanza-id/>`) and, as a migration fallback, the
+ * pre-0.18 Fluux payload (a bare XEP-0333 `<displayed id=…/>`), flagged
+ * `legacy`. Items with neither shape are skipped.
  * Exported so PubSub can reuse it for incoming `+notify` events.
  */
 export function parseMdsItems(itemsEl: Element): DisplayedMarker[] {
   const markers: DisplayedMarker[] = []
   for (const item of itemsEl.getChildren('item')) {
     const conversationJid = item.attrs.id
-    const stanzaId = item.getChild('displayed', NS_CHAT_MARKERS)?.attrs.id
-    if (conversationJid && stanzaId) {
+    if (!conversationJid) continue
+    const stanzaId = item
+      .getChild('displayed', NS_MDS)
+      ?.getChild('stanza-id', NS_STANZA_ID)?.attrs.id
+    if (stanzaId) {
       markers.push({ conversationJid, stanzaId })
+      continue
+    }
+    const legacyStanzaId = item.getChild('displayed', NS_CHAT_MARKERS)?.attrs.id
+    if (legacyStanzaId) {
+      markers.push({ conversationJid, stanzaId: legacyStanzaId, legacy: true })
     }
   }
   return markers
@@ -46,18 +63,23 @@ export class Mds {
   }
 
   /**
-   * Publish the last-displayed stanza-id for a 1:1 conversation.
+   * Publish the last-displayed stanza-id for a conversation.
    * The node is created on first publish with current-value semantics
    * (max_items=max so all conversations are retained; one item per JID).
+   *
+   * @param stanzaIdBy - XEP-0359 `by`: the archive that assigned the stanza-id
+   *   (our own bare JID for 1:1, the room JID for MUC).
    */
-  async publishDisplayed(conversationJid: string, stanzaId: string): Promise<void> {
+  async publishDisplayed(conversationJid: string, stanzaId: string, stanzaIdBy: string): Promise<void> {
     if (!this.deps.getCurrentJid()) throw new Error('Not connected')
 
     const iq = xml('iq', { type: 'set', id: `mds_set_${generateUUID()}` },
       xml('pubsub', { xmlns: NS_PUBSUB },
         xml('publish', { node: NS_MDS },
           xml('item', { id: conversationJid },
-            xml('displayed', { xmlns: NS_CHAT_MARKERS, id: stanzaId }),
+            xml('displayed', { xmlns: NS_MDS },
+              xml('stanza-id', { xmlns: NS_STANZA_ID, id: stanzaId, by: stanzaIdBy }),
+            ),
           ),
         ),
         xml('publish-options', {},

--- a/packages/fluux-sdk/src/core/modules/PubSub.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.test.ts
@@ -270,7 +270,37 @@ describe('PubSub Module', () => {
         },
       ])
 
-    it('emits read:displayed-synced for own MDS node notifications', async () => {
+    it('emits read:displayed-synced for own MDS node notifications (XEP-0490 payload)', async () => {
+      await connectClient()
+
+      // Spec payload, as published by other compliant clients (Conversations,
+      // Gajim, …): mds-namespaced <displayed/> wrapping a XEP-0359 stanza-id.
+      mockXmppClientInstance._emit('stanza', mdsEvent('user@example.com', [
+        {
+          name: 'item',
+          attrs: { id: 'juliet@capulet.example' },
+          children: [
+            {
+              name: 'displayed',
+              attrs: { xmlns: 'urn:xmpp:mds:displayed:0' },
+              children: [
+                {
+                  name: 'stanza-id',
+                  attrs: { xmlns: 'urn:xmpp:sid:0', id: 'stanza-99', by: 'user@example.com' },
+                },
+              ],
+            },
+          ],
+        },
+      ]))
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('read:displayed-synced', {
+        conversationId: 'juliet@capulet.example',
+        stanzaId: 'stanza-99',
+      })
+    })
+
+    it('emits read:displayed-synced for legacy pre-0.18 Fluux payloads (migration read path)', async () => {
       await connectClient()
 
       mockXmppClientInstance._emit('stanza', mdsEvent('user@example.com', [


### PR DESCRIPTION
0.17.0 read states synced between Fluux clients but not with other XMPP clients (reported by foss-). Root cause: the MDS item payload was a bare XEP-0333 `<displayed xmlns='urn:xmpp:chat-markers:0' id=…/>`, and the parser read only that shape — spec-compliant clients ignored our items and we ignored theirs.

- `publishDisplayed` now emits the XEP-0490 payload: `<displayed xmlns='urn:xmpp:mds:displayed:0'>` wrapping a XEP-0359 `<stanza-id id=… by=…/>` (`by` = room JID for MUC, own bare JID for 1:1).
- `parseMdsItems` reads the spec shape first and falls back to the legacy shape, flagged `legacy` for migration.
- The fresh-session seed republishes legacy items in spec format once the JID can be classified (known 1:1 entities at seed time; stashed room markers when their bookmark drains), so markers already on users' nodes convert automatically.