### PR TITLE
feat(mds): muted provisional new-message divider while read sync resolves

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -53,7 +53,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   const { t } = useTranslation()
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
-  const { activeConversation, firstNewMessageId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const { activeConversation, firstNewMessageId, firstNewMessageIsProvisional, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, activeMAMState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -497,6 +497,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
             hasKeyboardSelection={hasKeyboardSelection}
             showToolbarForSelection={showToolbarForSelection}
             firstNewMessageId={firstNewMessageId}
+            firstNewMessageIsProvisional={firstNewMessageIsProvisional}
             targetMessageId={targetMessageId}
             clearTargetMessageId={clearTargetMessageId}
             clearFirstNewMessageId={handleClearFirstNewMessageId}
@@ -602,6 +603,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   hasKeyboardSelection,
   showToolbarForSelection,
   firstNewMessageId,
+  firstNewMessageIsProvisional,
   targetMessageId,
   clearTargetMessageId,
   clearFirstNewMessageId,
@@ -645,6 +647,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   hasKeyboardSelection: boolean
   showToolbarForSelection: boolean
   firstNewMessageId?: string
+  firstNewMessageIsProvisional?: boolean
   targetMessageId?: string | null
   clearTargetMessageId?: () => void
   clearFirstNewMessageId: () => void
@@ -748,6 +751,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       messages={messages}
       conversationId={conversationId}
       firstNewMessageId={firstNewMessageId}
+      firstNewMessageIsProvisional={firstNewMessageIsProvisional}
       targetMessageId={targetMessageId}
       onTargetMessageConsumed={clearTargetMessageId}
       clearFirstNewMessageId={clearFirstNewMessageId}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -93,7 +93,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // Active-room state + messaging/scroll actions. Poll / moderation /
   // management actions come from the focused hooks below (they subscribe to no
   // store, so they add no re-render triggers).
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeMAMState, targetMessageId, clearTargetMessageId, firstNewMessageId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, updateLastSeenMessageId, joinRoom, joinResult, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeMAMState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional } = useRoomActive()
   const { sendPoll, votePoll, closePoll } = usePolls()
   const { moderateMessage, setAffiliation, setRole } = useRoomModeration()
   const { setRoomNotifyAll, setRoomAvatar, clearRoomAvatar, submitRoomConfig, setSubject, destroyRoom } = useRoomManagement()
@@ -574,6 +574,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
             hasKeyboardSelection={hasKeyboardSelection}
             showToolbarForSelection={showToolbarForSelection}
             firstNewMessageId={firstNewMessageId}
+            firstNewMessageIsProvisional={firstNewMessageIsProvisional}
             targetMessageId={targetMessageId}
             clearTargetMessageId={clearTargetMessageId}
             clearFirstNewMessageId={handleClearFirstNewMessageId}
@@ -858,6 +859,7 @@ export const RoomMessageList = memo(function RoomMessageList({
   hasKeyboardSelection,
   showToolbarForSelection,
   firstNewMessageId,
+  firstNewMessageIsProvisional,
   targetMessageId,
   clearTargetMessageId,
   clearFirstNewMessageId,
@@ -905,6 +907,7 @@ export const RoomMessageList = memo(function RoomMessageList({
   hasKeyboardSelection: boolean
   showToolbarForSelection: boolean
   firstNewMessageId?: string
+  firstNewMessageIsProvisional?: boolean
   targetMessageId?: string | null
   clearTargetMessageId?: () => void
   clearFirstNewMessageId: () => void
@@ -1143,6 +1146,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       messages={messages}
       conversationId={room.jid}
       firstNewMessageId={firstNewMessageId}
+      firstNewMessageIsProvisional={firstNewMessageIsProvisional}
       targetMessageId={targetMessageId}
       onTargetMessageConsumed={clearTargetMessageId}
       clearFirstNewMessageId={clearFirstNewMessageId}

--- a/apps/fluux/src/components/conversation/MessageList.newMessageMarker.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.newMessageMarker.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * MessageList → NewMessageMarker plumbing.
+ *
+ * Guards the divider contract end to end at the component level:
+ * - the divider renders exactly once, inside the row of firstNewMessageId;
+ * - `firstNewMessageIsProvisional` reaches the marker (muted "tentative"
+ *   rendering while a synced XEP-0490 read position is unresolved);
+ * - omitted flag renders the definitive (accent) divider.
+ *
+ * Uses staticMode so every row mounts under jsdom (no virtualizer window).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import { createTestMessages } from './MessageList.test-utils'
+import { scrollStateManager } from '@/utils/scrollStateManager'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(),
+    selectionCount: 0,
+    isSelecting: false,
+    selectAll: vi.fn(),
+    extendTo: vi.fn(),
+    clearSelection: vi.fn(),
+    copySelected: vi.fn(),
+  })),
+}))
+
+describe('MessageList — new-message divider plumbing', () => {
+  beforeEach(() => scrollStateManager.reset())
+  afterEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  const messages = createTestMessages(10)
+  const renderMessage = (m: { id: string }) => <div>{m.id}</div>
+
+  function renderList(props: { firstNewMessageId?: string; firstNewMessageIsProvisional?: boolean }) {
+    return render(
+      <MessageList
+        messages={messages}
+        conversationId="marker-conv"
+        renderMessage={renderMessage}
+        staticMode
+        {...props}
+      />,
+    )
+  }
+
+  it('renders the divider exactly once, inside the firstNewMessageId row', () => {
+    const { container } = renderList({ firstNewMessageId: 'msg-5' })
+    const markers = container.querySelectorAll('[data-new-message-marker]')
+    expect(markers).toHaveLength(1)
+    expect(container.querySelector('[data-message-id="msg-5"] [data-new-message-marker]')).not.toBeNull()
+  })
+
+  it('renders no divider without firstNewMessageId', () => {
+    const { container } = renderList({})
+    expect(container.querySelectorAll('[data-new-message-marker]')).toHaveLength(0)
+  })
+
+  it('passes the provisional flag through to the marker (muted rendering)', () => {
+    const { container } = renderList({ firstNewMessageId: 'msg-5', firstNewMessageIsProvisional: true })
+    const marker = container.querySelector('[data-new-message-marker]') as HTMLElement
+    expect(marker.dataset.provisional).toBe('true')
+    expect(marker.querySelector('span')?.style.color).toBe('var(--fluux-text-muted)')
+  })
+
+  it('renders the definitive (accent) divider when the flag is omitted', () => {
+    const { container } = renderList({ firstNewMessageId: 'msg-5' })
+    const marker = container.querySelector('[data-new-message-marker]') as HTMLElement
+    expect(marker.dataset.provisional).toBeUndefined()
+    expect(marker.querySelector('span')?.style.color).toBe('var(--fluux-text-self)')
+  })
+})

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -70,6 +70,8 @@ export interface MessageListProps<T extends BaseMessage> {
   conversationId: string
   /** ID of the first unread message (for new message marker) */
   firstNewMessageId?: string
+  /** Divider derived while a synced XEP-0490 read position is still unresolved — rendered muted */
+  firstNewMessageIsProvisional?: boolean
   /** ID of a specific message to scroll to (e.g., from activity log click) */
   targetMessageId?: string | null
   /** Called after scrolling to target message (to clear the store value) */
@@ -152,6 +154,7 @@ export function MessageList<T extends BaseMessage>({
   messages,
   conversationId,
   firstNewMessageId,
+  firstNewMessageIsProvisional = false,
   clearFirstNewMessageId,
   targetMessageId,
   onTargetMessageConsumed,
@@ -656,7 +659,7 @@ export function MessageList<T extends BaseMessage>({
             {msg.id === gapMarkerMessageId && onCatchUpHistory && (
               <HistoryGapMarker onLoadMore={onCatchUpHistory} isLoading={isCatchingUp ?? false} />
             )}
-            {item.isFirstNew && <NewMessageMarker />}
+            {item.isFirstNew && <NewMessageMarker provisional={firstNewMessageIsProvisional} />}
             {renderMessage(msg, item.indexInGroup, item.groupMessages, item.isFirstNew, handleMediaLoad)}
           </div>
         )
@@ -811,7 +814,7 @@ export function MessageList<T extends BaseMessage>({
                     style={msg.id === lastSentMessageId ? { animation: 'message-send var(--fluux-duration-slow) var(--fluux-ease-standard)' } : undefined}
                   >
                     {showGapMarker && <HistoryGapMarker onLoadMore={onCatchUpHistory} isLoading={isCatchingUp ?? false} />}
-                    {showNewMarker && <NewMessageMarker />}
+                    {showNewMarker && <NewMessageMarker provisional={firstNewMessageIsProvisional} />}
                     {renderMessage(msg, idx, group.messages, showNewMarker, handleMediaLoad)}
                   </div>
                 )

--- a/apps/fluux/src/components/conversation/NewMessageMarker.test.tsx
+++ b/apps/fluux/src/components/conversation/NewMessageMarker.test.tsx
@@ -15,4 +15,21 @@ describe('NewMessageMarker', () => {
     const styled = container.querySelectorAll('[style*="--fluux-text-self"]')
     expect(styled.length).toBe(3)
   })
+
+  // Provisional = derived from the local read pointer while a synced XEP-0490
+  // read position is still unresolved; it may move or vanish once the marker
+  // resolves, so it renders muted rather than looking definitive.
+  it('renders muted grey when provisional', () => {
+    const { container } = render(<NewMessageMarker provisional />)
+    const marker = container.querySelector('[data-new-message-marker]') as HTMLElement
+    expect(marker?.dataset.provisional).toBe('true')
+    expect(container.querySelectorAll('[style*="--fluux-text-muted"]').length).toBe(3)
+    expect(container.querySelectorAll('[style*="--fluux-text-self"]').length).toBe(0)
+  })
+
+  it('is not marked provisional by default', () => {
+    const { container } = render(<NewMessageMarker />)
+    const marker = container.querySelector('[data-new-message-marker]') as HTMLElement
+    expect(marker?.dataset.provisional).toBeUndefined()
+  })
 })

--- a/apps/fluux/src/components/conversation/NewMessageMarker.tsx
+++ b/apps/fluux/src/components/conversation/NewMessageMarker.tsx
@@ -3,17 +3,26 @@ import { useTranslation } from 'react-i18next'
 /**
  * Displays an accent horizontal line with "New Messages" label.
  * Used to indicate where unread messages begin in the conversation.
+ *
+ * `provisional`: the position was derived from the local read pointer while a
+ * synced XEP-0490 read position is still unresolved — it may move or vanish
+ * once the marker resolves, so it renders muted instead of the accent color.
  */
-export function NewMessageMarker() {
+export function NewMessageMarker({ provisional = false }: { provisional?: boolean }) {
   const { t } = useTranslation()
+  const color = provisional ? 'var(--fluux-text-muted)' : 'var(--fluux-text-self)'
 
   return (
-    <div className="flex items-center gap-4 h-12" data-new-message-marker>
-      <div className="flex-1 h-px" style={{ backgroundColor: 'var(--fluux-text-self)' }} />
-      <span className="text-xs font-semibold" style={{ color: 'var(--fluux-text-self)' }}>
+    <div
+      className="flex items-center gap-4 h-12"
+      data-new-message-marker
+      {...(provisional ? { 'data-provisional': 'true' } : {})}
+    >
+      <div className="flex-1 h-px" style={{ backgroundColor: color }} />
+      <span className="text-xs font-semibold" style={{ color }}>
         {t('chat.newMessages')}
       </span>
-      <div className="flex-1 h-px" style={{ backgroundColor: 'var(--fluux-text-self)' }} />
+      <div className="flex-1 h-px" style={{ backgroundColor: color }} />
     </div>
   )
 }

--- a/packages/fluux-sdk/src/hooks/useChatActive.ts
+++ b/packages/fluux-sdk/src/hooks/useChatActive.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { chatStore, connectionStore } from '../stores'
+import { chatSelectors } from '../stores/chatSelectors'
 import { useChatStore, useConnectionStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
 import type { Conversation, MAMQueryState, Message } from '../core'
@@ -88,6 +89,12 @@ export function useChatActive() {
   const activeFirstNewMessageId = useChatStore((s) => {
     if (!s.activeConversationId) return undefined
     return s.firstNewMessageMarkers.get(s.activeConversationId)
+  })
+  // Provisional divider: derived from the local pointer while a synced XEP-0490
+  // read position is still unresolved — rendered muted until confirmed.
+  const activeFirstNewMessageIsProvisional = useChatStore((s) => {
+    if (!s.activeConversationId) return false
+    return chatSelectors.firstNewMessageIsProvisionalFor(s.activeConversationId)(s)
   })
 
   // Reconstruct a stable activeConversation object from individual primitive fields.
@@ -310,6 +317,7 @@ export function useChatActive() {
       activeConversationId,
       activeConversation,
       firstNewMessageId: activeFirstNewMessageId,
+      firstNewMessageIsProvisional: activeFirstNewMessageIsProvisional,
       activeMessages,
       activeTypingUsers,
       activeAnimation,
@@ -320,7 +328,7 @@ export function useChatActive() {
       ...actions,
     }),
     [
-      activeConversationId, activeConversation, activeFirstNewMessageId, activeMessages,
+      activeConversationId, activeConversation, activeFirstNewMessageId, activeFirstNewMessageIsProvisional, activeMessages,
       activeTypingUsers, activeAnimation, targetMessageId, supportsMAM, activeMAMState,
       activeWindowAtLiveEdge, actions,
     ]

--- a/packages/fluux-sdk/src/hooks/useRoomActive.ts
+++ b/packages/fluux-sdk/src/hooks/useRoomActive.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { roomStore, connectionStore } from '../stores'
+import { roomSelectors } from '../stores/roomSelectors'
 import { useRoomStore } from '../react/storeHooks'
 import { useXMPPContext } from '../provider'
 import type { Room, RoomMessage, MentionReference, ChatStateNotification, FileAttachment, MAMQueryState, RoomFeatures } from '../core/types'
@@ -84,6 +85,13 @@ export function useRoomActive() {
   const activeFirstNewMessageId = useRoomStore((s) => {
     if (!s.activeRoomJid) return undefined
     return s.firstNewMessageMarkers.get(s.activeRoomJid)
+  })
+
+  // Provisional divider: derived from the local pointer while a synced XEP-0490
+  // read position is still unresolved — rendered muted until confirmed.
+  const activeFirstNewMessageIsProvisional = useRoomStore((s) => {
+    if (!s.activeRoomJid) return false
+    return roomSelectors.firstNewMessageIsProvisionalFor(s.activeRoomJid)(s)
   })
 
   const activeRoomRuntime = useRoomStore((s) => {
@@ -490,6 +498,7 @@ export function useRoomActive() {
       targetMessageId,
       activeMAMState,
       firstNewMessageId: activeFirstNewMessageId,
+      firstNewMessageIsProvisional: activeFirstNewMessageIsProvisional,
       windowAtLiveEdge: activeWindowAtLiveEdge,
 
       // Actions (spread memoized actions)
@@ -504,6 +513,7 @@ export function useRoomActive() {
       targetMessageId,
       activeMAMState,
       activeFirstNewMessageId,
+      activeFirstNewMessageIsProvisional,
       activeWindowAtLiveEdge,
       actions,
     ]

--- a/packages/fluux-sdk/src/stores/chatSelectors.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.ts
@@ -232,6 +232,19 @@ export const chatSelectors = {
     return state.firstNewMessageMarkers.get(conversationId)
   },
 
+  /**
+   * Is the conversation's new-message divider provisional? True while a synced
+   * XEP-0490 read position is still unresolved (pendingRemoteDisplayedStanzaId
+   * set): the divider was derived from the local read pointer and may move or
+   * vanish once the marker's message loads. Purely derived — resolving the
+   * marker (advance OR clear-pending) confirms the divider with no extra state.
+   */
+  firstNewMessageIsProvisionalFor: (conversationId: string) => (state: ChatState): boolean => {
+    if (!state.firstNewMessageMarkers.has(conversationId)) return false
+    const meta = state.conversationMeta.get(conversationId) ?? state.conversations.get(conversationId)
+    return meta?.pendingRemoteDisplayedStanzaId !== undefined
+  },
+
   // ============================================================
   // METADATA SELECTORS - Fine-grained subscriptions (Phase 6)
   // ============================================================

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -579,4 +579,53 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     // …and the divider derives from it, not from the stale local pointer (m2 → 'm3').
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m6')
   })
+
+  // A divider derived while a pending marker is still UNRESOLVED is provisional —
+  // the synced read position may move or erase it once the marker's message loads.
+  // The UI renders it muted until it is confirmed (pending resolved).
+  it('flags the divider provisional while the pending marker is unresolved, confirmed once it resolves', async () => {
+    const cid = 'provisional@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    const messages = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4)]
+    seedMessages(cid, messages)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's0' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's0' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+
+    // Divider derived from the local pointer, but the synced position is unknown → provisional.
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(true)
+
+    // The marker's message arrives (merge): it sits BEHIND the pointer → clear-pending.
+    // The divider is untouched but now confirmed.
+    chatStore.getState().applyRemoteDisplayed(cid, 's0', [timed('m0', 's0', 0), ...messages])
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
+  })
+
+  it('a divider derived with no pending marker is never provisional', async () => {
+    const cid = 'confirmed@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    seedMessages(cid, [timed('m1', 's1', 1), timed('m2', 's2', 2)])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm1' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm1' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m2')
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
+  })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -628,4 +628,74 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m2')
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
   })
+
+  it('a pending marker without a divider is not provisional (nothing to render)', () => {
+    const cid = 'pending-no-divider@capulet.example'
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm1', pendingRemoteDisplayedStanzaId: 's9' })
+      return { conversationMeta: newMeta }
+    })
+
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
+  })
+
+  // The flash scenario, made explicit: a provisional divider must settle to its
+  // DEFINITIVE position (moved, confirmed) when the marker resolves AHEAD of it
+  // on the active conversation — and stop being provisional.
+  it('moves the divider and confirms it when the marker resolves ahead of it (active conversation)', async () => {
+    const cid = 'resolve-ahead@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    // m4 is NOT loaded at activation (deep gap) — the marker for s4 can only stash.
+    const loaded = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m5', 's5', 5)]
+    seedMessages(cid, loaded)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's4' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm2', pendingRemoteDisplayedStanzaId: 's4' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+    // Provisional divider from the stale local pointer (m2 → m3).
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m3')
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(true)
+
+    // The marker's message arrives (merge): the synced read is ahead → the divider
+    // settles after the synced position, definitive.
+    const full = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4), timed('m5', 's5', 5)]
+    chatStore.getState().applyRemoteDisplayed(cid, 's4', full)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m4')
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m5')
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
+  })
+
+  it('erases the provisional divider when the marker resolves at the newest message (all read elsewhere)', async () => {
+    const cid = 'resolve-erase@capulet.example'
+    const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
+    const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
+    const loaded = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3)]
+    seedMessages(cid, loaded)
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId: 'm1', pendingRemoteDisplayedStanzaId: 's9' })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId: 'm1', pendingRemoteDisplayedStanzaId: 's9' })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+
+    await chatStore.getState().activateConversation(cid)
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m2')
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(true)
+
+    // The other device read everything: the marker resolves at the newest message.
+    chatStore.getState().applyRemoteDisplayed(cid, 's9', [...loaded, timed('m9', 's9', 9)])
+
+    expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
+    expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+  })
 })

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -360,6 +360,19 @@ export const roomSelectors = {
   },
 
   /**
+   * Is the room's new-message divider provisional? True while a synced
+   * XEP-0490 read position is still unresolved (pendingRemoteDisplayedStanzaId
+   * set): the divider was derived from the local read pointer and may move or
+   * vanish once the marker's message loads. Purely derived — resolving the
+   * marker (advance OR clear-pending) confirms the divider with no extra state.
+   */
+  firstNewMessageIsProvisionalFor: (roomJid: string) => (state: RoomState): boolean => {
+    if (!state.firstNewMessageMarkers.has(roomJid)) return false
+    const meta = state.roomMeta.get(roomJid) ?? state.rooms.get(roomJid)
+    return meta?.pendingRemoteDisplayedStanzaId !== undefined
+  },
+
+  /**
    * Get self occupant for a specific room.
    */
   selfOccupantFor: (roomJid: string) => (state: RoomState): RoomOccupant | undefined => {

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -453,6 +453,69 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     expect(roomSelectors.firstNewMessageIdFor(CONF_ROOM)(roomStore.getState())).toBe('m2')
     expect(roomSelectors.firstNewMessageIsProvisionalFor(CONF_ROOM)(roomStore.getState())).toBe(false)
   })
