### PR TITLE
fix(chat): center typing indicator vertically between last message and composer

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -569,7 +569,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
           </div>
         </div>
         <div
-          class="absolute bottom-4 start-4 z-30 max-w-[calc(100%-5rem)] pointer-events-none animate-toast-in"
+          class="absolute bottom-0.5 start-4 z-30 max-w-[calc(100%-5rem)] pointer-events-none animate-toast-in"
         >
           <div
             class="rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5"

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -871,10 +871,13 @@ export function MessageList<T extends BaseMessage>({
       {/* Floating typing indicator — anchored to the bottom of the message area rather than living
           inside the scroll content, so it (a) stays visible whether the user is at the bottom or
           scrolled up in history, and (b) never changes the scroll height (toggling it inline used to
-          re-pin the viewport and fight an upward scroll — issue #918). Bottom-start keeps it clear of
-          the bottom-end FAB; pointer-events-none so it never intercepts taps on the message beneath. */}
+          re-pin the viewport and fight an upward scroll — issue #918). The spacer above grows to
+          pb-12 (48px) while typing; bottom-0.5 centres the ~30px pill vertically in that band so it
+          sits evenly (~16px each side) between the last message and the composer instead of hugging
+          the message. start-4 keeps it aligned under the messages and clear of the bottom-end FAB;
+          pointer-events-none so it never intercepts taps on the message beneath. */}
       {typingUsers.length > 0 && (
-        <div className="absolute bottom-4 start-4 z-30 max-w-[calc(100%-5rem)] pointer-events-none animate-toast-in">
+        <div className="absolute bottom-0.5 start-4 z-30 max-w-[calc(100%-5rem)] pointer-events-none animate-toast-in">
           <div className="rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5">
             <TypingIndicator typingUsers={typingUsers} formatUser={formatTypingUser} variant="compact" />
           </div>


### PR DESCRIPTION
The floating typing indicator was pinned near the bottom of the message area (`bottom-4`), leaving it hugging the last message with a large gap below before the composer.

While typing, the spacer below the last message grows to `pb-12` (48px). Changing the pill's offset to `bottom-0.5` centers it in that band, so it sits evenly (~16px each side) between the last message and the composer. Horizontal position (left-aligned under the messages, clear of the FAB) is unchanged.