### PR TITLE
perf(scroll): cut pin-bottom forced layout/repaint cost on WebKitGTK

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * pinVirtualizedBottom cost-control behavior (the WebKitGTK freeze fixes):
+ *
+ * 1. CONVERGENCE EARLY-EXIT — the ~60-frame re-assert loop must stop once the
+ *    geometry has been stable for a few consecutive frames instead of always
+ *    burning its full budget of per-frame forced layouts.
+ * 2. GATED REPAINT — the full-scroller repaint (overflowY toggle) is the most
+ *    expensive step on WebKitGTK and exists only for WebKit's stale paint after
+ *    a *programmatic scroll*; a pin that did not move scrollTop must skip it.
+ * 3. TYPING DEFERRAL — a typing-indicator toggle while a pin-bottom loop is
+ *    already running must not synchronously restart the pin (the active loop
+ *    picks up the height change on its next frame).
+ *
+ * Same harness as MessageList.pinBottomRepaint.test.tsx: mocked virtualizer,
+ * fake rAF queue, instrumented scroller geometry.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import type { BaseMessage } from '@fluux/sdk'
+
+const scrollToEndCalls = { count: 0 }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(), selectionCount: 0, isSelecting: false,
+    selectAll: vi.fn(), extendTo: vi.fn(), clearSelection: vi.fn(), copySelected: vi.fn(),
+  })),
+}))
+vi.mock('./tanstackMessageVirtualizer', () => ({
+  useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
+    getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
+    getTotalSize: () => args.items.length * 40,
+    itemCount: args.items.length,
+    getOffsetForMessageId: () => 0,
+    getIndexForMessageId: (id: string) => { const i = args.items.findIndex((it) => it.key === id); return i >= 0 ? i : null },
+    ensureMessageMounted: vi.fn(() => Promise.resolve()),
+    measureElement: () => {},
+    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    scrollToIndex: (_index: number, opts?: { align?: string }) => {
+      const el = args.scrollRef.current; if (!el) return
+      if (opts?.align === 'end') { scrollToEndCalls.count += 1; el.scrollTop = el.scrollHeight }
+      else el.scrollTop = _index * 40
+    },
+  }),
+}))
+
+function makeMessages(count: number, prefix = 'msg'): BaseMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`, from: 'user@example.com', body: `Body ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i % 60), isOutgoing: false, type: 'chat' as const,
+  }))
+}
+
+describe('MessageList — pinVirtualizedBottom cost control', () => {
+  let realRaf: typeof requestAnimationFrame
+  let rafQueue: FrameRequestCallback[]
+  const flush = (frames: number) => { for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0)) }
+
+  const repaint = { overflowSets: [] as string[] }
+  // Mutable geometry so a test can grow the content (a send) or keep it static (a no-op pin).
+  const geo = { scrollHeight: 2000, clientHeight: 500 }
+
+  function instrumentScroller(scroller: HTMLElement) {
+    let top = 0
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => geo.scrollHeight, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { get: () => geo.clientHeight, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => top,
+      set: (v: number) => { top = Math.max(0, Math.min(v, geo.scrollHeight - geo.clientHeight)) },
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'offsetHeight', { get: () => 0, configurable: true })
+    const realStyle = scroller.style
+    let overflowY = ''
+    Object.defineProperty(realStyle, 'overflowY', {
+      get: () => overflowY,
+      set: (v: string) => { overflowY = v; repaint.overflowSets.push(v) },
+      configurable: true,
+    })
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length }) as typeof requestAnimationFrame
+    scrollToEndCalls.count = 0
+    repaint.overflowSets = []
+    geo.scrollHeight = 2000
+    geo.clientHeight = 500
+  })
+  afterEach(() => { globalThis.requestAnimationFrame = realRaf; localStorage.clear() })
+
+  const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div>, onScrollToTop: vi.fn(), isHistoryComplete: false }
+  const sent: BaseMessage = { id: 'sent-1', from: 'me@example.com', body: 'hi', timestamp: new Date(2024, 0, 1, 13, 0), isOutgoing: true, type: 'chat' }
+
+  function renderPinned() {
+    const isAtBottomRef = { current: true }
+    const view = render(
+      <MessageList messages={makeMessages(50)} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70) // settle the entry pin completely
+    scrollToEndCalls.count = 0
+    repaint.overflowSets = []
+    return { ...view, isAtBottomRef }
+  }
+
+  it('stops the re-assert loop early once geometry is stable (convergence exit)', () => {
+    const { rerender, isAtBottomRef } = renderPinned()
+
+    geo.scrollHeight = 2040 // the sent row grows the content
+    rerender(<MessageList messages={[...makeMessages(50), sent]} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} {...props} />)
+    flush(2)
+    // The pin loop is alive right after the send…
+    expect(rafQueue.length).toBeGreaterThan(0)
+
+    // …but with stable geometry it must settle and stop well before the 60-frame
+    // budget (8 stable frames + margin), leaving nothing scheduled.
+    flush(15)
+    expect(rafQueue.length).toBe(0)
+  })
+
+  it('skips the forced repaint when the pin did not move scrollTop', () => {
+    const { isAtBottomRef } = renderPinned()
+    expect(isAtBottomRef.current).toBe(true)
+
+    // A viewport resize at unchanged geometry re-pins, but the scroll position is
+    // already exactly at the bottom: no programmatic scroll happened, so the
+    // WebKit stale-paint overflow toggle must be skipped entirely.
+    window.dispatchEvent(new Event('resize'))
+    flush(20)
+
+    expect(scrollToEndCalls.count).toBeGreaterThan(0) // the pin ran
+    expect(repaint.overflowSets).not.toContain('hidden') // but never forced a repaint
+  })
+
+  // The complementary case — a pin that DOES move scrollTop still forces the repaint — is the
+  // canonical send-stick test in MessageList.pinBottomRepaint.test.tsx.
+
+  it('defers a typing toggle to the already-running pin loop instead of restarting it', () => {
+    const { rerender, isAtBottomRef } = renderPinned()
+
+    geo.scrollHeight = 2040
+    const messagesWithSent = [...makeMessages(50), sent]
+    rerender(<MessageList messages={messagesWithSent} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} {...props} />)
+    flush(1) // loop started, far from settled
+
+    const callsWhileLoopActive = scrollToEndCalls.count
+    rerender(<MessageList messages={messagesWithSent} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} typingUsers={['alice']} {...props} />)
+
+    // No synchronous restart from the typing layout effect — the active loop owns the pin.
+    expect(scrollToEndCalls.count).toBe(callsWhileLoopActive)
+
+    // Once the loop has settled, a later typing toggle pins again (deferral is
+    // scoped to an ACTIVE loop only).
+    flush(30)
+    expect(rafQueue.length).toBe(0)
+    const callsAfterSettle = scrollToEndCalls.count
+    rerender(<MessageList messages={messagesWithSent} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} typingUsers={[]} {...props} />)
+    expect(scrollToEndCalls.count).toBeGreaterThan(callsAfterSettle)
+  })
+})

