### PR TITLE
fix(macos): keep traffic lights centered in the app bar

### DIFF
--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -856,8 +856,12 @@ html, body {
 /* Bottom inset is intentionally NOT applied to #root — instead, bottom-aligned */
 /* components (e.g. MessageComposer) add it to their own padding so their */
 /* background color fills the home-indicator zone seamlessly. */
+/* Web/PWA only: the desktop app (data-tauri on <html>, set in main.tsx) is
+   excluded because its macOS overlay title bar reports a non-zero
+   env(safe-area-inset-top) that would push the AppBar — and thus the native
+   traffic lights' alignment — down off the window's top edge. */
 @supports (padding-top: env(safe-area-inset-top)) {
-  #root {
+  :root:not([data-tauri]) #root {
     box-sizing: border-box;
     padding-top: env(safe-area-inset-top);
     padding-left: env(safe-area-inset-left);

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -23,6 +23,16 @@ import { useLoginPrefillStore } from './stores/loginPrefillStore'
 // Check if running in Tauri
 const isTauri = '__TAURI_INTERNALS__' in window
 
+// Mark the desktop app on <html> (synchronously, before first paint) so CSS can
+// exclude it from the mobile safe-area insets. On macOS the overlay title bar
+// (titleBarStyle: "Overlay") makes WebKit report a non-zero
+// env(safe-area-inset-top); applied to #root that inset pushes the whole app —
+// including the AppBar that hosts the native traffic lights — down off the
+// window's top edge, so the fixed-position dots read as too high in the bar.
+// Desktop windows have no notch/home-indicator, so dropping the insets there is
+// purely correct; the web PWA keeps them.
+if (isTauri) document.documentElement.dataset.tauri = 'true'
+
 // Enable native TCP/TLS proxy in Tauri unless explicitly disabled
 const disableTcpProxy = localStorage.getItem('fluux:disable-tcp-proxy') === 'true'
 const proxyAdapter = isTauri && !disableTcpProxy ? tauriProxyAdapter : undefined


### PR DESCRIPTION
## Summary

The macOS traffic-light dots were sitting too high in the desktop app bar (regression, no OS change).

**Cause:** `#root` gets `padding-top: env(safe-area-inset-top)` (added for iOS-PWA notches, activated by `viewport-fit=cover`). On the macOS Tauri window the overlay title bar (`titleBarStyle: "Overlay"`) makes WebKit report a non-zero top safe-area inset, so that padding pushes the whole app — including the AppBar — down from the window's top edge. The native traffic lights stay pinned ~20px from the *window* top, so they read as too high in the displaced bar. It's the only top offset in the chain, so it fully accounts for the drift.

**Fix:** mark the desktop app with `data-tauri` on `<html>` (synchronously, before first paint) and scope the safe-area block to `:root:not([data-tauri]) #root`. Desktop windows have no notch/home-indicator and the AppBar owns the top edge, so excluding them is correct; the web PWA keeps its insets unchanged.