### PR TITLE
feat(pwa): request persistent storage to protect origin from eviction

### DIFF
--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -15,6 +15,7 @@ import { installBeforeInputGuard } from './utils/tauriInputFix'
 import { logStartupCapabilities } from './utils/startupDiagnostics'
 import { startStallSentinel } from './utils/stallSentinel'
 import { registerServiceWorker } from './utils/serviceWorkerUpdate'
+import { requestPersistentStorage } from './utils/persistStorage'
 import { sweepExpiredPassphrases } from './e2ee/webPassphraseCache'
 import { getReconnectIntent } from './utils/reconnectIntent'
 import { captureWebLoginPrefill } from './utils/loginPrefillSources'
@@ -46,6 +47,10 @@ if (!isTauri) {
   // Purge any cached passphrases past their 24h expiry as early as possible
   // (covers reopen-after-24h and stale cross-account records).
   void sweepExpiredPassphrases()
+  // Ask the browser to mark this origin's storage as persistent so the
+  // 'fluux-media' runtime cache can't push us over quota and get the whole
+  // origin (incl. IndexedDB / OMEMO device identity) evicted. Best-effort.
+  void requestPersistentStorage()
 }
 
 // Web: capture any login-prefill params from the launch URL (e.g. a shared

--- a/apps/fluux/src/utils/persistStorage.test.ts
+++ b/apps/fluux/src/utils/persistStorage.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Control platform detection per test.
+const isTauri = vi.fn(() => false)
+vi.mock('./tauri', () => ({ isTauri: () => isTauri() }))
+
+import { requestPersistentStorage } from './persistStorage'
+
+function stubStorage(storage: unknown) {
+  vi.stubGlobal('navigator', { storage })
+}
+
+describe('requestPersistentStorage', () => {
+  beforeEach(() => {
+    isTauri.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('requests persistence when the origin is not yet persisted', async () => {
+    const persist = vi.fn().mockResolvedValue(true)
+    const persisted = vi.fn().mockResolvedValue(false)
+    stubStorage({ persist, persisted })
+
+    const result = await requestPersistentStorage()
+
+    expect(persisted).toHaveBeenCalledOnce()
+    expect(persist).toHaveBeenCalledOnce()
+    expect(result).toBe(true)
+  })
+
+  it('skips the request when the origin is already persisted', async () => {
+    const persist = vi.fn().mockResolvedValue(true)
+    const persisted = vi.fn().mockResolvedValue(true)
+    stubStorage({ persist, persisted })
+
+    const result = await requestPersistentStorage()
+
+    expect(persist).not.toHaveBeenCalled()
+    expect(result).toBe(true)
+  })
+
+  it('is a no-op under Tauri', async () => {
+    isTauri.mockReturnValue(true)
+    const persist = vi.fn().mockResolvedValue(true)
+    stubStorage({ persist, persisted: vi.fn().mockResolvedValue(false) })
+
+    const result = await requestPersistentStorage()
+
+    expect(persist).not.toHaveBeenCalled()
+    expect(result).toBe(false)
+  })
+
+  it('is a no-op when the Storage API is unavailable', async () => {
+    stubStorage(undefined)
+
+    const result = await requestPersistentStorage()
+
+    expect(result).toBe(false)
+  })
+
+  it('is a no-op when persist() is not implemented', async () => {
+    stubStorage({ persisted: vi.fn().mockResolvedValue(false) })
+
+    const result = await requestPersistentStorage()
+
+    expect(result).toBe(false)
+  })
+
+  it('never throws when persist() rejects', async () => {
+    const persist = vi.fn().mockRejectedValue(new Error('quota denied'))
+    stubStorage({ persist, persisted: vi.fn().mockResolvedValue(false) })
+
+    const result = await requestPersistentStorage()
+
+    expect(result).toBe(false)
+  })
+})

--- a/apps/fluux/src/utils/persistStorage.ts
+++ b/apps/fluux/src/utils/persistStorage.ts
@@ -1,0 +1,32 @@
+import { isTauri } from './tauri'
+
+/**
+ * Best-effort request for persistent storage on the web/PWA build.
+ *
+ * The service worker runtime-caches cross-origin media in the 'fluux-media'
+ * cache (see sw.ts / utils/mediaCache.ts). Chromium pads opaque responses
+ * heavily in quota accounting (~7 MB apiece), so under storage pressure the
+ * browser could evict the entire origin — including the IndexedDB that will
+ * hold OMEMO device identity (see docs/2026-07-16-e2ee-device-identity-design.md).
+ * Marking storage as persistent exempts the origin from best-effort eviction.
+ *
+ * No-op under Tauri (desktop storage is not subject to browser eviction) and on
+ * browsers without the Storage API. Never throws; returns whether storage is
+ * persistent after the call.
+ */
+export async function requestPersistentStorage(): Promise<boolean> {
+  if (isTauri()) return false
+
+  const storage = typeof navigator !== 'undefined' ? navigator.storage : undefined
+  if (!storage || typeof storage.persist !== 'function') return false
+
+  try {
+    // Already persistent (granted in a previous session) — nothing to request.
+    if (typeof storage.persisted === 'function' && (await storage.persisted())) {
+      return true
+    }
+    return await storage.persist()
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

The service worker runtime-caches cross-origin images in the `fluux-media` cache (`apps/fluux/src/sw.ts` / `utils/mediaCache.ts`). Chromium pads opaque responses heavily in quota accounting (~7 MB apiece), so under storage pressure the browser could evict the whole origin — including the IndexedDB that will hold OMEMO device identity (see `docs/2026-07-16-e2ee-device-identity-design.md`).

This adds a best-effort `navigator.storage.persist()` request that marks the origin persistent, exempting it from best-effort eviction.

- New `utils/persistStorage.ts` — web/PWA only (skipped under Tauri), feature-detected, never throws. Short-circuits via `storage.persisted()` so it only requests until granted (a later boot can succeed if Chromium denied it early under low engagement).
- Wired into the existing web-only boot block in `main.tsx`, best-effort.
- Unit test covers: requests when not persisted, skips when already persisted, no-op under Tauri, no-op when the Storage API / `persist()` is absent, and never throws on rejection.

From the whole-branch review of #1030.