### PR TITLE
fix(updater): throttle download progress to avoid render-loop crash (#994)

### DIFF
--- a/apps/fluux/src/hooks/downloadProgressTracker.test.ts
+++ b/apps/fluux/src/hooks/downloadProgressTracker.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { createDownloadProgressTracker } from './downloadProgressTracker'
+
+describe('createDownloadProgressTracker', () => {
+  it('emits 0 on Started and 100 on Finished', () => {
+    const now = 0
+    const tracker = createDownloadProgressTracker(100, () => now)
+
+    expect(tracker.handle({ event: 'Started', data: { contentLength: 1000 } })).toBe(0)
+    expect(tracker.handle({ event: 'Finished' })).toBe(100)
+  })
+
+  it('throttles rapid Progress events to one emit per interval', () => {
+    let now = 0
+    const tracker = createDownloadProgressTracker(100, () => now)
+    tracker.handle({ event: 'Started', data: { contentLength: 1000 } }) // lastEmit = 0
+
+    // 100 chunks of 1 byte each, all arriving within the same 100ms window.
+    let emits = 0
+    for (let i = 0; i < 100; i++) {
+      now = i // advance <100ms total
+      if (tracker.handle({ event: 'Progress', data: { chunkLength: 1 } }) !== null) emits++
+    }
+
+    // None should have emitted — all fell inside the throttle interval.
+    expect(emits).toBe(0)
+  })
+
+  it('emits the accumulated progress once the interval has elapsed', () => {
+    let now = 0
+    const tracker = createDownloadProgressTracker(100, () => now)
+    tracker.handle({ event: 'Started', data: { contentLength: 1000 } })
+
+    // 200 bytes accumulate silently within the interval...
+    for (let i = 0; i < 200; i++) {
+      now = i / 10 // 0..19.9ms
+      tracker.handle({ event: 'Progress', data: { chunkLength: 1 } })
+    }
+    // ...then a chunk after the interval flushes the accumulated 20%.
+    now = 100
+    const emitted = tracker.handle({ event: 'Progress', data: { chunkLength: 1 } })
+    expect(emitted).toBeCloseTo(20.1, 5)
+  })
+
+  it('caps Progress at 99 during download', () => {
+    let now = 0
+    const tracker = createDownloadProgressTracker(0, () => now)
+    tracker.handle({ event: 'Started', data: { contentLength: 100 } })
+
+    // One giant chunk that would overshoot 100%.
+    now = 1
+    expect(tracker.handle({ event: 'Progress', data: { chunkLength: 1000 } })).toBe(99)
+  })
+
+  it('skips Progress events when contentLength is unknown', () => {
+    let now = 0
+    const tracker = createDownloadProgressTracker(0, () => now)
+    tracker.handle({ event: 'Started', data: {} }) // no contentLength
+
+    now = 1
+    expect(tracker.handle({ event: 'Progress', data: { chunkLength: 50 } })).toBeNull()
+  })
+})

--- a/apps/fluux/src/hooks/downloadProgressTracker.ts
+++ b/apps/fluux/src/hooks/downloadProgressTracker.ts
@@ -1,0 +1,71 @@
+/**
+ * Download progress tracker for the Tauri auto-updater.
+ *
+ * Accumulates the updater's `Started` / `Progress` / `Finished` events into a
+ * single 0-100 progress value and *throttles* the frequent `Progress` events so
+ * the consumer re-renders at most once per `minIntervalMs`.
+ *
+ * Why throttle: on a fast connection the updater emits a `Progress` event per
+ * network chunk — hundreds per second. The previous code called `setState` on
+ * every one, which (because the update state lives in `App`) re-rendered the
+ * whole component tree at chunk frequency and tripped the render-loop detector,
+ * replacing the UI with the "render loop detected" error screen mid-download.
+ * See issue #994.
+ *
+ * `Started` (0%) and `Finished` (100%) are terminal states the UI must always
+ * reflect, so they bypass the throttle. Sub-percent `Progress` deltas are
+ * invisible anyway (the bar shows `Math.round(progress)`), so dropping the
+ * throttled ones costs nothing visually.
+ */
+
+export type UpdaterDownloadEvent =
+  | { event: 'Started'; data: { contentLength?: number } }
+  | { event: 'Progress'; data: { chunkLength: number } }
+  | { event: 'Finished' }
+
+export interface DownloadProgressTracker {
+  /**
+   * Fold one updater event into the running progress. Returns the new 0-100
+   * progress value to flush to state, or `null` when the event was throttled
+   * (or carried no visible change) and no re-render is warranted.
+   */
+  handle(event: UpdaterDownloadEvent): number | null
+}
+
+export function createDownloadProgressTracker(
+  minIntervalMs: number,
+  now: () => number = Date.now,
+): DownloadProgressTracker {
+  let contentLength = 0
+  let progress = 0
+  let lastEmit = 0
+
+  return {
+    handle(event) {
+      switch (event.event) {
+        case 'Started':
+          contentLength = event.data.contentLength ?? 0
+          progress = 0
+          lastEmit = now()
+          return 0
+
+        case 'Progress': {
+          // Without a known total we can't compute a fraction — mirror the old
+          // behavior of not touching state until `Started` supplied the length.
+          if (contentLength <= 0) return null
+          progress = Math.min(progress + (event.data.chunkLength / contentLength) * 100, 99)
+          const t = now()
+          if (t - lastEmit >= minIntervalMs) {
+            lastEmit = t
+            return progress
+          }
+          return null
+        }
+
+        case 'Finished':
+          progress = 100
+          return 100
+      }
+    },
+  }
+}

--- a/apps/fluux/src/hooks/uploadProgressReporter.test.ts
+++ b/apps/fluux/src/hooks/uploadProgressReporter.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createUploadProgressReporter } from './uploadProgressReporter'
+
+describe('createUploadProgressReporter', () => {
+  it('skips emits when the rounded overall percent is unchanged', () => {
+    const emit = vi.fn()
+    const reporter = createUploadProgressReporter(100, 0, emit)
+
+    reporter.setMain(0)  // overall 0 — matches the initial 0 baseline → skip
+    reporter.setMain(5)  // → 5
+    reporter.setMain(5)  // same integer repeats (the redundant-render case) → skip
+    reporter.setMain(42) // → 42
+
+    expect(emit.mock.calls.map(c => c[0])).toEqual([5, 42])
+  })
+
+  it('weights main and thumbnail progress by their byte size', () => {
+    const emit = vi.fn()
+    // 75-byte main + 25-byte thumb → main weight 0.75, thumb weight 0.25.
+    const reporter = createUploadProgressReporter(75, 25, emit)
+
+    reporter.setMain(100)      // round(100*0.75 + 0*0.25) = 75
+    reporter.setThumbnail(100) // round(100*0.75 + 100*0.25) = 100
+
+    expect(emit.mock.calls.map(c => c[0])).toEqual([75, 100])
+  })
+
+  it('reports raw main percent when there is no thumbnail', () => {
+    const emit = vi.fn()
+    const reporter = createUploadProgressReporter(100, 0, emit)
+
+    reporter.setMain(37)
+
+    expect(emit).toHaveBeenCalledExactlyOnceWith(37)
+  })
+})

