### PR TITLE
fix(mam): record history-gap seams at formation and close them from both directions

### DIFF
--- a/docs/superpowers/plans/2026-07-15-mam-discontinuity-safety-net.md
+++ b/docs/superpowers/plans/2026-07-15-mam-discontinuity-safety-net.md
@@ -1,0 +1,961 @@
+# MAM Discontinuity Safety Net Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record a history-hole "seam" the moment it forms (a `before:''` fetch-latest page landing disjoint above held history) and close it progressively from both directions, so silent MAM gaps can never form unrecorded again.
+
+**Architecture:** All detection is structural (query direction + dedupe overlap + above/below ordering) — no timestamp-gap heuristics. New pure transitions live in the shared `mamGap.ts` module (chat/room twin rule); both stores' merge functions route their gap-sync through one shared `syncGapAfterArchiveMerge` function. A new `isFetchLatest` flag travels from the MAM query call site through the SDK event to the merge. The persisted `roomGaps`/`conversationGaps` maps, the `HistoryGapMarker` UI, and the catch-up cursor policy are reused unchanged.
+
+**Tech Stack:** TypeScript, Zustand vanilla stores, Vitest. Monorepo: `packages/fluux-sdk` (all changes are SDK-side; zero app changes).
+
+**Spec:** `docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md`
+
+## Global Constraints
+
+- Chat/room parity: behavior changes go in the shared module (`packages/fluux-sdk/src/stores/shared/`), never inline in one store only.
+- Before every commit: SDK tests pass with no errors or stderr; commit messages have NO Claude footer.
+- Run SDK tests from the workspace: `cd packages/fluux-sdk && npx vitest run <file>` (never from repo root).
+- SDK type changes: run `npm run build:sdk` before the root `npm run typecheck` (worktree SDK resolves to root dist — if app typecheck sees stale types, rebuild).
+- Final gates (Task 5): full SDK suite, `npm run build:sdk`, `npm run typecheck`, `npm run test:scroll`.
+- No new UI, no new persisted structures, no timestamps-as-signal (page *extents* and ordering are structural facts, not gap-size heuristics).
+- Commit signing: SSH key should already be loaded (`ssh-add -l` to verify); if signing fails mid-session, `--no-gpg-sign` is approved.
+
+---
+
+### Task 1: Pure seam helpers in `mamGap.ts`
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/shared/mamGap.ts`
+- Test: `packages/fluux-sdk/src/stores/shared/mamGap.test.ts`
+
+**Interfaces:**
+- Consumes: existing `GapInterval` (same file).
+- Produces (Task 2 relies on these exact signatures):
+  - `interface PageExtent { oldestTs?: number; newestTs?: number }`
+  - `messagePageExtent(messages: Array<{ timestamp?: Date }>): PageExtent`
+  - `detectFetchLatestSeam(fetched: Array<{ timestamp?: Date }>, newMessagesCount: number, patchedCount: number, newestHeldBelowTs: number | undefined): GapInterval | undefined`
+  - `closeGapWithBackwardPage(gap: GapInterval, page: PageExtent, complete: boolean): GapInterval | undefined`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/fluux-sdk/src/stores/shared/mamGap.test.ts` (follow the file's existing import style — it already imports from `./mamGap`; extend that import with the new names):
+
+```typescript
+import {
+  messagePageExtent,
+  detectFetchLatestSeam,
+  closeGapWithBackwardPage,
+  type GapInterval,
+} from './mamGap'
+
+const msg = (iso: string) => ({ timestamp: new Date(iso) })
+const ts = (iso: string) => new Date(iso).getTime()
+
+describe('messagePageExtent', () => {
+  it('returns min/max timestamps, robust to unsorted input', () => {
+    const extent = messagePageExtent([msg('2026-07-10T00:00:00Z'), msg('2026-07-06T00:00:00Z'), msg('2026-07-08T00:00:00Z')])
+    expect(extent).toEqual({ oldestTs: ts('2026-07-06T00:00:00Z'), newestTs: ts('2026-07-10T00:00:00Z') })
+  })
+
+  it('skips messages without timestamps; empty input yields undefined bounds', () => {
+    expect(messagePageExtent([{}, msg('2026-07-06T00:00:00Z')])).toEqual({
+      oldestTs: ts('2026-07-06T00:00:00Z'), newestTs: ts('2026-07-06T00:00:00Z'),
+    })
+    expect(messagePageExtent([])).toEqual({ oldestTs: undefined, newestTs: undefined })
+  })
+})
+
+describe('detectFetchLatestSeam', () => {
+  const page = [msg('2026-07-14T00:00:00Z'), msg('2026-07-15T00:00:00Z')]
+  const heldBelowTs = ts('2026-07-06T00:00:00Z')
+
+  it('plants a seam when the page lands entirely above held history with no overlap', () => {
+    expect(detectFetchLatestSeam(page, 2, 0, heldBelowTs)).toEqual({
+      start: heldBelowTs,               // newest pre-existing message below
+      end: ts('2026-07-14T00:00:00Z'),  // oldest fetched message
+    })
+  })
+
+  it('no seam on dedupe overlap (some fetched messages already held)', () => {
+    expect(detectFetchLatestSeam(page, 1, 0, heldBelowTs)).toBeUndefined()
+  })
+
+  it('no seam on archive-id backfill (reflection patched onto held messages)', () => {
+    expect(detectFetchLatestSeam(page, 2, 1, heldBelowTs)).toBeUndefined()
+  })
+
+  it('no seam when nothing is held below', () => {
+    expect(detectFetchLatestSeam(page, 2, 0, undefined)).toBeUndefined()
+  })
+
+  it('no seam when the page interleaves with held history (ambiguous)', () => {
+    // Held newest (July 14T12:00) sits inside the page span — not entirely above.
+    expect(detectFetchLatestSeam(page, 2, 0, ts('2026-07-14T12:00:00Z'))).toBeUndefined()
+  })
+
+  it('no seam for an empty page or a page with no timestamps', () => {
+    expect(detectFetchLatestSeam([], 0, 0, heldBelowTs)).toBeUndefined()
+    expect(detectFetchLatestSeam([{}], 1, 0, heldBelowTs)).toBeUndefined()
+  })
+})
+
+describe('closeGapWithBackwardPage', () => {
+  const gap: GapInterval = { start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') }
+
+  it('clears the gap when the page crosses it (oldest fetched reaches held history below)', () => {
+    const page = { oldestTs: ts('2026-07-05T00:00:00Z'), newestTs: ts('2026-07-14T06:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toBeUndefined()
+  })
+
+  it('shrinks the gap when the page reaches into it from above', () => {
+    const page = { oldestTs: ts('2026-07-10T00:00:00Z'), newestTs: ts('2026-07-14T06:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toEqual({
+      start: gap.start, end: ts('2026-07-10T00:00:00Z'),
+    })
+  })
+
+  it('ignores a page entirely below the gap (older-region pagination says nothing)', () => {
+    const page = { oldestTs: ts('2026-07-01T00:00:00Z'), newestTs: ts('2026-07-05T00:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toBe(gap)
+    // Even archive-start (complete=true) below the gap must NOT clear it.
+    expect(closeGapWithBackwardPage(gap, page, true)).toBe(gap)
+  })
+
+  it('clears the gap when a page from at/above it reaches archive start (complete)', () => {
+    const page = { oldestTs: ts('2026-07-08T00:00:00Z'), newestTs: ts('2026-07-14T06:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, true)).toBeUndefined()
+  })
+
+  it('ignores an empty page (no positional info), even when complete', () => {
+    expect(closeGapWithBackwardPage(gap, { oldestTs: undefined, newestTs: undefined }, true)).toBe(gap)
+  })
+
+  it('ignores a page entirely above the gap end (recent-region pagination not yet at the seam)', () => {
+    const page = { oldestTs: ts('2026-07-14T12:00:00Z'), newestTs: ts('2026-07-15T00:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toBe(gap)
+  })
+
+  it('shrinks an open-ended gap (end undefined) instead of ignoring it', () => {
+    const openGap: GapInterval = { start: ts('2026-07-06T00:00:00Z') }
+    const page = { oldestTs: ts('2026-07-10T00:00:00Z'), newestTs: ts('2026-07-15T00:00:00Z') }
+    expect(closeGapWithBackwardPage(openGap, page, false)).toEqual({
+      start: openGap.start, end: ts('2026-07-10T00:00:00Z'),
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/mamGap.test.ts`
+Expected: FAIL — `messagePageExtent`, `detectFetchLatestSeam`, `closeGapWithBackwardPage` are not exported.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `packages/fluux-sdk/src/stores/shared/mamGap.ts`:
+
+```typescript
+/** Min/max timestamps (epoch ms) of a message page. Robust to unsorted input
+ *  and messages without timestamps. */
+export interface PageExtent {
+  oldestTs?: number
+  newestTs?: number
+}
+
+/** Compute the timestamp extent of a page of messages. */
+export function messagePageExtent(messages: Array<{ timestamp?: Date }>): PageExtent {
+  let oldestTs: number | undefined
+  let newestTs: number | undefined
+  for (const message of messages) {
+    const ts = message.timestamp?.getTime()
+    if (ts === undefined) continue
+    if (oldestTs === undefined || ts < oldestTs) oldestTs = ts
+    if (newestTs === undefined || ts > newestTs) newestTs = ts
+  }
+  return { oldestTs, newestTs }
+}
+
+/**
+ * Detect a disjoint fetch-latest page: a backward `before:''` page that landed
+ * entirely above held history without any connection proof.
+ *
+ * All checks are STRUCTURAL — direction, dedupe overlap, archive-id backfill,
+ * above/below ordering — never a gap-size heuristic:
+ * - any dedupe hit (`newMessagesCount < fetched.length`) or archive-id backfill
+ *   (`patchedCount > 0`) proves the page connects to held history → no seam;
+ * - nothing held below → nothing to disconnect from → no seam;
+ * - a page that interleaves with held history is ambiguous → no seam
+ *   (conservative: never plant a marker on uncertain evidence).
+ *
+ * @param fetched - The incoming page, as handed to the merge
+ * @param newMessagesCount - How many of `fetched` survived dedupe (merge output)
+ * @param patchedCount - Archive-id backfills onto held messages (merge output)
+ * @param newestHeldBelowTs - Newest message held BEFORE this merge (resident
+ *   newest, or the persisted preview timestamp when the resident array is empty)
+ * @returns The seam to record, or undefined when the page is connected/ambiguous
+ */
+export function detectFetchLatestSeam(
+  fetched: Array<{ timestamp?: Date }>,
+  newMessagesCount: number,
+  patchedCount: number,
+  newestHeldBelowTs: number | undefined,
+): GapInterval | undefined {
+  if (fetched.length === 0) return undefined
+  if (newMessagesCount < fetched.length || patchedCount > 0) return undefined
+  if (newestHeldBelowTs === undefined) return undefined
+  const { oldestTs } = messagePageExtent(fetched)
+  if (oldestTs === undefined) return undefined
+  if (oldestTs <= newestHeldBelowTs) return undefined
+  return { start: newestHeldBelowTs, end: oldestTs }
+}
+
+/**
+ * Reconcile a recorded gap against a merged BACKWARD page (scroll-up
+ * pagination). Backward pages walk contiguously down from their cursor, so a
+ * page's extent proves the span it covered:
+ *
+ * - page entirely below the gap (`newestTs <= start`): older-region pagination,
+ *   says nothing about the gap — even `complete` (archive start below the gap)
+ *   must not clear it;
+ * - `complete` from at/above the gap: everything below the cursor was fetched,
+ *   the gap region included → clear;
+ * - page reaching held history below (`oldestTs <= start`): regions connected → clear;
+ * - page reaching into the gap from above: shrink (`end` moves down to the
+ *   page's oldest);
+ * - empty page: no positional info → unchanged.
+ *
+ * @returns The new gap (`undefined` = clear); returns `gap` by reference when unchanged.
+ */
+export function closeGapWithBackwardPage(
+  gap: GapInterval,
+  page: PageExtent,
+  complete: boolean,
+): GapInterval | undefined {
+  if (page.oldestTs === undefined || page.newestTs === undefined) return gap
+  if (page.newestTs <= gap.start) return gap
+  if (complete) return undefined
+  if (page.oldestTs <= gap.start) return undefined
+  if (gap.end === undefined || page.oldestTs < gap.end) return { start: gap.start, end: page.oldestTs }
+  return gap
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/mamGap.test.ts`
+Expected: PASS, all tests (existing + new), no stderr.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/src/stores/shared/mamGap.ts packages/fluux-sdk/src/stores/shared/mamGap.test.ts
+git commit -m "feat(sdk): pure seam detection/closure helpers in mamGap"
+```
+
+---
+
+### Task 2: Shared `syncGapAfterArchiveMerge` transition
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/stores/shared/mamGap.ts`
+- Test: `packages/fluux-sdk/src/stores/shared/mamGap.test.ts`
+
+**Interfaces:**
+- Consumes (Task 1): `detectFetchLatestSeam`, `closeGapWithBackwardPage`, `messagePageExtent`, plus existing `computeGapEnd`, `syncGap`, `GapInterval`.
+- Produces (Tasks 3–4 rely on this exact signature):
+  ```typescript
+  interface ArchiveMergeGapInput {
+    gaps: Map<string, GapInterval>
+    id: string
+    direction: 'backward' | 'forward'
+    complete: boolean
+    forwardGapTimestamp: number | undefined
+    merged: Array<{ timestamp?: Date }>
+    fetched: Array<{ timestamp?: Date }>
+    newMessagesCount: number
+    patchedCount: number
+    isFetchLatest: boolean
+    newestHeldBelowTs: number | undefined
+    preserveGapMarker: boolean
+  }
+  syncGapAfterArchiveMerge(input: ArchiveMergeGapInput): Map<string, GapInterval>
+  ```
+  Copy-on-write: returns the SAME map reference when nothing changes (callers skip persistence on identity).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/fluux-sdk/src/stores/shared/mamGap.test.ts` (add `syncGapAfterArchiveMerge` and `type ArchiveMergeGapInput` to the import):
+
+```typescript
+describe('syncGapAfterArchiveMerge', () => {
+  const id = 'room@conference.example.com'
+  const base = (over: Partial<ArchiveMergeGapInput>): ArchiveMergeGapInput => ({
+    gaps: new Map(),
+    id,
+    direction: 'backward',
+    complete: false,
+    forwardGapTimestamp: undefined,
+    merged: [],
+    fetched: [],
+    newMessagesCount: 0,
+    patchedCount: 0,
+    isFetchLatest: false,
+    newestHeldBelowTs: undefined,
+    preserveGapMarker: false,
+    ...over,
+  })
+
+  it('forward: mirrors forwardGapTimestamp into the map with computeGapEnd (existing behavior)', () => {
+    const merged = [msg('2026-07-06T00:00:00Z'), msg('2026-07-15T00:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      direction: 'forward', forwardGapTimestamp: ts('2026-07-06T00:00:00Z'), merged,
+    }))
+    expect(out.get(id)).toEqual({ start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-15T00:00:00Z') })
+  })
+
+  it('forward: clears the gap when forwardGapTimestamp is undefined (complete catch-up)', () => {
+    const gaps = new Map([[id, { start: 1000, end: 5000 }]])
+    const out = syncGapAfterArchiveMerge(base({ direction: 'forward', gaps, complete: true }))
+    expect(out.has(id)).toBe(false)
+  })
+
+  it('preserveGapMarker: returns the map untouched for BOTH directions', () => {
+    const gaps = new Map([[id, { start: 1000, end: 5000 }]])
+    expect(syncGapAfterArchiveMerge(base({ direction: 'forward', gaps, preserveGapMarker: true }))).toBe(gaps)
+    expect(syncGapAfterArchiveMerge(base({ gaps, preserveGapMarker: true, isFetchLatest: true }))).toBe(gaps)
+  })
+
+  it('backward formation: fetch-latest page disjoint above held history plants a seam', () => {
+    const fetched = [msg('2026-07-14T00:00:00Z'), msg('2026-07-15T00:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      fetched, newMessagesCount: 2, isFetchLatest: true,
+      newestHeldBelowTs: ts('2026-07-06T00:00:00Z'),
+    }))
+    expect(out.get(id)).toEqual({ start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') })
+  })
+
+  it('backward formation: NOT planted for a plain pagination page (isFetchLatest=false)', () => {
+    const fetched = [msg('2026-07-14T00:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      fetched, newMessagesCount: 1, newestHeldBelowTs: ts('2026-07-06T00:00:00Z'),
+    }))
+    expect(out.has(id)).toBe(false)
+  })
+
+  it('backward closure: an existing gap takes priority over formation and shrinks/clears', () => {
+    const gaps = new Map([[id, { start: ts('2026-07-01T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') }]])
+    const fetched = [msg('2026-07-10T00:00:00Z'), msg('2026-07-14T06:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      gaps, fetched, newMessagesCount: 2, isFetchLatest: true, // fetch-latest flag must NOT re-plant
+      newestHeldBelowTs: ts('2026-06-01T00:00:00Z'),
+    }))
+    expect(out.get(id)).toEqual({ start: ts('2026-07-01T00:00:00Z'), end: ts('2026-07-10T00:00:00Z') })
+  })
+
+  it('backward no-op: returns the SAME map reference when nothing changes', () => {
+    const gaps = new Map([[id, { start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') }]])
+    const fetched = [msg('2026-07-01T00:00:00Z')] // entirely below the gap
+    const out = syncGapAfterArchiveMerge(base({ gaps, fetched, newMessagesCount: 1 }))
+    expect(out).toBe(gaps)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/mamGap.test.ts`
+Expected: FAIL — `syncGapAfterArchiveMerge` not exported.
+
+- [ ] **Step 3: Implement `syncGapAfterArchiveMerge` and update the module doc**
+
+Append to `packages/fluux-sdk/src/stores/shared/mamGap.ts`:
+
+```typescript
+/** Everything the gap transition needs from an archive merge, both directions. */
+export interface ArchiveMergeGapInput {
+  /** Current persisted gap map (`roomGaps` / `conversationGaps`). */
+  gaps: Map<string, GapInterval>
+  /** Room JID / conversation id. */
+  id: string
+  direction: 'backward' | 'forward'
+  /** Server's `<fin complete=…>` for this merge. */
+  complete: boolean
+  /** `forwardGapTimestamp` AFTER `setMAMQueryCompleted` for this merge (forward only). */
+  forwardGapTimestamp: number | undefined
+  /** Merged timeline (for `computeGapEnd` on the forward path). */
+  merged: Array<{ timestamp?: Date }>
+  /** The incoming page, as handed to the merge. */
+  fetched: Array<{ timestamp?: Date }>
+  /** How many of `fetched` survived dedupe. */
+  newMessagesCount: number
+  /** Archive-id backfills onto held messages. */
+  patchedCount: number
+  /** The query was a `before:''` fetch-latest. */
+  isFetchLatest: boolean
+  /** Newest message held BEFORE this merge (resident newest ?? persisted preview ts). */
+  newestHeldBelowTs: number | undefined
+  /** Bounded force-repair: leave the marker untouched (neither set nor cleared). */
+  preserveGapMarker: boolean
+}
+
+/**
+ * The single gap transition for BOTH stores and BOTH merge directions.
+ *
+ * Forward: mirror the (complete=false-driven) `forwardGapTimestamp` into the
+ * persisted map — unchanged behavior, extracted from the near-twin blocks in
+ * `mergeRoomMAMMessages` / `mergeMAMMessages`.
+ *
+ * Backward: an existing gap is reconciled against the page (closure takes
+ * priority — a fetch-latest while a gap is already recorded must not re-plant
+ * a shallower seam over a deeper one); otherwise a disjoint fetch-latest page
+ * plants a new seam at formation.
+ *
+ * Copy-on-write: returns the same map reference when nothing changes, so
+ * callers can skip persistence and re-renders.
+ */
+export function syncGapAfterArchiveMerge(input: ArchiveMergeGapInput): Map<string, GapInterval> {
+  const {
+    gaps, id, direction, complete, forwardGapTimestamp, merged, fetched,
+    newMessagesCount, patchedCount, isFetchLatest, newestHeldBelowTs, preserveGapMarker,
+  } = input
+
+  if (preserveGapMarker) return gaps
+
+  if (direction === 'forward') {
+    const gapEnd = forwardGapTimestamp !== undefined ? computeGapEnd(merged, forwardGapTimestamp) : undefined
+    return syncGap(gaps, id, forwardGapTimestamp, gapEnd)
+  }
+
+  const existing = gaps.get(id)
+  const next = existing
+    ? closeGapWithBackwardPage(existing, messagePageExtent(fetched), complete)
+    : isFetchLatest
+      ? detectFetchLatestSeam(fetched, newMessagesCount, patchedCount, newestHeldBelowTs)
+      : undefined
+  return syncGap(gaps, id, next?.start, next?.end)
+}
+```
+
+Also replace the module doc paragraph (current lines 12–16):
+
+```typescript
+ * Detection is driven ONLY by reliable structural signals — never by timestamp
+ * discontinuities (a quiet period and a real gap are indistinguishable by
+ * timestamp, and ejabberd archive ids are non-sequential):
+ * 1. a forward catch-up that ended `complete=false` (the server said there is
+ *    more, and we stopped at the page cap);
+ * 2. a `before:''` fetch-latest page that landed entirely above held history
+ *    with no dedupe overlap — the page provably does not connect to what we
+ *    hold, so the boundary between them is a seam (recorded at formation).
+ * Recorded gaps close progressively from both directions: forward catch-up
+ * resumes from the boundary; backward scroll-up pagination shrinks/clears the
+ * gap when its pages reach into or across it.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/shared/mamGap.test.ts`
+Expected: PASS, no stderr.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/src/stores/shared/mamGap.ts packages/fluux-sdk/src/stores/shared/mamGap.test.ts
+git commit -m "feat(sdk): shared syncGapAfterArchiveMerge gap transition (both stores, both directions)"
+```
+
+---
+
+### Task 3: Room wiring — `isFetchLatest` flag + merge integration
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/types/sdk-events.ts` (`'room:mam-messages'` payload, ~line 391)
+- Modify: `packages/fluux-sdk/src/core/modules/MAM.ts` (`queryRoomArchive` emit, ~line 491)
+- Modify: `packages/fluux-sdk/src/bindings/storeBindings.ts` (`'room:mam-messages'` handler, ~line 424)
+- Modify: `packages/fluux-sdk/src/stores/roomStore.ts` (type ~line 642, impl `mergeRoomMAMMessages` ~line 2495)
+- Test: `packages/fluux-sdk/src/stores/roomStore.test.ts` (extend the existing gap describe block, ~line 2140 area)
+
+**Interfaces:**
+- Consumes (Task 2): `syncGapAfterArchiveMerge`, `messagePageExtent` from `./shared/mamGap` (roomStore already imports `computeGapEnd`/`syncGap` from there — extend that import; `syncGap` may become unused in this file after this task, remove it from the import if so).
+- Produces: `mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker?, isFetchLatest?)` — Task 4 mirrors this shape for chat.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the gap describe block in `packages/fluux-sdk/src/stores/roomStore.test.ts` (same file region as the existing `'clears the persisted gap when a forward catch-up completes'` test; reuse its `jid`, `createRoom`, `RoomMessage` literal idiom):
+
+```typescript
+    it('plants a seam when a fetch-latest page lands disjoint above held history', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-06T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'fresh', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
+      }
+      // backward + isFetchLatest=true = a `before:''` fetch-latest page
+      roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, true, 'backward', false, true)
+
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-15T00:00:00Z').getTime(),
+      })
+    })
+
+    it('does NOT plant a seam when the fetch-latest page overlaps held history (dedupe)', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'shared', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'shared', timestamp: new Date('2026-07-14T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+
+      const fresh: RoomMessage = {
+        type: 'groupchat', id: 'fresh', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
+      }
+      const dupe: RoomMessage = { ...held } // same id → dedupe hit → connection proof
+      roomStore.getState().mergeRoomMAMMessages(jid, [dupe, fresh], {}, true, 'backward', false, true)
+
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('does NOT plant a seam for a plain backward pagination page (isFetchLatest omitted)', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-06T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+      const older: RoomMessage = {
+        type: 'groupchat', id: 'older', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'older', timestamp: new Date('2026-07-01T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [older], {}, false, 'backward')
+
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('falls back to the persisted preview timestamp when the resident array is empty', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-06T00:00:00Z'), isOutgoing: false,
+      }
+      // Fresh-run shape: resident array EMPTY, preview (meta.lastMessage) persisted.
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, lastMessage: held }))
+
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'fresh', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, true, 'backward', false, true)
+
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-15T00:00:00Z').getTime(),
+      })
+    })
+
+    it('backward closure: a scroll-up page reaching into the gap shrinks it; crossing clears it', () => {
+      roomStore.getState().addRoom(createRoom(jid))
+      roomStore.setState({ roomGaps: new Map([[jid, {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }]]) })
+
+      const mid: RoomMessage = {
+        type: 'groupchat', id: 'mid', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'mid', timestamp: new Date('2026-07-10T00:00:00Z'), isOutgoing: false,
+      }
+      const upper: RoomMessage = {
+        type: 'groupchat', id: 'upper', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'upper', timestamp: new Date('2026-07-14T06:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [mid, upper], {}, false, 'backward')
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-10T00:00:00Z').getTime(),
+      })
+
+      const below: RoomMessage = {
+        type: 'groupchat', id: 'below', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'below', timestamp: new Date('2026-07-05T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [below, mid], {}, false, 'backward')
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('backward closure: an older-region page below the gap leaves it untouched', () => {
+      roomStore.getState().addRoom(createRoom(jid))
+      const gap = {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }
+      roomStore.setState({ roomGaps: new Map([[jid, gap]]) })
+
+      const ancient: RoomMessage = {
+        type: 'groupchat', id: 'ancient', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'ancient', timestamp: new Date('2026-07-01T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [ancient], {}, true, 'backward')
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual(gap)
+    })
+```
+
+(`createRoom(jid, options)` is the file's existing factory — the `messages`/`lastMessage`/`joined` options are already used by neighboring tests, e.g. the sidebar tests near line 127.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.test.ts`
+Expected: FAIL — new tests fail (`roomGaps` never set on backward merges); all pre-existing tests still pass.
+
+- [ ] **Step 3: Implement the room wiring**
+
+**(a)** `packages/fluux-sdk/src/core/types/sdk-events.ts` — add to the `'room:mam-messages'` payload after `preserveGapMarker`:
+
+```typescript
+    /** The query was a `before:''` fetch-latest (seam formation candidate). */
+    isFetchLatest?: boolean
+```
+
+**(b)** `packages/fluux-sdk/src/core/modules/MAM.ts`, `queryRoomArchive` emit (~line 491) — add the flag:
+
+```typescript
+          this.deps.emitSDK('room:mam-messages', {
+            roomJid,
+            messages: collectedMessages,
+            rsm,
+            complete,
+            direction,
+            preserveGapMarker,
+            isFetchLatest: !isForward && !before,
+          })
+```
+
+(`before` is already destructured from `options` at the top of the method — with NO default, so a backward query can carry `before: ''` OR `before: undefined`; both mean "newest page" to the server, hence `!before`, which stays false for a real pagination id. The after-cursor-purged degrade path recurses with `before: ''`, so its emit correctly carries `isFetchLatest: true`.)
+
+**(c)** `packages/fluux-sdk/src/bindings/storeBindings.ts` (~line 424):
+
+```typescript
+  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest }) => {
+    const stores = getStores()
+    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest)
+  })
+```
+
+**(d)** `packages/fluux-sdk/src/stores/roomStore.ts`:
+
+Type (~line 642):
+
+```typescript
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean) => void
+```
+
+Impl (~line 2495) — signature and pre-`set` fallback read:
+
+```typescript
+  mergeRoomMAMMessages: (roomJid, mamMessages, rsm, complete, direction, preserveGapMarker = false, isFetchLatest = false) => {
+    // Newest persisted timestamp (entity preview) — the seam-formation fallback
+    // when the resident array is empty this run (fresh session, history on disk).
+    const fallbackHeldTs = get().getRoomLastTimestamp(roomJid)
+```
+
+Then replace the forward-only gap block (currently ~lines 2543–2550):
+
+```typescript
+      // Mirror the (reliable, complete=false-driven) forward gap into the PERSISTED
+      // roomGaps map so the marker survives a reload. `end` = oldest message held
+      // above the gap. preserveGapMarker (bounded force repair) leaves it untouched.
+      let newGaps = state.roomGaps
+      if (direction === 'forward' && !preserveGapMarker) {
+        const gapStart = newStates.get(roomJid)?.forwardGapTimestamp
+        const gapEnd = gapStart !== undefined ? computeGapEnd(merged, gapStart) : undefined
+        newGaps = syncGap(state.roomGaps, roomJid, gapStart, gapEnd)
+        if (newGaps !== state.roomGaps) saveGapsToStorage(newGaps)
+      }
+```
+
+with:
+
+```typescript
+      // Persisted gap sync (shared transition, both directions):
+      // - forward: mirror the complete=false-driven forwardGapTimestamp (marker
+      //   survives a reload);
+      // - backward: close/shrink a recorded gap when a scroll-up page reaches
+      //   into or across it, or plant a seam when a `before:''` fetch-latest
+      //   page lands disjoint above held history (formation).
+      const newGaps = syncGapAfterArchiveMerge({
+        gaps: state.roomGaps,
+        id: roomJid,
+        direction,
+        complete,
+        forwardGapTimestamp: newStates.get(roomJid)?.forwardGapTimestamp,
+        merged,
+        fetched: mamMessages,
+        newMessagesCount: newFromMAM.length,
+        patchedCount: patched.length,
+        isFetchLatest,
+        newestHeldBelowTs: messagePageExtent(existingMessages).newestTs ?? fallbackHeldTs,
+        preserveGapMarker,
+      })
+      if (newGaps !== state.roomGaps) saveGapsToStorage(newGaps)
+```
+
+Update the `./shared/mamGap` import: add `syncGapAfterArchiveMerge`, `messagePageExtent`; drop `computeGapEnd`/`syncGap` from it if this was their only use in the file (grep first).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.test.ts src/stores/shared/mamGap.test.ts`
+Expected: PASS (new + all pre-existing gap/persistence/account-scoping tests), no stderr.
+
+- [ ] **Step 5: Run the room-adjacent suites (merge path consumers)**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/roomStore.mds.test.ts src/core/modules/MAM.catchup.test.ts src/core/modules/MAM.preview.test.ts src/core/modules/MUC.test.ts`
+Expected: PASS, no stderr.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/types/sdk-events.ts packages/fluux-sdk/src/core/modules/MAM.ts packages/fluux-sdk/src/bindings/storeBindings.ts packages/fluux-sdk/src/stores/roomStore.ts packages/fluux-sdk/src/stores/roomStore.test.ts
+git commit -m "feat(sdk): record room history seam at fetch-latest formation; close it on backward scroll"
+```
+
+---
+
+### Task 4: Chat wiring — parity with rooms
+
+**Files:**
+- Modify: `packages/fluux-sdk/src/core/types/sdk-events.ts` (`'chat:mam-messages'` payload, ~line 196)
+- Modify: `packages/fluux-sdk/src/core/modules/MAM.ts` (`queryArchive` emit, ~line 339)
+- Modify: `packages/fluux-sdk/src/bindings/storeBindings.ts` (`'chat:mam-messages'` handler, ~line 269)
+- Modify: `packages/fluux-sdk/src/stores/chatStore.ts` (type `mergeMAMMessages` ~line 290 region, impl ~line 1600)
+- Test: `packages/fluux-sdk/src/stores/chatStore.test.ts` (extend `describe('mergeMAMMessages gap tracking …')`, ~line 157)
+
+**Interfaces:**
+- Consumes (Task 2): `syncGapAfterArchiveMerge`, `messagePageExtent` from `./shared/mamGap`.
+- Produces: `mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest?)`. Chat has no `preserveGapMarker` (no chat force-repair) — pass `preserveGapMarker: false` to the shared function.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add inside `describe('mergeMAMMessages gap tracking (persisted conversationGaps)')` in `packages/fluux-sdk/src/stores/chatStore.test.ts`, reusing its `cid`, `createConversation`, `createMessage` helpers:
+
+```typescript
+    it('plants a seam when a fetch-latest page lands disjoint above held history (parity with rooms)', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const held = { ...createMessage(cid, 'held'), id: 'held', timestamp: new Date('2026-07-06T00:00:00Z') }
+      chatStore.getState().addMessage(held)
+
+      const fetched = { ...createMessage(cid, 'fresh'), id: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [fetched], {}, true, 'backward', true)
+
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-15T00:00:00Z').getTime(),
+      })
+    })
+
+    it('does NOT plant a seam on dedupe overlap or plain backward pagination', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const held = { ...createMessage(cid, 'shared'), id: 'shared', timestamp: new Date('2026-07-14T00:00:00Z') }
+      chatStore.getState().addMessage(held)
+
+      // Overlapping fetch-latest: dedupe hit → connected.
+      const fresh = { ...createMessage(cid, 'fresh'), id: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [{ ...held }, fresh], {}, true, 'backward', true)
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+
+      // Plain pagination (isFetchLatest omitted): never a formation candidate.
+      const older = { ...createMessage(cid, 'older'), id: 'older', timestamp: new Date('2026-07-01T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [older], {}, false, 'backward')
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+    })
+
+    it('backward closure: scroll-up pages shrink then clear a recorded gap', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState({ conversationGaps: new Map([[cid, {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }]]) })
+
+      const mid = { ...createMessage(cid, 'mid'), id: 'mid', timestamp: new Date('2026-07-10T00:00:00Z') }
+      const upper = { ...createMessage(cid, 'upper'), id: 'upper', timestamp: new Date('2026-07-14T06:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [mid, upper], {}, false, 'backward')
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-10T00:00:00Z').getTime(),
+      })
+
+      const below = { ...createMessage(cid, 'below'), id: 'below', timestamp: new Date('2026-07-05T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [below, { ...mid }], {}, false, 'backward')
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+    })
+
+    it('backward closure: an older-region page below the gap leaves it untouched', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const gap = {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }
+      chatStore.setState({ conversationGaps: new Map([[cid, gap]]) })
+
+      const ancient = { ...createMessage(cid, 'ancient'), id: 'ancient', timestamp: new Date('2026-07-01T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [ancient], {}, true, 'backward')
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual(gap)
+    })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/chatStore.test.ts`
+Expected: FAIL — new tests only; pre-existing pass.
+
+- [ ] **Step 3: Implement the chat wiring**
+
+**(a)** `sdk-events.ts` — add to the `'chat:mam-messages'` payload:
+
+```typescript
+    /** The query was a `before:''` fetch-latest (seam formation candidate). */
+    isFetchLatest?: boolean
+```
+
+**(b)** `MAM.ts`, `queryArchive` emit (~line 339) — add the flag (`before` is destructured from `options` at the top of `queryArchive`; the chat method emits once after its pagination loop, anchored at latest when `before === ''`):
+
+```typescript
+      this.deps.emitSDK('chat:mam-messages', {
+        conversationId,
+        messages: allMessages,
+        rsm: lastRsm,
+        complete: isComplete,
+        direction,
+        isFetchLatest: direction === 'backward' && !before,
+      })
+```
+
+(In `queryArchive` the destructure is `before = ''` — it defaults to fetch-latest — so `!before` is true exactly when no pagination cursor was provided.)
+
+**(c)** `storeBindings.ts` (~line 269):
+
+```typescript
+  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest }) => {
+    const stores = getStores()
+    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest)
+  })
+```
+
+**(d)** `chatStore.ts`:
+
+Type:
+
+```typescript
+  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean) => void
+```
+
+Impl — signature + pre-`set` fallback read:
+
+```typescript
+      mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction, isFetchLatest = false) => {
+        // Newest persisted timestamp (entity preview) — the seam-formation fallback
+        // when the resident array is empty this run (fresh session, history on disk).
+        const fallbackHeldTs = get().getConversationLastTimestamp(conversationId)
+```
+
+Replace the forward-only gap block (currently the `let newGaps = state.conversationGaps; if (direction === 'forward') { … }` block, ~lines 1640–1647):
+
+```typescript
+          // Persisted gap sync (shared transition, both directions) — see
+          // syncGapAfterArchiveMerge. Chat has no bounded force-repair, so
+          // preserveGapMarker is always false.
+          const newGaps = syncGapAfterArchiveMerge({
+            gaps: state.conversationGaps,
+            id: conversationId,
+            direction,
+            complete,
+            forwardGapTimestamp: newStates.get(conversationId)?.forwardGapTimestamp,
+            merged: trimmed,
+            fetched: mamMessages,
+            newMessagesCount: newMessages.length,
+            patchedCount: patched.length,
+            isFetchLatest,
+            newestHeldBelowTs: messagePageExtent(rawExisting).newestTs ?? fallbackHeldTs,
+            preserveGapMarker: false,
+          })
+```
+
+(Chat's `conversationGaps` persistence is subscription-driven — no explicit save call here; leave that mechanism untouched.) Update the `./shared/mamGap` import: add `syncGapAfterArchiveMerge`, `messagePageExtent`; drop `computeGapEnd`/`syncGap` if now unused in this file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/fluux-sdk && npx vitest run src/stores/chatStore.test.ts src/stores/chatStore.mds.test.ts src/core/modules/Chat.mam.test.ts`
+Expected: PASS, no stderr.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fluux-sdk/src/core/types/sdk-events.ts packages/fluux-sdk/src/core/modules/MAM.ts packages/fluux-sdk/src/bindings/storeBindings.ts packages/fluux-sdk/src/stores/chatStore.ts packages/fluux-sdk/src/stores/chatStore.test.ts
+git commit -m "feat(sdk): chat parity for seam formation + backward closure"
+```
+
+---
+
+### Task 5: Simplification audit + full verification gates
+
+**Files:**
+- Possibly modify: `packages/fluux-sdk/src/stores/shared/mamGap.ts`, `roomStore.ts`, `chatStore.ts` (fold only what the audit confirms)
+- No new files.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: the final, verified branch state.
+
+- [ ] **Step 1: Simplification audit (spec-mandated; report findings, fold only genuine duplication)**
+
+Check each and apply only what holds:
+1. **Twin gap blocks folded?** After Tasks 3–4 both stores should call `syncGapAfterArchiveMerge` and neither should import `computeGapEnd`/`syncGap` directly anymore. Grep: `grep -n 'computeGapEnd\|syncGap(' packages/fluux-sdk/src/stores/roomStore.ts packages/fluux-sdk/src/stores/chatStore.ts` — expect no hits outside the shared call. Remove leftover imports.
+2. **`computeGapEnd` vs new helpers:** `computeGapEnd(messages, start)` is "oldest ts strictly newer than start" — semantically `messagePageExtent`-adjacent but not identical (threshold filter). If, after reading both, one can express the other in ≤2 lines without contortion, fold; otherwise leave and note why in the commit message body. Do NOT force it.
+3. **Dead `newestFetchedTimestamp` duplication:** both merge functions compute `newestFetchedTimestamp` for `setMAMQueryCompleted` with identical 3-line expressions. If trivially extractable into `mamState` or `mamGap` without changing signatures, do it; otherwise leave.
+4. **Unused exports:** if `messagePageExtent` ended up used only inside `mamGap.ts` (stores inline their own extent), un-export it.
+
+- [ ] **Step 2: Full SDK suite**
+
+Run: `cd packages/fluux-sdk && npx vitest run`
+Expected: PASS, zero failures, no stderr.
+
+- [ ] **Step 3: Build + typecheck (SDK types changed → app must see fresh dist)**
+
+Run from repo root:
+```bash
+npm run build:sdk && npm run typecheck
+```
+Expected: both succeed. (Worktree gotcha: the app resolves the SDK to the root dist — `build:sdk` must run before the root typecheck or the app sees stale types.)
+
+- [ ] **Step 4: Scroll regression gate**
+
+Run: `npm run test:scroll`
+Expected: PASS. (Merges into the active conversation must not disturb scroll; this gate is mandatory for any change on the merge path.)
+
+- [ ] **Step 5: App test suite (SDK event payload changed — verify the app mock still aligns)**
+
+Run: `cd apps/fluux && npx vitest run`
+Expected: PASS. The new event field is optional and no app-facing SDK export changed, so no mock updates should be needed — if a mock complains about `mergeMAMMessages` arity, extend the app's SDK mock in `test-setup.ts` via the `importOriginal` spread pattern.
+
+- [ ] **Step 6: Commit (audit results) and wrap up**
+
+```bash
+git add -A
+git commit -m "refactor(sdk): fold gap-sync duplication after seam safety net (audit results in body)"
+```
+
+Then follow `superpowers:finishing-a-development-branch` — the branch is `mr/message-loading-gaps-c50347`; target a PR to `main` (squash-merge flow), concise description, no test plans, no Claude footer.
+
+---
+
+## Verification checklist (maps plan → spec)
+
+- Spec "formation signal 2" → Task 1 `detectFetchLatestSeam` + Task 3/4 wiring + formation tests.
+- Spec "IndexedDB-held history visible to the check" → `fallbackHeldTs` from entity preview (`getRoomLastTimestamp` / `getConversationLastTimestamp`) + "falls back to the persisted preview timestamp" tests.
+- Spec "backward closure NEW WIRING" → Task 1 `closeGapWithBackwardPage` + closure tests in both stores.
+- Spec "forward unchanged (regression)" → existing forward gap tests must stay green (Tasks 3/4 Step 4 runs them); `preserveGapMarker` covered in Task 2 tests + existing room test.
+- Spec "persistence + account scoping" → existing localStorage tests stay green (Task 3 Step 4).
+- Spec "simplification pass" → Task 5 Step 1.
+- Spec "no new UI" → no app source files touched anywhere in this plan.
+- Spec regression gates → Task 5 Steps 2–5.

--- a/docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md
+++ b/docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md
@@ -1,8 +1,8 @@
 # MAM Discontinuity Safety Net — Design
 
 **Date:** 2026-07-15
-**Status:** Approved-in-principle (A + B), pending spec review → implementation plan
-**Scope:** `@fluux/sdk` (MAM catch-up / gap machinery) + minimal app wiring. Chat + room parity.
+**Status:** Approved-in-principle (Part A only), pending spec review → implementation plan
+**Scope:** `@fluux/sdk` (MAM catch-up / gap machinery). Chat + room parity. No new UI.
 
 ## Problem
 
@@ -12,205 +12,175 @@ deliberate: `mamGap.ts` refuses to infer holes from timestamp discontinuities
 because a quiet period and a real gap look identical by timestamp, and ejabberd
 archive ids are non-sequential.
 
-That leaves a blind spot. A forward catch-up anchors its cursor on the **newest
-message that predates the session** (`findCatchUpCursorMessage`). If a hole
-already sits *below* that anchor — old history up to a date, plus a newer disjoint
-block, with nothing between — every forward query starts *above* the hole,
-returns `complete=true`, and the hole is **never detected, never recorded, never
-healed**. It survives restarts and upgrades and is self-perpetuating: once the
-recent block exists, the cursor sits above the hole forever.
+That leaves a blind spot: a hole can *form* without ever producing a
+`complete=false`. If a catch-up falls back to a `before:''` fetch-latest while
+older history is already held, the fetched recent page lands **disjoint above**
+the older messages. The query completes clean, nothing is recorded, and the hole
+is invisible forever after: every later forward catch-up anchors its cursor on
+the newest held message — *above* the hole — returns `complete=true`, and never
+looks down. The hole is silent, permanent, and self-perpetuating.
 
-Observed in the field: a MUC room showing messages up to ~July 6 and then recent
-messages, with a multi-day hole between and no marker.
+### Field case and root cause
+
+A MUC room showed messages up to ~July 6 and then recent messages, with a
+multi-day hole between and no marker. Root cause (established from git history):
+the hole formed under **0.17.0**, whose cursor fallback chain was weaker —
+cached cursor → preview timestamp → `before:''`. The MDS-stanza-id `after`
+fallback (#869) landed 13 hours after the 0.17.0 tag and shipped only in 0.17.1.
+In the corner case (empty cache + unavailable preview timestamp at catch-up
+time), 0.17.0 dropped straight to `before:''` and manufactured the seam.
+
+0.17.1's hardened chain makes formation much rarer, but the class of bug is not
+closed: any future fallback regression, or any path that legitimately resorts to
+`before:''` over held history, re-creates it — and today it would again be
+recorded nowhere.
+
+### Legacy holes (out of scope, by decision)
+
+Holes already formed under 0.17.0 carry no surviving query-edge evidence
+(`mamQueryStates` is ephemeral — rebuilt as `new Map()` each load; only
+`roomGaps` etc. persist). Recovering them automatically would require a
+timestamp-located, server-confirmed probe (the dropped "Part B"). Decision:
+**not worth the machinery** for a one-off legacy population. Remedy for affected
+users: **Rooms sidebar → "+" → "Catch up all rooms"** (`forceCatchUpAllRooms`,
+45-day window, `preserveGapMarker`) heals the hole manually.
 
 ## Core principle: a seam is an un-connected MAM query edge
 
 A hole can only exist where **one MAM query's result stops and a different
 query's result begins without proof they connect** — a *seam*. It is a property
 of the *fetches*, not of the message timeline. A large timestamp gap *inside* a
-single contiguously-fetched range is a quiet period, not a hole. A marker may
-therefore appear only at a seam, which exists in very few places.
+contiguously-fetched range is a quiet period, not a hole. Markers may therefore
+appear only at seams, which exist in very few places — and with Part B dropped,
+**no timestamp is consulted anywhere in this design.**
 
-We do **not** make a timestamp gap the *definition* of a hole. Where a real query
-edge exists (Part A), we use it directly and never look at timestamps. Where the
-edge evidence is gone (Part B, legacy data), a timestamp gap only chooses *where
-to ask the server*; the server remains the sole authority on whether a hole is
-real.
+## Part A — record the seam at formation (pure query-edge)
 
-## Feasibility finding (drives the A/B split)
+Two reliable fetch-edge signals write a seam into the persisted
+`roomGaps`/`conversationGaps`:
 
-`roomStore`/`chatStore` use vanilla `createStore` — **no `persist()`/`partialize`**.
-`mamQueryStates` (holding `oldestFetchedId`, `forwardGapTimestamp`) is
-re-initialized to `new Map()` on every load; only `roomGaps` and friends persist
-via manual localStorage helpers. The backward-pagination cursor is derived from
-the **oldest resident message's** stanza-id, explicitly preferred over
-`mamState.oldestFetchedId` (`createFetchOlderHistory.ts`).
+1. **`complete=false` forward catch-up** — already implemented; unchanged
+   (regression coverage only).
 
-**Therefore no persisted structural marker of a region's edge exists.** A hole
-formed in a past session leaves only the timestamp discontinuity in the message
-data. Query-edge detection can cover holes formed *from now on* (edge known at
-fetch time, persisted at formation); already-formed holes can only be recovered
-via a server-confirmed probe.
+2. **Non-overlapping fetch-latest over held history — NEW.** Detected entirely
+   at merge time, where all evidence is in hand (existing messages, fetched
+   page, direction, dedupe result):
 
-## Part A — going-forward edge detection (pure query-edge)
+   > A backward `before:''` (fetch-latest) page that **does not overlap** any
+   > held message (no dedupe hit) and lands **entirely above** existing history
+   > creates a seam: `start` = newest pre-existing message's timestamp,
+   > `end` = oldest fetched message's timestamp.
 
-Record a seam into the persisted `roomGaps`/`conversationGaps` at the moments a
-hole is *created*, using only reliable fetch signals — no timestamps:
+   - Overlap (any dedupe hit) → proven connected → no seam.
+   - No pre-existing messages below → nothing to disconnect from → no seam.
+   - The `start`/`end` values are stored positions for the marker; the
+     *detection* uses only structural facts (direction, overlap, above/below
+     ordering), never a gap-size heuristic.
 
-1. **`complete=false` forward catch-up** — already implemented; keep as-is.
-2. **`before:''` fetch-latest over existing older history** — the exact path that
-   manufactures the reported hole. When `selectCatchUpQuery` resorts to
-   `{ before: '' }` (no cached cursor, no preview timestamp, no MDS pointer) yet
-   the conversation has older persisted history, the fetched recent page's lower
-   edge is a seam against that older history. After the merge, record it:
-   `start` = newest held message below the fetched page, `end` = oldest message
-   of the fetched page.
+   "Held history" must include IndexedDB-persisted messages, not just the
+   resident array — the formation case is precisely a run where the resident
+   cache is empty but the archive on disk is not. The merge path already loads
+   a cache slice for cursor computation (`loadMessagesFromCache(peek)` in
+   `catchUpRoom`); the implementation must ensure the seam check sees the
+   newest *persisted* message, not just RAM.
 
-Both are written at formation and persist, so the marker survives reload and the
-self-perpetuating cursor never has to "re-detect" anything.
+Recorded at formation, the seam persists (existing `roomGaps` localStorage
+path), survives reload, and positions the existing `HistoryGapMarker` with its
+"Load missing messages" button. No re-detection is ever needed.
 
-Note: with the existing fallback chain (`getRoomLastTimestamp`, MDS pointer),
-`before:''` is already rare — which is correct: seams are rare. Part A closes the
-residual window where a fetch-latest fires despite older data in IndexedDB.
+## Progressive closure (forward and backward)
 
-## Part B — legacy recovery (already-formed holes)
+A seam converges from both edges, riding pagination the user already does:
 
-For holes that predate this feature (the reported bug), no live query edge and no
-persisted edge exist. On conversation activation (chat **and** room), after the
-resident window hydrates:
-
-1. **Locate a candidate seam.** If no seam is already recorded for the
-   conversation, scan the hydrated window for the boundary between the recent
-   contiguous block and older history (the largest adjacent discontinuity). This
-   is a *candidate location only*, never a marker.
-2. **Confirm with the server.** Issue a bounded MAM query confined to the
-   interval, as a **forward** query so the existing gap-sync path positions the
-   seam:
-   `queryRoomArchive({ roomJid, start: olderTs+1ms, end: newerTs−1ms, max: MAM_CATCHUP_FORWARD_MAX })`
-   (1:1 mirror: `queryArchive({ with, start, end, max })`). `start`/`end` bounds
-   are already supported (precedent: MAM.ts jump-to-message uses `end`).
-3. **Act on the server's verdict** (via the existing merge):
-   - **empty + complete** → not a hole. Nothing recorded; no marker.
-   - **non-empty + complete** → small hole; merged messages heal it; no marker.
-   - **non-empty + `complete=false`** → real large hole; the merge records the
-     seam into `roomGaps` and positions the marker.
-4. **Session guard.** Record the probed candidate in an ephemeral session-scoped
-   set so reopening the same conversation in one session does not re-probe. Not
-   persisted; a genuinely-quiet legacy conversation costs one bounded probe per
-   session on first open — negligible and self-limiting as legacy data ages out.
-
-B never plants a marker on a timestamp gap alone — only the server's confirmation
-creates one.
-
-## Progressive verification (forward and backward)
-
-A large seam converges from both edges, riding the pagination the user already
-does:
-
-- **Forward** — the Part B probe, and thereafter `continueRoomCatchUp` ("Load
-  missing messages") / background catch-up. Each `complete=true` page proves its
-  span contiguous and moves the seam's lower edge **up** (existing path).
-- **Backward** — when the user scrolls up in the recent block, load-older pages
-  extend that region **down**; when a backward page overlaps into the older
-  region (dedupe overlap / crosses the seam), the ranges have met. **New wiring:**
-  extend the merge so a backward page that crosses/overlaps the seam also calls
-  `syncGap` to shrink or clear it (today gaps are forward-only driven).
-- Whichever edge reaches the other first closes the seam; `syncGap` deletes the
-  mark once resolved (existing behavior).
-
-## Persistence model
-
-- **Persist only hole marks** — the existing `roomGaps`/`conversationGaps`
-  `Map<jid, GapInterval>`, now written by both Part A (edge at formation) and Part
-  B (server-confirmed). **Deleted on resolution** by the existing `syncGap`.
-- **A contiguous probe persists nothing** — no marker created, nothing to delete.
-  No "verified-contiguous" watermark, no negative cache.
-- **Ephemeral in-session guard** for Part B probes; discarded on reload.
+- **Forward** — `continueRoomCatchUp` ("Load missing messages") / background
+  catch-up resumes from the seam boundary (existing: recorded gap wins the
+  cursor policy in `selectCatchUpQuery`). Each `complete=true` page moves the
+  seam's lower edge up; reaching held messages above clears it (existing
+  `syncGap` path).
+- **Backward — NEW WIRING.** When the user scrolls up in the recent block,
+  load-older pages extend that region down. A backward page that overlaps into
+  the region below the seam (dedupe hit / crosses the seam boundary) proves the
+  ranges connect: shrink or clear the seam via `syncGap`. Today gap sync is
+  forward-only; this extends the shared merge path so both directions maintain
+  the same invariant.
+- Whichever edge reaches the other first deletes the mark (existing `syncGap`
+  clear semantics). Persist only hole marks; nothing else. A healed seam leaves
+  no residue.
 
 ## Components
 
-### New (small, isolated)
-- **`packages/fluux-sdk/src/stores/shared/discontinuityScan.ts`** — pure,
-  chat/room shared: `findSeamCandidate(messages, { knownGap, probed }) → { start, end } | undefined`.
-  Returns the single recent/older discontinuity for Part B, or undefined.
-  Threshold `DISCONTINUITY_MIN_GAP_MS` (default `3_600_000`) bounds probe volume
-  only — correctness comes from the server. Fully unit-testable.
-- **Activation helper** (thin) — runs the scanner, fires the Part B probe via the
-  existing MAM methods, maintains the session probed-set. Shared, called from
-  both chat and room activation paths (`useChatActive`/`useRoomActive`).
+### Modified (no new modules expected)
 
-### Modified
-- **`selectCatchUpQuery` call sites (`catchUpRoom`/`catchUpConversation`)** — when
-  the result is `{ before: '' }` and older persisted history exists, record the
-  Part A seam after the merge.
-- **`mergeRoomMAMMessages`/`mergeMAMMessages`** — backward-direction seam closure
-  (the new wiring above), kept in the shared timeline/merge path for parity.
+- **Shared timeline/merge path** (`mergeRoomMAMMessages` / `mergeMAMMessages`
+  and the shared `timeline.mergeArchive` machinery):
+  - New formation check (signal 2) on backward `before:''` merges.
+  - New backward closure: seam shrink/clear when a backward page connects the
+    regions.
+  - Both changes live in the **shared** module so chat and room cannot drift
+    (per the chat/room twin rule).
+- **`mamGap.ts`** — possibly a small pure helper (e.g.
+  `reconcileGapAgainstMerge(gap, mergedPage, direction)`) so formation,
+  forward closure, and backward closure share one transition function.
 
 ### Reused unchanged
-`queryArchive`/`queryRoomArchive` (bounded `start`+`end`), the existing forward
-gap-sync path, `roomGaps`/`conversationGaps` + `GapInterval`, `computeGapEnd`/
-`syncGap`, `HistoryGapMarker`, `continueRoomCatchUp` + chat twin. **No new UI.**
+
+`queryArchive`/`queryRoomArchive`, `selectCatchUpQuery` (recorded gap already
+wins the cursor), `roomGaps`/`conversationGaps` + `GapInterval`,
+`computeGapEnd`/`syncGap` + persistence, `HistoryGapMarker`,
+`continueRoomCatchUp` + chat twin. **No new UI, no new persisted structures, no
+timestamps-as-signal.**
 
 ## Simplification pass (required after implementation)
 
-The net adds a second and third producer of gap marks (Part A edge, Part B
-probe) alongside `complete=false`. Before finishing, audit and fold genuine
-duplication:
-- Unify the gap-sync blocks in the room and chat merge functions into one shared
-  helper (they are near-twins).
-- Share a single "reconcile gap against merged timeline" function between the
-  forward and new backward closure paths.
-- Check whether the Part B session probed-set is subsumable by existing
-  `mamState` rather than a new structure.
+The change adds a second producer and a second consumer of gap marks. Before
+finishing, audit and fold genuine duplication:
 
-Report concrete findings; fold what genuinely duplicates.
+- Unify the near-twin gap-sync blocks in `mergeRoomMAMMessages` and
+  `mergeMAMMessages` into one shared helper.
+- Fold formation + forward closure + backward closure into a single
+  "reconcile gap against merged page" pure function in `mamGap.ts` if the three
+  transitions turn out to share shape.
+- Re-examine whether `computeGapEnd` and the new helper overlap.
+
+Report concrete findings; fold what genuinely duplicates, leave what doesn't.
 
 ## Testing
 
-### Pure scanner (`discontinuityScan.test.ts`)
-- No discontinuity → undefined; one → returned; recent/older seam chosen over an
-  ancient one; already covered by `knownGap` → undefined; already `probed` →
-  undefined; unsorted input & missing timestamps → robust.
-
-### Part A — edge at formation (SDK, mock client), chat **and** room
-- `before:''` fetch-latest with older persisted history → seam recorded in
-  `roomGaps`/`conversationGaps`, marker positioned.
-- `before:''` with **no** older history → no seam (correct: nothing below).
+### Formation (signal 2) — SDK, mock client, chat **and** room
+- `before:''` page, no overlap, older history held (in IndexedDB only — resident
+  empty) → seam recorded with correct `start`/`end`; marker positioned.
+- `before:''` page overlapping held messages (dedupe hit) → no seam.
+- `before:''` page with no pre-existing history → no seam.
 - `complete=false` forward path → unchanged (regression).
-
-### Part B — server-confirmed recovery (SDK, mock client), chat **and** room
-- Candidate → probe empty+complete → no gap; candidate marked probed.
-- Candidate → probe non-empty+complete → merged, no marker.
-- Candidate → probe non-empty+`complete=false` → seam recorded, marker positioned.
-- Session-dedupe → second activation issues no probe.
+- Force repair (`preserveGapMarker`) → still neither plants nor clears (regression).
 
 ### Progressive closure
-- Forward `continueRoomCatchUp` reaching the seam → mark cleared (existing path;
-  add coverage if absent).
-- **Backward** load-older page crossing the seam → mark shrinks then clears (new).
+- Forward catch-up from seam boundary: `complete=true` reaching held messages →
+  seam cleared; stopping short (`complete=false`) → seam shrunk (lower edge
+  moved up), not cleared.
+- **Backward** load-older page crossing/overlapping the seam → seam shrunk then
+  cleared (new path), persisted map updated, marker disappears.
+- Closure from both directions interleaved → converges, no resurrection of a
+  cleared seam.
+
+### Persistence
+- Seam recorded → survives store re-create (deserialize) → marker repositions.
+- Seam cleared → removed from localStorage (no residue).
 
 ### App / UI
-- Extend existing `HistoryGapMarker` render tests for the confirmed large-hole
-  path rather than duplicating.
+- Extend existing `HistoryGapMarker` render tests for the formation-recorded
+  seam (reuse, don't duplicate).
 
 ### Regression gates
-- `npm run test:scroll` — probe/merge into the **active** conversation must not
-  disturb scroll position.
-- SDK type change → `build:sdk` before app typecheck; new SDK export used by the
-  app → add to the app test mock.
+- Full SDK suite + `npm run test:scroll` (merges into the active conversation
+  must not disturb scroll).
+- `build:sdk` before app typecheck; new SDK export used by the app → add to the
+  app test mock.
 
-## Out of scope (v1)
+## Out of scope
 
-- Holes entirely outside the loaded resident window (deep history) — only the
-  seam in the hydrated window is scanned for Part B.
-- Scanning unopened conversations (activation-only).
-- Multiple simultaneous seams per conversation — v1 handles the single
-  recent/older seam; the `GapInterval` structure leaves room to extend.
-- Persisted negative ("verified-contiguous") cache — deliberately omitted.
-
-## Immediate user remedy (independent of this work)
-
-The existing **Rooms sidebar → "+" → "Catch up all rooms"**
-(`forceCatchUpAllRooms`, fixed 45-day window, `preserveGapMarker`) already
-backfills a hole within 45 days. This safety net makes recovery automatic and
-discoverable rather than manual.
+- **Part B (legacy recovery)** — dropped by decision; manual "Catch up all
+  rooms" is the remedy for pre-existing holes.
+- Multiple simultaneous seams per conversation — `GapInterval` holds one; the
+  structure leaves room to extend if ever needed.
+- Any timestamp-discontinuity scanning or probing.

--- a/docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md
+++ b/docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md
@@ -1,0 +1,200 @@
+# MAM Discontinuity Safety Net — Design
+
+**Date:** 2026-07-15
+**Status:** Approved (design), pending implementation plan
+**Scope:** `@fluux/sdk` (MAM catch-up / gap machinery) + minimal app wiring. Chat + room parity.
+
+## Problem
+
+Fluux records a history hole and shows the `HistoryGapMarker` ("Load missing
+messages") **only** when a forward MAM catch-up ends `complete=false` (the server
+said "there is more" and we stopped at the page cap). This is deliberate:
+`mamGap.ts` refuses to infer holes from timestamp discontinuities because a quiet
+period and a real gap look identical by timestamp, and ejabberd archive ids are
+non-sequential.
+
+That leaves a blind spot. A forward catch-up anchors its cursor on the **newest
+message that predates the session** (`findCatchUpCursorMessage`). If a hole
+already sits *below* that anchor — e.g. the client holds old history up to a
+date, plus a newer disjoint block fetched by a `before:''` fetch-latest, with
+nothing in between — every forward query starts *above* the hole, returns
+`complete=true`, and the hole is **never detected, never recorded, and never
+healed**. It survives restarts and upgrades because forward-only catch-up is
+structurally blind to a hole beneath its anchor, and there is no timestamp
+fallback.
+
+Observed in the field: a MUC room showing messages up to ~July 6 and then recent
+messages, with a multi-day hole between and no marker.
+
+## Design principle
+
+Holes can only exist at a **seam** between two separately-fetched regions. Seams
+are few — for v1, the single seam between the recent/live block and the older
+history beneath it. A marker can therefore only ever sit at a seam, never
+scattered across quiet stretches. This is what makes the feature
+false-positive-proof by construction.
+
+We do **not** reverse the "never guess from timestamps" rule. A timestamp gap is
+used only to decide **where to ask the server**; the server (via a bounded MAM
+query) remains the sole authority on whether a hole is real. Timestamps locate a
+*candidate* seam; MAM confirms it.
+
+## Signal flow
+
+On conversation activation (chat **and** room), after the resident window
+hydrates:
+
+1. **Detect the seam (pure, shared).** Scan the resident messages for the single
+   boundary between the recent contiguous block and the older history — the
+   largest adjacent gap `≥ DISCONTINUITY_MIN_GAP_MS` (default **1 hour**) not
+   already covered by a known `roomGaps`/`conversationGaps` entry and not already
+   probed this session. At most **one** candidate.
+
+2. **Eager bounded probe.** Issue a MAM query confined to the interval:
+   `queryRoomArchive({ roomJid, start: olderTs+1ms, end: newerTs−1ms, max: MAM_CATCHUP_FORWARD_MAX })`
+   (1:1 mirror: `queryArchive({ with, start, end, max })`), issued as a **forward**
+   query so the existing forward gap-sync path positions the seam. `start`/`end`
+   bounds are already supported (precedent: MAM.ts jump-to-message uses `end`).
+
+3. **Confirm via the existing merge.** Results flow through
+   `mergeRoomMAMMessages` / `mergeMAMMessages`, which already merge + dedupe and,
+   on `complete=false`, record `forwardGapTimestamp` → `roomGaps` → position the
+   `HistoryGapMarker`. Therefore:
+   - **Probe empty + complete** → not a hole. Nothing recorded; no marker.
+   - **Probe non-empty + complete** → small hole; merged messages heal it; no
+     marker.
+   - **Probe non-empty + `complete=false`** → large hole; the merge records the
+     seam and positions the marker automatically.
+
+4. **Record the probe in a session-scoped guard** (ephemeral) so reopening the
+   same conversation in one session does not re-probe the same seam. Not
+   persisted — see Persistence.
+
+## Progressive verification (forward and backward)
+
+A large seam is not closed by one giant fetch; it converges from both edges,
+riding the pagination the user already does.
+
+- **Forward** — the initial probe, and thereafter `continueRoomCatchUp` ("Load
+  missing messages") / background catch-up. Each `complete=true` page proves its
+  span contiguous and moves the seam's lower edge **up**. (Existing path.)
+- **Backward** — when the user scrolls up in the recent block, load-older pages
+  extend that region **down**. When a backward page overlaps into the older
+  region (dedupe overlap / crosses the seam boundary), the two regions have met.
+  (**New wiring** — see below.)
+- Whichever edge reaches the other first closes the seam; `syncGap` deletes the
+  mark once resolved (existing behavior).
+
+## Persistence model
+
+- **Persist only hole marks** — the existing `roomGaps` / `conversationGaps`
+  `Map<jid, GapInterval>`. Created when a probe (or `complete=false`) confirms a
+  seam; **deleted on resolution** by the existing `syncGap`. Survives reload so
+  the marker isn't silent again next session.
+- **A contiguous probe persists nothing** — it simply never creates a mark, so
+  there is nothing to delete. No "verified-contiguous" watermark, no negative
+  cache. Re-probing a genuinely quiet seam on a later session costs one bounded
+  MAM query — negligible because candidate detection is limited to one seam.
+- **Ephemeral in-session guard** — a session-scoped set of already-probed seams,
+  thrown away on reload.
+
+## Components
+
+### New (small, isolated)
+
+- **`packages/fluux-sdk/src/stores/shared/discontinuityScan.ts`** — pure,
+  chat/room shared:
+  ```
+  findSeamCandidate(
+    messages: Array<{ timestamp?: Date }>,
+    opts: { minGapMs: number; knownGap?: GapInterval; probed: (start: number, end: number) => boolean },
+  ): { start: number; end: number } | undefined
+  ```
+  Returns the single recent/older seam, or undefined. Fully unit-testable.
+
+- **Activation helper** (thin) — runs the scanner against the resident window,
+  fires the bounded probe via the existing MAM methods, and maintains the
+  session probed-set. Invoked from both the chat and room activation paths
+  (`useChatActive` / `useRoomActive`, where the resident window already
+  hydrates). Shared implementation, called from both twins.
+
+- **Constant** `DISCONTINUITY_MIN_GAP_MS` (default `3_600_000`).
+
+### Modified
+
+- **`mergeRoomMAMMessages` / `mergeMAMMessages`** — extend the gap-sync block so
+  a **backward** page that crosses/overlaps the seam also calls `syncGap` to
+  shrink or clear the interval. Forward already shrinks it. Keep this change in
+  the shared timeline/merge path so chat and room stay in parity.
+
+### Reused unchanged
+
+`queryArchive` / `queryRoomArchive` (bounded `start`+`end`), both merge
+functions' existing forward path, `roomGaps` / `conversationGaps` + `GapInterval`
+(the seam), `computeGapEnd` / `syncGap`, `HistoryGapMarker`,
+`continueRoomCatchUp` + chat twin. **No new UI.**
+
+## Simplification pass (required after implementation)
+
+The net makes the safety net a *second* producer of gap marks (alongside the
+`complete=false` path). Before finishing, audit and fold genuine duplication:
+
+- Can the gap-sync blocks in the room and chat merge functions be unified into
+  one shared helper (they should already be near-twins)?
+- Does the new backward-closure logic overlap the existing forward
+  `computeGapEnd`/`syncGap` enough to share a single "reconcile gap against
+  merged timeline" function usable by both directions?
+- Is the session probed-set subsumable by existing `mamState` rather than a new
+  structure?
+
+Report concrete findings; fold what genuinely duplicates, leave what doesn't.
+
+## Testing
+
+### Pure scanner (`discontinuityScan.test.ts`)
+- No gap → undefined.
+- One seam above threshold → returned.
+- Sub-threshold gap → undefined.
+- Multiple gaps → the recent/older seam selected (not an ancient one).
+- Seam already covered by `knownGap` → undefined.
+- Seam already in `probed` → undefined.
+- Unsorted input; messages with missing timestamps → robust.
+
+### Probe → merge integration (SDK, mock client) — chat **and** room
+- Candidate → probe empty + complete → no gap recorded; seam marked probed.
+- Candidate → probe non-empty + complete → merged; no marker.
+- Candidate → probe non-empty + `complete=false` → `forwardGapTimestamp` /
+  `roomGaps` set; marker positioned at the seam.
+- Session-dedupe → second activation issues no probe.
+
+### Progressive closure
+- Forward `continueRoomCatchUp` reaching the seam → `syncGap` clears the mark
+  (existing path; add a covering test if absent).
+- **Backward** load-older page crossing the seam → mark shrinks then clears
+  (new path).
+
+### App / UI
+- Extend existing `HistoryGapMarker` render tests for the probe-confirmed
+  large-hole path rather than duplicating.
+
+### Regression gates
+- `npm run test:scroll` — probe results merged into the **active** conversation
+  must not disturb scroll position.
+- SDK type change → `build:sdk` before app typecheck. New SDK export used by the
+  app → add to the app test mock.
+
+## Out of scope (v1)
+
+- Holes entirely outside the loaded resident window (deep history) — only the
+  seam visible in the hydrated window is scanned.
+- Scanning unopened conversations (activation-only).
+- Multiple simultaneous seams per conversation — v1 handles the single
+  recent/older seam; the interval structure leaves room to extend later.
+- Persisted negative ("verified-contiguous") cache — deliberately omitted.
+
+## Immediate user remedy (independent of this work)
+
+The existing **Rooms sidebar → "+" → "Catch up all rooms"**
+(`forceCatchUpAllRooms`, fixed 45-day window, `preserveGapMarker`) already
+backfills a hole within 45 days. This safety net makes recovery automatic and
+discoverable rather than manual.

--- a/docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md
+++ b/docs/superpowers/specs/2026-07-15-mam-discontinuity-safety-net-design.md
@@ -1,195 +1,211 @@
 # MAM Discontinuity Safety Net — Design
 
 **Date:** 2026-07-15
-**Status:** Approved (design), pending implementation plan
+**Status:** Approved-in-principle (A + B), pending spec review → implementation plan
 **Scope:** `@fluux/sdk` (MAM catch-up / gap machinery) + minimal app wiring. Chat + room parity.
 
 ## Problem
 
 Fluux records a history hole and shows the `HistoryGapMarker` ("Load missing
-messages") **only** when a forward MAM catch-up ends `complete=false` (the server
-said "there is more" and we stopped at the page cap). This is deliberate:
-`mamGap.ts` refuses to infer holes from timestamp discontinuities because a quiet
-period and a real gap look identical by timestamp, and ejabberd archive ids are
-non-sequential.
+messages") **only** when a forward MAM catch-up ends `complete=false`. This is
+deliberate: `mamGap.ts` refuses to infer holes from timestamp discontinuities
+because a quiet period and a real gap look identical by timestamp, and ejabberd
+archive ids are non-sequential.
 
 That leaves a blind spot. A forward catch-up anchors its cursor on the **newest
 message that predates the session** (`findCatchUpCursorMessage`). If a hole
-already sits *below* that anchor — e.g. the client holds old history up to a
-date, plus a newer disjoint block fetched by a `before:''` fetch-latest, with
-nothing in between — every forward query starts *above* the hole, returns
-`complete=true`, and the hole is **never detected, never recorded, and never
-healed**. It survives restarts and upgrades because forward-only catch-up is
-structurally blind to a hole beneath its anchor, and there is no timestamp
-fallback.
+already sits *below* that anchor — old history up to a date, plus a newer disjoint
+block, with nothing between — every forward query starts *above* the hole,
+returns `complete=true`, and the hole is **never detected, never recorded, never
+healed**. It survives restarts and upgrades and is self-perpetuating: once the
+recent block exists, the cursor sits above the hole forever.
 
 Observed in the field: a MUC room showing messages up to ~July 6 and then recent
 messages, with a multi-day hole between and no marker.
 
-## Design principle
+## Core principle: a seam is an un-connected MAM query edge
 
-Holes can only exist at a **seam** between two separately-fetched regions. Seams
-are few — for v1, the single seam between the recent/live block and the older
-history beneath it. A marker can therefore only ever sit at a seam, never
-scattered across quiet stretches. This is what makes the feature
-false-positive-proof by construction.
+A hole can only exist where **one MAM query's result stops and a different
+query's result begins without proof they connect** — a *seam*. It is a property
+of the *fetches*, not of the message timeline. A large timestamp gap *inside* a
+single contiguously-fetched range is a quiet period, not a hole. A marker may
+therefore appear only at a seam, which exists in very few places.
 
-We do **not** reverse the "never guess from timestamps" rule. A timestamp gap is
-used only to decide **where to ask the server**; the server (via a bounded MAM
-query) remains the sole authority on whether a hole is real. Timestamps locate a
-*candidate* seam; MAM confirms it.
+We do **not** make a timestamp gap the *definition* of a hole. Where a real query
+edge exists (Part A), we use it directly and never look at timestamps. Where the
+edge evidence is gone (Part B, legacy data), a timestamp gap only chooses *where
+to ask the server*; the server remains the sole authority on whether a hole is
+real.
 
-## Signal flow
+## Feasibility finding (drives the A/B split)
 
-On conversation activation (chat **and** room), after the resident window
-hydrates:
+`roomStore`/`chatStore` use vanilla `createStore` — **no `persist()`/`partialize`**.
+`mamQueryStates` (holding `oldestFetchedId`, `forwardGapTimestamp`) is
+re-initialized to `new Map()` on every load; only `roomGaps` and friends persist
+via manual localStorage helpers. The backward-pagination cursor is derived from
+the **oldest resident message's** stanza-id, explicitly preferred over
+`mamState.oldestFetchedId` (`createFetchOlderHistory.ts`).
 
-1. **Detect the seam (pure, shared).** Scan the resident messages for the single
-   boundary between the recent contiguous block and the older history — the
-   largest adjacent gap `≥ DISCONTINUITY_MIN_GAP_MS` (default **1 hour**) not
-   already covered by a known `roomGaps`/`conversationGaps` entry and not already
-   probed this session. At most **one** candidate.
+**Therefore no persisted structural marker of a region's edge exists.** A hole
+formed in a past session leaves only the timestamp discontinuity in the message
+data. Query-edge detection can cover holes formed *from now on* (edge known at
+fetch time, persisted at formation); already-formed holes can only be recovered
+via a server-confirmed probe.
 
-2. **Eager bounded probe.** Issue a MAM query confined to the interval:
+## Part A — going-forward edge detection (pure query-edge)
+
+Record a seam into the persisted `roomGaps`/`conversationGaps` at the moments a
+hole is *created*, using only reliable fetch signals — no timestamps:
+
+1. **`complete=false` forward catch-up** — already implemented; keep as-is.
+2. **`before:''` fetch-latest over existing older history** — the exact path that
+   manufactures the reported hole. When `selectCatchUpQuery` resorts to
+   `{ before: '' }` (no cached cursor, no preview timestamp, no MDS pointer) yet
+   the conversation has older persisted history, the fetched recent page's lower
+   edge is a seam against that older history. After the merge, record it:
+   `start` = newest held message below the fetched page, `end` = oldest message
+   of the fetched page.
+
+Both are written at formation and persist, so the marker survives reload and the
+self-perpetuating cursor never has to "re-detect" anything.
+
+Note: with the existing fallback chain (`getRoomLastTimestamp`, MDS pointer),
+`before:''` is already rare — which is correct: seams are rare. Part A closes the
+residual window where a fetch-latest fires despite older data in IndexedDB.
+
+## Part B — legacy recovery (already-formed holes)
+
+For holes that predate this feature (the reported bug), no live query edge and no
+persisted edge exist. On conversation activation (chat **and** room), after the
+resident window hydrates:
+
+1. **Locate a candidate seam.** If no seam is already recorded for the
+   conversation, scan the hydrated window for the boundary between the recent
+   contiguous block and older history (the largest adjacent discontinuity). This
+   is a *candidate location only*, never a marker.
+2. **Confirm with the server.** Issue a bounded MAM query confined to the
+   interval, as a **forward** query so the existing gap-sync path positions the
+   seam:
    `queryRoomArchive({ roomJid, start: olderTs+1ms, end: newerTs−1ms, max: MAM_CATCHUP_FORWARD_MAX })`
-   (1:1 mirror: `queryArchive({ with, start, end, max })`), issued as a **forward**
-   query so the existing forward gap-sync path positions the seam. `start`/`end`
-   bounds are already supported (precedent: MAM.ts jump-to-message uses `end`).
+   (1:1 mirror: `queryArchive({ with, start, end, max })`). `start`/`end` bounds
+   are already supported (precedent: MAM.ts jump-to-message uses `end`).
+3. **Act on the server's verdict** (via the existing merge):
+   - **empty + complete** → not a hole. Nothing recorded; no marker.
+   - **non-empty + complete** → small hole; merged messages heal it; no marker.
+   - **non-empty + `complete=false`** → real large hole; the merge records the
+     seam into `roomGaps` and positions the marker.
+4. **Session guard.** Record the probed candidate in an ephemeral session-scoped
+   set so reopening the same conversation in one session does not re-probe. Not
+   persisted; a genuinely-quiet legacy conversation costs one bounded probe per
+   session on first open — negligible and self-limiting as legacy data ages out.
 
-3. **Confirm via the existing merge.** Results flow through
-   `mergeRoomMAMMessages` / `mergeMAMMessages`, which already merge + dedupe and,
-   on `complete=false`, record `forwardGapTimestamp` → `roomGaps` → position the
-   `HistoryGapMarker`. Therefore:
-   - **Probe empty + complete** → not a hole. Nothing recorded; no marker.
-   - **Probe non-empty + complete** → small hole; merged messages heal it; no
-     marker.
-   - **Probe non-empty + `complete=false`** → large hole; the merge records the
-     seam and positions the marker automatically.
-
-4. **Record the probe in a session-scoped guard** (ephemeral) so reopening the
-   same conversation in one session does not re-probe the same seam. Not
-   persisted — see Persistence.
+B never plants a marker on a timestamp gap alone — only the server's confirmation
+creates one.
 
 ## Progressive verification (forward and backward)
 
-A large seam is not closed by one giant fetch; it converges from both edges,
-riding the pagination the user already does.
+A large seam converges from both edges, riding the pagination the user already
+does:
 
-- **Forward** — the initial probe, and thereafter `continueRoomCatchUp` ("Load
+- **Forward** — the Part B probe, and thereafter `continueRoomCatchUp` ("Load
   missing messages") / background catch-up. Each `complete=true` page proves its
-  span contiguous and moves the seam's lower edge **up**. (Existing path.)
+  span contiguous and moves the seam's lower edge **up** (existing path).
 - **Backward** — when the user scrolls up in the recent block, load-older pages
-  extend that region **down**. When a backward page overlaps into the older
-  region (dedupe overlap / crosses the seam boundary), the two regions have met.
-  (**New wiring** — see below.)
+  extend that region **down**; when a backward page overlaps into the older
+  region (dedupe overlap / crosses the seam), the ranges have met. **New wiring:**
+  extend the merge so a backward page that crosses/overlaps the seam also calls
+  `syncGap` to shrink or clear it (today gaps are forward-only driven).
 - Whichever edge reaches the other first closes the seam; `syncGap` deletes the
   mark once resolved (existing behavior).
 
 ## Persistence model
 
-- **Persist only hole marks** — the existing `roomGaps` / `conversationGaps`
-  `Map<jid, GapInterval>`. Created when a probe (or `complete=false`) confirms a
-  seam; **deleted on resolution** by the existing `syncGap`. Survives reload so
-  the marker isn't silent again next session.
-- **A contiguous probe persists nothing** — it simply never creates a mark, so
-  there is nothing to delete. No "verified-contiguous" watermark, no negative
-  cache. Re-probing a genuinely quiet seam on a later session costs one bounded
-  MAM query — negligible because candidate detection is limited to one seam.
-- **Ephemeral in-session guard** — a session-scoped set of already-probed seams,
-  thrown away on reload.
+- **Persist only hole marks** — the existing `roomGaps`/`conversationGaps`
+  `Map<jid, GapInterval>`, now written by both Part A (edge at formation) and Part
+  B (server-confirmed). **Deleted on resolution** by the existing `syncGap`.
+- **A contiguous probe persists nothing** — no marker created, nothing to delete.
+  No "verified-contiguous" watermark, no negative cache.
+- **Ephemeral in-session guard** for Part B probes; discarded on reload.
 
 ## Components
 
 ### New (small, isolated)
-
 - **`packages/fluux-sdk/src/stores/shared/discontinuityScan.ts`** — pure,
-  chat/room shared:
-  ```
-  findSeamCandidate(
-    messages: Array<{ timestamp?: Date }>,
-    opts: { minGapMs: number; knownGap?: GapInterval; probed: (start: number, end: number) => boolean },
-  ): { start: number; end: number } | undefined
-  ```
-  Returns the single recent/older seam, or undefined. Fully unit-testable.
-
-- **Activation helper** (thin) — runs the scanner against the resident window,
-  fires the bounded probe via the existing MAM methods, and maintains the
-  session probed-set. Invoked from both the chat and room activation paths
-  (`useChatActive` / `useRoomActive`, where the resident window already
-  hydrates). Shared implementation, called from both twins.
-
-- **Constant** `DISCONTINUITY_MIN_GAP_MS` (default `3_600_000`).
+  chat/room shared: `findSeamCandidate(messages, { knownGap, probed }) → { start, end } | undefined`.
+  Returns the single recent/older discontinuity for Part B, or undefined.
+  Threshold `DISCONTINUITY_MIN_GAP_MS` (default `3_600_000`) bounds probe volume
+  only — correctness comes from the server. Fully unit-testable.
+- **Activation helper** (thin) — runs the scanner, fires the Part B probe via the
+  existing MAM methods, maintains the session probed-set. Shared, called from
+  both chat and room activation paths (`useChatActive`/`useRoomActive`).
 
 ### Modified
-
-- **`mergeRoomMAMMessages` / `mergeMAMMessages`** — extend the gap-sync block so
-  a **backward** page that crosses/overlaps the seam also calls `syncGap` to
-  shrink or clear the interval. Forward already shrinks it. Keep this change in
-  the shared timeline/merge path so chat and room stay in parity.
+- **`selectCatchUpQuery` call sites (`catchUpRoom`/`catchUpConversation`)** — when
+  the result is `{ before: '' }` and older persisted history exists, record the
+  Part A seam after the merge.
+- **`mergeRoomMAMMessages`/`mergeMAMMessages`** — backward-direction seam closure
+  (the new wiring above), kept in the shared timeline/merge path for parity.
 
 ### Reused unchanged
-
-`queryArchive` / `queryRoomArchive` (bounded `start`+`end`), both merge
-functions' existing forward path, `roomGaps` / `conversationGaps` + `GapInterval`
-(the seam), `computeGapEnd` / `syncGap`, `HistoryGapMarker`,
-`continueRoomCatchUp` + chat twin. **No new UI.**
+`queryArchive`/`queryRoomArchive` (bounded `start`+`end`), the existing forward
+gap-sync path, `roomGaps`/`conversationGaps` + `GapInterval`, `computeGapEnd`/
+`syncGap`, `HistoryGapMarker`, `continueRoomCatchUp` + chat twin. **No new UI.**
 
 ## Simplification pass (required after implementation)
 
-The net makes the safety net a *second* producer of gap marks (alongside the
-`complete=false` path). Before finishing, audit and fold genuine duplication:
+The net adds a second and third producer of gap marks (Part A edge, Part B
+probe) alongside `complete=false`. Before finishing, audit and fold genuine
+duplication:
+- Unify the gap-sync blocks in the room and chat merge functions into one shared
+  helper (they are near-twins).
+- Share a single "reconcile gap against merged timeline" function between the
+  forward and new backward closure paths.
+- Check whether the Part B session probed-set is subsumable by existing
+  `mamState` rather than a new structure.
 
-- Can the gap-sync blocks in the room and chat merge functions be unified into
-  one shared helper (they should already be near-twins)?
-- Does the new backward-closure logic overlap the existing forward
-  `computeGapEnd`/`syncGap` enough to share a single "reconcile gap against
-  merged timeline" function usable by both directions?
-- Is the session probed-set subsumable by existing `mamState` rather than a new
-  structure?
-
-Report concrete findings; fold what genuinely duplicates, leave what doesn't.
+Report concrete findings; fold what genuinely duplicates.
 
 ## Testing
 
 ### Pure scanner (`discontinuityScan.test.ts`)
-- No gap → undefined.
-- One seam above threshold → returned.
-- Sub-threshold gap → undefined.
-- Multiple gaps → the recent/older seam selected (not an ancient one).
-- Seam already covered by `knownGap` → undefined.
-- Seam already in `probed` → undefined.
-- Unsorted input; messages with missing timestamps → robust.
+- No discontinuity → undefined; one → returned; recent/older seam chosen over an
+  ancient one; already covered by `knownGap` → undefined; already `probed` →
+  undefined; unsorted input & missing timestamps → robust.
 
-### Probe → merge integration (SDK, mock client) — chat **and** room
-- Candidate → probe empty + complete → no gap recorded; seam marked probed.
-- Candidate → probe non-empty + complete → merged; no marker.
-- Candidate → probe non-empty + `complete=false` → `forwardGapTimestamp` /
-  `roomGaps` set; marker positioned at the seam.
+### Part A — edge at formation (SDK, mock client), chat **and** room
+- `before:''` fetch-latest with older persisted history → seam recorded in
+  `roomGaps`/`conversationGaps`, marker positioned.
+- `before:''` with **no** older history → no seam (correct: nothing below).
+- `complete=false` forward path → unchanged (regression).
+
+### Part B — server-confirmed recovery (SDK, mock client), chat **and** room
+- Candidate → probe empty+complete → no gap; candidate marked probed.
+- Candidate → probe non-empty+complete → merged, no marker.
+- Candidate → probe non-empty+`complete=false` → seam recorded, marker positioned.
 - Session-dedupe → second activation issues no probe.
 
 ### Progressive closure
-- Forward `continueRoomCatchUp` reaching the seam → `syncGap` clears the mark
-  (existing path; add a covering test if absent).
-- **Backward** load-older page crossing the seam → mark shrinks then clears
-  (new path).
+- Forward `continueRoomCatchUp` reaching the seam → mark cleared (existing path;
+  add coverage if absent).
+- **Backward** load-older page crossing the seam → mark shrinks then clears (new).
 
 ### App / UI
-- Extend existing `HistoryGapMarker` render tests for the probe-confirmed
-  large-hole path rather than duplicating.
+- Extend existing `HistoryGapMarker` render tests for the confirmed large-hole
+  path rather than duplicating.
 
 ### Regression gates
-- `npm run test:scroll` — probe results merged into the **active** conversation
-  must not disturb scroll position.
-- SDK type change → `build:sdk` before app typecheck. New SDK export used by the
+- `npm run test:scroll` — probe/merge into the **active** conversation must not
+  disturb scroll position.
+- SDK type change → `build:sdk` before app typecheck; new SDK export used by the
   app → add to the app test mock.
 
 ## Out of scope (v1)
 
 - Holes entirely outside the loaded resident window (deep history) — only the
-  seam visible in the hydrated window is scanned.
+  seam in the hydrated window is scanned for Part B.
 - Scanning unopened conversations (activation-only).
 - Multiple simultaneous seams per conversation — v1 handles the single
-  recent/older seam; the interval structure leaves room to extend later.
+  recent/older seam; the `GapInterval` structure leaves room to extend.
 - Persisted negative ("verified-contiguous") cache — deliberately omitted.
 
 ## Immediate user remedy (independent of this work)

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -266,9 +266,9 @@ export function createStoreBindings(
     stores.chat.setMAMError(conversationId, error)
   })
 
-  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest }) => {
+  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker }) => {
     const stores = getStores()
-    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest)
+    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker)
   })
 
   // ============================================================================

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -421,9 +421,9 @@ export function createStoreBindings(
     stores.room.setRoomMAMError(roomJid, error)
   })
 
-  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker }) => {
+  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest }) => {
     const stores = getStores()
-    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker)
+    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest)
   })
 
   on('room:members', ({ roomJid, members }) => {

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -266,9 +266,9 @@ export function createStoreBindings(
     stores.chat.setMAMError(conversationId, error)
   })
 
-  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction }) => {
+  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest }) => {
     const stores = getStores()
-    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction)
+    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest)
   })
 
   // ============================================================================

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -2911,7 +2911,8 @@ describe('XMPPClient MAM', () => {
         messages: expect.any(Array),
         rsm: expect.objectContaining({ first: 'first-id', last: 'last-id' }),
         complete: true,
-        direction: 'backward'
+        direction: 'backward',
+        isFetchLatest: true // no before, no start = fetch-latest
       })
     })
 
@@ -3030,7 +3031,8 @@ describe('XMPPClient MAM', () => {
         messages: expect.any(Array),
         rsm: expect.any(Object),
         complete: true, // complete from server
-        direction: 'forward' // direction - store will only set isCaughtUpToLive, not isHistoryComplete
+        direction: 'forward', // direction - store will only set isCaughtUpToLive, not isHistoryComplete
+        isFetchLatest: false // forward query, never a fetch-latest
       })
     })
 
@@ -3081,7 +3083,8 @@ describe('XMPPClient MAM', () => {
         messages: expect.any(Array),
         rsm: expect.any(Object),
         complete: true, // complete from server
-        direction: 'backward' // direction - store will set isHistoryComplete
+        direction: 'backward', // direction - store will set isHistoryComplete
+        isFetchLatest: false // real pagination cursor ('some-stanza-id'), not a fetch-latest
       })
     })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -401,7 +401,8 @@ describe('XMPPClient MAM', () => {
         messages: expect.any(Array),
         rsm: expect.any(Object),
         complete: true,
-        direction: 'backward'
+        direction: 'backward',
+        isFetchLatest: true
       })
     })
 
@@ -2511,7 +2512,8 @@ describe('XMPPClient MAM', () => {
         messages: expect.any(Array),
         rsm: expect.any(Object),
         complete: true, // complete from server
-        direction: 'forward' // direction - store will only set isCaughtUpToLive, not isHistoryComplete
+        direction: 'forward', // direction - store will only set isCaughtUpToLive, not isHistoryComplete
+        isFetchLatest: false // forward queries are never fetch-latest candidates
       })
     })
 
@@ -2547,7 +2549,8 @@ describe('XMPPClient MAM', () => {
         messages: expect.any(Array),
         rsm: expect.any(Object),
         complete: true, // complete from server
-        direction: 'backward' // direction - store will set isHistoryComplete
+        direction: 'backward', // direction - store will set isHistoryComplete
+        isFetchLatest: true // before:'' fetch-latest candidate
       })
     })
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -495,6 +495,7 @@ export class MAM extends BaseModule {
             complete,
             direction,
             preserveGapMarker,
+            isFetchLatest: !isForward && !before,
           })
 
           allMessages.push(...collectedMessages)

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -342,6 +342,7 @@ export class MAM extends BaseModule {
         rsm: lastRsm,
         complete: isComplete,
         direction,
+        isFetchLatest: direction === 'backward' && !before,
       })
 
       // Modifications whose target is not in this batch belong to a message

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -174,7 +174,7 @@ export class MAM extends BaseModule {
    * @returns Query result with messages, completion status, and pagination info
    */
   async queryArchive(options: MAMQueryOptions): Promise<MAMResult> {
-    const { with: withJid, max = 50, before = '', start, end, after, maxAutoPages: maxAutoPagesOpt } = options
+    const { with: withJid, max = 50, before = '', start, end, after, preserveGapMarker, maxAutoPages: maxAutoPagesOpt } = options
     const conversationId = getBareJid(withJid)
     const mamStart = Date.now()
 
@@ -268,7 +268,7 @@ export class MAM extends BaseModule {
               // The archive no longer holds the after-anchor (expired/purged):
               // degrade to fetch-latest (spec §5 — degrade gracefully, never error).
               logInfo(`MAM after-cursor purged for ...@${getDomain(conversationId) || '*'} — degrading to fetch-latest`)
-              return this.queryArchive({ with: withJid, max, before: '' })
+              return this.queryArchive({ with: withJid, max, before: '', preserveGapMarker })
             }
             throw iqError
           }
@@ -342,6 +342,7 @@ export class MAM extends BaseModule {
         rsm: lastRsm,
         complete: isComplete,
         direction,
+        preserveGapMarker,
         isFetchLatest: direction === 'backward' && !before,
       })
 
@@ -779,11 +780,15 @@ export class MAM extends BaseModule {
     // Fetch messages before and after the target timestamp
     const oneHourBefore = new Date(new Date(targetTimestamp).getTime() - 3600000).toISOString()
 
+    // Bounded windowed forward query: its `complete` says nothing about
+    // contiguity outside the [oneHourBefore, ...] window, so it must not
+    // clear (or plant) a recorded gap — `preserveGapMarker` leaves it alone.
     if (isRoom) {
       const result = await this.queryRoomArchive({
         roomJid: conversationId,
         max: contextSize * 2,
         start: oneHourBefore,
+        preserveGapMarker: true,
       })
       return { messages: result.messages }
     } else {
@@ -792,6 +797,7 @@ export class MAM extends BaseModule {
         max: contextSize * 2,
         start: oneHourBefore,
         end: new Date(new Date(targetTimestamp).getTime() + 3600000).toISOString(),
+        preserveGapMarker: true,
       })
       return { messages: result.messages }
     }

--- a/packages/fluux-sdk/src/core/types/pagination.ts
+++ b/packages/fluux-sdk/src/core/types/pagination.ts
@@ -68,6 +68,13 @@ export interface MAMQueryOptions {
    * existing single-page behavior.
    */
   maxAutoPages?: number
+  /**
+   * When true, the resulting merge leaves the forward gap marker untouched.
+   * Used by bounded "force repair"/windowed context queries so a windowed
+   * completion can't hide a real gap older than the window (nor plant a
+   * spurious one inside it).
+   */
+  preserveGapMarker?: boolean
 }
 
 /**

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -199,6 +199,8 @@ export interface ChatEvents {
     rsm: RSMResponse
     complete: boolean
     direction: MAMQueryDirection
+    /** The query was a `before:''` fetch-latest (seam formation candidate). */
+    isFetchLatest?: boolean
   }
 
   /**

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -396,6 +396,8 @@ export interface RoomEvents {
     direction: MAMQueryDirection
     /** When true, leave the gap marker untouched (bounded force-repair queries). */
     preserveGapMarker?: boolean
+    /** The query was a `before:''` fetch-latest (seam formation candidate). */
+    isFetchLatest?: boolean
   }
 
   /** Room member affiliations discovered (XEP-0045 admin query) */

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -199,6 +199,8 @@ export interface ChatEvents {
     rsm: RSMResponse
     complete: boolean
     direction: MAMQueryDirection
+    /** When true, leave the gap marker untouched (bounded windowed context queries). */
+    preserveGapMarker?: boolean
     /** The query was a `before:''` fetch-latest (seam formation candidate). */
     isFetchLatest?: boolean
   }

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -259,6 +259,16 @@ describe('chatStore', () => {
       chatStore.getState().mergeMAMMessages(cid, [ancient], {}, true, 'backward')
       expect(chatStore.getState().conversationGaps.get(cid)).toEqual(gap)
     })
+
+    it('preserveGapMarker leaves an existing conversation gap untouched on a forward complete=true merge', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState({ conversationGaps: new Map([[cid, { start: 1000, end: 5000 }]]) })
+
+      // A bounded windowed context fetch completes within its window — must not clear an older gap.
+      chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward', false, true)
+
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual({ start: 1000, end: 5000 })
+    })
   })
 
   describe('addConversation', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -196,6 +196,69 @@ describe('chatStore', () => {
       // Never the bare (unscoped) key.
       expect(localStorageMock._store['xmpp-chat-storage']).toBeUndefined()
     })
+
+    it('plants a seam when a fetch-latest page lands disjoint above held history (parity with rooms)', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const held = { ...createMessage(cid, 'held'), id: 'held', timestamp: new Date('2026-07-06T00:00:00Z') }
+      chatStore.getState().addMessage(held)
+
+      const fetched = { ...createMessage(cid, 'fresh'), id: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [fetched], {}, true, 'backward', true)
+
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-15T00:00:00Z').getTime(),
+      })
+    })
+
+    it('does NOT plant a seam on dedupe overlap or plain backward pagination', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const held = { ...createMessage(cid, 'shared'), id: 'shared', timestamp: new Date('2026-07-14T00:00:00Z') }
+      chatStore.getState().addMessage(held)
+
+      // Overlapping fetch-latest: dedupe hit → connected.
+      const fresh = { ...createMessage(cid, 'fresh'), id: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [{ ...held }, fresh], {}, true, 'backward', true)
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+
+      // Plain pagination (isFetchLatest omitted): never a formation candidate.
+      const older = { ...createMessage(cid, 'older'), id: 'older', timestamp: new Date('2026-07-01T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [older], {}, false, 'backward')
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+    })
+
+    it('backward closure: scroll-up pages shrink then clear a recorded gap', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState({ conversationGaps: new Map([[cid, {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }]]) })
+
+      const mid = { ...createMessage(cid, 'mid'), id: 'mid', timestamp: new Date('2026-07-10T00:00:00Z') }
+      const upper = { ...createMessage(cid, 'upper'), id: 'upper', timestamp: new Date('2026-07-14T06:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [mid, upper], {}, false, 'backward')
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-10T00:00:00Z').getTime(),
+      })
+
+      const below = { ...createMessage(cid, 'below'), id: 'below', timestamp: new Date('2026-07-05T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [below, { ...mid }], {}, false, 'backward')
+      expect(chatStore.getState().conversationGaps.has(cid)).toBe(false)
+    })
+
+    it('backward closure: an older-region page below the gap leaves it untouched', () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      const gap = {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }
+      chatStore.setState({ conversationGaps: new Map([[cid, gap]]) })
+
+      const ancient = { ...createMessage(cid, 'ancient'), id: 'ancient', timestamp: new Date('2026-07-01T00:00:00Z') }
+      chatStore.getState().mergeMAMMessages(cid, [ancient], {}, true, 'backward')
+      expect(chatStore.getState().conversationGaps.get(cid)).toEqual(gap)
+    })
   })
 
   describe('addConversation', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -9,7 +9,7 @@ import * as messageCache from '../utils/messageCache'
 import * as searchIndex from '../utils/searchIndex'
 import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
-import { computeGapEnd, syncGap, type GapInterval } from './shared/mamGap'
+import { syncGapAfterArchiveMerge, messagePageExtent, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
@@ -297,7 +297,7 @@ interface ChatState {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection) => void
+  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean) => void
   getMAMQueryState: (conversationId: string) => MAMQueryState
   resetMAMStates: () => void
   /** Mark all conversations as needing a catch-up MAM query (called on reconnect) */
@@ -1596,7 +1596,10 @@ export const chatStore = createStore<ChatState>()(
         }))
       },
 
-      mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction) => {
+      mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction, isFetchLatest = false) => {
+        // Newest persisted timestamp (entity preview) — the seam-formation fallback
+        // when the resident array is empty this run (fresh session, history on disk).
+        const fallbackHeldTs = get().getConversationLastTimestamp(conversationId)
         // Captured from inside set() so the post-set MDS marker resolution can read the
         // merged array even for a non-active conversation (whose array isn't in RAM).
         let mergedForMarker: Message[] = []
@@ -1636,16 +1639,23 @@ export const chatStore = createStore<ChatState>()(
             newestFetchedTimestamp
           )
 
-          // Mirror the forward gap into the PERSISTED conversationGaps (account-scoped
-          // via the chat storage blob) so the marker survives a reload. Forward
-          // complete=false sets it, complete=true clears it; backward leaves it.
-          // `end` = oldest message held above the gap.
-          let newGaps = state.conversationGaps
-          if (direction === 'forward') {
-            const gapStart = newStates.get(conversationId)?.forwardGapTimestamp
-            const gapEnd = gapStart !== undefined ? computeGapEnd(trimmed, gapStart) : undefined
-            newGaps = syncGap(state.conversationGaps, conversationId, gapStart, gapEnd)
-          }
+          // Persisted gap sync (shared transition, both directions) — see
+          // syncGapAfterArchiveMerge. Chat has no bounded force-repair, so
+          // preserveGapMarker is always false.
+          const newGaps = syncGapAfterArchiveMerge({
+            gaps: state.conversationGaps,
+            id: conversationId,
+            direction,
+            complete,
+            forwardGapTimestamp: newStates.get(conversationId)?.forwardGapTimestamp,
+            merged: trimmed,
+            fetched: mamMessages,
+            newMessagesCount: newMessages.length,
+            patchedCount: patched.length,
+            isFetchLatest,
+            newestHeldBelowTs: messagePageExtent(rawExisting).newestTs ?? fallbackHeldTs,
+            preserveGapMarker: false,
+          })
 
           // If no new messages (all duplicates), only update MAM state to avoid
           // unnecessary re-renders. Exception: a stanzaId backfill onto existing

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -297,7 +297,7 @@ interface ChatState {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean) => void
+  mergeMAMMessages: (conversationId: string, messages: Message[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, isFetchLatest?: boolean, preserveGapMarker?: boolean) => void
   getMAMQueryState: (conversationId: string) => MAMQueryState
   resetMAMStates: () => void
   /** Mark all conversations as needing a catch-up MAM query (called on reconnect) */
@@ -1596,7 +1596,7 @@ export const chatStore = createStore<ChatState>()(
         }))
       },
 
-      mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction, isFetchLatest = false) => {
+      mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction, isFetchLatest = false, preserveGapMarker = false) => {
         // Newest persisted timestamp (entity preview) — the seam-formation fallback
         // when the resident array is empty this run (fresh session, history on disk).
         const fallbackHeldTs = get().getConversationLastTimestamp(conversationId)
@@ -1634,12 +1634,14 @@ export const chatStore = createStore<ChatState>()(
             complete,
             direction,
             rsm.first, // Pagination cursor for fetching older messages
-            newestFetchedTimestamp
+            newestFetchedTimestamp,
+            preserveGapMarker
           )
 
           // Persisted gap sync (shared transition, both directions) — see
-          // syncGapAfterArchiveMerge. Chat has no bounded force-repair, so
-          // preserveGapMarker is always false.
+          // syncGapAfterArchiveMerge. Bounded windowed context fetches
+          // (fetchContext) pass preserveGapMarker so their windowed
+          // completion can't hide a real gap outside the window.
           const newGaps = syncGapAfterArchiveMerge({
             gaps: state.conversationGaps,
             id: conversationId,
@@ -1651,8 +1653,11 @@ export const chatStore = createStore<ChatState>()(
             newMessagesCount: newMessages.length,
             patchedCount: patched.length,
             isFetchLatest,
+            // Fallback trusts the preview ts to be an archived message; a non-archived
+            // preview (noLocalStore/tombstone) above the true archive newest could plant
+            // a spurious — click-healable — seam.
             newestHeldBelowTs: messagePageExtent(rawExisting).newestTs ?? fallbackHeldTs,
-            preserveGapMarker: false,
+            preserveGapMarker,
           })
 
           // If no new messages (all duplicates), only update MAM state to avoid

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1624,9 +1624,7 @@ export const chatStore = createStore<ChatState>()(
 
           // Newest fetched message timestamp marks the gap edge for an incomplete
           // forward catch-up (parity with rooms).
-          const newestFetchedTimestamp = direction === 'forward' && mamMessages.length > 0
-            ? Math.max(...mamMessages.map(m => m.timestamp?.getTime() ?? 0))
-            : undefined
+          const newestFetchedTimestamp = mamState.computeNewestFetchedTimestamp(mamMessages, direction)
 
           // Update MAM query state with pagination cursor using the two-marker approach
           // This must always be updated to track query completion and cursors

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2158,6 +2158,123 @@ describe('roomStore', () => {
       expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
     })
 
+    it('plants a seam when a fetch-latest page lands disjoint above held history', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-06T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'fresh', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
+      }
+      // backward + isFetchLatest=true = a `before:''` fetch-latest page
+      roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, true, 'backward', false, true)
+
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-15T00:00:00Z').getTime(),
+      })
+    })
+
+    it('does NOT plant a seam when the fetch-latest page overlaps held history (dedupe)', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'shared', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'shared', timestamp: new Date('2026-07-14T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+
+      const fresh: RoomMessage = {
+        type: 'groupchat', id: 'fresh', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
+      }
+      const dupe: RoomMessage = { ...held } // same id → dedupe hit → connection proof
+      roomStore.getState().mergeRoomMAMMessages(jid, [dupe, fresh], {}, true, 'backward', false, true)
+
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('does NOT plant a seam for a plain backward pagination page (isFetchLatest omitted)', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-06T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+      const older: RoomMessage = {
+        type: 'groupchat', id: 'older', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'older', timestamp: new Date('2026-07-01T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [older], {}, false, 'backward')
+
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('falls back to the persisted preview timestamp when the resident array is empty', () => {
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-06T00:00:00Z'), isOutgoing: false,
+      }
+      // Fresh-run shape: resident array EMPTY, preview (meta.lastMessage) persisted.
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, lastMessage: held }))
+
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'fresh', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'fresh', timestamp: new Date('2026-07-15T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [fetched], {}, true, 'backward', false, true)
+
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-15T00:00:00Z').getTime(),
+      })
+    })
+
+    it('backward closure: a scroll-up page reaching into the gap shrinks it; crossing clears it', () => {
+      roomStore.getState().addRoom(createRoom(jid))
+      roomStore.setState({ roomGaps: new Map([[jid, {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }]]) })
+
+      const mid: RoomMessage = {
+        type: 'groupchat', id: 'mid', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'mid', timestamp: new Date('2026-07-10T00:00:00Z'), isOutgoing: false,
+      }
+      const upper: RoomMessage = {
+        type: 'groupchat', id: 'upper', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'upper', timestamp: new Date('2026-07-14T06:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [mid, upper], {}, false, 'backward')
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual({
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-10T00:00:00Z').getTime(),
+      })
+
+      const below: RoomMessage = {
+        type: 'groupchat', id: 'below', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'below', timestamp: new Date('2026-07-05T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [below, mid], {}, false, 'backward')
+      expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
+    })
+
+    it('backward closure: an older-region page below the gap leaves it untouched', () => {
+      roomStore.getState().addRoom(createRoom(jid))
+      const gap = {
+        start: new Date('2026-07-06T00:00:00Z').getTime(),
+        end: new Date('2026-07-14T00:00:00Z').getTime(),
+      }
+      roomStore.setState({ roomGaps: new Map([[jid, gap]]) })
+
+      const ancient: RoomMessage = {
+        type: 'groupchat', id: 'ancient', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'ancient', timestamp: new Date('2026-07-01T00:00:00Z'), isOutgoing: false,
+      }
+      roomStore.getState().mergeRoomMAMMessages(jid, [ancient], {}, true, 'backward')
+      expect(roomStore.getState().roomGaps.get(jid)).toEqual(gap)
+    })
+
     it('leaves the persisted gap untouched when preserveGapMarker is set (bounded repair)', () => {
       roomStore.getState().addRoom(createRoom(jid))
       roomStore.setState({ roomGaps: new Map([[jid, { start: 1000, end: 5000 }]]) })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2556,6 +2556,9 @@ export const roomStore = createStore<RoomState>()(
         newMessagesCount: newFromMAM.length,
         patchedCount: patched.length,
         isFetchLatest,
+        // Fallback trusts the preview ts to be an archived message; a non-archived
+        // preview (noLocalStore/tombstone) above the true archive newest could plant
+        // a spurious — click-healable — seam.
         newestHeldBelowTs: messagePageExtent(existingMessages).newestTs ?? fallbackHeldTs,
         preserveGapMarker,
       })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -22,7 +22,7 @@ import * as searchIndex from '../utils/searchIndex'
 import type { GetMessagesOptions } from '../utils/messageCache'
 import * as mamState from './shared/mamState'
 import type { MAMQueryDirection } from './shared/mamState'
-import { computeGapEnd, syncGap, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
+import { syncGapAfterArchiveMerge, messagePageExtent, serializeGaps, deserializeGaps, type GapInterval } from './shared/mamGap'
 import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
@@ -639,7 +639,7 @@ export interface RoomState {
    * @param complete - Whether server indicated query is complete
    * @param direction - Query direction: 'backward' for older history, 'forward' for catching up
    */
-  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean) => void
+  mergeRoomMAMMessages: (roomJid: string, messages: RoomMessage[], rsm: RSMResponse, complete: boolean, direction: MAMQueryDirection, preserveGapMarker?: boolean, isFetchLatest?: boolean) => void
   getRoomMAMQueryState: (roomJid: string) => MAMQueryState
   resetRoomMAMStates: () => void
   /** Mark all rooms as needing a catch-up MAM query (called on reconnect) */
@@ -2492,7 +2492,10 @@ export const roomStore = createStore<RoomState>()(
     }))
   },
 
-  mergeRoomMAMMessages: (roomJid, mamMessages, rsm, complete, direction, preserveGapMarker = false) => {
+  mergeRoomMAMMessages: (roomJid, mamMessages, rsm, complete, direction, preserveGapMarker = false, isFetchLatest = false) => {
+    // Newest persisted timestamp (entity preview) — the seam-formation fallback
+    // when the resident array is empty this run (fresh session, history on disk).
+    const fallbackHeldTs = get().getRoomLastTimestamp(roomJid)
     // Captured from inside set() so the post-set MDS marker resolution can read the
     // merged array even for a non-active room (whose array isn't resident).
     let mergedForMarker: RoomMessage[] = []
@@ -2538,16 +2541,27 @@ export const roomStore = createStore<RoomState>()(
         preserveGapMarker
       )
 
-      // Mirror the (reliable, complete=false-driven) forward gap into the PERSISTED
-      // roomGaps map so the marker survives a reload. `end` = oldest message held
-      // above the gap. preserveGapMarker (bounded force repair) leaves it untouched.
-      let newGaps = state.roomGaps
-      if (direction === 'forward' && !preserveGapMarker) {
-        const gapStart = newStates.get(roomJid)?.forwardGapTimestamp
-        const gapEnd = gapStart !== undefined ? computeGapEnd(merged, gapStart) : undefined
-        newGaps = syncGap(state.roomGaps, roomJid, gapStart, gapEnd)
-        if (newGaps !== state.roomGaps) saveGapsToStorage(newGaps)
-      }
+      // Persisted gap sync (shared transition, both directions):
+      // - forward: mirror the complete=false-driven forwardGapTimestamp (marker
+      //   survives a reload);
+      // - backward: close/shrink a recorded gap when a scroll-up page reaches
+      //   into or across it, or plant a seam when a `before:''` fetch-latest
+      //   page lands disjoint above held history (formation).
+      const newGaps = syncGapAfterArchiveMerge({
+        gaps: state.roomGaps,
+        id: roomJid,
+        direction,
+        complete,
+        forwardGapTimestamp: newStates.get(roomJid)?.forwardGapTimestamp,
+        merged,
+        fetched: mamMessages,
+        newMessagesCount: newFromMAM.length,
+        patchedCount: patched.length,
+        isFetchLatest,
+        newestHeldBelowTs: messagePageExtent(existingMessages).newestTs ?? fallbackHeldTs,
+        preserveGapMarker,
+      })
+      if (newGaps !== state.roomGaps) saveGapsToStorage(newGaps)
 
       // If no new messages (all duplicates), only update MAM state - skip room messages
       // This prevents unnecessary re-renders when merging duplicates.

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2525,9 +2525,7 @@ export const roomStore = createStore<RoomState>()(
 
       // Compute the newest fetched timestamp for gap marker positioning.
       // When a forward catch-up ends incomplete, this marks where the gap starts.
-      const newestFetchedTimestamp = direction === 'forward' && mamMessages.length > 0
-        ? Math.max(...mamMessages.map(m => m.timestamp?.getTime() ?? 0))
-        : undefined
+      const newestFetchedTimestamp = mamState.computeNewestFetchedTimestamp(mamMessages, direction)
 
       // Update MAM query state using the two-marker approach
       // This must always be updated to track query completion and cursors

--- a/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
@@ -7,7 +7,9 @@ import {
   messagePageExtent,
   detectFetchLatestSeam,
   closeGapWithBackwardPage,
+  syncGapAfterArchiveMerge,
   type GapInterval,
+  type ArchiveMergeGapInput,
 } from './mamGap'
 
 describe('computeGapEnd', () => {
@@ -174,5 +176,78 @@ describe('closeGapWithBackwardPage', () => {
     expect(closeGapWithBackwardPage(openGap, page, false)).toEqual({
       start: openGap.start, end: ts('2026-07-10T00:00:00Z'),
     })
+  })
+})
+
+describe('syncGapAfterArchiveMerge', () => {
+  const id = 'room@conference.example.com'
+  const base = (over: Partial<ArchiveMergeGapInput>): ArchiveMergeGapInput => ({
+    gaps: new Map(),
+    id,
+    direction: 'backward',
+    complete: false,
+    forwardGapTimestamp: undefined,
+    merged: [],
+    fetched: [],
+    newMessagesCount: 0,
+    patchedCount: 0,
+    isFetchLatest: false,
+    newestHeldBelowTs: undefined,
+    preserveGapMarker: false,
+    ...over,
+  })
+
+  it('forward: mirrors forwardGapTimestamp into the map with computeGapEnd (existing behavior)', () => {
+    const merged = [msg('2026-07-06T00:00:00Z'), msg('2026-07-15T00:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      direction: 'forward', forwardGapTimestamp: ts('2026-07-06T00:00:00Z'), merged,
+    }))
+    expect(out.get(id)).toEqual({ start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-15T00:00:00Z') })
+  })
+
+  it('forward: clears the gap when forwardGapTimestamp is undefined (complete catch-up)', () => {
+    const gaps = new Map([[id, { start: 1000, end: 5000 }]])
+    const out = syncGapAfterArchiveMerge(base({ direction: 'forward', gaps, complete: true }))
+    expect(out.has(id)).toBe(false)
+  })
+
+  it('preserveGapMarker: returns the map untouched for BOTH directions', () => {
+    const gaps = new Map([[id, { start: 1000, end: 5000 }]])
+    expect(syncGapAfterArchiveMerge(base({ direction: 'forward', gaps, preserveGapMarker: true }))).toBe(gaps)
+    expect(syncGapAfterArchiveMerge(base({ gaps, preserveGapMarker: true, isFetchLatest: true }))).toBe(gaps)
+  })
+
+  it('backward formation: fetch-latest page disjoint above held history plants a seam', () => {
+    const fetched = [msg('2026-07-14T00:00:00Z'), msg('2026-07-15T00:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      fetched, newMessagesCount: 2, isFetchLatest: true,
+      newestHeldBelowTs: ts('2026-07-06T00:00:00Z'),
+    }))
+    expect(out.get(id)).toEqual({ start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') })
+  })
+
+  it('backward formation: NOT planted for a plain pagination page (isFetchLatest=false)', () => {
+    const fetched = [msg('2026-07-14T00:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      fetched, newMessagesCount: 1, newestHeldBelowTs: ts('2026-07-06T00:00:00Z'),
+    }))
+    expect(out.has(id)).toBe(false)
+  })
+
+  it('backward closure: an existing gap takes priority over formation and shrinks/clears', () => {
+    const gaps = new Map([[id, { start: ts('2026-07-01T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') }]])
+    const fetched = [msg('2026-07-10T00:00:00Z'), msg('2026-07-14T06:00:00Z')]
+    const out = syncGapAfterArchiveMerge(base({
+      gaps, fetched, newMessagesCount: 2, isFetchLatest: true, // fetch-latest flag must NOT re-plant
+      newestHeldBelowTs: ts('2026-06-01T00:00:00Z'),
+    }))
+    expect(out.get(id)).toEqual({ start: ts('2026-07-01T00:00:00Z'), end: ts('2026-07-10T00:00:00Z') })
+  })
+
+  it('backward no-op: returns the SAME map reference when nothing changes', () => {
+    const gaps = new Map([[id, { start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') }]])
+    const fetched = [msg('2026-07-01T00:00:00Z')] // entirely below the gap
+    const out = syncGapAfterArchiveMerge(base({ gaps, fetched, newMessagesCount: 1 }))
+    expect(out).toBe(gaps)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.test.ts
@@ -4,6 +4,9 @@ import {
   syncGap,
   serializeGaps,
   deserializeGaps,
+  messagePageExtent,
+  detectFetchLatestSeam,
+  closeGapWithBackwardPage,
   type GapInterval,
 } from './mamGap'
 
@@ -75,5 +78,101 @@ describe('serializeGaps / deserializeGaps', () => {
 
   it('returns an empty map for malformed JSON', () => {
     expect(deserializeGaps('not json').size).toBe(0)
+  })
+})
+
+const msg = (iso: string) => ({ timestamp: new Date(iso) })
+const ts = (iso: string) => new Date(iso).getTime()
+
+describe('messagePageExtent', () => {
+  it('returns min/max timestamps, robust to unsorted input', () => {
+    const extent = messagePageExtent([msg('2026-07-10T00:00:00Z'), msg('2026-07-06T00:00:00Z'), msg('2026-07-08T00:00:00Z')])
+    expect(extent).toEqual({ oldestTs: ts('2026-07-06T00:00:00Z'), newestTs: ts('2026-07-10T00:00:00Z') })
+  })
+
+  it('skips messages without timestamps; empty input yields undefined bounds', () => {
+    expect(messagePageExtent([{}, msg('2026-07-06T00:00:00Z')])).toEqual({
+      oldestTs: ts('2026-07-06T00:00:00Z'), newestTs: ts('2026-07-06T00:00:00Z'),
+    })
+    expect(messagePageExtent([])).toEqual({ oldestTs: undefined, newestTs: undefined })
+  })
+})
+
+describe('detectFetchLatestSeam', () => {
+  const page = [msg('2026-07-14T00:00:00Z'), msg('2026-07-15T00:00:00Z')]
+  const heldBelowTs = ts('2026-07-06T00:00:00Z')
+
+  it('plants a seam when the page lands entirely above held history with no overlap', () => {
+    expect(detectFetchLatestSeam(page, 2, 0, heldBelowTs)).toEqual({
+      start: heldBelowTs,               // newest pre-existing message below
+      end: ts('2026-07-14T00:00:00Z'),  // oldest fetched message
+    })
+  })
+
+  it('no seam on dedupe overlap (some fetched messages already held)', () => {
+    expect(detectFetchLatestSeam(page, 1, 0, heldBelowTs)).toBeUndefined()
+  })
+
+  it('no seam on archive-id backfill (reflection patched onto held messages)', () => {
+    expect(detectFetchLatestSeam(page, 2, 1, heldBelowTs)).toBeUndefined()
+  })
+
+  it('no seam when nothing is held below', () => {
+    expect(detectFetchLatestSeam(page, 2, 0, undefined)).toBeUndefined()
+  })
+
+  it('no seam when the page interleaves with held history (ambiguous)', () => {
+    // Held newest (July 14T12:00) sits inside the page span — not entirely above.
+    expect(detectFetchLatestSeam(page, 2, 0, ts('2026-07-14T12:00:00Z'))).toBeUndefined()
+  })
+
+  it('no seam for an empty page or a page with no timestamps', () => {
+    expect(detectFetchLatestSeam([], 0, 0, heldBelowTs)).toBeUndefined()
+    expect(detectFetchLatestSeam([{}], 1, 0, heldBelowTs)).toBeUndefined()
+  })
+})
+
+describe('closeGapWithBackwardPage', () => {
+  const gap: GapInterval = { start: ts('2026-07-06T00:00:00Z'), end: ts('2026-07-14T00:00:00Z') }
+
+  it('clears the gap when the page crosses it (oldest fetched reaches held history below)', () => {
+    const page = { oldestTs: ts('2026-07-05T00:00:00Z'), newestTs: ts('2026-07-14T06:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toBeUndefined()
+  })
+
+  it('shrinks the gap when the page reaches into it from above', () => {
+    const page = { oldestTs: ts('2026-07-10T00:00:00Z'), newestTs: ts('2026-07-14T06:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toEqual({
+      start: gap.start, end: ts('2026-07-10T00:00:00Z'),
+    })
+  })
+
+  it('ignores a page entirely below the gap (older-region pagination says nothing)', () => {
+    const page = { oldestTs: ts('2026-07-01T00:00:00Z'), newestTs: ts('2026-07-05T00:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toBe(gap)
+    // Even archive-start (complete=true) below the gap must NOT clear it.
+    expect(closeGapWithBackwardPage(gap, page, true)).toBe(gap)
+  })
+
+  it('clears the gap when a page from at/above it reaches archive start (complete)', () => {
+    const page = { oldestTs: ts('2026-07-08T00:00:00Z'), newestTs: ts('2026-07-14T06:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, true)).toBeUndefined()
+  })
+
+  it('ignores an empty page (no positional info), even when complete', () => {
+    expect(closeGapWithBackwardPage(gap, { oldestTs: undefined, newestTs: undefined }, true)).toBe(gap)
+  })
+
+  it('ignores a page entirely above the gap end (recent-region pagination not yet at the seam)', () => {
+    const page = { oldestTs: ts('2026-07-14T12:00:00Z'), newestTs: ts('2026-07-15T00:00:00Z') }
+    expect(closeGapWithBackwardPage(gap, page, false)).toBe(gap)
+  })
+
+  it('shrinks an open-ended gap (end undefined) instead of ignoring it', () => {
+    const openGap: GapInterval = { start: ts('2026-07-06T00:00:00Z') }
+    const page = { oldestTs: ts('2026-07-10T00:00:00Z'), newestTs: ts('2026-07-15T00:00:00Z') }
+    expect(closeGapWithBackwardPage(openGap, page, false)).toEqual({
+      start: openGap.start, end: ts('2026-07-10T00:00:00Z'),
+    })
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/mamGap.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.ts
@@ -9,11 +9,17 @@
  * *above* the gap after the session-start fix) would never re-detect it, leaving
  * the gap silent again.
  *
- * Detection is driven ONLY by the reliable signal: a forward catch-up that ended
- * `complete=false` (the server said there is more, and we stopped at the page
- * cap). We never infer holes from timestamp discontinuities — a quiet period and
- * a real gap are indistinguishable by timestamp, and ejabberd archive ids are
- * non-sequential.
+ * Detection is driven ONLY by reliable structural signals — never by timestamp
+ * discontinuities (a quiet period and a real gap are indistinguishable by
+ * timestamp, and ejabberd archive ids are non-sequential):
+ * 1. a forward catch-up that ended `complete=false` (the server said there is
+ *    more, and we stopped at the page cap);
+ * 2. a `before:''` fetch-latest page that landed entirely above held history
+ *    with no dedupe overlap — the page provably does not connect to what we
+ *    hold, so the boundary between them is a seam (recorded at formation).
+ * Recorded gaps close progressively from both directions: forward catch-up
+ * resumes from the boundary; backward scroll-up pagination shrinks/clears the
+ * gap when its pages reach into or across it.
  *
  * @module Stores/Shared/MamGap
  */
@@ -171,4 +177,68 @@ export function closeGapWithBackwardPage(
   if (page.oldestTs <= gap.start) return undefined
   if (gap.end === undefined || page.oldestTs < gap.end) return { start: gap.start, end: page.oldestTs }
   return gap
+}
+
+/** Everything the gap transition needs from an archive merge, both directions. */
+export interface ArchiveMergeGapInput {
+  /** Current persisted gap map (`roomGaps` / `conversationGaps`). */
+  gaps: Map<string, GapInterval>
+  /** Room JID / conversation id. */
+  id: string
+  direction: 'backward' | 'forward'
+  /** Server's `<fin complete=…>` for this merge. */
+  complete: boolean
+  /** `forwardGapTimestamp` AFTER `setMAMQueryCompleted` for this merge (forward only). */
+  forwardGapTimestamp: number | undefined
+  /** Merged timeline (for `computeGapEnd` on the forward path). */
+  merged: Array<{ timestamp?: Date }>
+  /** The incoming page, as handed to the merge. */
+  fetched: Array<{ timestamp?: Date }>
+  /** How many of `fetched` survived dedupe. */
+  newMessagesCount: number
+  /** Archive-id backfills onto held messages. */
+  patchedCount: number
+  /** The query was a `before:''` fetch-latest. */
+  isFetchLatest: boolean
+  /** Newest message held BEFORE this merge (resident newest ?? persisted preview ts). */
+  newestHeldBelowTs: number | undefined
+  /** Bounded force-repair: leave the marker untouched (neither set nor cleared). */
+  preserveGapMarker: boolean
+}
+
+/**
+ * The single gap transition for BOTH stores and BOTH merge directions.
+ *
+ * Forward: mirror the (complete=false-driven) `forwardGapTimestamp` into the
+ * persisted map — unchanged behavior, extracted from the near-twin blocks in
+ * `mergeRoomMAMMessages` / `mergeMAMMessages`.
+ *
+ * Backward: an existing gap is reconciled against the page (closure takes
+ * priority — a fetch-latest while a gap is already recorded must not re-plant
+ * a shallower seam over a deeper one); otherwise a disjoint fetch-latest page
+ * plants a new seam at formation.
+ *
+ * Copy-on-write: returns the same map reference when nothing changes, so
+ * callers can skip persistence and re-renders.
+ */
+export function syncGapAfterArchiveMerge(input: ArchiveMergeGapInput): Map<string, GapInterval> {
+  const {
+    gaps, id, direction, complete, forwardGapTimestamp, merged, fetched,
+    newMessagesCount, patchedCount, isFetchLatest, newestHeldBelowTs, preserveGapMarker,
+  } = input
+
+  if (preserveGapMarker) return gaps
+
+  if (direction === 'forward') {
+    const gapEnd = forwardGapTimestamp !== undefined ? computeGapEnd(merged, forwardGapTimestamp) : undefined
+    return syncGap(gaps, id, forwardGapTimestamp, gapEnd)
+  }
+
+  const existing = gaps.get(id)
+  const next = existing
+    ? closeGapWithBackwardPage(existing, messagePageExtent(fetched), complete)
+    : isFetchLatest
+      ? detectFetchLatestSeam(fetched, newMessagesCount, patchedCount, newestHeldBelowTs)
+      : undefined
+  return syncGap(gaps, id, next?.start, next?.end)
 }

--- a/packages/fluux-sdk/src/stores/shared/mamGap.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamGap.ts
@@ -88,3 +88,87 @@ export function deserializeGaps(json: string): Map<string, GapInterval> {
     return new Map()
   }
 }
+
+/** Min/max timestamps (epoch ms) of a message page. Robust to unsorted input
+ *  and messages without timestamps. */
+export interface PageExtent {
+  oldestTs?: number
+  newestTs?: number
+}
+
+/** Compute the timestamp extent of a page of messages. */
+export function messagePageExtent(messages: Array<{ timestamp?: Date }>): PageExtent {
+  let oldestTs: number | undefined
+  let newestTs: number | undefined
+  for (const message of messages) {
+    const ts = message.timestamp?.getTime()
+    if (ts === undefined) continue
+    if (oldestTs === undefined || ts < oldestTs) oldestTs = ts
+    if (newestTs === undefined || ts > newestTs) newestTs = ts
+  }
+  return { oldestTs, newestTs }
+}
+
+/**
+ * Detect a disjoint fetch-latest page: a backward `before:''` page that landed
+ * entirely above held history without any connection proof.
+ *
+ * All checks are STRUCTURAL — direction, dedupe overlap, archive-id backfill,
+ * above/below ordering — never a gap-size heuristic:
+ * - any dedupe hit (`newMessagesCount < fetched.length`) or archive-id backfill
+ *   (`patchedCount > 0`) proves the page connects to held history → no seam;
+ * - nothing held below → nothing to disconnect from → no seam;
+ * - a page that interleaves with held history is ambiguous → no seam
+ *   (conservative: never plant a marker on uncertain evidence).
+ *
+ * @param fetched - The incoming page, as handed to the merge
+ * @param newMessagesCount - How many of `fetched` survived dedupe (merge output)
+ * @param patchedCount - Archive-id backfills onto held messages (merge output)
+ * @param newestHeldBelowTs - Newest message held BEFORE this merge (resident
+ *   newest, or the persisted preview timestamp when the resident array is empty)
+ * @returns The seam to record, or undefined when the page is connected/ambiguous
+ */
+export function detectFetchLatestSeam(
+  fetched: Array<{ timestamp?: Date }>,
+  newMessagesCount: number,
+  patchedCount: number,
+  newestHeldBelowTs: number | undefined,
+): GapInterval | undefined {
+  if (fetched.length === 0) return undefined
+  if (newMessagesCount < fetched.length || patchedCount > 0) return undefined
+  if (newestHeldBelowTs === undefined) return undefined
+  const { oldestTs } = messagePageExtent(fetched)
+  if (oldestTs === undefined) return undefined
+  if (oldestTs <= newestHeldBelowTs) return undefined
+  return { start: newestHeldBelowTs, end: oldestTs }
+}
+
+/**
+ * Reconcile a recorded gap against a merged BACKWARD page (scroll-up
+ * pagination). Backward pages walk contiguously down from their cursor, so a
+ * page's extent proves the span it covered:
+ *
+ * - page entirely below the gap (`newestTs <= start`): older-region pagination,
+ *   says nothing about the gap — even `complete` (archive start below the gap)
+ *   must not clear it;
+ * - `complete` from at/above the gap: everything below the cursor was fetched,
+ *   the gap region included → clear;
+ * - page reaching held history below (`oldestTs <= start`): regions connected → clear;
+ * - page reaching into the gap from above: shrink (`end` moves down to the
+ *   page's oldest);
+ * - empty page: no positional info → unchanged.
+ *
+ * @returns The new gap (`undefined` = clear); returns `gap` by reference when unchanged.
+ */
+export function closeGapWithBackwardPage(
+  gap: GapInterval,
+  page: PageExtent,
+  complete: boolean,
+): GapInterval | undefined {
+  if (page.oldestTs === undefined || page.newestTs === undefined) return gap
+  if (page.newestTs <= gap.start) return gap
+  if (complete) return undefined
+  if (page.oldestTs <= gap.start) return undefined
+  if (gap.end === undefined || page.oldestTs < gap.end) return { start: gap.start, end: page.oldestTs }
+  return gap
+}

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -70,6 +70,22 @@ export function setMAMError(
 export type MAMQueryDirection = 'backward' | 'forward'
 
 /**
+ * Newest fetched message timestamp (epoch ms), for gap marker positioning by
+ * a forward catch-up. `undefined` for backward queries or an empty page —
+ * matches the `newestFetchedTimestamp` argument expected by
+ * `setMAMQueryCompleted` below. Shared by `chatStore`/`roomStore` to fold
+ * their identical inline computation.
+ */
+export function computeNewestFetchedTimestamp(
+  fetched: Array<{ timestamp?: Date }>,
+  direction: MAMQueryDirection
+): number | undefined {
+  return direction === 'forward' && fetched.length > 0
+    ? Math.max(...fetched.map(m => m.timestamp?.getTime() ?? 0))
+    : undefined
+}
+
+/**
  * Create a new MAM states map with query completed state.
  *
  * @param states - Current MAM states map


### PR DESCRIPTION
## Summary

Fixes the silent-history-hole class reported in the Fluux room (gap from July 6 with no marker): a `before:''` fetch-latest MAM page landing disjoint above already-held history created a hole that was never recorded — every later forward catch-up anchored *above* it and returned `complete=true`, so the gap stayed invisible and permanent.

- **Record the seam at formation**: a backward fetch-latest page with no dedupe overlap that lands entirely above held history writes a `GapInterval` into the persisted `roomGaps`/`conversationGaps` (drives the existing *Load missing messages* marker). Detection is purely structural (query direction, dedupe overlap, ordering) — no timestamp-gap heuristics.
- **Close it progressively from both directions**: forward catch-up resumes from the boundary (existing cursor policy); backward scroll-up pages now shrink/clear the seam when they reach into or across it (new).
- **Single shared transition** `syncGapAfterArchiveMerge` in `mamGap.ts` — both stores route all gap sync through it; folded the duplicated `newestFetchedTimestamp` computation into `mamState`.
- **Bounded context fetches** (search preview / jump-to-message) now pass `preserveGapMarker` so their windowed `complete=true` can't wipe a seam they never consulted; chat gains the `preserveGapMarker` threading rooms already had.

SDK-only; no UI changes. Legacy holes that predate this fix remain healable via *Catch up all rooms*.