### PR TITLE
fix(header): tighten mobile conversation-header spacing

### DIFF
--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -93,7 +93,7 @@ export function ChatHeader({
   const kebabWrapperClass = hasAlwaysShownEntry ? undefined : kebabClass('search')
 
   return (
-    <header className="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
+    <header className="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-2 md:gap-3" {...dragRegionProps}>
       {/* Back button - mobile only */}
       {onBack && (
         <button
@@ -130,7 +130,7 @@ export function ChatHeader({
               {fullContact ? getTranslatedStatusText(fullContact, t) : jid}
             </p>
             {contactTime && (
-              <Tooltip content={t('presence.localTime')} position="bottom" className="inline-flex items-center">
+              <Tooltip content={t('presence.localTime')} position="bottom" className="hidden @[400px]:inline-flex items-center">
                 <span className="text-xs text-fluux-muted flex-shrink-0 flex items-center gap-1">
                   · <Clock className="size-3" />{contactTime}
                 </span>
@@ -140,34 +140,38 @@ export function ChatHeader({
         )}
       </div>
 
-      {/* Encryption status icon — only for 1:1 chats with active E2EE */}
-      {encryptionState && encryptionState.kind !== 'disabled' && encryptionState.kind !== 'unsupported' && (
-        <EncryptionIcon
-          state={encryptionState}
-          peerName={name}
-          onVerifyClick={onEncryptionClick}
-          onDisableClick={onDisableEncryptionClick}
-          onEnableClick={onEnableEncryptionClick}
-        />
-      )}
+      {/* Trailing action cluster — grouped tightly on mobile (gap-1) so the
+          shield reads as part of the menu; desktop keeps the header's md gap. */}
+      <div className="flex items-center gap-1 md:gap-3">
+        {/* Encryption status icon — only for 1:1 chats with active E2EE */}
+        {encryptionState && encryptionState.kind !== 'disabled' && encryptionState.kind !== 'unsupported' && (
+          <EncryptionIcon
+            state={encryptionState}
+            peerName={name}
+            onVerifyClick={onEncryptionClick}
+            onDisableClick={onDisableEncryptionClick}
+            onEnableClick={onEnableEncryptionClick}
+          />
+        )}
 
-      {/* Search in conversation — inline copy (collapses on narrow widths) */}
-      {onSearchInConversation && (
-        <div className={inlineClass('search')}>
-          <button
-            onClick={onSearchInConversation}
-            className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
-            aria-label={t('chat.searchInConversation', 'Search in conversation')}
-            title={t('chat.searchInConversation', 'Search in conversation')}
-          >
-            <Search className="size-4" />
-          </button>
+        {/* Search in conversation — inline copy (collapses on narrow widths) */}
+        {onSearchInConversation && (
+          <div className={inlineClass('search')}>
+            <button
+              onClick={onSearchInConversation}
+              className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+              aria-label={t('chat.searchInConversation', 'Search in conversation')}
+              title={t('chat.searchInConversation', 'Search in conversation')}
+            >
+              <Search className="size-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Overflow (kebab) menu */}
+        <div className={kebabWrapperClass}>
+          <HeaderOverflowKebab ariaLabel={t('contacts.actionsMenu')} entries={overflowEntries} />
         </div>
-      )}
-
-      {/* Overflow (kebab) menu */}
-      <div className={kebabWrapperClass}>
-        <HeaderOverflowKebab ariaLabel={t('contacts.actionsMenu')} entries={overflowEntries} />
       </div>
     </header>
   )

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -101,7 +101,7 @@ export function RoomHeader({
   })
 
   return (
-    <header className="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3" {...dragRegionProps}>
+    <header className="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-2 md:gap-3" {...dragRegionProps}>
       {/* Back button - mobile only */}
       {onBack && (
         <button
@@ -129,92 +129,97 @@ export function RoomHeader({
         </p>
       </div>
 
-      {/* Notification settings — inline copy (wide tier) */}
-      <div className={inlineClass('wide')}>
-        <HeaderSubmenuButton
-          ariaLabel={t('rooms.notificationSettings')}
-          tooltip={t('rooms.notificationSettings')}
-          icon={NotifyIcon}
-          active={mode !== 'mentions'}
-          group={notifyGroup}
-        />
-      </div>
-
-      {/* Invite member — inline copy (wide tier) */}
-      <div className={inlineClass('wide')}>
-        <Tooltip content={t('rooms.inviteMember')} position="bottom">
-          <button
-            onClick={openInvite}
-            className="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
-            aria-label={t('rooms.inviteMember')}
-          >
-            <UserPlus className="size-4" />
-          </button>
-        </Tooltip>
-      </div>
-
-      {/* Room management — inline copy (wide tier, owners/admins only) */}
-      {managementGroup && (
+      {/* Trailing action cluster — grouped tightly on mobile (gap-1) so the
+          kebab and members pill read as one unit; desktop keeps the header's md
+          gap so the wide-tier controls are spaced as before. */}
+      <div className="flex items-center gap-1 md:gap-3">
+        {/* Notification settings — inline copy (wide tier) */}
         <div className={inlineClass('wide')}>
           <HeaderSubmenuButton
-            ariaLabel={t('rooms.manageRoom')}
-            tooltip={t('rooms.manageRoom')}
-            icon={Settings}
-            group={managementGroup}
+            ariaLabel={t('rooms.notificationSettings')}
+            tooltip={t('rooms.notificationSettings')}
+            icon={NotifyIcon}
+            active={mode !== 'mentions'}
+            group={notifyGroup}
           />
         </div>
-      )}
 
-      {/* Search — inline copy (search tier) */}
-      {onSearchInConversation && (
-        <div className={inlineClass('search')}>
-          <Tooltip content={t('chat.searchInConversation', 'Search in conversation')} position="bottom">
+        {/* Invite member — inline copy (wide tier) */}
+        <div className={inlineClass('wide')}>
+          <Tooltip content={t('rooms.inviteMember')} position="bottom">
             <button
-              onClick={onSearchInConversation}
-              className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
-              aria-label={t('chat.searchInConversation', 'Search in conversation')}
+              onClick={openInvite}
+              className="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+              aria-label={t('rooms.inviteMember')}
             >
-              <Search className="size-4" />
+              <UserPlus className="size-4" />
             </button>
           </Tooltip>
         </div>
-      )}
 
-      {/* Overflow kebab — holds the collapsed copies. Every room entry also has
-          an inline copy, so once the header is wide enough to show them all the
-          kebab is redundant: KEBAB_TRIGGER_CLASS hides it at the wide tier. */}
-      <div className={KEBAB_TRIGGER_CLASS}>
-        <HeaderOverflowKebab
-          ariaLabel={t('rooms.roomActions', 'Room actions')}
-          entries={[
-            ...(onSearchInConversation
-              ? [{ kind: 'action', key: 'search', label: t('chat.searchInConversation', 'Search in conversation'), icon: Search, onSelect: onSearchInConversation, kebabClassName: kebabClass('search') } as OverflowEntry]
-              : []),
-            { kind: 'action', key: 'invite', label: t('rooms.inviteMember'), icon: UserPlus, onSelect: openInvite, kebabClassName: kebabClass('wide') },
-            { kind: 'submenu', key: 'notify', label: t('rooms.notificationSettings'), icon: NotifyIcon, group: notifyGroup, kebabClassName: kebabClass('wide') },
-            ...(managementGroup
-              ? [{ kind: 'submenu', key: 'manage', label: t('rooms.manageRoom'), icon: Settings, group: managementGroup, kebabClassName: kebabClass('wide') } as OverflowEntry]
-              : []),
-          ]}
-        />
+        {/* Room management — inline copy (wide tier, owners/admins only) */}
+        {managementGroup && (
+          <div className={inlineClass('wide')}>
+            <HeaderSubmenuButton
+              ariaLabel={t('rooms.manageRoom')}
+              tooltip={t('rooms.manageRoom')}
+              icon={Settings}
+              group={managementGroup}
+            />
+          </div>
+        )}
+
+        {/* Search — inline copy (search tier) */}
+        {onSearchInConversation && (
+          <div className={inlineClass('search')}>
+            <Tooltip content={t('chat.searchInConversation', 'Search in conversation')} position="bottom">
+              <button
+                onClick={onSearchInConversation}
+                className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+                aria-label={t('chat.searchInConversation', 'Search in conversation')}
+              >
+                <Search className="size-4" />
+              </button>
+            </Tooltip>
+          </div>
+        )}
+
+        {/* Overflow kebab — holds the collapsed copies. Every room entry also has
+            an inline copy, so once the header is wide enough to show them all the
+            kebab is redundant: KEBAB_TRIGGER_CLASS hides it at the wide tier. */}
+        <div className={KEBAB_TRIGGER_CLASS}>
+          <HeaderOverflowKebab
+            ariaLabel={t('rooms.roomActions', 'Room actions')}
+            entries={[
+              ...(onSearchInConversation
+                ? [{ kind: 'action', key: 'search', label: t('chat.searchInConversation', 'Search in conversation'), icon: Search, onSelect: onSearchInConversation, kebabClassName: kebabClass('search') } as OverflowEntry]
+                : []),
+              { kind: 'action', key: 'invite', label: t('rooms.inviteMember'), icon: UserPlus, onSelect: openInvite, kebabClassName: kebabClass('wide') },
+              { kind: 'submenu', key: 'notify', label: t('rooms.notificationSettings'), icon: NotifyIcon, group: notifyGroup, kebabClassName: kebabClass('wide') },
+              ...(managementGroup
+                ? [{ kind: 'submenu', key: 'manage', label: t('rooms.manageRoom'), icon: Settings, group: managementGroup, kebabClassName: kebabClass('wide') } as OverflowEntry]
+                : []),
+            ]}
+          />
+        </div>
+
+        {/* Occupant toggle button */}
+        <Tooltip content={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')} position="bottom">
+          <button
+            onClick={onToggleOccupants}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
+                       ${showOccupants
+                         ? 'bg-fluux-brand/20 text-fluux-brand'
+                         : 'hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text'
+                       }`}
+            aria-label={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')}
+          >
+            <Users className="size-4" />
+            <span className="text-sm font-medium">{uniqueOccupantCount}</span>
+            <ChevronRight className={`size-4 transition-transform ${showOccupants ? 'rotate-180' : ''}`} />
+          </button>
+        </Tooltip>
       </div>
-
-      {/* Occupant toggle button */}
-      <Tooltip content={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')} position="bottom">
-        <button
-          onClick={onToggleOccupants}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
-                     ${showOccupants
-                       ? 'bg-fluux-brand/20 text-fluux-brand'
-                       : 'hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text'
-                     }`}
-          aria-label={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')}
-        >
-          <Users className="size-4" />
-          <span className="text-sm font-medium">{uniqueOccupantCount}</span>
-          <ChevronRight className={`size-4 transition-transform ${showOccupants ? 'rotate-180' : ''}`} />
-        </button>
-      </Tooltip>
 
       {/* Room avatar error message */}
       {avatarError && (

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
     class="flex flex-col h-full min-h-0 relative"
   >
     <header
-      class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+      class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-2 md:gap-3"
     >
       <div
         data-testid="avatar"
@@ -33,23 +33,27 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
           </p>
         </div>
       </div>
-      <div>
-        <div
-          class="relative"
-        >
-          <button
-            aria-expanded="false"
-            aria-haspopup="menu"
-            aria-label="contacts.actionsMenu"
-            class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
-            type="button"
+      <div
+        class="flex items-center gap-1 md:gap-3"
+      >
+        <div>
+          <div
+            class="relative"
           >
-            <span
-              data-testid="icon-more-vertical"
+            <button
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-label="contacts.actionsMenu"
+              class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+              type="button"
             >
-              More
-            </span>
-          </button>
+              <span
+                data-testid="icon-more-vertical"
+              >
+                More
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </header>
@@ -433,7 +437,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
               </div>
             </div>
             <div
-              class="pb-4"
+              class="pb-2"
             />
           </div>
         </div>
@@ -483,7 +487,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
     class="flex flex-col h-full min-h-0 relative"
   >
     <header
-      class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+      class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-2 md:gap-3"
     >
       <div
         data-testid="avatar"
@@ -508,23 +512,27 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
           </p>
         </div>
       </div>
-      <div>
-        <div
-          class="relative"
-        >
-          <button
-            aria-expanded="false"
-            aria-haspopup="menu"
-            aria-label="contacts.actionsMenu"
-            class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
-            type="button"
+      <div
+        class="flex items-center gap-1 md:gap-3"
+      >
+        <div>
+          <div
+            class="relative"
           >
-            <span
-              data-testid="icon-more-vertical"
+            <button
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-label="contacts.actionsMenu"
+              class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+              type="button"
             >
-              More
-            </span>
-          </button>
+              <span
+                data-testid="icon-more-vertical"
+              >
+                More
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
       class="flex flex-col flex-1 min-w-0"
     >
       <header
-        class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3"
+        class="@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-2 md:gap-3"
       >
         <div
           data-name="Test Room"
@@ -32,97 +32,101 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
           </p>
         </div>
         <div
-          class="hidden @[600px]:flex"
+          class="flex items-center gap-1 md:gap-3"
         >
           <div
-            class="relative"
+            class="hidden @[600px]:flex"
+          >
+            <div
+              class="relative"
+            >
+              <div
+                class="inline-flex"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
+                  aria-label="rooms.notificationSettings"
+                  class="flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
+                >
+                  <span
+                    data-testid="icon-bell-off"
+                  >
+                    BellOff
+                  </span>
+                  <span
+                    data-testid="icon-chevron-down"
+                  >
+                    ChevronDown
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="hidden @[600px]:flex"
           >
             <div
               class="inline-flex"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="menu"
-                aria-label="rooms.notificationSettings"
-                class="flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
+                aria-label="rooms.inviteMember"
+                class="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
               >
                 <span
-                  data-testid="icon-bell-off"
+                  data-testid="icon-user-plus"
                 >
-                  BellOff
-                </span>
-                <span
-                  data-testid="icon-chevron-down"
-                >
-                  ChevronDown
+                  UserPlus
                 </span>
               </button>
             </div>
           </div>
-        </div>
-        <div
-          class="hidden @[600px]:flex"
-        >
+          <div
+            class="flex @[600px]:hidden"
+          >
+            <div
+              class="relative"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="menu"
+                aria-label="rooms.roomActions"
+                class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+                type="button"
+              >
+                <span
+                  data-testid="icon-more-vertical"
+                >
+                  MoreVertical
+                </span>
+              </button>
+            </div>
+          </div>
           <div
             class="inline-flex"
           >
             <button
-              aria-label="rooms.inviteMember"
-              class="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+              aria-label="rooms.showMembers"
+              class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
+                       hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
             >
               <span
-                data-testid="icon-user-plus"
+                data-testid="icon-users"
               >
-                UserPlus
+                Users
+              </span>
+              <span
+                class="text-sm font-medium"
+              >
+                0
+              </span>
+              <span
+                data-testid="icon-chevron-right"
+              >
+                ChevronRight
               </span>
             </button>
           </div>
-        </div>
-        <div
-          class="flex @[600px]:hidden"
-        >
-          <div
-            class="relative"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="menu"
-              aria-label="rooms.roomActions"
-              class="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
-              type="button"
-            >
-              <span
-                data-testid="icon-more-vertical"
-              >
-                MoreVertical
-              </span>
-            </button>
-          </div>
-        </div>
-        <div
-          class="inline-flex"
-        >
-          <button
-            aria-label="rooms.showMembers"
-            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
-                     hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
-          >
-            <span
-              data-testid="icon-users"
-            >
-              Users
-            </span>
-            <span
-              class="text-sm font-medium"
-            >
-              0
-            </span>
-            <span
-              data-testid="icon-chevron-right"
-            >
-              ChevronRight
-            </span>
-          </button>
         </div>
       </header>
       <div

--- a/docs/superpowers/specs/2026-07-10-mobile-header-spacing-design.md
+++ b/docs/superpowers/specs/2026-07-10-mobile-header-spacing-design.md
@@ -1,0 +1,102 @@
+# Mobile conversation-header spacing
+
+## Problem
+
+On small screens the conversation header (1:1 and rooms) wastes horizontal
+space and mis-groups its controls:
+
+- The encryption shield floats in the middle of the header, visually detached
+  from the kebab menu, instead of reading as part of the trailing action
+  cluster.
+- The contact name and presence text truncate far earlier than necessary
+  ("Jérôme Sa…", "En li…") even when there is apparent room.
+
+### Root cause
+
+The header is a flat flex row with a uniform `gap-3` (12px):
+
+```
+[back] [avatar] [name (flex-1)] [shield] [search] [kebab]
+```
+
+On touch devices, `.tap-target` (index.css:906) inflates every icon button to a
+44px invisible box. So the 16px shield glyph sits centred in a 44px box, then a
+12px gap, then the kebab glyph centred in *its* 44px box — the glyphs end up
+~40px apart even though only a 12px gap was requested. Those invisible boxes plus
+the uniform gaps also consume the horizontal budget, forcing the name to
+truncate early.
+
+A secondary issue: in the status line the local-time clock is `flex-shrink-0`
+while the presence text is `truncate`, so under width pressure the meaningful
+word ("En ligne") is clipped to keep the less-important time.
+
+## Scope
+
+Both header components, since they share the identical header shell:
+
+- `apps/fluux/src/components/ChatHeader.tsx` (1:1 and lightweight group chats)
+- `apps/fluux/src/components/RoomHeader.tsx` (MUC rooms)
+
+Shared shell today (duplicated verbatim in both):
+`@container relative aurora-horizon h-14 px-4 flex items-center border-b border-fluux-bg shadow-sm gap-3`
+
+## Design
+
+Three linked changes. All are className / structure-only, gated so **desktop
+layout is unchanged**.
+
+### 1. Group the trailing action cluster
+
+Wrap the trailing action buttons in a single flex container with a tight
+internal gap, so they read as one unit and their glyphs sit close together:
+
+- `ChatHeader`: wrap `EncryptionIcon` + inline-search `div` + kebab wrapper in
+  `<div className="flex items-center gap-1">`.
+- `RoomHeader`: wrap the trailing inline action `div`s + kebab in the same
+  `flex items-center gap-1` container.
+
+`gap-1` (4px) — the "slight breathing room" option: grouped as a unit but the
+two icons stay individually legible. The 44px tap boxes still guarantee the
+touch-target separation underneath.
+
+The cluster gap is uniform (not media-gated): grouping trailing icons tightly is
+a correct pattern at every width, and on desktop it is a subtle improvement (the
+icons read as a group rather than three evenly-spread controls).
+
+### 2. Tighten the outer rhythm on mobile only
+
+Change the header shell gap from `gap-3` to `gap-2 md:gap-3` in both components.
+This reclaims spacing between back / avatar / name / cluster on phones while
+leaving desktop at the current 12px rhythm.
+
+Combined with #1, roughly ~25px of horizontal budget is returned to the name
+area — enough that "Jérôme Sautret" and "En ligne" fit on a normal phone.
+
+### 3. Protect the presence text from the clock (1:1 status line)
+
+In `ChatHeader`'s status row, hide the local-time clock below a narrow
+container-query width so the presence word is never sacrificed to the time. The
+clock is wrapped so it is `hidden` under the threshold and `flex` above it, e.g.
+`hidden @[400px]:flex` (literal string, per the JIT-scanner constraint in
+`headerOverflow.ts`). The exact threshold is tuned against preview during
+implementation.
+
+Above the threshold, behaviour is unchanged: a long custom status message still
+truncates first and the clock still shows. Only the narrowest widths drop the
+clock to keep the short presence label intact.
+
+## Non-goals
+
+- No change to icon glyphs, colours, trust semantics, or the encryption popover.
+- No change to the overflow-tier collapse thresholds (`440px` / `600px`).
+- No broader header refactor. The duplicated shell className is edited in place
+  in both files; extracting a shared constant is out of scope for this change.
+
+## Verification
+
+- Preview at phone widths (375 / 390 / 414) via `preview_resize` + dark mode:
+  confirm shield sits beside the kebab, name shows in full, status shows
+  "En ligne" (no clock) at the narrowest width and gains the clock as width
+  grows.
+- Confirm desktop (`md+`) header spacing is visually identical to before.
+- `npm run typecheck` and the app test suite for the two header components.

--- a/docs/superpowers/specs/2026-07-10-mobile-header-spacing-design.md
+++ b/docs/superpowers/specs/2026-07-10-mobile-header-spacing-design.md
@@ -52,8 +52,13 @@ internal gap, so they read as one unit and their glyphs sit close together:
 
 - `ChatHeader`: wrap `EncryptionIcon` + inline-search `div` + kebab wrapper in
   `<div className="flex items-center gap-1">`.
-- `RoomHeader`: wrap the trailing inline action `div`s + kebab in the same
-  `flex items-center gap-1` container.
+- `RoomHeader`: wrap the trailing controls in the same `flex items-center gap-1`
+  container. This must include the notify / invite / management / search inline
+  `div`s, the kebab wrapper, **and** the occupant-toggle "members pill"
+  (RoomHeader.tsx:203) — the pill is a direct child, not wrapped in a tier
+  `div`, and on a phone it plus the kebab are the only inline controls, so it
+  must be part of the cluster or grouping the kebab alone would leave it
+  stranded exactly as the shield is today.
 
 `gap-1` (4px) — the "slight breathing room" option: grouped as a unit but the
 two icons stay individually legible. The 44px tap boxes still guarantee the
@@ -84,6 +89,10 @@ implementation.
 Above the threshold, behaviour is unchanged: a long custom status message still
 truncates first and the clock still shows. Only the narrowest widths drop the
 clock to keep the short presence label intact.
+
+This change is 1:1-only. Rooms have no presence/clock line — the room subtitle
+(topic/JID) simply truncates with nothing competing beside it — so there is no
+RoomHeader equivalent.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-07-10-mobile-header-spacing-design.md
+++ b/docs/superpowers/specs/2026-07-10-mobile-header-spacing-design.md
@@ -60,13 +60,13 @@ internal gap, so they read as one unit and their glyphs sit close together:
   must be part of the cluster or grouping the kebab alone would leave it
   stranded exactly as the shield is today.
 
-`gap-1` (4px) — the "slight breathing room" option: grouped as a unit but the
-two icons stay individually legible. The 44px tap boxes still guarantee the
-touch-target separation underneath.
-
-The cluster gap is uniform (not media-gated): grouping trailing icons tightly is
-a correct pattern at every width, and on desktop it is a subtle improvement (the
-icons read as a group rather than three evenly-spread controls).
+Cluster gap is `gap-1 md:gap-3` — 4px on mobile ("slight breathing room":
+grouped as a unit but the icons stay individually legible; the 44px tap boxes
+still guarantee touch separation underneath), and 12px on desktop so the trailing
+controls keep their current `md:` header-gap spacing. This keeps desktop
+**visually identical** (important for RoomHeader, which shows five trailing
+controls at the wide tier) while delivering the grouping only where it is needed,
+on small screens.
 
 ### 2. Tighten the outer rhythm on mobile only
 


### PR DESCRIPTION
On small screens the conversation header wasted horizontal space and mis-grouped its controls: the encryption shield floated mid-header (detached from the kebab), and the contact name and presence text truncated far earlier than necessary.

Root cause: the header is a flat flex row with a uniform `gap-3`, and on touch each icon button is inflated to a 44px `.tap-target` box — so trailing glyphs ended up ~40px apart and the fixed controls ate the name's width budget.

Changes (both `ChatHeader` and `RoomHeader`, which share the same shell):

- **Group the trailing controls** into one `flex items-center gap-1 md:gap-3` cluster — shield/search/kebab in 1:1, and the kebab + members pill in rooms — so they read as one unit on mobile (4px apart) while desktop keeps its 12px spacing.
- **Tighten the shell gap** to `gap-2 md:gap-3` — 8px on mobile to reclaim width for the name, 12px on desktop (unchanged).
- **Hide the 1:1 local-time clock** below a narrow container width (`hidden @[400px]:inline-flex`) so the presence label ("En ligne") is never truncated to keep a lower-priority timestamp.

Desktop layout is unchanged (verified: header and cluster gaps both resolve to 12px at `md+`). Header component snapshots updated for the new wrapper div.