--- a/apps/fluux/src/components/conversation/MessageList.pinBottomRepaint.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomRepaint.test.tsx
@@ -67,12 +67,18 @@ describe('MessageList — pin forces a repaint after a programmatic scroll (WebK
   // records the overflowY values set, so we can assert the toggle happened and was restored.
   const repaint = { offsetHeightReads: 0, overflowSets: [] as string[] }
 
+  // Mutable so the send can GROW the content, as it does in reality: the repaint is gated on the
+  // pin actually moving scrollTop, and a static scrollHeight would make the send pin a no-op.
+  const geo = { scrollHeight: 2000, clientHeight: 500 }
+
   function instrumentScroller(scroller: HTMLElement) {
     let top = 0
-    Object.defineProperty(scroller, 'scrollHeight', { get: () => 2000, configurable: true })
-    Object.defineProperty(scroller, 'clientHeight', { get: () => 500, configurable: true })
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => geo.scrollHeight, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { get: () => geo.clientHeight, configurable: true })
     Object.defineProperty(scroller, 'scrollTop', {
-      get: () => top, set: (v: number) => { top = Math.max(0, Math.min(v, 1500)) }, configurable: true,
+      get: () => top,
+      set: (v: number) => { top = Math.max(0, Math.min(v, geo.scrollHeight - geo.clientHeight)) },
+      configurable: true,
     })
     Object.defineProperty(scroller, 'offsetHeight', { get: () => { repaint.offsetHeightReads += 1; return 0 }, configurable: true })
     // Track overflowY writes (forceRepaint sets 'hidden' then '').
@@ -94,6 +100,8 @@ describe('MessageList — pin forces a repaint after a programmatic scroll (WebK
     scrollToEndCalls.count = 0
     repaint.offsetHeightReads = 0
     repaint.overflowSets = []
+    geo.scrollHeight = 2000
+    geo.clientHeight = 500
   })
   afterEach(() => { globalThis.requestAnimationFrame = realRaf; localStorage.clear() })
 
