### PR TITLE
refactor(sdk): move presence bridge off StoreBindings into a PresenceReader dep

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -11,6 +11,7 @@ import type {
   StorageAdapter,
   ProxyAdapter,
   PrivacyOptions,
+  PresenceOptions,
 } from './types'
 import {
   presenceMachine,
@@ -109,7 +110,8 @@ import { DeferredDecryptEngine } from './e2ee/deferredDecrypt'
 import { SessionLifecycleEngine } from './sessionLifecycle'
 import { dataToElement } from './e2ee/stanzaAdapter'
 import { NS_MAM } from './namespaces'
-import { createDefaultStoreBindings, type DefaultStoreBindingsOptions } from './defaultStoreBindings'
+import { createDefaultStoreBindings } from './defaultStoreBindings'
+import { createPresenceReader, type PresenceReader } from './presenceReader'
 import { initSearchIndex, backfillFromMessageCache } from '../utils/searchIndex'
 import { getMessagesWithEncryptedPayload, updateMessage as cacheUpdateMessage, deleteMessage as cacheDeleteMessage } from '../utils/messageCache'
 
@@ -326,6 +328,15 @@ export class XMPPClient {
   public presenceActor!: PresenceActor
 
   /**
+   * Narrow read surface over the presence machine, injected into every module
+   * via `moduleDeps.presence`. Built once in the constructor from the presence
+   * getters (machine snapshot + any custom `presenceOptions`), so it survives
+   * re-init via {@link bindStores}.
+   * @internal
+   */
+  private presenceReader!: PresenceReader
+
+  /**
    * XState connection actor managing connection lifecycle state.
    *
    * The connection machine handles explicit state transitions for the XMPP
@@ -474,8 +485,11 @@ export class XMPPClient {
     // Note: presence persistence subscription is set up in setupBindings()
     // so it can be re-established after destroy() in React StrictMode.
 
-    // Create presence options that read from the machine (single source of truth)
-    const presenceOptions: DefaultStoreBindingsOptions = {
+    // Presence getters read from the machine (single source of truth), merged
+    // with any custom integration the consumer provided. Modules consume these
+    // through the injected PresenceReader (moduleDeps.presence), not the
+    // connection store binding — presence is machine state, not store state.
+    const presenceOptions: PresenceOptions = {
       getPresenceShow: () => {
         const state = this.presenceActor.getSnapshot()
         const stateValue = state.value as PresenceStateValue
@@ -498,27 +512,13 @@ export class XMPPClient {
         const state = this.presenceActor.getSnapshot()
         return (state.context as PresenceMachineContext).preAutoAwayStatusMessage
       },
-      setPresenceState: (show, message) => {
-        // Send event to machine - it manages state transitions
-        const showMap = { online: 'online', away: 'away', dnd: 'dnd', offline: 'online' } as const
-        this.presenceActor.send({
-          type: 'SET_PRESENCE',
-          show: showMap[show] || 'online',
-          status: message ?? undefined,
-        })
-      },
-      setAutoAway: () => {
-        // No-op: auto-away is managed by the machine via IDLE_DETECTED events
-      },
-      clearPreAutoAwayState: () => {
-        // No-op: pre-auto-away state is managed by the machine internally
-      },
       // Merge any custom options provided by the user
       ...config.presenceOptions,
     }
+    this.presenceReader = createPresenceReader(presenceOptions)
 
     // Initialize with default store bindings (using global Zustand stores)
-    this.initializeModules(createDefaultStoreBindings(presenceOptions))
+    this.initializeModules(createDefaultStoreBindings())
 
     // Set up all bindings (presence sync, store bindings, side effects).
     // Extracted to a method so XMPPProvider can call setupBindings/destroy
@@ -622,6 +622,7 @@ export class XMPPClient {
 
     const moduleDeps = {
       stores: this.stores,
+      presence: this.presenceReader,
       sendStanza: (stanza: Element) => this.sendStanza(stanza),
       sendIQ: (iq: Element, timeoutMs?: number) => this.sendIQ(iq, timeoutMs),
       getCurrentJid: () => this.currentJid,

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -19,7 +19,7 @@ import {
   adminStore,
   blockingStore,
 } from '../stores'
-import type { StoreBindings, PresenceOptions } from './types/client'
+import type { StoreBindings } from './types/client'
 import {
   connectionBindingMethodKeys,
   chatBindingMethodKeys,
@@ -50,49 +50,22 @@ function bindStoreMethods<S, K extends keyof S>(
 }
 
 /**
- * Options for creating default store bindings.
- */
-export type DefaultStoreBindingsOptions = PresenceOptions
-
-/**
  * Create default StoreBindings using the global Zustand stores.
  *
- * This is the standard way to create store bindings for XMPPClient.
- * The presence getters/setters are optional - if not provided, they
- * return defaults (useful for headless bots that don't need presence state machine).
+ * This is the standard way to create store bindings for XMPPClient. Presence
+ * is no longer part of the store bindings — it is a separate PresenceReader
+ * dependency (see `presenceReader.ts`), since presence is machine state, not
+ * connection-store state.
  *
- * @param options - Optional presence getters/setters from PresenceOptions
  * @returns StoreBindings object for XMPPClient
  *
- * @example Bot usage (no presence machine)
+ * @example
  * ```typescript
  * const client = new XMPPClient()
- * // Uses createDefaultStoreBindings() internally with default presence
- * ```
- *
- * @example React app with XState presence machine
- * ```typescript
- * const presenceActor = createActor(presenceMachine).start()
- * const client = new XMPPClient({
- *   presenceOptions: {
- *     getPresenceShow: () => getPresenceStatusFromState(presenceActor.getSnapshot().value),
- *     setPresenceState: (show, msg) => presenceActor.send({ type: 'SET_PRESENCE', show, status: msg }),
- *     // ...
- *   },
- * })
+ * // Uses createDefaultStoreBindings() internally
  * ```
  */
-export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions = {}): StoreBindings {
-  // Extract presence options with defaults for headless usage
-  const getPresenceShow = options.getPresenceShow ?? (() => 'online' as const)
-  const getStatusMessage = options.getStatusMessage ?? (() => null)
-  const getIsAutoAway = options.getIsAutoAway ?? (() => false)
-  const getPreAutoAwayState = options.getPreAutoAwayState ?? (() => null)
-  const getPreAutoAwayStatusMessage = options.getPreAutoAwayStatusMessage ?? (() => null)
-  const setPresenceState = options.setPresenceState ?? (() => {})
-  const setAutoAway = options.setAutoAway ?? (() => {})
-  const clearPreAutoAwayState = options.clearPreAutoAwayState ?? (() => {})
-
+export function createDefaultStoreBindings(): StoreBindings {
   return {
     connection: {
       ...bindStoreMethods(connectionStore, connectionBindingMethodKeys),
@@ -104,15 +77,6 @@ export function createDefaultStoreBindings(options: DefaultStoreBindingsOptions 
       getWebPushServices: () => connectionStore.getState().webPushServices,
       getWebPushEnabled: () => connectionStore.getState().webPushEnabled,
       getServerInfo: () => connectionStore.getState().serverInfo,
-      // Presence from external machine (or defaults for headless)
-      getPresenceShow,
-      getStatusMessage,
-      getIsAutoAway,
-      getPreAutoAwayState,
-      getPreAutoAwayStatusMessage,
-      setPresenceState,
-      setAutoAway,
-      clearPreAutoAwayState,
     },
     chat: {
       ...bindStoreMethods(chatStore, chatBindingMethodKeys),

--- a/packages/fluux-sdk/src/core/index.ts
+++ b/packages/fluux-sdk/src/core/index.ts
@@ -3,7 +3,6 @@ export { XMPPClient } from './XMPPClient'
 
 // Default store bindings for headless usage
 export { createDefaultStoreBindings } from './defaultStoreBindings'
-export type { DefaultStoreBindingsOptions } from './defaultStoreBindings'
 
 // Re-export xml builder from @xmpp/client for raw stanza construction
 export { xml } from '@xmpp/client'

--- a/packages/fluux-sdk/src/core/modules/BaseModule.ts
+++ b/packages/fluux-sdk/src/core/modules/BaseModule.ts
@@ -1,6 +1,7 @@
 import type { Element } from '@xmpp/client'
 import type { StoreBindings, XMPPClientEvents, SDKEvents, StorageAdapter, ProxyAdapter, PrivacyOptions } from '../types'
 import type { E2EEManager } from '../e2ee'
+import type { PresenceReader } from '../presenceReader'
 
 /**
  * Dependencies injected into each module by XMPPClient.
@@ -12,6 +13,12 @@ import type { E2EEManager } from '../e2ee'
  */
 export interface ModuleDependencies {
   stores: StoreBindings | null
+  /**
+   * Read surface for presence-machine state. Presence is machine state, not
+   * connection-store state, so modules consult it here rather than through the
+   * connection store binding. Always provided (defaults to a headless reader).
+   */
+  presence: PresenceReader
   sendStanza: (stanza: Element) => Promise<void>
   sendIQ: (iq: Element, timeoutMs?: number) => Promise<Element>
   getCurrentJid: () => string | null

--- a/packages/fluux-sdk/src/core/modules/Blocking.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Blocking.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Blocking } from './Blocking'
-import { createMockElement, createMockStores } from '../test-utils'
+import { createMockElement, createMockStores, createMockPresenceReader } from '../test-utils'
 import { NS_BLOCKING } from '../namespaces'
 import type { Element } from '@xmpp/client'
 import type { ModuleDependencies } from './BaseModule'
@@ -22,6 +22,7 @@ describe('Blocking module', () => {
 
     blocking = new Blocking({
       stores: mockStores,
+      presence: createMockPresenceReader(),
       sendStanza,
       sendIQ,
       getCurrentJid: () => 'user@example.com',

--- a/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.e2ee.test.ts
@@ -6,6 +6,7 @@
  * so we cover stanza construction, claim routing, and async decrypt-reprocess.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { Chat } from './Chat'
@@ -140,6 +141,7 @@ function makeDeps(options: {
   const sdkEmitted: unknown[] = []
   const deps: ModuleDependencies = {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async (stanza) => {
       options.captureStanza(stanza)
     },
@@ -1035,6 +1037,7 @@ describe('Chat E2EE wiring', () => {
       const sdkEmitted: unknown[] = []
       const deps: ModuleDependencies = {
         stores: null,
+        presence: createPresenceReader(),
         sendStanza: async () => {},
         sendIQ: async () => xml('iq', {}) as Element,
         getCurrentJid: () => jid,

--- a/packages/fluux-sdk/src/core/modules/Discovery.pepSupport.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.pepSupport.test.ts
@@ -6,6 +6,7 @@
  * (`fetchServerInfo`) does not advertise PEP — only the account entity does.
  */
 import { describe, it, expect } from 'vitest'
+import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { Discovery, discoSupportsPep } from './Discovery'
@@ -17,6 +18,7 @@ function makeDeps(
 ): ModuleDependencies {
   return {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ,
     getCurrentJid: () => currentJid,

--- a/packages/fluux-sdk/src/core/modules/Discovery.queryInfo.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Discovery.queryInfo.test.ts
@@ -3,6 +3,7 @@
  * to exercise the same stanza path plugins will hit.
  */
 import { describe, it, expect } from 'vitest'
+import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { Discovery } from './Discovery'
@@ -11,6 +12,7 @@ import type { ModuleDependencies } from './BaseModule'
 function makeDeps(sendIQ: (iq: Element) => Promise<Element>): ModuleDependencies {
   return {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ,
     getCurrentJid: () => 'me@example.com',

--- a/packages/fluux-sdk/src/core/modules/EntityTime.test.ts
+++ b/packages/fluux-sdk/src/core/modules/EntityTime.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EntityTime, parseTzo, getBestResource } from './EntityTime'
-import { createMockElement, createMockStores } from '../test-utils'
+import { createMockElement, createMockStores, createMockPresenceReader } from '../test-utils'
 import type { Element } from '@xmpp/client'
 import type { ModuleDependencies } from './BaseModule'
 import type { ResourcePresence } from '../types'
@@ -114,6 +114,7 @@ describe('EntityTime module', () => {
 
     entityTime = new EntityTime({
       stores: mockStores,
+      presence: createMockPresenceReader(),
       sendStanza: vi.fn(),
       sendIQ,
       getCurrentJid: () => 'user@example.com',

--- a/packages/fluux-sdk/src/core/modules/LastActivity.test.ts
+++ b/packages/fluux-sdk/src/core/modules/LastActivity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { LastActivity } from './LastActivity'
-import { createMockElement, createMockStores } from '../test-utils'
+import { createMockElement, createMockStores, createMockPresenceReader } from '../test-utils'
 import type { Element } from '@xmpp/client'
 import type { ModuleDependencies } from './BaseModule'
 
@@ -55,6 +55,7 @@ describe('LastActivity module', () => {
 
     lastActivity = new LastActivity({
       stores: mockStores,
+      presence: createMockPresenceReader(),
       sendStanza: vi.fn(),
       sendIQ,
       getCurrentJid: () => 'user@example.com',

--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -12,6 +12,7 @@
  * sender's XEP-0373 hint body and no decrypt attempt.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { MAM } from './MAM'
@@ -98,6 +99,7 @@ function makeHarness(options: {
 
   const deps: ModuleDependencies = {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ: () =>
       new Promise<Element>((resolve) => {
@@ -147,6 +149,7 @@ function makeHarnessNoManager(jid: string): TestHarness {
 
   const deps: ModuleDependencies = {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ: () =>
       new Promise<Element>((resolve) => {
@@ -926,6 +929,7 @@ describe('MAM forward catch-up — cross-page modification resolution (1:1)', ()
     }
     const deps: ModuleDependencies = {
       stores: null,
+      presence: createPresenceReader(),
       sendStanza: async () => {},
       sendIQ: () =>
         new Promise<Element>((resolve) => {
@@ -1065,6 +1069,7 @@ describe('MAM preview refresh E2EE (sidebar preview)', () => {
     let captured: { body: string; from: string; encryptedPayload?: string } | null = null
 
     const deps: ModuleDependencies = {
+      presence: createPresenceReader(),
       stores: {
         chat: {
           getAllConversations: () => [{ id: conversationId }],

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -9,6 +9,7 @@ import { MUC } from './MUC'
 import {
   createMockElement,
   createMockStores,
+  createMockPresenceReader,
 } from '../test-utils'
 import type { ModuleDependencies } from './BaseModule'
 
@@ -29,6 +30,7 @@ describe('MUC Module', () => {
 
     const deps = {
       stores: mockStores,
+      presence: createMockPresenceReader(),
       sendIQ: mockSendIQ,
       sendStanza: mockSendStanza,
       emit: mockEmit,

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -760,8 +760,8 @@ export class MUC extends BaseModule {
     ]
 
     // Include current presence show (away, dnd, xa) if not online
-    const currentPresence = this.deps.stores?.connection.getPresenceShow()
-    const currentStatus = this.deps.stores?.connection.getStatusMessage()
+    const currentPresence = this.deps.presence.getPresenceShow()
+    const currentStatus = this.deps.presence.getStatusMessage()
     if (currentPresence && currentPresence !== 'online' && currentPresence !== 'offline') {
       const showValue = currentPresence === 'away' ? 'away' : currentPresence === 'dnd' ? 'dnd' : undefined
       if (showValue) {
@@ -875,8 +875,8 @@ export class MUC extends BaseModule {
     })
 
     // Preserve current presence show/status on the directed presence.
-    const currentPresence = this.deps.stores?.connection.getPresenceShow()
-    const currentStatus = this.deps.stores?.connection.getStatusMessage()
+    const currentPresence = this.deps.presence.getPresenceShow()
+    const currentStatus = this.deps.presence.getStatusMessage()
     const children: Element[] = []
     if (currentPresence && currentPresence !== 'online' && currentPresence !== 'offline') {
       const showValue = currentPresence === 'away' ? 'away' : currentPresence === 'dnd' ? 'dnd' : undefined

--- a/packages/fluux-sdk/src/core/modules/Presence.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Presence.test.ts
@@ -9,6 +9,7 @@ import { XMPPClient } from '../XMPPClient'
 import {
   createMockXmppClient,
   createMockStores,
+  createMockPresenceReader,
   createMockElement,
   createMockRoom,
   type MockXmppClient,
@@ -39,6 +40,7 @@ import { client as xmppClientFactory } from '@xmpp/client'
 describe('XMPPClient Presence', () => {
   let xmppClient: XMPPClient
   let mockStores: MockStoreBindings
+  let mockPresence: ReturnType<typeof createMockPresenceReader>
   let emitSDKSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
@@ -47,7 +49,10 @@ describe('XMPPClient Presence', () => {
     vi.mocked(xmppClientFactory).mockReturnValue(mockXmppClientInstance as any)
 
     mockStores = createMockStores()
-    xmppClient = new XMPPClient({ debug: false })
+    mockPresence = createMockPresenceReader()
+    // Presence is injected as a dependency now (not a store binding); the
+    // client wraps these getters, so tests drive presence via mockPresence.
+    xmppClient = new XMPPClient({ debug: false, presenceOptions: mockPresence })
     xmppClient.bindStores(mockStores)
     emitSDKSpy = vi.spyOn(xmppClient, 'emitSDK')
   })
@@ -532,8 +537,8 @@ describe('XMPPClient Presence', () => {
 
     it('should preserve DND presence on reconnect', async () => {
       // Set up mock to return DND presence
-      mockStores.connection.getPresenceShow.mockReturnValue('dnd')
-      mockStores.connection.getIsAutoAway.mockReturnValue(false)
+      mockPresence.getPresenceShow.mockReturnValue('dnd')
+      mockPresence.getIsAutoAway.mockReturnValue(false)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -559,8 +564,8 @@ describe('XMPPClient Presence', () => {
       // Stale away: previous session had auto-away but isAutoAway is transient (false).
       // We can't distinguish from manual away, so we default to online to avoid
       // being stuck in 'away' on every reconnect.
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(false)
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(false)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -584,8 +589,8 @@ describe('XMPPClient Presence', () => {
 
     it('should clear auto-away to online on reconnect', async () => {
       // Set up mock to return auto-away
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(true)
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(true)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -613,10 +618,10 @@ describe('XMPPClient Presence', () => {
 
     it('should restore pre-auto-away DND presence when recovering from auto-away/sleep', async () => {
       // Set up mock: was in DND before sleep, now in auto-away
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(true)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('dnd')
-      mockStores.connection.getPreAutoAwayStatusMessage.mockReturnValue('Busy working')
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(true)
+      mockPresence.getPreAutoAwayState.mockReturnValue('dnd')
+      mockPresence.getPreAutoAwayStatusMessage.mockReturnValue('Busy working')
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -648,10 +653,10 @@ describe('XMPPClient Presence', () => {
 
     it('should restore pre-auto-away presence when recovering from auto-away/sleep', async () => {
       // Set up mock: was manually away before idle timeout, now in auto-away
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(true)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('away')
-      mockStores.connection.getPreAutoAwayStatusMessage.mockReturnValue('In a meeting')
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(true)
+      mockPresence.getPreAutoAwayState.mockReturnValue('away')
+      mockPresence.getPreAutoAwayStatusMessage.mockReturnValue('In a meeting')
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -679,11 +684,11 @@ describe('XMPPClient Presence', () => {
 
     it('should default to online when isAutoAway=false and no preAutoAwayState (stale away) on reconnect', async () => {
       // Set up mock: was online with no status before sleep
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getStatusMessage.mockReturnValue('Computer went to sleep...')
-      mockStores.connection.getIsAutoAway.mockReturnValue(true)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('online')
-      mockStores.connection.getPreAutoAwayStatusMessage.mockReturnValue(null)
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getStatusMessage.mockReturnValue('Computer went to sleep...')
+      mockPresence.getIsAutoAway.mockReturnValue(true)
+      mockPresence.getPreAutoAwayState.mockReturnValue('online')
+      mockPresence.getPreAutoAwayStatusMessage.mockReturnValue(null)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -711,8 +716,8 @@ describe('XMPPClient Presence', () => {
 
     it('should send online presence when status was online', async () => {
       // Set up mock to return online
-      mockStores.connection.getPresenceShow.mockReturnValue('online')
-      mockStores.connection.getIsAutoAway.mockReturnValue(false)
+      mockPresence.getPresenceShow.mockReturnValue('online')
+      mockPresence.getIsAutoAway.mockReturnValue(false)
 
       const connectPromise = xmppClient.connect({
         jid: 'user@example.com',
@@ -1636,8 +1641,8 @@ describe('XMPPClient Presence', () => {
       await connectClient()
 
       // Set user presence to DND
-      mockStores.connection.getPresenceShow.mockReturnValue('dnd')
-      mockStores.connection.getStatusMessage.mockReturnValue('Busy')
+      mockPresence.getPresenceShow.mockReturnValue('dnd')
+      mockPresence.getStatusMessage.mockReturnValue('Busy')
 
       // Join a room
       await xmppClient.muc.joinRoom('room@conference.example.com', 'testnick')
@@ -1668,8 +1673,8 @@ describe('XMPPClient Presence', () => {
       await connectClient()
 
       // Set user presence to away
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getStatusMessage.mockReturnValue(null)
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getStatusMessage.mockReturnValue(null)
 
       // Join a room
       await xmppClient.muc.joinRoom('room@conference.example.com', 'testnick')
@@ -1695,8 +1700,8 @@ describe('XMPPClient Presence', () => {
       await connectClient()
 
       // Set user presence to online (default)
-      mockStores.connection.getPresenceShow.mockReturnValue('online')
-      mockStores.connection.getStatusMessage.mockReturnValue(null)
+      mockPresence.getPresenceShow.mockReturnValue('online')
+      mockPresence.getStatusMessage.mockReturnValue(null)
 
       // Join a room
       await xmppClient.muc.joinRoom('room@conference.example.com', 'testnick')

--- a/packages/fluux-sdk/src/core/modules/PubSub.pep.test.ts
+++ b/packages/fluux-sdk/src/core/modules/PubSub.pep.test.ts
@@ -6,6 +6,7 @@
  * real plugins will exercise.
  */
 import { describe, it, expect, vi } from 'vitest'
+import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { PubSub } from './PubSub'
@@ -15,6 +16,7 @@ import type { PEPItem } from '../e2ee'
 function makeDeps(sendIQ: (iq: Element) => Promise<Element>): ModuleDependencies {
   return {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ,
     getCurrentJid: () => 'me@example.com',

--- a/packages/fluux-sdk/src/core/modules/Roster.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.test.ts
@@ -9,6 +9,7 @@ import { XMPPClient } from '../XMPPClient'
 import {
   createMockXmppClient,
   createMockStores,
+  createMockPresenceReader,
   createMockElement,
   createIQHandlerTester,
   type MockXmppClient,
@@ -39,6 +40,7 @@ import { client as xmppClientFactory } from '@xmpp/client'
 describe('XMPPClient Roster', () => {
   let xmppClient: XMPPClient
   let mockStores: MockStoreBindings
+  let mockPresence: ReturnType<typeof createMockPresenceReader>
   let emitSDKSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
@@ -47,7 +49,10 @@ describe('XMPPClient Roster', () => {
     vi.mocked(xmppClientFactory).mockReturnValue(mockXmppClientInstance as any)
 
     mockStores = createMockStores()
-    xmppClient = new XMPPClient({ debug: false })
+    mockPresence = createMockPresenceReader()
+    // Presence is injected as a dependency now (not a store binding); the
+    // client wraps these getters, so tests drive presence via mockPresence.
+    xmppClient = new XMPPClient({ debug: false, presenceOptions: mockPresence })
     xmppClient.bindStores(mockStores)
     emitSDKSpy = vi.spyOn(xmppClient, 'emitSDK')
   })
@@ -454,11 +459,11 @@ describe('XMPPClient Roster', () => {
      * The fix: setPresence() should NOT call setPresenceState().
      * The presence machine is the source of truth.
      */
-    it('should NOT call setPresenceState when sending presence (prevents circular dependency)', async () => {
+    it('should NOT feed presence back into the machine when sending presence (prevents circular dependency)', async () => {
       await connectClient()
 
-      // Clear any calls from connection
-      mockStores.connection.setPresenceState.mockClear()
+      // Watch the presence machine — setPresence must not re-enter it.
+      const machineSend = vi.spyOn(xmppClient.presenceActor, 'send')
 
       // Call setPresence (as setupPresenceSync does when machine state changes)
       await xmppClient.roster.setPresence('away', 'Auto away')
@@ -468,18 +473,20 @@ describe('XMPPClient Roster', () => {
       const sentStanza = vi.mocked(mockXmppClientInstance.send).mock.calls[0][0]
       expect(sentStanza.name).toBe('presence')
 
-      // CRITICAL: setPresenceState should NOT have been called
-      // This would create a circular dependency that breaks auto-away restoration
-      expect(mockStores.connection.setPresenceState).not.toHaveBeenCalled()
+      // CRITICAL: setPresence must NOT push a SET_PRESENCE event back into the
+      // machine — that would create a circular dependency that breaks auto-away
+      // restoration. Presence is read-only from the module's perspective now.
+      expect(machineSend).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'SET_PRESENCE' }))
     })
 
-    it('should NOT call setPresenceState for any presence show value', async () => {
+    it('should NOT feed presence back into the machine for any presence show value', async () => {
       await connectClient()
 
       const showValues: Array<'away' | 'dnd' | 'xa' | 'online'> = ['away', 'dnd', 'xa', 'online']
 
       for (const show of showValues) {
-        mockStores.connection.setPresenceState.mockClear()
+        const machineSend = vi.spyOn(xmppClient.presenceActor, 'send')
+        machineSend.mockClear()
         vi.mocked(mockXmppClientInstance.send).mockClear()
 
         await xmppClient.roster.setPresence(show, 'Status message')
@@ -487,8 +494,8 @@ describe('XMPPClient Roster', () => {
         // Verify presence was sent
         expect(mockXmppClientInstance.send).toHaveBeenCalled()
 
-        // setPresenceState should NEVER be called from setPresence
-        expect(mockStores.connection.setPresenceState).not.toHaveBeenCalled()
+        // setPresence must never push SET_PRESENCE back into the machine.
+        expect(machineSend).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'SET_PRESENCE' }))
       }
     })
   })
@@ -502,10 +509,10 @@ describe('XMPPClient Roster', () => {
       await connectClient()
 
       // Simulate auto-away state: presenceShow='away', isAutoAway=true, preAutoAwayState='online'
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(true)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('online')
-      mockStores.connection.getPreAutoAwayStatusMessage.mockReturnValue(null)
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(true)
+      mockPresence.getPreAutoAwayState.mockReturnValue('online')
+      mockPresence.getPreAutoAwayStatusMessage.mockReturnValue(null)
 
       await xmppClient.roster.sendInitialPresence()
 
@@ -531,10 +538,10 @@ describe('XMPPClient Roster', () => {
 
       // Simulate corrupted state: presenceShow='away' (not updated), isAutoAway=false (cleared),
       // preAutoAwayState='online' (still exists because it's proof auto-away was active)
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(false)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('online')
-      mockStores.connection.getPreAutoAwayStatusMessage.mockReturnValue(null)
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(false)
+      mockPresence.getPreAutoAwayState.mockReturnValue('online')
+      mockPresence.getPreAutoAwayStatusMessage.mockReturnValue(null)
 
       await xmppClient.roster.sendInitialPresence()
 
@@ -555,10 +562,10 @@ describe('XMPPClient Roster', () => {
       // Simulate stale away: previous session had auto-away but isAutoAway is false
       // (because it's transient). We can't distinguish this from manual away, so
       // we default to online to avoid being stuck in 'away' on every reconnect.
-      mockStores.connection.getPresenceShow.mockReturnValue('away')
-      mockStores.connection.getIsAutoAway.mockReturnValue(false)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue(null)
-      mockStores.connection.getStatusMessage.mockReturnValue('Out for lunch')
+      mockPresence.getPresenceShow.mockReturnValue('away')
+      mockPresence.getIsAutoAway.mockReturnValue(false)
+      mockPresence.getPreAutoAwayState.mockReturnValue(null)
+      mockPresence.getStatusMessage.mockReturnValue('Out for lunch')
 
       await xmppClient.roster.sendInitialPresence()
 
@@ -567,19 +574,16 @@ describe('XMPPClient Roster', () => {
       const sentStanza = vi.mocked(mockXmppClientInstance.send).mock.calls[0][0]
       const showElement = findChild(sentStanza, 'show') as { children: unknown[] } | undefined
       expect(showElement).toBeUndefined()
-
-      // Should NOT clear auto-away state (wasn't auto-away)
-      expect(mockStores.connection.setAutoAway).not.toHaveBeenCalled()
     })
 
     it('should preserve DND regardless of auto-away state', async () => {
       await connectClient()
 
       // DND should always be preserved, even if auto-away data exists
-      mockStores.connection.getPresenceShow.mockReturnValue('dnd')
-      mockStores.connection.getIsAutoAway.mockReturnValue(true) // Would normally trigger recovery
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('online')
-      mockStores.connection.getStatusMessage.mockReturnValue('In a meeting')
+      mockPresence.getPresenceShow.mockReturnValue('dnd')
+      mockPresence.getIsAutoAway.mockReturnValue(true) // Would normally trigger recovery
+      mockPresence.getPreAutoAwayState.mockReturnValue('online')
+      mockPresence.getStatusMessage.mockReturnValue('In a meeting')
 
       await xmppClient.roster.sendInitialPresence()
 
@@ -596,10 +600,10 @@ describe('XMPPClient Roster', () => {
 
       // User was manually 'away', then went idle and got auto-xa.
       // Pre-auto-away state should be 'away' (what they had before auto-xa)
-      mockStores.connection.getPresenceShow.mockReturnValue('xa' as any)
-      mockStores.connection.getIsAutoAway.mockReturnValue(true)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue('away')
-      mockStores.connection.getPreAutoAwayStatusMessage.mockReturnValue('Be right back')
+      mockPresence.getPresenceShow.mockReturnValue('xa' as any)
+      mockPresence.getIsAutoAway.mockReturnValue(true)
+      mockPresence.getPreAutoAwayState.mockReturnValue('away')
+      mockPresence.getPreAutoAwayStatusMessage.mockReturnValue('Be right back')
 
       await xmppClient.roster.sendInitialPresence()
 
@@ -620,10 +624,10 @@ describe('XMPPClient Roster', () => {
       await connectClient()
 
       // Normal online state
-      mockStores.connection.getPresenceShow.mockReturnValue('online')
-      mockStores.connection.getIsAutoAway.mockReturnValue(false)
-      mockStores.connection.getPreAutoAwayState.mockReturnValue(null)
-      mockStores.connection.getStatusMessage.mockReturnValue(null)
+      mockPresence.getPresenceShow.mockReturnValue('online')
+      mockPresence.getIsAutoAway.mockReturnValue(false)
+      mockPresence.getPreAutoAwayState.mockReturnValue(null)
+      mockPresence.getStatusMessage.mockReturnValue(null)
 
       await xmppClient.roster.sendInitialPresence()
 

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -326,12 +326,12 @@ export class Roster extends BaseModule {
       this.capsHash = await calculateCapsHash()
     }
 
-    const currentPresence = this.deps.stores?.connection.getPresenceShow()
-    const isAutoAway = this.deps.stores?.connection.getIsAutoAway()
-    const currentStatusMessage = this.deps.stores?.connection.getStatusMessage()
+    const currentPresence = this.deps.presence.getPresenceShow()
+    const isAutoAway = this.deps.presence.getIsAutoAway()
+    const currentStatusMessage = this.deps.presence.getStatusMessage()
 
-    const preAutoAwayState = this.deps.stores?.connection.getPreAutoAwayState()
-    const preAutoAwayStatusMessage = this.deps.stores?.connection.getPreAutoAwayStatusMessage()
+    const preAutoAwayState = this.deps.presence.getPreAutoAwayState()
+    const preAutoAwayStatusMessage = this.deps.presence.getPreAutoAwayStatusMessage()
 
     let showToSend: 'away' | 'dnd' | 'xa' | undefined
     let statusToSend: string | null | undefined

--- a/packages/fluux-sdk/src/core/modules/reactionsLiveFlag.test.ts
+++ b/packages/fluux-sdk/src/core/modules/reactionsLiveFlag.test.ts
@@ -5,6 +5,7 @@
  * - MAM module (history replay) must emit isLive: false
  */
 import { describe, it, expect, beforeEach } from 'vitest'
+import { createPresenceReader } from '../presenceReader'
 import { xml } from '@xmpp/client'
 import type { Element } from '@xmpp/client'
 import { Chat } from './Chat'
@@ -28,6 +29,7 @@ function makeDeps(jid: string): {
   const emitted: { event: string; payload: Record<string, unknown> }[] = []
   const deps: ModuleDependencies = {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ: async () => xml('iq', {}) as Element,
     getCurrentJid: () => jid,
@@ -84,6 +86,7 @@ function makeMAMHarness(jid: string): MAMHarness {
 
   const deps: ModuleDependencies = {
     stores: null,
+    presence: createPresenceReader(),
     sendStanza: async () => {},
     sendIQ: () =>
       new Promise<Element>((resolve) => {

--- a/packages/fluux-sdk/src/core/presenceReader.test.ts
+++ b/packages/fluux-sdk/src/core/presenceReader.test.ts
@@ -1,0 +1,48 @@
+/**
+ * createPresenceReader unit tests.
+ *
+ * The presence reader is the narrow read surface the domain modules use to
+ * consult the presence machine, decoupled from the connection store binding.
+ * It fills sensible defaults when no external presence integration is provided
+ * (headless/bot usage) and passes through the caller's getters otherwise.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createPresenceReader } from './presenceReader'
+
+describe('createPresenceReader', () => {
+  it('returns headless defaults when no options are provided', () => {
+    const reader = createPresenceReader()
+
+    expect(reader.getPresenceShow()).toBe('online')
+    expect(reader.getStatusMessage()).toBeNull()
+    expect(reader.getIsAutoAway()).toBe(false)
+    expect(reader.getPreAutoAwayState()).toBeNull()
+    expect(reader.getPreAutoAwayStatusMessage()).toBeNull()
+  })
+
+  it('passes through the provided getters', () => {
+    const reader = createPresenceReader({
+      getPresenceShow: () => 'dnd',
+      getStatusMessage: () => 'In a meeting',
+      getIsAutoAway: () => true,
+      getPreAutoAwayState: () => 'away',
+      getPreAutoAwayStatusMessage: () => 'Be right back',
+    })
+
+    expect(reader.getPresenceShow()).toBe('dnd')
+    expect(reader.getStatusMessage()).toBe('In a meeting')
+    expect(reader.getIsAutoAway()).toBe(true)
+    expect(reader.getPreAutoAwayState()).toBe('away')
+    expect(reader.getPreAutoAwayStatusMessage()).toBe('Be right back')
+  })
+
+  it('fills defaults for any getters the options omit', () => {
+    const getPresenceShow = vi.fn(() => 'away' as const)
+    const reader = createPresenceReader({ getPresenceShow })
+
+    expect(reader.getPresenceShow()).toBe('away')
+    // Omitted getters fall back to defaults rather than throwing.
+    expect(reader.getStatusMessage()).toBeNull()
+    expect(reader.getIsAutoAway()).toBe(false)
+  })
+})

--- a/packages/fluux-sdk/src/core/presenceReader.ts
+++ b/packages/fluux-sdk/src/core/presenceReader.ts
@@ -1,0 +1,40 @@
+/**
+ * Presence reader — the narrow read surface the domain modules use to consult
+ * the presence machine.
+ *
+ * Presence is machine state, not connection-store state, so it does not belong
+ * on the connection store binding. Modules receive a `PresenceReader` through
+ * their dependencies instead; the client builds one from the presence machine
+ * (see `XMPPClient`), and headless/bot consumers that supply no presence
+ * integration get sensible defaults.
+ */
+import type { PresenceOptions } from './types/client'
+
+/**
+ * The presence getters modules actually consume. A read-only projection of the
+ * presence machine — deliberately excludes the {@link PresenceOptions} setters,
+ * which no module calls (presence transitions go through the machine directly).
+ */
+export interface PresenceReader {
+  getPresenceShow: () => 'online' | 'away' | 'dnd' | 'offline'
+  getStatusMessage: () => string | null
+  getIsAutoAway: () => boolean
+  getPreAutoAwayState: () => 'online' | 'away' | 'dnd' | 'offline' | null
+  getPreAutoAwayStatusMessage: () => string | null
+}
+
+/**
+ * Build a {@link PresenceReader} from optional presence integration getters,
+ * filling headless defaults for anything omitted. The defaults mirror a
+ * disconnected/never-away client so bots and tests behave predictably without
+ * wiring a presence machine.
+ */
+export function createPresenceReader(options?: PresenceOptions): PresenceReader {
+  return {
+    getPresenceShow: options?.getPresenceShow ?? (() => 'online'),
+    getStatusMessage: options?.getStatusMessage ?? (() => null),
+    getIsAutoAway: options?.getIsAutoAway ?? (() => false),
+    getPreAutoAwayState: options?.getPreAutoAwayState ?? (() => null),
+    getPreAutoAwayStatusMessage: options?.getPreAutoAwayStatusMessage ?? (() => null),
+  }
+}

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -633,15 +633,6 @@ export const createMockStores = (): MockStoreBindings => ({
     getWebPushServices: vi.fn().mockReturnValue([]),
     getWebPushEnabled: vi.fn().mockReturnValue(true),
     getServerInfo: vi.fn().mockReturnValue(null),
-    // Presence bridge
-    getPresenceShow: vi.fn().mockReturnValue('online'),
-    getStatusMessage: vi.fn().mockReturnValue(null),
-    getIsAutoAway: vi.fn().mockReturnValue(false),
-    getPreAutoAwayState: vi.fn().mockReturnValue(null),
-    getPreAutoAwayStatusMessage: vi.fn().mockReturnValue(null),
-    setPresenceState: vi.fn(),
-    setAutoAway: vi.fn(),
-    clearPreAutoAwayState: vi.fn(),
   },
   chat: {
     ...mockMethods(chatBindingMethodKeys),
@@ -698,6 +689,19 @@ export const createMockStores = (): MockStoreBindings => ({
     isBlocked: vi.fn().mockReturnValue(false),
     getBlockedJids: vi.fn().mockReturnValue([]),
   },
+})
+
+/**
+ * Mock PresenceReader with headless defaults. Use as `moduleDeps.presence` in
+ * module tests, or pass to `new XMPPClient({ presenceOptions })` so tests that
+ * drive presence-dependent behaviour can `.mockReturnValue(...)` on a getter.
+ */
+export const createMockPresenceReader = () => ({
+  getPresenceShow: vi.fn().mockReturnValue('online' as const),
+  getStatusMessage: vi.fn().mockReturnValue(null),
+  getIsAutoAway: vi.fn().mockReturnValue(false),
+  getPreAutoAwayState: vi.fn().mockReturnValue(null),
+  getPreAutoAwayStatusMessage: vi.fn().mockReturnValue(null),
 })
 
 /**

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -61,9 +61,7 @@ import {
  * @category Internal
  */
 export interface StoreBindings {
-  connection: Pick<ConnectionState, (typeof connectionBindingMethodKeys)[number]> &
-    // Presence bridge to the external state machine (defaults for headless)
-    Required<PresenceOptions> & {
+  connection: Pick<ConnectionState, (typeof connectionBindingMethodKeys)[number]> & {
       // State getters
       getStatus: () => ConnectionStatus
       getOwnNickname: () => string | null


### PR DESCRIPTION
Phase 3 step 3 (partial): decouple presence from the store bindings.

**What**
Presence-machine state was riding on the connection *store* binding — `StoreBindings.connection` carried `Required<PresenceOptions>` (5 getters + 3 setters). Only `MUC` and `Roster` read the getters; no SDK module ever called the setters. Presence is machine state, not connection-store state, so it doesn't belong there.

- New narrow read-only `PresenceReader` (`core/presenceReader.ts`), injected into every module via `moduleDeps.presence`. `XMPPClient` builds it once from the presence machine (+ any custom `presenceOptions`).
- `MUC`/`Roster` now read `this.deps.presence.*` instead of `this.deps.stores.connection.*`.
- Removed the presence bridge from the `StoreBindings.connection` type, `createDefaultStoreBindings` (and its now-empty `DefaultStoreBindingsOptions`), and `createMockStores`, shrinking the connection binding to actual connection-store state.

**Preserved**
The public `PresenceOptions` type and `config.presenceOptions` are unchanged — external presence integration works as before.