### PR TITLE
fix(sdk): close chat/room store parity drifts and entry-point hygiene gaps

### DIFF
--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { useConnectionStatus, useXMPPContext, hasFastToken } from '@fluux/sdk'
+import { useConnectionStatus, useXMPPContext, hasFastToken, getBareJid, getDomain } from '@fluux/sdk'
 import { registerE2EEPlugins } from './e2ee/registerPlugins'
 import { isKeyLocked } from './e2ee/webPassphraseStore'
 import { attemptCachedUnlockOrPrompt } from '@/e2ee/silentRestore'
@@ -174,7 +174,7 @@ function App() {
     const savedServer = localStorage.getItem('xmpp-last-server')
     // Fallback: derive server from JID domain when savedServer is empty
     // (backward compat with older sessions that stored '' for the server field)
-    const effectiveServer = savedServer || (savedJid ? savedJid.split('@')[1] : null)
+    const effectiveServer = savedServer || (savedJid ? getDomain(savedJid) : null)
     return !!(rememberMe && savedJid && effectiveServer && hasFastToken(savedJid))
   })
 
@@ -244,7 +244,7 @@ function App() {
         //     advertises an identity (fresh device / cleared browser).
         //     Silent generation would fork the identity, so we route to a
         //     deliberate choice instead.
-        const accountJid = jid ? jid.split('/')[0] : null
+        const accountJid = jid ? getBareJid(jid) : null
         const plugin = client.e2ee?.getPlugin('openpgp') as
           | {
               hasNoLocalKey?: () => Promise<boolean>

--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Server, Plus, ArrowLeft, Menu } from 'lucide-react'
-import { useAdmin, useXMPP, adminStore, type AdminCategory, type AdminUser, type AdminRoom } from '@fluux/sdk'
+import { useAdmin, useXMPP, adminStore, getLocalPart, type AdminCategory, type AdminUser, type AdminRoom } from '@fluux/sdk'
 import { useAdminStore } from '@fluux/sdk/react'
 import { useModalInput } from '@/hooks'
 import { useWindowedList } from '../hooks/useWindowedList'
@@ -103,7 +103,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
       } else {
         // User not in current list - create a minimal AdminUser object
         // This handles cases where the user exists but wasn't in the first page
-        const username = pendingSelectedUserJid.split('@')[0]
+        const username = getLocalPart(pendingSelectedUserJid)
         setSelectedUser({
           jid: pendingSelectedUserJid,
           username,

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -64,7 +64,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { uploadFile, isUploading, progress, isSupported, error: uploadError, clearError: clearUploadError } = useFileUpload()
   const { processMessageForLinkPreview } = useLinkPreview()
   const { resolvedMode } = useMode()
-  const myBareJid = jid?.split('/')[0]
+  const myBareJid = jid ? getBareJid(jid) : undefined
 
   // Reply state - which message are we replying to
   const [replyingTo, setReplyingTo] = useState<Message | null>(null)

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -361,7 +361,7 @@ function CommandPaletteContent({
       items.push({
         id: `room-${room.jid}`,
         type: 'room',
-        label: room.name || room.jid.split('@')[0],
+        label: room.name || getLocalPart(room.jid),
         sublabel: room.jid,
         lastMessagePreview: preview,
         lastMessageBody: room.lastMessage?.body,
@@ -379,7 +379,7 @@ function CommandPaletteContent({
       items.push({
         id: `bookmark-${room.jid}`,
         type: 'room',
-        label: room.name || room.jid.split('@')[0],
+        label: room.name || getLocalPart(room.jid),
         sublabel: `${room.jid} (${t('rooms.bookmarked')})`,
         avatarIdentifier: room.jid,
         avatarUrl: room.avatar,

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -105,6 +105,25 @@ describe('XMPPClient', () => {
       expect(typeof client.roster.addContact).toBe('function')
     })
 
+    it('installs the crypto.randomUUID polyfill in the constructor (legacy webviews)', () => {
+      // The polyfill must NOT rely on an import-time side effect (the package
+      // is sideEffects:false, so bundlers may drop those) — constructing a
+      // client must be enough, on any entry point.
+      vi.stubGlobal('crypto', {
+        getRandomValues: (arr: Uint8Array) => {
+          for (let i = 0; i < arr.length; i++) arr[i] = i
+          return arr
+        },
+      })
+      try {
+        expect(typeof (globalThis.crypto as Crypto).randomUUID).toBe('undefined')
+        new XMPPClient({ debug: false })
+        expect(typeof (globalThis.crypto as Crypto).randomUUID).toBe('function')
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    })
+
     it('should allow bindStores to override default bindings (backwards compatibility)', () => {
       const client = new XMPPClient({ debug: false })
 

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -26,6 +26,7 @@ import {
 } from './presenceMachine'
 import type { ConnectionActor, ConnectionStateValue } from './connectionMachine'
 import { generateUUID } from '../utils/uuid'
+import { ensureCryptoRandomUUID } from './polyfill'
 import { createStoreBindings } from '../bindings/storeBindings'
 import { setupStoreSideEffects } from './sideEffects'
 import {
@@ -484,6 +485,11 @@ export class XMPPClient {
    * ```
    */
   constructor(config: XMPPClientConfig = {}) {
+    // Legacy webviews lack crypto.randomUUID, which @xmpp/client calls when
+    // generating ids. Installed here (not as an import-time side effect) so
+    // it survives tree-shaking and covers the /core entry point too.
+    ensureCryptoRandomUUID()
+
     // Detect platform early for caps/client identification
     // This is async but we fire-and-forget; the result is cached for later use
     void detectPlatform()
@@ -1538,25 +1544,52 @@ export class XMPPClient {
    * ```
    */
   async sendRawXml(xmlString: string): Promise<void> {
-    const xmpp = this.getXmpp()
-    if (!xmpp) {
-      // Defensive check: if client is null but status says 'online', fix the inconsistency
-      const currentStatus = this.stores?.connection.getStatus?.()
-      if (currentStatus === 'online') {
-        this.stores?.console.addEvent('Client null but status online - triggering reconnect', 'error')
-        this.connection.handleDeadSocket()
-      }
-      throw new Error('Not connected')
-    }
+    const xmpp = this.requireTransport()
     try {
       await (xmpp as any).write(xmlString)
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err)
-      if (isDeadSocketError(errorMessage)) {
-        this.connection.handleDeadSocket()
-      }
-      throw err
+      this.repairAndRethrowSendError(err)
     }
+  }
+
+  /**
+   * Fetch the live transport for an outbound write, or throw.
+   *
+   * Repairs the "status says online but the client/socket is gone" race by
+   * triggering a reconnect before throwing. `label` distinguishes the console
+   * diagnostics (e.g. 'IQ'); `checkSocket` additionally verifies the
+   * underlying socket exists (the client object can outlive a dead socket).
+   */
+  private requireTransport(label = '', options: { checkSocket?: boolean } = {}): Client {
+    const suffix = label ? ` (${label})` : ''
+    const xmpp = this.getXmpp()
+    if (!xmpp) {
+      this.reconnectIfStatusOnline(`Client null but status online${suffix} - triggering reconnect`)
+      throw new Error('Not connected')
+    }
+    if (options.checkSocket && !(xmpp as any).socket) {
+      this.reconnectIfStatusOnline(`Socket null but status online${suffix} - triggering reconnect`)
+      throw new Error('Socket not available')
+    }
+    return xmpp
+  }
+
+  /** Trigger a dead-socket reconnect when the store still believes we are online. */
+  private reconnectIfStatusOnline(message: string): void {
+    const currentStatus = this.stores?.connection.getStatus?.()
+    if (currentStatus === 'online') {
+      this.stores?.console.addEvent(message, 'error')
+      this.connection.handleDeadSocket()
+    }
+  }
+
+  /** Classify an outbound-write failure, kick off a reconnect on a dead socket, and rethrow. */
+  private repairAndRethrowSendError(err: unknown): never {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    if (isDeadSocketError(errorMessage)) {
+      this.connection.handleDeadSocket()
+    }
+    throw err
   }
 
   // ============================================================================
@@ -2589,62 +2622,16 @@ export class XMPPClient {
   }
 
   protected async sendStanza(stanza: Element): Promise<void> {
-    const xmpp = this.getXmpp()
-    if (!xmpp) {
-      // Defensive check: if client is null but status says 'online', fix the inconsistency
-      // This can happen in rare race conditions (e.g., socket died but status not yet updated)
-      const currentStatus = this.stores?.connection.getStatus?.()
-      if (currentStatus === 'online') {
-        this.stores?.console.addEvent('Client null but status online - triggering reconnect', 'error')
-        this.connection.handleDeadSocket()
-      }
-      throw new Error('Not connected')
-    }
-
-    // Additional socket health check: verify the underlying socket exists
-    // This catches the race condition where xmpp client exists but socket is dead
-    const socket = (xmpp as any).socket
-    if (!socket) {
-      const currentStatus = this.stores?.connection.getStatus?.()
-      if (currentStatus === 'online') {
-        this.stores?.console.addEvent('Socket null but status online - triggering reconnect', 'error')
-        this.connection.handleDeadSocket()
-      }
-      throw new Error('Socket not available')
-    }
-
+    const xmpp = this.requireTransport('', { checkSocket: true })
     try {
       await xmpp.send(stanza)
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err)
-      if (isDeadSocketError(errorMessage)) {
-        this.connection.handleDeadSocket()
-      }
-      throw err
+      this.repairAndRethrowSendError(err)
     }
   }
 
   protected async sendIQ(iq: Element, timeoutMs?: number): Promise<Element> {
-    const xmpp = this.getXmpp()
-    if (!xmpp) {
-      const currentStatus = this.stores?.connection.getStatus?.()
-      if (currentStatus === 'online') {
-        this.stores?.console.addEvent('Client null but status online (IQ) - triggering reconnect', 'error')
-        this.connection.handleDeadSocket()
-      }
-      throw new Error('Not connected')
-    }
-
-    const socket = (xmpp as any).socket
-    if (!socket) {
-      const currentStatus = this.stores?.connection.getStatus?.()
-      if (currentStatus === 'online') {
-        this.stores?.console.addEvent('Socket null but status online (IQ) - triggering reconnect', 'error')
-        this.connection.handleDeadSocket()
-      }
-      throw new Error('Socket not available')
-    }
-
+    const xmpp = this.requireTransport('IQ', { checkSocket: true })
     try {
       const request = (xmpp as any).iqCaller.request(iq)
       if (timeoutMs != null) {
@@ -2657,11 +2644,7 @@ export class XMPPClient {
       }
       return await request
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err)
-      if (isDeadSocketError(errorMessage)) {
-        this.connection.handleDeadSocket()
-      }
-      throw err
+      this.repairAndRethrowSendError(err)
     }
   }
 

--- a/packages/fluux-sdk/src/core/polyfill.test.ts
+++ b/packages/fluux-sdk/src/core/polyfill.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { webcrypto } from 'node:crypto'
+import { ensureCryptoRandomUUID } from './polyfill'
+
+describe('ensureCryptoRandomUUID', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('installs a spec-shaped randomUUID when missing (old WebKitGTK/Chromium)', () => {
+    // Simulate an old webview: getRandomValues exists, randomUUID does not.
+    vi.stubGlobal('crypto', {
+      getRandomValues: (arr: Uint8Array<ArrayBuffer>) => webcrypto.getRandomValues(arr),
+    })
+
+    ensureCryptoRandomUUID()
+
+    const uuid = (globalThis.crypto as Crypto).randomUUID()
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  it('creates the crypto global when entirely absent', () => {
+    vi.stubGlobal('crypto', undefined)
+
+    ensureCryptoRandomUUID()
+
+    expect(typeof (globalThis.crypto as Crypto | undefined)?.randomUUID).toBe('function')
+  })
+
+  it('leaves a native implementation untouched', () => {
+    const native = () => 'native-uuid' as ReturnType<Crypto['randomUUID']>
+    vi.stubGlobal('crypto', { randomUUID: native })
+
+    ensureCryptoRandomUUID()
+
+    expect((globalThis.crypto as Crypto).randomUUID).toBe(native)
+  })
+})

--- a/packages/fluux-sdk/src/core/polyfill.ts
+++ b/packages/fluux-sdk/src/core/polyfill.ts
@@ -1,0 +1,34 @@
+/**
+ * Runtime polyfills for legacy webviews (old Chromium <92, old WebKitGTK).
+ *
+ * Called from the XMPPClient constructor rather than run as a module-level
+ * side effect: the package declares `"sideEffects": false`, so bundlers are
+ * free to drop any import-time side effect during tree-shaking. An explicit
+ * call at the first point of use is both tree-shake-safe and covers every
+ * entry point (`@fluux/sdk` and `@fluux/sdk/core` alike).
+ */
+
+/**
+ * Ensure `crypto.randomUUID` exists. @xmpp/client calls it internally when
+ * generating stanza/session ids; legacy webviews only ship
+ * `crypto.getRandomValues`. Idempotent — a native implementation is left
+ * untouched.
+ */
+export function ensureCryptoRandomUUID(): void {
+  if (typeof globalThis === 'undefined') return
+  if (typeof globalThis.crypto === 'undefined') {
+    // @ts-expect-error - polyfill for environments without crypto
+    globalThis.crypto = {}
+  }
+  if (typeof globalThis.crypto.randomUUID !== 'function') {
+    globalThis.crypto.randomUUID = (): `${string}-${string}-${string}-${string}-${string}` => {
+      const bytes = new Uint8Array(16)
+      crypto.getRandomValues(bytes)
+      // Set version (4) and variant (RFC 4122)
+      bytes[6] = (bytes[6] & 0x0f) | 0x40
+      bytes[8] = (bytes[8] & 0x3f) | 0x80
+      const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as `${string}-${string}-${string}-${string}-${string}`
+    }
+  }
+}

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -1,24 +1,3 @@
-// Polyfill crypto.randomUUID for older browsers/webviews
-// Must run before @xmpp/client is imported (it uses crypto.randomUUID internally)
-// Supports: old Chromium (<92), old WebKitGTK, and other legacy environments
-if (typeof globalThis !== 'undefined') {
-  if (typeof globalThis.crypto === 'undefined') {
-    // @ts-expect-error - polyfill for environments without crypto
-    globalThis.crypto = {}
-  }
-  if (typeof globalThis.crypto.randomUUID !== 'function') {
-    globalThis.crypto.randomUUID = (): `${string}-${string}-${string}-${string}-${string}` => {
-      const bytes = new Uint8Array(16)
-      crypto.getRandomValues(bytes)
-      // Set version (4) and variant (RFC 4122)
-      bytes[6] = (bytes[6] & 0x0f) | 0x40
-      bytes[8] = (bytes[8] & 0x3f) | 0x80
-      const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')
-      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as `${string}-${string}-${string}-${string}-${string}`
-    }
-  }
-}
-
 /**
  * # Fluux SDK
  *
@@ -63,8 +42,10 @@ if (typeof globalThis !== 'undefined') {
  * ## Headless Usage (Bots/CLI)
  *
  * ```typescript
- * import { XMPPClient, createDefaultStoreBindings } from '@fluux/sdk/core'
+ * import { XMPPClient } from '@fluux/sdk/core'
  *
+ * // The constructor wires the default store bindings automatically —
+ * // no React and no extra setup needed.
  * const client = new XMPPClient()
  * await client.connect({ jid: 'bot@example.com', password: 'secret', server: 'example.com' })
  * client.chat.sendMessage('user@example.com', 'Hello!')

--- a/packages/fluux-sdk/src/react/barrelParity.test.ts
+++ b/packages/fluux-sdk/src/react/barrelParity.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import * as main from '../index'
+import * as react from './index'
+
+/**
+ * Guard against entry-point barrel drift: every React hook exported from the
+ * main entry (`@fluux/sdk`) must also be exported from `@fluux/sdk/react`,
+ * otherwise "React-only bundle" users silently get a smaller API.
+ * (The reverse is not required: /react additionally exports the store hooks
+ * that are deliberately kept out of the main entry.)
+ */
+describe('entry-point barrel parity', () => {
+  it('exports every main-entry React hook from @fluux/sdk/react', () => {
+    const mainHooks = Object.keys(main).filter((key) => /^use[A-Z]/.test(key))
+    expect(mainHooks.length).toBeGreaterThan(0)
+
+    const reactKeys = new Set(Object.keys(react))
+    const missing = mainHooks.filter((key) => !reactKeys.has(key))
+    expect(missing).toEqual([])
+  })
+})

--- a/packages/fluux-sdk/src/react/index.ts
+++ b/packages/fluux-sdk/src/react/index.ts
@@ -25,7 +25,7 @@
  * ```
  *
  * For framework-agnostic usage (bots, CLI tools, other frameworks),
- * use the core SDK: `import { XMPPClient } from '@fluux/sdk'`
+ * use the core SDK: `import { XMPPClient } from '@fluux/sdk/core'`
  *
  * @packageDocumentation
  * @module React
@@ -40,14 +40,20 @@ export { useConnection } from '../hooks/useConnection'
 export { useConnectionStatus } from '../hooks/useConnectionStatus'
 export { useConnectionActions } from '../hooks/useConnectionActions'
 export { useChat } from '../hooks/useChat'
+export { useChatActive } from '../hooks/useChatActive'
+export { useChatActions } from '../hooks/useChatActions'
 export { useRoster } from '../hooks/useRoster'
 export { useRosterActions } from '../hooks/useRosterActions'
+export { useContactIdentities, type ContactIdentity } from '../hooks/useContactIdentities'
 export { useConsole } from '../hooks/useConsole'
 export { useEvents } from '../hooks/useEvents'
 export { useRoom } from '../hooks/useRoom'
 export { useRoomActive } from '../hooks/useRoomActive'
+export { useRoomActions } from '../hooks/useRoomActions'
+export { useReferencedMessage, type ReferencedMessageParams } from '../hooks/useReferencedMessage'
 export { useXMPP } from '../hooks/useXMPP'
 export { useAdmin } from '../hooks/useAdmin'
+export { useAdminPermissions } from '../hooks/useAdminPermissions'
 export { useBlocking } from '../hooks/useBlocking'
 export { useIgnore } from '../hooks/useIgnore'
 export { usePresence } from '../hooks/usePresence'
@@ -59,7 +65,7 @@ export type { NotificationEventHandlers } from '../hooks/useNotificationEvents'
 export { useContactTime } from '../hooks/useContactTime'
 export { useLastActivity } from '../hooks/useLastActivity'
 export { useSearch } from '../hooks/useSearch'
-export type { SearchResult } from '../hooks/useSearch'
+export type { SearchResult, SearchResultContext, SearchFilterType, InPrefixSuggestion } from '../hooks/useSearch'
 
 // Fine-grained metadata subscription hooks
 export {
@@ -76,6 +82,7 @@ export {
   useRoomRuntime,
   useRoomMessages,
   useRoomOccupants,
+  useRoomOccupantCount,
   useAllRoomSidebarItems,
   useRoomSidebarItems,
   useRoomTotalMentionsCount,

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -3,6 +3,7 @@ import { chatStore } from './chatStore'
 import type { Message, Conversation } from '../core/types'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
+import { setResidentWindowSize } from './shared/residentWindow'
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -3516,6 +3517,109 @@ describe('chatStore', () => {
       chatStore.getState().setTargetMessageId('msg-123')
       chatStore.getState().reset()
       expect(chatStore.getState().targetMessageId).toBeNull()
+    })
+  })
+})
+
+// Regression tests for chat/room parity drifts: each of these behaviors already
+// exists in roomStore and had silently diverged in chatStore (or vice versa).
+describe('chatStore parity drift regressions', () => {
+  const convId = 'peer@example.com'
+
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    localStorageMock.clear()
+    chatStore.setState({
+      conversationEntities: new Map(),
+      conversationMeta: new Map(),
+      conversations: new Map(),
+      messages: new Map(),
+      activeConversationId: null,
+      archivedConversations: new Set(),
+      firstNewMessageMarkers: new Map(),
+      windowAtLiveEdge: new Map(),
+      mamQueryStates: new Map(),
+      conversationGaps: new Map(),
+    })
+    chatStore.getState().addConversation(createConversation(convId))
+    chatStore.setState({ activeConversationId: convId })
+  })
+
+  afterEach(() => {
+    setResidentWindowSize(5000)
+  })
+
+  function messageAt(id: string, body: string, iso: string): Message {
+    return {
+      type: 'chat',
+      id,
+      conversationId: convId,
+      from: convId,
+      body,
+      timestamp: new Date(iso),
+      isOutgoing: false,
+    }
+  }
+
+  describe('addMessage sliding-window trim (parity with roomStore)', () => {
+    it('trims the resident array to the window bound on live append', () => {
+      setResidentWindowSize(3)
+      for (let i = 1; i <= 4; i++) {
+        chatStore.getState().addMessage(messageAt(`m-${i}`, `m${i}`, `2024-01-15T10:0${i}:00Z`))
+      }
+      const resident = chatStore.getState().messages.get(convId) || []
+      expect(resident.map((m) => m.id)).toEqual(['m-2', 'm-3', 'm-4'])
+    })
+  })
+
+  describe('updateReactions cache fallback (parity with roomStore)', () => {
+    it('updates the durable cache when the conversation is resident but the message is not', () => {
+      chatStore.getState().addMessage(messageAt('resident-1', 'still here', '2024-01-15T10:00:00Z'))
+      vi.mocked(messageCache.updateMessageReactions).mockClear()
+      const residentBefore = chatStore.getState().messages.get(convId)
+
+      chatStore.getState().updateReactions(convId, 'evicted-1', 'bob@example.com', ['👍'])
+
+      expect(messageCache.updateMessageReactions).toHaveBeenCalledWith('evicted-1', 'bob@example.com', ['👍'])
+      // The resident array is untouched — only the durable copy is patched.
+      expect(chatStore.getState().messages.get(convId)).toBe(residentBefore)
+    })
+  })
+
+  describe('cache pagination dedupe (parity with roomStore)', () => {
+    it('loadOlderMessagesFromCache dedupes and sorts an overlapping, out-of-order batch', async () => {
+      const current = messageAt('cur-1', 'current', '2024-01-15T11:00:00Z')
+      chatStore.setState((state) => ({ messages: new Map(state.messages).set(convId, [current]) }))
+
+      // Batch overlaps the resident window (cur-1 again) and arrives out of order.
+      vi.mocked(messageCache.getMessages).mockReset()
+      vi.mocked(messageCache.getMessages).mockResolvedValue([
+        { ...current },
+        messageAt('old-2', 'older 2', '2024-01-15T10:30:00Z'),
+        messageAt('old-1', 'older 1', '2024-01-15T10:00:00Z'),
+      ])
+
+      await chatStore.getState().loadOlderMessagesFromCache(convId)
+
+      const resident = chatStore.getState().messages.get(convId) || []
+      expect(resident.map((m) => m.id)).toEqual(['old-1', 'old-2', 'cur-1'])
+    })
+
+    it('loadNewerMessagesFromCache dedupes and sorts an overlapping, out-of-order batch', async () => {
+      const current = messageAt('cur-1', 'current', '2024-01-15T11:00:00Z')
+      chatStore.setState((state) => ({ messages: new Map(state.messages).set(convId, [current]) }))
+
+      vi.mocked(messageCache.getMessages).mockReset()
+      vi.mocked(messageCache.getMessages).mockResolvedValue([
+        messageAt('new-2', 'newer 2', '2024-01-15T13:00:00Z'),
+        { ...current },
+        messageAt('new-1', 'newer 1', '2024-01-15T12:00:00Z'),
+      ])
+
+      await chatStore.getState().loadNewerMessagesFromCache(convId)
+
+      const resident = chatStore.getState().messages.get(convId) || []
+      expect(resident.map((m) => m.id)).toEqual(['cur-1', 'new-1', 'new-2'])
     })
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -907,7 +907,10 @@ export const chatStore = createStore<ChatState>()(
           // below still run). ABSENT or true = at the live edge; only explicit false gates.
           const atLiveEdge = state.windowAtLiveEdge.get(msg.conversationId) !== false
           const newMessages = new Map(state.messages)
-          newMessages.set(msg.conversationId, atLiveEdge ? [...convMessages, msg] : convMessages)
+          newMessages.set(
+            msg.conversationId,
+            atLiveEdge ? trimMessages([...convMessages, msg], getResidentWindowSize()) : convMessages
+          )
 
           const conv = state.conversations.get(msg.conversationId)
           const meta = state.conversationMeta.get(msg.conversationId)
@@ -1307,7 +1310,14 @@ export const chatStore = createStore<ChatState>()(
           // Resolve by id/stanzaId first, origin-id only as fallback (reactions
           // may reference any tier; origin-id must not shadow a real id).
           const messageIndex = findMessageIndexById(convMessages, messageId)
-          if (messageIndex === -1) return state
+          if (messageIndex === -1) {
+            // The conversation is resident but the target message is not (the
+            // sliding window evicted it). Update the durable cache so the
+            // reaction survives instead of being silently dropped.
+            logInfo(`Reaction for message ${messageId} not in resident window — updating in cache`)
+            void messageCache.updateMessageReactions(messageId, reactorJid, emojis)
+            return state
+          }
 
           const message = convMessages[messageIndex]
           const currentReactions = message.reactions || {}
@@ -1834,9 +1844,16 @@ export const chatStore = createStore<ChatState>()(
             set((state) => {
               const currentMessages = state.messages.get(conversationId) || []
 
-              // Merge older messages at the beginning and trim using shared utility.
+              // Dedupe against the resident array (in-memory messages take precedence):
+              // a cache slice can overlap the window at the `before:` boundary.
+              const existingKeys = buildMessageKeySet(currentMessages, getChatMessageKeys)
+              const newFromCache = olderMessages.filter(
+                (msg) => !isMessageDuplicate(msg, existingKeys, getChatMessageKeys)
+              )
+
+              // Merge older messages at the beginning, sort, and trim using shared utilities.
               // Load-older slides the window (keep oldest) so scroll-back past the bound works.
-              const merged = [...olderMessages, ...currentMessages]
+              const merged = sortMessagesByTimestamp([...newFromCache, ...currentMessages])
               const trimmed = trimMessagesKeepOldest(merged, getResidentWindowSize())
 
               const newMessagesMap = new Map(state.messages)
@@ -1886,9 +1903,16 @@ export const chatStore = createStore<ChatState>()(
             set((state) => {
               const currentMessages = state.messages.get(conversationId) || []
 
-              // Merge newer messages at the end and trim using shared utility.
+              // Dedupe against the resident array (in-memory messages take precedence):
+              // a cache slice can overlap the window at the `after:` boundary.
+              const existingKeys = buildMessageKeySet(currentMessages, getChatMessageKeys)
+              const newFromCache = newerMessages.filter(
+                (msg) => !isMessageDuplicate(msg, existingKeys, getChatMessageKeys)
+              )
+
+              // Merge newer messages at the end, sort, and trim using shared utilities.
               // Load-newer slides the window (keep newest) so sliding back down works.
-              const merged = [...currentMessages, ...newerMessages]
+              const merged = sortMessagesByTimestamp([...currentMessages, ...newFromCache])
               const trimmed = trimMessages(merged, getResidentWindowSize())
 
               const newMessagesMap = new Map(state.messages)

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3,6 +3,7 @@ import { roomStore } from './roomStore'
 import type { Room, RoomMessage } from '../core/types'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
+import { setResidentWindowSize } from './shared/residentWindow'
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -4713,5 +4714,118 @@ describe('acknowledged non-anonymous rooms', () => {
     } finally {
       _resetStorageScopeForTesting()
     }
+  })
+})
+
+// Regression tests for chat/room parity drifts: each of these behaviors already
+// exists in chatStore and had silently diverged in roomStore (or vice versa).
+describe('roomStore parity drift regressions', () => {
+  const roomJid = 'drift@conference.example.com'
+
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    localStorageMock.clear()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      firstNewMessageMarkers: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+    })
+    roomStore.getState().addRoom(createRoom(roomJid, { joined: true }))
+  })
+
+  afterEach(() => {
+    setResidentWindowSize(5000)
+  })
+
+  function messageAt(id: string, nick: string, body: string, iso: string): RoomMessage {
+    return {
+      type: 'groupchat',
+      id,
+      roomJid,
+      from: `${roomJid}/${nick}`,
+      nick,
+      body,
+      timestamp: new Date(iso),
+      isOutgoing: false,
+    }
+  }
+
+  describe('addMessage archive-id backfill (parity with chatStore)', () => {
+    it('backfills the server stanzaId from a dropped duplicate echo', () => {
+      const original: RoomMessage = {
+        ...messageAt('orig-1', 'testuser', 'hello', '2024-01-15T10:00:00Z'),
+        isOutgoing: true,
+        originId: 'origin-abc',
+      }
+      roomStore.getState().addMessage(roomJid, original)
+      vi.mocked(messageCache.updateRoomMessage).mockClear()
+
+      // The MAM/archive copy of the same message arrives with the server archive id.
+      const archived: RoomMessage = { ...original, stanzaId: 'archive-123' }
+      roomStore.getState().addMessage(roomJid, archived)
+
+      const messages = roomStore.getState().rooms.get(roomJid)?.messages || []
+      expect(messages).toHaveLength(1)
+      expect(messages[0].stanzaId).toBe('archive-123')
+      // The runtime mirror must receive the same patched array.
+      expect(roomStore.getState().roomRuntime.get(roomJid)?.messages[0]?.stanzaId).toBe('archive-123')
+      // The backfill must also persist so the cursor survives a reload.
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+        'orig-1',
+        expect.objectContaining({ stanzaId: 'archive-123' })
+      )
+    })
+  })
+
+  describe('backward MAM merge preview guard (parity with chatStore)', () => {
+    it('does not regress the sidebar preview when keep-oldest evicts the newest tail', () => {
+      setResidentWindowSize(2)
+      roomStore.setState({ activeRoomJid: roomJid })
+
+      const newest = messageAt('new-1', 'alice', 'newest', '2024-01-15T12:00:00Z')
+      roomStore.getState().addMessage(roomJid, newest)
+      expect(roomStore.getState().rooms.get(roomJid)?.lastMessage?.id).toBe('new-1')
+
+      // Scroll-up merge: two older messages + window of 2 → keep-oldest evicts 'new-1'.
+      const older = [
+        messageAt('old-1', 'bob', 'old 1', '2024-01-15T10:00:00Z'),
+        messageAt('old-2', 'bob', 'old 2', '2024-01-15T10:30:00Z'),
+      ]
+      roomStore.getState().mergeRoomMAMMessages(roomJid, older, { first: 'cursor-1' }, false, 'backward')
+
+      // The resident window slid, but the sidebar preview must stay on the newest message.
+      expect(roomStore.getState().rooms.get(roomJid)?.messages.map((m) => m.id)).toEqual(['old-1', 'old-2'])
+      expect(roomStore.getState().rooms.get(roomJid)?.lastMessage?.id).toBe('new-1')
+      expect(roomStore.getState().roomMeta.get(roomJid)?.lastMessage?.id).toBe('new-1')
+    })
+
+    it('still heals a preview stuck on an encrypted fallback (isResolvedSamePreview)', () => {
+      // A non-resident room whose preview holds the undecrypted fallback: the
+      // resolved copy arriving via MAM has the SAME id and timestamp, so the
+      // newer-only guard alone would refuse it — the heal path must let it through.
+      const encrypted: RoomMessage = {
+        ...messageAt('enc-1', 'alice', '[OpenPGP-encrypted message]', '2024-01-15T12:00:00Z'),
+        encryptedPayload: '<openpgp xmlns="urn:xmpp:openpgp:0">…</openpgp>',
+      }
+      roomStore.setState((state) => {
+        const rooms = new Map(state.rooms)
+        const room = rooms.get(roomJid)!
+        rooms.set(roomJid, { ...room, messages: [], lastMessage: encrypted })
+        const roomMeta = new Map(state.roomMeta)
+        roomMeta.set(roomJid, { ...roomMeta.get(roomJid)!, lastMessage: encrypted })
+        return { rooms, roomMeta }
+      })
+
+      const resolved: RoomMessage = { ...encrypted, body: 'decrypted at last', encryptedPayload: undefined }
+      roomStore.getState().mergeRoomMAMMessages(roomJid, [resolved], {}, true, 'forward')
+
+      expect(roomStore.getState().rooms.get(roomJid)?.lastMessage?.body).toBe('decrypted at last')
+      expect(roomStore.getState().roomMeta.get(roomJid)?.lastMessage?.body).toBe('decrypted at last')
+    })
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -23,8 +23,8 @@ import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
 import { computeGapEnd, syncGap, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
-import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, trimMessagesKeepOldest, prependOlderMessages, mergeAndProcessMessages } from './shared/messageArrayUtils'
-import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
+import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, trimMessagesKeepOldest, prependOlderMessages, mergeAndProcessMessages, backfillArchiveIds } from './shared/messageArrayUtils'
+import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, isResolvedSamePreview, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
 import { roomActivityTone } from './roomSelectors'
 import * as notifState from './shared/notificationState'
@@ -1184,7 +1184,23 @@ export const roomStore = createStore<RoomState>()(
       // XEP-0359: Deduplicate messages using shared utility
       const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
       if (isMessageDuplicate(messageToAdd, existingKeys, getRoomMessageKeys)) {
-        return state // Don't add duplicate message
+        // The duplicate may be the archived/reflected copy of an outgoing
+        // message that has no stanzaId yet. Backfill the server archive id
+        // onto the in-memory copy (matched by originId) so backward MAM
+        // pagination has a valid cursor — then still skip adding the dup
+        // (parity with chatStore.addMessage).
+        const { messages: backfilled, patched } = backfillArchiveIds(existing.messages, [messageToAdd], getRoomMessageKeys)
+        if (patched.length === 0) return state
+        for (const p of patched) {
+          void messageCache.updateRoomMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+        }
+        newRooms.set(roomJid, { ...existing, messages: backfilled })
+        const patchedRuntime = new Map(state.roomRuntime)
+        const runtimeEntry = patchedRuntime.get(roomJid)
+        if (runtimeEntry) {
+          patchedRuntime.set(roomJid, { ...runtimeEntry, messages: backfilled })
+        }
+        return { rooms: newRooms, roomRuntime: patchedRuntime }
       }
 
       // Sliding window: only append the live message to the resident array when the
@@ -2473,8 +2489,17 @@ export const roomStore = createStore<RoomState>()(
         searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
       }
 
-      // Sidebar preview = newest non-ignored across the merged set.
-      const lastMessage = (merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, room.nickToJidCache) : undefined) ?? room.lastMessage
+      // Sidebar preview: newest non-ignored message across the merged set — but only
+      // when it genuinely supersedes the current preview. A backward (scroll-up) merge
+      // whose keep-oldest trim evicted the newest tail yields a candidate OLDER than
+      // the current preview; replacing would regress the sidebar (parity with
+      // chatStore.mergeMAMMessages). isResolvedSamePreview heals a preview stuck on
+      // an encrypted fallback after its deferred decrypt.
+      const previewCandidate = merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, room.nickToJidCache) : undefined
+      const lastMessage = previewCandidate &&
+        (shouldReplaceLastMessage(room.lastMessage, previewCandidate) || isResolvedSamePreview(room.lastMessage, previewCandidate))
+        ? previewCandidate
+        : room.lastMessage
 
       const newMeta = new Map(state.roomMeta)
       const existingMeta = newMeta.get(roomJid)


### PR DESCRIPTION
Phase 0 of the SDK improvement roadmap: fixes five live chat/room store parity drifts found during the codebase review, each locked in with a regression test, plus small packaging/API hygiene repairs.

**Store parity fixes**
- `chatStore.addMessage` now trims the resident array at the live edge — an active conversation grew unboundedly during long live sessions (rooms already trimmed).
- `chatStore.updateReactions` falls back to the durable cache when the target message slid out of the resident window instead of dropping the reaction.
- `roomStore.mergeRoomMAMMessages` no longer regresses the sidebar preview when a backward (scroll-up) merge evicts the newest tail, and now heals previews stuck on an encrypted fallback (parity with chat).
- `chatStore.loadOlder/loadNewerMessagesFromCache` dedupe and sort cache batches — boundary overlap could duplicate or misorder messages (rooms already did both).
- `roomStore.addMessage` backfills the MAM archive `stanzaId` from dropped duplicate echoes so backward pagination keeps a valid cursor (parity with chat).

**Hygiene**
- The `crypto.randomUUID` polyfill was an import-time side effect in a `sideEffects:false` package — bundlers were free to drop it, and `/core` consumers never got it. It now runs in the `XMPPClient` constructor.
- `@fluux/sdk/react` had silently lost 7 hooks vs the main entry (`useChatActions`, `useRoomActions`, `useChatActive`, `useContactIdentities`, `useReferencedMessage`, `useAdminPermissions`, `useRoomOccupantCount`); a new barrel-parity test guards against future drift.
- The dead-socket transport guard in `XMPPClient` was copy-pasted three times; now one helper.
- Headless/bot docs pointed at the wrong entry point; review-flagged raw JID splits in the app now use the SDK JID utils.