### PR TITLE
Harden MUC nicks against whitespace/invisible-char impersonation

### DIFF
--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -167,6 +167,7 @@ vi.mock('@fluux/sdk', () => ({
   }),
   // Used by auroraSenderColor (imported by ChatMessageBubble)
   generateConsistentColorHexSync: () => '#4a90d9',
+  splitNickForDisplay: (nick: string) => ({ leading: '', core: nick, trailing: '', hasHiddenChars: false }),
 }))
 
 // Mock React store hooks (from @fluux/sdk/react)

--- a/apps/fluux/src/components/NickText.test.tsx
+++ b/apps/fluux/src/components/NickText.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { NickText, NickSentence } from './NickText'
+
+describe('NickText', () => {
+  it('renders a clean nick verbatim with no markers', () => {
+    const { container } = render(<NickText nick="admin" />)
+    expect(container.textContent).toBe('admin')
+    expect(container.querySelector('[data-testid="nick-ws-marker"]')).toBeNull()
+    expect(container.querySelector('[data-testid="nick-hidden-chars"]')).toBeNull()
+  })
+
+  it('preserves an internal space without a marker', () => {
+    const { container } = render(<NickText nick="ad min" />)
+    expect(container.textContent).toBe('ad min')
+    expect(container.querySelector('[data-testid="nick-ws-marker"]')).toBeNull()
+  })
+
+  it('reveals trailing whitespace with a marker while keeping the name readable', () => {
+    const { container } = render(<NickText nick="admin " />)
+    expect(container.textContent).toContain('admin')
+    expect(container.querySelector('[data-testid="nick-ws-marker"]')).not.toBeNull()
+  })
+
+  it('reveals leading whitespace with a marker', () => {
+    const { container } = render(<NickText nick=" admin" />)
+    expect(container.querySelector('[data-testid="nick-ws-marker"]')).not.toBeNull()
+  })
+
+  it('flags a hidden zero-width character with a badge', () => {
+    const { container } = render(<NickText nick={'admin​'} />)
+    expect(container.querySelector('[data-testid="nick-hidden-chars"]')).not.toBeNull()
+  })
+})
+
+describe('NickSentence', () => {
+  it('renders a translated sentence verbatim for a clean nick', () => {
+    const { container } = render(<NickSentence i18nKey="rooms.whisperThread" nick="admin" />)
+    expect(container.textContent).toBe('Private with admin')
+    expect(container.querySelector('[data-testid="nick-ws-marker"]')).toBeNull()
+  })
+
+  it('reveals whitespace on a padded nick interpolated into the sentence', () => {
+    const { container } = render(<NickSentence i18nKey="rooms.whisperThread" nick="admin " />)
+    expect(container.textContent).toContain('Private with')
+    expect(container.querySelector('[data-testid="nick-ws-marker"]')).not.toBeNull()
+  })
+
+  it('places the nick correctly when it leads the sentence', () => {
+    const { container } = render(<NickSentence i18nKey="rooms.whisperCounterpartGone" nick={'admin​'} />)
+    expect(container.textContent).toContain('is no longer in the room')
+    expect(container.querySelector('[data-testid="nick-hidden-chars"]')).not.toBeNull()
+  })
+
+  it('tolerates an undefined nick without crashing', () => {
+    const { container } = render(<NickSentence i18nKey="rooms.whisperThread" nick={undefined} />)
+    expect(container.textContent).toBe('Private with ')
+  })
+})

