### PR TITLE
refactor(hooks): options-object signature for room sendMessage (Phase 2)

### DIFF
--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1651,7 +1651,7 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
 interface RoomMessageInputProps {
   roomJid: string
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>
-  sendMessage: (roomJid: string, body: string, replyTo?: { id: string; to: string; fallback?: { author: string; body: string } }, references?: MentionReference[], attachment?: FileAttachment) => Promise<string>
+  sendMessage: (roomJid: string, body: string, options?: { replyTo?: { id: string; to: string; fallback?: { author: string; body: string } }; references?: MentionReference[]; attachment?: FileAttachment }) => Promise<string>
   sendCorrection: (roomJid: string, messageId: string, newBody: string, attachment?: FileAttachment) => Promise<void>
   retractMessage: (roomJid: string, messageId: string) => Promise<void>
   sendChatState: (roomJid: string, state: ChatStateNotification) => Promise<void>
@@ -1946,7 +1946,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
 
     // The body is the file URL if no text was entered, otherwise the user's text
     const body = sendText || attachment?.url || ''
-    const messageId = await sendMessage(roomJid, body, replyTo, references.length > 0 ? references : undefined, attachment ?? undefined)
+    const messageId = await sendMessage(roomJid, body, { replyTo, references: references.length > 0 ? references : undefined, attachment: attachment ?? undefined })
     setReferences([])
 
     // Notify parent of sent message ID for animation

--- a/docs/MULTI_ACCOUNT.md
+++ b/docs/MULTI_ACCOUNT.md
@@ -1,0 +1,103 @@
+# Multi-Account — Design & Migration Spec
+
+**Status:** future work · seam in place, migration not started
+**Origin:** [STRATEGIC_REVIEW.md](STRATEGIC_REVIEW.md) §4 · [ROADMAP_2026.md](ROADMAP_2026.md)
+
+Fluux is single-account today. Running several accounts at once (each with its own
+connection, roster, rooms, and persisted state) is planned but not built. The SDK already
+exposes the *seam* for it — `new XMPPClient({ stores })` — but a working multi-account
+client needs more than that seam. This doc records what exists, what's missing, and the
+concrete known gaps so they aren't "fixed" piecemeal in ways that don't actually compose.
+
+---
+
+## 1. What exists today: the store-injection seam
+
+The client no longer reaches for the module-global store singletons directly. It takes an
+`SDKStores` bundle (`packages/fluux-sdk/src/stores/sdkStores.ts`) via
+`new XMPPClient({ stores })`, defaulting to `defaultStores` — the process-wide singletons —
+so existing single-account usage is unchanged.
+
+`SDKStores` is a bundle of nine vanilla Zustand **store handles** (get/set/subscribe):
+connection, chat, roster, room, events, admin, blocking, console, ignore. (`searchStore` is
+intentionally excluded — it is not part of the client's store bindings.)
+
+Accepting a custom bundle is necessary but **not sufficient** for multi-account.
+
+---
+
+## 2. What's still missing
+
+1. **A `createStores()` factory.** Each store is a module singleton today
+   (`export const chatStore = createStore(...)`); refactor to `createXStore()` factories
+   (keeping the singletons as `defaultStores`) so every account gets an isolated set.
+
+2. **Per-instance storage scope.** `storageScope.ts` holds ONE module-global
+   `currentStorageScopeJid`. Persisted stores (chat, ignore), the message cache (IndexedDB)
+   and the search index already namespace by it (`buildScopedStorageKey` /
+   `getStorageScopeJid`), so the keys are fine — but the scope must become
+   per-bundle/per-client instead of a global, since only one account's scope can be active
+   at a time right now.
+
+3. **Threading the bundle through direct-global consumers.** Anything that imports the raw
+   store singletons instead of reading `client.stores` (some side-effect submodules, utils,
+   bindings) must take the bundle instead. See §3 for the known instances.
+
+4. **The app's React layer.** App hooks bind to the global singletons; multi-account needs
+   an account-scoped context providing the active client + stores, with hooks resolving from
+   it rather than the module singletons.
+
+5. **Tab coordination.** Multi-account is currently *actively prevented* by the
+   single-instance tab-coordination logic (STRATEGIC_REVIEW.md §4). That guard has to become
+   account-aware.
+
+---
+
+## 3. Known direct-global consumers (§2.3 checklist)
+
+These import a raw store singleton instead of resolving it from the injected bundle. Each
+must be threaded through `client.stores` before multi-account works. **Do not "fix" them in
+isolation** — several can't be fixed correctly without a signature/plumbing change, and a
+naive fix compiles-then-breaks (see the ignore-subscription case below).
+
+### 3.1 `storeBindings.ts` ignore subscription — line ~626
+
+```ts
+// Recalculate room lastMessage previews when users are un-ignored
+let prevIgnoredUsers = ignoreStoreInstance.getState().ignoredUsers
+const unsubIgnore = ignoreStoreInstance.subscribe((state) => { ... })
+```
+
+`ignoreStoreInstance` is the **module-global singleton** (imported at the top of the file),
+while the handler body correctly resolves `stores.room` through the injected
+`getStores()`. So the *trigger* watches the global ignore store while the *effect* writes to
+the injected room store.
+
+- **Impact today:** none. Single-account always uses `defaultStores`, so
+  `ignoreStoreInstance === client.stores.ignore` — same object, subscription fires correctly.
+- **Impact under multi-account:** a non-default account's un-ignore would not recompute its
+  room previews (cosmetic, self-healing on the next message).
+- **Why the obvious fix is wrong:** `createStoreBindings(client, getStores)` receives
+  `getStores: () => StoreRefs`, and `StoreRefs` values are `getState()` **snapshots**, not
+  store handles — a snapshot has no `.subscribe`. So `getStores().ignore.subscribe(...)`
+  would throw. The correct fix threads the `SDKStores` **handle** bundle into
+  `createStoreBindings` (a signature change) so it can subscribe to the injected ignore
+  store. Reported by Codex as a "P2 injected-ref inconsistency"; this is the accurate scoping.
+
+_(Add further direct-global consumers here as they're found during the migration audit — a
+`grep` for raw `Store` singleton imports outside `sdkStores.ts`/`defaultStores` is the way to
+enumerate them.)_
+
+---
+
+## 4. Sequencing
+
+Rough order to keep each step shippable behind the existing single-account default:
+
+1. `createStores()` factories (§2.1) — mechanical, no behavior change; singletons stay as
+   `defaultStores`.
+2. Per-client storage scope (§2.2) — make scope resolution take the bundle/client.
+3. Thread direct-global consumers (§2.3 / §3) — including the `storeBindings` signature
+   change so the ignore subscription binds to the injected store.
+4. App account-scoped context + hooks (§2.4).
+5. Account-aware tab coordination (§2.5).

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -622,7 +622,11 @@ export function createStoreBindings(
     stores.console.addPacket(direction, xml)
   })
 
-  // Recalculate room lastMessage previews when users are un-ignored
+  // Recalculate room lastMessage previews when users are un-ignored.
+  // NOTE: this subscribes to the module-global ignore singleton, not the injected
+  // bundle. Harmless in single-account (the singleton IS client.stores.ignore), but a
+  // known direct-global consumer to thread through the bundle for multi-account — see
+  // docs/MULTI_ACCOUNT.md §3.1 for why getStores().ignore is NOT the fix.
   let prevIgnoredUsers = ignoreStoreInstance.getState().ignoredUsers
   const unsubIgnore = ignoreStoreInstance.subscribe((state) => {
     const curr = state.ignoredUsers

--- a/packages/fluux-sdk/src/hooks/useRoomActions.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActions.ts
@@ -133,11 +133,13 @@ export function useRoomActions() {
     async (
       roomJid: string,
       body: string,
-      replyTo?: { id: string; to: string; fallback?: { author: string; body: string } },
-      references?: MentionReference[],
-      attachment?: FileAttachment
+      options?: {
+        replyTo?: { id: string; to: string; fallback?: { author: string; body: string } }
+        references?: MentionReference[]
+        attachment?: FileAttachment
+      }
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, 'groupchat', replyTo, references, attachment)
+      return await client.chat.sendMessage(roomJid, body, 'groupchat', options?.replyTo, options?.references, options?.attachment)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -210,11 +210,13 @@ export function useRoomActive() {
     async (
       roomJid: string,
       body: string,
-      replyTo?: { id: string; to: string; fallback?: { author: string; body: string } },
-      references?: MentionReference[],
-      attachment?: FileAttachment
+      options?: {
+        replyTo?: { id: string; to: string; fallback?: { author: string; body: string } }
+        references?: MentionReference[]
+        attachment?: FileAttachment
+      }
     ): Promise<string> => {
-      return await client.chat.sendMessage(roomJid, body, 'groupchat', replyTo, references, attachment)
+      return await client.chat.sendMessage(roomJid, body, 'groupchat', options?.replyTo, options?.references, options?.attachment)
     },
     [client]
   )

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -210,6 +210,53 @@ describe('chatStore.applyRemoteDisplayed', () => {
   })
 })
 
+describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  // At the live edge the newest loaded message IS the true newest; clearing the
+  // badge means the user caught up to it, so the read pointer must advance for the
+  // MDS publisher (which watches lastSeenMessageId) to sync the marker.
+  it('advances lastSeenMessageId to the newest loaded message when at the live edge', () => {
+    const cid = 'juliet@capulet.example'
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    chatStore.getState().markAsRead(cid)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
+    expect(chatStore.getState().conversations.get(cid)?.lastSeenMessageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
+  })
+
+  // Slid up into history: the badge still clears (the user acknowledged the
+  // conversation) but the pointer must stay put so MDS never publishes a read
+  // position past messages the user has not seen.
+  it('does NOT advance lastSeenMessageId when the window is slid up into history', () => {
+    const cid = 'juliet@capulet.example'
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newEdge = new Map(state.windowAtLiveEdge)
+      newEdge.set(cid, false)
+      return { conversationMeta: newMeta, conversations: newConvs, windowAtLiveEdge: newEdge }
+    })
+
+    chatStore.getState().markAsRead(cid)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
+  })
+})
+
 describe('chatStore — new-message divider is session-only', () => {
   beforeEach(() => chatStore.getState().reset())
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1016,29 +1016,32 @@ export const chatStore = createStore<ChatState>()(
           const lastMessage = messages[messages.length - 1]
           const lastMessageTimestamp = lastMessage?.timestamp
 
-          // Delegate to pure function
-          const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp)
+          // When the loaded window is at the live edge, the newest loaded message
+          // IS the true newest and clearing the badge means the user caught up to
+          // it — advance the read pointer so the XEP-0490 publisher (which watches
+          // lastSeenMessageId) syncs the marker to other devices. Slid up into
+          // history we leave the pointer where the user actually read, so MDS never
+          // publishes a position past unseen messages.
+          const atLiveEdge = state.windowAtLiveEdge.get(conversationId) !== false
+          const advanceSeenTo = atLiveEdge ? lastMessage?.id : undefined
 
-          // If no change (same reference returned), skip state update
-          if (updated.unreadCount === notifInput.unreadCount && updated.lastReadAt === notifInput.lastReadAt) {
-            // Also check by value for deserialized timestamps
-            const existingTime = notifInput.lastReadAt instanceof Date
-              ? notifInput.lastReadAt.getTime()
-              : notifInput.lastReadAt ? new Date(notifInput.lastReadAt as unknown as string).getTime() : 0
-            const newTime = updated.lastReadAt instanceof Date ? updated.lastReadAt.getTime() : 0
-            if (existingTime === newTime) return {}
-          }
+          // Delegate to pure function
+          const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp, advanceSeenTo)
+
+          // Pure function returns the same reference when nothing changed.
+          if (updated === notifInput) return {}
 
           const newMetaEntry = {
             ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined }),
             unreadCount: updated.unreadCount,
             lastReadAt: updated.lastReadAt,
