### PR TITLE
fix(muc): detect allow-invites config field from form for quick chats

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.quickchat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.quickchat.test.ts
@@ -459,6 +459,105 @@ describe('XMPPClient Quick Chat', () => {
     })
   })
 
+  describe('createQuickChat allow-invites config', () => {
+    // Build a muc#owner config-form response advertising the given field vars.
+    const buildConfigFormResponse = (fieldVars: string[]) =>
+      createMockElement('iq', { type: 'result' }, [
+        {
+          name: 'query',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#owner' },
+          children: [
+            {
+              name: 'x',
+              attrs: { xmlns: 'jabber:x:data', type: 'form' },
+              children: fieldVars.map((v) => ({
+                name: 'field',
+                attrs: { var: v, type: 'boolean' },
+                children: [{ name: 'value', text: '0' }],
+              })),
+            },
+          ],
+        },
+      ])
+
+    // Override the muc#owner branch so config-form GET returns a form and
+    // config SET returns success; delegate everything else to the base mock.
+    const installConfigForm = (fieldVars: string[]) => {
+      const base = mockXmppClientInstance.iqCaller.request.getMockImplementation()!
+      mockXmppClientInstance.iqCaller.request.mockImplementation(async (iq: any) => {
+        const xmlns = iq.children?.[0]?.attrs?.xmlns
+        if (xmlns === 'http://jabber.org/protocol/muc#owner') {
+          if (iq.attrs?.type === 'get') return buildConfigFormResponse(fieldVars)
+          return createMockElement('iq', { type: 'result' }, [])
+        }
+        return base(iq)
+      })
+    }
+
+    const getConfigSubmit = () => {
+      const requestCalls = mockXmppClientInstance.iqCaller.request.mock.calls
+      return requestCalls.find((call: any[]) => {
+        const iq = call[0]
+        return iq?.attrs?.type === 'set' &&
+               iq?.children?.some((c: any) => c.attrs?.xmlns === 'http://jabber.org/protocol/muc#owner')
+      })
+    }
+
+    it('sets the Prosody allow-member-invites field when the server advertises it', async () => {
+      installConfigForm(['{http://prosody.im/protocol/muc}roomconfig_allowmemberinvites'])
+
+      await xmppClient.muc.createQuickChat('testuser')
+
+      const configCall = getConfigSubmit()
+      expect(configCall).toBeDefined()
+      const xmlStr = JSON.stringify(configCall![0])
+      // Prosody field must be submitted...
+      expect(xmlStr).toContain('{http://prosody.im/protocol/muc}roomconfig_allowmemberinvites')
+      // ...and the unsupported ejabberd field must NOT be submitted.
+      expect(xmlStr).not.toContain('muc#roomconfig_allowinvites')
+    })
+
+    it('detects the allow-member-invites field regardless of its namespace prefix', async () => {
+      // A server that namespaces the field with a different URI than Prosody's:
+      // matching is by local name, so it should still be found and submitted verbatim.
+      installConfigForm(['{urn:example:muc}roomconfig_allowmemberinvites'])
+
+      await xmppClient.muc.createQuickChat('testuser')
+
+      const configCall = getConfigSubmit()
+      expect(configCall).toBeDefined()
+      const xmlStr = JSON.stringify(configCall![0])
+      expect(xmlStr).toContain('{urn:example:muc}roomconfig_allowmemberinvites')
+    })
+
+    it('sets the ejabberd allowinvites field when the server advertises it', async () => {
+      installConfigForm(['muc#roomconfig_allowinvites'])
+
+      await xmppClient.muc.createQuickChat('testuser')
+
+      const configCall = getConfigSubmit()
+      expect(configCall).toBeDefined()
+      const xmlStr = JSON.stringify(configCall![0])
+      expect(xmlStr).toContain('muc#roomconfig_allowinvites')
+    })
+
+    it('omits allow-invites fields entirely when the server advertises neither', async () => {
+      // Prosody-style form without any allow-invites field at all.
+      installConfigForm(['muc#roomconfig_persistentroom', 'muc#roomconfig_publicroom'])
+
+      await xmppClient.muc.createQuickChat('testuser')
+
+      const configCall = getConfigSubmit()
+      // Config must still be submitted (otherwise the room stays locked)...
+      expect(configCall).toBeDefined()
+      const xmlStr = JSON.stringify(configCall![0])
+      expect(xmlStr).toContain('muc#roomconfig_persistentroom')
+      // ...but no allow-invites field should be included.
+      expect(xmlStr).not.toContain('allowinvites')
+      expect(xmlStr).not.toContain('allowmemberinvites')
+    })
+  })
+
   describe('sendMediatedInvitation', () => {
     beforeEach(() => {
       // Clear send mock to isolate invitation tests from setup stanzas

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -1602,17 +1602,47 @@ export class MUC extends BaseModule {
   }
 
   /**
+   * Matches the MUC config-form field that lets occupants invite others.
+   * The var is not standardized across servers, so we match by local name
+   * (after stripping any Clark-notation `{namespace}` prefix) rather than a
+   * fixed string:
+   *   - ejabberd / XEP-0045: `muc#roomconfig_allowinvites`
+   *   - Prosody: `{http://prosody.im/protocol/muc}roomconfig_allowmemberinvites`
+   */
+  private static readonly ALLOW_INVITE_FIELD_RE = /^(?:muc#)?roomconfig_allow(?:member)?invites$/
+
+  /**
    * Configure a room as a temporary quick chat (non-persistent, private).
+   *
+   * The freshly created room is locked until its initial configuration is
+   * submitted (XEP-0045 §10.1.3). Submitting a field the server doesn't
+   * advertise makes the whole form fail, which leaves the room locked and
+   * unusable. We therefore fetch the config form first and only enable the
+   * "allow invites" field the server actually offers, using the exact var
+   * name it advertised.
    */
   private async configureQuickChat(roomJid: string, roomName: string, description?: string): Promise<void> {
     const values: Record<string, string | string[]> = {
       'muc#roomconfig_persistentroom': '0',
       'muc#roomconfig_roomname': roomName,
       'muc#roomconfig_publicroom': '0',
-      'muc#roomconfig_allowinvites': '1',
     }
     if (description) {
       values['muc#roomconfig_roomdesc'] = description
+    }
+
+    // Enable occupant invites, but only if the server's config form advertises
+    // such a field. We match by local name and submit the exact var the server
+    // used. If the form can't be read, omit it so the config submit still
+    // succeeds and unlocks the room.
+    const options = await this.fetchRoomOptions(roomJid)
+    if (options) {
+      for (const varName of Object.keys(options)) {
+        const localName = varName.replace(/^\{[^}]*\}/, '')
+        if (MUC.ALLOW_INVITE_FIELD_RE.test(localName)) {
+          values[varName] = '1'
+        }
+      }
     }
 
     try {


### PR DESCRIPTION
Fixes #898.

Quick chat creation blindly submitted `muc#roomconfig_allowinvites`, which Prosody does not advertise — it uses the namespaced `{http://prosody.im/protocol/muc}roomconfig_allowmemberinvites`. Submitting an unknown field fails the config form, and per XEP-0045 a freshly created room stays locked until its initial config succeeds, so the quick chat could not be created on Prosody.

Now `configureQuickChat` fetches the room config form first and only enables the allow-invites field the server actually advertises — matching by local name (namespace-agnostic) and submitting the exact var the server used. If the form can't be read, the field is omitted so the submit still succeeds and unlocks the room.