### PR TITLE
fix(notifications): notify from a store arrival signal, not the sidebar preview

### DIFF
--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.test.tsx
@@ -16,11 +16,34 @@ const mockRooms = new Map()
 let mockActiveRoomJid: string | null = null
 let mockWindowVisible = false
 
+// Simulated chatStore.lastArrivedMessage — the store's "a message was
+// delivered" signal, which addMessage writes and no merge or preview swap
+// touches.
+//
+// Default: a conversation's lastMessage is also treated as its latest arrival,
+// which is the ordinary case and keeps every test that just sets a lastMessage
+// exercising the real decision path (rather than passing vacuously because no
+// arrival was ever recorded). A test that needs a preview to move WITHOUT a
+// delivery pins the arrival with pinArrival() — the pin then wins over the
+// derived value for that conversation.
+const mockArrivedMessages = new Map()
+
+const pinArrival = (conversationId: string, message: unknown) => {
+  mockArrivedMessages.set(conversationId, message)
+}
+
 // Helper to trigger store subscriptions
 const triggerChatStoreUpdate = () => {
+  const lastArrivedMessage = new Map(mockArrivedMessages)
+  for (const [id, conv] of mockConversations) {
+    if (!lastArrivedMessage.has(id) && conv.lastMessage) {
+      lastArrivedMessage.set(id, conv.lastMessage)
+    }
+  }
   const state = {
     conversations: mockConversations,
     activeConversationId: mockActiveConversationId,
+    lastArrivedMessage,
   }
   chatStoreSubscribers.forEach(sub => sub(state))
 }
