### PR TITLE
fix(avatar): proportional square-avatar radius so rooms aren't circles

### DIFF
--- a/apps/fluux/src/components/Avatar.test.tsx
+++ b/apps/fluux/src/components/Avatar.test.tsx
@@ -249,8 +249,20 @@ describe('Avatar', () => {
     test('Avatar shape="square" renders a rounded square', () => {
       const { container } = render(<Avatar identifier="team@conference.fluux.chat" name="Team" shape="square" />)
       const root = container.firstChild as HTMLElement
-      expect(root.className).toContain('rounded-xl')
+      expect(root.className).toContain('rounded-[28%]')
       expect(root.className).not.toContain('rounded-full')
+    })
+
+    test('square avatar uses a proportional radius so it stays square at every size (a fixed 12px is a circle at 24px)', () => {
+      // Percentage radius scales with the box, so xs (24px) is a rounded-square, not a circle.
+      for (const size of ['xs', 'sm', 'md', 'xl'] as const) {
+        const { container } = render(
+          <Avatar identifier="team@conference.fluux.chat" name="Team" shape="square" size={size} />
+        )
+        const root = container.firstChild as HTMLElement
+        expect(root.className).toContain('rounded-[28%]')
+        expect(root.className).not.toContain('rounded-full')
+      }
     })
   })
 })

--- a/apps/fluux/src/components/Avatar.tsx
+++ b/apps/fluux/src/components/Avatar.tsx
@@ -17,6 +17,15 @@ const SIZES = {
 
 export type AvatarSize = keyof typeof SIZES
 
+/**
+ * Corner radius for square (room/group) avatars. A PERCENTAGE radius is relative
+ * to the element's own size, so a single value stays visually identical at every
+ * avatar size — unlike a fixed px radius, where the corner/size ratio drifts (12px
+ * is a full circle at 24px but barely rounded at 96px). 28% reads as a consistent
+ * rounded-square; 50% would be a circle.
+ */
+const SQUARE_RADIUS = 'rounded-[28%]'
+
 export interface AvatarProps {
   /**
    * Unique identifier used for consistent color generation (JID, nickname, etc.)
@@ -314,7 +323,7 @@ export function Avatar({
   // Get size classes
   const sizeClasses = SIZES[size]
 
-  const radiusClass = shape === 'square' ? 'rounded-xl' : 'rounded-full'
+  const radiusClass = shape === 'square' ? SQUARE_RADIUS : 'rounded-full'
 
   // Determine presence color
   // Uses CSS custom properties for smooth color transitions between states

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -199,7 +199,8 @@ describe('CommandPalette', () => {
       // "Development" has unreadCount 0 and mentionsCount 0, so its row has no
       // unread badge (badges are rounded-full) — the only shaped element is its avatar.
       const row = screen.getByText('Development').closest('button')!
-      expect(row.querySelector('.rounded-xl')).not.toBeNull()
+      // Room avatars use a proportional rounded-square radius (rounded-[28%]), never a circle.
+      expect(row.querySelector('[class*="rounded-[28%]"]')).not.toBeNull()
       expect(row.querySelector('.rounded-full')).toBeNull()
     })
 

--- a/apps/fluux/src/components/RoomAvatar.test.tsx
+++ b/apps/fluux/src/components/RoomAvatar.test.tsx
@@ -6,7 +6,7 @@ describe('RoomAvatar', () => {
   test('renders a rounded square, not a circle', () => {
     const { container } = render(<RoomAvatar identifier="team@conference.example.com" name="Team" />)
     const root = container.firstChild as HTMLElement
-    expect(root.className).toContain('rounded-xl')
+    expect(root.className).toContain('rounded-[28%]')
     expect(root.className).not.toContain('rounded-full')
   })
 


### PR DESCRIPTION
Follow-up to #961, which merged before this fix landed.

#961 routed search room avatars through `RoomAvatar` (`shape="square"`), but `Avatar` hard-coded `rounded-xl` (12px) for *every* square size. On a 24px (`xs`) box a 12px radius equals half the side length — a full circle — so room avatars in search results and the command palette still rendered as circles at that size.

This makes the square corner radius a **percentage** (`rounded-[28%]`). A percentage border-radius is relative to the element's own size, so a single value reads as the same rounded-square at every avatar size, rather than a fixed px radius whose corner/size ratio drifts (circle at 24px, barely rounded at 96px). This also makes room-avatar rounding consistent across the app.

Verified `rounded-[28%]` compiles to `border-radius: 28%` in-app.