### PR TITLE
fix(fab): don't flash scroll-to-bottom button on open-at-bottom

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -442,7 +442,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
           </div>
         </div>
         <div
-          class="absolute bottom-4 end-4 z-40 animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none"
+          class="absolute bottom-4 end-4 z-40 opacity-0 pointer-events-none"
           inert=""
         >
           <div
@@ -600,7 +600,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
           </div>
         </div>
         <div
-          class="absolute bottom-4 end-4 z-40 animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none"
+          class="absolute bottom-4 end-4 z-40 opacity-0 pointer-events-none"
           inert=""
         >
           <div

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
             </div>
           </div>
           <div
-            class="absolute bottom-4 end-4 z-40 animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none"
+            class="absolute bottom-4 end-4 z-40 opacity-0 pointer-events-none"
             inert=""
           >
             <div

--- a/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
@@ -293,6 +293,72 @@ describe('MessageList FAB badge and scroll behavior', () => {
     })
   })
 
+  describe('no flash on fresh open at bottom', () => {
+    it('does not play the spring-out exit animation on initial mount', () => {
+      // When a conversation opens already at the bottom, the FAB should be hidden with NO
+      // animation. The exit keyframe (fab-spring-out) starts at opacity:1 (fully visible), so
+      // running it on mount paints the FAB visible on frame 0 and springs it away — a flash.
+      const messages = createTestMessages(10)
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      setupScrollContainer()
+
+      // Do NOT dispatch a scroll event — this is the fresh open-at-bottom state.
+      const fab = document.querySelector('button[aria-label="chat.scrollToBottom"]')
+      expect(fab).toBeTruthy()
+
+      const wrapper = fab!.closest('div.z-40') as HTMLElement
+      expect(wrapper).toBeTruthy()
+      // Must not run the exit animation on a FAB that was never shown.
+      expect(wrapper.className).not.toContain('fab-spring-out')
+      // Must be statically hidden and non-interactive instead.
+      expect(wrapper.className).toContain('opacity-0')
+      expect(wrapper.className).toContain('pointer-events-none')
+    })
+
+    it('plays the spring-out exit animation only after the FAB has been shown', () => {
+      const messages = createTestMessages(10)
+
+      render(
+        <MessageList
+          messages={messages}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />
+      )
+
+      const scrollCtx = setupScrollContainer()
+      if (!scrollCtx) return
+
+      // Scroll up: FAB springs in.
+      simulateScrollUp(scrollCtx.container)
+      let fab = document.querySelector('button[aria-label="chat.scrollToBottom"]')
+      let wrapper = fab!.closest('div.z-40') as HTMLElement
+      expect(wrapper.className).toContain('fab-spring-in')
+
+      // Scroll back to bottom: now that it has been shown, the exit animation is allowed.
+      Object.defineProperty(scrollCtx.container, 'scrollTop', {
+        get: () => 1500, // scrollHeight 2000 - clientHeight 500 = bottom
+        set: () => {},
+        configurable: true,
+      })
+      act(() => { scrollCtx.container.dispatchEvent(new Event('scroll')) })
+
+      fab = document.querySelector('button[aria-label="chat.scrollToBottom"]')
+      wrapper = fab!.closest('div.z-40') as HTMLElement
+      expect(wrapper.className).toContain('fab-spring-out')
+    })
+  })
+
   describe('two-step scroll behavior', () => {
     it('should scroll to bottom directly when there is no firstNewMessageId', () => {
       const messages = createTestMessages(10)

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -1462,7 +1462,7 @@ describe('MessageList scroll behavior', () => {
         })
 
         // FAB should NOT be visible - wrapper div should have inert set
-        const fabWrapper = document.querySelector('.animate-\\[fab-spring-out_0\\.25s_ease-in_forwards\\]')
+        const fabWrapper = document.querySelector('[data-fab="scroll-to-bottom"]')?.closest('div.z-40')
         expect(fabWrapper?.hasAttribute('inert')).toBe(true)
       }
     })
@@ -1496,7 +1496,7 @@ describe('MessageList scroll behavior', () => {
           container.dispatchEvent(new Event('scroll'))
         })
 
-        let fabWrapper = document.querySelector('[class*="fab-spring"]')
+        let fabWrapper = document.querySelector('[data-fab="scroll-to-bottom"]')?.closest('div.z-40')
         expect(fabWrapper?.hasAttribute('inert')).toBe(true)
 
         // Scroll up far from bottom
@@ -1507,7 +1507,7 @@ describe('MessageList scroll behavior', () => {
         })
 
         // Now FAB should be visible
-        fabWrapper = document.querySelector('[class*="fab-spring"]')
+        fabWrapper = document.querySelector('[data-fab="scroll-to-bottom"]')?.closest('div.z-40')
         expect(fabWrapper?.hasAttribute('inert')).toBe(false)
       }
     })
