### PR TITLE
fix(dev): defer render-loop event dispatch out of the render phase

### DIFF
--- a/apps/fluux/src/components/RenderLoopBoundary.warningBanner.test.tsx
+++ b/apps/fluux/src/components/RenderLoopBoundary.warningBanner.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { RenderLoopWarningBanner } from './RenderLoopBoundary'
+import { detectRenderLoop, resetRenderLoopDetector } from '@/utils/renderLoopDetector'
+
+// test-setup.ts mocks the detector globally; this suite needs the real counters.
+vi.mock('@/utils/renderLoopDetector', async (importOriginal) => await importOriginal())
+
+const WARNING_THRESHOLD = 30
+
+/** Calls the detector during render, exactly as an instrumented component does. */
+function Offender(): null {
+  detectRenderLoop('Offender')
+  return null
+}
+
+describe('RenderLoopWarningBanner', () => {
+  let errors: string[]
+
+  beforeEach(() => {
+    resetRenderLoopDetector()
+    errors = []
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '))
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not set state while the offending component is still rendering', () => {
+    // Mount first so the banner's listener is attached before the warning fires.
+    const { rerender } = render(
+      <>
+        <RenderLoopWarningBanner />
+        <div />
+      </>,
+    )
+
+    // Warm the window to one render short of the threshold.
+    for (let i = 0; i < WARNING_THRESHOLD - 1; i++) detectRenderLoop('Offender')
+
+    // This render is the one that trips the warning — the detector dispatches while
+    // React is rendering Offender, so a listener that setStates violates React's rules.
+    rerender(
+      <>
+        <RenderLoopWarningBanner />
+        <Offender />
+      </>,
+    )
+
+    expect(errors.filter((e) => e.includes('Cannot update a component'))).toEqual([])
+  })
+
+  it('still surfaces the warning to the user', async () => {
+    const { rerender } = render(
+      <>
+        <RenderLoopWarningBanner />
+        <div />
+      </>,
+    )
+
+    for (let i = 0; i < WARNING_THRESHOLD - 1; i++) detectRenderLoop('Offender')
+    rerender(
+      <>
+        <RenderLoopWarningBanner />
+        <Offender />
+      </>,
+    )
+
+    // Deferring the dispatch must not drop it — the banner still has to appear.
+    await waitFor(() => {
+      expect(screen.getByText(/Render loop warning/)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/fluux/src/utils/renderLoopDetector.ts
+++ b/apps/fluux/src/utils/renderLoopDetector.ts
@@ -102,6 +102,31 @@ function getComponentState(componentName: string): ComponentState {
 }
 
 /**
+ * Dispatch a detector event *after* the current render finishes.
+ *
+ * detectRenderLoop is called from a component's render phase, so dispatching
+ * synchronously would run listeners mid-render. A listener that sets state — the
+ * on-screen warning banner does — then trips React's "Cannot update a component
+ * while rendering a different component" invariant, turning a diagnostic into a
+ * second error that points at the innocent component being rendered.
+ *
+ * A macrotask defers past the whole render+commit cycle. queueMicrotask would not
+ * be reliable: React can yield mid-render, which flushes microtasks before commit.
+ * The detail payload is captured by value at call time, so the snapshot still
+ * describes the render that tripped the threshold.
+ */
+function dispatchAfterRender(type: string, detail: unknown): void {
+  if (typeof window === 'undefined') return
+  setTimeout(() => {
+    try {
+      window.dispatchEvent(new CustomEvent(type, { detail }))
+    } catch {
+      // CustomEvent not available — ignore
+    }
+  }, 0)
+}
+
+/**
  * Get a simplified stack trace for debugging.
  * Only captures in development mode to minimize overhead.
  */
@@ -200,15 +225,9 @@ export function detectRenderLoop(componentName: string): void {
         `${state.emaRate.toFixed(0)}/sec for ${(heldFor / 1000).toFixed(1)}s ` +
         `(sub-threshold storm — likely a broken memo or a churning store map).`
       )
-      if (typeof window !== 'undefined') {
-        try {
-          window.dispatchEvent(new CustomEvent('fluux:render-loop-sustained', {
-            detail: { componentName, rate: Math.round(state.emaRate), heldMs: heldFor },
-          }))
-        } catch {
-          // CustomEvent not available — ignore
-        }
-      }
+      dispatchAfterRender('fluux:render-loop-sustained', {
+        componentName, rate: Math.round(state.emaRate), heldMs: heldFor,
+      })
     }
   } else {
     state.sustainedSince = 0
@@ -229,15 +248,9 @@ export function detectRenderLoop(componentName: string): void {
     }
     // Dispatch a window event so the app can surface an on-screen warning
     // (useful on mobile where the console is hard to reach).
-    if (typeof window !== 'undefined') {
-      try {
-        window.dispatchEvent(new CustomEvent('fluux:render-loop-warning', {
-          detail: { componentName, renderCount: state.renderCount, windowMs: TIME_WINDOW_MS },
-        }))
-      } catch {
-        // CustomEvent not available — ignore
-      }
-    }
+    dispatchAfterRender('fluux:render-loop-warning', {
+      componentName, renderCount: state.renderCount, windowMs: TIME_WINDOW_MS,
+    })
   }
 
   const effectiveThreshold = now < syncGraceUntil ? SYNC_GRACE_THRESHOLD : MAX_RENDERS_PER_WINDOW


### PR DESCRIPTION
`detectRenderLoop()` is called at the top of a component's render and dispatched its `CustomEvent` **synchronously**, so listeners ran mid-render. `RenderLoopWarningBanner` listens and calls `setState`, which violates React's rule against updating one component while another is rendering.

React then reports the bad `setState` against whichever component happened to be rendering, so a render-loop warning surfaced as:

```
Cannot update a component (`RenderLoopWarningBanner`) while rendering a
different component (`SearchView`). To locate the bad setState() call
inside `SearchView` …
```

pointing at a component that was doing nothing wrong.

Both dispatches now defer to a macrotask so listeners run after render and commit. `queueMicrotask` is not sufficient here: React can yield mid-render, which flushes microtasks before it commits. The detail payload is captured by value, so the snapshot still describes the render that tripped the threshold.