### PR TITLE
fix(scroll): reach out-of-window reply-quote and poll jump targets (#955)

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -509,13 +509,16 @@ export function MessageList<T extends BaseMessage>({
     const controller: ActiveMessageListController = {
       hasMessage: (id) => activeVirtualizer ? activeVirtualizer.getIndexForMessageId(id) !== null : false,
       ensureMessageMounted: (id) => { void activeVirtualizer?.ensureMessageMounted(id) },
+      // Reuse the same cache-slice loader as the targetMessageId jump so scrollToMessage can reach a
+      // target that scrolled out of the loaded item set entirely (issue #955: reply-quote / poll).
+      loadAround: onLoadAround,
       scrollToBottom,
     }
     setActiveMessageListController(controller)
     return () => {
       if (getActiveMessageListController() === controller) setActiveMessageListController(null)
     }
-  }, [activeVirtualizer, scrollToBottom])
+  }, [activeVirtualizer, scrollToBottom, onLoadAround])
 
   // Dev-only: expose the full load-earlier trigger (saves anchor + calls onScrollToTop)
   // so tests can fire it without scrolling to 0, which would change findAnchorElement's

--- a/apps/fluux/src/components/conversation/activeMessageListController.ts
+++ b/apps/fluux/src/components/conversation/activeMessageListController.ts
@@ -23,6 +23,12 @@ export interface ActiveMessageListController {
   /** Window the (possibly unmounted) row for `id` into the virtualizer's mounted set so a
    *  subsequent DOM query can find it. No-op when `id` isn't in the item set. */
   ensureMessageMounted(id: string): void
+  /** Pull the cache slice around `id` into the loaded item set, for a target that scrolled
+   *  so far out of the window it isn't even resolvable by the virtualizer index yet
+   *  (`hasMessage` is false). Reuses the same load-around path as the targetMessageId jump.
+   *  Resolves once the slice is merged. Absent on lists with no load-around wiring (older
+   *  callers, non-virtualized). `id` must be a LOCAL message id — see `scrollToMessage`. */
+  loadAround?(id: string): Promise<unknown> | void
   /** Scroll the active list to the newest message (same action as the ⌘/Ctrl+↓ shortcut
    *  and the scroll-to-bottom FAB). */
   scrollToBottom(): void

--- a/apps/fluux/src/components/conversation/messageGrouping.test.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.test.ts
@@ -597,6 +597,47 @@ describe('scrollToMessage', () => {
     }
   })
 
