### PR TITLE
fix(toolbar): vertically center the reaction emoji in its hover fill

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -142,19 +142,19 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       >
                         <button
                           aria-label="chat.reactWith"
-                          class="px-2 py-1.5 transition-colors text-base hover:bg-fluux-hover "
+                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
                         >
                           👍
                         </button>
                         <button
                           aria-label="chat.reactWith"
-                          class="px-2 py-1.5 transition-colors text-base hover:bg-fluux-hover "
+                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
                         >
                           ❤️
                         </button>
                         <button
                           aria-label="chat.reactWith"
-                          class="px-2 py-1.5 transition-colors text-base hover:bg-fluux-hover "
+                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
                         >
                           😂
                         </button>
@@ -308,19 +308,19 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                       >
                         <button
                           aria-label="chat.reactWith"
-                          class="px-2 py-1.5 transition-colors text-base hover:bg-fluux-hover "
+                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
                         >
                           👍
                         </button>
                         <button
                           aria-label="chat.reactWith"
-                          class="px-2 py-1.5 transition-colors text-base hover:bg-fluux-hover "
+                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
                         >
                           ❤️
                         </button>
                         <button
                           aria-label="chat.reactWith"
-                          class="px-2 py-1.5 transition-colors text-base hover:bg-fluux-hover "
+                          class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
                         >
                           😂
                         </button>

--- a/apps/fluux/src/components/conversation/MessageToolbar.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.tsx
@@ -175,7 +175,10 @@ export const MessageToolbar = memo(function MessageToolbar({
             }
             handleReaction(emoji)
           }}
-          className={`px-2 py-1.5 transition-colors text-base ${
+          // leading-none collapses the emoji's line box to its em square so the
+          // glyph sits centered in the hover/active fill; the default text-base
+          // line-height (1.5) adds leading that rides the emoji high in the pill.
+          className={`px-2 py-1.5 leading-none transition-colors text-base ${
             showReactionPicker || showMoreMenu ? '' : 'hover:bg-fluux-hover'
           } ${myReactions.includes(emoji) ? 'bg-fluux-brand/20' : ''}`}
           aria-label={t('chat.reactWith', { emoji })}


### PR DESCRIPTION
## Summary

Follow-up to #976. The reaction emoji buttons used `text-base`'s 1.5 line-height, whose extra leading rode the glyph high inside the padded hover/active pill, so the highlight looked bottom-heavy (not vertically centered).

`leading-none` collapses the line box to the em square, centering the glyph in the fill and making the emoji buttons the same height as the icon buttons.