### PR TITLE
fix(notifications): advance read pointer on markAsRead at the live edge so MDS syncs

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -210,6 +210,53 @@ describe('chatStore.applyRemoteDisplayed', () => {
   })
 })
 
+describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () => {
+  beforeEach(() => chatStore.getState().reset())
+
+  // At the live edge the newest loaded message IS the true newest; clearing the
+  // badge means the user caught up to it, so the read pointer must advance for the
+  // MDS publisher (which watches lastSeenMessageId) to sync the marker.
+  it('advances lastSeenMessageId to the newest loaded message when at the live edge', () => {
+    const cid = 'juliet@capulet.example'
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    chatStore.getState().markAsRead(cid)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
+    expect(chatStore.getState().conversations.get(cid)?.lastSeenMessageId).toBe('m3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
+  })
+
+  // Slid up into history: the badge still clears (the user acknowledged the
+  // conversation) but the pointer must stay put so MDS never publishes a read
+  // position past messages the user has not seen.
+  it('does NOT advance lastSeenMessageId when the window is slid up into history', () => {
+    const cid = 'juliet@capulet.example'
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, lastSeenMessageId: 'm1' })
+      const newEdge = new Map(state.windowAtLiveEdge)
+      newEdge.set(cid, false)
+      return { conversationMeta: newMeta, conversations: newConvs, windowAtLiveEdge: newEdge }
+    })
+
+    chatStore.getState().markAsRead(cid)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(0)
+  })
+})
+
 describe('chatStore — new-message divider is session-only', () => {
   beforeEach(() => chatStore.getState().reset())
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1016,29 +1016,32 @@ export const chatStore = createStore<ChatState>()(
           const lastMessage = messages[messages.length - 1]
           const lastMessageTimestamp = lastMessage?.timestamp
 
-          // Delegate to pure function
-          const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp)
+          // When the loaded window is at the live edge, the newest loaded message
+          // IS the true newest and clearing the badge means the user caught up to
+          // it — advance the read pointer so the XEP-0490 publisher (which watches
+          // lastSeenMessageId) syncs the marker to other devices. Slid up into
+          // history we leave the pointer where the user actually read, so MDS never
+          // publishes a position past unseen messages.
+          const atLiveEdge = state.windowAtLiveEdge.get(conversationId) !== false
+          const advanceSeenTo = atLiveEdge ? lastMessage?.id : undefined
 
-          // If no change (same reference returned), skip state update
-          if (updated.unreadCount === notifInput.unreadCount && updated.lastReadAt === notifInput.lastReadAt) {
-            // Also check by value for deserialized timestamps
-            const existingTime = notifInput.lastReadAt instanceof Date
-              ? notifInput.lastReadAt.getTime()
-              : notifInput.lastReadAt ? new Date(notifInput.lastReadAt as unknown as string).getTime() : 0
-            const newTime = updated.lastReadAt instanceof Date ? updated.lastReadAt.getTime() : 0
-            if (existingTime === newTime) return {}
-          }
+          // Delegate to pure function
+          const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp, advanceSeenTo)
+
+          // Pure function returns the same reference when nothing changed.
+          if (updated === notifInput) return {}
 
           const newMetaEntry = {
             ...(meta ?? { unreadCount: 0, lastReadAt: undefined, lastSeenMessageId: undefined }),
             unreadCount: updated.unreadCount,
             lastReadAt: updated.lastReadAt,
+            lastSeenMessageId: updated.lastSeenMessageId,
           }
           const newMeta = new Map(state.conversationMeta)
           newMeta.set(conversationId, newMetaEntry)
 
           const newConversations = new Map(state.conversations)
-          newConversations.set(conversationId, { ...conv, unreadCount: updated.unreadCount, lastReadAt: updated.lastReadAt })
+          newConversations.set(conversationId, { ...conv, unreadCount: updated.unreadCount, lastReadAt: updated.lastReadAt, lastSeenMessageId: updated.lastSeenMessageId })
 
           return { conversationMeta: newMeta, conversations: newConversations }
         })

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -406,3 +406,56 @@ describe('roomStore — new-message divider is session-only', () => {
     expect(roomStore.getState().firstNewMessageMarkers.get(ROOM_B)).toBeUndefined()
   })
 })
