### PR TITLE
fix(scroll): stop intermittent re-focus blink — width bucket as validity tag, robust metrics sampling

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -393,6 +393,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                     <div
                       class="relative w-fit max-w-full min-w-0 touch:select-none touch:[-webkit-touch-callout:none]  message-own-tint message-own-tint-start message-own-tint-end"
                       data-msg-chrome="header"
+                      data-msg-own=""
                     >
                       <div
                         class="flex items-baseline gap-2 pb-1 flex-wrap"

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -589,6 +589,9 @@ export const MessageBubble = memo(function MessageBubble({
         ref={ownGroupRef}
         className={`relative ${contentWidthClass} min-w-0 touch:select-none touch:[-webkit-touch-callout:none] ${isSelected || showActionSheet ? 'bg-fluux-selection -my-0.5 py-0.5 -ms-2 ps-2 -me-4 pe-4 rounded-s' : ''}${inThread ? ` bg-fluux-private-soft border-x border-fluux-private-border px-2.5 py-1 ${threadStart ? 'border-t rounded-t-lg' : ''} ${threadEnd ? 'border-b rounded-b-lg' : ''}` : ''} ${ownTintClass}`}
         data-msg-chrome={showAvatar ? 'header' : 'cont'}
+        // Marks hug-width (w-fit) own bubbles so useRowMetrics never samples their text box
+        // as the conversation's content width (it is only as wide as the text itself).
+        data-msg-own={ownTint ? '' : undefined}
         onTouchStart={handleContentTouchStart}
         onTouchEnd={cancelLongPress}
         onTouchMove={cancelLongPress}

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -41,7 +41,7 @@ import {
   getActiveMessageListController,
   type ActiveMessageListController,
 } from './activeMessageListController'
-import { useRowMetrics } from './useRowMetrics'
+import { useRowMetrics, ROW_METRICS_FALLBACK } from './useRowMetrics'
 import { estimateRowHeight } from './rowHeightEstimator'
 import { isEstimateDebugEnabled, estimateDebugLog } from '@/utils/scrollDebug'
 import {
@@ -306,16 +306,15 @@ export function MessageList<T extends BaseMessage>({
       if (item === undefined) {
         return rowMetricsRef.current.chrome.continuation // safe fallback for any out-of-range probe
       }
-      const mountBucketPx = Math.round(rowMetricsRef.current.contentWidthPx / 20) * 20
-      const cached = getCachedHeight(conversationId, item.key, scalePct, mountBucketPx)
+      const cached = getCachedHeight(conversationId, item.key, scalePct)
       return cached ?? estimateRowHeight(item, rowMetricsRef.current)
     },
     [virtualItems, rowMetricsRef, conversationId, scalePct],
   )
 
   // Build the initialMeasurements seed from the persistent cache. Only when virtualized —
-  // flag-OFF path is unchanged. Filter to keys that match the width bucket + scale so stale
-  // entries from a different viewport/font-size are not applied.
+  // flag-OFF path is unchanged. Entries are keyed id@scale; width validity is a per-conversation
+  // tag (a changed real width wipes the map), so everything present is valid to seed.
   // Use a ref so it is evaluated once at mount without needing eslint-disable on empty deps.
   // MOUNT-SCOPED: this builds the seed exactly once per mount and relies on MessageList
   // remounting on every conversation switch (the cache is the whole point — it survives that
@@ -329,17 +328,11 @@ export function MessageList<T extends BaseMessage>({
     // FIRST mount after a reload seeds real heights (the in-memory cache alone dies with
     // the page, which made every conversation re-open on estimates → the reload blink).
     hydrateHeightCache()
-    // The mount-time content width is still the 560 fallback here (useRowMetrics samples the real
-    // width in a rAF after layout), so prefer the REAL bucket persisted by a prior write-back. The
-    // common case — re-entering at the same viewport — then hits; a genuine width change falls back
-    // to the mount-time bucket and just re-measures on mount as before.
-    const mountWidthBucketPx = Math.round(rowMetricsRef.current.contentWidthPx / 20) * 20
-    const widthBucketPx = getConversationWidthBucket(conversationId) ?? mountWidthBucketPx
     const stored = getCachedHeights(conversationId)
     if (stored.size > 0) {
-      const suffix = `@${widthBucketPx}@${scalePct}`
-      // Iterate the stored map; for each stored key that matches bucket+scale, extract messageId
-      // (strip `@bucket@scale` suffix) and include it if the messageId is a key in virtualItems.
+      const suffix = `@${scalePct}`
+      // For each stored key at the current scale, extract the item key (strip `@scale`) and
+      // include it if it is a key in virtualItems.
       const virtualKeys = new Set(virtualItems.map((item) => item.key))
       const result = new Map<string, number>()
       for (const [k, size] of stored) {
@@ -354,7 +347,7 @@ export function MessageList<T extends BaseMessage>({
     }
     estimateDebugLog('seed', {
       conversationId,
-      bucket: widthBucketPx,
+      bucket: getConversationWidthBucket(conversationId),
       scale: scalePct,
       seeded: initialMeasurementsRef.current?.size ?? 0,
       candidates: stored.size,
@@ -373,16 +366,21 @@ export function MessageList<T extends BaseMessage>({
       virtualized
         ? (key: string, size: number) => {
             const { conversationId: cid, scalePct: scale, rowMetricsRef: metricsRef, indexById: idMap, virtualItems: items } = onMeasuredParamsRef.current
-            // Real sampled bucket. Persist it alongside the entry so the next mount's seed (which
-            // runs before the real width is sampled) can filter by this same bucket and hit.
-            const widthBucketPx = Math.round(metricsRef.current.contentWidthPx / 20) * 20
-            recordMeasuredHeight(cid, heightCacheKey(key, widthBucketPx, scale), size)
-            noteConversationWidthBucket(cid, widthBucketPx)
+            const idx = idMap.get(key)
+            const item = idx != null ? items[idx] : undefined
+            // isFirstNew rows include the "new messages" divider, which comes and goes with
+            // read-state between opens — caching their height re-blinks the next open.
+            if (!(item?.kind === 'message' && item.isFirstNew)) {
+              recordMeasuredHeight(cid, heightCacheKey(key, scale), size)
+            }
+            // Note the width-validity tag only once the REAL width has been sampled — the
+            // mount-time fallback must never wipe (or masquerade as) a real bucket.
+            if (metricsRef.current !== ROW_METRICS_FALLBACK) {
+              noteConversationWidthBucket(cid, Math.round(metricsRef.current.contentWidthPx / 20) * 20)
+            }
             // Estimate-accuracy trace (estimate-debug only): predicted vs first-measured per row.
             // Gated up front so the predict (which may call pretext) is skipped when debug is off.
             if (isEstimateDebugEnabled()) {
-              const idx = idMap.get(key)
-              const item = idx != null ? items[idx] : undefined
               const predicted = item ? estimateRowHeight(item, metricsRef.current) : undefined
               estimateDebugLog('row', key, {
                 kind: item?.kind,
@@ -390,6 +388,12 @@ export function MessageList<T extends BaseMessage>({
                 measured: size,
                 delta: predicted != null ? Math.round(size - predicted) : undefined,
               })
+              // The re-entry blink signal: a row whose SEEDED height disagrees with what it
+              // measures on mount reflows after the first paint and re-asserts the bottom pin.
+              const seeded = initialMeasurementsRef.current?.get(key)
+              if (seeded !== undefined && seeded !== size) {
+                estimateDebugLog('seed-mismatch', key, { seeded, measured: size })
+              }
             }
           }
         : undefined,
@@ -422,13 +426,23 @@ export function MessageList<T extends BaseMessage>({
     const snapshotSettledRows = () => {
       if (!scroller) return
       const { conversationId: cid, scalePct: scale, rowMetricsRef: metricsRef, virtualItems: items } = onMeasuredParamsRef.current
-      const widthBucketPx = Math.round(metricsRef.current.contentWidthPx / 20) * 20
-      const settled = collectSettledRowHeights(scroller, items, widthBucketPx, scale)
+      // Note the width-validity tag BEFORE recording, so a genuine width change wipes the
+      // stale map first and the snapshot lands under the new tag. Only from a real sample —
+      // the mount-time fallback must never wipe a real bucket.
+      const sampled = metricsRef.current !== ROW_METRICS_FALLBACK
+      if (sampled) {
+        noteConversationWidthBucket(cid, Math.round(metricsRef.current.contentWidthPx / 20) * 20)
+      }
+      const settled = collectSettledRowHeights(scroller, items, scale)
       for (const [key, height] of settled) {
         recordMeasuredHeight(cid, key, height)
       }
-      if (settled.size > 0) noteConversationWidthBucket(cid, widthBucketPx)
-      persistHeightSnapshot(cid, settled, widthBucketPx)
+      // Persist under the conversation's validity tag; without one (sample never landed —
+      // pathological), skip persisting rather than stamping heights with a made-up width.
+      const bucket = getConversationWidthBucket(cid)
+      if (bucket !== undefined) {
+        persistHeightSnapshot(cid, settled, bucket)
+      }
     }
     window.addEventListener('pagehide', snapshotSettledRows)
     return () => {

--- a/apps/fluux/src/components/conversation/messageHeightCache.test.ts
+++ b/apps/fluux/src/components/conversation/messageHeightCache.test.ts
@@ -15,47 +15,40 @@ import {
 beforeEach(() => __clearHeightCache())
 
 describe('messageHeightCache', () => {
-  it('keys by message id + width bucket + scale', () => {
-    expect(heightCacheKey('m1', 560, 100)).toBe('m1@560@100')
-    expect(heightCacheKey('m1', 560, 125)).not.toBe(heightCacheKey('m1', 560, 100))
+  it('keys by message id + scale (width validity lives on the conversation, not the key)', () => {
+    expect(heightCacheKey('m1', 100)).toBe('m1@100')
+    expect(heightCacheKey('m1', 125)).not.toBe(heightCacheKey('m1', 100))
   })
   it('records and reads back a measured height per conversation', () => {
-    recordMeasuredHeight('conv1', heightCacheKey('m1', 560, 100), 84)
-    expect(getCachedHeights('conv1').get('m1@560@100')).toBe(84)
-    expect(getCachedHeights('conv2').get('m1@560@100')).toBeUndefined()
+    recordMeasuredHeight('conv1', heightCacheKey('m1', 100), 84)
+    expect(getCachedHeights('conv1').get('m1@100')).toBe(84)
+    expect(getCachedHeights('conv2').get('m1@100')).toBeUndefined()
   })
   it('does not record zero or negative heights', () => {
-    recordMeasuredHeight('conv1', heightCacheKey('m1', 560, 100), 0)
-    recordMeasuredHeight('conv1', heightCacheKey('m2', 560, 100), -5)
-    expect(getCachedHeights('conv1').get('m1@560@100')).toBeUndefined()
-    expect(getCachedHeights('conv1').get('m2@560@100')).toBeUndefined()
+    recordMeasuredHeight('conv1', heightCacheKey('m1', 100), 0)
+    recordMeasuredHeight('conv1', heightCacheKey('m2', 100), -5)
+    expect(getCachedHeights('conv1').get('m1@100')).toBeUndefined()
+    expect(getCachedHeights('conv1').get('m2@100')).toBeUndefined()
   })
   it('evicts the oldest conversation when LRU limit is exceeded', () => {
     for (let i = 0; i < 8; i++) {
-      recordMeasuredHeight(`conv${i}`, heightCacheKey('m1', 560, 100), 40 + i)
+      recordMeasuredHeight(`conv${i}`, heightCacheKey('m1', 100), 40 + i)
     }
     // All 8 conversations exist
-    expect(getCachedHeights('conv0').get('m1@560@100')).toBe(40)
+    expect(getCachedHeights('conv0').get('m1@100')).toBe(40)
     // Adding a 9th (conv8) should evict the LRU entry. conv0 was accessed last by getCachedHeights
     // above, so conv1 is now LRU.
-    recordMeasuredHeight('conv8', heightCacheKey('m1', 560, 100), 48)
-    expect(getCachedHeights('conv8').get('m1@560@100')).toBe(48)
-    expect(getCachedHeights('conv1').get('m1@560@100')).toBeUndefined()
+    recordMeasuredHeight('conv8', heightCacheKey('m1', 100), 48)
+    expect(getCachedHeights('conv8').get('m1@100')).toBe(48)
+    expect(getCachedHeights('conv1').get('m1@100')).toBeUndefined()
   })
-  it('resolves a cached height by item key, preferring the persisted real width bucket', () => {
-    // Entries written under the conversation's REAL bucket (700), reader mounts at the 560 fallback
-    recordMeasuredHeight('conv1', heightCacheKey('m1', 700, 100), 84)
-    noteConversationWidthBucket('conv1', 700)
-    expect(getCachedHeight('conv1', 'm1', 100, 560)).toBe(84)
+  it('resolves a cached height by item key + scale', () => {
+    recordMeasuredHeight('conv1', heightCacheKey('m1', 100), 84)
+    expect(getCachedHeight('conv1', 'm1', 100)).toBe(84)
     // Unknown key, other scale, other conversation -> undefined
-    expect(getCachedHeight('conv1', 'm2', 100, 560)).toBeUndefined()
-    expect(getCachedHeight('conv1', 'm1', 125, 560)).toBeUndefined()
-    expect(getCachedHeight('conv2', 'm1', 100, 560)).toBeUndefined()
-  })
-
-  it('resolves via the fallback bucket when no real bucket was recorded', () => {
-    recordMeasuredHeight('conv1', heightCacheKey('m1', 560, 100), 62)
-    expect(getCachedHeight('conv1', 'm1', 100, 560)).toBe(62)
+    expect(getCachedHeight('conv1', 'm2', 100)).toBeUndefined()
+    expect(getCachedHeight('conv1', 'm1', 125)).toBeUndefined()
+    expect(getCachedHeight('conv2', 'm1', 100)).toBeUndefined()
   })
 
   it('records and reads back the real width bucket per conversation', () => {
@@ -65,6 +58,32 @@ describe('messageHeightCache', () => {
     expect(getConversationWidthBucket('other')).toBeUndefined()
     __clearHeightCache()
     expect(getConversationWidthBucket('c')).toBeUndefined()
+  })
+
+  it('keeps heights when the noted bucket is unchanged', () => {
+    recordMeasuredHeight('conv1', heightCacheKey('m1', 100), 84)
+    noteConversationWidthBucket('conv1', 700)
+    recordMeasuredHeight('conv1', heightCacheKey('m2', 100), 90)
+    noteConversationWidthBucket('conv1', 700)
+    expect(getCachedHeights('conv1').get('m1@100')).toBe(84)
+    expect(getCachedHeights('conv1').get('m2@100')).toBe(90)
+  })
+
+  it('invalidates a conversation’s heights when its real width bucket changes', () => {
+    // The bucket is the validity tag for the whole map: heights measured at one content
+    // width are meaningless at another, and stale entries under a different bucket were
+    // exactly the immortal-poison bug (corrections written under bucket A while the seed
+    // read bucket B, so a stale seed value re-blinked on every re-open).
+    noteConversationWidthBucket('conv1', 700)
+    recordMeasuredHeight('conv1', heightCacheKey('m1', 100), 84)
+    noteConversationWidthBucket('conv1', 900)
+    expect(getCachedHeights('conv1').size).toBe(0)
+    expect(getConversationWidthBucket('conv1')).toBe(900)
+    // Other conversations are untouched
+    noteConversationWidthBucket('conv2', 700)
+    recordMeasuredHeight('conv2', heightCacheKey('m1', 100), 60)
+    noteConversationWidthBucket('conv1', 920)
+    expect(getCachedHeights('conv2').get('m1@100')).toBe(60)
   })
 })
 
@@ -84,7 +103,7 @@ describe('messageHeightCache persistence across reloads', () => {
 
   it('round-trips a settled snapshot through storage (entries + width bucket)', () => {
     const storage = memoryStorage()
-    persistHeightSnapshot('conv1', entries({ 'm1@880@100': 84, 'm2@880@100': 423 }), 880, {
+    persistHeightSnapshot('conv1', entries({ 'm1@100': 84, 'm2@100': 423 }), 880, {
       storage,
       version: '1.0.0',
       now: 1000,
@@ -93,14 +112,14 @@ describe('messageHeightCache persistence across reloads', () => {
     __clearHeightCache() // simulate reload: in-memory cache is gone
     hydrateHeightCache({ storage, version: '1.0.0' })
 
-    expect(getCachedHeights('conv1').get('m1@880@100')).toBe(84)
-    expect(getCachedHeights('conv1').get('m2@880@100')).toBe(423)
+    expect(getCachedHeights('conv1').get('m1@100')).toBe(84)
+    expect(getCachedHeights('conv1').get('m2@100')).toBe(423)
     expect(getConversationWidthBucket('conv1')).toBe(880)
   })
 
   it('drops persisted heights written under a different app version', () => {
     const storage = memoryStorage()
-    persistHeightSnapshot('conv1', entries({ 'm1@880@100': 84 }), 880, {
+    persistHeightSnapshot('conv1', entries({ 'm1@100': 84 }), 880, {
       storage,
       version: '1.0.0',
       now: 1000,
@@ -115,12 +134,12 @@ describe('messageHeightCache persistence across reloads', () => {
 
   it('starts a fresh payload when persisting under a new version', () => {
     const storage = memoryStorage()
-    persistHeightSnapshot('old', entries({ 'm1@880@100': 84 }), 880, {
+    persistHeightSnapshot('old', entries({ 'm1@100': 84 }), 880, {
       storage,
       version: '1.0.0',
       now: 1000,
     })
-    persistHeightSnapshot('new', entries({ 'm2@880@100': 90 }), 880, {
+    persistHeightSnapshot('new', entries({ 'm2@100': 90 }), 880, {
       storage,
       version: '1.1.0',
       now: 2000,
@@ -130,7 +149,7 @@ describe('messageHeightCache persistence across reloads', () => {
     hydrateHeightCache({ storage, version: '1.1.0' })
 
     expect(getCachedHeights('old').size).toBe(0)
-    expect(getCachedHeights('new').get('m2@880@100')).toBe(90)
+    expect(getCachedHeights('new').get('m2@100')).toBe(90)
   })
 
   it('tolerates corrupt stored JSON without throwing', () => {
@@ -139,7 +158,7 @@ describe('messageHeightCache persistence across reloads', () => {
     expect(getCachedHeights('conv1').size).toBe(0)
     // A later persist still works on top of the corrupt payload
     expect(() =>
-      persistHeightSnapshot('conv1', entries({ 'm1@880@100': 84 }), 880, {
+      persistHeightSnapshot('conv1', entries({ 'm1@100': 84 }), 880, {
         storage,
         version: '1.0.0',
         now: 1000,
@@ -161,7 +180,7 @@ describe('messageHeightCache persistence across reloads', () => {
     }
     expect(() => hydrateHeightCache({ storage: throwing, version: '1.0.0' })).not.toThrow()
     expect(() =>
-      persistHeightSnapshot('c', entries({ 'm1@880@100': 84 }), 880, {
+      persistHeightSnapshot('c', entries({ 'm1@100': 84 }), 880, {
         storage: throwing,
         version: '1.0.0',
         now: 1000,
@@ -172,7 +191,7 @@ describe('messageHeightCache persistence across reloads', () => {
   it('merges snapshots for several conversations and evicts the oldest beyond the cap', () => {
     const storage = memoryStorage()
     for (let i = 0; i < 9; i++) {
-      persistHeightSnapshot(`conv${i}`, entries({ [`m@880@100`]: 40 + i }), 880, {
+      persistHeightSnapshot(`conv${i}`, entries({ [`m@100`]: 40 + i }), 880, {
         storage,
         version: '1.0.0',
         now: 1000 + i,
@@ -184,14 +203,14 @@ describe('messageHeightCache persistence across reloads', () => {
 
     // conv0 (oldest) was evicted; conv1..conv8 survive. Probe conv0 LAST: getCachedHeights
     // creates-and-touches in the in-memory LRU, and a 9th map would evict a hydrated one.
-    expect(getCachedHeights('conv1').get('m@880@100')).toBe(41)
-    expect(getCachedHeights('conv8').get('m@880@100')).toBe(48)
+    expect(getCachedHeights('conv1').get('m@100')).toBe(41)
+    expect(getCachedHeights('conv8').get('m@100')).toBe(48)
     expect(getCachedHeights('conv0').size).toBe(0)
   })
 
   it('ignores an empty snapshot instead of clobbering the stored one', () => {
     const storage = memoryStorage()
-    persistHeightSnapshot('conv1', entries({ 'm1@880@100': 84 }), 880, {
+    persistHeightSnapshot('conv1', entries({ 'm1@100': 84 }), 880, {
       storage,
       version: '1.0.0',
       now: 1000,
@@ -201,12 +220,24 @@ describe('messageHeightCache persistence across reloads', () => {
     __clearHeightCache()
     hydrateHeightCache({ storage, version: '1.0.0' })
 
-    expect(getCachedHeights('conv1').get('m1@880@100')).toBe(84)
+    expect(getCachedHeights('conv1').get('m1@100')).toBe(84)
+  })
+
+  it('drops a payload with the old (v1) schema', () => {
+    const storage = memoryStorage({
+      [HEIGHT_CACHE_STORAGE_KEY]: JSON.stringify({
+        v: 1,
+        app: '1.0.0',
+        conversations: { conv1: { bucket: 880, at: 1, entries: { 'm1@880@100': 84 } } },
+      }),
+    })
+    hydrateHeightCache({ storage, version: '1.0.0' })
+    expect(getCachedHeights('conv1').size).toBe(0)
   })
 
   it('hydrates only once until the cache is cleared', () => {
     const storage = memoryStorage()
-    persistHeightSnapshot('conv1', entries({ 'm1@880@100': 84 }), 880, {
+    persistHeightSnapshot('conv1', entries({ 'm1@100': 84 }), 880, {
       storage,
       version: '1.0.0',
       now: 1000,
@@ -215,9 +246,9 @@ describe('messageHeightCache persistence across reloads', () => {
     __clearHeightCache()
     hydrateHeightCache({ storage, version: '1.0.0' })
     // In-session measurement overrides the hydrated value…
-    recordMeasuredHeight('conv1', 'm1@880@100', 99)
+    recordMeasuredHeight('conv1', 'm1@100', 99)
     // …and a second hydrate call must NOT re-apply the stale persisted value.
     hydrateHeightCache({ storage, version: '1.0.0' })
-    expect(getCachedHeights('conv1').get('m1@880@100')).toBe(99)
+    expect(getCachedHeights('conv1').get('m1@100')).toBe(99)
   })
 })

--- a/apps/fluux/src/components/conversation/messageHeightCache.ts
+++ b/apps/fluux/src/components/conversation/messageHeightCache.ts
@@ -1,10 +1,18 @@
 /**
- * Module-level measured-height cache, keyed by messageId + widthBucket + scale.
+ * Module-level measured-height cache, keyed by messageId + scale, with the content-width
+ * bucket as a PER-CONVERSATION validity tag.
  *
  * @tanstack/react-virtual caches measured row heights by item key for the SESSION, but loses
  * them when MessageList unmounts (conversation switch). Re-entering a conversation then
  * re-snaps from estimates ("jumpy when you just opened it"). This module-level cache survives
  * remounts and seeds the virtualizer so resident rows start at their real measured height.
+ *
+ * WIDTH MODEL: heights are only valid for the content width they were measured at. Instead of
+ * embedding a width bucket in every key (which split a conversation's entries across buckets
+ * whenever the sampled width churned — corrections were then written under one bucket while
+ * the seed read another, making stale values IMMORTAL and re-blinking every re-open), the
+ * bucket is a single per-conversation tag: when it genuinely changes, that conversation's
+ * heights are wiped wholesale (they are all invalid at the new width anyway).
  *
  * Cache structure: conversationId -> Map<heightCacheKey -> px>
  * LRU eviction per conversation (max 8 conversations, max 6000 entries each).
@@ -17,24 +25,17 @@ const MAX_ENTRIES_PER_CONVERSATION = 6000
 const cache = new Map<string, Map<string, number>>()
 
 /**
- * Last REAL width bucket (px) each conversation's entries were written under. The seed is built at
- * synchronous mount when `rowMetricsRef.current.contentWidthPx` is still the 560 fallback (the live
- * width is only sampled in a rAF after layout), but the write-back stores entries under the real
- * sampled bucket. Persisting the real bucket here lets the seed filter by it, so same-width
- * re-entry hits the cache instead of missing every entry.
+ * The real width bucket (px) each conversation's entries are valid for. Written when a REAL
+ * (non-fallback) sample is available; a change wipes the conversation's heights (see above).
  */
 const widthBucketByConversation = new Map<string, number>()
 
 /**
  * Build the lookup key for a single row.
- * Format: `messageId@widthBucketPx@scalePct`
+ * Format: `messageId@scalePct` (the width bucket is a conversation-level tag, not part of the key).
  */
-export function heightCacheKey(
-  messageId: string,
-  widthBucketPx: number,
-  scalePct: number,
-): string {
-  return `${messageId}@${widthBucketPx}@${scalePct}`
+export function heightCacheKey(messageId: string, scalePct: number): string {
+  return `${messageId}@${scalePct}`
 }
 
 /**
@@ -79,24 +80,28 @@ export function recordMeasuredHeight(
 }
 
 /**
- * Record the REAL width bucket (px) a conversation's entries are written under. Called from the
- * write-back path alongside recordMeasuredHeight, using the same real bucket as the key.
+ * Record the REAL width bucket (px) a conversation's heights are valid for. A CHANGED bucket
+ * wipes that conversation's heights: they were measured at a different content width and
+ * would otherwise linger as stale seeds (the immortal-poison re-open blink). Call only with a
+ * bucket derived from a real sample, never from the mount-time fallback.
  */
 export function noteConversationWidthBucket(conversationId: string, widthBucketPx: number): void {
+  const prev = widthBucketByConversation.get(conversationId)
+  if (prev !== undefined && prev !== widthBucketPx) {
+    cache.get(conversationId)?.clear()
+  }
   widthBucketByConversation.set(conversationId, widthBucketPx)
 }
 
 /**
- * Read the last real width bucket persisted for a conversation, or undefined if none recorded yet.
- * The seed uses this (falling back to the mount-time bucket) to filter cached entries.
+ * Read the last real width bucket recorded for a conversation, or undefined if none yet.
  */
 export function getConversationWidthBucket(conversationId: string): number | undefined {
   return widthBucketByConversation.get(conversationId)
 }
 
 /**
- * Resolve one row's cached measured height by item key, using the conversation's real width
- * bucket (falling back to the caller's mount-time bucket). Lets estimateSize return the real
+ * Resolve one row's cached measured height by item key. Lets estimateSize return the real
  * height for rows that appear AFTER mount (e.g. messages streaming in from MAM on a reload),
  * which the mount-time initialMeasurements seed cannot cover.
  */
@@ -104,12 +109,10 @@ export function getCachedHeight(
   conversationId: string,
   itemKey: string,
   scalePct: number,
-  fallbackBucketPx: number,
 ): number | undefined {
-  const m = cache.get(conversationId)
-  if (!m) return undefined
-  const bucket = widthBucketByConversation.get(conversationId) ?? fallbackBucketPx
-  return m.get(heightCacheKey(itemKey, bucket, scalePct))
+  // Direct map access (no getCachedHeights) so a hot-path read miss neither creates a map
+  // nor perturbs the LRU order.
+  return cache.get(conversationId)?.get(heightCacheKey(itemKey, scalePct))
 }
 
 // --------------------------------------------------------------------------
@@ -125,6 +128,9 @@ export function getCachedHeight(
 
 /** localStorage key for the persisted snapshot payload. */
 export const HEIGHT_CACHE_STORAGE_KEY = 'fluux:msg-heights'
+
+/** Payload schema version. v2: bucket moved from the entry keys to the conversation tag. */
+const PAYLOAD_SCHEMA = 2
 
 const MAX_PERSISTED_CONVERSATIONS = 8
 /** A settled snapshot is one mounted window (~window+overscan rows); cap defensively. */
@@ -143,7 +149,7 @@ interface PersistedConversation {
 }
 
 interface PersistedPayload {
-  v: 1
+  v: typeof PAYLOAD_SCHEMA
   app: string
   conversations: Record<string, PersistedConversation>
 }
@@ -165,7 +171,11 @@ function readPayload(storage: StorageLike, version: string): PersistedPayload | 
   if (!raw) return undefined
   try {
     const parsed = JSON.parse(raw) as PersistedPayload
-    if (parsed?.v !== 1 || parsed.app !== version || typeof parsed.conversations !== 'object') {
+    if (
+      parsed?.v !== PAYLOAD_SCHEMA ||
+      parsed.app !== version ||
+      typeof parsed.conversations !== 'object'
+    ) {
       return undefined
     }
     return parsed
@@ -192,7 +202,7 @@ export function persistHeightSnapshot(
   const version = opts.version ?? defaultVersion()
   try {
     const payload: PersistedPayload = readPayload(storage, version) ?? {
-      v: 1,
+      v: PAYLOAD_SCHEMA,
       app: version,
       conversations: {},
     }
@@ -238,18 +248,20 @@ export function hydrateHeightCache(opts: { storage?: StorageLike; version?: stri
   try {
     const payload = readPayload(storage, version)
     if (!payload) {
-      // Absent is normal; corrupt or version-mismatched payloads are cleared so they
-      // don't linger across sessions.
+      // Absent is normal; corrupt, version-mismatched, or old-schema payloads are cleared so
+      // they don't linger across sessions.
       if (storage.getItem(HEIGHT_CACHE_STORAGE_KEY) !== null) {
         storage.removeItem(HEIGHT_CACHE_STORAGE_KEY)
       }
       return
     }
     for (const [conversationId, snap] of Object.entries(payload.conversations)) {
+      // Note the bucket FIRST: with an empty map the change-wipe is a no-op, and subsequent
+      // records land under the correct validity tag.
+      noteConversationWidthBucket(conversationId, snap.bucket)
       for (const [key, px] of Object.entries(snap.entries)) {
         recordMeasuredHeight(conversationId, key, px)
       }
-      noteConversationWidthBucket(conversationId, snap.bucket)
     }
   } catch {
     // storage unavailable — start unseeded, same as today

--- a/apps/fluux/src/components/conversation/rowMetricsSampling.test.ts
+++ b/apps/fluux/src/components/conversation/rowMetricsSampling.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { pickWidthSampleEl, pickChromeSampleEl } from './useRowMetrics'
+
+function el(html: string): HTMLElement {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  return root
+}
+
+function setWidth(e: Element, w: number): void {
+  Object.defineProperty(e, 'clientWidth', { get: () => w, configurable: true })
+}
+
+describe('pickWidthSampleEl', () => {
+  it('prefers a text element outside own (hug-width) bubbles', () => {
+    // Own bubbles are w-fit: their [data-msg-text] clientWidth is the hugged TEXT width, not
+    // the available content width — sampling one poisons the width bucket for the whole
+    // conversation (bucket churns with whichever row happens to be first).
+    const root = el(`
+      <div data-msg-chrome="cont" data-msg-own><div data-msg-text>ok</div></div>
+      <div data-msg-chrome="header"><div data-msg-text>a longer peer message</div></div>
+    `)
+    const own = root.querySelector('[data-msg-own] [data-msg-text]')!
+    const peer = root.querySelector('[data-msg-chrome="header"] [data-msg-text]')!
+    setWidth(own, 38)
+    setWidth(peer, 890)
+    expect(pickWidthSampleEl(root)).toBe(peer)
+  })
+
+  it('falls back to the widest own text element when only own rows are mounted', () => {
+    const root = el(`
+      <div data-msg-chrome="cont" data-msg-own><div data-msg-text>ok</div></div>
+      <div data-msg-chrome="cont" data-msg-own><div data-msg-text>a much longer own message</div></div>
+    `)
+    const [short, long] = Array.from(root.querySelectorAll('[data-msg-text]'))
+    setWidth(short, 38)
+    setWidth(long, 542)
+    expect(pickWidthSampleEl(root)).toBe(long)
+  })
+
+  it('returns null when nothing is mounted', () => {
+    expect(pickWidthSampleEl(el(''))).toBeNull()
+  })
+})
+
+describe('pickChromeSampleEl', () => {
+  it('skips rows containing block content the text predictor cannot model', () => {
+    // A quote/code/media row's outer height wildly exceeds the predicted plain-text height of
+    // its textContent, so chrome = outer - predicted comes out as garbage (observed: a
+    // continuation chrome of 369px vs the real ~6px), poisoning every unseeded estimate.
+    const root = el(`
+      <div data-msg-chrome="cont"><blockquote>quoted wall</blockquote><div data-msg-text>reply</div></div>
+      <div data-msg-chrome="cont"><div data-msg-text>plain continuation</div></div>
+    `)
+    const clean = root.querySelectorAll('[data-msg-chrome="cont"]')[1]
+    expect(pickChromeSampleEl(root, 'cont')).toBe(clean)
+  })
+
+  it('skips own hug-width rows (their text box does not span the content width)', () => {
+    const root = el(`
+      <div data-msg-chrome="header" data-msg-own><div data-msg-text>own</div></div>
+      <div data-msg-chrome="header"><div data-msg-text>peer</div></div>
+    `)
+    const peer = root.querySelectorAll('[data-msg-chrome="header"]')[1]
+    expect(pickChromeSampleEl(root, 'header')).toBe(peer)
+  })
+
+  it('returns null when no clean row of the requested shape exists', () => {
+    const root = el(`
+      <div data-msg-chrome="cont"><pre>code</pre><div data-msg-text>x</div></div>
+    `)
+    expect(pickChromeSampleEl(root, 'cont')).toBeNull()
+    expect(pickChromeSampleEl(root, 'header')).toBeNull()
+  })
+})

--- a/apps/fluux/src/components/conversation/settledRowSnapshot.test.ts
+++ b/apps/fluux/src/components/conversation/settledRowSnapshot.test.ts
@@ -20,14 +20,14 @@ function scrollerWith(rows: Array<{ index: string; height: number }>): HTMLEleme
 const items = [{ key: 'm1' }, { key: 'm2' }, { key: 'date:2026-07-13' }]
 
 describe('collectSettledRowHeights', () => {
-  it('maps each mounted row to its height-cache key at the given bucket/scale', () => {
+  it('maps each mounted row to its height-cache key at the given scale', () => {
     const scroller = scrollerWith([
       { index: '0', height: 84 },
       { index: '2', height: 48 },
     ])
-    const result = collectSettledRowHeights(scroller, items, 880, 100)
-    expect(result.get('m1@880@100')).toBe(84)
-    expect(result.get('date:2026-07-13@880@100')).toBe(48)
+    const result = collectSettledRowHeights(scroller, items, 100)
+    expect(result.get('m1@100')).toBe(84)
+    expect(result.get('date:2026-07-13@100')).toBe(48)
     expect(result.size).toBe(2)
   })
 
@@ -38,13 +38,25 @@ describe('collectSettledRowHeights', () => {
       { index: 'x', height: 40 }, // malformed
       { index: '1', height: 116 },
     ])
-    const result = collectSettledRowHeights(scroller, items, 880, 100)
+    const result = collectSettledRowHeights(scroller, items, 100)
     expect(result.size).toBe(1)
-    expect(result.get('m2@880@100')).toBe(116)
+    expect(result.get('m2@100')).toBe(116)
+  })
+
+  it('skips first-new rows: their height includes the new-messages divider, which changes between opens', () => {
+    const withDivider = [{ key: 'm1' }, { key: 'm2', isFirstNew: true }, { key: 'm3' }]
+    const scroller = scrollerWith([
+      { index: '0', height: 84 },
+      { index: '1', height: 106 },
+      { index: '2', height: 62 },
+    ])
+    const result = collectSettledRowHeights(scroller, withDivider, 100)
+    expect(result.size).toBe(2)
+    expect(result.get('m2@100')).toBeUndefined()
   })
 
   it('returns an empty map when no spacer rows are mounted', () => {
     const scroller = document.createElement('div')
-    expect(collectSettledRowHeights(scroller, items, 880, 100).size).toBe(0)
+    expect(collectSettledRowHeights(scroller, items, 100).size).toBe(0)
   })
 })

--- a/apps/fluux/src/components/conversation/settledRowSnapshot.ts
+++ b/apps/fluux/src/components/conversation/settledRowSnapshot.ts
@@ -8,23 +8,26 @@ import { heightCacheKey } from './messageHeightCache'
  * hold transient (pre-settle) values. Reading offsetHeight while the rows are still attached
  * (unmount commit, or pagehide before a reload) yields the settled truth.
  *
- * Returns heightCacheKey(itemKey, bucket, scale) -> px for every row that maps to a known
- * item and has a positive height. Rows with a stale/malformed data-index are skipped.
+ * Returns heightCacheKey(itemKey, scale) -> px for every row that maps to a known item and
+ * has a positive height. Skipped rows:
+ * - stale/malformed data-index (no matching item)
+ * - zero height (detached / unsettled)
+ * - isFirstNew rows: their height includes the "new messages" divider, which comes and goes
+ *   with read-state between opens — caching it re-blinks the next open when the divider is gone.
  */
 export function collectSettledRowHeights(
   scroller: HTMLElement,
-  items: ReadonlyArray<{ key: string }>,
-  widthBucketPx: number,
+  items: ReadonlyArray<{ key: string; isFirstNew?: boolean }>,
   scalePct: number,
 ): Map<string, number> {
   const result = new Map<string, number>()
   const rows = scroller.querySelectorAll<HTMLElement>('[data-virtualizer-spacer] > [data-index]')
   for (const el of rows) {
     const idx = Number(el.dataset.index)
-    const key = Number.isNaN(idx) ? undefined : items[idx]?.key
+    const item = Number.isNaN(idx) ? undefined : items[idx]
     const height = el.offsetHeight
-    if (key && height > 0) {
-      result.set(heightCacheKey(key, widthBucketPx, scalePct), height)
+    if (item?.key && !item.isFirstNew && height > 0) {
+      result.set(heightCacheKey(item.key, scalePct), height)
     }
   }
   return result

--- a/apps/fluux/src/components/conversation/useRowMetrics.ts
+++ b/apps/fluux/src/components/conversation/useRowMetrics.ts
@@ -32,6 +32,45 @@ export const ROW_METRICS_FALLBACK: RowEstimatorContext = {
   chrome: FALLBACK_CHROME,
 }
 
+/**
+ * Pick the text element whose clientWidth is the conversation's real CONTENT width.
+ *
+ * Own bubbles are `w-fit` (hug width): their `[data-msg-text]` is only as wide as the text,
+ * so sampling whichever row happens to be first poisons the width (and therefore the height
+ * cache's width-bucket validity tag) with an essentially random value. Prefer the first text
+ * element OUTSIDE `[data-msg-own]`; if only own rows are mounted, the widest own text box is
+ * the best available lower bound.
+ */
+export function pickWidthSampleEl(root: HTMLElement): HTMLElement | null {
+  const all = root.querySelectorAll<HTMLElement>('[data-msg-text]')
+  let widestOwn: HTMLElement | null = null
+  for (const el of all) {
+    if (!el.closest('[data-msg-own]')) return el
+    if (!widestOwn || el.clientWidth > widestOwn.clientWidth) widestOwn = el
+  }
+  return widestOwn
+}
+
+/**
+ * Pick a row for chrome sampling (chrome = outer height − predicted text height): it must be
+ * a PLAIN-TEXT row. Quote/code/media rows make the prediction meaningless (observed: a
+ * continuation "chrome" of 369px vs the real ~6px), and own hug-width rows wrap at the bubble
+ * width rather than the content width. Returns the first clean row of the shape, or null.
+ */
+export function pickChromeSampleEl(
+  root: HTMLElement,
+  shape: 'header' | 'cont',
+): HTMLElement | null {
+  const rows = root.querySelectorAll<HTMLElement>(`[data-msg-chrome="${shape}"]`)
+  for (const row of rows) {
+    if (row.hasAttribute('data-msg-own')) continue
+    if (!row.querySelector('[data-msg-text]')) continue
+    if (row.querySelector('blockquote, pre, img, video, audio')) continue
+    return row
+  }
+  return null
+}
+
 function fontSpecFrom(el: HTMLElement): FontSpec {
   const cs = getComputedStyle(el)
   const fontSizePx = parseFloat(cs.fontSize) || 16
@@ -68,7 +107,7 @@ export function useRowMetrics(
   const sample = useCallback(() => {
     const root = scrollRef.current
     if (!root) return
-    const textEl = root.querySelector<HTMLElement>('[data-msg-text]')
+    const textEl = pickWidthSampleEl(root)
     if (!textEl) return // nothing mounted yet; keep current/fallback
 
     const fontSpec = fontSpecFrom(textEl)
@@ -89,7 +128,7 @@ export function useRowMetrics(
     const chrome: RowChrome = { ...ctxRef.current.chrome }
 
     const measureChromeFor = (shape: 'header' | 'cont'): number | null => {
-      const rowEl = root.querySelector<HTMLElement>(`[data-msg-chrome="${shape}"]`)
+      const rowEl = pickChromeSampleEl(root, shape)
       const t = rowEl?.querySelector<HTMLElement>('[data-msg-text]')
       if (!rowEl || !t) return null
       const outer = rowEl.getBoundingClientRect().height


### PR DESCRIPTION
Follow-up to #982: after the reload fix, some conversations still blinked intermittently on re-focus — not always the same one. A new estimate-debug `seed-mismatch` probe (shipped, gated) exposed three cache poisons:

- **Bucket-split immortality (keystone).** `onMeasured` keyed entries to the width bucket at measure time — the 560 fallback before the rAF width sample, the real bucket after — so one conversation's entries split across buckets. Corrections were written under one bucket while the seed read another: a stale seed value never healed and re-blinked on every re-open. The bucket is now a per-conversation **validity tag** instead of part of the key (`id@scale`): a genuinely changed real width wipes that conversation's heights, and the tag is only written from a real sample, never the mount-time fallback. Persisted payload schema → v2 (old payloads dropped cleanly).
- **w-fit sampling poison.** `useRowMetrics` sampled the first `[data-msg-text]`; inside an own (hug-width) bubble that is only as wide as its text, so the sampled content width churned with whichever row was first — and chrome sampling on quote/code rows produced garbage (observed 369px "continuation" chrome vs the real 6px). New `data-msg-own` marker + `pickWidthSampleEl`/`pickChromeSampleEl` skip those rows.
- **isFirstNew rows.** The new-messages divider renders inside the row, so its cached height went stale whenever read-state changed between opens (observed: an immortal 106-vs-72 mismatch on every re-open). Such rows are no longer cached.

After the fix, the refocus-cycle trace is clean: stable bucket, seeds fully hit (20/20 vs 20/33 before), no repeated mismatches except a known bounded +8px class (rows whose content upgrades async post-mount, e.g. code-block highlight) — if a visible blink remains on WebKit, `__fluuxEstimateDebug(true)` now names the offending rows.