### PR TITLE
fix(scroll): keep bottom glued when a reaction grows a mid-viewport row

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -252,53 +252,65 @@ describe('MessageList scroll behavior', () => {
   })
 
   describe('reactions scroll', () => {
-    // A reaction grows the last message's row. While the reader is sticked to the bottom we keep it
-    // visible with a GENTLE single smooth nudge (not the heavy multi-frame pin loop, and not the old
-    // hard yank). It is gated on LIVE geometry, so a reader scrolled up into history is never nudged.
+    // A reaction grows a message's row. While the reader is sticked to the bottom we keep the newest
+    // message glued to the bottom edge via reassertBottom — the same shared helper new messages and the
+    // typing footer use. On the non-virtualized path that's an INSTANT scrollTop = scrollHeight write
+    // (no smooth animation, which is what used to visibly shove the newest message down). It is gated
+    // on LIVE geometry, so a reader scrolled up into history is never re-pinned.
     const reactOnLast = (msgs: ReturnType<typeof createTestMessages>) => {
       const copy = [...msgs]
       copy[copy.length - 1] = { ...copy[copy.length - 1], reactions: { '👍': ['someone@example.com'] } }
       return copy
     }
-    const instrument = (container: HTMLDivElement, scrollTop: number) => {
+    const instrument = (container: HTMLDivElement, initialScrollTop: number) => {
       Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
       Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
-      Object.defineProperty(container, 'scrollTop', { value: scrollTop, writable: true, configurable: true })
+      let scrollTopValue = initialScrollTop
+      const scrollTopWrites = vi.fn()
+      Object.defineProperty(container, 'scrollTop', {
+        get: () => scrollTopValue,
+        set: (v) => { scrollTopValue = v; scrollTopWrites(v) },
+        configurable: true,
+      })
       const scrollToSpy = vi.fn()
       container.scrollTo = scrollToSpy
-      return scrollToSpy
+      return { scrollToSpy, scrollTopWrites, getScrollTop: () => scrollTopValue }
     }
 
-    it('gently nudges the bottom (smooth) when the last message gets a reaction while sticked', () => {
+    it('instantly re-pins the bottom (no smooth animation) when a message gets a reaction while sticked', () => {
       const messages = createTestMessages(5)
       const { rerender } = render(
         <MessageList messages={messages} conversationId="conv-1" clearFirstNewMessageId={vi.fn()} renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>} />
       )
       const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
       // scrollTop 500 → distFromBottom 0 (< AT_BOTTOM_THRESHOLD): the reader is sticked to the bottom.
-      const scrollToSpy = instrument(container, 500)
+      const { scrollToSpy, getScrollTop } = instrument(container, 500)
 
       rerender(
         <MessageList messages={reactOnLast(messages)} conversationId="conv-1" clearFirstNewMessageId={vi.fn()} renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>} />
       )
 
-      expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ top: 1000, behavior: 'smooth' }))
+      // Instant pin: scrollTop is written straight to scrollHeight, NOT a smooth scrollTo nudge.
+      expect(getScrollTop()).toBe(1000)
+      expect(scrollToSpy).not.toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
     })
 
