### PR TITLE
fix(composer): inset reply accent bar so it clears the card's rounded corner

### DIFF
--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -782,8 +782,8 @@ export function MessageComposer({
       {replyingTo && !editingMessage && (() => {
         const replyColor = replyingTo.senderColor || 'var(--fluux-brand)'
         return (
-        <div className="px-3 py-2 flex items-start gap-2 border-s-2 border-b border-fluux-border"
-             style={{ borderInlineStartColor: replyColor }}>
+        <div className="relative px-3 py-2 flex items-start gap-2 border-b border-fluux-border">
+          <span aria-hidden="true" className="pointer-events-none absolute inset-y-1.5 start-1.5 w-0.5 rounded-full" style={{ background: replyColor }} />
           <Reply className="rtl-mirror size-4 flex-shrink-0 mt-0.5" style={{ color: replyColor }} />
           <div className="flex-1 min-w-0">
             <p className="text-xs font-medium" style={{ color: replyColor }}>

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1027,6 +1027,14 @@ html, body {
   border-color: var(--fluux-brand);
   box-shadow: 0 0 0 3px hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.22);
 }
+/* Round the top of the first stacked row (edit / reply / attachment / key-change
+ * indicator, or the input row itself). Without this its square accent bar and
+ * bottom border poke past the card's rounded top corner. Inset by the 1px card
+ * border so the curve tracks the inner edge. */
+.composer-card > :first-child {
+  border-start-start-radius: calc(var(--fluux-radius-l) - 1px);
+  border-start-end-radius: calc(var(--fluux-radius-l) - 1px);
+}
 
 /* Composer action row. On narrow widths (phone, narrowed pane) the input + send
  * sit on a top row and the secondary controls (+ / lock / emoji) form a drawer


### PR DESCRIPTION
Fixes #914 — the green reply accent line was misaligned in the message composer.

The reply preview used the row's flush left border as its accent, so its square top corner poked past the composer card's rounded corner. It's now a 2px rounded bar inset from the card edge, clearly detached from the focus ring.

Also rounds the top corners of the card's first stacked row (`.composer-card > :first-child`) so the edit / attachment / key-change / upload-error chips clear the rounded corner too.

Closes #914