### PR TITLE
feat(command-palette): notify-all rooms in Needs attention + red attention pill

### DIFF
--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -1336,6 +1336,50 @@ describe('CommandPalette', () => {
     })
   })
 
+  describe('Notify-all rooms in attention (red pill)', () => {
+    function getGroupContainer(labelText: string): HTMLElement {
+      const label = screen.getByText(labelText)
+      return label.parentElement as HTMLElement
+    }
+
+    it('promotes a notify-all room with unread (no mention) into the attention group', () => {
+      mockRooms = [
+        ...defaultRooms,
+        { jid: 'ops@conference.example.com', name: 'Ops Alerts', joined: true, unreadCount: 4, mentionsCount: 0, notifyAllPersistent: true, lastMessage: { body: 'disk 90%', timestamp: new Date('2026-07-07T07:00:00Z') } },
+      ]
+      render(<CommandPalette {...defaultProps} />)
+      const attention = getGroupContainer('Needs attention')
+      expect(within(attention).getByText('Ops Alerts')).toBeInTheDocument()
+    })
+
+    it('gives a notify-all unread room a red (bg-fluux-brand) pill', () => {
+      mockRooms = [
+        ...defaultRooms,
+        { jid: 'ops@conference.example.com', name: 'Ops Alerts', joined: true, unreadCount: 4, mentionsCount: 0, notifyAllPersistent: true },
+      ]
+      render(<CommandPalette {...defaultProps} />)
+      const row = screen.getByText('Ops Alerts').closest('button')!
+      const badge = within(row).getByText('4')
+      expect(badge.className).toContain('bg-fluux-brand')
+    })
+
+    it('gives an ordinary unread room (not notify-all, no mention) a grey (bg-fluux-hover) pill', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // General Chat: unread 3, mentionsCount 0, no notify-all -> neutral tone
+      const row = screen.getByText('General Chat').closest('button')!
+      const badge = within(row).getByText('3')
+      expect(badge.className).toContain('bg-fluux-hover')
+    })
+
+    it('gives an unread DM a red (bg-fluux-brand) pill', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // Bob: unreadCount 2 -> attention tier -> red
+      const row = screen.getByText('Bob Jones').closest('button')!
+      const badge = within(row).getByText('2')
+      expect(badge.className).toContain('bg-fluux-brand')
+    })
+  })
+
   describe('Unread badge', () => {
     it('shows a count badge for unread DMs in the default view', () => {
       render(<CommandPalette {...defaultProps} />)

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -14,11 +14,12 @@ const mockConversations: Array<{ id: string; name: string; unreadCount: number; 
   { id: 'bob@example.com', name: 'Bob Jones', unreadCount: 2, type: 'chat', lastMessage: { body: 'The exponential backoff is working now', timestamp: new Date('2026-07-07T10:00:00Z') } },
 ]
 
-const mockRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; lastMessage?: { body: string; timestamp?: Date } }> = [
+const defaultRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; notifyAll?: boolean; notifyAllPersistent?: boolean; muted?: boolean; lastMessage?: { body: string; timestamp?: Date } }> = [
   { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully', timestamp: new Date('2026-07-07T08:00:00Z') } },
   { jid: 'general@conference.example.com', name: 'General Chat', joined: true, unreadCount: 3, mentionsCount: 0 },
   { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1, lastMessage: { body: 'Release is out', timestamp: new Date('2026-07-07T11:00:00Z') } },
 ]
+let mockRooms = defaultRooms
 
 const mockBookmarkedRooms = [
   { jid: 'archived@conference.example.com', name: 'Archived Room', joined: false },
@@ -65,6 +66,13 @@ vi.mock('@fluux/sdk', () => ({
   searchStore: { getState: () => ({ search: mockSearchFn }) },
   // Entity rows now render <Avatar>, which derives its fallback color from this.
   generateConsistentColorHexSync: () => '#888888',
+  roomActivityTone: (room: { joined?: boolean; muted?: boolean; unreadCount?: number; mentionsCount?: number; notifyAll?: boolean; notifyAllPersistent?: boolean }) => {
+    if (!room.joined || room.muted) return 'none'
+    const notifyAll = room.notifyAll || room.notifyAllPersistent
+    if ((room.mentionsCount ?? 0) > 0 || (notifyAll && (room.unreadCount ?? 0) > 0)) return 'accent'
+    if ((room.unreadCount ?? 0) > 0) return 'neutral'
+    return 'none'
+  },
 }))
 
 // Mock React store hooks (from @fluux/sdk/react)
@@ -148,6 +156,7 @@ describe('CommandPalette', () => {
     vi.clearAllMocks()
     mockIsArchived.mockReturnValue(false)
     mockArchivedConversations = []
+    mockRooms = defaultRooms
     mockActiveConversationId = null
     mockActiveRoomJid = null
     useAdvancedModeStore.setState({ advancedMode: false })

--- a/apps/fluux/src/components/CommandPalette.test.tsx
+++ b/apps/fluux/src/components/CommandPalette.test.tsx
@@ -66,6 +66,7 @@ vi.mock('@fluux/sdk', () => ({
   searchStore: { getState: () => ({ search: mockSearchFn }) },
   // Entity rows now render <Avatar>, which derives its fallback color from this.
   generateConsistentColorHexSync: () => '#888888',
+  // Faithful copy of the SDK selector — keep in sync with roomSelectors.ts roomActivityTone().
   roomActivityTone: (room: { joined?: boolean; muted?: boolean; unreadCount?: number; mentionsCount?: number; notifyAll?: boolean; notifyAllPersistent?: boolean }) => {
     if (!room.joined || room.muted) return 'none'
     const notifyAll = room.notifyAll || room.notifyAllPersistent

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -11,11 +11,11 @@ import {
   Users,
   Search,
 } from 'lucide-react'
-import { useChat, useRoom, useRoster, matchNameOrJid, getLocalPart, searchStore } from '@fluux/sdk'
+import { useChat, useRoom, useRoster, matchNameOrJid, getLocalPart, searchStore, roomActivityTone } from '@fluux/sdk'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { useChatStore, useConnectionStore, useRoomStore } from '@fluux/sdk/react'
-import type { PresenceStatus } from '@fluux/sdk'
+import type { PresenceStatus, RoomActivityTone } from '@fluux/sdk'
 import type { SidebarView } from './Sidebar'
 import { Avatar } from './Avatar'
 import { RoomAvatar } from './RoomAvatar'
@@ -47,6 +47,8 @@ interface CommandItem {
   unreadCount?: number
   /** Mention count for room rows (ranks a mentioned room above merely-unread ones). */
   mentionsCount?: number
+  /** Activity tone for room rows, from roomActivityTone(): 'accent' = attention tier. */
+  activityTone?: RoomActivityTone
   /** Last-message time (ms) for recency ordering in the attention group. */
   sortTimestamp?: number
   action: () => void
@@ -158,9 +160,17 @@ function groupItemsByType(items: CommandItem[], t: (key: string) => string): Ite
 
 // Unread ranking tier for a room row: mentions outrank plain unread, which outrank read.
 function roomTier(item: CommandItem): number {
-  if ((item.mentionsCount ?? 0) > 0) return 0
+  if (item.activityTone === 'accent') return 0
   if ((item.unreadCount ?? 0) > 0) return 1
   return 2
+}
+
+// Attention tier: unread DMs, plus rooms whose activity tone is 'accent'
+// (a mention, or a notify-all room with unread). Drives both the "Needs
+// attention" group membership and the red pill.
+function isAttentionItem(item: CommandItem): boolean {
+  if (item.type === 'room') return item.activityTone === 'accent'
+  return (item.unreadCount ?? 0) > 0
 }
 
 // =============================================================================
@@ -180,9 +190,9 @@ function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): I
   const roomItems = items.filter((i) => i.type === 'room')
 
   // Top group: unread DMs + rooms with a mention/whisper, interleaved by recency, capped.
-  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0)
-  const mentionRooms = roomItems.filter((i) => (i.mentionsCount ?? 0) > 0)
-  const attention = [...unreadConvs, ...mentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
+  const attentionConvs = conversations.filter(isAttentionItem)
+  const attentionRooms = roomItems.filter(isAttentionItem)
+  const attention = [...attentionConvs, ...attentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
   if (attention.length > 0) {
     groups.push({ key: 'attention', type: 'conversation', label: t('commandPalette.attention'), items: attention })
   }
@@ -386,6 +396,7 @@ function CommandPaletteContent({
         lastMessageBody: room.lastMessage?.body,
         unreadCount: room.unreadCount,
         mentionsCount: room.mentionsCount,
+        activityTone: roomActivityTone(room),
         sortTimestamp: room.lastMessage?.timestamp?.getTime(),
         avatarIdentifier: room.jid,
         avatarUrl: room.avatar,
@@ -702,7 +713,7 @@ function CommandPaletteContent({
                       {isDefaultView && (item.unreadCount ?? 0) > 0 && (
                         <span
                           className={`ms-2 flex-shrink-0 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-semibold ${
-                            (item.mentionsCount ?? 0) > 0
+                            isAttentionItem(item)
                               ? 'bg-fluux-brand text-white'
                               : 'bg-fluux-hover text-fluux-text'
                           }`}

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -158,7 +158,7 @@ function groupItemsByType(items: CommandItem[], t: (key: string) => string): Ite
   return groups
 }
 
-// Unread ranking tier for a room row: mentions outrank plain unread, which outrank read.
+// Unread ranking tier for a room row: the attention tier (a mention, or a notify-all room with unread) outranks plain unread, which outranks read.
 function roomTier(item: CommandItem): number {
   if (item.activityTone === 'accent') return 0
   if ((item.unreadCount ?? 0) > 0) return 1
@@ -189,7 +189,7 @@ function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): I
   const conversations = items.filter((i) => i.type === 'conversation')
   const roomItems = items.filter((i) => i.type === 'room')
 
-  // Top group: unread DMs + rooms with a mention/whisper, interleaved by recency, capped.
+  // Top group: unread DMs + attention-tier rooms (a mention/whisper, or notify-all with unread), interleaved by recency, capped.
   const attentionConvs = conversations.filter(isAttentionItem)
   const attentionRooms = roomItems.filter(isAttentionItem)
   const attention = [...attentionConvs, ...attentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
@@ -204,7 +204,7 @@ function buildDefaultGroups(items: CommandItem[], t: (key: string) => string): I
     groups.push({ key: 'conversation', type: 'conversation', label: t('sidebar.messages'), items: readConvs })
   }
 
-  // Rooms group: everything not already promoted, tier-sorted (mention overflow lands at tier 0).
+  // Rooms group: everything not already promoted, tier-sorted (attention-tier overflow lands at tier 0).
   const rooms = roomItems
     .filter((i) => !promotedIds.has(i.id))
     .sort((a, b) => roomTier(a) - roomTier(b))

--- a/docs/superpowers/plans/2026-07-13-command-palette-attention-red-pill.md
+++ b/docs/superpowers/plans/2026-07-13-command-palette-attention-red-pill.md
@@ -1,0 +1,270 @@
+# Command Palette Attention Red Pill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the command palette's default view, put notify-all rooms with unread into the "Needs attention" group and color the attention-tier pill red, reusing the SDK's `roomActivityTone`.
+
+**Architecture:** A single predicate, `isAttentionItem`, decides both group membership and pill color. Room `CommandItem`s carry an `activityTone` computed via `roomActivityTone(room)` (existing `@fluux/sdk` export). DMs qualify on plain unread. All changes are in `apps/fluux/src/components/CommandPalette.tsx`; no SDK or i18n changes.
+
+**Tech Stack:** React + TypeScript, Vitest + @testing-library/react (app workspace, happy-dom).
+
+## Global Constraints
+
+- Change lives entirely in the app layer; **no** SDK, type, or i18n changes.
+- Reuse `roomActivityTone` from `@fluux/sdk` — do not re-derive the tone rule in component logic.
+- Two-tier pill model must match the sidebar: **red = attention** (`bg-fluux-brand`), **grey = ambient unread** (`bg-fluux-hover`).
+- Pills remain default-view only (unchanged guard `isDefaultView && (unreadCount ?? 0) > 0`).
+- Tests run per-workspace: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`. Must pass with no stderr.
+- The test file fully mocks `@fluux/sdk` (no `importOriginal`); any new SDK symbol the component imports must be added to that mock.
+
+---
+
+### Task 1: Test harness — expose `roomActivityTone` in the SDK mock and make room fixtures overridable
+
+The component will import `roomActivityTone` from `@fluux/sdk`. The test's manual mock must provide it, and the new behavior tests need to inject a notify-all room without disturbing the shared ordering fixtures used by existing tests.
+
+**Files:**
+- Modify: `apps/fluux/src/components/CommandPalette.test.tsx`
+
+**Interfaces:**
+- Produces: an SDK mock exposing `roomActivityTone(room)` with the same rule as `packages/fluux-sdk/src/stores/roomSelectors.ts`; a reassignable `mockRooms` binding reset per test.
+
+- [ ] **Step 1: Make `mockRooms` reassignable and reset per test**
+
+Change the `mockRooms` declaration (currently `const mockRooms = [...]` at ~line 17) so the array can be swapped by individual tests, mirroring the existing `mockArchivedConversations` pattern. Rename the literal to a default and add a mutable binding:
+
+```typescript
+const defaultRooms: Array<{ jid: string; name: string; joined: boolean; unreadCount?: number; mentionsCount?: number; notifyAll?: boolean; notifyAllPersistent?: boolean; muted?: boolean; lastMessage?: { body: string; timestamp?: Date } }> = [
+  { jid: 'dev@conference.example.com', name: 'Development', joined: true, unreadCount: 0, mentionsCount: 0, lastMessage: { body: 'PR merged successfully', timestamp: new Date('2026-07-07T08:00:00Z') } },
+  { jid: 'general@conference.example.com', name: 'General Chat', joined: true, unreadCount: 3, mentionsCount: 0 },
+  { jid: 'announce@conference.example.com', name: 'Announcements', joined: true, unreadCount: 1, mentionsCount: 1, lastMessage: { body: 'Release is out', timestamp: new Date('2026-07-07T11:00:00Z') } },
+]
+let mockRooms = defaultRooms
+```
+
+- [ ] **Step 2: Reset `mockRooms` in the outer `beforeEach`**
+
+In the `beforeEach` (currently ~line 147), add the reset alongside the other resets:
+
+```typescript
+    mockRooms = defaultRooms
+```
+
+- [ ] **Step 3: Add `roomActivityTone` to the `@fluux/sdk` mock**
+
+In the `vi.mock('@fluux/sdk', () => ({ ... }))` factory (~line 42), add a faithful copy of the selector (the manual mock does not spread the real module, so the logic is inlined here to match `roomSelectors.ts`):
+
+```typescript
+  roomActivityTone: (room: { joined?: boolean; muted?: boolean; unreadCount?: number; mentionsCount?: number; notifyAll?: boolean; notifyAllPersistent?: boolean }) => {
+    if (!room.joined || room.muted) return 'none'
+    const notifyAll = room.notifyAll || room.notifyAllPersistent
+    if ((room.mentionsCount ?? 0) > 0 || (notifyAll && (room.unreadCount ?? 0) > 0)) return 'accent'
+    if ((room.unreadCount ?? 0) > 0) return 'neutral'
+    return 'none'
+  },
+```
+
+- [ ] **Step 4: Run the existing suite to confirm the harness change is inert**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+Expected: PASS — all existing tests still green (fixtures unchanged in value; `roomActivityTone` unused by the component yet, so its presence in the mock is harmless).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/components/CommandPalette.test.tsx
+git commit -m "test(command-palette): expose roomActivityTone mock + overridable room fixtures"
+```
+
+---
+
+### Task 2: Promote notify-all-unread rooms into "Needs attention" and color the attention pill red
+
+Add `activityTone` to room `CommandItem`s, use `isAttentionItem` for group membership, tier-sort, and pill color.
+
+**Files:**
+- Modify: `apps/fluux/src/components/CommandPalette.tsx`
+- Test: `apps/fluux/src/components/CommandPalette.test.tsx`
+
+**Interfaces:**
+- Consumes: `roomActivityTone` and type `RoomActivityTone` from `@fluux/sdk`.
+- Produces: `CommandItem.activityTone?: RoomActivityTone`; helper `isAttentionItem(item: CommandItem): boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block near the existing "Needs attention group" / "Unread badge" blocks in `CommandPalette.test.tsx`. It reassigns `mockRooms` to include a notify-all room, and asserts membership + pill colors. The badge span is located by its count text within the row (same approach as the existing "Unread badge" test), and the color is read from that span's `className`.
+
+```typescript
+  describe('Notify-all rooms in attention (red pill)', () => {
+    function getGroupContainer(labelText: string): HTMLElement {
+      const label = screen.getByText(labelText)
+      return label.parentElement as HTMLElement
+    }
+
+    it('promotes a notify-all room with unread (no mention) into the attention group', () => {
+      mockRooms = [
+        ...defaultRooms,
+        { jid: 'ops@conference.example.com', name: 'Ops Alerts', joined: true, unreadCount: 4, mentionsCount: 0, notifyAllPersistent: true, lastMessage: { body: 'disk 90%', timestamp: new Date('2026-07-07T07:00:00Z') } },
+      ]
+      render(<CommandPalette {...defaultProps} />)
+      const attention = getGroupContainer('Needs attention')
+      expect(within(attention).getByText('Ops Alerts')).toBeInTheDocument()
+    })
+
+    it('gives a notify-all unread room a red (bg-fluux-brand) pill', () => {
+      mockRooms = [
+        ...defaultRooms,
+        { jid: 'ops@conference.example.com', name: 'Ops Alerts', joined: true, unreadCount: 4, mentionsCount: 0, notifyAllPersistent: true },
+      ]
+      render(<CommandPalette {...defaultProps} />)
+      const row = screen.getByText('Ops Alerts').closest('button')!
+      const badge = within(row).getByText('4')
+      expect(badge.className).toContain('bg-fluux-brand')
+    })
+
+    it('gives an ordinary unread room (not notify-all, no mention) a grey (bg-fluux-hover) pill', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // General Chat: unread 3, mentionsCount 0, no notify-all -> neutral tone
+      const row = screen.getByText('General Chat').closest('button')!
+      const badge = within(row).getByText('3')
+      expect(badge.className).toContain('bg-fluux-hover')
+    })
+
+    it('gives an unread DM a red (bg-fluux-brand) pill', () => {
+      render(<CommandPalette {...defaultProps} />)
+      // Bob: unreadCount 2 -> attention tier -> red
+      const row = screen.getByText('Bob Jones').closest('button')!
+      const badge = within(row).getByText('2')
+      expect(badge.className).toContain('bg-fluux-brand')
+    })
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Notify-all rooms in attention"`
+Expected: FAIL — "Ops Alerts" is not in the attention group (current filter keys off `mentionsCount` only); Bob's pill is `bg-fluux-hover` not `bg-fluux-brand` (current color keys off `mentionsCount`).
+
+- [ ] **Step 3: Import the selector and its type**
+
+In `apps/fluux/src/components/CommandPalette.tsx`, extend the existing `@fluux/sdk` import (line 14) to add `roomActivityTone`, and the type-only import (line 18) to add `RoomActivityTone`:
+
+```typescript
+import { useChat, useRoom, useRoster, matchNameOrJid, getLocalPart, searchStore, roomActivityTone } from '@fluux/sdk'
+```
+```typescript
+import type { PresenceStatus, RoomActivityTone } from '@fluux/sdk'
+```
+
+- [ ] **Step 4: Add `activityTone` to the `CommandItem` interface**
+
+In the `CommandItem` interface (~line 33), add the optional field after `mentionsCount`:
+
+```typescript
+  /** Activity tone for room rows, from roomActivityTone(): 'accent' = attention tier. */
+  activityTone?: RoomActivityTone
+```
+
+- [ ] **Step 5: Add the `isAttentionItem` predicate**
+
+Add this helper next to `roomTier` (~line 159), above `buildDefaultGroups`:
+
+```typescript
+// Attention tier: unread DMs, plus rooms whose activity tone is 'accent'
+// (a mention, or a notify-all room with unread). Drives both the "Needs
+// attention" group membership and the red pill.
+function isAttentionItem(item: CommandItem): boolean {
+  if (item.type === 'room') return item.activityTone === 'accent'
+  return (item.unreadCount ?? 0) > 0
+}
+```
+
+- [ ] **Step 6: Populate `activityTone` on room items**
+
+In the joined-rooms builder loop (~line 380, the `items.push({ ... })` for `type: 'room'`), add the computed tone after `mentionsCount`:
+
+```typescript
+        activityTone: roomActivityTone(room),
+```
+
+- [ ] **Step 7: Use `isAttentionItem` for the attention group membership**
+
+In `buildDefaultGroups` (~line 183), replace the two-filter attention computation:
+
+```typescript
+  const unreadConvs = conversations.filter((i) => (i.unreadCount ?? 0) > 0)
+  const mentionRooms = roomItems.filter((i) => (i.mentionsCount ?? 0) > 0)
+  const attention = [...unreadConvs, ...mentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
+```
+
+with the predicate-driven version (interleave attention DMs + attention rooms by recency):
+
+```typescript
+  const attentionConvs = conversations.filter(isAttentionItem)
+  const attentionRooms = roomItems.filter(isAttentionItem)
+  const attention = [...attentionConvs, ...attentionRooms].sort(byRecency).slice(0, ATTENTION_CAP)
+```
+
+- [ ] **Step 8: Rank accent rooms at tier 0 in `roomTier`**
+
+Update `roomTier` (~line 160) so leftover-Rooms-group ordering agrees with the new membership rule (accent = top tier, then plain unread, then read):
+
+```typescript
+function roomTier(item: CommandItem): number {
+  if (item.activityTone === 'accent') return 0
+  if ((item.unreadCount ?? 0) > 0) return 1
+  return 2
+}
+```
+
+- [ ] **Step 9: Color the pill by `isAttentionItem`**
+
+In the render (~line 705), change the pill color condition from `(item.mentionsCount ?? 0) > 0` to `isAttentionItem(item)`:
+
+```tsx
+                          className={`ms-2 flex-shrink-0 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-semibold ${
+                            isAttentionItem(item)
+                              ? 'bg-fluux-brand text-white'
+                              : 'bg-fluux-hover text-fluux-text'
+                          }`}
+```
+
+- [ ] **Step 10: Run the new tests to verify they pass**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx -t "Notify-all rooms in attention"`
+Expected: PASS (all four cases).
+
+- [ ] **Step 11: Run the full CommandPalette suite for regressions**
+
+Run: `cd apps/fluux && npx vitest run src/components/CommandPalette.test.tsx`
+Expected: PASS. Note: the existing "does not promote an unread room without a mention" (General Chat) still passes — General Chat has no notify-all, so tone is `neutral`. The "orders rooms mentions-first" test still passes — Announcements is `accent` (tier 0), General Chat `neutral` (tier 1), Development read (tier 2).
+
+- [ ] **Step 12: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS, no errors.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add apps/fluux/src/components/CommandPalette.tsx apps/fluux/src/components/CommandPalette.test.tsx
+git commit -m "feat(command-palette): notify-all rooms in Needs attention + red attention pill"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "notify-all rooms with unread → Needs attention" → Task 2 Steps 5–7 (`isAttentionItem` + membership). ✓
+- "red pill for attention tier (incl. unread DMs)" → Task 2 Step 9. ✓
+- "grey pill for ambient unread rooms" → covered by the `else` branch; asserted in Task 2 Step 1 (General Chat). ✓
+- "reuse `roomActivityTone`" → Task 2 Steps 3, 6. ✓
+- "`roomTier` consistent with membership" → Task 2 Step 8. ✓
+- "default-view only, no i18n/SDK changes" → no i18n/SDK files touched; pill guard unchanged. ✓
+- Testing (notify-all room in attention + red, ordinary unread grey, unread DM red, mention room unchanged) → Task 2 Step 1 plus existing mention-room tests retained. ✓
+- "ensure the mock exposes `roomActivityTone`" → Task 1 Step 3. ✓
+
+**Placeholder scan:** No TBD/TODO; all code shown. ✓
+
+**Type consistency:** `activityTone?: RoomActivityTone` defined (Task 2 Step 4) and set with `roomActivityTone(room)` (Step 6); `isAttentionItem(item: CommandItem): boolean` defined once (Step 5) and used in Steps 7 and 9; `roomTier` reads `activityTone` set in Step 6. Consistent. ✓

--- a/docs/superpowers/specs/2026-07-13-command-palette-attention-red-pill-design.md
+++ b/docs/superpowers/specs/2026-07-13-command-palette-attention-red-pill-design.md
@@ -1,0 +1,89 @@
+# Command Palette: notify-all rooms in "Needs attention" + red pill
+
+**Date:** 2026-07-13
+**Area:** `apps/fluux/src/components/CommandPalette.tsx`
+**Type:** App-layer behavior change, no SDK or i18n changes.
+
+## Problem
+
+The command palette's default (empty-query) view has a **"Needs attention"** group. Today it promotes:
+
+- unread DMs (`unreadCount > 0`), and
+- rooms with a **mention** (`mentionsCount > 0`).
+
+A room the user has set to **notify for all messages** (`notifyAll` / `notifyAllPersistent`) that has unread messages but *no* mention is **not** promoted into the group, and its unread pill renders grey. This is inconsistent with the sidebar and icon-rail, which already treat that room as the red "attention" tier via `roomActivityTone` (`packages/fluux-sdk/src/stores/roomSelectors.ts`).
+
+The palette should reuse the same source of truth so it matches the rest of the app: **red = needs your attention, grey = ambient unread.**
+
+## Source of truth
+
+`roomActivityTone(room)` (exported from `@fluux/sdk`, already used in `RoomsList.tsx`) returns:
+
+- `'accent'` → a mention, **or** a notify-all room with unread (unless muted / not joined)
+- `'neutral'` → other unread
+- `'none'` → nothing to signal
+
+## Design
+
+A single predicate drives both group membership and pill color:
+
+```
+isAttentionItem(item):
+  conversation → (unreadCount ?? 0) > 0        // any unread DM
+  room         → activityTone === 'accent'     // mention OR notify-all-unread
+```
+
+### Changes (all in `CommandPalette.tsx`)
+
+1. **`CommandItem` interface** — add an optional field:
+   `activityTone?: RoomActivityTone` (imported type from `@fluux/sdk`). Populated for room rows only.
+
+2. **Room item builder** (the `joinedRooms` loop, ~line 377) — compute
+   `activityTone: roomActivityTone(room)` when building each room `CommandItem`.
+   The `Room` objects from `useRoom().joinedRooms` already carry `joined`,
+   `muted`, `unreadCount`, `mentionsCount`, `notifyAll`, `notifyAllPersistent`.
+   (Bookmarked-not-joined rooms have no unread and need no tone.)
+
+3. **Attention group membership** (`buildDefaultGroups`, ~line 184) — replace the
+   two separate filters with `isAttentionItem`:
+   - unread DMs: unchanged (`unreadCount > 0`)
+   - rooms: `activityTone === 'accent'` (was `mentionsCount > 0`) — keeps mention
+     rooms and now also includes notify-all-unread rooms.
+
+4. **`roomTier`** (~line 160) — rank `activityTone === 'accent'` rooms at tier 0 so
+   any overflow in the leftover Rooms group stays consistent with the new
+   membership rule. Plain unread (`neutral`) stays tier 1, read stays tier 2.
+
+5. **Pill color** (render, ~line 705) — color the pill red (`bg-fluux-brand`) when
+   `isAttentionItem(item)`, grey (`bg-fluux-hover`) otherwise. The pill still shows
+   the numeric `unreadCount` and still only renders in the default view.
+
+### Resulting pill colors (default view)
+
+| Item                                            | Pill  |
+|-------------------------------------------------|-------|
+| Unread DM                                       | red   |
+| Room with a mention                             | red   |
+| Notify-all room with unread                     | red   |
+| Ordinary room, plain unread (no notify-all/mention) | grey  |
+| No unread                                        | none  |
+
+## Non-goals
+
+- No change to search/filter-mode rendering (pills remain default-view only).
+- No change to notification/badge counting logic in the SDK.
+- No new i18n keys (the "Needs attention" label already exists).
+
+## Testing
+
+- Unit tests in `CommandPalette.test.tsx`:
+  - A notify-all room with unread (no mention) appears in "Needs attention" and
+    renders a red pill.
+  - An ordinary unread room (not notify-all, no mention) stays out of the
+    attention group and renders a grey pill.
+  - An unread DM renders a red pill.
+  - A mention room is unchanged (still red, still in attention).
+- Ensure the app's `@fluux/sdk` test mock exposes `roomActivityTone` (it is already
+  a real export used by `RoomsList`; confirm the `CommandPalette.test.tsx` mock
+  path resolves it, mirroring `importOriginal` spread if needed).
+- `npm run typecheck` and the app test workspace must pass clean (no stderr).


### PR DESCRIPTION
The command palette's default-view **Needs attention** group now also promotes rooms set to *notify for all messages* (`notifyAll`/`notifyAllPersistent`) that have unread — previously only unread DMs and rooms with a mention were promoted.

A single predicate `isAttentionItem` drives both group membership and the unread pill color, reusing the SDK's `roomActivityTone` (already used by the sidebar) so the palette matches the rest of the app:

- **Red pill** (`bg-fluux-brand`) for the attention tier: unread DMs, mention rooms, and notify-all rooms with unread.
- **Grey pill** (`bg-fluux-hover`) for ambient unread (ordinary rooms with plain unread).

App-layer only — no SDK or i18n changes. `roomTier` updated so accent rooms sort first in the overflow Rooms group.

Includes the design spec and implementation plan under `docs/superpowers/`.