### PR TITLE
fix(rooms): make the jump-to-last-read pill work after a jump-to-present (#870)

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
@@ -407,7 +407,11 @@ describe('MessageList FAB badge and scroll behavior', () => {
       )
     })
 
-    it('should clear the unread marker when the FAB intentionally goes to bottom', () => {
+    it('should NOT clear the unread marker when the FAB intentionally goes to bottom (#870)', () => {
+      // The FAB jump-to-present must scroll to the live bottom WITHOUT clearing
+      // firstNewMessageId — the per-visit divider anchor has to survive the jump so the
+      // jump-to-last-read pill can appear afterward. See useMessageListScroll's
+      // scrollToBottom callback and the "reached bottom" clear guarded by !programmaticScroll.
       const messages = createTestMessages(10)
       const clearFirstNewMessageId = vi.fn()
 
@@ -436,7 +440,7 @@ describe('MessageList FAB badge and scroll behavior', () => {
 
       act(() => { fireEvent.click(fab) })
 
-      expect(clearFirstNewMessageId).toHaveBeenCalled()
+      expect(clearFirstNewMessageId).not.toHaveBeenCalled()
       expect(scrollCtx.scrollToSpy).toHaveBeenCalledWith(
         expect.objectContaining({ top: 2000, behavior: 'smooth' })
       )

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1335,10 +1335,6 @@ export function useMessageListScroll({
       }
     }
 
-    if (firstNewMessageId) {
-      clearFirstNewMessageId?.()
-    }
-
     const virtFab = latestRef.current.virtualizer
     if (virtFab && virtFab.itemCount > 0) {
       reassertBottom('fab')
@@ -1347,7 +1343,7 @@ export function useMessageListScroll({
 
     rememberBottomIntent()
     scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
-  }, [firstNewMessageId, clearFirstNewMessageId, reassertBottom, rememberBottomIntent])
+  }, [firstNewMessageId, reassertBottom, rememberBottomIntent])
 
   const scrollToTop = useCallback(() => {
     lastLoadTimeRef.current = Date.now() // prevent auto-load trigger
@@ -1799,25 +1795,14 @@ export function useMessageListScroll({
         userHasScrolledSinceMarkerRef.current = true
         debugLog('MARKER CLEAR armed (first scroll)', { firstNewMessageId, distFromBottom })
       } else if (distFromBottom < AT_BOTTOM_THRESHOLD) {
-        // User reached the bottom — all new messages are visible
+        // User genuinely read through to the bottom — the "skipped vs read-through" clear.
+        // NOTE: gated by `!programmaticScroll` above, so a FAB jump-to-present (which drives a
+        // reassert loop) does NOT clear the anchor — the jump-to-last-read pill (#870) needs the
+        // per-visit divider anchor to survive a skip. Scrolled-past / DOM-trimmed no longer clear:
+        // those are exactly the states where the pill must show (moved toward the present without
+        // reading). The anchor now clears only on read-through, Esc, mark-all-read, or deactivation.
         debugLog('MARKER CLEAR (reached bottom)', { firstNewMessageId, distFromBottom })
         clearFirstNewMessageId()
-      } else {
-        const escapedId = CSS.escape(firstNewMessageId)
-        const markerEl = el.querySelector(`[data-message-id="${escapedId}"]`) as HTMLElement | null
-        if (markerEl) {
-          const scrollerRect = el.getBoundingClientRect()
-          const markerRect = markerEl.getBoundingClientRect()
-          // Marker is "scrolled past" when its bottom edge is above the viewport
-          if (markerRect.bottom < scrollerRect.top) {
-            debugLog('MARKER CLEAR (scrolled past)', { firstNewMessageId })
-            clearFirstNewMessageId()
-          }
-        } else {
-          // Marker element not in DOM (trimmed) — clear it
-          debugLog('MARKER CLEAR (not in DOM/trimmed)', { firstNewMessageId, distFromBottom })
-          clearFirstNewMessageId()
-        }
       }
     }
 

--- a/docs/superpowers/plans/2026-07-06-jump-to-last-read-pill-fix.md
+++ b/docs/superpowers/plans/2026-07-06-jump-to-last-read-pill-fix.md
@@ -1,0 +1,289 @@
+# Jump-to-Last-Read Pill Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the jump-to-last-read pill (#870) durably appear after a jump-to-present, by stopping the message-list scroll layer from clearing the per-visit divider anchor on non-read events.
+
+**Architecture:** `firstNewMessageId` is already a purely-visual, decoupled per-visit divider anchor at the store level (`firstNewMessageMarkers` Map; clearing it has no read-state side effects). The fix is a net *removal* of three over-aggressive clear branches in `useMessageListScroll.ts` (scrolled-past, DOM-trimmed, FAB-explicit), keeping only the genuine read-through clear (manual reach-bottom). No new state, no store changes. The pill's visibility, count, action, and the rendered divider row all continue to ride the one persisted anchor and stay in sync by construction.
+
+**Tech Stack:** React + Zustand (SDK), Vitest (unit), Playwright (`scripts/scroll-invariants.ts`, driven by `npm run test:scroll`).
+
+## Global Constraints
+
+- This is the codebase's most fragile area. `npm run test:scroll` (46 invariants, ~3 min) MUST be green **before and after** the change.
+- Chosen clear semantics — "skipped vs read-through": manual scroll *down* through the divider to the bottom clears it (read-through); a FAB / programmatic jump-to-present keeps the anchor and shows the pill (skip). Esc, mark-all-read, leave-tab/deactivation, and message-sent still clear it — those paths are unchanged and out of scope.
+- No em-dashes / en-dashes in any user-facing text (none are added here; the pill copy already exists).
+- Fraction/pixel anchors are not verifiable in jsdom — the pill behavior MUST be pinned by a real Playwright test in `scripts/scroll-invariants.ts`, not a unit test.
+- Run app vitest from `apps/fluux` (root config lacks the `@` alias). Root typecheck is `npm run typecheck` from the repo root.
+- No Claude footer in commit messages.
+
+## File Structure
+
+- Modify: `apps/fluux/src/components/conversation/useMessageListScroll.ts` — remove the two non-read clear branches in the scroll handler and the explicit clear in the FAB `scrollToBottom`.
+- Modify (test): `scripts/scroll-invariants.ts` — add one Playwright test that FAB-jumps past a divider, asserts the pill appears, clicks it, and asserts the divider is returned to view.
+- Unchanged (kept as-is): `apps/fluux/src/components/conversation/JumpToLastReadPill.tsx`, `JumpToLastReadPill.test.tsx`, `MessageList.tsx`, both stores.
+
+---
+
+### Task 1: Fix the clear conditions, pinned by a new scroll-invariant e2e
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/useMessageListScroll.ts` (scroll handler ~1801-1822; `scrollToBottom` ~1338-1340 and its dep array ~1350)
+- Test: `scripts/scroll-invariants.ts` (append one `test.describe` block near the end of the file)
+
+**Interfaces:**
+- Consumes (existing, unchanged): the store anchor `firstNewMessageId` and `clearFirstNewMessageId()` passed into `useMessageListScroll`; `markerAboveViewport` (returned) drives the pill; `scrollToMarker` (returned) is the pill's `onJump`.
+- Produces: no new exported symbols. Behavior change only.
+- Existing DOM contracts used by the test: scroller `[data-message-list]`, divider row `[data-new-message-marker]`, pill `[data-jump-to-last-read]`, FAB button `[data-fab="scroll-to-bottom"]`. Stress room JID constant already in the test file: `STRESS_ROOM_JID = 'stress-0@conference.fluux.chat'`. Helpers already in the file: `loadDemo`, `navigateToStressRoom`, `scrollToBottom`.
+
+- [ ] **Step 1: Confirm the baseline is green**
+
+Run from the repo root:
+
+```bash
+npm run test:scroll
+```
+
+Expected: all existing invariants PASS (green). Record this — it is the mandated before-gate. Do not proceed if red; investigate environment first (see the worktree preview note: `dev-wt` needs `--strictPort`).
+
+- [ ] **Step 2: Write the failing e2e**
+
+Append this block to the end of `scripts/scroll-invariants.ts`:
+
+```ts
+// ── Jump-to-last-read pill: survives a jump-to-present and returns to the divider (#870) ──
+//
+// Reproduces the "dead pill": read a room to the bottom, leave, receive MANY new messages
+// while away, return (opens at the divider). Jump to present via the FAB. The per-visit
+// anchor must SURVIVE the jump so the pill shows "N new · Jump to last read", and clicking
+// it must return the divider to view. With the pre-fix clear branches this pill never
+// durably appears, so this test goes RED against the bug.
+test.describe('Jump-to-last-read pill', () => {
+  test('pill appears after FAB jump-to-present and returns to the divider', async ({ page }) => {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+
+    // Read the room the real way, then pin lastSeen to the true last message.
+    await scrollToBottom(page)
+    await page.waitForTimeout(400)
+    await page.evaluate((jid) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rs = (window as any).__roomStore.getState()
+      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const last = msgs[msgs.length - 1]
+      if (last) rs.updateLastSeenMessageId(jid, last.id)
+    }, STRESS_ROOM_JID)
+
+    // Leave the room (genuinely at the bottom, so no restore-position is saved).
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void (window as any).__roomStore.getState().activateRoom(null)
+    })
+    await page.waitForTimeout(300)
+
+    // Many new messages arrive while away, so the divider sits well above the live edge
+    // (and its row is trimmed from the DOM once we jump — exercising the trim-survival path).
+    const baseTs = Date.now()
+    await page.evaluate(([jid, count, base]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      for (let i = 0; i < (count as number); i++) {
+        c.emitSDK('room:message', {
+          roomJid: jid,
+          message: {
+            type: 'groupchat', id: `pill-new-${base}-${i}`, from: `${jid}/AwayBot`, nick: 'AwayBot',
+            body: `away message ${i} — the divider must survive a jump to present`,
+            timestamp: new Date((base as number) + i), isOutgoing: false, roomJid: jid,
+          },
+          incrementUnread: true,
+        })
+      }
+    }, [STRESS_ROOM_JID, 30, baseTs])
+    await page.waitForTimeout(200)
+
+    // Re-enter: opens at the divider, so the pill is hidden (divider visible).
+    await navigateToStressRoom(page)
+    await page.waitForTimeout(1500) // let the marker re-assert loop settle
+    await expect(page.locator('[data-new-message-marker]'), 'divider row should exist on re-entry').toBeVisible()
+    await expect(page.locator('[data-jump-to-last-read]'), 'pill is hidden while the divider is visible').toHaveCount(0)
+
+    // Jump to present via the FAB (two-step: to marker, then to bottom). Click until at bottom.
+    const fab = page.locator('[data-fab="scroll-to-bottom"]')
+    for (let i = 0; i < 3; i++) {
+      if (await fab.isVisible().catch(() => false)) {
+        await fab.click()
+        await page.waitForTimeout(600)
+      }
+      const dist = await page.evaluate(() => {
+        const s = document.querySelector('[data-message-list]') as HTMLElement | null
+        return s ? Math.round(s.scrollHeight - s.scrollTop - s.clientHeight) : 99999
+      })
+      if (dist < 8) break
+    }
+
+    // The anchor survived the jump: the pill now shows and offers the return.
+    await expect(page.locator('[data-jump-to-last-read]'), 'pill must appear after a jump-to-present').toBeVisible({ timeout: 4000 })
+
+    // Click the pill: the divider returns to view.
+    await page.locator('[data-jump-to-last-read] button').click()
+    await page.waitForTimeout(1200)
+    const dividerVisible = await page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const m = document.querySelector('[data-new-message-marker]') as HTMLElement | null
+      if (!s || !m) return false
+      const sr = s.getBoundingClientRect()
+      const mr = m.getBoundingClientRect()
+      return mr.bottom > sr.top && mr.top < sr.bottom
+    })
+    expect(dividerVisible, 'clicking the pill must return the divider to view').toBe(true)
+  })
+})
+```
+
+- [ ] **Step 3: Run the new e2e and verify it FAILS**
+
+Run:
+
+```bash
+npx playwright test --config playwright.scroll.config.ts -g "pill appears after FAB"
+```
+
+Expected: FAIL at the "pill must appear after a jump-to-present" assertion (timeout) — the pre-fix clear branches kill the anchor, so the pill never shows.
+
+- [ ] **Step 4: Remove the two non-read clear branches in the scroll handler**
+
+In `apps/fluux/src/components/conversation/useMessageListScroll.ts`, find the marker-clear block (starts `if (firstNewMessageId && clearFirstNewMessageId && !programmaticScroll) {`). Replace the reached-bottom `else if` and its trailing `else` so ONLY the reached-bottom clear remains.
+
+Replace this:
+
+```ts
+      } else if (distFromBottom < AT_BOTTOM_THRESHOLD) {
+        // User reached the bottom — all new messages are visible
+        debugLog('MARKER CLEAR (reached bottom)', { firstNewMessageId, distFromBottom })
+        clearFirstNewMessageId()
+      } else {
+        const escapedId = CSS.escape(firstNewMessageId)
+        const markerEl = el.querySelector(`[data-message-id="${escapedId}"]`) as HTMLElement | null
+        if (markerEl) {
+          const scrollerRect = el.getBoundingClientRect()
+          const markerRect = markerEl.getBoundingClientRect()
+          // Marker is "scrolled past" when its bottom edge is above the viewport
+          if (markerRect.bottom < scrollerRect.top) {
+            debugLog('MARKER CLEAR (scrolled past)', { firstNewMessageId })
+            clearFirstNewMessageId()
+          }
+        } else {
+          // Marker element not in DOM (trimmed) — clear it
+          debugLog('MARKER CLEAR (not in DOM/trimmed)', { firstNewMessageId, distFromBottom })
+          clearFirstNewMessageId()
+        }
+      }
+```
+
+With this:
+
+```ts
+      } else if (distFromBottom < AT_BOTTOM_THRESHOLD) {
+        // User genuinely read through to the bottom — the "skipped vs read-through" clear.
+        // NOTE: gated by `!programmaticScroll` above, so a FAB jump-to-present (which drives a
+        // reassert loop) does NOT clear the anchor — the jump-to-last-read pill (#870) needs the
+        // per-visit divider anchor to survive a skip. Scrolled-past / DOM-trimmed no longer clear:
+        // those are exactly the states where the pill must show (moved toward the present without
+        // reading). The anchor now clears only on read-through, Esc, mark-all-read, or deactivation.
+        debugLog('MARKER CLEAR (reached bottom)', { firstNewMessageId, distFromBottom })
+        clearFirstNewMessageId()
+      }
+```
+
+- [ ] **Step 5: Remove the explicit clear in the FAB `scrollToBottom`**
+
+In the same file, in the `scrollToBottom` callback, delete the explicit clear that runs on the jump-to-present step:
+
+```ts
+    if (firstNewMessageId) {
+      clearFirstNewMessageId?.()
+    }
+
+```
+
+(Delete those four lines. The lines immediately after — `const virtFab = latestRef.current.virtualizer` etc. — stay. The two-step marker check earlier in the callback that reads `firstNewMessageId` stays unchanged.)
+
+- [ ] **Step 6: Drop the now-unused dep from `scrollToBottom`**
+
+`scrollToBottom` no longer references `clearFirstNewMessageId`. Update its dependency array. Change:
+
+```ts
+  }, [firstNewMessageId, clearFirstNewMessageId, reassertBottom, rememberBottomIntent])
+```
+
+to:
+
+```ts
+  }, [firstNewMessageId, reassertBottom, rememberBottomIntent])
+```
+
+- [ ] **Step 7: Run the new e2e and verify it PASSES**
+
+Run:
+
+```bash
+npx playwright test --config playwright.scroll.config.ts -g "pill appears after FAB"
+```
+
+Expected: PASS — the pill appears after the FAB jump and clicking it returns the divider to view.
+
+- [ ] **Step 8: Run the full scroll suite and verify no regressions**
+
+Run:
+
+```bash
+npm run test:scroll
+```
+
+Expected: all invariants PASS (green), including the new test. This is the mandated after-gate. Pay attention to invariant-3/4/5 (FAB + new-message-at-bottom) — if the reached-bottom clear now fires on a settling FAB scroll, harden its gate by replacing the `!programmaticScroll` guard on the clear block with the windowed `isProgrammaticScroll(programmaticScroll, Date.now(), lastProgrammaticScrollAtRef.current)` (already imported and used for the save-gate a few lines above), then re-run.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/fluux/src/components/conversation/useMessageListScroll.ts scripts/scroll-invariants.ts
+git commit -m "fix(rooms): keep jump-to-last-read divider anchor through a jump-to-present (#870)"
+```
+
+---
+
+### Task 2: Full-suite verification
+
+**Files:** none (verification only; touch code only if a suite goes red).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the app unit suite**
+
+Run from `apps/fluux`:
+
+```bash
+cd apps/fluux && npx vitest run
+```
+
+Expected: PASS, no stderr. In particular `JumpToLastReadPill.test.tsx` (props-driven, unchanged) and `NewMessageMarker.test.tsx` stay green. If a mock or snapshot broke, fix it in the test (the runtime contract did not change — the pill/divider components were not modified), then re-run.
+
+- [ ] **Step 2: Run the root typecheck**
+
+Run from the repo root:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS with no errors. (No SDK types changed, so no `build:sdk` is required first.)
+
+- [ ] **Step 3: Commit any incidental fixes**
+
+Only if Step 1 or 2 required an edit:
+
+```bash
+git add -A
+git commit -m "test: keep suite green after jump-to-last-read pill fix (#870)"
+```
+
+If nothing changed, skip this commit.

