### PR TITLE
fix(reactions): jump to reacted message by reference, not DOM node (#923)

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import type { CopyMessageMeta } from '@/utils/buildCopyText'
-import { useChatActive, useContactIdentities, useReferencedMessage, getBareJid, getLocalPart, getMyReactions, useXMPPContext, type Message, type ContactIdentity } from '@fluux/sdk'
+import { useChatActive, useContactIdentities, useReferencedMessage, getBareJid, getLocalPart, getMyReactions, useXMPPContext, chatStore, type Message, type ContactIdentity } from '@fluux/sdk'
 import { useVerifiedPeerKeysStore } from '@/stores/verifiedPeerKeysStore'
 import { useToastStore } from '@/stores/toastStore'
 import { useConversationPlaintextOverrideStore } from '@/stores/conversationPlaintextOverrideStore'
@@ -522,7 +522,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
       </div>
 
       {/* Reaction mention pills — pinned above the composer */}
-      <ReactionMentions conversationId={activeConversation.id} />
+      <ReactionMentions conversationId={activeConversation.id} onSee={(id) => chatStore.getState().setTargetMessageId(id)} />
 
       {/* Input */}
       <MessageInput

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -603,7 +603,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
         </div>
 
         {/* Reaction mention pills — pinned above the composer */}
-        <ReactionMentions conversationId={activeRoom.jid} />
+        <ReactionMentions conversationId={activeRoom.jid} onSee={(id) => roomStore.getState().setTargetMessageId(id)} />
 
         {/* Input - show composer if joined, join prompt if not */}
         {activeRoom.joined ? (

--- a/apps/fluux/src/components/conversation/ReactionMentions.test.tsx
+++ b/apps/fluux/src/components/conversation/ReactionMentions.test.tsx
@@ -4,21 +4,20 @@ import { reactionMentionStore } from '@/stores/reactionMentionStore'
 import { ReactionMentions } from './ReactionMentions'
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, o?: Record<string, unknown>) => (o ? `${k}:${JSON.stringify(o)}` : k) }) }))
-const scrollToMessage = vi.fn()
-vi.mock('./messageGrouping', () => ({ scrollToMessage: (id: string) => scrollToMessage(id) }))
 
 describe('ReactionMentions', () => {
   beforeEach(() => { vi.clearAllMocks(); reactionMentionStore.getState().clearConversation('c1') })
 
   it('renders nothing when there are no mentions', () => {
-    const { container } = render(<ReactionMentions conversationId="c1" />)
+    const { container } = render(<ReactionMentions conversationId="c1" onSee={vi.fn()} />)
     expect(container.firstChild).toBeNull()
   })
-  it('renders a mention, jumps on See, and dismisses on ✕', () => {
+  it('renders a mention, invokes onSee with the message id, and dismisses on ✕', () => {
+    const onSee = vi.fn()
     reactionMentionStore.getState().addMention({ id: 'c1:m1', conversationId: 'c1', messageId: 'm1', reactorName: 'Marie', emoji: '❤️', preview: 'hi' })
-    render(<ReactionMentions conversationId="c1" />)
+    render(<ReactionMentions conversationId="c1" onSee={onSee} />)
     fireEvent.click(screen.getByText('reactions.see'))
-    expect(scrollToMessage).toHaveBeenCalledWith('m1')
+    expect(onSee).toHaveBeenCalledWith('m1')
     fireEvent.click(screen.getByLabelText('common.dismiss'))
     expect(reactionMentionStore.getState().mentions.get('c1')?.length ?? 0).toBe(0)
   })

--- a/apps/fluux/src/components/conversation/ReactionMentions.tsx
+++ b/apps/fluux/src/components/conversation/ReactionMentions.tsx
@@ -1,11 +1,19 @@
 import { useTranslation } from 'react-i18next'
 import { X } from 'lucide-react'
 import { useReactionMentionStore } from '@/stores/reactionMentionStore'
-import { scrollToMessage } from './messageGrouping'
 
-interface ReactionMentionsProps { conversationId: string }
+interface ReactionMentionsProps {
+  conversationId: string
+  /**
+   * Jump to the reacted message. The parent sets the active conversation's / room's
+   * `targetMessageId`, which drives the message list's load-around-by-id + scroll —
+   * the same path search uses. This works even when the target has scrolled out of the
+   * loaded window, unlike a DOM query (#923).
+   */
+  onSee: (messageId: string) => void
+}
 
-export function ReactionMentions({ conversationId }: ReactionMentionsProps) {
+export function ReactionMentions({ conversationId, onSee }: ReactionMentionsProps) {
   const { t } = useTranslation()
   const mentions = useReactionMentionStore((s) => s.mentions.get(conversationId))
   const dismissMention = useReactionMentionStore((s) => s.dismissMention)
@@ -17,7 +25,7 @@ export function ReactionMentions({ conversationId }: ReactionMentionsProps) {
       {mentions.map((m) => (
         <div key={m.id} className="mx-auto max-w-md flex items-center justify-center gap-2 text-xs text-fluux-muted bg-fluux-hover/60 rounded-full px-3 py-1">
           <span className="truncate">{t('reactions.mention', { name: m.reactorName, emoji: m.emoji, preview: m.preview })}</span>
-          <button onClick={() => scrollToMessage(m.messageId)} className="font-medium text-fluux-brand hover:underline flex-shrink-0">
+          <button onClick={() => onSee(m.messageId)} className="font-medium text-fluux-brand hover:underline flex-shrink-0">
             {t('reactions.see')}
           </button>
           <button onClick={() => dismissMention(conversationId, m.id)} aria-label={t('common.dismiss')} className="text-fluux-muted hover:text-fluux-text flex-shrink-0">

--- a/apps/fluux/src/hooks/useReactionNotifications.test.tsx
+++ b/apps/fluux/src/hooks/useReactionNotifications.test.tsx
@@ -52,13 +52,11 @@ vi.mock('@/stores/reactionMentionStore', () => ({
   useReactionMentionStore: { getState: () => ({ addMention: mockAddMention }) },
 }))
 
-const mockNavigateToMessages = vi.fn()
-const mockNavigateToRooms = vi.fn()
-vi.mock('@/hooks', () => ({
-  useRouteSync: () => ({ navigateToMessages: mockNavigateToMessages, navigateToRooms: mockNavigateToRooms }),
+const mockNavigateToConversation = vi.fn()
+const mockNavigateToRoom = vi.fn()
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({ navigateToConversation: mockNavigateToConversation, navigateToRoom: mockNavigateToRoom }),
 }))
-
-vi.mock('@/components/conversation/messageGrouping', () => ({ scrollToMessage: vi.fn() }))
 
 /** Grab a subscribed handler by event name. */
 function handlerFor(event: string): (ev: Record<string, unknown>) => Promise<void> {
@@ -103,6 +101,12 @@ describe('useReactionNotifications — chat reaction resolution', () => {
     expect(mockAddToast).toHaveBeenCalledTimes(1)
     expect(mockAddToast).toHaveBeenCalledWith('info', expect.stringContaining('reactions.mention'), 6000, expect.any(Function))
     expect(mockAddMention).not.toHaveBeenCalled()
+
+    // Clicking the toast must jump by message reference (load-around-by-id), not a DOM query,
+    // so it works even when the reacted message has scrolled out of the loaded window (#923).
+    const onClick = mockAddToast.mock.calls[0][3] as () => void
+    onClick()
+    expect(mockNavigateToConversation).toHaveBeenCalledWith('peer@example.com', 'm1')
   })
 
   it('tries stanzaId lookup when the client-id cache read misses', async () => {
@@ -204,6 +208,11 @@ describe('useReactionNotifications — room reaction resolution', () => {
 
     expect(mockAddToast).toHaveBeenCalledTimes(1)
     expect(mockAddMention).not.toHaveBeenCalled()
+
+    // Room toast jumps by message reference too (#923).
+    const onClick = mockAddToast.mock.calls[0][3] as () => void
+    onClick()
+    expect(mockNavigateToRoom).toHaveBeenCalledWith(ROOM, 'r1')
   })
 
   it('falls back to the durable room cache when the reacted message is not resident', async () => {

--- a/apps/fluux/src/hooks/useReactionNotifications.ts
+++ b/apps/fluux/src/hooks/useReactionNotifications.ts
@@ -7,8 +7,7 @@ import { getMessage as getCachedMessage, getMessageByStanzaId as getCachedMessag
 import { getRoomMessage as getCachedRoomMessage, getRoomMessageByStanzaId as getCachedRoomMessageByStanzaId } from '@fluux/sdk/cache'
 import { useToastStore } from '@/stores/toastStore'
 import { useReactionMentionStore } from '@/stores/reactionMentionStore'
-import { useRouteSync } from '@/hooks'
-import { scrollToMessage } from '@/components/conversation/messageGrouping'
+import { useNavigateToTarget } from './useNavigateToTarget'
 import { decideReactionNotification, type ReactionDecision } from './reactionNotificationDecision'
 
 /**
@@ -22,7 +21,7 @@ import { decideReactionNotification, type ReactionDecision } from './reactionNot
 export function useReactionNotifications(): void {
   const { client } = useXMPP()
   const { t } = useTranslation()
-  const { navigateToMessages, navigateToRooms } = useRouteSync()
+  const { navigateToConversation, navigateToRoom } = useNavigateToTarget()
 
   useEffect(() => {
     if (!client?.subscribe) return
@@ -44,12 +43,16 @@ export function useReactionNotifications(): void {
 
       if (decision.kind === 'toast') {
         useToastStore.getState().addToast('info', label, 6000, () => {
+          // Navigate by message reference: navigateToConversation/navigateToRoom set the
+          // target's `targetMessageId` before activating, so the message list loads the
+          // history slice around it (getMessagesAround) and scrolls — even when the reacted
+          // message is far outside the loaded window. A DOM-query jump would silently no-op
+          // there (#923).
           if (m.isRoom) {
-            navigateToRooms(m.conversationId)
+            navigateToRoom(m.conversationId, m.messageId)
           } else {
-            navigateToMessages(m.conversationId)
+            navigateToConversation(m.conversationId, m.messageId)
           }
-          setTimeout(() => scrollToMessage(m.messageId), 100)
         })
       } else {
         // decision.kind === 'mention'
@@ -160,5 +163,5 @@ export function useReactionNotifications(): void {
       unsubChat()
       unsubRoom()
     }
-  }, [client, t, navigateToMessages, navigateToRooms])
+  }, [client, t, navigateToConversation, navigateToRoom])
 }


### PR DESCRIPTION
Fixes #923.

Clicking **See** on a reaction (chip or toast) did nothing when the reacted message had scrolled out of the loaded window, because both paths located the target with `scrollToMessage()` — a DOM query that silently no-ops for a message that isn't rendered.

Both now go through the existing load-around-by-id mechanism (the same one search and notifications use): the target's `targetMessageId` is set, the message list pulls the history slice around it (`getMessagesAround`) and scrolls — even when it's far outside the window.

- `ReactionMentions` gains an `onSee(messageId)` callback; `ChatView`/`RoomView` wire it to `setTargetMessageId` on the active store.
- The reaction toast navigates via `useNavigateToTarget`, which sets the target before activating, dropping the fragile `setTimeout(scrollToMessage, 100)`.

The same out-of-window limitation still affects reply-quote and poll jumps; those are tracked as a follow-up (hardening `scrollToMessage` at the source) since they also depend on multi-tier id resolution the target path doesn't cover. Find-on-page is unaffected (its matches are always in the loaded set).