### PR TITLE
fix(modal): don't ring the topic link when opening the room info modal

### DIFF
--- a/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
@@ -18,4 +18,24 @@ describe('ModalOverlay focus trap', () => {
     fireEvent.keyDown(omega, { key: 'Tab' })
     expect(document.activeElement).toBe(getByText('alpha'))
   })
+
+  it('focuses the first child on open by default', () => {
+    const { getByText } = render(
+      <ModalOverlay onClose={vi.fn()}>
+        <a href="https://example.com">link</a>
+      </ModalOverlay>,
+    )
+    expect(document.activeElement).toBe(getByText('link'))
+  })
+
+  it('focuses the panel (not a content control) with initialFocus="panel"', () => {
+    const { getByText, container } = render(
+      <ModalOverlay onClose={vi.fn()} initialFocus="panel">
+        <a href="https://example.com">link</a>
+      </ModalOverlay>,
+    )
+    const panel = container.querySelector('.fluux-glass')
+    expect(document.activeElement).toBe(panel)
+    expect(document.activeElement).not.toBe(getByText('link'))
+  })
 })

--- a/apps/fluux/src/components/ModalOverlay.tsx
+++ b/apps/fluux/src/components/ModalOverlay.tsx
@@ -36,6 +36,13 @@ interface ModalOverlayProps {
   /** Focus target restored when the OS window refocuses; defaults to the panel.
    *  See useRestoreFocus for the rationale. */
   focusRef?: RefObject<HTMLElement | null>
+  /** Where focus lands when the modal opens (ignored when `focusRef` is set):
+   *  - `'auto'` (default): the first focusable child, so form modals focus their
+   *    input. Read-only modals whose first focusable is a content control (a
+   *    link, a Show more toggle) would draw an unsolicited focus ring here.
+   *  - `'panel'`: the panel container itself, so no control is ringed on open.
+   *    Tab still moves into the content. Use for display-only modals. */
+  initialFocus?: 'auto' | 'panel'
   /** Extra attributes for the panel element (role, aria-modal, …). onKeyDown is
    *  owned by `onPanelKeyDown` — pass that instead. */
   panelProps?: Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'onKeyDown' | 'ref'>
@@ -82,6 +89,7 @@ export function ModalOverlay({
   panelClassName,
   panelInClass,
   focusRef,
+  initialFocus = 'auto',
   panelProps,
   onPanelKeyDown,
   closeOnEscape = true,
@@ -98,7 +106,11 @@ export function ModalOverlay({
   const close = useCallback(() => requestClose(onClose), [requestClose, onClose])
 
   // Trap Tab focus inside the panel and return focus to the opener on close.
-  useFocusTrap(panelRef, { initialFocusRef: focusRef })
+  // `focusRef` wins; otherwise `initialFocus='panel'` lands on the container so a
+  // display-only modal never rings a content control on open.
+  useFocusTrap(panelRef, {
+    initialFocusRef: focusRef ?? (initialFocus === 'panel' ? panelRef : undefined),
+  })
   // Keep keyboard focus inside the modal across OS window blur/refocus.
   useRestoreFocus(panelRef, focusRef)
 

--- a/apps/fluux/src/components/ModalShell.tsx
+++ b/apps/fluux/src/components/ModalShell.tsx
@@ -10,6 +10,10 @@ interface ModalShellProps {
   width?: string
   /** Extra classes on the panel div, e.g. 'max-h-[80vh]' */
   panelClassName?: string
+  /** Where focus lands on open. `'panel'` avoids ringing a content control in a
+   *  read-only modal; defaults to `'auto'` (first focusable child). See
+   *  {@link ModalOverlay}. */
+  initialFocus?: 'auto' | 'panel'
   children: React.ReactNode
 }
 
@@ -24,12 +28,13 @@ export function ModalShell({
   onClose,
   width = 'max-w-sm',
   panelClassName,
+  initialFocus,
   children,
 }: ModalShellProps) {
   const { t } = useTranslation()
 
   return (
-    <ModalOverlay onClose={onClose} width={width} panelClassName={panelClassName}>
+    <ModalOverlay onClose={onClose} width={width} panelClassName={panelClassName} initialFocus={initialFocus}>
       {({ close }) => (
         <>
           {/* Header */}

--- a/apps/fluux/src/components/RoomInfoModal.tsx
+++ b/apps/fluux/src/components/RoomInfoModal.tsx
@@ -20,7 +20,15 @@ interface RoomInfoModalProps {
  */
 export function RoomInfoModal({ room, onClose }: RoomInfoModalProps) {
   return (
-    <ModalShell title={room.name} onClose={onClose} width="max-w-md" panelClassName="max-h-[80vh] flex flex-col">
+    <ModalShell
+      title={room.name}
+      onClose={onClose}
+      width="max-w-md"
+      panelClassName="max-h-[80vh] flex flex-col"
+      // Read-only modal: the first focusable child is a topic link / Show more
+      // toggle, so land focus on the panel instead of ringing a content control.
+      initialFocus="panel"
+    >
       <div className="p-4 flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto">
         {/* Identity — centered hero (the name is the modal title above) */}
         <div className="flex flex-col items-center gap-2 text-center">


### PR DESCRIPTION
The modal focus trap focuses the first focusable child on open. In the read-only `RoomInfoModal`, that's the topic link, so opening the modal drew an unsolicited focus ring on it.

Adds an opt-in `initialFocus="panel"` mode on `ModalOverlay`/`ModalShell` that lands focus on the panel container instead of a content control, and uses it for `RoomInfoModal`. Form modals keep the first-focusable default so their input still auto-focuses. Tab-into-content and Escape-to-close are unaffected.