### PR TITLE
fix(notifications): stop room banner reappearing when the room is reopened

### DIFF
--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -822,4 +822,116 @@ describe('useNotificationEvents', () => {
       expect(onRoomRead).toHaveBeenCalledTimes(1)
     })
   })
+
+  // A room notification must fire at most once per message id. The room path
+  // detects "new activity" by message-array length growth, which a cache
+  // re-hydration (activateRoom → loadMessagesFromCache, prepending older
+  // history) also trips — even though the newest message is unchanged. Without
+  // an identity guard this resurrects a banner for a message already delivered,
+  // matching the observed "notification reappears when I open the room" bug.
+  // The 1:1 path is already immune (it dedupes by lastMessage.id).
+  describe('room notification idempotency', () => {
+    const roomJid = 'tech@conference.example.com'
+
+    const roomMsg = (id: string, body: string, timestamp: Date, nick = 'jerome') => ({
+      id,
+      roomJid,
+      from: `${roomJid}/${nick}`,
+      nick,
+      body,
+      timestamp,
+      isOutgoing: false,
+    })
+
+    it('does not notify twice for the same room message when the window is re-hydrated from cache', () => {
+      const onRoomMessage = vi.fn()
+      const now = new Date()
+      const twoMinutesAgo = new Date(now.getTime() - 2 * 60 * 1000)
+
+      renderHook(() => useNotificationEvents({ onRoomMessage }))
+
+      // Seed one prior message so the next arrival is an incremental notify
+      // (not an initial-history batch, which the >5 guard would skip).
+      act(() => {
+        mockRooms.set(roomJid, {
+          jid: roomJid,
+          name: 'Tech',
+          joined: true,
+          notifyAllPersistent: true,
+          mentionsCount: 0,
+          messages: [roomMsg('seed', 'earlier', twoMinutesAgo, 'old')],
+        })
+        triggerRoomStoreUpdate()
+      })
+      onRoomMessage.mockClear()
+
+      // A fresh message arrives → exactly one notification.
+      act(() => {
+        mockRooms.set(roomJid, {
+          ...mockRooms.get(roomJid),
+          messages: [
+            ...mockRooms.get(roomJid).messages,
+            roomMsg('fresh', 'Yes, but we should add Content-Disposition', now),
+          ],
+        })
+        triggerRoomStoreUpdate()
+      })
+      expect(onRoomMessage).toHaveBeenCalledTimes(1)
+
+      // Opening the room re-hydrates its resident window from cache, prepending
+      // older history. The array grows (length-based detection sees "new
+      // messages") but the newest message is the SAME one already delivered.
+      act(() => {
+        const older = Array.from({ length: 20 }, (_, i) =>
+          roomMsg(`hist-${i}`, `history ${i}`, new Date(now.getTime() - (300 + i) * 1000), 'old'),
+        )
+        mockRooms.set(roomJid, {
+          ...mockRooms.get(roomJid),
+          messages: [
+            ...older,
+            roomMsg('seed', 'earlier', twoMinutesAgo, 'old'),
+            roomMsg('fresh', 'Yes, but we should add Content-Disposition', now),
+          ],
+        })
+        triggerRoomStoreUpdate()
+      })
+
+      // Re-hydration is not a new message — still a single notification.
+      expect(onRoomMessage).toHaveBeenCalledTimes(1)
+    })
+
+    it('still notifies when a genuinely new message arrives after re-hydration', () => {
+      const onRoomMessage = vi.fn()
+      const now = new Date()
+
+      renderHook(() => useNotificationEvents({ onRoomMessage }))
+
+      act(() => {
+        mockRooms.set(roomJid, {
+          jid: roomJid,
+          name: 'Tech',
+          joined: true,
+          notifyAllPersistent: true,
+          mentionsCount: 0,
+          messages: [roomMsg('first', 'first', now)],
+        })
+        triggerRoomStoreUpdate()
+      })
+      expect(onRoomMessage).toHaveBeenCalledTimes(1)
+
+      // A second, distinct message must still notify (the guard is per id).
+      act(() => {
+        mockRooms.set(roomJid, {
+          ...mockRooms.get(roomJid),
+          messages: [
+            ...mockRooms.get(roomJid).messages,
+            roomMsg('second', 'second', now),
+          ],
+        })
+        triggerRoomStoreUpdate()
+      })
+      expect(onRoomMessage).toHaveBeenCalledTimes(2)
+      expect(onRoomMessage.mock.calls[1][1].id).toBe('second')
+    })
+  })
 })

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
@@ -117,6 +117,15 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
   const prevConversationsRef = useRef<Conversation[]>([])
   const prevRoomsRef = useRef<Map<string, PrevRoomState>>(new Map())
 
+  // Highest message id we've already fired a room notification for, per room.
+  // Rooms detect new activity by message-array length growth, which a cache
+  // re-hydration (activateRoom → loadMessagesFromCache, prepending older
+  // history) also trips even though the newest message is unchanged. Keying the
+  // notify-once decision on the message id — not the count — stops a reload from
+  // resurrecting a banner already delivered. The 1:1 path is already immune
+  // because it dedupes by lastMessage.id.
+  const lastNotifiedRoomMessageIdRef = useRef<Map<string, string>>(new Map())
+
   // Watch for new messages in 1:1 conversations
   // Uses Zustand subscribe() to avoid re-rendering the parent component
   useEffect(() => {
@@ -255,7 +264,11 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
           )
 
           if (result.shouldNotify) {
+            // Notify at most once per message id: a re-hydration that grows
+            // room.messages must not re-fire for a message already delivered.
+            if (lastNotifiedRoomMessageIdRef.current.get(room.jid) === msg.id) break
             onRoomMessage(room, msg, result.isMention)
+            lastNotifiedRoomMessageIdRef.current.set(room.jid, msg.id)
             break // Only notify for the latest relevant message
           }
 


### PR DESCRIPTION
Room notifications reappeared after opening the room. The room path detected new activity by message-array **length growth**, and opening a room re-hydrates its resident window from cache (`activateRoom` → `loadMessagesFromCache`, prepending older history) — growing the array and re-firing a banner for the same newest message already delivered.

The fix keys the notify-once decision on the **message id** via a per-room watermark, so a re-hydration can no longer resurrect a delivered banner. The 1:1 path was already immune because it dedupes by `lastMessage.id`.

Scoped to the observed re-post mechanism; the rarer avatar-fetch ordering race (async `post_notification` landing after a `remove`) is untouched.