+            lastSeenMessageId: updated.lastSeenMessageId,
           }
           const newMeta = new Map(state.conversationMeta)
           newMeta.set(conversationId, newMetaEntry)
 
           const newConversations = new Map(state.conversations)
-          newConversations.set(conversationId, { ...conv, unreadCount: updated.unreadCount, lastReadAt: updated.lastReadAt })
+          newConversations.set(conversationId, { ...conv, unreadCount: updated.unreadCount, lastReadAt: updated.lastReadAt, lastSeenMessageId: updated.lastSeenMessageId })
 
           return { conversationMeta: newMeta, conversations: newConversations }
         })

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -406,3 +406,56 @@ describe('roomStore — new-message divider is session-only', () => {
     expect(roomStore.getState().firstNewMessageMarkers.get(ROOM_B)).toBeUndefined()
   })
 })
+
+describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  // At the live edge, clearing the badge means the user caught up to the newest
+  // message — advance the read pointer so the MDS publisher syncs the marker.
+  it('advances lastSeenMessageId to the newest loaded message when at the live edge', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(ROOM, { ...m.get(ROOM)!, unreadCount: 2 })
+      return { roomMeta: m }
+    })
+
+    roomStore.getState().markAsRead(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m3')
+    expect(roomStore.getState().rooms.get(ROOM)?.lastSeenMessageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+  })
+
+  // Slid up into history: badge clears but the pointer stays put, so MDS never
+  // publishes a read position past messages the user has not seen.
+  it('does NOT advance lastSeenMessageId when the window is slid up into history', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(ROOM, { ...m.get(ROOM)!, unreadCount: 2 })
+      const rt = new Map(s.roomRuntime)
+      rt.set(ROOM, { ...rt.get(ROOM)!, windowAtLiveEdge: false })
+      return { roomMeta: m, roomRuntime: rt }
+    })
+
+    roomStore.getState().markAsRead(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1498,13 +1498,19 @@ export const roomStore = createStore<RoomState>()(
       const lastMessage = messages[messages.length - 1]
       const lastMessageTimestamp = lastMessage?.timestamp
 
-      const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp)
+      // At the live edge the newest loaded message is the true newest and clearing
+      // the badge means the user caught up — advance the read pointer so the
+      // XEP-0490 publisher syncs the marker. Slid up into history we leave it put.
+      const atLiveEdge = runtime?.windowAtLiveEdge !== false
+      const advanceSeenTo = atLiveEdge ? lastMessage?.id : undefined
+
+      const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp, advanceSeenTo)
 
       // Skip update if no change
       if (updated === notifInput) return {}
 
       const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...existing, unreadCount: updated.unreadCount, mentionsCount: updated.mentionsCount, lastReadAt: updated.lastReadAt })