@@ -1545,7 +1545,7 @@ describe('MessageList scroll behavior', () => {
           container.dispatchEvent(new Event('scroll'))
         })
 
-        const fabWrapper = document.querySelector('[class*="fab-spring"]')
+        const fabWrapper = document.querySelector('[data-fab="scroll-to-bottom"]')?.closest('div.z-40')
         expect(fabWrapper?.hasAttribute('inert')).toBe(false)
       }
     })

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -31,6 +31,7 @@ import { isFeatureEnabled } from '@/utils/featureFlags'
 import { useSettingsStore } from '@/stores/settingsStore'
 import type { CopyMessageMeta } from '@/utils/buildCopyText'
 import { buildMessageListItems, type RenderItem } from './messageListItems'
+import { fabAnimationClass } from './fabAnimationClass'
 import { FloatingDateHeader } from './FloatingDateHeader'
 import { JumpToLastReadPill } from './JumpToLastReadPill'
 import { getTopVisibleDate } from './getTopVisibleDate'
@@ -661,6 +662,11 @@ export function MessageList<T extends BaseMessage>({
   // whenever the window is slid up (newer content exists off-screen), not only past the FAB threshold.
   const windowSlidUp = windowAtLiveEdge === false
   const fabVisible = showScrollToBottom || windowSlidUp
+  // Track whether the FAB has ever been shown in this mount so the exit animation (whose first
+  // keyframe is fully-visible) never runs on a fresh open-at-bottom, which would flash the FAB.
+  // MessageList is remounted per conversation via `key`, so this ref resets on every open.
+  const hasFabBeenVisibleRef = useRef(false)
+  if (fabVisible) hasFabBeenVisibleRef.current = true
   const handleJumpToBottom = () => {
     if (windowSlidUp && onJumpToLatest) {
       // Recenter the resident window to the newest slice, then scroll to the bottom. If the
@@ -832,11 +838,7 @@ export function MessageList<T extends BaseMessage>({
 
       {/* Scroll to bottom FAB with spring animation */}
       <div
-        className={`absolute bottom-4 end-4 z-40 ${
-          fabVisible
-            ? 'animate-[fab-spring-in_0.4s_var(--fluux-ease-spring)_forwards]'
-            : 'animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none'
-        }`}
+        className={`absolute bottom-4 end-4 z-40 ${fabAnimationClass(fabVisible, hasFabBeenVisibleRef.current)}`}
         inert={!fabVisible}
       >
         <Tooltip content={t('chat.scrollToBottom') + ` (${isMac ? '⌘↓' : 'Ctrl+↓'})`} position="left">

--- a/apps/fluux/src/components/conversation/fabAnimationClass.test.ts
+++ b/apps/fluux/src/components/conversation/fabAnimationClass.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { fabAnimationClass } from './fabAnimationClass'
+
+describe('fabAnimationClass', () => {
+  it('is statically hidden with no exit animation when never shown (fresh open at bottom)', () => {
+    const cls = fabAnimationClass(false, false)
+    expect(cls).not.toContain('fab-spring-out')
+    expect(cls).not.toContain('fab-spring-in')
+    expect(cls).toContain('opacity-0')
+    expect(cls).toContain('pointer-events-none')
+  })
+
+  it('plays the spring-in animation when visible', () => {
+    const cls = fabAnimationClass(true, false)
+    expect(cls).toContain('fab-spring-in')
+  })
+
+  it('plays the spring-out animation only after having been visible', () => {
+    const cls = fabAnimationClass(false, true)
+    expect(cls).toContain('fab-spring-out')
+    expect(cls).toContain('pointer-events-none')
+  })
+
+  it('prefers the spring-in animation when visible even after prior visibility', () => {
+    const cls = fabAnimationClass(true, true)
+    expect(cls).toContain('fab-spring-in')
+    expect(cls).not.toContain('fab-spring-out')
+  })
+})

--- a/apps/fluux/src/components/conversation/fabAnimationClass.ts
+++ b/apps/fluux/src/components/conversation/fabAnimationClass.ts
@@ -1,0 +1,22 @@
+/**
+ * Compute the animation/visibility class for the scroll-to-bottom FAB.
+ *
+ * The FAB div is always mounted; its visibility is driven purely by CSS animations whose
+ * `forwards` fill holds the end state. On a fresh conversation open at the bottom the FAB is
+ * hidden and must stay hidden WITHOUT playing the exit animation — otherwise the `fab-spring-out`
+ * keyframe (which starts at opacity:1, fully visible) paints the FAB on frame 0 and springs it
+ * away, producing a visible flash on every open (MessageList is remounted per conversation via
+ * `key`, so a plain mount replays the animation).
+ *
+ * So the exit animation only runs once the FAB has actually been shown at least once. Before that,
+ * a static hidden state (`opacity-0`) keeps it invisible with no animation.
+ */
+export function fabAnimationClass(fabVisible: boolean, hasBeenVisible: boolean): string {
+  if (fabVisible) {
+    return 'animate-[fab-spring-in_0.4s_var(--fluux-ease-spring)_forwards]'
+  }
+  if (hasBeenVisible) {
+    return 'animate-[fab-spring-out_0.25s_ease-in_forwards] pointer-events-none'
+  }
+  return 'opacity-0 pointer-events-none'
+}

--- a/apps/fluux/src/themes/motionTokens.test.ts
+++ b/apps/fluux/src/themes/motionTokens.test.ts
@@ -40,7 +40,9 @@ describe('component animations reference motion tokens', () => {
   it('MessageList send + FAB animations use tokens', () => {
     const f = read('src/components/conversation/MessageList.tsx')
     expect(f).toMatch(/message-send var\(--fluux-duration-slow\) var\(--fluux-ease-standard\)/)
-    expect(f).toMatch(/fab-spring-in_0\.4s_var\(--fluux-ease-spring\)_forwards/)
+    // The FAB spring class lives in the extracted fabAnimationClass helper.
+    const fab = read('src/components/conversation/fabAnimationClass.ts')
+    expect(fab).toMatch(/fab-spring-in_0\.4s_var\(--fluux-ease-spring\)_forwards/)
   })
 
   it('Sidebar view-enter uses tokens', () => {


### PR DESCRIPTION
## Summary

Opening a conversation briefly flashed the scroll-to-bottom FAB, even when the list loads already at the bottom.

**Cause:** The FAB `<div>` is always mounted and its visibility was driven purely by CSS animations. When hidden it rendered the `fab-spring-out` exit animation, whose first keyframe is fully visible (`opacity: 1`) before springing to `opacity: 0`. Because `MessageList` remounts per conversation via `key`, that exit animation replayed on every open — flashing the FAB on frame 0.

**Fix:** Only run the exit animation once the FAB has actually been shown; otherwise render a static hidden state (`opacity-0`). The class logic is extracted into a pure `fabAnimationClass()` helper with unit tests. A per-mount ref tracks whether the FAB has been visible (resets on each conversation open via the remount).

Verified in demo mode: open-at-bottom now renders with no animation and `inert`; scrolling up still springs the FAB in correctly.