@@ -61,6 +84,7 @@ describe('useNotificationEvents', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     mockConversations.clear()
+    mockArrivedMessages.clear()
     mockRooms.clear()
     mockActiveConversationId = null
     mockActiveRoomJid = null
@@ -829,7 +853,8 @@ describe('useNotificationEvents', () => {
   // history) also trips — even though the newest message is unchanged. Without
   // an identity guard this resurrects a banner for a message already delivered,
   // matching the observed "notification reappears when I open the room" bug.
-  // The 1:1 path is already immune (it dedupes by lastMessage.id).
+  // The 1:1 path detects arrivals by lastMessage.id and has its own guard —
+  // see "conversation notification idempotency" below.
   describe('room notification idempotency', () => {
     const roomJid = 'tech@conference.example.com'
 
@@ -932,6 +957,164 @@ describe('useNotificationEvents', () => {
       })
       expect(onRoomMessage).toHaveBeenCalledTimes(2)
       expect(onRoomMessage.mock.calls[1][1].id).toBe('second')
+    })
+  })
+
+  // The 1:1 twin of the room re-hydration bug (#999). The conversation path
+  // dedupes on lastMessage.id, which holds only while that id is stable across a
+  // cache re-hydration. It is not always stable: when the stored preview is a
+  // NON-previewable placeholder (a bodiless encrypted signal), the reopen merge
+  // runs derivePreviewAfterMerge → shouldReplaceLastMessage, whose
+  // `!isPreviewableMessage(existing)` branch swaps the preview to the newest
+  // *previewable* message — an OLDER message with a DIFFERENT id. That id change
+  // reads as "new message" to the dedupe.
+  //
+  // Nothing downstream catches it during the reopen window: activateConversation
+  // awaits loadMessagesFromCache BEFORE setActiveConversation, so isActive is
+  // still false and unreadCount is not yet zeroed.
+  describe('conversation notification idempotency', () => {
+    const convId = 'dave@example.com'
+
+    it('does not re-notify when a reopen swaps the preview off a bodiless placeholder', () => {
+      const onConversationMessage = vi.fn()
+      const now = new Date()
+      const earlier = new Date(now.getTime() - 60 * 1000)
+      const real1 = { id: 'real-1', body: 'ping', timestamp: earlier, isOutgoing: false }
+      const signal2 = { id: 'signal-2', body: '', timestamp: now, isOutgoing: false }
+
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      // A real incoming message arrives and is notified.
+      act(() => {
+        pinArrival(convId, real1)
+        mockConversations.set(convId, {
+          id: convId,
+          name: 'Dave',
+          unreadCount: 1,
+          lastSeenMessageId: undefined,
+          lastMessage: real1,
+        })
+        triggerChatStoreUpdate()
+      })
+      expect(onConversationMessage).toHaveBeenCalledTimes(1)
+
+      // A bodiless encrypted signal is delivered: newest, but NOT previewable.
+      act(() => {
+        pinArrival(convId, signal2)
+        mockConversations.set(convId, {
+          ...mockConversations.get(convId),
+          unreadCount: 2,
+          lastMessage: signal2,
+        })
+        triggerChatStoreUpdate()
+      })
+      onConversationMessage.mockClear()
+
+      // Reopen: loadMessagesFromCache merges the cached slice and the preview
+      // policy demotes the placeholder back to the newest previewable message
+      // ('real-1' — older, different id). setActiveConversation has NOT run yet,
+      // so isActive is false and unreadCount is still > 0. Crucially NOTHING was
+      // delivered, so the arrival signal stays pinned on 'signal-2'.
+      act(() => {
+        mockConversations.set(convId, {
+          ...mockConversations.get(convId),
+          lastMessage: real1,
+        })
+        triggerChatStoreUpdate()
+      })
+
+      // A preview demotion is not a delivery — no banner may be re-posted.
+      expect(onConversationMessage).not.toHaveBeenCalled()
+    })
+
+    // Second, wider trigger — no placeholder and no E2EE required. addMessage
+    // sets the preview from the incoming message with NO timestamp guard
+    // (chatStore.ts:1035), unlike every merge path, so a delayed/offline-replay
+    // message moves lastMessage BACKWARDS. Notifying for that delayed message is
+    // intended (#586). The damage comes on the next merge: shouldReplaceLastMessage
+    // sees a strictly-newer candidate and restores the previous newest message,
+    // whose id differs from the regressed preview — so a message already notified
+    // is notified a second time.
+    it('does not re-notify the newest message when a merge restores it after a regressed preview', () => {
+      const onConversationMessage = vi.fn()
+      const newestAt = new Date()
+      const olderAt = new Date(newestAt.getTime() - 5 * 60 * 1000)
+      const newest = { id: 'newest', body: 'latest', timestamp: newestAt, isOutgoing: false }
+      const offline = { id: 'offline', body: 'sent while you were away', timestamp: olderAt, isOutgoing: false }
+
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      // Newest message arrives and is notified.
+      act(() => {
+        pinArrival(convId, newest)
+        mockConversations.set(convId, {
+          id: convId,
+          name: 'Dave',
+          unreadCount: 1,
+          lastSeenMessageId: undefined,
+          lastMessage: newest,
+        })
+        triggerChatStoreUpdate()
+      })
+      expect(onConversationMessage).toHaveBeenCalledTimes(1)
+
+      // Offline replay: an OLDER message is delivered via addMessage, which has
+      // no timestamp guard — the preview regresses. This IS a delivery and must
+      // still notify (#586), even though it moves the preview backwards.
+      act(() => {
+        pinArrival(convId, offline)
+        mockConversations.set(convId, {
+          ...mockConversations.get(convId),
+          unreadCount: 2,
+          lastMessage: offline,
+        })
+        triggerChatStoreUpdate()
+      })
+      expect(onConversationMessage).toHaveBeenCalledTimes(2)
+      expect(onConversationMessage.mock.calls[1][1].id).toBe('offline')
+      onConversationMessage.mockClear()
+
+      // Any later merge (reopen cache load or MAM page) picks the newest
+      // previewable message and restores 'newest' — already notified above.
+      // Nothing was delivered, so the arrival stays pinned on 'offline'.
+      act(() => {
+        mockConversations.set(convId, {
+          ...mockConversations.get(convId),
+          lastMessage: newest,
+        })
+        triggerChatStoreUpdate()
+      })
+
+      expect(onConversationMessage).not.toHaveBeenCalled()
+    })
+
+    // The arrival signal also carries the notification BODY. Previously the
+    // banner was built from conv.lastMessage, so a delivery landing while the
+    // preview pointed elsewhere (a bodiless placeholder demoted to an older
+    // message) announced the wrong text.
+    it('notifies with the delivered message, not the current preview', () => {
+      const onConversationMessage = vi.fn()
+      const now = new Date()
+      const preview = { id: 'preview-old', body: 'an older previewable line', timestamp: new Date(now.getTime() - 60 * 1000), isOutgoing: false }
+      const delivered = { id: 'delivered', body: 'the actual new message', timestamp: now, isOutgoing: false }
+
+      renderHook(() => useNotificationEvents({ onConversationMessage }))
+
+      act(() => {
+        pinArrival(convId, delivered)
+        mockConversations.set(convId, {
+          id: convId,
+          name: 'Dave',
+          unreadCount: 1,
+          lastSeenMessageId: undefined,
+          lastMessage: preview,
+        })
+        triggerChatStoreUpdate()
+      })
+
+      expect(onConversationMessage).toHaveBeenCalledTimes(1)
+      expect(onConversationMessage.mock.calls[0][1].id).toBe('delivered')
+      expect(onConversationMessage.mock.calls[0][1].body).toBe('the actual new message')
     })
   })
 })