--- a/apps/fluux/src/hooks/uploadProgressReporter.ts
+++ b/apps/fluux/src/hooks/uploadProgressReporter.ts
@@ -1,0 +1,56 @@
+/**
+ * Upload progress reporter for XEP-0363 HTTP File Upload.
+ *
+ * Combines the main-file and (optional) thumbnail upload progress into one
+ * size-weighted 0-100 percent, and emits only when that rounded percent
+ * actually changes.
+ *
+ * Why the changed-value gate: on the web (XHR) path, `xhr.upload.onprogress`
+ * fires per network buffer flush, and the previous code called `setState` on
+ * every event — building a fresh state object each time even when the rounded
+ * percent hadn't moved. That re-rendered the conversation pane redundantly.
+ * The updater had the same class of bug (issue #994); uploads are milder
+ * because the value is already integer-quantized, so a plain dedupe (rather
+ * than a time throttle) is enough: it caps emits at ~one per whole percent.
+ *
+ * The baseline starts at 0 to match `useFileUpload`'s initial `progress: 0`
+ * state, so an opening `setMain(0)` doesn't emit a redundant 0.
+ */
+export interface UploadProgressReporter {
+  /** Report the main file's upload progress (0-100). */
+  setMain(progress: number): void
+  /** Report the thumbnail's upload progress (0-100). */
+  setThumbnail(progress: number): void
+}
+
+export function createUploadProgressReporter(
+  fileSize: number,
+  thumbnailSize: number,
+  emit: (overall: number) => void,
+): UploadProgressReporter {
+  const totalSize = fileSize + thumbnailSize
+  let mainProgress = 0
+  let thumbProgress = 0
+  let lastOverall = 0
+
+  const flush = () => {
+    const overall =
+      totalSize > 0
+        ? Math.round((mainProgress * fileSize + thumbProgress * thumbnailSize) / totalSize)
+        : 0
+    if (overall === lastOverall) return
+    lastOverall = overall
+    emit(overall)
+  }
+
+  return {
+    setMain(progress) {
+      mainProgress = progress
+      flush()
+    },
+    setThumbnail(progress) {
+      thumbProgress = progress
+      flush()
+    },
+  }
+}

