### PR TITLE
fix(attachments): don't save ciphertext URL from image lightbox/context menu

### DIFF
--- a/apps/fluux/src/components/FileAttachments.tsx
+++ b/apps/fluux/src/components/FileAttachments.tsx
@@ -240,6 +240,7 @@ export const ImageAttachment = memo(function ImageAttachment({ attachment, onLoa
       <ImageContextMenu
         originalUrl={attachment.url}
         proxiedUrl={effectiveSrc}
+        encryption={attachment.encryption}
         filename={attachment.name}
         menu={imageMenu}
       />

--- a/apps/fluux/src/components/ImageContextMenu.test.tsx
+++ b/apps/fluux/src/components/ImageContextMenu.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createRef } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ImageContextMenu } from './ImageContextMenu'
+import type { ContextMenuState } from '@/hooks/useContextMenu'
+
+const { downloadFileSpy, downloadAttachmentSpy, copyToClipboardSpy } = vi.hoisted(() => ({
+  downloadFileSpy: vi.fn(),
+  downloadAttachmentSpy: vi.fn(),
+  copyToClipboardSpy: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+vi.mock('@/utils/download', () => ({
+  downloadFile: (...args: unknown[]) => downloadFileSpy(...args),
+  downloadAttachment: (...args: unknown[]) => downloadAttachmentSpy(...args),
+}))
+vi.mock('@/utils/clipboard', () => ({ copyToClipboard: (...args: unknown[]) => copyToClipboardSpy(...args) }))
+vi.mock('@/utils/openInBrowser', () => ({ openInBrowser: vi.fn() }))
+vi.mock('@/hooks/useFocusTrap', () => ({ useFocusTrap: () => {} }))
+
+function makeMenu(): ContextMenuState {
+  return {
+    isOpen: true,
+    position: { x: 10, y: 20 },
+    menuRef: createRef<HTMLDivElement>(),
+    longPressTriggered: { current: false },
+    close: vi.fn(),
+    handleContextMenu: vi.fn(),
+    handleTouchStart: vi.fn(),
+    handleTouchEnd: vi.fn(),
+  }
+}
+
+describe('ImageContextMenu save (encrypted)', () => {
+  const encryption = { cipher: 'aes-256-gcm' as const, key: new Uint8Array(32), iv: new Uint8Array(12) }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('with no decrypted URL, decrypts on demand — never saves the ciphertext URL', () => {
+    render(
+      <ImageContextMenu
+        originalUrl="https://x/cipher.bin"
+        proxiedUrl={null}
+        encryption={encryption}
+        filename="secret.jpg"
+        menu={makeMenu()}
+      />,
+    )
+    fireEvent.click(screen.getByText('chat.saveImage'))
+
+    expect(downloadAttachmentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://x/cipher.bin', encryption }),
+      expect.anything(),
+    )
+    // The raw ciphertext URL is never handed to the direct save path.
+    expect(downloadFileSpy).not.toHaveBeenCalled()
+  })
+
+  it('saves the decrypted blob directly once resolved (no re-decrypt)', () => {
+    render(
+      <ImageContextMenu
+        originalUrl="https://x/cipher.bin"
+        proxiedUrl="blob:decrypted"
+        encryption={encryption}
+        filename="secret.jpg"
+        menu={makeMenu()}
+      />,
+    )
+    fireEvent.click(screen.getByText('chat.saveImage'))
+    expect(downloadFileSpy).toHaveBeenCalledWith('blob:decrypted', 'secret.jpg', expect.anything())
+    expect(downloadAttachmentSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('ImageContextMenu save (plaintext)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves the proxied URL when present', () => {
+    render(
+      <ImageContextMenu
+        originalUrl="https://x/plain.jpg"
+        proxiedUrl="blob:proxied"
+        filename="plain.jpg"
+        menu={makeMenu()}
+      />,
+    )
+    fireEvent.click(screen.getByText('chat.saveImage'))
+    expect(downloadFileSpy).toHaveBeenCalledWith('blob:proxied', 'plain.jpg', expect.anything())
+    expect(downloadAttachmentSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the original URL when nothing is proxied (unencrypted only)', () => {
+    render(
+      <ImageContextMenu
+        originalUrl="https://x/plain.jpg"
+        proxiedUrl={null}
+        filename="plain.jpg"
+        menu={makeMenu()}
+      />,
+    )
+    fireEvent.click(screen.getByText('chat.saveImage'))
+    expect(downloadFileSpy).toHaveBeenCalledWith('https://x/plain.jpg', 'plain.jpg', expect.anything())
+    expect(downloadAttachmentSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/components/ImageContextMenu.tsx
+++ b/apps/fluux/src/components/ImageContextMenu.tsx
@@ -1,20 +1,24 @@
 import { useTranslation } from 'react-i18next'
 import { Link, ExternalLink, Download } from 'lucide-react'
+import type { FileEncryption } from '@fluux/sdk'
 import { MenuButton } from './sidebar-components/SidebarListMenu'
 import { copyToClipboard } from '@/utils/clipboard'
 import { openInBrowser } from '@/utils/openInBrowser'
-import { downloadFile } from '@/utils/download'
+import { downloadFile, downloadAttachment } from '@/utils/download'
 import type { ContextMenuState } from '@/hooks/useContextMenu'
 import { useFocusTrap } from '@/hooks/useFocusTrap'
 
 interface ImageContextMenuProps {
   originalUrl: string
+  /** Already-resolved (decrypted/proxied) blob URL, or null when not yet available. */
   proxiedUrl: string | null
+  /** Encryption params when the image is AES-GCM ciphertext; gates the decrypt-on-save path. */
+  encryption?: FileEncryption
   filename?: string
   menu: ContextMenuState
 }
 
-export function ImageContextMenu({ originalUrl, proxiedUrl, filename, menu }: ImageContextMenuProps) {
+export function ImageContextMenu({ originalUrl, proxiedUrl, encryption, filename, menu }: ImageContextMenuProps) {
   const { t } = useTranslation()
 
   // This menu can render inside an already-trapped overlay (e.g. ImageLightbox). A Tab keydown
@@ -36,9 +40,17 @@ export function ImageContextMenu({ originalUrl, proxiedUrl, filename, menu }: Im
 
   const handleSave = () => {
     menu.close()
-    void downloadFile(proxiedUrl ?? originalUrl, filename || 'image', {
-      errorMessage: t('common.downloadFailed'),
-    })
+    const options = { errorMessage: t('common.downloadFailed') }
+    if (proxiedUrl) {
+      // Already-resolved bytes (decrypted or plaintext-proxied): save them directly.
+      void downloadFile(proxiedUrl, filename || 'image', options)
+    } else if (encryption) {
+      // Encrypted but not yet resolved: decrypt on demand. The ciphertext URL is
+      // never handed to the save path.
+      void downloadAttachment({ url: originalUrl, name: filename, encryption }, options)
+    } else {
+      void downloadFile(originalUrl, filename || 'image', options)
+    }
   }
 
   return (

--- a/apps/fluux/src/components/ImageLightbox.test.tsx
+++ b/apps/fluux/src/components/ImageLightbox.test.tsx
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ImageLightbox } from './ImageLightbox'
 
-const { useAttachmentUrlSpy, useCachedMediaUrlSpy, downloadFileSpy } = vi.hoisted(() => ({
+const { useAttachmentUrlSpy, useCachedMediaUrlSpy, downloadFileSpy, downloadAttachmentSpy } = vi.hoisted(() => ({
   useAttachmentUrlSpy: vi.fn(),
   useCachedMediaUrlSpy: vi.fn(),
   downloadFileSpy: vi.fn(),
+  downloadAttachmentSpy: vi.fn(),
 }))
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
@@ -15,7 +16,10 @@ vi.mock('@/hooks', () => ({
 vi.mock('@/hooks/useCachedMediaUrl', () => ({
   useCachedMediaUrl: (u: string | undefined, e: unknown, enabled?: boolean) => useCachedMediaUrlSpy(u, e, enabled),
 }))
-vi.mock('@/utils/download', () => ({ downloadFile: (...args: unknown[]) => downloadFileSpy(...args) }))
+vi.mock('@/utils/download', () => ({
+  downloadFile: (...args: unknown[]) => downloadFileSpy(...args),
+  downloadAttachment: (...args: unknown[]) => downloadAttachmentSpy(...args),
+}))
 vi.mock('./ImageContextMenu', () => ({ ImageContextMenu: () => null }))
 vi.mock('@/hooks/useContextMenu', () => ({ useContextMenu: () => ({ handleContextMenu: vi.fn() }) }))
 
@@ -105,5 +109,53 @@ describe('ImageLightbox download button', () => {
     )
     fireEvent.click(screen.getByTitle('common.download'))
     expect(downloadFileSpy).toHaveBeenCalledWith('https://x/full.jpg', 'image', expect.anything())
+  })
+})
+
+describe('ImageLightbox encrypted download', () => {
+  const encryption = { cipher: 'aes-256-gcm' as const, key: new Uint8Array(32), iv: new Uint8Array(12) }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // No resolved (decrypted) bytes: proxied + cached are both null.
+    useAttachmentUrlSpy.mockReturnValue({ url: null, isLoading: false, error: new Error('Failed to fetch') })
+    useCachedMediaUrlSpy.mockReturnValue({ cachedUrl: null, isPeeking: false })
+  })
+
+  it('decrypts on demand and NEVER hands the ciphertext URL to the save path', () => {
+    render(
+      <ImageLightbox
+        src="https://x/cipher.bin"
+        downloadUrl="https://x/cipher.bin"
+        encryption={encryption}
+        filename="secret.jpg"
+        onClose={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTitle('common.download'))
+
+    // Routes through the decrypting helper with the attachment shape...
+    expect(downloadAttachmentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://x/cipher.bin', encryption }),
+      expect.anything(),
+    )
+    // ...and never saves the raw ciphertext URL directly.
+    expect(downloadFileSpy).not.toHaveBeenCalled()
+  })
+
+  it('downloads the decrypted blob directly once resolved (no re-decrypt)', () => {
+    useAttachmentUrlSpy.mockReturnValue({ url: 'blob:decrypted', isLoading: false, error: null })
+    render(
+      <ImageLightbox
+        src="https://x/cipher.bin"
+        downloadUrl="https://x/cipher.bin"
+        encryption={encryption}
+        filename="secret.jpg"
+        onClose={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTitle('common.download'))
+    expect(downloadFileSpy).toHaveBeenCalledWith('blob:decrypted', 'secret.jpg', expect.anything())
+    expect(downloadAttachmentSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/fluux/src/components/ImageLightbox.tsx
+++ b/apps/fluux/src/components/ImageLightbox.tsx
@@ -11,7 +11,7 @@ import type { FileEncryption } from '@fluux/sdk'
 import { useAttachmentUrl } from '@/hooks'
 import { useCachedMediaUrl } from '@/hooks/useCachedMediaUrl'
 import { useContextMenu } from '@/hooks/useContextMenu'
-import { downloadFile } from '@/utils/download'
+import { downloadFile, downloadAttachment } from '@/utils/download'
 import { ImageContextMenu } from './ImageContextMenu'
 
 interface ImageLightboxProps {
@@ -50,6 +50,20 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
   }, [onClose])
 
   const displaySrc = proxiedSrc ?? cachedFullRes ?? placeholderSrc
+  // Already-resolved (decrypted or plaintext-proxied) full-res bytes, or null.
+  const resolvedUrl = proxiedSrc ?? cachedFullRes
+
+  const handleDownload = () => {
+    const options = { errorMessage: t('common.downloadFailed') }
+    if (resolvedUrl) {
+      void downloadFile(resolvedUrl, filename || 'image', options)
+    } else if (encryption) {
+      // Encrypted but not yet resolved: decrypt on demand. Never save the ciphertext URL.
+      void downloadAttachment({ url: downloadUrl, name: filename, encryption }, options)
+    } else {
+      void downloadFile(downloadUrl, filename || 'image', options)
+    }
+  }
 
   return createPortal(
     <div
@@ -68,11 +82,7 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
       <div className="absolute top-4 end-4 z-10 flex items-center gap-2">
         <button
           type="button"
-          onClick={() =>
-            void downloadFile(proxiedSrc ?? cachedFullRes ?? downloadUrl, filename || 'image', {
-              errorMessage: t('common.downloadFailed'),
-            })
-          }
+          onClick={handleDownload}
           className="p-2 text-white/70 hover:text-white rounded-full hover:bg-white/10 transition-colors"
           title={t('common.download')}
         >
@@ -109,7 +119,8 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
 
       <ImageContextMenu
         originalUrl={src}
-        proxiedUrl={proxiedSrc ?? cachedFullRes ?? downloadUrl}
+        proxiedUrl={resolvedUrl}
+        encryption={encryption}
         filename={filename}
         menu={imageMenu}
       />


### PR DESCRIPTION
Closes the follow-up left open by #1036 (decrypt-on-download).

Two save paths could still fall back to the raw ciphertext URL for an encrypted image when the decrypted bytes were not yet resolved:

- `ImageLightbox` download button — `downloadFile(proxiedSrc ?? cachedFullRes ?? downloadUrl, …)`
- `ImageContextMenu` "Save image" — `downloadFile(proxiedUrl ?? originalUrl, …)`, used by both the lightbox and the inline image card

In that state the user gets a file that looks like an image but contains AES-GCM ciphertext. The lightbox also passed `proxiedSrc ?? cachedFullRes ?? downloadUrl` down as the menu's `proxiedUrl`, so the menu could never distinguish "resolved bytes" from "raw URL fallback".

Both paths now branch explicitly: resolved bytes save directly; encrypted-but-unresolved routes through the existing `downloadAttachment` helper, which decrypts on demand; plaintext is unchanged. The ciphertext URL only ever reaches the direct save path when the attachment is not encrypted. `ImageContextMenu` takes `encryption` as a prop so the inline image card gets the same guarantee.