### PR TITLE
ci(e2e): share Playwright browser cache across PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,19 @@ jobs:
         run: npm run build:sdk
 
       # Cache the browser binaries (~/.cache/ms-playwright) so a slow CDN can't add minutes to
-      # the download. The OS-level deps (apt) live on the ephemeral runner and are (re)installed
-      # separately each run via `install-deps`.
+      # the download. Caches created in pull_request runs are scoped to that PR, so the shared
+      # copy is seeded from main by playwright-cache.yml; restore-keys lets a Playwright bump
+      # start from the previous cache and download only the changed browsers. The OS-level deps
+      # (apt) live on the ephemeral runner and are (re)installed separately each run via
+      # `install-deps`.
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/playwright-cache.yml
+++ b/.github/workflows/playwright-cache.yml
@@ -1,0 +1,52 @@
+name: Seed Playwright cache
+
+# CI only runs on pull_request, and caches created in PR runs are scoped to that PR —
+# other PRs can't see them, so every PR's first e2e run re-downloads the browsers.
+# Caches created on the default branch ARE visible to all PRs, so this workflow keeps
+# a shared copy warm from main. It short-circuits in ~10s when the cache already
+# exists for the current package-lock.json.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  seed:
+    name: Seed Playwright browser cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Check for existing cache
+        id: check
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          lookup-only: true
+
+      - name: Setup Node.js
+        if: steps.check.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Install Playwright browsers
+        if: steps.check.outputs.cache-hit != 'true'
+        run: npx playwright install chromium webkit
+
+      - name: Save cache
+        if: steps.check.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
The e2e job's Playwright browser cache missed on the first run of every PR: CI only runs on `pull_request`, and caches created in PR runs are scoped to that PR, so there was never a shared copy to inherit.

- New `playwright-cache.yml` workflow seeds the cache from `main` (visible to all PRs); it short-circuits when the cache already exists for the current `package-lock.json`.
- Added `restore-keys` to the e2e cache step so a Playwright version bump starts from the previous cache and only downloads the changed browsers.

The apt `install-deps` step stays as-is — system packages on an ephemeral runner can't be cached with `actions/cache`.