### PR TITLE
fix(toolbar): keep an end button's hover fill inside the toolbar's rounded border

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       data-message-toolbar="true"
                     >
                       <div
-                        class="flex items-center fluux-popover rounded-md "
+                        class="flex items-center p-0.5 fluux-popover rounded-md "
                       >
                         <button
                           aria-label="chat.reactWith"
@@ -304,7 +304,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       data-message-toolbar="true"
                     >
                       <div
-                        class="flex items-center fluux-popover rounded-md "
+                        class="flex items-center p-0.5 fluux-popover rounded-md "
                       >
                         <button
                           aria-label="chat.reactWith"

--- a/apps/fluux/src/components/conversation/MessageToolbar.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.tsx
@@ -154,10 +154,14 @@ export const MessageToolbar = memo(function MessageToolbar({
       data-message-toolbar
       className={`absolute ${showAvatar ? '-top-16' : '-top-12'} -end-2 p-4 z-20 select-none pointer-events-none transition-all duration-200 ease-out ${visibilityClass}`}
     >
-      {/* Visible toolbar */}
+      {/* Visible toolbar. The p-0.5 inset keeps each control's square hover/active
+          fill (hover:bg-fluux-hover, reacted bg-fluux-brand/20) clear of the
+          rounded-md corners — without it, an end button's fill pokes past the
+          popover's rounded border. Clipping via overflow-hidden isn't an option
+          here because the reaction picker and more-menu dropdowns overflow the bar. */}
       <div
         ref={toolbarRef}
-        className={`flex items-center fluux-popover rounded-md ${interactivityClass}`}
+        className={`flex items-center p-0.5 fluux-popover rounded-md ${interactivityClass}`}
         onMouseEnter={onToolbarMouseEnter}
       >
       {/* Quick reaction emojis (hidden when reactions are disabled) */}


### PR DESCRIPTION
## Summary

Follow-up to #974. Each control in the message action toolbar has a square hover/active fill (`hover:bg-fluux-hover`, and the reacted `bg-fluux-brand/20`) that sat flush to the popover edge, so a first/last button's fill poked past the `rounded-md` corners.

A `p-0.5` inset on the bar tucks those square fills inside the rounded border. `overflow-hidden` isn't usable here because the reaction-picker and more-menu dropdowns overflow the bar.