### PR TITLE
feat(sdk): add XEP-0334 no-store hint to standalone chat states

### DIFF
--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -685,6 +685,28 @@ describe('XMPPClient Message', () => {
       expect(mockXmppClientInstance.send).toHaveBeenCalled()
     })
 
+    it('should attach a no-store hint (XEP-0334) to standalone chat states', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.roster.getContact).mockReturnValue({
+        jid: 'online@example.com',
+        name: 'Online User',
+        presence: 'online',
+        subscription: 'both',
+      })
+
+      await xmppClient.chat.sendChatState('online@example.com', 'composing', 'chat')
+      await xmppClient.chat.sendChatState('room@conference.example.com', 'composing', 'groupchat')
+
+      expect(mockXmppClientInstance.send).toHaveBeenCalledTimes(2)
+      for (const [sentStanza] of mockXmppClientInstance.send.mock.calls) {
+        const hint = sentStanza.children.find((c: any) => c.name === 'no-store')
+        expect(hint).toBeDefined()
+        expect(hint.attrs.xmlns).toBe('urn:xmpp:hints')
+        expect(sentStanza.children.find((c: any) => c.name === 'body')).toBeUndefined()
+      }
+    })
+
     it('should emit room:typing for composing notification in MUC room', async () => {
       await connectClient()
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -1145,7 +1145,12 @@ export class Chat extends BaseModule {
       if (contact?.presence === 'offline') return
     }
 
-    const message = xml('message', { to: recipient, type }, xml(state, { xmlns: NS_CHATSTATES }))
+    // XEP-0334: standalone chat states are transient — tell the server not to
+    // archive them (and, per the same convention, not to wake devices for them).
+    const message = xml('message', { to: recipient, type },
+      xml(state, { xmlns: NS_CHATSTATES }),
+      xml('no-store', { xmlns: NS_HINTS }),
+    )
     await this.deps.sendStanza(message)
   }
 


### PR DESCRIPTION
Standalone XEP-0085 chat states (typing indicators) are transient and should not be archived. `sendChatState` now attaches an explicit `<no-store xmlns='urn:xmpp:hints'/>` to both 1:1 and groupchat chat states, matching the hint `sendWhisperChatState` already carried. Most servers already skip bodiless stanzas in MAM, but the hint makes the intent explicit per XEP-0334.