### PR TITLE
perf(upload): move desktop file upload to a native Tauri command

### DIFF
--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
 name = "fluux"
 version = "0.17.1"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "axum",

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -66,6 +66,12 @@ sequoia-openpgp = { version = "2.0", default-features = false, features = [
 anyhow = "1"
 base64 = "0.22"
 
+# XEP-0454 media encryption for the native upload path (upload.rs). The
+# WebView cannot ship large bodies over IPC without a main-thread stall, so
+# file encryption + HTTP PUT both run in Rust; aes-gcm matches the
+# WebCrypto AES-256-GCM shape used by the web build (tag appended).
+aes-gcm = "0.10"
+
 # Unicode NFKD normalization for the backup passphrase. BIP-39 wordlists
 # for non-English languages contain precomposed diacritics that user
 # keyboards and copy-paste sources may decompose differently; applying

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -196,6 +196,7 @@ use tauri_plugin_deep_link::DeepLinkExt;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri_plugin_opener::OpenerExt;
 
+mod upload;
 mod xmpp_proxy;
 mod openpgp;
 mod openpgp_backup;
@@ -1496,6 +1497,7 @@ fn main() {
             delete_credentials,
             exit_app,
             fetch_url_metadata,
+            upload::upload_file,
             start_xmpp_proxy,
             stop_xmpp_proxy,
             mcp_start_server,

--- a/apps/fluux/src-tauri/src/upload.rs
+++ b/apps/fluux/src-tauri/src/upload.rs
@@ -21,7 +21,7 @@
 //! 12-byte IV per call, 128-bit auth tag appended to the ciphertext.
 
 use aes_gcm::aead::{Aead, OsRng};
-use aes_gcm::{AeadCore, Aes256Gcm, Key, KeyInit};
+use aes_gcm::{AeadCore, Aes256Gcm, KeyInit};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use serde::Serialize;
@@ -93,20 +93,32 @@ pub fn parse_upload_args(headers: &HeaderMap) -> Result<UploadArgs, String> {
     })
 }
 
+/// One AES-256-GCM encryption result. Key + IV are one-shot — never reuse.
+pub struct EncryptedUpload {
+    /// Ciphertext with the 128-bit auth tag appended (WebCrypto-compatible).
+    pub ciphertext: Vec<u8>,
+    pub key: [u8; 32],
+    pub iv: [u8; 12],
+}
+
 /// Encrypt file bytes with a fresh AES-256-GCM key and IV.
 ///
 /// Mirrors the WebCrypto path (`MediaEncryption.encryptFile`): the returned
 /// ciphertext has the 128-bit auth tag appended, and key/IV are one-shot —
 /// generated here, never accepted from a caller, so nonce reuse is
 /// impossible by construction.
-pub fn encrypt_for_upload(plaintext: &[u8]) -> Result<(Vec<u8>, [u8; 32], [u8; 12]), String> {
+pub fn encrypt_for_upload(plaintext: &[u8]) -> Result<EncryptedUpload, String> {
     let key = Aes256Gcm::generate_key(OsRng);
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
     let cipher = Aes256Gcm::new(&key);
     let ciphertext = cipher
         .encrypt(&nonce, plaintext)
         .map_err(|_| "upload_file: AES-GCM encryption failed".to_string())?;
-    Ok((ciphertext, key.into(), nonce.into()))
+    Ok(EncryptedUpload {
+        ciphertext,
+        key: key.into(),
+        iv: nonce.into(),
+    })
 }
 
 /// `Read` adapter that counts bytes handed to reqwest and emits one progress
@@ -124,7 +136,7 @@ impl<R: Read> Read for ProgressReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let n = self.inner.read(buf)?;
         self.sent += n as u64;
-        let percent = if self.total == 0 { 100 } else { self.sent * 100 / self.total };
+        let percent = (self.sent * 100).checked_div(self.total).unwrap_or(100);
         if percent > self.last_percent {
             self.last_percent = percent;
             let _ = self.app.emit(
@@ -194,12 +206,12 @@ pub async fn upload_file(
 
     tauri::async_runtime::spawn_blocking(move || {
         let (payload, response) = if args.encrypt {
-            let (ciphertext, key, iv) = encrypt_for_upload(&bytes)?;
+            let encrypted = encrypt_for_upload(&bytes)?;
             (
-                ciphertext,
+                encrypted.ciphertext,
                 UploadResponse {
-                    key: Some(BASE64.encode(key)),
-                    iv: Some(BASE64.encode(iv)),
+                    key: Some(BASE64.encode(encrypted.key)),
+                    iv: Some(BASE64.encode(encrypted.iv)),
                 },
             )
         } else {
@@ -216,6 +228,7 @@ pub async fn upload_file(
 mod tests {
     use super::*;
     use aes_gcm::aead::Payload;
+    use aes_gcm::Key;
     use tauri::http::HeaderValue;
 
     fn headers(entries: &[(&str, &str)]) -> HeaderMap {
@@ -274,16 +287,16 @@ mod tests {
     #[test]
     fn encrypt_for_upload_appends_tag_and_roundtrips() {
         let plaintext = b"attachment bytes".to_vec();
-        let (ciphertext, key, iv) = encrypt_for_upload(&plaintext).unwrap();
+        let encrypted = encrypt_for_upload(&plaintext).unwrap();
 
         // WebCrypto-compatible shape: ciphertext || 16-byte GCM tag.
-        assert_eq!(ciphertext.len(), plaintext.len() + 16);
+        assert_eq!(encrypted.ciphertext.len(), plaintext.len() + 16);
 
-        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&encrypted.key));
         let decrypted = cipher
             .decrypt(
-                (&iv).into(),
-                Payload { msg: &ciphertext, aad: &[] },
+                (&encrypted.iv).into(),
+                Payload { msg: encrypted.ciphertext.as_slice(), aad: &[] },
             )
             .unwrap();
         assert_eq!(decrypted, plaintext);
@@ -291,9 +304,9 @@ mod tests {
 
     #[test]
     fn encrypt_for_upload_generates_fresh_key_and_iv() {
-        let (_, key_a, iv_a) = encrypt_for_upload(b"x").unwrap();
-        let (_, key_b, iv_b) = encrypt_for_upload(b"x").unwrap();
-        assert_ne!(key_a, key_b);
-        assert_ne!(iv_a, iv_b);
+        let a = encrypt_for_upload(b"x").unwrap();
+        let b = encrypt_for_upload(b"x").unwrap();
+        assert_ne!(a.key, b.key);
+        assert_ne!(a.iv, b.iv);
     }
 }

--- a/apps/fluux/src-tauri/src/upload.rs
+++ b/apps/fluux/src-tauri/src/upload.rs
@@ -1,0 +1,299 @@
+//! Native XEP-0363 HTTP upload with optional AES-256-GCM media encryption
+//! (XEP-0454).
+//!
+//! The WebView invokes `upload_file` with the file bytes as Tauri's RAW IPC
+//! body. This replaces the `@tauri-apps/plugin-http` upload path, whose JS
+//! shim converts the whole body into a plain number array
+//! (`Array.from(new Uint8Array(buffer))`) and JSON-serializes it through
+//! `invoke` — ~20ms of main-thread blocking per MB, i.e. a full ~1s UI freeze
+//! for a 40MB attachment. The raw IPC body is a single memcpy instead.
+//!
+//! Metadata rides in invoke headers (raw-body invokes carry no JSON args):
+//! - `x-put-url`: XEP-0363 slot PUT URL
+//! - `x-content-type`: Content-Type for the PUT
+//! - `x-encrypt`: "1" to AES-256-GCM-encrypt the bytes before upload
+//! - `x-upload-id`: opaque id echoed in progress events
+//! - `x-extra-headers`: JSON object of extra PUT headers from the slot
+//!
+//! Progress is emitted as `fluux://upload-progress` events (`{id, sent,
+//! total}`), at most once per integer percent. Encryption matches
+//! `MediaEncryption.encryptFile` on the web path: fresh 32-byte key +
+//! 12-byte IV per call, 128-bit auth tag appended to the ciphertext.
+
+use aes_gcm::aead::{Aead, OsRng};
+use aes_gcm::{AeadCore, Aes256Gcm, Key, KeyInit};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use serde::Serialize;
+use std::io::Read;
+use std::time::Duration;
+use tauri::http::HeaderMap;
+use tauri::ipc::InvokeBody;
+use tauri::Emitter;
+
+const PROGRESS_EVENT: &str = "fluux://upload-progress";
+const UPLOAD_TIMEOUT_SECS: u64 = 600;
+
+/// Parsed invoke-header metadata for one upload.
+#[derive(Debug, PartialEq)]
+pub struct UploadArgs {
+    pub put_url: String,
+    pub content_type: String,
+    pub encrypt: bool,
+    pub upload_id: String,
+    pub extra_headers: Vec<(String, String)>,
+}
+
+/// AES-GCM key/IV returned to the WebView when `x-encrypt: 1`.
+/// Base64 so it survives JSON; the JS side decodes back to `Uint8Array`.
+#[derive(Serialize)]
+pub struct UploadResponse {
+    pub key: Option<String>,
+    pub iv: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct ProgressPayload {
+    id: String,
+    sent: u64,
+    total: u64,
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Result<&'a str, String> {
+    headers
+        .get(name)
+        .ok_or_else(|| format!("upload_file: missing required header `{name}`"))?
+        .to_str()
+        .map_err(|_| format!("upload_file: header `{name}` is not valid UTF-8"))
+}
+
+/// Extract upload metadata from invoke headers. Pure, unit-tested.
+pub fn parse_upload_args(headers: &HeaderMap) -> Result<UploadArgs, String> {
+    let extra_json = headers
+        .get("x-extra-headers")
+        .map(|v| v.to_str().map_err(|_| "upload_file: header `x-extra-headers` is not valid UTF-8".to_string()))
+        .transpose()?
+        .unwrap_or("{}");
+    let extra: serde_json::Map<String, serde_json::Value> = serde_json::from_str(extra_json)
+        .map_err(|e| format!("upload_file: invalid `x-extra-headers` JSON: {e}"))?;
+    let extra_headers = extra
+        .into_iter()
+        .map(|(k, v)| match v {
+            serde_json::Value::String(s) => Ok((k, s)),
+            other => Err(format!("upload_file: extra header `{k}` must be a string, got {other}")),
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    Ok(UploadArgs {
+        put_url: header_str(headers, "x-put-url")?.to_string(),
+        content_type: header_str(headers, "x-content-type")?.to_string(),
+        encrypt: header_str(headers, "x-encrypt")? == "1",
+        upload_id: header_str(headers, "x-upload-id")?.to_string(),
+        extra_headers,
+    })
+}
+
+/// Encrypt file bytes with a fresh AES-256-GCM key and IV.
+///
+/// Mirrors the WebCrypto path (`MediaEncryption.encryptFile`): the returned
+/// ciphertext has the 128-bit auth tag appended, and key/IV are one-shot —
+/// generated here, never accepted from a caller, so nonce reuse is
+/// impossible by construction.
+pub fn encrypt_for_upload(plaintext: &[u8]) -> Result<(Vec<u8>, [u8; 32], [u8; 12]), String> {
+    let key = Aes256Gcm::generate_key(OsRng);
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let cipher = Aes256Gcm::new(&key);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|_| "upload_file: AES-GCM encryption failed".to_string())?;
+    Ok((ciphertext, key.into(), nonce.into()))
+}
+
+/// `Read` adapter that counts bytes handed to reqwest and emits one progress
+/// event per integer-percent step (plus a final 100%).
+struct ProgressReader<R: Read> {
+    inner: R,
+    sent: u64,
+    total: u64,
+    last_percent: u64,
+    app: tauri::AppHandle,
+    upload_id: String,
+}
+
+impl<R: Read> Read for ProgressReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.sent += n as u64;
+        let percent = if self.total == 0 { 100 } else { self.sent * 100 / self.total };
+        if percent > self.last_percent {
+            self.last_percent = percent;
+            let _ = self.app.emit(
+                PROGRESS_EVENT,
+                ProgressPayload {
+                    id: self.upload_id.clone(),
+                    sent: self.sent,
+                    total: self.total,
+                },
+            );
+        }
+        Ok(n)
+    }
+}
+
+/// Blocking PUT of `bytes` to the slot URL. Runs inside `spawn_blocking` —
+/// never on the main thread (see project rule on sync Tauri commands).
+fn put_blocking(app: tauri::AppHandle, args: &UploadArgs, bytes: Vec<u8>) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(UPLOAD_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("upload_file: failed to build HTTP client: {e}"))?;
+
+    let total = bytes.len() as u64;
+    let reader = ProgressReader {
+        inner: std::io::Cursor::new(bytes),
+        sent: 0,
+        total,
+        last_percent: 0,
+        app,
+        upload_id: args.upload_id.clone(),
+    };
+
+    let mut request = client
+        .put(&args.put_url)
+        .header("Content-Type", &args.content_type)
+        .body(reqwest::blocking::Body::sized(reader, total));
+    for (name, value) in &args.extra_headers {
+        request = request.header(name, value);
+    }
+
+    let response = request
+        .send()
+        .map_err(|e| format!("upload_file: PUT request failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("Upload failed: {}", response.status().as_u16()));
+    }
+    Ok(())
+}
+
+/// Upload a file to an XEP-0363 slot, optionally AES-256-GCM-encrypting it
+/// first. File bytes arrive as the raw IPC body — do NOT route uploads
+/// through `@tauri-apps/plugin-http`, whose number-array marshaling blocks
+/// the WebView main thread for ~1s on large files.
+#[tauri::command]
+pub async fn upload_file(
+    app: tauri::AppHandle,
+    request: tauri::ipc::Request<'_>,
+) -> Result<UploadResponse, String> {
+    let args = parse_upload_args(request.headers())?;
+    let bytes = match request.body() {
+        InvokeBody::Raw(bytes) => bytes.clone(),
+        InvokeBody::Json(_) => {
+            return Err("upload_file: expected raw body, got JSON — invoke with an ArrayBuffer/Uint8Array payload".to_string())
+        }
+    };
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let (payload, response) = if args.encrypt {
+            let (ciphertext, key, iv) = encrypt_for_upload(&bytes)?;
+            (
+                ciphertext,
+                UploadResponse {
+                    key: Some(BASE64.encode(key)),
+                    iv: Some(BASE64.encode(iv)),
+                },
+            )
+        } else {
+            (bytes, UploadResponse { key: None, iv: None })
+        };
+        put_blocking(app, &args, payload)?;
+        Ok(response)
+    })
+    .await
+    .map_err(|e| format!("upload_file: task join error: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes_gcm::aead::Payload;
+    use tauri::http::HeaderValue;
+
+    fn headers(entries: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in entries {
+            map.insert(
+                tauri::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn parse_upload_args_reads_all_fields() {
+        let map = headers(&[
+            ("x-put-url", "https://up.example.com/slot/1"),
+            ("x-content-type", "image/jpeg"),
+            ("x-encrypt", "1"),
+            ("x-upload-id", "abc-123"),
+            ("x-extra-headers", r#"{"Authorization":"Bearer t"}"#),
+        ]);
+        let args = parse_upload_args(&map).unwrap();
+        assert_eq!(
+            args,
+            UploadArgs {
+                put_url: "https://up.example.com/slot/1".into(),
+                content_type: "image/jpeg".into(),
+                encrypt: true,
+                upload_id: "abc-123".into(),
+                extra_headers: vec![("Authorization".into(), "Bearer t".into())],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_upload_args_defaults_extra_headers_and_plain_mode() {
+        let map = headers(&[
+            ("x-put-url", "https://up.example.com/slot/2"),
+            ("x-content-type", "application/pdf"),
+            ("x-encrypt", "0"),
+            ("x-upload-id", "id-2"),
+        ]);
+        let args = parse_upload_args(&map).unwrap();
+        assert!(!args.encrypt);
+        assert!(args.extra_headers.is_empty());
+    }
+
+    #[test]
+    fn parse_upload_args_rejects_missing_url() {
+        let map = headers(&[("x-content-type", "image/png")]);
+        let err = parse_upload_args(&map).unwrap_err();
+        assert!(err.contains("x-put-url"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn encrypt_for_upload_appends_tag_and_roundtrips() {
+        let plaintext = b"attachment bytes".to_vec();
+        let (ciphertext, key, iv) = encrypt_for_upload(&plaintext).unwrap();
+
+        // WebCrypto-compatible shape: ciphertext || 16-byte GCM tag.
+        assert_eq!(ciphertext.len(), plaintext.len() + 16);
+
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+        let decrypted = cipher
+            .decrypt(
+                (&iv).into(),
+                Payload { msg: &ciphertext, aad: &[] },
+            )
+            .unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn encrypt_for_upload_generates_fresh_key_and_iv() {
+        let (_, key_a, iv_a) = encrypt_for_upload(b"x").unwrap();
+        let (_, key_b, iv_b) = encrypt_for_upload(b"x").unwrap();
+        assert_ne!(key_a, key_b);
+        assert_ne!(iv_a, iv_b);
+    }
+}

--- a/apps/fluux/src/hooks/useFileUpload.ts
+++ b/apps/fluux/src/hooks/useFileUpload.ts
@@ -6,6 +6,7 @@ import {
   type FileAttachment,
   type FileEncryption,
   type ThumbnailInfo,
+  type UploadSlot,
 } from '@fluux/sdk'
 import { useConnectionStore } from '@fluux/sdk/react'
 import {
@@ -21,16 +22,12 @@ import {
   getEffectiveMimeType,
   type ThumbnailResult,
 } from '@/utils/thumbnail'
+import { isTauri } from '@/utils/tauri'
+import { uploadFileTauri } from '@/utils/tauriUpload'
 import { createUploadProgressReporter } from './uploadProgressReporter'
 
-/**
- * Check if running in Tauri dynamically.
- * IMPORTANT: Must be checked at call time, not module load time,
- * because __TAURI_INTERNALS__ may not be available when the module first loads.
- */
-function isTauri(): boolean {
-  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
-}
+/** WebCrypto/aes-gcm append a 128-bit auth tag, so ciphertext = plaintext + 16. */
+const GCM_TAG_BYTES = 16
 
 interface UploadState {
   isUploading: boolean
@@ -39,6 +36,78 @@ interface UploadState {
 }
 
 export type { FileAttachment, ThumbnailInfo }
+
+type RequestSlot = (filename: string, size: number, contentType: string) => Promise<UploadSlot>
+
+interface SlotUploadOutcome {
+  /** Plain HTTPS URL of the uploaded (cipher)text. */
+  getUrl: string
+  /** AES-GCM params when the blob was encrypted before upload. */
+  encryption?: FileEncryption
+}
+
+/**
+ * Upload one blob through an XEP-0363 slot, optionally AES-256-GCM-encrypted
+ * (XEP-0454). Shared by the main file and its thumbnail.
+ *
+ * Encrypted uploads never leak the original filename/mimetype to the upload
+ * server — the real ones ride inside the encrypted `<file-metadata/>` — and
+ * the slot is requested with the CIPHERTEXT size (plaintext + GCM tag) so
+ * the server's size limit applies to what actually goes on the wire.
+ *
+ * Transport is platform-split:
+ * - Desktop: the Rust `upload_file` command receives the plaintext bytes as
+ *   Tauri's raw IPC body and does encryption + PUT natively. Do NOT use
+ *   `@tauri-apps/plugin-http` here — its JS shim turns the body into a
+ *   number array and JSON-serializes it, which blocks the main thread ~1s
+ *   for a 40MB file (the `[MainThreadStall]` class).
+ * - Web: WebCrypto encryption + XHR PUT; the browser streams the body off
+ *   the main thread.
+ */
+async function uploadBlobViaSlot(
+  blob: Blob,
+  filename: string,
+  mimeType: string,
+  encrypt: boolean,
+  requestSlot: RequestSlot,
+  onProgress: (percent: number) => void,
+): Promise<SlotUploadOutcome> {
+  const uploadFilename = encrypt ? `${crypto.randomUUID()}.bin` : filename
+  const uploadMimeType = encrypt ? 'application/octet-stream' : mimeType
+  const uploadSize = encrypt ? blob.size + GCM_TAG_BYTES : blob.size
+
+  const slot = await requestSlot(uploadFilename, uploadSize, uploadMimeType)
+
+  if (isTauri()) {
+    const encryption = await uploadFileTauri({
+      bytes: await blob.arrayBuffer(),
+      putUrl: slot.putUrl,
+      contentType: uploadMimeType,
+      headers: slot.headers,
+      encrypt,
+      onProgress,
+    })
+    return { getUrl: slot.getUrl, encryption }
+  }
+
+  let uploadBlob = blob
+  let encryption: FileEncryption | undefined
+  if (encrypt) {
+    // Each call generates a fresh key + IV; reuse would be catastrophic
+    // for GCM.
+    const enc = await encryptFile(new Uint8Array(await blob.arrayBuffer()))
+    encryption = { cipher: 'aes-256-gcm', key: enc.key, iv: enc.iv }
+    uploadBlob = new Blob([enc.ciphertext as BlobPart], { type: uploadMimeType })
+  }
+  await uploadWithXHR(
+    slot.putUrl,
+    new File([uploadBlob], uploadFilename, { type: uploadMimeType }),
+    uploadMimeType,
+    slot.headers,
+    onProgress,
+  )
+  return { getUrl: slot.getUrl, encryption }
+}
 
 /**
  * Hook for uploading files via XEP-0363 HTTP File Upload.
@@ -76,12 +145,11 @@ export function useFileUpload() {
    * - Audio: extracts duration
    *
    * When `encrypt` is true the file bytes (and thumbnail bytes, if any)
-   * are AES-256-GCM-encrypted client-side before HTTP Upload. The returned
+   * are AES-256-GCM-encrypted before HTTP Upload. The returned
    * `FileAttachment.url` is the HTTPS URL of the ciphertext, and
    * `encryption` carries the per-file key/IV — the SDK's Chat module then
    * embeds an `aesgcm://` URI inside the E2EE `<payload/>` so the XMPP
-   * server never sees the key. Each call generates fresh key + IV; reuse
-   * would be catastrophic for GCM.
+   * server never sees the key.
    *
    * Returns FileAttachment with URL, thumbnail info, duration, and
    * optional encryption metadata, or null on failure.
@@ -146,8 +214,8 @@ export function useFileUpload() {
 
       // Combine main-file + optional-thumbnail progress into one size-weighted
       // percent. The reporter only fires when the rounded percent changes, so a
-      // fast web upload can't re-render the conversation pane once per XHR
-      // progress event (same render-storm class as issue #994).
+      // fast upload can't re-render the conversation pane once per progress
+      // event (same render-storm class as issue #994).
       const thumbnailSize = thumbnailResult?.blob.size || 0
       const progressReporter = createUploadProgressReporter(
         file.size,
@@ -155,76 +223,28 @@ export function useFileUpload() {
         overall => setState(s => ({ ...s, progress: overall })),
       )
 
-      // 1. Prepare main file bytes — encrypted or plaintext depending on mode.
-      // When encrypting we PUT the ciphertext (plaintext_len + 16-byte GCM
-      // tag) and store the key/IV in `encryption` for the downstream stanza
-      // assembly. The XEP-0363 slot is requested with the CIPHERTEXT size
-      // so the server's size limit applies to what actually goes on the wire.
       const effectiveMimeType = getEffectiveMimeType(file)
-      let mainEncryption: FileEncryption | undefined
-      let mainUploadBlob: Blob = file
-      let mainUploadMimeType = effectiveMimeType
-      let mainUploadFilename = file.name
-      let mainUploadSize = file.size
-      if (shouldEncrypt) {
-        const plaintextBytes = new Uint8Array(await file.arrayBuffer())
-        const enc = await encryptFile(plaintextBytes)
-        mainEncryption = { cipher: 'aes-256-gcm', key: enc.key, iv: enc.iv }
-        mainUploadBlob = new Blob([enc.ciphertext as BlobPart], { type: 'application/octet-stream' })
-        // Don't leak the original filename / mimetype via HTTP Upload — the
-        // real name/mimetype ride inside the encrypted `<file-metadata/>`.
-        mainUploadMimeType = 'application/octet-stream'
-        mainUploadFilename = `${crypto.randomUUID()}.bin`
-        mainUploadSize = enc.ciphertext.byteLength
-      }
-      const slot = await requestUploadSlot(
-        mainUploadFilename,
-        mainUploadSize,
-        mainUploadMimeType,
-      )
-
-      // 2. Upload main file (ciphertext or plaintext) via HTTP PUT with progress.
-      await uploadWithProgress(
-        slot.putUrl,
-        new File([mainUploadBlob], mainUploadFilename, { type: mainUploadMimeType }),
-        mainUploadMimeType,
-        slot.headers,
+      const main = await uploadBlobViaSlot(
+        file,
+        file.name,
+        effectiveMimeType,
+        shouldEncrypt,
+        requestUploadSlot,
         (progress) => progressReporter.setMain(progress),
       )
 
-      // 3. Upload thumbnail if generated. Encrypted attachments get an
+      // Upload thumbnail if generated. Encrypted attachments get an
       // encrypted thumbnail too — a plaintext thumbnail would leak a
       // preview of the very file we just protected.
       let thumbnailInfo: ThumbnailInfo | undefined
       if (thumbnailResult) {
-        let thumbBytes: Uint8Array
-        let thumbUploadMime: string
-        let thumbFilename: string
-        let thumbEncryption: FileEncryption | undefined
-        if (shouldEncrypt) {
-          const thumbPlain = new Uint8Array(await thumbnailResult.blob.arrayBuffer())
-          const enc = await encryptFile(thumbPlain)
-          thumbBytes = enc.ciphertext
-          thumbEncryption = { cipher: 'aes-256-gcm', key: enc.key, iv: enc.iv }
-          thumbUploadMime = 'application/octet-stream'
-          thumbFilename = `${crypto.randomUUID()}.bin`
-        } else {
-          thumbBytes = new Uint8Array(await thumbnailResult.blob.arrayBuffer())
-          thumbUploadMime = thumbnailResult.mediaType
-          thumbFilename = `thumb_${file.name.replace(/\.[^.]+$/, '')}.jpg`
-        }
-
-        const thumbSlot = await requestUploadSlot(
+        const thumbFilename = `thumb_${file.name.replace(/\.[^.]+$/, '')}.jpg`
+        const thumb = await uploadBlobViaSlot(
+          thumbnailResult.blob,
           thumbFilename,
-          thumbBytes.byteLength,
-          thumbUploadMime,
-        )
-
-        await uploadWithProgress(
-          thumbSlot.putUrl,
-          new File([thumbBytes as BlobPart], thumbFilename, { type: thumbUploadMime }),
-          thumbUploadMime,
-          thumbSlot.headers,
+          thumbnailResult.mediaType,
+          shouldEncrypt,
+          requestUploadSlot,
           (progress) => progressReporter.setThumbnail(progress),
         )
 
@@ -232,11 +252,11 @@ export function useFileUpload() {
         // separate field. Chat.ts converts to `aesgcm://` only when
         // building the outgoing stanza's OOB thumbnail attribute.
         thumbnailInfo = {
-          uri: thumbSlot.getUrl,
+          uri: thumb.getUrl,
           mediaType: thumbnailResult.mediaType,
           width: thumbnailResult.width,
           height: thumbnailResult.height,
-          ...(thumbEncryption && { encryption: thumbEncryption }),
+          ...(thumb.encryption && { encryption: thumb.encryption }),
         }
       }
 
@@ -249,7 +269,7 @@ export function useFileUpload() {
       // local form separate means UI code can fetch the URL directly and
       // renderers reason about encryption as an explicit field.
       return {
-        url: slot.getUrl,
+        url: main.getUrl,
         name: file.name,
         size: file.size,
         mediaType: effectiveMimeType,
@@ -257,7 +277,7 @@ export function useFileUpload() {
         height,
         thumbnail: thumbnailInfo,
         duration,
-        ...(mainEncryption && { encryption: mainEncryption }),
+        ...(main.encryption && { encryption: main.encryption }),
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : t('upload.failed')
@@ -273,47 +293,6 @@ export function useFileUpload() {
     isSupported: !!httpUploadService,
     maxFileSize: httpUploadService?.maxFileSize,
   }
-}
-
-/**
- * Upload file using Tauri's HTTP plugin (bypasses CORS).
- * Progress tracking is not available with Tauri's fetch.
- */
-async function uploadWithTauri(
-  url: string,
-  file: File,
-  contentType: string,
-  headers?: Record<string, string>,
-  onProgress?: (progress: number) => void
-): Promise<void> {
-  // Dynamic import to avoid bundling Tauri code in web builds
-  const { fetch } = await import('@tauri-apps/plugin-http')
-
-  // Read file as Uint8Array for Tauri fetch
-  // Note: Tauri's fetch expects Uint8Array, not ArrayBuffer
-  const arrayBuffer = await file.arrayBuffer()
-  const body = new Uint8Array(arrayBuffer)
-
-  // Build headers
-  const requestHeaders: Record<string, string> = {
-    'Content-Type': contentType,
-    ...headers,
-  }
-
-  // Tauri fetch doesn't support progress, simulate it
-  onProgress?.(50)
-
-  const response = await fetch(url, {
-    method: 'PUT',
-    headers: requestHeaders,
-    body,
-  })
-
-  if (!response.ok) {
-    throw new Error(`Upload failed: ${response.status}`)
-  }
-
-  onProgress?.(100)
 }
 
 /**
@@ -365,24 +344,6 @@ async function uploadWithXHR(
 
     xhr.send(file)
   })
-}
-
-/**
- * Upload file with progress tracking.
- * Uses Tauri HTTP plugin in desktop app (bypasses CORS),
- * falls back to XMLHttpRequest for web.
- */
-async function uploadWithProgress(
-  url: string,
-  file: File,
-  contentType: string,
-  headers?: Record<string, string>,
-  onProgress?: (progress: number) => void
-): Promise<void> {
-  if (isTauri()) {
-    return uploadWithTauri(url, file, contentType, headers, onProgress)
-  }
-  return uploadWithXHR(url, file, contentType, headers, onProgress)
 }
 
 /**

--- a/apps/fluux/src/utils/tauriUpload.test.ts
+++ b/apps/fluux/src/utils/tauriUpload.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const invokeMock = vi.hoisted(() => vi.fn())
+const listenMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: listenMock }))
+
+import { uploadFileTauri } from './tauriUpload'
+
+function bytesOf(...values: number[]): ArrayBuffer {
+  return new Uint8Array(values).buffer
+}
+
+describe('uploadFileTauri', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+    listenMock.mockReset()
+    invokeMock.mockResolvedValue({ key: null, iv: null })
+    listenMock.mockResolvedValue(() => {})
+  })
+
+  it('invokes upload_file with raw bytes and metadata headers', async () => {
+    await uploadFileTauri({
+      bytes: bytesOf(1, 2, 3),
+      putUrl: 'https://up.example.com/slot/1',
+      contentType: 'image/jpeg',
+      headers: { Authorization: 'Bearer t' },
+      encrypt: false,
+    })
+
+    expect(invokeMock).toHaveBeenCalledTimes(1)
+    const [command, payload, options] = invokeMock.mock.calls[0]
+    expect(command).toBe('upload_file')
+    // Raw-body invoke: the payload must be the bytes themselves, NOT a
+    // JSON-serializable args object (that would re-create the number-array
+    // marshaling stall this transport exists to avoid).
+    expect(payload).toBeInstanceOf(Uint8Array)
+    expect(Array.from(payload as Uint8Array)).toEqual([1, 2, 3])
+    expect(options.headers['x-put-url']).toBe('https://up.example.com/slot/1')
+    expect(options.headers['x-content-type']).toBe('image/jpeg')
+    expect(options.headers['x-encrypt']).toBe('0')
+    expect(options.headers['x-upload-id']).toMatch(/\S/)
+    expect(JSON.parse(options.headers['x-extra-headers'])).toEqual({ Authorization: 'Bearer t' })
+  })
+
+  it('returns undefined encryption for plain uploads', async () => {
+    const result = await uploadFileTauri({
+      bytes: bytesOf(1),
+      putUrl: 'https://up.example.com/slot/1',
+      contentType: 'application/pdf',
+      encrypt: false,
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('decodes base64 key/iv into FileEncryption for encrypted uploads', async () => {
+    const key = new Uint8Array(32).fill(7)
+    const iv = new Uint8Array(12).fill(9)
+    invokeMock.mockResolvedValue({
+      key: btoa(String.fromCharCode(...key)),
+      iv: btoa(String.fromCharCode(...iv)),
+    })
+
+    const result = await uploadFileTauri({
+      bytes: bytesOf(1, 2),
+      putUrl: 'https://up.example.com/slot/2',
+      contentType: 'image/png',
+      encrypt: true,
+    })
+
+    expect(result).toEqual({ cipher: 'aes-256-gcm', key, iv })
+    const [, , options] = invokeMock.mock.calls[0]
+    expect(options.headers['x-encrypt']).toBe('1')
+  })
+
+  it('throws when an encrypted upload returns no key material', async () => {
+    invokeMock.mockResolvedValue({ key: null, iv: null })
+    await expect(
+      uploadFileTauri({
+        bytes: bytesOf(1),
+        putUrl: 'https://up.example.com/slot/3',
+        contentType: 'image/png',
+        encrypt: true,
+      }),
+    ).rejects.toThrow(/no encryption params/)
+  })
+
+  it('reports progress only for its own upload id and unsubscribes after', async () => {
+    let handler: ((event: { payload: { id: string; sent: number; total: number } }) => void) | null = null
+    const unlisten = vi.fn()
+    listenMock.mockImplementation(async (_event: string, cb: typeof handler) => {
+      handler = cb
+      return unlisten
+    })
+    invokeMock.mockImplementation(async (_cmd: string, _payload: unknown, options: { headers: Record<string, string> }) => {
+      const id = options.headers['x-upload-id']
+      handler?.({ payload: { id, sent: 50, total: 100 } })
+      handler?.({ payload: { id: 'someone-else', sent: 99, total: 100 } })
+      handler?.({ payload: { id, sent: 100, total: 100 } })
+      return { key: null, iv: null }
+    })
+
+    const onProgress = vi.fn()
+    await uploadFileTauri({
+      bytes: bytesOf(1),
+      putUrl: 'https://up.example.com/slot/4',
+      contentType: 'application/pdf',
+      encrypt: false,
+      onProgress,
+    })
+
+    expect(onProgress.mock.calls.map(([p]) => p)).toEqual([50, 100])
+    expect(unlisten).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the progress listener entirely when no callback is given', async () => {
+    await uploadFileTauri({
+      bytes: bytesOf(1),
+      putUrl: 'https://up.example.com/slot/5',
+      contentType: 'application/pdf',
+      encrypt: false,
+    })
+    expect(listenMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/utils/tauriUpload.ts
+++ b/apps/fluux/src/utils/tauriUpload.ts
@@ -1,0 +1,100 @@
+/**
+ * Native upload transport for the desktop app.
+ *
+ * Invokes the Rust `upload_file` command with the file bytes as Tauri's RAW
+ * IPC body. Do NOT route uploads through `@tauri-apps/plugin-http`: its JS
+ * shim expands the body into a plain number array and JSON-serializes it,
+ * blocking the WebView main thread ~20ms per MB (a ~1s freeze at 40MB —
+ * the `[MainThreadStall]` class). The raw body is a single memcpy.
+ *
+ * Metadata travels in invoke headers because raw-body invokes carry no JSON
+ * args. When `encrypt` is set, AES-256-GCM runs in Rust and the fresh
+ * key/IV come back base64-encoded; this mirrors the web build, where
+ * `MediaEncryption.encryptFile` (WebCrypto) produces the same
+ * ciphertext-with-appended-tag shape.
+ */
+
+import type { FileEncryption } from '@fluux/sdk'
+
+const PROGRESS_EVENT = 'fluux://upload-progress'
+
+interface ProgressPayload {
+  id: string
+  sent: number
+  total: number
+}
+
+interface UploadFileResponse {
+  key: string | null
+  iv: string | null
+}
+
+export interface TauriUploadParams {
+  /** Plaintext file bytes — encryption, when requested, happens in Rust. */
+  bytes: ArrayBuffer
+  putUrl: string
+  contentType: string
+  /** Extra PUT headers from the XEP-0363 slot (e.g. Authorization). */
+  headers?: Record<string, string>
+  /** AES-256-GCM-encrypt in Rust before the PUT (XEP-0454). */
+  encrypt: boolean
+  onProgress?: (percent: number) => void
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+/**
+ * PUT a file to an upload slot via the native `upload_file` command.
+ * Returns the encryption params when `encrypt` was requested, undefined
+ * otherwise.
+ */
+export async function uploadFileTauri(params: TauriUploadParams): Promise<FileEncryption | undefined> {
+  // Dynamic imports keep Tauri APIs out of the web bundle (same pattern as
+  // the rest of the app's Tauri integrations).
+  const [{ invoke }, { listen }] = await Promise.all([
+    import('@tauri-apps/api/core'),
+    import('@tauri-apps/api/event'),
+  ])
+
+  const uploadId = crypto.randomUUID()
+  const { onProgress } = params
+  const unlisten = onProgress
+    ? await listen<ProgressPayload>(PROGRESS_EVENT, (event) => {
+        if (event.payload.id !== uploadId) return
+        const { sent, total } = event.payload
+        onProgress(total > 0 ? Math.round((sent / total) * 100) : 100)
+      })
+    : null
+
+  try {
+    const result = await invoke<UploadFileResponse>('upload_file', new Uint8Array(params.bytes), {
+      headers: {
+        'x-put-url': params.putUrl,
+        'x-content-type': params.contentType,
+        'x-encrypt': params.encrypt ? '1' : '0',
+        'x-upload-id': uploadId,
+        'x-extra-headers': JSON.stringify(params.headers ?? {}),
+      },
+    })
+    if (params.encrypt) {
+      if (!result.key || !result.iv) {
+        throw new Error('upload_file returned no encryption params for an encrypted upload')
+      }
+      return {
+        cipher: 'aes-256-gcm',
+        key: base64ToBytes(result.key),
+        iv: base64ToBytes(result.iv),
+      }
+    }
+    return undefined
+  } finally {
+    unlisten?.()
+  }
+}


### PR DESCRIPTION
Fixes the `[MainThreadStall] main thread blocked ~1000ms` warnings seen while sending attachments on desktop.

**Cause:** `@tauri-apps/plugin-http`'s fetch shim expands the whole PUT body into a plain JS number array (`Array.from(new Uint8Array(buffer))`) and JSON-serializes it through `invoke` — measured ~20ms of main-thread blocking per MB, i.e. a full ~1s freeze for a 40MB file.

**Fix:** new `upload_file` Tauri command:
- file bytes cross the IPC boundary as the raw invoke body (single memcpy); metadata rides in invoke headers
- optional AES-256-GCM in Rust (XEP-0454) with fresh one-shot key/IV, matching the WebCrypto ciphertext shape — key/IV return to JS and ride the OpenPGP envelope exactly as before
- PUT via blocking reqwest in `spawn_blocking`, with real per-percent progress events replacing the fake 0/50/100 desktop progress

`useFileUpload` now routes main file + thumbnail through one shared `uploadBlobViaSlot` helper (Tauri raw-IPC path on desktop, unchanged WebCrypto + XHR on web). Covers both encrypted and plain uploads.

Verified: cargo tests (header parsing, GCM roundtrip/freshness), 6 new vitest cases for the invoke transport, full app suite (4904 tests), typecheck + eslint clean. Not covered here: the symmetric download-side marshaling (same class, follow-up).