### PR TITLE
fix(muc): don't let a delayed message drag the room preview backwards

### DIFF
--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -5,6 +5,7 @@ import { isNoLocalStore } from '../core/types/message-internal'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
 import { setResidentWindowSize } from './shared/residentWindow'
+import { ignoreStore } from './ignoreStore'
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -1399,6 +1400,101 @@ describe('roomStore', () => {
 
       const room = roomStore.getState().rooms.get('test@conference.example.com')
       expect(room?.unreadCount).toBe(1)
+    })
+
+    describe('lastMessage preview — delayed arrivals must not regress the sidebar', () => {
+      // MUC twin of the chatStore regression. The preview was derived from the
+      // appended array with NO timestamp gate, so a delayed arrival older than
+      // the current preview dragged the sidebar backwards — and roomMeta is
+      // persisted, so it survived a reload.
+      //
+      // The reachable route is not join-time history replay (that is
+      // oldest-to-newest, and MUC.ts requests maxstanzas=0 on MAM-capable rooms,
+      // so it self-corrects). It is MAM.fetchRoomMessageById: a live
+      // <poll-closed> whose original poll is not resident triggers a deferred
+      // MAM {ids} fetch, which emits `room:message` carrying the ORIGINAL POLL —
+      // isDelayed, previewable (isPreviewableMessage is true for msg.poll), and
+      // older than the poll-closed by construction. appendLive cannot dedupe it
+      // because the resident array is empty off the active room.
+      const ROOM = 'test@conference.example.com'
+
+      function delayed(id: string, body: string, at: string): RoomMessage {
+        return { ...createMessage(id, ROOM, 'alice', body), timestamp: new Date(at), isDelayed: true }
+      }
+
+      /** Fresh-run shape: preview persisted, resident array EMPTY. */
+      function seedPersistedPreview(preview: RoomMessage): void {
+        roomStore.getState().addRoom(createRoom(ROOM, { joined: true, lastMessage: preview }))
+        const meta = roomStore.getState().roomMeta.get(ROOM)
+        if (meta) {
+          roomStore.setState({
+            roomMeta: new Map(roomStore.getState().roomMeta).set(ROOM, { ...meta, lastMessage: preview }),
+          })
+        }
+      }
+
+      it('keeps the newer preview when an older delayed message arrives', () => {
+        seedPersistedPreview(delayed('closed-1', 'Poll closed', '2026-07-18T12:00:00Z'))
+
+        roomStore.getState().addMessage(ROOM, delayed('poll-1', 'Original poll', '2026-07-18T09:00:00Z'))
+
+        expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe('Poll closed')
+        expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage?.body).toBe('Poll closed')
+      })
+
+      it('does not drag lastInteractedAt backwards with the preview', () => {
+        // lastInteractedAt is derived from the preview timestamp — a regressed
+        // preview would also demote the room's sidebar ordering.
+        seedPersistedPreview(delayed('closed-1', 'Poll closed', '2026-07-18T12:00:00Z'))
+
+        roomStore.getState().addMessage(ROOM, delayed('poll-1', 'Original poll', '2026-07-18T09:00:00Z'))
+
+        const lastInteractedAt = roomStore.getState().rooms.get(ROOM)?.lastInteractedAt
+        expect(lastInteractedAt?.getTime()).toBe(new Date('2026-07-18T12:00:00Z').getTime())
+      })
+
+      it('still stores the older delayed message in the timeline', () => {
+        seedPersistedPreview(delayed('closed-1', 'Poll closed', '2026-07-18T12:00:00Z'))
+
+        roomStore.getState().addMessage(ROOM, delayed('poll-1', 'Original poll', '2026-07-18T09:00:00Z'))
+
+        const bodies = (roomStore.getState().rooms.get(ROOM)?.messages ?? []).map((m) => m.body)
+        expect(bodies).toContain('Original poll')
+      })
+
+      it('advances the preview across a replay burst sharing one second-precision delay stamp', () => {
+        const stamp = '2026-07-18T09:00:00Z'
+        seedPersistedPreview(delayed('burst-1', 'Burst 1', stamp))
+
+        roomStore.getState().addMessage(ROOM, delayed('burst-2', 'Burst 2', stamp))
+        roomStore.getState().addMessage(ROOM, delayed('burst-3', 'Burst 3', stamp))
+
+        expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe('Burst 3')
+      })
+
+      it('advances the preview for a live message newer than the persisted preview', () => {
+        seedPersistedPreview(delayed('old-1', 'Older', '2026-07-18T09:00:00Z'))
+
+        roomStore.getState().addMessage(ROOM, {
+          ...createMessage('live-1', ROOM, 'bob', 'Fresh live message'),
+          timestamp: new Date('2026-07-18T12:00:00Z'),
+        })
+
+        expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe('Fresh live message')
+      })
+
+      it('still skips an ignored sender when the candidate is newer', () => {
+        // The ignored-sender scan must survive the new timestamp gate.
+        seedPersistedPreview(delayed('old-1', 'Visible', '2026-07-18T09:00:00Z'))
+        ignoreStore.getState().addIgnored(ROOM, { identifier: 'spammer', displayName: 'spammer' })
+
+        roomStore.getState().addMessage(ROOM, {
+          ...createMessage('spam-1', ROOM, 'spammer', 'Spam'),
+          timestamp: new Date('2026-07-18T12:00:00Z'),
+        })
+
+        expect(roomStore.getState().rooms.get(ROOM)?.lastMessage?.body).toBe('Visible')
+      })
     })
   })
 

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1358,7 +1358,21 @@ export const roomStore = createStore<RoomState>()(
       // Get the last non-ignored message for sidebar preview. Use the appended set
       // (not the possibly-gated resident array) so the preview still advances to the
       // incoming message even when the window has slid off the live edge.
-      const lastMessage = findLastNonIgnoredMessage(appendedMessages, roomJid, existing.nickToJidCache) ?? existing.lastMessage
+      //
+      // appendLive appends at the END without sorting, so a DELAYED arrival
+      // (gateway/offline replay, or the MAM {ids} fetch behind deferred
+      // poll-closed verification, which emits the ORIGINAL POLL — older than the
+      // poll-closed that triggered it) becomes the array's last element and would
+      // drag the preview backwards. Dedupe can't protect us: appendLive keys off
+      // the RESIDENT array, which is empty off the active room. roomMeta is
+      // persisted, so an ungated assignment survives a reload. tie: 'replace' so a
+      // replay burst sharing one second-precision <delay/> stamp still advances.
+      const heldLastMessage = existingMeta?.lastMessage ?? existing.lastMessage
+      const previewCandidate = findLastNonIgnoredMessage(appendedMessages, roomJid, existing.nickToJidCache)
+      const lastMessage =
+        previewCandidate && shouldReplaceLastMessage(heldLastMessage, previewCandidate, 'replace')
+          ? previewCandidate
+          : heldLastMessage
 
       // Update lastInteractedAt so the room bubbles up in the sidebar:
       // - Active room: always update (user is viewing it)


### PR DESCRIPTION
MUC twin of the 1:1 defect fixed in 8f685c2f, now rebased on top of it.

`roomStore.addMessage` derived the sidebar preview from the appended array via `findLastNonIgnoredMessage` with no timestamp comparison. `timeline.appendLive` appends at the END without sorting, so a **delayed arrival became the array's last element and took over the preview**. `roomMeta` is persisted, so it survived a reload.