### PR TITLE
docs(changelog): finalize 0.17.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to Fluux Messenger are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.2] - 2026-07-17
+## [0.17.2] - 2026-07-21
 
 ### Added
 
+- Emoji autocomplete in the composer: type ":" followed by a keyword to complete emoji inline, with arrow-key navigation and Enter or Tab to insert
 - The send button responds with a press and glow-pulse animation when a message goes out
 - Web (PWA): an unread badge on the app icon, service-worker media caching for fewer re-downloads, and repeated messages from one sender coalesced into a single "N new messages" notification
 
@@ -27,8 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Encryption: a leftover unread badge from an undecryptable reaction now clears once its placeholder is dropped
 - Web (PWA): an update already downloaded but parked is now applied automatically at launch instead of trailing the deployed build indefinitely
 - Clicking a reaction notification now always jumps to the reacted message
+- Reopening a conversation no longer re-posts a notification for a message you have already seen
+- An encrypted message with no readable content stays silent until it is decrypted, instead of posting a blank notification and playing a sound
+- A delayed message (an offline replay or a catch-up copy older than what you already have) no longer drags the sidebar preview back to older text, in both 1:1 chats and group chats
 - The sidebar keeps its scroll position when conversations reorder during catch-up
 - Authentication: a wrong saved password no longer triggers an endless keychain retry loop
+- Connecting to a server whose domain contains non-ASCII characters now works
 - Encryption: the key-backup passphrase is now used exactly as displayed, so backups restore in other XMPP clients; older backups still open and are healed to the portable format on restore
 - Desktop: downloading an update no longer risks freezing the app while showing progress
 - Linux: fixed a performance issue when many new messages arrived at once

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Emoji autocomplete in the composer: type ":" followed by a keyword to complete emoji inline, with arrow-key navigation and Enter or Tab to insert
 - The send button responds with a press and glow-pulse animation when a message goes out
 - Web (PWA): an unread badge on the app icon, service-worker media caching for fewer re-downloads, and repeated messages from one sender coalesced into a single "N new messages" notification
 
@@ -20,8 +21,12 @@
 - Encryption: a leftover unread badge from an undecryptable reaction now clears once its placeholder is dropped
 - Web (PWA): an update already downloaded but parked is now applied automatically at launch instead of trailing the deployed build indefinitely
 - Clicking a reaction notification now always jumps to the reacted message
+- Reopening a conversation no longer re-posts a notification for a message you have already seen
+- An encrypted message with no readable content stays silent until it is decrypted, instead of posting a blank notification and playing a sound
+- A delayed message (an offline replay or a catch-up copy older than what you already have) no longer drags the sidebar preview back to older text, in both 1:1 chats and group chats
 - The sidebar keeps its scroll position when conversations reorder during catch-up
 - Authentication: a wrong saved password no longer triggers an endless keychain retry loop
+- Connecting to a server whose domain contains non-ASCII characters now works
 - Encryption: the key-backup passphrase is now used exactly as displayed, so backups restore in other XMPP clients; older backups still open and are healed to the portable format on restore
 - Desktop: downloading an update no longer risks freezing the app while showing progress
 - Linux: fixed a performance issue when many new messages arrived at once

