### PR TITLE
Reserve space for the typing indicator instead of overlaying it

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -149,23 +149,26 @@ describe('MessageList — pinVirtualizedBottom cost control', () => {
   // canonical send-stick test in MessageList.pinBottomRepaint.test.tsx.
 
   // Issue #918: the typing indicator floats OVER the list rather than living in the scroll content,
-  // so toggling it changes no scroll height and must NEVER re-pin the viewport — the inline height
-  // churn was what "fought" an upward scroll while another participant was typing.
-  it('does not re-pin the list when the typing indicator toggles at the bottom', () => {
+  // so toggling it changes no scroll height on its own — the inline height churn was what "fought"
+  // an upward scroll while another participant was typing. The footer's reserved clearance for the
+  // pill DOES grow while genuinely at the bottom (a gentle nudge, same mechanism as a reaction
+  // growing the last row) — see the next test for the invariant that still matters: a reader
+  // scrolled up must never be yanked back down.
+  it('gently nudges to reveal the footer clearance when typing starts at the bottom, not when it stops', () => {
     const { rerender, isAtBottomRef } = renderPinned()
     flush(30) // quiesce any residual pin activity
     expect(rafQueue.length).toBe(0)
     const baseline = scrollToEndCalls.count
 
-    // Typing starts → no pin.
+    // Typing starts while genuinely at the bottom → nudges once to reveal the grown footer.
     rerender(<MessageList messages={makeMessages(50)} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} typingUsers={['alice']} {...props} />)
     flush(5)
-    expect(scrollToEndCalls.count).toBe(baseline)
+    expect(scrollToEndCalls.count).toBe(baseline + 1)
 
-    // Typing stops → still no pin.
+    // Typing stops → the footer shrinks; the browser clamps scrollTop on its own, no extra nudge.
     rerender(<MessageList messages={makeMessages(50)} conversationId="conv-pin-behavior" isAtBottomRef={isAtBottomRef} typingUsers={[]} {...props} />)
     flush(5)
-    expect(scrollToEndCalls.count).toBe(baseline)
+    expect(scrollToEndCalls.count).toBe(baseline + 1)
   })
 
   it('does not yank a scrolled-up viewport back to the bottom when typing toggles (issue #918)', () => {

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -140,10 +140,13 @@ describe('MessageList scroll behavior', () => {
   })
 
   describe('typing indicator scroll', () => {
-    // The typing indicator floats OVER the list (it is not part of the scroll content), so toggling
-    // it changes no scroll height and must never move the viewport — whether the user is at the
-    // bottom or scrolled up in history (issue #918: inline height churn fought an upward scroll).
-    it('should NOT scroll when typing indicator appears and user is at bottom (it floats)', () => {
+    // The typing indicator floats OVER the list (it is not part of the scroll content); toggling it
+    // never changes scroll height on its own. But the footer reserves extra bottom padding to clear
+    // the pill while it's shown, and that DOES grow the scroll content — so while genuinely sticked
+    // to the bottom, reassertBottom re-pins to reveal the new clearance (same shared helper new
+    // messages use — a one-shot smooth nudge lands short because a virtualized footer needs a
+    // remeasure pass first). A reader scrolled up must never be yanked back (issue #918).
+    it('re-pins to the bottom when typing starts while sticked', () => {
       const messages = createTestMessages(5)
       const scrollSpy = vi.fn()
 
@@ -187,8 +190,8 @@ describe('MessageList scroll behavior', () => {
           />
         )
 
-        // The floating indicator changes no scroll height → no scroll write.
-        expect(scrollSpy).not.toHaveBeenCalled()
+        // Sticked to the bottom → the grown footer clearance is revealed by a re-pin to bottom.
+        expect(scrollSpy).toHaveBeenCalledWith(1000)
       }
     })
 

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -484,6 +484,7 @@ export function MessageList<T extends BaseMessage>({
     windowAtLiveEdge,
     isHistoryComplete,
     lastMessageReactionsKey,
+    hasTypingIndicator: typingUsers.length > 0,
     lastMessageIsOutgoing: lastMessage?.isOutgoing ?? false,
     lastMessageId: lastMessage?.id,
     staticMode,
@@ -637,12 +638,16 @@ export function MessageList<T extends BaseMessage>({
         )
       }
       case 'footer':
-        // Typing indicator is NOT rendered here — it floats over the list (see below) so it never
-        // changes the scroll height (which used to re-pin the viewport and fight an upward scroll).
+        // Typing indicator is NOT rendered here — it floats over the list (see below). The footer's
+        // padding grows to pb-12 (clears the pill's ~46px height) only while it's shown, and shrinks
+        // back to pb-4 otherwise, so idle conversations don't carry the pill's clearance as dead
+        // space. The grow edge is paired with a live-geometry-gated nudge in useMessageListScroll
+        // (only when already at the bottom) so this never re-pins a reader scrolled up into history —
+        // the #918 bug was a stale isAtBottomRef latch, not a reactive footer height per se.
         return (
           <div data-row-kind="footer">
             {extraContent}
-            <div className="pb-4" />
+            <div className={typingUsers.length > 0 ? 'pb-12' : 'pb-4'} />
           </div>
         )
     }
@@ -789,8 +794,10 @@ export function MessageList<T extends BaseMessage>({
           {extraContent}
 
           {/* Bottom breathing room. The typing indicator floats over the list (see below) rather
-              than living here, so toggling it never changes scroll height. */}
-          <div className="pb-4" />
+              than living here. The padding grows to pb-12 (clears the pill) only while it's shown
+              and shrinks back to pb-4 otherwise — see the footer render case above for the safety
+              rationale (live-geometry-gated nudge, never re-pins a reader scrolled up). */}
+          <div className={typingUsers.length > 0 ? 'pb-12' : 'pb-4'} />
         </div>
         ))}
       </div>

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -253,6 +253,12 @@ export interface UseMessageListScrollOptions {
   /** Signature of the last message's reactions. Changes when a reaction is added/removed on the last
    *  row (growing/shrinking it); drives a gentle bottom nudge while the reader is sticked to bottom. */
   lastMessageReactionsKey: string
+  /** Whether the floating typing-indicator pill is currently shown. The footer reserves extra bottom
+   *  padding to clear the pill only while this is true; the 0→true edge drives the same gentle
+   *  bottom nudge as a reaction growing the last row, gated on live geometry (see the reactions
+   *  effect) so it never fires for a reader scrolled up into history — the #918 "fight" was a stale
+   *  isAtBottomRef latch, not the padding change itself. */
+  hasTypingIndicator?: boolean
   /** Whether the newest message is the local user's own (outgoing). When a NEW such message
    *  appears we scroll to the bottom regardless of position — you always want to see what you
    *  just sent — whereas an incoming message only auto-follows when already near the bottom. */
@@ -315,6 +321,7 @@ export function useMessageListScroll({
   windowAtLiveEdge,
   isHistoryComplete,
   lastMessageReactionsKey,
+  hasTypingIndicator = false,
   lastMessageIsOutgoing = false,
   lastMessageId,
   staticMode = false,
@@ -2722,7 +2729,8 @@ export function useMessageListScroll({
   // into history reads distFromBottom >= threshold and is never nudged (this is what made a typing
   // toggle "fight" the scroll in #918: a stale-true latch); (2) it fires only on an actual reactions
   // change WITHIN the same conversation, so a conversation switch / restore is never disturbed.
-  // (The typing indicator itself no longer participates at all — it floats OVER the list, #918.)
+  // (The typing indicator pill itself still floats OVER the list, #918 — it never lives in scroll
+  // content. Only the footer's reserved clearance for it participates; see the next effect.)
   const prevReactionsKeyRef = useRef(lastMessageReactionsKey)
   const reactionsConvRef = useRef(conversationId)
   useLayoutEffect(() => {
@@ -2747,6 +2755,37 @@ export function useMessageListScroll({
       scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
     }
   }, [lastMessageReactionsKey, conversationId, staticMode])
+
+  // ==========================================================================
+  // EFFECT: Typing indicator appears — reveal its footer clearance while sticked
+  // ==========================================================================
+
+  // The footer reserves extra bottom padding only while the typing pill is shown (see
+  // MessageList's footer render), so that clearance grows when typing starts. Unlike a reaction's
+  // few-pixel growth, the virtualized footer row needs a remeasure pass before the virtualizer's
+  // computed end offset accounts for the taller padding — a one-shot scrollToIndex lands short (the
+  // spacer hasn't caught up yet), leaving a residual gap under the pill. So this routes through the
+  // shared reassertBottom/pinVirtualizedBottom (the same multi-frame convergence new messages use)
+  // instead of the reactions effect's single smooth nudge. Same two safeguards though: live-geometry
+  // gate (not the latchable isAtBottomRef) and a same-conversation check. Only the false→true edge
+  // nudges; typing stopping SHRINKS the footer, which the browser clamps scrollTop for on its own.
+  const prevHasTypingRef = useRef(hasTypingIndicator)
+  const typingConvRef = useRef(conversationId)
+  useLayoutEffect(() => {
+    const sameConversation = typingConvRef.current === conversationId
+    typingConvRef.current = conversationId
+    const prevHasTyping = prevHasTypingRef.current
+    prevHasTypingRef.current = hasTypingIndicator
+    if (!sameConversation) return // conversation switch → rebaseline, never nudge
+    if (!hasTypingIndicator || prevHasTyping) return // only the off→on edge grows the footer
+
+    const scroller = scrollerRef.current
+    if (!scroller || staticMode) return
+    // Live-geometry gate: only re-pin when genuinely at/near the bottom right now.
+    if (getDistanceFromBottom(scroller) >= AT_BOTTOM_THRESHOLD) return
+
+    reassertBottom('typing')
+  }, [hasTypingIndicator, conversationId, staticMode, reassertBottom])
 
   // ==========================================================================
   // EFFECT: Container resize (composer grows/shrinks)


### PR DESCRIPTION
## Summary
The floating typing pill (#918) could overlay and hide the last message when the reader is at the bottom of a conversation. The footer now reserves a small constant idle padding (`pb-4`) that grows just enough to clear the pill (`pb-12`) only while it's shown — and only nudges the view when the reader is genuinely sticked to the bottom, gated on live geometry rather than the latchable `isAtBottomRef` so a reader scrolled up into history is never re-pinned (preserving the #918 fix).