### PR TITLE
perf(download): move desktop media download to a native Tauri command

### DIFF
--- a/apps/fluux/src-tauri/src/download.rs
+++ b/apps/fluux/src-tauri/src/download.rs
@@ -1,0 +1,353 @@
+//! Native HTTP download with optional AES-256-GCM media decryption
+//! (XEP-0454).
+//!
+//! The WebView invokes `download_file` and gets the response bytes back as
+//! Tauri's RAW IPC body (`tauri::ipc::Response`). This replaces the
+//! `@tauri-apps/plugin-http` download path, whose `fetch_read_body` loop
+//! returns every response chunk as a plain JS number array through JSON
+//! invoke — ~20ms of main-thread blocking per MB, i.e. chunked UI stalls
+//! when fetching large attachments/media (same `[MainThreadStall]` class as
+//! the upload side fixed in `upload.rs`). The raw IPC body is a single
+//! memcpy instead.
+//!
+//! Metadata rides in invoke headers, mirroring `upload_file`:
+//! - `x-get-url`: URL to GET
+//! - `x-download-id`: opaque id echoed in progress events
+//! - `x-decrypt-key` / `x-decrypt-iv`: base64 AES-256-GCM key (32 bytes) and
+//!   IV (12 bytes); when present the response body is decrypted in Rust
+//!   before being returned (XEP-0454 aesgcm attachments)
+//!
+//! Progress is emitted as `fluux://download-progress` events
+//! (`{id, received, total}`), at most once per integer percent while the
+//! Content-Length is known, plus a final event.
+//!
+//! A raw IPC response carries no headers, so the returned body is a small
+//! envelope: a 4-byte little-endian JSON length, the JSON metadata
+//! (`{"contentType": ...}`), then the file bytes. `tauriDownload.ts` parses
+//! it back apart.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, Key, KeyInit};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use serde::Serialize;
+use std::io::Read;
+use std::time::Duration;
+use tauri::http::HeaderMap;
+use tauri::Emitter;
+
+const PROGRESS_EVENT: &str = "fluux://download-progress";
+const DOWNLOAD_TIMEOUT_SECS: u64 = 600;
+const READ_CHUNK_BYTES: usize = 64 * 1024;
+
+/// Parsed invoke-header metadata for one download.
+#[derive(Debug, PartialEq)]
+pub struct DownloadArgs {
+    pub get_url: String,
+    pub download_id: String,
+    /// AES-256-GCM (key, IV) when the payload must be decrypted in Rust.
+    pub decrypt: Option<([u8; 32], [u8; 12])>,
+}
+
+#[derive(Serialize, Clone)]
+struct ProgressPayload {
+    id: String,
+    received: u64,
+    total: u64,
+}
+
+#[derive(Serialize)]
+struct EnvelopeMeta<'a> {
+    #[serde(rename = "contentType")]
+    content_type: Option<&'a str>,
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Result<&'a str, String> {
+    headers
+        .get(name)
+        .ok_or_else(|| format!("download_file: missing required header `{name}`"))?
+        .to_str()
+        .map_err(|_| format!("download_file: header `{name}` is not valid UTF-8"))
+}
+
+fn decode_fixed<const N: usize>(headers: &HeaderMap, name: &str) -> Result<[u8; N], String> {
+    let raw = header_str(headers, name)?;
+    let bytes = BASE64
+        .decode(raw)
+        .map_err(|e| format!("download_file: header `{name}` is not valid base64: {e}"))?;
+    <[u8; N]>::try_from(bytes.as_slice())
+        .map_err(|_| format!("download_file: header `{name}` must decode to {N} bytes, got {}", bytes.len()))
+}
+
+/// Extract download metadata from invoke headers. Pure, unit-tested.
+pub fn parse_download_args(headers: &HeaderMap) -> Result<DownloadArgs, String> {
+    let has_key = headers.contains_key("x-decrypt-key");
+    let has_iv = headers.contains_key("x-decrypt-iv");
+    let decrypt = match (has_key, has_iv) {
+        (true, true) => Some((
+            decode_fixed::<32>(headers, "x-decrypt-key")?,
+            decode_fixed::<12>(headers, "x-decrypt-iv")?,
+        )),
+        (false, false) => None,
+        _ => {
+            return Err(
+                "download_file: `x-decrypt-key` and `x-decrypt-iv` must be provided together".to_string(),
+            )
+        }
+    };
+
+    Ok(DownloadArgs {
+        get_url: header_str(headers, "x-get-url")?.to_string(),
+        download_id: header_str(headers, "x-download-id")?.to_string(),
+        decrypt,
+    })
+}
+
+/// Decrypt an XEP-0454 attachment body (ciphertext with the 128-bit GCM tag
+/// appended — the shape both `MediaEncryption.encryptFile` and
+/// `upload::encrypt_for_upload` produce).
+pub fn decrypt_for_download(
+    ciphertext: &[u8],
+    key: &[u8; 32],
+    iv: &[u8; 12],
+) -> Result<Vec<u8>, String> {
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    cipher
+        .decrypt(iv.into(), ciphertext)
+        .map_err(|_| "download_file: AES-GCM decryption failed (wrong key/IV or corrupt payload)".to_string())
+}
+
+/// Wrap the response body in the raw-IPC envelope:
+/// `[4-byte LE meta length][meta JSON][body bytes]`.
+pub fn build_response_envelope(content_type: Option<&str>, body: &[u8]) -> Vec<u8> {
+    let meta = serde_json::to_vec(&EnvelopeMeta { content_type })
+        .expect("EnvelopeMeta serialization cannot fail");
+    let mut out = Vec::with_capacity(4 + meta.len() + body.len());
+    out.extend_from_slice(&(meta.len() as u32).to_le_bytes());
+    out.extend_from_slice(&meta);
+    out.extend_from_slice(body);
+    out
+}
+
+/// Blocking GET of the download URL. Runs inside `spawn_blocking` — never on
+/// the main thread (see project rule on sync Tauri commands). Emits one
+/// progress event per integer-percent step while Content-Length is known,
+/// plus a final event.
+fn get_blocking(
+    app: tauri::AppHandle,
+    args: &DownloadArgs,
+) -> Result<(Vec<u8>, Option<String>), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(DOWNLOAD_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("download_file: failed to build HTTP client: {e}"))?;
+
+    let mut response = client
+        .get(&args.get_url)
+        .send()
+        .map_err(|e| format!("download_file: GET request failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("Download failed: {}", response.status().as_u16()));
+    }
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let total = response.content_length().unwrap_or(0);
+
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut buf = [0u8; READ_CHUNK_BYTES];
+    let mut received: u64 = 0;
+    let mut last_percent: u64 = 0;
+    loop {
+        let n = response
+            .read(&mut buf)
+            .map_err(|e| format!("download_file: reading response body failed: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        received += n as u64;
+        // checked_div: None when Content-Length was unknown (total == 0) —
+        // no intermediate events, just the final one below.
+        if let Some(percent) = (received * 100).checked_div(total) {
+            if percent > last_percent {
+                last_percent = percent;
+                let _ = app.emit(
+                    PROGRESS_EVENT,
+                    ProgressPayload { id: args.download_id.clone(), received, total },
+                );
+            }
+        }
+    }
+    // Final event — also covers the unknown-Content-Length case.
+    let _ = app.emit(
+        PROGRESS_EVENT,
+        ProgressPayload {
+            id: args.download_id.clone(),
+            received,
+            total: if total > 0 { total } else { received },
+        },
+    );
+
+    Ok((bytes, content_type))
+}
+
+/// Download a file, optionally AES-256-GCM-decrypting it (XEP-0454), and
+/// return the bytes as the raw IPC body. Do NOT route large downloads
+/// through `@tauri-apps/plugin-http`, whose chunked number-array marshaling
+/// blocks the WebView main thread ~20ms per MB.
+#[tauri::command]
+pub async fn download_file(
+    app: tauri::AppHandle,
+    request: tauri::ipc::Request<'_>,
+) -> Result<tauri::ipc::Response, String> {
+    let args = parse_download_args(request.headers())?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let (body, content_type) = get_blocking(app, &args)?;
+        let payload = match &args.decrypt {
+            Some((key, iv)) => decrypt_for_download(&body, key, iv)?,
+            None => body,
+        };
+        Ok(tauri::ipc::Response::new(build_response_envelope(
+            content_type.as_deref(),
+            &payload,
+        )))
+    })
+    .await
+    .map_err(|e| format!("download_file: task join error: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::upload::encrypt_for_upload;
+    use tauri::http::HeaderValue;
+
+    fn headers(entries: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in entries {
+            map.insert(
+                tauri::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn parse_download_args_reads_plain_fields() {
+        let map = headers(&[
+            ("x-get-url", "https://dl.example.com/file/1"),
+            ("x-download-id", "dl-123"),
+        ]);
+        let args = parse_download_args(&map).unwrap();
+        assert_eq!(
+            args,
+            DownloadArgs {
+                get_url: "https://dl.example.com/file/1".into(),
+                download_id: "dl-123".into(),
+                decrypt: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_download_args_decodes_key_and_iv() {
+        let key = [7u8; 32];
+        let iv = [9u8; 12];
+        let map = headers(&[
+            ("x-get-url", "https://dl.example.com/file/2"),
+            ("x-download-id", "dl-2"),
+            ("x-decrypt-key", &BASE64.encode(key)),
+            ("x-decrypt-iv", &BASE64.encode(iv)),
+        ]);
+        let args = parse_download_args(&map).unwrap();
+        assert_eq!(args.decrypt, Some((key, iv)));
+    }
+
+    #[test]
+    fn parse_download_args_rejects_missing_url() {
+        let map = headers(&[("x-download-id", "dl-3")]);
+        let err = parse_download_args(&map).unwrap_err();
+        assert!(err.contains("x-get-url"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_download_args_rejects_key_without_iv() {
+        let map = headers(&[
+            ("x-get-url", "https://dl.example.com/file/4"),
+            ("x-download-id", "dl-4"),
+            ("x-decrypt-key", &BASE64.encode([1u8; 32])),
+        ]);
+        let err = parse_download_args(&map).unwrap_err();
+        assert!(err.contains("together"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_download_args_rejects_wrong_key_length() {
+        let map = headers(&[
+            ("x-get-url", "https://dl.example.com/file/5"),
+            ("x-download-id", "dl-5"),
+            ("x-decrypt-key", &BASE64.encode([1u8; 16])),
+            ("x-decrypt-iv", &BASE64.encode([2u8; 12])),
+        ]);
+        let err = parse_download_args(&map).unwrap_err();
+        assert!(err.contains("32 bytes"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn parse_download_args_rejects_invalid_base64() {
+        let map = headers(&[
+            ("x-get-url", "https://dl.example.com/file/6"),
+            ("x-download-id", "dl-6"),
+            ("x-decrypt-key", "!!!not-base64!!!"),
+            ("x-decrypt-iv", &BASE64.encode([2u8; 12])),
+        ]);
+        let err = parse_download_args(&map).unwrap_err();
+        assert!(err.contains("base64"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn decrypt_for_download_roundtrips_upload_encryption() {
+        // The download decryptor must accept exactly what the upload
+        // encryptor (and the WebCrypto path it mirrors) produces.
+        let plaintext = b"attachment bytes".to_vec();
+        let encrypted = encrypt_for_upload(&plaintext).unwrap();
+        let decrypted =
+            decrypt_for_download(&encrypted.ciphertext, &encrypted.key, &encrypted.iv).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_for_download_rejects_tampered_ciphertext() {
+        let mut encrypted = encrypt_for_upload(b"payload").unwrap();
+        encrypted.ciphertext[0] ^= 0xff;
+        let err =
+            decrypt_for_download(&encrypted.ciphertext, &encrypted.key, &encrypted.iv).unwrap_err();
+        assert!(err.contains("decryption failed"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn build_response_envelope_prefixes_meta_json() {
+        let envelope = build_response_envelope(Some("image/png"), &[1, 2, 3]);
+        let meta_len = u32::from_le_bytes(envelope[0..4].try_into().unwrap()) as usize;
+        let meta: serde_json::Value =
+            serde_json::from_slice(&envelope[4..4 + meta_len]).unwrap();
+        assert_eq!(meta["contentType"], "image/png");
+        assert_eq!(&envelope[4 + meta_len..], &[1, 2, 3]);
+    }
+
+    #[test]
+    fn build_response_envelope_encodes_missing_content_type_as_null() {
+        let envelope = build_response_envelope(None, &[]);
+        let meta_len = u32::from_le_bytes(envelope[0..4].try_into().unwrap()) as usize;
+        let meta: serde_json::Value =
+            serde_json::from_slice(&envelope[4..4 + meta_len]).unwrap();
+        assert!(meta["contentType"].is_null());
+        assert_eq!(envelope.len(), 4 + meta_len);
+    }
+}

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -196,6 +196,7 @@ use tauri_plugin_deep_link::DeepLinkExt;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri_plugin_opener::OpenerExt;
 
+mod download;
 mod upload;
 mod xmpp_proxy;
 mod openpgp;
@@ -1498,6 +1499,7 @@ fn main() {
             exit_app,
             fetch_url_metadata,
             upload::upload_file,
+            download::download_file,
             start_xmpp_proxy,
             stop_xmpp_proxy,
             mcp_start_server,

--- a/apps/fluux/src/utils/mediaCache.test.ts
+++ b/apps/fluux/src/utils/mediaCache.test.ts
@@ -36,14 +36,14 @@ vi.mock('@tauri-apps/api/core', () => ({
   convertFileSrc: (path: string) => mockConvertFileSrc(path),
 }))
 
-// Mock Tauri HTTP plugin
-const mockTauriFetch = vi.fn()
-vi.mock('@tauri-apps/plugin-http', () => ({
-  fetch: (url: string, opts: unknown) => mockTauriFetch(url, opts),
+// Mock the native download transport (tauriDownload → Rust download_file)
+const mockDownloadFileTauri = vi.fn()
+vi.mock('./tauriDownload', () => ({
+  downloadFileTauri: (params: unknown) => mockDownloadFileTauri(params),
 }))
 
 import { resolveMediaUrl, resolveWebMediaUrl, resolveEncryptedMediaUrl, clearMediaCache, getMediaCacheSize, resetMediaUrlCache, peekMediaCache, peekEncryptedMediaCache, peekWebMediaCache, peekWebEncryptedMediaCache, resolveWebEncryptedMediaUrl } from './mediaCache'
-import { encryptFile } from '@fluux/sdk'
+import { encryptFile, decryptFile } from '@fluux/sdk'
 
 describe('mediaCache', () => {
   beforeEach(() => {
@@ -62,21 +62,15 @@ describe('mediaCache', () => {
   describe('resolveMediaUrl', () => {
     it('should fetch, cache, and return asset URL on cache miss', async () => {
       const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]) // PNG header
-      const mockBlob = new Blob([imageData], { type: 'image/png' })
 
-      mockTauriFetch.mockResolvedValue({
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      })
+      mockDownloadFileTauri.mockResolvedValue({ bytes: imageData, contentType: 'image/png' })
 
       const result = await resolveMediaUrl('https://upload.example.com/files/photo.png')
 
-      // Should have fetched the URL
-      expect(mockTauriFetch).toHaveBeenCalledWith(
-        'https://upload.example.com/files/photo.png',
-        { method: 'GET' },
-      )
+      // Should have fetched the URL through the native transport
+      expect(mockDownloadFileTauri).toHaveBeenCalledWith({
+        url: 'https://upload.example.com/files/photo.png',
+      })
 
       // Should have written the file
       expect(mockWriteFile).toHaveBeenCalledTimes(1)
@@ -87,18 +81,16 @@ describe('mediaCache', () => {
     })
 
     it('should return cached URL from memory on second call', async () => {
-      const mockBlob = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/jpeg' })
-      mockTauriFetch.mockResolvedValue({
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/jpeg' }),
-        blob: () => Promise.resolve(mockBlob),
+      mockDownloadFileTauri.mockResolvedValue({
+        bytes: new Uint8Array([1, 2, 3]),
+        contentType: 'image/jpeg',
       })
 
       const url1 = await resolveMediaUrl('https://upload.example.com/files/photo.jpg')
       const url2 = await resolveMediaUrl('https://upload.example.com/files/photo.jpg')
 
       // Should only fetch once
-      expect(mockTauriFetch).toHaveBeenCalledTimes(1)
+      expect(mockDownloadFileTauri).toHaveBeenCalledTimes(1)
       expect(url1).toBe(url2)
     })
 
@@ -114,30 +106,24 @@ describe('mediaCache', () => {
       expect(mockMkdir).toHaveBeenCalled()
 
       // Should NOT have fetched (file was found on disk)
-      expect(mockTauriFetch).not.toHaveBeenCalled()
+      expect(mockDownloadFileTauri).not.toHaveBeenCalled()
 
       // Should return an asset URL
       expect(result).toMatch(/^https:\/\/asset\.localhost\//)
     })
 
     it('should throw on fetch failure', async () => {
-      mockTauriFetch.mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-      })
+      mockDownloadFileTauri.mockRejectedValue(new Error('Download failed: 404'))
 
       await expect(
         resolveMediaUrl('https://upload.example.com/files/missing.png')
-      ).rejects.toThrow('Fetch failed: 404 Not Found')
+      ).rejects.toThrow('Download failed: 404')
     })
 
     it('should deduplicate concurrent requests for the same URL', async () => {
-      const mockBlob = new Blob([new Uint8Array([1])], { type: 'image/png' })
-      mockTauriFetch.mockResolvedValue({
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
+      mockDownloadFileTauri.mockResolvedValue({
+        bytes: new Uint8Array([1]),
+        contentType: 'image/png',
       })
 
       // Fire two concurrent requests
@@ -147,16 +133,14 @@ describe('mediaCache', () => {
       ])
 
       // Should only fetch once
-      expect(mockTauriFetch).toHaveBeenCalledTimes(1)
+      expect(mockDownloadFileTauri).toHaveBeenCalledTimes(1)
       expect(url1).toBe(url2)
     })
 
     it('should infer extension from URL when MIME type is unknown', async () => {
-      const mockBlob = new Blob([new Uint8Array([1])], { type: '' })
-      mockTauriFetch.mockResolvedValue({
-        ok: true,
-        headers: new Headers(),
-        blob: () => Promise.resolve(mockBlob),
+      mockDownloadFileTauri.mockResolvedValue({
+        bytes: new Uint8Array([1]),
+        contentType: null,
       })
 
       await resolveMediaUrl('https://upload.example.com/files/photo.webp')
@@ -170,15 +154,13 @@ describe('mediaCache', () => {
   describe('clearMediaCache', () => {
     it('should clear in-memory cache and remove filesystem directory', async () => {
       // Populate memory cache first
-      const mockBlob = new Blob([new Uint8Array([1])], { type: 'image/png' })
-      mockTauriFetch.mockResolvedValue({
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
+      mockDownloadFileTauri.mockResolvedValue({
+        bytes: new Uint8Array([1]),
+        contentType: 'image/png',
       })
 
       await resolveMediaUrl('https://upload.example.com/test.png')
-      expect(mockTauriFetch).toHaveBeenCalledTimes(1)
+      expect(mockDownloadFileTauri).toHaveBeenCalledTimes(1)
 
       await clearMediaCache()
 
@@ -189,7 +171,7 @@ describe('mediaCache', () => {
 
       // After clearing, next call should fetch again
       await resolveMediaUrl('https://upload.example.com/test.png')
-      expect(mockTauriFetch).toHaveBeenCalledTimes(2)
+      expect(mockDownloadFileTauri).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -231,14 +213,14 @@ describe('peekMediaCache (Tauri, network-free)', () => {
     mockExists.mockResolvedValue(false)
     const result = await peekMediaCache('https://upload.example.com/a.png')
     expect(result).toBeNull()
-    expect(mockTauriFetch).not.toHaveBeenCalled()
+    expect(mockDownloadFileTauri).not.toHaveBeenCalled()
   })
 
   it('returns the asset URL on a filesystem hit without fetching', async () => {
     mockExists.mockResolvedValue(true)
     const result = await peekMediaCache('https://upload.example.com/a.png')
     expect(result).toMatch(/^https:\/\/asset\.localhost\//)
-    expect(mockTauriFetch).not.toHaveBeenCalled()
+    expect(mockDownloadFileTauri).not.toHaveBeenCalled()
   })
 })
 
@@ -255,13 +237,17 @@ describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () 
     mockConvertFileSrc.mockImplementation((p: string) => `https://asset.localhost/${p}`)
   })
 
-  it('fetches ciphertext, decrypts, writes plaintext, and returns a .dec asset URL', async () => {
+  it('downloads+decrypts natively, writes plaintext, and returns a .dec asset URL', async () => {
     const plaintext = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 8, 7])
     const enc = await encryptFile(plaintext)
-    mockTauriFetch.mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(enc.ciphertext.slice().buffer),
-    })
+    // Faithful native-transport mock: decrypt with the key/iv the caller
+    // actually passed, exactly like the Rust command — wrong params throw.
+    mockDownloadFileTauri.mockImplementation(
+      async ({ decrypt }: { decrypt: { key: Uint8Array; iv: Uint8Array } }) => ({
+        bytes: new Uint8Array(await decryptFile(enc.ciphertext, decrypt.key, decrypt.iv)),
+        contentType: 'application/octet-stream',
+      }),
+    )
 
     const url = await resolveEncryptedMediaUrl('https://upload.example.com/enc.bin', {
       cipher: 'aes-256-gcm',
@@ -269,7 +255,10 @@ describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () 
       iv: enc.iv,
     })
 
-    expect(mockTauriFetch).toHaveBeenCalledWith('https://upload.example.com/enc.bin', { method: 'GET' })
+    expect(mockDownloadFileTauri).toHaveBeenCalledWith({
+      url: 'https://upload.example.com/enc.bin',
+      decrypt: { key: enc.key, iv: enc.iv },
+    })
     // The DECRYPTED plaintext (not the ciphertext) is what gets written to the
     // `.dec` cache file, so no AES key needs to persist across sessions.
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
@@ -280,13 +269,12 @@ describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () 
   })
 
   it('serves the cached .dec file on a second call without re-fetching or re-decrypting', async () => {
-    const enc = await encryptFile(new Uint8Array([1, 1, 2, 3, 5, 8]))
-    mockTauriFetch.mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(enc.ciphertext.slice().buffer),
+    mockDownloadFileTauri.mockResolvedValue({
+      bytes: new Uint8Array([1, 1, 2, 3, 5, 8]),
+      contentType: null,
     })
     const httpsUrl = 'https://upload.example.com/enc-again.bin'
-    const encryption = { cipher: 'aes-256-gcm' as const, key: enc.key, iv: enc.iv }
+    const encryption = { cipher: 'aes-256-gcm' as const, key: new Uint8Array(32), iv: new Uint8Array(12) }
 
     const first = await resolveEncryptedMediaUrl(httpsUrl, encryption)
     resetMediaUrlCache()               // drop in-memory index → consult filesystem
@@ -296,12 +284,12 @@ describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () 
     expect(first).toMatch(/\.dec$/)
     expect(second).toMatch(/\.dec$/)
     // Second resolve is a pure cache hit: no download, no second decrypt+write.
-    expect(mockTauriFetch).toHaveBeenCalledTimes(1)
+    expect(mockDownloadFileTauri).toHaveBeenCalledTimes(1)
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
   })
 
-  it('throws on a non-ok fetch without writing anything', async () => {
-    mockTauriFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' })
+  it('throws on a failed download without writing anything', async () => {
+    mockDownloadFileTauri.mockRejectedValue(new Error('Download failed: 404'))
 
     await expect(
       resolveEncryptedMediaUrl('https://upload.example.com/missing.bin', {
@@ -309,7 +297,7 @@ describe('resolveEncryptedMediaUrl (Tauri filesystem, encrypted full path)', () 
         key: new Uint8Array(32),
         iv: new Uint8Array(12),
       }),
-    ).rejects.toThrow('Fetch failed: 404 Not Found')
+    ).rejects.toThrow('Download failed: 404')
     expect(mockWriteFile).not.toHaveBeenCalled()
   })
 })
@@ -329,7 +317,7 @@ describe('peekEncryptedMediaCache (Tauri, network-free)', () => {
     mockExists.mockResolvedValue(true)
     const result = await peekEncryptedMediaCache('https://upload.example.com/enc.bin')
     expect(result).toMatch(/^https:\/\/asset\.localhost\/.*\.dec$/)
-    expect(mockTauriFetch).not.toHaveBeenCalled()
+    expect(mockDownloadFileTauri).not.toHaveBeenCalled()
   })
 
   it('returns null on a miss', async () => {

--- a/apps/fluux/src/utils/mediaCache.ts
+++ b/apps/fluux/src/utils/mediaCache.ts
@@ -94,7 +94,7 @@ async function getCacheFilePath(url: string, mimeType?: string): Promise<string>
  *
  * 1. Check in-memory map (instant)
  * 2. Check filesystem (fast)
- * 3. Fetch via Tauri HTTP plugin → write to cache → return asset URL
+ * 3. Fetch via the native download_file command → write to cache → return asset URL
  *
  * @returns asset.localhost URL for use in <img>/<video>/<audio> tags
  * @throws on fetch/write failure (caller should fall back to direct URL)
@@ -143,23 +143,18 @@ async function doResolve(originalUrl: string): Promise<string> {
   const peeked = await peekMediaCache(originalUrl)
   if (peeked) return peeked
 
-  // 3. Fetch and cache
+  // 3. Fetch and cache. Native `download_file` command, NOT
+  // @tauri-apps/plugin-http — its chunked number-array marshaling blocks the
+  // WebView main thread ~20ms/MB on large media (see tauriDownload.ts).
   const { convertFileSrc } = await import('@tauri-apps/api/core')
-  const { fetch: tauriFetch } = await import('@tauri-apps/plugin-http')
+  const { downloadFileTauri } = await import('./tauriDownload')
 
-  const response = await tauriFetch(originalUrl, { method: 'GET' })
-  if (!response.ok) {
-    throw new Error(`Fetch failed: ${response.status} ${response.statusText}`)
-  }
+  const { bytes, contentType } = await downloadFileTauri({ url: originalUrl })
 
-  const blob = await response.blob()
-  const mimeType = blob.type || response.headers.get('content-type') || undefined
-
-  const finalPath = await getCacheFilePath(originalUrl, mimeType)
+  const finalPath = await getCacheFilePath(originalUrl, contentType ?? undefined)
 
   const { writeFile } = await import('@tauri-apps/plugin-fs')
-  const arrayBuffer = await new Response(blob).arrayBuffer()
-  await writeFile(finalPath, new Uint8Array(arrayBuffer))
+  await writeFile(finalPath, bytes)
 
   const assetUrl = convertFileSrc(finalPath)
   urlCache.set(originalUrl, assetUrl)
@@ -188,8 +183,9 @@ async function getDecryptedCacheFilePath(httpsUrl: string): Promise<string> {
 /**
  * Resolve an encrypted attachment URL for Tauri desktop.
  *
- * Downloads ciphertext from `httpsUrl`, AES-GCM decrypts it, and writes the
- * plaintext to `{appCacheDir}/media/{sha256}.dec`. Subsequent calls return
+ * Downloads and AES-GCM-decrypts `httpsUrl` in Rust (native `download_file`
+ * command), then writes the plaintext to `{appCacheDir}/media/{sha256}.dec`.
+ * Subsequent calls return
  * the cached `asset://localhost` URL without re-downloading or re-decrypting.
  *
  * Storing the decrypted content means no AES key needs to be persisted
@@ -249,17 +245,18 @@ async function doResolveEncrypted(
   const { convertFileSrc } = await import('@tauri-apps/api/core')
   const { writeFile } = await import('@tauri-apps/plugin-fs')
 
-  const { fetch: tauriFetch } = await import('@tauri-apps/plugin-http')
-  const response = await tauriFetch(httpsUrl, { method: 'GET' })
-  if (!response.ok) {
-    throw new Error(`Fetch failed: ${response.status} ${response.statusText}`)
-  }
-
-  const ciphertext = new Uint8Array(await response.arrayBuffer())
-  const plaintext = await decryptFile(ciphertext, encryption.key, encryption.iv)
+  // Native `download_file` command with the AES params passed through:
+  // Rust downloads AND decrypts (XEP-0454), so neither the ciphertext nor
+  // the plaintext takes plugin-http's number-array path through the WebView
+  // main thread (see tauriDownload.ts).
+  const { downloadFileTauri } = await import('./tauriDownload')
+  const { bytes: plaintext } = await downloadFileTauri({
+    url: httpsUrl,
+    decrypt: { key: encryption.key, iv: encryption.iv },
+  })
 
   const filePath = await getDecryptedCacheFilePath(httpsUrl)
-  await writeFile(filePath, new Uint8Array(plaintext))
+  await writeFile(filePath, plaintext)
 
   const assetUrl = convertFileSrc(filePath)
   urlCache.set(cacheKey, assetUrl)

--- a/apps/fluux/src/utils/tauriDownload.test.ts
+++ b/apps/fluux/src/utils/tauriDownload.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const invokeMock = vi.hoisted(() => vi.fn())
+const listenMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: listenMock }))
+
+import { downloadFileTauri, parseDownloadEnvelope } from './tauriDownload'
+
+/** Build the `[4-byte LE meta length][meta JSON][body]` envelope Rust returns. */
+function envelope(meta: { contentType: string | null }, body: number[]): ArrayBuffer {
+  const metaBytes = new TextEncoder().encode(JSON.stringify(meta))
+  const out = new Uint8Array(4 + metaBytes.length + body.length)
+  new DataView(out.buffer).setUint32(0, metaBytes.length, true)
+  out.set(metaBytes, 4)
+  out.set(body, 4 + metaBytes.length)
+  return out.buffer
+}
+
+describe('parseDownloadEnvelope', () => {
+  it('splits metadata and body apart', () => {
+    const result = parseDownloadEnvelope(envelope({ contentType: 'image/png' }, [1, 2, 3]))
+    expect(result.contentType).toBe('image/png')
+    expect(Array.from(result.bytes)).toEqual([1, 2, 3])
+  })
+
+  it('strips content-type parameters', () => {
+    const result = parseDownloadEnvelope(envelope({ contentType: 'text/plain; charset=utf-8' }, []))
+    expect(result.contentType).toBe('text/plain')
+  })
+
+  it('passes null content-type through', () => {
+    const result = parseDownloadEnvelope(envelope({ contentType: null }, [7]))
+    expect(result.contentType).toBeNull()
+    expect(Array.from(result.bytes)).toEqual([7])
+  })
+
+  it('rejects a truncated envelope', () => {
+    expect(() => parseDownloadEnvelope(new Uint8Array([1, 2]).buffer)).toThrow(/malformed envelope/)
+  })
+
+  it('rejects a meta length pointing past the buffer', () => {
+    const out = new Uint8Array(8)
+    new DataView(out.buffer).setUint32(0, 100, true)
+    expect(() => parseDownloadEnvelope(out.buffer)).toThrow(/malformed envelope/)
+  })
+})
+
+describe('downloadFileTauri', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+    listenMock.mockReset()
+    invokeMock.mockResolvedValue(envelope({ contentType: null }, []))
+    listenMock.mockResolvedValue(() => {})
+  })
+
+  it('invokes download_file with metadata headers and returns the body', async () => {
+    invokeMock.mockResolvedValue(envelope({ contentType: 'image/jpeg' }, [1, 2, 3]))
+
+    const result = await downloadFileTauri({ url: 'https://dl.example.com/file/1' })
+
+    expect(invokeMock).toHaveBeenCalledTimes(1)
+    const [command, payload, options] = invokeMock.mock.calls[0]
+    expect(command).toBe('download_file')
+    expect(payload).toBeUndefined()
+    expect(options.headers['x-get-url']).toBe('https://dl.example.com/file/1')
+    expect(options.headers['x-download-id']).toMatch(/\S/)
+    expect(options.headers['x-decrypt-key']).toBeUndefined()
+    expect(options.headers['x-decrypt-iv']).toBeUndefined()
+    expect(result.contentType).toBe('image/jpeg')
+    expect(Array.from(result.bytes)).toEqual([1, 2, 3])
+  })
+
+  it('sends base64 key/iv headers when decrypt params are given', async () => {
+    const key = new Uint8Array(32).fill(7)
+    const iv = new Uint8Array(12).fill(9)
+
+    await downloadFileTauri({
+      url: 'https://dl.example.com/file/2',
+      decrypt: { key, iv },
+    })
+
+    const [, , options] = invokeMock.mock.calls[0]
+    expect(options.headers['x-decrypt-key']).toBe(btoa(String.fromCharCode(...key)))
+    expect(options.headers['x-decrypt-iv']).toBe(btoa(String.fromCharCode(...iv)))
+  })
+
+  it('reports progress only for its own download id and unsubscribes after', async () => {
+    let handler: ((event: { payload: { id: string; received: number; total: number } }) => void) | null = null
+    const unlisten = vi.fn()
+    listenMock.mockImplementation(async (_event: string, cb: typeof handler) => {
+      handler = cb
+      return unlisten
+    })
+    invokeMock.mockImplementation(async (_cmd: string, _payload: unknown, options: { headers: Record<string, string> }) => {
+      const id = options.headers['x-download-id']
+      handler?.({ payload: { id, received: 50, total: 100 } })
+      handler?.({ payload: { id: 'someone-else', received: 99, total: 100 } })
+      handler?.({ payload: { id, received: 100, total: 100 } })
+      return envelope({ contentType: null }, [])
+    })
+
+    const onProgress = vi.fn()
+    await downloadFileTauri({ url: 'https://dl.example.com/file/3', onProgress })
+
+    expect(onProgress.mock.calls.map(([p]) => p)).toEqual([50, 100])
+    expect(unlisten).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the progress listener entirely when no callback is given', async () => {
+    await downloadFileTauri({ url: 'https://dl.example.com/file/4' })
+    expect(listenMock).not.toHaveBeenCalled()
+  })
+
+  it('unsubscribes the progress listener when the invoke rejects', async () => {
+    const unlisten = vi.fn()
+    listenMock.mockResolvedValue(unlisten)
+    invokeMock.mockRejectedValue(new Error('Download failed: 404'))
+
+    await expect(
+      downloadFileTauri({ url: 'https://dl.example.com/file/5', onProgress: vi.fn() }),
+    ).rejects.toThrow(/404/)
+    expect(unlisten).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/fluux/src/utils/tauriDownload.ts
+++ b/apps/fluux/src/utils/tauriDownload.ts
@@ -1,0 +1,110 @@
+/**
+ * Native download transport for the desktop app.
+ *
+ * Invokes the Rust `download_file` command and receives the response bytes
+ * as Tauri's RAW IPC body. Do NOT route large downloads through
+ * `@tauri-apps/plugin-http`: its `fetch_read_body` loop returns every
+ * response chunk as a plain number array through JSON invoke, blocking the
+ * WebView main thread ~20ms per MB (the `[MainThreadStall]` class — same
+ * problem the upload side fixed via `upload_file`/`tauriUpload.ts`). The raw
+ * body is a single memcpy.
+ *
+ * Metadata travels in invoke headers, mirroring the upload transport. When
+ * `decrypt` is set, the AES-256-GCM key/IV go over base64-encoded and Rust
+ * returns the decrypted plaintext (XEP-0454), so ciphertext never needs a
+ * second pass through the WebView.
+ *
+ * A raw IPC response carries no headers, so Rust prefixes the body with a
+ * small envelope — `[4-byte LE meta length][meta JSON][file bytes]` — that
+ * {@link parseDownloadEnvelope} splits back apart (the JSON carries the
+ * response Content-Type).
+ */
+
+import type { FileEncryption } from '@fluux/sdk'
+
+const PROGRESS_EVENT = 'fluux://download-progress'
+
+interface ProgressPayload {
+  id: string
+  received: number
+  total: number
+}
+
+export interface TauriDownloadParams {
+  url: string
+  /** AES-256-GCM params — decrypt in Rust before returning (XEP-0454). */
+  decrypt?: Pick<FileEncryption, 'key' | 'iv'>
+  onProgress?: (percent: number) => void
+}
+
+export interface TauriDownloadResult {
+  /** File bytes — already decrypted when `decrypt` was passed. */
+  bytes: Uint8Array
+  /** Response Content-Type with any parameters (e.g. charset) stripped. */
+  contentType: string | null
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+/** Split the raw IPC envelope from `download_file` into metadata + bytes. */
+export function parseDownloadEnvelope(data: ArrayBuffer): TauriDownloadResult {
+  if (data.byteLength < 4) {
+    throw new Error('download_file returned a malformed envelope (too short)')
+  }
+  const metaLength = new DataView(data).getUint32(0, true)
+  if (4 + metaLength > data.byteLength) {
+    throw new Error('download_file returned a malformed envelope (bad meta length)')
+  }
+  const meta = JSON.parse(
+    new TextDecoder().decode(new Uint8Array(data, 4, metaLength)),
+  ) as { contentType: string | null }
+  const contentType = meta.contentType?.split(';')[0].trim() || null
+  return {
+    bytes: new Uint8Array(data, 4 + metaLength),
+    contentType,
+  }
+}
+
+/**
+ * GET a file via the native `download_file` command, optionally decrypting
+ * it in Rust. Returns the (plaintext) bytes plus the response Content-Type.
+ */
+export async function downloadFileTauri(params: TauriDownloadParams): Promise<TauriDownloadResult> {
+  // Dynamic imports keep Tauri APIs out of the web bundle (same pattern as
+  // the rest of the app's Tauri integrations).
+  const [{ invoke }, { listen }] = await Promise.all([
+    import('@tauri-apps/api/core'),
+    import('@tauri-apps/api/event'),
+  ])
+
+  const downloadId = crypto.randomUUID()
+  const { onProgress } = params
+  const unlisten = onProgress
+    ? await listen<ProgressPayload>(PROGRESS_EVENT, (event) => {
+        if (event.payload.id !== downloadId) return
+        const { received, total } = event.payload
+        onProgress(total > 0 ? Math.round((received / total) * 100) : 100)
+      })
+    : null
+
+  try {
+    const headers: Record<string, string> = {
+      'x-get-url': params.url,
+      'x-download-id': downloadId,
+    }
+    if (params.decrypt) {
+      headers['x-decrypt-key'] = bytesToBase64(params.decrypt.key)
+      headers['x-decrypt-iv'] = bytesToBase64(params.decrypt.iv)
+    }
+    const data = await invoke<ArrayBuffer>('download_file', undefined, { headers })
+    return parseDownloadEnvelope(data)
+  } finally {
+    unlisten?.()
+  }
+}


### PR DESCRIPTION
Download-side mirror of #1016. `@tauri-apps/plugin-http`'s `fetch_read_body` loop returns response chunks as plain JS number arrays through JSON invoke (~20ms/MB of main-thread blocking), so fetching large attachments/media on desktop causes chunked `[MainThreadStall]` freezes.

New `download_file` command in `src-tauri/src/download.rs` (same shape as `upload.rs`): GET via reqwest in `spawn_blocking`, optional AES-256-GCM decryption in Rust (XEP-0454, key/IV base64 in invoke headers), `fluux://download-progress` events, and the bytes returned as the raw IPC body. Raw responses carry no headers, so the body is prefixed with a tiny length-prefixed JSON envelope carrying the Content-Type; `tauriDownload.ts` splits it apart.

`mediaCache.ts`'s two Tauri paths now use it — plaintext media, and encrypted media where Rust downloads *and* decrypts so neither ciphertext nor plaintext takes the plugin-http path. `useTextPreview` stays on plugin-http (Range-fetches only 1KB, no stall). `download.ts` already used webview-native fetch.

Follow-up to #1016 (now merged); rebased onto main.
