### PR TITLE
Room typing follow-ups: draft precedence + RTL-safe text

### DIFF
--- a/apps/fluux/src/components/conversation/TypingIndicator.tsx
+++ b/apps/fluux/src/components/conversation/TypingIndicator.tsx
@@ -81,7 +81,7 @@ export function TypingIndicator({ typingUsers, formatUser, className = '', varia
         <span className="size-1.5 rounded-full typing-dot" />
         <span className="size-1.5 rounded-full typing-dot" />
       </span>
-      <span className={variant === 'compact' ? 'truncate' : ''}>{text}</span>
+      <span dir="auto" className={variant === 'compact' ? 'truncate' : ''}>{text}</span>
     </div>
   )
 }

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -344,8 +344,10 @@ export const RoomItem = memo(function RoomItem({
   // user is caught up on (zero unread) and is not currently viewing — the moment
   // a settled conversation is about to get a new message. Busy rooms keep their
   // unread badge and paint no typing (the two never fight for the same pixels).
+  // A pending draft wins over typing: your own unsent text is the stronger
+  // personal signal, so we never hide it behind someone else's composing.
   const typingNicks =
-    room.joined && room.unreadCount === 0 && !isActive
+    room.joined && room.unreadCount === 0 && !isActive && !draft
       ? visibleRoomTypingNicks(room, ignoredForRoom)
       : []
   const showTyping = typingNicks.length > 0

--- a/apps/fluux/src/components/sidebar-components/RoomsList.typing.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.typing.test.tsx
@@ -142,19 +142,21 @@ describe('RoomItem sidebar typing', () => {
     expect(screen.queryByText('chat.typing.one')).toBeNull()
   })
 
-  it('shows typing instead of the draft line when someone is typing', () => {
+  it('keeps the draft line and suppresses typing when a draft is present', () => {
+    // A pending draft is the user's own content — it wins over an occupant's
+    // transient composing, so typing is not shown while a draft exists.
     renderRoom(makeRoom({ typingUsers: new Set(['Alice']) }), false, {
-      draft: 'hello there',
-    })
-    expect(screen.getByText('chat.typing.one')).toBeTruthy()
-    expect(screen.queryByText('conversations.draft', { exact: false })).toBeNull()
-  })
-
-  it('reverts to the draft line once typing stops', () => {
-    renderRoom(makeRoom({ typingUsers: new Set() }), false, {
       draft: 'hello there',
     })
     expect(screen.queryByText('chat.typing.one')).toBeNull()
     expect(screen.getByText('conversations.draft', { exact: false })).toBeTruthy()
+  })
+
+  it('shows typing once the draft is cleared', () => {
+    renderRoom(makeRoom({ typingUsers: new Set(['Alice']) }), false, {
+      draft: undefined,
+    })
+    expect(screen.getByText('chat.typing.one')).toBeTruthy()
+    expect(screen.queryByText('conversations.draft', { exact: false })).toBeNull()
   })
 })

--- a/apps/fluux/src/utils/roomTyping.ts
+++ b/apps/fluux/src/utils/roomTyping.ts
@@ -6,7 +6,9 @@ import type { IgnoredUser } from '@fluux/sdk/stores'
  * nick and any ignored users removed. Order-preserving. Returns [] when none apply.
  *
  * Mirrors the ignore filter RoomView applies to its live typing indicator so the
- * sidebar and the open room agree on who counts as typing.
+ * sidebar and the open room agree on who counts as typing, and additionally
+ * excludes the user's own nick (RoomView's live filter does not) — you never
+ * surface your own composing on your own row.
  */
 export function visibleRoomTypingNicks(room: Room, ignoredForRoom: IgnoredUser[]): string[] {
   if (!room.typingUsers || room.typingUsers.size === 0) return []


### PR DESCRIPTION
Three deferred minors from the gated room-typing feature (#896).

- **Draft wins over typing.** A pending draft in a caught-up room now suppresses the room typing indicator instead of being replaced by it — your own unsent text is the stronger personal signal. Reverses the earlier "typing replaces the draft line" behavior. (`RoomsList.tsx` gate gains `&& !draft`.)
- **RTL-safe typing text.** The typing label span gets `dir="auto"`, so a typing nick in an RTL script gets correct bidi (applies to both the sidebar compact indicator and the message-view one). (`TypingIndicator.tsx`)
- **JSDoc clarification.** `visibleRoomTypingNicks` notes it adds own-nick exclusion on top of RoomView's ignore filter.

Flipped the draft-precedence test to assert draft-wins.