### PR TITLE
fix(pwa): auto-apply an update still parked in waiting at launch

### DIFF
--- a/apps/fluux/src/utils/serviceWorkerUpdate.test.ts
+++ b/apps/fluux/src/utils/serviceWorkerUpdate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   installUpdateReadyDetection,
+  dispatchUpdateReady,
   applyWaitingUpdate,
   createFocusUpdateChecker,
 } from './serviceWorkerUpdate'
@@ -56,7 +57,7 @@ function createFakeContainer() {
 }
 
 describe('installUpdateReadyDetection', () => {
-  it('reports ready immediately when a worker is already waiting', () => {
+  it('reports a worker already waiting at registration as waiting-at-registration', () => {
     const onReady = vi.fn()
     const reg = createFakeRegistration()
     reg.waiting = createFakeWorker('installed')
@@ -64,9 +65,10 @@ describe('installUpdateReadyDetection', () => {
     installUpdateReadyDetection(reg as unknown as ServiceWorkerRegistration, () => true, onReady)
 
     expect(onReady).toHaveBeenCalledTimes(1)
+    expect(onReady).toHaveBeenCalledWith('waiting-at-registration')
   })
 
-  it('reports ready when an installing worker finishes while a controller exists (an update)', () => {
+  it('reports an installing worker finishing mid-session (controller exists) as update-found', () => {
     const onReady = vi.fn()
     const reg = createFakeRegistration()
     installUpdateReadyDetection(reg as unknown as ServiceWorkerRegistration, () => true, onReady)
@@ -76,6 +78,7 @@ describe('installUpdateReadyDetection', () => {
     reg.installing.setState('installed')
 
     expect(onReady).toHaveBeenCalledTimes(1)
+    expect(onReady).toHaveBeenCalledWith('update-found')
   })
 
   it('does not report ready on a first install (installed with no controller)', () => {
@@ -100,6 +103,29 @@ describe('installUpdateReadyDetection', () => {
     reg.installing.setState('redundant')
 
     expect(onReady).not.toHaveBeenCalled()
+  })
+})
+
+describe('dispatchUpdateReady', () => {
+  it('applies immediately (safety net) when the update was already waiting at registration', () => {
+    const apply = vi.fn()
+    const offer = vi.fn()
+
+    dispatchUpdateReady('waiting-at-registration', apply, offer)
+
+    expect(apply).toHaveBeenCalledTimes(1)
+    expect(offer).not.toHaveBeenCalled()
+  })
+
+  it('offers the update (rail icon) when it arrived mid-session', () => {
+    const apply = vi.fn()
+    const offer = vi.fn()
+
+    dispatchUpdateReady('update-found', apply, offer)
+
+    expect(offer).toHaveBeenCalledTimes(1)
+    expect(offer).toHaveBeenCalledWith(apply)
+    expect(apply).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/fluux/src/utils/serviceWorkerUpdate.ts
+++ b/apps/fluux/src/utils/serviceWorkerUpdate.ts
@@ -9,10 +9,15 @@
  * Previously we reloaded the page automatically as soon as the new worker took
  * control. On an installed PWA that fires on nearly every foreground-after-deploy
  * (see the focus update check below), so the app reloaded out from under the user
- * mid-session. Now, when a waiting worker is detected we flag
+ * mid-session. Now, when an update installs mid-session we flag
  * `appUpdateStore.webUpdateReady` so the sidebar surfaces an "update available"
  * button; clicking it runs `applyWaitingUpdate`, which tells the waiting worker to
  * `skipWaiting()` and reloads once it takes control.
+ *
+ * Safety net: a worker still parked in `waiting` when the page boots (the icon
+ * was never tapped last session — or never shown: the login screen has no rail)
+ * is applied immediately, so an installed PWA can't trail the deployed build
+ * indefinitely (see `dispatchUpdateReady`).
  *
  * The browser only checks for an updated `sw.js` on `register()`, on navigations
  * within scope, and on its own ~24h timer — none of which fire for a backgrounded,
@@ -28,8 +33,16 @@ import { useAppUpdateStore } from '@/stores/appUpdateStore'
 export const FOCUS_UPDATE_MIN_INTERVAL_MS = 60_000
 
 /**
+ * How an update became ready to activate:
+ *  - `waiting-at-registration`: a worker was already parked in `waiting` when the
+ *    page registered — i.e. it was found in a previous session and never applied.
+ *  - `update-found`: a fresh `updatefound` finished installing mid-session.
+ */
+export type UpdateReadySource = 'waiting-at-registration' | 'update-found'
+
+/**
  * Watch a registration for an update that is ready to activate, and invoke
- * `onReady` when one is.
+ * `onReady` (with how it got there) when one is.
  *
  * "Ready" means a worker is `waiting` — either already (from a check on a prior
  * page load) or after a fresh `updatefound` reaches the `installed` state while a
@@ -39,10 +52,10 @@ export const FOCUS_UPDATE_MIN_INTERVAL_MS = 60_000
 export function installUpdateReadyDetection(
   registration: ServiceWorkerRegistration,
   hasController: () => boolean,
-  onReady: () => void,
+  onReady: (source: UpdateReadySource) => void,
 ): void {
   if (registration.waiting) {
-    onReady()
+    onReady('waiting-at-registration')
     return
   }
   registration.addEventListener('updatefound', () => {
@@ -50,10 +63,30 @@ export function installUpdateReadyDetection(
     if (!installing) return
     installing.addEventListener('statechange', () => {
       if (installing.state === 'installed' && hasController()) {
-        onReady()
+        onReady('update-found')
       }
     })
   })
+}
+
+/**
+ * Policy for a ready update: safety net at boot, opt-in mid-session.
+ *
+ * A worker still `waiting` at registration means the previous session parked an
+ * update the user never applied (icon unnoticed, or no rail at all on the login
+ * screen). We are at page load — a reload is invisible — so `applyUpdate` right
+ * away rather than letting the app trail the deployed build indefinitely (an
+ * installed PWA the OS rarely kills may otherwise stay old for days).
+ * An update found mid-session keeps today's behavior: `offerUpdate` surfaces the
+ * rail icon and the user applies it when they wish.
+ */
+export function dispatchUpdateReady(
+  source: UpdateReadySource,
+  applyUpdate: () => void,
+  offerUpdate: (apply: () => void) => void,
+): void {
+  if (source === 'waiting-at-registration') applyUpdate()
+  else offerUpdate(applyUpdate)
 }
 
 /**
@@ -121,14 +154,17 @@ export function registerServiceWorker(): void {
     navigator.serviceWorker
       .register('./sw.js')
       .then((registration) => {
-        // A waiting worker means a new build is ready. Surface the button and
-        // register the apply action (skipWaiting + one reload) for it.
+        // A waiting worker means a new build is ready. Parked at boot → apply
+        // silently (safety net); found mid-session → surface the rail button
+        // with the apply action (skipWaiting + one reload).
         installUpdateReadyDetection(
           registration,
           () => navigator.serviceWorker.controller !== null,
-          () => {
-            useAppUpdateStore.getState().setWebUpdateReady(true, () =>
-              applyWaitingUpdate(registration, navigator.serviceWorker, () => window.location.reload()),
+          (source) => {
+            dispatchUpdateReady(
+              source,
+              () => applyWaitingUpdate(registration, navigator.serviceWorker, () => window.location.reload()),
+              (apply) => useAppUpdateStore.getState().setWebUpdateReady(true, apply),
             )
           },
         )


### PR DESCRIPTION
A service worker still parked in `waiting` when the page boots means the previous session's update was never applied — the rail icon went unnoticed, or was never shown at all (the login screen has no rail). Without this, an installed PWA the OS rarely kills can trail the deployed build indefinitely.

Now a worker waiting at registration time is applied silently at launch (skipWaiting + one reload, invisible at boot). Updates that install mid-session keep the opt-in rail icon from #783.

`installUpdateReadyDetection` now reports how the update became ready (`waiting-at-registration` vs `update-found`) and the new `dispatchUpdateReady` policy routes between silent apply and the icon offer.