### PR TITLE
fix(preview): interop-correct OGP fastening + non-blocking metadata fetch

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -698,9 +698,25 @@ pub struct UrlMetadata {
     pub site_name: Option<String>,
 }
 
-/// Fetch URL and extract Open Graph metadata for link previews
+/// Fetch URL and extract Open Graph metadata for link previews.
+///
+/// The actual work (a blocking HTTP request with a multi-second timeout plus a
+/// synchronous HTML parse) runs on the blocking thread pool via
+/// [`tauri::async_runtime::spawn_blocking`] so the main thread stays free. A
+/// synchronous command would run this on the main thread and freeze the UI for
+/// the duration of the fetch — most visibly on Linux/WebKitGTK, where the
+/// webview renders on that same thread.
 #[tauri::command]
-fn fetch_url_metadata(url: String) -> Result<UrlMetadata, String> {
+async fn fetch_url_metadata(url: String) -> Result<UrlMetadata, String> {
+    tauri::async_runtime::spawn_blocking(move || fetch_url_metadata_blocking(url))
+        .await
+        .unwrap_or_else(|join_err| Err(format!("Link preview task panicked: {join_err}")))
+}
+
+/// Blocking implementation of [`fetch_url_metadata`]. Runs off the main thread.
+/// Uses `reqwest::blocking` and `scraper` (whose parsed document is `!Send`, so
+/// it must live entirely within this synchronous function).
+fn fetch_url_metadata_blocking(url: String) -> Result<UrlMetadata, String> {
     // Validate URL
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err("Invalid URL: must start with http:// or https://".to_string());

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -755,8 +755,26 @@ fn fetch_url_metadata_blocking(url: String) -> Result<UrlMetadata, String> {
         format!("Failed to read response: {}", e)
     })?;
 
-    // Parse HTML and extract OG metadata
-    let document = Html::parse_document(&html);
+    let metadata = parse_og_metadata(&url, &html);
+
+    // Only return success if we got at least a title
+    if metadata.title.is_some() {
+        Ok(metadata)
+    } else {
+        tracing::debug!(url = %url, "Link preview: no title found in page metadata");
+        Err("Could not extract metadata from URL".to_string())
+    }
+}
+
+/// Extract Open Graph (and fallback) metadata from an HTML document.
+///
+/// Pure function over `(request_url, html)` — no I/O — so it is unit-testable.
+/// `og:*` tags win, with `<title>` and `<meta name="description">` as fallbacks;
+/// `og:url` overrides the canonical url when present. Never fails: an empty
+/// document yields a `UrlMetadata` with only `url` set (the caller enforces the
+/// "must have a title" business rule).
+fn parse_og_metadata(url: &str, html: &str) -> UrlMetadata {
+    let document = Html::parse_document(html);
 
     // Selectors for Open Graph meta tags
     let og_title = Selector::parse(r#"meta[property="og:title"]"#).ok();
@@ -770,7 +788,7 @@ fn fetch_url_metadata_blocking(url: String) -> Result<UrlMetadata, String> {
     let meta_desc = Selector::parse(r#"meta[name="description"]"#).ok();
 
     let mut metadata = UrlMetadata {
-        url: url.clone(),
+        url: url.to_string(),
         ..Default::default()
     };
 
@@ -839,13 +857,7 @@ fn fetch_url_metadata_blocking(url: String) -> Result<UrlMetadata, String> {
         }
     }
 
-    // Only return success if we got at least a title
-    if metadata.title.is_some() {
-        Ok(metadata)
-    } else {
-        tracing::debug!(url = %url, "Link preview: no title found in page metadata");
-        Err("Could not extract metadata from URL".to_string())
-    }
+    metadata
 }
 
 /// Check if window is visible on any monitor, reset to center if off-screen
@@ -2460,5 +2472,74 @@ mod tests {
         let cloned = payload.clone();
         assert!(!cloned.display_active);
         assert_eq!(cloned.slept_ms, 0);
+    }
+
+    // --- Link-preview OG metadata extraction (parse_og_metadata) ---
+
+    #[test]
+    fn test_parse_og_metadata_full_open_graph() {
+        let html = r#"
+            <html><head>
+              <meta property="og:title" content="The Rock">
+              <meta property="og:description" content="A 1996 action film">
+              <meta property="og:image" content="https://example.com/rock.jpg">
+              <meta property="og:site_name" content="IMDb">
+              <meta property="og:url" content="https://example.com/canonical">
+            </head></html>
+        "#;
+        let m = parse_og_metadata("https://example.com/requested", html);
+        assert_eq!(m.title.as_deref(), Some("The Rock"));
+        assert_eq!(m.description.as_deref(), Some("A 1996 action film"));
+        assert_eq!(m.image.as_deref(), Some("https://example.com/rock.jpg"));
+        assert_eq!(m.site_name.as_deref(), Some("IMDb"));
+        // og:url overrides the requested url as the canonical link.
+        assert_eq!(m.url, "https://example.com/canonical");
+    }
+
+    #[test]
+    fn test_parse_og_metadata_falls_back_to_title_and_meta_description() {
+        let html = r#"
+            <html><head>
+              <title>  Plain Title  </title>
+              <meta name="description" content="Plain description">
+            </head></html>
+        "#;
+        let m = parse_og_metadata("https://example.com/a", html);
+        // <title> is trimmed; used when og:title is absent.
+        assert_eq!(m.title.as_deref(), Some("Plain Title"));
+        assert_eq!(m.description.as_deref(), Some("Plain description"));
+        assert_eq!(m.image, None);
+        assert_eq!(m.site_name, None);
+        // No og:url → keep the requested url.
+        assert_eq!(m.url, "https://example.com/a");
+    }
+
+    #[test]
+    fn test_parse_og_metadata_prefers_og_title_over_title_tag() {
+        let html = r#"
+            <html><head>
+              <title>Fallback Title</title>
+              <meta property="og:title" content="OG Title">
+            </head></html>
+        "#;
+        let m = parse_og_metadata("https://example.com/a", html);
+        assert_eq!(m.title.as_deref(), Some("OG Title"));
+    }
+
+    #[test]
+    fn test_parse_og_metadata_empty_document_yields_only_url() {
+        let m = parse_og_metadata("https://example.com/a", "<html></html>");
+        assert_eq!(m.url, "https://example.com/a");
+        assert_eq!(m.title, None);
+        assert_eq!(m.description, None);
+        assert_eq!(m.image, None);
+        assert_eq!(m.site_name, None);
+    }
+
+    #[test]
+    fn test_parse_og_metadata_ignores_empty_title_tag() {
+        // A whitespace-only <title> must not become a spurious title.
+        let m = parse_og_metadata("https://example.com/a", "<html><head><title>   </title></head></html>");
+        assert_eq!(m.title, None);
     }
 }

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -1819,7 +1819,13 @@ describe('Chat E2EE wiring', () => {
       await plainChat.sendLinkPreview('bob@example.com', 'orig-id', preview)
 
       const sent = captured[0]
-      expect(sent.getChild('apply-to', 'urn:xmpp:fasten:0')).toBeDefined()
+      const applyTo = sent.getChild('apply-to', 'urn:xmpp:fasten:0')
+      expect(applyTo).toBeDefined()
+      // Interop wire format: OGP <meta> are direct children of <apply-to>, with
+      // no invalid <external> wrapper (mod_ogp / Gajim / Movim convention).
+      expect(applyTo!.getChild('external', 'urn:xmpp:fasten:0')).toBeUndefined()
+      const metas = applyTo!.getChildren('meta', 'http://www.w3.org/1999/xhtml')
+      expect(metas.map((m) => m.attrs.property)).toContain('og:title')
       expect(sent.getChild('no-store', 'urn:xmpp:hints')).toBeDefined()
       expect(sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')).toBeUndefined()
     })

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -1829,6 +1829,36 @@ describe('Chat E2EE wiring', () => {
       expect(sent.getChild('no-store', 'urn:xmpp:hints')).toBeDefined()
       expect(sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')).toBeUndefined()
     })
+
+    it('renders a foreign (mod_ogp / Gajim) preview: meta direct under apply-to, no <external>', () => {
+      const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
+      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+
+      // Shape emitted by Prosody mod_ogp: OGP <meta> as direct children of
+      // <apply-to>, from the room, applying to the message's id/origin-id.
+      const inbound = xml(
+        'message',
+        { from: 'room@muc.example.com/alice', to: 'me@example.com', type: 'groupchat', id: 'muc-msg-1' },
+        xml(
+          'apply-to',
+          { xmlns: 'urn:xmpp:fasten:0', id: 'muc-msg-1' },
+          xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:url', content: 'https://example.com/a' }),
+          xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:title', content: 'Foreign Title' }),
+          xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:image', content: 'https://example.com/i.jpg' }),
+        ),
+      )
+
+      rxChat.handle(inbound)
+
+      const evt = rxBuilt.sdkEmitted.find(
+        (e) => (e as { event: string }).event === 'room:message-updated',
+      ) as { payload: { roomJid: string; messageId: string; updates: { linkPreview?: { title?: string; image?: string } } } } | undefined
+      expect(evt).toBeDefined()
+      expect(evt!.payload.roomJid).toBe('room@muc.example.com')
+      expect(evt!.payload.messageId).toBe('muc-msg-1')
+      expect(evt!.payload.updates.linkPreview?.title).toBe('Foreign Title')
+      expect(evt!.payload.updates.linkPreview?.image).toBe('https://example.com/i.jpg')
+    })
   })
 
   describe('reply-quote leak protection (cleartext reply to an encrypted message)', () => {

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -1830,6 +1830,79 @@ describe('Chat E2EE wiring', () => {
       expect(sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')).toBeUndefined()
     })
 
+    // Build a Chat with no E2EE plugin so the fastening goes out in cleartext and
+    // its wire format is directly inspectable.
+    const makePlainChat = () => {
+      const emptyManager = new E2EEManager({
+        storage: new InMemoryStorageBackend(),
+        xmpp: stubXmppPrimitives(async () => {}),
+        account: { jid: 'me@example.com' },
+      })
+      const localCaptured: Element[] = []
+      const { deps } = makeDeps({
+        jid: 'me@example.com',
+        manager: emptyManager,
+        captureStanza: (el) => localCaptured.push(el),
+      })
+      return { chat: new Chat(deps, stubMAM()), captured: localCaptured }
+    }
+
+    // Collapse the OGP <meta> children of <apply-to> into a { property: content } map.
+    const ogMapOf = (sent: Element): Record<string, string> => {
+      const applyTo = sent.getChild('apply-to', 'urn:xmpp:fasten:0')!
+      const map: Record<string, string> = {}
+      for (const m of applyTo.getChildren('meta', 'http://www.w3.org/1999/xhtml')) {
+        map[m.attrs.property] = m.attrs.content
+      }
+      return map
+    }
+
+    it('emits every OGP field as a direct <meta> child with the XHTML namespace', async () => {
+      const { chat: plainChat, captured: local } = makePlainChat()
+
+      await plainChat.sendLinkPreview('bob@example.com', 'orig-id', preview)
+
+      const applyTo = local[0].getChild('apply-to', 'urn:xmpp:fasten:0')!
+      expect(applyTo.attrs.id).toBe('orig-id')
+      // Every <meta> uses the XHTML namespace.
+      const metas = applyTo.getChildren('meta', 'http://www.w3.org/1999/xhtml')
+      expect(metas).toHaveLength(5)
+      for (const m of metas) expect(m.attrs.xmlns).toBe('http://www.w3.org/1999/xhtml')
+      expect(ogMapOf(local[0])).toEqual({
+        'og:url': 'https://secret.example.com/article',
+        'og:title': 'Confidential Title',
+        'og:description': 'A description the server must not see',
+        'og:image': 'https://secret.example.com/preview.jpg',
+        'og:site_name': 'Secret Site',
+      })
+    })
+
+    it('omits optional OGP fields that are absent from the preview (only og:url is mandatory)', async () => {
+      const { chat: plainChat, captured: local } = makePlainChat()
+
+      await plainChat.sendLinkPreview('bob@example.com', 'orig-id', { url: 'https://example.com/a' })
+
+      expect(ogMapOf(local[0])).toEqual({ 'og:url': 'https://example.com/a' })
+    })
+
+    it('sends a groupchat preview in cleartext with the interop wire format (no encryption)', async () => {
+      const { chat: plainChat, captured: local } = makePlainChat()
+
+      await plainChat.sendLinkPreview('room@muc.example.com', 'muc-orig', preview, 'groupchat')
+
+      const sent = local[0]
+      expect(sent.attrs.to).toBe('room@muc.example.com')
+      expect(sent.attrs.type).toBe('groupchat')
+      // groupchat is never encrypted (only 1:1 chat fastenings are).
+      expect(sent.getChild('plain', 'urn:fluux:e2ee-dummy:0')).toBeUndefined()
+      expect(sent.getChild('encryption', 'urn:xmpp:eme:0')).toBeUndefined()
+      const applyTo = sent.getChild('apply-to', 'urn:xmpp:fasten:0')
+      expect(applyTo).toBeDefined()
+      expect(applyTo!.getChild('external', 'urn:xmpp:fasten:0')).toBeUndefined()
+      expect(ogMapOf(sent)['og:title']).toBe('Confidential Title')
+      expect(sent.getChild('no-store', 'urn:xmpp:hints')).toBeDefined()
+    })
+
     it('renders a foreign (mod_ogp / Gajim) preview: meta direct under apply-to, no <external>', () => {
       const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
       const rxChat = new Chat(rxBuilt.deps, stubMAM())
@@ -1858,6 +1931,60 @@ describe('Chat E2EE wiring', () => {
       expect(evt!.payload.messageId).toBe('muc-msg-1')
       expect(evt!.payload.updates.linkPreview?.title).toBe('Foreign Title')
       expect(evt!.payload.updates.linkPreview?.image).toBe('https://example.com/i.jpg')
+    })
+
+    it('renders a foreign 1:1 preview (direct-meta apply-to on a chat stanza)', () => {
+      const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
+      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+
+      const inbound = xml(
+        'message',
+        { from: 'bob@example.com/r', to: 'me@example.com', type: 'chat', id: 'chat-msg-1' },
+        xml(
+          'apply-to',
+          { xmlns: 'urn:xmpp:fasten:0', id: 'chat-msg-1' },
+          xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:url', content: 'https://example.com/a' }),
+          xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:title', content: 'Foreign 1:1' }),
+        ),
+      )
+
+      rxChat.handle(inbound)
+
+      const evt = rxBuilt.sdkEmitted.find(
+        (e) => (e as { event: string }).event === 'chat:message-updated',
+      ) as { payload: { conversationId: string; messageId: string; updates: { linkPreview?: { title?: string } } } } | undefined
+      expect(evt).toBeDefined()
+      expect(evt!.payload.conversationId).toBe('bob@example.com')
+      expect(evt!.payload.messageId).toBe('chat-msg-1')
+      expect(evt!.payload.updates.linkPreview?.title).toBe('Foreign 1:1')
+    })
+
+    it('still renders an inbound legacy <external>-wrapped preview (older Fluux builds)', () => {
+      const rxBuilt = makeDeps({ jid: 'me@example.com', manager, captureStanza: () => {} })
+      const rxChat = new Chat(rxBuilt.deps, stubMAM())
+
+      const inbound = xml(
+        'message',
+        { from: 'room@muc.example.com/alice', to: 'me@example.com', type: 'groupchat', id: 'muc-legacy-1' },
+        xml(
+          'apply-to',
+          { xmlns: 'urn:xmpp:fasten:0', id: 'muc-legacy-1' },
+          xml(
+            'external',
+            { xmlns: 'urn:xmpp:fasten:0', name: 'ogp' },
+            xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:url', content: 'https://example.com/a' }),
+            xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:title', content: 'Legacy Wrapped' }),
+          ),
+        ),
+      )
+
+      rxChat.handle(inbound)
+
+      const evt = rxBuilt.sdkEmitted.find(
+        (e) => (e as { event: string }).event === 'room:message-updated',
+      ) as { payload: { updates: { linkPreview?: { title?: string } } } } | undefined
+      expect(evt).toBeDefined()
+      expect(evt!.payload.updates.linkPreview?.title).toBe('Legacy Wrapped')
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1582,10 +1582,13 @@ export class Chat extends BaseModule {
     if (preview.image) metaElements.push(xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:image', content: preview.image }))
     if (preview.siteName) metaElements.push(xml('meta', { xmlns: 'http://www.w3.org/1999/xhtml', property: 'og:site_name', content: preview.siteName }))
 
+    // The OGP <meta> elements are direct children of <apply-to>, matching the
+    // de-facto convention (Prosody mod_ogp, Movim, Gajim). Do NOT wrap them in
+    // <external>: per XEP-0422 <external> is an empty pointer to a top-level
+    // stanza child, so wrapping payload in it makes the fastening invalid and
+    // interop clients silently drop the preview.
     const children: Element[] = [
-      xml('apply-to', { xmlns: NS_FASTEN, id: originalId },
-        xml('external', { xmlns: NS_FASTEN, name: 'ogp' }, ...metaElements)
-      ),
+      xml('apply-to', { xmlns: NS_FASTEN, id: originalId }, ...metaElements),
       xml('no-store', { xmlns: NS_HINTS }),
     ]
 

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
@@ -1029,5 +1029,49 @@ describe('messagingUtils', () => {
       ])
       expect(parseOgpFastening(applyTo)).toBeNull()
     })
+
+    it('parses a url-only preview (title/description/image/siteName optional)', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        meta('og:url', 'https://example.com/a'),
+      ])
+      expect(parseOgpFastening(applyTo)).toEqual({ url: 'https://example.com/a' })
+    })
+
+    it('skips meta elements missing a content attribute', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        meta('og:url', 'https://example.com/a'),
+        { name: 'meta', attrs: { xmlns: NS_XHTML, property: 'og:title' } }, // no content
+      ])
+      expect(parseOgpFastening(applyTo)).toEqual({ url: 'https://example.com/a' })
+    })
+
+    it('ignores og properties it does not map (only the known set is extracted)', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        meta('og:url', 'https://example.com/a'),
+        meta('og:locale', 'en_US'),
+        meta('og:type', 'article'),
+        meta('og:title', 'Title'),
+      ])
+      expect(parseOgpFastening(applyTo)).toEqual({
+        url: 'https://example.com/a',
+        title: 'Title',
+      })
+    })
+
+    it('prefers the legacy <external> wrapper when both shapes are present', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        {
+          name: 'external',
+          attrs: { xmlns: 'urn:xmpp:fasten:0', name: 'ogp' },
+          children: [meta('og:url', 'https://legacy.example.com'), meta('og:title', 'Legacy')],
+        },
+        meta('og:url', 'https://direct.example.com'),
+        meta('og:title', 'Direct'),
+      ])
+      expect(parseOgpFastening(applyTo)).toEqual({
+        url: 'https://legacy.example.com',
+        title: 'Legacy',
+      })
+    })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyRetraction, applyCorrection, parseOobData, parseMessageContent, parseOriginId, parseStanzaId, createOriginIdElement, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal, isMessageSignal } from './messagingUtils'
+import { applyRetraction, applyCorrection, parseOobData, parseMessageContent, parseOriginId, parseStanzaId, createOriginIdElement, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal, isMessageSignal, parseOgpFastening } from './messagingUtils'
 import { createMockElement } from '../test-utils'
 
 describe('messagingUtils', () => {
@@ -975,6 +975,59 @@ describe('messagingUtils', () => {
         const stanza = createMockElement('message', {}, [{ name: 'body', text: 'hello' }])
         expect(isMessageSignal(stanza)).toBe(false)
       })
+    })
+  })
+
+  describe('parseOgpFastening', () => {
+    const NS_XHTML = 'http://www.w3.org/1999/xhtml'
+    const meta = (property: string, content: string) => ({
+      name: 'meta',
+      attrs: { xmlns: NS_XHTML, property, content },
+    })
+
+    it('parses OGP meta as direct children of apply-to (mod_ogp / interop shape)', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        meta('og:url', 'https://example.com/a'),
+        meta('og:title', 'Title'),
+        meta('og:description', 'Desc'),
+        meta('og:image', 'https://example.com/i.jpg'),
+        meta('og:site_name', 'Example'),
+      ])
+
+      expect(parseOgpFastening(applyTo)).toEqual({
+        url: 'https://example.com/a',
+        title: 'Title',
+        description: 'Desc',
+        image: 'https://example.com/i.jpg',
+        siteName: 'Example',
+      })
+    })
+
+    it('still parses the legacy <external name="ogp"> wrapper for backward compatibility', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        {
+          name: 'external',
+          attrs: { xmlns: 'urn:xmpp:fasten:0', name: 'ogp' },
+          children: [meta('og:url', 'https://example.com/a'), meta('og:title', 'Title')],
+        },
+      ])
+
+      expect(parseOgpFastening(applyTo)).toEqual({
+        url: 'https://example.com/a',
+        title: 'Title',
+      })
+    })
+
+    it('returns null when there are no meta elements', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [])
+      expect(parseOgpFastening(applyTo)).toBeNull()
+    })
+
+    it('returns null when og:url is missing', () => {
+      const applyTo = createMockElement('apply-to', { xmlns: 'urn:xmpp:fasten:0', id: 'orig' }, [
+        meta('og:title', 'Title'),
+      ])
+      expect(parseOgpFastening(applyTo)).toBeNull()
     })
   })
 })

