### PR TITLE
fix(sidebar): keep list position when it reorders during catch-up (#993)

### DIFF
--- a/apps/fluux/src/hooks/useListKeyboardNav.test.tsx
+++ b/apps/fluux/src/hooks/useListKeyboardNav.test.tsx
@@ -1142,4 +1142,108 @@ describe('useListKeyboardNav', () => {
       expect(result.current.selectedIndex).toBe(-1)
     })
   })
+
+  // Regression: issue #993 — the conversation/room sidebar must NOT scroll the
+  // active item back into view when the list merely reorders (activity sort during
+  // catch-up). Scrolling is only allowed when the active item's identity genuinely
+  // changes (click / shortcut / programmatic nav) or on keyboard navigation.
+  describe('auto-scroll on selection identity change (issue #993)', () => {
+    let scrollSpy: Mock
+    let originalScrollIntoView: typeof Element.prototype.scrollIntoView | undefined
+
+    beforeEach(() => {
+      scrollSpy = vi.fn()
+      originalScrollIntoView = Element.prototype.scrollIntoView
+      // jsdom does not implement scrollIntoView — install a spy.
+      Element.prototype.scrollIntoView = scrollSpy as unknown as typeof Element.prototype.scrollIntoView
+    })
+
+    afterEach(() => {
+      if (originalScrollIntoView) {
+        Element.prototype.scrollIntoView = originalScrollIntoView
+      } else {
+        // @ts-expect-error cleanup of test-only polyfill
+        delete Element.prototype.scrollIntoView
+      }
+    })
+
+    /**
+     * Builds a hook harness backed by a real (detached) DOM container whose child
+     * rows mirror the current `items`, so the hook's `querySelector` + scrollIntoView
+     * path exercises for real. Rows are rebuilt each render to reflect reordering.
+     */
+    function createScrollHarness() {
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      const listRef = { current: container } as React.RefObject<HTMLDivElement>
+      const syncRows = (items: TestItem[]) => {
+        container.textContent = ''
+        for (const it of items) {
+          const row = document.createElement('div')
+          row.setAttribute('data-item-id', it.id)
+          container.appendChild(row)
+        }
+      }
+      const useHarness = ({
+        items,
+        activeItemId,
+      }: {
+        items: TestItem[]
+        activeItemId: string | null | undefined
+      }) => {
+        // Keep the DOM in sync with the current items BEFORE effects run.
+        syncRows(items)
+        return useListKeyboardNav<TestItem>({
+          items,
+          onSelect: mockOnSelect,
+          listRef,
+          getItemId: (item) => item.id,
+          itemAttribute: 'data-item-id',
+          activeItemId,
+        })
+      }
+      return { useHarness, container }
+    }
+
+    it('does NOT scroll when the list reorders under a stable active item', () => {
+      const { useHarness } = createScrollHarness()
+      const { rerender } = renderHook(useHarness, {
+        initialProps: { items: mockItems, activeItemId: '3' as string | null | undefined },
+      })
+      // Ignore the initial activation scroll.
+      scrollSpy.mockClear()
+
+      // Reorder: same ids, brand-new array reference, active item unchanged.
+      const reordered: TestItem[] = [mockItems[2], mockItems[0], mockItems[1]]
+      rerender({ items: reordered, activeItemId: '3' })
+
+      expect(scrollSpy).not.toHaveBeenCalled()
+    })
+
+    it('scrolls the active item into view when activeItemId changes value', () => {
+      const { useHarness } = createScrollHarness()
+      const { rerender } = renderHook(useHarness, {
+        initialProps: { items: mockItems, activeItemId: '1' as string | null | undefined },
+      })
+      scrollSpy.mockClear()
+
+      rerender({ items: mockItems, activeItemId: '3' })
+
+      expect(scrollSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('scrolls the highlighted item into view on keyboard navigation', () => {
+      const { useHarness } = createScrollHarness()
+      renderHook(useHarness, {
+        initialProps: { items: mockItems, activeItemId: null as string | null | undefined },
+      })
+      scrollSpy.mockClear()
+
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }))
+      })
+
+      expect(scrollSpy).toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/fluux/src/hooks/useListKeyboardNav.ts
+++ b/apps/fluux/src/hooks/useListKeyboardNav.ts
@@ -149,6 +149,25 @@ export function useListKeyboardNav<T>({
   const itemIdToIndexRef = useRef(itemIdToIndex)
   itemIdToIndexRef.current = itemIdToIndex
 
+  // Imperatively scroll a row into view by id. This is called at the two moments a
+  // scroll is actually wanted — a keyboard move, or the active item's identity
+  // changing — NOT reactively off `items`. Scrolling off `items` (as a bare effect
+  // dependency) fires on every reorder and yanks the list away from where the user
+  // scrolled while the sidebar re-sorts during catch-up (issue #993).
+  const scrollItemIntoView = useCallback(
+    (itemId: string) => {
+      const selector = `[${itemAttribute}="${CSS.escape(itemId)}"]`
+      const element = listRef.current?.querySelector(selector)
+      element?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    },
+    [listRef, itemAttribute],
+  )
+
+  // The active item id we last scrolled to, so the external-sync effect can scroll
+  // ONLY when the active item's identity genuinely changes — and stay put when the
+  // list merely reorders under a stable active item.
+  const lastScrolledActiveIdRef = useRef<string | null>(null)
+
   // When items change, try to preserve the selection by matching the previously selected item ID.
   // This prevents the selection from resetting to -1 when items are appended (e.g., pagination).
   useEffect(() => {
@@ -166,19 +185,30 @@ export function useListKeyboardNav<T>({
     selectedItemIdRef.current = null
   }, [itemsKey])
 
-  // Sync selectedIndex with externally-controlled active item.
-  // When the parent owns activation (clicks, global keyboard shortcuts, programmatic
-  // navigation), pass `activeItemId` so the list scrolls the active item into view
-  // via the existing auto-scroll effect.
+  // Sync selectedIndex with externally-controlled active item, and scroll it into
+  // view when the active item's identity changes. When the parent owns activation
+  // (clicks, global keyboard shortcuts, programmatic navigation), pass `activeItemId`.
   useEffect(() => {
-    if (activeItemId == null) return
-    const newIndex = itemIdToIndexRef.current.get(activeItemId)
-    if (newIndex !== undefined) {
-      selectionSourceRef.current = 'external'
-      setSelectedIndex(newIndex)
-      selectedItemIdRef.current = activeItemId
+    if (activeItemId == null) {
+      lastScrolledActiveIdRef.current = null
+      return
     }
-  }, [activeItemId, itemsKey])
+    const newIndex = itemIdToIndexRef.current.get(activeItemId)
+    // Active item not in the list yet (e.g. list still populating). Leave the
+    // "last scrolled" marker untouched so we scroll once it appears.
+    if (newIndex === undefined) return
+    selectionSourceRef.current = 'external'
+    setSelectedIndex(newIndex)
+    selectedItemIdRef.current = activeItemId
+    // Scroll into view only when the ACTIVE item's identity changes — never on a
+    // bare reorder (same active item, new position). This is the fix for #993:
+    // the effect still re-runs on `itemsKey` (to re-map the index), but the scroll
+    // is gated on the active id actually changing.
+    if (lastScrolledActiveIdRef.current !== activeItemId) {
+      lastScrolledActiveIdRef.current = activeItemId
+      scrollItemIntoView(activeItemId)
+    }
+  }, [activeItemId, itemsKey, scrollItemIntoView])
 
   // Keyboard event handler — stored in a ref so the effect listener is stable
   const handleKeyDownRef = useRef<(e: KeyboardEvent) => void>(() => {})
@@ -295,7 +325,10 @@ export function useListKeyboardNav<T>({
         // Update state and track selected item ID for preservation across list changes
         selectionSourceRef.current = 'keyboard'
         setSelectedIndex(newIndex)
-        selectedItemIdRef.current = newIndex >= 0 && newIndex < items.length ? getItemId(items[newIndex]) : null
+        const newSelectedId = newIndex >= 0 && newIndex < items.length ? getItemId(items[newIndex]) : null
+        selectedItemIdRef.current = newSelectedId
+        // Keyboard navigation deliberately moves the highlight — scroll it into view.
+        if (newSelectedId) scrollItemIntoView(newSelectedId)
 
         // If Alt+arrow and activateOnAltNav, call onSelect (only if actually navigated)
         if (e.altKey && activateOnAltNav && !bounced && newIndex !== selectedIndex && newIndex >= 0 && newIndex < items.length) {
@@ -321,17 +354,13 @@ export function useListKeyboardNav<T>({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [enabled, handleKeyDown])
 
-  // Auto-scroll selected item into view (keyboard and external sources only —
-  // mouse hover must not trigger scrollIntoView or it fights touchpad momentum).
-  useEffect(() => {
-    if (selectionSourceRef.current === 'mouse') return
-    if (selectedIndex < 0 || !listRef.current || !items[selectedIndex]) return
-
-    const itemId = getItemId(items[selectedIndex])
-    const selector = `[${itemAttribute}="${CSS.escape(itemId)}"]`
-    const element = listRef.current.querySelector(selector)
-    element?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
-  }, [selectedIndex, items, listRef, getItemId, itemAttribute])
+  // NOTE: there is deliberately NO reactive "scroll selectedIndex into view" effect
+  // keyed on `items`. Such an effect re-fires on every reorder (new `items` array
+  // reference during activity re-sort) and yanks the list back to the active row
+  // while the user is manually scrolling during catch-up (issue #993). Scrolling is
+  // instead driven imperatively at the two moments it is genuinely wanted: keyboard
+  // navigation (see the keydown handler) and a real change of the active item's
+  // identity (see the activeItemId effect above). Mouse hover never scrolls.
 
   // Per-item hover handlers are cached (keyed by item id) so their identities stay
   // stable across renders AND reorders. Passing fresh onMouseEnter/onMouseMove would defeat


### PR DESCRIPTION
Fixes #993.

The conversation/room sidebar scrolled the active item back into view on every list reorder, fighting manual scrolling while the list re-sorts as messages arrive during catch-up after being away. This affected wheel/trackpad/scrollbar scrolling, which had no protection — only hover was guarded.

## Cause
`useListKeyboardNav` had a reactive scroll effect keyed on the `items` array. Because the activity-sorted id list gets a new reference on every reorder, the effect re-fired on each incoming message and scrolled the active row into view, regardless of whether the active item actually changed.

## Fix
Scroll imperatively at the two moments a scroll is genuinely wanted:
- keyboard navigation (the keydown handler scrolls the newly-highlighted row), and
- a real change of the active item's identity (the `activeItemId` effect, guarded by a "last scrolled id" ref so a bare reorder under a stable active item never scrolls).

Both sidebar twins (chat + room) share the hook, so both are fixed. Lists that don't pass `activeItemId` (contacts, search, browse-rooms) were never on this path and are unchanged; their keyboard auto-scroll is preserved.