+      newRooms.set(roomJid, { ...existing, unreadCount: updated.unreadCount, mentionsCount: updated.mentionsCount, lastReadAt: updated.lastReadAt, lastSeenMessageId: updated.lastSeenMessageId })
 
       const newMeta = new Map(state.roomMeta)
       const newMetaEntry = {
@@ -1512,6 +1518,7 @@ export const roomStore = createStore<RoomState>()(
         unreadCount: updated.unreadCount,
         mentionsCount: updated.mentionsCount,
         lastReadAt: updated.lastReadAt,
+        lastSeenMessageId: updated.lastSeenMessageId,
       }
       newMeta.set(roomJid, newMetaEntry)
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -572,6 +572,35 @@ describe('onMarkAsRead', () => {
     expect(result.lastReadAt!.getTime()).toBeGreaterThanOrEqual(before)
     expect(result.lastReadAt!.getTime()).toBeLessThanOrEqual(after)
   })
+
+  it('leaves lastSeenMessageId untouched when no advance id is given', () => {
+    const state = makeState({ unreadCount: 3, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, new Date())
+    expect(result.lastSeenMessageId).toBe('seen-1')
+  })
+
+  it('advances lastSeenMessageId to the supplied id (read pointer catches up)', () => {
+    const state = makeState({ unreadCount: 3, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, new Date(), 'newest-9')
+    expect(result.lastSeenMessageId).toBe('newest-9')
+    expect(result.unreadCount).toBe(0)
+  })
+
+  it('advances lastSeenMessageId even when the badge is already clear', () => {
+    // The IntersectionObserver may lag: unread already 0 but the pointer is behind.
+    const ts = new Date('2025-01-15T12:00:00Z')
+    const state = makeState({ unreadCount: 0, lastReadAt: ts, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, ts, 'newest-9')
+    expect(result).not.toBe(state)
+    expect(result.lastSeenMessageId).toBe('newest-9')
+  })
+
+  it('returns same reference when the supplied id equals the current pointer', () => {
+    const ts = new Date('2025-01-15T12:00:00Z')
+    const state = makeState({ unreadCount: 0, mentionsCount: 0, lastReadAt: ts, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, ts, 'seen-1')
+    expect(result).toBe(state)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -334,17 +334,28 @@ export function onDeactivate(
  * Clears unreadCount and mentionsCount, updates lastReadAt.
  * Preserves firstNewMessageId — the marker has a separate lifecycle
  * (set on activate, cleared on deactivate or explicit clear).
+ *
+ * When `advanceSeenTo` is supplied, the read pointer (lastSeenMessageId) is
+ * advanced to it. Callers pass the newest message id ONLY when the user has
+ * genuinely caught up to it (the loaded window is at the live edge) — this is
+ * what lets the XEP-0490 publisher, which watches lastSeenMessageId, sync the
+ * read marker to other devices. Omitting it (the scrolled-into-history case)
+ * clears the local badge without publishing a read position past what the user
+ * actually saw. The advance is forward-only in practice because the caller only
+ * ever supplies the tail of a live-edge window (>= the current pointer).
  */
 export function onMarkAsRead(
   state: EntityNotificationState,
-  lastMessageTimestamp?: Date
+  lastMessageTimestamp?: Date,
+  advanceSeenTo?: string
 ): EntityNotificationState {
   const lastReadAt = lastMessageTimestamp ?? new Date()
   // Skip update if nothing to change (prevents unnecessary state updates)
   const existingTime = state.lastReadAt instanceof Date
     ? state.lastReadAt.getTime()
     : state.lastReadAt ? new Date(state.lastReadAt as unknown as string).getTime() : 0
-  if (state.unreadCount === 0 && state.mentionsCount === 0 && existingTime === lastReadAt.getTime()) {
+  const seenUnchanged = advanceSeenTo === undefined || advanceSeenTo === state.lastSeenMessageId
+  if (state.unreadCount === 0 && state.mentionsCount === 0 && existingTime === lastReadAt.getTime() && seenUnchanged) {
     return state
   }
   return {
@@ -352,6 +363,7 @@ export function onMarkAsRead(
     unreadCount: 0,
     mentionsCount: 0,
     lastReadAt,
+    lastSeenMessageId: advanceSeenTo ?? state.lastSeenMessageId,
   }
 }
 


### PR DESCRIPTION
Finishes the Phase 2 `sendMessage` work that #901 started on the chat hook.

The room send hooks (`useRoomActions`, `useRoomActive`) took `(roomJid, body, replyTo, references, attachment)` positionally while the chat hook already took an options object — an asymmetry apps had to remember. Both room hooks now take `(roomJid, body, options?)` matching the chat hook; the app call site and `RoomMessageInput` prop type follow.

The core `Chat.sendMessage` keeps its current signature — it stays encapsulated behind the hooks and `mcpTools`, so collapsing it would only churn tests for no user-facing gain.