### PR TITLE
fix(rooms): de-duplicate public room directory and stop on server boundary (#1010)

### DIFF
--- a/apps/fluux/src/components/BrowseRoomsModal.test.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.test.tsx
@@ -611,6 +611,43 @@ describe('BrowseRoomsModal', () => {
   })
 
   describe('pagination', () => {
+    // Mirror of PAGE_SIZE in BrowseRoomsModal — a "full" page signals more pages.
+    const PAGE_SIZE = 50
+
+    // Install an IntersectionObserver whose callback we can fire on demand to
+    // trigger load-more. Returns a trigger fn and a restore fn.
+    const installCapturingObserver = () => {
+      let observerCallback: IntersectionObserverCallback | null = null
+      const originalIO = globalThis.IntersectionObserver
+      class CapturingIO {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+        constructor(cb: IntersectionObserverCallback) {
+          observerCallback = cb
+        }
+      }
+      globalThis.IntersectionObserver = CapturingIO as unknown as typeof IntersectionObserver
+      return {
+        trigger: () =>
+          act(async () => {
+            observerCallback?.(
+              [{ isIntersecting: true } as IntersectionObserverEntry],
+              {} as IntersectionObserver
+            )
+          }),
+        restore: () => {
+          globalThis.IntersectionObserver = originalIO
+        },
+      }
+    }
+
+    const makeFullPage = (prefix: string) =>
+      Array.from({ length: PAGE_SIZE }, (_, i) => ({
+        jid: `${prefix}${i}@conference.example.com`,
+        name: `${prefix} Room ${i}`,
+      }))
+
     it('should pass RSM max parameter on initial fetch', async () => {
       render(<BrowseRoomsModal onClose={mockOnClose} />)
 
@@ -619,10 +656,12 @@ describe('BrowseRoomsModal', () => {
       })
     })
 
-    it('should show total count in footer when server provides it', async () => {
+    it('should show total count in footer while more pages remain', async () => {
+      // Full page + cursor → more pages available, so the "/ N" progress hint
+      // is meaningful.
       mockBrowsePublicRooms.mockResolvedValue({
-        rooms: sampleRooms,
-        pagination: { first: 'first-id', last: 'last-id', count: 150 },
+        rooms: makeFullPage('p1'),
+        pagination: { first: 'p10', last: 'p1last', count: 150 },
       })
 
       render(<BrowseRoomsModal onClose={mockOnClose} />)
@@ -630,6 +669,39 @@ describe('BrowseRoomsModal', () => {
       await waitFor(() => {
         expect(screen.getByText(/\/ 150/)).toBeInTheDocument()
       })
+    })
+
+    it('should drop the total-count hint once the last page is reached (issue #1010)', async () => {
+      const observer = installCapturingObserver()
+      try {
+        // Page 1: full page, more available. count is inflated (150).
+        mockBrowsePublicRooms.mockResolvedValueOnce({
+          rooms: makeFullPage('p1'),
+          pagination: { first: 'p10', last: 'p1last', count: 150 },
+        })
+        // Page 2: short page → authoritative end, but count still says 150.
+        mockBrowsePublicRooms.mockResolvedValueOnce({
+          rooms: [{ jid: 'tail@conference.example.com', name: 'Tail Room' }],
+          pagination: { first: 'tail', last: 'tail', count: 150 },
+        })
+
+        render(<BrowseRoomsModal onClose={mockOnClose} />)
+
+        await waitFor(() => {
+          expect(screen.getByText(/\/ 150/)).toBeInTheDocument()
+        })
+
+        await observer.trigger()
+
+        await waitFor(() => {
+          expect(screen.getByText('Tail Room')).toBeInTheDocument()
+        })
+
+        // We've loaded everything listable; the inflated "/ 150" must be gone.
+        expect(screen.queryByText(/\/ 150/)).not.toBeInTheDocument()
+      } finally {
+        observer.restore()
+      }
     })
 
     it('should not show total count when rooms are fully loaded', async () => {
@@ -646,6 +718,84 @@ describe('BrowseRoomsModal', () => {
 
       // Should NOT show "/ 3" since all rooms are loaded
       expect(screen.queryByText(/\/ 3/)).not.toBeInTheDocument()
+    })
+
+    it('should not duplicate a room repeated across pages (issue #1010)', async () => {
+      const observer = installCapturingObserver()
+      try {
+        // Page 1: a full page whose last room is B (a page boundary).
+        const page1 = makeFullPage('p1')
+        const roomB = { jid: 'b@conference.example.com', name: 'Room B' }
+        page1[PAGE_SIZE - 1] = roomB
+        mockBrowsePublicRooms.mockResolvedValueOnce({
+          rooms: page1,
+          pagination: { first: 'p10', last: 'b', count: 100 },
+        })
+        // Page 2: repeats boundary room B, then adds C.
+        mockBrowsePublicRooms.mockResolvedValueOnce({
+          rooms: [roomB, { jid: 'c@conference.example.com', name: 'Room C' }],
+          pagination: { first: 'b', last: 'c', count: 100 },
+        })
+
+        render(<BrowseRoomsModal onClose={mockOnClose} />)
+
+        await waitFor(() => {
+          expect(screen.getByText('Room B')).toBeInTheDocument()
+        })
+
+        await observer.trigger()
+
+        await waitFor(() => {
+          expect(screen.getByText('Room C')).toBeInTheDocument()
+        })
+
+        // Room B must appear exactly once despite being returned on both pages.
+        expect(screen.getAllByText('Room B')).toHaveLength(1)
+      } finally {
+        observer.restore()
+      }
+    })
+
+    it('should stop paging on a short page even when count stays high (issue #1010)', async () => {
+      const observer = installCapturingObserver()
+      try {
+        // Page 1: a full page — more pages available. count is inflated (e.g.
+        // ejabberd reports total online rooms, including empty ones it filters
+        // out of the listing), so it must NOT drive the stop decision.
+        mockBrowsePublicRooms.mockResolvedValueOnce({
+          rooms: makeFullPage('p1'),
+          pagination: { first: 'p10', last: 'p1last', count: 150 },
+        })
+        // Page 2: a SHORT page — the server's ordered walk reached the end,
+        // even though count (150) still exceeds the rooms loaded so far (60).
+        mockBrowsePublicRooms.mockResolvedValueOnce({
+          rooms: Array.from({ length: 10 }, (_, i) => ({
+            jid: `p2${i}@conference.example.com`,
+            name: `p2 Room ${i}`,
+          })),
+          pagination: { first: 'p20', last: 'p2last', count: 150 },
+        })
+
+        render(<BrowseRoomsModal onClose={mockOnClose} />)
+
+        await waitFor(() => {
+          expect(screen.getByText('p1 Room 0')).toBeInTheDocument()
+        })
+
+        // First load-more fetches the short page 2.
+        await observer.trigger()
+        await waitFor(() => {
+          expect(screen.getByText('p2 Room 0')).toBeInTheDocument()
+        })
+        expect(mockBrowsePublicRooms).toHaveBeenCalledTimes(2)
+
+        // Firing again must NOT fetch a third page: the short page 2 is the
+        // authoritative end signal, regardless of the still-high count.
+        await observer.trigger()
+        expect(mockBrowsePublicRooms).toHaveBeenCalledTimes(2)
+      } finally {
+        observer.restore()
+      }
     })
 
     it('should reset pagination when switching MUC service', async () => {

--- a/apps/fluux/src/components/BrowseRoomsModal.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.tsx
@@ -19,6 +19,21 @@ import { getRoomJoinErrorMessage } from '@/utils/roomJoinError'
 
 const PAGE_SIZE = 50
 
+/**
+ * Whether more pages are available. The authoritative signal is the server's
+ * own boundary: a page shorter than the requested max means the RSM walk
+ * reached the end. We deliberately do NOT compare against the RSM `count` —
+ * ejabberd reports it as the total online-room count, which drifts as rooms
+ * churn and can exceed the number of listable rooms once empty rooms are
+ * filtered out at scale, so it would stop us early or loop us forever (#1010).
+ */
+function hasMorePages(result: {
+  rooms: unknown[]
+  pagination: { last?: string }
+}): boolean {
+  return result.rooms.length >= PAGE_SIZE && !!result.pagination.last
+}
+
 interface BrowseRoomsModalProps {
   onClose: () => void
 }
@@ -111,12 +126,7 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
         setRooms(result.rooms)
         setPaginationCursor(result.pagination.last)
         setTotalCount(result.pagination.count)
-        // Determine if there are more pages
-        if (result.pagination.count !== undefined) {
-          setHasMore(result.rooms.length < result.pagination.count)
-        } else {
-          setHasMore(result.rooms.length >= PAGE_SIZE && !!result.pagination.last)
-        }
+        setHasMore(hasMorePages(result))
       } catch (err) {
         setError(err instanceof Error ? err.message : t('rooms.failedToLoadRooms'))
         setRooms([])
@@ -143,20 +153,21 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
       .then((result) => {
         if (result.rooms.length === 0) {
           setHasMore(false)
-        } else {
-          setRooms((prev) => {
-            const updated = [...prev, ...result.rooms]
-            // Compute hasMore from the actual new total (avoids stale closure)
-            if (result.pagination.count !== undefined) {
-              setHasMore(updated.length < result.pagination.count)
-              setTotalCount(result.pagination.count)
-            } else {
-              setHasMore(result.rooms.length >= PAGE_SIZE && !!result.pagination.last)
-            }
-            return updated
-          })
-          setPaginationCursor(result.pagination.last)
+          return
         }
+        setRooms((prev) => {
+          // Deduplicate by JID: a boundary room can repeat across RSM pages
+          // (issue #1010). Append only rooms we haven't already listed.
+          const seen = new Set(prev.map((r) => r.jid))
+          const fresh = result.rooms.filter((r) => !seen.has(r.jid))
+          return [...prev, ...fresh]
+        })
+        if (result.pagination.count !== undefined) {
+          setTotalCount(result.pagination.count)
+        }
+        // Stop signal comes from the server boundary (short page), not `count`.
+        setHasMore(hasMorePages(result))
+        setPaginationCursor(result.pagination.last)
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : t('rooms.failedToLoadRooms'))
@@ -479,7 +490,11 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
         <div className="px-4 py-3 border-t border-fluux-hover flex-shrink-0">
           <p className="text-xs text-fluux-muted">
             {t('rooms.browseRoomsHint', { count: rooms.length })}
-            {totalCount !== undefined && totalCount > rooms.length && ` / ${totalCount}`}
+            {/* Only a progress hint while more pages remain. Once the server's
+                boundary is reached (hasMore false), the count is dropped: the
+                RSM `count` can exceed the listable rooms (empty rooms filtered
+                out at scale), so keeping "/ N" would look like a stalled load. */}
+            {hasMore && totalCount !== undefined && totalCount > rooms.length && ` / ${totalCount}`}
           </p>
         </div>
     </ModalShell>

--- a/packages/fluux-sdk/src/core/modules/Admin.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Admin.test.ts
@@ -1042,6 +1042,39 @@ describe('XMPPClient Admin', () => {
       expect(result.rooms).toHaveLength(1)
     })
 
+    it('should deduplicate rooms that share the same JID (issue #1010)', async () => {
+      await connectClient()
+
+      // A MUC service may emit the same room more than once in a single
+      // disco#items response (or repeat a boundary item across RSM pages).
+      const mockQuery = createAdminMockElement('query', {
+        xmlns: 'http://jabber.org/protocol/disco#items',
+      }, [
+        { name: 'item', attrs: { jid: 'room1@conference.example.com', name: 'Room 1' }, getChildren: () => [] },
+        { name: 'item', attrs: { jid: 'room1@conference.example.com', name: 'Room 1' }, getChildren: () => [] },
+        { name: 'item', attrs: { jid: 'room2@conference.example.com', name: 'Room 2' }, getChildren: () => [] },
+      ])
+
+      const mockResponse = {
+        getChild: (name: string, xmlns?: string) => {
+          if (name === 'query' && xmlns === 'http://jabber.org/protocol/disco#items') {
+            return mockQuery
+          }
+          return undefined
+        },
+      }
+
+      mockXmppClientInstance.iqCaller.request.mockResolvedValue(mockResponse)
+
+      const result = await xmppClient.admin.fetchRoomList('custom.muc.server.com')
+
+      expect(result.rooms).toHaveLength(2)
+      expect(result.rooms.map((r) => r.jid)).toEqual([
+        'room1@conference.example.com',
+        'room2@conference.example.com',
+      ])
+    })
+
     it('should throw error when not connected', async () => {
       await expect(xmppClient.admin.fetchRoomList('muc.example.com')).rejects.toThrow('Not connected')
     })

--- a/packages/fluux-sdk/src/core/modules/Admin.ts
+++ b/packages/fluux-sdk/src/core/modules/Admin.ts
@@ -998,14 +998,18 @@ export class Admin extends BaseModule {
     const setEl = query.getChild('set', NS_RSM)
     const pagination = parseRSMResponse(setEl)
 
-    // Parse room items
+    // Parse room items. Deduplicate by JID: some MUC services emit the same
+    // room more than once in a single disco#items response, and a boundary
+    // room can repeat across RSM pages (issue #1010).
     const rooms: AdminRoom[] = []
+    const seen = new Set<string>()
     const items = query.getChildren('item') || []
 
     for (const item of items) {
       const jid = item.attrs.jid
       const name = item.attrs.name || getLocalPart(jid)
-      if (jid) {
+      if (jid && !seen.has(jid)) {
+        seen.add(jid)
         rooms.push({ jid, name })
       }
     }


### PR DESCRIPTION
Fixes #1010 — duplicate rooms listed in Browse Public Rooms.

## What
- **Dedup by JID** at two points where duplicates entered the list: the SDK `disco#items` parse (`Admin.fetchRoomList`) and the modal's cross-page append. A MUC service can emit a room twice in one response (e.g. a room that is both online and persistent) or repeat a boundary room across RSM pages.
- **Authoritative completion signal.** Pagination now stops on the server's own boundary — a page shorter than `max` means the RSM walk reached the end — instead of comparing against the RSM `count`. On ejabberd `count` is the total online-room count: it drifts as rooms churn and can exceed the number of listable rooms once empty rooms are filtered at scale, which could stop paging early (missing rooms) or loop forever.
- **Footer hint** `/ N` now shows only while more pages remain; once the last page is reached it collapses to just the loaded count, so an inflated `count` no longer looks like a stalled load.

## Why
Keyset pagination on the room JID (identity) is already the stable cursor; the instability was in trusting `count` for completeness. This makes the traversal gap- and duplicate-safe end to end. The only residual (a room created behind the scroll cursor mid-browse) is a fundamental RSM limitation that a refresh resolves.