### PR TITLE
Aurora-color the 1:1 sidebar typing overlay

### DIFF
--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -448,9 +448,10 @@ export function Avatar({
 export function TypingIndicator() {
   return (
     <div className="absolute -bottom-0.5 -end-0.5 w-5 h-3.5 bg-fluux-bg rounded-full border-2 border-fluux-sidebar flex items-center justify-center gap-0.5">
-      <span className="size-1 bg-fluux-muted rounded-full animate-typing-dot-1" />
-      <span className="size-1 bg-fluux-muted rounded-full animate-typing-dot-2" />
-      <span className="size-1 bg-fluux-muted rounded-full animate-typing-dot-3" />
+      {/* Aurora-shimmer dots, matching the room sidebar typing indicator (delays + colors in CSS). */}
+      <span className="size-1 rounded-full typing-dot" />
+      <span className="size-1 rounded-full typing-dot" />
+      <span className="size-1 rounded-full typing-dot" />
     </div>
   )
 }

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1287,33 +1287,6 @@ input[type="range"]::-moz-range-thumb {
   will-change: transform, opacity;
 }
 
-/* Typing indicator animation - three dots bouncing */
-@keyframes typing-dot {
-  0%, 60%, 100% {
-    transform: translateY(0);
-    opacity: 0.5;
-  }
-  30% {
-    transform: translateY(-2px);
-    opacity: 1;
-  }
-}
-
-.animate-typing-dot-1 {
-  animation: typing-dot 1.2s ease-in-out infinite;
-  animation-delay: 0s;
-}
-
-.animate-typing-dot-2 {
-  animation: typing-dot 1.2s ease-in-out infinite;
-  animation-delay: 0.2s;
-}
-
-.animate-typing-dot-3 {
-  animation: typing-dot 1.2s ease-in-out infinite;
-  animation-delay: 0.4s;
-}
-
 /* Sidebar view enter animation - gentle fade in on view switch */
 @keyframes sidebar-view-enter {
   from { opacity: 0; }


### PR DESCRIPTION
Makes the 1:1 avatar typing overlay use the same aurora-shimmer `.typing-dot` styling as the room sidebar typing indicator (#896), instead of grey `bg-fluux-muted` dots. Both indicators now derive their color from one shared CSS rule.

Also removes the now-dead `@keyframes typing-dot` and `.animate-typing-dot-*` classes — the overlay was their only consumer.