### PR TITLE
fix(mds): correct unread position after catching up on another device

### DIFF
--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -110,6 +110,29 @@ Each scene is tagged `variant: 'reel'` (appears in both videos) or `variant: 'fu
 - `populateDemo(data: DemoData)` seeds all Zustand stores synchronously via `emitSDK()` calls
 - `startAnimation(steps: DemoAnimationStep[])` schedules timed events (typing, messages, reactions) on `setTimeout`s
 - Sets MAM query state to "history complete" so no loading spinners appear
+- Serves the XEP-0490 MDS PEP node from an in-memory registry, so `client.mds.publishDisplayed/fetchAllDisplayed/retractDisplayed` round-trip in demo mode
+
+### Simulating cross-device read sync (XEP-0490 MDS)
+
+Seeded and stress-generated messages carry a deterministic XEP-0359 stanza-id
+(`sid-<messageId>`), and `DemoClient.simulateRemoteDisplayed(jid, stanzaId)`
+plays the "another of my devices read up to this message" notify: it upserts
+the marker on the simulated PEP node and emits `read:displayed-synced`.
+
+Example — reproduce the unread divider position after catching up elsewhere:
+
+```js
+// 1. Seed a deep room backlog (1000 messages, stanza-ids sid-stress-0-0 … sid-stress-0-999)
+__demoClient.runStressScenario({ kind: 'room-join', rooms: 1, occupants: 5, messagesPerRoom: 1000, mode: 'backfill', msgStepMs: 0 })
+
+// 2. Watch marker decisions in the console
+localStorage.setItem('fluux:scroll-debug', '1')
+
+// 3. With the room closed, simulate the other device having read to message 850
+__demoClient.simulateRemoteDisplayed('stress-0@conference.fluux.chat', 'sid-stress-0-850')
+
+// 4. Open the room — the "new messages" divider should sit just after message 850
+```
 
 The SDK also exports the `DemoData`, `DemoAnimationStep`, and related type interfaces, plus time-offset helpers (`minutesAgo`, `hoursAgo`, `daysAgo`) so any app can build its own demo data.
 

--- a/packages/fluux-sdk/src/demo/DemoClient.mds.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.mds.test.ts
@@ -78,13 +78,14 @@ describe('DemoClient.simulateRemoteDisplayed', () => {
 describe('DemoClient.populateDemo stanza-id defaulting', () => {
   function makeDemoData(): DemoData {
     const chatMessage: Message = {
+      type: 'chat',
       id: 'demo-msg-1',
+      conversationId: 'ava@fluux.chat',
       from: 'ava@fluux.chat',
-      to: 'you@fluux.chat',
       body: 'hi',
       timestamp: new Date(),
       isOutgoing: false,
-    } as Message
+    }
     const roomMessages: RoomMessage[] = [
       {
         type: 'groupchat', id: 'demo-room-1', from: `${ROOM_JID}/Emma`, nick: 'Emma',

--- a/packages/fluux-sdk/src/demo/DemoClient.mds.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.mds.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Demo-mode XEP-0490 (MDS) simulation:
+ * - DemoClient answers the MDS PEP-node IQs (publish / items / retract) from an
+ *   in-memory node, so `client.mds.*` round-trips work without a server.
+ * - simulateRemoteDisplayed() plays the "another device read up to X" +notify:
+ *   it seeds the node AND emits `read:displayed-synced` like PubSub would.
+ * - populateDemo defaults a stanza-id onto seeded messages (marker resolution
+ *   matches on `m.stanzaId`, so markers against id-less demo messages could
+ *   never resolve).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { DemoClient } from './DemoClient'
+import type { DemoData } from './types'
+import type { Room, RoomMessage } from '../core/types/room'
+import type { Message } from '../core/types/chat'
+
+function makeClient(): DemoClient {
+  const client = new DemoClient()
+  ;(client as unknown as { currentJid: string | null }).currentJid = 'you@fluux.chat'
+  ;(client as unknown as { selfJid: string }).selfJid = 'you@fluux.chat'
+  return client
+}
+
+const ROOM_JID = 'team@conference.fluux.chat'
+
+describe('DemoClient MDS PEP node simulation', () => {
+  it('publishDisplayed then fetchAllDisplayed round-trips the marker', async () => {
+    const client = makeClient()
+    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
+
+    const markers = await client.mds.fetchAllDisplayed()
+    expect(markers).toEqual([{ conversationJid: 'ava@fluux.chat', stanzaId: 'sid-42' }])
+  })
+
+  it('a re-publish for the same conversation overwrites the item (current-value node)', async () => {
+    const client = makeClient()
+    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
+    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-99', 'you@fluux.chat')
+
+    const markers = await client.mds.fetchAllDisplayed()
+    expect(markers).toEqual([{ conversationJid: 'ava@fluux.chat', stanzaId: 'sid-99' }])
+  })
+
+  it('retractDisplayed removes the item', async () => {
+    const client = makeClient()
+    await client.mds.publishDisplayed('ava@fluux.chat', 'sid-42', 'you@fluux.chat')
+    await client.mds.retractDisplayed('ava@fluux.chat')
+
+    expect(await client.mds.fetchAllDisplayed()).toEqual([])
+  })
+
+  it('fetchAllDisplayed returns [] when nothing was published', async () => {
+    const client = makeClient()
+    expect(await client.mds.fetchAllDisplayed()).toEqual([])
+  })
+})
+
+describe('DemoClient.simulateRemoteDisplayed', () => {
+  it('emits read:displayed-synced with the conversation and stanza-id', () => {
+    const client = makeClient()
+    const received: Array<{ conversationId: string; stanzaId: string }> = []
+    client.subscribe('read:displayed-synced', (payload) => received.push(payload))
+
+    client.simulateRemoteDisplayed('ava@fluux.chat', 'sid-7')
+
+    expect(received).toEqual([{ conversationId: 'ava@fluux.chat', stanzaId: 'sid-7' }])
+  })
+
+  it('seeds the node so a later fetchAllDisplayed (fresh-session seed) sees it', async () => {
+    const client = makeClient()
+    client.simulateRemoteDisplayed('ava@fluux.chat', 'sid-7')
+
+    const markers = await client.mds.fetchAllDisplayed()
+    expect(markers).toEqual([{ conversationJid: 'ava@fluux.chat', stanzaId: 'sid-7' }])
+  })
+})
+
+describe('DemoClient.populateDemo stanza-id defaulting', () => {
+  function makeDemoData(): DemoData {
+    const chatMessage: Message = {
+      id: 'demo-msg-1',
+      from: 'ava@fluux.chat',
+      to: 'you@fluux.chat',
+      body: 'hi',
+      timestamp: new Date(),
+      isOutgoing: false,
+    } as Message
+    const roomMessages: RoomMessage[] = [
+      {
+        type: 'groupchat', id: 'demo-room-1', from: `${ROOM_JID}/Emma`, nick: 'Emma',
+        body: 'hello', timestamp: new Date(), isOutgoing: false, roomJid: ROOM_JID,
+      },
+      {
+        type: 'groupchat', id: 'demo-room-2', from: `${ROOM_JID}/Emma`, nick: 'Emma',
+        body: 'explicit', timestamp: new Date(), isOutgoing: false, roomJid: ROOM_JID,
+        stanzaId: 'custom-sid',
+      },
+    ]
+    return {
+      self: { jid: 'you@fluux.chat', nick: 'You', domain: 'fluux.chat' },
+      contacts: [],
+      presences: [],
+      conversations: [],
+      messages: new Map([['ava@fluux.chat', [chatMessage]]]),
+      rooms: [
+        {
+          room: { jid: ROOM_JID, name: 'Team', joined: true, messages: [] } as unknown as Room,
+          occupants: [],
+          messages: roomMessages,
+        },
+      ],
+    }
+  }
+
+  it('defaults stanzaId to sid-<id> on seeded messages and preserves explicit ones', () => {
+    const client = makeClient()
+    const emitted: Array<{ event: string; payload: unknown }> = []
+    vi.spyOn(client as unknown as { emitSDK: (e: string, p: unknown) => void }, 'emitSDK')
+      .mockImplementation((event, payload) => emitted.push({ event, payload }))
+
+    client.populateDemo(makeDemoData())
+
+    const chatMsgs = emitted
+      .filter((e) => e.event === 'chat:message')
+      .map((e) => (e.payload as { message: Message }).message)
+    expect(chatMsgs).toHaveLength(1)
+    expect(chatMsgs[0].stanzaId).toBe('sid-demo-msg-1')
+
+    const roomMsgs = emitted
+      .filter((e) => e.event === 'room:message')
+      .map((e) => (e.payload as { message: RoomMessage }).message)
+    expect(roomMsgs).toHaveLength(2)
+    expect(roomMsgs.find((m) => m.id === 'demo-room-1')?.stanzaId).toBe('sid-demo-room-1')
+    expect(roomMsgs.find((m) => m.id === 'demo-room-2')?.stanzaId).toBe('custom-sid')
+  })
+})

--- a/packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
@@ -1,6 +1,24 @@
 // packages/fluux-sdk/src/demo/DemoClient.stress.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { DemoClient } from './DemoClient'
+import { buildStressEvents } from './stress'
+import type { RoomMessage } from '../core/types/room'
+
+describe('buildStressEvents', () => {
+  it('gives every generated room message a unique stanzaId (MDS markers match on it)', () => {
+    const events = buildStressEvents(
+      { kind: 'room-join', rooms: 2, occupants: 2, messagesPerRoom: 5, msgStepMs: 0, roomStepMs: 0 },
+      { selfJid: 'you@fluux.chat', selfNick: 'you', conferenceService: 'conference.fluux.chat' }
+    )
+    const messages = events
+      .filter((e) => e.type === 'room:message')
+      .map((e) => (e.payload as { message: RoomMessage }).message)
+    expect(messages).toHaveLength(10)
+    const stanzaIds = messages.map((m) => m.stanzaId)
+    expect(stanzaIds.every((sid) => typeof sid === 'string' && sid.length > 0)).toBe(true)
+    expect(new Set(stanzaIds).size).toBe(10)
+  })
+})
 
 describe('DemoClient.runStressScenario', () => {
   beforeEach(() => vi.useFakeTimers())

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -53,6 +53,18 @@ const NS_COMMANDS = 'http://jabber.org/protocol/commands'
 const NS_DATA_FORMS = 'jabber:x:data'
 const NS_VERSION = 'jabber:iq:version'
 const NS_LAST = 'jabber:iq:last'
+const NS_MDS = 'urn:xmpp:mds:displayed:0'
+const NS_STANZA_ID = 'urn:xmpp:sid:0'
+
+/**
+ * Default an XEP-0359 stanza-id onto a seeded demo message. MDS (XEP-0490)
+ * marker resolution matches on `stanzaId`, so id-less demo messages could
+ * never be referenced by a simulated read position. Deterministic (`sid-<id>`)
+ * so demo scripts can point a marker at any seeded message.
+ */
+function withDefaultStanzaId<T extends { id: string; stanzaId?: string }>(message: T): T {
+  return message.stanzaId ? message : { ...message, stanzaId: `sid-${message.id}` }
+}
 
 /** Minimal Element-like object returned by mock IQ responses. */
 interface MockElement {
@@ -100,6 +112,10 @@ export class DemoClient extends XMPPClient {
   private seededRoomOccupants = new Map<string, RoomOccupant[]>()
   private seededContacts = new Map<string, Contact>()
   private seededRooms = new Map<string, Room>()
+  // Simulated XEP-0490 MDS PEP node: conversation bare JID → last-displayed
+  // marker. Backs the pubsub publish/items/retract IQs so client.mds.* and the
+  // fresh-session seed (fetchAllDisplayed) work in demo mode.
+  private mdsNodeItems = new Map<string, { stanzaId: string; by: string }>()
 
   /** Current animation state. */
   get animationState(): AnimationState {
@@ -116,6 +132,25 @@ export class DemoClient extends XMPPClient {
         this.knownRooms.set(room.jid, { name: room.name, occupantCount: room.occupantCount })
       }
     }
+  }
+
+  /**
+   * DEV/DEMO ONLY. Simulate another of our own devices publishing an MDS
+   * (XEP-0490) read position for a conversation or room: upserts the marker
+   * on the simulated PEP node (so a later `fetchAllDisplayed` seed sees it)
+   * and emits the live `read:displayed-synced` notify, exactly like PubSub
+   * does for a real +notify event.
+   *
+   * With seeded/stress messages carrying `sid-<messageId>` stanza-ids, this
+   * reproduces cross-device read-sync flows from the console, e.g.:
+   * `__demoClient.simulateRemoteDisplayed(roomJid, 'sid-stress-0-850')`
+   */
+  simulateRemoteDisplayed(conversationJid: string, stanzaId: string): void {
+    // XEP-0359 `by`: the archive that assigned the id — the room for MUC,
+    // our own bare JID for 1:1 (mirrors mdsSideEffects.stanzaIdBy).
+    const by = this.knownRooms.has(conversationJid) ? conversationJid : this.selfJid
+    this.mdsNodeItems.set(conversationJid, { stanzaId, by })
+    this.emitSDK('read:displayed-synced', { conversationId: conversationJid, stanzaId })
   }
 
   /**
@@ -237,6 +272,11 @@ export class DemoClient extends XMPPClient {
       (c: any) => c.name === 'pubsub' && c.attrs?.xmlns === NS_PUBSUB
     )
     if (pubsubChild) {
+      // XEP-0490 MDS node traffic is served from the in-memory node registry;
+      // other pubsub requests (avatars, nicknames) fall through to the
+      // generic empty-items response.
+      const mdsResponse = this.handleMdsPubSubIQ(pubsubChild)
+      if (mdsResponse) return mdsResponse
       return this.buildPubSubResponse(pubsubChild)
     }
 
@@ -335,7 +375,7 @@ export class DemoClient extends XMPPClient {
 
     for (const [, messages] of data.messages) {
       for (const message of messages) {
-        this.emitSDK('chat:message', { message })
+        this.emitSDK('chat:message', { message: withDefaultStanzaId(message) })
       }
     }
 
@@ -351,7 +391,7 @@ export class DemoClient extends XMPPClient {
       this.emitSDK('room:occupants-batch', { roomJid: room.jid, occupants })
 
       for (const message of messages) {
-        this.emitSDK('room:message', { roomJid: room.jid, message })
+        this.emitSDK('room:message', { roomJid: room.jid, message: withDefaultStanzaId(message) })
       }
 
       // Register seeded rooms in the internal registry
@@ -810,6 +850,57 @@ export class DemoClient extends XMPPClient {
     return this.mockElement('iq', { type: 'result' }, [
       this.mockElement('vCard', { xmlns: NS_VCARD_TEMP }, vcardChildren),
     ])
+  }
+
+  /**
+   * Serve XEP-0490 MDS node requests from the in-memory node registry:
+   * publish upserts an item (current-value semantics, one item per JID),
+   * retract deletes it, items returns the full node contents in the shape
+   * `parseMdsItems` expects. Returns undefined for non-MDS pubsub traffic.
+   *
+   * Works on both real ltx Elements (publish/retract are built with xml()
+   * by the Mds module) and mock elements, by navigating `children` directly.
+   */
+  private handleMdsPubSubIQ(pubsubChild: any): MockElement | undefined {
+    const childNamed = (parent: any, name: string) =>
+      parent?.children?.find?.((c: any) => c?.name === name)
+
+    const publish = childNamed(pubsubChild, 'publish')
+    if (publish?.attrs?.node === NS_MDS) {
+      const item = childNamed(publish, 'item')
+      const stanzaIdEl = childNamed(childNamed(item, 'displayed'), 'stanza-id')
+      const conversationJid = item?.attrs?.id
+      const stanzaId = stanzaIdEl?.attrs?.id
+      if (conversationJid && stanzaId) {
+        this.mdsNodeItems.set(conversationJid, { stanzaId, by: stanzaIdEl?.attrs?.by ?? '' })
+      }
+      return this.buildEmptyStub()
+    }
+
+    const retract = childNamed(pubsubChild, 'retract')
+    if (retract?.attrs?.node === NS_MDS) {
+      const itemId = childNamed(retract, 'item')?.attrs?.id
+      if (itemId) this.mdsNodeItems.delete(itemId)
+      return this.buildEmptyStub()
+    }
+
+    const items = childNamed(pubsubChild, 'items')
+    if (items?.attrs?.node === NS_MDS) {
+      const itemEls = [...this.mdsNodeItems].map(([jid, { stanzaId, by }]) =>
+        this.mockElement('item', { id: jid }, [
+          this.mockElement('displayed', { xmlns: NS_MDS }, [
+            this.mockElement('stanza-id', { xmlns: NS_STANZA_ID, id: stanzaId, ...(by ? { by } : {}) }),
+          ]),
+        ])
+      )
+      return this.mockElement('iq', { type: 'result' }, [
+        this.mockElement('pubsub', { xmlns: NS_PUBSUB }, [
+          this.mockElement('items', { node: NS_MDS }, itemEls),
+        ]),
+      ])
+    }
+
+    return undefined
   }
 
   /**

--- a/packages/fluux-sdk/src/demo/stress.ts
+++ b/packages/fluux-sdk/src/demo/stress.ts
@@ -66,6 +66,9 @@ export function buildStressEvents(scenario: StressScenario, ctx: StressContext):
       const message: RoomMessage = {
         type: 'groupchat', id: `stress-${i}-${m}`, from: `${roomJid}/${nick}`, nick,
         body: `stress message ${m}`, timestamp: new Date(ts), isOutgoing: false, roomJid,
+        // XEP-0359 archive id: MDS (XEP-0490) markers match on stanzaId, so
+        // stress backlogs must carry one to exercise read-sync flows in demo.
+        stanzaId: `sid-stress-${i}-${m}`,
       }
       events.push({ delayMs: base + 20 + m * msgStepMs, type: 'room:message', payload: { roomJid, message } })
       globalMsg++

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -7,10 +7,27 @@
  * 3. Pending high-water mark: stanza-id not in loaded messages → stored in
  *    pendingRemoteDisplayedStanzaId; lastSeenMessageId unchanged.
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { chatStore } from './chatStore'
 import { chatSelectors } from './chatSelectors'
 import type { Message } from '../core/types/chat'
+
+// Mock messageCache: the deep-pointer activation tests need getMessagesAround to
+// return a controlled around-slice; everything else is a harmless stub.
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    isMessageCacheAvailable: vi.fn().mockReturnValue(true),
+    saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessages: vi.fn().mockResolvedValue(undefined),
+    getMessages: vi.fn().mockResolvedValue([]),
+    getMessagesAround: vi.fn().mockResolvedValue([]),
+    updateMessage: vi.fn().mockResolvedValue(undefined),
+    deleteMessages: vi.fn().mockResolvedValue(undefined),
+  }
+})
+import * as messageCache from '../utils/messageCache'
 
 // Mock localStorage (required by chatStore's persist middleware)
 const localStorageMock = (() => {
@@ -494,5 +511,72 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     })
     await chatStore.getState().activateConversation(cid)
     expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
+  })
+
+  // Regression (gate burn on stash): a fold that could not resolve (marker's message not
+  // loaded) must not consume the session gate — otherwise the pending marker is stuck for
+  // the whole session (re-entry skips the fold as "already consumed").
+  it('retries the fold on a later activation when the first fold could not resolve (marker message not yet loaded)', async () => {
+    const cid = 'retry-stash@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    const early = [timed('m1', 's1', 1), timed('m2', 's2', 2)]
+    seedMessages(cid, early)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm1', pendingRemoteDisplayedStanzaId: 's9' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm1', pendingRemoteDisplayedStanzaId: 's9' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+    // Unresolvable → stash survives, pointer untouched.
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m1')
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
+
+    await chatStore.getState().activateConversation(null)
+
+    // The archive healed since (catch-up landed): the marker's message is loadable now.
+    seedMessages(cid, [...early, timed('m9', 's9', 9)])
+
+    await chatStore.getState().activateConversation(cid)
+    // The gate must allow the retry (the marker was never actually folded).
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m9')
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+  })
+
+  // Regression (fold ran only before the load-around): with a deep backlog the pending
+  // marker's message is outside the latest-100 slice, so the first fold stashes. The
+  // load-around of the stale pointer brings it in — the fold must re-attempt against
+  // the around-slice so the divider reflects the synced read position.
+  it('re-attempts the fold against the slice loaded around a deep stale pointer', async () => {
+    const cid = 'deep-pointer@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:${String(n).padStart(2, '0')}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    const latest = [timed('m10', 's10', 10), timed('m11', 's11', 11), timed('m12', 's12', 12)]
+    // Resident window = latest slice; the read pointer (m2) is deeper than it.
+    seedMessages(cid, latest)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's5' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's5' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+    // The IndexedDB slice around the stale pointer contains the marker's message (m5).
+    const aroundSlice = [
+      timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3),
+      timed('m4', 's4', 4), timed('m5', 's5', 5), timed('m6', 's6', 6),
+    ]
+    vi.mocked(messageCache.getMessagesAround).mockResolvedValueOnce(aroundSlice)
+
+    await chatStore.getState().activateConversation(cid)
+
+    // The retried fold advances the pointer to the synced position…
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m5')
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+    // …and the divider derives from it, not from the stale local pointer (m2 → 'm3').
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m6')
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -14,7 +14,7 @@ import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
-import { resolveRemoteDisplayed, createMdsSessionGate } from './shared/readMarkerSync'
+import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
@@ -742,31 +742,35 @@ export const chatStore = createStore<ChatState>()(
           // session MDS seed runs before messages load, so the marker is stashed as
           // pendingRemoteDisplayedStanzaId; resolve it now (forward-only, against the
           // just-loaded messages) so the divider reflects reads synced from other
-          // devices instead of the stale local position.
-          // Fold a pending XEP-0490 synced read position into lastSeenMessageId BEFORE
-          // setActiveConversation derives the divider — but only once per distinct marker this
-          // session. The gate keys on the pending stanza-id so a marker synced from another device
-          // while this conversation was inactive (evicted → the live notify could only stash it)
-          // still folds on the next open, while an identical already-folded marker is skipped
-          // (re-folding would let a synced read position reposition the divider on each return).
-          const pending = get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId
-          const firstConsumeThisSession = pending !== undefined && mdsGate.consume(id, pending)
-          if (pending && firstConsumeThisSession) {
+          // devices instead of the stale local position. Applied only once per
+          // distinct RESOLVED marker this session — a fold that stashed (message
+          // not loaded) stays retryable, a resolved one is never re-folded (that
+          // would reposition the divider on every return). Gate + retry policy
+          // live in shared/readMarkerSync.
+          const foldOnce = (stage: string) => {
             const lastSeenBefore = get().conversationMeta.get(id)?.lastSeenMessageId
-            get().applyRemoteDisplayed(id, pending)
-            markerDebugLog('activation fold (XEP-0490 pending → divider, first open this session)', {
-              conversationId: id,
-              pendingStanzaId: pending,
-              lastSeenBefore,
-              lastSeenAfter: get().conversationMeta.get(id)?.lastSeenMessageId,
-              advanced: lastSeenBefore !== get().conversationMeta.get(id)?.lastSeenMessageId,
-            })
-          } else if (pending) {
-            markerDebugLog('activation fold SKIPPED (already consumed this session — PEP keeps it live)', {
-              conversationId: id,
-              pendingStanzaId: pending,
-            })
+            const fold = foldPendingRemoteDisplayed(
+              mdsGate,
+              id,
+              () => get().conversationMeta.get(id)?.pendingRemoteDisplayedStanzaId,
+              (stanzaId) => get().applyRemoteDisplayed(id, stanzaId)
+            )
+            if (fold.attempted) {
+              markerDebugLog(`activation fold (XEP-0490 pending → divider, ${stage})`, {
+                conversationId: id,
+                pendingStanzaId: fold.pending,
+                lastSeenBefore,
+                lastSeenAfter: get().conversationMeta.get(id)?.lastSeenMessageId,
+                resolved: fold.resolved,
+              })
+            } else if (fold.pending) {
+              markerDebugLog('activation fold SKIPPED (marker already resolved this session — PEP keeps it live)', {
+                conversationId: id,
+                pendingStanzaId: fold.pending,
+              })
+            }
           }
+          foldOnce('latest slice')
 
           // Resume anchor: if the read pointer is deeper than the latest-100
           // slice, reload the window AROUND it (IndexedDB only) so the divider
@@ -781,6 +785,10 @@ export const chatStore = createStore<ChatState>()(
             if (!loaded.some((m) => m.id === pointer)) {
               await get().loadMessagesAroundFromCache(id, pointer)
               if (token !== activationToken) return
+              // The around-slice sits just past the stale pointer — exactly where
+              // a marker too deep for the latest-100 window lives. Retry a fold
+              // that stashed above so the divider derives from the synced position.
+              foldOnce('around slice')
             }
           }
         }

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -36,10 +36,12 @@ vi.mock('../utils/messageCache', async (importOriginal) => {
     saveRoomMessage: vi.fn().mockResolvedValue(undefined),
     saveRoomMessages: vi.fn().mockResolvedValue(undefined),
     getRoomMessages: vi.fn().mockResolvedValue([]),
+    getRoomMessagesAround: vi.fn().mockResolvedValue([]),
     updateRoomMessage: vi.fn().mockResolvedValue(undefined),
     deleteRoomMessages: vi.fn().mockResolvedValue(undefined),
   }
 })
+import * as messageCache from '../utils/messageCache'
 
 const ROOM = 'room@conference.example'
 
@@ -344,6 +346,75 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     })
     await roomStore.getState().activateRoom(REOPEN_ROOM)
     expect(roomStore.getState().roomMeta.get(REOPEN_ROOM)?.lastSeenMessageId).toBe('m4')
+  })
+
+  // Regression (gate burn on stash): the first activation fold may find the marker's
+  // message NOT loaded (stash-pending). A fold that never applied must not consume the
+  // session gate — otherwise the marker stays stuck as pending forever: re-entry skips
+  // the fold ("already consumed") and re-entry of a caught-up room runs no MAM merge,
+  // leaving no heal path for the whole session.
+  it('retries the fold on a later activation when the first fold could not resolve (marker message not yet loaded)', async () => {
+    const RETRY_ROOM = 'retry-stash@conference.example'
+    const early = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2)]
+    seedRoom(RETRY_ROOM, early, 'm1')
+    // A remote device read up to s9 — that message is not in any loaded slice yet.
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(RETRY_ROOM, { ...m.get(RETRY_ROOM)!, pendingRemoteDisplayedStanzaId: 's9' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(RETRY_ROOM)
+    // Unresolvable → stash survives, pointer untouched.
+    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.lastSeenMessageId).toBe('m1')
+    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.pendingRemoteDisplayedStanzaId).toBe('s9')
+
+    await roomStore.getState().activateRoom(null)
+
+    // The archive healed since (e.g. catch-up landed): the marker's message is loadable now.
+    const healed = [...early, rmsg('m9', 's9', 9)]
+    roomStore.setState((s) => {
+      const rt = new Map(s.roomRuntime)
+      const existing = rt.get(RETRY_ROOM)
+      if (existing) rt.set(RETRY_ROOM, { ...existing, messages: healed })
+      return { roomRuntime: rt }
+    })
+
+    await roomStore.getState().activateRoom(RETRY_ROOM)
+    // The gate must allow the retry (the marker was never actually folded).
+    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.lastSeenMessageId).toBe('m9')
+    expect(roomStore.getState().roomMeta.get(RETRY_ROOM)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+  })
+
+  // Regression (fold ran only before the load-around): with a deep backlog the pending
+  // marker's message is outside the latest-100 slice, so the first fold stashes. The
+  // subsequent load-around of the stale pointer brings that message in — the fold must
+  // be re-attempted against the around-slice, or the divider derives from the stale
+  // local pointer and shows messages already read on the other device as new.
+  it('re-attempts the fold against the slice loaded around a deep stale pointer', async () => {
+    const DEEP_ROOM = 'deep-pointer@conference.example'
+    const latest = [rmsg('m10', 's10', 10), rmsg('m11', 's11', 11), rmsg('m12', 's12', 12)]
+    // Resident window = latest slice; the read pointer (m2) is deeper than it.
+    seedRoom(DEEP_ROOM, latest, 'm2')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(DEEP_ROOM, { ...m.get(DEEP_ROOM)!, pendingRemoteDisplayedStanzaId: 's5' })
+      return { roomMeta: m }
+    })
+    // The IndexedDB slice around the stale pointer contains the marker's message (m5).
+    const aroundSlice = [
+      rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3),
+      rmsg('m4', 's4', 4), rmsg('m5', 's5', 5), rmsg('m6', 's6', 6),
+    ]
+    vi.mocked(messageCache.getRoomMessagesAround).mockResolvedValueOnce(aroundSlice)
+
+    await roomStore.getState().activateRoom(DEEP_ROOM)
+
+    // The retried fold advances the pointer to the synced position…
+    expect(roomStore.getState().roomMeta.get(DEEP_ROOM)?.lastSeenMessageId).toBe('m5')
+    expect(roomStore.getState().roomMeta.get(DEEP_ROOM)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+    // …and the divider derives from it, not from the stale local pointer (m2 → 'm3').
+    expect(roomSelectors.firstNewMessageIdFor(DEEP_ROOM)(roomStore.getState())).toBe('m6')
   })
 })
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -27,7 +27,7 @@ import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
-import { resolveRemoteDisplayed, createMdsSessionGate } from './shared/readMarkerSync'
+import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
 import { roomActivityTone } from './roomSelectors'
 import * as notifState from './shared/notificationState'
@@ -1677,31 +1677,35 @@ export const roomStore = createStore<RoomState>()(
       if (token !== activationToken) return
       // XEP-0490: fold any pending remote read position into lastSeenMessageId
       // BEFORE setActiveRoom derives the new-message divider (parity with
-      // chatStore.activateConversation). Forward-only against the loaded messages.
-      // Fold a pending XEP-0490 synced read position into lastSeenMessageId BEFORE setActiveRoom
-      // derives the divider — but only once per distinct marker this session (parity with
-      // chatStore.activateConversation). The gate keys on the pending stanza-id so a marker synced
-      // from another device while this room was inactive (evicted → the live notify could only
-      // stash it) still folds on the next open, while an identical already-folded marker is skipped
-      // (re-folding would reposition the divider on every return).
-      const pending = get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId
-      const firstConsumeThisSession = pending !== undefined && mdsGate.consume(roomJid, pending)
-      if (pending && firstConsumeThisSession) {
+      // chatStore.activateConversation). Forward-only against the loaded
+      // messages, and applied only once per distinct RESOLVED marker this
+      // session — a fold that stashed (message not loaded) stays retryable, a
+      // resolved one is never re-folded (that would reposition the divider on
+      // every return). Gate + retry policy live in shared/readMarkerSync.
+      const foldOnce = (stage: string) => {
         const lastSeenBefore = get().roomMeta.get(roomJid)?.lastSeenMessageId
-        get().applyRemoteDisplayed(roomJid, pending)
-        markerDebugLog('activation fold (XEP-0490 pending → divider, first open this session)', {
+        const fold = foldPendingRemoteDisplayed(
+          mdsGate,
           roomJid,
-          pendingStanzaId: pending,
-          lastSeenBefore,
-          lastSeenAfter: get().roomMeta.get(roomJid)?.lastSeenMessageId,
-          advanced: lastSeenBefore !== get().roomMeta.get(roomJid)?.lastSeenMessageId,
-        })
-      } else if (pending) {
-        markerDebugLog('activation fold SKIPPED (already consumed this session — PEP keeps it live)', {
-          roomJid,
-          pendingStanzaId: pending,
-        })
+          () => get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId,
+          (stanzaId) => get().applyRemoteDisplayed(roomJid, stanzaId)
+        )
+        if (fold.attempted) {
+          markerDebugLog(`activation fold (XEP-0490 pending → divider, ${stage})`, {
+            roomJid,
+            pendingStanzaId: fold.pending,
+            lastSeenBefore,
+            lastSeenAfter: get().roomMeta.get(roomJid)?.lastSeenMessageId,
+            resolved: fold.resolved,
+          })
+        } else if (fold.pending) {
+          markerDebugLog('activation fold SKIPPED (marker already resolved this session — PEP keeps it live)', {
+            roomJid,
+            pendingStanzaId: fold.pending,
+          })
+        }
       }
+      foldOnce('latest slice')
 
       // Resume anchor: if the read pointer is deeper than the latest-100
       // slice, reload the window AROUND it (IndexedDB only) so the divider
@@ -1716,6 +1720,10 @@ export const roomStore = createStore<RoomState>()(
         if (!loaded.some((m) => m.id === pointer)) {
           await get().loadMessagesAroundFromCache(roomJid, pointer)
           if (token !== activationToken) return
+          // The around-slice sits just past the stale pointer — exactly where a
+          // marker too deep for the latest-100 window lives. Retry a fold that
+          // stashed above so the divider derives from the synced position.
+          foldOnce('around slice')
         }
       }
     }

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { resolveRemoteDisplayed, createMdsSessionGate } from './readMarkerSync'
+import { describe, it, expect, vi } from 'vitest'
+import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './readMarkerSync'
 import type { NotificationMessage } from './notificationState'
 
 /**
@@ -105,28 +105,71 @@ describe('resolveRemoteDisplayed', () => {
 })
 
 describe('createMdsSessionGate', () => {
-  it('consumes each (id, stanzaId) once per session and resets', () => {
+  it('blocks a marker only after it was marked folded, and resets', () => {
     const gate = createMdsSessionGate()
 
-    expect(gate.consume('a@example.com', 's1')).toBe(true)
-    // Same marker re-presented: already folded → skip.
-    expect(gate.consume('a@example.com', 's1')).toBe(false)
+    expect(gate.shouldFold('a@example.com', 's1')).toBe(true)
+    // Not yet marked folded (e.g. the fold stashed): still retryable.
+    expect(gate.shouldFold('a@example.com', 's1')).toBe(true)
+
+    gate.markFolded('a@example.com', 's1')
+    // Same marker re-presented after a RESOLVED fold: skip.
+    expect(gate.shouldFold('a@example.com', 's1')).toBe(false)
     // Distinct id: independent.
-    expect(gate.consume('b@example.com', 's1')).toBe(true)
+    expect(gate.shouldFold('b@example.com', 's1')).toBe(true)
 
     gate.reset()
-    expect(gate.consume('a@example.com', 's1')).toBe(true)
+    expect(gate.shouldFold('a@example.com', 's1')).toBe(true)
   })
 
-  it('re-arms when a newer marker arrives for an already-consumed id', () => {
+  it('re-arms when a newer marker arrives for an already-folded id', () => {
     const gate = createMdsSessionGate()
 
-    // First marker folds.
-    expect(gate.consume('a@example.com', 's1')).toBe(true)
+    gate.markFolded('a@example.com', 's1')
     // A different (newer) marker — synced from another device while this entity
     // was unloaded, so the live PEP notify could only stash it — must fold too.
-    expect(gate.consume('a@example.com', 's2')).toBe(true)
+    expect(gate.shouldFold('a@example.com', 's2')).toBe(true)
+    gate.markFolded('a@example.com', 's2')
     // …but re-presenting that same newer marker is now a no-op.
-    expect(gate.consume('a@example.com', 's2')).toBe(false)
+    expect(gate.shouldFold('a@example.com', 's2')).toBe(false)
+  })
+})
+
+describe('foldPendingRemoteDisplayed', () => {
+  it('does nothing when no marker is pending', () => {
+    const gate = createMdsSessionGate()
+    const apply = vi.fn()
+    const result = foldPendingRemoteDisplayed(gate, 'a@example.com', () => undefined, apply)
+    expect(result).toEqual({ attempted: false, resolved: false })
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('records a resolved fold on the gate so the same marker is not re-folded', () => {
+    const gate = createMdsSessionGate()
+    let pending: string | undefined = 's1'
+    const apply = vi.fn(() => { pending = undefined }) // apply resolved the marker
+    const first = foldPendingRemoteDisplayed(gate, 'a@example.com', () => pending, apply)
+    expect(first).toEqual({ pending: 's1', attempted: true, resolved: true })
+
+    // Same marker re-stashed later (e.g. our own publish echoed while unloaded):
+    pending = 's1'
+    const second = foldPendingRemoteDisplayed(gate, 'a@example.com', () => pending, apply)
+    expect(second).toEqual({ pending: 's1', attempted: false, resolved: false })
+    expect(apply).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a stashed (unresolved) fold retryable — the gate is NOT consumed', () => {
+    const gate = createMdsSessionGate()
+    let pending: string | undefined = 's1'
+    const stashApply = vi.fn() // apply could not resolve: pending survives
+    const first = foldPendingRemoteDisplayed(gate, 'a@example.com', () => pending, stashApply)
+    expect(first).toEqual({ pending: 's1', attempted: true, resolved: false })
+
+    // Retry (next activation / after a load-around): must attempt again…
+    const resolveApply = vi.fn(() => { pending = undefined })
+    const second = foldPendingRemoteDisplayed(gate, 'a@example.com', () => pending, resolveApply)
+    expect(second).toEqual({ pending: 's1', attempted: true, resolved: true })
+    // …and only now is the marker recorded as folded.
+    expect(gate.shouldFold('a@example.com', 's1')).toBe(false)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -116,28 +116,71 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
  * to apply it. Keying on id alone would suppress that fold (the entity was opened
  * before), leaving reads synced from another device stuck as unread. Keying on
  * the stanza-id instead re-arms for a genuinely newer marker while still skipping
- * the identical one. Each store owns one gate instance; `reset()` on account switch.
+ * the identical one.
+ *
+ * Only RESOLVED folds are recorded (via `markFolded`, called by
+ * {@link foldPendingRemoteDisplayed} when the apply actually advanced or cleared
+ * the marker). A fold that stashed — the marker's message wasn't in the loaded
+ * slice — never took effect, so recording it would strand the marker: the next
+ * activation would skip the fold as "already consumed" while no merge may ever
+ * retry it. Each store owns one gate instance; `reset()` on account switch.
  */
 export interface MdsSessionGate {
   /**
-   * True when `stanzaId` has not yet been folded for `id` this session — the
-   * first marker, or any newer/different one. Re-presenting the same value
-   * returns false. Records id → stanzaId.
+   * True when `stanzaId` has not been folded-and-RESOLVED for `id` this
+   * session — the first marker, any newer/different one, or a marker whose
+   * earlier fold attempts all stashed.
    */
-  consume(id: string, stanzaId: string): boolean
+  shouldFold(id: string, stanzaId: string): boolean
+  /** Record a fold that actually resolved (advanced or cleared the marker). */
+  markFolded(id: string, stanzaId: string): void
   reset(): void
 }
 
 export function createMdsSessionGate(): MdsSessionGate {
-  const consumed = new Map<string, string>()
+  const folded = new Map<string, string>()
   return {
-    consume(id: string, stanzaId: string): boolean {
-      const first = consumed.get(id) !== stanzaId
-      consumed.set(id, stanzaId)
-      return first
+    shouldFold(id: string, stanzaId: string): boolean {
+      return folded.get(id) !== stanzaId
+    },
+    markFolded(id: string, stanzaId: string): void {
+      folded.set(id, stanzaId)
     },
     reset(): void {
-      consumed.clear()
+      folded.clear()
     },
   }
+}
+
+/** Outcome of one activation-fold attempt, for the caller's debug logging. */
+export interface ActivationFoldResult {
+  /** The pending stanza-id that was considered (undefined = nothing pending). */
+  pending?: string
+  /** True when the fold ran (a marker was pending and the gate allowed it). */
+  attempted: boolean
+  /** True when the fold resolved the marker (advanced or cleared) — the pending mark is gone. */
+  resolved: boolean
+}
+
+/**
+ * One activation-fold attempt: apply the pending XEP-0490 marker (if any and
+ * not already resolved this session) and record it on the gate ONLY when it
+ * actually resolved. Shared by chatStore.activateConversation and
+ * roomStore.activateRoom, which call it twice per activation:
+ * once against the freshly loaded latest slice, and again after a load-around
+ * of a deep stale pointer may have brought the marker's message into the slice.
+ */
+export function foldPendingRemoteDisplayed(
+  gate: MdsSessionGate,
+  id: string,
+  getPending: () => string | undefined,
+  apply: (stanzaId: string) => void
+): ActivationFoldResult {
+  const pending = getPending()
+  if (pending === undefined) return { attempted: false, resolved: false }
+  if (!gate.shouldFold(id, pending)) return { pending, attempted: false, resolved: false }
+  apply(pending)
+  const resolved = getPending() !== pending
+  if (resolved) gate.markFolded(id, pending)
+  return { pending, attempted: true, resolved }
 }


### PR DESCRIPTION
Entering a room (or 1:1) after catching up on another device could show the "new messages" divider at the stale local position. Two activation-fold bugs, plus demo tooling to reproduce cross-device read sync without a server.

**Fixes**
- The fold consumed the session gate before knowing its outcome: a fold that stashed (marker's message not in the loaded slice) was skipped as "already consumed" on every later open, leaving the synced read position stuck for the whole session. The gate now records only resolved folds (`shouldFold`/`markFolded` via the shared `foldPendingRemoteDisplayed` helper in `readMarkerSync.ts`), so stashes stay retryable while resolved markers are still never re-folded.
- The fold ran only against the latest-100 slice; with a deep backlog the marker sits past the stale pointer, exactly in the load-around slice. It is now retried after `loadMessagesAroundFromCache` in both `activateConversation` and `activateRoom`.

**Demo simulation**
- `DemoClient` serves the XEP-0490 MDS PEP node in-memory (`client.mds.*` round-trips), `simulateRemoteDisplayed(jid, stanzaId)` plays the cross-device notify, and seeded/stress messages carry deterministic `sid-<id>` stanza-ids. Recipe in `docs/DEMO_MODE.md`.

Known gap (unchanged): a marker deeper than both the latest and around slices only resolves once a MAM merge carries its message; it is now retried on every activation instead of never.