### PR TITLE
Aurora: room-header hairline + light-mode send button

### DIFF
--- a/apps/fluux/src/components/RoomHeader.test.tsx
+++ b/apps/fluux/src/components/RoomHeader.test.tsx
@@ -180,6 +180,26 @@ describe('RoomHeader', () => {
       expect(screen.getByText('My Room')).toBeInTheDocument()
     })
 
+    it('carries the aurora horizon hairline', () => {
+      const { container } = render(
+        <RoomHeader
+          room={createRoom({ name: 'My Room' })}
+          showOccupants={false}
+          onToggleOccupants={mockOnToggleOccupants}
+          setRoomNotifyAll={mockSetRoomNotifyAll}
+          setRoomAvatar={mockSetRoomAvatar}
+          clearRoomAvatar={mockClearRoomAvatar}
+          submitRoomConfig={mockSubmitRoomConfig}
+          setSubject={mockSetSubject}
+          destroyRoom={mockDestroyRoom}
+        />
+      )
+      const header = container.querySelector('header')
+      expect(header).not.toBeNull()
+      expect(header!.className).toContain('aurora-horizon')
+      expect(header!.className).toContain('relative')
+    })
+
     it('renders room subject when available', () => {
       render(
         <RoomHeader

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -97,7 +97,7 @@ export function RoomHeader({
   })
 
   return (
-    <header className="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
+    <header className="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
       {/* Back button - mobile only */}
       {onBack && (
         <button

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
       class="flex flex-col flex-1 min-w-0"
     >
       <header
-        class="@container h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+        class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
       >
         <div
           class="size-9 rounded-xl flex items-center justify-center flex-shrink-0"

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1435,14 +1435,27 @@ input[type="range"]::-moz-range-thumb {
 .send-aurora:not(:disabled):hover {
   border-color: rgba(255, 255, 255, 0.45);
 }
+/* Light mode: a glow behind translucent white glass on a light background is
+   invisible, and the muted-dawn tokens are too pale to read on this small
+   control — so the light send button tints the glass itself with a saturated
+   aurora wash (teal → indigo → violet) over white, and the glow below uses the
+   vivid aurora hues rather than the dawn tokens. The ink icon still clears AA on
+   the resulting pastel. */
 .light .send-aurora {
-  background: rgba(255, 255, 255, 0.5);
-  border-color: rgba(30, 42, 70, 0.18);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 2px 6px rgba(30, 42, 70, 0.1);
+  background:
+    linear-gradient(130deg, rgba(47, 224, 192, 0.32), rgba(79, 182, 232, 0.24) 45%, rgba(124, 140, 255, 0.26) 72%, rgba(167, 139, 250, 0.32)),
+    rgba(255, 255, 255, 0.55);
+  border-color: rgba(56, 120, 180, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75), 0 2px 8px rgba(80, 100, 180, 0.2);
   color: var(--fluux-aurora-ink);
 }
 .light .send-aurora:not(:disabled):hover {
-  border-color: rgba(30, 42, 70, 0.32);
+  border-color: rgba(56, 120, 180, 0.5);
+}
+.light .send-aurora-glow {
+  background:
+    radial-gradient(50% 50% at 35% 65%, color-mix(in srgb, #2FE0C0, transparent 26%), transparent 70%),
+    radial-gradient(50% 50% at 70% 30%, color-mix(in srgb, #7C8CFF, transparent 26%), transparent 70%);
 }
 .send-aurora:disabled {
   background: transparent;


### PR DESCRIPTION
Two follow-ups to the Aurora identity (#871), both reported after merge:

- **Aurora horizon hairline in the room header** — the hairline shipped on the DM/conversation header (`ChatHeader`) but the room view uses its own `RoomHeader`, which didn't get it. Adds the same `relative aurora-horizon` treatment (and a test); the room-view snapshot is refreshed for the added classes.
- **Send button now reads as aurora in light mode** — a glow behind translucent white glass on a light background was invisible, and the muted-dawn tokens were too pale for this small control. The light send button now tints the glass itself with a saturated teal→indigo→violet aurora wash and uses vivid hues for the glow; the ink icon still clears AA on the resulting pastel.
