### PR TITLE
feat(app): add colon-triggered emoji autocomplete selector to MessageComposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 
 ### Rich Messaging
 - **Reactions, Replies & Styling** - Emoji reactions with quick toolbar, threaded replies, and rich text formatting (bold, italic, code blocks with syntax highlighting)
+- **Emoji Autocomplete** - Type `:` and a keyword to complete emojis inline, with arrow-key navigation and Enter or Tab to insert
 - **Message Retraction & Moderation** - Delete your own messages or moderate room messages with full audit trail
 - **Link Previews** - Automatic Open Graph previews for shared URLs
 - **File Sharing** - HTTP uploads with drag-and-drop, thumbnails, progress indicators, image lightbox, and text file preview

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -1310,6 +1310,7 @@ export const MessageInput = memo(function MessageInput({
         resolveInput={resolveInput}
         classifyInput={classifyInput}
         aboveInput={helpOpen ? <CommandHelpPanel commands={visibleCommands('chat')} onClose={() => setHelpOpen(false)} /> : undefined}
+        hasExternalOverlay={helpOpen}
         onEditLastMessage={onEditLastMessage}
         encryptionState={encryptionState}
         onEncryptionClick={onEncryptionClick}
@@ -1317,4 +1318,3 @@ export const MessageInput = memo(function MessageInput({
     </>
   )
 })
-

--- a/apps/fluux/src/components/MessageComposer.caret.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.caret.test.tsx
@@ -1,0 +1,109 @@
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MessageComposer, type MessageComposerHandle } from './MessageComposer'
+
+vi.mock('@emoji-mart/data', () => ({
+  default: {
+    emojis: {
+      heart: { name: 'Red Heart', skins: [{ native: '❤️' }], keywords: ['love'] },
+    },
+  },
+}))
+
+vi.mock('./EmojiPicker', () => ({ EmojiPicker: () => <div data-testid="full-emoji-picker" /> }))
+
+function renderComposer(onSelectionChange: (position: number) => void) {
+  render(
+    <MessageComposer
+      placeholder="Type a message"
+      onSend={vi.fn().mockResolvedValue(true)}
+      onSelectionChange={onSelectionChange}
+    />
+  )
+  return screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
+}
+
+/**
+ * Room mention and slash-command completion live in RoomView and are driven by
+ * the caret the composer reports. If the composer only reports on selection
+ * events, those menus never open while the user types — which is the only time
+ * they are useful.
+ */
+describe('MessageComposer caret reporting', () => {
+  it('reports the caret while the user types', () => {
+    const onSelectionChange = vi.fn()
+    const textarea = renderComposer(onSelectionChange)
+
+    fireEvent.change(textarea, {
+      target: { value: 'hi @Em', selectionStart: 6, selectionEnd: 6 },
+    })
+
+    expect(onSelectionChange).toHaveBeenCalledWith(6)
+  })
+
+  it('reports the caret when a selection event moves it', () => {
+    const onSelectionChange = vi.fn()
+    const textarea = renderComposer(onSelectionChange)
+
+    fireEvent.change(textarea, {
+      target: { value: 'hi @Em', selectionStart: 6, selectionEnd: 6 },
+    })
+    onSelectionChange.mockClear()
+
+    textarea.setSelectionRange(3, 3)
+    fireEvent.select(textarea)
+
+    expect(onSelectionChange).toHaveBeenCalledWith(3)
+  })
+
+  /**
+   * A room inserting a mention rewrites the text itself. Without this the
+   * browser drops the caret at the end of the value, so `ping @Em| about the
+   * release` becomes `ping @Emma  about the release|` and the next keystroke
+   * lands at the end of the message instead of after the mention.
+   */
+  it('places the caret after text the parent rewrote', async () => {
+    const onSelectionChange = vi.fn()
+    const ref = createRef<MessageComposerHandle>()
+    render(
+      <MessageComposer
+        ref={ref}
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value="ping @Emma  about the release"
+        onValueChange={vi.fn()}
+        onSelectionChange={onSelectionChange}
+      />
+    )
+    const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
+
+    act(() => {
+      ref.current?.placeCaret('ping @Emma  about the release', 11)
+    })
+
+    expect(onSelectionChange).toHaveBeenCalledWith(11)
+    await waitFor(() => {
+      expect(textarea.selectionStart).toBe(11)
+      expect(document.activeElement).toBe(textarea)
+    })
+  })
+
+  it('reports the caret the completion moved it to', async () => {
+    const onSelectionChange = vi.fn()
+    const textarea = renderComposer(onSelectionChange)
+
+    fireEvent.change(textarea, {
+      target: { value: ':hea', selectionStart: 4, selectionEnd: 4 },
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+    onSelectionChange.mockClear()
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    // ':hea' collapsed to '❤️', so the caret sits at the end of the emoji.
+    expect(onSelectionChange).toHaveBeenCalledWith('❤️'.length)
+  })
+})

--- a/apps/fluux/src/components/MessageComposer.caret.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.caret.test.tsx
@@ -1,7 +1,15 @@
 import { createRef } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { MessageComposer, type MessageComposerHandle } from './MessageComposer'
+
+/** The composer reports each of its renders to the (mocked) render-loop detector. */
+function composerRenderCount(): number {
+  return (detectRenderLoop as ReturnType<typeof vi.fn>).mock.calls.filter(
+    (call) => call[0] === 'MessageComposer'
+  ).length
+}
 
 vi.mock('@emoji-mart/data', () => ({
   default: {
@@ -55,6 +63,35 @@ describe('MessageComposer caret reporting', () => {
     fireEvent.select(textarea)
 
     expect(onSelectionChange).toHaveBeenCalledWith(3)
+  })
+
+  /**
+   * The caret is stored as an object so it can be paired with its text, but a
+   * fresh object on every selection event would re-render where the previous
+   * plain number let React bail out. Selection events that do not move the caret
+   * must stay free.
+   */
+  it('does not re-render when a selection event lands on the caret it already had', () => {
+    const textarea = renderComposer(vi.fn())
+    fireEvent.change(textarea, {
+      target: { value: 'stable text', selectionStart: 5, selectionEnd: 5 },
+    })
+
+    const beforeStationary = composerRenderCount()
+    for (let i = 0; i < 10; i++) {
+      textarea.selectionStart = textarea.selectionEnd = 5
+      fireEvent.select(textarea)
+    }
+    expect(composerRenderCount() - beforeStationary).toBe(0)
+
+    // Control: a caret that actually moves must still re-render, or the
+    // assertion above would pass simply because nothing is wired up.
+    const beforeMoving = composerRenderCount()
+    for (let i = 0; i < 10; i++) {
+      textarea.selectionStart = textarea.selectionEnd = i
+      fireEvent.select(textarea)
+    }
+    expect(composerRenderCount() - beforeMoving).toBe(10)
   })
 
   /**

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MessageComposer } from './MessageComposer'
@@ -29,6 +30,18 @@ function renderComposer(props: Partial<React.ComponentProps<typeof MessageCompos
       placeholder="Type a message"
       onSend={vi.fn().mockResolvedValue(true)}
       {...props}
+    />
+  )
+}
+
+function ControlledComposer() {
+  const [value, setValue] = useState('')
+  return (
+    <MessageComposer
+      placeholder="Type a message"
+      onSend={vi.fn().mockResolvedValue(true)}
+      value={value}
+      onValueChange={setValue}
     />
   )
 }
@@ -87,6 +100,60 @@ describe('MessageComposer emoji overlay coordination', () => {
     expect(nextOption).toHaveAttribute('aria-selected', 'true')
   })
 
+  it('completes from the keyboard and restores the cursor in uncontrolled mode', async () => {
+    renderComposer()
+    typeEmojiToken()
+
+    const textarea = screen.getByRole('combobox', { name: 'Type a message' }) as HTMLTextAreaElement
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('❤️')
+      expect(textarea.selectionStart).toBe('❤️'.length)
+      expect(document.activeElement).toBe(textarea)
+    })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('completes from a click and restores the cursor in controlled mode', async () => {
+    render(<ControlledComposer />)
+    typeEmojiToken()
+
+    const textarea = screen.getByRole('combobox', { name: 'Type a message' }) as HTMLTextAreaElement
+    const option = await screen.findByRole('option', { name: ':heart: Red Heart' })
+    fireEvent.mouseDown(option)
+    fireEvent.click(option)
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('❤️')
+      expect(textarea.selectionStart).toBe('❤️'.length)
+      expect(document.activeElement).toBe(textarea)
+    })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('preserves Shift+Enter as a newline while suggestions are open', async () => {
+    renderComposer()
+    typeEmojiToken()
+
+    const textarea = screen.getByRole('combobox', { name: 'Type a message' }) as HTMLTextAreaElement
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+
+    expect(fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true })).toBe(true)
+    fireEvent.change(textarea, {
+      target: { value: ':hea\n', selectionStart: 5, selectionEnd: 5 },
+    })
+
+    expect(textarea).toHaveValue(':hea\n')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
   it('gives an external composer overlay priority over emoji completion', async () => {
     const { rerender } = renderComposer({
       aboveInput: <div data-testid="external-overlay" />,
@@ -120,7 +187,9 @@ describe('MessageComposer emoji overlay coordination', () => {
     await waitFor(() => {
       expect(screen.getByText(':heart:')).toBeInTheDocument()
     })
-    expect(screen.queryByText('Create Poll')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText('Create Poll')).not.toBeInTheDocument()
+    })
   })
 
   it('closes the full emoji picker when emoji completion opens', async () => {

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MessageComposer } from './MessageComposer'
+
+vi.mock('@emoji-mart/data', () => ({
+  default: {
+    emojis: {
+      heart: {
+        name: 'Red Heart',
+        skins: [{ native: '❤️' }],
+        keywords: ['love'],
+      },
+      heart_eyes: {
+        name: 'Smiling Face with Heart-Eyes',
+        skins: [{ native: '😍' }],
+        keywords: ['love'],
+      },
+    },
+  },
+}))
+
+vi.mock('./EmojiPicker', () => ({
+  EmojiPicker: () => <div data-testid="full-emoji-picker" />,
+}))
+
+function renderComposer(props: Partial<React.ComponentProps<typeof MessageComposer>> = {}) {
+  return render(
+    <MessageComposer
+      placeholder="Type a message"
+      onSend={vi.fn().mockResolvedValue(true)}
+      {...props}
+    />
+  )
+}
+
+function typeEmojiToken() {
+  const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
+  fireEvent.change(textarea, {
+    target: { value: ':hea', selectionStart: 4, selectionEnd: 4 },
+  })
+}
+
+async function expectEscapeClosesBeforeCancel(
+  props: Partial<React.ComponentProps<typeof MessageComposer>>,
+  onCancel: ReturnType<typeof vi.fn>
+) {
+  renderComposer(props)
+  typeEmojiToken()
+
+  const textarea = screen.getByRole('combobox', { name: 'Type a message' })
+  await waitFor(() => {
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  fireEvent.keyDown(textarea, { key: 'Escape' })
+  expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  expect(onCancel).not.toHaveBeenCalled()
+
+  fireEvent.keyDown(textarea, { key: 'Escape' })
+  expect(onCancel).toHaveBeenCalledOnce()
+}
+
+describe('MessageComposer emoji overlay coordination', () => {
+  it('exposes listbox semantics and keeps textarea focus during keyboard navigation', async () => {
+    renderComposer()
+    typeEmojiToken()
+
+    const textarea = screen.getByRole('combobox', { name: 'Type a message' })
+    await waitFor(() => {
+      expect(textarea).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    const listbox = screen.getByRole('listbox')
+    const option = screen.getByRole('option', { name: ':heart: Red Heart' })
+    const nextOption = screen.getByRole('option', { name: ':heart_eyes: Smiling Face with Heart-Eyes' })
+    expect(listbox).toHaveAttribute('id')
+    expect(textarea).toHaveAttribute('aria-controls', listbox.id)
+    expect(textarea).toHaveAttribute('aria-activedescendant', option.id)
+    expect(option).toHaveAttribute('aria-selected', 'true')
+    expect(option.querySelector('[aria-hidden="true"]')).toHaveTextContent('❤️')
+
+    textarea.focus()
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(textarea)
+    expect(textarea).toHaveAttribute('aria-activedescendant', nextOption.id)
+    expect(option).toHaveAttribute('aria-selected', 'false')
+    expect(nextOption).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('gives an external composer overlay priority over emoji completion', async () => {
+    const { rerender } = renderComposer({
+      aboveInput: <div data-testid="external-overlay" />,
+      hasExternalOverlay: true,
+    })
+
+    typeEmojiToken()
+    expect(screen.getByTestId('external-overlay')).toBeInTheDocument()
+    expect(screen.queryByText(':heart:')).not.toBeInTheDocument()
+
+    rerender(
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        hasExternalOverlay={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(':heart:')).toBeInTheDocument()
+    })
+  })
+
+  it('closes the attachment drawer when emoji completion opens', async () => {
+    renderComposer({ onCreatePoll: vi.fn() })
+
+    fireEvent.click(screen.getByLabelText('upload.attachFile'))
+    expect(screen.getByText('Create Poll')).toBeInTheDocument()
+
+    typeEmojiToken()
+    await waitFor(() => {
+      expect(screen.getByText(':heart:')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Create Poll')).not.toBeInTheDocument()
+  })
+
+  it('closes the full emoji picker when emoji completion opens', async () => {
+    const { container } = renderComposer()
+    const emojiButton = container.querySelector<HTMLButtonElement>('[class*="grid-area:emoji"] > button')
+    expect(emojiButton).not.toBeNull()
+
+    fireEvent.click(emojiButton!)
+    await waitFor(() => {
+      expect(screen.getByTestId('full-emoji-picker')).toBeInTheDocument()
+    })
+
+    typeEmojiToken()
+    await waitFor(() => {
+      expect(screen.getByText(':heart:')).toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(screen.queryByTestId('full-emoji-picker')).not.toBeInTheDocument()
+    })
+  })
+
+  it('uses Escape to close autocomplete before cancelling reply mode', async () => {
+    const onCancelReply = vi.fn()
+    await expectEscapeClosesBeforeCancel({
+      replyingTo: { id: 'reply-1', senderName: 'Alice', body: 'Hello', from: 'alice@example.com' },
+      onCancelReply,
+    }, onCancelReply)
+  })
+
+  it('uses Escape to close autocomplete before cancelling edit mode', async () => {
+    const onCancelEdit = vi.fn()
+    await expectEscapeClosesBeforeCancel({
+      editingMessage: { id: 'edit-1', body: 'Original message' },
+      onCancelEdit,
+    }, onCancelEdit)
+  })
+})

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -127,7 +127,8 @@ describe('MessageComposer emoji overlay coordination', () => {
       expect(textarea).toHaveAttribute('aria-expanded', 'true')
     })
 
-    const listbox = screen.getByRole('listbox')
+    // t() falls through to the key for anything outside the test i18n subset.
+    const listbox = screen.getByRole('listbox', { name: 'chat.emojiSuggestions' })
     const option = screen.getByRole('option', { name: ':heart: Red Heart' })
     const nextOption = screen.getByRole('option', { name: ':heart_eyes: Smiling Face with Heart-Eyes' })
     expect(listbox).toHaveAttribute('id')

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -70,6 +70,26 @@ function CustomRoomInputComposer() {
   )
 }
 
+/**
+ * ChatView and RoomView read the active conversation from the store rather than
+ * taking it as a prop, so the composer is not remounted when the user switches
+ * conversations — only its controlled value is swapped.
+ */
+function SwappableDraftComposer() {
+  const [value, setValue] = useState('')
+  return (
+    <>
+      <button onClick={() => setValue('see you at :heart_eyes later')}>swap-draft</button>
+      <MessageComposer
+        placeholder="Type a message"
+        onSend={vi.fn().mockResolvedValue(true)}
+        value={value}
+        onValueChange={setValue}
+      />
+    </>
+  )
+}
+
 function typeEmojiToken() {
   const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
   fireEvent.change(textarea, {
@@ -204,6 +224,28 @@ describe('MessageComposer emoji overlay coordination', () => {
     })
 
     expect(textarea).toHaveValue(':hea\n')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('does not reuse the previous draft caret when the parent swaps the value', async () => {
+    render(<SwappableDraftComposer />)
+    const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
+
+    // Draft A: caret sits at 15, right after ":hea".
+    fireEvent.change(textarea, {
+      target: { value: 'chat about :hea', selectionStart: 15, selectionEnd: 15 },
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+
+    // Draft B arrives with no user input. Slicing it at the stale caret would
+    // yield "see you at :hea" and reopen completion on a caret that never moved.
+    fireEvent.click(screen.getByText('swap-draft'))
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('see you at :heart_eyes later')
+    })
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -227,6 +227,26 @@ describe('MessageComposer emoji overlay coordination', () => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 
+  it('completes a full shortcode as soon as the closing colon is typed', async () => {
+    renderComposer()
+    const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
+
+    // Typing the open shortcode is what pulls the emoji data into memory.
+    typeEmojiToken()
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+
+    fireEvent.change(textarea, {
+      target: { value: ':heart:', selectionStart: 7, selectionEnd: 7 },
+    })
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('❤️')
+    })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
   it('does not reuse the previous draft caret when the parent swaps the value', async () => {
     render(<SwappableDraftComposer />)
     const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -46,6 +46,30 @@ function ControlledComposer() {
   )
 }
 
+function CustomRoomInputComposer() {
+  const [value, setValue] = useState('')
+  return (
+    <MessageComposer
+      placeholder="Message room"
+      onSend={vi.fn().mockResolvedValue(true)}
+      value={value}
+      onValueChange={setValue}
+      renderInput={({ mergedRef, value: inputValue, onChange, onKeyDown, onSelect, placeholder, ariaProps }) => (
+        <textarea
+          ref={mergedRef}
+          value={inputValue}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          onSelect={onSelect}
+          placeholder={placeholder}
+          data-testid="custom-room-input"
+          {...ariaProps}
+        />
+      )}
+    />
+  )
+}
+
 function typeEmojiToken() {
   const textarea = screen.getByPlaceholderText('Type a message') as HTMLTextAreaElement
   fireEvent.change(textarea, {
@@ -98,9 +122,15 @@ describe('MessageComposer emoji overlay coordination', () => {
     expect(textarea).toHaveAttribute('aria-activedescendant', nextOption.id)
     expect(option).toHaveAttribute('aria-selected', 'false')
     expect(nextOption).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(textarea)
+    expect(textarea).toHaveAttribute('aria-activedescendant', option.id)
+    expect(option).toHaveAttribute('aria-selected', 'true')
+    expect(nextOption).toHaveAttribute('aria-selected', 'false')
   })
 
-  it('completes from the keyboard and restores the cursor in uncontrolled mode', async () => {
+  it('completes from the keyboard through the uncontrolled direct-chat input path', async () => {
     renderComposer()
     typeEmojiToken()
 
@@ -127,6 +157,29 @@ describe('MessageComposer emoji overlay coordination', () => {
     const option = await screen.findByRole('option', { name: ':heart: Red Heart' })
     fireEvent.mouseDown(option)
     fireEvent.click(option)
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('❤️')
+      expect(textarea.selectionStart).toBe('❤️'.length)
+      expect(document.activeElement).toBe(textarea)
+    })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('passes autocomplete behavior through the custom room input and completes with Tab', async () => {
+    render(<CustomRoomInputComposer />)
+
+    const textarea = screen.getByTestId('custom-room-input') as HTMLTextAreaElement
+    fireEvent.change(textarea, {
+      target: { value: ':hea', selectionStart: 4, selectionEnd: 4 },
+    })
+
+    const option = await screen.findByRole('option', { name: ':heart: Red Heart' })
+    expect(textarea).toHaveAttribute('role', 'combobox')
+    expect(textarea).toHaveAttribute('aria-controls', screen.getByRole('listbox').id)
+    expect(textarea).toHaveAttribute('aria-activedescendant', option.id)
+
+    fireEvent.keyDown(textarea, { key: 'Tab' })
 
     await waitFor(() => {
       expect(textarea).toHaveValue('❤️')

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -36,6 +36,18 @@ const COMPOSING_THROTTLE_MS = 2000
 const PAUSED_TIMEOUT_MS = 5000
 const COMPOSING_UI_TIMEOUT_MS = 1500
 
+function restoreTextareaCursor(
+  inputRef: RefObject<HTMLTextAreaElement | null>,
+  position: number,
+) {
+  setTimeout(() => {
+    const input = inputRef.current
+    if (!input) return
+    input.focus()
+    input.setSelectionRange(position, position)
+  }, 0)
+}
+
 // Base textarea classes - exported for custom renderInput implementations to reuse.
 // `no-focus-ring` opts the textarea out of the global `.user-interacted *:focus`
 // outline (index.css): the composer card's own `:focus-within` accent edge is the
@@ -368,13 +380,7 @@ export function MessageComposer({
       setText(editingMessage.body)
       setEditAttachmentRemoved(false) // Reset attachment removal state
       // Focus and move cursor to end
-      setTimeout(() => {
-        if (inputRef.current) {
-          inputRef.current.focus()
-          const len = editingMessage.body.length
-          inputRef.current.setSelectionRange(len, len)
-        }
-      }, 0)
+      restoreTextareaCursor(inputRef, editingMessage.body.length)
     } else if (!editingMessage) {
       // Reset when editing is cancelled
       lastEditedMessageIdRef.current = null
@@ -612,6 +618,14 @@ export function MessageComposer({
     }
   }
 
+  const selectEmoji = (index: number) => {
+    const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(index)
+    setText(newText)
+    setCursorPosition(newCursorPosition)
+    emojiAutocomplete.dismiss()
+    restoreTextareaCursor(inputRef, newCursorPosition)
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (isEmojiAutocompleteActive) {
       if (e.key === 'ArrowUp') {
@@ -624,18 +638,10 @@ export function MessageComposer({
         emojiAutocomplete.moveSelection('down')
         return
       }
-      if (e.key === 'Enter' || e.key === 'Tab') {
+      // Shift+Enter remains the native newline gesture even while completion is open.
+      if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
         e.preventDefault()
-        const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(emojiAutocomplete.state.selectedIndex)
-        setText(newText)
-        setCursorPosition(newCursorPosition)
-        emojiAutocomplete.dismiss()
-        setTimeout(() => {
-          if (inputRef.current) {
-            inputRef.current.focus()
-            inputRef.current.setSelectionRange(newCursorPosition, newCursorPosition)
-          }
-        }, 0)
+        selectEmoji(emojiAutocomplete.state.selectedIndex)
         return
       }
       if (e.key === 'Escape') {
@@ -752,12 +758,7 @@ export function MessageComposer({
     // Restore focus and set cursor after emoji
     const newCursorPos = cursorPos + emoji.length
     setCursorPosition(newCursorPos)
-    setTimeout(() => {
-      if (inputRef.current) {
-        inputRef.current.focus()
-        inputRef.current.setSelectionRange(newCursorPos, newCursorPos)
-      }
-    }, 0)
+    restoreTextareaCursor(inputRef, newCursorPos)
   }
 
   // Default input renderer (simple textarea)
@@ -811,18 +812,7 @@ export function MessageComposer({
           id={emojiAutocompleteListboxId}
           matches={emojiAutocomplete.state.matches}
           selectedIndex={emojiAutocomplete.state.selectedIndex}
-          onSelect={(idx) => {
-            const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(idx)
-            setText(newText)
-            setCursorPosition(newCursorPosition)
-            emojiAutocomplete.dismiss()
-            setTimeout(() => {
-              if (inputRef.current) {
-                inputRef.current.focus()
-                inputRef.current.setSelectionRange(newCursorPosition, newCursorPosition)
-              }
-            }, 0)
-          }}
+          onSelect={selectEmoji}
           onDismiss={emojiAutocomplete.dismiss}
         />
       )}

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -295,7 +295,14 @@ export function MessageComposer({
   const onSelectionChangeRef = useRef(onSelectionChange)
   onSelectionChangeRef.current = onSelectionChange
   const updateCaret = useCallback((nextText: string, position: number) => {
-    setCaret({ text: nextText, position })
+    // Keeping the previous object when nothing moved lets React bail out, the way
+    // it did when this was a plain number: a selection event that lands on the
+    // caret it already had should not cost a render.
+    setCaret((previous) =>
+      previous && previous.text === nextText && previous.position === position
+        ? previous
+        : { text: nextText, position }
+    )
     onSelectionChangeRef.current?.(position)
   }, [])
   const emojiAutocomplete = useEmojiAutocomplete(text, cursorPosition)

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { detectRenderLoop, notifyUserInput } from '@/utils/renderLoopDetector'
 import { Send, Smile, Paperclip, Reply, X, Pencil, Loader2, Image, FileText, Trash2, BarChart3, Plus, Lock, Shield, ShieldCheck, ShieldAlert, Terminal } from 'lucide-react'
 import { useClickOutside, useEmojiAutocomplete } from '@/hooks'
-import { EmojiAutocompleteMenu, emojiAutocompleteOptionId } from './composer/EmojiAutocompleteMenu'
+import { EmojiAutocompleteMenu } from './composer/EmojiAutocompleteMenu'
+import { composerAutocompleteAriaProps, type ComposerAutocompleteAriaProps } from './composer/autocompleteAria'
 import { Tooltip } from './Tooltip'
 import { TextArea } from './ui/TextInput'
 import type { InputClass } from '../commands/types'
@@ -92,10 +93,7 @@ interface UploadState {
   clearError: () => void
 }
 
-export type ComposerAutocompleteAriaProps = Pick<
-  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-  'role' | 'aria-label' | 'aria-autocomplete' | 'aria-expanded' | 'aria-controls' | 'aria-activedescendant'
->
+export type { ComposerAutocompleteAriaProps }
 
 /** Pending attachment staged for sending (not yet sent) */
 export interface PendingAttachment {
@@ -289,16 +287,14 @@ export function MessageComposer({
   // mention). Inline emoji completion is the final fallback in that priority.
   const isEmojiAutocompleteActive = !hasExternalOverlay && emojiAutocomplete.state.isActive
   const selectedEmojiMatch = emojiAutocomplete.state.matches[emojiAutocomplete.state.selectedIndex]
-  const composerAutocompleteAriaProps: ComposerAutocompleteAriaProps = {
-    role: 'combobox',
-    'aria-label': effectivePlaceholder,
-    'aria-autocomplete': 'list',
-    'aria-expanded': isEmojiAutocompleteActive,
-    'aria-controls': isEmojiAutocompleteActive ? emojiAutocompleteListboxId : undefined,
-    'aria-activedescendant': isEmojiAutocompleteActive && selectedEmojiMatch
-      ? emojiAutocompleteOptionId(emojiAutocompleteListboxId, selectedEmojiMatch.id)
-      : undefined,
-  }
+  // Emoji completion is the composer's own overlay. An owner of the external
+  // overlay slot (a room's mention list) replaces these with its own.
+  const autocompleteAriaProps = composerAutocompleteAriaProps({
+    label: effectivePlaceholder,
+    listboxId: emojiAutocompleteListboxId,
+    isOpen: isEmojiAutocompleteActive,
+    activeOptionKey: selectedEmojiMatch?.id,
+  })
   // Which glyph the send button shows (send / command / unknown). Derived from
   // the live text so it can never go stale — clearing the input after a command
   // runs, an edit cancels, etc. reverts the icon automatically, whereas a
@@ -792,7 +788,7 @@ export function MessageComposer({
       spellCheck={true}
       autoCorrect="on"
       autoCapitalize="sentences"
-      {...composerAutocompleteAriaProps}
+      {...autocompleteAriaProps}
       className={`${MESSAGE_INPUT_BASE_CLASSES} ${MESSAGE_INPUT_TEXT_CLASSES} [grid-area:input]`}
     />
   )
@@ -1101,7 +1097,7 @@ export function MessageComposer({
               onSelect: handleSelect,
               onPaste: handlePaste,
               placeholder: effectivePlaceholder,
-              ariaProps: composerAutocompleteAriaProps,
+              ariaProps: autocompleteAriaProps,
             })}
           </div>
         ) : (

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -498,8 +498,20 @@ export function MessageComposer({
     // *warning*. Arm the interaction grace so warnings stay quiet while typing;
     // the hard loop-break threshold is unaffected.
     notifyUserInput()
-    setText(e.target.value)
-    setCaret({ text: e.target.value, position: e.target.selectionStart })
+    // A completed `:name:` resolves to the emoji straight away, so the closing
+    // colon never lands in the message. Gated like the menu: an overlay that
+    // owns the composer keeps its own completion semantics.
+    const closedShortcode = hasExternalOverlay
+      ? null
+      : emojiAutocomplete.completeClosedShortcode(e.target.value, e.target.selectionStart)
+    if (closedShortcode) {
+      setText(closedShortcode.newText)
+      setCaret({ text: closedShortcode.newText, position: closedShortcode.newCursorPosition })
+      restoreTextareaCursor(inputRef, closedShortcode.newCursorPosition)
+    } else {
+      setText(e.target.value)
+      setCaret({ text: e.target.value, position: e.target.selectionStart })
+    }
     // inputClass is derived from `text` (see declaration), so it updates here
     // automatically — no manual sync needed.
 

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -2,7 +2,8 @@ import React, { useState, useRef, useEffect, useCallback, useMemo, Suspense, laz
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop, notifyUserInput } from '@/utils/renderLoopDetector'
 import { Send, Smile, Paperclip, Reply, X, Pencil, Loader2, Image, FileText, Trash2, BarChart3, Plus, Lock, Shield, ShieldCheck, ShieldAlert, Terminal } from 'lucide-react'
-import { useClickOutside } from '@/hooks'
+import { useClickOutside, useEmojiAutocomplete } from '@/hooks'
+import { EmojiAutocompleteMenu } from './composer/EmojiAutocompleteMenu'
 import { Tooltip } from './Tooltip'
 import { TextArea } from './ui/TextInput'
 import type { InputClass } from '../commands/types'
@@ -255,6 +256,8 @@ export function MessageComposer({
   const [sending, setSending] = useState(false)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [editAttachmentRemoved, setEditAttachmentRemoved] = useState(false)
+  const [cursorPosition, setCursorPosition] = useState(0)
+  const emojiAutocomplete = useEmojiAutocomplete(text, cursorPosition)
   // Which glyph the send button shows (send / command / unknown). Derived from
   // the live text so it can never go stale — clearing the input after a command
   // runs, an edit cancels, etc. reverts the icon automatically, whereas a
@@ -453,6 +456,7 @@ export function MessageComposer({
     // the hard loop-break threshold is unaffected.
     notifyUserInput()
     setText(e.target.value)
+    setCursorPosition(e.target.selectionStart)
     // inputClass is derived from `text` (see declaration), so it updates here
     // automatically — no manual sync needed.
 
@@ -577,6 +581,38 @@ export function MessageComposer({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (emojiAutocomplete.state.isActive) {
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        emojiAutocomplete.moveSelection('up')
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        emojiAutocomplete.moveSelection('down')
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(emojiAutocomplete.state.selectedIndex)
+        setText(newText)
+        setCursorPosition(newCursorPosition)
+        emojiAutocomplete.dismiss()
+        setTimeout(() => {
+          if (inputRef.current) {
+            inputRef.current.focus()
+            inputRef.current.setSelectionRange(newCursorPosition, newCursorPosition)
+          }
+        }, 0)
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        emojiAutocomplete.dismiss()
+        return
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       // Don't submit if disabled (e.g., offline) or send-gated (e.g., whisper
@@ -603,6 +639,7 @@ export function MessageComposer({
   }
 
   const handleSelect = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    setCursorPosition(e.currentTarget.selectionStart)
     onSelectionChange?.(e.currentTarget.selectionStart)
   }
 
@@ -681,10 +718,11 @@ export function MessageComposer({
     setShowEmojiPicker(false)
 
     // Restore focus and set cursor after emoji
+    const newCursorPos = cursorPos + emoji.length
+    setCursorPosition(newCursorPos)
     setTimeout(() => {
       if (inputRef.current) {
         inputRef.current.focus()
-        const newCursorPos = cursorPos + emoji.length
         inputRef.current.setSelectionRange(newCursorPos, newCursorPos)
       }
     }, 0)
@@ -733,6 +771,27 @@ export function MessageComposer({
     <form onSubmit={handleSubmit} className="px-4 pt-2 pb-safe relative">
       {/* Custom content above input (e.g., mention autocomplete) */}
       {aboveInput}
+
+      {/* Inline emoji autocomplete dropdown */}
+      {emojiAutocomplete.state.isActive && (
+        <EmojiAutocompleteMenu
+          matches={emojiAutocomplete.state.matches}
+          selectedIndex={emojiAutocomplete.state.selectedIndex}
+          onSelect={(idx) => {
+            const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(idx)
+            setText(newText)
+            setCursorPosition(newCursorPosition)
+            emojiAutocomplete.dismiss()
+            setTimeout(() => {
+              if (inputRef.current) {
+                inputRef.current.focus()
+                inputRef.current.setSelectionRange(newCursorPosition, newCursorPosition)
+              }
+            }, 0)
+          }}
+          onDismiss={emojiAutocomplete.dismiss}
+        />
+      )}
 
       <div className="composer-card bg-fluux-hover">
       {/* Edit indicator */}

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -84,6 +84,13 @@ export interface MessageComposerHandle {
   focus: () => void
   getText: () => string
   setText: (text: string) => void
+  /**
+   * Position the caret after the parent rewrote the text itself (a room
+   * inserting a mention). Programmatically replacing a textarea's value leaves
+   * the caret at the end, so the insertion point has to be restored explicitly
+   * — the same step the composer's own emoji completion performs inline.
+   */
+  placeCaret: (text: string, position: number) => void
 }
 
 interface UploadState {
@@ -281,6 +288,16 @@ export function MessageComposer({
   // "caret unknown" instead of being sliced at a caret from the previous draft.
   const [caret, setCaret] = useState<{ text: string; position: number } | null>(null)
   const cursorPosition = caret?.text === text ? caret.position : null
+  // The single place the caret is recorded. Owners of the external overlay slot
+  // drive their own completion (room mentions, slash commands) off the reported
+  // position, so anything that moves the caret — typing included, not just
+  // selection events — has to go through here or their menus never open.
+  const onSelectionChangeRef = useRef(onSelectionChange)
+  onSelectionChangeRef.current = onSelectionChange
+  const updateCaret = useCallback((nextText: string, position: number) => {
+    setCaret({ text: nextText, position })
+    onSelectionChangeRef.current?.(position)
+  }, [])
   const emojiAutocomplete = useEmojiAutocomplete(text, cursorPosition)
   const emojiAutocompleteListboxId = `${useId()}-emoji-autocomplete`
   // External overlays are already ordered by their owner (help, command, then
@@ -346,7 +363,11 @@ export function MessageComposer({
     focus: () => inputRef.current?.focus(),
     getText: () => text,
     setText: (t: string) => setText(t),
-  }), [text, setText])
+    placeCaret: (t: string, position: number) => {
+      updateCaret(t, position)
+      restoreTextareaCursor(inputRef, position)
+    },
+  }), [text, setText, updateCaret])
 
   // Close menus when clicking outside
   const closeAttachMenu = () => setShowAttachMenu(false)
@@ -502,11 +523,11 @@ export function MessageComposer({
       : emojiAutocomplete.completeClosedShortcode(e.target.value, e.target.selectionStart)
     if (closedShortcode) {
       setText(closedShortcode.newText)
-      setCaret({ text: closedShortcode.newText, position: closedShortcode.newCursorPosition })
+      updateCaret(closedShortcode.newText, closedShortcode.newCursorPosition)
       restoreTextareaCursor(inputRef, closedShortcode.newCursorPosition)
     } else {
       setText(e.target.value)
-      setCaret({ text: e.target.value, position: e.target.selectionStart })
+      updateCaret(e.target.value, e.target.selectionStart)
     }
     // inputClass is derived from `text` (see declaration), so it updates here
     // automatically — no manual sync needed.
@@ -634,7 +655,7 @@ export function MessageComposer({
   const selectEmoji = (index: number) => {
     const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(index)
     setText(newText)
-    setCaret({ text: newText, position: newCursorPosition })
+    updateCaret(newText, newCursorPosition)
     emojiAutocomplete.dismiss()
     restoreTextareaCursor(inputRef, newCursorPosition)
   }
@@ -690,8 +711,7 @@ export function MessageComposer({
   }
 
   const handleSelect = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
-    setCaret({ text: e.currentTarget.value, position: e.currentTarget.selectionStart })
-    onSelectionChange?.(e.currentTarget.selectionStart)
+    updateCaret(e.currentTarget.value, e.currentTarget.selectionStart)
   }
 
   // Handle clipboard paste - stage files as pending attachment
@@ -770,7 +790,7 @@ export function MessageComposer({
 
     // Restore focus and set cursor after emoji
     const newCursorPos = cursorPos + emoji.length
-    setCaret({ text: newText, position: newCursorPos })
+    updateCaret(newText, newCursorPos)
     restoreTextareaCursor(inputRef, newCursorPos)
   }
 

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useRef, useEffect, useCallback, useMemo, Suspense, lazy, type ReactNode, type RefObject, type Ref, useImperativeHandle } from 'react'
+import React, { useState, useRef, useEffect, useCallback, useMemo, useId, Suspense, lazy, type ReactNode, type RefObject, type Ref, useImperativeHandle } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop, notifyUserInput } from '@/utils/renderLoopDetector'
 import { Send, Smile, Paperclip, Reply, X, Pencil, Loader2, Image, FileText, Trash2, BarChart3, Plus, Lock, Shield, ShieldCheck, ShieldAlert, Terminal } from 'lucide-react'
 import { useClickOutside, useEmojiAutocomplete } from '@/hooks'
-import { EmojiAutocompleteMenu } from './composer/EmojiAutocompleteMenu'
+import { EmojiAutocompleteMenu, emojiAutocompleteOptionId } from './composer/EmojiAutocompleteMenu'
 import { Tooltip } from './Tooltip'
 import { TextArea } from './ui/TextInput'
 import type { InputClass } from '../commands/types'
@@ -80,6 +80,11 @@ interface UploadState {
   clearError: () => void
 }
 
+export type ComposerAutocompleteAriaProps = Pick<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'role' | 'aria-label' | 'aria-autocomplete' | 'aria-expanded' | 'aria-controls' | 'aria-activedescendant'
+>
+
 /** Pending attachment staged for sending (not yet sent) */
 export interface PendingAttachment {
   file: File
@@ -131,9 +136,12 @@ interface MessageComposerProps {
     onSelect?: (e: React.SyntheticEvent<HTMLTextAreaElement>) => void
     onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
     placeholder: string
+    ariaProps: ComposerAutocompleteAriaProps
   }) => ReactNode
   /** Content to render above the input (e.g., mention autocomplete dropdown) */
   aboveInput?: ReactNode
+  /** Whether a higher-priority command, mention, or help overlay currently owns the composer overlay slot. */
+  hasExternalOverlay?: boolean
   /** Text value (controlled) - if provided, component is controlled */
   value?: string
   /** Text change handler (for controlled mode) */
@@ -207,6 +215,7 @@ export function MessageComposer({
   typingNotificationsEnabled = true,
   renderInput,
   aboveInput,
+  hasExternalOverlay = false,
   value: controlledValue,
   onValueChange,
   onSelectionChange,
@@ -258,6 +267,21 @@ export function MessageComposer({
   const [editAttachmentRemoved, setEditAttachmentRemoved] = useState(false)
   const [cursorPosition, setCursorPosition] = useState(0)
   const emojiAutocomplete = useEmojiAutocomplete(text, cursorPosition)
+  const emojiAutocompleteListboxId = `${useId()}-emoji-autocomplete`
+  // External overlays are already ordered by their owner (help, command, then
+  // mention). Inline emoji completion is the final fallback in that priority.
+  const isEmojiAutocompleteActive = !hasExternalOverlay && emojiAutocomplete.state.isActive
+  const selectedEmojiMatch = emojiAutocomplete.state.matches[emojiAutocomplete.state.selectedIndex]
+  const composerAutocompleteAriaProps: ComposerAutocompleteAriaProps = {
+    role: 'combobox',
+    'aria-label': effectivePlaceholder,
+    'aria-autocomplete': 'list',
+    'aria-expanded': isEmojiAutocompleteActive,
+    'aria-controls': isEmojiAutocompleteActive ? emojiAutocompleteListboxId : undefined,
+    'aria-activedescendant': isEmojiAutocompleteActive && selectedEmojiMatch
+      ? emojiAutocompleteOptionId(emojiAutocompleteListboxId, selectedEmojiMatch.id)
+      : undefined,
+  }
   // Which glyph the send button shows (send / command / unknown). Derived from
   // the live text so it can never go stale — clearing the input after a command
   // runs, an edit cancels, etc. reverts the icon automatically, whereas a
@@ -316,6 +340,14 @@ export function MessageComposer({
   useClickOutside(attachMenuRef, closeAttachMenu, showAttachMenu)
   const closeEmojiPicker = () => setShowEmojiPicker(false)
   useClickOutside(emojiPickerRef, closeEmojiPicker, showEmojiPicker)
+
+  // Inline completion owns the composer overlay slot while active. Close the
+  // toolbar drawers so only one popover can occupy the area above the composer.
+  useEffect(() => {
+    if (!isEmojiAutocompleteActive) return
+    setShowAttachMenu(false)
+    setShowEmojiPicker(false)
+  }, [isEmojiAutocompleteActive])
 
   // Cleanup timeouts on unmount
   useEffect(() => {
@@ -581,7 +613,7 @@ export function MessageComposer({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (emojiAutocomplete.state.isActive) {
+    if (isEmojiAutocompleteActive) {
       if (e.key === 'ArrowUp') {
         e.preventDefault()
         emojiAutocomplete.moveSelection('up')
@@ -742,6 +774,7 @@ export function MessageComposer({
       spellCheck={true}
       autoCorrect="on"
       autoCapitalize="sentences"
+      {...composerAutocompleteAriaProps}
       className={`${MESSAGE_INPUT_BASE_CLASSES} ${MESSAGE_INPUT_TEXT_CLASSES} [grid-area:input]`}
     />
   )
@@ -773,8 +806,9 @@ export function MessageComposer({
       {aboveInput}
 
       {/* Inline emoji autocomplete dropdown */}
-      {emojiAutocomplete.state.isActive && (
+      {isEmojiAutocompleteActive && (
         <EmojiAutocompleteMenu
+          id={emojiAutocompleteListboxId}
           matches={emojiAutocomplete.state.matches}
           selectedIndex={emojiAutocomplete.state.selectedIndex}
           onSelect={(idx) => {
@@ -1060,6 +1094,7 @@ export function MessageComposer({
               onSelect: handleSelect,
               onPaste: handlePaste,
               placeholder: effectivePlaceholder,
+              ariaProps: composerAutocompleteAriaProps,
             })}
           </div>
         ) : (

--- a/apps/fluux/src/components/MessageComposer.tsx
+++ b/apps/fluux/src/components/MessageComposer.tsx
@@ -277,7 +277,12 @@ export function MessageComposer({
   const [sending, setSending] = useState(false)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [editAttachmentRemoved, setEditAttachmentRemoved] = useState(false)
-  const [cursorPosition, setCursorPosition] = useState(0)
+  // A caret offset only means something for the text it was measured against.
+  // Storing the two together lets an externally swapped value — a conversation
+  // switch, a mention or command insertion, an edit recall — be recognised as
+  // "caret unknown" instead of being sliced at a caret from the previous draft.
+  const [caret, setCaret] = useState<{ text: string; position: number } | null>(null)
+  const cursorPosition = caret?.text === text ? caret.position : null
   const emojiAutocomplete = useEmojiAutocomplete(text, cursorPosition)
   const emojiAutocompleteListboxId = `${useId()}-emoji-autocomplete`
   // External overlays are already ordered by their owner (help, command, then
@@ -494,7 +499,7 @@ export function MessageComposer({
     // the hard loop-break threshold is unaffected.
     notifyUserInput()
     setText(e.target.value)
-    setCursorPosition(e.target.selectionStart)
+    setCaret({ text: e.target.value, position: e.target.selectionStart })
     // inputClass is derived from `text` (see declaration), so it updates here
     // automatically — no manual sync needed.
 
@@ -621,7 +626,7 @@ export function MessageComposer({
   const selectEmoji = (index: number) => {
     const { newText, newCursorPosition } = emojiAutocomplete.selectMatch(index)
     setText(newText)
-    setCursorPosition(newCursorPosition)
+    setCaret({ text: newText, position: newCursorPosition })
     emojiAutocomplete.dismiss()
     restoreTextareaCursor(inputRef, newCursorPosition)
   }
@@ -677,7 +682,7 @@ export function MessageComposer({
   }
 
   const handleSelect = (e: React.SyntheticEvent<HTMLTextAreaElement>) => {
-    setCursorPosition(e.currentTarget.selectionStart)
+    setCaret({ text: e.currentTarget.value, position: e.currentTarget.selectionStart })
     onSelectionChange?.(e.currentTarget.selectionStart)
   }
 
@@ -757,7 +762,7 @@ export function MessageComposer({
 
     // Restore focus and set cursor after emoji
     const newCursorPos = cursorPos + emoji.length
-    setCursorPosition(newCursorPos)
+    setCaret({ text: newText, position: newCursorPos })
     restoreTextareaCursor(inputRef, newCursorPos)
   }
 

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
+import React, { useState, useRef, useEffect, useCallback, useId, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
 import { useRoomActive, usePolls, useRoomModeration, useRoomManagement, useRoomEntity, useContactIdentities, getBareJid, generateConsistentColorHexSync, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, WhisperCounterpartGoneError, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
@@ -8,15 +8,16 @@ import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, 
 import { MessageBubble, MessageList, RoomSystemLine, shouldShowAvatar, ownGroupKey as computeOwnGroupKey, whisperThreadPosition, whisperCounterpartPresent, resolveWhisperTarget, decideWhisperSend, decideChatStateRoute, buildReplyContext, canClosePoll, PollBanner, type WhisperThreadPosition, type WhisperTarget } from './conversation'
 import { FindOnPageBar } from './conversation/FindOnPageBar'
 import { useFindOnPage, type FindOnPageHandle } from '@/hooks/useFindOnPage'
-import { Avatar } from './Avatar'
 import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './conversation/roomSenderResolution'
 import { selectRoomInitialLoading } from './conversation/roomLoadingState'
 import { format } from 'date-fns'
 import type { CopyMessageMeta } from '@/utils/buildCopyText'
-import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, Users, MessageCircle, EyeOff, User, Settings, Ear, X, Hash } from 'lucide-react'
+import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, MessageCircle, EyeOff, User, Settings, Ear, X, Hash } from 'lucide-react'
 import { EasterEggAnimation } from './easter-eggs/EasterEggAnimation'
 import { TextInput, TextArea } from './ui/TextInput'
 import { MessageComposer, type ReplyInfo, type EditInfo, type MessageComposerHandle, type PendingAttachment, type ComposerAutocompleteAriaProps, MESSAGE_INPUT_BASE_CLASSES, MESSAGE_INPUT_OVERLAY_CLASSES } from './MessageComposer'
+import { MentionAutocompleteMenu } from './composer/MentionAutocompleteMenu'
+import { composerAutocompleteAriaProps } from './composer/autocompleteAria'
 import { RoomHeader } from './RoomHeader'
 import { OccupantPanel } from './OccupantPanel'
 import { OccupantModerationModal } from './OccupantModerationModal'
@@ -1863,6 +1864,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
     roomJid,
     messageNicks
   )
+  const mentionListboxId = `${useId()}-mention-autocomplete`
 
   // Handle mention selection
   const handleMentionSelect = (index: number) => {
@@ -2027,47 +2029,14 @@ export const RoomMessageInput = memo(function RoomMessageInput({
   }, [text])
 
   // Mention autocomplete dropdown
-  const mentionDropdown = mentionState.isActive && mentionState.matches.length > 0 ? (
-    <div
-      className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto
-                 fluux-popover rounded-lg z-30"
-    >
-      {mentionState.matches.map((match, idx) => (
-        <button
-          key={match.nick}
-          type="button"
-          onClick={() => handleMentionSelect(idx)}
-          className={`w-full px-3 py-2 text-start text-sm flex items-center gap-2 transition-colors
-                     ${idx === mentionState.selectedIndex
-                       ? 'bg-fluux-brand text-fluux-text-on-accent'
-                       : 'hover:bg-fluux-hover text-fluux-text'}`}
-        >
-          {/* Avatar */}
-          {match.isAll ? (
-            <div className="size-6 rounded-full flex items-center justify-center flex-shrink-0 bg-fluux-brand">
-              <Users className="size-3.5 text-fluux-text-on-accent" />
-            </div>
-          ) : (
-            <Avatar
-              identifier={match.nick}
-              name={match.nick}
-              size="xs"
-            />
-          )}
-          <span className="font-medium">@{match.nick}</span>
-          {match.isAll && (
-            <span className={`text-xs ${idx === mentionState.selectedIndex ? 'text-fluux-text-on-accent/70' : 'text-fluux-muted'}`}>
-              {t('rooms.notifyEveryone')}
-            </span>
-          )}
-          {match.role === 'moderator' && !match.isAll && (
-            <span className={`text-xs ${idx === mentionState.selectedIndex ? 'text-fluux-text-on-accent/70' : 'text-fluux-muted'}`}>
-              {t('rooms.mod')}
-            </span>
-          )}
-        </button>
-      ))}
-    </div>
+  const isMentionListboxOpen = mentionState.isActive && mentionState.matches.length > 0
+  const mentionDropdown = isMentionListboxOpen ? (
+    <MentionAutocompleteMenu
+      id={mentionListboxId}
+      matches={mentionState.matches}
+      selectedIndex={mentionState.selectedIndex}
+      onSelect={handleMentionSelect}
+    />
   ) : null
 
   // Popovers rendered above the composer, in priority order: help panel, then
@@ -2103,6 +2072,18 @@ export const RoomMessageInput = memo(function RoomMessageInput({
     placeholder: string
     ariaProps: ComposerAutocompleteAriaProps
   }) => {
+    // While the mention list owns the overlay slot the composer's own emoji
+    // completion is suppressed, so its aria props describe a closed popup.
+    // Announce the list the user can actually see instead.
+    const inputAriaProps = isMentionListboxOpen
+      ? composerAutocompleteAriaProps({
+          label: placeholder,
+          listboxId: mentionListboxId,
+          isOpen: true,
+          activeOptionKey: mentionState.matches[mentionState.selectedIndex]?.nick,
+        })
+      : ariaProps
+
     // Enhanced keydown handler for mentions
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Handle backspace/delete within a mention - delete the whole mention at once
@@ -2249,7 +2230,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
           spellCheck={true}
           autoCorrect="on"
           autoCapitalize="sentences"
-          {...ariaProps}
+          {...inputAriaProps}
           className={`${MESSAGE_INPUT_BASE_CLASSES} ${MESSAGE_INPUT_OVERLAY_CLASSES}`}
           style={{ caretColor: 'var(--fluux-text, #e4e4e7)' }}
         />

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -16,7 +16,7 @@ import type { CopyMessageMeta } from '@/utils/buildCopyText'
 import { Shield, Crown, Upload, Loader2, LogIn, AlertCircle, Users, MessageCircle, EyeOff, User, Settings, Ear, X, Hash } from 'lucide-react'
 import { EasterEggAnimation } from './easter-eggs/EasterEggAnimation'
 import { TextInput, TextArea } from './ui/TextInput'
-import { MessageComposer, type ReplyInfo, type EditInfo, type MessageComposerHandle, type PendingAttachment, MESSAGE_INPUT_BASE_CLASSES, MESSAGE_INPUT_OVERLAY_CLASSES } from './MessageComposer'
+import { MessageComposer, type ReplyInfo, type EditInfo, type MessageComposerHandle, type PendingAttachment, type ComposerAutocompleteAriaProps, MESSAGE_INPUT_BASE_CLASSES, MESSAGE_INPUT_OVERLAY_CLASSES } from './MessageComposer'
 import { RoomHeader } from './RoomHeader'
 import { OccupantPanel } from './OccupantPanel'
 import { OccupantModerationModal } from './OccupantModerationModal'
@@ -2092,7 +2092,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
   )
 
   // Custom input renderer with mention highlighting
-  const renderMentionInput = ({ inputRef, mergedRef, value, onChange, onKeyDown: baseKeyDown, onSelect, onPaste, placeholder }: {
+  const renderMentionInput = ({ inputRef, mergedRef, value, onChange, onKeyDown: baseKeyDown, onSelect, onPaste, placeholder, ariaProps }: {
     inputRef: React.RefObject<HTMLTextAreaElement | null>
     mergedRef: (node: HTMLTextAreaElement | null) => void
     value: string
@@ -2101,6 +2101,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
     onSelect?: (e: React.SyntheticEvent<HTMLTextAreaElement>) => void
     onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
     placeholder: string
+    ariaProps: ComposerAutocompleteAriaProps
   }) => {
     // Enhanced keydown handler for mentions
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -2248,6 +2249,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
           spellCheck={true}
           autoCorrect="on"
           autoCapitalize="sentences"
+          {...ariaProps}
           className={`${MESSAGE_INPUT_BASE_CLASSES} ${MESSAGE_INPUT_OVERLAY_CLASSES}`}
           style={{ caretColor: 'var(--fluux-text, #e4e4e7)' }}
         />
@@ -2317,6 +2319,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
         typingNotificationsEnabled={shouldSendTypingNotifications}
         renderInput={renderMentionInput}
         aboveInput={aboveInputNode}
+        hasExternalOverlay={aboveInputNode !== null}
         resolveInput={resolveInput}
         classifyInput={classifyInput}
         commandsEnabled={!whisperTarget}
@@ -2437,4 +2440,3 @@ function renderInputWithMentions(text: string, references: MentionReference[]): 
 
   return <>{parts}</>
 }
-

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1793,6 +1793,7 @@ export const RoomMessageInput = memo(function RoomMessageInput({
     focus: () => composerRef.current?.focus(),
     getText: () => composerRef.current?.getText() || '',
     setText: (t: string) => composerRef.current?.setText(t),
+    placeCaret: (t: string, position: number) => composerRef.current?.placeCaret(t, position),
   }), [])
 
   // Stable callback for draft restoration (resets mention references)
@@ -1871,11 +1872,9 @@ export const RoomMessageInput = memo(function RoomMessageInput({
     const { newText, newCursorPosition, reference } = selectMatch(index)
     setText(newText)
     setReferences(prev => [...prev, reference])
-    // Focus and set cursor position after state update
-    setTimeout(() => {
-      composerRef.current?.focus()
-    }, 0)
-    setCursorPosition(newCursorPosition)
+    // Restores focus, drops the caret after the mention rather than at the end
+    // of the message, and reports the new position back for the next lookup.
+    composerRef.current?.placeCaret(newText, newCursorPosition)
   }
 
   // Auto-focus composer when starting a reply

--- a/apps/fluux/src/components/composer/EmojiAutocompleteMenu.tsx
+++ b/apps/fluux/src/components/composer/EmojiAutocompleteMenu.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+import type { EmojiMatch } from '../../hooks/useEmojiAutocomplete'
+
+interface EmojiAutocompleteMenuProps {
+  matches: EmojiMatch[]
+  selectedIndex: number
+  onSelect: (index: number) => void
+  onDismiss: () => void
+}
+
+/**
+ * Inline emoji completion dropdown popover rendered above the message composer input field.
+ */
+export function EmojiAutocompleteMenu({ matches, selectedIndex, onSelect, onDismiss }: EmojiAutocompleteMenuProps) {
+  const selectedRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Keep the keyboard-highlighted item visible as selection moves past the popover edges.
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  // Dismiss on a pointer press anywhere outside the popover.
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        onDismiss()
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    return () => document.removeEventListener('pointerdown', handlePointerDown, true)
+  }, [onDismiss])
+
+  if (matches.length === 0) return null
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto fluux-popover rounded-lg z-30 flex flex-col"
+    >
+      {matches.map((match, idx) => (
+        <button
+          key={match.id}
+          ref={idx === selectedIndex ? selectedRef : undefined}
+          type="button"
+          onClick={() => onSelect(idx)}
+          className={`w-full px-3 py-2 text-start text-sm flex items-center gap-3 transition-colors ${
+            idx === selectedIndex
+              ? 'bg-fluux-brand text-fluux-text-on-accent'
+              : 'hover:bg-fluux-hover text-fluux-text'
+          }`}
+        >
+          <span className="text-lg leading-none" role="img" aria-label={match.name}>
+            {match.native}
+          </span>
+          <span className="font-mono text-xs font-semibold">:{match.id}:</span>
+          <span
+            className={`text-xs truncate ${
+              idx === selectedIndex ? 'text-fluux-text-on-accent/70' : 'text-fluux-muted'
+            }`}
+          >
+            {match.name}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/fluux/src/components/composer/EmojiAutocompleteMenu.tsx
+++ b/apps/fluux/src/components/composer/EmojiAutocompleteMenu.tsx
@@ -2,16 +2,21 @@ import { useEffect, useRef } from 'react'
 import type { EmojiMatch } from '../../hooks/useEmojiAutocomplete'
 
 interface EmojiAutocompleteMenuProps {
+  id: string
   matches: EmojiMatch[]
   selectedIndex: number
   onSelect: (index: number) => void
   onDismiss: () => void
 }
 
+export function emojiAutocompleteOptionId(listboxId: string, matchId: string): string {
+  return `${listboxId}-option-${encodeURIComponent(matchId)}`
+}
+
 /**
  * Inline emoji completion dropdown popover rendered above the message composer input field.
  */
-export function EmojiAutocompleteMenu({ matches, selectedIndex, onSelect, onDismiss }: EmojiAutocompleteMenuProps) {
+export function EmojiAutocompleteMenu({ id, matches, selectedIndex, onSelect, onDismiss }: EmojiAutocompleteMenuProps) {
   const selectedRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -35,14 +40,21 @@ export function EmojiAutocompleteMenu({ matches, selectedIndex, onSelect, onDism
 
   return (
     <div
+      id={id}
       ref={menuRef}
+      role="listbox"
       className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto fluux-popover rounded-lg z-30 flex flex-col"
     >
       {matches.map((match, idx) => (
         <button
           key={match.id}
+          id={emojiAutocompleteOptionId(id, match.id)}
           ref={idx === selectedIndex ? selectedRef : undefined}
           type="button"
+          role="option"
+          aria-selected={idx === selectedIndex}
+          tabIndex={-1}
+          onMouseDown={(event) => event.preventDefault()}
           onClick={() => onSelect(idx)}
           className={`w-full px-3 py-2 text-start text-sm flex items-center gap-3 transition-colors ${
             idx === selectedIndex
@@ -50,7 +62,7 @@ export function EmojiAutocompleteMenu({ matches, selectedIndex, onSelect, onDism
               : 'hover:bg-fluux-hover text-fluux-text'
           }`}
         >
-          <span className="text-lg leading-none" role="img" aria-label={match.name}>
+          <span className="text-lg leading-none" aria-hidden="true">
             {match.native}
           </span>
           <span className="font-mono text-xs font-semibold">:{match.id}:</span>

--- a/apps/fluux/src/components/composer/EmojiAutocompleteMenu.tsx
+++ b/apps/fluux/src/components/composer/EmojiAutocompleteMenu.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { autocompleteOptionId } from './autocompleteAria'
 import type { EmojiMatch } from '../../hooks/useEmojiAutocomplete'
 
 interface EmojiAutocompleteMenuProps {
@@ -9,14 +11,11 @@ interface EmojiAutocompleteMenuProps {
   onDismiss: () => void
 }
 
-export function emojiAutocompleteOptionId(listboxId: string, matchId: string): string {
-  return `${listboxId}-option-${encodeURIComponent(matchId)}`
-}
-
 /**
  * Inline emoji completion dropdown popover rendered above the message composer input field.
  */
 export function EmojiAutocompleteMenu({ id, matches, selectedIndex, onSelect, onDismiss }: EmojiAutocompleteMenuProps) {
+  const { t } = useTranslation()
   const selectedRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -43,12 +42,13 @@ export function EmojiAutocompleteMenu({ id, matches, selectedIndex, onSelect, on
       id={id}
       ref={menuRef}
       role="listbox"
+      aria-label={t('chat.emojiSuggestions')}
       className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto fluux-popover rounded-lg z-30 flex flex-col"
     >
       {matches.map((match, idx) => (
         <button
           key={match.id}
-          id={emojiAutocompleteOptionId(id, match.id)}
+          id={autocompleteOptionId(id, match.id)}
           ref={idx === selectedIndex ? selectedRef : undefined}
           type="button"
           role="option"

--- a/apps/fluux/src/components/composer/MentionAutocompleteMenu.test.tsx
+++ b/apps/fluux/src/components/composer/MentionAutocompleteMenu.test.tsx
@@ -51,6 +51,35 @@ describe('MentionAutocompleteMenu', () => {
     expect(onSelect).toHaveBeenCalledWith(2)
   })
 
+  // The popover is capped at max-h-48 and scrolls, so a selection driven past
+  // the visible edge by the arrow keys has to be brought back into view.
+  it('keeps the newly selected option in view', () => {
+    const scrollIntoView = vi.fn()
+    vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(scrollIntoView)
+
+    const { rerender } = render(
+      <MentionAutocompleteMenu id="mentions" matches={MATCHES} selectedIndex={0} onSelect={vi.fn()} />
+    )
+    scrollIntoView.mockClear()
+
+    rerender(
+      <MentionAutocompleteMenu id="mentions" matches={MATCHES} selectedIndex={2} onSelect={vi.fn()} />
+    )
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+    expect(scrollIntoView.mock.instances[0]).toBe(screen.getAllByRole('option')[2])
+  })
+
+  // Pressing an option must not blur the textarea, or the caret the completion
+  // is about to rewrite is gone by the time the click lands.
+  it('does not steal focus from the composer when an option is pressed', () => {
+    renderMenu()
+
+    const notPrevented = fireEvent.mouseDown(screen.getAllByRole('option')[1])
+
+    expect(notPrevented).toBe(false)
+  })
+
   it('renders nothing when there is nothing to suggest', () => {
     const { container } = render(
       <MentionAutocompleteMenu id="mentions" matches={[]} selectedIndex={0} onSelect={vi.fn()} />

--- a/apps/fluux/src/components/composer/MentionAutocompleteMenu.test.tsx
+++ b/apps/fluux/src/components/composer/MentionAutocompleteMenu.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MentionAutocompleteMenu } from './MentionAutocompleteMenu'
+import { autocompleteOptionId } from './autocompleteAria'
+import type { MentionMatch } from '../../hooks/useMentionAutocomplete'
+
+const MATCHES: MentionMatch[] = [
+  { nick: 'all', isAll: true },
+  { nick: 'ava', isAll: false, role: 'moderator' },
+  { nick: 'bo', isAll: false, role: 'participant' },
+]
+
+function renderMenu(selectedIndex = 0, onSelect = vi.fn()) {
+  render(
+    <MentionAutocompleteMenu
+      id="mentions"
+      matches={MATCHES}
+      selectedIndex={selectedIndex}
+      onSelect={onSelect}
+    />
+  )
+  return onSelect
+}
+
+describe('MentionAutocompleteMenu', () => {
+  it('exposes the suggestions as a named listbox', () => {
+    renderMenu()
+
+    // t() falls through to the key for anything outside the test i18n subset.
+    expect(screen.getByRole('listbox', { name: 'rooms.mentionSuggestions' })).toBeInTheDocument()
+    expect(screen.getAllByRole('option')).toHaveLength(3)
+  })
+
+  it('marks only the selected option and gives it a referable id', () => {
+    renderMenu(1)
+
+    const options = screen.getAllByRole('option')
+    expect(options.map((option) => option.getAttribute('aria-selected'))).toEqual([
+      'false',
+      'true',
+      'false',
+    ])
+    expect(options[1]).toHaveAttribute('id', autocompleteOptionId('mentions', 'ava'))
+  })
+
+  it('reports the index of a clicked option', () => {
+    const onSelect = renderMenu(0)
+
+    fireEvent.click(screen.getAllByRole('option')[2])
+
+    expect(onSelect).toHaveBeenCalledWith(2)
+  })
+
+  it('renders nothing when there is nothing to suggest', () => {
+    const { container } = render(
+      <MentionAutocompleteMenu id="mentions" matches={[]} selectedIndex={0} onSelect={vi.fn()} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/fluux/src/components/composer/MentionAutocompleteMenu.tsx
+++ b/apps/fluux/src/components/composer/MentionAutocompleteMenu.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from 'react-i18next'
+import { Users } from 'lucide-react'
+import { Avatar } from '../Avatar'
+import { autocompleteOptionId } from './autocompleteAria'
+import type { MentionMatch } from '../../hooks/useMentionAutocomplete'
+
+interface MentionAutocompleteMenuProps {
+  id: string
+  matches: MentionMatch[]
+  selectedIndex: number
+  onSelect: (index: number) => void
+}
+
+/**
+ * Occupant completion dropdown rendered above the room composer input.
+ * Mirrors the inline emoji completion popover so both announce themselves the
+ * same way — see [autocompleteAria] for the shared listbox contract.
+ */
+export function MentionAutocompleteMenu({
+  id,
+  matches,
+  selectedIndex,
+  onSelect,
+}: MentionAutocompleteMenuProps) {
+  const { t } = useTranslation()
+
+  if (matches.length === 0) return null
+
+  return (
+    <div
+      id={id}
+      role="listbox"
+      aria-label={t('rooms.mentionSuggestions')}
+      className="absolute bottom-full inset-x-0 mb-1 max-h-48 overflow-y-auto
+                 fluux-popover rounded-lg z-30"
+    >
+      {matches.map((match, idx) => (
+        <button
+          key={match.nick}
+          id={autocompleteOptionId(id, match.nick)}
+          type="button"
+          role="option"
+          aria-selected={idx === selectedIndex}
+          tabIndex={-1}
+          onClick={() => onSelect(idx)}
+          className={`w-full px-3 py-2 text-start text-sm flex items-center gap-2 transition-colors
+                     ${idx === selectedIndex
+                       ? 'bg-fluux-brand text-fluux-text-on-accent'
+                       : 'hover:bg-fluux-hover text-fluux-text'}`}
+        >
+          {/* Avatar */}
+          {match.isAll ? (
+            <div className="size-6 rounded-full flex items-center justify-center flex-shrink-0 bg-fluux-brand">
+              <Users className="size-3.5 text-fluux-text-on-accent" />
+            </div>
+          ) : (
+            <Avatar
+              identifier={match.nick}
+              name={match.nick}
+              size="xs"
+            />
+          )}
+          <span className="font-medium">@{match.nick}</span>
+          {match.isAll && (
+            <span className={`text-xs ${idx === selectedIndex ? 'text-fluux-text-on-accent/70' : 'text-fluux-muted'}`}>
+              {t('rooms.notifyEveryone')}
+            </span>
+          )}
+          {match.role === 'moderator' && !match.isAll && (
+            <span className={`text-xs ${idx === selectedIndex ? 'text-fluux-text-on-accent/70' : 'text-fluux-muted'}`}>
+              {t('rooms.mod')}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/fluux/src/components/composer/MentionAutocompleteMenu.tsx
+++ b/apps/fluux/src/components/composer/MentionAutocompleteMenu.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Users } from 'lucide-react'
 import { Avatar } from '../Avatar'
@@ -23,6 +24,12 @@ export function MentionAutocompleteMenu({
   onSelect,
 }: MentionAutocompleteMenuProps) {
   const { t } = useTranslation()
+  const selectedRef = useRef<HTMLButtonElement>(null)
+
+  // Keep the keyboard-highlighted item visible as selection moves past the popover edges.
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
 
   if (matches.length === 0) return null
 
@@ -38,10 +45,12 @@ export function MentionAutocompleteMenu({
         <button
           key={match.nick}
           id={autocompleteOptionId(id, match.nick)}
+          ref={idx === selectedIndex ? selectedRef : undefined}
           type="button"
           role="option"
           aria-selected={idx === selectedIndex}
           tabIndex={-1}
+          onMouseDown={(event) => event.preventDefault()}
           onClick={() => onSelect(idx)}
           className={`w-full px-3 py-2 text-start text-sm flex items-center gap-2 transition-colors
                      ${idx === selectedIndex

--- a/apps/fluux/src/components/composer/autocompleteAria.test.ts
+++ b/apps/fluux/src/components/composer/autocompleteAria.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { autocompleteOptionId, composerAutocompleteAriaProps } from './autocompleteAria'
+
+describe('autocompleteOptionId', () => {
+  it('namespaces the option under its listbox', () => {
+    expect(autocompleteOptionId('list-1', 'heart')).toBe('list-1-option-heart')
+  })
+
+  it('escapes keys that are not safe in a DOM id', () => {
+    expect(autocompleteOptionId('list-1', '+1')).toBe('list-1-option-%2B1')
+    expect(autocompleteOptionId('list-1', 'Ana María')).toBe('list-1-option-Ana%20Mar%C3%ADa')
+  })
+})
+
+describe('composerAutocompleteAriaProps', () => {
+  const base = { label: 'Send to Ava', listboxId: 'list-1' }
+
+  it('keeps the combobox role and drops the popup wiring while closed', () => {
+    expect(composerAutocompleteAriaProps({ ...base, isOpen: false, activeOptionKey: 'heart' })).toEqual({
+      role: 'combobox',
+      'aria-label': 'Send to Ava',
+      'aria-autocomplete': 'list',
+      'aria-expanded': false,
+      'aria-controls': undefined,
+      'aria-activedescendant': undefined,
+    })
+  })
+
+  it('points at the listbox and the active option while open', () => {
+    expect(composerAutocompleteAriaProps({ ...base, isOpen: true, activeOptionKey: 'heart' })).toEqual({
+      role: 'combobox',
+      'aria-label': 'Send to Ava',
+      'aria-autocomplete': 'list',
+      'aria-expanded': true,
+      'aria-controls': 'list-1',
+      'aria-activedescendant': 'list-1-option-heart',
+    })
+  })
+
+  it('still exposes the listbox when no option is active yet', () => {
+    expect(composerAutocompleteAriaProps({ ...base, isOpen: true })).toMatchObject({
+      'aria-expanded': true,
+      'aria-controls': 'list-1',
+      'aria-activedescendant': undefined,
+    })
+  })
+})

--- a/apps/fluux/src/components/composer/autocompleteAria.ts
+++ b/apps/fluux/src/components/composer/autocompleteAria.ts
@@ -1,0 +1,48 @@
+import type React from 'react'
+
+/**
+ * ARIA attributes the composer textarea carries while it drives a listbox popup.
+ * Shared so every overlay that owns the composer announces itself the same way.
+ */
+export type ComposerAutocompleteAriaProps = Pick<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'role' | 'aria-label' | 'aria-autocomplete' | 'aria-expanded' | 'aria-controls' | 'aria-activedescendant'
+>
+
+/** Stable DOM id for an autocomplete option, referenced by `aria-activedescendant`. */
+export function autocompleteOptionId(listboxId: string, optionKey: string): string {
+  return `${listboxId}-option-${encodeURIComponent(optionKey)}`
+}
+
+/**
+ * Wire a composer textarea to whichever completion popup currently owns it.
+ *
+ * The `combobox` role stays on the textarea even while closed — screen readers
+ * do not reliably pick up a role that appears and disappears — so the open state
+ * is carried by `aria-expanded` instead. Each overlay owner (emoji completion in
+ * the composer, mention completion in a room) builds its own props, which is what
+ * keeps the announced popup and the visible popup the same one.
+ */
+export function composerAutocompleteAriaProps({
+  label,
+  listboxId,
+  isOpen,
+  activeOptionKey,
+}: {
+  label: string
+  listboxId: string
+  isOpen: boolean
+  activeOptionKey?: string
+}): ComposerAutocompleteAriaProps {
+  return {
+    role: 'combobox',
+    'aria-label': label,
+    'aria-autocomplete': 'list',
+    'aria-expanded': isOpen,
+    'aria-controls': isOpen ? listboxId : undefined,
+    'aria-activedescendant':
+      isOpen && activeOptionKey !== undefined
+        ? autocompleteOptionId(listboxId, activeOptionKey)
+        : undefined,
+  }
+}

--- a/apps/fluux/src/hooks/index.ts
+++ b/apps/fluux/src/hooks/index.ts
@@ -13,6 +13,7 @@ export { useFocusZones, type FocusZone, type FocusZoneRefs } from './useFocusZon
 export { useLinkPreview } from './useLinkPreview'
 export { useListKeyboardNav } from './useListKeyboardNav'
 export { useMentionAutocomplete, type MentionMatch, type MentionAutocompleteState } from './useMentionAutocomplete'
+export { useEmojiAutocomplete, type EmojiMatch, type EmojiAutocompleteState } from './useEmojiAutocomplete'
 export { useMessageCopy } from './useMessageCopy'
 export { useMessageCopyFormatter } from './useMessageCopyFormatter'
 export { useMessageRangeSelection } from './useMessageRangeSelection'

--- a/apps/fluux/src/hooks/useConversationDraft.test.tsx
+++ b/apps/fluux/src/hooks/useConversationDraft.test.tsx
@@ -27,6 +27,7 @@ describe('useConversationDraft', () => {
         getText: vi.fn(() => ''),
         focus: vi.fn(),
         setText: vi.fn(),
+        placeCaret: vi.fn(),
       },
     }
   })

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -72,13 +72,39 @@ describe('useEmojiAutocomplete', () => {
       expect(result.current.state.isActive).toBe(false)
     })
 
-    it('should be active when colon and characters are typed at start of text after data loads', async () => {
-      const { result } = renderHook(() => useEmojiAutocomplete(':+', 2))
-      
+    // `:D`, `:p`, `:3` and friends are emoticons, not shortcode prefixes. A
+    // one-character token matches dozens of emojis, and completion would then
+    // swallow the Enter that was meant to send the message.
+    it.each([':d', ':D', ':p', ':o', ':v', ':x', ':3', 'haha :D'])(
+      'ignores the one-character token in %j so the emoticon can still be sent',
+      (text) => {
+        expect(matchEmojiAutocompleteTrigger(text, text.length)).toBeNull()
+      }
+    )
+
+    it('closes completion once the token shrinks back to a single character', async () => {
+      const { result, rerender } = renderHook(
+        ({ text, cursor }) => useEmojiAutocomplete(text, cursor),
+        { initialProps: { text: ':he', cursor: 3 } }
+      )
+
+      // Waiting for the active state proves the emoji data finished loading, so
+      // the assertion below cannot pass merely because matching had not started.
       await waitFor(() => {
         expect(result.current.state.isActive).toBe(true)
       })
-      expect(result.current.state.query).toBe('+')
+
+      rerender({ text: ':h', cursor: 2 })
+      expect(result.current.state.isActive).toBe(false)
+    })
+
+    it('should be active when colon and characters are typed at start of text after data loads', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':+1', 3))
+
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+      expect(result.current.state.query).toBe('+1')
       expect(result.current.state.triggerIndex).toBe(0)
     })
 

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -2,10 +2,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import {
+  emojiCandidatePool,
   loadEmojiAutocompleteData,
   matchEmojiAutocomplete,
   matchEmojiAutocompleteTrigger,
+  normalizeEmojiSearchText,
+  rankEmojiCandidates,
   useEmojiAutocomplete,
+  type EmojiAutocompleteData,
+  type EmojiCandidatePool,
 } from './useEmojiAutocomplete'
 
 // Mock the emoji database with a smaller subset of test emojis
@@ -294,6 +299,114 @@ describe('useEmojiAutocomplete', () => {
       const ids = result.current.state.matches.map(m => m.id)
       expect(ids).toContain('+1')
       expect(ids).toContain('heart')
+    })
+  })
+
+  describe('incremental narrowing', () => {
+    const DATA = {
+      emojis: {
+        heart: { name: 'Red Heart', skins: [{ native: '❤️' }], keywords: ['love'] },
+        heart_eyes: { name: 'Smiling Face with Heart-Eyes', skins: [{ native: '😍' }], keywords: ['love'] },
+        headphones: { name: 'Headphone', skins: [{ native: '🎧' }], keywords: ['music'] },
+        fire: { name: 'Fire', skins: [{ native: '🔥' }], keywords: ['hot'] },
+      },
+    }
+
+    /** Reading `emojis` means a full database scan happened. */
+    function dataThatFailsIfScanned(): EmojiAutocompleteData {
+      return {
+        get emojis(): never {
+          throw new Error('scanned the full emoji database instead of narrowing')
+        },
+      }
+    }
+
+    it('extends a previous query without rescanning the database', () => {
+      const pool = emojiCandidatePool(DATA, 'hea')
+      expect(pool.candidates.map((c) => c.id).sort()).toEqual(['headphones', 'heart', 'heart_eyes'])
+
+      const narrowed = emojiCandidatePool(dataThatFailsIfScanned(), 'heart', pool)
+
+      expect(narrowed.candidates.map((c) => c.id).sort()).toEqual(['heart', 'heart_eyes'])
+    })
+
+    it('produces exactly what a full scan produces, at every prefix length', () => {
+      let pool: EmojiCandidatePool | undefined
+      for (const query of ['he', 'hea', 'hear', 'heart']) {
+        pool = emojiCandidatePool(DATA, query, pool)
+        expect(pool.candidates.map((c) => c.id).sort()).toEqual(
+          emojiCandidatePool(DATA, query).candidates.map((c) => c.id).sort()
+        )
+      }
+    })
+
+    /**
+     * NFKC composition is not prefix-preserving: normalized 'café' does not start
+     * with normalized 'cafe', so the match set can GROW as the query lengthens.
+     * Narrowing there would lose the match, so the guard must fall back to a scan.
+     */
+    it('rescans when composition breaks the prefix relationship', () => {
+      const data = {
+        emojis: {
+          'café': { name: 'Café', skins: [{ native: '☕' }], keywords: [] },
+        },
+      }
+
+      const pool = emojiCandidatePool(data, 'cafe')
+      expect(pool.candidates).toEqual([])
+
+      const next = emojiCandidatePool(data, normalizeEmojiSearchText('CAFÉ'), pool)
+
+      expect(next.candidates.map((c) => c.id)).toEqual(['café'])
+    })
+
+    it('narrows a deletion by rescanning rather than reusing a narrower pool', () => {
+      const pool = emojiCandidatePool(DATA, 'heart')
+      expect(pool.candidates.map((c) => c.id).sort()).toEqual(['heart', 'heart_eyes'])
+
+      const widened = emojiCandidatePool(DATA, 'hea', pool)
+
+      expect(widened.candidates.map((c) => c.id).sort()).toEqual(['headphones', 'heart', 'heart_eyes'])
+    })
+
+    /**
+     * The pool holds every match, not the visible top eight: a candidate ranked
+     * below the cut for a short query can rank first once the query grows.
+     */
+    it('keeps candidates that only rank into view at a longer query', () => {
+      // Eight ids that tie 'zzz' on rank and length at 'zz' but sort ahead of it,
+      // filling the visible list. None of them survives the extra character.
+      const decoys = Object.fromEntries(
+        'abcdefgh'.split('').map((letter) => [
+          `zz${letter}`,
+          { name: `Decoy ${letter}`, skins: [{ native: `d-${letter}` }], keywords: [] },
+        ])
+      )
+      const data = { emojis: { ...decoys, zzz: { name: 'Target', skins: [{ native: '🎯' }], keywords: [] } } }
+
+      // 'zzz' is pushed out of the visible eight at the shorter query...
+      expect(matchEmojiAutocomplete(data, 'zz').map((m) => m.id)).not.toContain('zzz')
+
+      // ...but the pool keeps it, so extending the query can still surface it.
+      const narrowed = emojiCandidatePool(data, 'zzz', emojiCandidatePool(data, 'zz'))
+
+      expect(narrowed.candidates.map((c) => c.id)).toEqual(['zzz'])
+      expect(rankEmojiCandidates(narrowed.candidates, 'zzz')[0].id).toBe('zzz')
+    })
+
+    it('matches the same emojis whether typed progressively or in one go', async () => {
+      const { result, rerender } = renderHook(
+        ({ text, cursor }) => useEmojiAutocomplete(text, cursor),
+        { initialProps: { text: ':he', cursor: 3 } }
+      )
+      await waitFor(() => expect(result.current.state.isActive).toBe(true))
+
+      for (const [text, cursor] of [[':hea', 4], [':hear', 5], [':heart', 6]] as const) {
+        rerender({ text, cursor })
+      }
+      await waitFor(() => expect(result.current.state.matches.length).toBeGreaterThan(0))
+
+      expect(result.current.state.matches.map((m) => m.id)).toEqual(['heart'])
     })
   })
 

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { matchEmojiAutocomplete, useEmojiAutocomplete } from './useEmojiAutocomplete'
+import {
+  loadEmojiAutocompleteData,
+  matchEmojiAutocomplete,
+  matchEmojiAutocompleteTrigger,
+  useEmojiAutocomplete,
+} from './useEmojiAutocomplete'
 
 // Mock the emoji database with a smaller subset of test emojis
 vi.mock('@emoji-mart/data', () => ({
@@ -28,6 +33,15 @@ vi.mock('@emoji-mart/data', () => ({
 
 describe('useEmojiAutocomplete', () => {
   describe('trigger detection', () => {
+    it('parses a trigger into a stable position-and-token identity', () => {
+      expect(matchEmojiAutocompleteTrigger('hello :Hea', 10)).toEqual({
+        query: 'hea',
+        triggerIndex: 6,
+        token: 'Hea',
+        identity: JSON.stringify([6, 'Hea']),
+      })
+    })
+
     it('should not be active when no colon is typed', () => {
       const { result } = renderHook(() => useEmojiAutocomplete('hello world', 11))
       expect(result.current.state.isActive).toBe(false)
@@ -159,6 +173,14 @@ describe('useEmojiAutocomplete', () => {
     })
   })
 
+  describe('data loading', () => {
+    it('silently disables autocomplete when emoji data fails to load', async () => {
+      const data = await loadEmojiAutocompleteData(() => Promise.reject(new Error('chunk unavailable')))
+
+      expect(data).toBeNull()
+    })
+  })
+
   describe('selection and keyboard navigation', () => {
     it('should replace target string with selected emoji', async () => {
       const { result } = renderHook(() => useEmojiAutocomplete('check this :hea and continue', 15))
@@ -197,7 +219,7 @@ describe('useEmojiAutocomplete', () => {
       expect(result.current.state.selectedIndex).toBe(1) // wrapped back
     })
 
-    it('should allow dismissing selection', async () => {
+    it('keeps the dismissed token closed until its identity changes', async () => {
       const { result, rerender } = renderHook(
         ({ text, cursor }) => useEmojiAutocomplete(text, cursor),
         { initialProps: { text: ':hea', cursor: 4 } }
@@ -212,9 +234,34 @@ describe('useEmojiAutocomplete', () => {
       })
       expect(result.current.state.isActive).toBe(false)
 
-      // Rerendering with same trigger shouldn't reactivate it
-      rerender({ text: ':heart', cursor: 6 })
+      rerender({ text: ':hea', cursor: 4 })
       expect(result.current.state.isActive).toBe(false)
+
+      // Extending the token creates a new trigger identity and re-enables matching.
+      rerender({ text: ':heart', cursor: 6 })
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+    })
+
+    it('treats the same token at a different position as a new trigger', async () => {
+      const { result, rerender } = renderHook(
+        ({ text, cursor }) => useEmojiAutocomplete(text, cursor),
+        { initialProps: { text: ':hea', cursor: 4 } }
+      )
+
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      act(() => {
+        result.current.dismiss()
+      })
+
+      rerender({ text: 'x :hea', cursor: 6 })
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
     })
   })
 })

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -33,12 +33,32 @@ vi.mock('@emoji-mart/data', () => ({
 
 describe('useEmojiAutocomplete', () => {
   describe('trigger detection', () => {
+    it.each([
+      [':Hea', 4, 0],
+      ['hello :Hea', 10, 6],
+    ])('finds a trigger at a supported boundary in %j', (text, cursor, triggerIndex) => {
+      expect(matchEmojiAutocompleteTrigger(text, cursor)).toMatchObject({
+        query: 'hea',
+        triggerIndex,
+        token: 'Hea',
+      })
+    })
+
     it('parses a trigger into a stable position-and-token identity', () => {
       expect(matchEmojiAutocompleteTrigger('hello :Hea', 10)).toEqual({
         query: 'hea',
         triggerIndex: 6,
         token: 'Hea',
         identity: JSON.stringify([6, 'Hea']),
+      })
+    })
+
+    it('uses the caret rather than the end of the message to locate the trigger', () => {
+      expect(matchEmojiAutocompleteTrigger('say :hea and continue', 8)).toEqual({
+        query: 'hea',
+        triggerIndex: 4,
+        token: 'hea',
+        identity: JSON.stringify([4, 'hea']),
       })
     })
 
@@ -145,6 +165,20 @@ describe('useEmojiAutocomplete', () => {
       ])
     })
 
+    it('normalizes case and canonically equivalent Unicode before matching', () => {
+      const matches = matchEmojiAutocomplete({
+        emojis: {
+          'cafe\u0301': {
+            name: 'Cafe\u0301',
+            skins: [{ native: '☕' }],
+            keywords: ['COFFEE'],
+          },
+        },
+      }, 'CAFÉ')
+
+      expect(matches).toEqual([{ id: 'cafe\u0301', name: 'Cafe\u0301', native: '☕' }])
+    })
+
     it('should match and load mock emojis on active trigger', async () => {
       const { result } = renderHook(() => useEmojiAutocomplete(':hea', 4))
       
@@ -192,6 +226,23 @@ describe('useEmojiAutocomplete', () => {
       const { newText, newCursorPosition } = result.current.selectMatch(0)
       expect(newText).toBe('check this ❤️ and continue')
       expect(newCursorPosition).toBe(13) // trigger index (11) + ❤️ length (2)
+    })
+
+    it('leaves text and cursor unchanged for an invalid selection', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete('say :hea later', 8))
+
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      expect(result.current.selectMatch(-1)).toEqual({
+        newText: 'say :hea later',
+        newCursorPosition: 8,
+      })
+      expect(result.current.selectMatch(99)).toEqual({
+        newText: 'say :hea later',
+        newCursorPosition: 8,
+      })
     })
 
     it('should allow cycle keyboard navigation', async () => {
@@ -259,6 +310,30 @@ describe('useEmojiAutocomplete', () => {
       })
 
       rerender({ text: 'x :hea', cursor: 6 })
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+    })
+
+    it('reactivates a dismissed token after the trigger disappears', async () => {
+      const { result, rerender } = renderHook(
+        ({ text, cursor }) => useEmojiAutocomplete(text, cursor),
+        { initialProps: { text: ':hea', cursor: 4 } }
+      )
+
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      act(() => {
+        result.current.dismiss()
+      })
+      rerender({ text: '', cursor: 0 })
+      await waitFor(() => {
+        expect(result.current.state.query).toBe('')
+      })
+
+      rerender({ text: ':hea', cursor: 4 })
       await waitFor(() => {
         expect(result.current.state.isActive).toBe(true)
       })

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -47,6 +47,7 @@ describe('useEmojiAutocomplete', () => {
     it('parses a trigger into a stable position-and-token identity', () => {
       expect(matchEmojiAutocompleteTrigger('hello :Hea', 10)).toEqual({
         query: 'hea',
+        closed: false,
         triggerIndex: 6,
         token: 'Hea',
         identity: JSON.stringify([6, 'Hea']),
@@ -56,6 +57,7 @@ describe('useEmojiAutocomplete', () => {
     it('uses the caret rather than the end of the message to locate the trigger', () => {
       expect(matchEmojiAutocompleteTrigger('say :hea and continue', 8)).toEqual({
         query: 'hea',
+        closed: false,
         triggerIndex: 4,
         token: 'hea',
         identity: JSON.stringify([4, 'hea']),
@@ -127,6 +129,29 @@ describe('useEmojiAutocomplete', () => {
       const { result } = renderHook(() => useEmojiAutocomplete(':thumbs up', 10))
       expect(result.current.state.isActive).toBe(false)
     })
+
+    it('reads a closing colon as part of the shortcode rather than the query', () => {
+      expect(matchEmojiAutocompleteTrigger('say :+1:', 8)).toMatchObject({
+        query: '+1',
+        closed: true,
+        triggerIndex: 4,
+        token: '+1:',
+      })
+    })
+
+    it('marks an unterminated shortcode as open', () => {
+      expect(matchEmojiAutocompleteTrigger('say :+1', 7)).toMatchObject({
+        query: '+1',
+        closed: false,
+      })
+    })
+
+    // A closed shortcode carries no emoticon ambiguity — nobody types `:v:` as a
+    // smiley — so the two-character floor only applies while it is still open.
+    it('accepts a single-character query once the shortcode is closed', () => {
+      expect(matchEmojiAutocompleteTrigger(':v:', 3)).toMatchObject({ query: 'v', closed: true })
+      expect(matchEmojiAutocompleteTrigger(':v', 2)).toBeNull()
+    })
   })
 
   describe('matching and sorting', () => {
@@ -191,6 +216,45 @@ describe('useEmojiAutocomplete', () => {
       ])
     })
 
+    // Ties used to fall back to `id.localeCompare`, which put :-1: 👎 ahead of
+    // :+1: 👍 for "thumbs" purely because "-" sorts before "+".
+    it('breaks a keyword tie on how much of the keyword the query covers', () => {
+      const matches = matchEmojiAutocomplete({
+        emojis: {
+          '-1': {
+            name: 'Thumbs Down',
+            skins: [{ native: '👎' }],
+            keywords: ['-1', 'thumbsdown', 'no', 'dislike'],
+          },
+          '+1': {
+            name: 'Thumbs Up',
+            skins: [{ native: '👍' }],
+            keywords: ['+1', 'thumbsup', 'yes', 'good'],
+          },
+        },
+      }, 'thumbs')
+
+      expect(matches.map((match) => match.id)).toEqual(['+1', '-1'])
+    })
+
+    it('breaks a shortcode-prefix tie on the shortest matching shortcode', () => {
+      const matches = matchEmojiAutocomplete({
+        emojis: {
+          headphones: { name: 'Headphone', skins: [{ native: '🎧' }], keywords: [] },
+          headstone: { name: 'Headstone', skins: [{ native: '🪦' }], keywords: [] },
+          heart_decoration: { name: 'Heart Decoration', skins: [{ native: '💟' }], keywords: [] },
+          heart: { name: 'Red Heart', skins: [{ native: '❤️' }], keywords: [] },
+        },
+      }, 'hea')
+
+      expect(matches.map((match) => match.id)).toEqual([
+        'heart',
+        'headstone',
+        'headphones',
+        'heart_decoration',
+      ])
+    })
+
     it('normalizes case and canonically equivalent Unicode before matching', () => {
       const matches = matchEmojiAutocomplete({
         emojis: {
@@ -230,6 +294,41 @@ describe('useEmojiAutocomplete', () => {
       const ids = result.current.state.matches.map(m => m.id)
       expect(ids).toContain('+1')
       expect(ids).toContain('heart')
+    })
+  })
+
+  describe('closed shortcode completion', () => {
+    /** Completion only resolves once the emoji data is in memory. */
+    async function renderLoadedHook(text: string, cursor: number) {
+      const { result } = renderHook(
+        ({ text: t, cursor: c }) => useEmojiAutocomplete(t, c),
+        { initialProps: { text, cursor } }
+      )
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+      return result
+    }
+
+    it('resolves an exact shortcode once the closing colon is typed', async () => {
+      const result = await renderLoadedHook('love :hea', 9)
+
+      expect(result.current.completeClosedShortcode('love :heart:', 12)).toEqual({
+        newText: 'love ❤️',
+        newCursorPosition: 5 + '❤️'.length,
+      })
+    })
+
+    it('leaves a closed shortcode alone when nothing matches it exactly', async () => {
+      const result = await renderLoadedHook('love :hea', 9)
+
+      expect(result.current.completeClosedShortcode('love :hea:', 10)).toBeNull()
+    })
+
+    it('ignores a shortcode that is still open', async () => {
+      const result = await renderLoadedHook('love :hea', 9)
+
+      expect(result.current.completeClosedShortcode('love :heart', 11)).toBeNull()
     })
   })
 

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useEmojiAutocomplete } from './useEmojiAutocomplete'
+
+// Mock the emoji database with a smaller subset of test emojis
+vi.mock('@emoji-mart/data', () => ({
+  default: {
+    emojis: {
+      '+1': {
+        name: 'Thumbs Up',
+        skins: [{ native: '👍' }],
+        keywords: ['thumbsup', 'agree', 'like', 'plusone'],
+      },
+      'heart': {
+        name: 'Red Heart',
+        skins: [{ native: '❤️' }],
+        keywords: ['love', 'like'],
+      },
+      'smile': {
+        name: 'Smiling Face',
+        skins: [{ native: '😊' }],
+        keywords: ['happy', 'joy'],
+      },
+    },
+  },
+}))
+
+describe('useEmojiAutocomplete', () => {
+  describe('trigger detection', () => {
+    it('should not be active when no colon is typed', () => {
+      const { result } = renderHook(() => useEmojiAutocomplete('hello world', 11))
+      expect(result.current.state.isActive).toBe(false)
+    })
+
+    it('should not be active when a bare colon is typed', () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':', 1))
+      expect(result.current.state.isActive).toBe(false)
+    })
+
+    it('should be active when colon and characters are typed at start of text after data loads', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':+', 2))
+      
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+      expect(result.current.state.query).toBe('+')
+      expect(result.current.state.triggerIndex).toBe(0)
+    })
+
+    it('should be active when colon is typed after whitespace after data loads', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete('hello :hea', 10))
+      
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+      expect(result.current.state.query).toBe('hea')
+      expect(result.current.state.triggerIndex).toBe(6)
+    })
+
+    it('should not be active when colon is in the middle of a word with no preceding space', () => {
+      const { result } = renderHook(() => useEmojiAutocomplete('hello:hea', 9))
+      expect(result.current.state.isActive).toBe(false)
+    })
+
+    it('should not be active when query contains whitespace', () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':thumbs up', 10))
+      expect(result.current.state.isActive).toBe(false)
+    })
+  })
+
+  describe('matching and sorting', () => {
+    it('should match and load mock emojis on active trigger', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':hea', 4))
+      
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      expect(result.current.state.matches.length).toBe(1)
+      expect(result.current.state.matches[0]).toEqual({
+        id: 'heart',
+        name: 'Red Heart',
+        native: '❤️',
+      })
+    })
+
+    it('should match multiple emojis by keyword', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':lik', 4))
+      
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      const ids = result.current.state.matches.map(m => m.id)
+      expect(ids).toContain('+1')
+      expect(ids).toContain('heart')
+    })
+  })
+
+  describe('selection and keyboard navigation', () => {
+    it('should replace target string with selected emoji', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete('check this :hea and continue', 15))
+      
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      const { newText, newCursorPosition } = result.current.selectMatch(0)
+      expect(newText).toBe('check this ❤️ and continue')
+      expect(newCursorPosition).toBe(13) // trigger index (11) + ❤️ length (2)
+    })
+
+    it('should allow cycle keyboard navigation', async () => {
+      const { result } = renderHook(() => useEmojiAutocomplete(':lik', 4))
+      
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      expect(result.current.state.selectedIndex).toBe(0)
+
+      act(() => {
+        result.current.moveSelection('down')
+      })
+      expect(result.current.state.selectedIndex).toBe(1)
+
+      act(() => {
+        result.current.moveSelection('down')
+      })
+      expect(result.current.state.selectedIndex).toBe(0) // wrapped
+
+      act(() => {
+        result.current.moveSelection('up')
+      })
+      expect(result.current.state.selectedIndex).toBe(1) // wrapped back
+    })
+
+    it('should allow dismissing selection', async () => {
+      const { result, rerender } = renderHook(
+        ({ text, cursor }) => useEmojiAutocomplete(text, cursor),
+        { initialProps: { text: ':hea', cursor: 4 } }
+      )
+
+      await waitFor(() => {
+        expect(result.current.state.isActive).toBe(true)
+      })
+
+      act(() => {
+        result.current.dismiss()
+      })
+      expect(result.current.state.isActive).toBe(false)
+
+      // Rerendering with same trigger shouldn't reactivate it
+      rerender({ text: ':heart', cursor: 6 })
+      expect(result.current.state.isActive).toBe(false)
+    })
+  })
+})

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { useEmojiAutocomplete } from './useEmojiAutocomplete'
+import { matchEmojiAutocomplete, useEmojiAutocomplete } from './useEmojiAutocomplete'
 
 // Mock the emoji database with a smaller subset of test emojis
 vi.mock('@emoji-mart/data', () => ({
@@ -70,6 +70,67 @@ describe('useEmojiAutocomplete', () => {
   })
 
   describe('matching and sorting', () => {
+    it('keeps an exact shortcode first when more than eight broader matches precede it', () => {
+      const broadMatches = Object.fromEntries(
+        Array.from({ length: 8 }, (_, index) => [
+          `broad_${index}`,
+          {
+            name: `Heart symbol ${index}`,
+            skins: [{ native: `symbol-${index}` }],
+            keywords: [],
+          },
+        ])
+      )
+
+      const matches = matchEmojiAutocomplete({
+        emojis: {
+          ...broadMatches,
+          heart: {
+            name: 'Red Heart',
+            skins: [{ native: '❤️' }],
+            keywords: ['love'],
+          },
+        },
+      }, 'heart')
+
+      expect(matches).toHaveLength(8)
+      expect(matches[0]).toEqual({ id: 'heart', name: 'Red Heart', native: '❤️' })
+    })
+
+    it('ranks shortcode prefixes ahead of keyword and name matches', () => {
+      const matches = matchEmojiAutocomplete({
+        emojis: {
+          named: {
+            name: 'Heart symbol',
+            skins: [{ native: '🫀' }],
+            keywords: [],
+          },
+          keyword: {
+            name: 'Love Letter',
+            skins: [{ native: '💌' }],
+            keywords: ['heartfelt'],
+          },
+          heart_eyes: {
+            name: 'Smiling Face with Heart-Eyes',
+            skins: [{ native: '😍' }],
+            keywords: ['love'],
+          },
+          heart: {
+            name: 'Red Heart',
+            skins: [{ native: '❤️' }],
+            keywords: ['love'],
+          },
+        },
+      }, 'heart')
+
+      expect(matches.map((match) => match.id)).toEqual([
+        'heart',
+        'heart_eyes',
+        'keyword',
+        'named',
+      ])
+    })
+
     it('should match and load mock emojis on active trigger', async () => {
       const { result } = renderHook(() => useEmojiAutocomplete(':hea', 4))
       

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -32,6 +32,12 @@ export interface EmojiAutocompleteTrigger {
 }
 
 const MAX_EMOJI_MATCHES = 8
+/**
+ * A single character after the colon is an emoticon (`:D`, `:p`, `:3`), not a
+ * shortcode prefix. Matching those would open completion on almost every one and
+ * let it swallow the Enter meant to send the message, so require two characters.
+ */
+const MIN_EMOJI_QUERY_LENGTH = 2
 
 function normalizeEmojiSearchText(value: string): string {
   return value.normalize('NFKC').toLowerCase()
@@ -59,7 +65,7 @@ export function matchEmojiAutocompleteTrigger(
   if (colonIndex === -1) return null
 
   const token = beforeCursor.slice(colonIndex + 1)
-  if (!token || /\s/.test(token)) return null
+  if (token.length < MIN_EMOJI_QUERY_LENGTH || /\s/.test(token)) return null
 
   return {
     query: normalizeEmojiSearchText(token),
@@ -160,7 +166,8 @@ export function matchEmojiAutocomplete(
  */
 export function useEmojiAutocomplete(
   text: string,
-  cursorPosition: number,
+  /** `null` when the caret is unknown for the current text — no trigger is possible. */
+  cursorPosition: number | null,
 ): {
   state: EmojiAutocompleteState
   selectMatch: (index: number) => { newText: string; newCursorPosition: number }
@@ -170,7 +177,7 @@ export function useEmojiAutocomplete(
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [dismissedTriggerIdentity, setDismissedTriggerIdentity] = useState<string | null>(null)
   const trigger = useMemo(
-    () => matchEmojiAutocompleteTrigger(text, cursorPosition),
+    () => (cursorPosition === null ? null : matchEmojiAutocompleteTrigger(text, cursorPosition)),
     [text, cursorPosition],
   )
   const triggerIdentity = trigger?.identity ?? null
@@ -198,8 +205,8 @@ export function useEmojiAutocomplete(
 
   const selectMatch = (index: number): { newText: string; newCursorPosition: number } => {
     const match = matches[index]
-    if (!match) {
-      return { newText: text, newCursorPosition: cursorPosition }
+    if (!match || cursorPosition === null) {
+      return { newText: text, newCursorPosition: cursorPosition ?? text.length }
     }
 
     // Replace :query with the emoji character

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -26,9 +26,16 @@ export interface EmojiAutocompleteData {
 
 export interface EmojiAutocompleteTrigger {
   query: string
+  /** Whether the shortcode was terminated by a closing colon, as in `:+1:`. */
+  closed: boolean
   triggerIndex: number
   token: string
   identity: string
+}
+
+export interface EmojiCompletion {
+  newText: string
+  newCursorPosition: number
 }
 
 const MAX_EMOJI_MATCHES = 8
@@ -65,10 +72,19 @@ export function matchEmojiAutocompleteTrigger(
   if (colonIndex === -1) return null
 
   const token = beforeCursor.slice(colonIndex + 1)
-  if (token.length < MIN_EMOJI_QUERY_LENGTH || /\s/.test(token)) return null
+  if (/\s/.test(token)) return null
+
+  // A trailing colon terminates the shortcode — it is punctuation, not query
+  // text — so `:+1:` searches for "+1" the same way `:+1` does.
+  const closed = token.endsWith(':')
+  const query = closed ? token.slice(0, -1) : token
+  // The two-character floor only guards the open form, where `:D` and `:p` are
+  // emoticons rather than shortcode prefixes. Nobody types `:v:` as a smiley.
+  if (query.length < (closed ? 1 : MIN_EMOJI_QUERY_LENGTH)) return null
 
   return {
-    query: normalizeEmojiSearchText(token),
+    query: normalizeEmojiSearchText(query),
+    closed,
     triggerIndex: colonIndex,
     token,
     identity: JSON.stringify([colonIndex, token]),
@@ -110,10 +126,29 @@ function useEmojiAutocompleteData(enabled: boolean): EmojiAutocompleteData | nul
   return emojiData
 }
 
+/** Length of the shortest keyword the query is a prefix of, or null when none match. */
+function shortestKeywordPrefixLength(
+  keywords: string[] | undefined,
+  normalizedQuery: string,
+): number | null {
+  let shortest: number | null = null
+
+  for (const keyword of keywords ?? []) {
+    const normalized = normalizeEmojiSearchText(keyword)
+    if (!normalized.startsWith(normalizedQuery)) continue
+    if (shortest === null || normalized.length < shortest) shortest = normalized.length
+  }
+
+  return shortest
+}
+
 /**
  * Match and rank emoji suggestions independently of the source data's insertion order.
  * Exact shortcode matches come first, followed by shortcode prefixes, keyword prefixes,
- * and name matches. The result limit is applied only after all candidates are ranked.
+ * and name matches. Within a tier the query covering more of the matched text wins, so
+ * "thumbs" prefers `thumbsup` over `thumbsdown` and "hea" prefers `heart` over
+ * `heart_decoration`, rather than falling back to how the shortcodes happen to sort.
+ * The result limit is applied only after all candidates are ranked.
  */
 export function matchEmojiAutocomplete(
   data: EmojiAutocompleteData,
@@ -123,39 +158,62 @@ export function matchEmojiAutocomplete(
   const normalizedQuery = normalizeEmojiSearchText(query)
   if (!normalizedQuery || limit <= 0 || !data.emojis) return []
 
-  const rankedMatches: Array<EmojiMatch & { rank: number }> = []
+  const rankedMatches: Array<EmojiMatch & { rank: number; matchLength: number }> = []
 
   for (const [id, emoji] of Object.entries(data.emojis)) {
     const native = emoji.skins?.[0]?.native
     if (!native) continue
 
     const normalizedId = normalizeEmojiSearchText(id)
-    const isExactIdMatch = normalizedId === normalizedQuery
-    const isIdPrefixMatch = normalizedId.startsWith(normalizedQuery)
-    const isKeywordPrefixMatch = emoji.keywords?.some((keyword) =>
-      normalizeEmojiSearchText(keyword).startsWith(normalizedQuery)
-    ) ?? false
-    const isNameMatch = normalizeEmojiSearchText(emoji.name).includes(normalizedQuery)
+    let rank = -1
+    let matchLength = 0
 
-    const rank = isExactIdMatch
-      ? 0
-      : isIdPrefixMatch
-        ? 1
-        : isKeywordPrefixMatch
-          ? 2
-          : isNameMatch
-            ? 3
-            : -1
+    if (normalizedId === normalizedQuery) {
+      rank = 0
+      matchLength = normalizedId.length
+    } else if (normalizedId.startsWith(normalizedQuery)) {
+      rank = 1
+      matchLength = normalizedId.length
+    } else {
+      const keywordLength = shortestKeywordPrefixLength(emoji.keywords, normalizedQuery)
+      const normalizedName = normalizeEmojiSearchText(emoji.name)
+
+      if (keywordLength !== null) {
+        rank = 2
+        matchLength = keywordLength
+      } else if (normalizedName.includes(normalizedQuery)) {
+        rank = 3
+        matchLength = normalizedName.length
+      }
+    }
 
     if (rank >= 0) {
-      rankedMatches.push({ id, name: emoji.name, native, rank })
+      rankedMatches.push({ id, name: emoji.name, native, rank, matchLength })
     }
   }
 
   return rankedMatches
-    .sort((a, b) => a.rank - b.rank || a.id.localeCompare(b.id))
+    .sort((a, b) => a.rank - b.rank || a.matchLength - b.matchLength || a.id.localeCompare(b.id))
     .slice(0, limit)
     .map(({ id, name, native }) => ({ id, name, native }))
+}
+
+/** The emoji whose shortcode is exactly `query`, used to resolve a closed `:name:`. */
+export function findExactEmojiShortcode(
+  data: EmojiAutocompleteData,
+  query: string,
+): EmojiMatch | null {
+  const normalizedQuery = normalizeEmojiSearchText(query)
+  if (!normalizedQuery || !data.emojis) return null
+
+  for (const [id, emoji] of Object.entries(data.emojis)) {
+    const native = emoji.skins?.[0]?.native
+    if (native && normalizeEmojiSearchText(id) === normalizedQuery) {
+      return { id, name: emoji.name, native }
+    }
+  }
+
+  return null
 }
 
 /**
@@ -170,7 +228,8 @@ export function useEmojiAutocomplete(
   cursorPosition: number | null,
 ): {
   state: EmojiAutocompleteState
-  selectMatch: (index: number) => { newText: string; newCursorPosition: number }
+  selectMatch: (index: number) => EmojiCompletion
+  completeClosedShortcode: (text: string, cursorPosition: number) => EmojiCompletion | null
   moveSelection: (direction: 'up' | 'down') => void
   dismiss: () => void
 } {
@@ -219,6 +278,31 @@ export function useEmojiAutocomplete(
     return { newText, newCursorPosition }
   }
 
+  /**
+   * Resolve `:name:` the moment the closing colon lands, the way every other
+   * chat client does — no menu, no extra keystroke. Takes the incoming text and
+   * caret rather than reading state so the caller can apply it during the same
+   * change event that produced them.
+   */
+  const completeClosedShortcode = (
+    nextText: string,
+    nextCursorPosition: number,
+  ): EmojiCompletion | null => {
+    if (!emojiData) return null
+
+    const nextTrigger = matchEmojiAutocompleteTrigger(nextText, nextCursorPosition)
+    if (!nextTrigger?.closed) return null
+
+    const match = findExactEmojiShortcode(emojiData, nextTrigger.query)
+    if (!match) return null
+
+    return {
+      newText:
+        nextText.slice(0, nextTrigger.triggerIndex) + match.native + nextText.slice(nextCursorPosition),
+      newCursorPosition: nextTrigger.triggerIndex + match.native.length,
+    }
+  }
+
   const moveSelection = (direction: 'up' | 'down') => {
     if (matches.length === 0) return
 
@@ -245,6 +329,7 @@ export function useEmojiAutocomplete(
       matches,
     },
     selectMatch,
+    completeClosedShortcode,
     moveSelection,
     dismiss,
   }

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -14,6 +14,66 @@ export interface EmojiAutocompleteState {
   matches: EmojiMatch[]
 }
 
+interface EmojiAutocompleteDataEntry {
+  name: string
+  keywords?: string[]
+  skins?: Array<{ native?: string }>
+}
+
+interface EmojiAutocompleteData {
+  emojis?: Record<string, EmojiAutocompleteDataEntry>
+}
+
+const MAX_EMOJI_MATCHES = 8
+
+/**
+ * Match and rank emoji suggestions independently of the source data's insertion order.
+ * Exact shortcode matches come first, followed by shortcode prefixes, keyword prefixes,
+ * and name matches. The result limit is applied only after all candidates are ranked.
+ */
+export function matchEmojiAutocomplete(
+  data: EmojiAutocompleteData,
+  query: string,
+  limit = MAX_EMOJI_MATCHES,
+): EmojiMatch[] {
+  const normalizedQuery = query.toLowerCase()
+  if (!normalizedQuery || limit <= 0 || !data.emojis) return []
+
+  const rankedMatches: Array<EmojiMatch & { rank: number }> = []
+
+  for (const [id, emoji] of Object.entries(data.emojis)) {
+    const native = emoji.skins?.[0]?.native
+    if (!native) continue
+
+    const normalizedId = id.toLowerCase()
+    const isExactIdMatch = normalizedId === normalizedQuery
+    const isIdPrefixMatch = normalizedId.startsWith(normalizedQuery)
+    const isKeywordPrefixMatch = emoji.keywords?.some((keyword) =>
+      keyword.toLowerCase().startsWith(normalizedQuery)
+    ) ?? false
+    const isNameMatch = emoji.name.toLowerCase().includes(normalizedQuery)
+
+    const rank = isExactIdMatch
+      ? 0
+      : isIdPrefixMatch
+        ? 1
+        : isKeywordPrefixMatch
+          ? 2
+          : isNameMatch
+            ? 3
+            : -1
+
+    if (rank >= 0) {
+      rankedMatches.push({ id, name: emoji.name, native, rank })
+    }
+  }
+
+  return rankedMatches
+    .sort((a, b) => a.rank - b.rank || a.id.localeCompare(b.id))
+    .slice(0, limit)
+    .map(({ id, name, native }) => ({ id, name, native }))
+}
+
 /**
  * Hook for inline emoji autocomplete in the message composer.
  *
@@ -33,7 +93,7 @@ export function useEmojiAutocomplete(
   const [dismissed, setDismissed] = useState(false)
   const dismissedAtTriggerRef = useRef<number>(-1)
   const currentTriggerRef = useRef<number>(-1)
-  const [emojiData, setEmojiData] = useState<any>(null)
+  const [emojiData, setEmojiData] = useState<EmojiAutocompleteData | null>(null)
 
   // Detect : trigger and extract query
   const detectTrigger = (): { isActive: boolean; query: string; triggerIndex: number } => {
@@ -99,32 +159,7 @@ export function useEmojiAutocomplete(
   const matches = useMemo((): EmojiMatch[] => {
     if (!isActive || !emojiData || !query) return []
 
-    const list: EmojiMatch[] = []
-    const emojis = emojiData.emojis
-    if (!emojis) return []
-
-    for (const [id, emojiObj] of Object.entries<any>(emojis)) {
-      const native = emojiObj.skins?.[0]?.native
-      if (!native) continue
-
-      const isIdMatch = id.startsWith(query)
-      const isKeywordMatch = emojiObj.keywords?.some((kw: string) => kw.startsWith(query))
-      const isNameMatch = emojiObj.name.toLowerCase().includes(query)
-
-      if (isIdMatch || isKeywordMatch || isNameMatch) {
-        list.push({ id, name: emojiObj.name, native })
-      }
-      if (list.length >= 8) break // Limit to 8 matches for UX clean look
-    }
-
-    // Sort matches: prioritize exact shortcode match, then prefix matches, then alphabetize
-    return list.sort((a, b) => {
-      if (a.id === query) return -1
-      if (b.id === query) return 1
-      if (a.id.startsWith(query) && !b.id.startsWith(query)) return -1
-      if (!a.id.startsWith(query) && b.id.startsWith(query)) return 1
-      return a.id.localeCompare(b.id)
-    })
+    return matchEmojiAutocomplete(emojiData, query)
   }, [isActive, query, emojiData])
 
   // Reset selection index when matches change

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -1,0 +1,185 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+
+export interface EmojiMatch {
+  id: string
+  name: string
+  native: string
+}
+
+export interface EmojiAutocompleteState {
+  isActive: boolean
+  query: string
+  triggerIndex: number
+  selectedIndex: number
+  matches: EmojiMatch[]
+}
+
+/**
+ * Hook for inline emoji autocomplete in the message composer.
+ *
+ * Detects `:` followed by characters and queries the @emoji-mart/data
+ * emoji database to return matching suggestions.
+ */
+export function useEmojiAutocomplete(
+  text: string,
+  cursorPosition: number,
+): {
+  state: EmojiAutocompleteState
+  selectMatch: (index: number) => { newText: string; newCursorPosition: number }
+  moveSelection: (direction: 'up' | 'down') => void
+  dismiss: () => void
+} {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [dismissed, setDismissed] = useState(false)
+  const dismissedAtTriggerRef = useRef<number>(-1)
+  const currentTriggerRef = useRef<number>(-1)
+  const [emojiData, setEmojiData] = useState<any>(null)
+
+  // Detect : trigger and extract query
+  const detectTrigger = (): { isActive: boolean; query: string; triggerIndex: number } => {
+    if (dismissed) {
+      return { isActive: false, query: '', triggerIndex: currentTriggerRef.current }
+    }
+
+    // Look for : before cursor
+    const beforeCursor = text.slice(0, cursorPosition)
+
+    // Find the last : that could be an emoji trigger
+    // Must be at start or preceded by whitespace
+    let colonIndex = -1
+    for (let i = beforeCursor.length - 1; i >= 0; i--) {
+      if (beforeCursor[i] === ':') {
+        // Check if at start or preceded by whitespace
+        if (i === 0 || /\s/.test(beforeCursor[i - 1])) {
+          colonIndex = i
+          break
+        }
+      }
+      // Stop if we hit whitespace (emoji shortcode must not contain spaces)
+      if (/\s/.test(beforeCursor[i])) {
+        break
+      }
+    }
+
+    if (colonIndex === -1) {
+      return { isActive: false, query: '', triggerIndex: -1 }
+    }
+
+    // Extract query (text between : and cursor)
+    const queryText = beforeCursor.slice(colonIndex + 1)
+
+    // Query must be non-empty (to avoid triggering on a bare colon ":")
+    // and must not contain whitespace
+    if (!queryText || /\s/.test(queryText)) {
+      return { isActive: false, query: '', triggerIndex: -1 }
+    }
+
+    // Store current trigger position for dismiss tracking
+    currentTriggerRef.current = colonIndex
+    return { isActive: true, query: queryText.toLowerCase(), triggerIndex: colonIndex }
+  }
+
+  const { isActive, query, triggerIndex } = detectTrigger()
+
+  // Dynamically load emoji data when trigger becomes active
+  // Keeps initial bundle clean from ~150KB of emoji data
+  useEffect(() => {
+    if (isActive && !emojiData) {
+      import('@emoji-mart/data')
+        .then((m) => {
+          setEmojiData(m.default)
+        })
+        .catch(console.error)
+    }
+  }, [isActive, emojiData])
+
+  // Build matches list
+  const matches = useMemo((): EmojiMatch[] => {
+    if (!isActive || !emojiData || !query) return []
+
+    const list: EmojiMatch[] = []
+    const emojis = emojiData.emojis
+    if (!emojis) return []
+
+    for (const [id, emojiObj] of Object.entries<any>(emojis)) {
+      const native = emojiObj.skins?.[0]?.native
+      if (!native) continue
+
+      const isIdMatch = id.startsWith(query)
+      const isKeywordMatch = emojiObj.keywords?.some((kw: string) => kw.startsWith(query))
+      const isNameMatch = emojiObj.name.toLowerCase().includes(query)
+
+      if (isIdMatch || isKeywordMatch || isNameMatch) {
+        list.push({ id, name: emojiObj.name, native })
+      }
+      if (list.length >= 8) break // Limit to 8 matches for UX clean look
+    }
+
+    // Sort matches: prioritize exact shortcode match, then prefix matches, then alphabetize
+    return list.sort((a, b) => {
+      if (a.id === query) return -1
+      if (b.id === query) return 1
+      if (a.id.startsWith(query) && !b.id.startsWith(query)) return -1
+      if (!a.id.startsWith(query) && b.id.startsWith(query)) return 1
+      return a.id.localeCompare(b.id)
+    })
+  }, [isActive, query, emojiData])
+
+  // Reset selection index when matches change
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [matches.length])
+
+  // Reset dismissed state when a NEW : trigger appears at a different position
+  if (dismissed && triggerIndex >= 0 && triggerIndex !== dismissedAtTriggerRef.current) {
+    setDismissed(false)
+    dismissedAtTriggerRef.current = -1
+  }
+
+  const selectMatch = (index: number): { newText: string; newCursorPosition: number } => {
+    const match = matches[index]
+    if (!match) {
+      return { newText: text, newCursorPosition: cursorPosition }
+    }
+
+    // Replace :query with the emoji character
+    const beforeTrigger = text.slice(0, triggerIndex)
+    const afterCursor = text.slice(cursorPosition)
+    const replacement = match.native
+    const newText = beforeTrigger + replacement + afterCursor
+    const newCursorPosition = triggerIndex + replacement.length
+
+    return { newText, newCursorPosition }
+  }
+
+  const moveSelection = (direction: 'up' | 'down') => {
+    if (matches.length === 0) return
+
+    setSelectedIndex((prev) => {
+      if (direction === 'up') {
+        return prev <= 0 ? matches.length - 1 : prev - 1
+      } else {
+        return prev >= matches.length - 1 ? 0 : prev + 1
+      }
+    })
+  }
+
+  const dismiss = () => {
+    dismissedAtTriggerRef.current = currentTriggerRef.current
+    setDismissed(true)
+    setSelectedIndex(0)
+  }
+
+  return {
+    state: {
+      isActive: isActive && matches.length > 0,
+      query,
+      triggerIndex,
+      selectedIndex,
+      matches,
+    },
+    selectMatch,
+    moveSelection,
+    dismiss,
+  }
+}

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -37,10 +37,6 @@ export function useEmojiAutocomplete(
 
   // Detect : trigger and extract query
   const detectTrigger = (): { isActive: boolean; query: string; triggerIndex: number } => {
-    if (dismissed) {
-      return { isActive: false, query: '', triggerIndex: currentTriggerRef.current }
-    }
-
     // Look for : before cursor
     const beforeCursor = text.slice(0, cursorPosition)
 
@@ -76,6 +72,12 @@ export function useEmojiAutocomplete(
 
     // Store current trigger position for dismiss tracking
     currentTriggerRef.current = colonIndex
+
+    // If it's the exact same trigger index we dismissed, remain inactive
+    if (dismissed && colonIndex === dismissedAtTriggerRef.current) {
+      return { isActive: false, query: queryText.toLowerCase(), triggerIndex: colonIndex }
+    }
+
     return { isActive: true, query: queryText.toLowerCase(), triggerIndex: colonIndex }
   }
 

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -33,6 +33,10 @@ export interface EmojiAutocompleteTrigger {
 
 const MAX_EMOJI_MATCHES = 8
 
+function normalizeEmojiSearchText(value: string): string {
+  return value.normalize('NFKC').toLowerCase()
+}
+
 /** Pure: find the emoji shortcode token immediately before the caret. */
 export function matchEmojiAutocompleteTrigger(
   text: string,
@@ -58,7 +62,7 @@ export function matchEmojiAutocompleteTrigger(
   if (!token || /\s/.test(token)) return null
 
   return {
-    query: token.toLowerCase(),
+    query: normalizeEmojiSearchText(token),
     triggerIndex: colonIndex,
     token,
     identity: JSON.stringify([colonIndex, token]),
@@ -110,7 +114,7 @@ export function matchEmojiAutocomplete(
   query: string,
   limit = MAX_EMOJI_MATCHES,
 ): EmojiMatch[] {
-  const normalizedQuery = query.toLowerCase()
+  const normalizedQuery = normalizeEmojiSearchText(query)
   if (!normalizedQuery || limit <= 0 || !data.emojis) return []
 
   const rankedMatches: Array<EmojiMatch & { rank: number }> = []
@@ -119,13 +123,13 @@ export function matchEmojiAutocomplete(
     const native = emoji.skins?.[0]?.native
     if (!native) continue
 
-    const normalizedId = id.toLowerCase()
+    const normalizedId = normalizeEmojiSearchText(id)
     const isExactIdMatch = normalizedId === normalizedQuery
     const isIdPrefixMatch = normalizedId.startsWith(normalizedQuery)
     const isKeywordPrefixMatch = emoji.keywords?.some((keyword) =>
-      keyword.toLowerCase().startsWith(normalizedQuery)
+      normalizeEmojiSearchText(keyword).startsWith(normalizedQuery)
     ) ?? false
-    const isNameMatch = emoji.name.toLowerCase().includes(normalizedQuery)
+    const isNameMatch = normalizeEmojiSearchText(emoji.name).includes(normalizedQuery)
 
     const rank = isExactIdMatch
       ? 0
@@ -185,6 +189,11 @@ export function useEmojiAutocomplete(
   // A changed token represents a new completion interaction, even at the same position.
   useEffect(() => {
     setSelectedIndex(0)
+    setDismissedTriggerIdentity((dismissedIdentity) =>
+      dismissedIdentity !== null && dismissedIdentity !== triggerIdentity
+        ? null
+        : dismissedIdentity
+    )
   }, [triggerIdentity])
 
   const selectMatch = (index: number): { newText: string; newCursorPosition: number } => {

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 
 export interface EmojiMatch {
   id: string
@@ -46,8 +46,23 @@ const MAX_EMOJI_MATCHES = 8
  */
 const MIN_EMOJI_QUERY_LENGTH = 2
 
-function normalizeEmojiSearchText(value: string): string {
+export function normalizeEmojiSearchText(value: string): string {
   return value.normalize('NFKC').toLowerCase()
+}
+
+/** A database entry flattened to just what matching and rendering need. */
+export interface EmojiCandidate {
+  id: string
+  name: string
+  native: string
+  keywords?: string[]
+}
+
+/** Every emoji matching `query`, plus the query they were matched against. */
+export interface EmojiCandidatePool {
+  /** Normalized, so it can be compared against the next normalized query. */
+  query: string
+  candidates: EmojiCandidate[]
 }
 
 /** Pure: find the emoji shortcode token immediately before the caret. */
@@ -143,11 +158,99 @@ function shortestKeywordPrefixLength(
 }
 
 /**
- * Match and rank emoji suggestions independently of the source data's insertion order.
+ * Score one candidate against an already-normalized query, or null if it does not match.
  * Exact shortcode matches come first, followed by shortcode prefixes, keyword prefixes,
  * and name matches. Within a tier the query covering more of the matched text wins, so
  * "thumbs" prefers `thumbsup` over `thumbsdown` and "hea" prefers `heart` over
  * `heart_decoration`, rather than falling back to how the shortcodes happen to sort.
+ */
+function scoreEmojiCandidate(
+  candidate: EmojiCandidate,
+  normalizedQuery: string,
+): { rank: number; matchLength: number } | null {
+  const normalizedId = normalizeEmojiSearchText(candidate.id)
+
+  if (normalizedId === normalizedQuery) return { rank: 0, matchLength: normalizedId.length }
+  if (normalizedId.startsWith(normalizedQuery)) return { rank: 1, matchLength: normalizedId.length }
+
+  const keywordLength = shortestKeywordPrefixLength(candidate.keywords, normalizedQuery)
+  if (keywordLength !== null) return { rank: 2, matchLength: keywordLength }
+
+  const normalizedName = normalizeEmojiSearchText(candidate.name)
+  if (normalizedName.includes(normalizedQuery)) return { rank: 3, matchLength: normalizedName.length }
+
+  return null
+}
+
+/**
+ * Every emoji matching `query`, narrowed from `previous` when possible.
+ *
+ * Each predicate is monotonic over query prefixes — anything matching `heart`
+ * also matches `hea` — so extending a query can only ever shrink the match set,
+ * and the next set can be filtered from the previous one instead of rescanning
+ * all ~1900 emojis. The guard compares *normalized* queries because NFKC
+ * composition is not prefix-preserving: normalized `café` does not start with
+ * normalized `cafe`, so there the set grows and only a full scan is correct.
+ *
+ * The pool deliberately holds every match rather than the visible top eight: a
+ * candidate ranked below the cut for a short query can rank first once the query
+ * grows, so narrowing a limited set would lose it.
+ */
+export function emojiCandidatePool(
+  data: EmojiAutocompleteData,
+  query: string,
+  previous?: EmojiCandidatePool,
+): EmojiCandidatePool {
+  const normalizedQuery = normalizeEmojiSearchText(query)
+  const canNarrow =
+    previous !== undefined &&
+    previous.query.length > 0 &&
+    normalizedQuery.startsWith(previous.query)
+
+  if (canNarrow) {
+    return {
+      query: normalizedQuery,
+      candidates: previous.candidates.filter(
+        (candidate) => scoreEmojiCandidate(candidate, normalizedQuery) !== null
+      ),
+    }
+  }
+
+  const emojis = data.emojis
+  if (!normalizedQuery || !emojis) return { query: normalizedQuery, candidates: [] }
+
+  const candidates: EmojiCandidate[] = []
+  for (const [id, emoji] of Object.entries(emojis)) {
+    const native = emoji.skins?.[0]?.native
+    if (!native) continue
+
+    const candidate: EmojiCandidate = { id, name: emoji.name, native, keywords: emoji.keywords }
+    if (scoreEmojiCandidate(candidate, normalizedQuery) !== null) candidates.push(candidate)
+  }
+
+  return { query: normalizedQuery, candidates }
+}
+
+/** Order a pool's candidates best-match-first. The caller applies any display limit. */
+export function rankEmojiCandidates(candidates: EmojiCandidate[], query: string): EmojiMatch[] {
+  const normalizedQuery = normalizeEmojiSearchText(query)
+
+  return candidates
+    .map((candidate) => ({ candidate, score: scoreEmojiCandidate(candidate, normalizedQuery) }))
+    .filter((entry): entry is { candidate: EmojiCandidate; score: { rank: number; matchLength: number } } =>
+      entry.score !== null
+    )
+    .sort(
+      (a, b) =>
+        a.score.rank - b.score.rank ||
+        a.score.matchLength - b.score.matchLength ||
+        a.candidate.id.localeCompare(b.candidate.id)
+    )
+    .map(({ candidate }) => ({ id: candidate.id, name: candidate.name, native: candidate.native }))
+}
+
+/**
+ * Match and rank emoji suggestions independently of the source data's insertion order.
  * The result limit is applied only after all candidates are ranked.
  */
 export function matchEmojiAutocomplete(
@@ -155,47 +258,9 @@ export function matchEmojiAutocomplete(
   query: string,
   limit = MAX_EMOJI_MATCHES,
 ): EmojiMatch[] {
-  const normalizedQuery = normalizeEmojiSearchText(query)
-  if (!normalizedQuery || limit <= 0 || !data.emojis) return []
+  if (limit <= 0) return []
 
-  const rankedMatches: Array<EmojiMatch & { rank: number; matchLength: number }> = []
-
-  for (const [id, emoji] of Object.entries(data.emojis)) {
-    const native = emoji.skins?.[0]?.native
-    if (!native) continue
-
-    const normalizedId = normalizeEmojiSearchText(id)
-    let rank = -1
-    let matchLength = 0
-
-    if (normalizedId === normalizedQuery) {
-      rank = 0
-      matchLength = normalizedId.length
-    } else if (normalizedId.startsWith(normalizedQuery)) {
-      rank = 1
-      matchLength = normalizedId.length
-    } else {
-      const keywordLength = shortestKeywordPrefixLength(emoji.keywords, normalizedQuery)
-      const normalizedName = normalizeEmojiSearchText(emoji.name)
-
-      if (keywordLength !== null) {
-        rank = 2
-        matchLength = keywordLength
-      } else if (normalizedName.includes(normalizedQuery)) {
-        rank = 3
-        matchLength = normalizedName.length
-      }
-    }
-
-    if (rank >= 0) {
-      rankedMatches.push({ id, name: emoji.name, native, rank, matchLength })
-    }
-  }
-
-  return rankedMatches
-    .sort((a, b) => a.rank - b.rank || a.matchLength - b.matchLength || a.id.localeCompare(b.id))
-    .slice(0, limit)
-    .map(({ id, name, native }) => ({ id, name, native }))
+  return rankEmojiCandidates(emojiCandidatePool(data, query).candidates, query).slice(0, limit)
 }
 
 /** The emoji whose shortcode is exactly `query`, used to resolve a closed `:name:`. */
@@ -245,11 +310,19 @@ export function useEmojiAutocomplete(
   const triggerIndex = trigger?.triggerIndex ?? -1
   const emojiData = useEmojiAutocompleteData(isTriggerActive)
 
-  // Build matches list
+  // Extending a query only ever shrinks the match set, so each keystroke filters
+  // the previous candidates instead of rescanning the whole database. The cache is
+  // a pure optimization — `emojiCandidatePool` falls back to a full scan whenever
+  // the previous pool cannot cover the new query — so a stale or dropped entry can
+  // only cost time, never change the result.
+  const poolRef = useRef<EmojiCandidatePool | undefined>(undefined)
   const matches = useMemo((): EmojiMatch[] => {
     if (!isTriggerActive || !emojiData || !query) return []
 
-    return matchEmojiAutocomplete(emojiData, query)
+    const pool = emojiCandidatePool(emojiData, query, poolRef.current)
+    poolRef.current = pool
+
+    return rankEmojiCandidates(pool.candidates, query).slice(0, MAX_EMOJI_MATCHES)
   }, [isTriggerActive, query, emojiData])
 
   // A changed token represents a new completion interaction, even at the same position.

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -132,8 +132,8 @@ export function useEmojiAutocomplete(
     setSelectedIndex(0)
   }, [matches.length])
 
-  // Reset dismissed state when a NEW : trigger appears at a different position
-  if (dismissed && triggerIndex >= 0 && triggerIndex !== dismissedAtTriggerRef.current) {
+  // Reset dismissed state when the trigger disappears or changes to a different position
+  if (dismissed && (triggerIndex === -1 || (triggerIndex >= 0 && triggerIndex !== dismissedAtTriggerRef.current))) {
     setDismissed(false)
     dismissedAtTriggerRef.current = -1
   }

--- a/apps/fluux/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/fluux/src/hooks/useEmojiAutocomplete.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 
 export interface EmojiMatch {
   id: string
@@ -14,17 +14,91 @@ export interface EmojiAutocompleteState {
   matches: EmojiMatch[]
 }
 
-interface EmojiAutocompleteDataEntry {
+export interface EmojiAutocompleteDataEntry {
   name: string
   keywords?: string[]
   skins?: Array<{ native?: string }>
 }
 
-interface EmojiAutocompleteData {
+export interface EmojiAutocompleteData {
   emojis?: Record<string, EmojiAutocompleteDataEntry>
 }
 
+export interface EmojiAutocompleteTrigger {
+  query: string
+  triggerIndex: number
+  token: string
+  identity: string
+}
+
 const MAX_EMOJI_MATCHES = 8
+
+/** Pure: find the emoji shortcode token immediately before the caret. */
+export function matchEmojiAutocompleteTrigger(
+  text: string,
+  cursorPosition: number,
+): EmojiAutocompleteTrigger | null {
+  const beforeCursor = text.slice(0, cursorPosition)
+  let colonIndex = -1
+
+  for (let index = beforeCursor.length - 1; index >= 0; index--) {
+    if (beforeCursor[index] === ':') {
+      if (index === 0 || /\s/.test(beforeCursor[index - 1])) {
+        colonIndex = index
+        break
+      }
+    }
+
+    if (/\s/.test(beforeCursor[index])) break
+  }
+
+  if (colonIndex === -1) return null
+
+  const token = beforeCursor.slice(colonIndex + 1)
+  if (!token || /\s/.test(token)) return null
+
+  return {
+    query: token.toLowerCase(),
+    triggerIndex: colonIndex,
+    token,
+    identity: JSON.stringify([colonIndex, token]),
+  }
+}
+
+type EmojiAutocompleteDataModule = { default: EmojiAutocompleteData }
+type EmojiAutocompleteDataLoader = () => Promise<EmojiAutocompleteDataModule>
+
+/** Load emoji data without leaking import failures into the composer or console. */
+export async function loadEmojiAutocompleteData(
+  loader: EmojiAutocompleteDataLoader = () => import('@emoji-mart/data'),
+): Promise<EmojiAutocompleteData | null> {
+  try {
+    const module = await loader()
+    return module.default
+  } catch {
+    return null
+  }
+}
+
+/** Keep asynchronous data loading independent from trigger parsing and result matching. */
+function useEmojiAutocompleteData(enabled: boolean): EmojiAutocompleteData | null {
+  const [emojiData, setEmojiData] = useState<EmojiAutocompleteData | null>(null)
+
+  useEffect(() => {
+    if (!enabled || emojiData) return
+
+    let cancelled = false
+    void loadEmojiAutocompleteData().then((data) => {
+      if (!cancelled && data) setEmojiData(data)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, emojiData])
+
+  return emojiData
+}
 
 /**
  * Match and rank emoji suggestions independently of the source data's insertion order.
@@ -90,88 +164,28 @@ export function useEmojiAutocomplete(
   dismiss: () => void
 } {
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [dismissed, setDismissed] = useState(false)
-  const dismissedAtTriggerRef = useRef<number>(-1)
-  const currentTriggerRef = useRef<number>(-1)
-  const [emojiData, setEmojiData] = useState<EmojiAutocompleteData | null>(null)
-
-  // Detect : trigger and extract query
-  const detectTrigger = (): { isActive: boolean; query: string; triggerIndex: number } => {
-    // Look for : before cursor
-    const beforeCursor = text.slice(0, cursorPosition)
-
-    // Find the last : that could be an emoji trigger
-    // Must be at start or preceded by whitespace
-    let colonIndex = -1
-    for (let i = beforeCursor.length - 1; i >= 0; i--) {
-      if (beforeCursor[i] === ':') {
-        // Check if at start or preceded by whitespace
-        if (i === 0 || /\s/.test(beforeCursor[i - 1])) {
-          colonIndex = i
-          break
-        }
-      }
-      // Stop if we hit whitespace (emoji shortcode must not contain spaces)
-      if (/\s/.test(beforeCursor[i])) {
-        break
-      }
-    }
-
-    if (colonIndex === -1) {
-      return { isActive: false, query: '', triggerIndex: -1 }
-    }
-
-    // Extract query (text between : and cursor)
-    const queryText = beforeCursor.slice(colonIndex + 1)
-
-    // Query must be non-empty (to avoid triggering on a bare colon ":")
-    // and must not contain whitespace
-    if (!queryText || /\s/.test(queryText)) {
-      return { isActive: false, query: '', triggerIndex: -1 }
-    }
-
-    // Store current trigger position for dismiss tracking
-    currentTriggerRef.current = colonIndex
-
-    // If it's the exact same trigger index we dismissed, remain inactive
-    if (dismissed && colonIndex === dismissedAtTriggerRef.current) {
-      return { isActive: false, query: queryText.toLowerCase(), triggerIndex: colonIndex }
-    }
-
-    return { isActive: true, query: queryText.toLowerCase(), triggerIndex: colonIndex }
-  }
-
-  const { isActive, query, triggerIndex } = detectTrigger()
-
-  // Dynamically load emoji data when trigger becomes active
-  // Keeps initial bundle clean from ~150KB of emoji data
-  useEffect(() => {
-    if (isActive && !emojiData) {
-      import('@emoji-mart/data')
-        .then((m) => {
-          setEmojiData(m.default)
-        })
-        .catch(console.error)
-    }
-  }, [isActive, emojiData])
+  const [dismissedTriggerIdentity, setDismissedTriggerIdentity] = useState<string | null>(null)
+  const trigger = useMemo(
+    () => matchEmojiAutocompleteTrigger(text, cursorPosition),
+    [text, cursorPosition],
+  )
+  const triggerIdentity = trigger?.identity ?? null
+  const isTriggerActive = trigger !== null && triggerIdentity !== dismissedTriggerIdentity
+  const query = trigger?.query ?? ''
+  const triggerIndex = trigger?.triggerIndex ?? -1
+  const emojiData = useEmojiAutocompleteData(isTriggerActive)
 
   // Build matches list
   const matches = useMemo((): EmojiMatch[] => {
-    if (!isActive || !emojiData || !query) return []
+    if (!isTriggerActive || !emojiData || !query) return []
 
     return matchEmojiAutocomplete(emojiData, query)
-  }, [isActive, query, emojiData])
+  }, [isTriggerActive, query, emojiData])
 
-  // Reset selection index when matches change
+  // A changed token represents a new completion interaction, even at the same position.
   useEffect(() => {
     setSelectedIndex(0)
-  }, [matches.length])
-
-  // Reset dismissed state when the trigger disappears or changes to a different position
-  if (dismissed && (triggerIndex === -1 || (triggerIndex >= 0 && triggerIndex !== dismissedAtTriggerRef.current))) {
-    setDismissed(false)
-    dismissedAtTriggerRef.current = -1
-  }
+  }, [triggerIdentity])
 
   const selectMatch = (index: number): { newText: string; newCursorPosition: number } => {
     const match = matches[index]
@@ -202,14 +216,13 @@ export function useEmojiAutocomplete(
   }
 
   const dismiss = () => {
-    dismissedAtTriggerRef.current = currentTriggerRef.current
-    setDismissed(true)
+    setDismissedTriggerIdentity(triggerIdentity)
     setSelectedIndex(0)
   }
 
   return {
     state: {
-      isActive: isActive && matches.length > 0,
+      isActive: isTriggerActive && matches.length > 0,
       query,
       triggerIndex,
       selectedIndex,

--- a/apps/fluux/src/hooks/useMentionAutocomplete.test.tsx
+++ b/apps/fluux/src/hooks/useMentionAutocomplete.test.tsx
@@ -218,7 +218,9 @@ describe('useMentionAutocomplete', () => {
       expect(newCursorPosition).toBe(7)
     })
 
-    it('should insert mention in the middle of text', () => {
+    // The trailing space is padding, not part of the mention: when the caret is
+    // already followed by one, inserting another leaves a visible double space.
+    it('should insert mention in the middle of text without doubling the space', () => {
       const occupants = createOccupants(['alice', 'bob'])
       const { result } = renderHook(() =>
         useMentionAutocomplete('hey @a check this', 6, occupants, ownNickname, roomJid)
@@ -227,8 +229,34 @@ describe('useMentionAutocomplete', () => {
       const aliceIndex = result.current.state.matches.findIndex((m) => m.nick === 'alice')
       const { newText, newCursorPosition } = result.current.selectMatch(aliceIndex)
 
-      expect(newText).toBe('hey @alice  check this')
+      expect(newText).toBe('hey @alice check this')
+      // Past the space either way, so typing continues on the far side of it.
       expect(newCursorPosition).toBe(11)
+    })
+
+    it('should still pad the mention when nothing follows the caret', () => {
+      const occupants = createOccupants(['alice', 'bob'])
+      const { result } = renderHook(() =>
+        useMentionAutocomplete('hey @a', 6, occupants, ownNickname, roomJid)
+      )
+
+      const aliceIndex = result.current.state.matches.findIndex((m) => m.nick === 'alice')
+      const { newText, newCursorPosition } = result.current.selectMatch(aliceIndex)
+
+      expect(newText).toBe('hey @alice ')
+      expect(newCursorPosition).toBe(11)
+    })
+
+    it('should not pad when the caret is followed by a newline', () => {
+      const occupants = createOccupants(['alice', 'bob'])
+      const { result } = renderHook(() =>
+        useMentionAutocomplete('hey @a\nnext line', 6, occupants, ownNickname, roomJid)
+      )
+
+      const aliceIndex = result.current.state.matches.findIndex((m) => m.nick === 'alice')
+      const { newText } = result.current.selectMatch(aliceIndex)
+
+      expect(newText).toBe('hey @alice\nnext line')
     })
 
     it('should return correct reference for user mention', () => {

--- a/apps/fluux/src/hooks/useMentionAutocomplete.ts
+++ b/apps/fluux/src/hooks/useMentionAutocomplete.ts
@@ -158,12 +158,17 @@ export function useMentionAutocomplete(
       throw new Error('Invalid match index')
     }
 
-    // Replace @query with @nick (add space after)
+    // Replace @query with @nick, padded by a single trailing space. The space is
+    // padding rather than part of the mention, so completing before existing text
+    // that already starts with whitespace must not add a second one.
     const beforeTrigger = text.slice(0, triggerIndex)
     const afterCursor = text.slice(cursorPosition)
-    const replacement = `@${match.nick} `
+    const mention = `@${match.nick}`
+    const replacement = /^\s/.test(afterCursor) ? mention : `${mention} `
     const newText = beforeTrigger + replacement + afterCursor
-    const newCursorPosition = triggerIndex + replacement.length
+    // Land past the separating space either way, so typing continues on its far
+    // side instead of between the mention and the space.
+    const newCursorPosition = triggerIndex + mention.length + 1
 
     // Build reference
     // URI is xmpp:room@conf/nick for users, xmpp:room@conf for @all

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "الدعوات",
         "nickChanged": "أصبح {{oldNick}} يُعرف الآن باسم {{newNick}}",
         "nickEdgeWhitespace": "يحتوي الاسم على مسافات إضافية في الأطراف",
-        "nickHiddenChars": "يحتوي الاسم على أحرف مخفية"
+        "nickHiddenChars": "يحتوي الاسم على أحرف مخفية",
+        "mentionSuggestions": "اقتراحات الإشارات"
     },
     "events": {
         "invitedBy": "دعوة من {{name}}",
@@ -599,7 +600,8 @@
         "loadVideo": "تحميل الفيديو",
         "loadAudio": "تحميل الصوت",
         "loadFilePreview": "تحميل المعاينة",
-        "showLinkImage": "عرض الصورة"
+        "showLinkImage": "عرض الصورة",
+        "emojiSuggestions": "اقتراحات الرموز التعبيرية"
     },
     "dates": {
         "today": "اليوم",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Запрашэнні",
         "nickChanged": "{{oldNick}} цяпер вядомы як {{newNick}}",
         "nickEdgeWhitespace": "Імя змяшчае лішнія прабелы па краях",
-        "nickHiddenChars": "Імя змяшчае схаваныя сімвалы"
+        "nickHiddenChars": "Імя змяшчае схаваныя сімвалы",
+        "mentionSuggestions": "Прапановы згадванняў"
     },
     "events": {
         "invitedBy": "Запрошаны {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Загрузіць відэа",
         "loadAudio": "Загрузіць аўдыё",
         "loadFilePreview": "Загрузіць папярэдні прагляд",
-        "showLinkImage": "Паказаць выяву"
+        "showLinkImage": "Паказаць выяву",
+        "emojiSuggestions": "Прапановы эмодзі"
     },
     "dates": {
         "today": "Сёння",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Покани",
         "nickChanged": "{{oldNick}} вече е познат като {{newNick}}",
         "nickEdgeWhitespace": "Името съдържа излишни интервали в краищата",
-        "nickHiddenChars": "Името съдържа скрити знаци"
+        "nickHiddenChars": "Името съдържа скрити знаци",
+        "mentionSuggestions": "Предложения за споменавания"
     },
     "events": {
         "invitedBy": "Поканен от {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Зареди видео",
         "loadAudio": "Зареди аудио",
         "loadFilePreview": "Зареди преглед",
-        "showLinkImage": "Покажи изображение"
+        "showLinkImage": "Покажи изображение",
+        "emojiSuggestions": "Предложения за емоджи"
     },
     "dates": {
         "today": "Днес",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Invitacions",
         "nickChanged": "{{oldNick}} ara es coneix com a {{newNick}}",
         "nickEdgeWhitespace": "El nom té espais addicionals als extrems",
-        "nickHiddenChars": "El nom conté caràcters ocults"
+        "nickHiddenChars": "El nom conté caràcters ocults",
+        "mentionSuggestions": "Suggeriments de mencions"
     },
     "events": {
         "invitedBy": "Convidat per {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Carrega el vídeo",
         "loadAudio": "Carrega l'àudio",
         "loadFilePreview": "Carrega la previsualització",
-        "showLinkImage": "Mostra la imatge"
+        "showLinkImage": "Mostra la imatge",
+        "emojiSuggestions": "Suggeriments d'emoji"
     },
     "dates": {
         "today": "Avui",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Pozvánky",
         "nickChanged": "{{oldNick}} je nyní znám jako {{newNick}}",
         "nickEdgeWhitespace": "Jméno obsahuje mezery na okrajích",
-        "nickHiddenChars": "Jméno obsahuje skryté znaky"
+        "nickHiddenChars": "Jméno obsahuje skryté znaky",
+        "mentionSuggestions": "Návrhy zmínek"
     },
     "events": {
         "invitedBy": "Pozval(a) {{name}}",
@@ -599,7 +600,8 @@
         "loadVideo": "Načíst video",
         "loadAudio": "Načíst zvuk",
         "loadFilePreview": "Načíst náhled",
-        "showLinkImage": "Zobrazit obrázek"
+        "showLinkImage": "Zobrazit obrázek",
+        "emojiSuggestions": "Návrhy emoji"
     },
     "dates": {
         "today": "Dnes",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Invitationer",
         "nickChanged": "{{oldNick}} er nu kendt som {{newNick}}",
         "nickEdgeWhitespace": "Navnet har ekstra mellemrum i kanterne",
-        "nickHiddenChars": "Navnet indeholder skjulte tegn"
+        "nickHiddenChars": "Navnet indeholder skjulte tegn",
+        "mentionSuggestions": "Omtaleforslag"
     },
     "events": {
         "invitedBy": "Inviteret af {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Indlæs video",
         "loadAudio": "Indlæs lyd",
         "loadFilePreview": "Indlæs forhåndsvisning",
-        "showLinkImage": "Vis billede"
+        "showLinkImage": "Vis billede",
+        "emojiSuggestions": "Emoji-forslag"
     },
     "dates": {
         "today": "I dag",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Einladungen",
         "nickChanged": "{{oldNick}} heißt jetzt {{newNick}}",
         "nickEdgeWhitespace": "Der Name hat zusätzliche Leerzeichen am Rand",
-        "nickHiddenChars": "Der Name enthält versteckte Zeichen"
+        "nickHiddenChars": "Der Name enthält versteckte Zeichen",
+        "mentionSuggestions": "Erwähnungsvorschläge"
     },
     "events": {
         "invitedBy": "Eingeladen von {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Video laden",
         "loadAudio": "Audio laden",
         "loadFilePreview": "Vorschau laden",
-        "showLinkImage": "Bild anzeigen"
+        "showLinkImage": "Bild anzeigen",
+        "emojiSuggestions": "Emoji-Vorschläge"
     },
     "dates": {
         "today": "Heute",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -429,7 +429,8 @@
         "invitationsHeading": "Προσκλήσεις",
         "nickChanged": "{{oldNick}} είναι πλέον γνωστός ως {{newNick}}",
         "nickEdgeWhitespace": "Το όνομα έχει επιπλέον κενά στα άκρα",
-        "nickHiddenChars": "Το όνομα περιέχει κρυφούς χαρακτήρες"
+        "nickHiddenChars": "Το όνομα περιέχει κρυφούς χαρακτήρες",
+        "mentionSuggestions": "Προτάσεις αναφορών"
     },
     "events": {
         "invitedBy": "Πρόσκληση από {{name}}",
@@ -596,7 +597,8 @@
         "loadVideo": "Φόρτωση βίντεο",
         "loadAudio": "Φόρτωση ήχου",
         "loadFilePreview": "Φόρτωση προεπισκόπησης",
-        "showLinkImage": "Εμφάνιση εικόνας"
+        "showLinkImage": "Εμφάνιση εικόνας",
+        "emojiSuggestions": "Προτάσεις emoji"
     },
     "dates": {
         "today": "Σήμερα",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Invitations",
         "nickChanged": "{{oldNick}} is now known as {{newNick}}",
         "nickEdgeWhitespace": "Name has extra spaces at the edges",
-        "nickHiddenChars": "Name contains hidden characters"
+        "nickHiddenChars": "Name contains hidden characters",
+        "mentionSuggestions": "Mention suggestions"
     },
     "events": {
         "invitedBy": "Invited by {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Load video",
         "loadAudio": "Load audio",
         "loadFilePreview": "Load preview",
-        "showLinkImage": "Show image"
+        "showLinkImage": "Show image",
+        "emojiSuggestions": "Emoji suggestions"
     },
     "dates": {
         "today": "Today",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Invitaciones",
         "nickChanged": "{{oldNick}} ahora se conoce como {{newNick}}",
         "nickEdgeWhitespace": "El nombre tiene espacios adicionales en los extremos",
-        "nickHiddenChars": "El nombre contiene caracteres ocultos"
+        "nickHiddenChars": "El nombre contiene caracteres ocultos",
+        "mentionSuggestions": "Sugerencias de menciones"
     },
     "events": {
         "invitedBy": "Invitado por {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Cargar vídeo",
         "loadAudio": "Cargar audio",
         "loadFilePreview": "Cargar vista previa",
-        "showLinkImage": "Mostrar imagen"
+        "showLinkImage": "Mostrar imagen",
+        "emojiSuggestions": "Sugerencias de emojis"
     },
     "dates": {
         "today": "Hoy",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Kutsed",
         "nickChanged": "{{oldNick}} on nüüd tuntud kui {{newNick}}",
         "nickEdgeWhitespace": "Nimel on servades lisatühikud",
-        "nickHiddenChars": "Nimi sisaldab peidetud märke"
+        "nickHiddenChars": "Nimi sisaldab peidetud märke",
+        "mentionSuggestions": "Mainimiste soovitused"
     },
     "events": {
         "invitedBy": "Kutsuja {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Laadi video",
         "loadAudio": "Laadi heli",
         "loadFilePreview": "Laadi eelvaade",
-        "showLinkImage": "Kuva pilt"
+        "showLinkImage": "Kuva pilt",
+        "emojiSuggestions": "Emoji soovitused"
     },
     "dates": {
         "today": "Täna",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Kutsut",
         "nickChanged": "{{oldNick}} tunnetaan nyt nimellä {{newNick}}",
         "nickEdgeWhitespace": "Nimessä on ylimääräisiä välilyöntejä reunoilla",
-        "nickHiddenChars": "Nimi sisältää piilotettuja merkkejä"
+        "nickHiddenChars": "Nimi sisältää piilotettuja merkkejä",
+        "mentionSuggestions": "Mainintaehdotukset"
     },
     "events": {
         "invitedBy": "Kutsuja: {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Lataa video",
         "loadAudio": "Lataa ääni",
         "loadFilePreview": "Lataa esikatselu",
-        "showLinkImage": "Näytä kuva"
+        "showLinkImage": "Näytä kuva",
+        "emojiSuggestions": "Emoji-ehdotukset"
     },
     "dates": {
         "today": "Tänään",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -429,7 +429,8 @@
         "invitationsHeading": "Invitations",
         "nickChanged": "{{oldNick}} est désormais connu sous le nom de {{newNick}}",
         "nickEdgeWhitespace": "Le nom comporte des espaces au début ou à la fin",
-        "nickHiddenChars": "Le nom contient des caractères invisibles"
+        "nickHiddenChars": "Le nom contient des caractères invisibles",
+        "mentionSuggestions": "Suggestions de mentions"
     },
     "events": {
         "invitedBy": "Invité par {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Charger la vidéo",
         "loadAudio": "Charger l'audio",
         "loadFilePreview": "Charger l'aperçu",
-        "showLinkImage": "Afficher l'image"
+        "showLinkImage": "Afficher l'image",
+        "emojiSuggestions": "Suggestions d'emoji"
     },
     "dates": {
         "today": "Aujourd'hui",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Cuirí",
         "nickChanged": "Tugtar {{newNick}} ar {{oldNick}} anois",
         "nickEdgeWhitespace": "Tá spásanna breise ag imill an ainm",
-        "nickHiddenChars": "Tá carachtair fholaithe san ainm"
+        "nickHiddenChars": "Tá carachtair fholaithe san ainm",
+        "mentionSuggestions": "Moltaí tagartha"
     },
     "events": {
         "invitedBy": "Cuireadh ag {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Luchtaigh físeán",
         "loadAudio": "Luchtaigh fuaim",
         "loadFilePreview": "Luchtaigh réamhamharc",
-        "showLinkImage": "Taispeáin íomhá"
+        "showLinkImage": "Taispeáin íomhá",
+        "emojiSuggestions": "Moltaí emoji"
     },
     "dates": {
         "today": "Inniu",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "הזמנות",
         "nickChanged": "{{oldNick}} ידוע כעת בשם {{newNick}}",
         "nickEdgeWhitespace": "השם מכיל רווחים נוספים בקצוות",
-        "nickHiddenChars": "השם מכיל תווים נסתרים"
+        "nickHiddenChars": "השם מכיל תווים נסתרים",
+        "mentionSuggestions": "הצעות אזכור"
     },
     "events": {
         "invitedBy": "הוזמן על ידי {{name}}",
@@ -596,7 +597,8 @@
         "loadVideo": "טען סרטון",
         "loadAudio": "טען שמע",
         "loadFilePreview": "טען תצוגה מקדימה",
-        "showLinkImage": "הצג תמונה"
+        "showLinkImage": "הצג תמונה",
+        "emojiSuggestions": "הצעות אמוג'י"
     },
     "dates": {
         "today": "היום",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Pozivnice",
         "nickChanged": "{{oldNick}} sada je poznat kao {{newNick}}",
         "nickEdgeWhitespace": "Ime sadrži dodatne razmake na rubovima",
-        "nickHiddenChars": "Ime sadrži skrivene znakove"
+        "nickHiddenChars": "Ime sadrži skrivene znakove",
+        "mentionSuggestions": "Prijedlozi spominjanja"
     },
     "events": {
         "invitedBy": "Pozvao {{name}}",
@@ -596,7 +597,8 @@
         "loadVideo": "Učitaj video",
         "loadAudio": "Učitaj zvuk",
         "loadFilePreview": "Učitaj pretpregled",
-        "showLinkImage": "Prikaži sliku"
+        "showLinkImage": "Prikaži sliku",
+        "emojiSuggestions": "Prijedlozi emojija"
     },
     "dates": {
         "today": "Danas",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Meghívók",
         "nickChanged": "{{oldNick}} mostantól {{newNick}} néven ismert",
         "nickEdgeWhitespace": "A név szélein extra szóközök vannak",
-        "nickHiddenChars": "A név rejtett karaktereket tartalmaz"
+        "nickHiddenChars": "A név rejtett karaktereket tartalmaz",
+        "mentionSuggestions": "Említésjavaslatok"
     },
     "events": {
         "invitedBy": "Meghívta: {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Videó betöltése",
         "loadAudio": "Hang betöltése",
         "loadFilePreview": "Előnézet betöltése",
-        "showLinkImage": "Kép megjelenítése"
+        "showLinkImage": "Kép megjelenítése",
+        "emojiSuggestions": "Emoji javaslatok"
     },
     "dates": {
         "today": "Ma",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Boð",
         "nickChanged": "{{oldNick}} er nú þekktur sem {{newNick}}",
         "nickEdgeWhitespace": "Nafnið er með auka bil á endunum",
-        "nickHiddenChars": "Nafnið inniheldur falda stafi"
+        "nickHiddenChars": "Nafnið inniheldur falda stafi",
+        "mentionSuggestions": "Tillögur að tilvísunum"
     },
     "events": {
         "invitedBy": "Boðið af {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Hlaða myndband",
         "loadAudio": "Hlaða hljóð",
         "loadFilePreview": "Hlaða forskoðun",
-        "showLinkImage": "Sýna mynd"
+        "showLinkImage": "Sýna mynd",
+        "emojiSuggestions": "Emoji-tillögur"
     },
     "dates": {
         "today": "Í dag",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Inviti",
         "nickChanged": "{{oldNick}} ora è conosciuto come {{newNick}}",
         "nickEdgeWhitespace": "Il nome ha spazi aggiuntivi ai bordi",
-        "nickHiddenChars": "Il nome contiene caratteri nascosti"
+        "nickHiddenChars": "Il nome contiene caratteri nascosti",
+        "mentionSuggestions": "Suggerimenti menzioni"
     },
     "events": {
         "invitedBy": "Invitato da {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Carica video",
         "loadAudio": "Carica audio",
         "loadFilePreview": "Carica anteprima",
-        "showLinkImage": "Mostra immagine"
+        "showLinkImage": "Mostra immagine",
+        "emojiSuggestions": "Suggerimenti emoji"
     },
     "dates": {
         "today": "Oggi",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Kvietimai",
         "nickChanged": "{{oldNick}} dabar žinomas kaip {{newNick}}",
         "nickEdgeWhitespace": "Varde yra papildomų tarpų kraštuose",
-        "nickHiddenChars": "Varde yra paslėptų simbolių"
+        "nickHiddenChars": "Varde yra paslėptų simbolių",
+        "mentionSuggestions": "Paminėjimų pasiūlymai"
     },
     "events": {
         "invitedBy": "Pakvietė {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Įkelti vaizdo įrašą",
         "loadAudio": "Įkelti garsą",
         "loadFilePreview": "Įkelti peržiūrą",
-        "showLinkImage": "Rodyti nuotrauką"
+        "showLinkImage": "Rodyti nuotrauką",
+        "emojiSuggestions": "Emoji pasiūlymai"
     },
     "dates": {
         "today": "Šiandien",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -429,7 +429,8 @@
         "invitationsHeading": "Ielūgumi",
         "nickChanged": "{{oldNick}} tagad zināms kā {{newNick}}",
         "nickEdgeWhitespace": "Vārdam ir papildu atstarpes malās",
-        "nickHiddenChars": "Vārds satur slēptas rakstzīmes"
+        "nickHiddenChars": "Vārds satur slēptas rakstzīmes",
+        "mentionSuggestions": "Pieminējumu ieteikumi"
     },
     "events": {
         "invitedBy": "Uzaicināja {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Ielādēt videoklipu",
         "loadAudio": "Ielādēt audio",
         "loadFilePreview": "Ielādēt priekšskatījumu",
-        "showLinkImage": "Rādīt attēlu"
+        "showLinkImage": "Rādīt attēlu",
+        "emojiSuggestions": "Emoji ieteikumi"
     },
     "dates": {
         "today": "Šodien",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Stedini",
         "nickChanged": "{{oldNick}} issa magħruf bħala {{newNick}}",
         "nickEdgeWhitespace": "L-isem għandu spazji żejda fit-truf",
-        "nickHiddenChars": "L-isem fih karattri moħbija"
+        "nickHiddenChars": "L-isem fih karattri moħbija",
+        "mentionSuggestions": "Suġġerimenti ta' msemmija"
     },
     "events": {
         "invitedBy": "Mistieden minn {{name}}",
@@ -600,7 +601,8 @@
         "loadVideo": "Itgħabba l-vidjo",
         "loadAudio": "Itgħabba l-awdjo",
         "loadFilePreview": "Itgħabba l-anteprima",
-        "showLinkImage": "Uri l-immaġni"
+        "showLinkImage": "Uri l-immaġni",
+        "emojiSuggestions": "Suġġerimenti ta' emoji"
     },
     "dates": {
         "today": "Illum",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Invitasjoner",
         "nickChanged": "{{oldNick}} er nå kjent som {{newNick}}",
         "nickEdgeWhitespace": "Navnet har ekstra mellomrom i kantene",
-        "nickHiddenChars": "Navnet inneholder skjulte tegn"
+        "nickHiddenChars": "Navnet inneholder skjulte tegn",
+        "mentionSuggestions": "Omtaleforslag"
     },
     "events": {
         "invitedBy": "Invitert av {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Last inn video",
         "loadAudio": "Last inn lyd",
         "loadFilePreview": "Last inn forhåndsvisning",
-        "showLinkImage": "Vis bilde"
+        "showLinkImage": "Vis bilde",
+        "emojiSuggestions": "Emoji-forslag"
     },
     "dates": {
         "today": "I dag",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Uitnodigingen",
         "nickChanged": "{{oldNick}} heet nu {{newNick}}",
         "nickEdgeWhitespace": "De naam heeft extra spaties aan de randen",
-        "nickHiddenChars": "De naam bevat verborgen tekens"
+        "nickHiddenChars": "De naam bevat verborgen tekens",
+        "mentionSuggestions": "Vermeldingssuggesties"
     },
     "events": {
         "invitedBy": "Uitgenodigd door {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Video laden",
         "loadAudio": "Audio laden",
         "loadFilePreview": "Voorbeeld laden",
-        "showLinkImage": "Afbeelding tonen"
+        "showLinkImage": "Afbeelding tonen",
+        "emojiSuggestions": "Emoji-suggesties"
     },
     "dates": {
         "today": "Vandaag",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Zaproszenia",
         "nickChanged": "{{oldNick}} jest teraz znany jako {{newNick}}",
         "nickEdgeWhitespace": "Nazwa ma dodatkowe spacje na brzegach",
-        "nickHiddenChars": "Nazwa zawiera ukryte znaki"
+        "nickHiddenChars": "Nazwa zawiera ukryte znaki",
+        "mentionSuggestions": "Podpowiedzi wzmianek"
     },
     "events": {
         "invitedBy": "Zaproszony przez {{name}}",
@@ -599,7 +600,8 @@
         "loadVideo": "Załaduj wideo",
         "loadAudio": "Załaduj audio",
         "loadFilePreview": "Załaduj podgląd",
-        "showLinkImage": "Pokaż obraz"
+        "showLinkImage": "Pokaż obraz",
+        "emojiSuggestions": "Podpowiedzi emoji"
     },
     "dates": {
         "today": "Dzisiaj",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Convites",
         "nickChanged": "{{oldNick}} agora é conhecido como {{newNick}}",
         "nickEdgeWhitespace": "O nome tem espaços extra nas extremidades",
-        "nickHiddenChars": "O nome contém caracteres ocultos"
+        "nickHiddenChars": "O nome contém caracteres ocultos",
+        "mentionSuggestions": "Sugestões de menções"
     },
     "events": {
         "invitedBy": "Convidado por {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Carregar vídeo",
         "loadAudio": "Carregar áudio",
         "loadFilePreview": "Carregar pré-visualização",
-        "showLinkImage": "Mostrar imagem"
+        "showLinkImage": "Mostrar imagem",
+        "emojiSuggestions": "Sugestões de emojis"
     },
     "dates": {
         "today": "Hoje",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Invitații",
         "nickChanged": "{{oldNick}} este acum cunoscut ca {{newNick}}",
         "nickEdgeWhitespace": "Numele are spații suplimentare la margini",
-        "nickHiddenChars": "Numele conține caractere ascunse"
+        "nickHiddenChars": "Numele conține caractere ascunse",
+        "mentionSuggestions": "Sugestii de mențiuni"
     },
     "events": {
         "invitedBy": "Invitat de {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Încarcă videoclipul",
         "loadAudio": "Încarcă sunetul",
         "loadFilePreview": "Încarcă previzualizarea",
-        "showLinkImage": "Afișează imaginea"
+        "showLinkImage": "Afișează imaginea",
+        "emojiSuggestions": "Sugestii de emoji"
     },
     "dates": {
         "today": "Astăzi",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Приглашения",
         "nickChanged": "{{oldNick}} теперь известен как {{newNick}}",
         "nickEdgeWhitespace": "Имя содержит лишние пробелы по краям",
-        "nickHiddenChars": "Имя содержит скрытые символы"
+        "nickHiddenChars": "Имя содержит скрытые символы",
+        "mentionSuggestions": "Предложения упоминаний"
     },
     "events": {
         "invitedBy": "Пригласил(а) {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Загрузить видео",
         "loadAudio": "Загрузить аудио",
         "loadFilePreview": "Загрузить превью",
-        "showLinkImage": "Показать изображение"
+        "showLinkImage": "Показать изображение",
+        "emojiSuggestions": "Предложения эмодзи"
     },
     "dates": {
         "today": "Сегодня",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -429,7 +429,8 @@
         "invitationsHeading": "Pozvánky",
         "nickChanged": "{{oldNick}} je teraz známy ako {{newNick}}",
         "nickEdgeWhitespace": "Meno obsahuje medzery na okrajoch",
-        "nickHiddenChars": "Meno obsahuje skryté znaky"
+        "nickHiddenChars": "Meno obsahuje skryté znaky",
+        "mentionSuggestions": "Návrhy zmienok"
     },
     "events": {
         "invitedBy": "Pozval {{name}}",
@@ -598,7 +599,8 @@
         "loadVideo": "Načítať video",
         "loadAudio": "Načítať zvuk",
         "loadFilePreview": "Načítať náhľad",
-        "showLinkImage": "Zobraziť obrázok"
+        "showLinkImage": "Zobraziť obrázok",
+        "emojiSuggestions": "Návrhy emoji"
     },
     "dates": {
         "today": "Dnes",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -430,7 +430,8 @@
         "invitationsHeading": "Vabila",
         "nickChanged": "{{oldNick}} je zdaj znan kot {{newNick}}",
         "nickEdgeWhitespace": "Ime ima dodatne presledke na robovih",
-        "nickHiddenChars": "Ime vsebuje skrite znake"
+        "nickHiddenChars": "Ime vsebuje skrite znake",
+        "mentionSuggestions": "Predlogi omemb"
     },
     "events": {
         "invitedBy": "Povabil {{name}}",
@@ -599,7 +600,8 @@
         "loadVideo": "Naloži video",
         "loadAudio": "Naloži zvok",
         "loadFilePreview": "Naloži predogled",
-        "showLinkImage": "Prikaži sliko"
+        "showLinkImage": "Prikaži sliko",
+        "emojiSuggestions": "Predlogi emojijev"
     },
     "dates": {
         "today": "Danes",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Inbjudningar",
         "nickChanged": "{{oldNick}} är nu känd som {{newNick}}",
         "nickEdgeWhitespace": "Namnet har extra mellanslag i kanterna",
-        "nickHiddenChars": "Namnet innehåller dolda tecken"
+        "nickHiddenChars": "Namnet innehåller dolda tecken",
+        "mentionSuggestions": "Omnämnandeförslag"
     },
     "events": {
         "invitedBy": "Inbjuden av {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "Läs in video",
         "loadAudio": "Läs in ljud",
         "loadFilePreview": "Läs in förhandsgranskning",
-        "showLinkImage": "Visa bild"
+        "showLinkImage": "Visa bild",
+        "emojiSuggestions": "Emoji-förslag"
     },
     "dates": {
         "today": "Idag",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "Запрошення",
         "nickChanged": "{{oldNick}} тепер відомий як {{newNick}}",
         "nickEdgeWhitespace": "Ім'я містить зайві пробіли по краях",
-        "nickHiddenChars": "Ім'я містить приховані символи"
+        "nickHiddenChars": "Ім'я містить приховані символи",
+        "mentionSuggestions": "Пропозиції згадувань"
     },
     "events": {
         "invitedBy": "Запрошено {{name}}",
@@ -597,7 +598,8 @@
         "loadVideo": "Завантажити відео",
         "loadAudio": "Завантажити аудіо",
         "loadFilePreview": "Завантажити прев'ю",
-        "showLinkImage": "Показати зображення"
+        "showLinkImage": "Показати зображення",
+        "emojiSuggestions": "Пропозиції емодзі"
     },
     "dates": {
         "today": "Сьогодні",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -428,7 +428,8 @@
         "invitationsHeading": "邀请",
         "nickChanged": "{{oldNick}} 现在称为 {{newNick}}",
         "nickEdgeWhitespace": "名称的首尾包含多余的空格",
-        "nickHiddenChars": "名称包含隐藏字符"
+        "nickHiddenChars": "名称包含隐藏字符",
+        "mentionSuggestions": "提及建议"
     },
     "events": {
         "invitedBy": "邀请者 {{name}}",
@@ -595,7 +596,8 @@
         "loadVideo": "加载视频",
         "loadAudio": "加载音频",
         "loadFilePreview": "加载预览",
-        "showLinkImage": "显示图片"
+        "showLinkImage": "显示图片",
+        "emojiSuggestions": "表情符号建议"
     },
     "dates": {
         "today": "今天",

--- a/docs/ROADMAP_2026.md
+++ b/docs/ROADMAP_2026.md
@@ -133,6 +133,10 @@ Engage with the XMPP MLS XEP effort. Implement once the wire format stabilises.
 
 ## Polish & Backlog
 
+- **Localized emoji completion** — use locale-specific Unicode/CLDR annotations for
+  emoji names and search terms in composer autocomplete, while preserving canonical
+  shortcodes and English aliases for compatibility and fallback search.
+
 - **Filter muted users from search results** — the per-room ignore (mute) list is
   applied in the room view (messages, mentions, typing indicators and reactions are
   hidden) but not in cross-room search. Messages, mentions and reactions from muted


### PR DESCRIPTION
## Description

This PR introduces a GitHub/Slack-style inline emoji autocomplete selector to the message input. Typing : followed by a keyword (e.g. `:+1` or `:smile`) opens a popup menu showing matching emojis. Users can navigate suggestions using keyboard arrows and press Enter or Tab to insert the selected emoji directly.

Since this logic is encapsulated within the shared [MessageComposer.tsx](https://github.com/processone/fluux-messenger/blob/main/apps/fluux/src/components/MessageComposer.tsx) component, the autocomplete works out-of-the-box in both 1:1 direct messages and Multi-User Chat (MUC) rooms without code duplication.

## Key Features

1. Triggering: Activates on a : character that is at the start of the input or preceded by whitespace, followed by a search query (no spaces allowed).
2. Bundle-Size Optimization: Emojis contain large character sets (~150KB of metadata in @emoji-mart/data). The database is dynamically loaded in the background (import('@emoji-mart/data')) only when the user triggers the picker by typing :, ensuring zero impact on the initial application load time.
3. Keyboard Navigation: Fully interactive dropdown list:
    - ArrowUp / ArrowDown: Moves selection (loops back at boundaries).
    - Enter / Tab: Completes the selection and inserts the native emoji (e.g., 👍 for `:+1:`).
    - Escape: Closes the suggestions popup.
4. Autocomplete UI: Clean dropdown component matching the auroral styling tokens and other palettes (like the mentions and commands dropdowns).

## Screenshot

<img width="1284" height="392" alt="image" src="https://github.com/user-attachments/assets/6a866887-0eaa-4ee2-b7db-9db5d77225f2" />
<img width="1284" height="392" alt="image" src="https://github.com/user-attachments/assets/d05046bf-4d0d-4181-8961-56fa8e9dc2c6" />


## Changes Made

- Custom Hook: Created `useEmojiAutocomplete.ts` to detect colons, dynamically fetch database, sort, filter, and handle string substitutions.
- UI Component: Created `EmojiAutocompleteMenu.tsx` to render the popover above the input text area.
- Component Wiring: Updated `MessageComposer.tsx` to manage caret position state, bind keydown events, and render the suggestions.
- Unit Tests: Added `useEmojiAutocomplete.test.tsx` containing 11 tests verifying triggers, filtering logic, and selection cycling.

---

### 🤖 AI Disclosure

*This feature and its corresponding test suite were developed with pair-programming assistance from LLM