### PR TITLE
fix(rooms): suppress native context menu on own occupant row

### DIFF
--- a/apps/fluux/src/components/OccupantPanel.test.tsx
+++ b/apps/fluux/src/components/OccupantPanel.test.tsx
@@ -15,6 +15,11 @@ vi.mock('react-i18next', () => ({
 }))
 
 // Mock hooks
+const contextMenuMock = vi.hoisted(() => ({
+  handleContextMenu: vi.fn((e: { preventDefault: () => void }) => e.preventDefault()),
+  handleTouchStart: vi.fn(),
+  handleTouchEnd: vi.fn(),
+}))
 vi.mock('@/hooks', () => ({
   useWindowDrag: () => ({
     dragRegionProps: { 'data-tauri-drag-region': true },
@@ -26,6 +31,7 @@ vi.mock('@/hooks', () => ({
     close: vi.fn(),
     menuRef: { current: null },
     triggerHandlers: {},
+    ...contextMenuMock,
   }),
   useTheme: () => ({
     isDark: true,
@@ -316,6 +322,46 @@ describe('OccupantPanel', () => {
       )
 
       expect(screen.getByText('rooms.you')).toBeInTheDocument()
+    })
+
+    it('suppresses the native context menu on own row without opening the occupant menu', () => {
+      contextMenuMock.handleContextMenu.mockClear()
+      const occupants = new Map<string, RoomOccupant>([
+        ['me@room', createOccupant({ nick: 'Me' })],
+      ])
+      const room = createRoom({ occupants, nickname: 'Me' })
+
+      render(
+        <OccupantPanel
+          room={room}
+          contactsByJid={new Map()}
+          onClose={() => {}}
+        />
+      )
+
+      // fireEvent returns false when preventDefault() was called
+      const notCancelled = fireEvent.contextMenu(screen.getByText('rooms.you'))
+      expect(notCancelled).toBe(false)
+      expect(contextMenuMock.handleContextMenu).not.toHaveBeenCalled()
+    })
+
+    it('opens the occupant context menu on another occupant row', () => {
+      contextMenuMock.handleContextMenu.mockClear()
+      const occupants = new Map<string, RoomOccupant>([
+        ['other@room', createOccupant({ nick: 'Other' })],
+      ])
+      const room = createRoom({ occupants, nickname: 'Me' })
+
+      render(
+        <OccupantPanel
+          room={room}
+          contactsByJid={new Map()}
+          onClose={() => {}}
+        />
+      )
+
+      fireEvent.contextMenu(screen.getByText('Other'))
+      expect(contextMenuMock.handleContextMenu).toHaveBeenCalledTimes(1)
     })
 
     it('shows bare JID when available', () => {

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -323,7 +323,10 @@ export function OccupantPanel({
     rowHandlersRef.current = {
       onContextMenu: (group, e) => {
         const { menu, setMenuTarget, roomNickname } = rowCtxRef.current
-        if (group.connections.some(conn => conn.nick === roomNickname)) return // no menu for self
+        if (group.connections.some(conn => conn.nick === roomNickname)) {
+          e.preventDefault() // no occupant menu for self, but still suppress the browser menu
+          return
+        }
         setMenuTarget(group)
         menu.handleContextMenu(e)
       },


### PR DESCRIPTION
Right-clicking your own row in the occupant sidebar showed the browser's default context menu: the self-row guard returned before `preventDefault()` (only `handleContextMenu` calls it). Now the guard prevents the default first, so no menu of any kind appears on the own row, while other occupants keep the custom occupant menu.

Verified in demo mode: own row suppresses the native menu, other rows still open the occupant menu.