### PR TITLE
Derive aurora gradients per theme (harmonize with accent)

### DIFF
--- a/apps/fluux/src/hooks/useTheme.ts
+++ b/apps/fluux/src/hooks/useTheme.ts
@@ -239,6 +239,10 @@ export function useTheme() {
 
     // 2. Apply theme variable overrides
     const theme = getActiveTheme()
+    // Expose the active theme id so CSS can scope per-theme rules — notably the
+    // aurora-quartet derivation, which harmonizes non-Aurora themes with their
+    // own accent while Aurora keeps its explicit teal→violet signature.
+    root.dataset.theme = theme?.id || 'fluux'
     const modeVars = theme?.variables?.[resolved]
     applyThemeVariables(modeVars, previousVarsRef)
 

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1390,6 +1390,27 @@ input[type="range"]::-moz-range-thumb {
 .scrim-in  { animation: scrim-in var(--fluux-duration-base) var(--fluux-ease-standard); }
 .scrim-out { animation: scrim-out var(--fluux-duration-fast) var(--fluux-ease-standard) forwards; }
 
+/* ── Cross-theme aurora harmony ────────────────────────────────────────────
+   The aurora quartet (--fluux-aurora-1..4) drives the header hairline, the send
+   button, the typing dots and the modal scrim. Aurora (the default theme) keeps
+   its explicit teal→violet / muted-dawn signature from the :root / .light token
+   defaults above. Every OTHER theme derives the quartet from its own accent hue
+   instead of inheriting Aurora's teal→violet, so those accents harmonize with
+   each theme's palette. useTheme sets data-theme=<id> on <html>.
+
+   Lightness is floored well above mid so the dark ink icon on the send-button
+   solid fill (reduced-transparency / Linux fallback) clears WCAG AA on every
+   hue — guarded by auroraDerivation.test.ts. A theme may still override
+   --fluux-aurora-* directly for a hand-tuned quartet (see docs/THEMES.md).
+   Follow-up: hand-tune quartets for the busier builtin themes (e.g. gruvbox,
+   dracula) where a pure hue-fan around the accent is less characterful. */
+:root[data-theme]:not([data-theme='fluux']) {
+  --fluux-aurora-1: hsl(calc(var(--fluux-accent-h) - 50), var(--fluux-accent-s), clamp(66%, calc(var(--fluux-accent-l) + 14%), 80%));
+  --fluux-aurora-2: hsl(calc(var(--fluux-accent-h) - 18), var(--fluux-accent-s), clamp(66%, calc(var(--fluux-accent-l) + 14%), 80%));
+  --fluux-aurora-3: hsl(calc(var(--fluux-accent-h) + 16), var(--fluux-accent-s), clamp(66%, calc(var(--fluux-accent-l) + 14%), 80%));
+  --fluux-aurora-4: hsl(calc(var(--fluux-accent-h) + 50), var(--fluux-accent-s), clamp(66%, calc(var(--fluux-accent-l) + 14%), 80%));
+}
+
 /* Aurora horizon: a 1px identity hairline riding ON TOP of the header's
    standard divider (which stays underneath — the audit's seam-visibility
    guarantees are untouched). Fades at both ends; the tokens flip to the

--- a/apps/fluux/src/themes/auroraDerivation.test.ts
+++ b/apps/fluux/src/themes/auroraDerivation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+import { builtinThemes } from './builtins'
+
+/**
+ * Cross-theme aurora derivation guard.
+ *
+ * Non-Aurora themes derive the aurora quartet (--fluux-aurora-1..4) from their
+ * own accent hue via a pure-CSS rule in index.css
+ * (`:root[data-theme]:not([data-theme='fluux'])`). The dark ink icon on the
+ * send-button solid fill (reduced-transparency / Linux fallback) sits on those
+ * derived colours, so every possible derived stop must clear the WCAG 3:1 floor
+ * for graphical objects. The derivation floors lightness (66%), which is what
+ * makes that hold for every hue — this test pins both the floor value the CSS
+ * uses and the contrast invariant it guarantees.
+ */
+
+const INK = '#08111F' // --fluux-aurora-ink
+const AA_GRAPHIC = 3 // WCAG 2.1 non-text contrast
+
+// Derivation constants — MUST match the index.css rule.
+const HUE_OFFSETS = [-50, -18, 16, 50]
+const L_FLOOR = 66
+const L_ADD = 14
+const L_CEIL = 80
+
+const css = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../index.css'), 'utf8')
+
+type RGB = [number, number, number]
+function hslToRgb(h: number, s: number, l: number): RGB {
+  h = ((h % 360) + 360) % 360
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - c / 2
+  let r: number, g: number, b: number
+  if (h < 60) [r, g, b] = [c, x, 0]
+  else if (h < 120) [r, g, b] = [x, c, 0]
+  else if (h < 180) [r, g, b] = [0, c, x]
+  else if (h < 240) [r, g, b] = [0, x, c]
+  else if (h < 300) [r, g, b] = [x, 0, c]
+  else [r, g, b] = [c, 0, x]
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)]
+}
+function hexToRgb(hex: string): RGB {
+  const h = hex.slice(1)
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+}
+function relLum([r, g, b]: RGB): number {
+  const f = (c: number) => {
+    const s = c / 255
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+}
+function contrast(a: RGB, b: RGB): number {
+  const [hi, lo] = [relLum(a), relLum(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+function clamp(min: number, v: number, max: number): number {
+  return Math.max(min, Math.min(v, max))
+}
+function derivedStops(h: number, s: number, l: number): RGB[] {
+  const L = clamp(L_FLOOR, l + L_ADD, L_CEIL)
+  return HUE_OFFSETS.map((o) => hslToRgb(h + o, s / 100, L / 100))
+}
+
+const ink = hexToRgb(INK)
+
+describe('cross-theme aurora derivation', () => {
+  it('index.css uses the derivation this guard mirrors', () => {
+    expect(css).toMatch(/:root\[data-theme\]:not\(\[data-theme='fluux'\]\)/)
+    expect(css).toContain('clamp(66%, calc(var(--fluux-accent-l) + 14%), 80%)')
+    // the four hue offsets
+    for (const o of HUE_OFFSETS) {
+      const sign = o < 0 ? `- ${Math.abs(o)}` : `+ ${o}`
+      expect(css).toContain(`calc(var(--fluux-accent-h) ${sign})`)
+    }
+  })
+
+  it('ink clears the 3:1 graphic floor on any derived stop (floor lightness, every hue/saturation)', () => {
+    for (let h = 0; h < 360; h += 5) {
+      for (let s = 0; s <= 100; s += 10) {
+        const ratio = contrast(ink, hslToRgb(h, s / 100, L_FLOOR / 100))
+        expect(ratio, `ink on hsl(${h} ${s}% ${L_FLOOR}%) = ${ratio.toFixed(2)}`).toBeGreaterThanOrEqual(AA_GRAPHIC)
+      }
+    }
+  })
+
+  it("ink clears 3:1 on every builtin theme's derived stops (dark + light)", () => {
+    for (const theme of builtinThemes) {
+      if (theme.id === 'fluux') continue // Aurora keeps its explicit signature
+      for (const mode of ['dark', 'light'] as const) {
+        const v = theme.variables?.[mode]
+        const h = parseFloat(v?.['--fluux-accent-h'] ?? '')
+        const s = parseFloat(v?.['--fluux-accent-s'] ?? '')
+        const l = parseFloat(v?.['--fluux-accent-l'] ?? '')
+        if (Number.isNaN(h) || Number.isNaN(s) || Number.isNaN(l)) continue // inherits Aurora's accent
+        for (const rgb of derivedStops(h, s, l)) {
+          const ratio = contrast(ink, rgb)
+          expect(ratio, `${theme.id}/${mode} ink on derived stop = ${ratio.toFixed(2)}`).toBeGreaterThanOrEqual(AA_GRAPHIC)
+        }
+      }
+    }
+  })
+})

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -125,10 +125,22 @@ From these, the app computes:
 - `--fluux-search-highlight-bg` — translucent accent for search match highlighting
 - `--fluux-search-highlight-text` — text color inside search highlights
 - `--fluux-focus-ring` — translucent accent for focus outlines
+- `--fluux-aurora-1..4` — the **aurora quartet** used by the header hairline, the send button, the typing-indicator dots and the modal scrim. For every theme except Aurora, these are derived as a gentle hue-fan around your accent (`accent-h` ± ~50°), so those aurora accents harmonize with your palette instead of showing Aurora's teal→violet.
 
 The `--fluux-text-on-accent` color is calculated automatically using WCAG relative luminance. Light accents (e.g. Yellow or Pink in dark mode) get black text; dark accents (e.g. Blue in light mode) get white text. This ensures buttons, active icon rail tabs, and other accent-colored elements remain readable with any accent color and mode combination. Theme authors do not need to set this variable — it adapts automatically.
 
 **Tip:** Lower the lightness by ~8-10% for light mode so the accent remains readable on light backgrounds.
+
+**Aurora accents.** The `--fluux-aurora-1..4` quartet is derived from your accent automatically — you don't need to set it. The built-in **Aurora** theme is the one exception: it keeps its explicit teal→violet (dark) / muted-dawn (light) signature. If the auto-derived hue-fan isn't right for your palette, you can override the four tokens with a hand-tuned quartet in `variables.dark` / `variables.light`:
+
+```json
+"--fluux-aurora-1": "#2FE0C0",
+"--fluux-aurora-2": "#4FB6E8",
+"--fluux-aurora-3": "#7C8CFF",
+"--fluux-aurora-4": "#A78BFA"
+```
+
+The derivation floors the quartet's lightness so the send button's dark ink icon stays readable on every hue; `auroraDerivation.test.ts` guards this. If you hand-tune the quartet, keep the stops light enough (roughly L ≥ 60%) that the ink icon clears WCAG 3:1 on the send-button fill.
 
 ### Typography
 


### PR DESCRIPTION
The aurora gradients (header hairline, send button, typing dots, modal scrim) previously inherited Aurora's fixed teal→violet on every theme, which clashed with warm/off-hue palettes like gruvbox or dracula.

Now every theme **except Aurora** derives its aurora quartet (`--fluux-aurora-1..4`) from its own accent hue — a gentle hue-fan (`accent-h` ± ~50°) — so those accents harmonize with the theme's palette. Aurora keeps its explicit teal→violet (dark) / muted-dawn (light) signature.

- Pure CSS: a `:root[data-theme]:not([data-theme='fluux'])` rule builds the quartet with `hsl(calc(accent-h ± offset), accent-s, clamp(...))`. `useTheme` sets `data-theme=<id>` on `<html>`.
- The quartet's lightness is floored so the send button's dark ink icon (reduced-transparency / Linux fallback fill) clears WCAG 3:1 on every hue — proven for all hues and every builtin theme's accent in `auroraDerivation.test.ts`.
- A theme may still override `--fluux-aurora-*` directly for a hand-tuned quartet (documented in `docs/THEMES.md`).

Verified live: gruvbox's aurora now fans warm (pink→coral→amber) around its orange accent; Aurora is unchanged.

Follow-up (noted in the CSS + THEMES.md): hand-tuned quartets for the busier builtin themes where a pure hue-fan is less characterful.
