### PR TITLE
refactor(hooks): dedup connect via useConnectionActions in useSessionPersistence

### DIFF
--- a/apps/fluux/src/hooks/useSessionPersistence.reconnectIntent.test.tsx
+++ b/apps/fluux/src/hooks/useSessionPersistence.reconnectIntent.test.tsx
@@ -9,14 +9,18 @@ import { markLoggedOut, markConnectActive } from '@/utils/reconnectIntent'
 const mockConnect = vi.fn().mockResolvedValue(undefined)
 
 // Override the SDK mock from test-setup for this file only:
-//  - `useXMPPContext` returns our spy client (the real one needs a provider)
-//  - `connectionStore.getState()` exposes the setters the connect wrapper calls
+//  - `useConnectionActions` returns our spy `connect` (production now routes the
+//    auto-reconnect engine through the SDK's connect action, not a local wrapper)
+//  - `useXMPPContext` returns a stub client (the hook still reads it for avatar
+//    cache restore; the real one needs a provider)
+//  - `connectionStore.getState()` exposes the setters callers may touch
 //  - real `hasFastToken` / `getBareJid` / `deleteFastToken` are preserved so the
 //    FAST-token Path B reads our seeded token exactly like production
 vi.mock('@fluux/sdk', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@fluux/sdk')>()
   return {
     ...actual,
+    useConnectionActions: () => ({ connect: mockConnect }),
     useXMPPContext: () => ({ client: { connect: mockConnect } }),
     connectionStore: {
       getState: () => ({ setStatus: vi.fn(), setError: vi.fn() }),

--- a/apps/fluux/src/hooks/useSessionPersistence.ts
+++ b/apps/fluux/src/hooks/useSessionPersistence.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { connectionStore, useXMPPContext, getBareJid, getDomain, hasFastToken, deleteFastToken } from '@fluux/sdk'
+import { connectionStore, useXMPPContext, useConnectionActions, getBareJid, getDomain, hasFastToken, deleteFastToken } from '@fluux/sdk'
 import { useRosterStore, useConnectionStore, useRoomStore } from '@fluux/sdk/react'
 import type { Contact, Room, RoomOccupant, ServerInfo, HttpUploadService, RoomMessage, ResourcePresence, JoinedRoomInfo } from '@fluux/sdk'
 import { getResource } from '@/utils/xmppResource'
@@ -487,29 +487,10 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
   const isResumptionRef = useRef(false)
   const keychainRetryAttempted = useRef(false)
 
-  const connect = useCallback(async (
-    jid: string,
-    password: string | undefined,
-    server: string,
-    smState?: { id: string; inbound: number; outbound: number },
-    resource?: string,
-    lang?: string,
-    disableSmKeepalive?: boolean,
-    rememberSession?: boolean,
-    autoRetryOnTransientFailure?: boolean,
-    previouslyJoinedRooms?: JoinedRoomInfo[]
-  ) => {
-    connectionStore.getState().setStatus('connecting')
-    connectionStore.getState().setError(null)
-    try {
-      await client.connect({ jid, password, server, resource, smState, lang, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure, previouslyJoinedRooms })
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Connection failed'
-      connectionStore.getState().setStatus('error')
-      connectionStore.getState().setError(message)
-      throw err
-    }
-  }, [client])
+  // Reuse the SDK's connect action: it performs the identical connecting/error
+  // status wrapping around client.connect() and takes a ConnectOptions object.
+  // useConnectionActions() does zero store subscriptions, so it adds no renders.
+  const { connect } = useConnectionActions()
 
   // Note: SM state is now managed by SDK's storage adapter.
   // The SDK automatically loads SM state on connect and persists it on enable/resume.
@@ -620,14 +601,14 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
             isResumptionRef.current = false
             return
           }
-          connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry, joinedRoomInfos).catch((err) => {
+          connect({ jid: session.jid, password: session.password, server: session.server, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
             console.log('[Auth] Reconnection failed:', err?.message || err)
             clearSession()
             isResumptionRef.current = false
           })
         }).catch(() => {
           // Claim check failed, try connecting anyway
-          connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry, joinedRoomInfos).catch((err) => {
+          connect({ jid: session.jid, password: session.password, server: session.server, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
             console.log('[Auth] Reconnection failed:', err?.message || err)
             clearSession()
             isResumptionRef.current = false
@@ -636,7 +617,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         return
       }
 
-      connect(session.jid, session.password, session.server, undefined, resource, i18n.language, disableSmKeepalive, rememberSession, autoRetry, joinedRoomInfos).catch((err) => {
+      connect({ jid: session.jid, password: session.password, server: session.server, resource, lang: i18n.language, disableSmKeepalive, rememberSession, autoRetryOnTransientFailure: autoRetry, previouslyJoinedRooms: joinedRoomInfos }).catch((err) => {
         console.log('[Auth] Reconnection failed:', err?.message || err)
         // If auto-reconnect fails, clear session
         clearSession()
@@ -689,7 +670,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         // flakiness as page-reload. Auth failures (bad/expired token) still
         // surface via the machine's AUTH_ERROR path and delete the token.
         try {
-          await connect(savedJid, fallbackPassword, effectiveServer, undefined, resource, i18n.language, false, true, true)
+          await connect({ jid: savedJid, password: fallbackPassword, server: effectiveServer, resource, lang: i18n.language, disableSmKeepalive: false, rememberSession: true, autoRetryOnTransientFailure: true })
           // Save session for subsequent in-tab reconnects. Store the
           // fallback password so reloads (Path A) don't have to re-hit
           // the keychain; empty string preserves prior behavior when no
@@ -760,7 +741,7 @@ export function useSessionPersistence(claimConnection?: (jid: string) => Promise
         if (!creds || getBareJid(creds.jid) !== getBareJid(savedJid)) return
         console.log('[Auth] Auth failure on Tauri: retrying with keychain credentials')
         const resource = getResource()
-        await connect(savedJid, creds.password, effectiveServer, undefined, resource, i18n.language, false, true, true)
+        await connect({ jid: savedJid, password: creds.password, server: effectiveServer, resource, lang: i18n.language, disableSmKeepalive: false, rememberSession: true, autoRetryOnTransientFailure: true })
         saveSession(savedJid, creds.password, effectiveServer)
       } catch (err) {
         console.log('[Auth] Keychain retry after auth failure failed:', err instanceof Error ? err.message : err)


### PR DESCRIPTION
Removes the duplicate local `connect` wrapper in `useSessionPersistence` and routes reconnection through the SDK's `useConnectionActions().connect`, which performs the identical `connecting`/`error` status wrapping around `client.connect()` and already accepts a `ConnectOptions` object.

- Drop the ~23-line local `connect` `useCallback` (10 positional params) → `const { connect } = useConnectionActions()`. The action does zero store subscriptions, so it adds no re-renders.
- Convert all 5 callers from positional args to the `ConnectOptions` object (`autoRetryOnTransientFailure`, `previouslyJoinedRooms` already covered by the type).
- Update the `reconnectIntent` test mock to stub `useConnectionActions` (matching the existing `LoginScreen.test.tsx` pattern), since the auto-reconnect engine now reaches `client.connect` through the SDK action.

No behavior change. Verified: typecheck, session/reconnect tests, full app suite (4547 passed), lint (0 errors).