+
+describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    vi.clearAllMocks()
+  })
+
+  // At the live edge, clearing the badge means the user caught up to the newest
+  // message — advance the read pointer so the MDS publisher syncs the marker.
+  it('advances lastSeenMessageId to the newest loaded message when at the live edge', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(ROOM, { ...m.get(ROOM)!, unreadCount: 2 })
+      return { roomMeta: m }
+    })
+
+    roomStore.getState().markAsRead(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m3')
+    expect(roomStore.getState().rooms.get(ROOM)?.lastSeenMessageId).toBe('m3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+  })
+
+  // Slid up into history: badge clears but the pointer stays put, so MDS never
+  // publishes a read position past messages the user has not seen.
+  it('does NOT advance lastSeenMessageId when the window is slid up into history', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(ROOM, { ...m.get(ROOM)!, unreadCount: 2 })
+      const rt = new Map(s.roomRuntime)
+      rt.set(ROOM, { ...rt.get(ROOM)!, windowAtLiveEdge: false })
+      return { roomMeta: m, roomRuntime: rt }
+    })
+
+    roomStore.getState().markAsRead(ROOM)
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+  })
+})

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1498,13 +1498,19 @@ export const roomStore = createStore<RoomState>()(
       const lastMessage = messages[messages.length - 1]
       const lastMessageTimestamp = lastMessage?.timestamp
 
-      const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp)
+      // At the live edge the newest loaded message is the true newest and clearing
+      // the badge means the user caught up — advance the read pointer so the
+      // XEP-0490 publisher syncs the marker. Slid up into history we leave it put.
+      const atLiveEdge = runtime?.windowAtLiveEdge !== false
+      const advanceSeenTo = atLiveEdge ? lastMessage?.id : undefined
+
+      const updated = notifState.onMarkAsRead(notifInput, lastMessageTimestamp, advanceSeenTo)
 
       // Skip update if no change
       if (updated === notifInput) return {}
 
       const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...existing, unreadCount: updated.unreadCount, mentionsCount: updated.mentionsCount, lastReadAt: updated.lastReadAt })
