### PR TITLE
fix(toolbar): keep the hover toolbar's rounded border clear of the message-hover tint

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     class="relative flex-1 min-w-0"
                   >
                     <div
-                      class="absolute -top-7 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
+                      class="absolute -top-16 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
                       data-message-toolbar="true"
                     >
                       <div
@@ -300,7 +300,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     class="relative flex-1 min-w-0"
                   >
                     <div
-                      class="absolute -top-7 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
+                      class="absolute -top-16 -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out opacity-0 translate-x-2"
                       data-message-toolbar="true"
                     >
                       <div

--- a/apps/fluux/src/components/conversation/MessageToolbar.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.test.tsx
@@ -382,9 +382,10 @@ describe('MessageToolbar', () => {
         <MessageToolbar {...defaultProps} showAvatar={true} />
       )
 
-      // Outer hover zone has extended positioning to provide larger hit area
+      // Group-start rows are taller (name+time header), so the bar is lifted
+      // further (-top-16) to straddle the row's top edge and clear the hover tint.
       const toolbar = container.firstChild as HTMLElement
-      expect(toolbar).toHaveClass('-top-7')
+      expect(toolbar).toHaveClass('-top-16')
     })
 
     it('should position normally when showAvatar is false', () => {

--- a/apps/fluux/src/components/conversation/MessageToolbar.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.tsx
@@ -143,10 +143,16 @@ export const MessageToolbar = memo(function MessageToolbar({
 
   return (
     // Outer wrapper provides an extended hover zone (padding) around the visible toolbar
-    // select-none prevents toolbar from being included in text selection
+    // select-none prevents toolbar from being included in text selection.
+    // The top offset lifts the bar to straddle the row's top edge so its rounded
+    // border sits over the calm chat surface rather than inside the message-hover
+    // tint (which otherwise bleeds around the bar's corners, most visibly in light
+    // theme where the popover surface and the tint differ). A group-start row is
+    // taller (name+time header), so it needs the larger -top-16 to land the bar at
+    // the same visual height a continuation row reaches with -top-12.
     <div
       data-message-toolbar
-      className={`absolute ${showAvatar ? '-top-7' : '-top-12'} -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out ${visibilityClass}`}
+      className={`absolute ${showAvatar ? '-top-16' : '-top-12'} -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out ${visibilityClass}`}
     >
       {/* Visible toolbar */}
       <div


### PR DESCRIPTION
## Summary

The floating message action toolbar sits inside the message row, which carries the `bg-fluux-message-hover` tint on hover. For **group-start** rows (name+time header), the `-top-7` offset placed the bar entirely inside the tinted row, so the grey tint showed through the popover's `rounded-md` corners and made its border look cut off. It was most visible in **light theme**, where the popover surface (`base-00`) and the hover tint (`base-50`) differ; in dark theme both are `base-50`, so there was no visible defect.

**Continuation** rows (`-top-12`) already straddled the row's top edge and were unaffected.

The fix lifts group-start rows to `-top-16` so the bar clears the tint like continuation rows do, landing at the same visual height. The `p-4` hover halo still overlaps the message, so hover continuity is preserved.

Updated the positioning assertion and the ChatView snapshot to match.