### PR TITLE
fix(search): stop redundant store writes on every keystroke

### DIFF
--- a/apps/fluux/src/components/sidebar-components/SearchView.renderLoop.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.renderLoop.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { SearchView } from './SearchView'
+import type { SearchResult } from '@fluux/sdk'
+
+// The search box is a controlled input: every keystroke re-renders SearchView for the
+// query, then again for the debounced search cycle (isSearching true → results). At
+// ~3 renders/keystroke (×2 under StrictMode) normal typing speed crosses the detector's
+// 30-renders-per-second warning threshold with no loop present. Typing must therefore
+// arm the interaction grace, exactly as the message composer does.
+const notifyUserInput = vi.fn()
+vi.mock('@/utils/renderLoopDetector', () => ({
+  detectRenderLoop: () => {},
+  notifyUserInput: () => notifyUserInput(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useListKeyboardNav: () => ({
+    selectedIndex: -1,
+    isKeyboardNav: false,
+    getItemProps: () => ({}),
+    getItemAttribute: () => ({}),
+    getContainerProps: () => ({}),
+  }),
+}))
+
+vi.mock('@/hooks/useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({ navigateToConversation: vi.fn(), navigateToRoom: vi.fn() }),
+}))
+
+vi.mock('@/utils/dateFormat', () => ({ formatConversationTime: () => '12:00' }))
+vi.mock('./types', () => ({ useSidebarZone: () => ({ current: null }) }))
+vi.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { timeFormat: string }) => unknown) => selector({ timeFormat: '24h' }),
+}))
+
+let mockSearch: ReturnType<typeof baseSearch>
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  const emptyStore = {
+    getState: () => ({
+      rooms: { get: () => undefined },
+      contacts: { get: () => undefined },
+      conversationEntities: { get: () => undefined },
+    }),
+  }
+  return {
+    ...actual,
+    useSearch: () => mockSearch,
+    chatStore: emptyStore,
+    roomStore: emptyStore,
+    rosterStore: emptyStore,
+    getLocalPart: (jid: string) => jid.split('@')[0],
+  }
+})
+
+function baseSearch() {
+  return {
+    query: '', results: [] as SearchResult[], isSearching: false, error: null,
+    search: vi.fn(), clearSearch: vi.fn(), previewResult: null, setPreviewResult: vi.fn(),
+    isSearchingMAM: false, mamResults: [] as SearchResult[], hasMoreMAMResults: false, mamError: null,
+    searchScope: null, searchMAM: vi.fn(), loadMoreMAMResults: vi.fn(), setSearchScope: vi.fn(),
+    resultContext: new Map(), searchFilter: 'all', setSearchFilter: vi.fn(),
+    inPrefixSuggestions: [], isInPrefixActive: false, selectInPrefixSuggestion: vi.fn(),
+  }
+}
+
+describe('SearchView render-loop interaction grace', () => {
+  beforeEach(() => {
+    notifyUserInput.mockClear()
+    mockSearch = baseSearch()
+  })
+
+  it('arms the interaction grace on each keystroke in the search box', () => {
+    const { container } = render(<SearchView />)
+    const input = container.querySelector('input[type="text"]')
+    expect(input).not.toBeNull()
+
+    fireEvent.change(input!, { target: { value: 'd' } })
+    expect(notifyUserInput).toHaveBeenCalledTimes(1)
+
+    fireEvent.change(input!, { target: { value: 'de' } })
+    expect(notifyUserInput).toHaveBeenCalledTimes(2)
+
+    // The keystroke must still reach the store — the grace is additive, not a replacement.
+    expect(mockSearch.search).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -8,7 +8,7 @@ import { RoomAvatar } from '../RoomAvatar'
 import { useNavigateToTarget } from '@/hooks/useNavigateToTarget'
 import { useListKeyboardNav } from '@/hooks'
 import { formatConversationTime } from '@/utils/dateFormat'
-import { detectRenderLoop } from '@/utils/renderLoopDetector'
+import { detectRenderLoop, notifyUserInput } from '@/utils/renderLoopDetector'
 import { useSettingsStore, type TimeFormat } from '@/stores/settingsStore'
 import { useSidebarZone } from './types'
 import { Search, SearchX, X, Loader2, ExternalLink, Cloud, Users, MessageSquare, Hash } from 'lucide-react'
@@ -124,7 +124,15 @@ export function SearchView() {
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => search(e.target.value)}
+            onChange={(e) => {
+              // Each keystroke re-renders this controlled input for the query, then
+              // again for the debounced search cycle (isSearching → results) — about
+              // 3× per key, which normal typing speed multiplies past the render-loop
+              // *warning* threshold with no loop present. Arm the interaction grace,
+              // as the composer does; the hard loop-break threshold is unaffected.
+              notifyUserInput()
+              search(e.target.value)
+            }}
             onKeyDown={handleInPrefixKeyDown}
             placeholder={t('search.placeholder', 'Search messages…')}
             className="w-full ps-8 pe-8 py-1.5 text-sm bg-fluux-bg border border-fluux-border rounded-md

--- a/packages/fluux-sdk/src/stores/searchStore.test.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.test.ts
@@ -88,6 +88,33 @@ describe('searchStore', () => {
       expect(state.isSearching).toBe(true)
     })
 
+    // Every notification re-renders the search UI. A keystroke has exactly one
+    // synchronous effect — the query changed — so it must cost exactly one write.
+    it('notifies subscribers once per keystroke', () => {
+      searchStore.getState().search('hel')  // leave prefix state settled
+
+      let notifications = 0
+      const unsub = searchStore.subscribe(() => { notifications++ })
+      searchStore.getState().search('hell')
+      unsub()
+
+      expect(notifications).toBe(1)
+    })
+
+    // Re-allocating an already-empty collection changes its identity, which defeats
+    // the useShallow comparison in useSearch and forces a render for no state change.
+    it('keeps referential identity of collections that stay empty', () => {
+      searchStore.getState().search('hel')
+      const before = searchStore.getState()
+
+      searchStore.getState().search('hell')
+      const after = searchStore.getState()
+
+      expect(after.inPrefixSuggestions).toBe(before.inPrefixSuggestions)
+      expect(after.mamResults).toBe(before.mamResults)
+      expect(after.resultContext).toBe(before.resultContext)
+    })
+
     it('should debounce the actual search call', () => {
       searchStore.getState().search('hello')
 

--- a/packages/fluux-sdk/src/stores/searchStore.ts
+++ b/packages/fluux-sdk/src/stores/searchStore.ts
@@ -368,8 +368,12 @@ async function executeSearch(query: string): Promise<void> {
     }))
 
     // Only update if the query hasn't changed while we were searching
-    if (searchStore.getState().query === query) {
-      searchStore.setState({ results, isSearching: false, error: null })
+    const current = searchStore.getState()
+    if (current.query === query) {
+      // A no-match query maps to a fresh empty array; keeping the previous (also
+      // empty) one avoids invalidating useSearch for a result set that did not change.
+      const nextResults = results.length === 0 && current.results.length === 0 ? current.results : results
+      searchStore.setState({ results: nextResults, isSearching: false, error: null })
       // Fire-and-forget: load context messages for results
       void fetchResultContexts(results, query)
     }
@@ -556,7 +560,7 @@ async function indexMAMResults(results: SearchResult[]): Promise<void> {
   }
 }
 
-export const searchStore = createStore<SearchState>((set) => ({
+export const searchStore = createStore<SearchState>((set, get) => ({
   query: '',
   isSearching: false,
   results: [],
@@ -600,11 +604,25 @@ export const searchStore = createStore<SearchState>((set) => ({
       return
     }
 
-    // Clear in: state when not in prefix mode
-    set({ inPrefixSuggestions: [], isInPrefixActive: false })
-
-    // Reset MAM results and context on new query
-    set({ query, isSearching: true, error: null, mamResults: [], mamError: null, hasMoreMAMResults: false, resultContext: new Map() })
+    // One write per keystroke. Every `set` notifies subscribers and re-renders the
+    // search UI, so the in: reset and the query update go out together rather than as
+    // two back-to-back writes. The collections here are only ever *cleared*, and
+    // re-allocating one that is already empty would change its identity for no change
+    // in value — that defeats the useShallow comparison in useSearch and costs a render
+    // on every keystroke. Clear only what actually holds something.
+    const prev = get()
+    const patch: Partial<SearchState> = {
+      query,
+      isSearching: true,
+      error: null,
+      mamError: null,
+      hasMoreMAMResults: false,
+    }
+    if (prev.isInPrefixActive) patch.isInPrefixActive = false
+    if (prev.inPrefixSuggestions.length > 0) patch.inPrefixSuggestions = []
+    if (prev.mamResults.length > 0) patch.mamResults = []
+    if (prev.resultContext.size > 0) patch.resultContext = new Map()
+    set(patch)
     mamSearchGeneration++  // Cancel any in-flight MAM search
     mamRsmCursor = undefined
 


### PR DESCRIPTION
`searchStore.search()` issued two back-to-back `set()` calls per keystroke, and unconditionally re-allocated `inPrefixSuggestions`, `mamResults` and `resultContext` even when they were already empty. Each `set` notifies subscribers, and a fresh empty collection changes identity without changing value — which defeats the `useShallow` comparison in `useSearch`. The first write cost a full SearchView render while carrying no information at all.

This collapses the two writes into one and clears only the collections that actually hold something.