### PR TITLE
feat(theme): add "Pure" theme for OLED and e-ink displays (#952)

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -433,7 +433,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
               </div>
             </div>
             <div
-              class="pb-4"
+              class="pb-2"
             />
           </div>
         </div>

--- a/apps/fluux/src/hooks/useTheme.ts
+++ b/apps/fluux/src/hooks/useTheme.ts
@@ -344,6 +344,8 @@ export function useTheme() {
   // Apply transparency preference. Sets data-transparency="full"|"reduced" on <html>;
   // CSS frosts .fluux-glass by default and the [data-transparency="reduced"] rule
   // reverts to a solid surface. 'system' resolves from prefers-reduced-transparency.
+  // The active theme can also force 'reduced' (reduced-wins) via resolveTransparency,
+  // which is why getActiveTheme() is consulted here.
   useEffect(() => {
     const themeWantsReduced = getActiveTheme()?.transparency === 'reduced'
     const resolve = () =>

--- a/apps/fluux/src/hooks/useTheme.ts
+++ b/apps/fluux/src/hooks/useTheme.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useSettingsStore, type ThemeMode } from '@/stores/settingsStore'
 import { useThemeStore } from '@/stores/themeStore'
 import type { AccentPreset } from '@/themes/types'
+import { resolveTransparency } from '@/themes/transparency'
 import { isLinux } from '@/utils/tauri'
 
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
@@ -344,18 +345,20 @@ export function useTheme() {
   // CSS frosts .fluux-glass by default and the [data-transparency="reduced"] rule
   // reverts to a solid surface. 'system' resolves from prefers-reduced-transparency.
   useEffect(() => {
-    const resolve = () => {
-      if (transparencyMode === 'reduced') return 'reduced'
-      if (transparencyMode === 'full') return 'full'
-      return window.matchMedia('(prefers-reduced-transparency: reduce)').matches ? 'reduced' : 'full'
-    }
+    const themeWantsReduced = getActiveTheme()?.transparency === 'reduced'
+    const resolve = () =>
+      resolveTransparency({
+        themeWantsReduced,
+        transparencyMode,
+        systemReducedMatches: window.matchMedia('(prefers-reduced-transparency: reduce)').matches,
+      })
     document.documentElement.setAttribute('data-transparency', resolve())
     if (transparencyMode !== 'system') return
     const mq = window.matchMedia('(prefers-reduced-transparency: reduce)')
     const on = () => document.documentElement.setAttribute('data-transparency', resolve())
     mq.addEventListener('change', on)
     return () => mq.removeEventListener('change', on)
-  }, [transparencyMode])
+  }, [transparencyMode, activeThemeId, getActiveTheme])
 
   // Sync CSS snippets
   useEffect(() => {

--- a/apps/fluux/src/themes/builtins/index.test.ts
+++ b/apps/fluux/src/themes/builtins/index.test.ts
@@ -21,4 +21,18 @@ describe('builtin themes', () => {
     expect(builtinThemes[0].id).toBe('fluux')
     expect(builtinThemes[1].id).toBe('indigo')
   })
+
+  it('registers the Pure theme optimized for OLED/e-ink', () => {
+    const pure = getBuiltinTheme('pure')
+    expect(pure).toBeDefined()
+    expect(pure?.name).toBe('Pure')
+    // Forces solid glass so true-black / flat-white is not broken by frost.
+    expect(pure?.transparency).toBe('reduced')
+    // OLED: the main content + sidebar chrome are true black.
+    expect(pure?.variables.dark?.['--fluux-chat-bg']).toBe('#000000')
+    expect(pure?.variables.dark?.['--fluux-sidebar-bg']).toBe('#000000')
+    // e-ink: the main content + sidebar chrome are flat white.
+    expect(pure?.variables.light?.['--fluux-chat-bg']).toBe('#ffffff')
+    expect(pure?.variables.light?.['--fluux-sidebar-bg']).toBe('#ffffff')
+  })
 })

--- a/apps/fluux/src/themes/builtins/index.ts
+++ b/apps/fluux/src/themes/builtins/index.ts
@@ -11,6 +11,7 @@ import { rosePineTheme } from './rose-pine'
 import { kanagawaTheme } from './kanagawa'
 import { githubTheme } from './github'
 import { indigoTheme } from './indigo'
+import { pureTheme } from './pure'
 
 /**
  * Aurora — the default Fluux theme. Its variables live in index.css (:root /
@@ -65,6 +66,7 @@ export const builtinThemes: ThemeDefinition[] = [
   rosePineTheme,
   kanagawaTheme,
   githubTheme,
+  pureTheme,
 ]
 
 /** Look up a built-in theme by ID */

--- a/apps/fluux/src/themes/builtins/pure.ts
+++ b/apps/fluux/src/themes/builtins/pure.ts
@@ -1,0 +1,95 @@
+import type { ThemeDefinition } from '../types'
+
+/**
+ * Pure — true-black for OLED (dark) and flat-white for e-ink (light).
+ *
+ * Dark: chat + all chrome surfaces are #000000 so OLED panels power those pixels
+ * off (battery + no light bleed). Depth is carried by hairline borders and the
+ * inherited alpha divider, not by surface luminance — the surface-hierarchy guard
+ * requires luminance(sidebar) <= luminance(chat), so the chrome is deliberately
+ * flat black. Elevated non-chrome surfaces (float/popover/hover rows) get a hair
+ * of lift for affordance. Accent is Aurora's teal preset — restrained but vivid,
+ * it pops on black.
+ *
+ * Light: everything is #ffffff, flat, with strong dark structure and a near-black
+ * "ink" accent so interactive elements read as high-contrast bold and survive
+ * e-ink's shallow grayscale rendering. Muted text stays dark (not light gray).
+ *
+ * transparency: 'reduced' forces every glass surface solid (see resolveTransparency)
+ * — frosted translucency would break true black on OLED and does not render on e-ink.
+ *
+ * The palette (--fluux-color-*), syntax tokens, and --fluux-text-error are
+ * intentionally inherited: on pure black / pure white they clear the per-theme
+ * WCAG contrast guards by construction, so overriding them adds risk without benefit.
+ */
+export const pureTheme: ThemeDefinition = {
+  id: 'pure',
+  name: 'Pure',
+  author: 'Fluux',
+  version: '1.0.0',
+  description: 'True black for OLED, flat white for e-ink — maximum-contrast minimalism',
+  transparency: 'reduced',
+  variables: {
+    dark: {
+      // Foundation — neutral ramp. base-00..base-30 are true black so every
+      // chrome surface (bg-primary=base-10, sidebar=base-20, chat=base-30) is #000.
+      '--fluux-base-00': '#000000',
+      '--fluux-base-05': '#000000',
+      '--fluux-base-10': '#000000',
+      '--fluux-base-20': '#000000',
+      '--fluux-base-30': '#000000',
+      '--fluux-base-40': '#141414', // hover rows — subtle lift on the black canvas
+      '--fluux-base-50': '#1c1c1c', // float / popover surface
+      '--fluux-base-60': '#262626', // float hover
+      '--fluux-base-70': '#6e6e6e',
+      '--fluux-base-80': '#9a9a9a', // text-muted (≈7:1 on #000)
+      '--fluux-base-90': '#fafafa', // text-normal (just under #fff to soften halation)
+      '--fluux-base-100': '#ffffff',
+      // Foundation — accent (Aurora teal: pops on true black)
+      '--fluux-accent-h': '174',
+      '--fluux-accent-s': '70%',
+      '--fluux-accent-l': '52%',
+      // Borders — hairlines carry the depth the flat surfaces don't.
+      '--fluux-border-color': 'rgba(255, 255, 255, 0.14)',
+      '--fluux-glass-border': 'rgba(255, 255, 255, 0.18)',
+      // Pin the chrome surfaces to true black directly so the intent is explicit
+      // and independent of ramp-derivation changes.
+      '--fluux-chat-bg': '#000000',
+      '--fluux-sidebar-bg': '#000000',
+      '--fluux-bg-float': '#1c1c1c',
+    },
+    light: {
+      // Foundation — neutral ramp inverted; base-00..base-30 flat white so every
+      // chrome surface is #fff. Text ramp (base-90/100) is pure black ink.
+      '--fluux-base-00': '#ffffff',
+      '--fluux-base-05': '#ffffff',
+      '--fluux-base-10': '#ffffff',
+      '--fluux-base-20': '#ffffff',
+      '--fluux-base-30': '#ffffff',
+      '--fluux-base-40': '#f2f2f2', // hover rows — faint lift
+      '--fluux-base-50': '#ffffff', // float / popover (border carries elevation)
+      '--fluux-base-60': '#ebebeb',
+      '--fluux-base-70': '#8a8a8a',
+      '--fluux-base-80': '#3a3a3a', // text-muted kept dark for e-ink depth
+      '--fluux-base-90': '#000000', // text-normal ink
+      '--fluux-base-100': '#000000',
+      // Foundation — accent (near-black "ink"; text-on-accent computes to white)
+      '--fluux-accent-h': '0',
+      '--fluux-accent-s': '0%',
+      '--fluux-accent-l': '10%',
+      // Strong dark structure.
+      '--fluux-border-color': 'rgba(0, 0, 0, 0.22)',
+      '--fluux-glass-border': 'rgba(0, 0, 0, 0.18)',
+      // The .light block sets --fluux-bg-secondary to a tinted value; pin it and
+      // the chrome surfaces flat white.
+      '--fluux-bg-secondary': '#ffffff',
+      '--fluux-chat-bg': '#ffffff',
+      '--fluux-sidebar-bg': '#ffffff',
+      '--fluux-bg-float': '#ffffff',
+    },
+  },
+  swatches: {
+    dark: ['#000000', '#0a0a0a', '#38E0C4', '#fafafa'],
+    light: ['#ffffff', '#f2f2f2', '#1a1a1a', '#000000'],
+  },
+}

--- a/apps/fluux/src/themes/builtins/pure.ts
+++ b/apps/fluux/src/themes/builtins/pure.ts
@@ -49,8 +49,10 @@ export const pureTheme: ThemeDefinition = {
       '--fluux-accent-h': '174',
       '--fluux-accent-s': '70%',
       '--fluux-accent-l': '52%',
-      // Borders — hairlines carry the depth the flat surfaces don't.
-      '--fluux-border-color': 'rgba(255, 255, 255, 0.14)',
+      // Borders — hairlines carry the depth the flat surfaces don't; on pure
+      // black the chrome has no luminance to lean on, so the hairline is
+      // bumped slightly stronger (matches Aurora's dark default) to read clearly.
+      '--fluux-border-color': 'rgba(255, 255, 255, 0.16)',
       '--fluux-glass-border': 'rgba(255, 255, 255, 0.18)',
       // Pin the chrome surfaces to true black directly so the intent is explicit
       // and independent of ramp-derivation changes.
@@ -77,7 +79,9 @@ export const pureTheme: ThemeDefinition = {
       '--fluux-accent-h': '0',
       '--fluux-accent-s': '0%',
       '--fluux-accent-l': '10%',
-      // Strong dark structure.
+      // Strong dark structure. Alpha raised to 0.22 to clear the light-mode
+      // hairline-visibility contrast guard ("[pure/light] border-color reads
+      // as a hairline", which requires >=1.5:1; 0.16 measured only 1.45:1).
       '--fluux-border-color': 'rgba(0, 0, 0, 0.22)',
       '--fluux-glass-border': 'rgba(0, 0, 0, 0.18)',
       // The .light block sets --fluux-bg-secondary to a tinted value; pin it and

--- a/apps/fluux/src/themes/transparency.test.ts
+++ b/apps/fluux/src/themes/transparency.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { resolveTransparency } from './transparency'
+
+describe('resolveTransparency (reduced-wins merge)', () => {
+  it('theme requesting reduced forces reduced even when user chose full', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: true, transparencyMode: 'full', systemReducedMatches: false }),
+    ).toBe('reduced')
+  })
+
+  it('theme not requesting reduced defers to an explicit user setting', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'full', systemReducedMatches: true }),
+    ).toBe('full')
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'reduced', systemReducedMatches: false }),
+    ).toBe('reduced')
+  })
+
+  it('system mode resolves from the OS media query when the theme is neutral', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'system', systemReducedMatches: true }),
+    ).toBe('reduced')
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'system', systemReducedMatches: false }),
+    ).toBe('full')
+  })
+
+  it('a theme can never force full over a user/OS reduced preference', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'reduced', systemReducedMatches: false }),
+    ).toBe('reduced')
+  })
+})

