### PR TITLE
fix(notifications): dismiss native banner when a conversation is read from another device

### DIFF
--- a/apps/fluux/src/hooks/notificationCoalescer.test.ts
+++ b/apps/fluux/src/hooks/notificationCoalescer.test.ts
@@ -38,4 +38,15 @@ describe('createNotificationCoalescer', () => {
     expect(c.isOpen()).toBe(false)
     expect(c.flush()).toEqual([])
   })
+
+  it('delete removes a buffered entry so a later flush does not re-post it', () => {
+    const c = createNotificationCoalescer<string>()
+    c.open()
+    c.add('a', 'a1')
+    c.add('b', 'b1')
+    // Conversation 'a' was read (e.g. reply sent from mobile) before flush.
+    expect(c.delete('a')).toBe(true)
+    expect(c.delete('a')).toBe(false) // already gone
+    expect(c.flush()).toEqual([{ key: 'b', value: 'b1' }])
+  })
 })

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -19,6 +19,7 @@ import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { notificationDebug } from '@/utils/notificationDebug'
 import { showWebNotification } from '@/utils/webNotification'
 import { routeNotificationTarget } from '@/utils/notificationRouting'
+import { dismissNotification } from '@/utils/dismissNotification'
 import { createNotificationCoalescer } from './notificationCoalescer'
 
 /** Duration of the post-reconnect window during which offline-delivery
@@ -306,9 +307,25 @@ export function useDesktopNotifications(): void {
     await showConversationNotification(conv, message)
   }
 
+  // Dismiss the native notification when an entity is read — including reads
+  // that the navigation/focus paths never see: a reply sent from another device
+  // (sent carbon) or a synced cross-device read marker (MDS). Also drop any
+  // still-buffered catch-up notification so the post-reconnect flush does not
+  // re-post a banner for a conversation the user has since read/opened.
+  const handleConversationRead = (conversationId: string) => {
+    coalescerRef.current.delete(conversationId)
+    void dismissNotification('conversation', conversationId)
+  }
+
+  const handleRoomRead = (roomJid: string) => {
+    void dismissNotification('room', roomJid)
+  }
+
   // Subscribe to notification events
   useNotificationEvents({
     onConversationMessage: handleConversationMessage,
     onRoomMessage: showRoomNotification,
+    onConversationRead: handleConversationRead,
+    onRoomRead: handleRoomRead,
   })
 }

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -730,4 +730,96 @@ describe('useNotificationEvents', () => {
       expect(onConversationMessage).toHaveBeenCalledTimes(1)
     })
   })
+
+  // Read-transition signal: fires when an entity's unreadCount drops from >0 to
+  // 0 for ANY reason — local read, a sent carbon from another device (mobile),
+  // or a synced MDS read marker. Consumers use it to dismiss a delivered native
+  // notification that the navigation/focus paths would otherwise miss.
+  describe('entity read → dismiss signal', () => {
+    it('fires onConversationRead when a conversation unreadCount drops from >0 to 0', () => {
+      const onConversationRead = vi.fn()
+      renderHook(() => useNotificationEvents({ onConversationRead }))
+
+      // Unread message present.
+      act(() => {
+        mockConversations.set('alice@example.com', {
+          id: 'alice@example.com',
+          name: 'Alice',
+          unreadCount: 1,
+          lastMessage: {
+            id: 'm1',
+            timestamp: new Date(),
+            isOutgoing: false,
+            from: 'alice@example.com',
+          },
+        })
+        triggerChatStoreUpdate()
+      })
+      expect(onConversationRead).not.toHaveBeenCalled()
+
+      // Read elsewhere (e.g. reply sent from mobile → sent carbon) clears unread.
+      act(() => {
+        mockConversations.set('alice@example.com', {
+          ...mockConversations.get('alice@example.com'),
+          unreadCount: 0,
+        })
+        triggerChatStoreUpdate()
+      })
+      expect(onConversationRead).toHaveBeenCalledWith('alice@example.com')
+      expect(onConversationRead).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not fire onConversationRead when unreadCount was already 0', () => {
+      const onConversationRead = vi.fn()
+      renderHook(() => useNotificationEvents({ onConversationRead }))
+
+      act(() => {
+        mockConversations.set('bob@example.com', {
+          id: 'bob@example.com',
+          name: 'Bob',
+          unreadCount: 0,
+        })
+        triggerChatStoreUpdate()
+        // A later unrelated update, still read.
+        mockConversations.set('bob@example.com', {
+          id: 'bob@example.com',
+          name: 'Bob',
+          unreadCount: 0,
+        })
+        triggerChatStoreUpdate()
+      })
+
+      expect(onConversationRead).not.toHaveBeenCalled()
+    })
+
+    it('fires onRoomRead when a room unreadCount drops from >0 to 0', () => {
+      const onRoomRead = vi.fn()
+      renderHook(() => useNotificationEvents({ onRoomRead }))
+
+      act(() => {
+        mockRooms.set('room@conference.example.com', {
+          jid: 'room@conference.example.com',
+          name: 'Test Room',
+          joined: true,
+          unreadCount: 2,
+          mentionsCount: 1,
+          messages: [],
+        })
+        triggerRoomStoreUpdate()
+      })
+      expect(onRoomRead).not.toHaveBeenCalled()
+
+      // Read elsewhere clears unread.
+      act(() => {
+        mockRooms.set('room@conference.example.com', {
+          ...mockRooms.get('room@conference.example.com'),
+          unreadCount: 0,
+          mentionsCount: 0,
+        })
+        triggerRoomStoreUpdate()
+      })
+      expect(onRoomRead).toHaveBeenCalledWith('room@conference.example.com')
+      expect(onRoomRead).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
@@ -24,11 +24,29 @@ export interface NotificationEventHandlers {
    * @param isMention - Whether this message mentions the current user
    */
   onRoomMessage?: (room: Room, message: RoomMessage, isMention: boolean) => void
