### PR TITLE
fix(admin): never offer ban/delete on the signed-in admin's own account

### DIFF
--- a/apps/fluux/src/components/AdminUserView.test.tsx
+++ b/apps/fluux/src/components/AdminUserView.test.tsx
@@ -64,6 +64,7 @@ describe('AdminUserView', () => {
         onChangePassword={mockOnChangePassword}
         onBanAccount={mockOnBanAccount}
         canBanAccount={true}
+        isOwnAccount={false}
         isExecuting={false}
         fetchLastLogin={mockFetchLastLogin}
         hasLastLoginCommand={true}
@@ -123,6 +124,16 @@ describe('AdminUserView', () => {
       expect(screen.getByRole('button', { name: /end sessions/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /ban account/i })).toBeDisabled()
       expect(screen.getByRole('button', { name: /delete user/i })).toBeDisabled()
+    })
+  })
+
+  describe('own account', () => {
+    it('hides the ban and delete rows when viewing your own account', () => {
+      renderView({ isOwnAccount: true })
+      expect(screen.getByRole('button', { name: /change password/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /end sessions/i })).toBeInTheDocument()
+      expect(screen.queryByText('Ban account')).not.toBeInTheDocument()
+      expect(screen.queryByText('Delete user')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/fluux/src/components/AdminUserView.tsx
+++ b/apps/fluux/src/components/AdminUserView.tsx
@@ -18,6 +18,8 @@ interface AdminUserViewProps {
   onBanAccount: (jid: string) => void
   /** Discovery-driven: only render the Ban action when the server advertises it. */
   canBanAccount: boolean
+  /** Self-protection: hide Ban/Delete when the viewed user is the signed-in admin. */
+  isOwnAccount: boolean
   isExecuting: boolean
   /** Fetch a user's last-login value (raw, server-localized string — not parsed). */
   fetchLastLogin: (jid: string, lang: string) => Promise<string | null>
@@ -33,6 +35,7 @@ export function AdminUserView({
   onChangePassword,
   onBanAccount,
   canBanAccount,
+  isOwnAccount,
   isExecuting,
   fetchLastLogin,
   hasLastLoginCommand,
@@ -147,7 +150,7 @@ export function AdminUserView({
               <Power className="size-4 text-fluux-muted" aria-hidden />
             </SettingsRow>
 
-            {canBanAccount && (
+            {canBanAccount && !isOwnAccount && (
               <SettingsRow
                 label={t('admin.users.banAccount')}
                 onClick={() => setShowBanConfirm(true)}
@@ -158,14 +161,16 @@ export function AdminUserView({
               </SettingsRow>
             )}
 
-            <SettingsRow
-              label={t('admin.users.delete')}
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={isExecuting}
-              danger
-            >
-              <Trash2 className="size-4 text-fluux-error" aria-hidden />
-            </SettingsRow>
+            {!isOwnAccount && (
+              <SettingsRow
+                label={t('admin.users.delete')}
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isExecuting}
+                danger
+              >
+                <Trash2 className="size-4 text-fluux-error" aria-hidden />
+              </SettingsRow>
+            )}
           </SettingsGroup>
         </SettingsSection>
       </div>

--- a/apps/fluux/src/components/AdminView.test.tsx
+++ b/apps/fluux/src/components/AdminView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import type { AdminRoom } from '@fluux/sdk'
 
@@ -72,6 +72,16 @@ vi.mock('@fluux/sdk', () => ({
   useAdmin: () => adminState,
   useXMPP: () => ({ client: { muc: { destroyRoom } } }),
   adminStore: { getState: () => ({ setActiveCategory }) },
+  getBareJid: (jid: string) => jid.split('/')[0],
+}))
+
+// Controllable connection JID (own account) for the self-protection tests.
+const conn = vi.hoisted(() => ({ jid: null as string | null }))
+vi.mock('@fluux/sdk/react', () => ({
+  useAdminStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ usersTruncated: false, lastActivity: new Map(), lastActivitySupported: false }),
+  useConnectionStore: (selector: (s: { jid: string | null }) => unknown) =>
+    selector({ jid: conn.jid }),
 }))
 
 // Import after mocks are registered.
@@ -260,5 +270,45 @@ describe('AdminView content width', () => {
     render(<AdminView activeCategory="users" onBack={vi.fn()} />)
     const wrapper = screen.getByText('Password changed').closest('.max-w-2xl')
     expect(wrapper).toHaveClass('w-full', 'max-w-2xl', 'mx-auto')
+  })
+})
+
+// Self-protection: an admin must never be offered ban/delete on their own
+// account (resource and case differences in the connection JID must not
+// defeat the check).
+describe('AdminView own admin account protection', () => {
+  const originalHasCommand = adminState.hasCommand
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    adminState.currentSession = null
+    adminState.hasCommand = () => true
+    conn.jid = null
+  })
+
+  afterEach(() => {
+    adminState.hasCommand = originalHasCommand
+  })
+
+  it('hides ban and delete when the selected user is the signed-in account', () => {
+    conn.jid = 'Alice@Example.com/Fluux'
+    render(<AdminView activeCategory="users" onBack={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('alice@example.com'))
+
+    expect(screen.getByText('admin.users.changePassword')).toBeInTheDocument()
+    expect(screen.getByText('admin.users.endSessions')).toBeInTheDocument()
+    expect(screen.queryByText('admin.users.banAccount')).not.toBeInTheDocument()
+    expect(screen.queryByText('admin.users.delete')).not.toBeInTheDocument()
+  })
+
+  it('keeps ban and delete for other accounts', () => {
+    conn.jid = 'admin@example.com/Fluux'
+    render(<AdminView activeCategory="users" onBack={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('alice@example.com'))
+
+    expect(screen.getByText('admin.users.banAccount')).toBeInTheDocument()
+    expect(screen.getByText('admin.users.delete')).toBeInTheDocument()
   })
 })

--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Server, Plus, ArrowLeft, Menu } from 'lucide-react'
-import { useAdmin, useXMPP, adminStore, type AdminCategory, type AdminUser, type AdminRoom } from '@fluux/sdk'
-import { useAdminStore } from '@fluux/sdk/react'
+import { useAdmin, useXMPP, adminStore, getBareJid, type AdminCategory, type AdminUser, type AdminRoom } from '@fluux/sdk'
+import { useAdminStore, useConnectionStore } from '@fluux/sdk/react'
 import { useModalInput } from '@/hooks'
 import { useWindowedList } from '../hooks/useWindowedList'
 import { Tooltip } from './Tooltip'
@@ -70,6 +70,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
   } = useAdmin()
 
   const usersTruncated = useAdminStore((s) => s.usersTruncated)
+  const ownJid = useConnectionStore((s) => s.jid)
 
   // Local state
   const [userSearchQuery, setUserSearchQuery] = useState('')
@@ -364,6 +365,9 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
           onChangePassword={handleChangePassword}
           onBanAccount={handleBanAccount}
           canBanAccount={hasCommand('ban_account')}
+          isOwnAccount={
+            ownJid != null && getBareJid(ownJid).toLowerCase() === selectedUser.jid.toLowerCase()
+          }
           isExecuting={isExecuting}
           fetchLastLogin={fetchUserLastLogin}
           hasLastLoginCommand={hasCommand('get-user-lastlogin')}


### PR DESCRIPTION
The admin user detail view offered Ban account and Delete user on every account, including the signed-in admin's own, only one confirmation away from locking yourself out of your own server.

AdminUserView now takes an `isOwnAccount` prop and hides the Ban/Delete rows when it is set. AdminView computes it by comparing the connection JID (resource stripped, case-insensitive) with the selected user's JID, so it also covers drill-in via the roster "Manage" action.