### PR TITLE
fix(mds): apply cross-device read markers synced while a room was inactive

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -373,7 +373,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
   })
 
-  it('does NOT re-fold a remote read marker on a later activation in the same session', async () => {
+  it('does NOT re-fold the SAME already-folded read marker on a later activation', async () => {
     const cid = 'juliet@capulet.example'
     // Distinct, increasing timestamps so sortMessagesByTimestamp gives a stable order and the
     // index-based forward-only advance is deterministic.
@@ -382,7 +382,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const messages = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4)]
     seedMessages(cid, messages)
 
-    // First open: local read stale at m2, a remote device read up to s3 (pending).
+    // First open: local read stale at m2, a remote device read up to s3 (pending) → folds to m3.
     chatStore.setState((state) => {
       const newMeta = new Map(state.conversationMeta)
       newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's3' })
@@ -392,14 +392,52 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     })
 
     await chatStore.getState().activateConversation(cid)
-    // First open folds the synced read forward to m3.
     expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
 
     // Leave (deactivation evicts the resident message array — memory windowing).
     await chatStore.getState().activateConversation(null)
 
-    // Re-open: the cache reload brings the messages back (re-seed simulates it), and a NEW remote
-    // read (s4, further ahead) has arrived as a fresh pending marker since first open.
+    // Re-open with the SAME pending marker still set: the gate must skip re-folding the identical
+    // marker so it can't reposition the divider on every return (XEP-0490 markers broadcast live).
+    seedMessages(cid, messages)
+    chatStore.setState((state) => {
+      const meta = state.conversationMeta.get(cid)!
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { ...meta, pendingRemoteDisplayedStanzaId: 's3' })
+      return { conversationMeta: newMeta }
+    })
+    await chatStore.getState().activateConversation(cid)
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
+  })
+
+  // Regression (bug: "read on another device, still unread on return"): a NEWER remote read
+  // arrives while the conversation is inactive. Inactive conversations evict their message array,
+  // so the live `read:displayed-synced` notify can only stash it as pending. The next activation
+  // fold is the only path that can apply it, so the gate must NOT suppress a marker it has never
+  // folded, even though the conversation was opened before.
+  it('folds a NEWER read marker that arrived while the conversation was inactive', async () => {
+    const cid = 'romeo@montague.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    const messages = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4)]
+    seedMessages(cid, messages)
+
+    // First open: local read stale at m2, a remote device read up to s3 (pending) → folds to m3.
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's3' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's3' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
+
+    await chatStore.getState().activateConversation(null)
+
+    // Re-open: cache reload brings messages back, and a NEW further-ahead remote read (s4) has
+    // arrived as a fresh pending marker that the live notify could only stash while unloaded.
     seedMessages(cid, messages)
     chatStore.setState((state) => {
       const meta = state.conversationMeta.get(cid)!
@@ -407,11 +445,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
       newMeta.set(cid, { ...meta, pendingRemoteDisplayedStanzaId: 's4' })
       return { conversationMeta: newMeta }
     })
-
-    // Re-open in the SAME session: the synced marker must NOT be folded again — XEP-0490 markers
-    // broadcast live over PEP, so the read position (and the divider) stay where this client left
-    // it. Without the gate this would fold s4 and advance lastSeenMessageId to m4.
     await chatStore.getState().activateConversation(cid)
-    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -743,12 +743,13 @@ export const chatStore = createStore<ChatState>()(
           // just-loaded messages) so the divider reflects reads synced from other
           // devices instead of the stale local position.
           // Fold a pending XEP-0490 synced read position into lastSeenMessageId BEFORE
-          // setActiveConversation derives the divider — but only on the FIRST open of this
-          // conversation this session. XEP-0490 markers broadcast live over PEP, so after the
-          // first consumption the live `read:displayed-synced` notifies keep us current; re-folding
-          // on every open would let a synced read position reposition the divider on each return.
-          const firstConsumeThisSession = mdsGate.consume(id)
+          // setActiveConversation derives the divider — but only once per distinct marker this
+          // session. The gate keys on the pending stanza-id so a marker synced from another device
+          // while this conversation was inactive (evicted → the live notify could only stash it)
+          // still folds on the next open, while an identical already-folded marker is skipped
+          // (re-folding would let a synced read position reposition the divider on each return).
           const pending = get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId
+          const firstConsumeThisSession = pending !== undefined && mdsGate.consume(id, pending)
           if (pending && firstConsumeThisSession) {
             const lastSeenBefore = get().conversationMeta.get(id)?.lastSeenMessageId
             get().applyRemoteDisplayed(id, pending)

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -277,14 +277,14 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIdFor(ROOM)(roomStore.getState())).toBeUndefined()
   })
 
-  it('does NOT re-fold a remote room marker on a later activation in the same session', async () => {
+  it('does NOT re-fold the SAME already-folded room marker on a later activation', async () => {
     // Distinct jid: the session-scoped "consumed" set is module-level and (unlike chatStore's
     // reset-based beforeEach) this file's beforeEach only resets store STATE, so a room consumed by
     // an earlier test would otherwise pre-mark this one and skip the legitimate first-open fold.
-    const REOPEN_ROOM = 'reopen-stress@conference.example'
+    const REOPEN_ROOM = 'reopen-same@conference.example'
     const messages = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)]
     seedRoom(REOPEN_ROOM, messages, 'm2')
-    // First open: a remote device read up to s3 (pending).
+    // First open: a remote device read up to s3 (pending) → folds to m3.
     roomStore.setState((s) => {
       const m = new Map(s.roomMeta)
       m.set(REOPEN_ROOM, { ...m.get(REOPEN_ROOM)!, pendingRemoteDisplayedStanzaId: 's3' })
@@ -296,7 +296,44 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     // Leave (deactivation evicts the resident message array).
     await roomStore.getState().activateRoom(null)
 
-    // Re-open: rehydrate the messages (cache reload) and a NEW further-ahead remote read (s4).
+    // Re-open with the SAME pending marker still present (e.g. never cleared because the message
+    // was outside the loaded window). The gate must skip re-folding the identical marker so it
+    // can't reposition the divider on every return (XEP-0490 markers broadcast live over PEP).
+    roomStore.setState((s) => {
+      const rt = new Map(s.roomRuntime)
+      const existing = rt.get(REOPEN_ROOM)
+      if (existing) rt.set(REOPEN_ROOM, { ...existing, messages })
+      const m = new Map(s.roomMeta)
+      m.set(REOPEN_ROOM, { ...m.get(REOPEN_ROOM)!, pendingRemoteDisplayedStanzaId: 's3' })
+      return { roomRuntime: rt, roomMeta: m }
+    })
+    await roomStore.getState().activateRoom(REOPEN_ROOM)
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.lastSeenMessageId).toBe('m3')
+  })
+
+  // Regression (bug: "read on another device, still unread on return"): a NEWER remote read
+  // arrives while the room is inactive. Inactive rooms evict their message array, so the live
+  // `read:displayed-synced` notify can only stash it as pending — it cannot advance
+  // lastSeenMessageId. The next activation fold is the only path that can apply it, so the gate
+  // must NOT suppress a marker it has never folded, even though the room was opened before.
+  it('folds a NEWER remote room marker that arrived while the room was inactive', async () => {
+    const REOPEN_ROOM = 'reopen-newer@conference.example'
+    const messages = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)]
+    seedRoom(REOPEN_ROOM, messages, 'm2')
+    // First open: a remote device read up to s3 (pending) → folds to m3.
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(REOPEN_ROOM, { ...m.get(REOPEN_ROOM)!, pendingRemoteDisplayedStanzaId: 's3' })
+      return { roomMeta: m }
+    })
+    await roomStore.getState().activateRoom(REOPEN_ROOM)
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.lastSeenMessageId).toBe('m3')
+
+    // Leave (deactivation evicts the resident message array).
+    await roomStore.getState().activateRoom(null)
+
+    // Re-open: rehydrate the messages (cache reload) and a NEW further-ahead remote read (s4)
+    // that the live notify could only stash while the room was unloaded.
     roomStore.setState((s) => {
       const rt = new Map(s.roomRuntime)
       const existing = rt.get(REOPEN_ROOM)
@@ -305,11 +342,8 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
       m.set(REOPEN_ROOM, { ...m.get(REOPEN_ROOM)!, pendingRemoteDisplayedStanzaId: 's4' })
       return { roomRuntime: rt, roomMeta: m }
     })
