### PR TITLE
refactor(sdk): extract E2EE deferred-decrypt engine from XMPPClient

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -780,7 +780,10 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
         releaseGate = resolve
       })
       let passes = 0
-      ;(xmppClient as unknown as { retryDecryptSingle: () => Promise<unknown> }).retryDecryptSingle =
+      // The deferred-decrypt engine owns the per-payload decrypt now; gate it
+      // there so a second retry is requested while pass #1 is still parked.
+      ;(xmppClient as unknown as { deferredDecrypt: { decryptSingle: () => Promise<unknown> } })
+        .deferredDecrypt.decryptSingle =
         vi.fn(async () => {
           passes++
           if (passes === 1) await gate

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -1,5 +1,4 @@
 import { xml, Client, Element } from '@xmpp/client'
-import * as ltx from 'ltx'
 import { createActor, type Subscription, type Snapshot } from 'xstate'
 import type { EventHook } from './EventHook'
 import type {
@@ -12,8 +11,6 @@ import type {
   StorageAdapter,
   ProxyAdapter,
   PrivacyOptions,
-  FileAttachment,
-  MessageSecurityContext,
 } from './types'
 import {
   presenceMachine,
@@ -42,7 +39,6 @@ import {
 } from '../stores'
 import { detectPlatform, getCachedPlatform } from './platform'
 import { isDeadSocketError } from './modules/connectionUtils'
-import { parseMessageContent, applyRetraction, parseReactionsSignal, parseRetractionSignal } from './modules/messagingUtils'
 import {
   FRESH_SESSION_IQ_TIMEOUT_MS,
   FRESH_SESSION_SETUP_TIMEOUT_MS,
@@ -114,11 +110,11 @@ import { LastActivity } from './modules/LastActivity'
 import { MAM } from './modules/MAM'
 import { Poll } from './modules/Poll'
 import { E2EEManager, InMemoryStorageBackend, type StorageBackend, type XMPPPrimitives } from './e2ee'
+import { DeferredDecryptEngine } from './e2ee/deferredDecrypt'
 import { dataToElement } from './e2ee/stanzaAdapter'
-import { decryptStanzaInPlace, COULD_NOT_DECRYPT_BODY, MESSAGE_REJECTED_BODY } from './e2ee/stanzaDecrypt'
 import { NS_CARBONS, NS_MAM, NS_P1_PUSH_WEBPUSH } from './namespaces'
 import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './defaultStoreBindings'
-import { logDebug, logInfo, logWarn } from './logger'
+import { logInfo } from './logger'
 import { SDK_VERSION } from '../version'
 import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
 import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, deleteMessage as cacheDeleteMessage } from '../utils/messageCache'
@@ -188,35 +184,6 @@ import { bumpAvatarResumeCount } from '../utils/avatarCache'
  *
  * @category Core
  */
-
-/**
- * A bodiless signal stanza recovered from a deferred decrypt. The whole
- * element rode inside the encrypted payload (so the server never saw it), and
- * it has no `<body>` — it targets ANOTHER message rather than carrying content.
- * The placeholder "message" it was provisionally stored under must be replaced
- * by applying the signal to its target.
- */
-type RetryModification =
-  | { type: 'reactions'; targetId: string; emojis: string[] }
-  | { type: 'retract'; targetId: string }
-
-/**
- * Result of a single deferred-decrypt attempt.
- * - `decrypted`: plaintext recovered — update body/security/attachment, clear `encryptedPayload`.
- * - `modification`: decrypt surfaced a bodiless signal (XEP-0444 reaction or XEP-0424 retraction) —
- *   apply it to its target and remove the placeholder; there is no message body to update.
- * - `unsupported`: protocol we have no plugin for — clear `encryptedPayload`, tag `unsupportedEncryption`, keep body.
- * - `rejected`: signature is invalid (final, never retryable) — a real message placeholder is
- *   replaced with a "[Message rejected]" body; a bodiless-signal placeholder (forged reaction/
- *   retraction) is removed entirely so it never surfaces as a ghost bubble.
- * - `pending`: still cannot decrypt (key locked / plugin not ready) — leave `encryptedPayload`.
- */
-type RetryOutcome =
-  | { kind: 'decrypted'; body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment }
-  | { kind: 'modification'; modification: RetryModification }
-  | { kind: 'unsupported'; info: { namespace: string; name: string } }
-  | { kind: 'rejected'; securityContext?: MessageSecurityContext }
-  | { kind: 'pending' }
 
 export class XMPPClient {
   protected currentJid: string | null = null
@@ -422,21 +389,13 @@ export class XMPPClient {
   private isSmResumedSession = false
 
   /**
-   * Guard flag for {@link retryPendingDecrypts}. Prevents concurrent
-   * retry loops when multiple triggers (plugin-registered, key-unlocked)
-   * fire close together.
+   * E2EE deferred-decrypt engine. Repairs messages stored with an
+   * `encryptedPayload` once the blocking condition clears (plugin registered,
+   * key unlocked, peer key arrived). Constructed in {@link initializeModules}
+   * with getters onto the live manager / stores / identity.
    * @internal
    */
-  private isRetryingDecrypts = false
-
-  /**
-   * Set when a retry is requested while {@link retryPendingDecrypts} is
-   * already running. The in-flight pass re-runs once on completion so a
-   * trigger that arrives mid-pass (e.g. key-unlocked landing while the
-   * plugin-registered pass is still in flight) is coalesced, never dropped.
-   * @internal
-   */
-  private retryDecryptsRequested = false
+  private deferredDecrypt!: DeferredDecryptEngine
 
   /**
    * Monotonically increasing session generation counter.
@@ -653,6 +612,19 @@ export class XMPPClient {
     }
 
     this.stores = stores
+
+    // Deferred-decrypt engine reads/writes through getters so it always sees
+    // the current manager, stores, and identity — never a captured snapshot.
+    this.deferredDecrypt = new DeferredDecryptEngine({
+      getManager: () => this.e2ee,
+      getStores: () => this.stores,
+      getOwnBareJid: () => (this.currentJid ? getBareJid(this.currentJid) : ''),
+      cache: {
+        getMessagesWithEncryptedPayload,
+        updateMessage: cacheUpdateMessage,
+        deleteMessage: cacheDeleteMessage,
+      },
+    })
 
     // E2EEManager is NOT constructed here — it's tied to a logged-in
     // identity. See `ensureE2EEManager` (called from handleConnectionSuccess)
@@ -1687,446 +1659,15 @@ export class XMPPClient {
   }
 
   /**
-   * Re-decrypt all stored messages that carry an {@link encryptedPayload}
-   * because decryption failed at receive time (no plugin registered, key
-   * locked, etc.).
-   *
-   * Iterates both chat and room stores, reconstructs the stanza from the
-   * serialized XML, and re-runs {@link decryptStanzaInPlace}. On success
-   * the message body + securityContext are updated in-place via
-   * `store.updateMessage()`, and the `encryptedPayload` is cleared.
-   *
-   * Protected by a flag to prevent concurrent retry loops when multiple
-   * triggers fire close together.
+   * Re-decrypt all stored messages that carry an `encryptedPayload` because
+   * decryption failed at receive time (no plugin registered, key locked, etc.).
+   * Delegates to the {@link DeferredDecryptEngine}; kept on the client because
+   * backgroundSync triggers it via `client.retryPendingDecrypts()`.
    *
    * @returns the number of messages successfully decrypted
    */
   async retryPendingDecrypts(): Promise<number> {
-    if (this.isRetryingDecrypts) {
-      // A pass is already running. Remember the request so the in-flight
-      // pass re-runs on completion rather than dropping this trigger.
-      this.retryDecryptsRequested = true
-      return 0
-    }
-    const manager = this.e2ee
-    if (!manager || !manager.hasPlugins()) return 0
-    if (!this.stores) return 0
-
-    this.isRetryingDecrypts = true
-    let decryptedCount = 0
-    // Chat messages handled by the in-memory pass below, so the durable-cache
-    // pass can skip them (keyed by conversationId + message id).
-    const handledChatKeys = new Set<string>()
-
-    try {
-      const chatBindings = this.stores.chat
-      const roomBindings = this.stores.room
-
-      // --- 1:1 chat messages ---
-      // Read state from the imported Zustand stores (getState), mutate
-      // through StoreBindings so the abstract API contract is honoured.
-      const chatMessages = chatStore.getState().messages
-      for (const [conversationId, messages] of chatMessages) {
-        for (const msg of messages) {
-          if (!msg.encryptedPayload) continue
-          handledChatKeys.add(`${conversationId} ${msg.id}`)
-          const outcome = await this.retryDecryptSingle(
-            manager, msg.encryptedPayload, msg.from, conversationId,
-          )
-          if (outcome.kind === 'decrypted') {
-            chatBindings.updateMessage(conversationId, msg.id, {
-              body: outcome.body,
-              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-              ...(outcome.attachment && { attachment: outcome.attachment }),
-              encryptedPayload: undefined,
-            })
-            decryptedCount++
-          } else if (outcome.kind === 'modification') {
-            this.applyDeferredChatModification(conversationId, msg, outcome.modification, chatBindings)
-            decryptedCount++
-          } else if (outcome.kind === 'rejected') {
-            this.resolveRejectedChatPlaceholder(conversationId, msg, outcome.securityContext, chatBindings)
-          } else if (outcome.kind === 'unsupported') {
-            chatBindings.updateMessage(conversationId, msg.id, {
-              encryptedPayload: undefined,
-              unsupportedEncryption: outcome.info,
-            })
-          }
-        }
-      }
-
-      // --- Room messages ---
-      const roomRuntimes = roomStore.getState().roomRuntime
-      for (const [roomJid, runtime] of roomRuntimes) {
-        for (const msg of runtime.messages) {
-          if (!msg.encryptedPayload) continue
-          const outcome = await this.retryDecryptSingle(
-            manager, msg.encryptedPayload, msg.from, roomJid, 'room',
-          )
-          if (outcome.kind === 'decrypted') {
-            roomBindings.updateMessage(roomJid, msg.id, {
-              body: outcome.body,
-              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-              ...(outcome.attachment && { attachment: outcome.attachment }),
-              encryptedPayload: undefined,
-            })
-            decryptedCount++
-          } else if (outcome.kind === 'rejected') {
-            // MUC carries no encrypted bodiless signals, so a rejected room
-            // message always has real content — warn the user and clear the stash.
-            roomBindings.updateMessage(roomJid, msg.id, {
-              body: MESSAGE_REJECTED_BODY,
-              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-              encryptedPayload: undefined,
-            })
-          } else if (outcome.kind === 'unsupported') {
-            roomBindings.updateMessage(roomJid, msg.id, {
-              encryptedPayload: undefined,
-              unsupportedEncryption: outcome.info,
-            })
-          }
-        }
-      }
-
-      // --- Durable cache (web fresh-session reload) ---
-      // Conversations the user has not opened are absent from the in-memory
-      // store, so the loops above miss their stashed messages — they would
-      // stay permanently "could not be decrypted" even after unlock. Repair
-      // them straight in IndexedDB. The sparse `encryptedPayload` index makes
-      // this O(pending), not a full-archive scan, and near-free when nothing
-      // is pending (the steady state).
-      for (const msg of await getMessagesWithEncryptedPayload()) {
-        const conversationId = msg.conversationId
-        if (!msg.encryptedPayload || !conversationId) continue
-        if (handledChatKeys.has(`${conversationId} ${msg.id}`)) continue
-        const outcome = await this.retryDecryptSingle(
-          manager, msg.encryptedPayload, msg.from, conversationId,
-        )
-        if (outcome.kind === 'decrypted') {
-          const updates = {
-            body: outcome.body,
-            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-            ...(outcome.attachment && { attachment: outcome.attachment }),
-            encryptedPayload: undefined,
-          }
-          await cacheUpdateMessage(msg.id, updates)
-          // The conversation's messages aren't loaded (durable path), so the
-          // in-memory sidebar preview would keep the "[OpenPGP-encrypted
-          // message]" fallback. Heal it when this message IS the preview.
-          chatBindings.refreshLastMessageContent?.(conversationId, msg.id, updates)
-          decryptedCount++
-        } else if (outcome.kind === 'modification') {
-          // Conversation isn't loaded in memory. Apply best-effort to the
-          // in-memory target (no-op if absent) and drop the durable placeholder
-          // so it can't resurrect as a "[could not decrypt]" bubble. The store
-          // binding's removeMessage only touches in-memory state, so delete
-          // from the durable cache explicitly. For never-opened conversations
-          // the signal is reconciled on the next MAM catch-up, when the
-          // now-unlocked key decrypts it inline.
-          this.applyDeferredChatModification(conversationId, msg, outcome.modification, chatBindings)
-          await cacheDeleteMessage(msg.id)
-          decryptedCount++
-        } else if (outcome.kind === 'rejected') {
-          if (msg.body === COULD_NOT_DECRYPT_BODY) {
-            // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
-            await cacheDeleteMessage(msg.id)
-          } else {
-            const updates = {
-              body: MESSAGE_REJECTED_BODY,
-              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-              encryptedPayload: undefined,
-            }
-            await cacheUpdateMessage(msg.id, updates)
-            chatBindings.refreshLastMessageContent?.(conversationId, msg.id, updates)
-          }
-        } else if (outcome.kind === 'unsupported') {
-          const updates = {
-            encryptedPayload: undefined,
-            unsupportedEncryption: outcome.info,
-          }
-          await cacheUpdateMessage(msg.id, updates)
-          chatBindings.refreshLastMessageContent?.(conversationId, msg.id, updates)
-        }
-      }
-
-      if (decryptedCount > 0) {
-        logInfo(`E2EE deferred decrypt: successfully decrypted ${decryptedCount} message(s)`)
-      }
-    } finally {
-      this.isRetryingDecrypts = false
-    }
-
-    // A trigger that arrived mid-pass was coalesced — run once more so its
-    // newly-available state (e.g. a just-unlocked key) is applied.
-    if (this.retryDecryptsRequested) {
-      this.retryDecryptsRequested = false
-      decryptedCount += await this.retryPendingDecrypts()
-    }
-
-    return decryptedCount
-  }
-
-  /**
-   * Apply a bodiless signal (XEP-0444 reaction or XEP-0424 retraction)
-   * recovered from a deferred decrypt to its target message, then remove the
-   * "[could not decrypt]" placeholder it was provisionally stored under. The
-   * sender of the placeholder stanza is the actor — our own bare JID for a
-   * self-outgoing MAM replay, the peer's for an inbound one. A retraction is
-   * only honoured when that actor authored the target (mirrors the live path).
-   */
-  private applyDeferredChatModification(
-    conversationId: string,
-    placeholder: { id: string; from: string },
-    modification: RetryModification,
-    chatBindings: StoreBindings['chat'],
-  ): void {
-    const actorJid = getBareJid(placeholder.from)
-    // Diagnostic (race investigation): a deferred reaction/retraction can only
-    // attach to its target if that target is in the loaded set when this runs.
-    // retryPendingDecrypts is a one-shot pass (launch / key-unlock); nothing
-    // re-runs it when a target enters the store later via scroll/MAM. Record
-    // whether target + placeholder were present so a "resolved only after
-    // relaunch" report can be confirmed against the actual presence at apply
-    // time. Domains only — no message content.
-    const targetPresent = !!chatBindings.getMessage(conversationId, modification.targetId)
-    const placeholderPresent = !!chatBindings.getMessage(conversationId, placeholder.id)
-    logInfo(
-      `E2EE deferred modification: type=${modification.type} conv=${getDomain(conversationId)} ` +
-      `targetPresent=${targetPresent} placeholderPresent=${placeholderPresent}` +
-      (targetPresent ? '' : ' — target not loaded, signal cannot attach until a later pass'),
-    )
-    if (modification.type === 'reactions') {
-      chatBindings.updateReactions(conversationId, modification.targetId, actorJid, modification.emojis)
-    } else {
-      const target = chatBindings.getMessage(conversationId, modification.targetId)
-      const updates = applyRetraction(!!target && target.from === actorJid)
-      if (updates) chatBindings.updateMessage(conversationId, modification.targetId, updates)
-    }
-    chatBindings.removeMessage(conversationId, placeholder.id)
-  }
-
-  /**
-   * Resolve a chat placeholder whose deferred decrypt was finally rejected
-   * (invalid signature — final, never retried again). A bodiless-signal
-   * placeholder still carries the {@link COULD_NOT_DECRYPT_BODY} marker that
-   * stanzaDecrypt stamps onto reactions/retractions; it is removed entirely so
-   * a forged signal never surfaces as a ghost bubble. A real message
-   * placeholder (any other body) is replaced with a "[Message rejected]" body
-   * so the user is warned the message could not be trusted.
-   */
-  private resolveRejectedChatPlaceholder(
-    conversationId: string,
-    placeholder: { id: string; body: string },
-    securityContext: MessageSecurityContext | undefined,
-    chatBindings: StoreBindings['chat'],
-  ): void {
-    if (placeholder.body === COULD_NOT_DECRYPT_BODY) {
-      chatBindings.removeMessage(conversationId, placeholder.id)
-    } else {
-      chatBindings.updateMessage(conversationId, placeholder.id, {
-        body: MESSAGE_REJECTED_BODY,
-        ...(securityContext && { securityContext }),
-        encryptedPayload: undefined,
-      })
-    }
-  }
-
-  /**
-   * Attempt to decrypt a single stashed payload — either a full original
-   * `<message>` stanza (current format, keeps outer reply/fallback context)
-   * or a bare encrypted element (legacy persisted stashes).
-   * @returns `RetryOutcome` describing whether decryption succeeded, the
-   *   protocol is unsupported, or the message should remain pending.
-   * @internal
-   */
-  private async retryDecryptSingle(
-    manager: E2EEManager,
-    encryptedPayloadXml: string,
-    senderJid: string,
-    peer: string,
-    messageContext: 'chat' | 'room' = 'chat',
-  ): Promise<RetryOutcome> {
-    try {
-      const parsedPayload = ltx.parse(encryptedPayloadXml) as unknown as Element
-
-      // Current stashes hold the full original <message> stanza so outer
-      // cleartext context (XEP-0461 <reply>, XEP-0428 <fallback> ranges)
-      // survives until this retry. Stashes persisted before that format
-      // hold just the encrypted child and need a minimal wrapper.
-      const stanza =
-        parsedPayload.name === 'message'
-          ? parsedPayload
-          : (xml('message', { from: senderJid }, parsedPayload) as Element)
-      if (!stanza.attrs.from) stanza.attrs.from = senderJid
-
-      // Detect self-outgoing (sent carbon or MAM self-replay): when the
-      // sender's bare JID equals our own, the signcrypt envelope's <to/>
-      // addresses the conversation peer — not us — so the plugin's
-      // reflection check must be inverted via isSelfOutgoing.
-      const ownBareJid = this.currentJid ? getBareJid(this.currentJid) : ''
-      const isSelfOutgoing = ownBareJid !== '' && getBareJid(senderJid) === ownBareJid
-
-      const result = await decryptStanzaInPlace(
-        stanza, manager, peer, 'archive',
-        isSelfOutgoing ? { isSelfOutgoing: true } : undefined,
-      )
-
-      // Protocol we have no plugin for (e.g. OMEMO): nothing to retry. Drop the
-      // encryptedPayload and tag the message so the already-stored fallback body
-      // renders with an "unsupported method" hint.
-      if (result.unsupportedEncryption) {
-        return { kind: 'unsupported', info: result.unsupportedEncryption }
-      }
-
-      if (!result.attempted || result.encryptedPayloadXml) {
-        // Still can't decrypt
-        return { kind: 'pending' }
-      }
-
-      // A rejected signature is final — never retryable. decryptStanzaInPlace
-      // threw before unwrapping the payload, so no <reactions>/<retract>/<body>
-      // was surfaced; the caller decides whether to show a "[Message rejected]"
-      // bubble (real message placeholder) or drop it (bodiless-signal placeholder).
-      if (result.securityContext?.trust === 'rejected') {
-        return {
-          kind: 'rejected',
-          securityContext: {
-            protocolId: result.securityContext.protocolId,
-            trust: result.securityContext.trust,
-            ...(result.securityContext.notes && { notes: result.securityContext.notes }),
-          },
-        }
-      }
-
-      // Bodiless signal stanzas (XEP-0444 reactions, XEP-0424 retractions)
-      // carry no <body> — the whole element rode inside the encrypted payload
-      // and now sits at the stanza root after decryptStanzaInPlace unwrapped
-      // it. These were stored under a "[could not decrypt]" placeholder while
-      // the key was locked; returning 'pending' here (the historical body-only
-      // behaviour) silently dropped them. Surface them as a modification so the
-      // caller applies the signal to its target and removes the placeholder.
-      const reactions = parseReactionsSignal(stanza)
-      if (reactions?.targetId) {
-        return {
-          kind: 'modification',
-          modification: { type: 'reactions', targetId: reactions.targetId, emojis: reactions.emojis },
-        }
-      }
-      const retraction = parseRetractionSignal(stanza)
-      if (retraction?.targetId) {
-        return { kind: 'modification', modification: { type: 'retract', targetId: retraction.targetId } }
-      }
-
-      // Extract the decrypted body
-      const body = stanza.getChildText('body')
-      if (!body) return { kind: 'pending' }
-
-      // Re-run the shared content parse on the decrypted stanza: strips
-      // XEP-0428 fallback ranges (e.g. the XEP-0461 reply quote that the
-      // sender prefixed to the encrypted body) and extracts the attachment
-      // (aesgcm:// URI, XEP-0446 file metadata, XEP-0264 thumbnails).
-      // Legacy bare-element stashes carry no outer <fallback>, so their
-      // body passes through unchanged.
-      const parsed = parseMessageContent({ messageEl: stanza, body, messageContext })
-      const processedBody = parsed.processedBody
-      const attachment = parsed.attachment
-      if (attachment) {
-        logDebug(
-          `E2EE deferred decrypt: attachment from ${getDomain(senderJid)} — ` +
-          `url=${attachment.url.slice(0, 40)}… mediaType=${attachment.mediaType ?? 'none'} ` +
-          `encrypted=${!!attachment.encryption} name=${attachment.name ? '<redacted>' : 'none'}`,
-        )
-      }
-
-      // Map SecurityContext to MessageSecurityContext
-      let securityContext: MessageSecurityContext | undefined
-      if (result.securityContext) {
-        securityContext = {
-          protocolId: result.securityContext.protocolId,
-          trust: result.securityContext.trust,
-          ...(result.securityContext.notes && { notes: result.securityContext.notes }),
-          ...(result.securityContext.fingerprint && { fingerprint: result.securityContext.fingerprint }),
-        }
-      }
-
-      return {
-        kind: 'decrypted',
-        body: processedBody,
-        ...(securityContext && { securityContext }),
-        ...(attachment && { attachment }),
-      }
-    } catch (err) {
-      logWarn(`E2EE deferred decrypt failed for message from ${getDomain(senderJid)}: ${err instanceof Error ? err.message : String(err)}`)
-      return { kind: 'pending' }
-    }
-  }
-
-  /**
-   * Re-attempt deferred decrypts AND upgrade stale trust for a specific
-   * peer, triggered when that peer's PEP key material changes.
-   *
-   * Two categories of stored messages are handled:
-   *
-   * 1. Messages with `encryptedPayload` — the peer key was not available
-   *    when the message was first processed, so the signature could not be
-   *    verified. Re-decrypt now that the key may be cached.
-   *
-   * 2. Old messages without `encryptedPayload` but with
-   *    `securityContext.trust === 'untrusted'` and a "not cached" note —
-   *    these were persisted before the payload-stash fix landed. We cannot
-   *    re-verify their signatures (the ciphertext is gone), but the
-   *    decryption + signcrypt envelope validation succeeded, so upgrading
-   *    to `tofu` is a sound pragmatic trade-off.
-   */
-  private async retryPendingDecryptsForPeer(peer: string): Promise<void> {
-    const manager = this.e2ee
-    if (!manager || !manager.hasPlugins()) return
-    if (!this.stores) return
-
-    const chatBindings = this.stores.chat
-    const chatMessages = chatStore.getState().messages
-    const peerMessages = chatMessages.get(peer)
-    if (!peerMessages) return
-
-    let updated = 0
-    for (const msg of peerMessages) {
-      if (msg.encryptedPayload) {
-        const outcome = await this.retryDecryptSingle(
-          manager, msg.encryptedPayload, msg.from, peer,
-        )
-        if (outcome.kind === 'decrypted') {
-          chatBindings.updateMessage(peer, msg.id, {
-            body: outcome.body,
-            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
-            ...(outcome.attachment && { attachment: outcome.attachment }),
-            encryptedPayload: undefined,
-          })
-          updated++
-        } else if (outcome.kind === 'unsupported') {
-          chatBindings.updateMessage(peer, msg.id, {
-            encryptedPayload: undefined,
-            unsupportedEncryption: outcome.info,
-          })
-          updated++
-        }
-        continue
-      }
-      if (
-        msg.securityContext?.trust === 'untrusted' &&
-        msg.securityContext.notes?.some((n) => n.includes('not cached'))
-      ) {
-        chatBindings.updateMessage(peer, msg.id, {
-          securityContext: {
-            protocolId: msg.securityContext.protocolId,
-            trust: 'tofu',
-          },
-        })
-        updated++
-      }
-    }
-    if (updated > 0) {
-      logInfo(`E2EE peer key change: updated ${updated} message(s) for ${getDomain(peer)}`)
-    }
+    return this.deferredDecrypt.retryPending()
   }
 
   /**
@@ -2185,7 +1726,7 @@ export class XMPPClient {
     // have their signature verified and trust upgraded to tofu/verified.
     // Also upgrade old persisted messages that lack encryptedPayload.
     this.e2ee.onPeerKeysChanged((peer) => {
-      void this.retryPendingDecryptsForPeer(peer)
+      void this.deferredDecrypt.retryForPeer(peer)
     })
     // When a plugin reports the local key just became usable (passphrase
     // entered, server backup restored, key file imported, identity replaced),

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -142,6 +142,10 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
         const meta = chatStore.getState().conversationMeta.get(conversationId)
         return meta?.lastMessage
       },
+      getAllStoredMessages: () =>
+        Array.from(chatStore.getState().messages, ([id, messages]) => ({ id, messages })),
+      getConversationMessages: (conversationId: string) =>
+        chatStore.getState().messages.get(conversationId) ?? [],
     },
     roster: bindStoreMethods(rosterStore, rosterBindingMethodKeys),
     console: bindStoreMethods(consoleStore, consoleBindingMethodKeys),
@@ -151,6 +155,8 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       // Composite getter
       getRoomGapStart: (roomJid: string) => roomStore.getState().roomGaps.get(roomJid)?.start,
       getRoomPendingStanzaId: (roomJid: string) => roomStore.getState().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId,
+      getAllRoomMessages: () =>
+        Array.from(roomStore.getState().roomRuntime, ([jid, runtime]) => ({ jid, messages: runtime.messages })),
     },
     admin: {
       ...bindStoreMethods(adminStore, adminBindingMethodKeys),

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.test.ts
@@ -1,0 +1,166 @@
+/**
+ * DeferredDecryptEngine unit tests.
+ *
+ * The engine repairs messages that were stored with an `encryptedPayload`
+ * because decryption failed at receive time (no plugin, key locked). It reads
+ * and writes conversation state EXCLUSIVELY through the injected StoreBindings —
+ * never the global Zustand stores. That is the property these tests pin: driven
+ * by mock bindings (which the global stores know nothing about), a pending
+ * payload is decrypted and written back through those same bindings. A version
+ * that reached into the module-global chatStore/roomStore would find nothing to
+ * decrypt here and fail.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { DeferredDecryptEngine } from './deferredDecrypt'
+import {
+  E2EEManager,
+  InMemoryStorageBackend,
+  type XMPPPrimitives,
+} from '.'
+import { DummyPlaintextPlugin } from './DummyPlaintextPlugin'
+import { createMockStores, type MockStoreBindings } from '../test-utils'
+import type { StoreBindings } from '../types'
+import type { Message } from '../types/chat'
+
+function stubXmppPrimitives(): XMPPPrimitives {
+  return {
+    sendStanza: async () => {},
+    queryDisco: async () => ({ features: [], identities: [] }),
+    publishPEP: async () => {},
+    retractPEP: async () => {},
+    deletePEP: async () => {},
+    queryPEP: async () => [],
+    subscribePEP: () => ({ unsubscribe: () => {} }),
+  }
+}
+
+async function makeManagerWithDummyPlugin(selfJid: string): Promise<E2EEManager> {
+  const manager = new E2EEManager({
+    storage: new InMemoryStorageBackend(),
+    xmpp: stubXmppPrimitives(),
+    account: { jid: selfJid },
+  })
+  await manager.register(new DummyPlaintextPlugin())
+  return manager
+}
+
+// base64("hello") wrapped in the DummyPlaintextPlugin's element.
+const DUMMY_PAYLOAD_XML = `<plain xmlns="urn:fluux:e2ee-dummy:0">aGVsbG8=</plain>`
+
+const makeCache = () => ({
+  getMessagesWithEncryptedPayload: vi.fn().mockResolvedValue([]),
+  updateMessage: vi.fn().mockResolvedValue(undefined),
+  deleteMessage: vi.fn().mockResolvedValue(undefined),
+})
+
+describe('DeferredDecryptEngine', () => {
+  let manager: E2EEManager
+  let stores: MockStoreBindings
+  let cache: ReturnType<typeof makeCache>
+  let engine: DeferredDecryptEngine
+
+  beforeEach(async () => {
+    manager = await makeManagerWithDummyPlugin('me@example.com')
+    stores = createMockStores()
+    cache = makeCache()
+    engine = new DeferredDecryptEngine({
+      getManager: () => manager,
+      getStores: () => stores as unknown as StoreBindings,
+      getOwnBareJid: () => 'me@example.com',
+      cache,
+    })
+  })
+
+  it('decrypts a pending chat payload and writes back through the injected bindings', async () => {
+    // Verified so the outcome is committed (untrusted defers verification).
+    vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+      plaintext: new TextEncoder().encode('hello'),
+      senderDevice: { jid: 'me@example.com', deviceId: 'test' },
+      securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+    })
+
+    const pending: Message = {
+      type: 'chat',
+      id: 'msg-1',
+      conversationId: 'bob@example.com',
+      from: 'me@example.com',
+      body: '[dummy-plaintext payload]',
+      timestamp: new Date(),
+      isOutgoing: true,
+      encryptedPayload: DUMMY_PAYLOAD_XML,
+    }
+    // The engine must read the pending set from the injected bindings, not any
+    // global store — this conversation exists ONLY in the mock.
+    stores.chat.getAllStoredMessages.mockReturnValue([
+      { id: 'bob@example.com', messages: [pending] },
+    ])
+
+    const count = await engine.retryPending()
+
+    expect(count).toBe(1)
+    expect(stores.chat.updateMessage).toHaveBeenCalledTimes(1)
+    const [conversationId, messageId, updates] = stores.chat.updateMessage.mock.calls[0]
+    expect(conversationId).toBe('bob@example.com')
+    expect(messageId).toBe('msg-1')
+    expect(updates).toMatchObject({ body: 'hello', encryptedPayload: undefined })
+  })
+
+  it('scans peer messages through the injected bindings on a peer-key change', async () => {
+    vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+      plaintext: new TextEncoder().encode('hello'),
+      senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+      securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+    })
+
+    const pending: Message = {
+      type: 'chat',
+      id: 'msg-peer',
+      conversationId: 'bob@example.com',
+      from: 'bob@example.com',
+      body: '[dummy-plaintext payload]',
+      timestamp: new Date(),
+      isOutgoing: false,
+      encryptedPayload: DUMMY_PAYLOAD_XML,
+    }
+    stores.chat.getConversationMessages.mockReturnValue([pending])
+
+    await engine.retryForPeer('bob@example.com')
+
+    expect(stores.chat.getConversationMessages).toHaveBeenCalledWith('bob@example.com')
+    expect(stores.chat.updateMessage).toHaveBeenCalledTimes(1)
+    const [, messageId, updates] = stores.chat.updateMessage.mock.calls[0]
+    expect(messageId).toBe('msg-peer')
+    expect(updates).toMatchObject({ body: 'hello', encryptedPayload: undefined })
+  })
+
+  it('is a no-op when no E2EE manager is available', async () => {
+    engine = new DeferredDecryptEngine({
+      getManager: () => null,
+      getStores: () => stores as unknown as StoreBindings,
+      getOwnBareJid: () => 'me@example.com',
+      cache,
+    })
+    stores.chat.getAllStoredMessages.mockReturnValue([
+      {
+        id: 'bob@example.com',
+        messages: [
+          {
+            type: 'chat',
+            id: 'msg-1',
+            conversationId: 'bob@example.com',
+            from: 'bob@example.com',
+            body: 'x',
+            timestamp: new Date(),
+            isOutgoing: false,
+            encryptedPayload: DUMMY_PAYLOAD_XML,
+          } as Message,
+        ],
+      },
+    ])
+
+    const count = await engine.retryPending()
+
+    expect(count).toBe(0)
+    expect(stores.chat.updateMessage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
@@ -1,0 +1,539 @@
+/**
+ * Deferred-decrypt engine.
+ *
+ * Repairs messages that were stored with an {@link Message.encryptedPayload}
+ * because decryption failed at receive time — no E2EE plugin registered yet,
+ * the private key was still locked, or a peer's key was not cached so the
+ * signature could not be verified. When the blocking condition clears (plugin
+ * registers, key unlocks, peer key arrives) the engine re-runs decryption over
+ * the stashed payloads and commits the recovered plaintext / signals.
+ *
+ * This is a self-contained message-repair subsystem, not part of the client
+ * facade. It reads and writes conversation state EXCLUSIVELY through the
+ * injected {@link StoreBindings} and message-cache port — never the global
+ * Zustand stores — so a consumer that supplies custom stores gets correct
+ * behaviour. Its collaborators (E2EEManager, StoreBindings, own JID, cache)
+ * are provided as getters because each is rebuilt over the client's lifetime
+ * (the manager is `null` before login and rebuilt on identity change; stores
+ * can be re-bound).
+ */
+import { xml, Element } from '@xmpp/client'
+import * as ltx from 'ltx'
+import type { E2EEManager } from '.'
+import { decryptStanzaInPlace, COULD_NOT_DECRYPT_BODY, MESSAGE_REJECTED_BODY } from './stanzaDecrypt'
+import { parseMessageContent, applyRetraction, parseReactionsSignal, parseRetractionSignal } from '../modules/messagingUtils'
+import { getBareJid, getDomain } from '../jid'
+import { logDebug, logInfo, logWarn } from '../logger'
+import type { StoreBindings, MessageSecurityContext, FileAttachment, Message } from '../types'
+
+/**
+ * A bodiless signal stanza recovered from a deferred decrypt. The whole
+ * element rode inside the encrypted payload (so the server never saw it), and
+ * it has no `<body>` — it targets ANOTHER message rather than carrying content.
+ * The placeholder "message" it was provisionally stored under must be replaced
+ * by applying the signal to its target.
+ */
+type RetryModification =
+  | { type: 'reactions'; targetId: string; emojis: string[] }
+  | { type: 'retract'; targetId: string }
+
+/**
+ * Result of a single deferred-decrypt attempt.
+ * - `decrypted`: plaintext recovered — update body/security/attachment, clear `encryptedPayload`.
+ * - `modification`: decrypt surfaced a bodiless signal (XEP-0444 reaction or XEP-0424 retraction) —
+ *   apply it to its target and remove the placeholder; there is no message body to update.
+ * - `unsupported`: protocol we have no plugin for — clear `encryptedPayload`, tag `unsupportedEncryption`, keep body.
+ * - `rejected`: signature is invalid (final, never retryable) — a real message placeholder is
+ *   replaced with a "[Message rejected]" body; a bodiless-signal placeholder (forged reaction/
+ *   retraction) is removed entirely so it never surfaces as a ghost bubble.
+ * - `pending`: still cannot decrypt (key locked / plugin not ready) — leave `encryptedPayload`.
+ */
+type RetryOutcome =
+  | { kind: 'decrypted'; body: string; securityContext?: MessageSecurityContext; attachment?: FileAttachment }
+  | { kind: 'modification'; modification: RetryModification }
+  | { kind: 'unsupported'; info: { namespace: string; name: string } }
+  | { kind: 'rejected'; securityContext?: MessageSecurityContext }
+  | { kind: 'pending' }
+
+/**
+ * Message-cache port — the durable IndexedDB slice the engine repairs for
+ * conversations that are not loaded in memory. Injected so the engine has no
+ * direct module-global dependency and is unit-testable in isolation.
+ */
+export interface DeferredDecryptCache {
+  getMessagesWithEncryptedPayload: () => Promise<Message[]>
+  updateMessage: (id: string, updates: Partial<Message>) => Promise<void>
+  deleteMessage: (id: string) => Promise<void>
+}
+
+/**
+ * Explicit collaborators for {@link DeferredDecryptEngine}. All stateful
+ * dependencies are getters so the engine always observes the current manager /
+ * stores / identity rather than a snapshot captured at construction time.
+ */
+export interface DeferredDecryptDeps {
+  getManager: () => E2EEManager | null
+  getStores: () => StoreBindings | null
+  getOwnBareJid: () => string
+  cache: DeferredDecryptCache
+}
+
+export class DeferredDecryptEngine {
+  /**
+   * Guard flag for {@link retryPending}. Prevents concurrent retry loops when
+   * multiple triggers (plugin-registered, key-unlocked) fire close together.
+   */
+  private isRetrying = false
+
+  /**
+   * Set when a retry is requested while {@link retryPending} is already
+   * running. The in-flight pass re-runs once on completion so a trigger that
+   * arrives mid-pass (e.g. key-unlocked landing while the plugin-registered
+   * pass is still in flight) is coalesced, never dropped.
+   */
+  private retryRequested = false
+
+  constructor(private readonly deps: DeferredDecryptDeps) {}
+
+  /**
+   * Re-decrypt all stored messages that carry an {@link Message.encryptedPayload}
+   * because decryption failed at receive time (no plugin registered, key
+   * locked, etc.).
+   *
+   * Iterates both chat and room stores (via the injected bindings), reconstructs
+   * the stanza from the serialized XML, and re-runs {@link decryptStanzaInPlace}.
+   * On success the message body + securityContext are updated in-place via
+   * `bindings.updateMessage()`, and the `encryptedPayload` is cleared.
+   *
+   * Protected by a flag to prevent concurrent retry loops when multiple
+   * triggers fire close together.
+   *
+   * @returns the number of messages successfully decrypted
+   */
+  async retryPending(): Promise<number> {
+    if (this.isRetrying) {
+      // A pass is already running. Remember the request so the in-flight
+      // pass re-runs on completion rather than dropping this trigger.
+      this.retryRequested = true
+      return 0
+    }
+    const manager = this.deps.getManager()
+    if (!manager || !manager.hasPlugins()) return 0
+    const stores = this.deps.getStores()
+    if (!stores) return 0
+
+    this.isRetrying = true
+    let decryptedCount = 0
+    // Chat messages handled by the in-memory pass below, so the durable-cache
+    // pass can skip them (keyed by conversationId + message id).
+    const handledChatKeys = new Set<string>()
+
+    try {
+      const chatBindings = stores.chat
+      const roomBindings = stores.room
+
+      // --- 1:1 chat messages ---
+      // Read the full in-memory set (archived included) through the store
+      // bindings, and mutate through them too, so the abstract API contract is
+      // honoured for custom-store consumers.
+      for (const { id: conversationId, messages } of chatBindings.getAllStoredMessages()) {
+        for (const msg of messages) {
+          if (!msg.encryptedPayload) continue
+          handledChatKeys.add(`${conversationId} ${msg.id}`)
+          const outcome = await this.decryptSingle(
+            manager, msg.encryptedPayload, msg.from, conversationId,
+          )
+          if (outcome.kind === 'decrypted') {
+            chatBindings.updateMessage(conversationId, msg.id, {
+              body: outcome.body,
+              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+              ...(outcome.attachment && { attachment: outcome.attachment }),
+              encryptedPayload: undefined,
+            })
+            decryptedCount++
+          } else if (outcome.kind === 'modification') {
+            this.applyChatModification(conversationId, msg, outcome.modification, chatBindings)
+            decryptedCount++
+          } else if (outcome.kind === 'rejected') {
+            this.resolveRejectedPlaceholder(conversationId, msg, outcome.securityContext, chatBindings)
+          } else if (outcome.kind === 'unsupported') {
+            chatBindings.updateMessage(conversationId, msg.id, {
+              encryptedPayload: undefined,
+              unsupportedEncryption: outcome.info,
+            })
+          }
+        }
+      }
+
+      // --- Room messages ---
+      for (const { jid: roomJid, messages } of roomBindings.getAllRoomMessages()) {
+        for (const msg of messages) {
+          if (!msg.encryptedPayload) continue
+          const outcome = await this.decryptSingle(
+            manager, msg.encryptedPayload, msg.from, roomJid, 'room',
+          )
+          if (outcome.kind === 'decrypted') {
+            roomBindings.updateMessage(roomJid, msg.id, {
+              body: outcome.body,
+              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+              ...(outcome.attachment && { attachment: outcome.attachment }),
+              encryptedPayload: undefined,
+            })
+            decryptedCount++
+          } else if (outcome.kind === 'rejected') {
+            // MUC carries no encrypted bodiless signals, so a rejected room
+            // message always has real content — warn the user and clear the stash.
+            roomBindings.updateMessage(roomJid, msg.id, {
+              body: MESSAGE_REJECTED_BODY,
+              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+              encryptedPayload: undefined,
+            })
+          } else if (outcome.kind === 'unsupported') {
+            roomBindings.updateMessage(roomJid, msg.id, {
+              encryptedPayload: undefined,
+              unsupportedEncryption: outcome.info,
+            })
+          }
+        }
+      }
+
+      // --- Durable cache (web fresh-session reload) ---
+      // Conversations the user has not opened are absent from the in-memory
+      // store, so the loops above miss their stashed messages — they would
+      // stay permanently "could not be decrypted" even after unlock. Repair
+      // them straight in IndexedDB. The sparse `encryptedPayload` index makes
+      // this O(pending), not a full-archive scan, and near-free when nothing
+      // is pending (the steady state).
+      for (const msg of await this.deps.cache.getMessagesWithEncryptedPayload()) {
+        const conversationId = msg.conversationId
+        if (!msg.encryptedPayload || !conversationId) continue
+        if (handledChatKeys.has(`${conversationId} ${msg.id}`)) continue
+        const outcome = await this.decryptSingle(
+          manager, msg.encryptedPayload, msg.from, conversationId,
+        )
+        if (outcome.kind === 'decrypted') {
+          const updates = {
+            body: outcome.body,
+            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+            ...(outcome.attachment && { attachment: outcome.attachment }),
+            encryptedPayload: undefined,
+          }
+          await this.deps.cache.updateMessage(msg.id, updates)
+          // The conversation's messages aren't loaded (durable path), so the
+          // in-memory sidebar preview would keep the "[OpenPGP-encrypted
+          // message]" fallback. Heal it when this message IS the preview.
+          stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
+          decryptedCount++
+        } else if (outcome.kind === 'modification') {
+          // Conversation isn't loaded in memory. Apply best-effort to the
+          // in-memory target (no-op if absent) and drop the durable placeholder
+          // so it can't resurrect as a "[could not decrypt]" bubble. The store
+          // binding's removeMessage only touches in-memory state, so delete
+          // from the durable cache explicitly. For never-opened conversations
+          // the signal is reconciled on the next MAM catch-up, when the
+          // now-unlocked key decrypts it inline.
+          this.applyChatModification(conversationId, msg, outcome.modification, stores.chat)
+          await this.deps.cache.deleteMessage(msg.id)
+          decryptedCount++
+        } else if (outcome.kind === 'rejected') {
+          if (msg.body === COULD_NOT_DECRYPT_BODY) {
+            // Bodiless-signal placeholder (forged reaction/retraction) — drop it.
+            await this.deps.cache.deleteMessage(msg.id)
+          } else {
+            const updates = {
+              body: MESSAGE_REJECTED_BODY,
+              ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+              encryptedPayload: undefined,
+            }
+            await this.deps.cache.updateMessage(msg.id, updates)
+            stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
+          }
+        } else if (outcome.kind === 'unsupported') {
+          const updates = {
+            encryptedPayload: undefined,
+            unsupportedEncryption: outcome.info,
+          }
+          await this.deps.cache.updateMessage(msg.id, updates)
+          stores.chat.refreshLastMessageContent?.(conversationId, msg.id, updates)
+        }
+      }
+
+      if (decryptedCount > 0) {
+        logInfo(`E2EE deferred decrypt: successfully decrypted ${decryptedCount} message(s)`)
+      }
+    } finally {
+      this.isRetrying = false
+    }
+
+    // A trigger that arrived mid-pass was coalesced — run once more so its
+    // newly-available state (e.g. a just-unlocked key) is applied.
+    if (this.retryRequested) {
+      this.retryRequested = false
+      decryptedCount += await this.retryPending()
+    }
+
+    return decryptedCount
+  }
+
+  /**
+   * Apply a bodiless signal (XEP-0444 reaction or XEP-0424 retraction)
+   * recovered from a deferred decrypt to its target message, then remove the
+   * "[could not decrypt]" placeholder it was provisionally stored under. The
+   * sender of the placeholder stanza is the actor — our own bare JID for a
+   * self-outgoing MAM replay, the peer's for an inbound one. A retraction is
+   * only honoured when that actor authored the target (mirrors the live path).
+   */
+  private applyChatModification(
+    conversationId: string,
+    placeholder: { id: string; from: string },
+    modification: RetryModification,
+    chatBindings: StoreBindings['chat'],
+  ): void {
+    const actorJid = getBareJid(placeholder.from)
+    // Diagnostic (race investigation): a deferred reaction/retraction can only
+    // attach to its target if that target is in the loaded set when this runs.
+    // retryPending is a one-shot pass (launch / key-unlock); nothing re-runs it
+    // when a target enters the store later via scroll/MAM. Record whether
+    // target + placeholder were present so a "resolved only after relaunch"
+    // report can be confirmed against the actual presence at apply time.
+    // Domains only — no message content.
+    const targetPresent = !!chatBindings.getMessage(conversationId, modification.targetId)
+    const placeholderPresent = !!chatBindings.getMessage(conversationId, placeholder.id)
+    logInfo(
+      `E2EE deferred modification: type=${modification.type} conv=${getDomain(conversationId)} ` +
+      `targetPresent=${targetPresent} placeholderPresent=${placeholderPresent}` +
+      (targetPresent ? '' : ' — target not loaded, signal cannot attach until a later pass'),
+    )
+    if (modification.type === 'reactions') {
+      chatBindings.updateReactions(conversationId, modification.targetId, actorJid, modification.emojis)
+    } else {
+      const target = chatBindings.getMessage(conversationId, modification.targetId)
+      const updates = applyRetraction(!!target && target.from === actorJid)
+      if (updates) chatBindings.updateMessage(conversationId, modification.targetId, updates)
+    }
+    chatBindings.removeMessage(conversationId, placeholder.id)
+  }
+
+  /**
+   * Resolve a chat placeholder whose deferred decrypt was finally rejected
+   * (invalid signature — final, never retried again). A bodiless-signal
+   * placeholder still carries the {@link COULD_NOT_DECRYPT_BODY} marker that
+   * stanzaDecrypt stamps onto reactions/retractions; it is removed entirely so
+   * a forged signal never surfaces as a ghost bubble. A real message
+   * placeholder (any other body) is replaced with a "[Message rejected]" body
+   * so the user is warned the message could not be trusted.
+   */
+  private resolveRejectedPlaceholder(
+    conversationId: string,
+    placeholder: { id: string; body: string },
+    securityContext: MessageSecurityContext | undefined,
+    chatBindings: StoreBindings['chat'],
+  ): void {
+    if (placeholder.body === COULD_NOT_DECRYPT_BODY) {
+      chatBindings.removeMessage(conversationId, placeholder.id)
+    } else {
+      chatBindings.updateMessage(conversationId, placeholder.id, {
+        body: MESSAGE_REJECTED_BODY,
+        ...(securityContext && { securityContext }),
+        encryptedPayload: undefined,
+      })
+    }
+  }
+
+  /**
+   * Attempt to decrypt a single stashed payload — either a full original
+   * `<message>` stanza (current format, keeps outer reply/fallback context)
+   * or a bare encrypted element (legacy persisted stashes).
+   * @returns `RetryOutcome` describing whether decryption succeeded, the
+   *   protocol is unsupported, or the message should remain pending.
+   */
+  private async decryptSingle(
+    manager: E2EEManager,
+    encryptedPayloadXml: string,
+    senderJid: string,
+    peer: string,
+    messageContext: 'chat' | 'room' = 'chat',
+  ): Promise<RetryOutcome> {
+    try {
+      const parsedPayload = ltx.parse(encryptedPayloadXml) as unknown as Element
+
+      // Current stashes hold the full original <message> stanza so outer
+      // cleartext context (XEP-0461 <reply>, XEP-0428 <fallback> ranges)
+      // survives until this retry. Stashes persisted before that format
+      // hold just the encrypted child and need a minimal wrapper.
+      const stanza =
+        parsedPayload.name === 'message'
+          ? parsedPayload
+          : (xml('message', { from: senderJid }, parsedPayload) as Element)
+      if (!stanza.attrs.from) stanza.attrs.from = senderJid
+
+      // Detect self-outgoing (sent carbon or MAM self-replay): when the
+      // sender's bare JID equals our own, the signcrypt envelope's <to/>
+      // addresses the conversation peer — not us — so the plugin's
+      // reflection check must be inverted via isSelfOutgoing.
+      const ownBareJid = this.deps.getOwnBareJid()
+      const isSelfOutgoing = ownBareJid !== '' && getBareJid(senderJid) === ownBareJid
+
+      const result = await decryptStanzaInPlace(
+        stanza, manager, peer, 'archive',
+        isSelfOutgoing ? { isSelfOutgoing: true } : undefined,
+      )
+
+      // Protocol we have no plugin for (e.g. OMEMO): nothing to retry. Drop the
+      // encryptedPayload and tag the message so the already-stored fallback body
+      // renders with an "unsupported method" hint.
+      if (result.unsupportedEncryption) {
+        return { kind: 'unsupported', info: result.unsupportedEncryption }
+      }
+
+      if (!result.attempted || result.encryptedPayloadXml) {
+        // Still can't decrypt
+        return { kind: 'pending' }
+      }
+
+      // A rejected signature is final — never retryable. decryptStanzaInPlace
+      // threw before unwrapping the payload, so no <reactions>/<retract>/<body>
+      // was surfaced; the caller decides whether to show a "[Message rejected]"
+      // bubble (real message placeholder) or drop it (bodiless-signal placeholder).
+      if (result.securityContext?.trust === 'rejected') {
+        return {
+          kind: 'rejected',
+          securityContext: {
+            protocolId: result.securityContext.protocolId,
+            trust: result.securityContext.trust,
+            ...(result.securityContext.notes && { notes: result.securityContext.notes }),
+          },
+        }
+      }
+
+      // Bodiless signal stanzas (XEP-0444 reactions, XEP-0424 retractions)
+      // carry no <body> — the whole element rode inside the encrypted payload
+      // and now sits at the stanza root after decryptStanzaInPlace unwrapped
+      // it. These were stored under a "[could not decrypt]" placeholder while
+      // the key was locked; returning 'pending' here (the historical body-only
+      // behaviour) silently dropped them. Surface them as a modification so the
+      // caller applies the signal to its target and removes the placeholder.
+      const reactions = parseReactionsSignal(stanza)
+      if (reactions?.targetId) {
+        return {
+          kind: 'modification',
+          modification: { type: 'reactions', targetId: reactions.targetId, emojis: reactions.emojis },
+        }
+      }
+      const retraction = parseRetractionSignal(stanza)
+      if (retraction?.targetId) {
+        return { kind: 'modification', modification: { type: 'retract', targetId: retraction.targetId } }
+      }
+
+      // Extract the decrypted body
+      const body = stanza.getChildText('body')
+      if (!body) return { kind: 'pending' }
+
+      // Re-run the shared content parse on the decrypted stanza: strips
+      // XEP-0428 fallback ranges (e.g. the XEP-0461 reply quote that the
+      // sender prefixed to the encrypted body) and extracts the attachment
+      // (aesgcm:// URI, XEP-0446 file metadata, XEP-0264 thumbnails).
+      // Legacy bare-element stashes carry no outer <fallback>, so their
+      // body passes through unchanged.
+      const parsed = parseMessageContent({ messageEl: stanza, body, messageContext })
+      const processedBody = parsed.processedBody
+      const attachment = parsed.attachment
+      if (attachment) {
+        logDebug(
+          `E2EE deferred decrypt: attachment from ${getDomain(senderJid)} — ` +
+          `url=${attachment.url.slice(0, 40)}… mediaType=${attachment.mediaType ?? 'none'} ` +
+          `encrypted=${!!attachment.encryption} name=${attachment.name ? '<redacted>' : 'none'}`,
+        )
+      }
+
+      // Map SecurityContext to MessageSecurityContext
+      let securityContext: MessageSecurityContext | undefined
+      if (result.securityContext) {
+        securityContext = {
+          protocolId: result.securityContext.protocolId,
+          trust: result.securityContext.trust,
+          ...(result.securityContext.notes && { notes: result.securityContext.notes }),
+          ...(result.securityContext.fingerprint && { fingerprint: result.securityContext.fingerprint }),
+        }
+      }
+
+      return {
+        kind: 'decrypted',
+        body: processedBody,
+        ...(securityContext && { securityContext }),
+        ...(attachment && { attachment }),
+      }
+    } catch (err) {
+      logWarn(`E2EE deferred decrypt failed for message from ${getDomain(senderJid)}: ${err instanceof Error ? err.message : String(err)}`)
+      return { kind: 'pending' }
+    }
+  }
+
+  /**
+   * Re-attempt deferred decrypts AND upgrade stale trust for a specific
+   * peer, triggered when that peer's PEP key material changes.
+   *
+   * Two categories of stored messages are handled:
+   *
+   * 1. Messages with `encryptedPayload` — the peer key was not available
+   *    when the message was first processed, so the signature could not be
+   *    verified. Re-decrypt now that the key may be cached.
+   *
+   * 2. Old messages without `encryptedPayload` but with
+   *    `securityContext.trust === 'untrusted'` and a "not cached" note —
+   *    these were persisted before the payload-stash fix landed. We cannot
+   *    re-verify their signatures (the ciphertext is gone), but the
+   *    decryption + signcrypt envelope validation succeeded, so upgrading
+   *    to `tofu` is a sound pragmatic trade-off.
+   */
+  async retryForPeer(peer: string): Promise<void> {
+    const manager = this.deps.getManager()
+    if (!manager || !manager.hasPlugins()) return
+    const stores = this.deps.getStores()
+    if (!stores) return
+
+    const chatBindings = stores.chat
+    const peerMessages = chatBindings.getConversationMessages(peer)
+    if (peerMessages.length === 0) return
+
+    let updated = 0
+    for (const msg of peerMessages) {
+      if (msg.encryptedPayload) {
+        const outcome = await this.decryptSingle(
+          manager, msg.encryptedPayload, msg.from, peer,
+        )
+        if (outcome.kind === 'decrypted') {
+          chatBindings.updateMessage(peer, msg.id, {
+            body: outcome.body,
+            ...(outcome.securityContext && { securityContext: outcome.securityContext }),
+            ...(outcome.attachment && { attachment: outcome.attachment }),
+            encryptedPayload: undefined,
+          })
+          updated++
+        } else if (outcome.kind === 'unsupported') {
+          chatBindings.updateMessage(peer, msg.id, {
+            encryptedPayload: undefined,
+            unsupportedEncryption: outcome.info,
+          })
+          updated++
+        }
+        continue
+      }
+      if (
+        msg.securityContext?.trust === 'untrusted' &&
+        msg.securityContext.notes?.some((n) => n.includes('not cached'))
+      ) {
+        chatBindings.updateMessage(peer, msg.id, {
+          securityContext: {
+            protocolId: msg.securityContext.protocolId,
+            trust: 'tofu',
+          },
+        })
+        updated++
+      }
+    }
+    if (updated > 0) {
+      logInfo(`E2EE peer key change: updated ${updated} message(s) for ${getDomain(peer)}`)
+    }
+  }
+}

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -656,6 +656,8 @@ export const createMockStores = (): MockStoreBindings => ({
     getConversationPendingStanzaId: vi.fn().mockReturnValue(undefined),
     getArchivedConversations: vi.fn().mockReturnValue([]),
     getLastMessage: vi.fn().mockReturnValue(undefined),
+    getAllStoredMessages: vi.fn().mockReturnValue([]),
+    getConversationMessages: vi.fn().mockReturnValue([]),
   },
   roster: {
     ...mockMethods(rosterBindingMethodKeys),
@@ -681,6 +683,7 @@ export const createMockStores = (): MockStoreBindings => ({
     // Composite getter
     getRoomGapStart: vi.fn().mockReturnValue(undefined),
     getRoomPendingStanzaId: vi.fn().mockReturnValue(undefined),
+    getAllRoomMessages: vi.fn().mockReturnValue([]),
   },
   admin: {
     ...mockMethods(adminBindingMethodKeys),

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -8,6 +8,7 @@
 import type { Element } from '@xmpp/client'
 import type { ConnectionStatus } from './connection'
 import type { Message } from './chat'
+import type { RoomMessage } from './room'
 import type { PresenceStatus, Contact } from './roster'
 import type { ServerInfo } from './discovery'
 import type { HttpUploadService } from './upload'
@@ -85,6 +86,14 @@ export interface StoreBindings {
     // Smart MAM: archived conversation preview refresh
     getArchivedConversations?: () => Array<{ id: string; messages: Message[] }>
     getLastMessage?: (conversationId: string) => Message | undefined
+    // Every stored conversation (archived INCLUDED) with its in-memory
+    // messages. Read seam for the deferred-decrypt engine, which must retry
+    // pending encrypted payloads regardless of archive state — unlike
+    // getAllConversations, which returns only the active set.
+    getAllStoredMessages: () => Array<{ id: string; messages: Message[] }>
+    // In-memory messages for a single conversation (archived included). Read
+    // seam for peer-scoped deferred-decrypt retry on a PEP key change.
+    getConversationMessages: (conversationId: string) => Message[]
   }
   roster: Pick<RosterState, (typeof rosterBindingMethodKeys)[number]>
   console: Pick<ConsoleState, (typeof consoleBindingMethodKeys)[number]>
@@ -96,6 +105,9 @@ export interface StoreBindings {
     // can't be matched locally — seeds a forward `after` catch-up on an
     // empty-cache new device.
     getRoomPendingStanzaId?: (roomJid: string) => string | undefined
+    // Every room with its in-memory runtime messages. Read seam for the
+    // deferred-decrypt engine (mirrors chat.getAllStoredMessages for MUC).
+    getAllRoomMessages: () => Array<{ jid: string; messages: RoomMessage[] }>
   }
   admin: Pick<AdminState, (typeof adminBindingMethodKeys)[number]> & {
     // State getters


### PR DESCRIPTION
First step of Phase 3 (decomposing the ~2,630-line XMPPClient god class): move the E2EE deferred-decrypt subsystem into a self-contained `core/e2ee/deferredDecrypt.ts`.

**What**
- New `DeferredDecryptEngine` owns `retryPending` / `retryForPeer` and the per-payload decrypt + signal-application helpers (formerly `retryPendingDecrypts`, `retryDecryptSingle`, `applyDeferredChatModification`, `resolveRejectedChatPlaceholder`, `retryPendingDecryptsForPeer`), the retry-coalescing guard flags, and the `RetryOutcome`/`RetryModification` types.
- It receives its collaborators explicitly (E2EEManager, StoreBindings, own JID, message-cache port) as getters instead of reaching into module-global stores.
- `XMPPClient` keeps a thin public `retryPendingDecrypts()` that delegates, since backgroundSync triggers it via the client.

**Why**
It's the largest self-contained block in the class (~570 lines) and has nothing to do with being a client facade — it's a message-repair subsystem over the stores + IndexedDB cache.

**Bug fixed in passing**
The retry loops read conversation state directly from the global Zustand `chatStore`/`roomStore` instead of the injected `StoreBindings`, so a custom-store consumer never had its pending payloads scanned. Reads now route through three behavior-preserving binding seams: `chat.getAllStoredMessages` (archived included — unlike `getAllConversations`, which is active-only), `chat.getConversationMessages`, and `room.getAllRoomMessages`.

Behavior-preserving extraction. Existing `XMPPClient.e2ee.test.ts` stays green (one internal hook re-pointed at the engine seam); adds a focused `deferredDecrypt.test.ts` pinning that reads/writes route through the injected bindings, never the globals.