@@ -112,7 +120,8 @@ describe('MessageList — pin forces a repaint after a programmatic scroll (WebK
     repaint.overflowSets = []
     scrollToEndCalls.count = 0
 
-    // SEND — an outgoing message triggers the new-message pin.
+    // SEND — an outgoing message grows the content and triggers the new-message pin.
+    geo.scrollHeight = 2040
     rerender(<MessageList messages={[...makeMessages(50), sent]} conversationId="conv-repaint" isAtBottomRef={isAtBottomRef} {...props} />)
     flush(3)
 

--- a/apps/fluux/src/components/conversation/pinBottomRun.test.ts
+++ b/apps/fluux/src/components/conversation/pinBottomRun.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the pin-bottom run helper: per-run convergence tracking, forced-work
+ * accounting for the [PinLoopProbe] fluux.log line, and the repaint gating policy.
+ *
+ * Pure logic — timestamps and storage are passed in, no DOM.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createPinRunTracker,
+  shouldForceRepaint,
+  readPinRepaintMode,
+} from './pinBottomRun'
+
+describe('createPinRunTracker — convergence', () => {
+  it('settles after the configured number of consecutive stable (non-write) frames', () => {
+    const run = createPinRunTracker({ settledFrames: 3 })
+    expect(run.frame(false)).toBe('continue')
+    expect(run.frame(false)).toBe('continue')
+    expect(run.frame(false)).toBe('settled')
+  })
+
+  it('a write frame resets the stable streak', () => {
+    const run = createPinRunTracker({ settledFrames: 3 })
+    expect(run.frame(false)).toBe('continue')
+    expect(run.frame(false)).toBe('continue')
+    expect(run.frame(true)).toBe('continue') // height moved → re-pinned → not stable
+    expect(run.frame(false)).toBe('continue')
+    expect(run.frame(false)).toBe('continue')
+    expect(run.frame(false)).toBe('settled')
+  })
+
+  it('defaults to 8 stable frames (matches the marker/restore stability precedent)', () => {
+    const run = createPinRunTracker()
+    for (let i = 0; i < 7; i++) expect(run.frame(false)).toBe('continue')
+    expect(run.frame(false)).toBe('settled')
+  })
+})
+
+describe('createPinRunTracker — forced-work accounting', () => {
+  it('accumulates ms by kind and reports the total', () => {
+    const run = createPinRunTracker()
+    run.addMs('flush', 10.4)
+    run.addMs('flush', 5)
+    run.addMs('scroll', 2)
+    run.addMs('repaint', 30.2)
+    expect(run.totalForcedMs()).toBeCloseTo(47.6, 5)
+  })
+
+  it('summary line carries trigger, frame/write counts and rounded per-kind ms', () => {
+    const run = createPinRunTracker({ settledFrames: 4 })
+    run.frame(true)
+    run.frame(true)
+    run.frame(false)
+    run.addMs('flush', 12.6)
+    run.addMs('scroll', 1.2)
+    run.addMs('repaint', 40.4)
+    const line = run.summaryLine('typing-reactions')
+    expect(line).toContain('[PinLoopProbe]')
+    expect(line).toContain('trigger=typing-reactions')
+    expect(line).toContain('frames=3')
+    expect(line).toContain('writes=2')
+    expect(line).toContain('flush=13ms')
+    expect(line).toContain('scroll=1ms')
+    expect(line).toContain('repaint=40ms')
+    expect(line).toContain('total=54ms')
+  })
+})
+
+describe('shouldForceRepaint — repaint gating policy', () => {
+  it('on-write: repaints only when the pin actually moved scrollTop', () => {
+    expect(shouldForceRepaint(true, 'on-write')).toBe(true)
+    expect(shouldForceRepaint(false, 'on-write')).toBe(false)
+  })
+
+  it('always: repaints regardless of movement (on-device A/B escape hatch)', () => {
+    expect(shouldForceRepaint(true, 'always')).toBe(true)
+    expect(shouldForceRepaint(false, 'always')).toBe(true)
+  })
+
+  it('off: never repaints (on-device A/B escape hatch)', () => {
+    expect(shouldForceRepaint(true, 'off')).toBe(false)
+    expect(shouldForceRepaint(false, 'off')).toBe(false)
+  })
+})
+
+describe('readPinRepaintMode — localStorage override parsing', () => {
+  const storageWith = (value: string | null) => ({ getItem: () => value })
+
+  it('parses the two explicit overrides', () => {
+    expect(readPinRepaintMode(storageWith('always'))).toBe('always')
+    expect(readPinRepaintMode(storageWith('off'))).toBe('off')
+  })
+
+  it('defaults to on-write for unset, unknown or unavailable storage', () => {
+    expect(readPinRepaintMode(storageWith(null))).toBe('on-write')
+    expect(readPinRepaintMode(storageWith('garbage'))).toBe('on-write')
+    expect(readPinRepaintMode(undefined)).toBe('on-write')
+    expect(
+      readPinRepaintMode({
+        getItem: () => {
+          throw new Error('storage disabled')
+        },
+      })
+    ).toBe('on-write')
+  })
+})

