### PR TITLE
fix(muc): nick change (change nick, occupant list, timeline notice) + command-menu dismiss

### DIFF
--- a/apps/fluux/src/commands/registry.test.ts
+++ b/apps/fluux/src/commands/registry.test.ts
@@ -11,6 +11,7 @@ function makeCtx(overrides: Partial<CommandContext> = {}): CommandContext {
     sdk: {
       joinRoom: vi.fn().mockResolvedValue(undefined),
       joinResult: vi.fn().mockResolvedValue(undefined),
+      changeNick: vi.fn().mockResolvedValue(undefined),
       leaveRoom: vi.fn().mockResolvedValue(undefined),
       setSubject: vi.fn().mockResolvedValue(undefined),
       setRole: vi.fn().mockResolvedValue(undefined),
@@ -112,11 +113,19 @@ describe('runCommand', () => {
     expect(ctx.sdk.setAffiliation).not.toHaveBeenCalled()
   })
 
-  it('/nick rejoins and reports a conflict', async () => {
+  it('/nick changes the nick and reports success', async () => {
     const ctx = makeCtx()
-    ;(ctx.sdk.joinResult as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ condition: 'conflict' })
+    const res = await runCommand({ kind: 'command', name: 'nick', args: 'newname' }, ctx)
+    expect(ctx.sdk.changeNick).toHaveBeenCalledWith('room@conf.example.com', 'newname')
+    expect(ctx.sdk.joinRoom).not.toHaveBeenCalled()
+    expect(res).toEqual({ ok: true, toast: expect.stringContaining('commands.nick.changed') })
+  })
+
+  it('/nick reports a conflict when the nick is taken', async () => {
+    const ctx = makeCtx()
+    ;(ctx.sdk.changeNick as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ condition: 'conflict' })
     const res = await runCommand({ kind: 'command', name: 'nick', args: 'taken' }, ctx)
-    expect(ctx.sdk.joinRoom).toHaveBeenCalledWith('room@conf.example.com', 'taken')
+    expect(ctx.sdk.changeNick).toHaveBeenCalledWith('room@conf.example.com', 'taken')
     expect(res).toEqual({ ok: false, error: expect.stringContaining('commands.error.nickInUse') })
   })
 

--- a/apps/fluux/src/commands/registry.ts
+++ b/apps/fluux/src/commands/registry.ts
@@ -64,8 +64,7 @@ const nick: SlashCommand = {
     const newNick = args.trim()
     if (!newNick) return { ok: false, error: ctx.t('commands.error.needNick') }
     try {
-      await ctx.sdk.joinRoom(ctx.entityJid, newNick)
-      await ctx.sdk.joinResult(ctx.entityJid)
+      await ctx.sdk.changeNick(ctx.entityJid, newNick)
       return { ok: true, toast: ctx.t('commands.nick.changed', { nick: newNick }) }
     } catch (e) {
       if (joinErrorCondition(e) === 'conflict') {

--- a/apps/fluux/src/commands/types.ts
+++ b/apps/fluux/src/commands/types.ts
@@ -18,6 +18,7 @@ export interface CommandSelf {
 export interface CommandSdk {
   joinRoom(jid: string, nick: string): Promise<void>
   joinResult(jid: string): Promise<void>
+  changeNick(jid: string, newNick: string): Promise<void>
   leaveRoom(jid: string): Promise<void>
   setSubject(jid: string, subject: string): Promise<void>
   setRole(jid: string, nick: string, role: RoomRole, reason?: string): Promise<void>

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1096,6 +1096,7 @@ export const MessageInput = memo(function MessageInput({
       sdk: {
         joinRoom: notInRoom,
         joinResult: notInRoom,
+        changeNick: notInRoom,
         leaveRoom: notInRoom,
         setSubject: notInRoom,
         setRole: notInRoom,

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -5,7 +5,7 @@ import { useRoomActive, usePolls, useRoomModeration, useRoomManagement, useRoomE
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useMessageHoverState, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, useRoomOccupantCountBelow, isSmallScreen } from '@/hooks'
-import { MessageBubble, MessageList, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, decideChatStateRoute, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
+import { MessageBubble, MessageList, RoomSystemLine, shouldShowAvatar, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, decideChatStateRoute, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
 import { Avatar } from './Avatar'
@@ -1048,6 +1048,11 @@ export const RoomMessageList = memo(function RoomMessageList({
   })
 
   const renderMessage = (msg: RoomMessage, idx: number, groupMessages: RoomMessage[]) => {
+    // System notices (e.g. nick changes) render as a centered line, not a bubble.
+    if (msg.systemEvent) {
+      return <RoomSystemLine event={msg.systemEvent} />
+    }
+
     const sender = resolveRoomSender(msg, room, contactsByJid, selfOccupant)
 
     // Resolve the reply-preview avatar to PRIMITIVES (the wrapper builds the

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -2033,6 +2033,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
           commandMenu.dismiss()
         }
       }}
+      onDismiss={commandMenu.dismiss}
     />
   ) : (
     mentionDropdown

--- a/apps/fluux/src/components/composer/CommandMenu.test.tsx
+++ b/apps/fluux/src/components/composer/CommandMenu.test.tsx
@@ -10,14 +10,31 @@ describe('CommandMenu', () => {
   const nick = COMMANDS.find((c) => c.name === 'nick')!
 
   it('renders one row per match with the command name', () => {
-    render(<CommandMenu matches={[kick, nick]} selectedIndex={0} onSelect={() => {}} />)
+    render(<CommandMenu matches={[kick, nick]} selectedIndex={0} onSelect={() => {}} onDismiss={() => {}} />)
     expect(screen.getByText('/kick')).toBeInTheDocument()
     expect(screen.getByText('/nick')).toBeInTheDocument()
   })
   it('fires onSelect with the clicked index', () => {
     const onSelect = vi.fn()
-    render(<CommandMenu matches={[kick, nick]} selectedIndex={0} onSelect={onSelect} />)
+    render(<CommandMenu matches={[kick, nick]} selectedIndex={0} onSelect={onSelect} onDismiss={() => {}} />)
     fireEvent.click(screen.getByText('/nick'))
     expect(onSelect).toHaveBeenCalledWith(1)
+  })
+  it('dismisses on a pointer press outside the popover', () => {
+    const onDismiss = vi.fn()
+    render(
+      <div>
+        <button type="button">outside</button>
+        <CommandMenu matches={[kick, nick]} selectedIndex={0} onSelect={() => {}} onDismiss={onDismiss} />
+      </div>,
+    )
+    fireEvent.pointerDown(screen.getByText('outside'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+  it('does not dismiss on a pointer press inside the popover', () => {
+    const onDismiss = vi.fn()
+    render(<CommandMenu matches={[kick, nick]} selectedIndex={0} onSelect={() => {}} onDismiss={onDismiss} />)
+    fireEvent.pointerDown(screen.getByText('/nick'))
+    expect(onDismiss).not.toHaveBeenCalled()
   })
 })

--- a/apps/fluux/src/components/composer/CommandMenu.tsx
+++ b/apps/fluux/src/components/composer/CommandMenu.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SlashCommand } from '../../commands/types'
 
@@ -5,17 +6,44 @@ interface CommandMenuProps {
   matches: SlashCommand[]
   selectedIndex: number
   onSelect: (index: number) => void
+  /** Dismiss the menu (e.g. a pointer press outside the popover). */
+  onDismiss: () => void
 }
 
 /** Command-name completion popover, rendered through MessageComposer's `aboveInput` slot. */
-export function CommandMenu({ matches, selectedIndex, onSelect }: CommandMenuProps) {
+export function CommandMenu({ matches, selectedIndex, onSelect, onDismiss }: CommandMenuProps) {
   const { t } = useTranslation()
+  const selectedRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Keep the keyboard-highlighted item visible as selection moves past the popover edges.
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  // Dismiss on a pointer press anywhere outside the popover. A press on the
+  // composer's own textarea moves the caret, which already closes the menu via
+  // the match check, so we only need to guard the menu's own subtree here.
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        onDismiss()
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [onDismiss])
+
   if (matches.length === 0) return null
   return (
-    <div className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto fluux-popover rounded-lg z-30">
+    <div
+      ref={menuRef}
+      className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto fluux-popover rounded-lg z-30"
+    >
       {matches.map((cmd, idx) => (
         <button
           key={cmd.name}
+          ref={idx === selectedIndex ? selectedRef : undefined}
           type="button"
           onClick={() => onSelect(idx)}
           className={`w-full px-3 py-2 text-start text-sm flex items-baseline gap-2 transition-colors ${

--- a/apps/fluux/src/components/conversation/RoomSystemLine.test.tsx
+++ b/apps/fluux/src/components/conversation/RoomSystemLine.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RoomSystemLine } from './RoomSystemLine'
+
+describe('RoomSystemLine', () => {
+  it('renders a localized nick-change notice', () => {
+    render(<RoomSystemLine event={{ kind: 'nick-changed', oldNick: 'alice', newNick: 'alice2' }} />)
+    expect(screen.getByText('alice is now known as alice2')).toBeInTheDocument()
+  })
+
+  it('renders nothing for an unknown event kind', () => {
+    // @ts-expect-error — exercising the defensive default branch
+    const { container } = render(<RoomSystemLine event={{ kind: 'unknown' }} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/fluux/src/components/conversation/RoomSystemLine.tsx
+++ b/apps/fluux/src/components/conversation/RoomSystemLine.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next'
+import type { RoomSystemEvent } from '@fluux/sdk'
+
+export interface RoomSystemLineProps {
+  event: RoomSystemEvent
+}
+
+/**
+ * Centered, muted timeline notice for a room system event (currently occupant
+ * nick changes). Deliberately lighter than {@link DateSeparator}/{@link
+ * HistoryStartMarker} (no flanking rules) so a rename reads as an inline aside
+ * rather than a structural divider. Transient and session-scoped — see
+ * {@link RoomSystemEvent}.
+ */
+export function RoomSystemLine({ event }: RoomSystemLineProps) {
+  const { t } = useTranslation()
+
+  let text: string
+  switch (event.kind) {
+    case 'nick-changed':
+      text = t('rooms.nickChanged', { oldNick: event.oldNick, newNick: event.newNick })
+      break
+    default:
+      return null
+  }
+
+  return (
+    <div className="flex justify-center py-1.5 px-4">
+      <span className="text-xs text-fluux-muted text-center">{text}</span>
+    </div>
+  )
+}

--- a/apps/fluux/src/components/conversation/index.ts
+++ b/apps/fluux/src/components/conversation/index.ts
@@ -18,6 +18,9 @@ export { NewMessageMarker } from './NewMessageMarker'
 export { HistoryStartMarker } from './HistoryStartMarker'
 export { HistoryGapMarker } from './HistoryGapMarker'
 
+export { RoomSystemLine } from './RoomSystemLine'
+export type { RoomSystemLineProps } from './RoomSystemLine'
+
 export { MessageBubble, buildReplyContext } from './MessageBubble'
 export type { MessageBubbleProps } from './MessageBubble'
 

--- a/apps/fluux/src/hooks/useRoomCommandContext.ts
+++ b/apps/fluux/src/hooks/useRoomCommandContext.ts
@@ -17,7 +17,7 @@ interface RoomCommandContextArgs {
 export function useRoomCommandContext(args: RoomCommandContextArgs): CommandContext {
   const { roomJid, self, occupants, currentSubject, onOpenHelp, sendEasterEgg } = args
   const { t } = useTranslation()
-  const { joinRoom, joinResult, leaveRoom } = useRoomActions()
+  const { joinRoom, joinResult, changeNick, leaveRoom } = useRoomActions()
   const { setRole, setAffiliation } = useRoomModeration()
   const { setSubject, inviteToRoom } = useRoomManagement()
   const openInvite = useRoomUiStore((s) => s.openInvite)
@@ -32,6 +32,7 @@ export function useRoomCommandContext(args: RoomCommandContextArgs): CommandCont
       sdk: {
         joinRoom: (jid, nick) => joinRoom(jid, nick),
         joinResult: (jid) => joinResult(jid),
+        changeNick: (jid, newNick) => changeNick(jid, newNick),
         leaveRoom: (jid) => leaveRoom(jid),
         setSubject: (jid, subject) => setSubject(jid, subject),
         setRole: (jid, nick, role, reason) => setRole(jid, nick, role, reason),
@@ -45,7 +46,7 @@ export function useRoomCommandContext(args: RoomCommandContextArgs): CommandCont
     }),
     [
       roomJid, self, currentSubject, occupants, onOpenHelp, sendEasterEgg,
-      joinRoom, joinResult, leaveRoom, setSubject, setRole, setAffiliation, inviteToRoom,
+      joinRoom, joinResult, changeNick, leaveRoom, setSubject, setRole, setAffiliation, inviteToRoom,
       openInvite, openConfig, t,
     ],
   )

--- a/apps/fluux/src/hooks/useSlashCommands.test.tsx
+++ b/apps/fluux/src/hooks/useSlashCommands.test.tsx
@@ -12,6 +12,7 @@ function ctx(overrides: Partial<CommandContext> = {}): CommandContext {
     sdk: {
       joinRoom: vi.fn().mockResolvedValue(undefined),
       joinResult: vi.fn().mockResolvedValue(undefined),
+      changeNick: vi.fn().mockResolvedValue(undefined),
       leaveRoom: vi.fn().mockResolvedValue(undefined),
       setSubject: vi.fn().mockResolvedValue(undefined),
       setRole: vi.fn().mockResolvedValue(undefined),

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -424,7 +424,8 @@
         "hatUnassignError": "فشل إزالة الشارة",
         "selectHat": "اختيار شارة",
         "hatJidPlaceholder": "user@example.com",
-        "invitationsHeading": "الدعوات"
+        "invitationsHeading": "الدعوات",
+        "nickChanged": "أصبح {{oldNick}} يُعرف الآن باسم {{newNick}}"
     },
     "events": {
         "invitedBy": "دعوة من {{name}}",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Інфармацыя пра карыстальніка",
         "manageOccupant": "Кіраванне",
-        "invitationsHeading": "Запрашэнні"
+        "invitationsHeading": "Запрашэнні",
+        "nickChanged": "{{oldNick}} цяпер вядомы як {{newNick}}"
     },
     "events": {
         "invitedBy": "Запрошаны {{name}}",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Информация за потребителя",
         "manageOccupant": "Управление",
-        "invitationsHeading": "Покани"
+        "invitationsHeading": "Покани",
+        "nickChanged": "{{oldNick}} вече е познат като {{newNick}}"
     },
     "events": {
         "invitedBy": "Поканен от {{name}}",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info de l'usuari",
         "manageOccupant": "Gestionar",
-        "invitationsHeading": "Invitacions"
+        "invitationsHeading": "Invitacions",
+        "nickChanged": "{{oldNick}} ara es coneix com a {{newNick}}"
     },
     "events": {
         "invitedBy": "Convidat per {{name}}",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informace o uživateli",
         "manageOccupant": "Spravovat",
-        "invitationsHeading": "Pozvánky"
+        "invitationsHeading": "Pozvánky",
+        "nickChanged": "{{oldNick}} je nyní znám jako {{newNick}}"
     },
     "events": {
         "invitedBy": "Pozval(a) {{name}}",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Brugerinfo",
         "manageOccupant": "Administrer",
-        "invitationsHeading": "Invitationer"
+        "invitationsHeading": "Invitationer",
+        "nickChanged": "{{oldNick}} er nu kendt som {{newNick}}"
     },
     "events": {
         "invitedBy": "Inviteret af {{name}}",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Benutzerinfo",
         "manageOccupant": "Verwalten",
-        "invitationsHeading": "Einladungen"
+        "invitationsHeading": "Einladungen",
+        "nickChanged": "{{oldNick}} heißt jetzt {{newNick}}"
     },
     "events": {
         "invitedBy": "Eingeladen von {{name}}",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -425,7 +425,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Πληροφορίες χρήστη",
         "manageOccupant": "Διαχείριση",
-        "invitationsHeading": "Προσκλήσεις"
+        "invitationsHeading": "Προσκλήσεις",
+        "nickChanged": "{{oldNick}} είναι πλέον γνωστός ως {{newNick}}"
     },
     "events": {
         "invitedBy": "Πρόσκληση από {{name}}",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -424,7 +424,8 @@
         "hatUnassignError": "Failed to remove hat",
         "selectHat": "Select hat",
         "hatJidPlaceholder": "user@example.com",
-        "invitationsHeading": "Invitations"
+        "invitationsHeading": "Invitations",
+        "nickChanged": "{{oldNick}} is now known as {{newNick}}"
     },
     "events": {
         "invitedBy": "Invited by {{name}}",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info del usuario",
         "manageOccupant": "Gestionar",
-        "invitationsHeading": "Invitaciones"
+        "invitationsHeading": "Invitaciones",
+        "nickChanged": "{{oldNick}} ahora se conoce como {{newNick}}"
     },
     "events": {
         "invitedBy": "Invitado por {{name}}",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Kasutaja teave",
         "manageOccupant": "Halda",
-        "invitationsHeading": "Kutsed"
+        "invitationsHeading": "Kutsed",
+        "nickChanged": "{{oldNick}} on nüüd tuntud kui {{newNick}}"
     },
     "events": {
         "invitedBy": "Kutsuja {{name}}",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Käyttäjätiedot",
         "manageOccupant": "Hallitse",
-        "invitationsHeading": "Kutsut"
+        "invitationsHeading": "Kutsut",
+        "nickChanged": "{{oldNick}} tunnetaan nyt nimellä {{newNick}}"
     },
     "events": {
         "invitedBy": "Kutsuja: {{name}}",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -425,7 +425,8 @@
         "selectHat": "Sélectionner un badge",
         "hatJidPlaceholder": "user@example.com",
         "manageOccupant": "Gérer",
-        "invitationsHeading": "Invitations"
+        "invitationsHeading": "Invitations",
+        "nickChanged": "{{oldNick}} est désormais connu sous le nom de {{newNick}}"
     },
     "events": {
         "invitedBy": "Invité par {{name}}",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Eolas úsáideora",
         "manageOccupant": "Bainistigh",
-        "invitationsHeading": "Cuirí"
+        "invitationsHeading": "Cuirí",
+        "nickChanged": "Tugtar {{newNick}} ar {{oldNick}} anois"
     },
     "events": {
         "invitedBy": "Cuireadh ag {{name}}",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -424,7 +424,8 @@
         "hatUnassignError": "הסרת התג נכשלה",
         "selectHat": "בחר תג",
         "hatJidPlaceholder": "user@example.com",
-        "invitationsHeading": "הזמנות"
+        "invitationsHeading": "הזמנות",
+        "nickChanged": "{{oldNick}} ידוע כעת בשם {{newNick}}"
     },
     "events": {
         "invitedBy": "הוזמן על ידי {{name}}",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Podaci o korisniku",
         "manageOccupant": "Upravljaj",
-        "invitationsHeading": "Pozivnice"
+        "invitationsHeading": "Pozivnice",
+        "nickChanged": "{{oldNick}} sada je poznat kao {{newNick}}"
     },
     "events": {
         "invitedBy": "Pozvao {{name}}",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Felhasználó adatai",
         "manageOccupant": "Kezelés",
-        "invitationsHeading": "Meghívók"
+        "invitationsHeading": "Meghívók",
+        "nickChanged": "{{oldNick}} mostantól {{newNick}} néven ismert"
     },
     "events": {
         "invitedBy": "Meghívta: {{name}}",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Notandaupplýsingar",
         "manageOccupant": "Stjórna",
-        "invitationsHeading": "Boð"
+        "invitationsHeading": "Boð",
+        "nickChanged": "{{oldNick}} er nú þekktur sem {{newNick}}"
     },
     "events": {
         "invitedBy": "Boðið af {{name}}",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info utente",
         "manageOccupant": "Gestisci",
-        "invitationsHeading": "Inviti"
+        "invitationsHeading": "Inviti",
+        "nickChanged": "{{oldNick}} ora è conosciuto come {{newNick}}"
     },
     "events": {
         "invitedBy": "Invitato da {{name}}",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Naudotojo informacija",
         "manageOccupant": "Valdyti",
-        "invitationsHeading": "Kvietimai"
+        "invitationsHeading": "Kvietimai",
+        "nickChanged": "{{oldNick}} dabar žinomas kaip {{newNick}}"
     },
     "events": {
         "invitedBy": "Pakvietė {{name}}",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -425,7 +425,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Lietotāja informācija",
         "manageOccupant": "Pārvaldīt",
-        "invitationsHeading": "Ielūgumi"
+        "invitationsHeading": "Ielūgumi",
+        "nickChanged": "{{oldNick}} tagad zināms kā {{newNick}}"
     },
     "events": {
         "invitedBy": "Uzaicināja {{name}}",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info tal-utent",
         "manageOccupant": "Immaniġġja",
-        "invitationsHeading": "Stedini"
+        "invitationsHeading": "Stedini",
+        "nickChanged": "{{oldNick}} issa magħruf bħala {{newNick}}"
     },
     "events": {
         "invitedBy": "Mistieden minn {{name}}",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Brukerinfo",
         "manageOccupant": "Administrer",
-        "invitationsHeading": "Invitasjoner"
+        "invitationsHeading": "Invitasjoner",
+        "nickChanged": "{{oldNick}} er nå kjent som {{newNick}}"
     },
     "events": {
         "invitedBy": "Invitert av {{name}}",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Gebruikersinfo",
         "manageOccupant": "Beheren",
-        "invitationsHeading": "Uitnodigingen"
+        "invitationsHeading": "Uitnodigingen",
+        "nickChanged": "{{oldNick}} heet nu {{newNick}}"
     },
     "events": {
         "invitedBy": "Uitgenodigd door {{name}}",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informacje o użytkowniku",
         "manageOccupant": "Zarządzaj",
-        "invitationsHeading": "Zaproszenia"
+        "invitationsHeading": "Zaproszenia",
+        "nickChanged": "{{oldNick}} jest teraz znany jako {{newNick}}"
     },
     "events": {
         "invitedBy": "Zaproszony przez {{name}}",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info do utilizador",
         "manageOccupant": "Gerir",
-        "invitationsHeading": "Convites"
+        "invitationsHeading": "Convites",
+        "nickChanged": "{{oldNick}} agora é conhecido como {{newNick}}"
     },
     "events": {
         "invitedBy": "Convidado por {{name}}",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informații utilizator",
         "manageOccupant": "Gestionează",
-        "invitationsHeading": "Invitații"
+        "invitationsHeading": "Invitații",
+        "nickChanged": "{{oldNick}} este acum cunoscut ca {{newNick}}"
     },
     "events": {
         "invitedBy": "Invitat de {{name}}",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Информация о пользователе",
         "manageOccupant": "Управление",
-        "invitationsHeading": "Приглашения"
+        "invitationsHeading": "Приглашения",
+        "nickChanged": "{{oldNick}} теперь известен как {{newNick}}"
     },
     "events": {
         "invitedBy": "Пригласил(а) {{name}}",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -425,7 +425,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informácie o používateľovi",
         "manageOccupant": "Spravovať",
-        "invitationsHeading": "Pozvánky"
+        "invitationsHeading": "Pozvánky",
+        "nickChanged": "{{oldNick}} je teraz známy ako {{newNick}}"
     },
     "events": {
         "invitedBy": "Pozval {{name}}",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -426,7 +426,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Podatki o uporabniku",
         "manageOccupant": "Upravljaj",
-        "invitationsHeading": "Vabila"
+        "invitationsHeading": "Vabila",
+        "nickChanged": "{{oldNick}} je zdaj znan kot {{newNick}}"
     },
     "events": {
         "invitedBy": "Povabil {{name}}",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Användarinfo",
         "manageOccupant": "Hantera",
-        "invitationsHeading": "Inbjudningar"
+        "invitationsHeading": "Inbjudningar",
+        "nickChanged": "{{oldNick}} är nu känd som {{newNick}}"
     },
     "events": {
         "invitedBy": "Inbjuden av {{name}}",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Інформація про користувача",
         "manageOccupant": "Керувати",
-        "invitationsHeading": "Запрошення"
+        "invitationsHeading": "Запрошення",
+        "nickChanged": "{{oldNick}} тепер відомий як {{newNick}}"
     },
     "events": {
         "invitedBy": "Запрошено {{name}}",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -424,7 +424,8 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "用户信息",
         "manageOccupant": "管理",
-        "invitationsHeading": "邀请"
+        "invitationsHeading": "邀请",
+        "nickChanged": "{{oldNick}} 现在称为 {{newNick}}"
     },
     "events": {
         "invitedBy": "邀请者 {{name}}",

--- a/apps/fluux/src/test-setup.ts
+++ b/apps/fluux/src/test-setup.ts
@@ -85,6 +85,7 @@ void i18n.use(initReactI18next).init({
           browseRooms: 'Browse Rooms',
           catchUpAll: 'Catch up all rooms',
           markAllRead: 'Mark all as read',
+          nickChanged: '{{oldNick}} is now known as {{newNick}}',
         },
         messages: {
           showArchived: 'Show archived conversations',

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -2385,6 +2385,18 @@ describe('MUC Module', () => {
 
       // Old nick dropped; not mistaken for the occupant leaving-and-gone.
       expect(mockEmitSDK).toHaveBeenCalledWith('room:occupant-left', { roomJid: ROOM, nick: 'alice' })
+      // A transient, non-persisted system notice is added to the timeline.
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:message', {
+        roomJid: ROOM,
+        message: expect.objectContaining({
+          type: 'groupchat',
+          body: '',
+          noLocalStore: true,
+          systemEvent: { kind: 'nick-changed', oldNick: 'alice', newNick: 'alice2' },
+        }),
+        incrementUnread: false,
+        incrementMentions: false,
+      })
       // The paired available presence for the new nick then re-adds the occupant.
       mockStores.room.getRoom.mockReturnValue(joinedRoom('mynick'))
       muc.handle(
@@ -2420,6 +2432,33 @@ describe('MUC Module', () => {
       expect(mockEmitSDK).toHaveBeenCalledWith('room:occupant-left', { roomJid: ROOM, nick: 'oldnick' })
       // …but the room is NOT flipped to "not joined".
       expect(mockEmitSDK).not.toHaveBeenCalledWith('room:joined', { roomJid: ROOM, joined: false })
+      // Self rename also drops a timeline notice, flagged outgoing.
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:message', {
+        roomJid: ROOM,
+        message: expect.objectContaining({
+          isOutgoing: true,
+          systemEvent: { kind: 'nick-changed', oldNick: 'oldnick', newNick: 'newnick' },
+        }),
+        incrementUnread: false,
+        incrementMentions: false,
+      })
+    })
+
+    it('does not emit a system notice when the 303 carries no new nick', () => {
+      const presence = createMockElement('presence', { from: `${ROOM}/bob`, type: 'unavailable' }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+          children: [
+            { name: 'item', attrs: {} },
+            { name: 'status', attrs: { code: '303' } },
+          ],
+        },
+      ])
+      muc.handle(presence)
+
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:occupant-left', { roomJid: ROOM, nick: 'bob' })
+      expect(mockEmitSDK).not.toHaveBeenCalledWith('room:message', expect.anything())
     })
 
     it('confirms the rename on the new self-presence without re-running join completion', async () => {

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -2315,4 +2315,151 @@ describe('MUC Module', () => {
       })
     })
   })
+
+  describe('changeNick (XEP-0045 §7.6)', () => {
+    const ROOM = 'room@conference.example.org'
+
+    const joinedRoom = (nickname: string) => ({
+      jid: ROOM,
+      name: 'room',
+      joined: true,
+      isJoining: false,
+      nickname,
+      isBookmarked: true,
+      occupants: new Map(),
+      messages: [],
+      unreadCount: 0,
+      mentionsCount: 0,
+      typingUsers: new Set<string>(),
+    })
+
+    /** A status-110 self-presence for `nick` (what the server echoes after a rename). */
+    const selfPresence = (nick: string) =>
+      createMockElement('presence', { from: `${ROOM}/${nick}` }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+          children: [
+            { name: 'item', attrs: { affiliation: 'member', role: 'participant' } },
+            { name: 'status', attrs: { code: '110' } },
+          ],
+        },
+      ])
+
+    it('sends a directed presence to the new nick (no history request)', async () => {
+      mockStores.room.getRoom.mockReturnValue(joinedRoom('oldnick'))
+      const p = muc.changeNick(ROOM, 'newnick')
+      muc.handle(selfPresence('newnick')) // server confirms → settles the promise
+      await p
+
+      const presence = mockSendStanza.mock.calls[0][0]
+      expect(presence.attrs.to).toBe(`${ROOM}/newnick`)
+      // Unlike joinRoom, a nick change carries no <x muc> / history child.
+      expect(presence.getChild('x')).toBeUndefined()
+    })
+
+    it('rejects when not currently in the room', async () => {
+      mockStores.room.getRoom.mockReturnValue(undefined)
+      await expect(muc.changeNick(ROOM, 'newnick')).rejects.toMatchObject({ condition: 'not-joined' })
+      expect(mockSendStanza).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when the new nick equals the current nick', async () => {
+      mockStores.room.getRoom.mockReturnValue(joinedRoom('samenick'))
+      await muc.changeNick(ROOM, 'samenick')
+      expect(mockSendStanza).not.toHaveBeenCalled()
+    })
+
+    it('renames another occupant on their status-303 unavailable (no room:joined change)', () => {
+      const presence = createMockElement('presence', { from: `${ROOM}/alice`, type: 'unavailable' }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+          children: [
+            { name: 'item', attrs: { nick: 'alice2' } },
+            { name: 'status', attrs: { code: '303' } },
+          ],
+        },
+      ])
+      muc.handle(presence)
+
+      // Old nick dropped; not mistaken for the occupant leaving-and-gone.
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:occupant-left', { roomJid: ROOM, nick: 'alice' })
+      // The paired available presence for the new nick then re-adds the occupant.
+      mockStores.room.getRoom.mockReturnValue(joinedRoom('mynick'))
+      muc.handle(
+        createMockElement('presence', { from: `${ROOM}/alice2` }, [
+          {
+            name: 'x',
+            attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+            children: [{ name: 'item', attrs: { affiliation: 'member', role: 'participant' } }],
+          },
+        ]),
+      )
+      expect(mockEmitSDK).toHaveBeenCalledWith(
+        'room:occupant-joined',
+        expect.objectContaining({ occupant: expect.objectContaining({ nick: 'alice2' }) }),
+      )
+    })
+
+    it('treats a self status-303 unavailable as a rename, not a room leave', () => {
+      const presence = createMockElement('presence', { from: `${ROOM}/oldnick`, type: 'unavailable' }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+          children: [
+            { name: 'item', attrs: { nick: 'newnick' } },
+            { name: 'status', attrs: { code: '303' } },
+            { name: 'status', attrs: { code: '110' } },
+          ],
+        },
+      ])
+      muc.handle(presence)
+
+      // Old-nick occupant removed…
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:occupant-left', { roomJid: ROOM, nick: 'oldnick' })
+      // …but the room is NOT flipped to "not joined".
+      expect(mockEmitSDK).not.toHaveBeenCalledWith('room:joined', { roomJid: ROOM, joined: false })
+    })
+
+    it('confirms the rename on the new self-presence without re-running join completion', async () => {
+      mockStores.room.getRoom.mockReturnValue(joinedRoom('oldnick'))
+      const p = muc.changeNick(ROOM, 'newnick')
+      muc.handle(selfPresence('newnick'))
+      await p
+
+      expect(mockEmitSDK).toHaveBeenCalledWith(
+        'room:self-occupant',
+        expect.objectContaining({ roomJid: ROOM, occupant: expect.objectContaining({ nick: 'newnick' }) }),
+      )
+      expect(mockEmitSDK).toHaveBeenCalledWith(
+        'room:occupant-joined',
+        expect.objectContaining({ occupant: expect.objectContaining({ nick: 'newnick' }) }),
+      )
+      // No full join completion: no room:joined toggle, no mucJoined side effects.
+      expect(mockEmitSDK).not.toHaveBeenCalledWith('room:joined', { roomJid: ROOM, joined: true })
+      expect(mockEmit).not.toHaveBeenCalledWith('mucJoined', expect.anything(), expect.anything())
+    })
+
+    it('rejects with conflict on an error presence and keeps the room joined', async () => {
+      mockStores.room.getRoom.mockReturnValue(joinedRoom('oldnick'))
+      const p = muc.changeNick(ROOM, 'taken')
+
+      const errorPresence = createMockElement('presence', { from: `${ROOM}/taken`, type: 'error' }, [
+        {
+          name: 'error',
+          attrs: { type: 'cancel' },
+          children: [{ name: 'conflict', attrs: { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' } }],
+        },
+      ])
+      muc.handle(errorPresence)
+
+      await expect(p).rejects.toMatchObject({ condition: 'conflict' })
+      // A failed rename must not mark the room as left — we're still in it under the old nick.
+      expect(mockEmitSDK).not.toHaveBeenCalledWith(
+        'room:updated',
+        expect.objectContaining({ updates: expect.objectContaining({ joined: false }) }),
+      )
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -235,6 +235,30 @@ export class MUC extends BaseModule {
       // also carries status 110 and must not flip the room to "not joined".
       if (statuses.includes('303')) {
         this.deps.emitSDK('room:occupant-left', { roomJid, nick })
+        const newNick = item?.attrs.nick
+        if (newNick && newNick !== nick) {
+          // Transient, session-scoped timeline notice ("<old> is now known as
+          // <new>"). Empty body → never a sidebar preview; noLocalStore → not
+          // persisted or indexed (presence isn't archived, so it can't be
+          // reconstructed on reload anyway).
+          this.deps.emitSDK('room:message', {
+            roomJid,
+            message: {
+              type: 'groupchat',
+              id: generateUUID(),
+              roomJid,
+              from: `${roomJid}/${nick}`,
+              nick,
+              body: '',
+              timestamp: new Date(),
+              isOutgoing: isSelf,
+              noLocalStore: true,
+              systemEvent: { kind: 'nick-changed', oldNick: nick, newNick },
+            },
+            incrementUnread: false,
+            incrementMentions: false,
+          })
+        }
         return
       }
       if (isSelf) {

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -120,12 +120,30 @@ interface JoinDeferred {
   settled: boolean
 }
 
+/**
+ * Awaitable outcome of an in-flight nick change (XEP-0045 §7.6), returned by
+ * {@link MUC.changeNick}. Distinct from {@link JoinDeferred} because a *failed*
+ * nick change (e.g. the new nick is taken) leaves the occupant still in the room
+ * under the old nick — it must never touch the room's `joined` state.
+ */
+interface NickChangeDeferred {
+  newNick: string
+  promise: Promise<void>
+  resolve: () => void
+  reject: (err: RoomJoinError) => void
+  settled: boolean
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
 export class MUC extends BaseModule {
   /** Track pending room joins for timeout handling */
   private pendingJoins = new Map<string, PendingJoin>()
 
   /** Track the awaitable outcome of in-flight joins (see joinResult). */
   private joinDeferreds = new Map<string, JoinDeferred>()
+
+  /** Track in-flight nick changes (see changeNick), keyed by room JID. */
+  private pendingNickChanges = new Map<string, NickChangeDeferred>()
 
   /**
    * Buffer for occupant presences during room join.
@@ -150,12 +168,17 @@ export class MUC extends BaseModule {
         this.handleMUCPresence(stanza, mucUser)
         return true
       }
-      // Join-error presences echo <x muc> (or nothing), not muc#user, so they
-      // miss the gate above. Route them to fail the in-flight join.
+      // Join- and nick-change-error presences echo <x muc> (or nothing), not
+      // muc#user, so they miss the gate above. Route them to fail whichever
+      // request is in flight for the room.
       if (stanza.attrs.type === 'error') {
         const roomJid = getBareJid(stanza.attrs.from ?? '')
         if (roomJid && this.pendingJoins.has(roomJid)) {
           this.failJoin(stanza, roomJid)
+          return true
+        }
+        if (roomJid && this.pendingNickChanges.has(roomJid)) {
+          this.failNickChange(roomJid, stanza)
           return true
         }
       }
@@ -184,6 +207,10 @@ export class MUC extends BaseModule {
     if (type === 'error') {
       if (this.pendingJoins.has(roomJid)) {
         this.failJoin(stanza, roomJid)
+      } else if (this.pendingNickChanges.has(roomJid)) {
+        // A rejected nick change (e.g. conflict) — we stay in the room under the
+        // old nick, so only settle the changeNick() outcome; leave room state alone.
+        this.failNickChange(roomJid, stanza)
       } else {
         console.error(`[MUC] Presence error for ${from}`)
       }
@@ -201,6 +228,15 @@ export class MUC extends BaseModule {
     const isSelf = statuses.includes('110')
 
     if (type === 'unavailable') {
+      // XEP-0045 §7.6: a nick change is signalled by <status code="303"/> on the
+      // OLD nick's unavailable presence (the new nick rides in <item nick="…"/>).
+      // Drop the old-nick occupant; the paired available presence for the new nick
+      // re-adds it. This is NOT a room-leave — even for self, whose 303 presence
+      // also carries status 110 and must not flip the room to "not joined".
+      if (statuses.includes('303')) {
+        this.deps.emitSDK('room:occupant-left', { roomJid, nick })
+        return
+      }
       if (isSelf) {
         // SDK event only - binding calls store.setRoomJoined
         this.deps.emitSDK('room:joined', { roomJid, joined: false })
@@ -250,6 +286,21 @@ export class MUC extends BaseModule {
     }
 
     if (isSelf) {
+      // Nick change confirmed (XEP-0045 §7.6): the server echoes our new nick as a
+      // self-presence. We never left the room, so update our occupant + nickname and
+      // add the renamed occupant WITHOUT the full join completion (no MAM refetch,
+      // re-bookmark, or room:joined toggle).
+      const pendingNick = this.pendingNickChanges.get(roomJid)
+      if (pendingNick && pendingNick.newNick === nick) {
+        this.clearPendingNickChange(roomJid, 'resolve')
+        this.deps.emitSDK('room:self-occupant', { roomJid, occupant })
+        this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
+        if (avatarHash) {
+          this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
+        }
+        return
+      }
+
       // Clear the join timeout - we successfully joined
       this.clearPendingJoin(roomJid)
       this.settleJoinSuccess(roomJid)
@@ -458,6 +509,10 @@ export class MUC extends BaseModule {
       }
     }
     this.joinDeferreds.clear()
+    // Reject any unresolved nick changes so changeNick() awaiters don't hang.
+    for (const roomJid of Array.from(this.pendingNickChanges.keys())) {
+      this.clearPendingNickChange(roomJid, new RoomJoinError(roomJid, 'timeout'))
+    }
   }
 
   /**
@@ -727,6 +782,102 @@ export class MUC extends BaseModule {
     logInfo(`Room left: ${roomJid}`)
     // SDK event only - binding calls store.updateRoom
     this.deps.emitSDK('room:updated', { roomJid, updates: { joined: false, isJoining: false } })
+  }
+
+  /**
+   * Change your nickname in a room you're already in (XEP-0045 §7.6).
+   *
+   * Sends a directed presence to `room@service/newNick`. Unlike {@link joinRoom},
+   * this does NOT re-join, clear the occupant list, or request history — the room
+   * membership is preserved and the server reconciles the change via a status-303
+   * unavailable presence (old nick) followed by the new self-presence.
+   *
+   * @param roomJid - The room JID
+   * @param newNick - The desired new nickname
+   * @returns Resolves when the server confirms the new nick, rejects with a
+   *   {@link RoomJoinError} (condition `'conflict'` when the nick is taken, or
+   *   `'timeout'` if the server never responds).
+   *
+   * @remarks
+   * - No-op (resolves immediately) when `newNick` is empty or equals the current nick.
+   * - Rejects immediately if the room isn't currently joined.
+   */
+  async changeNick(roomJid: string, newNick: string): Promise<void> {
+    const trimmed = newNick.trim()
+    const room = this.deps.stores?.room.getRoom(roomJid)
+    if (!room || !room.joined) {
+      throw new RoomJoinError(roomJid, 'not-joined', 'cancel', 'Not in room')
+    }
+    if (!trimmed || trimmed === room.nickname) return
+
+    // Replace any in-flight nick change for this room (last request wins).
+    this.clearPendingNickChange(roomJid)
+
+    let resolve!: () => void
+    let reject!: (err: RoomJoinError) => void
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    // Swallow the rejection so an unawaited changeNick() doesn't surface as an
+    // unhandled promise rejection; direct callers still observe it via the return.
+    promise.catch(() => {})
+
+    const timeoutId = setTimeout(() => {
+      this.failNickChangeTimeout(roomJid)
+    }, JOIN_TIMEOUT_MS)
+
+    this.pendingNickChanges.set(roomJid, {
+      newNick: trimmed,
+      promise,
+      resolve,
+      reject,
+      settled: false,
+      timeoutId,
+    })
+
+    // Preserve current presence show/status on the directed presence.
+    const currentPresence = this.deps.stores?.connection.getPresenceShow()
+    const currentStatus = this.deps.stores?.connection.getStatusMessage()
+    const children: Element[] = []
+    if (currentPresence && currentPresence !== 'online' && currentPresence !== 'offline') {
+      const showValue = currentPresence === 'away' ? 'away' : currentPresence === 'dnd' ? 'dnd' : undefined
+      if (showValue) children.push(xml('show', {}, showValue))
+    }
+    if (currentStatus) children.push(xml('status', {}, currentStatus))
+
+    const presence = xml('presence', { to: `${roomJid}/${trimmed}` }, ...children)
+    logInfo(`Changing nick in ${roomJid} to ${trimmed}`)
+    await this.deps.sendStanza(presence)
+
+    return promise
+  }
+
+  /** Clear a pending nick change, optionally settling its deferred first. */
+  private clearPendingNickChange(roomJid: string, settle?: 'resolve' | RoomJoinError): void {
+    const pending = this.pendingNickChanges.get(roomJid)
+    if (!pending) return
+    clearTimeout(pending.timeoutId)
+    if (settle && !pending.settled) {
+      pending.settled = true
+      if (settle === 'resolve') pending.resolve()
+      else pending.reject(settle)
+    }
+    this.pendingNickChanges.delete(roomJid)
+  }
+
+  /** Reject an in-flight nick change from a server error presence (e.g. conflict). */
+  private failNickChange(roomJid: string, stanza: Element): void {
+    const error = parseXMPPError(stanza)
+    this.clearPendingNickChange(
+      roomJid,
+      new RoomJoinError(roomJid, error?.condition ?? 'undefined-condition', error?.type, error?.text)
+    )
+  }
+
+  /** Reject an in-flight nick change that the server never acknowledged. */
+  private failNickChangeTimeout(roomJid: string): void {
+    this.clearPendingNickChange(roomJid, new RoomJoinError(roomJid, 'timeout'))
   }
 
   /**

--- a/packages/fluux-sdk/src/core/types/index.ts
+++ b/packages/fluux-sdk/src/core/types/index.ts
@@ -42,6 +42,7 @@ export type {
   RoomOccupant,
   RoomMember,
   RoomMessage,
+  RoomSystemEvent,
   RoomEntity,
   RoomMetadata,
   RoomRuntime,

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -106,6 +106,22 @@ export interface RoomMember {
 }
 
 /**
+ * A client-synthesized, non-persisted timeline notice describing a room
+ * occurrence rather than user-authored content. Rendered as a centered system
+ * line (not a message bubble) and never written to the local cache or search
+ * index — it is live-session-scoped and reconstructed from the presence stream,
+ * so it does not survive a reload (MAM does not archive presence).
+ *
+ * @category MUC
+ */
+export type RoomSystemEvent = {
+  /** XEP-0045 §7.6 occupant nick change. */
+  kind: 'nick-changed'
+  oldNick: string
+  newNick: string
+}
+
+/**
  * A message in a MUC room.
  *
  * Extends {@link BaseMessage} with MUC-specific fields like
@@ -149,6 +165,13 @@ export interface RoomMessage extends Omit<BaseMessage, 'type'> {
    * can't be mis-addressed. Absent in rooms without occupant-id support.
    */
   whisperWithOccupantId?: string
+  /**
+   * When present, this is a synthetic system notice (e.g. an occupant nick
+   * change) rather than user-authored content. The app renders a localized,
+   * centered line from this structured payload; `body` is empty so the entry is
+   * never surfaced as a sidebar preview. Always paired with `noLocalStore`.
+   */
+  systemEvent?: RoomSystemEvent
 }
 
 /**

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -63,6 +63,13 @@ export function useRoomActions() {
     [client]
   )
 
+  const changeNick = useCallback(
+    async (roomJid: string, newNick: string): Promise<void> => {
+      await client.muc.changeNick(roomJid, newNick)
+    },
+    [client]
+  )
+
   /**
    * Inspect a room via disco#info WITHOUT joining (no side effects). Use before
    * joining to decide whether to warn about real-JID exposure (issue #37). The
@@ -227,6 +234,7 @@ export function useRoomActions() {
       // Core: messaging / lifecycle / read-state / drafts / history
       joinRoom,
       joinResult,
+      changeNick,
       getRoomInfo,
       acknowledgeNonAnonymousRoom,
       isNonAnonymousRoomAcknowledged,
@@ -259,6 +267,7 @@ export function useRoomActions() {
     [
       joinRoom,
       joinResult,
+      changeNick,
       getRoomInfo,
       acknowledgeNonAnonymousRoom,
       isNonAnonymousRoomAcknowledged,

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -186,6 +186,13 @@ export function useRoomActive() {
     [client],
   )
 
+  const changeNick = useCallback(
+    async (roomJid: string, newNick: string): Promise<void> => {
+      await client.muc.changeNick(roomJid, newNick)
+    },
+    [client],
+  )
+
   // Pre-join room inspection + real-JID-exposure acknowledgement (issue #37)
   const getRoomInfo = useCallback(
     async (roomJid: string): Promise<RoomFeatures | null> => client.muc.queryRoomFeatures(roomJid),
@@ -386,6 +393,7 @@ export function useRoomActive() {
     () => ({
       joinRoom,
       joinResult,
+      changeNick,
       getRoomInfo,
       acknowledgeNonAnonymousRoom,
       isNonAnonymousRoomAcknowledged,
@@ -427,6 +435,7 @@ export function useRoomActive() {
     [
       joinRoom,
       joinResult,
+      changeNick,
       getRoomInfo,
       acknowledgeNonAnonymousRoom,
       isNonAnonymousRoomAcknowledged,

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -230,6 +230,7 @@ export type {
   // Room types (MUC)
   Room,
   RoomMessage,
+  RoomSystemEvent,
   RoomOccupant,
   RoomMember,
   RoomAffiliation,


### PR DESCRIPTION
## Summary

Fixes MUC nick changes end-to-end and adds an idiomatic "now known as" timeline notice.

### Nick change
`/nick` never changed the nickname — it called `joinRoom()`, which early-returns when you're already in the room, so no presence was ever sent.

- **`MUC.changeNick()`** (XEP-0045 §7.6): directed presence to `room/newNick`, no re-join / occupant-clear / history request. Wired through the room hooks, `CommandSdk`, and `/nick`.
- **Status-303 handling**: a self nick-change presence also carries status 110 and was mistaken for a room *leave*. Now 303 drops the old-nick occupant (self **and** other users) without touching room-joined state; the paired new-nick presence re-adds them.
- **Conflict safety**: a rejected rename (nick taken) rejects with `'conflict'` but leaves you in the room under your old nick — it uses its own tracking, not the join machinery.

### Timeline notice
When an occupant renames, a transient **"X is now known as Y"** line is shown in the room timeline (centered muted `RoomSystemLine`, for self and others).

- Modeled as a synthetic `RoomMessage` with a structured `systemEvent` (SDK stays i18n-free; the app renders `rooms.nickChanged`, translated across all 33 locales).
- `noLocalStore` + empty body → never persisted, indexed, or surfaced as a sidebar preview. Deliberately **not durable**: presence isn't archived (no MAM), so it can't be reconstructed on reload — persisting only the witnessed subset would be a misleading partial record.

### Command menu
Scrolls the keyboard-highlighted item into view, and dismisses the popover on an outside pointer press (Escape already worked).