### PR TITLE
refactor(hooks): options-object sendMessage; drop the groupchat wire-type leak (Phase 2)

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1050,7 +1050,7 @@ export const MessageInput = memo(function MessageInput({
   onCancelReply: () => void
   editingMessage: Message | null
   onCancelEdit: () => void
-  sendMessage: (to: string, body: string, type?: 'chat' | 'groupchat', replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } }, attachment?: import('@fluux/sdk').FileAttachment) => Promise<string>
+  sendMessage: (to: string, body: string, options?: { replyTo?: { id: string; to?: string; fallback?: { author: string; body: string; fromEncrypted?: boolean } }; attachment?: import('@fluux/sdk').FileAttachment }) => Promise<string>
   sendCorrection: (conversationId: string, messageId: string, newBody: string, attachment?: import('@fluux/sdk').FileAttachment) => Promise<void>
   retractMessage: (conversationId: string, messageId: string) => Promise<void>
   sendChatState: (to: string, state: import('@fluux/sdk').ChatStateNotification, type?: 'chat' | 'groupchat') => Promise<void>
@@ -1210,7 +1210,7 @@ export const MessageInput = memo(function MessageInput({
 
     // The body is the file URL if no text was entered, otherwise the user's text
     const body = text || attachment?.url || ''
-    const messageId = await sendMessage(conversationId, body, type, replyTo, attachment ?? undefined)
+    const messageId = await sendMessage(conversationId, body, { replyTo, attachment: attachment ?? undefined })
 
     // Notify parent of sent message ID for animation
     onMessageIdSent?.(messageId)

--- a/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useChatActions.sendMessage.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { XMPPProvider } from '../provider'
+import { createMockXMPPClientForHooks } from '../core/test-utils'
+import { useChatActions } from './useChatActions'
+
+const mockClient = createMockXMPPClientForHooks()
+
+vi.mock('../provider', async () => {
+  const actual = await vi.importActual('../provider')
+  return {
+    ...actual,
+    useXMPPContext: () => ({ client: mockClient }),
+  }
+})
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <XMPPProvider>{children}</XMPPProvider>
+}
+
+/**
+ * The 1:1 chat hook's sendMessage takes an options object and never exposes
+ * the wire-level message `type` — it always sends a 'chat' message. replyTo
+ * and attachment ride in the options object instead of positional args.
+ */
+describe('useChatActions.sendMessage (options object)', () => {
+  beforeEach(() => {
+    mockClient.chat.sendMessage.mockClear()
+    mockClient.chat.sendMessage.mockResolvedValue('msg-id-1')
+  })
+
+  it('sends a plain message as type "chat" with no reply/attachment', async () => {
+    const { result } = renderHook(() => useChatActions(), { wrapper })
+
+    await act(async () => {
+      await result.current.sendMessage('bob@example.com', 'hi')
+    })
+
+    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith(
+      'bob@example.com', 'hi', 'chat', undefined, undefined, undefined
+    )
+  })
+
+  it('forwards replyTo and attachment from the options object', async () => {
+    const { result } = renderHook(() => useChatActions(), { wrapper })
+
+    const replyTo = { id: 'm1', to: 'bob@example.com', fallback: { author: 'Bob', body: 'earlier' } }
+    const attachment = { url: 'https://x/y.png', mediaType: 'image/png' }
+    await act(async () => {
+      await result.current.sendMessage('bob@example.com', 'see this', { replyTo, attachment })
+    })
+
+    expect(mockClient.chat.sendMessage).toHaveBeenCalledWith(
+      'bob@example.com', 'see this', 'chat', replyTo, undefined, attachment
+    )
+  })
+})

--- a/packages/fluux-sdk/src/hooks/useChatActions.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActions.ts
@@ -28,11 +28,13 @@ export function useChatActions() {
     async (
       to: string,
       body: string,
-      type: 'chat' | 'groupchat' = 'chat',
-      replyTo?: { id: string; to?: string; fallback?: { author: string; body: string } },
-      attachment?: FileAttachment
+      options?: {
+        replyTo?: { id: string; to?: string; fallback?: { author: string; body: string } }
+        attachment?: FileAttachment
+      }
     ): Promise<string> => {
-      return await client.chat.sendMessage(to, body, type, replyTo, undefined, attachment)
+      // 1:1 chat hook: always a 'chat'-type message (rooms use useRoomActions).
+      return await client.chat.sendMessage(to, body, 'chat', options?.replyTo, undefined, options?.attachment)
     },
     [client]
   )


### PR DESCRIPTION
The second of the two flagged options-object signatures (after `connect`, #887).

The 1:1 chat hook's `sendMessage` accepted `type: 'chat' | 'groupchat'` — leaking the wire-level message type into a DM API — and took `replyTo` / `attachment` as positional args with an `undefined` mentions placeholder:

```ts
// before
sendMessage(to, body, type, replyTo, undefined, attachment)
// after
sendMessage(to, body, { replyTo, attachment })   // always sends 'chat'
```

Thanks to the earlier hook dedup, `sendMessage` is defined **once** in `useChatActions` (`useChat`/`useChatActive` compose it), so this is one SDK edit + exactly **one** app call site (`ChatView`, where the conversation is always a 1:1 chat). New RED→GREEN test pins the forwarding to `client.chat.sendMessage(to, body, 'chat', replyTo, undefined, attachment)`.