### PR TITLE
fix(proxy): IDNA-encode host for DNS and TLS SNI (#1042)

### DIFF
--- a/apps/fluux/src-tauri/Cargo.lock
+++ b/apps/fluux/src-tauri/Cargo.lock
@@ -2023,6 +2023,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "hickory-resolver",
+ "idna",
  "keyring",
  "objc2",
  "objc2-app-kit",

--- a/apps/fluux/src-tauri/Cargo.toml
+++ b/apps/fluux/src-tauri/Cargo.toml
@@ -42,6 +42,12 @@ tokio-rustls = "0.26"
 rustls = { version = "0.23", features = ["ring"] }
 rustls-native-certs = "0.8"
 hickory-resolver = "0.26"
+# IDNA (RFC 5890) A-label conversion for internationalized domains. DNS and
+# rustls' ServerName accept ASCII names only, so a Unicode domain must be
+# punycoded before resolution and the TLS handshake. Already present in the
+# dependency tree via hickory-resolver/url; declared here because the proxy
+# calls it directly.
+idna = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/apps/fluux/src-tauri/src/xmpp_proxy/dns.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/dns.rs
@@ -39,9 +39,35 @@ pub struct XmppEndpoint {
 impl XmppEndpoint {
     /// Returns the hostname to use for TLS SNI and certificate verification.
     /// Uses the XMPP domain if available (SRV resolution), otherwise the host.
+    ///
+    /// This is the U-label (Unicode) form for internationalized domains; callers
+    /// pass it through [`to_ascii_host`] at the DNS and TLS boundaries.
     pub fn tls_name(&self) -> &str {
         self.domain.as_deref().unwrap_or(&self.host)
     }
+}
+
+/// Convert a hostname to its IDNA A-label ("punycode") form for DNS resolution
+/// and TLS.
+///
+/// `rustls::pki_types::ServerName` and most system resolvers accept ASCII names
+/// only, so an internationalized domain such as `ツ.com` must be converted to
+/// `xn--bdk.com` before either — otherwise the handshake fails with the opaque
+/// "invalid dns name" (issue #1042). Certificates for IDNs likewise carry the
+/// A-label in their `dNSName` SAN, so this is also the form to verify against.
+///
+/// Already-ASCII hostnames, existing A-labels, and IP literals pass through
+/// unchanged (uppercase is lowercased, which DNS and certificate matching treat
+/// as equivalent). The non-strict IDNA profile is deliberate: it tolerates
+/// hostnames that are common in practice but not valid IDNA, such as
+/// `my_host.local`, which must keep working.
+///
+/// Deliberately NOT applied to the XMPP domainpart on the wire: RFC 7622 §3.2.1
+/// requires domainpart slots (JIDs, the stream header `to=`) to carry U-labels
+/// and forbids A-labels. Only the DNS and TLS layers get the ASCII form.
+pub fn to_ascii_host(host: &str) -> Result<String, String> {
+    idna::domain_to_ascii(host)
+        .map_err(|e| format!("Invalid internationalized domain name '{}': {}", host, e))
 }
 
 /// Result of parsing the server input string.
@@ -541,6 +567,59 @@ mod tests {
                 Some("diebesban.de".to_string())
             )
         );
+    }
+
+    // --- to_ascii_host() tests ---
+
+    /// The bug from #1042: a Unicode domain reaches rustls, which rejects it with
+    /// "invalid dns name". `to_ascii_host` must yield the A-label instead.
+    #[test]
+    fn test_to_ascii_host_converts_unicode_to_a_label() {
+        assert_eq!(to_ascii_host("ツ.com").unwrap(), "xn--bdk.com");
+        assert_eq!(to_ascii_host("xmpp.ツ.com").unwrap(), "xmpp.xn--bdk.com");
+    }
+
+    /// Already-ASCII names must survive untouched, so the conversion can sit on
+    /// the hot path for every connection without changing existing behaviour.
+    #[test]
+    fn test_to_ascii_host_passes_through_ascii() {
+        assert_eq!(to_ascii_host("example.com").unwrap(), "example.com");
+        assert_eq!(
+            to_ascii_host("chat.process-one.net").unwrap(),
+            "chat.process-one.net"
+        );
+        assert_eq!(to_ascii_host("localhost").unwrap(), "localhost");
+    }
+
+    /// A-labels are already the target form; converting twice must be a no-op.
+    #[test]
+    fn test_to_ascii_host_is_idempotent_on_a_labels() {
+        assert_eq!(to_ascii_host("xn--bdk.com").unwrap(), "xn--bdk.com");
+    }
+
+    /// IP literals go through the same code path (`ParsedServer::Direct` keeps
+    /// them as `host`), so they must not be mangled or rejected. IPv6 arrives
+    /// already debracketed.
+    #[test]
+    fn test_to_ascii_host_preserves_ip_literals() {
+        assert_eq!(to_ascii_host("127.0.0.1").unwrap(), "127.0.0.1");
+        assert_eq!(to_ascii_host("::1").unwrap(), "::1");
+    }
+
+    /// Regression guard: hostnames that connect today must keep connecting.
+    /// Underscores and trailing dots are not valid IDNA but are common in the
+    /// wild, and `domain_to_ascii` (non-strict) lets them through.
+    #[test]
+    fn test_to_ascii_host_accepts_non_idna_hostnames() {
+        assert_eq!(to_ascii_host("my_host.local").unwrap(), "my_host.local");
+        assert_eq!(to_ascii_host("example.com.").unwrap(), "example.com.");
+    }
+
+    /// DNS and certificate matching are case-insensitive, so lowercasing (which
+    /// IDNA does as part of mapping) is safe and expected.
+    #[test]
+    fn test_to_ascii_host_lowercases() {
+        assert_eq!(to_ascii_host("EXAMPLE.com").unwrap(), "example.com");
     }
 
     // --- XmppEndpoint::tls_name() tests ---

