### PR TITLE
feat(sdk): accept an injectable store bundle on XMPPClient (store-injection seam)

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -24,6 +24,8 @@ import {
 } from './test-utils'
 import { VERIFY_CONNECTION_TIMEOUT_MS } from './modules/connectionTimeouts'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { defaultStores, type SDKStores } from '../stores'
+import { createDefaultStoreBindings } from './defaultStoreBindings'
 
 let mockXmppClientInstance: MockXmppClient
 
@@ -2187,6 +2189,53 @@ describe('XMPPClient', () => {
         'me',
         expect.objectContaining({ knownFeatures: expect.objectContaining({ isNonAnonymous: true }) }),
       )
+    })
+  })
+
+  describe('store injection', () => {
+    // Wrap a store so getState() returns the real state with a specific method
+    // replaced by a spy — lets the rest of the client run on real stores while
+    // we observe that a chosen call routes through THIS instance.
+    const withSpy = <S>(store: S, override: Record<string, unknown>): S => ({
+      ...store,
+      getState: () => ({ ...(store as { getState: () => object }).getState(), ...override }),
+    }) as S
+
+    it('createDefaultStoreBindings routes writes through the injected bundle', () => {
+      const addMessage = vi.fn()
+      const bundle: SDKStores = {
+        ...defaultStores,
+        chat: withSpy(defaultStores.chat, { addMessage }),
+      }
+
+      const bindings = createDefaultStoreBindings(bundle)
+      bindings.chat.addMessage({ id: 'm1' } as never)
+
+      expect(addMessage).toHaveBeenCalledWith({ id: 'm1' })
+    })
+
+    it('new XMPPClient({ stores }) routes connect account-switch through the injected bundle', () => {
+      const chatSwitch = vi.fn()
+      const roomSwitch = vi.fn()
+      const ignoreRehydrate = vi.fn()
+      const bundle: SDKStores = {
+        ...defaultStores,
+        chat: withSpy(defaultStores.chat, { switchAccount: chatSwitch }),
+        room: withSpy(defaultStores.room, { switchAccount: roomSwitch }),
+        ignore: withSpy(defaultStores.ignore, { rehydrate: ignoreRehydrate }),
+      }
+
+      const client = new XMPPClient({ debug: false, stores: bundle })
+      // switchAccount / rehydrate run synchronously at the top of connect(),
+      // before any await — so they fire before the socket work (which we let
+      // reject harmlessly against the mocked transport).
+      void client
+        .connect({ jid: 'account@example.com', password: 'p', server: 'example.com', skipDiscovery: true })
+        .catch(() => {})
+
+      expect(chatSwitch).toHaveBeenCalledWith('account@example.com')
+      expect(roomSwitch).toHaveBeenCalledWith('account@example.com')
+      expect(ignoreRehydrate).toHaveBeenCalled()
     })
   })
 })

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -26,17 +26,7 @@ import type { ConnectionActor, ConnectionStateValue } from './connectionMachine'
 import { ensureCryptoRandomUUID } from './polyfill'
 import { createStoreBindings } from '../bindings/storeBindings'
 import { setupStoreSideEffects } from './sideEffects'
-import {
-  connectionStore,
-  chatStore,
-  rosterStore,
-  consoleStore,
-  eventsStore,
-  roomStore,
-  adminStore,
-  blockingStore,
-  ignoreStore,
-} from '../stores'
+import { defaultStores, type SDKStores } from '../stores'
 import { detectPlatform } from './platform'
 import { isDeadSocketError } from './modules/connectionUtils'
 import { getBareJid, getDomain } from './jid'