--- a/docs/superpowers/specs/2026-07-06-jump-to-last-read-pill-fix-design.md
+++ b/docs/superpowers/specs/2026-07-06-jump-to-last-read-pill-fix-design.md
@@ -1,0 +1,151 @@
+# Jump-to-Last-Read Pill Fix Design
+
+**Date:** 2026-07-06
+**Status:** Approved (design), pending implementation plan
+**Resolves:** [#870](https://github.com/processone/fluux-messenger/issues/870) (jump-to-last-read pill is dead UI)
+**Follows:** [#869](https://github.com/processone/fluux-messenger/issues/869) (MUC catch-up & read-state redesign), spec `2026-07-06-muc-catchup-read-state-design.md` §2/§6
+
+## Problem
+
+The jump-to-last-read pill shipped with #869 but is effectively dead UI.
+Its visibility is `visible={!!firstNewMessageId && markerAboveViewport}`
+in `MessageList.tsx`, and its action (`scrollToMarker`) and count
+(`markerUnreadCount`) all ride the same `firstNewMessageId` value. The
+message-list scroll layer clears that value on three **non-read** events,
+collapsing the anchor's lifetime to the ~48px window where the divider
+straddles the viewport top:
+
+- **Scrolled past** — `markerRect.bottom < scrollerRect.top`
+  (`useMessageListScroll.ts` ~1812).
+- **Trimmed from DOM** — marker row virtualized away, element not found
+  (~1817).
+- **FAB second step** — `scrollToBottom` explicitly calls
+  `clearFirstNewMessageId()` (~1339) on the jump-to-present.
+
+Result: via the FAB two-step and via Esc (marks read), the anchor clears
+before the pill can durably show, and `scrollToMarker` would no-op even
+if it did. The pill essentially never appears.
+
+## Key finding: the anchor is already decoupled
+
+`clearFirstNewMessageId` is **purely visual**. In both stores it only
+deletes an entry from the `firstNewMessageMarkers` Map
+(`roomStore.ts` ~1720, mirror in `chatStore.ts`) — it has **no**
+read-state side effects. The read pointer (`lastSeenMessageId`) advances
+independently through the viewport IntersectionObserver
+(`updateLastSeenMessageId` → `notifState.onMessageSeen`, which never
+touches `firstNewMessageMarkers`) and through inbound MDS. Counts are
+always re-derivable from the pointer.
+
+So `firstNewMessageId` **already is** the "divider anchor for this visit"
+that spec §2 describes ("persists for the visit while the viewport
+advances `lastSeenMessageId` underneath"). The only defect is that the
+scroll layer clears it too aggressively. This makes approach (b) —
+repurpose the existing anchor by correcting its clear conditions —
+strictly better than approach (a) — introduce a parallel per-visit
+anchor. A parallel value would be redundant with the store anchor and
+would desync the pill's jump target from the rendered divider row.
+
+## Decision: clear semantics ("skipped vs read-through")
+
+The divider + pill clear on a genuine **read-through** gesture but persist
+through a **skip**:
+
+- **Read-through** — manually scrolling *down* through the divider to the
+  bottom = "I read the backlog" → clear, no pill.
+- **Skip** — a FAB / programmatic jump-to-present past the divider =
+  "I skipped it" → keep the anchor, show the pill so the reading position
+  stays one click away until the visit ends.
+- **Always clears** regardless of scroll gesture: Esc (mark read),
+  mark-all-read, leaving the tab / deactivation, and sending a message
+  (500ms, user is engaged).
+
+This resolves the source contradiction between spec §2 ("persists for the
+visit ... clears on deactivation") and #870 ("clear-on-genuine-read-scroll
+should stay") in favor of #870's model: distinguishing reading from
+skipping is the more useful UX and matches Slack/Discord, where the NEW
+line stays until you leave or mark read.
+
+## The fix (approach b)
+
+All changes are in `apps/fluux/src/components/conversation/useMessageListScroll.ts`.
+The net effect is a **removal** of clear branches from the fragile scroll
+logic — no new state, no new store surface.
+
+1. **Remove the "scrolled past" clear branch** (~1805–1815). This fires
+   exactly when the user has moved toward the present without reading to
+   the bottom — the pill's reason to exist.
+2. **Remove the "trimmed / not-in-DOM" clear branch** (~1816–1820). The
+   anchor must outlive virtualization. Pill visibility already computes
+   from the virtualizer offset (`getOffsetForMessageId`, ~1753), which
+   works for unmounted rows, so this survives trimming for free.
+3. **Remove the explicit clear in the FAB's `scrollToBottom`** (~1339).
+   The jump still marks read — the viewport observer advances the pointer
+   as the newest message enters view (unchanged) — but the anchor now
+   survives so the pill appears.
+4. **Keep the "reached bottom" manual clear** (~1801), already gated
+   `!programmaticScroll` and by the first-scroll / `recentUserScrollIntent`
+   guards. This is the read-through gesture. If `test:scroll` reveals that
+   a settling FAB `reassertBottom('fab')` scroll trips it after the loop
+   clears `reassertLoopRef`, harden the gate with the existing
+   `isProgrammaticScroll(...)` window rather than the bare
+   `!programmaticScroll` check.
+
+Everything the pill needs — visibility (`markerAboveViewport`), count
+(`markerUnreadCount`), action (`scrollToMarker` → `runMarkerReassertLoop`),
+and the rendered divider row (`showNewMarker`) — continues to ride the one
+persisted `firstNewMessageId`, so they stay in sync by construction.
+
+## Behavior after the fix
+
+- **Open at divider:** anchor visible → `offset ≈ scrollTop` → pill hidden.
+- **FAB two-step:** first click scrolls to the marker (align start;
+  `offset ≈ scrollTop`, pill hidden, divider at top); second click goes to
+  the bottom → divider now above viewport → pill shows "N new · Jump to
+  last read"; clicking it returns to the divider.
+- **Manual read-through:** scrolling down through the divider to the bottom
+  clears the anchor (read-through), pill gone.
+- **Esc / leave / mark-all-read:** clears the anchor.
+- **Next visit:** the pointer is at newest (the jump/read marked it read),
+  so activation derives no divider — caught up, opens at bottom.
+- **Degraded count:** when the count can't be derived from cache
+  (`markerUnreadCount === 0`), the pill degrades to "You were away · Jump
+  to last read" (existing `JumpToLastReadPill` copy).
+
+## Edge cases
+
+- **Non-virtualized mode:** all rows are always mounted, so the removed
+  trim branch was never reachable there and pill visibility uses the DOM
+  `offsetTop` fallback. No behavior change. Virtualization is default-on,
+  so this path is secondary.
+- **Prepend / append while anchor persists:** the divider is a fixed
+  message id; loading older or newer messages does not change which
+  message it points to. `markerUnreadCount` (messages from the divider to
+  the end) recomputes correctly.
+- **Own MDS echo mid-visit:** existing `lastConsideredSeenId` dedup makes
+  our own published marker a no-op on return, so the active-entity
+  `advanced-with-divider` recompute does not delete the divider mid-visit.
+  Unchanged by this fix; covered by existing tests.
+
+## Testing
+
+This is the codebase's most fragile area. Gate every change on
+`npm run test:scroll` — green **before and after**.
+
+- **Scroll invariants (`npm run test:scroll`, 46 invariants, ~3 min):**
+  run green before starting and after each change.
+- **New e2e (`scripts/scroll-invariants.ts`, Playwright):** the spec §6
+  test deferred from #869. FAB-jump past a divider → assert the pill
+  appears; click the pill → assert it returns to the divider. Fraction
+  anchors are not verifiable in jsdom, so this must be a real Playwright
+  test, not a unit test.
+- **Isolated `JumpToLastReadPill.test.tsx`** (props-driven) stays as-is.
+- **Full app suite** (`apps/fluux` vitest) + **root typecheck**
+  (`npm run typecheck`) green, no stderr.
+
+## Out of scope
+
+- No change to the read-pointer / MDS / counting machinery from #869.
+- No change to the store `firstNewMessageMarkers` surface or its
+  activation derivation (`onActivate`).
+- No new settings, no keyboard shortcut for the pill.

--- a/docs/superpowers/specs/2026-07-06-jump-to-last-read-pill-fix-design.md
+++ b/docs/superpowers/specs/2026-07-06-jump-to-last-read-pill-fix-design.md
@@ -114,10 +114,16 @@ persisted `firstNewMessageId`, so they stay in sync by construction.
 
 ## Edge cases
 
-- **Non-virtualized mode:** all rows are always mounted, so the removed
-  trim branch was never reachable there and pill visibility uses the DOM
-  `offsetTop` fallback. No behavior change. Virtualization is default-on,
-  so this path is secondary.
+- **Non-virtualized mode (opt-out only):** all rows are always mounted, so
+  the removed trim branch was never reachable there and pill visibility uses
+  the DOM `offsetTop` fallback. One benign difference: the FAB's second-click
+  path here falls through to a bare smooth `scrollTo` (no reassert loop), so
+  its landing at the bottom is not `programmaticScroll`-gated and trips the
+  reached-bottom clear, so the pill will not appear after a FAB jump in this
+  mode. This is acceptable: virtualization is default-on (this path is
+  opt-out only), and it is no worse than the pre-fix behavior where the pill
+  never appeared anywhere. If this path ever becomes non-secondary, route the
+  non-virtualized second click through the reassert loop.
 - **Prepend / append while anchor persists:** the divider is a fixed
   message id; loading older or newer messages does not change which
   message it points to. `markerUnreadCount` (messages from the divider to

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -1707,3 +1707,91 @@ test.describe('Sliding window (load-older past the cap)', () => {
     expect(recentered.count, `resident not bounded after recenter: ${JSON.stringify(recentered)}`).toBeLessThanOrEqual(100)
   })
 })
+
+// ── Jump-to-last-read pill: survives a jump-to-present and returns to the divider (#870) ──
+//
+// Reproduces the "dead pill": read a room to the bottom, leave, receive MANY new messages
+// while away, return (opens at the divider). Jump to present via the FAB. The per-visit
+// anchor must SURVIVE the jump so the pill shows "N new · Jump to last read", and clicking
+// it must return the divider to view. With the pre-fix clear branches this pill never
+// durably appears, so this test goes RED against the bug.
+test.describe('Jump-to-last-read pill', () => {
+  test('pill appears after FAB jump-to-present and returns to the divider', async ({ page }) => {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+
+    // Read the room the real way, then pin lastSeen to the true last message.
+    await scrollToBottom(page)
+    await page.waitForTimeout(400)
+    await page.evaluate((jid) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rs = (window as any).__roomStore.getState()
+      const msgs = rs.roomRuntime.get(jid)?.messages ?? rs.rooms.get(jid)?.messages ?? []
+      const last = msgs[msgs.length - 1]
+      if (last) rs.updateLastSeenMessageId(jid, last.id)
+    }, STRESS_ROOM_JID)
+
+    // Leave the room (genuinely at the bottom, so no restore-position is saved).
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void (window as any).__roomStore.getState().activateRoom(null)
+    })
+    await page.waitForTimeout(300)
+
+    // Many new messages arrive while away, so the divider sits well above the live edge
+    // (and its row is trimmed from the DOM once we jump — exercising the trim-survival path).
+    const baseTs = Date.now()
+    await page.evaluate(([jid, count, base]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      for (let i = 0; i < (count as number); i++) {
+        c.emitSDK('room:message', {
+          roomJid: jid,
+          message: {
+            type: 'groupchat', id: `pill-new-${base}-${i}`, from: `${jid}/AwayBot`, nick: 'AwayBot',
+            body: `away message ${i} — the divider must survive a jump to present`,
+            timestamp: new Date((base as number) + i), isOutgoing: false, roomJid: jid,
+          },
+          incrementUnread: true,
+        })
+      }
+    }, [STRESS_ROOM_JID, 30, baseTs])
+    await page.waitForTimeout(200)
+
+    // Re-enter: opens at the divider, so the pill is hidden (divider visible).
+    await navigateToStressRoom(page)
+    await page.waitForTimeout(1500) // let the marker re-assert loop settle
+    await expect(page.locator('[data-new-message-marker]'), 'divider row should exist on re-entry').toBeVisible()
+    await expect(page.locator('[data-jump-to-last-read]'), 'pill is hidden while the divider is visible').toHaveCount(0)
+
+    // Jump to present via the FAB (two-step: to marker, then to bottom). Click until at bottom.
+    const fab = page.locator('[data-fab="scroll-to-bottom"]')
+    for (let i = 0; i < 3; i++) {
+      if (await fab.isVisible().catch(() => false)) {
+        await fab.click()
+        await page.waitForTimeout(600)
+      }
+      const dist = await page.evaluate(() => {
+        const s = document.querySelector('[data-message-list]') as HTMLElement | null
+        return s ? Math.round(s.scrollHeight - s.scrollTop - s.clientHeight) : 99999
+      })
+      if (dist < 8) break
+    }
+
+    // The anchor survived the jump: the pill now shows and offers the return.
+    await expect(page.locator('[data-jump-to-last-read]'), 'pill must appear after a jump-to-present').toBeVisible({ timeout: 4000 })
+
+    // Click the pill: the divider returns to view.
+    await page.locator('[data-jump-to-last-read] button').click()
+    await page.waitForTimeout(1200)
+    const dividerVisible = await page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const m = document.querySelector('[data-new-message-marker]') as HTMLElement | null
+      if (!s || !m) return false
+      const sr = s.getBoundingClientRect()
+      const mr = m.getBoundingClientRect()
+      return mr.bottom > sr.top && mr.top < sr.bottom
+    })
+    expect(dividerVisible, 'clicking the pill must return the divider to view').toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #870. Follow-up to #869 (MUC catch-up & read-state redesign).

## Problem

The jump-to-last-read pill shipped with #869 but was effectively dead UI. Its visibility, count, action, and the rendered "New messages" divider all ride a single value, `firstNewMessageId`, but the message-list scroll layer cleared that value on three **non-read** events, collapsing its lifetime to the ~48px window where the divider straddles the viewport top:

- scrolled past the divider,
- the divider row trimmed from the virtualized DOM,
- the FAB jump-to-present (explicit clear).

Via the FAB two-step and via Esc, the anchor cleared before the pill could durably show, and its action would no-op even if it did.

## Key finding

`clearFirstNewMessageId` is **purely visual** — it only deletes a `firstNewMessageMarkers` Map entry, with no read-state side effects. The read pointer (`lastSeenMessageId`) advances independently via the viewport observer and MDS. So `firstNewMessageId` is already the decoupled per-visit divider anchor the design wants; the only defect was the scroll layer clearing it too aggressively.

## The fix

A net **removal** of the three non-read clear branches, keeping only the genuine read-through clear (manual reach-bottom, already gated by `!programmaticScroll`), plus the now-unused dep-array entry. No new state, no store changes — the pill's visibility, count, action, and the divider row stay in sync by construction.

Chosen semantics — "skipped vs read-through":

- Manual scroll **down** through the divider to the bottom = read-through -> clears, no pill.
- FAB / programmatic jump-to-present = skip -> keeps the anchor, shows the pill so the reading position stays one click away until the visit ends.
- Esc, mark-all-read, leave-tab/deactivation, and message-sent still clear it (untouched, out of scope).