--- a/apps/fluux/src/themes/transparency.ts
+++ b/apps/fluux/src/themes/transparency.ts
@@ -1,0 +1,21 @@
+export type TransparencyMode = 'full' | 'reduced' | 'system'
+export type ResolvedTransparency = 'full' | 'reduced'
+
+/**
+ * Resolve the effective transparency for the current theme + user setting.
+ *
+ * Reduced-wins: a theme may FORCE reduced transparency (the "Pure" theme does,
+ * so its glass surfaces render solid), but a theme can never force `full` over a
+ * user or OS `reduced` preference. When the theme is neutral, the user's own
+ * setting decides ('system' consults the OS prefers-reduced-transparency query).
+ */
+export function resolveTransparency(opts: {
+  themeWantsReduced: boolean
+  transparencyMode: TransparencyMode
+  systemReducedMatches: boolean
+}): ResolvedTransparency {
+  if (opts.themeWantsReduced) return 'reduced'
+  if (opts.transparencyMode === 'reduced') return 'reduced'
+  if (opts.transparencyMode === 'full') return 'full'
+  return opts.systemReducedMatches ? 'reduced' : 'full'
+}

--- a/apps/fluux/src/themes/types.ts
+++ b/apps/fluux/src/themes/types.ts
@@ -54,6 +54,14 @@ export interface ThemeDefinition {
     dark?: Record<string, string>
     light?: Record<string, string>
   }
