### PR TITLE
fix(sidebar): keep rail activity dot inside the button's rounded corner

### DIFF
--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -62,7 +62,7 @@ export function IconRailNavLink({
       >
         <Icon className="size-5" />
         {showBadge ? (
-          <span className={`absolute top-0.5 end-0.5 size-2.5 ${dotFillClass} rounded-full ring-2 ${ringClass}`} />
+          <span className={`absolute top-1 end-1 size-2.5 ${dotFillClass} rounded-full ring-2 ${ringClass}`} />
         ) : null}
       </button>
     </Tooltip>


### PR DESCRIPTION
The activity dot on a rail nav button (e.g. the active channels `#` button) bulged slightly past the button's top-right edge. The dot sat at `top-0.5 end-0.5` (2px inset); with its 2px ring painted outside, the outer edge reached flush to the *square* corner — but the button uses `rounded-xl` (12px radius), so near the corner the surface curves inward and the dot overshot it by ~2px.

Tuck the dot in to `top-1 end-1` (4px) so its ring stays within the rounded corner. Verified in demo: the dot is now fully contained on both the active (brand) and resting rail surfaces.

Fixes #916