### PR TITLE
refactor(stores): extract shared preview policy and XEP-0490 read-marker sync

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -11,7 +11,9 @@ import type { MAMQueryDirection } from './shared/mamState'
 import { computeGapEnd, syncGap, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
-import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage, isResolvedSamePreview } from './shared/lastMessageUtils'
+import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
+import { derivePreviewAfterMerge } from './shared/previewState'
+import { resolveRemoteDisplayed, createMdsSessionGate } from './shared/readMarkerSync'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
@@ -57,14 +59,10 @@ function conversationIdsByActivity(
 // call can't overwrite a newer activation when it finally resolves
 let activationToken = 0
 
-// Conversations whose pending XEP-0490 (Message Displayed Synchronization) read marker has
-// already been consumed for divider positioning THIS session. XEP-0490 markers are broadcast
-// live over PEP, so once we fold the synced read position on the first open of a conversation
-// this session, later opens must NOT re-check/re-fold it — the live `read:displayed-synced`
-// notifies keep loaded conversations current, and re-folding on every open lets a synced read
-// position reposition the divider on each return. Cleared on reset() (logout/account switch);
-// module-level so it is naturally per app session.
-const mdsConsumedThisSession = new Set<string>()
+// XEP-0490 first-open-per-session fold gate (see shared/readMarkerSync).
+// Reset on reset() (logout/account switch); module-level so it is naturally
+// per app session.
+const mdsGate = createMdsSessionGate()
 
 function getScopedStorageKey(jid?: string | null): string {
   return buildScopedStorageKey(STORAGE_KEY_BASE, jid)
@@ -95,18 +93,13 @@ function mergeCachedChatMessages(
   const newMessagesMap = new Map(state.messages)
   newMessagesMap.set(conversationId, trimmed)
 
-  // Update lastMessage with the newest previewable message after merge/sort, skipping bodiless
-  // signal placeholders. Opening a conversation whose stored preview is a stuck placeholder heals
-  // it here: a real cached message supersedes the placeholder even though the placeholder's
-  // timestamp is newer.
-  const lastMessage = findLastPreviewableMessage(trimmed)
+  // Sidebar preview via the shared policy: the newest previewable message
+  // supersedes (or heals) the stored preview — e.g. opening a conversation
+  // whose stored preview is a stuck placeholder heals it here.
   const meta = state.conversationMeta.get(conversationId)
   const conv = state.conversations.get(conversationId)
-  if (
-    meta && conv && lastMessage &&
-    (shouldReplaceLastMessage(meta.lastMessage, lastMessage) ||
-      isResolvedSamePreview(meta.lastMessage, lastMessage))
-  ) {
+  const { lastMessage, changed } = derivePreviewAfterMerge(meta?.lastMessage, trimmed, findLastPreviewableMessage)
+  if (meta && conv && changed) {
     const newMeta = new Map(state.conversationMeta)
     newMeta.set(conversationId, { ...meta, lastMessage })
     const newConversations = new Map(state.conversations)
@@ -750,8 +743,7 @@ export const chatStore = createStore<ChatState>()(
           // conversation this session. XEP-0490 markers broadcast live over PEP, so after the
           // first consumption the live `read:displayed-synced` notifies keep us current; re-folding
           // on every open would let a synced read position reposition the divider on each return.
-          const firstConsumeThisSession = !mdsConsumedThisSession.has(id)
-          mdsConsumedThisSession.add(id)
+          const firstConsumeThisSession = mdsGate.consume(id)
           const pending = get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId
           if (pending && firstConsumeThisSession) {
             const lastSeenBefore = get().conversationMeta.get(id)?.lastSeenMessageId
@@ -1082,103 +1074,50 @@ export const chatStore = createStore<ChatState>()(
 
           // A non-active conversation keeps no resident array (memory windowing), so
           // mergeMAMMessages passes the just-merged array here; otherwise read RAM.
+          // The resolution state machine (stash / clear-pending / forward-only
+          // advance / active-divider recompute) is shared — see shared/readMarkerSync.
           const messages = messagesOverride ?? (state.messages.get(conversationId) || [])
-          const match = messages.find((m) => m.stanzaId === stanzaId)
-
-          if (!match) {
-            // Message not yet loaded — remember the stanza-id as a high-water
-            // mark to be resolved when the message cache is loaded.
-            const newMeta = new Map(state.conversationMeta)
-            newMeta.set(conversationId, { ...meta, pendingRemoteDisplayedStanzaId: stanzaId })
-
-            if (conv) {
-              const newConversations = new Map(state.conversations)
-              newConversations.set(conversationId, { ...conv, pendingRemoteDisplayedStanzaId: stanzaId })
-              return { conversationMeta: newMeta, conversations: newConversations }
-            }
-
-            return { conversationMeta: newMeta }
-          }
-
-          // Forward-only advance using the shared comparator (compares by index).
-          const updated = notifState.onMessageSeen(
+          const resolution = resolveRemoteDisplayed(
             {
               unreadCount: meta.unreadCount,
               mentionsCount: 0,
               lastReadAt: meta.lastReadAt,
               lastSeenMessageId: meta.lastSeenMessageId,
-              firstNewMessageId: state.firstNewMessageMarkers.get(conversationId),
+              pendingRemoteDisplayedStanzaId: meta.pendingRemoteDisplayedStanzaId,
             },
-            match.id,
-            messages
+            messages,
+            state.firstNewMessageMarkers.get(conversationId),
+            stanzaId,
+            // 1:1 chats treat delayed messages as offline delivery.
+            { isActive: state.activeConversationId === conversationId, treatDelayedAsNew: true }
           )
+          if (resolution.kind === 'unchanged') return state
 
-          // No advance (same value or onMessageSeen guard prevented regression).
-          // The matching message IS loaded and the local position is at or past
-          // it, so this marker is resolved — clear any stale pending high-water
-          // mark so it doesn't re-fire a no-op applyRemoteDisplayed on every
-          // mergeMAMMessages. Leave lastSeenMessageId unchanged.
-          if (updated.lastSeenMessageId === meta.lastSeenMessageId) {
-            if (meta.pendingRemoteDisplayedStanzaId === undefined) return state
-            const newMeta = new Map(state.conversationMeta)
-            newMeta.set(conversationId, { ...meta, pendingRemoteDisplayedStanzaId: undefined })
-            if (conv) {
-              const newConversations = new Map(state.conversations)
-              newConversations.set(conversationId, {
-                ...conv,
-                pendingRemoteDisplayedStanzaId: undefined,
-              })
-              return { conversationMeta: newMeta, conversations: newConversations }
-            }
-            return { conversationMeta: newMeta }
-          }
+          const metaPatch =
+            resolution.kind === 'stash-pending'
+              ? { pendingRemoteDisplayedStanzaId: stanzaId }
+              : resolution.kind === 'clear-pending'
+                ? { pendingRemoteDisplayedStanzaId: undefined }
+                : { lastSeenMessageId: resolution.lastSeenMessageId, pendingRemoteDisplayedStanzaId: undefined }
 
           const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, {
-            ...meta,
-            lastSeenMessageId: updated.lastSeenMessageId,
-            // Resolved → clear any stale pending marker.
-            pendingRemoteDisplayedStanzaId: undefined,
-          })
+          newMeta.set(conversationId, { ...meta, ...metaPatch })
 
-          // XEP-0490: if this marker advances the CURRENTLY ACTIVE conversation, the
-          // new-message divider was already derived at activation from the (now stale)
-          // local read position — e.g. the fresh-session seed landed just after the
-          // conversation opened, so the fold at activation missed it. Recompute the
-          // divider from the advanced position so it reflects the synced read instead
-          // of freezing at the local one (the view otherwise stays at the last local
-          // place and only jumps to the synced place on the next open). Reuse
-          // onActivate's forward-scan derivation. For a non-active conversation the
-          // divider is recomputed on its next activation, so leave the map untouched.
+          // The divider is recomputed only for the active conversation; inactive
+          // ones recompute on their next activation.
           let newMarkers = state.firstNewMessageMarkers
-          if (state.activeConversationId === conversationId) {
-            const divider = notifState.onActivate(
-              {
-                unreadCount: 0,
-                mentionsCount: 0,
-                lastReadAt: meta.lastReadAt,
-                lastSeenMessageId: updated.lastSeenMessageId,
-                firstNewMessageId: undefined,
-              },
-              messages,
-              { treatDelayedAsNew: true }
-            ).firstNewMessageId
+          if (resolution.kind === 'advanced-with-divider') {
             newMarkers = new Map(state.firstNewMessageMarkers)
-            if (divider) newMarkers.set(conversationId, divider)
+            if (resolution.firstNewMessageId) newMarkers.set(conversationId, resolution.firstNewMessageId)
             else newMarkers.delete(conversationId)
           }
 
           if (conv) {
+            // Keep the combined map coherent with conversationMeta.
             const newConversations = new Map(state.conversations)
-            newConversations.set(conversationId, {
-              ...conv,
-              lastSeenMessageId: updated.lastSeenMessageId,
-              // Keep the combined map coherent with conversationMeta.
-              pendingRemoteDisplayedStanzaId: undefined,
-            })
+            newConversations.set(conversationId, { ...conv, ...metaPatch })
             return { conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
           }
-
           return { conversationMeta: newMeta, firstNewMessageMarkers: newMarkers }
         })
       },
@@ -1621,17 +1560,14 @@ export const chatStore = createStore<ChatState>()(
             searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
           }
 
-          // Sidebar preview: newest previewable message (skips bodiless signal
-          // placeholders; heals a stuck encrypted-fallback preview via
-          // shouldReplaceLastMessage / isResolvedSamePreview).
-          const lastMessage = findLastPreviewableMessage(trimmed)
+          // Sidebar preview via the shared policy: the newest previewable message
+          // supersedes (or heals) the stored preview — deep-history merges must
+          // not regress the sidebar.
           const meta = state.conversationMeta.get(conversationId)
           const conv = state.conversations.get(conversationId)
-          const previewUpdate = !!(
-            meta && conv && lastMessage &&
-            (shouldReplaceLastMessage(meta.lastMessage, lastMessage) ||
-              isResolvedSamePreview(meta.lastMessage, lastMessage))
-          )
+          const preview = derivePreviewAfterMerge(meta?.lastMessage, trimmed, findLastPreviewableMessage)
+          const lastMessage = preview.lastMessage
+          const previewUpdate = !!(meta && conv && preview.changed)
 
           // NON-ACTIVE conversation (background catch-up): the messages are durable
           // in IndexedDB and the preview/gap are updated, but we DON'T populate the
@@ -1934,7 +1870,7 @@ export const chatStore = createStore<ChatState>()(
       reset: () => {
         clearAllTypingTimeouts()
         // New session → the XEP-0490 synced read marker may be folded again on first open.
-        mdsConsumedThisSession.clear()
+        mdsGate.reset()
         // Clear persisted data on logout
         try {
           localStorage.removeItem(getScopedStorageKey())

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -4828,6 +4828,31 @@ describe('roomStore parity drift regressions', () => {
       expect(roomStore.getState().roomMeta.get(roomJid)?.lastMessage?.body).toBe('decrypted at last')
     })
 
+    it('deep-history around-load does not regress the sidebar preview (parity with chatStore)', async () => {
+      // A room whose resident array was evicted (non-active) but whose preview
+      // tracks the newest message — the state a scroll-position restore finds.
+      const newest = messageAt('new-1', 'alice', 'newest', '2024-01-15T12:00:00Z')
+      roomStore.setState((state) => {
+        const rooms = new Map(state.rooms)
+        rooms.set(roomJid, { ...rooms.get(roomJid)!, messages: [], lastMessage: newest })
+        const roomMeta = new Map(state.roomMeta)
+        roomMeta.set(roomJid, { ...roomMeta.get(roomJid)!, lastMessage: newest })
+        return { rooms, roomMeta }
+      })
+
+      // Scroll-position restore loads an OLD slice around an anchor.
+      const oldSlice = [
+        messageAt('old-1', 'bob', 'deep 1', '2024-01-15T09:00:00Z'),
+        messageAt('old-2', 'bob', 'deep 2', '2024-01-15T09:30:00Z'),
+      ]
+      vi.mocked(messageCache.getRoomMessagesAround).mockResolvedValueOnce(oldSlice)
+      await roomStore.getState().loadMessagesAroundFromCache(roomJid, 'old-1')
+
+      // The old slice must not replace the newest preview.
+      expect(roomStore.getState().rooms.get(roomJid)?.lastMessage?.id).toBe('new-1')
+      expect(roomStore.getState().roomMeta.get(roomJid)?.lastMessage?.id).toBe('new-1')
+    })
+
     it('MAM merge backfills the archive stanzaId onto resident messages (parity with chatStore)', () => {
       roomStore.setState({ activeRoomJid: roomJid })
       const own: RoomMessage = {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -24,7 +24,9 @@ import type { MAMQueryDirection } from './shared/mamState'
 import { computeGapEnd, syncGap, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
-import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, isResolvedSamePreview, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
+import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
+import { derivePreviewAfterMerge } from './shared/previewState'
+import { resolveRemoteDisplayed, createMdsSessionGate } from './shared/readMarkerSync'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
 import { roomActivityTone } from './roomSelectors'
 import * as notifState from './shared/notificationState'
@@ -233,11 +235,9 @@ const EMPTY_SIDEBAR_JIDS: string[] = []
 // can't overwrite a newer activation when it finally resolves
 let activationToken = 0
 
-// Rooms whose pending XEP-0490 read marker has already been consumed for divider positioning
-// THIS session (parity with chatStore). XEP-0490 markers broadcast live over PEP, so after the
-// first open's fold the live `read:displayed-synced` notifies keep us current; re-folding on
-// every open would reposition the divider on each return. Cleared on reset() (logout).
-const mdsConsumedThisSession = new Set<string>()
+// XEP-0490 first-open-per-session fold gate (see shared/readMarkerSync;
+// parity with chatStore). Reset on reset() (logout).
+const mdsGate = createMdsSessionGate()
 
 // Selector memoization caches.
 // Store selectors (joinedRooms, allRooms, etc.) are called on every Zustand subscription check.
@@ -294,8 +294,12 @@ function mergeCachedRoomMessages(
   // sort, and keep-newest trim.
   const { merged } = timeline.latestSlice(existing.messages, cachedMessages, roomTimelineConfig())
 
-  // Get last non-ignored message from merged messages for sidebar preview
-  const lastMessage = (merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, existing.nickToJidCache) : undefined) ?? existing.lastMessage
+  // Sidebar preview via the shared policy: only replace when the merged set's
+  // newest non-ignored message genuinely supersedes (or heals) the current
+  // preview — a deep-history slice (scroll-position restore) must not regress it.
+  const { lastMessage } = derivePreviewAfterMerge(existing.lastMessage, merged, (msgs) =>
+    findLastNonIgnoredMessage(msgs, roomJid, existing.nickToJidCache)
+  )
 
   newRooms.set(roomJid, { ...existing, messages: merged, lastMessage })
 
@@ -1144,7 +1148,7 @@ export const roomStore = createStore<RoomState>()(
     // They will be cleared when rooms are explicitly removed or user logs out
     // (The connection store's reset handles full logout cleanup via clearAllMessages)
     // New session → the XEP-0490 synced read marker may be folded again on first open.
-    mdsConsumedThisSession.clear()
+    mdsGate.reset()
     // Clear persisted room drafts and poll state on logout
     localStorage.removeItem(getRoomDraftsStorageKey())
     localStorage.removeItem(getRoomVotedPollsStorageKey())
@@ -1608,8 +1612,7 @@ export const roomStore = createStore<RoomState>()(
       // derives the divider — but only on the FIRST open of this room this session (parity with
       // chatStore.activateConversation). XEP-0490 markers broadcast live over PEP, so re-folding on
       // every open would reposition the divider on each return.
-      const firstConsumeThisSession = !mdsConsumedThisSession.has(roomJid)
-      mdsConsumedThisSession.add(roomJid)
+      const firstConsumeThisSession = mdsGate.consume(roomJid)
       const pending = get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId
       if (pending && firstConsumeThisSession) {
         const lastSeenBefore = get().roomMeta.get(roomJid)?.lastSeenMessageId
@@ -1685,84 +1688,48 @@ export const roomStore = createStore<RoomState>()(
       const runtime = state.roomRuntime.get(roomJid)
       // A non-active room keeps no resident array (memory windowing), so
       // mergeRoomMAMMessages passes the just-merged array here; else read runtime/rooms.
+      // The resolution state machine (stash / clear-pending / forward-only
+      // advance / active-divider recompute) is shared — see shared/readMarkerSync.
       const messages = messagesOverride ?? runtime?.messages ?? existing?.messages ?? []
-      const match = messages.find((m) => m.stanzaId === stanzaId)
-
-      if (!match) {
-        const newMeta = new Map(state.roomMeta)
-        newMeta.set(roomJid, { ...meta, pendingRemoteDisplayedStanzaId: stanzaId })
-        if (existing) {
-          const newRooms = new Map(state.rooms)
-          newRooms.set(roomJid, { ...existing, pendingRemoteDisplayedStanzaId: stanzaId })
-          return { roomMeta: newMeta, rooms: newRooms }
-        }
-        return { roomMeta: newMeta }
-      }
-
-      const updated = notifState.onMessageSeen(
+      const resolution = resolveRemoteDisplayed(
         {
           unreadCount: meta.unreadCount,
           mentionsCount: meta.mentionsCount,
           lastReadAt: meta.lastReadAt,
           lastSeenMessageId: meta.lastSeenMessageId,
-          firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
+          pendingRemoteDisplayedStanzaId: meta.pendingRemoteDisplayedStanzaId,
         },
-        match.id,
-        messages
+        messages,
+        state.firstNewMessageMarkers.get(roomJid),
+        stanzaId,
+        // Rooms treat delayed messages as history replay, so no treatDelayedAsNew.
+        { isActive: state.activeRoomJid === roomJid }
       )
+      if (resolution.kind === 'unchanged') return state
 
-      // No advance: the matching message is loaded and the local position is at
-      // or past it — the marker is resolved; clear any stale pending mark.
-      if (updated.lastSeenMessageId === meta.lastSeenMessageId) {
-        if (meta.pendingRemoteDisplayedStanzaId === undefined) return state
-        const newMeta = new Map(state.roomMeta)
-        newMeta.set(roomJid, { ...meta, pendingRemoteDisplayedStanzaId: undefined })
-        if (existing) {
-          const newRooms = new Map(state.rooms)
-          newRooms.set(roomJid, { ...existing, pendingRemoteDisplayedStanzaId: undefined })
-          return { roomMeta: newMeta, rooms: newRooms }
-        }
-        return { roomMeta: newMeta }
-      }
+      const metaPatch =
+        resolution.kind === 'stash-pending'
+          ? { pendingRemoteDisplayedStanzaId: stanzaId }
+          : resolution.kind === 'clear-pending'
+            ? { pendingRemoteDisplayedStanzaId: undefined }
+            : { lastSeenMessageId: resolution.lastSeenMessageId, pendingRemoteDisplayedStanzaId: undefined }
 
       const newMeta = new Map(state.roomMeta)
-      newMeta.set(roomJid, {
-        ...meta,
-        lastSeenMessageId: updated.lastSeenMessageId,
-        pendingRemoteDisplayedStanzaId: undefined,
-      })
+      newMeta.set(roomJid, { ...meta, ...metaPatch })
 
-      // XEP-0490: if this marker advances the CURRENTLY ACTIVE room, its new-message
-      // divider was already derived at activation from the (now stale) local read
-      // position — the fresh-session seed can land just after the room opens, so the
-      // fold at activation missed it. Recompute the divider from the advanced position
-      // (rooms treat delayed messages as history replay, so no treatDelayedAsNew) so it
-      // reflects the synced read instead of freezing at the local one. Inactive rooms
-      // recompute on their next activation, so leave the map untouched.
+      // The divider is recomputed only for the active room; inactive rooms
+      // recompute on their next activation.
       let newMarkers = state.firstNewMessageMarkers
-      if (state.activeRoomJid === roomJid) {
-        const divider = notifState.onActivate(
-          {
-            unreadCount: 0,
-            mentionsCount: 0,
-            lastReadAt: meta.lastReadAt,
-            lastSeenMessageId: updated.lastSeenMessageId,
-            firstNewMessageId: undefined,
-          },
-          messages
-        ).firstNewMessageId
+      if (resolution.kind === 'advanced-with-divider') {
         newMarkers = new Map(state.firstNewMessageMarkers)
-        if (divider) newMarkers.set(roomJid, divider)
+        if (resolution.firstNewMessageId) newMarkers.set(roomJid, resolution.firstNewMessageId)
         else newMarkers.delete(roomJid)
       }
 
       if (existing) {
+        // Keep the combined map coherent with roomMeta.
         const newRooms = new Map(state.rooms)
-        newRooms.set(roomJid, {
-          ...existing,
-          lastSeenMessageId: updated.lastSeenMessageId,
-          pendingRemoteDisplayedStanzaId: undefined,
-        })
+        newRooms.set(roomJid, { ...existing, ...metaPatch })
         return { roomMeta: newMeta, rooms: newRooms, firstNewMessageMarkers: newMarkers }
       }
       return { roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
@@ -2475,17 +2442,13 @@ export const roomStore = createStore<RoomState>()(
         searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))
       }
 
-      // Sidebar preview: newest non-ignored message across the merged set — but only
-      // when it genuinely supersedes the current preview. A backward (scroll-up) merge
-      // whose keep-oldest trim evicted the newest tail yields a candidate OLDER than
-      // the current preview; replacing would regress the sidebar (parity with
-      // chatStore.mergeMAMMessages). isResolvedSamePreview heals a preview stuck on
-      // an encrypted fallback after its deferred decrypt.
-      const previewCandidate = merged.length > 0 ? findLastNonIgnoredMessage(merged, roomJid, room.nickToJidCache) : undefined
-      const lastMessage = previewCandidate &&
-        (shouldReplaceLastMessage(room.lastMessage, previewCandidate) || isResolvedSamePreview(room.lastMessage, previewCandidate))
-        ? previewCandidate
-        : room.lastMessage
+      // Sidebar preview via the shared policy: only replace when the merged set's
+      // newest non-ignored message genuinely supersedes the current preview (a
+      // backward merge whose keep-oldest trim evicted the newest tail must not
+      // regress the sidebar) or heals its encrypted fallback after a deferred decrypt.
+      const { lastMessage } = derivePreviewAfterMerge(room.lastMessage, merged, (msgs) =>
+        findLastNonIgnoredMessage(msgs, roomJid, room.nickToJidCache)
+      )
 
       const newMeta = new Map(state.roomMeta)
       const existingMeta = newMeta.get(roomJid)

--- a/packages/fluux-sdk/src/stores/shared/lastMessageUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/lastMessageUtils.ts
@@ -84,7 +84,7 @@ export function shouldReplaceLastMessage<T extends PreviewableMessage & MessageW
 }
 
 /** Identity + encryption-state fields needed to recognise a resolved preview. */
-interface ResolvablePreview {
+export interface ResolvablePreview {
   id: string
   stanzaId?: string
   originId?: string

--- a/packages/fluux-sdk/src/stores/shared/previewState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/previewState.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { derivePreviewAfterMerge } from './previewState'
+import { findLastPreviewableMessage } from './lastMessageUtils'
+
+/**
+ * The single sidebar-preview policy applied after every bulk merge (MAM page
+ * or IndexedDB cache slice) in both stores. Historically each of the four
+ * call sites hand-rolled it and drifted: room merges replaced the preview
+ * unconditionally, regressing it when a deep-history slice loaded.
+ */
+
+interface TestMsg {
+  id: string
+  body: string
+  timestamp?: Date
+  encryptedPayload?: string
+}
+
+function msg(id: string, body: string, iso: string, extra: Partial<TestMsg> = {}): TestMsg {
+  return { id, body, timestamp: new Date(iso), ...extra }
+}
+
+const pickLastPreviewable = (messages: TestMsg[]) => findLastPreviewableMessage(messages)
+
+describe('derivePreviewAfterMerge', () => {
+  it('replaces the preview when the merged set holds a strictly newer message', () => {
+    const existing = msg('old', 'old news', '2024-01-15T10:00:00Z')
+    const merged = [existing, msg('new', 'fresh', '2024-01-15T11:00:00Z')]
+
+    const result = derivePreviewAfterMerge(existing, merged, pickLastPreviewable)
+
+    expect(result.changed).toBe(true)
+    expect(result.lastMessage?.id).toBe('new')
+  })
+
+  it('does NOT regress the preview when the merged set only holds older messages', () => {
+    const existing = msg('newest', 'latest', '2024-01-15T12:00:00Z')
+    const merged = [msg('m1', 'deep history', '2024-01-15T09:00:00Z'), msg('m2', 'older', '2024-01-15T10:00:00Z')]
+
+    const result = derivePreviewAfterMerge(existing, merged, pickLastPreviewable)
+
+    expect(result.changed).toBe(false)
+    expect(result.lastMessage?.id).toBe('newest')
+  })
+
+  it('replaces a non-previewable placeholder even with an older real message', () => {
+    // A stuck bodiless placeholder (e.g. undecrypted encrypted reaction) must
+    // yield to a real message regardless of timestamps.
+    const placeholder: TestMsg = { id: 'ph', body: '', timestamp: new Date('2024-01-15T12:00:00Z') }
+    const merged = [msg('real', 'actual content', '2024-01-15T10:00:00Z')]
+
+    const result = derivePreviewAfterMerge(placeholder, merged, pickLastPreviewable)
+
+    expect(result.changed).toBe(true)
+    expect(result.lastMessage?.id).toBe('real')
+  })
+
+  it('heals a same-id encrypted-fallback preview with its resolved copy (same timestamp)', () => {
+    const encrypted = msg('m1', '[OpenPGP-encrypted message]', '2024-01-15T10:00:00Z', { encryptedPayload: '<openpgp/>' })
+    const resolved = msg('m1', 'decrypted!', '2024-01-15T10:00:00Z')
+
+    const result = derivePreviewAfterMerge(encrypted, [resolved], pickLastPreviewable)
+
+    expect(result.changed).toBe(true)
+    expect(result.lastMessage?.body).toBe('decrypted!')
+  })
+
+  it('keeps the existing preview when the merged set has no previewable candidate', () => {
+    const existing = msg('keep', 'kept', '2024-01-15T10:00:00Z')
+    const bodiless: TestMsg = { id: 'sig', body: '', timestamp: new Date('2024-01-15T11:00:00Z') }
+
+    const result = derivePreviewAfterMerge(existing, [bodiless], pickLastPreviewable)
+
+    expect(result.changed).toBe(false)
+    expect(result.lastMessage?.id).toBe('keep')
+  })
+
+  it('adopts the candidate when there is no existing preview', () => {
+    const result = derivePreviewAfterMerge(undefined, [msg('first', 'hello', '2024-01-15T10:00:00Z')], pickLastPreviewable)
+
+    expect(result.changed).toBe(true)
+    expect(result.lastMessage?.id).toBe('first')
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/previewState.ts
+++ b/packages/fluux-sdk/src/stores/shared/previewState.ts
@@ -1,0 +1,44 @@
+/**
+ * The single sidebar-preview policy applied after a bulk merge (a MAM page or
+ * an IndexedDB cache slice) — shared by chatStore and roomStore.
+ *
+ * The candidate (newest previewable message in the merged set; rooms
+ * additionally skip ignored senders via their own scanner) replaces the
+ * current preview only when it genuinely supersedes it:
+ *
+ * - there is no existing preview, or the existing one is a non-previewable
+ *   placeholder (a real message always wins), or
+ * - the candidate is strictly newer, or
+ * - the candidate is the SAME message with its encrypted fallback resolved
+ *   (deferred-decrypt heal — same id and timestamp, so the newer-only rule
+ *   alone would refuse it).
+ *
+ * Historically each of the four call sites hand-rolled this and drifted: room
+ * merges replaced the preview unconditionally, so loading a deep-history
+ * slice regressed the sidebar to an old message.
+ */
+
+import type { PreviewableMessage, MessageWithTimestamp, ResolvablePreview } from './lastMessageUtils'
+import { shouldReplaceLastMessage, isResolvedSamePreview } from './lastMessageUtils'
+
+export interface PreviewUpdate<T> {
+  /** The preview to store: the candidate when it supersedes, else the existing one. */
+  lastMessage: T | undefined
+  /** True when the preview genuinely changed (callers can skip map writes otherwise). */
+  changed: boolean
+}
+
+export function derivePreviewAfterMerge<
+  T extends PreviewableMessage & MessageWithTimestamp & ResolvablePreview,
+>(
+  existing: T | undefined,
+  merged: T[],
+  pickCandidate: (messages: T[]) => T | undefined
+): PreviewUpdate<T> {
+  const candidate = merged.length > 0 ? pickCandidate(merged) : undefined
+  const changed = !!(
+    candidate &&
+    (shouldReplaceLastMessage(existing, candidate) || isResolvedSamePreview(existing, candidate))
+  )
+  return { lastMessage: changed ? candidate : existing, changed }
+}

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { resolveRemoteDisplayed, createMdsSessionGate } from './readMarkerSync'
+import type { NotificationMessage } from './notificationState'
+
+/**
+ * XEP-0490 remote-read-position resolution — the state machine that both
+ * stores' applyRemoteDisplayed previously implemented as ~100-line twins.
+ */
+
+type TestMsg = NotificationMessage & { stanzaId?: string }
+
+function msg(id: string, iso: string, extra: Partial<TestMsg> = {}): TestMsg {
+  return { id, timestamp: new Date(iso), isOutgoing: false, stanzaId: `arch-${id}`, ...extra }
+}
+
+const messages: TestMsg[] = [
+  msg('m1', '2024-01-15T10:01:00Z'),
+  msg('m2', '2024-01-15T10:02:00Z'),
+  msg('m3', '2024-01-15T10:03:00Z'),
+]
+
+const baseMeta = {
+  unreadCount: 2,
+  mentionsCount: 0,
+  lastReadAt: undefined,
+  lastSeenMessageId: undefined,
+  pendingRemoteDisplayedStanzaId: undefined,
+}
+
+describe('resolveRemoteDisplayed', () => {
+  it('stashes the stanza-id as a pending high-water mark when the message is not loaded', () => {
+    const result = resolveRemoteDisplayed(baseMeta, messages, undefined, 'arch-unknown', { isActive: false })
+
+    expect(result.kind).toBe('stash-pending')
+  })
+
+  it('advances the read position forward-only for a non-active entity (no divider)', () => {
+    const result = resolveRemoteDisplayed(
+      { ...baseMeta, lastSeenMessageId: 'm1' },
+      messages,
+      undefined,
+      'arch-m2',
+      { isActive: false }
+    )
+
+    expect(result).toEqual({ kind: 'advanced', lastSeenMessageId: 'm2' })
+  })
+
+  it('recomputes the divider for the ACTIVE entity from the advanced position', () => {
+    const result = resolveRemoteDisplayed(
+      { ...baseMeta, lastSeenMessageId: 'm1' },
+      messages,
+      undefined,
+      'arch-m2',
+      { isActive: true }
+    )
+
+    // Advanced to m2 → the first unseen incoming message after it is m3.
+    expect(result).toEqual({
+      kind: 'advanced-with-divider',
+      lastSeenMessageId: 'm2',
+      firstNewMessageId: 'm3',
+    })
+  })
+
+  it('clears the divider when the advanced position reaches the newest message', () => {
+    const result = resolveRemoteDisplayed(
+      { ...baseMeta, lastSeenMessageId: 'm1' },
+      messages,
+      'm2',
+      'arch-m3',
+      { isActive: true }
+    )
+
+    expect(result).toEqual({
+      kind: 'advanced-with-divider',
+      lastSeenMessageId: 'm3',
+      firstNewMessageId: undefined,
+    })
+  })
+
+  it('reports unchanged when the local position is already at the marker and no pending is stale', () => {
+    const result = resolveRemoteDisplayed(
+      { ...baseMeta, lastSeenMessageId: 'm3' },
+      messages,
+      undefined,
+      'arch-m2',
+      { isActive: false }
+    )
+
+    expect(result.kind).toBe('unchanged')
+  })
+
+  it('asks to clear a stale pending mark when resolved without an advance', () => {
+    const result = resolveRemoteDisplayed(
+      { ...baseMeta, lastSeenMessageId: 'm3', pendingRemoteDisplayedStanzaId: 'arch-m2' },
+      messages,
+      undefined,
+      'arch-m2',
+      { isActive: false }
+    )
+
+    expect(result.kind).toBe('clear-pending')
+  })
+})
+
+describe('createMdsSessionGate', () => {
+  it('consumes each id once per session and resets', () => {
+    const gate = createMdsSessionGate()
+
+    expect(gate.consume('a@example.com')).toBe(true)
+    expect(gate.consume('a@example.com')).toBe(false)
+    expect(gate.consume('b@example.com')).toBe(true)
+
+    gate.reset()
+    expect(gate.consume('a@example.com')).toBe(true)
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -1,0 +1,130 @@
+/**
+ * XEP-0490 (Message Displayed Synchronization) remote-read-position
+ * resolution — shared by chatStore and roomStore, whose applyRemoteDisplayed
+ * implementations were ~100-line twins that had to be kept in sync by hand.
+ *
+ * The stores keep their map fan-out (meta / combined / markers) and apply the
+ * returned resolution; everything decision-shaped lives here.
+ */
+
+import type { NotificationMessage } from './notificationState'
+import * as notifState from './notificationState'
+
+/** The notification-relevant slice of a conversation/room metadata entry. */
+export interface ReadMarkerMeta {
+  unreadCount: number
+  mentionsCount: number
+  lastReadAt?: Date
+  lastSeenMessageId?: string
+  pendingRemoteDisplayedStanzaId?: string
+}
+
+export type RemoteDisplayedResolution =
+  /**
+   * The referenced message is not loaded — remember the stanza-id as a
+   * pending high-water mark, to be resolved when messages arrive.
+   */
+  | { kind: 'stash-pending' }
+  /** No advance and nothing stale to clean up — state untouched. */
+  | { kind: 'unchanged' }
+  /**
+   * No advance (local position at or past the marker), but the marker is now
+   * resolved — clear the stale pending mark so it doesn't re-fire a no-op on
+   * every merge.
+   */
+  | { kind: 'clear-pending' }
+  /** Forward advance on a non-active entity (divider recomputes on next activation). */
+  | { kind: 'advanced'; lastSeenMessageId: string }
+  /**
+   * Forward advance on the ACTIVE entity: the new-message divider was already
+   * derived at activation from the now-stale local position, so it is
+   * recomputed here from the advanced position. `firstNewMessageId`
+   * undefined = no divider (delete the marker).
+   */
+  | { kind: 'advanced-with-divider'; lastSeenMessageId: string; firstNewMessageId: string | undefined }
+
+export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaId?: string }>(
+  meta: ReadMarkerMeta,
+  messages: T[],
+  currentFirstNewMessageId: string | undefined,
+  stanzaId: string,
+  options: { isActive: boolean; treatDelayedAsNew?: boolean }
+): RemoteDisplayedResolution {
+  const match = messages.find((m) => m.stanzaId === stanzaId)
+  if (!match) return { kind: 'stash-pending' }
+
+  // Forward-only advance using the shared comparator (compares by index).
+  const updated = notifState.onMessageSeen(
+    {
+      unreadCount: meta.unreadCount,
+      mentionsCount: meta.mentionsCount,
+      lastReadAt: meta.lastReadAt,
+      lastSeenMessageId: meta.lastSeenMessageId,
+      firstNewMessageId: currentFirstNewMessageId,
+    },
+    match.id,
+    messages
+  )
+
+  if (updated.lastSeenMessageId === meta.lastSeenMessageId || updated.lastSeenMessageId === undefined) {
+    return meta.pendingRemoteDisplayedStanzaId === undefined
+      ? { kind: 'unchanged' }
+      : { kind: 'clear-pending' }
+  }
+
+  if (!options.isActive) {
+    return { kind: 'advanced', lastSeenMessageId: updated.lastSeenMessageId }
+  }
+
+  // Recompute the divider from the advanced position (reuses onActivate's
+  // forward scan). Chat treats delayed messages as offline delivery
+  // (treatDelayedAsNew); rooms treat them as history replay.
+  const divider = notifState.onActivate(
+    {
+      unreadCount: 0,
+      mentionsCount: 0,
+      lastReadAt: meta.lastReadAt,
+      lastSeenMessageId: updated.lastSeenMessageId,
+      firstNewMessageId: undefined,
+    },
+    messages,
+    options.treatDelayedAsNew ? { treatDelayedAsNew: true } : undefined
+  ).firstNewMessageId
+
+  return {
+    kind: 'advanced-with-divider',
+    lastSeenMessageId: updated.lastSeenMessageId,
+    firstNewMessageId: divider,
+  }
+}
+
+// ============================================================================
+// First-open-per-session gate for the activation fold
+// ============================================================================
+
+/**
+ * XEP-0490 markers broadcast live over PEP, so a pending marker is folded
+ * into the divider only on the FIRST open of an entity per session — later
+ * opens rely on the live notifies (re-folding would reposition the divider on
+ * every return). Each store owns one gate instance; `reset()` on account
+ * switch.
+ */
+export interface MdsSessionGate {
+  /** True on the first call for this id since the last reset. Records the id. */
+  consume(id: string): boolean
+  reset(): void
+}
+
+export function createMdsSessionGate(): MdsSessionGate {
+  const consumed = new Set<string>()
+  return {
+    consume(id: string): boolean {
+      const first = !consumed.has(id)
+      consumed.add(id)
+      return first
+    },
+    reset(): void {
+      consumed.clear()
+    },
+  }
+}


### PR DESCRIPTION
The last two Phase 1 extractions — two more chat/room twins become single tested modules.

## `shared/previewState.ts`
`derivePreviewAfterMerge` — the one sidebar-preview policy after a bulk merge (MAM page or IndexedDB slice): the newest previewable (rooms: non-ignored) candidate replaces the preview only when it's strictly newer, replaces a bodiless placeholder, or heals the same message's encrypted fallback. All four hand-rolled call sites converted.

**Live bug fixed by the unification**: room's cached-slice merge replaced the preview *unconditionally*, so a scroll-position restore loading a deep-history slice regressed the room's sidebar preview to an old message (chat had the guard; room didn't — same class as the MAM-merge regression fixed in #859). Store-level regression test failed before the fix, passes after.

## `shared/readMarkerSync.ts`
`resolveRemoteDisplayed` — the XEP-0490 remote-read-position state machine (stash-pending / clear-pending / forward-only advance / active-divider recompute) that both stores implemented as ~100-line twins, plus `createMdsSessionGate` for the first-open-per-session activation fold. The stores keep only their map fan-out; the one intentional behavioral delta (chat treats delayed messages as offline delivery, rooms as history replay) is now an explicit `treatDelayedAsNew` option instead of a silently divergent copy.