--- a/apps/fluux/src/hooks/useAutoUpdate.ts
+++ b/apps/fluux/src/hooks/useAutoUpdate.ts
@@ -1,10 +1,17 @@
 import { useState, useEffect, useCallback } from 'react'
 import { isUpdaterEnabled } from '@/utils/tauri'
+import { createDownloadProgressTracker, type UpdaterDownloadEvent } from './downloadProgressTracker'
 
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
 // In-app updates are disabled on Linux - users update through their distro package manager
 const updaterEnabled = isUpdaterEnabled()
+
+// Cap download-progress re-renders to ~10/sec. The updater emits a Progress
+// event per network chunk (hundreds/sec on a fast link); updating React state on
+// every one re-rendered the whole tree past the render-loop detector threshold
+// and broke the UI mid-download (issue #994).
+const PROGRESS_UPDATE_INTERVAL_MS = 100
 
 export interface UpdateState {
   available: boolean
@@ -84,30 +91,18 @@ export function useAutoUpdate(options: UseAutoUpdateOptions = {}) {
     setState(prev => ({ ...prev, downloading: true, progress: 0, error: null }))
 
     try {
-      // Download with progress tracking
-      let contentLength = 0
+      // Throttle the per-chunk Progress events so a fast download can't
+      // re-render the app past the render-loop detector (issue #994).
+      const tracker = createDownloadProgressTracker(PROGRESS_UPDATE_INTERVAL_MS)
       await update.downloadAndInstall((event) => {
-        switch (event.event) {
-          case 'Started':
-            contentLength = (event.data as { contentLength?: number }).contentLength || 0
-            setState(prev => ({ ...prev, progress: 0 }))
-            break
-          case 'Progress':
-            if (contentLength > 0) {
-              const chunkLength = (event.data as { chunkLength: number }).chunkLength
-              setState(prev => {
-                const newProgress = Math.min(
-                  prev.progress + (chunkLength / contentLength) * 100,
-                  99
-                )
-                return { ...prev, progress: newProgress }
-              })
-            }
-            break
-          case 'Finished':
-            setState(prev => ({ ...prev, progress: 100, downloaded: true }))
-            break
-        }
+        const progress = tracker.handle(event as UpdaterDownloadEvent)
+        if (progress === null) return
+        const finished = event.event === 'Finished'
+        setState(prev => ({
+          ...prev,
+          progress,
+          ...(finished ? { downloaded: true } : {}),
+        }))
       })
 
       setState(prev => ({ ...prev, downloading: false, downloaded: true }))

--- a/apps/fluux/src/hooks/useFileUpload.ts
+++ b/apps/fluux/src/hooks/useFileUpload.ts
@@ -21,6 +21,7 @@ import {
   getEffectiveMimeType,
   type ThumbnailResult,
 } from '@/utils/thumbnail'
+import { createUploadProgressReporter } from './uploadProgressReporter'
 
 /**
  * Check if running in Tauri dynamically.
@@ -143,19 +144,16 @@ export function useFileUpload() {
         }
       }
 
-      // Calculate total upload size for progress (main file + optional thumbnail)
+      // Combine main-file + optional-thumbnail progress into one size-weighted
+      // percent. The reporter only fires when the rounded percent changes, so a
+      // fast web upload can't re-render the conversation pane once per XHR
+      // progress event (same render-storm class as issue #994).
       const thumbnailSize = thumbnailResult?.blob.size || 0
-      const totalSize = file.size + thumbnailSize
-      let mainProgress = 0
-      let thumbProgress = 0
-
-      const updateProgress = () => {
-        // Weight progress by size
-        const mainWeight = file.size / totalSize
-        const thumbWeight = thumbnailSize / totalSize
-        const overall = Math.round(mainProgress * mainWeight + thumbProgress * thumbWeight)
-        setState(s => ({ ...s, progress: overall }))
-      }
+      const progressReporter = createUploadProgressReporter(
+        file.size,
+        thumbnailSize,
+        overall => setState(s => ({ ...s, progress: overall })),
+      )
 
       // 1. Prepare main file bytes — encrypted or plaintext depending on mode.
       // When encrypting we PUT the ciphertext (plaintext_len + 16-byte GCM
@@ -191,10 +189,7 @@ export function useFileUpload() {
         new File([mainUploadBlob], mainUploadFilename, { type: mainUploadMimeType }),
         mainUploadMimeType,
         slot.headers,
-        (progress) => {
-          mainProgress = progress
-          updateProgress()
-        },
+        (progress) => progressReporter.setMain(progress),
       )
 
       // 3. Upload thumbnail if generated. Encrypted attachments get an
@@ -230,10 +225,7 @@ export function useFileUpload() {
           new File([thumbBytes as BlobPart], thumbFilename, { type: thumbUploadMime }),
           thumbUploadMime,
           thumbSlot.headers,
-          (progress) => {
-            thumbProgress = progress
-            updateProgress()
-          },
+          (progress) => progressReporter.setThumbnail(progress),
         )
 
         // Store plain HTTPS URL locally; encryption params ride in a


### PR DESCRIPTION
Fixes #994.

## Problem
Pressing the update button showed a "broken screen" — actually the app's own render-loop detector firing (whole tree re-rendering ~280×/sec). The Tauri updater emits a `Progress` event per network chunk (hundreds/sec on a fast link), and `downloadAndInstall` called `setState` on every one. Because the update state lives in `App`, each chunk re-rendered the entire tree past the detector's 200-renders/1000ms threshold, which throws and replaces the UI with the error screen mid-download. (The "after wake from sleep" correlation was just the trigger context — wake is when the update modal reappears and gets pressed — not an independent cause.)

## Changes
- **`downloadProgressTracker`** — accumulates `Started`/`Progress`/`Finished` into a 0-100 value and throttles `Progress` emits to ~10/sec; `Started` (0%) and `Finished` (100%) always flush. Wired into `useAutoUpdate`, covering both the update modal and the settings "check for updates" button.
- **`uploadProgressReporter`** (companion, same render-storm class) — file-sharing uploads had the same unthrottled per-event `setState` on the web XHR path (`updateProgress` rebuilt the state object on every progress event even when the rounded percent hadn't moved). The reporter size-weights main + thumbnail progress and emits only when the rounded value changes. Since upload progress is already integer-quantized, a changed-value gate suffices — no time throttle. The Tauri path already emits just 50/100.

Both fixes are covered by new unit tests; typecheck, lint, and the existing App/upload-stability suites pass.