### PR TITLE
refactor(sdk): move message impl-state off the public message types

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -60,6 +60,7 @@ import type {
   RoomMAMResult,
   PollClosedData,
 } from '../types'
+import { getCorrectionStanzaIds } from '../types/message-internal'
 import { parseMessageContent, parseOgpFastening, applyRetraction, applyCorrection, createOriginIdElement, parseStanzaId, hasRenderableContent, parseReactionsSignal, parseRetractionSignal, parseCorrectionSignal } from './messagingUtils'
 import { checkForMention } from '../mentionDetection'
 import { parsePollElement, parsePollClosedElement } from '../poll'
@@ -1908,7 +1909,7 @@ export class Chat extends BaseModule {
       if (original && this.isSameMucAuthor(original, from, senderOccupantId)) {
         const correctionData = applyCorrection(stanza, body, original.originalBody ?? original.body)
         if (correctionStanzaId) {
-          correctionData.correctionStanzaIds = [...(original.correctionStanzaIds ?? []), correctionStanzaId]
+          correctionData.correctionStanzaIds = [...(getCorrectionStanzaIds(original) ?? []), correctionStanzaId]
         }
         this.deps.emitSDK('room:message-updated', { roomJid: conversationId, messageId: originalId, updates: correctionData })
         return true
@@ -1918,7 +1919,7 @@ export class Chat extends BaseModule {
       if (original && original.from === bareFrom) {
         const correctionData = applyCorrection(stanza, body, original.originalBody ?? original.body)
         if (correctionStanzaId) {
-          correctionData.correctionStanzaIds = [...(original.correctionStanzaIds ?? []), correctionStanzaId]
+          correctionData.correctionStanzaIds = [...(getCorrectionStanzaIds(original) ?? []), correctionStanzaId]
         }
         this.deps.emitSDK('chat:message-updated', { conversationId, messageId: originalId, updates: correctionData })
         return true

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -80,6 +80,7 @@ import {
   recordUnclaimedEME,
 } from '../e2ee/stanzaDecrypt'
 import type { MessageSecurityContext } from '../types'
+import { getCorrectionStanzaIds, type MessageImplState } from '../types/message-internal'
 import { parseSearchQuery, tokenize } from '../../utils/searchIndex'
 
 /**
@@ -1606,7 +1607,7 @@ export class MAM extends BaseModule {
         target.encryptedPayload = correctionData.encryptedPayload
         // Track the correction's stanza-id so replies referencing it can resolve
         if (correction.correctionStanzaId) {
-          target.correctionStanzaIds = [...(target.correctionStanzaIds ?? []), correction.correctionStanzaId]
+          ;(target as MessageImplState).correctionStanzaIds = [...(getCorrectionStanzaIds(target) ?? []), correction.correctionStanzaId]
         }
       } else if (!target) {
         unresolved.corrections.push(correction)
@@ -1691,7 +1692,7 @@ export class MAM extends BaseModule {
       const cachedMessage = this.deps.stores?.chat.getMessage(conversationId, correction.targetId)
       const originalBody = cachedMessage?.originalBody ?? cachedMessage?.body ?? ''
       const correctionData = applyCorrection(correction.messageEl, correction.body, originalBody)
-      const existingIds = cachedMessage?.correctionStanzaIds ?? []
+      const existingIds = (cachedMessage ? getCorrectionStanzaIds(cachedMessage) : undefined) ?? []
       const correctionStanzaIds = correction.correctionStanzaId
         ? [...existingIds, correction.correctionStanzaId]
         : existingIds.length > 0 ? existingIds : undefined
@@ -1756,7 +1757,7 @@ export class MAM extends BaseModule {
       const originalBody = cachedMessage?.originalBody ?? cachedMessage?.body ?? ''
       const correctionData = applyCorrection(correction.messageEl, correction.body, originalBody)
       // Accumulate correction stanza-ids for reply lookup
-      const existingIds = cachedMessage?.correctionStanzaIds ?? []
+      const existingIds = (cachedMessage ? getCorrectionStanzaIds(cachedMessage) : undefined) ?? []
       const correctionStanzaIds = correction.correctionStanzaId
         ? [...existingIds, correction.correctionStanzaId]
         : existingIds.length > 0 ? existingIds : undefined

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -39,6 +39,7 @@ import type {
   AdminRoom,
   RoomFeatures,
 } from '../types'
+import type { StoredRoomMessage } from '../types/message-internal'
 import { parseXMPPError, formatXMPPError, hasErrorCondition } from '../../utils/xmppError'
 import { RoomJoinError } from '../errors'
 import { buildDataFormSubmit, parseDataForm } from '../../utils/dataForm'
@@ -242,20 +243,21 @@ export class MUC extends BaseModule {
           // <new>"). Empty body → never a sidebar preview; noLocalStore → not
           // persisted or indexed (presence isn't archived, so it can't be
           // reconstructed on reload anyway).
+          const nickChangeMessage: StoredRoomMessage = {
+            type: 'groupchat',
+            id: generateUUID(),
+            roomJid,
+            from: `${roomJid}/${nick}`,
+            nick,
+            body: '',
+            timestamp: new Date(),
+            isOutgoing: isSelf,
+            noLocalStore: true,
+            systemEvent: { kind: 'nick-changed', oldNick: nick, newNick },
+          }
           this.deps.emitSDK('room:message', {
             roomJid,
-            message: {
-              type: 'groupchat',
-              id: generateUUID(),
-              roomJid,
-              from: `${roomJid}/${nick}`,
-              nick,
-              body: '',
-              timestamp: new Date(),
-              isOutgoing: isSelf,
-              noLocalStore: true,
-              systemEvent: { kind: 'nick-changed', oldNick: nick, newNick },
-            },
+            message: nickChangeMessage,
             incrementUnread: false,
             incrementMentions: false,
           })

--- a/packages/fluux-sdk/src/core/types/message-base.ts
+++ b/packages/fluux-sdk/src/core/types/message-base.ts
@@ -122,14 +122,6 @@ export interface BaseMessage {
   isEdited?: boolean
   /** XEP-0308: Original body before correction */
   originalBody?: string
-  /**
-   * XEP-0308 + XEP-0359: Stanza-IDs from correction stanzas.
-   * When a message is corrected, the MUC service archives the correction as a
-   * new stanza with its own stanza-id. Other clients may reference this
-   * correction stanza-id in replies (XEP-0461), so we track them to ensure
-   * reply lookups resolve correctly.
-   */
-  correctionStanzaIds?: string[]
   /** XEP-0424: Message has been retracted (deleted) */
   isRetracted?: boolean
   /** XEP-0424: When the message was retracted */
@@ -144,17 +136,6 @@ export interface BaseMessage {
   attachment?: FileAttachment
   /** XEP-0422 + OGP: Link preview metadata for URLs in message */
   linkPreview?: LinkPreview
-  /**
-   * Local persistence opt-out. When true, this message is kept in the in-memory
-   * store only — it is NOT written to the local IndexedDB cache or the search
-   * index. Automatically set for messages in Quick Chat (transient) rooms.
-   *
-   * Independent of server archival: the XEP-0334 `<no-store>` wire hint that
-   * asks the server not to archive is added at the send site, not derived from
-   * this field. A message can be kept off the server archive yet still persisted
-   * locally (e.g. MUC whispers), or vice versa.
-   */
-  noLocalStore?: boolean
   /**
    * Delivery error received from the server for this message.
    * Set when the server returns a `<message type="error">` stanza,

--- a/packages/fluux-sdk/src/core/types/message-internal.test.ts
+++ b/packages/fluux-sdk/src/core/types/message-internal.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for the internal message impl-state helpers.
+ *
+ * `noLocalStore` and `correctionStanzaIds` are implementation state kept OFF
+ * the public message types (see message-internal.ts). These helpers are the
+ * single, typed read path the SDK internals use so the cast to the internal
+ * shape lives in exactly one place.
+ */
+import { describe, it, expect } from 'vitest'
+import { isNoLocalStore, getCorrectionStanzaIds, type StoredMessage } from './message-internal'
+import type { Message } from './chat'
+
+const baseMessage: Message = {
+  type: 'chat',
+  id: 'm1',
+  conversationId: 'alice@example.com',
+  from: 'alice@example.com',
+  body: 'hi',
+  timestamp: new Date(),
+  isOutgoing: false,
+}
+
+describe('isNoLocalStore', () => {
+  it('is true when the impl flag is set', () => {
+    const stored: StoredMessage = { ...baseMessage, noLocalStore: true }
+    expect(isNoLocalStore(stored)).toBe(true)
+  })
+
+  it('is false when the flag is absent or false', () => {
+    expect(isNoLocalStore(baseMessage)).toBe(false)
+    const stored: StoredMessage = { ...baseMessage, noLocalStore: false }
+    expect(isNoLocalStore(stored)).toBe(false)
+  })
+})
+
+describe('getCorrectionStanzaIds', () => {
+  it('returns the ids when present', () => {
+    const stored: StoredMessage = { ...baseMessage, correctionStanzaIds: ['s1', 's2'] }
+    expect(getCorrectionStanzaIds(stored)).toEqual(['s1', 's2'])
+  })
+
+  it('returns undefined when absent', () => {
+    expect(getCorrectionStanzaIds(baseMessage)).toBeUndefined()
+  })
+})
+
+describe('public message type surface', () => {
+  // Type-level regression guard (enforced by `tsc`, not the runtime): the impl
+  // fields must NOT be reachable on the public Message type. If someone re-adds
+  // one to BaseMessage, the @ts-expect-error goes unused and typecheck fails.
+  it('does not expose the impl fields on the public Message type', () => {
+    const m: Message = baseMessage
+    // @ts-expect-error noLocalStore is internal impl-state, not on public Message
+    void m.noLocalStore
+    // @ts-expect-error correctionStanzaIds is internal impl-state, not on public Message
+    void m.correctionStanzaIds
+    expect(m).toBeDefined()
+  })
+})

--- a/packages/fluux-sdk/src/core/types/message-internal.ts
+++ b/packages/fluux-sdk/src/core/types/message-internal.ts
@@ -1,0 +1,56 @@
+/**
+ * Internal message implementation-state.
+ *
+ * These fields are SDK-internal bookkeeping that used to live on the public
+ * {@link BaseMessage} and thus leaked onto `Message` / `RoomMessage`. They are
+ * not part of a message's public shape — no application code reads them — so
+ * they are kept here, off the exported types.
+ *
+ * This module is deliberately NOT re-exported from the package index: it is an
+ * internal seam. SDK code that needs the fields uses {@link StoredMessage} /
+ * {@link StoredRoomMessage} at the write site and the read helpers below, so
+ * the cast to the internal shape lives in exactly one place per field.
+ */
+import type { Message } from './chat'
+import type { RoomMessage } from './room'
+
+export interface MessageImplState {
+  /**
+   * Local persistence opt-out. When true, the message is kept in the in-memory
+   * store only — not written to the local IndexedDB cache or the search index.
+   * Set for Quick Chat (transient) rooms and MUC whisper placeholders.
+   *
+   * Independent of server archival: the XEP-0334 `<no-store>` wire hint is added
+   * at the send site, not derived from this flag.
+   */
+  noLocalStore?: boolean
+  /**
+   * XEP-0308 + XEP-0359: stanza-ids from correction stanzas. When a message is
+   * corrected, the MUC service archives the correction as a new stanza with its
+   * own stanza-id; other clients may reference that id in replies (XEP-0461),
+   * so we track them to keep reply lookups resolving correctly.
+   */
+  correctionStanzaIds?: string[]
+}
+
+/** A stored 1:1 message: the public {@link Message} plus internal impl-state. */
+export type StoredMessage = Message & MessageImplState
+
+/** A stored room message: the public {@link RoomMessage} plus internal impl-state. */
+export type StoredRoomMessage = RoomMessage & MessageImplState
+
+/**
+ * Whether a message is marked local-store-only. Centralizes the read so the
+ * cast to the internal shape lives in one place.
+ */
+export function isNoLocalStore(msg: Message | RoomMessage): boolean {
+  return (msg as MessageImplState).noLocalStore === true
+}
+
+/**
+ * The correction stanza-ids tracked on a message, if any. Centralizes the read
+ * so the cast to the internal shape lives in one place.
+ */
+export function getCorrectionStanzaIds(msg: Message | RoomMessage): string[] | undefined {
+  return (msg as MessageImplState).correctionStanzaIds
+}

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -10,6 +10,7 @@
 
 import type { Element } from '@xmpp/client'
 import type { Message, Conversation } from './chat'
+import type { StoredMessage, StoredRoomMessage } from './message-internal'
 import type { Contact, PresenceShow, VCardInfo } from './roster'
 import type { Room, RoomOccupant, RoomMember, RoomMessage, RoomAffiliation, RoomRole } from './room'
 import type { ServerInfo } from './discovery'
@@ -144,7 +145,9 @@ export interface ChatEvents {
   'chat:message-updated': {
     conversationId: string
     messageId: string
-    updates: Partial<Message>
+    // Partial<StoredMessage>, not Partial<Message>: a correction update carries
+    // internal impl-state (correctionStanzaIds) alongside the public fields.
+    updates: Partial<StoredMessage>
   }
 
   /** XEP-0490: a device synced its last-displayed (read) position for a conversation (1:1 or room) */
@@ -310,7 +313,7 @@ export interface RoomEvents {
   'room:message-updated': {
     roomJid: string
     messageId: string
-    updates: Partial<RoomMessage>
+    updates: Partial<StoredRoomMessage>
   }
 
   /** Reactions updated on room message */

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1,6 +1,7 @@
 import { createStore } from 'zustand/vanilla'
 import { persist, subscribeWithSelector } from 'zustand/middleware'
 import type { Message, Conversation, ConversationEntity, ConversationMetadata, MAMQueryState, RSMResponse } from '../core'
+import { isNoLocalStore } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout, clearAllTypingTimeouts } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
 import { logInfo } from '../core/logger'
@@ -908,7 +909,7 @@ export const chatStore = createStore<ChatState>()(
           // This runs regardless of the live-edge gate: a gated message is still
           // durable in the cache (and the meta/preview/unread updates below still
           // run); it reloads on jump-to-latest.
-          if (!msg.noLocalStore) {
+          if (!isNoLocalStore(msg)) {
             void messageCache.saveMessage(msg)
             searchIndex.indexMessage(msg).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
           }
@@ -1650,7 +1651,7 @@ export const chatStore = createStore<ChatState>()(
           }
 
           // Persist to IndexedDB regardless of active state (durable history).
-          const persistableMessages = newMessages.filter(msg => !msg.noLocalStore)
+          const persistableMessages = newMessages.filter(msg => !isNoLocalStore(msg))
           if (persistableMessages.length > 0) {
             void messageCache.saveMessages(persistableMessages)
             searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { roomStore } from './roomStore'
 import type { Room, RoomMessage } from '../core/types'
+import { isNoLocalStore } from '../core/types/message-internal'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
 import { setResidentWindowSize } from './shared/residentWindow'
@@ -1369,7 +1370,7 @@ describe('roomStore', () => {
       // But message should still be in memory with noLocalStore flag
       const room = roomStore.getState().rooms.get('quickchat@conference.example.com')
       expect(room?.messages.length).toBe(1)
-      expect(room?.messages[0].noLocalStore).toBe(true)
+      expect(isNoLocalStore(room!.messages[0])).toBe(true)
     })
 
     it('should still add noLocalStore message to in-memory store', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -12,6 +12,7 @@ import type {
   MAMQueryState,
   RSMResponse,
 } from '../core/types'
+import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
 import { getBareJid } from '../core/jid'
@@ -1179,12 +1180,12 @@ export const roomStore = createStore<RoomState>()(
     const room = get().rooms.get(roomJid)
 
     // Quick Chat rooms are transient: keep their messages in memory only
-    const messageToAdd = room?.isQuickChat
+    const messageToAdd: StoredRoomMessage = room?.isQuickChat
       ? { ...message, noLocalStore: true }
       : message
 
     // Save to IndexedDB only if the message is locally persistable
-    if (!messageToAdd.noLocalStore) {
+    if (!isNoLocalStore(messageToAdd)) {
       void messageCache.saveRoomMessage(messageToAdd)
       searchIndex.indexMessage(messageToAdd).catch((e) => console.warn('[searchIndex] indexMessage failed:', e))
     }
@@ -2553,7 +2554,7 @@ export const roomStore = createStore<RoomState>()(
 
       // Persist to IndexedDB regardless of active state — this is the durable
       // history that rehydrates on open (search index too).
-      const persistableMessages = newFromMAM.filter(msg => !msg.noLocalStore)
+      const persistableMessages = newFromMAM.filter(msg => !isNoLocalStore(msg))
       if (persistableMessages.length > 0) {
         void messageCache.saveRoomMessages(persistableMessages)
         searchIndex.indexMessages(persistableMessages).catch((e) => console.warn('[searchIndex] indexMessages failed:', e))

--- a/packages/fluux-sdk/src/utils/searchIndex.test.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
-import type { Message, RoomMessage } from '../core/types'
+import type { RoomMessage } from '../core/types'
+import type { StoredMessage } from '../core/types/message-internal'
 import { setStorageScopeJid, _resetStorageScopeForTesting } from './storageScope'
 
 // Must import after fake-indexeddb/auto
@@ -26,7 +27,7 @@ import { _resetDBForTesting as _resetMessageCacheDB } from './messageCache'
 // Test helpers
 // =============================================================================
 
-function createChatMessage(conversationId: string, overrides: Partial<Message> = {}): Message {
+function createChatMessage(conversationId: string, overrides: Partial<StoredMessage> = {}): StoredMessage {
   return {
     type: 'chat',
     id: `msg-${Math.random().toString(36).slice(2)}`,

--- a/packages/fluux-sdk/src/utils/searchIndex.ts
+++ b/packages/fluux-sdk/src/utils/searchIndex.ts
@@ -15,6 +15,7 @@
 
 import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
+import { isNoLocalStore } from '../core/types/message-internal'
 import { getStorageScopeJid } from './storageScope'
 import * as messageCache from './messageCache'
 
@@ -276,7 +277,7 @@ export async function initSearchIndex(scopeJid: string): Promise<void> {
  */
 export async function indexMessage(message: Message | RoomMessage): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  if (!message.body || message.isRetracted || message.noLocalStore) return
+  if (!message.body || message.isRetracted || isNoLocalStore(message)) return
 
   const indexId = getIndexId(message)
   const tokens = uniqueTokens(message.body)
@@ -340,7 +341,7 @@ const INDEX_BATCH_SIZE = 50
  */
 export async function indexMessages(messages: (Message | RoomMessage)[]): Promise<void> {
   if (!isIndexedDBAvailable()) return
-  const indexable = messages.filter((m) => m.body && !m.isRetracted && !m.noLocalStore)
+  const indexable = messages.filter((m) => m.body && !m.isRetracted && !isNoLocalStore(m))
   if (indexable.length === 0) return
 
   // Process in small batches to keep each IDB transaction short-lived


### PR DESCRIPTION
`noLocalStore` and `correctionStanzaIds` were SDK-internal bookkeeping living on the public `BaseMessage`, and thus leaked onto `Message` / `RoomMessage` / `Conversation` — the types the app renders. No application code reads either field.

**What**
- New internal `core/types/message-internal.ts` (NOT re-exported from the package index): `MessageImplState` + `StoredMessage`/`StoredRoomMessage`, plus two centralized read helpers (`isNoLocalStore`, `getCorrectionStanzaIds`) so the cast to the internal shape lives in one place per field.
- Removed both fields from `BaseMessage`. The public message shape is now clean (verified against the built dts).
- Write sites (MUC whisper, quick-chat, MAM/Chat corrections) type their object as `StoredMessage`; read sites go through the helpers. The local narrow interfaces in `messagingUtils` / `lastMessageUtils` / `messageLookup` already declared the field and are untouched.

**One threaded type**
The correction pipeline carries its ids through `message-updated`, whose `updates` payload is now `Partial<StoredMessage>` — an update legitimately touches impl-state. That's the accepted write-channel trade-off; the message *shape* itself stays clean.

**Runtime is unchanged** — only the public type narrows. A `@ts-expect-error` guard pins that `Message` no longer exposes either field. SDK-only; no app changes.