### PR TITLE
ci: cache apt .debs for the scroll-invariant e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,7 @@ jobs:
       # Cache the browser binaries (~/.cache/ms-playwright) so a slow CDN can't add minutes to
       # the download. Caches created in pull_request runs are scoped to that PR, so the shared
       # copy is seeded from main by playwright-cache.yml; restore-keys lets a Playwright bump
-      # start from the previous cache and download only the changed browsers. The OS-level deps
-      # (apt) live on the ephemeral runner and are (re)installed separately each run via
-      # `install-deps`.
+      # start from the previous cache and download only the changed browsers.
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v6
@@ -145,6 +143,31 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium webkit
+
+      # The OS-level deps (apt) live on the ephemeral runner, so `install-deps` must run every
+      # time — but the azure apt mirror can be very slow at certain times of day, so the
+      # downloaded .deb files are cached and pre-seeded into apt's archive dir. apt validates
+      # cached debs by hash and re-downloads only what changed, so a stale cache degrades
+      # gracefully. Keyed on the runner image version (package versions roll with it, ~weekly);
+      # restore-only here — the shared cache is seeded from main by playwright-cache.yml.
+      - name: Compute apt package cache key
+        id: apt-cache-key
+        run: echo "key=apt-debs-$ImageOS-$ImageVersion" >> "$GITHUB_OUTPUT"
+
+      - name: Restore apt package cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.apt-debs
+          key: ${{ steps.apt-cache-key.outputs.key }}
+          restore-keys: |
+            apt-debs-
+
+      - name: Seed apt archives from cache
+        run: |
+          if [ -d "$HOME/.apt-debs" ]; then
+            sudo cp "$HOME"/.apt-debs/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+            echo "Seeded $(ls "$HOME"/.apt-debs/*.deb 2>/dev/null | wc -l) cached .deb file(s)"
+          fi
 
       - name: Install Playwright OS dependencies
         run: npx playwright install-deps chromium webkit

--- a/.github/workflows/playwright-cache.yml
+++ b/.github/workflows/playwright-cache.yml
@@ -3,8 +3,10 @@ name: Seed Playwright cache
 # CI only runs on pull_request, and caches created in PR runs are scoped to that PR —
 # other PRs can't see them, so every PR's first e2e run re-downloads the browsers.
 # Caches created on the default branch ARE visible to all PRs, so this workflow keeps
-# a shared copy warm from main. It short-circuits in ~10s when the cache already
-# exists for the current package-lock.json.
+# two shared copies warm from main: the browser binaries (keyed on package-lock.json)
+# and the apt .deb files for the Playwright OS deps (keyed on the runner image version,
+# which rolls ~weekly — the azure apt mirror can be very slow at certain times of day).
+# Each job short-circuits in ~10s when its cache already exists for the current key.
 
 on:
   push:
@@ -50,3 +52,62 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+  seed-apt:
+    name: Seed apt package cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Compute apt package cache key
+        id: apt-cache-key
+        run: echo "key=apt-debs-$ImageOS-$ImageVersion" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing cache
+        id: check
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.apt-debs
+          key: ${{ steps.apt-cache-key.outputs.key }}
+          lookup-only: true
+
+      - name: Checkout
+        if: steps.check.outputs.cache-hit != 'true'
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        if: steps.check.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check.outputs.cache-hit != 'true'
+        run: npm ci
+
+      # apt-get keeps the downloaded .deb files in /var/cache/apt/archives; stage them
+      # in a runner-owned dir so the cache action can tar them without hitting the
+      # root-owned partial/ and lock files.
+      - name: Download Playwright OS dependencies
+        if: steps.check.outputs.cache-hit != 'true'
+        run: npx playwright install-deps chromium webkit
+
+      - name: Stage downloaded packages
+        if: steps.check.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$HOME/.apt-debs"
+          sudo cp /var/cache/apt/archives/*.deb "$HOME/.apt-debs/" 2>/dev/null || true
+          sudo chown -R "$USER" "$HOME/.apt-debs"
+          COUNT=$(ls "$HOME"/.apt-debs/*.deb 2>/dev/null | wc -l)
+          echo "Staged $COUNT .deb file(s)"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::warning::No .deb files found in /var/cache/apt/archives — apt cache seeding is a no-op"
+          fi
+
+      - name: Save cache
+        if: steps.check.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.apt-debs
+          key: ${{ steps.apt-cache-key.outputs.key }}


### PR DESCRIPTION
The azure apt mirror can be very slow at certain times of day, which is exactly the failure mode behind the earlier "stuck CI" episode (#966 added the timeout backstop). Steady-state the `install-deps` step is only ~30–60s, but the download portion is the part that blows up on a slow mirror.

This caches the downloaded `.deb` files rather than installed state, so it stays robust: apt validates cached debs by hash and re-downloads only what changed, so a stale cache degrades gracefully.

- **ci.yml (e2e-scroll):** restore-only cache of `~/.apt-debs`, pre-seeded into `/var/cache/apt/archives` before `npx playwright install-deps`. Keyed on the runner image version (`$ImageOS-$ImageVersion`), since package versions roll with it (~weekly); `restore-keys` falls back to the previous image's debs.
- **playwright-cache.yml:** new `seed-apt` job keeps the shared cache warm from `main` (PR-created caches are PR-scoped, same reason as the browser cache). Short-circuits when the cache already exists for the current image version; warns if apt kept no debs so a silent no-op is visible.