+      newRooms.set(roomJid, { ...existing, unreadCount: updated.unreadCount, mentionsCount: updated.mentionsCount, lastReadAt: updated.lastReadAt, lastSeenMessageId: updated.lastSeenMessageId })
 
       const newMeta = new Map(state.roomMeta)
       const newMetaEntry = {
@@ -1512,6 +1518,7 @@ export const roomStore = createStore<RoomState>()(
         unreadCount: updated.unreadCount,
         mentionsCount: updated.mentionsCount,
         lastReadAt: updated.lastReadAt,
+        lastSeenMessageId: updated.lastSeenMessageId,
       }
       newMeta.set(roomJid, newMetaEntry)
 

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -572,6 +572,35 @@ describe('onMarkAsRead', () => {
     expect(result.lastReadAt!.getTime()).toBeGreaterThanOrEqual(before)
     expect(result.lastReadAt!.getTime()).toBeLessThanOrEqual(after)
   })
+
+  it('leaves lastSeenMessageId untouched when no advance id is given', () => {
+    const state = makeState({ unreadCount: 3, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, new Date())
+    expect(result.lastSeenMessageId).toBe('seen-1')
+  })
+
+  it('advances lastSeenMessageId to the supplied id (read pointer catches up)', () => {
+    const state = makeState({ unreadCount: 3, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, new Date(), 'newest-9')
+    expect(result.lastSeenMessageId).toBe('newest-9')
+    expect(result.unreadCount).toBe(0)
+  })
+
+  it('advances lastSeenMessageId even when the badge is already clear', () => {
+    // The IntersectionObserver may lag: unread already 0 but the pointer is behind.
+    const ts = new Date('2025-01-15T12:00:00Z')
+    const state = makeState({ unreadCount: 0, lastReadAt: ts, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, ts, 'newest-9')
+    expect(result).not.toBe(state)
+    expect(result.lastSeenMessageId).toBe('newest-9')
+  })
+
+  it('returns same reference when the supplied id equals the current pointer', () => {
+    const ts = new Date('2025-01-15T12:00:00Z')
+    const state = makeState({ unreadCount: 0, mentionsCount: 0, lastReadAt: ts, lastSeenMessageId: 'seen-1' })
+    const result = onMarkAsRead(state, ts, 'seen-1')
+    expect(result).toBe(state)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -334,17 +334,28 @@ export function onDeactivate(
  * Clears unreadCount and mentionsCount, updates lastReadAt.
  * Preserves firstNewMessageId — the marker has a separate lifecycle
  * (set on activate, cleared on deactivate or explicit clear).
+ *
+ * When `advanceSeenTo` is supplied, the read pointer (lastSeenMessageId) is
+ * advanced to it. Callers pass the newest message id ONLY when the user has
+ * genuinely caught up to it (the loaded window is at the live edge) — this is
+ * what lets the XEP-0490 publisher, which watches lastSeenMessageId, sync the
+ * read marker to other devices. Omitting it (the scrolled-into-history case)
+ * clears the local badge without publishing a read position past what the user
+ * actually saw. The advance is forward-only in practice because the caller only
+ * ever supplies the tail of a live-edge window (>= the current pointer).
  */
 export function onMarkAsRead(
   state: EntityNotificationState,
-  lastMessageTimestamp?: Date
+  lastMessageTimestamp?: Date,
+  advanceSeenTo?: string
 ): EntityNotificationState {
   const lastReadAt = lastMessageTimestamp ?? new Date()
   // Skip update if nothing to change (prevents unnecessary state updates)
   const existingTime = state.lastReadAt instanceof Date
     ? state.lastReadAt.getTime()
     : state.lastReadAt ? new Date(state.lastReadAt as unknown as string).getTime() : 0
-  if (state.unreadCount === 0 && state.mentionsCount === 0 && existingTime === lastReadAt.getTime()) {
+  const seenUnchanged = advanceSeenTo === undefined || advanceSeenTo === state.lastSeenMessageId
+  if (state.unreadCount === 0 && state.mentionsCount === 0 && existingTime === lastReadAt.getTime() && seenUnchanged) {
     return state
   }
   return {
@@ -352,6 +363,7 @@ export function onMarkAsRead(
     unreadCount: 0,
     mentionsCount: 0,
     lastReadAt,
+    lastSeenMessageId: advanceSeenTo ?? state.lastSeenMessageId,
   }
 }
 


### PR DESCRIPTION
## Summary

`markAsRead` cleared the local unread badge (unread count + `lastReadAt`) but never advanced `lastSeenMessageId`. The XEP-0490 (MDS) read-position publisher fires **only** on `lastSeenMessageId` advances, so the focus-regain and tab-leave read paths (`useWindowVisibility`, `useViewNavigation`, which call `markAsRead`) cleared unread state locally without syncing the read marker to other devices — a message read here could stay unread on another device.

## Fix

- `onMarkAsRead` gains an optional `advanceSeenTo` id that advances the read pointer (folded into the no-op skip check).
- `chatStore` and `roomStore` `markAsRead` pass the newest loaded message id **only when `windowAtLiveEdge` is true**, then propagate the advanced pointer into the meta + combined maps so the publisher fires.

`windowAtLiveEdge` is the same gate the existing read path (`onMessageSeen`, live-append) already uses. When slid up into history the pointer is left where the user actually read, so MDS never publishes a position past unseen messages.