--- a/packages/fluux-sdk/src/core/modules/messagingUtils.ts
+++ b/packages/fluux-sdk/src/core/modules/messagingUtils.ts
@@ -36,12 +36,12 @@ import { logWarn } from '../logger'
  * Returns LinkPreview if valid OGP metadata is found, null otherwise.
  */
 export function parseOgpFastening(applyToEl: Element): LinkPreview | null {
-  // Look for external element containing OGP meta-tags
+  // OGP <meta> elements are direct children of <apply-to> (Prosody mod_ogp
+  // convention). Older Fluux builds wrapped them in <external name='ogp'>, which
+  // is invalid per XEP-0422 — still accept that shape so previews sent by those
+  // builds keep rendering.
   const externalEl = applyToEl.getChild('external', NS_FASTEN)
-  if (!externalEl) return null
-
-  // Get all meta-elements with OGP properties
-  const metaEls = externalEl.getChildren('meta', NS_XHTML)
+  const metaEls = (externalEl ?? applyToEl).getChildren('meta', NS_XHTML)
   if (metaEls.length === 0) return null
 
   let url: string | undefined


### PR DESCRIPTION
Two independent fixes for website/link previews, both from a user report.

## 1. Interop: emit OGP `<meta>` directly under `<apply-to>`
We wrapped the Open Graph meta elements in `<external name='ogp'>` inside the XEP-0422 fastening. Per XEP-0422, `<external>` is an empty pointer to a top-level stanza child, so wrapping payload in it is invalid — Gajim, Movim and Prosody mod_ogp look for `<meta>` directly under `<apply-to>` and silently drop ours. Only Fluux↔Fluux worked.

Now we emit `<meta>` as direct children of `<apply-to>` (the mod_ogp convention). The parser reads them directly and still accepts the legacy `<external>` shape for previews sent by older builds.

## 2. Performance: fetch metadata off the main thread
`fetch_url_metadata` was a synchronous Tauri command doing a blocking reqwest request (10s timeout) plus an HTML parse. Synchronous commands run on the main thread, freezing the whole app while the URL is fetched — most visibly on Linux/WebKitGTK where the webview renders on that same thread. Made the command async and offloaded the work to `spawn_blocking`.