### PR TITLE
fix(muc): send presence priority on directed MUC presence

### DIFF
--- a/packages/fluux-sdk/src/core/config.ts
+++ b/packages/fluux-sdk/src/core/config.ts
@@ -20,6 +20,20 @@ export const WELL_KNOWN_MUC_SERVERS = [
 export type WellKnownMucServer = typeof WELL_KNOWN_MUC_SERVERS[number]
 
 /**
+ * Presence priority advertised by this client (RFC 6121 §4.7.2.3, range -128..127).
+ *
+ * Sent on both broadcast presence and directed MUC presence — the two must match.
+ * MUC services arbitrate between a user's sessions sharing one nick by priority:
+ * ejabberd's `mod_muc_room:find_jid_by_nick/2` elects the strictly-highest-priority
+ * session as the nick's "representative" (tie → most recent joiner) and broadcasts
+ * only that session's presence, including the user's own status-110 self-echo.
+ * Directed presence without a <priority> reads as 0, so omitting it here makes this
+ * client lose that election to any later-joining client permanently — its away/dnd
+ * would be stored server-side but never broadcast to the room.
+ */
+export const PRESENCE_PRIORITY = '50'
+
+/**
  * Admin commands to hide from the command list in the sidebar.
  *
  * These commands are excluded because they are redundant with dedicated UI

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -2581,4 +2581,75 @@ describe('MUC Module', () => {
       )
     })
   })
+
+  describe('directed presence priority (ejabberd representative session)', () => {
+    const ROOM = 'room@conference.example.org'
+
+    const joinedRoom = () => ({
+      jid: ROOM,
+      name: 'room',
+      joined: true,
+      isJoining: false,
+      nickname: 'mynick',
+      isBookmarked: true,
+      occupants: new Map(),
+      messages: [],
+      unreadCount: 0,
+      mentionsCount: 0,
+      typingUsers: new Set<string>(),
+    })
+
+    /**
+     * ejabberd's mod_muc_room picks the "representative" session for a nick by
+     * strictly-highest <priority>, tie → most recent joiner, and broadcasts only
+     * that session's presence (including our own status-110 self-echo). Directed
+     * presence with no <priority> reads as 0, so omitting it loses arbitration to
+     * any later-joining client forever — the user's away/dnd never reaches the room.
+     */
+    const priorityOf = (presence: { getChildText: (name: string) => string | null }) =>
+      presence.getChildText('priority')
+
+    it('sends priority on presence updates to joined rooms', async () => {
+      mockStores.room.joinedRooms.mockReturnValue([joinedRoom()])
+
+      await muc.sendPresenceToRooms('away')
+
+      const presence = mockSendStanza.mock.calls[0][0]
+      expect(presence.attrs.to).toBe(`${ROOM}/mynick`)
+      expect(presence.getChildText('show')).toBe('away')
+      expect(priorityOf(presence)).toBe('50')
+    })
+
+    it('sends priority when joining a room', async () => {
+      mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }, []))
+      mockStores.room.getRoom.mockReturnValue(undefined)
+
+      await muc.joinRoom(ROOM, 'mynick')
+
+      const presence = mockSendStanza.mock.calls[0][0]
+      expect(priorityOf(presence)).toBe('50')
+    })
+
+    it('sends priority when changing nick', async () => {
+      mockStores.room.getRoom.mockReturnValue(joinedRoom())
+
+      const p = muc.changeNick(ROOM, 'newnick')
+      muc.handle(
+        createMockElement('presence', { from: `${ROOM}/newnick` }, [
+          {
+            name: 'x',
+            attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+            children: [
+              { name: 'item', attrs: { affiliation: 'member', role: 'participant' } },
+              { name: 'status', attrs: { code: '110' } },
+            ],
+          },
+        ]),
+      )
+      await p
+
+      const presence = mockSendStanza.mock.calls[0][0]
+      expect(priorityOf(presence)).toBe('50')
+    })
+  })
 })

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -6,6 +6,7 @@ import { generateUUID } from '../../utils/uuid'
 import { generateQuickChatSlug } from '../wordlist'
 import { hasStableOccupantIdentity, isNonAnonymousRoom, isPrivateRoom } from '../roomCapabilities'
 import { parseBookmarkItem } from '../bookmarkItem'
+import { PRESENCE_PRIORITY } from '../config'
 import {
   NS_MUC,
   NS_MUC_USER,
@@ -773,6 +774,7 @@ export class MUC extends BaseModule {
     if (currentStatus) {
       presenceChildren.push(xml('status', {}, currentStatus))
     }
+    presenceChildren.push(xml('priority', {}, PRESENCE_PRIORITY))
 
     const presence = xml(
       'presence',
@@ -885,6 +887,7 @@ export class MUC extends BaseModule {
       if (showValue) children.push(xml('show', {}, showValue))
     }
     if (currentStatus) children.push(xml('status', {}, currentStatus))
+    children.push(xml('priority', {}, PRESENCE_PRIORITY))
 
     const presence = xml('presence', { to: `${roomJid}/${trimmed}` }, ...children)
     logInfo(`Changing nick in ${roomJid} to ${trimmed}`)
@@ -945,6 +948,7 @@ export class MUC extends BaseModule {
       if (status) {
         children.push(xml('status', {}, status))
       }
+      children.push(xml('priority', {}, PRESENCE_PRIORITY))
 
       const presence = xml(
         'presence',

--- a/packages/fluux-sdk/src/core/modules/Roster.ts
+++ b/packages/fluux-sdk/src/core/modules/Roster.ts
@@ -5,6 +5,7 @@ import { isMucJid } from '../../utils/xmppUri'
 import { generateUUID } from '../../utils/uuid'
 import { calculateCapsHash, getCapsNode } from '../caps'
 import { getClientName } from '../clients'
+import { PRESENCE_PRIORITY } from '../config'
 import {
   NS_CAPS,
   NS_VCARD_UPDATE,
@@ -375,7 +376,7 @@ export class Roster extends BaseModule {
     const presence = xml('presence', {},
       showToSend ? xml('show', {}, showToSend) : undefined,
       statusToSend ? xml('status', {}, statusToSend) : undefined,
-      xml('priority', {}, '50'),
+      xml('priority', {}, PRESENCE_PRIORITY),
       xml('c', {
         xmlns: NS_CAPS,
         hash: 'sha-1',
@@ -407,7 +408,7 @@ export class Roster extends BaseModule {
     const children = [
       show !== 'online' ? xml('show', {}, show) : undefined,
       status ? xml('status', {}, status) : undefined,
-      xml('priority', {}, '50'),
+      xml('priority', {}, PRESENCE_PRIORITY),
       this.capsHash ? xml('c', {
         xmlns: NS_CAPS,
         hash: 'sha-1',


### PR DESCRIPTION
Your own presence showed as available in a room's member list while the sidebar showed away.

Fluux advertised `<priority>50</priority>` on broadcast presence but omitted it on directed MUC presence, where a missing priority is read as 0. ejabberd's `mod_muc_room` elects a representative session per nick (strictly-highest priority, tie → most recent joiner) and broadcasts only that session's presence, including your own status-110 self-echo. Scoring 0, this client lost that election to any later-joining client and its away/dnd was stored server-side but never reached the room.

Extracts `PRESENCE_PRIORITY` into `core/config.ts` and applies it to the three directed-presence paths that were missing it — `joinRoom`, `changeNick`, `sendPresenceToRooms` — de-duplicating the two hardcoded broadcast sites in `Roster` along the way.

Two known limits: two Fluux sessions both send 50, so between them it is still most-recent-joiner.