--- a/apps/fluux/src/components/NickText.tsx
+++ b/apps/fluux/src/components/NickText.tsx
@@ -1,0 +1,93 @@
+import { Fragment } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle } from 'lucide-react'
+import { splitNickForDisplay } from '@fluux/sdk'
+
+/**
+ * Renders a MUC occupant nick, revealing impersonation vectors that HTML would
+ * otherwise hide: leading/trailing whitespace is shown as a marked gap, and
+ * invisible / bidi-control characters are flagged with a warning badge. A clean
+ * nick renders verbatim (no wrapper, no cost).
+ *
+ * Emits inline content only — drop it in wherever a raw `{nick}` is rendered and
+ * let the surrounding element keep owning color/truncation/layout.
+ *
+ * Never mutates the nick: trimming a remote nick for display would *complete* an
+ * impersonation (`"admin "` and `"admin"` both collapse to `"admin"`). See
+ * docs/superpowers/specs/2026-07-07-muc-nick-whitespace-impersonation-design.md.
+ */
+export function NickText({ nick }: { nick: string }) {
+  const { t } = useTranslation()
+  const { leading, core, trailing, hasHiddenChars } = splitNickForDisplay(nick)
+
+  if (!leading && !trailing && !hasHiddenChars) {
+    return <>{nick}</>
+  }
+
+  return (
+    <>
+      {leading && <WhitespaceMarker run={leading} label={t('rooms.nickEdgeWhitespace')} />}
+      {core}
+      {trailing && <WhitespaceMarker run={trailing} label={t('rooms.nickEdgeWhitespace')} />}
+      {hasHiddenChars && (
+        <span
+          data-testid="nick-hidden-chars"
+          role="img"
+          aria-label={t('rooms.nickHiddenChars')}
+          title={t('rooms.nickHiddenChars')}
+          className="inline-flex items-center align-baseline shrink-0 mx-0.5"
+        >
+          <AlertTriangle className="size-3 text-amber-500" aria-hidden />
+        </span>
+      )}
+    </>
+  )
+}
+
+// A private-use character that will not occur in a translation or a nick, used
+// to mark where {{nick}} lands so we can splice a live <NickText> into an
+// otherwise-translated sentence without restructuring 33 locale files.
+const NICK_SLOT = ''
+
+/**
+ * Renders a translated sentence that interpolates a single `{{nick}}`, with the
+ * nick shown through {@link NickText} so its whitespace / hidden characters are
+ * revealed in-context (e.g. the whisper-thread header "Private with {{nick}}").
+ *
+ * The nick is placed wherever the translation puts it — right for RTL and for
+ * locales that lead with the name — because we split on the interpolated slot
+ * rather than assuming a position.
+ */
+export function NickSentence({ i18nKey, nick }: { i18nKey: string; nick: string | undefined }) {
+  const { t } = useTranslation()
+  const segments = t(i18nKey, { nick: NICK_SLOT }).split(NICK_SLOT)
+  return (
+    <>
+      {segments.map((segment, i) => (
+        <Fragment key={i}>
+          {segment}
+          {i < segments.length - 1 && <NickText nick={nick ?? ''} />}
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
+/**
+ * A run of edge whitespace rendered as visible NBSP cells on a faint amber
+ * ground so the padding is noticeable rather than an easy-to-miss gap. NBSP
+ * keeps the browser from collapsing it; one cell per source character signals
+ * presence (exact width is not important).
+ */
+function WhitespaceMarker({ run, label }: { run: string; label: string }) {
+  return (
+    <span
+      data-testid="nick-ws-marker"
+      title={label}
+      aria-label={label}
+      className="rounded-[2px] bg-amber-400/40 ring-1 ring-inset ring-amber-500/40 whitespace-pre"
+    >
+      {' '.repeat(run.length)}
+    </span>
+  )
+}

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -18,10 +18,11 @@ import { useRoomActions } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore } from '@fluux/sdk/react'
 import { ignoreStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { Avatar } from './Avatar'
+import { NickText } from './NickText'
 import { Tooltip } from './Tooltip'
 import { MenuButton, MenuDivider } from './sidebar-components/SidebarListMenu'
 import { useContextMenu, useTheme } from '@/hooks'
-import { auroraSenderColor } from '@/utils/senderColor'
+import { auroraSenderColor, nickColorSeed } from '@/utils/senderColor'
 import { bestTextColor } from '@/utils/contrastColor'
 import { useToastStore } from '@/stores/toastStore'
 import { getTranslatedShowText } from '@/utils/presence'
@@ -129,7 +130,12 @@ const OccupantRow = memo(function OccupantRow({
   // Per-person hue: same deterministic color the message list uses for this nick,
   // keyed on primaryNick + isDark. Derived as a plain string — memo still bails for
   // unchanged rows; when isDark flips all rows correctly re-render.
-  const identityColor = isMe ? undefined : auroraSenderColor(group.primaryNick, isDark)
+  const identityColor = isMe
+    ? undefined
+    : auroraSenderColor(
+        nickColorSeed({ occupantId: primaryOccupant.occupantId, bareJid: group.bareJid, nick: group.primaryNick }),
+        isDark,
+      )
   const nameColor = isMe ? 'var(--fluux-text-self)' : identityColor!
 
   // Get occupant avatar from XEP-0398 or fall back to contact avatar
@@ -197,7 +203,7 @@ const OccupantRow = memo(function OccupantRow({
           <div className="flex items-center gap-1.5">
             {isMe ? (
               <span className="min-w-0 truncate text-sm font-semibold" style={{ color: nameColor }}>
-                {group.primaryNick}
+                <NickText nick={group.primaryNick} />
                 <span className="text-fluux-muted font-normal"> {t('rooms.you')}</span>
               </span>
             ) : (
@@ -210,7 +216,7 @@ const OccupantRow = memo(function OccupantRow({
                 className="min-w-0"
               >
                 <span className="block truncate text-sm" style={{ color: nameColor }}>
-                  {group.primaryNick}
+                  <NickText nick={group.primaryNick} />
                 </span>
               </UserInfoPopover>
             )}

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -233,6 +233,7 @@ vi.mock('@fluux/sdk', () => ({
     return bareJids.size + noJidCount
   },
   generateConsistentColorHexSync: () => '#4a90d9',
+  splitNickForDisplay: (nick: string) => ({ leading: '', core: nick, trailing: '', hasHiddenChars: false }),
   getBestPresenceShow: () => 'online',
   getPresenceFromShow: () => 'online',
   createMessageLookup: (messages: RoomMessage[]) => {

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -39,7 +39,7 @@ import { MediaAutoloadProvider } from '@/contexts'
 import { computeMediaAutoload } from '@/utils/mediaAutoload'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { getRoomJoinErrorMessage } from '@/utils/roomJoinError'
-import { auroraSenderColor } from '@/utils/senderColor'
+import { auroraSenderColor, nickColorSeed } from '@/utils/senderColor'
 import { ReactionMentions } from './conversation/ReactionMentions'
 import { reactionMentionStore } from '@/stores/reactionMentionStore'
 
@@ -1330,7 +1330,13 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
   // Get sender color: dedicated AA-safe self color for own messages, contact's pre-calculated color, or fallback to nick-based generation
   const senderColor = message.isOutgoing
     ? 'var(--fluux-text-self)'
-    : resolveSenderColor(resolvedSenderName, contact, isDarkMode ?? true)
+    // Seed on stable identity (occupant-id, then real JID), not the display name,
+    // so an impersonator's look-alike nick renders in a different color.
+    : resolveSenderColor(
+        nickColorSeed({ occupantId: message.occupantId, bareJid: senderBareJid, nick: message.nick }),
+        contact,
+        isDarkMode ?? true,
+      )
 
   // Get my current reactions to this message (room — uses nick)
   const myReactions = getMyReactions(message.reactions, myNick, undefined, true)
@@ -1384,7 +1390,11 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
       // Same contact-color preference as the main senderColor above, so the
       // quote never disagrees with the sender's main-message color.
       const replyContact = replyBareJid ? contactsByJid.get(replyBareJid) : undefined
-      return resolveSenderColor(nick, replyContact, dark ?? true)
+      return resolveSenderColor(
+        nickColorSeed({ occupantId: originalMsg?.occupantId, bareJid: replyBareJid, nick }),
+        replyContact,
+        dark ?? true,
+      )
     },
     // Reply-target avatar resolved to primitives in the list layer (resolveReplyAvatar)
     // and passed in — so this callback reads no `room` and the row memo stays bail-able.
@@ -1839,7 +1849,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
         from: replyingTo.from,
         senderName: replyingTo.nick,
         body: replyingTo.body,
-        senderColor: auroraSenderColor(replyingTo.nick, isDarkMode ?? true),
+        senderColor: auroraSenderColor(nickColorSeed({ occupantId: replyingTo.occupantId, nick: replyingTo.nick }), isDarkMode ?? true),
       }
     : null
 

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -11,6 +11,7 @@ import { formatMessagePreview, formatXMPPError, getBareJid, type BaseMessage, ty
 import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { Avatar } from '../Avatar'
+import { NickText, NickSentence } from '../NickText'
 import { AvatarLightbox } from '../AvatarLightbox'
 import { MessageToolbar } from './MessageToolbar'
 import { MessageBody } from './MessageBody'
@@ -537,7 +538,7 @@ export const MessageBubble = memo(function MessageBubble({
         {threadStart && (counterpartGone ? (
           <div className="flex items-center gap-1.5 pb-1 text-xs font-medium text-fluux-private">
             <Ear className="size-3.5 shrink-0" />
-            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+            <span className="truncate"><NickSentence i18nKey="rooms.whisperThread" nick={whisperWith} /></span>
           </div>
         ) : (
           // Clicking the header re-enters whisper mode (same flow as the
@@ -549,7 +550,7 @@ export const MessageBubble = memo(function MessageBubble({
             className="flex max-w-full cursor-pointer items-center gap-1.5 -ms-1 mb-0.5 rounded px-1 py-0.5 text-xs font-medium text-fluux-private transition-colors hover:bg-fluux-private-hover"
           >
             <Ear className="size-3.5 shrink-0" />
-            <span className="truncate">{t('rooms.whisperThread', { nick: whisperWith })}</span>
+            <span className="truncate"><NickSentence i18nKey="rooms.whisperThread" nick={whisperWith} /></span>
           </button>
         ))}
         {/* Floating hover toolbar - hidden when user is composing or message is retracted */}
@@ -590,7 +591,7 @@ export const MessageBubble = memo(function MessageBubble({
                 onTouchStart={(e) => { e.stopPropagation(); onNickTouchStart?.(e) }}
                 onTouchEnd={onNickTouchEnd}
               >
-                {senderName}
+                <NickText nick={senderName} />
               </span>
             </UserInfoPopover>
             {nickExtras}
@@ -635,7 +636,7 @@ export const MessageBubble = memo(function MessageBubble({
               <span
                 className="font-medium"
                 style={{ color: replyContext.senderColor }}
-              >{replyContext.senderName}</span>
+              ><NickText nick={replyContext.senderName} /></span>
               <div className="reply-quote-preview opacity-75 max-h-16 overflow-hidden">{renderQuotePreview(replyContext.body)}</div>
             </div>
           </button>
@@ -745,7 +746,7 @@ export const MessageBubble = memo(function MessageBubble({
         {threadEnd && counterpartGone && (
           <div className="flex items-center gap-1.5 pt-1.5 text-xs text-fluux-muted">
             <UserX className="size-3.5 shrink-0" />
-            <span className="truncate">{t('rooms.whisperCounterpartGone', { nick: whisperWith })}</span>
+            <span className="truncate"><NickSentence i18nKey="rooms.whisperCounterpartGone" nick={whisperWith} /></span>
           </div>
         )}
       </div>

--- a/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
@@ -183,20 +183,27 @@ describe('resolveSenderColor', () => {
 })
 
 describe('resolveNickColor', () => {
-  // Aurora: resolveNickColor delegates to resolveSenderColor which now always
-  // returns auroraSenderColor — consistent for all senders regardless of roster.
+  // Aurora: resolveNickColor delegates to resolveSenderColor. The color is seeded
+  // on the mentioned person's STABLE identity (occupant-id, then real JID), not the
+  // nick string, so an impersonating look-alike nick diverges in color.
   const contact = { jid: 'alice@x', colorLight: '#7b4500', colorDark: '#ffa54c' } as any
-  it('returns auroraSenderColor(nick) when the nick maps to a JID via the live occupant', () => {
+  it('seeds on the real JID when the nick maps to a JID via the live occupant', () => {
     const r = room({
       occupants: new Map([['alice', occ('alice', { jid: 'alice@x/res' })]]),
     })
-    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), true)).toBe(auroraSenderColor('alice', true))
+    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), true)).toBe(auroraSenderColor('alice@x', true))
   })
-  it('returns auroraSenderColor(nick) when the JID comes from nickToJidCache', () => {
+  it('seeds on the real JID when it comes from nickToJidCache', () => {
     const r = room({ occupants: new Map(), nickToJidCache: new Map([['alice', 'alice@x']]) })
-    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), false)).toBe(auroraSenderColor('alice', false))
+    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), false)).toBe(auroraSenderColor('alice@x', false))
   })
-  it('returns auroraSenderColor(nick) for an unknown nick (no JID / not a contact)', () => {
+  it('prefers the occupant-id over the JID when both are known', () => {
+    const r = room({
+      occupants: new Map([['alice', occ('alice', { jid: 'alice@x/res', occupantId: 'oid-alice' })]]),
+    })
+    expect(resolveNickColor('alice', r, new Map([['alice@x', contact]]), true)).toBe(auroraSenderColor('oid-alice', true))
+  })
+  it('falls back to the nick for an unknown occupant (no JID / no occupant-id)', () => {
     const r = room({ occupants: new Map(), nickToJidCache: new Map() })
     expect(resolveNickColor('ghost', r, new Map(), true)).toBe(auroraSenderColor('ghost', true))
   })

--- a/apps/fluux/src/components/conversation/roomSenderResolution.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.ts
@@ -1,6 +1,6 @@
 import { getBareJid, getPresenceFromShow, canModerate, canBan } from '@fluux/sdk'
 import { whisperCounterpartPresent } from './'
-import { auroraSenderColor } from '@/utils/senderColor'
+import { auroraSenderColor, nickColorSeed } from '@/utils/senderColor'
 import type { Room, RoomMessage, RoomRole, RoomAffiliation, ContactIdentity, RoomOccupant } from '@fluux/sdk'
 
 export interface ResolvedRoomSender {
@@ -126,7 +126,9 @@ export function resolveNickColor(
   const occupant = room.occupants.get(nick)
   const bareJid = occupant?.jid ? getBareJid(occupant.jid) : room.nickToJidCache?.get(nick)
   const contact = bareJid ? contactsByJid.get(bareJid) : undefined
-  return resolveSenderColor(nick, contact, isDarkMode)
+  // Seed on stable identity so a mention of an impersonating look-alike nick
+  // still matches the real person's color (or diverges from it).
+  return resolveSenderColor(nickColorSeed({ occupantId: occupant?.occupantId, bareJid, nick }), contact, isDarkMode)
 }
 
 export function selectSelfOccupant(

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -424,7 +424,9 @@
         "hatUnassignError": "فشل إزالة الشارة",
         "selectHat": "اختيار شارة",
         "hatJidPlaceholder": "user@example.com",
-        "invitationsHeading": "الدعوات"
+        "invitationsHeading": "الدعوات",
+        "nickEdgeWhitespace": "يحتوي الاسم على مسافات إضافية في الأطراف",
+        "nickHiddenChars": "يحتوي الاسم على أحرف مخفية"
     },
     "events": {
         "invitedBy": "دعوة من {{name}}",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Інфармацыя пра карыстальніка",
         "manageOccupant": "Кіраванне",
-        "invitationsHeading": "Запрашэнні"
+        "invitationsHeading": "Запрашэнні",
+        "nickEdgeWhitespace": "Імя змяшчае лішнія прабелы па краях",
+        "nickHiddenChars": "Імя змяшчае схаваныя сімвалы"
     },
     "events": {
         "invitedBy": "Запрошаны {{name}}",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Информация за потребителя",
         "manageOccupant": "Управление",
-        "invitationsHeading": "Покани"
+        "invitationsHeading": "Покани",
+        "nickEdgeWhitespace": "Името съдържа излишни интервали в краищата",
+        "nickHiddenChars": "Името съдържа скрити знаци"
     },
     "events": {
         "invitedBy": "Поканен от {{name}}",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info de l'usuari",
         "manageOccupant": "Gestionar",
-        "invitationsHeading": "Invitacions"
+        "invitationsHeading": "Invitacions",
+        "nickEdgeWhitespace": "El nom té espais addicionals als extrems",
+        "nickHiddenChars": "El nom conté caràcters ocults"
     },
     "events": {
         "invitedBy": "Convidat per {{name}}",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informace o uživateli",
         "manageOccupant": "Spravovat",
-        "invitationsHeading": "Pozvánky"
+        "invitationsHeading": "Pozvánky",
+        "nickEdgeWhitespace": "Jméno obsahuje mezery na okrajích",
+        "nickHiddenChars": "Jméno obsahuje skryté znaky"
     },
     "events": {
         "invitedBy": "Pozval(a) {{name}}",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Brugerinfo",
         "manageOccupant": "Administrer",
-        "invitationsHeading": "Invitationer"
+        "invitationsHeading": "Invitationer",
+        "nickEdgeWhitespace": "Navnet har ekstra mellemrum i kanterne",
+        "nickHiddenChars": "Navnet indeholder skjulte tegn"
     },
     "events": {
         "invitedBy": "Inviteret af {{name}}",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Benutzerinfo",
         "manageOccupant": "Verwalten",
-        "invitationsHeading": "Einladungen"
+        "invitationsHeading": "Einladungen",
+        "nickEdgeWhitespace": "Der Name hat zusätzliche Leerzeichen am Rand",
+        "nickHiddenChars": "Der Name enthält versteckte Zeichen"
     },
     "events": {
         "invitedBy": "Eingeladen von {{name}}",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -425,7 +425,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Πληροφορίες χρήστη",
         "manageOccupant": "Διαχείριση",
-        "invitationsHeading": "Προσκλήσεις"
+        "invitationsHeading": "Προσκλήσεις",
+        "nickEdgeWhitespace": "Το όνομα έχει επιπλέον κενά στα άκρα",
+        "nickHiddenChars": "Το όνομα περιέχει κρυφούς χαρακτήρες"
     },
     "events": {
         "invitedBy": "Πρόσκληση από {{name}}",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -424,7 +424,9 @@
         "hatUnassignError": "Failed to remove hat",
         "selectHat": "Select hat",
         "hatJidPlaceholder": "user@example.com",
-        "invitationsHeading": "Invitations"
+        "invitationsHeading": "Invitations",
+        "nickEdgeWhitespace": "Name has extra spaces at the edges",
+        "nickHiddenChars": "Name contains hidden characters"
     },
     "events": {
         "invitedBy": "Invited by {{name}}",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info del usuario",
         "manageOccupant": "Gestionar",
-        "invitationsHeading": "Invitaciones"
+        "invitationsHeading": "Invitaciones",
+        "nickEdgeWhitespace": "El nombre tiene espacios adicionales en los extremos",
+        "nickHiddenChars": "El nombre contiene caracteres ocultos"
     },
     "events": {
         "invitedBy": "Invitado por {{name}}",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Kasutaja teave",
         "manageOccupant": "Halda",
-        "invitationsHeading": "Kutsed"
+        "invitationsHeading": "Kutsed",
+        "nickEdgeWhitespace": "Nimel on servades lisatühikud",
+        "nickHiddenChars": "Nimi sisaldab peidetud märke"
     },
     "events": {
         "invitedBy": "Kutsuja {{name}}",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Käyttäjätiedot",
         "manageOccupant": "Hallitse",
-        "invitationsHeading": "Kutsut"
+        "invitationsHeading": "Kutsut",
+        "nickEdgeWhitespace": "Nimessä on ylimääräisiä välilyöntejä reunoilla",
+        "nickHiddenChars": "Nimi sisältää piilotettuja merkkejä"
     },
     "events": {
         "invitedBy": "Kutsuja: {{name}}",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -425,7 +425,9 @@
         "selectHat": "Sélectionner un badge",
         "hatJidPlaceholder": "user@example.com",
         "manageOccupant": "Gérer",
-        "invitationsHeading": "Invitations"
+        "invitationsHeading": "Invitations",
+        "nickEdgeWhitespace": "Le nom comporte des espaces au début ou à la fin",
+        "nickHiddenChars": "Le nom contient des caractères invisibles"
     },
     "events": {
         "invitedBy": "Invité par {{name}}",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Eolas úsáideora",
         "manageOccupant": "Bainistigh",
-        "invitationsHeading": "Cuirí"
+        "invitationsHeading": "Cuirí",
+        "nickEdgeWhitespace": "Tá spásanna breise ag imill an ainm",
+        "nickHiddenChars": "Tá carachtair fholaithe san ainm"
     },
     "events": {
         "invitedBy": "Cuireadh ag {{name}}",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -424,7 +424,9 @@
         "hatUnassignError": "הסרת התג נכשלה",
         "selectHat": "בחר תג",
         "hatJidPlaceholder": "user@example.com",
-        "invitationsHeading": "הזמנות"
+        "invitationsHeading": "הזמנות",
+        "nickEdgeWhitespace": "השם מכיל רווחים נוספים בקצוות",
+        "nickHiddenChars": "השם מכיל תווים נסתרים"
     },
     "events": {
         "invitedBy": "הוזמן על ידי {{name}}",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Podaci o korisniku",
         "manageOccupant": "Upravljaj",
-        "invitationsHeading": "Pozivnice"
+        "invitationsHeading": "Pozivnice",
+        "nickEdgeWhitespace": "Ime sadrži dodatne razmake na rubovima",
+        "nickHiddenChars": "Ime sadrži skrivene znakove"
     },
     "events": {
         "invitedBy": "Pozvao {{name}}",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Felhasználó adatai",
         "manageOccupant": "Kezelés",
-        "invitationsHeading": "Meghívók"
+        "invitationsHeading": "Meghívók",
+        "nickEdgeWhitespace": "A név szélein extra szóközök vannak",
+        "nickHiddenChars": "A név rejtett karaktereket tartalmaz"
     },
     "events": {
         "invitedBy": "Meghívta: {{name}}",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Notandaupplýsingar",
         "manageOccupant": "Stjórna",
-        "invitationsHeading": "Boð"
+        "invitationsHeading": "Boð",
+        "nickEdgeWhitespace": "Nafnið er með auka bil á endunum",
+        "nickHiddenChars": "Nafnið inniheldur falda stafi"
     },
     "events": {
         "invitedBy": "Boðið af {{name}}",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info utente",
         "manageOccupant": "Gestisci",
-        "invitationsHeading": "Inviti"
+        "invitationsHeading": "Inviti",
+        "nickEdgeWhitespace": "Il nome ha spazi aggiuntivi ai bordi",
+        "nickHiddenChars": "Il nome contiene caratteri nascosti"
     },
     "events": {
         "invitedBy": "Invitato da {{name}}",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Naudotojo informacija",
         "manageOccupant": "Valdyti",
-        "invitationsHeading": "Kvietimai"
+        "invitationsHeading": "Kvietimai",
+        "nickEdgeWhitespace": "Varde yra papildomų tarpų kraštuose",
+        "nickHiddenChars": "Varde yra paslėptų simbolių"
     },
     "events": {
         "invitedBy": "Pakvietė {{name}}",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -425,7 +425,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Lietotāja informācija",
         "manageOccupant": "Pārvaldīt",
-        "invitationsHeading": "Ielūgumi"
+        "invitationsHeading": "Ielūgumi",
+        "nickEdgeWhitespace": "Vārdam ir papildu atstarpes malās",
+        "nickHiddenChars": "Vārds satur slēptas rakstzīmes"
     },
     "events": {
         "invitedBy": "Uzaicināja {{name}}",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info tal-utent",
         "manageOccupant": "Immaniġġja",
-        "invitationsHeading": "Stedini"
+        "invitationsHeading": "Stedini",
+        "nickEdgeWhitespace": "L-isem għandu spazji żejda fit-truf",
+        "nickHiddenChars": "L-isem fih karattri moħbija"
     },
     "events": {
         "invitedBy": "Mistieden minn {{name}}",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Brukerinfo",
         "manageOccupant": "Administrer",
-        "invitationsHeading": "Invitasjoner"
+        "invitationsHeading": "Invitasjoner",
+        "nickEdgeWhitespace": "Navnet har ekstra mellomrom i kantene",
+        "nickHiddenChars": "Navnet inneholder skjulte tegn"
     },
     "events": {
         "invitedBy": "Invitert av {{name}}",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Gebruikersinfo",
         "manageOccupant": "Beheren",
-        "invitationsHeading": "Uitnodigingen"
+        "invitationsHeading": "Uitnodigingen",
+        "nickEdgeWhitespace": "De naam heeft extra spaties aan de randen",
+        "nickHiddenChars": "De naam bevat verborgen tekens"
     },
     "events": {
         "invitedBy": "Uitgenodigd door {{name}}",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informacje o użytkowniku",
         "manageOccupant": "Zarządzaj",
-        "invitationsHeading": "Zaproszenia"
+        "invitationsHeading": "Zaproszenia",
+        "nickEdgeWhitespace": "Nazwa ma dodatkowe spacje na brzegach",
+        "nickHiddenChars": "Nazwa zawiera ukryte znaki"
     },
     "events": {
         "invitedBy": "Zaproszony przez {{name}}",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Info do utilizador",
         "manageOccupant": "Gerir",
-        "invitationsHeading": "Convites"
+        "invitationsHeading": "Convites",
+        "nickEdgeWhitespace": "O nome tem espaços extra nas extremidades",
+        "nickHiddenChars": "O nome contém caracteres ocultos"
     },
     "events": {
         "invitedBy": "Convidado por {{name}}",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informații utilizator",
         "manageOccupant": "Gestionează",
-        "invitationsHeading": "Invitații"
+        "invitationsHeading": "Invitații",
+        "nickEdgeWhitespace": "Numele are spații suplimentare la margini",
+        "nickHiddenChars": "Numele conține caractere ascunse"
     },
     "events": {
         "invitedBy": "Invitat de {{name}}",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Информация о пользователе",
         "manageOccupant": "Управление",
-        "invitationsHeading": "Приглашения"
+        "invitationsHeading": "Приглашения",
+        "nickEdgeWhitespace": "Имя содержит лишние пробелы по краям",
+        "nickHiddenChars": "Имя содержит скрытые символы"
     },
     "events": {
         "invitedBy": "Пригласил(а) {{name}}",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -425,7 +425,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Informácie o používateľovi",
         "manageOccupant": "Spravovať",
-        "invitationsHeading": "Pozvánky"
+        "invitationsHeading": "Pozvánky",
+        "nickEdgeWhitespace": "Meno obsahuje medzery na okrajoch",
+        "nickHiddenChars": "Meno obsahuje skryté znaky"
     },
     "events": {
         "invitedBy": "Pozval {{name}}",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -426,7 +426,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Podatki o uporabniku",
         "manageOccupant": "Upravljaj",
-        "invitationsHeading": "Vabila"
+        "invitationsHeading": "Vabila",
+        "nickEdgeWhitespace": "Ime ima dodatne presledke na robovih",
+        "nickHiddenChars": "Ime vsebuje skrite znake"
     },
     "events": {
         "invitedBy": "Povabil {{name}}",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Användarinfo",
         "manageOccupant": "Hantera",
-        "invitationsHeading": "Inbjudningar"
+        "invitationsHeading": "Inbjudningar",
+        "nickEdgeWhitespace": "Namnet har extra mellanslag i kanterna",
+        "nickHiddenChars": "Namnet innehåller dolda tecken"
     },
     "events": {
         "invitedBy": "Inbjuden av {{name}}",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "Інформація про користувача",
         "manageOccupant": "Керувати",
-        "invitationsHeading": "Запрошення"
+        "invitationsHeading": "Запрошення",
+        "nickEdgeWhitespace": "Ім'я містить зайві пробіли по краях",
+        "nickHiddenChars": "Ім'я містить приховані символи"
     },
     "events": {
         "invitedBy": "Запрошено {{name}}",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -424,7 +424,9 @@
         "hatJidPlaceholder": "user@example.com",
         "userInfo": "用户信息",
         "manageOccupant": "管理",
-        "invitationsHeading": "邀请"
+        "invitationsHeading": "邀请",
+        "nickEdgeWhitespace": "名称的首尾包含多余的空格",
+        "nickHiddenChars": "名称包含隐藏字符"
     },
     "events": {
         "invitedBy": "邀请者 {{name}}",

--- a/apps/fluux/src/test-setup.ts
+++ b/apps/fluux/src/test-setup.ts
@@ -85,6 +85,8 @@ void i18n.use(initReactI18next).init({
           browseRooms: 'Browse Rooms',
           catchUpAll: 'Catch up all rooms',
           markAllRead: 'Mark all as read',
+          whisperThread: 'Private with {{nick}}',
+          whisperCounterpartGone: "{{nick}} is no longer in the room, so you can't reply",
         },
         messages: {
           showArchived: 'Show archived conversations',

--- a/apps/fluux/src/utils/senderColor.test.ts
+++ b/apps/fluux/src/utils/senderColor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { auroraSenderColor } from './senderColor'
+import { auroraSenderColor, nickColorSeed } from './senderColor'
 import { getLuminance, contrastRatio, hexToRgb } from './contrastColor'
 
 // Chat-row + hover-row luminances for AA assertions.
@@ -10,6 +10,26 @@ function lum(hex: string) {
   const c = hexToRgb(hex)!
   return getLuminance(c.r, c.g, c.b)
 }
+
+describe('nickColorSeed', () => {
+  it('prefers the occupant-id (device-stable, works in anonymous rooms)', () => {
+    expect(nickColorSeed({ occupantId: 'occ-1', bareJid: 'a@x', nick: 'admin' })).toBe('occ-1')
+  })
+
+  it('falls back to the real bare JID when there is no occupant-id', () => {
+    expect(nickColorSeed({ bareJid: 'a@x', nick: 'admin' })).toBe('a@x')
+  })
+
+  it('falls back to the nick when no stable identity is known', () => {
+    expect(nickColorSeed({ nick: 'admin' })).toBe('admin')
+  })
+
+  it('gives a spoofed nick a different seed than the person it mimics', () => {
+    const real = nickColorSeed({ occupantId: 'real-occ', nick: 'admin' })
+    const spoof = nickColorSeed({ occupantId: 'spoof-occ', nick: 'admin ' })
+    expect(real).not.toBe(spoof)
+  })
+})
 
 describe('auroraSenderColor', () => {
   it('is deterministic per identifier + mode', () => {

--- a/apps/fluux/src/utils/senderColor.ts
+++ b/apps/fluux/src/utils/senderColor.ts
@@ -24,6 +24,20 @@ const DARK_ROW_LUMINANCE = 0.08
  * mode. Replaces the raw getConsistentTextColor for sender names so everyone
  * stays distinct in large rooms while harmonizing with Aurora.
  */
+/**
+ * The identity a nick's color is derived from. Prefer the XEP-0421 occupant-id
+ * (stable per real user within a room, shared across their devices, and present
+ * even in anonymous rooms), then the real bare JID, and only fall back to the
+ * nick string when no stable identity is known. Seeding on identity rather than
+ * the raw nick means an impersonator using a look-alike nick (padded / hidden
+ * characters) still renders in a *different* color than the person they mimic.
+ * A single precedence, used at every color site, keeps one person one color
+ * across the occupant list, message authors, mentions and reply quotes.
+ */
+export function nickColorSeed(opts: { occupantId?: string; bareJid?: string; nick: string }): string {
+  return opts.occupantId || opts.bareJid || opts.nick
+}
+
 export function auroraSenderColor(identifier: string, isDarkMode: boolean): string {
   if (isDarkMode) {
     // Luminous on near-black; lighten intrinsically-dark hues until they clear AA

--- a/docs/superpowers/specs/2026-07-07-muc-nick-whitespace-impersonation-design.md
+++ b/docs/superpowers/specs/2026-07-07-muc-nick-whitespace-impersonation-design.md
@@ -1,0 +1,143 @@
+# MUC nick whitespace / impersonation hardening
+
+**Date:** 2026-07-07
+**Status:** Approved (design)
+
+## Problem
+
+ejabberd-based MUC components permit occupant nicks with leading and trailing
+whitespace. An attacker can join a room as `"admin "` (trailing space) — or with
+invisible / zero-width / bidi-control characters — and reuse a trusted user's
+avatar. HTML collapses edge whitespace on render, so the nick looks identical to
+the real user. The attacker then whispers (XEP-0045 §7.5 private message) the
+victim while appearing to be a trusted admin. Openfire strips edge whitespace
+server-side; ejabberd does not.
+
+## Threat model
+
+The attacker is a **remote** occupant. Therefore:
+
+- Stripping whitespace from **our own** nick is hygiene — it stops *our* users
+  from being the impersonator and normalizes our outgoing presence — but it does
+  **not** defend a victim against a remote attacker.
+- The defenses that actually protect the victim act at **render time** on remote
+  nicks: make the padding *visible*, and make identity *visually distinct*.
+
+Trimming a **remote** occupant's nick for display would *complete* the
+impersonation (`"admin "` and `"admin"` both render as `"admin"`) and would break
+whisper addressing (the occupants map is keyed by the exact nick). So remote
+nicks are never mutated — only revealed.
+
+## Components
+
+### A — Normalize our own nick on join (SDK)
+
+New pure module `packages/fluux-sdk/src/core/nick.ts`:
+
+```ts
+// Single source of truth for the "dangerous invisibles" class, shared with the
+// display-reveal helper.
+const INVISIBLE_CHARS = /[​-‏‪-‮⁠-⁤⁦-⁯­﻿]/g
+
+export function stripNickWhitespace(nick: string): string {
+  // Remove zero-width / bidi-control / soft-hyphen chars anywhere, then trim
+  // Unicode edge whitespace (JS \s covers NBSP, U+2000–200A, U+3000, tab, etc.).
+  return nick.replace(INVISIBLE_CHARS, '').replace(/^\s+|\s+$/gu, '')
+}
+```
+
+Apply at the **top of `MUC.joinRoom()`** (`packages/fluux-sdk/src/core/modules/MUC.ts`,
+~line 573), before `PendingJoin` capture and before building the presence
+`to = ${roomJid}/${nickname}`. This is the single choke point covering:
+
+- the join modal and programmatic joins,
+- the `/nick` slash command (`apps/fluux/src/commands/registry.ts` dispatches to
+  `sdk.joinRoom`),
+- reconnection rejoin (`rejoinActiveRooms`).
+
+The modal's existing `nickname.trim()` and the `/nick` handler's `args.trim()`
+stay as cheap ASCII input hygiene. `setBookmark()` is intentionally **not**
+changed — `joinRoom` strips on every *use* of a bookmark nick, so a padded
+stored nick is harmless (YAGNI).
+
+Guard: if stripping yields an empty string, keep the original behavior of the
+caller (the `/nick` handler already rejects empty; `joinRoom` should not send an
+empty-resource presence — fall back to the un-stripped nick so we never silently
+change semantics for an all-whitespace input, which the server will reject
+meaningfully).
+
+### B — Reveal edge & invisible whitespace on remote nicks (app)
+
+Pure split helper in `nick.ts` (SDK), sharing `INVISIBLE_CHARS`:
+
+```ts
+export interface NickDisplay {
+  leading: string   // edge whitespace run (may be '')
+  core: string      // middle, internal spaces preserved as-is
+  trailing: string
+  hasHiddenChars: boolean  // any INVISIBLE_CHARS anywhere in the nick
+}
+export function splitNickForDisplay(nick: string): NickDisplay
+```
+
+App component `apps/fluux/src/components/NickText.tsx`:
+
+- Clean nick → renders the nick verbatim (no wrapper, no cost).
+- `leading` / `trailing` present → render as an NBSP gap wrapped in a faintly
+  marked span (subtle background/underline) so the padding is *noticeable*, not
+  just an easy-to-miss gap. (Pawel's NBSP idea, strengthened with a marker.)
+- `hasHiddenChars` → append a small warning glyph/badge with a tooltip
+  ("contains hidden characters"). NBSP can't reveal zero-width chars — the badge
+  does.
+
+Applied everywhere a **remote** nick is shown:
+
+- occupant list (`OccupantPanel.tsx`),
+- message author name (`RoomView.tsx` / message bubble via
+  `roomSenderResolution.ts`),
+- inline `@mention` pills,
+- reply-quote author,
+- **the PM / whisper header** — highest priority for this attack.
+
+### C — Color nicks by stable identity (app)
+
+Colors today are seeded from the **nick string**
+(`auroraSenderColor(identifier)` in `apps/fluux/src/utils/senderColor.ts`), so a
+spoofed nick currently gets the **same** color as the real person.
+
+Introduce a single seed resolver so every color site agrees:
+
+```
+seed = occupantId ?? bareJid ?? nick   // XEP-0421 first, real JID next, nick last
+```
+
+- `resolveRoomSender` exposes a `senderColorSeed`; the message bubble and reply
+  quote pass it to `resolveSenderColor`.
+- `resolveNickColor` (mentions) resolves the seed via the room's occupant map.
+- `OccupantPanel` seeds from the grouped user's `bareJid` (groups are already
+  by bare JID → one color per user across connections).
+
+A spoofed nick with a different `occupantId` then diverges in color from the
+real person. **Graceful degradation:** in a fully-anonymous room with no
+XEP-0421 support, the seed falls back to the nick and the color defense is
+inert — documented limitation. **One-time churn:** re-seeding changes existing
+users' colors once; acceptable.
+
+## Testing
+
+- **SDK** (`nick.test.ts`): `stripNickWhitespace` over ASCII space, tab, NBSP,
+  U+2000–200A, U+3000, zero-width (U+200B/C/D), bidi controls, soft hyphen,
+  mixed, all-whitespace (empty result), and clean nick (no-op). `joinRoom` sends
+  presence to the stripped `room/nick`.
+- **SDK**: `splitNickForDisplay` — clean, leading-only, trailing-only, both,
+  internal-space-preserved, hidden-char detection.
+- **App**: `NickText` renders a marker for padded nicks and a badge for hidden
+  chars; verbatim for clean nicks. `resolveNickColorSeed` fallback chain
+  (occupantId → bareJid → nick) and that a spoof gets a different color than the
+  real occupant.
+
+## Out of scope
+
+- Look-alike-occupant detection / active warning on PM start (considered, cut).
+- Normalizing stored bookmark nick data.
+- Server-side stripping (that is ejabberd's responsibility).

--- a/docs/superpowers/specs/2026-07-07-muc-nick-whitespace-impersonation-design.md
+++ b/docs/superpowers/specs/2026-07-07-muc-nick-whitespace-impersonation-design.md
@@ -90,14 +90,29 @@ App component `apps/fluux/src/components/NickText.tsx`:
   ("contains hidden characters"). NBSP can't reveal zero-width chars — the badge
   does.
 
-Applied everywhere a **remote** nick is shown:
+Applied everywhere a **remote** nick is an authoritative occupant identity:
 
 - occupant list (`OccupantPanel.tsx`),
-- message author name (`RoomView.tsx` / message bubble via
-  `roomSenderResolution.ts`),
-- inline `@mention` pills,
-- reply-quote author,
-- **the PM / whisper header** — highest priority for this attack.
+- message author name (`MessageBubble.tsx`, incl. every whisper message),
+- reply-quote author (`MessageBubble.tsx`),
+- **whisper-thread header** ("Private with {{nick}}") and the counterpart-gone
+  footer, via `NickSentence` (see below).
+
+**`NickSentence` — revealing a nick interpolated into a translated sentence.**
+The whisper header interpolates the nick into a `t()` string, and the codebase
+uses `t()` exclusively (zero `<Trans>`). Rather than restructure 33 locale files
+with placeholder tags, `NickSentence` runs the existing `t(key, { nick })` with a
+private-use sentinel (`U+E000`) as the nick, splits the result on the sentinel,
+and splices a live `<NickText>` into the gap. The nick lands wherever the
+translation places it — correct for RTL and for locales that lead with the name —
+with no locale edits and no new i18n pattern.
+
+Deferred (implementation note):
+
+- **Inline `@mention` pills** come from the sender's *typed body text*
+  (`renderStyledMessage`), not an authoritative occupant identity, so revealing
+  whitespace there is a weaker signal; the mention *color* is still hardened via
+  Component C.
 
 ### C — Color nicks by stable identity (app)
 
@@ -141,3 +156,13 @@ users' colors once; acceptable.
 - Look-alike-occupant detection / active warning on PM start (considered, cut).
 - Normalizing stored bookmark nick data.
 - Server-side stripping (that is ejabberd's responsibility).
+- Inline @mention whitespace reveal (see Component B deferred note).
+
+## Precedence note
+
+Color seed precedence is `occupantId ?? bareJid ?? nick`. XEP-0421 occupant-id
+is stable per real user within a room and shared across their devices, so it
+both distinguishes an impersonator and unifies a user's connections into one
+color; the real bare JID is the fallback when occupant-id is unsupported, and
+the nick is the last resort (fully-anonymous room with no occupant-id — the
+color defense degrades gracefully there).

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -797,6 +797,21 @@ describe('MUC Module', () => {
       })
     })
 
+    it('strips edge whitespace from our nick before sending join presence (impersonation hardening)', async () => {
+      await muc.joinRoom('room@conference.example.org', '  admin  ')
+
+      const presence = mockSendStanza.mock.calls[0][0]
+      expect(presence.attrs.to).toBe('room@conference.example.org/admin')
+    })
+
+    it('stores the stripped nick as the room self-nickname', async () => {
+      await muc.joinRoom('room@conference.example.org', 'admin​')
+
+      expect(mockEmitSDK).toHaveBeenCalledWith('room:added', {
+        room: expect.objectContaining({ nickname: 'admin' }),
+      })
+    })
+
     it('preserves a known supportsModeration value when a re-join disco fails (F3: no clobber to unknown)', async () => {
       // Existing, not-yet-joined room a prior disco resolved as moderation-unsupported.
       mockStores.room.getRoom.mockReturnValue({

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -1,6 +1,7 @@
 import { xml, Element } from '@xmpp/client'
 import { BaseModule } from './BaseModule'
 import { getBareJid, getLocalPart, getResource, getDomain } from '../jid'
+import { stripNickWhitespace } from '../nick'
 import { generateUUID } from '../../utils/uuid'
 import { generateQuickChatSlug } from '../wordlist'
 import { hasStableOccupantIdentity, isNonAnonymousRoom, isPrivateRoom } from '../roomCapabilities'
@@ -570,9 +571,19 @@ export class MUC extends BaseModule {
    */
   async joinRoom(
     roomJid: string,
-    nickname: string,
+    rawNickname: string,
     options?: { maxHistory?: number; password?: string; isQuickChat?: boolean; knownFeatures?: RoomFeatures | null }
   ): Promise<void> {
+    // Normalize our OWN nick before it goes on the wire. Every self-nick path —
+    // the join modal, programmatic joins, the `/nick` command, and reconnection
+    // rejoin — routes through here, so this single choke point strips edge
+    // whitespace and invisible/bidi characters that MUC services (e.g. ejabberd)
+    // would otherwise accept, keeping our users from becoming impersonators.
+    // Fall back to the raw value if stripping empties it, so an all-whitespace
+    // input still produces a presence the server rejects meaningfully rather
+    // than a silently-changed one (the `/nick` handler already blocks empty).
+    const nickname = stripNickWhitespace(rawNickname) || rawNickname
+
     const existingRoom = this.deps.stores?.room.getRoom(roomJid)
 
     // If already joined, don't send another presence (avoids leave/rejoin issues)

--- a/packages/fluux-sdk/src/core/nick.test.ts
+++ b/packages/fluux-sdk/src/core/nick.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { stripNickWhitespace, splitNickForDisplay } from './nick'
+
+describe('stripNickWhitespace', () => {
+  it('leaves a clean nick unchanged', () => {
+    expect(stripNickWhitespace('admin')).toBe('admin')
+  })
+
+  it('preserves internal spaces', () => {
+    expect(stripNickWhitespace('ad min')).toBe('ad min')
+  })
+
+  it('trims leading and trailing ASCII spaces', () => {
+    expect(stripNickWhitespace('  admin  ')).toBe('admin')
+    expect(stripNickWhitespace('admin ')).toBe('admin')
+    expect(stripNickWhitespace(' admin')).toBe('admin')
+  })
+
+  it('trims tabs and newlines at the edges', () => {
+    expect(stripNickWhitespace('\tadmin\n')).toBe('admin')
+  })
+
+  it('trims Unicode whitespace (NBSP, en-quad, ideographic space)', () => {
+    expect(stripNickWhitespace(' admin ')).toBe('admin')
+    expect(stripNickWhitespace(' admin　')).toBe('admin')
+    expect(stripNickWhitespace('admin ')).toBe('admin')
+  })
+
+  it('removes zero-width characters anywhere in the nick', () => {
+    expect(stripNickWhitespace('admin​')).toBe('admin')
+    expect(stripNickWhitespace('ad​min')).toBe('admin')
+    expect(stripNickWhitespace('﻿admin')).toBe('admin')
+  })
+
+  it('removes bidi control and soft-hyphen characters', () => {
+    expect(stripNickWhitespace('ad‮min')).toBe('admin')
+    expect(stripNickWhitespace('admin­')).toBe('admin')
+  })
+
+  it('returns empty string for all-whitespace / all-invisible input', () => {
+    expect(stripNickWhitespace('   ')).toBe('')
+    expect(stripNickWhitespace('​​')).toBe('')
+  })
+})
+
+describe('splitNickForDisplay', () => {
+  it('returns a clean nick as core with no edges', () => {
+    expect(splitNickForDisplay('admin')).toEqual({
+      leading: '', core: 'admin', trailing: '', hasHiddenChars: false,
+    })
+  })
+
+  it('keeps internal spaces in the core', () => {
+    expect(splitNickForDisplay('ad min')).toEqual({
+      leading: '', core: 'ad min', trailing: '', hasHiddenChars: false,
+    })
+  })
+
+  it('splits leading whitespace', () => {
+    expect(splitNickForDisplay(' admin')).toEqual({
+      leading: ' ', core: 'admin', trailing: '', hasHiddenChars: false,
+    })
+  })
+
+  it('splits trailing whitespace', () => {
+    expect(splitNickForDisplay('admin ')).toEqual({
+      leading: '', core: 'admin', trailing: ' ', hasHiddenChars: false,
+    })
+  })
+
+  it('splits both edges including NBSP', () => {
+    expect(splitNickForDisplay(' admin  ')).toEqual({
+      leading: ' ', core: 'admin', trailing: '  ', hasHiddenChars: false,
+    })
+  })
+
+  it('flags hidden characters without treating them as edges', () => {
+    const result = splitNickForDisplay('admin​')
+    expect(result.hasHiddenChars).toBe(true)
+    expect(result.core).toContain('admin')
+  })
+
+  it('does not double-count an all-whitespace nick', () => {
+    const result = splitNickForDisplay('   ')
+    expect(result.leading).toBe('   ')
+    expect(result.core).toBe('')
+    expect(result.trailing).toBe('')
+  })
+})

--- a/packages/fluux-sdk/src/core/nick.ts
+++ b/packages/fluux-sdk/src/core/nick.ts
@@ -1,0 +1,68 @@
+/**
+ * MUC nickname hygiene and display helpers.
+ *
+ * Some MUC services (notably ejabberd) permit occupant nicks with leading /
+ * trailing whitespace and invisible characters. This enables impersonation: an
+ * attacker joins as `"admin "` (trailing space) or with zero-width / bidi
+ * control characters and, reusing a trusted user's avatar, whispers a victim
+ * while appearing to be that user. HTML collapses edge whitespace on render, so
+ * the padded nick looks identical to the real one.
+ *
+ * - {@link stripNickWhitespace} normalizes our OWN outgoing nick (join / `/nick`)
+ *   so we never become the impersonator and never send a padded presence.
+ * - {@link splitNickForDisplay} lets the app REVEAL padding on remote nicks
+ *   (never mutate them — that would complete the impersonation and break
+ *   whisper addressing, which is keyed on the exact nick).
+ */
+
+// Invisible / zero-width / bidi-control / soft-hyphen characters that have no
+// legitimate place in a nick. Single source of truth shared by strip + reveal.
+// (JS \s already covers NBSP, U+2000–200A, U+3000, U+FEFF, etc., so those are
+// handled by the edge-trim; this class targets the non-\s invisibles.)
+const INVISIBLE_SOURCE =
+  '­​-‏‪-‮⁠-⁤⁦-⁯﻿'
+// `g` for replace-all; a separate non-global regex for stateless `.test()`.
+const INVISIBLE_STRIP = new RegExp(`[${INVISIBLE_SOURCE}]`, 'g')
+const INVISIBLE_TEST = new RegExp(`[${INVISIBLE_SOURCE}]`)
+
+const EDGE_WHITESPACE = /^\s+|\s+$/gu
+
+/**
+ * Normalize our own nick before it goes on the wire: remove invisible /
+ * bidi-control characters anywhere, then trim Unicode edge whitespace. Internal
+ * spaces are preserved (a legitimate nick may contain them). Returns `''` for an
+ * all-whitespace / all-invisible input; callers decide how to handle empty.
+ */
+export function stripNickWhitespace(nick: string): string {
+  return nick.replace(INVISIBLE_STRIP, '').replace(EDGE_WHITESPACE, '')
+}
+
+export interface NickDisplay {
+  /** Leading edge-whitespace run (may be ''). */
+  leading: string
+  /** Middle of the nick; internal spaces preserved as-is. */
+  core: string
+  /** Trailing edge-whitespace run (may be ''). */
+  trailing: string
+  /** True if the nick contains any invisible / bidi-control character. */
+  hasHiddenChars: boolean
+}
+
+/**
+ * Split a remote nick into edge-whitespace runs + core so the UI can reveal the
+ * padding (render the edges as visible gaps) without mutating the nick. Also
+ * reports whether the nick hides invisible characters (which whitespace-reveal
+ * can't show — the UI badges those separately).
+ */
+export function splitNickForDisplay(nick: string): NickDisplay {
+  const leading = nick.match(/^\s+/u)?.[0] ?? ''
+  const trailing = nick.match(/\s+$/u)?.[0] ?? ''
+  // Clamp so an all-whitespace nick doesn't count its run as both edges.
+  const trailingStart = Math.max(leading.length, nick.length - trailing.length)
+  return {
+    leading,
+    core: nick.slice(leading.length, trailingStart),
+    trailing: nick.slice(trailingStart),
+    hasHiddenChars: INVISIBLE_TEST.test(nick),
+  }
+}

--- a/packages/fluux-sdk/src/index.ts
+++ b/packages/fluux-sdk/src/index.ts
@@ -463,6 +463,10 @@ export {
 } from './core/jid'
 export type { ParsedJid, JidValidation } from './core/jid'
 
+// MUC nickname hygiene / display (impersonation hardening)
+export { stripNickWhitespace, splitNickForDisplay } from './core/nick'
+export type { NickDisplay } from './core/nick'
+
 // Service discovery utilities (XEP-0030 / XEP-0163)
 export { discoSupportsPep } from './core/modules/Discovery'
 


### PR DESCRIPTION
Some MUC services accept occupant nicks with leading/trailing whitespace and invisible/bidi characters. An attacker can join as `"admin "` (padded) or with zero-width characters, reuse a trusted user's avatar, and whisper a victim while appearing to be that user — HTML collapses the padding on render, so the nick looks identical. Openfire strips this server-side; ejabberd does not.

Since the attacker is a *remote* occupant, the real defenses act at render time. Three parts:

**Strip our own nick (SDK).** New `stripNickWhitespace()` removes invisible/bidi/zero-width chars anywhere and trims Unicode edge whitespace, applied at the top of `MUC.joinRoom()` — the single choke point covering the join modal, programmatic joins, `/nick`, and reconnection rejoin. Remote nicks are never trimmed (that would *complete* the impersonation and break whisper addressing, which is keyed on the exact nick).

**Reveal padding on remote nicks (app).** New `<NickText>`: edge whitespace renders as a marked gap, hidden characters get a warning badge, and clean nicks render verbatim (DOM-transparent). Applied to the occupant list, message author, reply-quote author, and — via `<NickSentence>` — the whisper-thread header/footer. `NickSentence` reveals a nick interpolated into a translated sentence (using a sentinel split) so no locale files are restructured and it stays position-correct for RTL.

**Color nicks by stable identity (app).** `nickColorSeed()` = `occupantId ?? bareJid ?? nick`, routed through every color site. Colors were previously seeded on the nick string, so a spoof got the same color as the real person; now it diverges.