@@ -188,6 +178,13 @@ export class XMPPClient {
   private proxyAdapter?: ProxyAdapter
   private privacyOptions?: PrivacyOptions
   private stateSnapshot?: StateSnapshot
+  /**
+   * The store bundle backing this client (default bindings, event→store
+   * wiring, account switching). Defaults to the process-wide singletons; an
+   * injected bundle is the store-injection seam (see `stores/sdkStores.ts`).
+   * @internal
+   */
+  private readonly sdkStores: SDKStores
 
   /**
    * Connection management module.
@@ -453,6 +450,10 @@ export class XMPPClient {
     // This is async but we fire-and-forget; the result is cached for later use
     void detectPlatform()
 
+    // Resolve the store bundle (injected or the process-wide singletons). Set
+    // before initializeModules / setupBindings, which both read it.
+    this.sdkStores = config.stores ?? defaultStores
+
     // Store storage adapter for session persistence
     this.storageAdapter = config.storageAdapter
     this.shouldAutoReconnect = config.shouldAutoReconnect
@@ -518,7 +519,7 @@ export class XMPPClient {
     this.presenceReader = createPresenceReader(presenceOptions)
 
     // Initialize with default store bindings (using global Zustand stores)
-    this.initializeModules(createDefaultStoreBindings())
+    this.initializeModules(createDefaultStoreBindings(this.sdkStores))
 
     // Set up all bindings (presence sync, store bindings, side effects).
     // Extracted to a method so XMPPProvider can call setupBindings/destroy
@@ -555,15 +556,15 @@ export class XMPPClient {
     // Set up SDK event -> Zustand store bindings
     // This wires SDK events (e.g., 'chat:message') to store updates (e.g., chatStore.addMessage)
     const unsubscribeStoreBindings = createStoreBindings(this, () => ({
-      connection: connectionStore.getState(),
-      chat: chatStore.getState(),
-      roster: rosterStore.getState(),
-      room: roomStore.getState(),
-      events: eventsStore.getState(),
-      admin: adminStore.getState(),
-      blocking: blockingStore.getState(),
-      console: consoleStore.getState(),
-      ignore: ignoreStore.getState(),
+      connection: this.sdkStores.connection.getState(),
+      chat: this.sdkStores.chat.getState(),
+      roster: this.sdkStores.roster.getState(),
+      room: this.sdkStores.room.getState(),
+      events: this.sdkStores.events.getState(),
+      admin: this.sdkStores.admin.getState(),
+      blocking: this.sdkStores.blocking.getState(),
+      console: this.sdkStores.console.getState(),
+      ignore: this.sdkStores.ignore.getState(),
     }))
     this.cleanupFunctions.push(unsubscribeStoreBindings)
 
@@ -995,9 +996,9 @@ export class XMPPClient {
     const previousScope = getStorageScopeJid()
     if (previousScope !== scopedJid) {
       setStorageScopeJid(scopedJid)
-      chatStore.getState().switchAccount(scopedJid)
-      roomStore.getState().switchAccount(scopedJid)
-      ignoreStore.getState().rehydrate()
+      this.sdkStores.chat.getState().switchAccount(scopedJid)
+      this.sdkStores.room.getState().switchAccount(scopedJid)
+      this.sdkStores.ignore.getState().rehydrate()
     }
 
     // Open the search index DB and backfill from message cache if needed (one-time migration)

--- a/packages/fluux-sdk/src/core/defaultStoreBindings.ts
+++ b/packages/fluux-sdk/src/core/defaultStoreBindings.ts
@@ -9,16 +9,7 @@
  * @module Core
  */
 
-import {
-  connectionStore,
-  chatStore,
-  rosterStore,
-  consoleStore,
-  eventsStore,
-  roomStore,
-  adminStore,
-  blockingStore,
-} from '../stores'
+import { defaultStores, type SDKStores } from '../stores'
 import type { StoreBindings } from './types/client'
 import {
   connectionBindingMethodKeys,
@@ -57,6 +48,9 @@ function bindStoreMethods<S, K extends keyof S>(
  * dependency (see `presenceReader.ts`), since presence is machine state, not
  * connection-store state.
  *
+ * @param stores - The store bundle to bind. Defaults to the process-wide
+ *   {@link defaultStores} singletons; an injected bundle is the store-injection
+ *   seam (see `sdkStores.ts`).
  * @returns StoreBindings object for XMPPClient
  *
  * @example
@@ -65,7 +59,17 @@ function bindStoreMethods<S, K extends keyof S>(
  * // Uses createDefaultStoreBindings() internally
  * ```
  */
-export function createDefaultStoreBindings(): StoreBindings {
+export function createDefaultStoreBindings(stores: SDKStores = defaultStores): StoreBindings {
+  const {
+    connection: connectionStore,
+    chat: chatStore,
+    roster: rosterStore,
+    console: consoleStore,
+    events: eventsStore,
+    room: roomStore,
+    admin: adminStore,
+    blocking: blockingStore,
+  } = stores
   return {
     connection: {
       ...bindStoreMethods(connectionStore, connectionBindingMethodKeys),

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -25,6 +25,7 @@ import type {
   RoomState,
   AdminState,
   BlockingState,
+  SDKStores,
 } from '../../stores'
 import {
   connectionBindingMethodKeys,
@@ -229,6 +230,13 @@ export interface PrivacyOptions {
 export interface XMPPClientConfig {
   /** Enable debug logging */
   debug?: boolean
+  /**
+   * Store bundle backing this client. Defaults to the process-wide singletons
+   * ({@link defaultStores}). Injecting a custom {@link SDKStores} bundle is the
+   * seam for future multi-account support — see `stores/sdkStores.ts` for what
+   * else that entails. Single-account apps should omit this.
+   */
+  stores?: SDKStores
   /**
    * Options for integrating an external presence state machine.
    * Only needed when using XState for presence management (e.g., in React apps).

--- a/packages/fluux-sdk/src/stores/index.ts
+++ b/packages/fluux-sdk/src/stores/index.ts
@@ -73,6 +73,10 @@ export type { IgnoreState, IgnoredUser } from './ignoreStore'
 export { searchStore, setSearchClient, getSearchClient } from './searchStore'
 export type { SearchState, SearchResult, ContextMessage, SearchResultContext, SearchFilterType, InPrefixSuggestion } from './searchStore'
 
+// Injectable store bundle (store-injection seam; see sdkStores.ts)
+export { defaultStores } from './sdkStores'
+export type { SDKStores } from './sdkStores'
+
 // =============================================================================
 // UTILITIES
 // =============================================================================

--- a/packages/fluux-sdk/src/stores/sdkStores.ts
+++ b/packages/fluux-sdk/src/stores/sdkStores.ts
@@ -1,0 +1,72 @@
+/**
+ * The bundle of vanilla Zustand stores an {@link XMPPClient} reads and writes.
+ *
+ * The client no longer reaches for the module-global store singletons directly:
+ * it takes an `SDKStores` bundle (via `new XMPPClient({ stores })`), defaulting
+ * to {@link defaultStores} — the process-wide singletons — so existing single-
+ * account usage is unchanged.
+ *
+ * ---
+ * MULTI-ACCOUNT (future work). Accepting a custom bundle is the *seam* for
+ * running several accounts at once, but it is NOT sufficient on its own. Full
+ * multi-account still needs:
+ *
+ * 1. A `createStores()` factory. Each store is a module singleton today
+ *    (`export const chatStore = createStore(...)`); refactor to `createXStore()`
+ *    factories (keeping the singletons as `defaultStores`) so every account gets
+ *    an isolated set.
+ * 2. Per-instance storage scope. `storageScope.ts` holds ONE module-global
+ *    `currentStorageScopeJid`. Persisted stores (chat, ignore), the message
+ *    cache (IndexedDB) and the search index already namespace by it
+ *    (`buildScopedStorageKey` / `getStorageScopeJid`), so the keys are fine —
+ *    but the scope must become per-bundle/per-client instead of a global, since
+ *    only one account's scope can be active at a time right now.
+ * 3. Threading the bundle through direct-global consumers. Anything that imports
+ *    the raw singletons instead of reading `client.stores` (some side-effect
+ *    submodules, utils) must take the bundle instead.
+ * 4. The app's React layer. App hooks bind to the global singletons; multi-
+ *    account needs an account-scoped context providing the active client +
+ *    stores, with hooks resolving from it rather than the module singletons.
+ */
+import { connectionStore } from './connectionStore'
+import { chatStore } from './chatStore'
+import { rosterStore } from './rosterStore'
+import { roomStore } from './roomStore'
+import { eventsStore } from './eventsStore'
+import { adminStore } from './adminStore'
+import { blockingStore } from './blockingStore'
+import { consoleStore } from './consoleStore'
+import { ignoreStore } from './ignoreStore'
+
+/**
+ * The nine vanilla stores that back the {@link StoreBindings}. Each is a Zustand
+ * `StoreApi` (get/set/subscribe). `searchStore` is intentionally excluded — it
+ * is not part of the client's store bindings.
+ */
+export interface SDKStores {
+  connection: typeof connectionStore
+  chat: typeof chatStore
+  roster: typeof rosterStore
+  room: typeof roomStore
+  events: typeof eventsStore
+  admin: typeof adminStore
+  blocking: typeof blockingStore
+  console: typeof consoleStore
+  ignore: typeof ignoreStore
+}
+
+/**
+ * The process-wide singleton bundle. Used by {@link XMPPClient} when no custom
+ * `stores` are injected, preserving today's single-account behaviour.
+ */
+export const defaultStores: SDKStores = {
+  connection: connectionStore,
+  chat: chatStore,
+  roster: rosterStore,
+  room: roomStore,
+  events: eventsStore,
+  admin: adminStore,
+  blocking: blockingStore,
+  console: consoleStore,
+  ignore: ignoreStore,
+}


### PR DESCRIPTION
Phase 3 step 4 — the enabling seam for store injection.

**What**
`XMPPClient` no longer reaches for the module-global store singletons directly. It takes an `SDKStores` bundle via `new XMPPClient({ stores })`, defaulting to the process-wide singletons (`defaultStores`), so existing single-account usage and the app are unchanged.

- New `stores/sdkStores.ts`: the `SDKStores` bundle type + `defaultStores`, with a doc comment spelling out what full multi-account still needs.
- `createDefaultStoreBindings(stores = defaultStores)` builds the bindings from the bundle.
- The client routes its three global-store touch points — the default bindings, the SDK-event→store wiring, and `connect()`'s `switchAccount`/`rehydrate` — through the injected bundle.

**Why**
Removes the last hard coupling between the client facade and the global store singletons, and is the seam that unlocks multiple simultaneous accounts later — without doing the (large) app-side migration now.

**Scope**
Behavior-preserving (default = globals). This is the seam only. The full multi-account migration — a `createStores()` factory, per-instance storage scope, threading the bundle through direct-global consumers, and an account-scoped React context in the app — is deferred and documented at the seam (`stores/sdkStores.ts`).