### PR TITLE
refactor(stores): extract the resident-window machine into shared/messageTimeline

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -10,7 +10,7 @@ import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
 import { computeGapEnd, syncGap, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
-import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, trimMessagesKeepOldest, prependOlderMessages, mergeAndProcessMessages, backfillArchiveIds } from './shared/messageArrayUtils'
+import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage, isResolvedSamePreview } from './shared/lastMessageUtils'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
@@ -85,15 +85,12 @@ function mergeCachedChatMessages(
 ): Pick<ChatState, 'messages' | 'conversationMeta' | 'conversations'> | { messages: ChatState['messages'] } | null {
   const existingMessages = state.messages.get(conversationId) || []
 
-  const existingKeySet = buildMessageKeySet(existingMessages, getChatMessageKeys)
-  const newMessages = cachedMessages.filter(
-    (m) => !isMessageDuplicate(m, existingKeySet, getChatMessageKeys)
+  const { merged: trimmed, newMessages } = timeline.latestSlice(
+    existingMessages,
+    cachedMessages,
+    chatTimelineConfig()
   )
-
   if (newMessages.length === 0) return null
-
-  const merged = sortMessagesByTimestamp([...existingMessages, ...newMessages])
-  const trimmed = trimMessages(merged, getResidentWindowSize())
 
   const newMessagesMap = new Map(state.messages)
   newMessagesMap.set(conversationId, trimmed)
@@ -137,6 +134,11 @@ function getChatMessageKeys(m: Message): string[] {
   if (m.originId) keys.push(`originId:${m.originId}`)
   keys.push(`from:${m.from}:id:${m.id}`)
   return keys
+}
+
+/** Timeline config for the shared resident-window machine (see shared/messageTimeline.ts). */
+function chatTimelineConfig(): timeline.TimelineConfig<Message> {
+  return { getKeys: getChatMessageKeys, windowSize: getResidentWindowSize() }
 }
 
 /**
@@ -871,45 +873,37 @@ export const chatStore = createStore<ChatState>()(
         set((state) => {
           const convMessages = state.messages.get(msg.conversationId) || []
 
-          // XEP-0359: Deduplicate using shared utility that checks ANY matching key
-          // (stanzaId OR from+id), avoiding the pitfall of short-circuiting on mismatched stanzaIds
-          const existingKeys = buildMessageKeySet(convMessages, getChatMessageKeys)
-          const isDuplicate = isMessageDuplicate(msg, existingKeys, getChatMessageKeys)
+          // Shared timeline machine: dedupe (XEP-0359 keys), archive-id
+          // backfill on duplicate echoes, live-edge gating (ABSENT or true =
+          // at the live edge; a slid window gates the append so a fresh
+          // message never splices after an OLD one), and window trim.
+          const atLiveEdge = state.windowAtLiveEdge.get(msg.conversationId) !== false
+          const append = timeline.appendLive(convMessages, msg, atLiveEdge, chatTimelineConfig())
 
-          if (isDuplicate) {
-            // The duplicate may be the archived/carbon copy of an outgoing
-            // message that has no stanzaId yet. Backfill the server archive id
-            // onto the in-memory copy (matched by originId) so backward MAM
-            // pagination has a valid cursor — then still skip adding the dup.
-            const { messages: backfilled, patched } = backfillArchiveIds(convMessages, [msg], getChatMessageKeys)
-            if (patched.length === 0) return state
-            for (const p of patched) {
+          if (append.kind === 'duplicate-unchanged') return state
+          if (append.kind === 'duplicate-backfilled') {
+            // Persist the backfilled archive ids so pagination cursors survive a reload.
+            for (const p of append.patched) {
               void messageCache.updateMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
             }
             const patchedMap = new Map(state.messages)
-            patchedMap.set(msg.conversationId, backfilled)
+            patchedMap.set(msg.conversationId, append.messages)
             return { messages: patchedMap }
           }
 
           // Save to IndexedDB + search index only if the message is locally persistable.
-          // This runs regardless of the live-edge gate below: a gated message is still
-          // durable in the cache and reloads on jump-to-latest.
+          // This runs regardless of the live-edge gate: a gated message is still
+          // durable in the cache (and the meta/preview/unread updates below still
+          // run); it reloads on jump-to-latest.
           if (!msg.noLocalStore) {
             void messageCache.saveMessage(msg)
             searchIndex.indexMessage(msg).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
           }
 
-          // Sliding window: only append the live message to the resident array when the
-          // window is at the live edge. If load-older slid the window up (evicting the
-          // newest tail), appending here would splice a fresh message directly after an
-          // OLD one — a visible false-adjacency gap. When gated we leave the resident
-          // array untouched (the cache write above + the meta/preview/unread updates
-          // below still run). ABSENT or true = at the live edge; only explicit false gates.
-          const atLiveEdge = state.windowAtLiveEdge.get(msg.conversationId) !== false
           const newMessages = new Map(state.messages)
           newMessages.set(
             msg.conversationId,
-            atLiveEdge ? trimMessages([...convMessages, msg], getResidentWindowSize()) : convMessages
+            append.kind === 'appended' ? append.messages : convMessages
           )
 
           const conv = state.conversations.get(msg.conversationId)
@@ -1563,32 +1557,19 @@ export const chatStore = createStore<ChatState>()(
           // Get existing messages for this conversation
           const rawExisting = state.messages.get(conversationId) || []
 
-          // Backfill server stanzaIds from archived copies onto stanzaId-less
-          // in-memory messages (e.g. outgoing messages) before merging, so the
-          // live copy gains a valid backward-pagination cursor. The archived
-          // copy itself still dedups away below.
-          const { messages: existingMessages, patched } = backfillArchiveIds(rawExisting, mamMessages, getChatMessageKeys)
+          // Shared timeline machine: archive-id backfill onto resident messages,
+          // direction-aware merge (backward = optimized prepend + keep-oldest,
+          // forward = full sort + keep-newest), dedupe, and eviction reporting.
+          const { merged: trimmed, newMessages, patched, newestEvicted } = timeline.mergeArchive(
+            rawExisting,
+            mamMessages,
+            direction,
+            chatTimelineConfig()
+          )
+          // Persist backfilled archive ids so pagination cursors survive a reload.
           for (const p of patched) {
             void messageCache.updateMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
           }
-
-          // Choose merge strategy based on direction:
-          // - Backward (scroll up for older): optimized prepend avoids full re-sort
-          // - Forward (catching up with newer): requires full sort since messages are newer
-          const { merged: trimmed, newMessages } =
-            direction === 'backward'
-              ? prependOlderMessages(
-                  existingMessages,
-                  mamMessages,
-                  getChatMessageKeys,
-                  getResidentWindowSize()
-                )
-              : mergeAndProcessMessages(
-                  existingMessages,
-                  mamMessages,
-                  getChatMessageKeys,
-                  getResidentWindowSize()
-                )
           mergedForMarker = trimmed
 
           // Newest fetched message timestamp marks the gap edge for an incomplete
@@ -1675,9 +1656,6 @@ export const chatStore = createStore<ChatState>()(
           // A backward (scroll-up) merge uses keep-oldest and can evict the newest tail,
           // sliding the window off the live edge (same gate as loadOlderMessagesFromCache).
           // Forward catch-up keeps the newest, so it never slides.
-          const newestEvicted =
-            direction === 'backward' &&
-            trimmed[trimmed.length - 1]?.id !== existingMessages[existingMessages.length - 1]?.id
           let newWindowAtLiveEdge = state.windowAtLiveEdge
           if (newestEvicted) {
             newWindowAtLiveEdge = new Map(state.windowAtLiveEdge)
@@ -1844,17 +1822,14 @@ export const chatStore = createStore<ChatState>()(
             set((state) => {
               const currentMessages = state.messages.get(conversationId) || []
 
-              // Dedupe against the resident array (in-memory messages take precedence):
-              // a cache slice can overlap the window at the `before:` boundary.
-              const existingKeys = buildMessageKeySet(currentMessages, getChatMessageKeys)
-              const newFromCache = olderMessages.filter(
-                (msg) => !isMessageDuplicate(msg, existingKeys, getChatMessageKeys)
+              // Shared timeline machine: dedupe against the resident array (a cache
+              // slice can overlap at the `before:` boundary), sort, keep-oldest trim
+              // (load-older slides the window so scroll-back past the bound works).
+              const { merged: trimmed, newestEvicted } = timeline.loadOlderSlice(
+                currentMessages,
+                olderMessages,
+                chatTimelineConfig()
               )
-
-              // Merge older messages at the beginning, sort, and trim using shared utilities.
-              // Load-older slides the window (keep oldest) so scroll-back past the bound works.
-              const merged = sortMessagesByTimestamp([...newFromCache, ...currentMessages])
-              const trimmed = trimMessagesKeepOldest(merged, getResidentWindowSize())
 
               const newMessagesMap = new Map(state.messages)
               newMessagesMap.set(conversationId, trimmed)
@@ -1862,8 +1837,6 @@ export const chatStore = createStore<ChatState>()(
               // If keep-oldest evicted the newest resident message, the window has slid
               // off the live edge → gate live appends in addMessage. If the batch fit
               // under the bound (newest unchanged), leave the flag as-is.
-              const newestEvicted =
-                trimmed[trimmed.length - 1]?.id !== currentMessages[currentMessages.length - 1]?.id
               if (!newestEvicted) return { messages: newMessagesMap }
 
               const newWindowAtLiveEdge = new Map(state.windowAtLiveEdge)
@@ -1903,17 +1876,13 @@ export const chatStore = createStore<ChatState>()(
             set((state) => {
               const currentMessages = state.messages.get(conversationId) || []
 
-              // Dedupe against the resident array (in-memory messages take precedence):
-              // a cache slice can overlap the window at the `after:` boundary.
-              const existingKeys = buildMessageKeySet(currentMessages, getChatMessageKeys)
-              const newFromCache = newerMessages.filter(
-                (msg) => !isMessageDuplicate(msg, existingKeys, getChatMessageKeys)
+              // Shared timeline machine: dedupe (overlap at the `after:` boundary),
+              // sort, keep-newest trim (load-newer slides the window back down).
+              const { merged: trimmed } = timeline.loadNewerSlice(
+                currentMessages,
+                newerMessages,
+                chatTimelineConfig()
               )
-
-              // Merge newer messages at the end, sort, and trim using shared utilities.
-              // Load-newer slides the window (keep newest) so sliding back down works.
-              const merged = sortMessagesByTimestamp([...currentMessages, ...newFromCache])
-              const trimmed = trimMessages(merged, getResidentWindowSize())
 
               const newMessagesMap = new Map(state.messages)
               newMessagesMap.set(conversationId, trimmed)

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -4827,5 +4827,29 @@ describe('roomStore parity drift regressions', () => {
       expect(roomStore.getState().rooms.get(roomJid)?.lastMessage?.body).toBe('decrypted at last')
       expect(roomStore.getState().roomMeta.get(roomJid)?.lastMessage?.body).toBe('decrypted at last')
     })
+
+    it('MAM merge backfills the archive stanzaId onto resident messages (parity with chatStore)', () => {
+      roomStore.setState({ activeRoomJid: roomJid })
+      const own: RoomMessage = {
+        ...messageAt('own-1', 'testuser', 'mine', '2024-01-15T10:00:00Z'),
+        isOutgoing: true,
+        originId: 'origin-merge',
+      }
+      roomStore.getState().addMessage(roomJid, own)
+      vi.mocked(messageCache.updateRoomMessage).mockClear()
+
+      // The archive copy of the same message arrives via MAM with the server id.
+      const archived: RoomMessage = { ...own, stanzaId: 'arch-merge' }
+      roomStore.getState().mergeRoomMAMMessages(roomJid, [archived], {}, true, 'forward')
+
+      const messages = roomStore.getState().rooms.get(roomJid)?.messages || []
+      expect(messages).toHaveLength(1)
+      expect(messages[0].stanzaId).toBe('arch-merge')
+      expect(roomStore.getState().roomRuntime.get(roomJid)?.messages[0]?.stanzaId).toBe('arch-merge')
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+        'own-1',
+        expect.objectContaining({ stanzaId: 'arch-merge' })
+      )
+    })
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -23,7 +23,7 @@ import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
 import { computeGapEnd, syncGap, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
-import { buildMessageKeySet, isMessageDuplicate, sortMessagesByTimestamp, trimMessages, trimMessagesKeepOldest, prependOlderMessages, mergeAndProcessMessages, backfillArchiveIds } from './shared/messageArrayUtils'
+import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, isResolvedSamePreview, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
 import { roomActivityTone } from './roomSelectors'
@@ -269,6 +269,11 @@ function getRoomMessageKeys(m: RoomMessage): string[] {
   return keys
 }
 
+/** Timeline config for the shared resident-window machine (see shared/messageTimeline.ts). */
+function roomTimelineConfig(): timeline.TimelineConfig<RoomMessage> {
+  return { getKeys: getRoomMessageKeys, windowSize: getResidentWindowSize() }
+}
+
 /**
  * Merge a batch of cached room messages into a room's resident array (and runtime mirror),
  * returning the partial state update (or `null` when the room is not present). Shared by
@@ -285,18 +290,9 @@ function mergeCachedRoomMessages(
   const existing = newRooms.get(roomJid)
   if (!existing) return null
 
-  // Build key set from in-memory messages (they take precedence)
-  const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
-
-  // Filter out duplicates from cached messages
-  const newFromCache = cachedMessages.filter(
-    (msg) => !isMessageDuplicate(msg, existingKeys, getRoomMessageKeys)
-  )
-
-  // Merge, sort, and trim using shared utilities
-  const combined = [...newFromCache, ...existing.messages]
-  const sorted = sortMessagesByTimestamp(combined)
-  const merged = trimMessages(sorted, getResidentWindowSize())
+  // Shared timeline machine: dedupe (in-memory messages take precedence),
+  // sort, and keep-newest trim.
+  const { merged } = timeline.latestSlice(existing.messages, cachedMessages, roomTimelineConfig())
 
   // Get last non-ignored message from merged messages for sidebar preview
   const lastMessage = (merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, existing.nickToJidCache) : undefined) ?? existing.lastMessage
@@ -1181,39 +1177,35 @@ export const roomStore = createStore<RoomState>()(
       const existing = newRooms.get(roomJid)
       if (!existing) return state
 
-      // XEP-0359: Deduplicate messages using shared utility
-      const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
-      if (isMessageDuplicate(messageToAdd, existingKeys, getRoomMessageKeys)) {
-        // The duplicate may be the archived/reflected copy of an outgoing
-        // message that has no stanzaId yet. Backfill the server archive id
-        // onto the in-memory copy (matched by originId) so backward MAM
-        // pagination has a valid cursor — then still skip adding the dup
-        // (parity with chatStore.addMessage).
-        const { messages: backfilled, patched } = backfillArchiveIds(existing.messages, [messageToAdd], getRoomMessageKeys)
-        if (patched.length === 0) return state
-        for (const p of patched) {
+      // Shared timeline machine: dedupe (XEP-0359 keys), archive-id backfill
+      // on duplicate reflected/archived echoes, live-edge gating (a slid
+      // window gates the append so a fresh message never splices after an OLD
+      // one), and window trim. Gated messages are still persisted to
+      // IndexedDB (above) and the preview/unread updates below still run;
+      // they reload on jump-to-latest.
+      const atLiveEdge = state.roomRuntime.get(roomJid)?.windowAtLiveEdge !== false
+      const append = timeline.appendLive(existing.messages, messageToAdd, atLiveEdge, roomTimelineConfig())
+
+      if (append.kind === 'duplicate-unchanged') return state
+      if (append.kind === 'duplicate-backfilled') {
+        // Persist the backfilled archive ids so pagination cursors survive a reload.
+        for (const p of append.patched) {
           void messageCache.updateRoomMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
         }
-        newRooms.set(roomJid, { ...existing, messages: backfilled })
+        newRooms.set(roomJid, { ...existing, messages: append.messages })
         const patchedRuntime = new Map(state.roomRuntime)
         const runtimeEntry = patchedRuntime.get(roomJid)
         if (runtimeEntry) {
-          patchedRuntime.set(roomJid, { ...runtimeEntry, messages: backfilled })
+          patchedRuntime.set(roomJid, { ...runtimeEntry, messages: append.messages })
         }
         return { rooms: newRooms, roomRuntime: patchedRuntime }
       }
 
-      // Sliding window: only append the live message to the resident array when the
-      // window is at the live edge. If load-older slid the window up (evicting the
-      // newest tail), appending here would splice a fresh message directly after an
-      // OLD one — a visible false-adjacency gap. When gated we leave the resident
-      // array untouched; the message is still persisted to IndexedDB (above) and the
-      // sidebar preview / unread badge still update. It reloads on jump-to-latest.
-      const atLiveEdge = state.roomRuntime.get(roomJid)?.windowAtLiveEdge !== false
-      // The append is also the basis for the newest-message preview; compute it either
-      // way (it is only STORED when at the live edge).
-      const appendedMessages = trimMessages([...existing.messages, messageToAdd], getResidentWindowSize())
-      const newMessages = atLiveEdge ? appendedMessages : existing.messages
+      // The appended set is also the basis for the newest-message preview even
+      // when the append was gated (the preview must still advance to the
+      // incoming message after the window slid off the live edge).
+      const appendedMessages = append.kind === 'appended' ? append.messages : [...existing.messages, messageToAdd]
+      const newMessages = append.kind === 'appended' ? append.messages : existing.messages
 
       // Delegate notification state to pure function
       const isActive = state.activeRoomJid === roomJid
@@ -2158,31 +2150,21 @@ export const roomStore = createStore<RoomState>()(
       })
 
       if (cachedMessages.length > 0) {
-        // Prepend to existing messages using shared utilities
+        // Prepend to existing messages via the shared timeline machine
         set((state) => {
           const newRooms = new Map(state.rooms)
           const existing = newRooms.get(roomJid)
           if (!existing) return state
 
-          // Build key set from in-memory messages (they take precedence)
-          const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
-
-          // Filter out duplicates from cached messages
-          const newFromCache = cachedMessages.filter(
-            (msg) => !isMessageDuplicate(msg, existingKeys, getRoomMessageKeys)
+          // Dedupe (in-memory messages take precedence), sort, keep-oldest trim
+          // (load-older slides the window so scroll-back past the bound works).
+          // If keep-oldest evicted the newest resident message, the window has
+          // slid off the live edge → gate live appends in addMessage.
+          const { merged, newestEvicted } = timeline.loadOlderSlice(
+            existing.messages,
+            cachedMessages,
+            roomTimelineConfig()
           )
-
-          // Merge, sort, and trim using shared utilities.
-          // Load-older slides the window (keep oldest) so scroll-back past the bound works.
-          const combined = [...newFromCache, ...existing.messages]
-          const sorted = sortMessagesByTimestamp(combined)
-          const merged = trimMessagesKeepOldest(sorted, getResidentWindowSize())
-
-          // If keep-oldest evicted the newest resident message, the window has slid off
-          // the live edge → gate live appends in addMessage. If the batch fit under the
-          // bound (newest unchanged), leave the flag as-is.
-          const newestEvicted =
-            merged[merged.length - 1]?.id !== existing.messages[existing.messages.length - 1]?.id
 
           newRooms.set(roomJid, { ...existing, messages: merged })
 
@@ -2235,25 +2217,19 @@ export const roomStore = createStore<RoomState>()(
       const reachedTail = cachedMessages.length < limit
 
       if (cachedMessages.length > 0) {
-        // Append to existing messages using shared utilities
+        // Append to existing messages via the shared timeline machine
         set((state) => {
           const newRooms = new Map(state.rooms)
           const existing = newRooms.get(roomJid)
           if (!existing) return state
 
-          // Build key set from in-memory messages (they take precedence)
-          const existingKeys = buildMessageKeySet(existing.messages, getRoomMessageKeys)
-
-          // Filter out duplicates from cached messages
-          const newFromCache = cachedMessages.filter(
-            (msg) => !isMessageDuplicate(msg, existingKeys, getRoomMessageKeys)
+          // Dedupe (in-memory messages take precedence), sort, keep-newest trim
+          // (load-newer slides the window back down toward the live edge).
+          const { merged } = timeline.loadNewerSlice(
+            existing.messages,
+            cachedMessages,
+            roomTimelineConfig()
           )
-
-          // Merge, sort, and trim using shared utilities.
-          // Load-newer slides the window (keep newest) so sliding back down works.
-          const combined = [...existing.messages, ...newFromCache]
-          const sorted = sortMessagesByTimestamp(combined)
-          const merged = trimMessages(sorted, getResidentWindowSize())
 
           newRooms.set(roomJid, { ...existing, messages: merged })
 
@@ -2427,23 +2403,21 @@ export const roomStore = createStore<RoomState>()(
       // Get existing messages for this room
       const existingMessages = room.messages || []
 
-      // Choose merge strategy based on direction:
-      // - Backward (scroll up for older): optimized prepend avoids full re-sort
-      // - Forward (catching up with newer): requires full sort since messages are newer
-      const { merged, newMessages: newFromMAM } =
-        direction === 'backward'
-          ? prependOlderMessages(
-              existingMessages,
-              mamMessages,
-              getRoomMessageKeys,
-              getResidentWindowSize()
-            )
-          : mergeAndProcessMessages(
-              existingMessages,
-              mamMessages,
-              getRoomMessageKeys,
-              getResidentWindowSize()
-            )
+      // Shared timeline machine: archive-id backfill onto resident messages
+      // (so an outgoing reflection gains its MAM cursor — was a chat-only
+      // behavior before the extraction), direction-aware merge (backward =
+      // optimized prepend + keep-oldest, forward = full sort + keep-newest),
+      // dedupe, and eviction reporting.
+      const { merged, newMessages: newFromMAM, patched, newestEvicted } = timeline.mergeArchive(
+        existingMessages,
+        mamMessages,
+        direction,
+        roomTimelineConfig()
+      )
+      // Persist backfilled archive ids so pagination cursors survive a reload.
+      for (const p of patched) {
+        void messageCache.updateRoomMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+      }
       mergedForMarker = merged
 
       // Compute the newest fetched timestamp for gap marker positioning.
@@ -2476,9 +2450,21 @@ export const roomStore = createStore<RoomState>()(
       }
 
       // If no new messages (all duplicates), only update MAM state - skip room messages
-      // This prevents unnecessary re-renders when merging duplicates
+      // This prevents unnecessary re-renders when merging duplicates.
+      // Exception: a stanzaId backfill onto existing RAM messages must persist —
+      // but only for the ACTIVE room (non-active rooms keep no resident array).
       if (newFromMAM.length === 0) {
-        return { mamQueryStates: newStates, roomGaps: newGaps }
+        if (patched.length === 0 || state.activeRoomJid !== roomJid) {
+          return { mamQueryStates: newStates, roomGaps: newGaps }
+        }
+        const backfilledRooms = new Map(state.rooms)
+        backfilledRooms.set(roomJid, { ...room, messages: merged })
+        const backfilledRuntime = new Map(state.roomRuntime)
+        const runtimeEntry = backfilledRuntime.get(roomJid)
+        if (runtimeEntry) {
+          backfilledRuntime.set(roomJid, { ...runtimeEntry, messages: merged })
+        }
+        return { rooms: backfilledRooms, roomRuntime: backfilledRuntime, mamQueryStates: newStates, roomGaps: newGaps }
       }
 
       // Persist to IndexedDB regardless of active state — this is the durable
@@ -2523,13 +2509,10 @@ export const roomStore = createStore<RoomState>()(
       const newRooms = new Map(state.rooms)
       newRooms.set(roomJid, { ...room, messages: merged, lastMessage })
 
-      // A backward (scroll-up) merge uses keep-oldest and can evict the newest tail,
-      // sliding the window off the live edge (same gate as loadOlderMessagesFromCache).
-      // Forward catch-up keeps the newest, so it never slides.
-      const newestEvicted =
-        direction === 'backward' &&
-        merged[merged.length - 1]?.id !== existingMessages[existingMessages.length - 1]?.id
-
+      // A backward (scroll-up) merge uses keep-oldest and can evict the newest tail
+      // (newestEvicted from the timeline machine), sliding the window off the live
+      // edge (same gate as loadOlderMessagesFromCache). Forward catch-up keeps the
+      // newest, so it never slides.
       const newRuntime = new Map(state.roomRuntime)
       const existingRuntime = newRuntime.get(roomJid)
       if (existingRuntime) {

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import { appendLive, mergeArchive, loadOlderSlice, loadNewerSlice, latestSlice } from './messageTimeline'
+
+/**
+ * The resident-window timeline machine shared by chatStore and roomStore.
+ *
+ * Every transition here used to exist twice (once per store) and drifted —
+ * missing trim, missing dedupe, missing archive-id backfill. These tests are
+ * the single specification both stores now delegate to.
+ */
+
+interface TestMsg {
+  id: string
+  stanzaId?: string
+  originId?: string
+  from: string
+  timestamp: Date
+}
+
+const getKeys = (m: TestMsg): string[] => {
+  const keys: string[] = []
+  if (m.stanzaId) keys.push(`stanzaId:${m.stanzaId}`)
+  if (m.originId) keys.push(`originId:${m.originId}`)
+  keys.push(`from:${m.from}:id:${m.id}`)
+  return keys
+}
+
+function msg(id: string, iso: string, extra: Partial<TestMsg> = {}): TestMsg {
+  return { id, from: 'peer@example.com', timestamp: new Date(iso), ...extra }
+}
+
+const cfg = { getKeys, windowSize: 3 }
+
+describe('messageTimeline', () => {
+  describe('appendLive', () => {
+    it('appends and trims to the window bound at the live edge', () => {
+      const resident = [msg('m1', '2024-01-15T10:01:00Z'), msg('m2', '2024-01-15T10:02:00Z'), msg('m3', '2024-01-15T10:03:00Z')]
+      const result = appendLive(resident, msg('m4', '2024-01-15T10:04:00Z'), true, cfg)
+
+      expect(result.kind).toBe('appended')
+      if (result.kind === 'appended') {
+        expect(result.messages.map((m) => m.id)).toEqual(['m2', 'm3', 'm4'])
+      }
+    })
+
+    it('gates the append when the window slid off the live edge', () => {
+      const resident = [msg('m1', '2024-01-15T10:01:00Z')]
+      const result = appendLive(resident, msg('m2', '2024-01-15T10:02:00Z'), false, cfg)
+
+      expect(result.kind).toBe('gated')
+    })
+
+    it('drops an exact duplicate without touching the array', () => {
+      const original = msg('m1', '2024-01-15T10:01:00Z', { stanzaId: 'arch-1' })
+      const result = appendLive([original], { ...original }, true, cfg)
+
+      expect(result.kind).toBe('duplicate-unchanged')
+    })
+
+    it('backfills the archive stanzaId from a dropped duplicate echo', () => {
+      const original = msg('m1', '2024-01-15T10:01:00Z', { originId: 'origin-1' })
+      const echo = { ...original, stanzaId: 'arch-1' }
+
+      const result = appendLive([original], echo, true, cfg)
+
+      expect(result.kind).toBe('duplicate-backfilled')
+      if (result.kind === 'duplicate-backfilled') {
+        expect(result.messages[0].stanzaId).toBe('arch-1')
+        expect(result.patched.map((p) => p.id)).toEqual(['m1'])
+      }
+    })
+  })
+
+  describe('mergeArchive', () => {
+    const resident = [msg('m5', '2024-01-15T10:05:00Z'), msg('m6', '2024-01-15T10:06:00Z')]
+
+    it('backward merge prepends older messages and keeps the oldest on overflow', () => {
+      const older = [msg('m1', '2024-01-15T10:01:00Z'), msg('m2', '2024-01-15T10:02:00Z')]
+      const result = mergeArchive(resident, older, 'backward', cfg)
+
+      // window 3, keep-oldest: m1, m2, m5 — the newest tail (m6) is evicted
+      expect(result.merged.map((m) => m.id)).toEqual(['m1', 'm2', 'm5'])
+      expect(result.newestEvicted).toBe(true)
+      expect(result.newMessages.map((m) => m.id)).toEqual(['m1', 'm2'])
+    })
+
+    it('backward merge under the bound does not evict', () => {
+      const older = [msg('m4', '2024-01-15T10:04:00Z')]
+      const result = mergeArchive(resident, older, 'backward', cfg)
+
+      expect(result.merged.map((m) => m.id)).toEqual(['m4', 'm5', 'm6'])
+      expect(result.newestEvicted).toBe(false)
+    })
+
+    it('forward merge sorts newer messages in and keeps the newest', () => {
+      const newer = [msg('m8', '2024-01-15T10:08:00Z'), msg('m7', '2024-01-15T10:07:00Z')]
+      const result = mergeArchive(resident, newer, 'forward', cfg)
+
+      expect(result.merged.map((m) => m.id)).toEqual(['m6', 'm7', 'm8'])
+      expect(result.newestEvicted).toBe(false)
+    })
+
+    it('reports no new messages when the batch is all duplicates', () => {
+      const result = mergeArchive(resident, [{ ...resident[0] }], 'forward', cfg)
+
+      expect(result.newMessages).toEqual([])
+      expect(result.merged).toBe(resident)
+    })
+
+    it('backfills archive ids onto resident messages before deduping (both directions)', () => {
+      const own = msg('own-1', '2024-01-15T10:06:30Z', { originId: 'origin-9' })
+      const archiveEcho = { ...own, stanzaId: 'arch-9' }
+
+      const result = mergeArchive([...resident, own], [archiveEcho], 'forward', { ...cfg, windowSize: 10 })
+
+      const patchedResident = result.merged.find((m) => m.id === 'own-1')
+      expect(patchedResident?.stanzaId).toBe('arch-9')
+      expect(result.patched.map((p) => p.id)).toEqual(['own-1'])
+      // The echo itself still dedups away
+      expect(result.newMessages).toEqual([])
+    })
+  })
+
+  describe('loadOlderSlice', () => {
+    it('dedupes, sorts, and keeps the oldest on overflow, reporting the slide', () => {
+      const current = [msg('m4', '2024-01-15T10:04:00Z'), msg('m5', '2024-01-15T10:05:00Z')]
+      const batch = [
+        { ...current[0] }, // overlap at the before: boundary
+        msg('m2', '2024-01-15T10:02:00Z'),
+        msg('m1', '2024-01-15T10:01:00Z'), // out of order
+      ]
+
+      const result = loadOlderSlice(current, batch, cfg)
+
+      expect(result.merged.map((m) => m.id)).toEqual(['m1', 'm2', 'm4'])
+      expect(result.newestEvicted).toBe(true)
+    })
+
+    it('does not report a slide when the batch fits under the bound', () => {
+      const current = [msg('m4', '2024-01-15T10:04:00Z')]
+      const result = loadOlderSlice(current, [msg('m3', '2024-01-15T10:03:00Z')], cfg)
+
+      expect(result.merged.map((m) => m.id)).toEqual(['m3', 'm4'])
+      expect(result.newestEvicted).toBe(false)
+    })
+  })
+
+  describe('loadNewerSlice', () => {
+    it('dedupes, sorts, and keeps the newest on overflow', () => {
+      const current = [msg('m1', '2024-01-15T10:01:00Z'), msg('m2', '2024-01-15T10:02:00Z')]
+      const batch = [
+        msg('m4', '2024-01-15T10:04:00Z'), // out of order
+        { ...current[1] }, // overlap at the after: boundary
+        msg('m3', '2024-01-15T10:03:00Z'),
+      ]
+
+      const result = loadNewerSlice(current, batch, cfg)
+
+      expect(result.merged.map((m) => m.id)).toEqual(['m2', 'm3', 'm4'])
+    })
+  })
+
+  describe('latestSlice', () => {
+    it('merges a cache slice into the resident array keeping the newest', () => {
+      const current = [msg('m2', '2024-01-15T10:02:00Z')]
+      const batch = [msg('m3', '2024-01-15T10:03:00Z'), { ...current[0] }, msg('m1', '2024-01-15T10:01:00Z')]
+
+      const result = latestSlice(current, batch, cfg)
+
+      expect(result.merged.map((m) => m.id)).toEqual(['m1', 'm2', 'm3'])
+    })
+  })
+})
+
+describe('messageTimeline slice results', () => {
+  const cfgLocal = { getKeys, windowSize: 3 }
+
+  it('slice loads report new messages and keep the input reference on all-duplicate batches', () => {
+    const current = [msg('m1', '2024-01-15T10:01:00Z')]
+
+    const older = loadOlderSlice(current, [{ ...current[0] }], cfgLocal)
+    expect(older.merged).toBe(current)
+    expect(older.newMessages).toEqual([])
+    expect(older.newestEvicted).toBe(false)
+
+    const newer = loadNewerSlice(current, [{ ...current[0] }], cfgLocal)
+    expect(newer.merged).toBe(current)
+    expect(newer.newMessages).toEqual([])
+
+    const latest = latestSlice(current, [{ ...current[0] }], cfgLocal)
+    expect(latest.merged).toBe(current)
+    expect(latest.newMessages).toEqual([])
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -1,0 +1,220 @@
+/**
+ * The resident-window timeline machine — one implementation of the sliding
+ * message window shared by chatStore (1:1 conversations) and roomStore (MUC).
+ *
+ * Each transition is a pure function over the resident array: dedupe (by the
+ * caller's XEP-0359 identity keys), archive-id backfill, timestamp sort, and
+ * the keep-oldest/keep-newest trims that make the window slide. The stores
+ * keep everything else (cache persistence, notification state, previews,
+ * live-edge bookkeeping in their own state shape) and act on the returned
+ * flags.
+ *
+ * Historical context: every transition here previously existed twice — once
+ * per store — and drifted (chat missed the live-append trim and pagination
+ * dedupe; room missed the archive-id backfill). See messageTimeline.test.ts
+ * for the single behavioral specification.
+ */
+
+import type { ArchiveIdentifiableMessage, TimestampedMessage } from './messageArrayUtils'
+import {
+  buildMessageKeySet,
+  isMessageDuplicate,
+  sortMessagesByTimestamp,
+  trimMessages,
+  trimMessagesKeepOldest,
+  prependOlderMessages,
+  mergeAndProcessMessages,
+  backfillArchiveIds,
+} from './messageArrayUtils'
+
+/** Minimal message shape the timeline needs (both Message and RoomMessage satisfy it). */
+export interface TimelineMessage extends ArchiveIdentifiableMessage, TimestampedMessage {
+  id: string
+}
+
+export interface TimelineConfig<T> {
+  /** XEP-0359 identity keys for deduplication (stanzaId / originId / from+id). */
+  getKeys: (message: T) => string[]
+  /** The resident-window bound (getResidentWindowSize() in production). */
+  windowSize: number
+}
+
+// ============================================================================
+// appendLive — a live message arrives (Chat/MUC live path)
+// ============================================================================
+
+export type AppendLiveResult<T> =
+  /** Duplicate carrying nothing new — resident array untouched. */
+  | { kind: 'duplicate-unchanged' }
+  /**
+   * Duplicate that donated its server archive id (XEP-0359) to a resident
+   * message that lacked one (outgoing echo/MAM copy). `patched` lists the
+   * updated messages so the caller can persist the backfill to its cache.
+   */
+  | { kind: 'duplicate-backfilled'; messages: T[]; patched: T[] }
+  /** Appended at the live edge; array is trimmed to the window bound. */
+  | { kind: 'appended'; messages: T[] }
+  /**
+   * The window slid off the live edge (load-older evicted the newest tail) —
+   * appending would create a false adjacency, so the resident array is left
+   * untouched. Callers still persist the message durably and update
+   * previews/unread; it reloads on jump-to-latest.
+   */
+  | { kind: 'gated' }
+
+export function appendLive<T extends TimelineMessage>(
+  messages: T[],
+  incoming: T,
+  atLiveEdge: boolean,
+  config: TimelineConfig<T>
+): AppendLiveResult<T> {
+  const existingKeys = buildMessageKeySet(messages, config.getKeys)
+  if (isMessageDuplicate(incoming, existingKeys, config.getKeys)) {
+    const { messages: backfilled, patched } = backfillArchiveIds(messages, [incoming], config.getKeys)
+    if (patched.length === 0) return { kind: 'duplicate-unchanged' }
+    return { kind: 'duplicate-backfilled', messages: backfilled, patched }
+  }
+
+  if (!atLiveEdge) return { kind: 'gated' }
+
+  return { kind: 'appended', messages: trimMessages([...messages, incoming], config.windowSize) }
+}
+
+// ============================================================================
+// mergeArchive — a MAM page arrives (scroll-up pagination or forward catch-up)
+// ============================================================================
+
+export interface MergeArchiveResult<T> {
+  /** The new resident array. Same reference as the input when nothing changed. */
+  merged: T[]
+  /** Genuinely new messages (non-duplicates) — for cache persistence and previews. */
+  newMessages: T[]
+  /**
+   * Resident messages that gained their server archive id from a duplicate
+   * archive copy — persist these to the durable cache.
+   */
+  patched: T[]
+  /**
+   * True when a backward (keep-oldest) merge evicted the newest resident
+   * message: the window slid off the live edge and live appends must be gated.
+   * Forward merges keep the newest, so they never slide.
+   */
+  newestEvicted: boolean
+}
+
+export function mergeArchive<T extends TimelineMessage>(
+  messages: T[],
+  incoming: T[],
+  direction: 'backward' | 'forward',
+  config: TimelineConfig<T>
+): MergeArchiveResult<T> {
+  // Backfill server stanzaIds from archived copies onto stanzaId-less resident
+  // messages (e.g. own outgoing) BEFORE merging, so the live copy gains a valid
+  // backward-pagination cursor. The archived copy itself still dedups away.
+  const { messages: existing, patched } = backfillArchiveIds(messages, incoming, config.getKeys)
+
+  const { merged, newMessages } =
+    direction === 'backward'
+      ? prependOlderMessages(existing, incoming, config.getKeys, config.windowSize)
+      : mergeAndProcessMessages(existing, incoming, config.getKeys, config.windowSize)
+
+  // Nothing new and nothing patched: hand back the ORIGINAL array reference so
+  // callers can cheaply skip a state write (the forward path re-sorts into a
+  // fresh array even when every incoming message deduped away).
+  if (newMessages.length === 0 && patched.length === 0) {
+    return { merged: messages, newMessages, patched, newestEvicted: false }
+  }
+
+  const newestEvicted =
+    direction === 'backward' &&
+    merged[merged.length - 1]?.id !== existing[existing.length - 1]?.id
+
+  return { merged, newMessages, patched, newestEvicted }
+}
+
+// ============================================================================
+// Cache-slice loads (IndexedDB pagination and rehydration)
+// ============================================================================
+
+export interface LoadOlderResult<T> {
+  merged: T[]
+  /** Genuinely new messages from the batch (non-duplicates). */
+  newMessages: T[]
+  /** True when keep-oldest evicted the newest resident message (window slid). */
+  newestEvicted: boolean
+}
+
+/**
+ * Merge an older cache batch below the window: dedupe against the resident
+ * array (a slice can overlap at the `before:` boundary), sort, and keep the
+ * OLDEST window-size messages so scroll-back past the bound slides the window.
+ */
+export function loadOlderSlice<T extends TimelineMessage>(
+  messages: T[],
+  cached: T[],
+  config: TimelineConfig<T>
+): LoadOlderResult<T> {
+  const existingKeys = buildMessageKeySet(messages, config.getKeys)
+  const newFromCache = cached.filter((m) => !isMessageDuplicate(m, existingKeys, config.getKeys))
+
+  if (newFromCache.length === 0) return { merged: messages, newMessages: [], newestEvicted: false }
+
+  const merged = trimMessagesKeepOldest(
+    sortMessagesByTimestamp([...newFromCache, ...messages]),
+    config.windowSize
+  )
+  const newestEvicted = merged[merged.length - 1]?.id !== messages[messages.length - 1]?.id
+
+  return { merged, newMessages: newFromCache, newestEvicted }
+}
+
+export interface LoadNewerResult<T> {
+  merged: T[]
+  /** Genuinely new messages from the batch (non-duplicates). */
+  newMessages: T[]
+}
+
+/**
+ * Merge a newer cache batch above the window: dedupe (overlap at the `after:`
+ * boundary), sort, and keep the NEWEST window-size messages so sliding back
+ * down toward the live edge works.
+ */
+export function loadNewerSlice<T extends TimelineMessage>(
+  messages: T[],
+  cached: T[],
+  config: TimelineConfig<T>
+): LoadNewerResult<T> {
+  const existingKeys = buildMessageKeySet(messages, config.getKeys)
+  const newFromCache = cached.filter((m) => !isMessageDuplicate(m, existingKeys, config.getKeys))
+  if (newFromCache.length === 0) return { merged: messages, newMessages: [] }
+
+  return {
+    merged: trimMessages(sortMessagesByTimestamp([...messages, ...newFromCache]), config.windowSize),
+    newMessages: newFromCache,
+  }
+}
+
+export interface LatestSliceResult<T> {
+  merged: T[]
+  /** Genuinely new messages from the slice (non-duplicates). */
+  newMessages: T[]
+}
+
+/**
+ * Merge a latest-N cache slice into the resident array (activation rehydrate,
+ * jump-to-latest): dedupe, sort, keep newest.
+ */
+export function latestSlice<T extends TimelineMessage>(
+  messages: T[],
+  cached: T[],
+  config: TimelineConfig<T>
+): LatestSliceResult<T> {
+  const existingKeys = buildMessageKeySet(messages, config.getKeys)
+  const newFromCache = cached.filter((m) => !isMessageDuplicate(m, existingKeys, config.getKeys))
+  if (newFromCache.length === 0) return { merged: messages, newMessages: [] }
+
+  return {
+    merged: trimMessages(sortMessagesByTimestamp([...newFromCache, ...messages]), config.windowSize),
+    newMessages: newFromCache,
+  }
+}


### PR DESCRIPTION
Phase 1's largest item: the sliding-window logic — historically the biggest chat/room drift surface (five live bugs fixed in #859 traced to it) — now has ONE tested implementation both stores delegate to.

**`shared/messageTimeline.ts`** — pure transitions over the resident array, each returning explicit flags the stores act on:
- `appendLive`: XEP-0359 dedupe, archive-id backfill on duplicate echoes, live-edge gating, keep-newest trim
- `mergeArchive`: direction-aware MAM merge (backward = optimized prepend + keep-oldest; forward = full sort + keep-newest) with backfill and newest-evicted reporting
- `loadOlderSlice` / `loadNewerSlice` / `latestSlice`: cache pagination and rehydration
- 14-test behavioral spec; all-duplicate inputs return the original array reference so stores can skip state writes

**Store conversions** — chatStore and roomStore keep what is genuinely theirs (cache persistence, notification state, previews, their own live-edge encodings) and lose ~175 lines of duplicated window choreography. Neither store touches the raw array utilities anymore.

**Parity gap closed by the unification**: room MAM merges now backfill archive stanzaIds onto resident messages (previously chat-only — own room messages never gained their backward-pagination cursor from the archive echo). Room-level regression test included.