### PR TITLE
Fix synced conversation scroll position

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -525,6 +525,7 @@ export function MessageList<T extends BaseMessage>({
     messageCount: messages.length,
     firstMessageId,
     firstNewMessageId,
+    lastSeenMessageId,
     clearFirstNewMessageId,
     targetMessageId,
     onTargetMessageConsumed,

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -31,6 +31,7 @@ interface HookHarnessProps {
   conversationId: string
   ids: string[]
   firstNewMessageId?: string
+  lastSeenMessageId?: string
   clearFirstNewMessageId?: () => void
   onLoadAround?: (anchorMessageId: string) => Promise<unknown> | void
   scrollHeight?: number
@@ -39,9 +40,9 @@ interface HookHarnessProps {
   onReady: (handle: HarnessHandle) => void
 }
 
-function seedSavedScrollPosition(conversationId: string, scrollTop = 200) {
+function seedSavedScrollPosition(conversationId: string, scrollTop = 200, readPositionId?: string) {
   scrollStateManager.enterConversation(conversationId, 10)
-  scrollStateManager.leaveConversation(conversationId, scrollTop, 1000, 500)
+  scrollStateManager.leaveConversation(conversationId, scrollTop, 1000, 500, undefined, readPositionId)
 }
 
 // Seed a saved CONTENT anchor whose scrollHeight differs from the harness scroller (1000) so the
@@ -59,6 +60,7 @@ function HookHarness({
   conversationId,
   ids,
   firstNewMessageId,
+  lastSeenMessageId,
   clearFirstNewMessageId,
   onLoadAround,
   scrollHeight = 1000,
@@ -77,6 +79,7 @@ function HookHarness({
     messageCount: ids.length,
     firstMessageId: ids[0],
     firstNewMessageId,
+    lastSeenMessageId,
     clearFirstNewMessageId,
     onLoadAround,
     reactionsSignature: '',
@@ -297,6 +300,68 @@ describe('useMessageListScroll saved-position restore', () => {
 
     expect(handle?.scrollTopSets).toContain(200)
     expect(handle?.scrollTopSets.some((v) => Math.abs(v - markerTarget) < 1)).toBe(false)
+  })
+
+  it('discards a saved position when a synced read pointer already reached the downloaded live edge', () => {
+    seedSavedScrollPosition('synced-live-edge', 200, 'msg-5')
+    let handle: HarnessHandle | undefined
+
+    render(
+      <HookHarness
+        conversationId="synced-live-edge"
+        ids={manyIds()}
+        lastSeenMessageId="msg-19"
+        onReady={(next) => { handle = next }}
+      />,
+    )
+
+    expect(handle?.scrollTopSets).not.toContain(200)
+    expect(handle?.getScrollTop()).toBe(1000)
+    expect(scrollStateManager.getSavedScrollTop('synced-live-edge')).toBeNull()
+  })
+
+  it('keeps a deliberate saved position when its read pointer was already at the live edge', () => {
+    seedSavedScrollPosition('same-live-edge', 200, 'msg-19')
+    let handle: HarnessHandle | undefined
+
+    render(
+      <HookHarness
+        conversationId="same-live-edge"
+        ids={manyIds()}
+        lastSeenMessageId="msg-19"
+        onReady={(next) => { handle = next }}
+      />,
+    )
+
+    expect(handle?.scrollTopSets).toContain(200)
+    expect(scrollStateManager.getSavedScrollTop('same-live-edge')).toBe(200)
+  })
+
+  it('settles to the bottom when MAM resolves the synced read pointer after restore', () => {
+    seedSavedScrollPosition('late-live-edge', 200, 'msg-5')
+    let handle: HarnessHandle | undefined
+    const view = render(
+      <HookHarness
+        conversationId="late-live-edge"
+        ids={manyIds()}
+        lastSeenMessageId="msg-5"
+        onReady={(next) => { handle = next }}
+      />,
+    )
+
+    expect(handle?.scrollTopSets).toContain(200)
+
+    view.rerender(
+      <HookHarness
+        conversationId="late-live-edge"
+        ids={manyIds()}
+        lastSeenMessageId="msg-19"
+        onReady={(next) => { handle = next }}
+      />,
+    )
+
+    expect(handle?.getScrollTop()).toBe(1000)
+    expect(scrollStateManager.getSavedScrollTop('late-live-edge')).toBeNull()
   })
 
   it('clears restored scrolled-up state only after explicit bottom intent', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -237,6 +237,8 @@ export interface UseMessageListScrollOptions {
   messageCount: number
   firstMessageId: string | undefined
   firstNewMessageId?: string  // ID of the first unread message (for new message marker)
+  /** Forward-only local id of the furthest read message, including XEP-0490 sync. */
+  lastSeenMessageId?: string
   targetMessageId?: string | null  // ID of a message to scroll to (e.g., from activity log click)
   onTargetMessageConsumed?: () => void  // Called after scrolling to target message
   externalScrollerRef?: React.RefObject<HTMLElement | null>
@@ -329,6 +331,7 @@ export function useMessageListScroll({
   messageCount,
   firstMessageId,
   firstNewMessageId,
+  lastSeenMessageId,
   clearFirstNewMessageId,
   targetMessageId,
   onTargetMessageConsumed,
@@ -419,6 +422,14 @@ export function useMessageListScroll({
   const prevLastMessageIdRef = useRef<string | undefined>(lastMessageId)
   const hasInitializedRef = useRef(false)
   const pendingRestoreConversationRef = useRef<string | null>(null)
+  const pendingSyncedLiveEdgeRef = useRef<{
+    conversationId: string
+    savedReadPositionId: string | undefined
+  } | null>(null)
+  const previousReadPositionRef = useRef(lastSeenMessageId)
+  useEffect(() => {
+    previousReadPositionRef.current = lastSeenMessageId
+  }, [conversationId, lastSeenMessageId])
   // Whether the user has GENUINELY scrolled since entering this conversation (wheel / touch /
   // keyboard / FAB). Reset on every conversation switch. The saved scroll position is only
   // overwritten once this is true: a restore can drift on its own as rows below the fold load media
@@ -1937,7 +1948,14 @@ export function useMessageListScroll({
     const now = Date.now()
     if (!programmaticScroll && userHasScrolledSinceEntryRef.current && now - lastSaveTimeRef.current > SAVE_THROTTLE_MS) {
       lastSaveTimeRef.current = now
-      scrollStateManager.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, lastAnchorRef.current ?? undefined)
+      scrollStateManager.saveScrollPosition(
+        conversationId,
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+        lastAnchorRef.current ?? undefined,
+        lastSeenMessageId,
+      )
     }
 
     // Track if user scrolled away from top (allows re-trigger of load)
@@ -2012,7 +2030,14 @@ export function useMessageListScroll({
     // position creep older on the next open (see userHasScrolledSinceEntryRef).
     if (prevConversationRef.current && lastScrollDataRef.current && userHasScrolledSinceEntryRef.current) {
       const { top, height, client } = lastScrollDataRef.current
-      scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined)
+      scrollStateManager.leaveConversation(
+        prevConversationRef.current,
+        top,
+        height,
+        client,
+        lastAnchorRef.current ?? undefined,
+        previousReadPositionRef.current,
+      )
     } else if (prevConversationRef.current) {
       scrollStateManager.markAsLeft(prevConversationRef.current)
     }
@@ -2025,6 +2050,7 @@ export function useMessageListScroll({
     lastAnchorRef.current = null
     prependRef.current = null
     pendingRestoreConversationRef.current = null
+    pendingSyncedLiveEdgeRef.current = null
     // Returning to this conversation later must be free to re-request its anchor slice.
     aroundLoadStatusRef.current.clear()
     // Fresh entry: the saved position is locked until the user genuinely scrolls (see the ref).
@@ -2062,8 +2088,31 @@ export function useMessageListScroll({
       const firstOpenThisSession = !scrollStateManager.isInitialized(conversationId)
 
       // Decide: restore position or scroll to bottom?
-      const action = scrollStateManager.enterConversation(conversationId, messageCount)
+      let action = scrollStateManager.enterConversation(conversationId, messageCount)
       const savedPos = scrollStateManager.getSavedScrollTop(conversationId)
+      const savedReadPositionId = scrollStateManager.getSavedReadPositionId(conversationId)
+
+      if (action === 'restore-position') {
+        pendingSyncedLiveEdgeRef.current = { conversationId, savedReadPositionId }
+        // The remote pointer can resolve before this mount. When it now identifies the newest
+        // downloaded row, a saved position tied to an older pointer must not win merely because
+        // there was never an unread divider.
+        if (
+          firstNewMessageId === undefined &&
+          lastSeenMessageId !== undefined &&
+          lastSeenMessageId === lastMessageId &&
+          lastSeenMessageId !== savedReadPositionId
+        ) {
+          scrollStateManager.clearSavedScrollState(conversationId)
+          pendingSyncedLiveEdgeRef.current = null
+          action = 'scroll-to-bottom'
+          debugLog('MDS LIVE EDGE: synced read supersedes saved position on entry', {
+            conversationId,
+            savedReadPositionId,
+            lastSeenMessageId,
+          })
+        }
+      }
 
       debugLog('CONVERSATION ACTION', { action, savedPos, firstOpenThisSession, scrollHeight: scroller.scrollHeight })
 
@@ -2146,8 +2195,31 @@ export function useMessageListScroll({
     prevConversationRef.current = conversationId
     prevMessageCountRef.current = messageCount
     prevLastMessageIdRef.current = lastMessageId
+    previousReadPositionRef.current = lastSeenMessageId
 
-  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, isAtBottomRef, staticMode, pinVirtualizedBottom, reassertBottom, restoreSavedPosition, runMarkerReassertLoop])
+  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, lastSeenMessageId, isAtBottomRef, staticMode, pinVirtualizedBottom, reassertBottom, restoreSavedPosition, runMarkerReassertLoop])
+
+  // Zero-unread twin of the divider-clear settle below. The old local position may be restored
+  // before MAM resolves the other device's pointer to the newest downloaded row; with no divider,
+  // observing that pointer transition is the only signal that the restore became obsolete.
+  useLayoutEffect(() => {
+    const pending = pendingSyncedLiveEdgeRef.current
+    if (!pending || pending.conversationId !== conversationId) return
+    if (staticMode || userHasScrolledSinceEntryRef.current) return
+    if (firstNewMessageId !== undefined || lastSeenMessageId === undefined) return
+    if (lastSeenMessageId !== lastMessageId || lastSeenMessageId === pending.savedReadPositionId) return
+
+    pendingSyncedLiveEdgeRef.current = null
+    pendingRestoreConversationRef.current = null
+    scrollStateManager.clearSavedScrollState(conversationId)
+    isAtBottomRef.current = true
+    debugLog('MDS LIVE EDGE: late synced read supersedes restored position', {
+      conversationId,
+      savedReadPositionId: pending.savedReadPositionId,
+      lastSeenMessageId,
+    })
+    reassertBottom('mds-live-edge')
+  }, [conversationId, firstNewMessageId, lastMessageId, lastSeenMessageId, staticMode, isAtBottomRef, reassertBottom])
 
   // XEP-0490 settle window: the fresh-session read-sync seed can land just AFTER a
   // conversation is opened. The SDK's entry fold races the async PEP fetch, so at
@@ -2225,7 +2297,14 @@ export function useMessageListScroll({
             anchorMessageId: lastAnchorRef.current?.messageId,
             anchorFraction: lastAnchorRef.current?.fraction,
           })
-          scrollStateManager.leaveConversation(prevConversationRef.current, top, height, client, lastAnchorRef.current ?? undefined)
+          scrollStateManager.leaveConversation(
+            prevConversationRef.current,
+            top,
+            height,
+            client,
+            lastAnchorRef.current ?? undefined,
+            previousReadPositionRef.current,
+          )
         } else {
           // No scroll data, or the user never scrolled this visit → don't overwrite the saved
           // position; just mark the conversation left so a return is detected as a switch.

--- a/apps/fluux/src/utils/scrollStateManager.ts
+++ b/apps/fluux/src/utils/scrollStateManager.ts
@@ -56,6 +56,9 @@ interface ScrollState {
    *  the anchor message's CURRENT measured height, so it survives re-measure / width / density /
    *  font-size changes. {@link ScrollState.scrollTop} is only a fallback when this is absent. */
   anchor?: ScrollAnchor
+  /** Read pointer current when this position was saved. A later synced pointer at the live edge
+   * makes the old local position obsolete. */
+  readPositionId?: string
 }
 
 interface ConversationState {
@@ -162,7 +165,8 @@ class ScrollStateManager {
     scrollTop: number,
     scrollHeight: number,
     clientHeight: number,
-    anchor?: ScrollAnchor
+    anchor?: ScrollAnchor,
+    readPositionId?: string
   ): void {
     const state = this.getState(conversationId)
     // scrollHeight/clientHeight are transient inputs used only to decide wasAtBottom here — they are
@@ -191,6 +195,7 @@ class ScrollStateManager {
         wasAtBottom,
         savedAt: Date.now(),
         anchor,
+        readPositionId,
       }
     }
   }
@@ -204,10 +209,11 @@ class ScrollStateManager {
     scrollTop: number,
     scrollHeight: number,
     clientHeight: number,
-    anchor?: ScrollAnchor
+    anchor?: ScrollAnchor,
+    readPositionId?: string
   ): void {
     // Save position first
-    this.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, anchor)
+    this.saveScrollPosition(conversationId, scrollTop, scrollHeight, clientHeight, anchor, readPositionId)
 
     const state = this.getState(conversationId)
     this.log('leaveConversation', {
@@ -271,6 +277,14 @@ class ScrollStateManager {
       return null
     }
     return state.scrollState.anchor ?? null
+  }
+
+  /** Read pointer captured alongside the saved scroll position. */
+  getSavedReadPositionId(conversationId: string): string | undefined {
+    const state = this.states.get(conversationId)
+    if (!state?.scrollState || state.scrollState.wasAtBottom) return undefined
+    if (Date.now() - state.scrollState.savedAt > this.staleThresholdMs) return undefined
+    return state.scrollState.readPositionId
   }
 
   /**


### PR DESCRIPTION
Fix fully read conversations opening at an outdated local scroll position after multi-device history sync.

Saved positions now track their read pointer and are discarded when synced read state reaches the downloaded live edge.