### PR TITLE
fix(chat): keep quote and reply cards distinct when a message is selected (#1008)

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -592,6 +592,9 @@ export const MessageBubble = memo(function MessageBubble({
         // Marks hug-width (w-fit) own bubbles so useRowMetrics never samples their text box
         // as the conversation's content width (it is only as wide as the text itself).
         data-msg-own={ownTint ? '' : undefined}
+        // Selected/action-sheet state: hooks the CSS that keeps quote and reply-card
+        // fills distinct from the selection tint (issue #1008).
+        data-msg-selected={isSelected || showActionSheet ? '' : undefined}
         onTouchStart={handleContentTouchStart}
         onTouchEnd={cancelLongPress}
         onTouchMove={cancelLongPress}
@@ -666,8 +669,14 @@ export const MessageBubble = memo(function MessageBubble({
         {!message.isRetracted && replyContext && (
           <button
             onClick={() => scrollToMessage(replyContext.messageId)}
-            className="flex items-start gap-1.5 py-1 pe-2 ps-2 mb-1.5 border-s-2 text-start min-w-0 bg-fluux-bg-secondary hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
-            style={{ borderColor: replyContext.senderColor }}
+            className="reply-quote-card flex items-start gap-1.5 py-1 pe-2 ps-2 mb-1.5 border-s-2 text-start min-w-0 bg-fluux-bg-secondary hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
+            // When the row is selected the selection tint melts into the card fill
+            // (light themes); a full frame in the sender's colour keeps the card
+            // distinct in every theme/mode without touching the fill. Issue #1008.
+            style={{
+              borderColor: replyContext.senderColor,
+              boxShadow: isSelected || showActionSheet ? `inset 0 0 0 1px ${replyContext.senderColor}` : undefined,
+            }}
           >
             <CornerUpRight
               className="rtl-mirror size-3.5 flex-shrink-0 mt-0.5"

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -275,6 +275,12 @@
 
   /* Selection */
   --fluux-selection-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);
+  /* Extra fill laid over a quote/reply card when its message row is selected, to
+     keep the card distinct from the selection tint (issue #1008). Dark mode
+     needs none — the card's opaque --fluux-bg-secondary already contrasts with
+     the lighter selection tint; the .light override supplies the accent nudge
+     where the two would otherwise collide. */
+  --fluux-quote-selected-overlay: transparent;
 
   /* Search highlight */
   --fluux-search-highlight-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.35);
@@ -509,6 +515,10 @@
   --fluux-bg-float-hover: var(--fluux-base-20);
   --fluux-selection-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.15);
   --fluux-search-highlight-bg: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.25);
+  /* Light themes are where the selection tint collides with the card fill; a
+     gentle accent nudge (kept low so the card's muted preview text stays legible
+     — the selected frame carries the actual separation guarantee). Issue #1008. */
+  --fluux-quote-selected-overlay: hsla(var(--fluux-accent-h), var(--fluux-accent-s), var(--fluux-accent-l), 0.14);
   --fluux-scrollbar-thumb: #c4c9ce;
   --fluux-scrollbar-thumb-hover: #a8adb3;
   /* Sidebar sits on a grayer surface than the white content area, so its thumb is
@@ -958,6 +968,29 @@ html, body {
   margin-bottom: 0.125rem;
   border-left: 2px solid var(--fluux-brand);
   opacity: 0.85;
+}
+
+/* Selection-aware quote/reply framing (issue #1008). When a message row is
+   selected it gets a translucent accent selection tint; in light themes that
+   lands almost exactly on the quote/reply card's own --fluux-bg-secondary,
+   erasing the card. Two cues restore the separation, both scoped to the
+   selected row via [data-msg-selected]:
+     1. A gentle accent fill nudge in light mode (transparent in dark, where no
+        collision exists) — the "differentiated fill" look.
+     2. An accent frame (inset ring) that stays high-contrast against both the
+        fill and the selection tint in every theme and both modes — the frame is
+        what guarantees the card is always readable as a distinct block.
+   The reply card carries its frame inline in the sender's colour (see
+   MessageBubble); the blockquote uses the brand accent it already borders with. */
+[data-msg-selected] .blockquote-decorated,
+[data-msg-selected] .reply-quote-card {
+  background-image: linear-gradient(
+    var(--fluux-quote-selected-overlay),
+    var(--fluux-quote-selected-overlay)
+  );
+}
+[data-msg-selected] .blockquote-decorated {
+  box-shadow: inset 0 0 0 1px var(--fluux-brand);
 }
 
 /* Remove default focus outline */


### PR DESCRIPTION
Closes #1008.

When a message is selected, the row paints a translucent accent selection tint. In light themes that tint lands almost exactly on the reply card / blockquote's own `--fluux-bg-secondary` fill, so the card melts into the selection and its frame disappears.

## Fix

Two cues restore the separation, both scoped to the selected row (`[data-msg-selected]`):

1. **Frame** — an inset 1px ring that carries the separation guarantee, staying high-contrast against both the fill and the selection tint in every built-in theme and both modes. The reply card frames in the sender's colour (extending its existing left bar); the blockquote uses the brand accent it already borders with.
2. **Gentle accent fill nudge, light mode only** — `--fluux-quote-selected-overlay` (transparent in dark, where there is no collision), kept low so the muted quote-preview text stays legible.

A fill-only approach was rejected: additive accent regresses dark mode (where the card was already distinct) and, pushed strong enough to separate in light, it crushes the quote's own muted text. The frame avoids both.