### PR TITLE
fix(occupants): make member row hover perceptible

### DIFF
--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -179,7 +179,7 @@ const OccupantRow = memo(function OccupantRow({
         onTouchStart={(e) => onTouchStart(group, e)}
         onTouchEnd={onTouchEnd}
         onTouchMove={onTouchMove}
-        className={`px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-hover/50 cursor-default
+        className={`px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-message-hover transition-colors cursor-default
                    ${isMe ? 'bg-fluux-brand/10' : ''}
                    ${ignored ? 'opacity-40' : ''}`}
       >
@@ -588,7 +588,7 @@ export function OccupantPanel({
             position="left"
             className="block"
           >
-            <div className="px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-hover/50 cursor-default opacity-60">
+            <div className="px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-message-hover transition-colors cursor-default opacity-60">
               <Avatar
                 identifier={displayName}
                 name={displayName}
@@ -644,7 +644,7 @@ export function OccupantPanel({
               onTouchStart={(e) => handleOccupantTouchStart(e, syntheticGroup)}
               onTouchEnd={menu.handleTouchEnd}
               onTouchMove={menu.handleTouchEnd}
-              className="px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-hover/50 cursor-default opacity-40"
+              className="px-4 py-1.5 flex items-center gap-2 hover:bg-fluux-message-hover transition-colors cursor-default opacity-40"
             >
               <Avatar
                 identifier={displayName}


### PR DESCRIPTION
The occupant/members panel had no visible hover on its rows, unlike the other sidebars.

**Cause:** the panel sits on the `bg-fluux-chat` canvas (base-30), but rows hovered to `bg-fluux-hover/50` — base-40 is only one ramp step above the canvas, and the `/50` opacity halves even that, so the highlight read as almost nothing. This is the exact trap already documented in `index.css` for message rows on the same canvas.

**Fix:** switch all three row types (occupant, offline member, ignored) to `bg-fluux-message-hover` (base-50) — the token the message list already uses for a clearly perceptible but quiet highlight on this canvas — and add `transition-colors` for parity with the other sidebar rows.