### PR TITLE
fix(chat): re-fit own-message group width when media finishes loading

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -473,7 +473,17 @@ export const MessageBubble = memo(function MessageBubble({
   // signature captures every field that changes the row's natural width so the
   // group re-fits on content edits but not on hover/selection churn.
   const ownGroupWidthSignature = `${message.body ?? ''}|${showAvatar ? 1 : 0}|${timeFormat}|${message.isRetracted ? 1 : 0}|${message.isEdited ? 1 : 0}|${JSON.stringify(message.reactions ?? {})}|${replyContext?.messageId ?? ''}|${message.attachment ? 1 : 0}|${message.linkPreview ? 1 : 0}|${message.poll ? 1 : 0}|${message.encryptedPayload ? 1 : 0}|${message.unsupportedEncryption?.name ?? ''}`
-  const ownGroupRef = useOwnGroupWidth(ownTint ? ownGroupKey : undefined, message.id, ownGroupWidthSignature)
+  const { ref: ownGroupRef, remeasure: remeasureOwnGroup } = useOwnGroupWidth(ownTint ? ownGroupKey : undefined, message.id, ownGroupWidthSignature)
+
+  // Media (image/video/link-preview) reaches its final layout width only once it
+  // loads — after the own-group's initial width measure. Re-fit the group then so
+  // the loaded row's width is shared with its text siblings (else it overflows
+  // the pre-load pin and the tint reads as a ragged edge). Also forwards the
+  // parent's scroll re-pin so the timeline stays glued to the bottom.
+  const handleMediaLoad = () => {
+    onMediaLoad?.()
+    remeasureOwnGroup()
+  }
 
   const { canReply, canEdit, canDelete } = actions
   const canCopyBody = !!message.body && !message.isRetracted && !message.encryptedPayload && !message.unsupportedEncryption
@@ -716,10 +726,10 @@ export const MessageBubble = memo(function MessageBubble({
           )}
 
           {/* File attachments (image, video, audio, text preview, document card) - hidden for retracted */}
-          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={onMediaLoad} isSelected={isSelected} isHovered={isHovered} isOwnMessage={message.isOutgoing} />}
+          {!message.isRetracted && <MessageAttachments attachment={message.attachment} onMediaLoad={handleMediaLoad} isSelected={isSelected} isHovered={isHovered} isOwnMessage={message.isOutgoing} />}
 
           {/* Link preview - hidden for retracted */}
-          {!message.isRetracted && message.linkPreview && <LinkPreviewCard preview={message.linkPreview} onLoad={onMediaLoad} isOwnMessage={message.isOutgoing} />}
+          {!message.isRetracted && message.linkPreview && <LinkPreviewCard preview={message.linkPreview} onLoad={handleMediaLoad} isOwnMessage={message.isOutgoing} />}
 
           {/* Poll display - hidden for retracted */}
           {!message.isRetracted && message.poll && (

--- a/apps/fluux/src/components/conversation/messageGroupWidth.test.ts
+++ b/apps/fluux/src/components/conversation/messageGroupWidth.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { createElement, type ReactNode } from 'react'
+import { render, act } from '@testing-library/react'
+import { OwnGroupWidthRegistry, OwnGroupWidthProvider, useOwnGroupWidth } from './messageGroupWidth'
+
+/**
+ * jsdom reports offsetWidth as 0, so we drive the registry with a controllable
+ * natural width per element. The registry sets `width: max-content` before
+ * reading offsetWidth; our getter ignores style and returns the injected value,
+ * which is exactly the "natural width" the flush wants to read.
+ */
+function memberWithWidth(width: number): HTMLElement & { __w: number } {
+  const el = document.createElement('div') as unknown as HTMLElement & { __w: number }
+  el.__w = width
+  Object.defineProperty(el, 'offsetWidth', { get: () => el.__w, configurable: true })
+  return el
+}
+
+/** Let the registry's queued-microtask flush run. */
+const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve))
+
+describe('OwnGroupWidthRegistry', () => {
+  it('pins every group member to the widest natural width', async () => {
+    const reg = new OwnGroupWidthRegistry()
+    const a = memberWithWidth(374)
+    const b = memberWithWidth(400)
+    reg.register('g', 'a', a)
+    reg.register('g', 'b', b)
+    await flush()
+
+    expect(a.style.minWidth).toBe('min(400px, 100%)')
+    expect(b.style.minWidth).toBe('min(400px, 100%)')
+  })
+
+  it('re-fits the group when a member grows after load (markDirty)', async () => {
+    const reg = new OwnGroupWidthRegistry()
+    // The image row starts under-measured (image not yet settled) …
+    const text = memberWithWidth(374)
+    const image = memberWithWidth(374)
+    reg.register('g', 'text', text)
+    reg.register('g', 'image', image)
+    await flush()
+    expect(text.style.minWidth).toBe('min(374px, 100%)')
+
+    // … then the image settles to its final width. Without a re-fit the group
+    // stays pinned at the stale 374, leaving a ragged edge.
+    image.__w = 400
+    reg.markDirty('g')
+    await flush()
+
+    expect(image.style.minWidth).toBe('min(400px, 100%)')
+    expect(text.style.minWidth).toBe('min(400px, 100%)')
+  })
+
+  it('re-fits downward when the widest member shrinks', async () => {
+    const reg = new OwnGroupWidthRegistry()
+    const a = memberWithWidth(374)
+    const b = memberWithWidth(400)
+    reg.register('g', 'a', a)
+    reg.register('g', 'b', b)
+    await flush()
+
+    b.__w = 300
+    reg.markDirty('g')
+    await flush()
+
+    expect(a.style.minWidth).toBe('min(374px, 100%)')
+    expect(b.style.minWidth).toBe('min(374px, 100%)')
+  })
+
+  it('clears the pinned width when a member unregisters', async () => {
+    const reg = new OwnGroupWidthRegistry()
+    const a = memberWithWidth(374)
+    const b = memberWithWidth(400)
+    reg.register('g', 'a', a)
+    reg.register('g', 'b', b)
+    await flush()
+
+    reg.unregister('g', 'b')
+    expect(b.style.minWidth).toBe('')
+    expect(b.style.width).toBe('')
+  })
+})
+
+describe('useOwnGroupWidth', () => {
+  // A member component that reports a controllable natural width, mirroring the
+  // real hook usage: attach the returned ref to the tint box, and call remeasure
+  // to simulate media finishing loading.
+  const remeasurers = new Map<string, () => void>()
+  const nodes = new Map<string, HTMLElement & { __w: number }>()
+
+  function Member({ id, width }: { id: string; width: number }): ReactNode {
+    const { ref, remeasure } = useOwnGroupWidth('g', id, id)
+    remeasurers.set(id, remeasure)
+    const attach = (node: HTMLDivElement | null) => {
+      if (node) {
+        const el = node as unknown as HTMLDivElement & { __w: number }
+        el.__w = width
+        Object.defineProperty(el, 'offsetWidth', { get: () => el.__w, configurable: true })
+        nodes.set(id, el)
+      }
+      ref(node)
+    }
+    return createElement('div', { ref: attach })
+  }
+
+  it('remeasure() re-fits the group after a member grows (media-load path)', async () => {
+    remeasurers.clear()
+    nodes.clear()
+    render(
+      createElement(OwnGroupWidthProvider, null,
+        createElement(Member, { id: 'text', width: 374 }),
+        createElement(Member, { id: 'image', width: 374 }),
+      ),
+    )
+    await act(flush)
+    expect(nodes.get('text')!.style.minWidth).toBe('min(374px, 100%)')
+
+    // Image settles to its final width, then the load handler calls remeasure.
+    nodes.get('image')!.__w = 400
+    await act(async () => {
+      remeasurers.get('image')!()
+      await flush()
+    })
+
+    expect(nodes.get('image')!.style.minWidth).toBe('min(400px, 100%)')
+    expect(nodes.get('text')!.style.minWidth).toBe('min(400px, 100%)')
+  })
+})

--- a/apps/fluux/src/components/conversation/messageGroupWidth.tsx
+++ b/apps/fluux/src/components/conversation/messageGroupWidth.tsx
@@ -37,7 +37,7 @@ interface GroupEntry {
   mounted: Map<string, HTMLElement>
 }
 
-class OwnGroupWidthRegistry {
+export class OwnGroupWidthRegistry {
   private groups = new Map<string, GroupEntry>()
   private dirty = new Set<string>()
   private scheduled = false
@@ -156,19 +156,25 @@ export function OwnGroupWidthProvider({ children }: { children: ReactNode }) {
 }
 
 /**
- * Attach the returned callback ref to a grouped own-message's tint box so it
- * shares the group's width. Pass `groupId === undefined` for solo/incoming rows
- * (the box then keeps its CSS `w-fit`); safe with no provider (tests no-op too).
+ * Attach the returned `ref` to a grouped own-message's tint box so it shares the
+ * group's width. Pass `groupId === undefined` for solo/incoming rows (the box
+ * then keeps its CSS `w-fit`); safe with no provider (tests no-op too).
  *
  * `widthSignature` is any value derived from the row's width-affecting content
  * (body, reactions, reply, attachment…). When it changes, the group re-measures;
  * hover/selection churn leaves it untouched, so those re-renders cost nothing.
+ *
+ * The returned `remeasure` re-fits the group on demand — used when a member's
+ * media (image/video/link-preview) finishes loading and only THEN reaches its
+ * final layout width. The initial measure at mount happens before the media
+ * settles, so without this the group stays pinned to the pre-load (too-narrow)
+ * width and the loaded row overflows it. No-op when the row is solo/incoming.
  */
 export function useOwnGroupWidth(
   groupId: string | undefined,
   memberId: string,
   widthSignature: unknown,
-): (node: HTMLDivElement | null) => void {
+): { ref: (node: HTMLDivElement | null) => void; remeasure: () => void } {
   const registry = useContext(OwnGroupWidthContext)
   const nodeRef = useRef<HTMLDivElement | null>(null)
   const active = registry != null && groupId != null
@@ -184,7 +190,13 @@ export function useOwnGroupWidth(
     // re-fits. The transient unregister settles before the microtask flush.
   }, [registry, active, groupId, memberId, widthSignature])
 
-  return useCallback((node: HTMLDivElement | null) => {
+  const ref = useCallback((node: HTMLDivElement | null) => {
     nodeRef.current = node
   }, [])
+
+  const remeasure = useCallback(() => {
+    if (active) registry.markDirty(groupId)
+  }, [registry, active, groupId])
+
+  return { ref, remeasure }
 }


### PR DESCRIPTION
## Summary

An own-message group shares its widest line's width so the tint reads as one clean rectangle. But the group was measured at mount — **before** an image (or video/link-preview) reached its final layout width — so the group max was pinned too narrow while the loaded row overflowed it, leaving a ragged edge (text rows at 374px, image row at 400px).

`onMediaLoad` was wired only to the scroll re-pin (`useMessageListScroll`), never to the width registry, so nothing re-fit the group once the image settled.

## Fix

- `useOwnGroupWidth` now returns `{ ref, remeasure }`; `remeasure()` calls the registry's existing `markDirty(groupId)` (no-op for solo/incoming rows).
- `MessageBubble` wraps media-load so a loaded image re-fits its group **and** re-pins scroll: `handleMediaLoad = () => { onMediaLoad?.(); remeasureOwnGroup() }`.

Reuses the registry's batched reads-before-writes microtask flush — no new observers, no render loop, no change to the virtualizer or scroll anchoring. Real XMPP images (no width/height hints) are worse-affected than the demo case.

Verified live: a text+image own group went from `[374, 400, 374]` → `[400, 400, 400]`. New unit tests cover re-fit up/down and the media-load `remeasure` path; typecheck, lint, and the 649 conversation tests pass.