### PR TITLE
fix(fab): stop scroll-to-bottom button flashing during open pin-to-bottom race

### DIFF
--- a/apps/fluux/src/components/conversation/fabVisibility.test.ts
+++ b/apps/fluux/src/components/conversation/fabVisibility.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowScrollToBottomFab } from './fabVisibility'
+
+describe('shouldShowScrollToBottomFab', () => {
+  it('shows the FAB when scrolled past the threshold and not pinning', () => {
+    expect(shouldShowScrollToBottomFab(400, 300, false)).toBe(true)
+  })
+
+  it('hides the FAB within the threshold', () => {
+    expect(shouldShowScrollToBottomFab(100, 300, false)).toBe(false)
+  })
+
+  it('never shows the FAB while pinning to the bottom, even when a transient measurement reports a large distance', () => {
+    // On WebKit, late row measurement grows scrollHeight and fires a 'scroll' event with a
+    // transiently large distFromBottom DURING the open pin-to-bottom loop, before the loop re-pins.
+    // The loop's whole purpose is to settle AT the bottom, so the FAB must stay hidden — otherwise
+    // it flashes on open (intermittent, timing-dependent).
+    expect(shouldShowScrollToBottomFab(1300, 300, true)).toBe(false)
+  })
+})

--- a/apps/fluux/src/components/conversation/fabVisibility.ts
+++ b/apps/fluux/src/components/conversation/fabVisibility.ts
@@ -1,0 +1,20 @@
+/**
+ * Decide whether the scroll-to-bottom FAB should be shown for the current scroll position.
+ *
+ * The obvious rule — "show it once we are more than `threshold` px from the bottom" — is not enough
+ * on its own. When a conversation opens at the bottom, a pin-to-bottom loop repeatedly re-measures
+ * and re-pins as rows lay out. On WebKit (the Tauri desktop app / macOS WKWebView) that late
+ * measurement grows scrollHeight and fires 'scroll' events reporting a transiently large
+ * distFromBottom BEFORE the loop re-pins. Without a guard the FAB flips on for those frames and then
+ * off again — an intermittent, timing-dependent flash on open. While the loop is actively pinning to
+ * the bottom the FAB must stay hidden: the loop is settling at the bottom, so a "scroll to bottom"
+ * affordance is both wrong and flickery.
+ */
+export function shouldShowScrollToBottomFab(
+  distFromBottom: number,
+  threshold: number,
+  pinningToBottom: boolean,
+): boolean {
+  if (pinningToBottom) return false
+  return distFromBottom > threshold
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -24,6 +24,7 @@ import type { ReassertLoopHandle } from './reassertLoopMonitor'
 import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { isProgrammaticScroll } from './scrollGate'
+import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
 
@@ -1746,8 +1747,11 @@ export function useMessageListScroll({
       mediaLoadSnapshotRef.current.userScrolled = true
     }
 
-    // FAB visibility (only React state in scroll handler)
-    const shouldShowFab = distFromBottom > FAB_THRESHOLD
+    // FAB visibility (only React state in scroll handler). Suppressed while the pin-bottom loop owns
+    // scrollTop: on WebKit a tall bottom row's post-paint growth fires 'scroll' events reporting a
+    // transiently large distFromBottom before the loop re-pins, which would otherwise flash the FAB
+    // on open-at-bottom (intermittent race). The loop settles AT the bottom, so the FAB stays hidden.
+    const shouldShowFab = shouldShowScrollToBottomFab(distFromBottom, FAB_THRESHOLD, pinBottomActiveRef.current)
     setShowScrollToBottom(prev => prev !== shouldShowFab ? shouldShowFab : prev)
 
     // Jump-to-last-read pill visibility: is the first-new-message divider currently scrolled


### PR DESCRIPTION
## Summary

Follow-up to #975. That PR removed the exit-animation-on-mount flash, but the scroll-to-bottom FAB could still flash briefly on opening a conversation — intermittently, only on the WebKit desktop app.

**Cause:** `setShowScrollToBottom` was updated from raw per-scroll-event geometry with no guard against the pin-to-bottom loop. On WebKit, a tall bottom row's post-paint growth fires `scroll` events reporting a transiently large `distFromBottom` *before* the loop re-pins. For those frames the FAB flipped on, then off once the loop re-settled — a timing-dependent flash on open-at-bottom. (Chromium measures synchronously, so it doesn't reproduce there.)

**Fix:** Gate FAB visibility on `pinBottomActiveRef` — while the pin loop is actively settling at the bottom, the FAB stays hidden (a "scroll to bottom" affordance is both wrong and flickery there). The decision is extracted into a pure `shouldShowScrollToBottomFab()` helper with unit tests. The pin loop yields to genuine user scroll intent, so scrolling up still shows the FAB normally.

Note: this race is WebKit-specific and can't be reproduced in a Chromium browser, so verification is via the unit test plus manual confirmation on the desktop build.
