### PR TITLE
ci(flatpak): embed --runtime-repo so bundle installs auto-pull GNOME runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,7 +454,10 @@ jobs:
           flatpak-builder --user --force-clean --disable-updates --repo=repo build-dir com.processone.fluux.yaml
 
           # Create single-file bundle
-          flatpak build-bundle repo "fluux-messenger-${VERSION}-linux-${ARCH}.flatpak" com.processone.fluux
+          # --runtime-repo lets `flatpak install <bundle>.flatpak` auto-pull the GNOME
+          # runtime from Flathub (in the user's chosen scope) when it is missing, instead
+          # of failing with "missing org.gnome.Platform//49".
+          flatpak build-bundle --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo repo "fluux-messenger-${VERSION}-linux-${ARCH}.flatpak" com.processone.fluux
 
           # Move to dist
           mv *.flatpak ../dist/


### PR DESCRIPTION
Single-file `.flatpak` bundles carried no reference to a remote for the GNOME Platform runtime. So `flatpak install <bundle>.flatpak` failed with "missing org.gnome.Platform//49" whenever the runtime was absent in the install scope the user chose — notably the user/system scope mismatch on atomic distros (SecureBlue, Silverblue, Bazzite), where everything is user-scope but a bundle install defaults to system.

Adding `--runtime-repo=flathub` to `flatpak build-bundle` makes Flatpak offer to pull GNOME 49 from Flathub in the user's chosen scope instead of dead-ending. Standard practice for distributed single-file bundles.