+
+  /**
+   * Called when a conversation's unreadCount drops from >0 to 0 — i.e. it was
+   * read. This fires regardless of cause: a local read, a message sent from
+   * another device (sent carbon), or a synced cross-device read marker (MDS).
+   * Consumers use it to dismiss a delivered native notification that the
+   * navigation/focus paths would otherwise leave behind.
+   * @param conversationId - The conversation that became read
+   */
+  onConversationRead?: (conversationId: string) => void
+
+  /**
+   * Called when a room's unreadCount drops from >0 to 0 — see
+   * {@link NotificationEventHandlers.onConversationRead} for the rationale.
+   * @param roomJid - The room that became read
+   */
+  onRoomRead?: (roomJid: string) => void
 }
 
 interface PrevRoomState {
   mentionsCount: number
   messagesLength: number
+  unreadCount: number
 }
 
 /**
@@ -107,8 +125,9 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
       const activeConversationId = state.activeConversationId
       const prevConversations = prevConversationsRef.current
       const onConversationMessage = handlersRef.current.onConversationMessage
+      const onConversationRead = handlersRef.current.onConversationRead
 
-      if (!onConversationMessage) {
+      if (!onConversationMessage && !onConversationRead) {
         prevConversationsRef.current = conversations
         return
       }
@@ -118,8 +137,20 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
       for (const conv of conversations) {
         const prevConv = prevConversations.find(c => c.id === conv.id)
 
+        // Read transition: unreadCount dropped from >0 to 0 (local read, sent
+        // carbon from another device, or a synced MDS marker). Fire so the
+        // consumer can dismiss a lingering native notification.
+        if (
+          onConversationRead &&
+          prevConv &&
+          (prevConv.unreadCount ?? 0) > 0 &&
+          conv.unreadCount === 0
+        ) {
+          onConversationRead(conv.id)
+        }
+
         // Check if this conversation has a new message
-        if (conv.lastMessage) {
+        if (onConversationMessage && conv.lastMessage) {
           const isNewMessage = !prevConv?.lastMessage ||
             prevConv.lastMessage.id !== conv.lastMessage.id
           if (!isNewMessage) continue
@@ -160,12 +191,19 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
       const activeRoomJid = state.activeRoomJid
       const prevRooms = prevRoomsRef.current
       const onRoomMessage = handlersRef.current.onRoomMessage
+      const onRoomRead = handlersRef.current.onRoomRead
 
-      if (!onRoomMessage) {
-        // Still update refs even if no handler
-        prevRoomsRef.current = new Map(
-          allRooms.map(r => [r.jid, { mentionsCount: r.mentionsCount, messagesLength: r.messages.length }])
+      const snapshotRooms = () =>
+        new Map(
+          allRooms.map(r => [
+            r.jid,
+            { mentionsCount: r.mentionsCount, messagesLength: r.messages.length, unreadCount: r.unreadCount ?? 0 },
+          ])
         )
+
+      if (!onRoomMessage && !onRoomRead) {
+        // Still update refs even if no handler
+        prevRoomsRef.current = snapshotRooms()
         return
       }
 
@@ -175,6 +213,16 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
         if (!room.joined) continue
 
         const prev = prevRooms.get(room.jid)
+
+        // Read transition: unreadCount dropped from >0 to 0 (local read or a
+        // synced cross-device read marker). Fire so the consumer can dismiss a
+        // lingering native notification.
+        if (onRoomRead && prev && prev.unreadCount > 0 && (room.unreadCount ?? 0) === 0) {
+          onRoomRead(room.jid)
+        }
+
+        if (!onRoomMessage) continue
+
         const prevMessagesLength = prev?.messagesLength ?? 0
         const hasNewMessages = room.messages.length > prevMessagesLength
         const newMessageCount = room.messages.length - prevMessagesLength
@@ -217,9 +265,7 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
       }
 
       // Update refs
-      prevRoomsRef.current = new Map(
-        allRooms.map(r => [r.jid, { mentionsCount: r.mentionsCount, messagesLength: r.messages.length }])
-      )
+      prevRoomsRef.current = snapshotRooms()
     })
 
     return unsubscribe


### PR DESCRIPTION
Native macOS/PWA notification dismissal fired only on navigation or the window focus-transition. Two read paths slipped through and left a banner behind:

- **Read from another device** — a reply sent from mobile (sent carbon) or a synced cross-device read marker (MDS) cleared the in-app unread count but never dismissed the OS notification.
- **Post-reconnect catch-up race** ("first message of the day") — the 3s coalescer flushed buffered notifications unconditionally, re-posting a banner for a conversation the user had already opened during the window. Only the reconnect transition opens that window, hence the once-a-day symptom.

## Fix
Add `onConversationRead`/`onRoomRead` to the SDK `useNotificationEvents`, firing when an entity's `unreadCount` transitions from >0 to 0 for any cause (reuses existing prev-state tracking; handlers independently guarded so `useSoundNotification` is unaffected). The app dismisses the native notification on that signal and drops any still-buffered catch-up entry, killing the re-post race. Detection stays in the SDK (generic); dismissing the native banner stays app-side (platform concern).

Dismiss is idempotent best-effort, so redundant local-read fires are harmless. No-op on Windows/Linux Tauri (the plugin can't target a notification by JID tag), matching the reported platform.