### PR TITLE
fix(styling): hug in-body blockquote to its longest line

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -863,6 +863,10 @@ html, body {
    Nested levels use a plain accent line (.blockquote-nested). */
 .blockquote-decorated {
   position: relative;
+  /* Shrink-wrap to the longest line so the recessed card hugs its content
+     (like the reply chip) instead of stretching to the full row width. */
+  width: fit-content;
+  max-width: 100%;
   border-left: 2px solid var(--fluux-brand);
   background: var(--fluux-bg-secondary);
   border-radius: 0 var(--fluux-radius-m) var(--fluux-radius-m) 0;


### PR DESCRIPTION
The decorated in-body blockquote stretched to the full message-row width, while the reply chip already shrink-wraps to its content. This adds `width: fit-content` (bounded by `max-width: 100%`) to `.blockquote-decorated` so a quoted block hugs its longest line, matching the reply-card behavior instead of spanning the whole row. Nested quotes inherit the hugged width automatically.