--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -15,11 +15,12 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '0.17.2',
-    date: '2026-07-17',
+    date: '2026-07-21',
     sections: [
       {
         type: 'added',
         items: [
+          'Emoji autocomplete in the composer: type ":" followed by a keyword to complete emoji inline, with arrow-key navigation and Enter or Tab to insert',
           'The send button responds with a press and glow-pulse animation when a message goes out',
           'Web (PWA): an unread badge on the app icon, service-worker media caching for fewer re-downloads, and repeated messages from one sender coalesced into a single "N new messages" notification',
         ],
@@ -42,8 +43,12 @@ export const changelog: ChangelogEntry[] = [
           'Encryption: a leftover unread badge from an undecryptable reaction now clears once its placeholder is dropped',
           'Web (PWA): an update already downloaded but parked is now applied automatically at launch instead of trailing the deployed build indefinitely',
           'Clicking a reaction notification now always jumps to the reacted message',
+          'Reopening a conversation no longer re-posts a notification for a message you have already seen',
+          'An encrypted message with no readable content stays silent until it is decrypted, instead of posting a blank notification and playing a sound',
+          'A delayed message (an offline replay or a catch-up copy older than what you already have) no longer drags the sidebar preview back to older text, in both 1:1 chats and group chats',
           'The sidebar keeps its scroll position when conversations reorder during catch-up',
           'Authentication: a wrong saved password no longer triggers an endless keychain retry loop',
+          'Connecting to a server whose domain contains non-ASCII characters now works',
           'Encryption: the key-backup passphrase is now used exactly as displayed, so backups restore in other XMPP clients; older backups still open and are healed to the portable format on restore',
           'Desktop: downloading an update no longer risks freezing the app while showing progress',
           'Linux: fixed a performance issue when many new messages arrived at once',

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,5 +1,6 @@
 fluux-messenger (0.17.2-1) unstable; urgency=medium
 
+  * Emoji autocomplete in the composer: type ":" followed by a keyword to complete emoji inline, with arrow-key navigation and Enter or Tab to insert
   * The send button responds with a press and glow-pulse animation when a message goes out
   * Web (PWA): an unread badge on the app icon, service-worker media caching for fewer re-downloads, and repeated messages from one sender coalesced into a single "N new messages" notification
   * The new-messages divider and the unread badge on the scroll-to-bottom button now follow your read position, staying consistent with the sidebar and read-marker sync
@@ -12,8 +13,12 @@ fluux-messenger (0.17.2-1) unstable; urgency=medium
   * Encryption: a leftover unread badge from an undecryptable reaction now clears once its placeholder is dropped
   * Web (PWA): an update already downloaded but parked is now applied automatically at launch instead of trailing the deployed build indefinitely
   * Clicking a reaction notification now always jumps to the reacted message
+  * Reopening a conversation no longer re-posts a notification for a message you have already seen
+  * An encrypted message with no readable content stays silent until it is decrypted, instead of posting a blank notification and playing a sound
+  * A delayed message (an offline replay or a catch-up copy older than what you already have) no longer drags the sidebar preview back to older text, in both 1:1 chats and group chats
   * The sidebar keeps its scroll position when conversations reorder during catch-up
   * Authentication: a wrong saved password no longer triggers an endless keychain retry loop
+  * Connecting to a server whose domain contains non-ASCII characters now works
   * Encryption: the key-backup passphrase is now used exactly as displayed, so backups restore in other XMPP clients; older backups still open and are healed to the portable format on restore
   * Desktop: downloading an update no longer risks freezing the app while showing progress
   * Linux: fixed a performance issue when many new messages arrived at once
@@ -26,4 +31,4 @@ fluux-messenger (0.17.2-1) unstable; urgency=medium
   * macOS: the traffic-light window buttons stay centered in the app bar
   * Web: the notification permission card in Settings uses platform-neutral wording instead of "Desktop Notifications"
 
- -- ProcessOne <contact@process-one.net>  Fri, 17 Jul 2026 12:00:00 +0000
+ -- ProcessOne <contact@process-one.net>  Tue, 21 Jul 2026 12:00:00 +0000

--- a/packaging/flatpak/com.processone.fluux.metainfo.xml
+++ b/packaging/flatpak/com.processone.fluux.metainfo.xml
@@ -90,7 +90,7 @@
   </content_rating>
 
   <releases>
-    <release version="0.17.2" date="2026-07-17">
+    <release version="0.17.2" date="2026-07-21">
       <description>
         <p>See release notes for details.</p>
       </description>


### PR DESCRIPTION
Covers the user-visible changes that landed after the last changelog pass: emoji autocomplete (#1038), the notification fixes (#1046 and bodiless encrypted arrivals), the delayed-message sidebar preview regression (1:1 and rooms, #1047), and the IDN connection fix (#1042).

Release date moved to 2026-07-21, and `npm run release:prepare 0.17.2` re-run so CHANGELOG.md, RELEASE_NOTES.md, the Debian changelog and the flatpak metainfo match changelog.ts.