--- a/apps/fluux/src/components/conversation/pinBottomRun.ts
+++ b/apps/fluux/src/components/conversation/pinBottomRun.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-run helpers for `pinVirtualizedBottom` (useMessageListScroll).
+ *
+ * On WebKitGTK the pin's forced layouts (`flushTailLayout`) and forced repaints
+ * (`forceRepaint`'s overflow toggle) are the dominant main-thread cost in busy
+ * rooms — RenderCostProbe shows layoutPaint 189–359ms with react as low as 2ms.
+ * These helpers make the pin loop (a) converge and stop early instead of always
+ * burning its full frame budget, (b) skip the full-scroller repaint when the pin
+ * did not actually move scrollTop, and (c) attribute the remaining forced work in
+ * fluux.log with a single `[PinLoopProbe]` line per costly run.
+ *
+ * Pure logic — timestamps and storage are passed in, unit-testable.
+ */
+
+/**
+ * Consecutive stable (non-write) frames before a pin run is declared settled and
+ * its rAF loop stops. Matches the marker/restore stability precedent
+ * (MARKER_STABLE_FRAMES / RESTORE_STABLE_FRAMES = 8): flushTailLayout forces
+ * WebKit's late row measurements through on every frame, so 8 frames with no
+ * height change and the list at the bottom means layout has genuinely settled.
+ */
+const PIN_SETTLED_FRAMES = 8
+
+/**
+ * When to force the full-scroller repaint (the `overflowY` toggle) after a pin:
+ * - 'on-write' (default): only when the pin actually moved scrollTop — the WebKit
+ *   stale-paint bug is specific to programmatic scrolls, so a no-op pin needs no
+ *   repaint and skipping it removes the most expensive step on WebKitGTK.
+ * - 'always' / 'off': on-device A/B escape hatches (localStorage
+ *   `fluux:pin-repaint`) to validate the gating on the real Linux build.
+ */
+export type PinRepaintMode = 'on-write' | 'always' | 'off'
+
+export function readPinRepaintMode(
+  storage: Pick<Storage, 'getItem'> | undefined
+): PinRepaintMode {
+  try {
+    const value = storage?.getItem('fluux:pin-repaint')
+    if (value === 'always' || value === 'off') return value
+  } catch {
+    // storage unavailable (privacy mode) — fall through to the default
+  }
+  return 'on-write'
+}
+
+export function shouldForceRepaint(
+  scrollTopMoved: boolean,
+  mode: PinRepaintMode
+): boolean {
+  if (mode === 'always') return true
+  if (mode === 'off') return false
+  return scrollTopMoved
+}
+
+/** Forced-work categories a pin run accumulates for the probe line. */
+export type PinWorkKind = 'flush' | 'scroll' | 'repaint'
+
+export interface PinRunTracker {
+  /**
+   * Record one loop frame. `wrote` is true when the frame re-pinned (height
+   * moved or the list was measurably off the bottom). Returns 'settled' once
+   * the run has been stable for the configured number of consecutive frames.
+   */
+  frame(wrote: boolean): 'continue' | 'settled'
+  /** Accumulate forced-work time (ms) of one kind. */
+  addMs(kind: PinWorkKind, ms: number): void
+  /** Total forced-work ms across all kinds. */
+  totalForcedMs(): number
+  /** One fluux.log line attributing this run's forced work. */
+  summaryLine(trigger: string): string
+}
+
+export function createPinRunTracker(
+  opts: { settledFrames?: number } = {}
+): PinRunTracker {
+  const settledFrames = opts.settledFrames ?? PIN_SETTLED_FRAMES
+
+  let frames = 0
+  let writes = 0
+  let stableStreak = 0
+  const ms: Record<PinWorkKind, number> = { flush: 0, scroll: 0, repaint: 0 }
+  const totalForcedMs = () => ms.flush + ms.scroll + ms.repaint
+
+  return {
+    frame(wrote: boolean): 'continue' | 'settled' {
+      frames++
+      if (wrote) {
+        writes++
+        stableStreak = 0
+        return 'continue'
+      }
+      stableStreak++
+      return stableStreak >= settledFrames ? 'settled' : 'continue'
+    },
+
+    addMs(kind: PinWorkKind, value: number): void {
+      ms[kind] += value
+    },
+
+    totalForcedMs,
+
+    summaryLine(trigger: string): string {
+      return (
+        `[PinLoopProbe] pin-bottom run: trigger=${trigger} frames=${frames} writes=${writes} ` +
+        `flush=${Math.round(ms.flush)}ms scroll=${Math.round(ms.scroll)}ms ` +
+        `repaint=${Math.round(ms.repaint)}ms total=${Math.round(totalForcedMs())}ms`
+      )
+    },
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -21,6 +21,8 @@ import { createResizeLoopMonitor } from './resizeLoopMonitor'
 import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
 import { createReassertLoopMonitor } from './reassertLoopMonitor'
 import type { ReassertLoopHandle } from './reassertLoopMonitor'
+import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
+import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { isProgrammaticScroll } from './scrollGate'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
@@ -121,6 +123,10 @@ const RESTORE_DRIFT_PX = 8
 // no-op once truly pinned, so this converges and cannot oscillate. Sub-row tolerance keeps it from
 // firing on harmless subpixel rounding.
 const BOTTOM_PIN_TOLERANCE = 4
+// A pin run whose cumulative forced work (layout flushes + scroll writes + repaints) reaches this
+// is worth one rate-limited [PinLoopProbe] line in fluux.log — it attributes the layoutPaint cost
+// RenderCostProbe can only measure in aggregate. ~3 frame budgets; healthy runs stay far below.
+const PIN_PROBE_THRESHOLD_MS = 50
 
 // ============================================================================
 // KINETIC SCROLL
@@ -331,6 +337,12 @@ export function useMessageListScroll({
   // pin-bottom vs prepend target opposite positions (bottom vs a history anchor). Single-flight:
   // latest call wins with a fresh settle window.
   const reassertLoopRef = useRef<{ raf: number; handle: ReassertLoopHandle } | null>(null)
+  // True while a pin-bottom re-assert loop is in flight. The typing/reactions re-pin defers to an
+  // active loop (it re-checks scrollHeight every frame and picks the change up itself) instead of
+  // restarting it — the restart's synchronous forced layout + repaint is the WebKitGTK hot path.
+  const pinBottomActiveRef = useRef(false)
+  // Rate-limits the [PinLoopProbe] fluux.log line to one per cooldown (like RenderCostProbe).
+  const pinRunProbeRef = useRef<RenderCostProbe | null>(null)
   // Supersede any in-flight re-assert loop. Held in a ref (read as `.current()`) so callers in
   // useCallback / useLayoutEffect don't need it as a dependency — react-hooks treats refs as stable.
   const supersedeReassertLoopRef = useRef(() => {
@@ -339,6 +351,7 @@ export function useMessageListScroll({
       reassertLoopRef.current.handle.end()
       reassertLoopRef.current = null
     }
+    pinBottomActiveRef.current = false
   })
 
   // Track scroll position - always create internal ref to follow rules of hooks
@@ -652,7 +665,7 @@ export function useMessageListScroll({
             isAtBottom: isAtBottomRef.current,
             scrollTopBefore: currentScrollTop,
           })
-          reassertBottom()
+          reassertBottom('content-growth')
         } else if (newHeight !== lastHeight) {
           debugLog('RESIZE NO SCROLL', {
             newHeight,
@@ -741,7 +754,7 @@ export function useMessageListScroll({
   // oscillation. Re-pins only when scrollHeight actually changed since the previous frame, and
   // yields the moment the user takes over (deliberate scroll intent, or simply scrolling away
   // from the bottom). No-op for the non-virtualized path — callers keep their direct scrollTop.
-  const pinVirtualizedBottom = useCallback(() => {
+  const pinVirtualizedBottom = useCallback((trigger: string = 'unknown') => {
     const virt = virtualizerRef.current
     const scroller = scrollerRef.current
     if (!virt || !scroller || virt.itemCount === 0) return
@@ -754,6 +767,14 @@ export function useMessageListScroll({
     // window — and a send can land mid-prepend — so re-entry is routine.
     supersedeReassertLoopRef.current()
 
+    // Per-run forced-work accounting + convergence tracking. On WebKitGTK the forced layouts and
+    // repaints below are the dominant main-thread cost in busy rooms (RenderCostProbe layoutPaint
+    // 189–359ms with react as low as 2ms) — the tracker attributes them in fluux.log.
+    const run = createPinRunTracker()
+    const repaintMode = readPinRepaintMode(
+      typeof window === 'undefined' ? undefined : window.localStorage
+    )
+
     // Prompt WebKit's LATE row measure. Rows are absolutely positioned, so scrollHeight is the spacer's
     // declared height (= @tanstack getTotalSize), which grows only once a just-added row's ResizeObserver
     // delivers — and WebKit (Safari + Tauri) delivers that late. Reading a row's getBoundingClientRect
@@ -763,11 +784,13 @@ export function useMessageListScroll({
     const flushTailLayout = () => {
       const ss = scrollerRef.current
       if (!ss) return
+      const started = performance.now()
       ss.getBoundingClientRect()
       const rows = ss.querySelectorAll('[data-message-id]')
       for (let i = Math.max(0, rows.length - 3); i < rows.length; i++) {
         rows[i].getBoundingClientRect()
       }
+      run.addMs('flush', performance.now() - started)
     }
 
     // THE ACTUAL SEND-STICK FIX — force a repaint after a programmatic scroll. On the Tauri WKWebView,
@@ -779,43 +802,73 @@ export function useMessageListScroll({
     // already-correctly-positioned message appear without any scroll). Toggling overflow forces the
     // scroll container to re-layout and repaint at the current position; `overflowY = ''` yields the
     // property back to the CSS class (overflow-y-auto) and scrollTop is preserved. A cheap extra reflow
-    // on Chromium, which repaints on its own.
+    // on Chromium, which repaints on its own — but a FULL re-layout + repaint of the scroller on
+    // WebKitGTK, which is why writePin gates it on the scroll actually having moved.
     const forceRepaint = () => {
       const ss = scrollerRef.current
       if (!ss) return
+      const started = performance.now()
       ss.style.overflowY = 'hidden'
       void ss.offsetHeight // forced reflow → WebKit repaints the scrolled content
       ss.style.overflowY = ''
+      run.addMs('repaint', performance.now() - started)
+    }
+
+    // Pin write + gated repaint. The stale-paint bug is specific to a PROGRAMMATIC SCROLL, so when
+    // scrollToIndex lands on the scrollTop the scroller already had (a no-op re-assert — typing
+    // toggles, resize re-pins) there is nothing stale to draw and the expensive repaint is skipped.
+    // `fluux:pin-repaint` = 'always' | 'off' overrides the gate for on-device A/B on Linux.
+    let wroteAny = false
+    const writePin = (): boolean => {
+      const ss = scrollerRef.current
+      const v = virtualizerRef.current
+      if (!ss || !v || v.itemCount === 0) return false
+      const before = ss.scrollTop
+      const started = performance.now()
+      v.scrollToIndex(v.itemCount - 1, { align: 'end' })
+      run.addMs('scroll', performance.now() - started)
+      const moved = ss.scrollTop !== before
+      if (moved) wroteAny = true
+      if (shouldForceRepaint(moved, repaintMode)) forceRepaint()
+      return moved
     }
 
     // Immediate pin (pre-paint when called from a layout effect).
     flushTailLayout()
-    virt.scrollToIndex(virt.itemCount - 1, { align: 'end' })
-    forceRepaint()
+    writePin()
     debugLog('PIN start', {
+      trigger,
       itemCount: virt.itemCount,
       distFromBottom: scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
     })
 
     const startedAt = Date.now()
     const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('pin-bottom', performance.now())
+    pinBottomActiveRef.current = true
     let framesLeft = BOTTOM_REASSERT_FRAMES
     let lastHeight = scroller.scrollHeight
     const finish = () => {
       loop.end()
       reassertLoopRef.current = null
+      pinBottomActiveRef.current = false
+      // One rate-limited fluux.log line attributing this run's forced work (flush/scroll/repaint),
+      // so the next on-device freeze report says which pin trigger paid what.
+      const probe = (pinRunProbeRef.current ??= createRenderCostProbe({ thresholdMs: PIN_PROBE_THRESHOLD_MS }))
+      if (probe.record(run.totalForcedMs(), performance.now())) {
+        console.warn(run.summaryLine(trigger))
+      }
     }
     const step = () => {
       const s = scrollerRef.current
       if (framesLeft-- <= 0) {
-        // Loop ran its full budget. Re-derive isAtBottom from geometry (accurate — the position is
-        // correct even when WebKit withheld the paint) and force one final repaint so the settled
-        // position is actually drawn.
+        // Loop ran its full budget without converging. Re-derive isAtBottom from geometry (accurate —
+        // the position is correct even when WebKit withheld the paint) and force one final repaint —
+        // if anything was written — so the settled position is actually drawn.
         if (s) {
           flushTailLayout()
           const dist = s.scrollHeight - s.scrollTop - s.clientHeight
           isAtBottomRef.current = dist < AT_BOTTOM_THRESHOLD
-          forceRepaint()
+          if (shouldForceRepaint(wroteAny, repaintMode)) forceRepaint()
           debugLog('PIN settled (frames exhausted)', { distFromBottom: dist })
         }
         finish()
@@ -841,19 +894,29 @@ export function useMessageListScroll({
       flushTailLayout()
       const h = s.scrollHeight
       // Re-pin when the layout grew/shrank OR we're still measurably short of the bottom. Idempotent
-      // once pinned. Every scrollToIndex is followed by forceRepaint because WebKit will not otherwise
-      // draw the programmatic scroll — the root cause of the send-stick.
+      // once pinned; the repaint is gated inside writePin on the scroll actually moving.
       const dist = h - s.scrollTop - s.clientHeight
       let wrote = false
       if (h !== lastHeight || dist > BOTTOM_PIN_TOLERANCE) {
         debugLog('PIN re-assert', { distFromBottom: dist, heightChanged: h !== lastHeight })
         lastHeight = h
-        v.scrollToIndex(v.itemCount - 1, { align: 'end' })
-        forceRepaint()
+        writePin()
         wrote = true
       }
       const warning = loop.frame(performance.now(), wrote)
       if (warning) console.warn(warning)
+      // CONVERGENCE EARLY-EXIT: once the geometry has been stable for a few consecutive frames the
+      // measurement settle is over — running out the remaining budget would only burn one forced
+      // layout per frame (the WebKitGTK freeze pattern). Late media loads re-pin via their own site.
+      if (run.frame(wrote) === 'settled') {
+        isAtBottomRef.current = dist < AT_BOTTOM_THRESHOLD
+        debugLog('PIN settled (converged)', {
+          distFromBottom: dist,
+          framesUsed: BOTTOM_REASSERT_FRAMES - framesLeft,
+        })
+        finish()
+        return
+      }
       reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
     }
     reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
@@ -865,9 +928,9 @@ export function useMessageListScroll({
   // preview). Routes through the virtualizer when active so the mounted window re-windows before
   // paint (a raw scrollTop write leaves @tanstack's offset stale → blank/clipped); otherwise a
   // direct scrollTop write. Callers must have already confirmed the user is at/near the bottom.
-  const reassertBottom = useCallback(() => {
+  const reassertBottom = useCallback((trigger: string = 'unknown') => {
     if (virtualizerRef.current) {
-      pinVirtualizedBottom()
+      pinVirtualizedBottom(trigger)
     } else {
       const s = scrollerRef.current
       if (s) s.scrollTop = s.scrollHeight
@@ -1068,7 +1131,7 @@ export function useMessageListScroll({
       }
 
       debugLog('RESTORE: anchor not indexed, no savedPos, scrolling to bottom', { source, savedAnchor })
-      reassertBottom()
+      reassertBottom('restore-fallback')
       return 'bottom'
     }
 
@@ -1093,7 +1156,7 @@ export function useMessageListScroll({
     debugLog('RESTORE out of bounds / anchor missing, scrolling to bottom', {
       source, savedPos, maxScrollTop, scrollHeight: scroller.scrollHeight,
     })
-    reassertBottom()
+    reassertBottom('restore-fallback')
     return 'bottom'
   }, [
     conversationId,
@@ -1165,7 +1228,7 @@ export function useMessageListScroll({
 
     const virtFab = latestRef.current.virtualizer
     if (virtFab && virtFab.itemCount > 0) {
-      reassertBottom()
+      reassertBottom('fab')
       return
     }
 
@@ -1192,7 +1255,7 @@ export function useMessageListScroll({
   useEffect(() => {
     if (staticMode) return
     const onViewportResize = () => {
-      if (isAtBottomRef.current) reassertBottom()
+      if (isAtBottomRef.current) reassertBottom('viewport-resize')
     }
     window.addEventListener('resize', onViewportResize)
     const vv = window.visualViewport
@@ -1474,7 +1537,7 @@ export function useMessageListScroll({
             userScrolled,
             scrollHeight: currentScroller.scrollHeight,
           })
-          reassertBottom()
+          reassertBottom('media-load')
         } else {
           // User actively scrolled during the batch - respect their position
           debugLog('MEDIA LOAD: batch complete, user scrolled away', {
@@ -1803,7 +1866,7 @@ export function useMessageListScroll({
             // view at the top; fall back to the bottom. End first so the handoff to reassertBottom
             // (which begins a pin-bottom loop) is not miscounted as an overlap.
             finishMarker()
-            if (!resolved) reassertBottom()
+            if (!resolved) reassertBottom('marker-fallback')
             return
           }
           const s = scrollerRef.current
@@ -1837,7 +1900,7 @@ export function useMessageListScroll({
             if (offset <= viewportHeight / 3) {
               isAtBottomRef.current = true
               finishMarker()
-              reassertBottom()
+              reassertBottom('marker-fallback')
               return
             }
             // Position the marker row via the virtualizer's measurement-aware scrollToIndex.
@@ -1901,7 +1964,7 @@ export function useMessageListScroll({
           // scrollHeight undershoots when bottom rows are taller than estimateSize.
           // pinVirtualizedBottom re-asserts across frames as those rows measure, so the
           // last message isn't left clipped (taller) or floating above empty space (shorter).
-          pinVirtualizedBottom()
+          pinVirtualizedBottom('switch')
         } else {
           void scroller.offsetHeight  // Force layout calculation
           scroller.scrollTop = scroller.scrollHeight
@@ -1960,7 +2023,7 @@ export function useMessageListScroll({
       prevMarker: prev.divider,
     })
     isAtBottomRef.current = true
-    reassertBottom()
+    reassertBottom('mds-settle')
   }, [conversationId, firstNewMessageId, staticMode, isAtBottomRef, reassertBottom])
 
   // Retry a saved-position restore that entered before any rows were mounted.
@@ -2572,7 +2635,7 @@ export function useMessageListScroll({
           scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
       })
       isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
-      reassertBottom()
+      reassertBottom('new-message')
     } else if (newBottomRow) {
       debugLog('NEW MSG NO SCROLL (incoming, not at bottom)', {
         messageCount,
@@ -2627,7 +2690,12 @@ export function useMessageListScroll({
   // conversation switch (the stale "not at bottom" state gets persisted).
   useLayoutEffect(() => {
     if (!isAtBottomRef.current) return
-    reassertBottom()
+    // Defer to an in-flight pin-bottom loop: it re-reads scrollHeight every frame and re-pins on
+    // any change, so it picks this height change up by the next frame on its own. Restarting it
+    // here would add a synchronous forced layout (and possibly a full-scroller repaint) per typing
+    // toggle — in a busy room that is a keystroke-frequency event and the WebKitGTK freeze pattern.
+    if (pinBottomActiveRef.current) return
+    reassertBottom('typing-reactions')
   }, [typingUsersCount, lastMessageReactionsKey, isAtBottomRef, reassertBottom])
 
   // ==========================================================================
@@ -2667,7 +2735,7 @@ export function useMessageListScroll({
         const wasNear = getDistanceFromBottom(scrollerRef.current) <= shrunk + AT_BOTTOM_THRESHOLD
         // Route through reassertBottom so the virtualized path re-windows (scrollToIndex) rather
         // than a raw scrollTop write that would leave the mounted window stale → blank/clipped.
-        if (wasNear) reassertBottom()
+        if (wasNear) reassertBottom('container-shrink')
       } else if (
         newWidth !== null && lastWidth !== null && newWidth !== lastWidth &&
         scrollerRef.current && isAtBottomRef.current
@@ -2680,7 +2748,7 @@ export function useMessageListScroll({
         // drifted off the bottom. Re-assert while the user is following along, mirroring the
         // window-resize handler. The scroller's own width only changes on real layout changes,
         // not on row measurement, so this cannot feed back into the @tanstack spacer churn.
-        reassertBottom()
+        reassertBottom('width-change')
       }
 
       lastHeight = newHeight


### PR DESCRIPTION
Fixes the remaining Linux/WebKitGTK freezes in busy rooms: the bottom-pin loop forced a full layout every frame for 60 frames and a full-scroller repaint (overflow toggle) on every trigger — new message, typing toggle, reaction — multiplying WebKitGTK's expensive layout/paint (RenderCostProbe layoutPaint 189–359ms).

- Pin loop exits early once geometry is stable for 8 frames.
- The forced repaint only runs when the pin actually moved scrollTop (`fluux:pin-repaint=always|off` to A/B on-device).
- Typing/reaction toggles defer to an already-running pin loop instead of restarting it.
- New `[PinLoopProbe]` log line attributes each costly pin run (trigger, frames, flush/scroll/repaint ms) in fluux.log.