+
+  it('a pending marker without a divider is not provisional (nothing to render)', () => {
+    const NO_DIVIDER_ROOM = 'pending-no-divider@conference.example'
+    seedRoom(NO_DIVIDER_ROOM, [rmsg('m1', 's1', 1)], 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(NO_DIVIDER_ROOM, { ...m.get(NO_DIVIDER_ROOM)!, pendingRemoteDisplayedStanzaId: 's9' })
+      return { roomMeta: m }
+    })
+
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(NO_DIVIDER_ROOM)(roomStore.getState())).toBe(false)
+  })
+
+  // The flash scenario, made explicit: a provisional divider must settle to its
+  // DEFINITIVE position (moved, confirmed) when the marker resolves AHEAD of it
+  // on the active room — and stop being provisional.
+  it('moves the divider and confirms it when the marker resolves ahead of it (active room)', async () => {
+    const AHEAD_ROOM = 'resolve-ahead@conference.example'
+    // m4 is NOT loaded at activation (deep gap) — the marker for s4 can only stash.
+    const loaded = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m5', 's5', 5)]
+    seedRoom(AHEAD_ROOM, loaded, 'm2')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(AHEAD_ROOM, { ...m.get(AHEAD_ROOM)!, pendingRemoteDisplayedStanzaId: 's4' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(AHEAD_ROOM)
+    // Provisional divider from the stale local pointer (m2 → m3).
+    expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m3')
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(AHEAD_ROOM)(roomStore.getState())).toBe(true)
+
+    // The marker's message arrives (merge): the synced read is ahead → the divider
+    // settles after the synced position, definitive.
+    const full = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4), rmsg('m5', 's5', 5)]
+    roomStore.getState().applyRemoteDisplayed(AHEAD_ROOM, 's4', full)
+
+    expect(roomStore.getState().roomMeta.get(AHEAD_ROOM)?.lastSeenMessageId).toBe('m4')
+    expect(roomSelectors.firstNewMessageIdFor(AHEAD_ROOM)(roomStore.getState())).toBe('m5')
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(AHEAD_ROOM)(roomStore.getState())).toBe(false)
+  })
+
+  it('erases the provisional divider when the marker resolves at the newest message (all read elsewhere)', async () => {
+    const ERASE_ROOM = 'resolve-erase@conference.example'
+    const loaded = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)]
+    seedRoom(ERASE_ROOM, loaded, 'm1')
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(ERASE_ROOM, { ...m.get(ERASE_ROOM)!, pendingRemoteDisplayedStanzaId: 's9' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(ERASE_ROOM)
+    expect(roomSelectors.firstNewMessageIdFor(ERASE_ROOM)(roomStore.getState())).toBe('m2')
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(ERASE_ROOM)(roomStore.getState())).toBe(true)
+
+    // The other device read everything: the marker resolves at the newest message.
+    roomStore.getState().applyRemoteDisplayed(ERASE_ROOM, 's9', [...loaded, rmsg('m9', 's9', 9)])
+
+    expect(roomSelectors.firstNewMessageIdFor(ERASE_ROOM)(roomStore.getState())).toBeUndefined()
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(ERASE_ROOM)(roomStore.getState())).toBe(false)
+    expect(roomStore.getState().roomMeta.get(ERASE_ROOM)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+  })
 })
 
 describe('roomStore — new-message divider is session-only', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -416,6 +416,43 @@ describe('roomStore.activateRoom — XEP-0490 divider sync', () => {
     // …and the divider derives from it, not from the stale local pointer (m2 → 'm3').
     expect(roomSelectors.firstNewMessageIdFor(DEEP_ROOM)(roomStore.getState())).toBe('m6')
   })
+
+  // A divider derived while a pending marker is still UNRESOLVED is provisional —
+  // the synced read position may move or erase it once the marker's message loads.
+  // The UI renders it muted until it is confirmed (pending resolved).
+  it('flags the divider provisional while the pending marker is unresolved, confirmed once it resolves', async () => {
+    const PROV_ROOM = 'provisional@conference.example'
+    const messages = [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3), rmsg('m4', 's4', 4)]
+    seedRoom(PROV_ROOM, messages, 'm2')
+    // A marker references a message that is not loadable yet (e.g. s0 predates the slice).
+    roomStore.setState((s) => {
+      const m = new Map(s.roomMeta)
+      m.set(PROV_ROOM, { ...m.get(PROV_ROOM)!, pendingRemoteDisplayedStanzaId: 's0' })
+      return { roomMeta: m }
+    })
+
+    await roomStore.getState().activateRoom(PROV_ROOM)
+
+    // Divider derived from the local pointer, but the synced position is unknown → provisional.
+    expect(roomSelectors.firstNewMessageIdFor(PROV_ROOM)(roomStore.getState())).toBe('m3')
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(PROV_ROOM)(roomStore.getState())).toBe(true)
+
+    // The marker's message arrives (merge): it sits BEHIND the pointer → clear-pending.
+    // The divider is untouched but now confirmed.
+    roomStore.getState().applyRemoteDisplayed(PROV_ROOM, 's0', [rmsg('m0', 's0', 0), ...messages])
+    expect(roomSelectors.firstNewMessageIdFor(PROV_ROOM)(roomStore.getState())).toBe('m3')
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(PROV_ROOM)(roomStore.getState())).toBe(false)
+  })
+
+  it('a divider derived with no pending marker is never provisional', async () => {
+    const CONF_ROOM = 'confirmed@conference.example'
+    seedRoom(CONF_ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2)], 'm1')
+
+    await roomStore.getState().activateRoom(CONF_ROOM)
+
+    expect(roomSelectors.firstNewMessageIdFor(CONF_ROOM)(roomStore.getState())).toBe('m2')
+    expect(roomSelectors.firstNewMessageIsProvisionalFor(CONF_ROOM)(roomStore.getState())).toBe(false)
+  })
 })
 
 describe('roomStore — new-message divider is session-only', () => {


### PR DESCRIPTION
Follow-up to #981. Opening a conversation while a XEP-0490 marker was still unresolved derived the divider from the stale local pointer, then erased or moved it when the marker resolved — the divider flashed and vanished with no explanation.

The divider now has a derived **provisional** state: true while the entity still has an unresolved `pendingRemoteDisplayedStanzaId`. Provisional dividers render muted grey (`--fluux-text-muted`); any resolution (advance, active-divider recompute, or clear-pending) removes the pending mark, flipping the divider to the definitive accent color in place — or repositioning/removing it, now visually explained as a tentative marker settling.

No new store state: `firstNewMessageIsProvisionalFor` selectors derive it, `useChatActive`/`useRoomActive` expose `firstNewMessageIsProvisional`, and `NewMessageMarker` renders the muted variant (plus a `data-provisional` attribute for tests/e2e).