--- a/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useNotificationEvents.ts
@@ -122,9 +122,17 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
   // re-hydration (activateRoom → loadMessagesFromCache, prepending older
   // history) also trips even though the newest message is unchanged. Keying the
   // notify-once decision on the message id — not the count — stops a reload from
-  // resurrecting a banner already delivered. The 1:1 path is already immune
-  // because it dedupes by lastMessage.id.
+  // resurrecting a banner already delivered. The 1:1 path gets its arrival
+  // signal from the store instead — see prevArrivedMessageIdsRef below.
   const lastNotifiedRoomMessageIdRef = useRef<Map<string, string>>(new Map())
+
+  // Last ARRIVED message id we've seen per conversation, mirroring
+  // chatStore.lastArrivedMessage. Diffing that store field — rather than the
+  // sidebar preview — is what makes one delivery produce exactly one
+  // notification: the store writes it only in addMessage past the duplicate
+  // early-returns, so it cannot move for a merge, a duplicate echo, or a
+  // preview swap. See its declaration in chatStore for the full rationale.
+  const prevArrivedMessageIdsRef = useRef<Map<string, string>>(new Map())
 
   // Watch for new messages in 1:1 conversations
   // Uses Zustand subscribe() to avoid re-rendering the parent component
@@ -133,11 +141,18 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
       const conversations = Array.from(state.conversations.values())
       const activeConversationId = state.activeConversationId
       const prevConversations = prevConversationsRef.current
+      // Defensive default: the field is always present on a real store, but the
+      // SDK is consumed by apps that mock chatStore in their own test setups.
+      const arrivedMessages = state.lastArrivedMessage ?? new Map()
+      const prevArrived = prevArrivedMessageIdsRef.current
       const onConversationMessage = handlersRef.current.onConversationMessage
       const onConversationRead = handlersRef.current.onConversationRead
 
       if (!onConversationMessage && !onConversationRead) {
         prevConversationsRef.current = conversations
+        // Keep the arrival baseline current, or attaching a handler later would
+        // replay every delivery buffered since mount as if it were new.
+        for (const [id, msg] of arrivedMessages) prevArrived.set(id, msg.id)
         return
       }
 
@@ -158,19 +173,25 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
           onConversationRead(conv.id)
         }
 
-        // Check if this conversation has a new message
-        if (onConversationMessage && conv.lastMessage) {
-          const isNewMessage = !prevConv?.lastMessage ||
-            prevConv.lastMessage.id !== conv.lastMessage.id
-          if (!isNewMessage) continue
+        // Did a message ARRIVE in this conversation? Ask the store's arrival
+        // signal, which moves once per delivery — never for the preview swaps
+        // and merges that also rewrite conv.lastMessage.
+        if (onConversationMessage) {
+          const arrived = arrivedMessages.get(conv.id)
+          if (!arrived) continue
+          if (arrived.id === prevArrived.get(conv.id)) continue
+
+          // Mark it seen before deciding: a delivery we chose NOT to notify for
+          // has still been handled, and must not be reconsidered on every tick.
+          prevArrived.set(conv.id, arrived.id)
 
           const isActive = conv.id === activeConversationId
           const notify = shouldNotifyConversation(
             {
-              id: conv.lastMessage.id,
-              timestamp: conv.lastMessage.timestamp,
-              isOutgoing: conv.lastMessage.isOutgoing,
-              isDelayed: conv.lastMessage.isDelayed,
+              id: arrived.id,
+              timestamp: arrived.timestamp,
+              isOutgoing: arrived.isOutgoing,
+              isDelayed: arrived.isDelayed,
             },
             {
               isActive,
@@ -180,9 +201,10 @@ export function useNotificationEvents(handlers: NotificationEventHandlers): void
             }
           )
 
-          if (notify) {
-            onConversationMessage(conv, conv.lastMessage)
-          }
+          // Notify with the message that ARRIVED, not the current preview —
+          // they can differ, and the preview would put the wrong body in the
+          // banner.
+          if (notify) onConversationMessage(conv, arrived)
         }
       }
 

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -214,6 +214,24 @@ interface ChatState {
   // is rebuilt from the newest window, so a stale `false` would wrongly gate live
   // messages. This is why the flag lives here and NOT in the persisted conversationMeta.
   windowAtLiveEdge: Map<string, boolean>
+  // The last message that genuinely ARRIVED in each conversation, as opposed to
+  // the last message we currently DISPLAY (conversationMeta.lastMessage).
+  //
+  // Written only by addMessage, past the duplicate early-returns — so it changes
+  // exactly once per delivered message and never for a duplicate echo, a MAM or
+  // cache merge, or a preview swap. That makes it the authoritative "a message
+  // arrived" signal for notification consumers, which must not fire twice for
+  // one message.
+  //
+  // lastMessage cannot serve that role: it is display state and legitimately
+  // moves BACKWARDS as well as forwards (a merge demotes it off a bodiless
+  // placeholder onto an older previewable message; addMessage sets it from an
+  // offline-replay message with no timestamp guard). Diffing it re-reads an
+  // already-delivered message as new — see useNotificationEvents.
+  //
+  // EPHEMERAL: never persisted (absent from partialize). A restored arrival
+  // would be re-read as a fresh delivery on the next launch.
+  lastArrivedMessage: Map<string, Message>
 
   // Computed
   activeConversation: () => Conversation | null
@@ -578,7 +596,7 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
   }
 }
 
