### PR TITLE
Aurora typing indicator shimmer

### DIFF
--- a/apps/fluux/src/components/conversation/TypingIndicator.test.tsx
+++ b/apps/fluux/src/components/conversation/TypingIndicator.test.tsx
@@ -55,18 +55,17 @@ describe('TypingIndicator', () => {
   })
 
   describe('animated dots', () => {
-    it('should render three animated dots', () => {
+    it('should render three aurora typing dots', () => {
       render(<TypingIndicator typingUsers={['Alice']} />)
-      const dots = document.querySelectorAll('.animate-bounce')
+      const dots = document.querySelectorAll('.typing-dot')
       expect(dots).toHaveLength(3)
+      // shape is retained; bounce + aurora-hue shimmer (and their stagger) live in CSS
+      dots.forEach((dot) => expect(dot).toHaveClass('rounded-full'))
     })
 
-    it('should have staggered animation delays', () => {
+    it('marks the dots decorative (the text conveys who is typing)', () => {
       render(<TypingIndicator typingUsers={['Alice']} />)
-      const dots = document.querySelectorAll('.animate-bounce')
-      expect(dots[0]).toHaveStyle({ animationDelay: '0ms' })
-      expect(dots[1]).toHaveStyle({ animationDelay: '150ms' })
-      expect(dots[2]).toHaveStyle({ animationDelay: '300ms' })
+      expect(document.querySelector('.typing-dot')?.closest('[aria-hidden="true"]')).not.toBeNull()
     })
   })
 

--- a/apps/fluux/src/components/conversation/TypingIndicator.tsx
+++ b/apps/fluux/src/components/conversation/TypingIndicator.tsx
@@ -65,20 +65,11 @@ export function TypingIndicator({ typingUsers, formatUser, className = '' }: Typ
 
   return (
     <div className={`py-2 px-4 text-sm text-fluux-muted italic flex items-center gap-2 ${className}`}>
-      {/* Animated bouncing dots */}
-      <span className="flex gap-0.5">
-        <span
-          className="size-1.5 rounded-full bg-fluux-muted animate-bounce"
-          style={{ animationDelay: '0ms' }}
-        />
-        <span
-          className="size-1.5 rounded-full bg-fluux-muted animate-bounce"
-          style={{ animationDelay: '150ms' }}
-        />
-        <span
-          className="size-1.5 rounded-full bg-fluux-muted animate-bounce"
-          style={{ animationDelay: '300ms' }}
-        />
+      {/* Dots bounce and shimmer through the aurora hues (delays + colors in CSS). */}
+      <span className="flex gap-0.5" aria-hidden="true">
+        <span className="size-1.5 rounded-full typing-dot" />
+        <span className="size-1.5 rounded-full typing-dot" />
+        <span className="size-1.5 rounded-full typing-dot" />
       </span>
       <span>{text}</span>
     </div>

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1413,6 +1413,32 @@ input[type="range"]::-moz-range-thumb {
   opacity: 0.65;
 }
 
+/* Typing indicator dots: they bounce and shimmer through the aurora hues — a
+   slow traveling wave of aurora light (staggered per dot). Reduced motion
+   stills both and leaves the dots a single aurora tone. */
+@keyframes typing-dot-bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-3px); }
+}
+@keyframes typing-dot-aurora {
+  0%   { background-color: var(--fluux-aurora-1); }
+  25%  { background-color: var(--fluux-aurora-2); }
+  50%  { background-color: var(--fluux-aurora-3); }
+  75%  { background-color: var(--fluux-aurora-4); }
+  100% { background-color: var(--fluux-aurora-1); }
+}
+.typing-dot {
+  background-color: var(--fluux-aurora-3);
+  animation: typing-dot-bounce 1.2s ease-in-out infinite, typing-dot-aurora 2.4s linear infinite;
+}
+.typing-dot:nth-child(1) { animation-delay: 0ms, 0ms; }
+.typing-dot:nth-child(2) { animation-delay: 150ms, -0.8s; }
+.typing-dot:nth-child(3) { animation-delay: 300ms, -1.6s; }
+[data-motion="reduced"] .typing-dot {
+  animation: none;
+  background-color: var(--fluux-aurora-3);
+}
+
 /* Aurora send button: liquid glass over an aurora glow, only when a message is
    ready to send. Disabled = the previous muted icon. Reduced transparency (and
    thereby also the platforms where glass is off) falls back to the validated


### PR DESCRIPTION
Makes the typing-indicator dots read as aurora light: each dot bounces and slowly shimmers through the aurora hues, staggered so a wave of colour travels across the three dots.

- The dots now use a `typing-dot` class (CSS in `index.css`) with two composed animations — a subtle bounce and a `background-color` cycle through `--fluux-aurora-1..4` — with per-dot delays for the traveling-wave effect.
- Theme-aware: night aurora (teal→blue→violet) in dark, muted-dawn in light, and other themes inherit their aurora tokens.
- `prefers-reduced-motion` / `[data-motion="reduced"]` stills both animations and leaves the dots a single aurora tone. The dots are marked `aria-hidden` (the "X is typing…" text conveys the state).
