### PR TITLE
fix(e2ee): clear phantom unread badge when a deferred-decrypted reaction placeholder is dropped

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -556,6 +556,89 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       expect(ghost).toBeUndefined()
     })
 
+    it('clears the phantom unread badge when a deferred inbound reaction is dropped', async () => {
+      // The user-facing bug: an INBOUND encrypted reaction that arrives
+      // undecryptable during catch-up is stored as a placeholder and counted as
+      // unread (nothing yet knows it is a reaction). When the deferred decrypt
+      // later reveals it was a reaction and drops the placeholder, the unread
+      // badge it inflated must drop too — otherwise the conversation shows a
+      // notification with nothing new to read.
+      const reactionEnvelope =
+        `<payload xmlns="jabber:client">` +
+        `<reactions xmlns="urn:xmpp:reactions:0" id="read-msg"><reaction>👍</reaction></reactions>` +
+        `</payload>`
+      vi.spyOn(manager, 'decryptArchive').mockResolvedValue({
+        plaintext: new TextEncoder().encode(reactionEnvelope),
+        senderDevice: { jid: 'bob@example.com', deviceId: 'test' },
+        securityContext: { protocolId: 'dummy-plaintext', trust: 'verified' },
+      })
+
+      chatStore.getState().addConversation({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        lastMessage: undefined,
+        unreadCount: 0,
+      })
+      // A message the user has already read — the reaction targets it.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'read-msg',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: 'already read',
+        timestamp: new Date('2026-06-10T00:00:00Z'),
+        isOutgoing: false,
+      })
+      // A genuinely-unread incoming message.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'real-unread',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: 'genuinely new',
+        timestamp: new Date('2026-06-10T00:01:00Z'),
+        isOutgoing: false,
+      })
+      // Bob's reaction, stashed as an inbound placeholder while the key was locked.
+      chatStore.getState().addMessage({
+        type: 'chat',
+        id: 'reaction-ghost',
+        conversationId: 'bob@example.com',
+        from: 'bob@example.com',
+        body: '[Encrypted message: could not decrypt]',
+        timestamp: new Date('2026-06-10T00:02:00Z'),
+        isOutgoing: false,
+        encryptedPayload: DUMMY_PAYLOAD_XML,
+      })
+      // Model the catch-up state: read pointer at 'read-msg', with the two later
+      // incoming messages (the real one + the phantom reaction) counted as unread.
+      chatStore.setState((s) => {
+        const conversationMeta = new Map(s.conversationMeta)
+        conversationMeta.set('bob@example.com', {
+          ...conversationMeta.get('bob@example.com')!,
+          unreadCount: 2,
+          lastSeenMessageId: 'read-msg',
+        })
+        const conversations = new Map(s.conversations)
+        conversations.set('bob@example.com', {
+          ...conversations.get('bob@example.com')!,
+          unreadCount: 2,
+          lastSeenMessageId: 'read-msg',
+        })
+        return { conversationMeta, conversations, activeConversationId: null }
+      })
+
+      await xmppClient.retryPendingDecrypts()
+
+      const messages = chatStore.getState().messages.get('bob@example.com') ?? []
+      // The reaction landed and the placeholder is gone.
+      expect(messages.find((m) => m.id === 'read-msg')?.reactions).toEqual({ '👍': ['bob@example.com'] })
+      expect(messages.find((m) => m.id === 'reaction-ghost')).toBeUndefined()
+      // The phantom unread is gone — only the genuinely-unread message counts.
+      expect(chatStore.getState().conversationMeta.get('bob@example.com')?.unreadCount).toBe(1)
+    })
+
     it('applies a deferred-decrypted retraction to its target and drops the placeholder', async () => {
       // Retractions are the sibling of reactions: sendRetraction keeps an outer
       // fallback body, but the <retract> element itself is bodiless inside the

--- a/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/deferredDecrypt.ts
@@ -153,9 +153,15 @@ export class DeferredDecryptEngine {
             decryptedCount++
           } else if (outcome.kind === 'modification') {
             this.applyChatModification(conversationId, msg, outcome.modification, chatBindings)
+            // The placeholder was provisionally counted as unread; dropping it
+            // must clear that phantom badge. removeMessage above has already
+            // pruned the resident window, so this recount reads a clean slice.
+            await chatBindings.recomputeUnreadForConversation?.(conversationId)
             decryptedCount++
           } else if (outcome.kind === 'rejected') {
-            this.resolveRejectedPlaceholder(conversationId, msg, outcome.securityContext, chatBindings)
+            if (this.resolveRejectedPlaceholder(conversationId, msg, outcome.securityContext, chatBindings)) {
+              await chatBindings.recomputeUnreadForConversation?.(conversationId)
+            }
           } else if (outcome.kind === 'unsupported') {
             chatBindings.updateMessage(conversationId, msg.id, {
               encryptedPayload: undefined,
@@ -237,6 +243,11 @@ export class DeferredDecryptEngine {
           // now-unlocked key decrypts it inline.
           this.applyChatModification(conversationId, msg, outcome.modification, stores.chat)
           await this.deps.cache.deleteMessage(msg.id)
+          // Never-opened conversation: its unread badge was hydrated from the
+          // durable cache during catch-up and still counts this placeholder.
+          // Recompute now that the row is gone from the cache (deleted above),
+          // so the phantom badge clears without waiting for the user to open it.
+          await stores.chat.recomputeUnreadForConversation?.(conversationId)
           decryptedCount++
         } else if (outcome.kind === 'rejected') {
           if (msg.body === COULD_NOT_DECRYPT_BODY) {
@@ -377,16 +388,19 @@ export class DeferredDecryptEngine {
     placeholder: { id: string; body: string },
     securityContext: MessageSecurityContext | undefined,
     chatBindings: StoreBindings['chat'],
-  ): void {
+  ): boolean {
     if (placeholder.body === COULD_NOT_DECRYPT_BODY) {
+      // Dropped a bodiless-signal placeholder that had been counted as unread —
+      // signal the caller to reconcile the badge.
       chatBindings.removeMessage(conversationId, placeholder.id)
-    } else {
-      chatBindings.updateMessage(conversationId, placeholder.id, {
-        body: MESSAGE_REJECTED_BODY,
-        ...(securityContext && { securityContext }),
-        encryptedPayload: undefined,
-      })
+      return true
     }
+    chatBindings.updateMessage(conversationId, placeholder.id, {
+      body: MESSAGE_REJECTED_BODY,
+      ...(securityContext && { securityContext }),
+      encryptedPayload: undefined,
+    })
+    return false
   }
 
   /**

--- a/packages/fluux-sdk/src/core/storeBindingKeys.ts
+++ b/packages/fluux-sdk/src/core/storeBindingKeys.ts
@@ -66,6 +66,7 @@ export const chatBindingMethodKeys = [
   'updateReactions',
   'updateMessage',
   'removeMessage',
+  'recomputeUnreadForConversation',
   'getMessage',
   'triggerAnimation',
   // XEP-0313: MAM support

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -155,6 +155,83 @@ describe('chatStore', () => {
     })
   })
 
+  describe('recomputeUnreadForConversation (phantom-badge cleanup)', () => {
+    // Regression: an encrypted reaction/retraction that arrives undecryptable
+    // during catch-up is stored as a bodiless placeholder and counted as unread.
+    // When a later deferred-decrypt reveals it was a signal and drops it, the
+    // unread badge must drop too. This method reconciles the count against the
+    // read pointer using the resident window (or the durable cache when the
+    // conversation was never opened).
+    const cid = 'carol@example.com'
+
+    function withId(m: Message, id: string, ts: string): Message {
+      return { ...m, id, timestamp: new Date(ts) }
+    }
+
+    it('recomputes the count from the resident window after a counted placeholder is dropped', async () => {
+      const read = withId(createMessage(cid, 'read'), 'm-read', '2026-06-10T00:00:00Z')
+      const realUnread = withId(createMessage(cid, 'still unread'), 'm-real', '2026-06-10T00:02:00Z')
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState((s) => {
+        const conversationMeta = new Map(s.conversationMeta)
+        // unreadCount is 2 (stale): it still includes the reaction placeholder
+        // that has already been removed from the resident array below.
+        conversationMeta.set(cid, {
+          ...conversationMeta.get(cid)!,
+          unreadCount: 2,
+          lastSeenMessageId: read.id,
+        })
+        const conversations = new Map(s.conversations)
+        conversations.set(cid, { ...conversations.get(cid)!, unreadCount: 2, lastSeenMessageId: read.id })
+        const messages = new Map(s.messages)
+        messages.set(cid, [read, realUnread])
+        return { conversationMeta, conversations, messages, activeConversationId: null }
+      })
+
+      await chatStore.getState().recomputeUnreadForConversation(cid)
+
+      expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(1)
+      expect(chatStore.getState().conversations.get(cid)?.unreadCount).toBe(1)
+    })
+
+    it('recomputes from the durable cache when the conversation is not resident', async () => {
+      const read = withId(createMessage(cid, 'read'), 'm-read', '2026-06-10T00:00:00Z')
+      const realUnread = withId(createMessage(cid, 'still unread'), 'm-real', '2026-06-10T00:02:00Z')
+      vi.mocked(messageCache.getMessages).mockResolvedValueOnce([read, realUnread])
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState((s) => {
+        const conversationMeta = new Map(s.conversationMeta)
+        conversationMeta.set(cid, {
+          ...conversationMeta.get(cid)!,
+          unreadCount: 2,
+          lastSeenMessageId: read.id,
+        })
+        const conversations = new Map(s.conversations)
+        conversations.set(cid, { ...conversations.get(cid)!, unreadCount: 2, lastSeenMessageId: read.id })
+        // No resident messages array — the durable (never-opened) path.
+        return { conversationMeta, conversations, activeConversationId: null }
+      })
+
+      await chatStore.getState().recomputeUnreadForConversation(cid)
+
+      expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(1)
+    })
+
+    it('does not touch the active conversation (activation owns its counts)', async () => {
+      chatStore.getState().addConversation(createConversation(cid))
+      chatStore.setState((s) => {
+        const conversationMeta = new Map(s.conversationMeta)
+        conversationMeta.set(cid, { ...conversationMeta.get(cid)!, unreadCount: 5 })
+        return { conversationMeta, activeConversationId: cid }
+      })
+
+      await chatStore.getState().recomputeUnreadForConversation(cid)
+
+      expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(5)
+      expect(messageCache.getMessages).not.toHaveBeenCalled()
+    })
+  })
+
   describe('mergeMAMMessages gap tracking (persisted conversationGaps)', () => {
     const cid = 'alice@example.com'
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -285,6 +285,15 @@ interface ChatState {
    * disappear once the real reaction is applied to its target.
    */
   removeMessage: (conversationId: string, messageId: string) => void
+  /**
+   * Reconcile a non-active conversation's unread count against its persisted
+   * read pointer, using the resident window when loaded or the durable cache
+   * otherwise. Called after a deferred-decrypt drops a bodiless-signal
+   * placeholder (reaction/retraction) that had been provisionally counted as
+   * unread — {@link removeMessage} clears the row but not the phantom badge it
+   * left behind. No-op for the active conversation (activation owns its counts).
+   */
+  recomputeUnreadForConversation: (conversationId: string) => Promise<void>
   getMessage: (conversationId: string, messageId: string) => Message | undefined
   /**
    * Epoch ms of the conversation's persisted last-known message (the entity
@@ -1664,6 +1673,66 @@ export const chatStore = createStore<ChatState>()(
           }
 
           return { messages: newMessages }
+        })
+      },
+
+      recomputeUnreadForConversation: async (conversationId) => {
+        // Active conversation counts are owned by activation (they are already
+        // zero while viewed); a bulk recompute here could race it.
+        if (get().activeConversationId === conversationId) return
+
+        // Prefer the resident window: it already reflects a just-dropped
+        // placeholder synchronously, so no cache-write race. A never-opened
+        // conversation has no resident array — fall back to the newest cached
+        // window (sized to one catch-up pass, mirroring the MDS recount).
+        const resident = get().messages.get(conversationId)
+        let slice: Message[]
+        if (resident && resident.length > 0) {
+          slice = resident
+        } else {
+          try {
+            slice = await messageCache.getMessages(conversationId, {
+              limit: MAM_POINTER_RECOUNT_CACHE_LIMIT,
+              latest: true,
+            })
+          } catch {
+            return
+          }
+        }
+        if (slice.length === 0) return
+
+        set((state) => {
+          // Re-check: the conversation may have become active while the cache
+          // read was in flight — activation recomputes counts itself.
+          if (state.activeConversationId === conversationId) return state
+          const meta = state.conversationMeta.get(conversationId)
+          if (!meta) return state
+          const pointerState: notifState.EntityNotificationState = {
+            unreadCount: meta.unreadCount,
+            mentionsCount: 0,
+            lastReadAt: meta.lastReadAt,
+            lastSeenMessageId: meta.lastSeenMessageId,
+            firstNewMessageId: state.firstNewMessageMarkers.get(conversationId),
+          }
+          const recomputed = notifState.recomputeCountsFromPointer(pointerState, slice)
+          // Same-reference return = nothing changed; skip the map churn.
+          if (recomputed === pointerState) return state
+
+          const newMeta = new Map(state.conversationMeta)
+          newMeta.set(conversationId, {
+            ...meta,
+            unreadCount: recomputed.unreadCount,
+            lastSeenMessageId: recomputed.lastSeenMessageId,
+          })
+          const conv = state.conversations.get(conversationId)
+          if (!conv) return { conversationMeta: newMeta }
+          const newConversations = new Map(state.conversations)
+          newConversations.set(conversationId, {
+            ...conv,
+            unreadCount: recomputed.unreadCount,
+            lastSeenMessageId: recomputed.lastSeenMessageId,
+          })
+          return { conversationMeta: newMeta, conversations: newConversations }
         })
       },
 


### PR DESCRIPTION
## Summary

In an encrypted 1:1 conversation, an inbound reaction (or reaction removal / retraction) that arrives undecryptable during catch-up (key locked / E2EE not yet initialized) is stored as a bodiless `[could not decrypt]` placeholder and counted as unread. When the deferred decrypt later reveals it was a signal, applies it to its target, and drops the placeholder, nothing decremented the unread count — the conversation kept a phantom badge with nothing new to read until it was opened.

## Fix

- New `chatStore.recomputeUnreadForConversation(conversationId)`: reconciles a non-active conversation's unread count against its read pointer, using the resident window when loaded or the durable cache (newest window) when the conversation was never opened. No-op for the active conversation (activation owns its counts).
- `DeferredDecryptEngine` calls it after every placeholder drop: applied modification (resident + durable-cache paths) and rejected bodiless signal (`resolveRejectedPlaceholder` now reports whether it dropped).