+  /**
+   * Optional display-optimisation hint. When set to 'reduced', selecting this
+   * theme forces the app into reduced-transparency mode (glass surfaces render
+   * solid) regardless of the user's transparency setting — used by "Pure" so its
+   * true-black / flat-white surfaces are not broken by frosted panels. A theme
+   * can only tighten transparency, never loosen it. See resolveTransparency().
+   */
+  transparency?: 'reduced'
   /** Preview swatch colors for the theme picker UI (3-5 hex values) */
   swatches?: {
     dark?: string[]

--- a/docs/superpowers/plans/2026-07-10-pure-theme.md
+++ b/docs/superpowers/plans/2026-07-10-pure-theme.md
@@ -1,0 +1,452 @@
+# Pure Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Pure" builtin theme whose dark mode is true-black (OLED) and light mode is flat-white (e-ink), with glass/blur automatically flattened when it is active.
+
+**Architecture:** Pure is a single `ThemeDefinition` (dark = OLED, light = e-ink) registered like any other builtin, so it inherits the picker, swatches, persistence, and mode toggle for free. The only mechanism added is an optional `transparency?: 'reduced'` field on `ThemeDefinition` that `useTheme` folds into the effective `data-transparency` attribute (reduced-wins), reusing the codebase's existing `[data-transparency="reduced"]` solid-fallback CSS to flatten every glass surface. No new CSS selectors, no store changes, no UI changes.
+
+**Tech Stack:** React + TypeScript, Zustand stores, CSS custom properties (`--fluux-*`), Vitest.
+
+## Global Constraints
+
+- Theme id is `pure`, display name is `Pure`, author `Fluux`, version `1.0.0` — exact strings.
+- Only Tier-1 foundation vars + a handful of explicit surface/border pins are overridden; semantic/component tokens cascade. Do not override the palette (`--fluux-color-*`) or `--fluux-text-error` — Pure intentionally inherits them (they clear the per-theme contrast tests on pure black/white by construction).
+- Keep `--fluux-surface-divider` at its inherited alpha-on-surface value (white-alpha dark / black-alpha light). Do NOT override it — the surface-hierarchy divider-direction test depends on it.
+- The main content surface must be true black on OLED: `--fluux-chat-bg` resolves to `#000000` in dark, `#ffffff` in light. Because the surface-hierarchy test requires `luminance(sidebar-bg) <= luminance(chat-bg)`, the sidebar/rail/primary chrome surfaces must be equally black/white (flat) — hierarchy is carried by borders, not surface luminance.
+- Transparency merge is **reduced-wins**: a theme may force `reduced`, never force `full` over a user/OS `reduced` preference.
+- All work happens in `apps/fluux/`. Run theme tests from that package: `cd apps/fluux && npx vitest run src/themes/`.
+- No Claude footer in commits.
+
+---
+
+## File Structure
+
+- **Create** `apps/fluux/src/themes/transparency.ts` — pure `resolveTransparency()` helper (the reduced-wins merge), unit-testable without React.
+- **Create** `apps/fluux/src/themes/transparency.test.ts` — unit tests for the helper.
+- **Modify** `apps/fluux/src/themes/types.ts` — add optional `transparency?: 'reduced'` to `ThemeDefinition`.
+- **Modify** `apps/fluux/src/hooks/useTheme.ts` — use `resolveTransparency()` in the transparency effect; add `activeThemeId` to its deps.
+- **Create** `apps/fluux/src/themes/builtins/pure.ts` — the Pure `ThemeDefinition`.
+- **Modify** `apps/fluux/src/themes/builtins/index.ts` — import + register `pureTheme`.
+- **Modify** `apps/fluux/src/themes/builtins/index.test.ts` — assert Pure is registered with correct identity, transparency flag, and true-black/white chrome anchors.
+
+---
+
+## Task 1: Transparency preference plumbing
+
+Adds the `transparency?: 'reduced'` field and the reduced-wins merge, wired into `useTheme`. Extracting the merge into a pure helper keeps it unit-testable without rendering the hook.
+
+**Files:**
+- Create: `apps/fluux/src/themes/transparency.ts`
+- Test: `apps/fluux/src/themes/transparency.test.ts`
+- Modify: `apps/fluux/src/themes/types.ts`
+- Modify: `apps/fluux/src/hooks/useTheme.ts:346-358`
+
+**Interfaces:**
+- Produces: `resolveTransparency(opts: { themeWantsReduced: boolean; transparencyMode: 'full' | 'reduced' | 'system'; systemReducedMatches: boolean }): 'full' | 'reduced'`
+- Produces: `ThemeDefinition.transparency?: 'reduced'`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/themes/transparency.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { resolveTransparency } from './transparency'
+
+describe('resolveTransparency (reduced-wins merge)', () => {
+  it('theme requesting reduced forces reduced even when user chose full', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: true, transparencyMode: 'full', systemReducedMatches: false }),
+    ).toBe('reduced')
+  })
+
+  it('theme not requesting reduced defers to an explicit user setting', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'full', systemReducedMatches: true }),
+    ).toBe('full')
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'reduced', systemReducedMatches: false }),
+    ).toBe('reduced')
+  })
+
+  it('system mode resolves from the OS media query when the theme is neutral', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'system', systemReducedMatches: true }),
+    ).toBe('reduced')
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'system', systemReducedMatches: false }),
+    ).toBe('full')
+  })
+
+  it('a theme can never force full over a user/OS reduced preference', () => {
+    expect(
+      resolveTransparency({ themeWantsReduced: false, transparencyMode: 'reduced', systemReducedMatches: false }),
+    ).toBe('reduced')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/themes/transparency.test.ts`
+Expected: FAIL — cannot find module `./transparency`.
+
+- [ ] **Step 3: Create the helper**
+
+Create `apps/fluux/src/themes/transparency.ts`:
+
+```typescript
+export type TransparencyMode = 'full' | 'reduced' | 'system'
+export type ResolvedTransparency = 'full' | 'reduced'
+
+/**
+ * Resolve the effective transparency for the current theme + user setting.
+ *
+ * Reduced-wins: a theme may FORCE reduced transparency (the "Pure" theme does,
+ * so its glass surfaces render solid), but a theme can never force `full` over a
+ * user or OS `reduced` preference. When the theme is neutral, the user's own
+ * setting decides ('system' consults the OS prefers-reduced-transparency query).
+ */
+export function resolveTransparency(opts: {
+  themeWantsReduced: boolean
+  transparencyMode: TransparencyMode
+  systemReducedMatches: boolean
+}): ResolvedTransparency {
+  if (opts.themeWantsReduced) return 'reduced'
+  if (opts.transparencyMode === 'reduced') return 'reduced'
+  if (opts.transparencyMode === 'full') return 'full'
+  return opts.systemReducedMatches ? 'reduced' : 'full'
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/themes/transparency.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Add the `transparency` field to the type**
+
+In `apps/fluux/src/themes/types.ts`, inside `interface ThemeDefinition`, add the field immediately after the `variables: { … }` block (before `swatches?`):
+
+```typescript
+  /**
+   * Optional display-optimisation hint. When set to 'reduced', selecting this
+   * theme forces the app into reduced-transparency mode (glass surfaces render
+   * solid) regardless of the user's transparency setting — used by "Pure" so its
+   * true-black / flat-white surfaces are not broken by frosted panels. A theme
+   * can only tighten transparency, never loosen it. See resolveTransparency().
+   */
+  transparency?: 'reduced'
+```
+
+- [ ] **Step 6: Wire the helper into `useTheme`**
+
+In `apps/fluux/src/hooks/useTheme.ts`, add the import near the other theme imports at the top of the file:
+
+```typescript
+import { resolveTransparency } from '@/themes/transparency'
+```
+
+Then replace the transparency effect (currently at lines 346-358):
+
+```typescript
+  useEffect(() => {
+    const resolve = () => {
+      if (transparencyMode === 'reduced') return 'reduced'
+      if (transparencyMode === 'full') return 'full'
+      return window.matchMedia('(prefers-reduced-transparency: reduce)').matches ? 'reduced' : 'full'
+    }
+    document.documentElement.setAttribute('data-transparency', resolve())
+    if (transparencyMode !== 'system') return
+    const mq = window.matchMedia('(prefers-reduced-transparency: reduce)')
+    const on = () => document.documentElement.setAttribute('data-transparency', resolve())
+    mq.addEventListener('change', on)
+    return () => mq.removeEventListener('change', on)
+  }, [transparencyMode])
+```
+
+with:
+
+```typescript
+  useEffect(() => {
+    const themeWantsReduced = getActiveTheme()?.transparency === 'reduced'
+    const resolve = () =>
+      resolveTransparency({
+        themeWantsReduced,
+        transparencyMode,
+        systemReducedMatches: window.matchMedia('(prefers-reduced-transparency: reduce)').matches,
+      })
+    document.documentElement.setAttribute('data-transparency', resolve())
+    if (transparencyMode !== 'system') return
+    const mq = window.matchMedia('(prefers-reduced-transparency: reduce)')
+    const on = () => document.documentElement.setAttribute('data-transparency', resolve())
+    mq.addEventListener('change', on)
+    return () => mq.removeEventListener('change', on)
+  }, [transparencyMode, activeThemeId, getActiveTheme])
+```
+
+(The `activeThemeId` dep makes the effect re-run when the user switches themes, so a theme's `transparency` preference is applied/cleared on switch. `activeThemeId` and `getActiveTheme` are already destructured in the hook at lines 220-221.)
+
+- [ ] **Step 7: Typecheck**
+
+Run: `cd apps/fluux && npx tsc --noEmit -p tsconfig.json` (or `npm run typecheck` from repo root).
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/fluux/src/themes/transparency.ts apps/fluux/src/themes/transparency.test.ts apps/fluux/src/themes/types.ts apps/fluux/src/hooks/useTheme.ts
+git commit -m "feat(theme): add theme transparency preference (reduced-wins)"
+```
+
+---
+
+## Task 2: Pure theme definition + registration
+
+Creates the Pure theme and registers it. The token map is chosen so every builtin-theme contrast/hierarchy test passes by construction (true-black/white surfaces = maximum contrast; flat chrome satisfies the `<=` hierarchy check; inherited palette/error tokens clear AA against pure black/white).
+
+**Files:**
+- Create: `apps/fluux/src/themes/builtins/pure.ts`
+- Modify: `apps/fluux/src/themes/builtins/index.ts`
+- Test: `apps/fluux/src/themes/builtins/index.test.ts`
+
+**Interfaces:**
+- Consumes: `ThemeDefinition` (incl. `transparency?` from Task 1).
+- Produces: `export const pureTheme: ThemeDefinition` with `id: 'pure'`; appended to `builtinThemes`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/fluux/src/themes/builtins/index.test.ts`, add these cases inside the `describe('builtin themes', …)` block:
+
+```typescript
+  it('registers the Pure theme optimized for OLED/e-ink', () => {
+    const pure = getBuiltinTheme('pure')
+    expect(pure).toBeDefined()
+    expect(pure?.name).toBe('Pure')
+    // Forces solid glass so true-black / flat-white is not broken by frost.
+    expect(pure?.transparency).toBe('reduced')
+    // OLED: the main content + sidebar chrome are true black.
+    expect(pure?.variables.dark?.['--fluux-chat-bg']).toBe('#000000')
+    expect(pure?.variables.dark?.['--fluux-sidebar-bg']).toBe('#000000')
+    // e-ink: the main content + sidebar chrome are flat white.
+    expect(pure?.variables.light?.['--fluux-chat-bg']).toBe('#ffffff')
+    expect(pure?.variables.light?.['--fluux-sidebar-bg']).toBe('#ffffff')
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/themes/builtins/index.test.ts`
+Expected: FAIL — `getBuiltinTheme('pure')` is `undefined`.
+
+- [ ] **Step 3: Create the Pure theme**
+
+Create `apps/fluux/src/themes/builtins/pure.ts`:
+
+```typescript
+import type { ThemeDefinition } from '../types'
+
+/**
+ * Pure — true-black for OLED (dark) and flat-white for e-ink (light).
+ *
+ * Dark: chat + all chrome surfaces are #000000 so OLED panels power those pixels
+ * off (battery + no light bleed). Depth is carried by hairline borders and the
+ * inherited alpha divider, not by surface luminance — the surface-hierarchy guard
+ * requires luminance(sidebar) <= luminance(chat), so the chrome is deliberately
+ * flat black. Elevated non-chrome surfaces (float/popover/hover rows) get a hair
+ * of lift for affordance. Accent is Aurora's teal preset — restrained but vivid,
+ * it pops on black.
+ *
+ * Light: everything is #ffffff, flat, with strong dark structure and a near-black
+ * "ink" accent so interactive elements read as high-contrast bold and survive
+ * e-ink's shallow grayscale rendering. Muted text stays dark (not light gray).
+ *
+ * transparency: 'reduced' forces every glass surface solid (see resolveTransparency)
+ * — frosted translucency would break true black on OLED and does not render on e-ink.
+ *
+ * The palette (--fluux-color-*), syntax tokens, and --fluux-text-error are
+ * intentionally inherited: on pure black / pure white they clear the per-theme
+ * WCAG contrast guards by construction, so overriding them adds risk without benefit.
+ */
+export const pureTheme: ThemeDefinition = {
+  id: 'pure',
+  name: 'Pure',
+  author: 'Fluux',
+  version: '1.0.0',
+  description: 'True black for OLED, flat white for e-ink — maximum-contrast minimalism',
+  transparency: 'reduced',
+  variables: {
+    dark: {
+      // Foundation — neutral ramp. base-00..base-30 are true black so every
+      // chrome surface (bg-primary=base-10, sidebar=base-20, chat=base-30) is #000.
+      '--fluux-base-00': '#000000',
+      '--fluux-base-05': '#000000',
+      '--fluux-base-10': '#000000',
+      '--fluux-base-20': '#000000',
+      '--fluux-base-30': '#000000',
+      '--fluux-base-40': '#141414', // hover rows — subtle lift on the black canvas
+      '--fluux-base-50': '#1c1c1c', // float / popover surface
+      '--fluux-base-60': '#262626', // float hover
+      '--fluux-base-70': '#6e6e6e',
+      '--fluux-base-80': '#9a9a9a', // text-muted (≈7:1 on #000)
+      '--fluux-base-90': '#fafafa', // text-normal (just under #fff to soften halation)
+      '--fluux-base-100': '#ffffff',
+      // Foundation — accent (Aurora teal: pops on true black)
+      '--fluux-accent-h': '174',
+      '--fluux-accent-s': '70%',
+      '--fluux-accent-l': '52%',
+      // Borders — hairlines carry the depth the flat surfaces don't.
+      '--fluux-border-color': 'rgba(255, 255, 255, 0.14)',
+      '--fluux-glass-border': 'rgba(255, 255, 255, 0.18)',
+      // Pin the chrome surfaces to true black directly so the intent is explicit
+      // and independent of ramp-derivation changes.
+      '--fluux-chat-bg': '#000000',
+      '--fluux-sidebar-bg': '#000000',
+      '--fluux-bg-float': '#1c1c1c',
+    },
+    light: {
+      // Foundation — neutral ramp inverted; base-00..base-30 flat white so every
+      // chrome surface is #fff. Text ramp (base-90/100) is pure black ink.
+      '--fluux-base-00': '#ffffff',
+      '--fluux-base-05': '#ffffff',
+      '--fluux-base-10': '#ffffff',
+      '--fluux-base-20': '#ffffff',
+      '--fluux-base-30': '#ffffff',
+      '--fluux-base-40': '#f2f2f2', // hover rows — faint lift
+      '--fluux-base-50': '#ffffff', // float / popover (border carries elevation)
+      '--fluux-base-60': '#ebebeb',
+      '--fluux-base-70': '#8a8a8a',
+      '--fluux-base-80': '#3a3a3a', // text-muted kept dark for e-ink depth
+      '--fluux-base-90': '#000000', // text-normal ink
+      '--fluux-base-100': '#000000',
+      // Foundation — accent (near-black "ink"; text-on-accent computes to white)
+      '--fluux-accent-h': '0',
+      '--fluux-accent-s': '0%',
+      '--fluux-accent-l': '10%',
+      // Strong dark structure.
+      '--fluux-border-color': 'rgba(0, 0, 0, 0.16)',
+      '--fluux-glass-border': 'rgba(0, 0, 0, 0.18)',
+      // The .light block sets --fluux-bg-secondary to a tinted value; pin it and
+      // the chrome surfaces flat white.
+      '--fluux-bg-secondary': '#ffffff',
+      '--fluux-chat-bg': '#ffffff',
+      '--fluux-sidebar-bg': '#ffffff',
+      '--fluux-bg-float': '#ffffff',
+    },
+  },
+  swatches: {
+    dark: ['#000000', '#0a0a0a', '#38E0C4', '#fafafa'],
+    light: ['#ffffff', '#f2f2f2', '#1a1a1a', '#000000'],
+  },
+}
+```
+
+- [ ] **Step 4: Register the theme**
+
+In `apps/fluux/src/themes/builtins/index.ts`, add the import alongside the other builtin imports (after the `indigoTheme` import):
+
+```typescript
+import { pureTheme } from './pure'
+```
+
+Then append `pureTheme` to the `builtinThemes` array (last entry, after `githubTheme`):
+
+```typescript
+export const builtinThemes: ThemeDefinition[] = [
+  fluuxTheme,
+  indigoTheme,
+  draculaTheme,
+  nordTheme,
+  gruvboxTheme,
+  catppuccinMochaTheme,
+  solarizedTheme,
+  oneDarkTheme,
+  tokyoNightTheme,
+  monokaiTheme,
+  rosePineTheme,
+  kanagawaTheme,
+  githubTheme,
+  pureTheme,
+]
+```
+
+- [ ] **Step 5: Run the registration test to verify it passes**
+
+Run: `cd apps/fluux && npx vitest run src/themes/builtins/index.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full theme test suite (contrast + hierarchy + glass gates)**
+
+Run: `cd apps/fluux && npx vitest run src/themes/`
+Expected: PASS — including `themeContrast.test.ts`, `surfaceHierarchy.test.ts`, and `glass.test.ts` for `pure/dark` and `pure/light`.
+
+If a per-theme case fails, adjust only the failing token (keep the intent):
+- `glass … border perceptible`: raise the `--fluux-glass-border` alpha (e.g. 0.18 → 0.22).
+- `surfaceHierarchy depth order`: ensure `--fluux-sidebar-bg` luminance ≤ `--fluux-chat-bg` (they are equal here, which passes).
+- `text-error … AA` or `sender-name … AA`: these pass by construction on #000/#fff; if not, that indicates a token was overridden that should have been inherited — remove the override.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/fluux/src/themes/builtins/pure.ts apps/fluux/src/themes/builtins/index.ts apps/fluux/src/themes/builtins/index.test.ts
+git commit -m "feat(theme): add Pure theme (true-black OLED / flat-white e-ink) (#952)"
+```
+
+---
+
+## Task 3: Full verification (tests, typecheck, manual demo)
+
+Confirms the whole app is green and the theme behaves in the running app — glass flattens when Pure is active and restores when switching away.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full app test suite**
+
+Run: `cd apps/fluux && npx vitest run`
+Expected: PASS, no stderr. (Pure is now part of every `builtinThemes` iteration.)
+
+- [ ] **Step 2: Typecheck the whole repo**
+
+Run: `npm run typecheck` (repo root).
+Expected: no errors.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint` (repo root) — or the app's lint script if scoped.
+Expected: no new errors.
+
+- [ ] **Step 4: Manual verification in demo mode**
+
+Start the dev server (`npm run dev`, open `http://localhost:5173/demo.html?tutorial=false`) or use the preview tooling. Then:
+- Settings → Appearance → pick **Pure**. In **dark** mode confirm the chat and sidebar are true black `#000` with a visible hairline divider; the accent (send button, active item) reads as teal.
+- Switch to **light** mode: confirm flat white `#fff`, dark structure, near-black accent.
+- Open a modal and the command palette (⌘K): confirm the panels are **solid** (no frosted translucency) in both modes.
+- Note the current transparency setting, then switch from Pure back to Aurora: confirm frosted glass **returns** (Pure's forced-reduced state was not persisted onto the user's setting).
+
+- [ ] **Step 5: Capture proof**
+
+Take a screenshot of Pure dark (a chat view + an open modal) and Pure light, to attach to the PR / issue #952.
+
+- [ ] **Step 6: Final commit (only if any fixup was needed in steps 1-4)**
+
+```bash
+git add -A
+git commit -m "test(theme): verify Pure theme across suites"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- One theme, two modes (dark=OLED, light=e-ink) → Task 2 (`pure.ts`), selected via existing mode toggle (no change needed). ✓
+- True black `#000` OLED surfaces / flat white `#fff` e-ink → Task 2 token map + `builtins/index.test.ts` anchors. ✓
+- Split accent (teal OLED / ink e-ink) → Task 2 accent HSL per mode. ✓
+- Flatten glass via theme transparency preference (reduced-wins) → Task 1. ✓
+- Validation gates (themeContrast, surfaceHierarchy, glass, typecheck, manual) → Task 2 Step 6, Task 3. ✓
+- No i18n key, no store change, no motion coupling → nothing in the plan adds them. ✓
+
+**Placeholder scan:** none — every code step contains complete content.
+
+**Type consistency:** `resolveTransparency` signature is identical in Task 1's helper, test, and `useTheme` call site. `transparency?: 'reduced'` is defined in Task 1 (types.ts) and consumed in Task 2 (`pure.ts`) and the `useTheme` effect. `pureTheme` export name matches its import in `index.ts`. Token names (`--fluux-chat-bg`, `--fluux-sidebar-bg`, `--fluux-glass-border`, `--fluux-surface-divider`) match the derivations verified in `index.css`.

--- a/docs/superpowers/specs/2026-07-10-pure-theme-design.md
+++ b/docs/superpowers/specs/2026-07-10-pure-theme-design.md
@@ -1,0 +1,175 @@
+# "Pure" theme — design
+
+**Issue:** [#952 — Add "Pure" themes optimized for OLED and e-ink displays](https://github.com/processone/fluux-messenger/issues/952)
+**Date:** 2026-07-10
+**Status:** Approved design, pending implementation plan
+
+## Summary
+
+Add a single builtin theme, **Pure**, whose two modes are each tuned for a
+display technology:
+
+- **Dark mode → pure black (OLED).** True `#000000` background so OLED panels
+  power down black pixels (battery + no light bleed).
+- **Light mode → pure white (e-ink).** Flat `#ffffff` everywhere with crisp
+  black structure, tuned for the shallow grayscale depth and slow refresh of
+  e-ink.
+
+It is one `ThemeDefinition` because Fluux themes already carry both a dark and a
+light variant, and the existing dark/light/**system** mode toggle selects
+between them. `system` mode then yields a genuinely useful behaviour: OLED-black
+at night, e-ink-white by day.
+
+## Goals / non-goals
+
+**Goals**
+- A "Pure" entry in the theme picker, selectable like any builtin.
+- OLED variant: true-black surfaces, hierarchy carried by hairline borders, a
+  restrained vivid accent that pops on black.
+- E-ink variant: flat pure-white surfaces, near-black "ink" accent, strong
+  structure, high contrast that survives grayscale rendering.
+- Glass/blur neutralised so panels render solid — on OLED so true black is not
+  broken by translucency behind modals, on e-ink because blur does not render.
+
+**Non-goals**
+- No theme→motion coupling. Reduced motion stays the user's global setting.
+  (E-ink users can enable it themselves; we do not force it.)
+- No new store fields, no changes to the mode toggle, no new settings UI.
+- No new i18n key (a theme's display name renders directly from its definition).
+
+## Architecture fit
+
+The theme system has three independent, separately-persisted axes: **mode**
+(`light`/`dark`/`system`, in `settingsStore`), **theme identity** (builtins +
+custom, in `themeStore`), and **accent preset**. Colors are 3-tier CSS custom
+properties (`--fluux-*`) declared in `apps/fluux/src/index.css` (`:root` = dark,
+`.light` = light); a theme supplies inline overrides on `document.documentElement`
+that win over those defaults. Theme authors normally override only the ~15–20
+Tier‑1 foundation vars; semantic/component vars cascade.
+
+Pure is therefore a normal builtin `ThemeDefinition` and inherits the picker,
+swatches, persistence, mode-switching, and accent presets for free. The **only**
+work outside the theme file is a small extension so the theme can request glass
+be flattened (below).
+
+## Components / changes
+
+### 1. `apps/fluux/src/themes/builtins/pure.ts` (new)
+
+A `ThemeDefinition` (`id: 'pure'`, `name: 'Pure'`, `author: 'Fluux'`) modeled on
+`nord.ts`, plus the new `transparency: 'reduced'` field (see §3).
+
+**Dark / OLED (`variables.dark`) — design intent + anchors:**
+- Neutral ramp anchored at `--fluux-base-00: #000000` (the deepest background /
+  chat surface), ramping up through very-near-black elevated surfaces
+  (`~#0a0a0a`–`#141414` for sidebar/float/modal) to `--fluux-base-100` ≈ `#fafafa`
+  for text (a hair below pure white to soften OLED halation).
+- Hierarchy is carried by **hairline borders** (`rgba(255,255,255,0.10–0.14)`),
+  not by shadows or large surface-luminance steps.
+- Accent = **Aurora's Teal preset** (`h 174, s 70%, l 52%`, i.e. `#38E0C4`
+  family) — restrained but vivid, brand-coherent, pops on black.
+- Muted text kept legible on near-black (`~#8a8a8a`, verified against AA).
+
+**Light / e-ink (`variables.light`) — design intent + anchors:**
+- Background **and all elevated surfaces** = `#ffffff`, flat. No subtle gray
+  elevation (e-ink cannot render it cleanly); hierarchy comes from borders.
+- Text = `#000000` normal; muted kept **dark** (`~#3a3a3a`), not light gray, for
+  e-ink's shallow grayscale depth.
+- Accent = near-black **ink** (`h 0, s 0%, l ~10%`). `--fluux-text-on-accent`
+  computes to white automatically (existing WCAG logic in `useTheme.ts`), so
+  buttons/links read as high-contrast bold and survive grayscale.
+- Borders = strong dark hairlines (`rgba(0,0,0,~0.8)`) for crisp structure.
+
+**Both modes:** keep `--fluux-chat-bg` as the contrast-guaranteed surface
+(`#000`/`#fff`) against `--fluux-text-normal` (`#fafafa`/`#000`) so the glass
+surface's text stays AAA. Keep the **divider** tokens as alpha-on-surface
+(white-alpha on dark, black-alpha on light) so the surface-hierarchy divider
+check passes.
+
+Exact hex values for the full ramp are finalised during implementation against
+the contrast tests (§4); the anchors above define the intent.
+
+`swatches`: `{ dark: ['#000000', '#0a0a0a', '#38E0C4', '#fafafa'], light:
+['#ffffff', '#111111', '#000000'] }` for the picker card.
+
+Accent presets: omit (inherit the default list), or optionally ship a tiny
+curated pair (teal for OLED, ink for e-ink). Default is fine for v1.
+
+### 2. `apps/fluux/src/themes/builtins/index.ts`
+
+Import `pureTheme` and append it to `builtinThemes[]`.
+
+### 3. Glass flattening — a theme transparency preference
+
+`.fluux-glass` translucency (`color-mix(... transparent 15/40%)` +
+`backdrop-filter: blur(var(--fluux-glass-blur))`) is applied by **selector
+rules** in `index.css`, not by a single token, so a variables-only theme cannot
+flatten it. The codebase already has a complete set of solid-fallback rules gated
+on `[data-transparency="reduced"]` covering every glass surface (`.fluux-glass`,
+`.modal-scrim`, `.send-aurora`, `.modal-scrim-aurora`, …). We reuse that path:
+
+- Add optional `transparency?: 'reduced'` to `ThemeDefinition`
+  (`apps/fluux/src/themes/types.ts`).
+- In `useTheme`'s transparency effect (`apps/fluux/src/hooks/useTheme.ts:346`),
+  fold the active theme's preference into `resolve()` with **reduced-wins**
+  semantics — a leading `if (theme?.transparency === 'reduced') return 'reduced'`
+  — and add `theme?.transparency` to the effect's dependency array. A theme can
+  force flat, but can never force glass back on over a user who chose reduced.
+- `pure.ts` sets `transparency: 'reduced'`.
+
+**Why this over parallel `[data-theme="pure"]` selectors:** it is derived, not
+persisted (switching away from Pure restores the user's real transparency
+setting); it reuses every already-validated flatten rule so the send-button and
+scrim flatten too; and any future glass surface stays in sync for free with **zero
+new CSS selectors**. The mechanism is reusable by future themes.
+
+Popovers (`.fluux-popover`) are already solid — they read `--fluux-bg-float`, so
+the palette handles them with no extra work.
+
+## Data flow
+
+1. User selects "Pure" in AppearanceSettings → `themeStore.activeThemeId = 'pure'`.
+2. `useTheme` resolves the theme, sets `data-theme="pure"`, applies
+   `variables.dark` or `variables.light` (per resolved mode) as inline vars on
+   `<html>`, and — via the §3 change — resolves `data-transparency="reduced"`
+   because the theme requests it.
+3. CSS cascade produces true-black/pure-white surfaces; the existing
+   reduced-transparency rules render all glass surfaces solid.
+4. Switching mode (or `system` flipping) swaps dark↔light variant. Switching away
+   from Pure clears the inline vars and restores the user's own transparency.
+
+## Testing / validation gates
+
+These builtin-theme test suites iterate `builtinThemes`, so Pure must pass them:
+
+- **`themeContrast.test.ts`** — borders must read as hairlines (Pattern A); body/
+  muted text must clear WCAG AA (Pattern B). Flat pure + alpha hairline borders +
+  dark-enough muted text satisfies this; tune muted/border alphas until green.
+- **`surfaceHierarchy.test.ts`** — asserts `luminance(rail) <= luminance(sidebar)
+  <= luminance(main)` (non-strict `<=`, so flat equal surfaces pass) and that the
+  divider composite is lighter than a dark surface / darker than a light surface.
+  Keep divider tokens as alpha-on-surface (do not override opaque).
+- **`glass.test.ts`**, **`builtins/index.test.ts`** — run and satisfy whatever
+  invariants they assert for a new builtin (id uniqueness, swatch shape, glass
+  token integrity).
+- **`npm run typecheck`** — the new `transparency?` field and `pure.ts` typecheck.
+- **Manual (demo mode):** verify both modes; open a modal and the command palette
+  (`.fluux-glass`) and confirm they render solid; confirm switching away from
+  Pure restores the prior transparency behaviour.
+
+## Risks
+
+- **Flat surfaces vs. surface-hierarchy test:** mitigated — the test uses `<=`.
+  If a strict-inequality assertion exists elsewhere, introduce a 1–2 point
+  luminance step on elevated surfaces (still reads as "pure").
+- **Muted text on near-black / dark-gray on white:** must clear AA; finalise
+  exact values against `themeContrast.test.ts` rather than by eye.
+- **Reduced-wins transparency merge:** a user on `transparency: full` who selects
+  Pure will see glass disappear. This is intended ("Pure" = flat) and reversible
+  by switching themes.
+
+## Out of scope (future)
+
+- Motion coupling (could later reuse the same theme-preference mechanism for a
+  `motion?: 'reduced'` field, but explicitly excluded here).
+- A curated accent-preset list specific to Pure.


### PR DESCRIPTION
Adds a **Pure** theme (closes #952) as a single builtin whose two modes are each tuned for a display technology:

- **Dark → true black `#000` (OLED):** chat and all chrome surfaces are pure black so OLED panels power those pixels off; depth is carried by hairline borders, not surface luminance. Restrained teal accent pops on black.
- **Light → flat white `#fff` (e-ink):** flat white throughout with a near-black "ink" accent and pure-black text for high, grayscale-safe contrast.

Selected via the existing dark/light/**system** toggle — no new UI. With `system` mode it flips OLED-black at night / e-ink-white by day.

### Glass flattening (reusable mechanism)
Frosted glass would break true black on OLED and doesn't render on e-ink. Rather than add per-theme CSS, this introduces an optional `transparency?: 'reduced'` field on `ThemeDefinition` that `useTheme` folds into the effective `data-transparency` attribute with **reduced-wins** semantics (a theme can force flat, never force glass back on). This reuses the existing `[data-transparency="reduced"]` solid-fallback rules — **zero new CSS selectors** — so every glass surface flattens and stays in sync. The preference is derived, not persisted: switching away from Pure restores the user's own transparency setting.

### Notes
- Palette, syntax, and error tokens are intentionally inherited — they clear the per-theme WCAG contrast guards on pure black/white by construction.
- Passes the existing `themeContrast` / `surfaceHierarchy` / `glass` builtin-theme suites for both `pure/dark` and `pure/light`; typecheck and lint clean.