### PR TITLE
View full room topic via Room Info modal (#922)

### DIFF
--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -124,12 +124,12 @@ export function RoomHeader({
       />
 
       {/* Name and info — opens Room Info modal; tooltip peeks the full topic */}
-      <Tooltip content={room.subject || room.jid} position="bottom">
+      <Tooltip content={room.subject || room.jid} position="bottom" className="flex-1 min-w-0">
         <button
           type="button"
           onClick={() => setShowInfoModal(true)}
-          aria-label={t('rooms.showRoomInfo', 'Room info')}
-          className="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+          aria-label={`${t('rooms.showRoomInfo', 'Room info')}: ${room.name}`}
+          className="w-full min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
         >
           <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
           <p className="text-xs text-fluux-muted truncate">

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -19,6 +19,7 @@ import { InviteToRoomModal } from './InviteToRoomModal'
 import { RoomConfigModal } from './RoomConfigModal'
 import { RoomMembersModal } from './RoomMembersModal'
 import { RoomHatsModal } from './RoomHatsModal'
+import { RoomInfoModal } from './RoomInfoModal'
 import { HeaderSubmenuButton } from './header/HeaderSubmenuButton'
 import { HeaderOverflowKebab, type OverflowEntry } from './header/HeaderOverflowKebab'
 import { buildNotifyGroup, buildManagementGroup, notifyModeOf } from './header/roomHeaderActions'
@@ -68,6 +69,7 @@ export function RoomHeader({
   const [showAvatarModal, setShowAvatarModal] = useState(false)
   const [showMembersModal, setShowMembersModal] = useState(false)
   const [showHatsModal, setShowHatsModal] = useState(false)
+  const [showInfoModal, setShowInfoModal] = useState(false)
   const [avatarError, setAvatarError] = useState<string | null>(null)
   const { dragRegionProps } = useWindowDrag()
   const configModalOpen = useRoomUiStore((s) => s.configModalOpen)
@@ -121,13 +123,20 @@ export function RoomHeader({
         size="header"
       />
 
-      {/* Name and info */}
-      <div className="flex-1 min-w-0">
-        <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
-        <p className="text-xs text-fluux-muted truncate">
-          {room.subject ? renderTextWithLinks(room.subject) : room.jid}
-        </p>
-      </div>
+      {/* Name and info — opens Room Info modal; tooltip peeks the full topic */}
+      <Tooltip content={room.subject || room.jid} position="bottom">
+        <button
+          type="button"
+          onClick={() => setShowInfoModal(true)}
+          aria-label={t('rooms.showRoomInfo', 'Room info')}
+          className="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+        >
+          <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
+          <p className="text-xs text-fluux-muted truncate">
+            {room.subject ? renderTextWithLinks(room.subject) : room.jid}
+          </p>
+        </button>
+      </Tooltip>
 
       {/* Notification settings — inline copy (wide tier) */}
       <div className={inlineClass('wide')}>
@@ -275,6 +284,13 @@ export function RoomHeader({
         <RoomHatsModal
           room={room}
           onClose={() => setShowHatsModal(false)}
+        />
+      )}
+
+      {showInfoModal && (
+        <RoomInfoModal
+          room={room}
+          onClose={() => setShowInfoModal(false)}
         />
       )}
     </header>

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -124,16 +124,16 @@ export function RoomHeader({
       />
 
       {/* Name and info — opens Room Info modal; tooltip peeks the full topic */}
-      <Tooltip content={room.subject || room.jid} position="bottom" className="flex-1 min-w-0">
+      <Tooltip content={room.subject?.trim() || room.jid} position="bottom" className="flex-1 min-w-0">
         <button
           type="button"
           onClick={() => setShowInfoModal(true)}
           aria-label={`${t('rooms.showRoomInfo', 'Room info')}: ${room.name}`}
           className="w-full min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
         >
-          <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
+          <span className="block font-semibold text-fluux-text truncate leading-tight">{room.name}</span>
           <p className="text-xs text-fluux-muted truncate">
-            {room.subject ? renderTextWithLinks(room.subject) : room.jid}
+            {room.subject?.trim() ? renderTextWithLinks(room.subject) : room.jid}
           </p>
         </button>
       </Tooltip>

--- a/apps/fluux/src/components/RoomInfoModal.test.tsx
+++ b/apps/fluux/src/components/RoomInfoModal.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RoomInfoModal } from './RoomInfoModal'
+import type { Room } from '@fluux/sdk'
+
+// Surface i18n keys verbatim so assertions target keys, not translated copy.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+function makeRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    jid: 'general@conference.example.com',
+    name: 'General',
+    subject: 'Welcome to the general room',
+    ...overrides,
+  } as Room
+}
+
+// Helper to force the topic element to report overflow in jsdom (which
+// otherwise reports scrollHeight === clientHeight === 0).
+function forceOverflow(scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true, get() { return scrollHeight },
+  })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true, get() { return clientHeight },
+  })
+}
+
+afterEach(() => {
+  // Restore jsdom defaults so overflow overrides don't leak between tests.
+  delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollHeight
+  delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight
+})
+
+describe('RoomInfoModal', () => {
+  it('renders the room name (title), JID and full topic', () => {
+    render(<RoomInfoModal room={makeRoom()} onClose={() => {}} />)
+    expect(screen.getByText('General')).toBeTruthy()
+    expect(screen.getByText('general@conference.example.com')).toBeTruthy()
+    expect(screen.getByText('Welcome to the general room')).toBeTruthy()
+    expect(screen.getByText('rooms.topic')).toBeTruthy()
+  })
+
+  it('omits the topic section when the room has no subject', () => {
+    render(<RoomInfoModal room={makeRoom({ subject: undefined })} onClose={() => {}} />)
+    expect(screen.queryByText('rooms.topic')).toBeNull()
+    // Identity still renders.
+    expect(screen.getByText('General')).toBeTruthy()
+  })
+
+  it('shows no Show more toggle when the topic fits', () => {
+    forceOverflow(50, 50)
+    render(<RoomInfoModal room={makeRoom()} onClose={() => {}} />)
+    expect(screen.queryByText('chat.showMore')).toBeNull()
+    expect(screen.queryByText('chat.showLess')).toBeNull()
+  })
+
+  it('shows a Show more toggle when the topic overflows, and toggles to Show less', () => {
+    forceOverflow(300, 120)
+    render(<RoomInfoModal room={makeRoom({ subject: 'x'.repeat(2000) })} onClose={() => {}} />)
+    const moreBtn = screen.getByText('chat.showMore')
+    expect(moreBtn).toBeTruthy()
+    fireEvent.click(moreBtn)
+    expect(screen.getByText('chat.showLess')).toBeTruthy()
+  })
+})

--- a/apps/fluux/src/components/RoomInfoModal.tsx
+++ b/apps/fluux/src/components/RoomInfoModal.tsx
@@ -20,8 +20,8 @@ interface RoomInfoModalProps {
  */
 export function RoomInfoModal({ room, onClose }: RoomInfoModalProps) {
   return (
-    <ModalShell title={room.name} onClose={onClose} width="max-w-md" panelClassName="max-h-[80vh]">
-      <div className="p-4 flex flex-col gap-4 overflow-y-auto">
+    <ModalShell title={room.name} onClose={onClose} width="max-w-md" panelClassName="max-h-[80vh] flex flex-col">
+      <div className="p-4 flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto">
         {/* Identity row */}
         <div className="flex items-center gap-3 min-w-0">
           <RoomAvatar identifier={room.jid} name={room.name} avatarUrl={room.avatar} size="xl" />
@@ -29,7 +29,7 @@ export function RoomInfoModal({ room, onClose }: RoomInfoModalProps) {
         </div>
 
         {/* Topic — only when set */}
-        {room.subject && <RoomTopic subject={room.subject} />}
+        {room.subject?.trim() && <RoomTopic subject={room.subject} />}
       </div>
     </ModalShell>
   )
@@ -62,6 +62,7 @@ function RoomTopic({ subject }: { subject: string }) {
       </div>
       {overflowing && (
         <button
+          type="button"
           onClick={() => setExpanded(v => !v)}
           className="flex items-center gap-1 mt-1 text-sm text-fluux-muted hover:text-fluux-text transition-colors select-none self-start"
         >

--- a/apps/fluux/src/components/RoomInfoModal.tsx
+++ b/apps/fluux/src/components/RoomInfoModal.tsx
@@ -1,0 +1,77 @@
+import { useState, useRef, useLayoutEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import type { Room } from '@fluux/sdk'
+import { ModalShell } from './ModalShell'
+import { RoomAvatar } from './RoomAvatar'
+import { renderTextWithLinks } from '@/utils/messageStyles'
+
+interface RoomInfoModalProps {
+  room: Room
+  onClose: () => void
+}
+
+/**
+ * Read-only room details for any member: avatar, name (modal title), JID, and
+ * the full topic/description (`room.subject`). Long topics collapse to six lines
+ * behind a Show more / Show less toggle. Kept independent of the message-list
+ * collapse machinery (which needs a messageId + width context) so it stays
+ * self-contained and testable.
+ */
+export function RoomInfoModal({ room, onClose }: RoomInfoModalProps) {
+  return (
+    <ModalShell title={room.name} onClose={onClose} width="max-w-md" panelClassName="max-h-[80vh]">
+      <div className="p-4 flex flex-col gap-4 overflow-y-auto">
+        {/* Identity row */}
+        <div className="flex items-center gap-3 min-w-0">
+          <RoomAvatar identifier={room.jid} name={room.name} avatarUrl={room.avatar} size="xl" />
+          <p className="text-sm text-fluux-muted break-all select-text">{room.jid}</p>
+        </div>
+
+        {/* Topic — only when set */}
+        {room.subject && <RoomTopic subject={room.subject} />}
+      </div>
+    </ModalShell>
+  )
+}
+
+function RoomTopic({ subject }: { subject: string }) {
+  const { t } = useTranslation()
+  const topicRef = useRef<HTMLDivElement>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [overflowing, setOverflowing] = useState(false)
+
+  // Measure only while collapsed; when expanded the clamp is off so scrollHeight
+  // would equal clientHeight. Keeping `overflowing` sticky preserves the toggle.
+  useLayoutEffect(() => {
+    const el = topicRef.current
+    if (!el || expanded) return
+    setOverflowing(el.scrollHeight > el.clientHeight + 1)
+  }, [subject, expanded])
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-fluux-muted">
+        {t('rooms.topic')}
+      </span>
+      <div
+        ref={topicRef}
+        className={`text-sm text-fluux-text whitespace-pre-wrap break-words ${expanded ? '' : 'line-clamp-6'}`}
+      >
+        {renderTextWithLinks(subject)}
+      </div>
+      {overflowing && (
+        <button
+          onClick={() => setExpanded(v => !v)}
+          className="flex items-center gap-1 mt-1 text-sm text-fluux-muted hover:text-fluux-text transition-colors select-none self-start"
+        >
+          {expanded ? (
+            <><ChevronUp className="size-4" />{t('chat.showLess')}</>
+          ) : (
+            <><ChevronDown className="size-4" />{t('chat.showMore')}</>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -20,16 +20,22 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
         <div
           class="flex-1 min-w-0"
         >
-          <h2
-            class="font-semibold text-fluux-text truncate leading-tight"
+          <button
+            aria-label="rooms.showRoomInfo: Test Room"
+            class="w-full min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+            type="button"
           >
-            Test Room
-          </h2>
-          <p
-            class="text-xs text-fluux-muted truncate"
-          >
-            room@conference.example.com
-          </p>
+            <span
+              class="block font-semibold text-fluux-text truncate leading-tight"
+            >
+              Test Room
+            </span>
+            <p
+              class="text-xs text-fluux-muted truncate"
+            >
+              room@conference.example.com
+            </p>
+          </button>
         </div>
         <div
           class="hidden @[600px]:flex"

--- a/docs/superpowers/plans/2026-07-10-room-full-topic-view.md
+++ b/docs/superpowers/plans/2026-07-10-room-full-topic-view.md
@@ -1,0 +1,348 @@
+# Room Info Modal — View Full Room Topic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let any room member read a MUC room's full topic/description via a Room Info modal opened from the header, with a hover tooltip for a quick peek (#922).
+
+**Architecture:** A new self-contained `RoomInfoModal` (built on the existing `ModalShell` primitive) renders the room avatar, JID, and the full subject with a local Show more/less collapse for long text. `RoomHeader`'s name+subject block becomes a keyboard-accessible button that opens the modal and carries a tooltip of the full subject. No SDK, store, or i18n changes.
+
+**Tech Stack:** React + TypeScript, Tailwind, `react-i18next`, Vitest + Testing Library (jsdom).
+
+## Global Constraints
+
+- No SDK changes — the topic value is `room.subject`, already on the `Room` object.
+- No new i18n keys — reuse `rooms.topic`, `chat.showMore`, `chat.showLess`; the modal title is the room **name** (not a translated string).
+- App unit tests run per-workspace: `cd apps/fluux && npx vitest run <file>`.
+- DOM tests pin jsdom via a `@vitest-environment jsdom` docblock at the top of the test file.
+- No em-dash connectors in any user-facing copy (none added here, but keep it true).
+- Follow existing modal patterns: `ModalShell` for chrome, conditional render alongside the other header modals.
+
+---
+
+### Task 1: `RoomInfoModal` component
+
+**Files:**
+- Create: `apps/fluux/src/components/RoomInfoModal.tsx`
+- Test: `apps/fluux/src/components/RoomInfoModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `ModalShell` (`{ title, onClose, width?, children }`), `RoomAvatar` (`{ identifier, name?, avatarUrl?, size? }`), `renderTextWithLinks(text: string)`, `Room` type (`@fluux/sdk`).
+- Produces: `export function RoomInfoModal(props: RoomInfoModalProps)` where `interface RoomInfoModalProps { room: Room; onClose: () => void }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/components/RoomInfoModal.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RoomInfoModal } from './RoomInfoModal'
+import type { Room } from '@fluux/sdk'
+
+// Surface i18n keys verbatim so assertions target keys, not translated copy.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+function makeRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    jid: 'general@conference.example.com',
+    name: 'General',
+    subject: 'Welcome to the general room',
+    ...overrides,
+  } as Room
+}
+
+// Helper to force the topic element to report overflow in jsdom (which
+// otherwise reports scrollHeight === clientHeight === 0).
+function forceOverflow(scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true, get() { return scrollHeight },
+  })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true, get() { return clientHeight },
+  })
+}
+
+afterEach(() => {
+  // Restore jsdom defaults so overflow overrides don't leak between tests.
+  delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollHeight
+  delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight
+})
+
+describe('RoomInfoModal', () => {
+  it('renders the room name (title), JID and full topic', () => {
+    render(<RoomInfoModal room={makeRoom()} onClose={() => {}} />)
+    expect(screen.getByText('General')).toBeTruthy()
+    expect(screen.getByText('general@conference.example.com')).toBeTruthy()
+    expect(screen.getByText('Welcome to the general room')).toBeTruthy()
+    expect(screen.getByText('rooms.topic')).toBeTruthy()
+  })
+
+  it('omits the topic section when the room has no subject', () => {
+    render(<RoomInfoModal room={makeRoom({ subject: undefined })} onClose={() => {}} />)
+    expect(screen.queryByText('rooms.topic')).toBeNull()
+    // Identity still renders.
+    expect(screen.getByText('General')).toBeTruthy()
+  })
+
+  it('shows no Show more toggle when the topic fits', () => {
+    forceOverflow(50, 50)
+    render(<RoomInfoModal room={makeRoom()} onClose={() => {}} />)
+    expect(screen.queryByText('chat.showMore')).toBeNull()
+    expect(screen.queryByText('chat.showLess')).toBeNull()
+  })
+
+  it('shows a Show more toggle when the topic overflows, and toggles to Show less', () => {
+    forceOverflow(300, 120)
+    render(<RoomInfoModal room={makeRoom({ subject: 'x'.repeat(2000) })} onClose={() => {}} />)
+    const moreBtn = screen.getByText('chat.showMore')
+    expect(moreBtn).toBeTruthy()
+    fireEvent.click(moreBtn)
+    expect(screen.getByText('chat.showLess')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/fluux && npx vitest run src/components/RoomInfoModal.test.tsx`
+Expected: FAIL — cannot resolve `./RoomInfoModal` (module not found).
+
+- [ ] **Step 3: Write the component**
+
+Create `apps/fluux/src/components/RoomInfoModal.tsx`:
+
+```tsx
+import { useState, useRef, useLayoutEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import type { Room } from '@fluux/sdk'
+import { ModalShell } from './ModalShell'
+import { RoomAvatar } from './RoomAvatar'
+import { renderTextWithLinks } from '@/utils/messageStyles'
+
+interface RoomInfoModalProps {
+  room: Room
+  onClose: () => void
+}
+
+/**
+ * Read-only room details for any member: avatar, name (modal title), JID, and
+ * the full topic/description (`room.subject`). Long topics collapse to six lines
+ * behind a Show more / Show less toggle. Kept independent of the message-list
+ * collapse machinery (which needs a messageId + width context) so it stays
+ * self-contained and testable.
+ */
+export function RoomInfoModal({ room, onClose }: RoomInfoModalProps) {
+  return (
+    <ModalShell title={room.name} onClose={onClose} width="max-w-md" panelClassName="max-h-[80vh]">
+      <div className="p-4 flex flex-col gap-4 overflow-y-auto">
+        {/* Identity row */}
+        <div className="flex items-center gap-3 min-w-0">
+          <RoomAvatar identifier={room.jid} name={room.name} avatarUrl={room.avatar} size="xl" />
+          <p className="text-sm text-fluux-muted break-all select-text">{room.jid}</p>
+        </div>
+
+        {/* Topic — only when set */}
+        {room.subject && <RoomTopic subject={room.subject} />}
+      </div>
+    </ModalShell>
+  )
+}
+
+function RoomTopic({ subject }: { subject: string }) {
+  const { t } = useTranslation()
+  const topicRef = useRef<HTMLDivElement>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [overflowing, setOverflowing] = useState(false)
+
+  // Measure only while collapsed; when expanded the clamp is off so scrollHeight
+  // would equal clientHeight. Keeping `overflowing` sticky preserves the toggle.
+  useLayoutEffect(() => {
+    const el = topicRef.current
+    if (!el || expanded) return
+    setOverflowing(el.scrollHeight > el.clientHeight + 1)
+  }, [subject, expanded])
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-fluux-muted">
+        {t('rooms.topic')}
+      </span>
+      <div
+        ref={topicRef}
+        className={`text-sm text-fluux-text whitespace-pre-wrap break-words ${expanded ? '' : 'line-clamp-6'}`}
+      >
+        {renderTextWithLinks(subject)}
+      </div>
+      {overflowing && (
+        <button
+          onClick={() => setExpanded(v => !v)}
+          className="flex items-center gap-1 mt-1 text-sm text-fluux-muted hover:text-fluux-text transition-colors select-none self-start"
+        >
+          {expanded ? (
+            <><ChevronUp className="size-4" />{t('chat.showLess')}</>
+          ) : (
+            <><ChevronDown className="size-4" />{t('chat.showMore')}</>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+Note: `useTranslation` is imported once and used only inside `RoomTopic` (the modal title is `room.name`, not a translated string). That is intentional — do not add a `useTranslation()` call to `RoomInfoModal`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/components/RoomInfoModal.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/components/RoomInfoModal.tsx apps/fluux/src/components/RoomInfoModal.test.tsx
+git commit -m "feat(rooms): add RoomInfoModal to view full room topic (#922)"
+```
+
+---
+
+### Task 2: Wire the modal into `RoomHeader`
+
+**Files:**
+- Modify: `apps/fluux/src/components/RoomHeader.tsx`
+
+**Interfaces:**
+- Consumes: `RoomInfoModal` from Task 1 (`{ room, onClose }`), existing `Tooltip`, `useState`.
+- Produces: no new exports; behavior change only.
+
+- [ ] **Step 1: Add the import and modal state**
+
+In `apps/fluux/src/components/RoomHeader.tsx`, add to the modal imports (near line 17-21):
+
+```tsx
+import { RoomInfoModal } from './RoomInfoModal'
+```
+
+Add state alongside the existing modal flags (near line 68-70):
+
+```tsx
+const [showInfoModal, setShowInfoModal] = useState(false)
+```
+
+- [ ] **Step 2: Make the name+subject block open the modal, with a tooltip**
+
+Replace the name+info block (currently lines 124-130):
+
+```tsx
+      {/* Name and info */}
+      <div className="flex-1 min-w-0">
+        <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
+        <p className="text-xs text-fluux-muted truncate">
+          {room.subject ? renderTextWithLinks(room.subject) : room.jid}
+        </p>
+      </div>
+```
+
+with:
+
+```tsx
+      {/* Name and info — opens Room Info modal; tooltip peeks the full topic */}
+      <Tooltip content={room.subject || room.jid} position="bottom">
+        <button
+          type="button"
+          onClick={() => setShowInfoModal(true)}
+          aria-label={t('rooms.showRoomInfo', 'Room info')}
+          className="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+        >
+          <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
+          <p className="text-xs text-fluux-muted truncate">
+            {room.subject ? renderTextWithLinks(room.subject) : room.jid}
+          </p>
+        </button>
+      </Tooltip>
+```
+
+Note: the `t('rooms.showRoomInfo', 'Room info')` call uses an inline i18n default so no locale edit is required; if the project lint forbids inline defaults, replace with `aria-label="Room info"` (English `aria-label` is acceptable for a non-visual label here, but prefer the inline-default form to match `t('rooms.roomActions', 'Room actions')` already used at line 188).
+
+- [ ] **Step 3: Conditionally render the modal**
+
+Add near the other conditionally-rendered modals (after the `showHatsModal` block, ~line 274-278):
+
+```tsx
+      {showInfoModal && (
+        <RoomInfoModal
+          room={room}
+          onClose={() => setShowInfoModal(false)}
+        />
+      )}
+```
+
+- [ ] **Step 4: Typecheck and lint**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+Run: `cd apps/fluux && npx eslint src/components/RoomHeader.tsx src/components/RoomInfoModal.tsx`
+Expected: no errors.
+
+- [ ] **Step 5: Run the room-header-adjacent tests**
+
+Run: `cd apps/fluux && npx vitest run src/components/RoomInfoModal.test.tsx`
+Expected: PASS.
+
+If a `RoomHeader.test.tsx` exists, run it too and update any snapshot/label assertions the new button introduces:
+Run: `cd apps/fluux && npx vitest run src/components/RoomHeader.test.tsx`
+Expected: PASS (or updated assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/components/RoomHeader.tsx
+git commit -m "feat(rooms): open Room Info modal from room header title (#922)"
+```
+
+---
+
+### Task 3: Manual verification in demo mode
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Seed a long topic**
+
+In demo mode, pick a room and give it a long, multi-line subject. Either edit `apps/fluux/src/demo/DemoClient.ts` where room subjects are seeded, or set it at runtime. A quick runtime option (browser devtools console on the demo page) is to use the room config, but the reliable path is to set a long `subject` on a demo room in the seed data, e.g.:
+
+```ts
+subject: 'This is a deliberately very long room topic that wraps across many lines. '.repeat(8),
+```
+
+- [ ] **Step 2: Run the demo and verify**
+
+Run: `npm run dev` then open `http://localhost:5173/demo.html?tutorial=false`.
+
+Verify:
+- Hovering the room title in the header shows a tooltip with the full subject.
+- Clicking the room title opens the Room Info modal.
+- The modal shows the room name (title), JID, and the full topic.
+- The topic collapses to six lines with a "Show more" button; clicking expands it and shows "Show less".
+- Links inside the topic are clickable in the modal.
+- A room with no subject opens the modal showing name + JID and no topic section.
+
+- [ ] **Step 3: Final full-suite sanity + finish**
+
+Run: `cd apps/fluux && npx vitest run src/components/RoomInfoModal.test.tsx`
+Run: `npm run typecheck`
+Expected: PASS / no errors.
+
+No commit (verification task). Proceed to open a PR against `main`.
+
+---
+
+## Notes / decisions locked from the spec
+
+- The members panel (`OccupantPanel`) is intentionally **not** touched — the topic there read as out of place.
+- `CollapsibleContent` is intentionally **not** reused — it requires a `messageId`, `expandedMessagesStore`, and `messageWidthContext`, none of which exist outside the message list.
+- No-subject rooms omit the topic block rather than showing a placeholder, avoiding a new i18n key across 33 locales.

--- a/docs/superpowers/specs/2026-07-10-room-full-topic-view-design.md
+++ b/docs/superpowers/specs/2026-07-10-room-full-topic-view-design.md
@@ -1,0 +1,94 @@
+# Room Info modal — view a room's full topic/description (#922)
+
+**Issue:** [#922](https://github.com/processone/fluux-messenger/issues/922) — "No way to view a room's full description when it is too long." Milestone 0.17.1.
+
+## Problem
+
+A MUC room's description (`muc#roomconfig_roomdesc`) is surfaced in the app as `room.subject`. It renders in only one place — the header topic line in `RoomHeader.tsx` — where it is hard-clipped to a single line via Tailwind `truncate`:
+
+```jsx
+// apps/fluux/src/components/RoomHeader.tsx:125-130
+<div className="flex-1 min-w-0">
+  <h2 className="font-semibold text-fluux-text truncate leading-tight">{room.name}</h2>
+  <p className="text-xs text-fluux-muted truncate">
+    {room.subject ? renderTextWithLinks(room.subject) : room.jid}
+  </p>
+</div>
+```
+
+When the topic exceeds one line, the rest is unreachable — there is no room-info surface that shows it in full. The only existing room modal is the owner-only `RoomConfigModal` (edit/config), which is not a viewing surface for regular members.
+
+## Goal
+
+Give any room member a way to read the complete topic/description, plus a lightweight quick-peek in the header. Keep the change minimal and consistent with existing patterns.
+
+## Non-goals
+
+- No SDK changes. `room.subject` already carries the text.
+- No new i18n keys — `rooms.topic`, `chat.showMore`, `chat.showLess` already exist.
+- Not adding the topic to the members panel (`OccupantPanel`) — it reads as out of place there.
+- Not building a general-purpose room-details surface. The modal is scoped to identity + topic; it can grow later.
+
+## Design
+
+Two complementary changes.
+
+### 1. New `RoomInfoModal` (dedicated viewing area)
+
+New component `apps/fluux/src/components/RoomInfoModal.tsx`, built on the standard `ModalShell` primitive (`title`, `onClose`, `width?`, `children`; provides glass panel, scrim, Escape, focus restore).
+
+Props:
+```ts
+interface RoomInfoModalProps {
+  room: Room
+  onClose: () => void
+}
+```
+
+Content (top to bottom):
+- **Identity row**: `RoomAvatar` (existing component) + room `name`.
+- **JID**: `room.jid`, shown in muted text with a copy affordance consistent with how JIDs are copied elsewhere (e.g. the occupant "copy JID" toast pattern). Copy is a nice-to-have; if it adds friction, render as selectable text only.
+- **Topic block**: label `t('rooms.topic')` ("Topic"), then the full subject rendered with `renderTextWithLinks(room.subject)` inside a container with `whitespace-pre-wrap break-words` so it wraps fully and links stay clickable. When `room.subject` is empty, show a muted `t('rooms.noTopic')`-style placeholder — **verify the key exists**; if not, fall back to an existing empty-state key or add one following the i18n-surgical-edit workflow (all 33 locales, no English placeholders).
+
+**Long-topic collapse (self-contained, no message-list coupling):**
+The topic body collapses past ~6 lines using CSS `line-clamp-6` with a local `useState` `expanded` flag and a **Show more / Show less** toggle (`chat.showMore` / `chat.showLess` + `ChevronDown`/`ChevronUp`). The toggle renders only when the content actually overflows, detected by a measure-on-mount + on-resize check (compare `scrollHeight` to `clientHeight` on the clamped element via a ref). This deliberately does **not** reuse `CollapsibleContent`, which requires a `messageId`, `expandedMessagesStore`, and the `messageWidthContext` provider — none of which exist outside the message list. The collapse logic here is ~40 lines and independently testable.
+
+### 2. `RoomHeader` — open the modal + quick-peek tooltip
+
+In `RoomHeader.tsx`:
+- Add modal state: `const [showInfoModal, setShowInfoModal] = useState(false)` (matching the existing `showAvatarModal` / `showMembersModal` / `showHatsModal` pattern).
+- Make the name+subject block (lines 125-130) a keyboard-accessible **button** (`role="button"`, focusable, `Enter`/`Space`) that calls `setShowInfoModal(true)`. Add a subtle hover affordance (e.g. `hover:bg-fluux-hover` rounded) so the click target is discoverable. Preserve the desktop drag region — the title button must stop the drag interaction from swallowing the click (opt the button out of the drag region as other interactive header controls do).
+- Wrap the block (or the subject `<p>`) in the existing `Tooltip` with `content={room.subject}` and `position="bottom"`, rendered only when `room.subject` is present, for an instant hover/long-press peek.
+- Render `{showInfoModal && <RoomInfoModal room={room} onClose={() => setShowInfoModal(false)} />}` alongside the other conditionally-rendered modals near the end of the component.
+
+## Data flow
+
+`room` (already available in `RoomHeader`) → `RoomInfoModal` via props. No store or SDK reads beyond the existing `Room` object. The topic value is `room.subject`.
+
+## Error / edge cases
+
+- **No subject**: header shows `room.jid` (unchanged); modal shows the empty-topic placeholder. Header title still opens the modal (useful for JID/avatar).
+- **Very long / multi-paragraph subject**: handled by `whitespace-pre-wrap` + line-clamp collapse.
+- **Links in subject**: clickable in the modal (`renderTextWithLinks`); not clickable in the tooltip (acceptable — tooltip is a peek).
+- **RTL**: rely on existing logical-property utilities; no hardcoded left/right.
+
+## Testing
+
+- **Unit** (`RoomInfoModal.test.tsx`, jsdom env per the app DOM-test convention):
+  - Renders room name, JID, and full topic text.
+  - With a short topic, no Show more toggle is present.
+  - With a long topic (mock `scrollHeight > clientHeight`), the Show more toggle appears and toggling flips to Show less.
+  - Empty subject renders the placeholder, not a blank block.
+  - New SDK/app exports used by the modal must be added to the app test mock if applicable (none expected here).
+- **Manual (demo mode)**: seed a room with a long multi-line topic (via `DemoClient` / storage), open the room, confirm the header tooltip peek and that clicking the title opens the modal showing the full topic with working collapse and clickable links.
+
+## Files touched
+
+- `apps/fluux/src/components/RoomInfoModal.tsx` — new.
+- `apps/fluux/src/components/RoomInfoModal.test.tsx` — new.
+- `apps/fluux/src/components/RoomHeader.tsx` — modal state, clickable title, tooltip, conditional render.
+- i18n: only if a no-topic placeholder key is missing (surgical edit across all locales).
+
+## Rollout
+
+Single PR against a feature branch off `main`, squash-merged. No migration, no config, no SDK rebuild required.


### PR DESCRIPTION
Adds a way to read a room's full topic/description, which was previously only shown as a single-line truncated line in the room header (#922).

## Changes
- New `RoomInfoModal` (built on `ModalShell`): room avatar, JID, and the full topic with `whitespace-pre-wrap break-words` so it wraps and links stay clickable. Long topics collapse to 6 lines behind a Show more/less toggle. The modal body scrolls within `max-h-[80vh]` so even very long expanded topics stay reachable.
- `RoomHeader`: the room name+subject block is now a keyboard-accessible button that opens the modal, wrapped in a tooltip that peeks the full subject.

No SDK changes and no new i18n keys (modal title is the room name; reuses `rooms.topic`, `chat.showMore`, `chat.showLess`).

Closes #922