### PR TITLE
feat(cmdk): surface mention/whisper rooms in top Needs attention group

### DIFF
--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -9,15 +9,15 @@ beforeAll(() => {
 })
 
 // Mock data
-const mockConversations: Array<{ id: string; name: string; unreadCount: number; type: 'chat'; lastMessage?: { body: string } }> = [
-  { id: 'alice@example.com', name: 'Alice Smith', unreadCount: 0, type: 'chat', lastMessage: { body: 'Can we discuss the deployment?' } },
-  { id: 'bob@example.com', name: 'Bob Jones', unreadCount: 2, type: 'chat', lastMessage: { body: 'The exponential backoff is working now' } },
+const mockConversations: Array<{ id: string; name: string; unreadCount: number; type: 'chat'; lastMessage?: { body: string; timestamp: Date } }> = [
+  { id: 'alice@example.com', name: 'Alice Smith', unreadCount: 0, type: 'chat', lastMessage: { body: 'Can we discuss the deployment?', timestamp: new Date('2026-07-07T09:00:00Z') } },
+  { id: 'bob@example.com', name: 'Bob Jones', unreadCount: 2, type: 'chat', lastMessage: { body: 'The exponential backoff is working now', timestamp: new Date('2026-07-07T10:00:00Z') } },
 ]
 
-const mockRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; lastMessage?: { body: string } }> = [
-  { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully' } },
+const mockRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; lastMessage?: { body: string; timestamp?: Date } }> = [
+  { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully', timestamp: new Date('2026-07-07T08:00:00Z') } },
   { jid: 'general@conference.example.com', name: 'General Chat', joined: true, unreadCount: 3, mentionsCount: 0 },
-  { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1 },
+  { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1, lastMessage: { body: 'Release is out', timestamp: new Date('2026-07-07T11:00:00Z') } },
 ]
 
 const mockBookmarkedRooms = [
@@ -106,6 +106,7 @@ vi.mock('react-i18next', () => ({
         'commandPalette.filteringCommands': 'Filtering commands...',
         'commandPalette.searchMessages': 'Search messages for "{{query}}"',
         'commandPalette.unread': 'Unread',
+        'commandPalette.attention': 'Needs attention',
         'sidebar.messages': 'Messages',
         'sidebar.rooms': 'Rooms',
         'sidebar.connections': 'Connections',
@@ -392,8 +393,9 @@ describe('CommandPalette', () => {
     it('should select first item by default', () => {
       render(<CommandPalette {...defaultProps} />)
 
-      // Bob (unreadCount 2) is in the Unread section, which comes first
-      const firstItem = screen.getByText('Bob Jones').closest('button')
+      // Announcements (mention, 11:00) leads the Needs attention group, ahead of
+      // Bob's DM (10:00) — interleaved by recency.
+      const firstItem = screen.getByText('Announcements').closest('button')
       expect(firstItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -403,8 +405,8 @@ describe('CommandPalette', () => {
 
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
 
-      // Second item is Alice (in the Messages section, after the Unread section)
-      const secondItem = screen.getByText('Alice Smith').closest('button')
+      // Second item is Bob (still in the Needs attention group, after Announcements)
+      const secondItem = screen.getByText('Bob Jones').closest('button')
       expect(secondItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -412,15 +414,15 @@ describe('CommandPalette', () => {
       render(<CommandPalette {...defaultProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Move down first
+      // Move down first (index 0 -> 1 -> 2, i.e. Announcements -> Bob -> Alice)
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
 
       // Then move up
       fireEvent.keyDown(container!, { key: 'ArrowUp' })
 
-      // Back to index 1 = Alice (Messages section)
-      const secondItem = screen.getByText('Alice Smith').closest('button')
+      // Back to index 1 = Bob (Needs attention group)
+      const secondItem = screen.getByText('Bob Jones').closest('button')
       expect(secondItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -447,8 +449,8 @@ describe('CommandPalette', () => {
         fireEvent.keyDown(container!, { key: 'ArrowUp' })
       }
 
-      // First item should still be selected (Bob, in the Unread section)
-      const firstItem = screen.getByText('Bob Jones').closest('button')
+      // First item should still be selected (Announcements, leading the Needs attention group)
+      const firstItem = screen.getByText('Announcements').closest('button')
       expect(firstItem).toHaveAttribute('data-selected', 'true')
     })
 
@@ -487,8 +489,9 @@ describe('CommandPalette', () => {
 
       fireEvent.keyDown(container!, { key: 'Enter' })
 
-      // First item is Bob (unread, in the Unread section), should set active conversation
-      expect(mockSetActiveConversation).toHaveBeenCalledWith('bob@example.com')
+      // First item is Announcements (mention room, leading the Needs attention group),
+      // should set active room
+      expect(mockSetActiveRoom).toHaveBeenCalledWith('announce@conference.example.com')
       expect(defaultProps.onClose).toHaveBeenCalled()
     })
 
@@ -671,8 +674,8 @@ describe('CommandPalette', () => {
       rerender(<CommandPalette {...defaultProps} isOpen={false} />)
       rerender(<CommandPalette {...defaultProps} isOpen={true} />)
 
-      // First item should be selected again (Bob, in the Unread section)
-      const firstItem = screen.getByText('Bob Jones').closest('button')
+      // First item should be selected again (Announcements, leading the Needs attention group)
+      const firstItem = screen.getByText('Announcements').closest('button')
       expect(firstItem).toHaveAttribute('data-selected', 'true')
     })
   })
@@ -702,7 +705,9 @@ describe('CommandPalette', () => {
       render(<CommandPalette {...defaultProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Navigate to Alice Smith (second item — Bob is first in Unread section)
+      // Navigate to Alice Smith (third item — Announcements then Bob lead the
+      // Needs attention group, ahead of Alice in the Messages section)
+      fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
 
       // Verify Alice is selected
@@ -720,9 +725,9 @@ describe('CommandPalette', () => {
       const { rerender } = render(<CommandPalette {...defaultProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // First selection: Bob (first item, in Unread section)
+      // First selection: Announcements (first item, leading the Needs attention group)
       fireEvent.keyDown(container!, { key: 'Enter' })
-      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('bob@example.com')
+      expect(mockSetActiveRoom).toHaveBeenLastCalledWith('announce@conference.example.com')
 
       vi.clearAllMocks()
 
@@ -732,11 +737,11 @@ describe('CommandPalette', () => {
 
       const container2 = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Navigate to Alice (index 1) and select
+      // Navigate to Bob (index 1) and select
       fireEvent.keyDown(container2!, { key: 'ArrowDown' })
       fireEvent.keyDown(container2!, { key: 'Enter' })
 
-      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('alice@example.com')
+      expect(mockSetActiveConversation).toHaveBeenLastCalledWith('bob@example.com')
     })
 
     it('should select correct item after filtering and navigating', () => {
@@ -790,14 +795,14 @@ describe('CommandPalette', () => {
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'ArrowUp' })
 
-      // Third item in the list should be a room (Announcements — tier 0, has mention)
-      // Order: Bob (Unread), Alice (Messages), Announcements (Rooms tier 0), General Chat (tier 1), Development (tier 2)...
-      const announceRoom = screen.getByText('Announcements').closest('button')
-      expect(announceRoom).toHaveAttribute('data-selected', 'true')
+      // Third item in the list should be Alice (read DM, in the Messages section)
+      // Order: Announcements + Bob (Needs attention), Alice (Messages), General Chat (Rooms tier 1), Development (tier 2)...
+      const aliceItem = screen.getByText('Alice Smith').closest('button')
+      expect(aliceItem).toHaveAttribute('data-selected', 'true')
 
       fireEvent.keyDown(container!, { key: 'Enter' })
 
-      expect(mockSetActiveRoom).toHaveBeenCalledWith('announce@conference.example.com')
+      expect(mockSetActiveConversation).toHaveBeenCalledWith('alice@example.com')
     })
 
     it('should work correctly with rapid consecutive selections', () => {
@@ -809,12 +814,12 @@ describe('CommandPalette', () => {
 
         const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-        // Navigate down to the second item (Alice, Messages section) then select —
-        // exercises index-tracking under rapid reopen, not just Enter-on-first.
+        // Navigate down to the second item (Bob, still in the Needs attention group)
+        // then select — exercises index-tracking under rapid reopen, not just Enter-on-first.
         fireEvent.keyDown(container!, { key: 'ArrowDown' })
         fireEvent.keyDown(container!, { key: 'Enter' })
 
-        expect(mockSetActiveConversation).toHaveBeenCalledWith('alice@example.com')
+        expect(mockSetActiveConversation).toHaveBeenCalledWith('bob@example.com')
 
         // Close and reopen
         rerender(<CommandPalette {...defaultProps} isOpen={false} />)
@@ -1246,20 +1251,61 @@ describe('CommandPalette', () => {
   })
 
   describe('Unread section', () => {
-    it('shows unread DMs under an Unread header, read DMs under Messages, no duplication', () => {
+    it('shows unread DMs under a Needs attention header, read DMs under Messages, no duplication', () => {
       render(<CommandPalette {...defaultProps} />)
 
-      // The Unread section header is present
-      expect(screen.getByText('Unread')).toBeInTheDocument()
+      // The section header is now "Needs attention" (merges unread DMs + mention rooms)
+      expect(screen.getByText('Needs attention')).toBeInTheDocument()
 
       // Bob (unreadCount 2) appears exactly once, Alice (unreadCount 0) appears exactly once
       expect(screen.getAllByText('Bob Jones')).toHaveLength(1)
       expect(screen.getAllByText('Alice Smith')).toHaveLength(1)
 
-      // Bob's row is above Alice's row (Unread section precedes Messages section)
+      // Bob's row is above Alice's row (Needs attention section precedes Messages section)
       const bob = screen.getByText('Bob Jones')
       const alice = screen.getByText('Alice Smith')
       expect(bob.compareDocumentPosition(alice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
+  describe('Needs attention group', () => {
+    // Groups render as `<div key={group.key}><div class="command-group-label">{label}</div>{...items}</div>`
+    // (see CommandPalette.tsx render section) — there is no role="group" wrapper. The label text node's
+    // own element IS the label div, so scoping to the group's subtree means walking up to its parentElement
+    // (the shared wrapper `<div>` for the label + all item rows), not `.closest('div')` (which would just
+    // resolve back to the label div itself, since a div matches `closest` on itself).
+    function getGroupContainer(labelText: string): HTMLElement {
+      const label = screen.getByText(labelText)
+      return label.parentElement as HTMLElement
+    }
+
+    it('promotes a room with a mention into the attention group', () => {
+      render(<CommandPalette {...defaultProps} />)
+      const attention = getGroupContainer('Needs attention')
+      // Announcements has mentionsCount 1 -> belongs to the attention group
+      expect(within(attention).getByText('Announcements')).toBeInTheDocument()
+    })
+
+    it('does not promote an unread room without a mention', () => {
+      render(<CommandPalette {...defaultProps} />)
+      const attention = getGroupContainer('Needs attention')
+      // General Chat has unreadCount 3 but mentionsCount 0 -> stays in the rooms group
+      expect(within(attention).queryByText('General Chat')).not.toBeInTheDocument()
+    })
+
+    it('does not duplicate a promoted room in the rooms group', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // Announcements appears exactly once across the whole default view
+      expect(screen.getAllByText('Announcements')).toHaveLength(1)
+    })
+
+    it('orders the attention group by most-recent activity', () => {
+      render(<CommandPalette {...defaultProps} />)
+      const attention = getGroupContainer('Needs attention')
+      // Announcements (11:00) is newer than Bob Jones' DM (10:00) -> appears first within the group
+      const announce = within(attention).getByText('Announcements')
+      const bob = within(attention).getByText('Bob Jones')
+      expect(announce.compareDocumentPosition(bob) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     })
   })
 
@@ -1371,7 +1417,8 @@ describe('CommandPalette', () => {
       render(<CommandPalette {...trackingProps} />)
       const container = screen.getByPlaceholderText('Go to...').closest('div')?.parentElement
 
-      // Bob is first (Unread section), Alice is second (Messages section). Navigate to Alice.
+      // Announcements and Bob lead the Needs attention group; Alice is third (Messages section).
+      fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'ArrowDown' })
       fireEvent.keyDown(container!, { key: 'Enter' })
 

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -195,10 +195,18 @@ describe('CommandPalette', () => {
       expect(screen.getByText('General Chat')).toBeInTheDocument()
     })
 
-    it('should display contacts not in conversations', () => {
+    it('should NOT display contacts without a conversation in the default view', () => {
       render(<CommandPalette {...defaultProps} />)
+      // The empty-query view surfaces threads/views/actions only, not roster padding.
+      expect(screen.queryByText('Charlie Brown')).not.toBeInTheDocument()
+      expect(screen.queryByText('Diana Prince')).not.toBeInTheDocument()
+    })
+
+    it('should surface a contact without a conversation once the user types', () => {
+      render(<CommandPalette {...defaultProps} />)
+      const input = screen.getByPlaceholderText('Go to...')
+      fireEvent.change(input, { target: { value: 'charlie' } })
       expect(screen.getByText('Charlie Brown')).toBeInTheDocument()
-      expect(screen.getByText('Diana Prince')).toBeInTheDocument()
     })
 
     it('should display view options', () => {
@@ -220,7 +228,8 @@ describe('CommandPalette', () => {
       const labelTexts = Array.from(groupLabels).map(el => el.textContent)
       expect(labelTexts).toContain('Messages')
       expect(labelTexts).toContain('Rooms')
-      expect(labelTexts).toContain('Contacts')
+      // Contacts group is no longer part of the default view.
+      expect(labelTexts).not.toContain('Contacts')
     })
 
     it('should show last message preview for conversations', () => {
@@ -857,8 +866,8 @@ describe('CommandPalette', () => {
       expect(screen.getByText('Alice Smith')).toBeInTheDocument()
       expect(screen.getByText('Bob Jones')).toBeInTheDocument()
 
-      // Should show contacts (those without conversations)
-      expect(screen.getByText('Charlie Brown')).toBeInTheDocument()
+      // Should NOT show contacts without a conversation (roster padding removed)
+      expect(screen.queryByText('Charlie Brown')).not.toBeInTheDocument()
 
       // Should show rooms
       expect(screen.getByText('Development')).toBeInTheDocument()

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -105,7 +105,6 @@ vi.mock('react-i18next', () => ({
         'commandPalette.filteringRooms': 'Filtering rooms...',
         'commandPalette.filteringCommands': 'Filtering commands...',
         'commandPalette.searchMessages': 'Search messages for "{{query}}"',
-        'commandPalette.unread': 'Unread',
         'commandPalette.attention': 'Needs attention',
         'sidebar.messages': 'Messages',
         'sidebar.rooms': 'Rooms',

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -202,10 +202,10 @@ function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): I
     groups.push({ key: 'room', type: 'room', label: t('sidebar.rooms'), items: rooms })
   }
 
-  const contacts = items.filter((i) => i.type === 'contact').slice(0, 3)
-  if (contacts.length > 0) {
-    groups.push({ key: 'contact', type: 'contact', label: t('sidebar.contacts'), items: contacts })
-  }
+  // Contacts without an active conversation are intentionally omitted from the
+  // default view — it surfaces things you already have a thread with (or a
+  // view/action). Such contacts remain reachable by typing a name (or the
+  // `@` prefix), which routes through the search/filter path below.
 
   const views = items.filter((i) => i.type === 'view').slice(0, 3)
   if (views.length > 0) {

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -46,6 +46,8 @@ interface CommandItem {
   unreadCount?: number
   /** Mention count for room rows (ranks a mentioned room above merely-unread ones). */
   mentionsCount?: number
+  /** Last-message time (ms) for recency ordering in the attention group. */
+  sortTimestamp?: number
   action: () => void
   keywords?: string[]
   presence?: PresenceStatus
@@ -164,21 +166,36 @@ function roomTier(item: CommandItem): number {
 // Helper: Build groups for the empty-query default view (unread-first)
 // =============================================================================
 
+// Cap on the number of items promoted into the top "Needs attention" group.
+const ATTENTION_CAP = 6
+
+// Most-recent-first; items without a timestamp sort last.
+const byRecency = (a: CommandItem, b: CommandItem) => (b.sortTimestamp ?? 0) - (a.sortTimestamp ?? 0)
+
 function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): ItemGroup[] {
   const groups: ItemGroup[] = []
 
   const conversations = items.filter((i) => i.type === 'conversation')
-  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0).slice(0, 5)
-  const readConvs = conversations.filter((i) => (i.unreadCount ?? 0) === 0).slice(0, 5)
-  if (unreadConvs.length > 0) {
-    groups.push({ key: 'unread', type: 'conversation', label: t('commandPalette.unread'), items: unreadConvs })
+  const roomItems = items.filter((i) => i.type === 'room')
+
+  // Top group: unread DMs + rooms with a mention/whisper, interleaved by recency, capped.
+  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0)
+  const mentionRooms = roomItems.filter((i) => (i.mentionsCount ?? 0) > 0)
+  const attention = [...unreadConvs, ...mentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
+  if (attention.length > 0) {
+    groups.push({ key: 'attention', type: 'conversation', label: t('commandPalette.attention'), items: attention })
   }
+  const promotedIds = new Set(attention.map((i) => i.id))
+
+  // Read DMs stay in their own group below.
+  const readConvs = conversations.filter((i) => (i.unreadCount ?? 0) === 0).slice(0, 5)
   if (readConvs.length > 0) {
     groups.push({ key: 'conversation', type: 'conversation', label: t('sidebar.messages'), items: readConvs })
   }
 
-  const rooms = items
-    .filter((i) => i.type === 'room')
+  // Rooms group: everything not already promoted, tier-sorted (mention overflow lands at tier 0).
+  const rooms = roomItems
+    .filter((i) => !promotedIds.has(i.id))
     .sort((a, b) => roomTier(a) - roomTier(b))
     .slice(0, 4)
   if (rooms.length > 0) {
@@ -315,6 +332,7 @@ function CommandPaletteContent({
         lastMessagePreview: preview,
         lastMessageBody: conv.lastMessage?.body,
         unreadCount: conv.unreadCount,
+        sortTimestamp: conv.lastMessage?.timestamp?.getTime(),
         avatarIdentifier: conv.id,
         avatarUrl: contact?.avatar,
         action: () => selectConversation(conv.id),
@@ -367,6 +385,7 @@ function CommandPaletteContent({
         lastMessageBody: room.lastMessage?.body,
         unreadCount: room.unreadCount,
         mentionsCount: room.mentionsCount,
+        sortTimestamp: room.lastMessage?.timestamp?.getTime(),
         avatarIdentifier: room.jid,
         avatarUrl: room.avatar,
         action: () => selectRoom(room.jid),

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -1232,7 +1232,8 @@
         "filteringRooms": "تصفية الغرف...",
         "filteringCommands": "تصفية الأوامر...",
         "searchMessages": "البحث في الرسائل عن \"{{query}}\"",
-        "unread": "غير مقروءة"
+        "unread": "غير مقروءة",
+        "attention": "تحتاج إلى انتباه"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "الاسم المعروض في قوائم الغرف والعنوان.",

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -1232,7 +1232,6 @@
         "filteringRooms": "تصفية الغرف...",
         "filteringCommands": "تصفية الأوامر...",
         "searchMessages": "البحث في الرسائل عن \"{{query}}\"",
-        "unread": "غير مقروءة",
         "attention": "تحتاج إلى انتباه"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Фільтрацыя пакояў...",
         "filteringCommands": "Фільтрацыя каманд...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрачытаныя",
         "attention": "Патрабуе ўвагі"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Фільтрацыя пакояў...",
         "filteringCommands": "Фільтрацыя каманд...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрачытаныя"
+        "unread": "Непрачытаныя",
+        "attention": "Патрабуе ўвагі"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Імя, якое адлюстроўваецца ў спісе пакояў і ў загалоўку.",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Филтриране на стаи...",
         "filteringCommands": "Филтриране на команди...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрочетени",
         "attention": "Изисква внимание"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Филтриране на стаи...",
         "filteringCommands": "Филтриране на команди...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрочетени"
+        "unread": "Непрочетени",
+        "attention": "Изисква внимание"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Показваното име в списъка със стаи и в заглавието.",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "Filtrant sales...",
         "filteringCommands": "Filtrant comandes...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "No llegits",
         "attention": "Requereix atenció"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "Filtrant sales...",
         "filteringCommands": "Filtrant comandes...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "No llegits"
+        "unread": "No llegits",
+        "attention": "Requereix atenció"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "El nom visible que es mostra a la llista de sales i a la capçalera.",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -1232,7 +1232,6 @@
         "filteringRooms": "Filtrování místností...",
         "filteringCommands": "Filtrování příkazů...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nepřečtené",
         "attention": "Vyžaduje pozornost"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -1232,7 +1232,8 @@
         "filteringRooms": "Filtrování místností...",
         "filteringCommands": "Filtrování příkazů...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nepřečtené"
+        "unread": "Nepřečtené",
+        "attention": "Vyžaduje pozornost"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Zobrazovaný název v seznamu místností a v záhlaví.",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Filtrerer rum...",
         "filteringCommands": "Filtrerer kommandoer...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ulæste",
         "attention": "Kræver opmærksomhed"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Filtrerer rum...",
         "filteringCommands": "Filtrerer kommandoer...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ulæste"
+        "unread": "Ulæste",
+        "attention": "Kræver opmærksomhed"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Det viste navn i rumlister og overskriften.",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Räume werden gefiltert...",
         "filteringCommands": "Befehle werden gefiltert...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ungelesen"
+        "unread": "Ungelesen",
+        "attention": "Benötigt Aufmerksamkeit"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Der Anzeigename in der Raumliste und der Kopfzeile.",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Räume werden gefiltert...",
         "filteringCommands": "Befehle werden gefiltert...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ungelesen",
         "attention": "Benötigt Aufmerksamkeit"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -1229,7 +1229,8 @@
         "filteringRooms": "Φιλτράρισμα δωματίων...",
         "filteringCommands": "Φιλτράρισμα εντολών...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Μη αναγνωσμένα"
+        "unread": "Μη αναγνωσμένα",
+        "attention": "Χρειάζεται προσοχή"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Το εμφανιζόμενο όνομα στη λίστα δωματίων και στην κεφαλίδα.",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -1229,7 +1229,6 @@
         "filteringRooms": "Φιλτράρισμα δωματίων...",
         "filteringCommands": "Φιλτράρισμα εντολών...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Μη αναγνωσμένα",
         "attention": "Χρειάζεται προσοχή"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Filtering rooms...",
         "filteringCommands": "Filtering commands...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Unread",
         "attention": "Needs attention"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Filtering rooms...",
         "filteringCommands": "Filtering commands...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Unread"
+        "unread": "Unread",
+        "attention": "Needs attention"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "The display name shown in room listings and the header.",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "Filtrando salas...",
         "filteringCommands": "Filtrando comandos...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "No leídos",
         "attention": "Requiere atención"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "Filtrando salas...",
         "filteringCommands": "Filtrando comandos...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "No leídos"
+        "unread": "No leídos",
+        "attention": "Requiere atención"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "El nombre mostrado en la lista de salas y en el encabezado.",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Tubade filtreerimine...",
         "filteringCommands": "Käskude filtreerimine...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Lugemata",
         "attention": "Vajab tähelepanu"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Tubade filtreerimine...",
         "filteringCommands": "Käskude filtreerimine...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Lugemata"
+        "unread": "Lugemata",
+        "attention": "Vajab tähelepanu"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Kuvatav nimi ruumide loendis ja päises.",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Suodatetaan huoneita...",
         "filteringCommands": "Suodatetaan komentoja...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Lukematta",
         "attention": "Vaatii huomiota"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Suodatetaan huoneita...",
         "filteringCommands": "Suodatetaan komentoja...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Lukematta"
+        "unread": "Lukematta",
+        "attention": "Vaatii huomiota"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Huoneluettelossa ja otsikossa näkyvä nimi.",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Filtrage des salons...",
         "filteringCommands": "Filtrage des commandes...",
         "searchMessages": "Rechercher dans les messages \"{{query}}\"",
-        "unread": "Non lus",
         "attention": "À traiter"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Filtrage des salons...",
         "filteringCommands": "Filtrage des commandes...",
         "searchMessages": "Rechercher dans les messages \"{{query}}\"",
-        "unread": "Non lus"
+        "unread": "Non lus",
+        "attention": "À traiter"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Le nom affiché dans les listes de salons et l'en-tête.",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "Ag scagadh seomraí...",
         "filteringCommands": "Ag scagadh orduithe...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neamhléite"
+        "unread": "Neamhléite",
+        "attention": "Aird de dhíth"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "An t-ainm taispeána a thaispeántar i liostaí seomraí agus sa cheanntásc.",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "Ag scagadh seomraí...",
         "filteringCommands": "Ag scagadh orduithe...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neamhléite",
         "attention": "Teastaíonn aird"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -1232,7 +1232,7 @@
         "filteringCommands": "Ag scagadh orduithe...",
         "searchMessages": "Search messages for \"{{query}}\"",
         "unread": "Neamhléite",
-        "attention": "Aird de dhíth"
+        "attention": "Teastaíonn aird"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "An t-ainm taispeána a thaispeántar i liostaí seomraí agus sa cheanntásc.",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -1229,7 +1229,6 @@
         "filteringRooms": "מסנן חדרים...",
         "filteringCommands": "מסנן פקודות...",
         "searchMessages": "חיפוש הודעות עבור \"{{query}}\"",
-        "unread": "לא נקראו",
         "attention": "דורש תשומת לב"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -1229,7 +1229,8 @@
         "filteringRooms": "מסנן חדרים...",
         "filteringCommands": "מסנן פקודות...",
         "searchMessages": "חיפוש הודעות עבור \"{{query}}\"",
-        "unread": "לא נקראו"
+        "unread": "לא נקראו",
+        "attention": "דורש תשומת לב"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "שם התצוגה המוצג ברשימות החדרים ובכותרת.",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -1229,7 +1229,6 @@
         "filteringRooms": "Filtriranje soba...",
         "filteringCommands": "Filtriranje naredbi...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nepročitano",
         "attention": "Zahtijeva pažnju"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -1229,7 +1229,8 @@
         "filteringRooms": "Filtriranje soba...",
         "filteringCommands": "Filtriranje naredbi...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nepročitano"
+        "unread": "Nepročitano",
+        "attention": "Zahtijeva pažnju"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Prikazano ime na popisu soba i u zaglavlju.",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Szobák szűrése...",
         "filteringCommands": "Parancsok szűrése...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Olvasatlan",
         "attention": "Figyelmet igényel"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Szobák szűrése...",
         "filteringCommands": "Parancsok szűrése...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Olvasatlan"
+        "unread": "Olvasatlan",
+        "attention": "Figyelmet igényel"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "A szobalistákban és a fejlécben megjelenő megjelenítési név.",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Sía herbergi...",
         "filteringCommands": "Sía skipanir...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ólesin"
+        "unread": "Ólesin",
+        "attention": "Þarfnast athygli"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Birtingarnafnið sem birtist í herbergjalista og haus.",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Sía herbergi...",
         "filteringCommands": "Sía skipanir...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ólesin",
         "attention": "Þarfnast athygli"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "Filtraggio stanze...",
         "filteringCommands": "Filtraggio comandi...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Non letti",
         "attention": "Richiede attenzione"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "Filtraggio stanze...",
         "filteringCommands": "Filtraggio comandi...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Non letti"
+        "unread": "Non letti",
+        "attention": "Richiede attenzione"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Il nome visualizzato nell'elenco delle stanze e nell'intestazione.",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Filtruojami kambariai...",
         "filteringCommands": "Filtruojamos komandos...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neperskaityti"
+        "unread": "Neperskaityti",
+        "attention": "Reikia dėmesio"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Rodomas pavadinimas kambarių sąraše ir antraštėje.",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Filtruojami kambariai...",
         "filteringCommands": "Filtruojamos komandos...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neperskaityti",
         "attention": "Reikia dėmesio"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Filtrē istabas...",
         "filteringCommands": "Filtrē komandas...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nelasīti",
         "attention": "Nepieciešama uzmanība"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Filtrē istabas...",
         "filteringCommands": "Filtrē komandas...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nelasīti"
+        "unread": "Nelasīti",
+        "attention": "Nepieciešama uzmanība"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Attēlojamais nosaukums istabu sarakstā un galvenē.",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -1233,7 +1233,6 @@
         "filteringRooms": "Qed jiffiltra kmamar...",
         "filteringCommands": "Qed jiffiltra kmandi...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Mhux moqrija",
         "attention": "Jeħtieġ attenzjoni"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -1233,7 +1233,8 @@
         "filteringRooms": "Qed jiffiltra kmamar...",
         "filteringCommands": "Qed jiffiltra kmandi...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Mhux moqrija"
+        "unread": "Mhux moqrija",
+        "attention": "Jeħtieġ attenzjoni"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "L-isem tal-wiri muri fil-lista tal-kmamar u fl-header.",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Filtrerer rom...",
         "filteringCommands": "Filtrerer kommandoer...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Uleste",
         "attention": "Krever oppmerksomhet"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Filtrerer rom...",
         "filteringCommands": "Filtrerer kommandoer...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Uleste"
+        "unread": "Uleste",
+        "attention": "Krever oppmerksomhet"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Visningsnavnet som vises i romlister og overskriften.",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Groepen filteren...",
         "filteringCommands": "Commando's filteren...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ongelezen"
+        "unread": "Ongelezen",
+        "attention": "Vereist aandacht"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "De weergavenaam in de kamerlijst en de koptekst.",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Groepen filteren...",
         "filteringCommands": "Commando's filteren...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Ongelezen",
         "attention": "Vereist aandacht"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -1232,7 +1232,6 @@
         "filteringRooms": "Filtrowanie pokoi...",
         "filteringCommands": "Filtrowanie poleceń...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nieprzeczytane",
         "attention": "Wymaga uwagi"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -1232,7 +1232,8 @@
         "filteringRooms": "Filtrowanie pokoi...",
         "filteringCommands": "Filtrowanie poleceń...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Nieprzeczytane"
+        "unread": "Nieprzeczytane",
+        "attention": "Wymaga uwagi"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Wyświetlana nazwa na liście pokojów i w nagłówku.",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "A filtrar salas...",
         "filteringCommands": "A filtrar comandos...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Não lidas",
         "attention": "Requer atenção"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "A filtrar salas...",
         "filteringCommands": "A filtrar comandos...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Não lidas"
+        "unread": "Não lidas",
+        "attention": "Requer atenção"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "O nome exibido na lista de salas e no cabeçalho.",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "Se filtrează camerele...",
         "filteringCommands": "Se filtrează comenzile...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Necitite",
         "attention": "Necesită atenție"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "Se filtrează camerele...",
         "filteringCommands": "Se filtrează comenzile...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Necitite"
+        "unread": "Necitite",
+        "attention": "Necesită atenție"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Numele afișat în lista camerelor și în antet.",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Фильтр конференций...",
         "filteringCommands": "Фильтр команд...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрочитанные",
         "attention": "Требует внимания"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Фильтр конференций...",
         "filteringCommands": "Фильтр команд...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрочитанные"
+        "unread": "Непрочитанные",
+        "attention": "Требует внимания"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Отображаемое имя в списке комнат и в заголовке.",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -1231,7 +1231,8 @@
         "filteringRooms": "Filtrujú sa miestnosti...",
         "filteringCommands": "Filtrujú sa príkazy...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neprečítané"
+        "unread": "Neprečítané",
+        "attention": "Vyžaduje pozornosť"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Zobrazovaný názov v zozname miestností a v hlavičke.",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -1231,7 +1231,6 @@
         "filteringRooms": "Filtrujú sa miestnosti...",
         "filteringCommands": "Filtrujú sa príkazy...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neprečítané",
         "attention": "Vyžaduje pozornosť"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -1232,7 +1232,8 @@
         "filteringRooms": "Filtriranje sob...",
         "filteringCommands": "Filtriranje ukazov...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neprebrano"
+        "unread": "Neprebrano",
+        "attention": "Zahteva pozornost"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Prikazano ime na seznamu sob in v glavi.",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -1232,7 +1232,6 @@
         "filteringRooms": "Filtriranje sob...",
         "filteringCommands": "Filtriranje ukazov...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Neprebrano",
         "attention": "Zahteva pozornost"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "Filtrerar rum...",
         "filteringCommands": "Filtrerar kommandon...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Olästa",
         "attention": "Kräver uppmärksamhet"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "Filtrerar rum...",
         "filteringCommands": "Filtrerar kommandon...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Olästa"
+        "unread": "Olästa",
+        "attention": "Kräver uppmärksamhet"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Visningsnamnet som visas i rumslistor och rubriken.",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -1230,7 +1230,8 @@
         "filteringRooms": "Фільтрація кімнат...",
         "filteringCommands": "Фільтрація команд...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрочитані"
+        "unread": "Непрочитані",
+        "attention": "Потребує уваги"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "Ім'я, що відображається у списку кімнат та в заголовку.",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -1230,7 +1230,6 @@
         "filteringRooms": "Фільтрація кімнат...",
         "filteringCommands": "Фільтрація команд...",
         "searchMessages": "Search messages for \"{{query}}\"",
-        "unread": "Непрочитані",
         "attention": "Потребує уваги"
     },
     "dataFormHints": {

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -1228,7 +1228,8 @@
         "filteringRooms": "正在筛选房间…",
         "filteringCommands": "正在筛选命令…",
         "searchMessages": "搜索包含“{{query}}”的消息",
-        "unread": "未读"
+        "unread": "未读",
+        "attention": "需要关注"
     },
     "dataFormHints": {
         "muc#roomconfig_roomname": "在房间列表和标题栏中显示的名称。",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -1228,7 +1228,6 @@
         "filteringRooms": "正在筛选房间…",
         "filteringCommands": "正在筛选命令…",
         "searchMessages": "搜索包含“{{query}}”的消息",
-        "unread": "未读",
         "attention": "需要关注"
     },
     "dataFormHints": {

--- a/docs/superpowers/plans/2026-07-07-cmdk-attention-rooms.md
+++ b/docs/superpowers/plans/2026-07-07-cmdk-attention-rooms.md
@@ -1,0 +1,281 @@
+# Cmd+K "Needs attention" Group Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Cmd+K default view surface rooms with a mention or unread whisper in the top group, interleaved by recency with unread DMs, under a "Needs attention" label.
+
+**Architecture:** Pure `apps/fluux` change in `CommandPalette.tsx`. Add a `sortTimestamp` to `CommandItem`, populate it from each entity's `lastMessage.timestamp`, and rewrite `buildDefaultGroups` so the top group merges unread DMs + rooms with `mentionsCount > 0` (this single predicate already covers whispers, which bump `mentionsCount` in the SDK). Rooms shown up top are excluded from the rooms group below. No SDK change.
+
+**Tech Stack:** React + TypeScript, Vitest + @testing-library/react, react-i18next (33 locale JSON files).
+
+## Global Constraints
+
+- **App-only.** No changes under `packages/fluux-sdk/`.
+- **i18n:** new key `commandPalette.attention` must be translated in ALL 33 locale files (`apps/fluux/src/i18n/locales/*.json`). No English placeholders in non-English files. No em-dash (`—`) connectors in any value.
+- **Locale edits are surgical:** parse JSON → add the one key → write back with `JSON.stringify(obj, null, 4) + "\n"`. Do not reformat or reorder existing keys.
+- **Attention group cap:** 6 items total (named constant).
+- **Verify before completion:** `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx` passes with no stderr; `npm run typecheck` passes.
+
+---
+
+### Task 1: Add the `commandPalette.attention` i18n key to all 33 locales
+
+**Files:**
+- Modify: `apps/fluux/src/i18n/locales/en.json` (+ 32 sibling locale files)
+- Modify: `apps/fluux/src/test-setup.ts` (i18n asserted-label subset, if `attention` is asserted by text)
+
+**Interfaces:**
+- Produces: i18n key `commandPalette.attention` resolving to "Needs attention" (English) and the localized equivalent per file.
+
+- [ ] **Step 1: Write the translation script**
+
+Create a throwaway script at `apps/fluux/scripts/add-attention-key.mjs`:
+
+```js
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dir = new URL('../src/i18n/locales/', import.meta.url).pathname
+
+// "Needs attention" per locale. No em-dashes.
+const T = {
+  ar: 'تحتاج إلى انتباه', be: 'Патрабуе ўвагі', bg: 'Изисква внимание',
+  ca: 'Requereix atenció', cs: 'Vyžaduje pozornost', da: 'Kræver opmærksomhed',
+  de: 'Benötigt Aufmerksamkeit', el: 'Χρειάζεται προσοχή', en: 'Needs attention',
+  es: 'Requiere atención', et: 'Vajab tähelepanu', fi: 'Vaatii huomiota',
+  fr: 'À traiter', ga: 'Aird de dhíth', he: 'דורש תשומת לב',
+  hr: 'Zahtijeva pažnju', hu: 'Figyelmet igényel', is: 'Þarfnast athygli',
+  it: 'Richiede attenzione', lt: 'Reikia dėmesio', lv: 'Nepieciešama uzmanība',
+  mt: 'Jeħtieġ attenzjoni', nb: 'Krever oppmerksomhet', nl: 'Vereist aandacht',
+  pl: 'Wymaga uwagi', pt: 'Requer atenção', ro: 'Necesită atenție',
+  ru: 'Требует внимания', sk: 'Vyžaduje pozornosť', sl: 'Zahteva pozornost',
+  sv: 'Kräver uppmärksamhet', uk: 'Потребує уваги', 'zh-CN': '需要关注',
+}
+
+for (const [lang, value] of Object.entries(T)) {
+  const path = join(dir, `${lang}.json`)
+  const obj = JSON.parse(readFileSync(path, 'utf8'))
+  if (!obj.commandPalette) throw new Error(`no commandPalette block in ${lang}.json`)
+  obj.commandPalette.attention = value
+  writeFileSync(path, JSON.stringify(obj, null, 4) + '\n')
+}
+console.log(`Added commandPalette.attention to ${Object.keys(T).length} locales`)
+```
+
+- [ ] **Step 2: Run the script**
+
+Run: `cd apps/fluux && node scripts/add-attention-key.mjs`
+Expected: `Added commandPalette.attention to 33 locales`
+
+- [ ] **Step 3: Verify the key landed and no file was reformatted**
+
+Run: `cd apps/fluux && git diff --stat src/i18n/locales/ | tail -3`
+Expected: 33 files changed, each `+1` insertion (one added line). If any file shows a large diff, the round-trip reformatted it — investigate before continuing.
+
+Run: `grep -c '"attention"' src/i18n/locales/*.json | grep -v ':1' || echo "all locales have exactly one"`
+Expected: `all locales have exactly one`
+
+- [ ] **Step 4: Delete the throwaway script**
+
+Run: `cd apps/fluux && rm scripts/add-attention-key.mjs`
+
+- [ ] **Step 5: Add the key to the test i18n subset (only if asserted by text)**
+
+Open `apps/fluux/src/test-setup.ts`, find the block that lists `commandPalette.*` label keys used in assertions (search for `commandPalette.unread` or `'Unread'`). If present, add alongside it:
+
+```ts
+'commandPalette.attention': 'Needs attention',
+```
+
+If `test-setup.ts` has no such literal map for commandPalette labels, skip this step — the CommandPalette test file mocks `react-i18next` locally (Task 2 handles that mock).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/i18n/locales apps/fluux/src/test-setup.ts
+git commit -m "i18n(cmdk): add commandPalette.attention key for all locales"
+```
+
+---
+
+### Task 2: Rewrite `buildDefaultGroups` to merge attention-rooms into the top group
+
+**Files:**
+- Modify: `apps/fluux/src/components/CommandPalette.tsx` (interface `CommandItem` ~L32-52; item construction ~L305-375; `buildDefaultGroups` ~L167-204)
+- Test: `apps/fluux/src/components/CommandPalette.test.tsx`
+
+**Interfaces:**
+- Consumes: `CommandItem` (`type`, `unreadCount`, `mentionsCount`), `roomTier(item)` (existing, unchanged), i18n key `commandPalette.attention` (Task 1).
+- Produces: updated `buildDefaultGroups(items, t)` returning the "Needs attention" group first (key `'attention'`), then read-DM group, then rooms group (excluding promoted rooms), then contacts/views/actions unchanged. New `CommandItem.sortTimestamp?: number`.
+
+- [ ] **Step 1: Extend the test mocks with timestamps and the new label**
+
+In `apps/fluux/src/components/CommandPalette.test.tsx`:
+
+Add `timestamp` to the mock `lastMessage` shapes and mention data. Update the type annotations and the mock arrays (around L12-20) so entities carry a comparable recency. Example — set the two mention/unread entities so a mention-room is MORE recent than an unread DM:
+
+```ts
+const mockConversations: Array<{ id: string; name: string; unreadCount: number; type: 'chat'; lastMessage?: { body: string; timestamp: Date } }> = [
+  { id: 'alice@example.com', name: 'Alice Smith', unreadCount: 0, type: 'chat', lastMessage: { body: 'Can we discuss the deployment?', timestamp: new Date('2026-07-07T09:00:00Z') } },
+  { id: 'bob@example.com', name: 'Bob Jones', unreadCount: 2, type: 'chat', lastMessage: { body: 'The exponential backoff is working now', timestamp: new Date('2026-07-07T10:00:00Z') } },
+]
+
+const mockRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; lastMessage?: { body: string; timestamp?: Date } }> = [
+  { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully', timestamp: new Date('2026-07-07T08:00:00Z') } },
+  { jid: 'general@conference.example.com', name: 'General Chat', joined: true, unreadCount: 3, mentionsCount: 0 },
+  { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1, lastMessage: { body: 'Release is out', timestamp: new Date('2026-07-07T11:00:00Z') } },
+]
+```
+
+In the local `react-i18next` mock's translation map (search for `'commandPalette.unread': 'Unread'`), add:
+
+```ts
+'commandPalette.attention': 'Needs attention',
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add a `describe('Needs attention group', ...)` block. These assert against the rendered default view (empty query):
+
+```ts
+describe('Needs attention group', () => {
+  it('promotes a room with a mention into the attention group', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const attention = screen.getByText('Needs attention').closest('[role="group"], div')!
+    // Announcements has mentionsCount 1 -> belongs to attention group
+    expect(within(attention as HTMLElement).getByText('Announcements')).toBeInTheDocument()
+  })
+
+  it('does not promote an unread room without a mention', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const attention = screen.getByText('Needs attention').closest('[role="group"], div')!
+    // General Chat has unreadCount 3 but mentionsCount 0 -> stays in rooms group
+    expect(within(attention as HTMLElement).queryByText('General Chat')).not.toBeInTheDocument()
+  })
+
+  it('does not duplicate a promoted room in the rooms group', () => {
+    render(<CommandPalette {...defaultProps} />)
+    // Announcements appears exactly once across the whole default view
+    expect(screen.getAllByText('Announcements')).toHaveLength(1)
+  })
+
+  it('orders the attention group by most-recent activity', () => {
+    render(<CommandPalette {...defaultProps} />)
+    const labels = screen.getAllByText(/Announcements|Bob Jones/).map((n) => n.textContent)
+    // Announcements (11:00) is newer than Bob Jones DM (10:00) -> appears first
+    expect(labels.indexOf('Announcements')).toBeLessThan(labels.indexOf('Bob Jones'))
+  })
+})
+```
+
+> Note on the group selector: adapt `.closest(...)` to how groups are actually rendered in this file (check an existing group-scoped assertion in the test for the real selector/`data-*` attribute). The intent is "assert within the Needs-attention group's subtree."
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Needs attention"`
+Expected: FAIL — no element with text "Needs attention" (group not built yet).
+
+- [ ] **Step 4: Add `sortTimestamp` to the `CommandItem` interface**
+
+In `CommandPalette.tsx`, in the `CommandItem` interface (after `mentionsCount`):
+
+```ts
+  /** Last-message time (ms) for recency ordering in the attention group. */
+  sortTimestamp?: number
+```
+
+- [ ] **Step 5: Populate `sortTimestamp` when building conversation and room items**
+
+In the conversation loop (the `items.push({ id: `conv-...` })` call), add:
+
+```ts
+        sortTimestamp: conv.lastMessage?.timestamp?.getTime(),
+```
+
+In the joined-rooms loop (the `items.push({ id: `room-...` })` call), add:
+
+```ts
+        sortTimestamp: room.lastMessage?.timestamp?.getTime(),
+```
+
+(Bookmarked-not-joined rooms, contacts, views, actions do not set it — they never enter the attention group.)
+
+- [ ] **Step 6: Rewrite `buildDefaultGroups`**
+
+Replace the current body (the DM-unread / DM-read / rooms section, lines ~170-186) with:
+
+```ts
+  const ATTENTION_CAP = 6
+
+  const byRecency = (a: CommandItem, b: CommandItem) =>
+    (b.sortTimestamp ?? 0) - (a.sortTimestamp ?? 0)
+
+  const conversations = items.filter((i) => i.type === 'conversation')
+  const roomItems = items.filter((i) => i.type === 'room')
+
+  // Top group: unread DMs + rooms with a mention/whisper, interleaved by recency, capped.
+  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0)
+  const mentionRooms = roomItems.filter((i) => (i.mentionsCount ?? 0) > 0)
+  const attention = [...unreadConvs, ...mentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
+  if (attention.length > 0) {
+    groups.push({ key: 'attention', type: 'conversation', label: t('commandPalette.attention'), items: attention })
+  }
+  const promotedIds = new Set(attention.map((i) => i.id))
+
+  // Read DMs stay in their own group below.
+  const readConvs = conversations.filter((i) => (i.unreadCount ?? 0) === 0).slice(0, 5)
+  if (readConvs.length > 0) {
+    groups.push({ key: 'conversation', type: 'conversation', label: t('sidebar.messages'), items: readConvs })
+  }
+
+  // Rooms group: everything not already promoted, tier-sorted (mention overflow lands at tier 0).
+  const rooms = roomItems
+    .filter((i) => !promotedIds.has(i.id))
+    .sort((a, b) => roomTier(a) - roomTier(b))
+    .slice(0, 4)
+  if (rooms.length > 0) {
+    groups.push({ key: 'room', type: 'room', label: t('sidebar.rooms'), items: rooms })
+  }
+```
+
+Leave the contacts / views / actions sections that follow unchanged.
+
+- [ ] **Step 7: Run the new tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Needs attention"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 8: Run the full palette test file for regressions**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+Expected: PASS, no stderr. If a pre-existing test asserted the old "Unread" DM label, update it to "Needs attention" (the label moved; the group still leads with unread DMs).
+
+- [ ] **Step 9: Typecheck**
+
+Run: `cd apps/fluux && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/fluux/src/components/CommandPalette.tsx apps/fluux/src/components/CommandPalette.test.tsx
+git commit -m "feat(cmdk): surface mention/whisper rooms in top Needs attention group"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Top group = unread DMs + `mentionsCount > 0` rooms → Task 2 Step 6. ✓
+- Whispers covered by `mentionsCount` predicate (no SDK change) → design; no task needed. ✓
+- Interleave by recency → `sortTimestamp` (Steps 4-5) + `byRecency` (Step 6). ✓
+- Cap at 6, overflow rooms fall to rooms group at tier 0 → `ATTENTION_CAP` + `promotedIds` filter (Step 6); test covers no-duplicate. ✓
+- Rooms group excludes promoted rooms → `promotedIds` filter (Step 6) + duplicate test (Step 2). ✓
+- Read DMs unchanged → Step 6 read-DM block. ✓
+- Label `commandPalette.attention` "Needs attention", all 33 locales, no em-dash → Task 1. ✓
+- Ties/missing timestamp → `?? 0` default in `byRecency` (Step 6); documented in spec Edge cases. ✓
+
+**Placeholder scan:** No TBD/TODO. The one soft spot is the test group-selector (`.closest(...)`), flagged with an instruction to match the file's real group markup — acceptable because the exact selector is file-specific and the reviewer verifies via passing tests.
+
+**Type consistency:** `sortTimestamp?: number` defined in Task 2 Step 4, consumed in Steps 5-6. `timestamp: Date` (`.getTime()` → number) matches `message-base.ts`. `roomTier` reused unchanged. Group `key: 'attention'` is new; no collision with existing keys (`unread` key is retired).

--- a/docs/superpowers/specs/2026-07-07-cmdk-attention-rooms-design.md
+++ b/docs/superpowers/specs/2026-07-07-cmdk-attention-rooms-design.md
@@ -1,0 +1,140 @@
+# Cmd+K: promote attention-rooms into the top "Needs attention" group
+
+**Date:** 2026-07-07
+**Status:** Design — approved for planning
+**Scope:** `apps/fluux` only. No SDK changes.
+
+## Problem
+
+The Cmd+K command palette's default (empty-query) view builds groups in a fixed
+order in `buildDefaultGroups` ([CommandPalette.tsx:167](../../../apps/fluux/src/components/CommandPalette.tsx)):
+
+1. Unread DMs (`unreadCount > 0`), up to 5 — label `commandPalette.unread`
+2. Read DMs, up to 5 — label `sidebar.messages`
+3. Rooms, up to 4, tier-sorted internally (mentions → unread → read) — label `sidebar.rooms`
+
+Because rooms are always their own group *below* the DM groups, a room where
+the user was **@mentioned** or received an **unread whisper** renders below
+already-read DMs. The mention priority (`roomTier`) only orders rooms *within*
+the rooms group; it never lets an attention-room compete for the top slot.
+
+The top group should surface everything addressed to the user specifically —
+unread DMs and attention-rooms alike — not just DMs.
+
+## Key insight: one predicate covers mentions + whispers
+
+Incoming whispers (XEP-0045 private messages) already increment a room's
+`mentionsCount` — see `Chat.ts` `processRoomWhisper` emitting `room:whisper`
+with `incrementMentions: !isOutgoing`. There is no separate whisper-unread
+counter, and none is needed.
+
+Therefore **"mention or unread whisper" collapses to a single condition:
+`room.mentionsCount > 0`**. This is exactly the "someone addressed me
+specifically" signal, and it is already tracked in `RoomMetadata`. No SDK work
+is required.
+
+## Design
+
+### Top group: "Needs attention"
+
+Replace the DM-only unread group with a combined **attention** group that
+contains:
+
+- Unread DMs — conversations with `unreadCount > 0`
+- Attention-rooms — rooms with `mentionsCount > 0`
+
+Ordering: **interleave DMs and attention-rooms by most-recent activity**
+(the `lastMessage` timestamp), so the group reads as one chronological
+"what's waiting for me" list rather than "all DMs, then all rooms." The
+existing red mention badge already distinguishes attention-rooms visually
+([CommandPalette.tsx:678](../../../apps/fluux/src/components/CommandPalette.tsx)),
+so mixing types in one list stays readable.
+
+Cap the group at **6 items total**. DMs and attention-rooms compete for those
+slots purely by recency. Any attention-room that overflows the cap still
+appears in the rooms group below (unchanged tier-sort), so nothing is lost.
+
+Label: new i18n key **`commandPalette.attention`** → "Needs attention"
+(translated to all 33 locales; no English placeholders).
+
+### Rooms group below: exclude promoted rooms
+
+The rooms group must exclude rooms already shown in the attention group to
+avoid duplicates. A room appears in the attention group iff it has
+`mentionsCount > 0` **and** it made the 6-item cap. Concretely:
+
+- Compute the attention group first, capturing the set of room JIDs it contains.
+- The rooms group filters those JIDs out, then keeps its existing behavior:
+  tier-sort (`roomTier`) the remainder, take up to 4, label `sidebar.rooms`.
+
+This means a mention-room that overflowed the attention cap still shows below —
+and since `roomTier` puts `mentionsCount > 0` at tier 0, it lands at the top of
+the rooms group. No mention-room disappears.
+
+### Read DMs group: unchanged
+
+Read DMs (`unreadCount === 0`) keep their own group under `sidebar.messages`,
+up to 5, below the attention group. Only *unread* DMs move into the attention
+group (they already were in the top group; the change is that rooms now join
+them, not that DMs move).
+
+## Data changes
+
+`CommandItem` needs a sortable timestamp to interleave by recency. Add:
+
+```ts
+/** Timestamp (ms) of the last message, for recency ordering in the attention group. */
+sortTimestamp?: number
+```
+
+Populate it when building items from `conv.lastMessage` and `room.lastMessage`
+(read the message timestamp field — verify exact field name on `RoomMessage` /
+conversation message at implementation time). Items without a last message
+(contacts, bookmarked-not-joined rooms, views, actions) leave it undefined;
+they never enter the attention group so ordering is unaffected.
+
+## Behavior summary
+
+| Item | Where it appears |
+|------|------------------|
+| Unread DM | Attention group (by recency); if pushed out by the cap, not shown in the default view — see Edge cases |
+| DM, read | `sidebar.messages` group |
+| Room, `mentionsCount > 0` | Attention group if within cap; else top of rooms group (tier 0) |
+| Room, unread no mention | Rooms group (tier 1) |
+| Room, read | Rooms group (tier 2) |
+
+## Edge cases
+
+- **Attention cap vs. unread DMs.** Today unread DMs cap at 5. With a shared
+  6-item attention cap, if a user has many unread DMs *and* mention-rooms, some
+  unread DMs could be pushed out. Unlike rooms, DMs have no "overflow" group to
+  catch them (read-DM group is `unreadCount === 0` only). Decision: the shared
+  cap is acceptable — the palette default view is a shortcut, not a complete
+  inbox; the full lists live in the sidebar. If this proves too tight in
+  practice, raise the cap. Document the cap constant clearly.
+- **Active conversation/room excluded.** The existing guards (`activeConversationId`,
+  `activeRoomJid`) still skip the currently-open item before grouping. Unchanged.
+- **Ties in `sortTimestamp`.** Fall back to a stable order (e.g. keep DMs before
+  rooms, or by JID) so rendering is deterministic.
+- **Missing timestamp.** An attention-room with no `lastMessage` (edge: mention
+  recorded but preview absent) sorts to the bottom of the attention group via a
+  `?? 0` default, not excluded.
+
+## Testing
+
+Extend `CommandPalette.test.tsx`:
+
+- Room with `mentionsCount > 0` appears in the attention group, above read DMs.
+- Attention group interleaves a mention-room and an unread DM by recency.
+- A mention-room that overflows the cap appears in the rooms group (tier 0), not
+  duplicated in the attention group.
+- Unread room with `mentionsCount === 0` stays in the rooms group, not promoted.
+- Group label renders `commandPalette.attention`. Add the key to the
+  `test-setup.ts` i18n subset if asserted by label text.
+
+## Out of scope
+
+- No new SDK field or store selector (whispers already bump `mentionsCount`).
+- No separate whisper-unread counter or per-occupant whisper tracking.
+- No change to search/filter mode (non-empty query) ranking.
+- No change to 1:1 mention detection (DMs still have no mention concept).


### PR DESCRIPTION
Two changes sharpening the relevance of the Cmd+K default (empty-query) view.

## 1. Surface mention/whisper rooms in the top group

The default view built its top "Unread" group from 1:1 conversations only. Rooms were always their own group below the DM groups, so a room where you were @mentioned (or received a whisper) rendered *below* already-read DMs.

The top group is renamed **Needs attention** and now merges:
- unread 1:1 conversations (`unreadCount > 0`)
- rooms with `mentionsCount > 0` — a single predicate covering both @mentions and unread whispers (incoming whispers already increment `mentionsCount`)

Items are interleaved by most-recent activity and capped at 6. Rooms promoted into the top group are excluded from the rooms group below (overflow mention-rooms still land at tier 0 there, so nothing is lost).

New i18n key `commandPalette.attention` added to all 33 locales.

## 2. Drop conversationless contacts from the default view

The default view padded itself with roster contacts you have no conversation with, sorted alphabetically — rows unlikely to be what you reach for. They are removed from the empty-query view and remain reachable by typing a name (search / `@` prefix).