-function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge'> {
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
   return {
     conversationEntities: new Map(),
     conversationMeta: new Map(),
@@ -596,6 +614,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
     targetMessageId: null,
     firstNewMessageMarkers: new Map(),
     windowAtLiveEdge: new Map(),
+    lastArrivedMessage: new Map(),
   }
 }
 
@@ -605,7 +624,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
  * Legacy versions stored chat data under a single unscoped key. For safety, we only migrate
  * conversation lists (active + archived classification) and intentionally skip drafts/messages.
  */
-function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge'> | null {
+function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> | null {
   if (!jid) return null
 
   const legacyKey = getLegacyStorageKey()
@@ -644,7 +663,7 @@ function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatSt
   }
 }
 
-function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge'> {
+function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
   const baseState = createEmptyChatState()
   const scopedStorageKey = getScopedStorageKey(jid)
 
@@ -1007,6 +1026,15 @@ export const chatStore = createStore<ChatState>()(
             append.kind === 'appended' ? append.messages : convMessages
           )
 
+          // Record the arrival. Both surviving append kinds are genuine
+          // deliveries — 'appended' spliced into the resident window, 'gated'
+          // held out of a window slid back into history — and the duplicate
+          // kinds already returned above. This is the signal notification
+          // consumers diff; see the field's declaration for why the sidebar
+          // preview cannot be used instead.
+          const newArrived = new Map(state.lastArrivedMessage)
+          newArrived.set(msg.conversationId, msg)
+
           const conv = state.conversations.get(msg.conversationId)
           const meta = state.conversationMeta.get(msg.conversationId)
           if (conv && meta) {
@@ -1072,14 +1100,15 @@ export const chatStore = createStore<ChatState>()(
                   conversations: newConversations,
                   archivedConversations: newArchived,
                   firstNewMessageMarkers: newMarkers,
+                  lastArrivedMessage: newArrived,
                 }
               }
             }
 
-            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
+            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers, lastArrivedMessage: newArrived }
           }
 
-          return { messages: newMessages }
+          return { messages: newMessages, lastArrivedMessage: newArrived }
         })
       },
 


### PR DESCRIPTION
Follow-up to #999, which stopped a **room** notification reappearing when the room is reopened. The 1:1 path had the same bug by a different route.

`useNotificationEvents` detected arrivals by diffing `conversationMeta.lastMessage`. That field is *display* state and legitimately moves backwards as well as forwards, so either move re-read an already-delivered message as new and re-posted its banner:

- a reopen merge demotes the preview off a bodiless placeholder onto an older previewable message (`shouldReplaceLastMessage`'s `!isPreviewableMessage` branch). `setActiveConversation` evicts the resident array on deactivate, so the reopen slice is never a no-op merge and the demotion always runs;
- `addMessage` sets the preview from an offline-replay message with no timestamp guard, unlike every merge path.

The fix adds an ephemeral `chatStore.lastArrivedMessage`, written only in `addMessage` past the duplicate early-returns, and diffs that instead. It moves exactly once per delivered message and never for a merge, duplicate echo or preview swap. Notifications now carry the *arrived* message rather than the preview, which could otherwise put the wrong body in the banner.