--- a/apps/fluux/src-tauri/src/xmpp_proxy/happy_eyeballs.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/happy_eyeballs.rs
@@ -21,6 +21,8 @@ use std::time::Duration;
 
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio::net::{lookup_host, TcpStream};
+
+use super::dns::to_ascii_host;
 use tracing::info;
 
 /// RFC 8305 "Connection Attempt Delay": how long to wait before starting the
@@ -164,7 +166,11 @@ pub async fn connect_tcp(
     attempt_delay: Duration,
     overall_timeout: Duration,
 ) -> Result<TcpStream, String> {
-    let addrs: Vec<SocketAddr> = lookup_host((host, port))
+    // Resolve the A-label: `lookup_host` goes through the system resolver, and
+    // getaddrinfo does not reliably handle Unicode hostnames across platforms.
+    // Errors keep reporting the U-label the user actually typed.
+    let ascii_host = to_ascii_host(host)?;
+    let addrs: Vec<SocketAddr> = lookup_host((ascii_host.as_str(), port))
         .await
         .map_err(|e| format!("DNS resolution failed for {}:{}: {}", host, port, e))?
         .collect();

--- a/apps/fluux/src-tauri/src/xmpp_proxy/mod.rs
+++ b/apps/fluux/src-tauri/src/xmpp_proxy/mod.rs
@@ -2,7 +2,10 @@ mod dns;
 mod framing;
 mod happy_eyeballs;
 
-use dns::{parse_server_input, resolve_xmpp_server, ConnectionMode, ParsedServer, XmppEndpoint};
+use dns::{
+    parse_server_input, resolve_xmpp_server, to_ascii_host, ConnectionMode, ParsedServer,
+    XmppEndpoint,
+};
 use framing::{
     extract_open_to, extract_stanza, extract_stream_error_condition, translate_tcp_to_ws,
     translate_ws_to_tcp,
@@ -357,7 +360,10 @@ async fn upgrade_to_tls(
     host: &str,
 ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, String> {
     let connector = create_tls_connector()?;
-    let server_name = ServerName::try_from(host.to_string())
+    // Internationalized domains must be punycoded here: rustls accepts ASCII
+    // names only, and certificates for IDNs carry the A-label in their SAN.
+    // The XMPP domainpart stays a U-label on the wire (see `perform_starttls`).
+    let server_name = ServerName::try_from(to_ascii_host(host)?)
         .map_err(|e| format!("Invalid server name: {}", e))?;
 
     connector
@@ -1825,6 +1831,60 @@ mod tests {
         assert!(
             header.contains("to='explicit.example'"),
             "?domain= override must win over <open to=>, got: {header}"
+        );
+    }
+
+    /// Guard (#1042) at the real call site: `upgrade_to_tls` must no longer
+    /// reject an internationalized domain before the handshake even starts.
+    ///
+    /// The peer is a plain TCP listener that hangs up immediately, so the
+    /// handshake is expected to fail — what matters is *how*. Before the fix,
+    /// `ServerName::try_from("ツ.com")` failed with "Invalid server name" and no
+    /// ClientHello was ever sent; now the A-label is accepted and the failure is
+    /// an ordinary transport-level handshake error.
+    #[tokio::test]
+    async fn test_upgrade_to_tls_accepts_internationalized_domain() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind peer");
+        let addr = listener.local_addr().expect("peer addr");
+        tokio::spawn(async move {
+            // Accept, then drop the socket so the client sees EOF promptly.
+            let _ = listener.accept().await;
+        });
+
+        let stream = TcpStream::connect(addr).await.expect("connect to peer");
+        let err = upgrade_to_tls(stream, "ツ.com")
+            .await
+            .expect_err("plain-TCP peer cannot complete a TLS handshake");
+
+        assert!(
+            !err.contains("Invalid server name"),
+            "IDN must be punycoded before rustls sees it, got: {err}"
+        );
+        assert!(
+            err.contains("TLS handshake failed"),
+            "expected a transport-level handshake failure, got: {err}"
+        );
+    }
+
+    /// Guard (#1042): for an internationalized domain, the STARTTLS stream
+    /// header MUST carry the U-label (Unicode) form. RFC 7622 §3.2.1 requires
+    /// domainpart slots to hold U-labels and forbids A-labels, and ejabberd
+    /// matches virtual hosts with `jid:nameprep` (Unicode-preserving), so
+    /// punycoding the wire form here would produce `host-unknown`.
+    ///
+    /// Only DNS resolution and the TLS SNI name are converted to the A-label —
+    /// see `to_ascii_host` in `dns.rs`.
+    #[tokio::test]
+    async fn test_starttls_header_keeps_unicode_u_label_for_idn_domain() {
+        let client_open = "<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='ツ.com' from='me@ツ.com' version='1.0'/>";
+        let header = capture_proxy_starttls_header(client_open, None).await;
+        assert!(
+            header.contains("to='ツ.com'"),
+            "STARTTLS header must carry the Unicode U-label per RFC 7622, got: {header}"
+        );
+        assert!(
+            !header.contains("xn--"),
+            "STARTTLS header must NOT carry the punycode A-label, got: {header}"
         );
     }
 


### PR DESCRIPTION
Fixes #1042.

Connecting to an XMPP domain with non-ASCII characters (e.g. `ツ.com`) failed on every endpoint: rustls' `ServerName` accepts ASCII DNS names only and rejected the Unicode domain with `invalid dns name`, so neither direct TLS (5223) nor STARTTLS (5222) could complete a handshake.

Adds `to_ascii_host()` and applies it at the two boundaries that actually require ASCII — the TLS SNI name in `upgrade_to_tls` and the system resolver lookup in `connect_tcp`. Certificates for IDNs carry the A-label in their `dNSName` SAN, so this is also the correct name to verify against.