### PR TITLE
fix(settings): keep platform-gated settings panels off the wrong platform

### DIFF
--- a/apps/fluux/src/components/SettingsView.tsx
+++ b/apps/fluux/src/components/SettingsView.tsx
@@ -15,11 +15,9 @@ import {
   PrivacySettings,
   AdvancedSettings,
   McpSettings,
-  type SettingsCategory,
   SETTINGS_CATEGORIES,
-  DEFAULT_SETTINGS_CATEGORY,
+  resolveSettingsCategory,
 } from './settings-components'
-import { isUpdaterEnabled } from '@/utils/tauri'
 import { ArrowLeft } from 'lucide-react'
 
 interface SettingsViewProps {
@@ -36,8 +34,10 @@ export function SettingsView({ onBack }: SettingsViewProps) {
   const { dragRegionProps } = useWindowDrag()
   const { settingsCategory } = useRouteSync()
 
-  // Current category (default to profile if none specified)
-  const activeCategory = (settingsCategory as SettingsCategory) || DEFAULT_SETTINGS_CATEGORY
+  // Current category: default to profile if none specified, and fall back to
+  // profile when the URL names a category this platform doesn't offer (e.g. a
+  // deep link to the Tauri-only `mcp` or `storage` panels in the web build).
+  const activeCategory = resolveSettingsCategory(settingsCategory)
 
   // Get the active category's config for icon and label
   const activeCategoryConfig = SETTINGS_CATEGORIES.find(cat => cat.id === activeCategory)
@@ -60,8 +60,9 @@ export function SettingsView({ onBack }: SettingsViewProps) {
       case 'privacy':
         return <PrivacySettings />
       case 'updates':
-        // Updates only available on macOS/Windows, not Linux (users update via package manager)
-        return isUpdaterEnabled() ? <UpdatesSettings /> : <ProfileSettings />
+        // Platform availability is handled by resolveSettingsCategory above
+        // (updaterOnly config), so this case only renders where it applies.
+        return <UpdatesSettings />
       case 'blocked':
         return <BlockedUsersSettings />
       case 'storage':

--- a/apps/fluux/src/components/settings-components/index.ts
+++ b/apps/fluux/src/components/settings-components/index.ts
@@ -16,6 +16,7 @@ export {
   type SettingsCategoryConfig,
   SETTINGS_CATEGORIES,
   getVisibleCategories,
+  resolveSettingsCategory,
   isTauri,
   DEFAULT_SETTINGS_CATEGORY,
 } from './types'

--- a/apps/fluux/src/components/settings-components/types.test.ts
+++ b/apps/fluux/src/components/settings-components/types.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { getVisibleCategories, getGroupedVisibleCategories } from './types'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { getVisibleCategories, getGroupedVisibleCategories, resolveSettingsCategory } from './types'
 import { useAdvancedModeStore } from '@/stores/advancedModeStore'
+
+function setTauriEnv(on: boolean) {
+  if (on) (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+  else delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+}
 
 describe('getVisibleCategories — advanced category', () => {
   beforeEach(() => {
@@ -55,5 +60,38 @@ describe('getGroupedVisibleCategories', () => {
     // hidden; the system group still has advanced, so it is present.
     const system = getGroupedVisibleCategories().find((g) => g.group === 'system')!
     expect(system.items.map((c) => c.id)).toEqual(['advanced'])
+  })
+})
+
+describe('resolveSettingsCategory — platform gating', () => {
+  afterEach(() => {
+    setTauriEnv(false)
+  })
+
+  it('falls back to profile for a Tauri-only category deep-linked in the web build', () => {
+    setTauriEnv(false)
+    expect(resolveSettingsCategory('mcp')).toBe('profile')
+    expect(resolveSettingsCategory('storage')).toBe('profile')
+  })
+
+  it('keeps a Tauri-only category on the desktop build', () => {
+    setTauriEnv(true)
+    expect(resolveSettingsCategory('mcp')).toBe('mcp')
+    expect(resolveSettingsCategory('storage')).toBe('storage')
+  })
+
+  it('defaults to profile when no category is requested', () => {
+    expect(resolveSettingsCategory(undefined)).toBe('profile')
+    expect(resolveSettingsCategory(null)).toBe('profile')
+    expect(resolveSettingsCategory('')).toBe('profile')
+  })
+
+  it('falls back to profile for an unknown category string', () => {
+    expect(resolveSettingsCategory('not-a-category')).toBe('profile')
+  })
+
+  it('passes through categories available on every platform', () => {
+    expect(resolveSettingsCategory('appearance')).toBe('appearance')
+    expect(resolveSettingsCategory('advanced')).toBe('advanced')
   })
 })

--- a/apps/fluux/src/components/settings-components/types.ts
+++ b/apps/fluux/src/components/settings-components/types.ts
@@ -66,6 +66,18 @@ export function getVisibleCategories(): SettingsCategoryConfig[] {
  */
 export const DEFAULT_SETTINGS_CATEGORY: SettingsCategory = 'profile'
 
+/**
+ * Resolve a (possibly absent or platform-unavailable) requested category to
+ * one that may actually render. The sidebar already hides platform-gated
+ * entries, but the category also arrives via the URL, so a deep link on the
+ * wrong platform (e.g. `mcp` or `storage` in the web build) must fall back to
+ * the default instead of rendering a panel for a feature that cannot work.
+ */
+export function resolveSettingsCategory(requested: string | null | undefined): SettingsCategory {
+  const category = (requested as SettingsCategory) || DEFAULT_SETTINGS_CATEGORY
+  return getVisibleCategories().some((cat) => cat.id === category) ? category : DEFAULT_SETTINGS_CATEGORY
+}
+
 export interface SettingsGroupSection {
   group: SettingsGroup
   /** i18n key for the group header, or null for a group rendered with no header */


### PR DESCRIPTION
The settings sidebar already hides Tauri-only categories (mcp, storage) but the active category also arrives via the URL: in the web build, a deep link to `/settings/mcp` rendered the MCP panel, including its enable toggle and a "starting local server" status that can never resolve there.

Adds `resolveSettingsCategory`: a requested category that isn't visible on the current platform falls back to the default (profile). This gates `mcp` and `storage` uniformly and absorbs the `updates` case's ad-hoc `isUpdaterEnabled` ternary into the same mechanism.

Verified in the web preview: `#/settings/mcp` now lands on Profile, and the settings list shows no MCP or Storage entries; on desktop the panels are unaffected (covered by new unit tests for both platforms).