-
-    // Re-open in the SAME session: the synced marker must NOT be folded again (XEP-0490 markers
-    // broadcast live over PEP). Without the gate this would advance lastSeenMessageId to m4.
     await roomStore.getState().activateRoom(REOPEN_ROOM)
-    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.lastSeenMessageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.lastSeenMessageId).toBe('m4')
   })
 })
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1671,11 +1671,13 @@ export const roomStore = createStore<RoomState>()(
       // BEFORE setActiveRoom derives the new-message divider (parity with
       // chatStore.activateConversation). Forward-only against the loaded messages.
       // Fold a pending XEP-0490 synced read position into lastSeenMessageId BEFORE setActiveRoom
-      // derives the divider — but only on the FIRST open of this room this session (parity with
-      // chatStore.activateConversation). XEP-0490 markers broadcast live over PEP, so re-folding on
-      // every open would reposition the divider on each return.
-      const firstConsumeThisSession = mdsGate.consume(roomJid)
+      // derives the divider — but only once per distinct marker this session (parity with
+      // chatStore.activateConversation). The gate keys on the pending stanza-id so a marker synced
+      // from another device while this room was inactive (evicted → the live notify could only
+      // stash it) still folds on the next open, while an identical already-folded marker is skipped
+      // (re-folding would reposition the divider on every return).
       const pending = get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId
+      const firstConsumeThisSession = pending !== undefined && mdsGate.consume(roomJid, pending)
       if (pending && firstConsumeThisSession) {
         const lastSeenBefore = get().roomMeta.get(roomJid)?.lastSeenMessageId
         get().applyRemoteDisplayed(roomJid, pending)

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -105,14 +105,28 @@ describe('resolveRemoteDisplayed', () => {
 })
 
 describe('createMdsSessionGate', () => {
-  it('consumes each id once per session and resets', () => {
+  it('consumes each (id, stanzaId) once per session and resets', () => {
     const gate = createMdsSessionGate()
 
-    expect(gate.consume('a@example.com')).toBe(true)
-    expect(gate.consume('a@example.com')).toBe(false)
-    expect(gate.consume('b@example.com')).toBe(true)
+    expect(gate.consume('a@example.com', 's1')).toBe(true)
+    // Same marker re-presented: already folded → skip.
+    expect(gate.consume('a@example.com', 's1')).toBe(false)
+    // Distinct id: independent.
+    expect(gate.consume('b@example.com', 's1')).toBe(true)
 
     gate.reset()
-    expect(gate.consume('a@example.com')).toBe(true)
+    expect(gate.consume('a@example.com', 's1')).toBe(true)
+  })
+
+  it('re-arms when a newer marker arrives for an already-consumed id', () => {
+    const gate = createMdsSessionGate()
+
+    // First marker folds.
+    expect(gate.consume('a@example.com', 's1')).toBe(true)
+    // A different (newer) marker — synced from another device while this entity
+    // was unloaded, so the live PEP notify could only stash it — must fold too.
+    expect(gate.consume('a@example.com', 's2')).toBe(true)
+    // …but re-presenting that same newer marker is now a no-op.
+    expect(gate.consume('a@example.com', 's2')).toBe(false)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -104,24 +104,36 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
 // ============================================================================
 
 /**
- * XEP-0490 markers broadcast live over PEP, so a pending marker is folded
- * into the divider only on the FIRST open of an entity per session — later
- * opens rely on the live notifies (re-folding would reposition the divider on
- * every return). Each store owns one gate instance; `reset()` on account
- * switch.
+ * XEP-0490 markers broadcast live over PEP, so the activation fold applies a
+ * pending marker only ONCE per distinct value per session — re-folding the same
+ * marker on every open would reposition the divider on each return, and the live
+ * `read:displayed-synced` notifies already keep LOADED entities current.
+ *
+ * The gate keys on (id, stanzaId), not just id: a live notify that arrives while
+ * an entity is INACTIVE has no resident message array to advance against (memory
+ * windowing evicts it), so it can only stash the position as
+ * `pendingRemoteDisplayedStanzaId`. The next activation fold is then the only way
+ * to apply it. Keying on id alone would suppress that fold (the entity was opened
+ * before), leaving reads synced from another device stuck as unread. Keying on
+ * the stanza-id instead re-arms for a genuinely newer marker while still skipping
+ * the identical one. Each store owns one gate instance; `reset()` on account switch.
  */
 export interface MdsSessionGate {
-  /** True on the first call for this id since the last reset. Records the id. */
-  consume(id: string): boolean
+  /**
+   * True when `stanzaId` has not yet been folded for `id` this session — the
+   * first marker, or any newer/different one. Re-presenting the same value
+   * returns false. Records id → stanzaId.
+   */
+  consume(id: string, stanzaId: string): boolean
   reset(): void
 }
 
 export function createMdsSessionGate(): MdsSessionGate {
-  const consumed = new Set<string>()
+  const consumed = new Map<string, string>()
   return {
-    consume(id: string): boolean {
-      const first = !consumed.has(id)
-      consumed.add(id)
+    consume(id: string, stanzaId: string): boolean {
+      const first = consumed.get(id) !== stanzaId
+      consumed.set(id, stanzaId)
       return first
     },
     reset(): void {


### PR DESCRIPTION
## Summary

Read markers synced from another device (XEP-0490) were silently ignored when returning to a room/conversation already opened earlier in the session — messages read elsewhere stayed unread on return.

**Root cause:** The first-open-per-session fold gate keyed on the conversation/room JID alone. Inactive rooms evict their resident message array (memory windowing), so a live `read:displayed-synced` notify arriving while the entity is inactive can't advance `lastSeenMessageId` — it only stashes `pendingRemoteDisplayedStanzaId`. The activation fold was the sole path to apply it, but the id-keyed gate suppressed it because the entity had been opened before.

**Fix:** Key the gate on `(id, stanzaId)`. It still folds each marker exactly once (no divider repositioning on every return) but re-arms for a genuinely newer read position that the live notify could only stash. Forward-only semantics guarantee no read-state regression.

The prior "does NOT re-fold further-ahead pending on re-open" tests encoded the bug; flipped to assert the newer marker folds, kept same-marker-skip coverage.