### PR TITLE
test(chatview): regenerate stale 'with messages' snapshot

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 data-message-id="msg-1"
               >
                 <div
-                  class="group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start"
+                  class="group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start message-group-end"
                   data-message-body="Hello there!"
                   data-message-from="Alice Smith"
                   data-message-id="msg-1"
@@ -267,7 +267,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                 data-message-id="msg-2"
               >
                 <div
-                  class="group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start"
+                  class="group flex gap-4  -mx-4 px-4 py-0.5 transition-colors message-group-start message-group-end"
                   data-message-body="Hi! How are you?"
                   data-message-from="Me"
                   data-message-id="msg-2"


### PR DESCRIPTION
The committed ChatView snapshot lagged a prior message-grouping change: message-group rows now carry a `message-group-end` class alongside `message-group-start`, but the snapshot was never regenerated.

Result: the app **Test** job fails on **every open PR** — including #885 and #887 — even though none of them touch ChatView. Verified on clean main (stash any PR's diff and the mismatch is identical), so it's a pre-existing main breakage, not a per-PR regression.

The diff is exactly the two `message-group-end` class additions — no other markup changes. Merging this unblocks CI for the open PRs (they'll go green on their next rebase/run).