### PR TITLE
fix(mentions): don't split @domain.tld tokens into a fake mention

### DIFF
--- a/apps/fluux/src/utils/messageStyles.test.tsx
+++ b/apps/fluux/src/utils/messageStyles.test.tsx
@@ -615,6 +615,27 @@ Steps to follow:
       expect(container.textContent).toContain('user@example.com')
     })
 
+    it('does not render @domain.tld references as mentions', () => {
+      // "@nsa.gov" is a domain reference, not a mention: the whole token must
+      // stay plain text — never split into a "@nsa" mention plus a ".gov" tail.
+      const container = renderRoomText('@nsa.gov publicly stated their goal')
+      expect(container.querySelector('[data-mention]')).toBeFalsy()
+      expect(container.textContent).toContain('@nsa.gov')
+    })
+
+    it('does not render @host.domain references mid-message as mentions', () => {
+      const container = renderRoomText('ping @bob.dev now')
+      expect(container.querySelector('[data-mention]')).toBeFalsy()
+      expect(container.textContent).toContain('@bob.dev')
+    })
+
+    it('still highlights a mention followed by a sentence period', () => {
+      const container = renderRoomText('Thanks @alice.')
+      const mention = container.querySelector('[data-mention]')
+      expect(mention).toBeTruthy()
+      expect(mention?.textContent).toBe('@alice')
+    })
+
     it('renders mentions with URLs correctly', () => {
       const container = renderRoomText('@alice check https://example.com')
       expect(container.querySelector('[data-mention]')).toBeTruthy()

--- a/apps/fluux/src/utils/messageStyles.tsx
+++ b/apps/fluux/src/utils/messageStyles.tsx
@@ -31,7 +31,12 @@ const URL_REGEX = /(https?:\/\/[^\s<>]+[^\s<>.,;:!?)"'\]])/g
 // Used as fallback when XEP-0372 references aren't available
 // Uses Unicode property escapes (\p{L} for letters, \p{N} for numbers) to support
 // all valid XMPP nicks including accented, Cyrillic, Chinese, Japanese, etc.
-const MENTION_REGEX = /(?:^|(?<=\s))(@[\p{L}\p{N}_]+)/gu
+// The trailing lookahead rejects domain-like tokens such as "@nsa.gov" or
+// "@bob.dev": without it the word run stops at the dot and only "@nsa" would be
+// highlighted, splitting the domain into a fake mention plus a plain ".gov" tail.
+// The lookahead also fails on shorter (backtracked) matches — the next char after
+// a partial word is itself a word char — so the whole token stays plain text.
+const MENTION_REGEX = /(?:^|(?<=\s))(@[\p{L}\p{N}_]+)(?![\p{L}\p{N}_]|\.[\p{L}\p{N}])/gu
 
 // Escape sequences: \* \_ \~ \` \>
 const ESCAPE_PLACEHOLDER = '\u0000'


### PR DESCRIPTION
In MUC rooms, the regex fallback that highlights `@mentions` (used when no XEP-0372 references are present) matched any `@word`. Its word class stops at a dot, so `@nsa.gov` rendered as a green `@nsa` mention pill followed by a plain `.gov` tail — a visibly broken split.

A trailing lookahead now rejects domain-like tokens (`@nsa.gov`, `@bob.dev`) so the whole token stays plain text. Genuine mentions are unaffected, including `@alice.` at the end of a sentence. The word-char branch in the lookahead also defeats regex backtracking that would otherwise shorten `@nsa` to `@ns`.