### PR TITLE
fix(rooms): remove redundant hover tooltip on room header title

### DIFF
--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -123,20 +123,18 @@ export function RoomHeader({
         size="header"
       />
 
-      {/* Name and info — opens Room Info modal; tooltip peeks the full topic */}
-      <Tooltip content={room.subject?.trim() || room.jid} position="bottom" className="flex-1 min-w-0">
-        <button
-          type="button"
-          onClick={() => setShowInfoModal(true)}
-          aria-label={`${t('rooms.showRoomInfo', 'Room info')}: ${room.name}`}
-          className="w-full min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
-        >
-          <span className="block font-semibold text-fluux-text truncate leading-tight">{room.name}</span>
-          <p className="text-xs text-fluux-muted truncate">
-            {room.subject?.trim() ? renderTextWithLinks(room.subject) : room.jid}
-          </p>
-        </button>
-      </Tooltip>
+      {/* Name and info — opens Room Info modal with the full topic and details */}
+      <button
+        type="button"
+        onClick={() => setShowInfoModal(true)}
+        aria-label={`${t('rooms.showRoomInfo', 'Room info')}: ${room.name}`}
+        className="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+      >
+        <span className="block font-semibold text-fluux-text truncate leading-tight">{room.name}</span>
+        <p className="text-xs text-fluux-muted truncate">
+          {room.subject?.trim() ? renderTextWithLinks(room.subject) : room.jid}
+        </p>
+      </button>
 
       {/* Trailing action cluster — grouped tightly on mobile (gap-1) so the
           kebab and members pill read as one unit; desktop keeps the header's md

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -17,26 +17,22 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
           data-name="Test Room"
           data-testid="avatar"
         />
-        <div
-          class="flex-1 min-w-0"
+        <button
+          aria-label="rooms.showRoomInfo: Test Room"
+          class="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+          type="button"
         >
-          <button
-            aria-label="rooms.showRoomInfo: Test Room"
-            class="w-full min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
-            type="button"
+          <span
+            class="block font-semibold text-fluux-text truncate leading-tight"
           >
-            <span
-              class="block font-semibold text-fluux-text truncate leading-tight"
-            >
-              Test Room
-            </span>
-            <p
-              class="text-xs text-fluux-muted truncate"
-            >
-              room@conference.example.com
-            </p>
-          </button>
-        </div>
+            Test Room
+          </span>
+          <p
+            class="text-xs text-fluux-muted truncate"
+          >
+            room@conference.example.com
+          </p>
+        </button>
         <div
           class="flex items-center gap-1 md:gap-3"
         >


### PR DESCRIPTION
Now that clicking the room header opens a Room Info modal with the full topic and details, the hover tooltip that peeked the topic/JID was duplicating that information. This removes the `Tooltip` wrapper around the header title button and moves its `flex-1 min-w-0` layout classes onto the button itself.

The other header buttons (invite, search, occupants) still use `Tooltip`.