-    it('does NOT nudge when a reaction arrives while the reader is scrolled up', () => {
+    it('does NOT re-pin when a reaction arrives while the reader is scrolled up', () => {
       const messages = createTestMessages(5)
       const { rerender } = render(
         <MessageList messages={messages} conversationId="conv-1" clearFirstNewMessageId={vi.fn()} renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>} />
       )
       const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
       // scrollTop 200 → distFromBottom 300 (>= AT_BOTTOM_THRESHOLD 150): scrolled up into history.
-      const scrollToSpy = instrument(container, 200)
+      const { scrollToSpy, scrollTopWrites, getScrollTop } = instrument(container, 200)
 
       rerender(
         <MessageList messages={reactOnLast(messages)} conversationId="conv-1" clearFirstNewMessageId={vi.fn()} renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>} />
       )
 
+      expect(scrollTopWrites).not.toHaveBeenCalled()
       expect(scrollToSpy).not.toHaveBeenCalled()
+      expect(getScrollTop()).toBe(200)
     })
   })
 

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -234,12 +234,20 @@ export function MessageList<T extends BaseMessage>({
   // Compute derived values for scroll hook
   const firstMessageId = deduplicatedMessages[0]?.id
   const lastMessage = messages[messages.length - 1]
-  // Signature of the last message's reactions — changes when a reaction is added/removed on it, which
-  // grows/shrinks its row. Used only to give a gentle bottom nudge while the reader is sticked to the
-  // bottom (see the reactions effect in useMessageListScroll).
-  const lastMessageReactionsKey = lastMessage
-    ? JSON.stringify(lastMessage.reactions || {})
-    : ''
+  // Signature of every resident message's reactions — changes when a reaction is added/removed
+  // anywhere in the window, which grows/shrinks that row. Cheap: only messages that actually carry
+  // reactions contribute, so the common no-reaction rows cost a bare iteration. Drives an instant
+  // bottom re-pin while the reader is sticked to the bottom, so reaction growth is absorbed above
+  // (previous messages scroll up) instead of shoving the newest message down (see the reactions
+  // effect in useMessageListScroll).
+  const reactionsSignature = useMemo(() => {
+    let sig = ''
+    for (const m of deduplicatedMessages) {
+      const r = m.reactions
+      if (r && Object.keys(r).length > 0) sig += `${m.id}:${JSON.stringify(r)};`
+    }
+    return sig
+  }, [deduplicatedMessages])
 
   // --------------------------------------------------------------------------
   // SCROLL BEHAVIOR (delegated to hook)
@@ -518,7 +526,7 @@ export function MessageList<T extends BaseMessage>({
     isLoadingNewer,
     windowAtLiveEdge,
     isHistoryComplete,
-    lastMessageReactionsKey,
+    reactionsSignature,
     hasTypingIndicator: typingUsers.length > 0,
     lastMessageIsOutgoing: lastMessage?.isOutgoing ?? false,
     lastMessageId: lastMessage?.id,

--- a/apps/fluux/src/components/conversation/useMessageListScroll.loadNewer.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.loadNewer.test.tsx
@@ -38,7 +38,7 @@ function Harness({
     conversationId: 'room@conf.example.com',
     messageCount: 20,
     firstMessageId: 'm-0',
-    lastMessageReactionsKey: '',
+    reactionsSignature: '',
     lastMessageId: 'm-19',
     onLoadNewer,
     isLoadingNewer,

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -79,7 +79,7 @@ function HookHarness({
     firstNewMessageId,
     clearFirstNewMessageId,
     onLoadAround,
-    lastMessageReactionsKey: '',
+    reactionsSignature: '',
     lastMessageId: ids.at(-1),
   })
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -250,12 +250,14 @@ export interface UseMessageListScrollOptions {
    *  ⇒ at the live edge — unchanged behavior. */
   windowAtLiveEdge?: boolean
   isHistoryComplete?: boolean
-  /** Signature of the last message's reactions. Changes when a reaction is added/removed on the last
-   *  row (growing/shrinking it); drives a gentle bottom nudge while the reader is sticked to bottom. */
-  lastMessageReactionsKey: string
+  /** Signature of the reactions across the resident window. Changes when a reaction is added/removed on
+   *  ANY row (growing/shrinking it); drives an instant bottom re-pin while the reader is sticked to the
+   *  bottom, so the growth is absorbed above (previous messages scroll up) instead of shoving the
+   *  newest message down. */
+  reactionsSignature: string
   /** Whether the floating typing-indicator pill is currently shown. The footer reserves extra bottom
-   *  padding to clear the pill only while this is true; the 0→true edge drives the same gentle
-   *  bottom nudge as a reaction growing the last row, gated on live geometry (see the reactions
+   *  padding to clear the pill only while this is true; the 0→true edge drives the same instant
+   *  bottom re-pin as a reaction growing a row, gated on live geometry (see the reactions
    *  effect) so it never fires for a reader scrolled up into history — the #918 "fight" was a stale
    *  isAtBottomRef latch, not the padding change itself. */
   hasTypingIndicator?: boolean
@@ -320,7 +322,7 @@ export function useMessageListScroll({
   isLoadingNewer,
   windowAtLiveEdge,
   isHistoryComplete,
-  lastMessageReactionsKey,
+  reactionsSignature,
   hasTypingIndicator = false,
   lastMessageIsOutgoing = false,
   lastMessageId,
@@ -2749,43 +2751,46 @@ export function useMessageListScroll({
   }, [firstNewMessageId])
 
   // ==========================================================================
-  // EFFECT: Reaction on the last message — gentle bottom nudge (only when sticked)
+  // EFFECT: Reaction added/removed — keep the bottom glued (only when sticked)
   // ==========================================================================
 
-  // A reaction added to the last message grows its row a little. While the reader is sticked to the
-  // bottom we keep the reaction visible with a GENTLE, single smooth nudge — NOT the multi-frame
-  // pinVirtualizedBottom loop (that WebKitGTK-heavy re-assert is for new messages; a reaction is a
-  // tiny ambient growth and a jolt would be jarring). Two safeguards keep it from ever fighting a
-  // scroll: (1) it's gated on LIVE geometry, not the latchable isAtBottomRef — a reader scrolled up
-  // into history reads distFromBottom >= threshold and is never nudged (this is what made a typing
-  // toggle "fight" the scroll in #918: a stale-true latch); (2) it fires only on an actual reactions
-  // change WITHIN the same conversation, so a conversation switch / restore is never disturbed.
-  // (The typing indicator pill itself still floats OVER the list, #918 — it never lives in scroll
-  // content. Only the footer's reserved clearance for it participates; see the next effect.)
-  const prevReactionsKeyRef = useRef(lastMessageReactionsKey)
+  // A reaction grows (or shrinks) its message row. While the reader is sticked to the bottom we keep
+  // the newest message glued to the bottom edge and let the growth be absorbed ABOVE (previous
+  // messages scroll up) — rather than letting the row growth shove the newest message down. This runs
+  // for a reaction on ANY resident row, not just the last one: a reaction in the middle of the
+  // viewport would otherwise push everything below it (including the newest message) down.
+  //
+  // We route through reassertBottom (the same multi-frame pinVirtualizedBottom convergence new
+  // messages and the typing footer use) rather than a one-shot scrollToIndex, because the row's
+  // ResizeObserver reports the grown height a frame or two AFTER the chip mounts — a single
+  // synchronous pin would land on the pre-growth height and still let the bottom dip. The loop polls
+  // scrollHeight per frame and re-pins instantly (no smooth easing, so nothing visibly animates),
+  // converging in a handful of frames. It's pure imperative scroll work — no React re-render.
+  //
+  // Two safeguards keep it from ever fighting a scroll: (1) it's gated on LIVE geometry, not the
+  // latchable isAtBottomRef — a reader scrolled up into history reads distFromBottom >= threshold and
+  // is never re-pinned (a stale-true latch is what made a typing toggle "fight" the scroll in #918);
+  // (2) it fires only on an actual reactions change WITHIN the same conversation, so a conversation
+  // switch / restore is never disturbed.
+  const prevReactionsKeyRef = useRef(reactionsSignature)
   const reactionsConvRef = useRef(conversationId)
   useLayoutEffect(() => {
     const sameConversation = reactionsConvRef.current === conversationId
     reactionsConvRef.current = conversationId
     const prevKey = prevReactionsKeyRef.current
-    prevReactionsKeyRef.current = lastMessageReactionsKey
-    if (!sameConversation) return // conversation switch → rebaseline, never nudge
-    if (prevKey === lastMessageReactionsKey) return // no actual reactions change (unrelated re-render)
+    prevReactionsKeyRef.current = reactionsSignature
+    if (!sameConversation) return // conversation switch → rebaseline, never re-pin
+    if (prevKey === reactionsSignature) return // no actual reactions change (unrelated re-render)
 
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return
-    // Live-geometry gate: only nudge when genuinely at/near the bottom right now.
+    // Live-geometry gate: only re-pin when genuinely at/near the bottom right now.
     if (getDistanceFromBottom(scroller) >= AT_BOTTOM_THRESHOLD) return
-    // A running pin loop already keeps the bottom pinned — don't stack a second scroll on it.
+    // A running pin loop already keeps the bottom pinned — don't stack a second one.
     if (pinBottomActiveRef.current) return
 
-    const virt = virtualizerRef.current
-    if (virt && virt.itemCount > 0) {
-      virt.scrollToIndex(virt.itemCount - 1, { align: 'end', behavior: 'smooth' })
-    } else {
-      scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
-    }
-  }, [lastMessageReactionsKey, conversationId, staticMode])
+    reassertBottom('reaction')
+  }, [reactionsSignature, conversationId, staticMode, reassertBottom])
 
   // ==========================================================================
   // EFFECT: Typing indicator appears — reveal its footer clearance while sticked

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -1607,6 +1607,92 @@ test.describe('Send-stick diagnostic (1:1)', () => {
   })
 })
 
+// ── Reaction bottom-stick: a reaction growing a mid-viewport row must not shove the newest down ──
+//
+// Adding the first reaction to a message grows its row by the reaction chip. While the reader is
+// sticked to the bottom, that growth must be absorbed ABOVE (previous messages scroll up) so the
+// newest message stays glued to the bottom edge — NOT pushed down/out of view. This covers the
+// mid-viewport case specifically: a reaction on a message a few rows above the last pushes everything
+// below it (including the newest message) down, and the browser's overflow-anchor does NOT compensate
+// for growth below its chosen top anchor. RED before the fix (the old effect only re-pinned for a
+// reaction on the LAST row, so a mid-viewport reaction left the newest row dipped below the fold);
+// GREEN once any reaction re-asserts the bottom via the pin loop.
+test.describe('Reaction bottom-stick (room)', () => {
+  test('a reaction on a mid-viewport row keeps the newest message glued to the bottom', async ({ page }) => {
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+    await scrollToBottom(page)
+    await page.waitForTimeout(300)
+
+    // Pick the newest message id and a target to react to: a row fully inside the viewport, NOT the
+    // last, and WITHOUT existing reactions (so adding one is a genuine 0→chip growth). A fully-visible
+    // mid-viewport row sits below the browser's top overflow-anchor, so its growth is not auto-
+    // compensated — it pushes the rows below it (the newest included) down. Also capture the newest
+    // row's pre-reaction distance so we assert it was glued to begin with.
+    const pick = await page.evaluate((jid) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rs = (window as any).__roomStore.getState()
+      const msgs = rs.rooms.get(jid)?.messages ?? []
+      const lastId: string | null = msgs[msgs.length - 1]?.id ?? null
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const hasReactions = new Set(msgs.filter((m: any) => m.reactions && Object.keys(m.reactions).length > 0).map((m: any) => m.id))
+
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return { lastId, targetId: null as string | null, beforeDist: -1 }
+      const sRect = s.getBoundingClientRect()
+      const rows = (Array.from(s.querySelectorAll('.message-row[data-message-id]')) as HTMLElement[])
+        .filter((el) => {
+          if (el.offsetHeight <= 0) return false
+          const r = el.getBoundingClientRect()
+          const id = el.dataset.messageId!
+          return r.top >= sRect.top && r.bottom <= sRect.bottom && id !== lastId && !hasReactions.has(id)
+        })
+      // Choose one around the middle of the fully-visible, reaction-free rows.
+      const target = rows.length ? rows[Math.floor(rows.length / 2)] : null
+      return {
+        lastId,
+        targetId: target?.dataset.messageId ?? null,
+        beforeDist: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+      }
+    }, STRESS_ROOM_JID)
+
+    expect(pick.lastId, 'precondition: a newest message id exists').toBeTruthy()
+    expect(pick.targetId, 'precondition: a fully-visible, reaction-free, non-last row to react to').toBeTruthy()
+    expect(pick.beforeDist, 'precondition: the view is glued to the bottom before the reaction').toBeLessThan(AT_BOTTOM_OK_PX)
+
+    // Apply a reaction on the mid-viewport target through the real store path (grows its row).
+    await page.evaluate(([jid, targetId]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).__roomStore.getState().updateReactions(jid, targetId, 'Reactor', ['👍'])
+    }, [STRESS_ROOM_JID, pick.targetId] as const)
+
+    // Confirm the chip actually mounted (the row genuinely grew), then let the pin loop converge.
+    await page.waitForFunction((targetId) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const el = s?.querySelector(`[data-message-id="${CSS.escape(targetId)}"]`) as HTMLElement | null
+      return !!el && el.textContent?.includes('👍')
+    }, pick.targetId as string, { timeout: 5_000 })
+    await page.waitForTimeout(800)
+
+    const after = await page.evaluate((lastId) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return { lastVisible: false, distFromBottom: -1 }
+      const el = s.querySelector(`[data-message-id="${CSS.escape(lastId)}"]`) as HTMLElement | null
+      const sRect = s.getBoundingClientRect()
+      const r = el?.getBoundingClientRect()
+      return {
+        // The newest row's bottom must still sit at (not past) the viewport bottom — a mid-viewport
+        // reaction pushing it down would leave r.bottom well below sRect.bottom (by the chip height).
+        lastVisible: !!(r && r.bottom <= sRect.bottom + 8 && r.bottom > sRect.top),
+        distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+      }
+    }, pick.lastId as string)
+
+    expect(after.lastVisible, `newest message pushed below the fold by a mid-viewport reaction — distFromBottom=${after.distFromBottom}`).toBe(true)
+    expect(after.distFromBottom, 'the view must stay pinned to the bottom after a mid-viewport reaction').toBeLessThan(AT_BOTTOM_OK_PX)
+  })
+})
+
 // ── 11: Media decoding above a scrolled-up viewport must not drift the reading position ──────────
 //
 // The reported bug (real WebKitGTK trace): switch INTO a conversation, the saved scrolled-up anchor


### PR DESCRIPTION
Adding the first reaction to a message grows its row. While sticked to the bottom, the newest message would get pushed down — either shoved by a reaction on a message above it, or visibly animated away by the old last-row-only smooth nudge.

Now any reaction change (while at bottom) routes through the existing instant pin loop, so the newest message stays glued to the bottom edge and the growth is absorbed above (previous messages scroll up). The pin is pure imperative scroll work — no extra React re-render. The reactions signal is broadened from the last message only to a resident-window signature that only stringifies rows that actually carry reactions.

Adds an e2e scroll invariant (verified RED without the fix, GREEN with it, on both Chromium and WebKit): a reaction on a mid-viewport row keeps the newest message glued to the bottom. Full scroll suite 50/50 on both engines; typecheck, lint, and unit tests pass.