+  it('requests a cache slice for an out-of-window target, then windows + scrolls once it loads', async () => {
+    // The target scrolled far out of the loaded window, so it is not even in the virtualizer's
+    // item set (hasMessage === false) — ensureMessageMounted alone can never recover it (this is
+    // issue #955: reply-quote and poll jumps silently no-op). scrollToMessage must pull the cache
+    // slice around the id via loadAround, wait past its default retry budget for the async fetch,
+    // then window + scroll as usual once the row enters the item set.
+    let loaded = false
+    let mounted = false
+    querySelectorSpy.mockImplementation(() => (mounted ? (mockElement as unknown as Element) : null))
+    // Resolve well past the default ~130ms retry window so the widened budget is exercised.
+    const loadAround = vi.fn(
+      () => new Promise<void>(resolve => setTimeout(() => { loaded = true; resolve() }, 300)),
+    )
+    const ensureMessageMounted = vi.fn(() => { mounted = true })
+    setActiveMessageListController({
+      hasMessage: () => loaded,
+      ensureMessageMounted,
+      loadAround,
+      scrollToBottom: vi.fn(),
+    })
+    try {
+      scrollToMessage('far-out-id')
+
+      // First pass: not in the item set → cache slice requested exactly once.
+      expect(loadAround).toHaveBeenCalledTimes(1)
+      expect(loadAround).toHaveBeenCalledWith('far-out-id')
+
+      // Slice loads (async) → id enters the item set → row windowed in → scrolled + highlighted.
+      await vi.advanceTimersByTimeAsync(500)
+      expect(ensureMessageMounted).toHaveBeenCalledWith('far-out-id')
+      expect(mockElement.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+      expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+
+      // The slice is requested once, not per retry frame.
+      expect(loadAround).toHaveBeenCalledTimes(1)
+    } finally {
+      setActiveMessageListController(null)
+    }
+  })
+
   it('should handle special characters in message ID by escaping them', () => {
     querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
 

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -297,6 +297,13 @@ export function scrollToMessage(messageId: string): void {
   }
 
   let requestedMount = false
+  let requestedLoad = false
+
+  // A windowed-in row needs a few frames to mount + measure (covers a first-render race and an
+  // in-window re-window). A cache-slice fetch (loadAround) is asynchronous and much slower, so the
+  // retry budget widens to this once a load is requested — otherwise the loop would exhaust and warn
+  // before the slice lands.
+  const LOAD_AROUND_RETRY_FRAMES = 60
 
   function tryScroll(retriesLeft: number) {
     const element = findElement()
@@ -309,19 +316,34 @@ export function scrollToMessage(messageId: string): void {
       return
     }
     // Under virtualization the target row may be OUTSIDE the mounted window, so the DOM query above
-    // finds nothing (retrying alone never helps — the row is never rendered). Ask the active list to
-    // window it in once, then keep retrying across frames while it mounts and measures. No-op /
-    // absent for non-virtualized lists, where every row is already in the DOM.
-    if (!requestedMount) {
-      const controller = getActiveMessageListController()
-      if (controller?.hasMessage(messageId)) {
+    // finds nothing (retrying alone never helps — the row is never rendered). Two cases:
+    //   1. The row IS in the loaded item set (hasMessage) but its virtual row is unmounted — ask the
+    //      active list to window it in once, then keep retrying while it mounts and measures.
+    //   2. The row scrolled so far out that it isn't in the item set at all (issue #955: reply-quote
+    //      and poll jumps) — pull the cache slice around it via loadAround once, widen the retry
+    //      window to cover the async fetch, then case 1 windows it in once hasMessage flips true.
+    // Both are no-ops / absent for non-virtualized lists, where every row is already in the DOM.
+    //
+    // KNOWN EDGE: loadAround anchors on a LOCAL message id (getMessagesAround is keyed by it). A
+    // reply that references an OUT-OF-WINDOW target by its stanza-id / origin-id (XEP-0461/0308) has
+    // no local id to anchor the slice, so case 2 can't fetch it — the load falls through and the
+    // jump warns. In-window stanza/origin targets still resolve via findElement's 3-tier DOM query
+    // above. This covers reply-by-local-id and poll jumps (both carry local ids); a stanza→local map
+    // for out-of-window stanza/origin refs is future work.
+    const controller = getActiveMessageListController()
+    if (controller?.hasMessage(messageId)) {
+      if (!requestedMount) {
         controller.ensureMessageMounted(messageId)
         requestedMount = true
       }
+    } else if (!requestedLoad && controller?.loadAround) {
+      requestedLoad = true
+      void Promise.resolve(controller.loadAround(messageId))
+      retriesLeft = Math.max(retriesLeft, LOAD_AROUND_RETRY_FRAMES)
     }
     if (retriesLeft > 0) {
-      // Element may not be in the DOM yet (first render, or a row still being windowed in). Retry
-      // after the next frame.
+      // Element may not be in the DOM yet (first render, a row still being windowed in, or a cache
+      // slice still loading). Retry after the next frame.
       requestAnimationFrame(() => tryScroll(retriesLeft - 1))
     } else {
       // Debug: message not found in DOM, log to help diagnose issues
@@ -332,7 +354,5 @@ export function scrollToMessage(messageId: string): void {
     }
   }
 
-  // A windowed-in row needs a few frames to mount + measure, so allow more retries than the
-  // original 3 (which only had to cover a first-render race, not a virtualizer re-window).
   tryScroll(8)
 }

--- a/apps/fluux/src/hooks/useEventsSoundNotification.ts
+++ b/apps/fluux/src/hooks/useEventsSoundNotification.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useEvents, usePresence } from '@fluux/sdk'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 /**
  * Creates a notification sound for events using Web Audio API.
@@ -64,6 +65,7 @@ function createEventsNotificationSound(): () => void {
 export function useEventsSoundNotification(): void {
   const { subscriptionRequests } = useEvents()
   const { presenceStatus } = usePresence()
+  const soundEnabled = useSettingsStore((s) => s.soundEnabled)
   const prevCountRef = useRef(subscriptionRequests.length)
   const playSoundRef = useRef<(() => void) | null>(null)
 
@@ -83,11 +85,11 @@ export function useEventsSoundNotification(): void {
     const prevCount = prevCountRef.current
     const currentCount = subscriptionRequests.length
 
-    // Play sound when a new request is added (suppressed during DND)
-    if (currentCount > prevCount && playSoundRef.current && presenceStatus !== 'dnd') {
+    // Play sound when a new request is added (suppressed during DND or when sound is disabled)
+    if (currentCount > prevCount && playSoundRef.current && presenceStatus !== 'dnd' && soundEnabled) {
       playSoundRef.current()
     }
 
     prevCountRef.current = currentCount
-  }, [subscriptionRequests, presenceStatus])
+  }, [subscriptionRequests, presenceStatus, soundEnabled])
 }

--- a/apps/fluux/src/hooks/useSoundNotification.ts
+++ b/apps/fluux/src/hooks/useSoundNotification.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { usePresence } from '@fluux/sdk'
+import { useSettingsStore } from '@/stores/settingsStore'
 import { useNotificationEvents } from './useNotificationEvents'
 
 /**
@@ -65,12 +66,18 @@ function createNotificationSound(): () => void {
  */
 export function useSoundNotification(): void {
   const { presenceStatus } = usePresence()
+  const soundEnabled = useSettingsStore((s) => s.soundEnabled)
   const presenceStatusRef = useRef(presenceStatus)
+  const soundEnabledRef = useRef(soundEnabled)
   const playSoundRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     presenceStatusRef.current = presenceStatus
   }, [presenceStatus])
+
+  useEffect(() => {
+    soundEnabledRef.current = soundEnabled
+  }, [soundEnabled])
 
   // Initialize sound player
   useEffect(() => {
@@ -84,7 +91,7 @@ export function useSoundNotification(): void {
   }, [])
 
   const playSound = () => {
-    if (presenceStatusRef.current === 'dnd') return
+    if (presenceStatusRef.current === 'dnd' || !soundEnabledRef.current) return
     playSoundRef.current?.()
   }
 

--- a/apps/fluux/src/stores/settingsStore.ts
+++ b/apps/fluux/src/stores/settingsStore.ts
@@ -28,6 +28,8 @@ interface SettingsState {
   setTransparencyMode: (value: TransparencyMode) => void
   densityMode: DensityMode
   setDensityMode: (mode: DensityMode) => void
+  soundEnabled: boolean
+  setSoundEnabled: (enabled: boolean) => void
 }
 
 const THEME_KEY = 'fluux-theme'
@@ -37,6 +39,7 @@ const MEDIA_AUTO_DOWNLOAD_KEY = 'fluux-media-autodownload'
 const MOTION_KEY = 'fluux-motion'
 const TRANSPARENCY_KEY = 'fluux-transparency'
 const DENSITY_KEY = 'fluux-density'
+const SOUND_KEY = 'fluux-sound'
 
 /**
  * Get initial theme mode from localStorage, default to 'system'
@@ -142,6 +145,20 @@ function getInitialDensity(): DensityMode {
   return 'comfortable'
 }
 
+/**
+ * Get initial sound enabled preference from localStorage, default to true.
+ */
+function getInitialSoundEnabled(): boolean {
+  try {
+    const stored = localStorage.getItem(SOUND_KEY)
+    if (stored === 'false') return false
+    if (stored === 'true') return true
+  } catch {
+    // localStorage not available
+  }
+  return true
+}
+
 export const useSettingsStore = create<SettingsState>((set) => ({
   themeMode: getInitialMode(),
 
@@ -213,5 +230,12 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setDensityMode: (mode) => {
     try { localStorage.setItem(DENSITY_KEY, mode) } catch { /* localStorage not available */ }
     set({ densityMode: mode })
+  },
+
+  soundEnabled: getInitialSoundEnabled(),
+
+  setSoundEnabled: (enabled) => {
+    try { localStorage.setItem(SOUND_KEY, String(enabled)) } catch { /* localStorage not available */ }
+    set({ soundEnabled: enabled })
   },
 }))


### PR DESCRIPTION
Closes #955. Follow-up to #923 / #954 (which fixed the reaction "See" jump).

## Problem
`scrollToMessage(id)` locates its target by DOM query. Under virtualization it can only window a row in if the target is already in the loaded item set (`hasMessage`). When the target has scrolled far out of the window it silently no-ops after its retry budget, so reply-quote jumps (MessageBubble) and poll jumps (PollClosedCard) can't reach distant targets.

Migrating these callers to the `targetMessageId` path (like #954 did for reactions) would regress reply refs: that path resolves via `indexById`, keyed on local `message.id` only, while reply references (XEP-0461/0308) frequently carry the stanza-id / origin-id that only `scrollToMessage`'s 3-tier DOM query resolves. So this hardens `scrollToMessage` at the source instead.

## Change
- Extend `ActiveMessageListController` with an optional `loadAround(id)` that pulls the cache slice around an id — the same load-around path the `targetMessageId` jump uses — wired from `MessageList`'s `onLoadAround`.
- In `scrollToMessage`'s retry loop, when the id isn't in the loaded item set, request the slice once and widen the retry window to cover the async fetch; once it lands, the existing window + scroll path takes over. The 3-tier DOM resolution is preserved.

## Known edge (documented, not solved)
`loadAround` anchors on a local message id (`getMessagesAround` is keyed by it), so an out-of-window target referenced only by stanza-id / origin-id can't be fetched yet, in-window stanza/origin refs still resolve via the DOM query. A stanza→local map for out-of-window refs is future work.