### PR TITLE
fix(retraction): don't render the XEP-0428 fallback body as a message

### DIFF
--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -210,6 +210,16 @@ export function createStoreBindings(
     stores.chat.updateMessage(conversationId, messageId, updates)
   })
 
+  on('chat:retraction-pending', ({ conversationId, targetId, actorJid }) => {
+    const stores = getStores()
+    stores.chat.recordPendingRetraction(conversationId, targetId, actorJid)
+  })
+
+  on('room:retraction-pending', ({ roomJid, targetId, actorJid, actorOccupantId }) => {
+    const stores = getStores()
+    stores.room.recordPendingRetraction(roomJid, targetId, actorJid, actorOccupantId)
+  })
+
   on('message:security-updated', ({ conversationId, messageId, securityContext, body }) => {
     const stores = getStores()
     stores.chat.updateMessage(conversationId, messageId, {

--- a/packages/fluux-sdk/src/core/modules/Chat.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.test.ts
@@ -12,6 +12,7 @@ import {
   createMockXmppClient,
   createMockStores,
   createMockElement,
+  createMockRoom,
   type MockXmppClient,
   type MockStoreBindings,
 } from '../test-utils'
@@ -3448,6 +3449,67 @@ describe('XMPPClient Message', () => {
       mockXmppClientInstance._emit('stanza', retractionStanza)
 
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message-updated', expect.anything())
+    })
+
+    // The retraction body is only the XEP-0428 fallback notice for clients that
+    // don't support XEP-0424. It must never surface as a message, even when the
+    // target can't be resolved — only the ACTIVE conversation is resident, so a
+    // retraction landing on a backgrounded conversation always misses.
+    it('claims a 1:1 retraction whose target is not resident, recording it instead of showing the fallback', async () => {
+      await connectClient()
+
+      vi.mocked(mockStores.chat.getMessage).mockReturnValue(undefined)
+
+      const retractionStanza = createMockElement('message', {
+        from: 'contact@example.com/desktop',
+        to: 'user@example.com',
+        type: 'chat',
+        id: 'retraction-msg-id',
+      }, [
+        { name: 'retract', attrs: { xmlns: 'urn:xmpp:message-retract:1', id: 'target-msg-id' } },
+        { name: 'fallback', attrs: { xmlns: 'urn:xmpp:fallback:0', for: 'urn:xmpp:message-retract:1' } },
+        { name: 'body', text: 'This message has been retracted by the sender.' },
+      ])
+
+      mockXmppClientInstance._emit('stanza', retractionStanza)
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('chat:message', expect.anything())
+      expect(emitSDKSpy).toHaveBeenCalledWith('chat:retraction-pending', {
+        conversationId: 'contact@example.com',
+        targetId: 'target-msg-id',
+        actorJid: 'contact@example.com',
+      })
+    })
+
+    it('claims a MUC retraction whose target is not resident, recording the occupant-id', async () => {
+      await connectClient()
+
+      // The room IS joined (so a fall-through really would store the fallback
+      // body as a room message) — only the retraction's target is unloaded.
+      vi.mocked(mockStores.room.getRoom).mockReturnValue(
+        createMockRoom('room@conference.example.com', { joined: true, nickname: 'me' })
+      )
+      vi.mocked(mockStores.room.getMessage).mockReturnValue(undefined)
+
+      const retractionStanza = createMockElement('message', {
+        from: 'room@conference.example.com/edaveine',
+        type: 'groupchat',
+        id: 'retraction-msg-id',
+      }, [
+        { name: 'retract', attrs: { xmlns: 'urn:xmpp:message-retract:1', id: 'server-stanza-id-999' } },
+        { name: 'occupant-id', attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'occ-1' } },
+        { name: 'body', text: 'This message has been retracted by the sender.' },
+      ])
+
+      mockXmppClientInstance._emit('stanza', retractionStanza)
+
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('room:message', expect.anything())
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:retraction-pending', {
+        roomJid: 'room@conference.example.com',
+        targetId: 'server-stanza-id-999',
+        actorJid: 'room@conference.example.com/edaveine',
+        actorOccupantId: 'occ-1',
+      })
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/Chat.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.ts
@@ -356,7 +356,7 @@ export class Chat extends BaseModule {
           return { handled: true }
         }
       }
-      if (this.handleIncomingRetraction(
+      this.handleIncomingRetraction(
         retraction.targetId,
         from,
         bareFrom,
@@ -364,7 +364,11 @@ export class Chat extends BaseModule {
         type,
         isSentCarbon,
         stanza.getChild('occupant-id', NS_OCCUPANT_ID)?.attrs.id
-      )) return { handled: true }
+      )
+      // Claimed either way: the body is only the XEP-0428 fallback notice for
+      // clients without XEP-0424 support, never a message. An unresolved target
+      // is deferred inside handleIncomingRetraction, not dropped.
+      return { handled: true }
     }
 
     // XEP-0425: Message Moderation (legacy: moderated as direct child)
@@ -1933,11 +1937,22 @@ export class Chat extends BaseModule {
     return false
   }
 
-  private handleIncomingRetraction(originalId: string, from: string, bareFrom: string, bareTo: string | undefined, type: string, isSentCarbon: boolean, senderOccupantId?: string): boolean {
+  /**
+   * XEP-0424: apply an incoming retraction, or defer it when its target is not
+   * loaded.
+   *
+   * Only the ACTIVE conversation keeps its messages resident, so a retraction
+   * arriving for a backgrounded conversation — or for a message older than the
+   * loaded window — cannot resolve here. That is not a reason to drop it: the
+   * store records it and replays it the moment the target loads. A target that
+   * IS loaded but was written by someone else is an unauthorized retraction and
+   * is dropped outright.
+   */
+  private handleIncomingRetraction(originalId: string, from: string, bareFrom: string, bareTo: string | undefined, type: string, isSentCarbon: boolean, senderOccupantId?: string): void {
     const myBareJid = getBareJid(this.deps.getCurrentJid() ?? '')
     const isOutgoing = isSentCarbon || bareFrom === myBareJid
     const conversationId = isOutgoing ? bareTo : bareFrom
-    if (!conversationId) return false
+    if (!conversationId) return
 
     // SDK events only - bindings call store methods
     if (type === 'groupchat') {
@@ -1945,17 +1960,23 @@ export class Chat extends BaseModule {
       const retractionData = applyRetraction(!!original && this.isSameMucAuthor(original, from, senderOccupantId))
       if (retractionData) {
         this.deps.emitSDK('room:message-updated', { roomJid: conversationId, messageId: originalId, updates: retractionData })
-        return true
+      } else if (!original) {
+        this.deps.emitSDK('room:retraction-pending', {
+          roomJid: conversationId,
+          targetId: originalId,
+          actorJid: from,
+          ...(senderOccupantId ? { actorOccupantId: senderOccupantId } : {}),
+        })
       }
     } else {
       const original = this.deps.stores?.chat.getMessage(conversationId, originalId)
       const retractionData = applyRetraction(!!original && original.from === bareFrom)
       if (retractionData) {
         this.deps.emitSDK('chat:message-updated', { conversationId, messageId: originalId, updates: retractionData })
-        return true
+      } else if (!original) {
+        this.deps.emitSDK('chat:retraction-pending', { conversationId, targetId: originalId, actorJid: bareFrom })
       }
     }
-    return false
   }
 
   /**

--- a/packages/fluux-sdk/src/core/storeBindingKeys.ts
+++ b/packages/fluux-sdk/src/core/storeBindingKeys.ts
@@ -65,6 +65,7 @@ export const chatBindingMethodKeys = [
   'updateMessage',
   'removeMessage',
   'recomputeUnreadForConversation',
+  'recordPendingRetraction',
   'getMessage',
   'triggerAnimation',
   // XEP-0313: MAM support
@@ -130,6 +131,7 @@ export const roomBindingMethodKeys = [
   'addMessage',
   'updateReactions',
   'updateMessage',
+  'recordPendingRetraction',
   'getMessage',
   'markAsRead',
   'getActiveRoomJid',

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -150,6 +150,31 @@ export interface ChatEvents {
     updates: Partial<StoredMessage>
   }
 
+  /**
+   * XEP-0424: a retraction arrived for a message that is not in the resident
+   * window (backgrounded conversation, or older than the loaded slice). The
+   * store records it and replays it once the target loads — dropping it would
+   * lose the tombstone, and letting the stanza through would surface its
+   * XEP-0428 fallback body as a message.
+   */
+  'chat:retraction-pending': {
+    conversationId: string
+    /** The `<retract id="…">` reference — any id tier of the target. */
+    targetId: string
+    /** Bare JID the retraction came from; must match the target's author. */
+    actorJid: string
+  }
+
+  /** XEP-0424: room twin of `chat:retraction-pending`. */
+  'room:retraction-pending': {
+    roomJid: string
+    targetId: string
+    /** Full room JID (room@service/nick) the retraction came from. */
+    actorJid: string
+    /** XEP-0421 occupant-id, when the sender advertises one — the stable author identity. */
+    actorOccupantId?: string
+  }
+
   /** XEP-0490: a device synced its last-displayed (read) position for a conversation (1:1 or room) */
   'read:displayed-synced': {
     /** Conversation bare JID (1:1 contact or MUC room). */

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -4419,6 +4419,103 @@ describe('chatStore', () => {
       expect(chatStore.getState().targetMessageId).toBeNull()
     })
   })
+
+  // XEP-0424: a retraction can land while its target is outside the resident
+  // window (only the ACTIVE conversation keeps messages in RAM). It is recorded
+  // and replayed rather than dropped.
+  describe('pending retractions', () => {
+    const convId = 'peer@example.com'
+
+    function incoming(id: string, body = 'to retract'): Message {
+      return {
+        type: 'chat',
+        id,
+        conversationId: convId,
+        from: convId,
+        body,
+        timestamp: new Date('2026-07-22T03:52:00Z'),
+        isOutgoing: false,
+      }
+    }
+
+    beforeEach(() => {
+      chatStore.getState().addConversation(createConversation(convId))
+    })
+
+    it('tombstones the target when it arrives after the retraction', () => {
+      chatStore.getState().recordPendingRetraction(convId, 'msg-1', convId)
+      expect(chatStore.getState().pendingRetractions.get(convId)).toHaveLength(1)
+
+      chatStore.getState().addMessage(incoming('msg-1'))
+
+      expect(chatStore.getState().messages.get(convId)?.[0]).toMatchObject({
+        id: 'msg-1',
+        isRetracted: true,
+      })
+      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+    })
+
+    it('applies to a resident target without recording anything', () => {
+      chatStore.setState({ activeConversationId: convId })
+      chatStore.getState().addMessage(incoming('msg-1'))
+
+      chatStore.getState().recordPendingRetraction(convId, 'msg-1', convId)
+
+      expect(chatStore.getState().messages.get(convId)?.[0]).toMatchObject({ isRetracted: true })
+      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+      expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        'msg-1',
+        expect.objectContaining({ isRetracted: true })
+      )
+    })
+
+    it('never tombstones a message authored by someone else', () => {
+      chatStore.getState().recordPendingRetraction(convId, 'msg-1', 'mallory@example.com')
+
+      chatStore.getState().addMessage(incoming('msg-1'))
+
+      expect(chatStore.getState().messages.get(convId)?.[0].isRetracted).toBeUndefined()
+      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+    })
+
+    it('replays the record when the conversation hydrates from the cache', async () => {
+      chatStore.getState().recordPendingRetraction(convId, 'msg-1', convId)
+      vi.mocked(messageCache.getMessages).mockResolvedValue([incoming('msg-1')])
+
+      await chatStore.getState().loadMessagesFromCache(convId)
+
+      expect(chatStore.getState().messages.get(convId)?.[0]).toMatchObject({ isRetracted: true })
+      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+      // Written through, so the tombstone survives a reload without the record.
+      expect(messageCache.updateMessage).toHaveBeenCalledWith(
+        'msg-1',
+        expect.objectContaining({ isRetracted: true })
+      )
+    })
+
+    it('replays the record when the target arrives in a MAM page', () => {
+      chatStore.setState({ activeConversationId: convId })
+      chatStore.getState().recordPendingRetraction(convId, 'msg-1', convId)
+
+      chatStore.getState().mergeMAMMessages(convId, [incoming('msg-1')], {}, true, 'backward')
+
+      expect(chatStore.getState().messages.get(convId)?.[0]).toMatchObject({
+        id: 'msg-1',
+        isRetracted: true,
+      })
+      expect(chatStore.getState().pendingRetractions.get(convId) ?? []).toHaveLength(0)
+      // The tombstone rides the archive write instead of racing it.
+      expect(messageCache.saveMessages).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'msg-1', isRetracted: true }),
+      ])
+    })
+
+    it('is cleared by reset', () => {
+      chatStore.getState().recordPendingRetraction(convId, 'msg-1', convId)
+      chatStore.getState().reset()
+      expect(chatStore.getState().pendingRetractions.size).toBe(0)
+    })
+  })
 })
 
 // Regression tests for chat/room parity drifts: each of these behaviors already

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -16,6 +16,7 @@ import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
+import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
@@ -84,15 +85,20 @@ function mergeCachedChatMessages(
   state: ChatState,
   conversationId: string,
   cachedMessages: Message[]
-): Pick<ChatState, 'messages' | 'conversationMeta' | 'conversations'> | { messages: ChatState['messages'] } | null {
+): Partial<Pick<ChatState, 'messages' | 'conversationMeta' | 'conversations' | 'pendingRetractions'>> | null {
   const existingMessages = state.messages.get(conversationId) || []
 
-  const { merged: trimmed, newMessages } = timeline.latestSlice(
+  const { merged, newMessages } = timeline.latestSlice(
     existingMessages,
     cachedMessages,
     chatTimelineConfig()
   )
   if (newMessages.length === 0) return null
+
+  // XEP-0424: a retraction recorded while this conversation was unloaded applies
+  // here, the moment its target becomes resident.
+  const resolved = resolvePendingRetractions(state, conversationId, merged)
+  const trimmed = resolved.messages
 
   const newMessagesMap = new Map(state.messages)
   newMessagesMap.set(conversationId, trimmed)
@@ -103,15 +109,56 @@ function mergeCachedChatMessages(
   const meta = state.conversationMeta.get(conversationId)
   const conv = state.conversations.get(conversationId)
   const { lastMessage, changed } = derivePreviewAfterMerge(meta?.lastMessage, trimmed, findLastPreviewableMessage)
+  const retractionPatch = resolved.pendingRetractions ? { pendingRetractions: resolved.pendingRetractions } : {}
   if (meta && conv && changed) {
     const newMeta = new Map(state.conversationMeta)
     newMeta.set(conversationId, { ...meta, lastMessage })
     const newConversations = new Map(state.conversations)
     newConversations.set(conversationId, { ...conv, lastMessage })
-    return { messages: newMessagesMap, conversationMeta: newMeta, conversations: newConversations }
+    return { messages: newMessagesMap, conversationMeta: newMeta, conversations: newConversations, ...retractionPatch }
   }
 
-  return { messages: newMessagesMap }
+  return { messages: newMessagesMap, ...retractionPatch }
+}
+
+/** XEP-0424 authorship gate: only a message's own author may retract it. */
+const chatRetractionAuthor = (message: Message, record: PendingRetraction): boolean =>
+  message.from === record.actorJid
+
+/**
+ * Replay a conversation's pending retractions against a slice of its messages.
+ *
+ * Returns the patched slice plus the new `pendingRetractions` map when anything
+ * resolved (`undefined` when nothing did, so callers can skip the state write).
+ * Tombstones are written through to the durable cache — the record is dropped
+ * once resolved, so the tombstone has to outlive it. `persist: false` is for a
+ * message not yet in the cache: its own save writes the tombstone, and a
+ * concurrent update would race that save.
+ */
+function resolvePendingRetractions(
+  state: ChatState,
+  conversationId: string,
+  slice: Message[],
+  options: { persist?: boolean } = {}
+): { messages: Message[]; pendingRetractions?: ChatState['pendingRetractions'] } {
+  const pending = state.pendingRetractions.get(conversationId)
+  if (!pending || pending.length === 0) return { messages: slice }
+
+  const { messages, applied, remaining } = applyPendingRetractions(slice, pending, chatRetractionAuthor)
+  if (remaining.length === pending.length) return { messages }
+
+  if (options.persist !== false) {
+    for (const { messageId, retractedAt } of applied) {
+      void messageCache.updateMessage(messageId, { isRetracted: true, retractedAt })
+      const retracted = findMessageById(messages, messageId)
+      if (retracted) void searchIndex.removeMessage(retracted)
+    }
+  }
+
+  const nextPending = new Map(state.pendingRetractions)
+  if (remaining.length === 0) nextPending.delete(conversationId)
+  else nextPending.set(conversationId, remaining)
+  return { messages, pendingRetractions: nextPending }
 }
 
 function getLegacyStorageKey(): string {
@@ -200,6 +247,12 @@ interface ChatState {
   // conversationGaps; survives fresh sessions and gap closure). Parity with
   // roomStore.roomCoverage. See shared/mamCoverage.ts.
   conversationCoverage: Map<string, CoverageRecord>
+  // XEP-0424 retractions whose target was not resident when they arrived (only the
+  // ACTIVE conversation keeps messages in RAM, and a target older than the loaded
+  // slice is absent even there). Persisted so the tombstone still lands after a
+  // reload; each record clears the moment its target loads. See
+  // shared/pendingRetractions.ts.
+  pendingRetractions: Map<string, PendingRetraction[]>
   // Target message to scroll to after navigation (ephemeral, not persisted)
   targetMessageId: string | null
   // Session-only new-message divider per conversation (jid -> messageId). Derived
@@ -318,6 +371,16 @@ interface ChatState {
    * left behind. No-op for the active conversation (activation owns its counts).
    */
   recomputeUnreadForConversation: (conversationId: string) => Promise<void>
+  /**
+   * XEP-0424: apply an incoming retraction, deferring it when its target is not
+   * resident. Applies immediately (and writes through to the durable cache) when
+   * the target is in the window; otherwise records it and replays it the moment
+   * the target arrives live or loads from the cache. Only the message's own
+   * author can retract it — a mismatched actor is dropped, never tombstoned.
+   *
+   * @param actorJid - Bare JID the retraction came from.
+   */
+  recordPendingRetraction: (conversationId: string, targetId: string, actorJid: string) => void
   getMessage: (conversationId: string, messageId: string) => Message | undefined
   /**
    * Epoch ms of the conversation's persisted last-known message (the entity
@@ -447,13 +510,14 @@ interface PersistedState {
   drafts?: [string, string][] // Optional for backwards compatibility
   conversationGaps?: [string, GapInterval][] // Optional for backwards compatibility
   conversationCoverage?: [string, CoverageRecord][] // Optional for backwards compatibility
+  pendingRetractions?: [string, PendingRetraction[]][] // Optional for backwards compatibility
   // Legacy fields, kept for backwards compatibility when reading old storage
   messages?: [string, Message[]][] // May exist in old storage, will be migrated
   activeConversationId?: string | null
 }
 
 // Serialize Maps to arrays for JSON storage
-function serializeState(state: Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'archivedConversations' | 'drafts'> & { conversationGaps?: Map<string, GapInterval>; conversationCoverage?: Map<string, CoverageRecord> }): PersistedState {
+function serializeState(state: Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'archivedConversations' | 'drafts'> & { conversationGaps?: Map<string, GapInterval>; conversationCoverage?: Map<string, CoverageRecord>; pendingRetractions?: Map<string, PendingRetraction[]> }): PersistedState {
   return {
     // Serialize separated maps (Phase 6)
     conversationEntities: Array.from(state.conversationEntities.entries()),
@@ -467,12 +531,14 @@ function serializeState(state: Pick<ChatState, 'conversationEntities' | 'convers
     conversationGaps: Array.from((state.conversationGaps ?? new Map<string, GapInterval>()).entries()),
     // Persisted contiguous-with-live coverage (positive twin of the gaps)
     conversationCoverage: Array.from((state.conversationCoverage ?? new Map<string, CoverageRecord>()).entries()),
+    // XEP-0424 retractions still waiting for their target to load
+    pendingRetractions: Array.from((state.pendingRetractions ?? new Map<string, PendingRetraction[]>()).entries()),
   }
 }
 
 // Deserialize arrays back to Maps, reset unread counts, restore Date objects
 // Also handles migration of old localStorage messages to IndexedDB
-function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'drafts' | 'conversationGaps' | 'conversationCoverage'> {
+function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'drafts' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions'> {
   // Helper to restore Date objects in lastMessage
   const restoreLastMessage = (lastMessage?: Message): Message | undefined => {
     if (!lastMessage) return undefined
@@ -581,6 +647,9 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
   // Restore coverage records (backwards compatible - default to empty map)
   const conversationCoverage = new Map<string, CoverageRecord>(persisted.conversationCoverage || [])
 
+  // Restore pending retractions (backwards compatible - default to empty map)
+  const pendingRetractions = new Map<string, PendingRetraction[]>(persisted.pendingRetractions || [])
+
   return {
     conversationEntities,
     conversationMeta,
@@ -593,10 +662,11 @@ function deserializeState(persisted: PersistedState): Pick<ChatState, 'conversat
     drafts,
     conversationGaps,
     conversationCoverage,
+    pendingRetractions,
   }
 }
 
-function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
   return {
     conversationEntities: new Map(),
     conversationMeta: new Map(),
@@ -611,6 +681,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
     mamQueryStates: new Map(),
     conversationGaps: new Map(),
     conversationCoverage: new Map(),
+    pendingRetractions: new Map(),
     targetMessageId: null,
     firstNewMessageMarkers: new Map(),
     windowAtLiveEdge: new Map(),
@@ -624,7 +695,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
  * Legacy versions stored chat data under a single unscoped key. For safety, we only migrate
  * conversation lists (active + archived classification) and intentionally skip drafts/messages.
  */
-function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> | null {
+function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> | null {
   if (!jid) return null
 
   const legacyKey = getLegacyStorageKey()
@@ -663,7 +734,7 @@ function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatSt
   }
 }
 
-function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
+function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
   const baseState = createEmptyChatState()
   const scopedStorageKey = getScopedStorageKey(jid)
 
@@ -686,6 +757,7 @@ function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationE
       drafts: restored.drafts,
       conversationGaps: restored.conversationGaps,
       conversationCoverage: restored.conversationCoverage,
+      pendingRetractions: restored.pendingRetractions,
     }
   } catch {
     try {
@@ -989,7 +1061,15 @@ export const chatStore = createStore<ChatState>()(
         })
       },
 
-      addMessage: (msg) => {
+      addMessage: (incoming) => {
+        // XEP-0424: a retraction can outrun its target (live retraction against a
+        // non-resident message, out-of-order delivery). Tombstone BEFORE the
+        // append so the cache write below persists the tombstone — patching
+        // afterwards would race saveMessage.
+        const arrival = resolvePendingRetractions(get(), incoming.conversationId, [incoming], { persist: false })
+        const msg = arrival.messages[0]
+        if (arrival.pendingRetractions) set({ pendingRetractions: arrival.pendingRetractions })
+
         set((state) => {
           const convMessages = state.messages.get(msg.conversationId) || []
 
@@ -1709,6 +1789,28 @@ export const chatStore = createStore<ChatState>()(
         })
       },
 
+      recordPendingRetraction: (conversationId, targetId, actorJid) => {
+        const resident = get().messages.get(conversationId)
+        const target = resident ? findMessageById(resident, targetId) : undefined
+        if (target) {
+          // Resolved on the spot — updateMessage carries the write-through to
+          // IndexedDB and the search-index removal.
+          if (!target.isRetracted && target.from === actorJid) {
+            get().updateMessage(conversationId, target.id, { isRetracted: true, retractedAt: new Date() })
+          }
+          return
+        }
+
+        set((state) => {
+          const existing = state.pendingRetractions.get(conversationId) ?? []
+          const next = addPendingRetraction(existing, { targetId, actorJid, retractedAt: Date.now() })
+          if (next === existing) return state
+          const nextPending = new Map(state.pendingRetractions)
+          nextPending.set(conversationId, next)
+          return { pendingRetractions: nextPending }
+        })
+      },
+
       getMessage: (conversationId, messageId) => {
         const convMessages = get().messages.get(conversationId)
         if (!convMessages) return undefined
@@ -1870,7 +1972,15 @@ export const chatStore = createStore<ChatState>()(
         }))
       },
 
-      mergeMAMMessages: (conversationId, mamMessages, rsm, complete, direction, isFetchLatest = false, preserveGapMarker = false, extras = undefined) => {
+      mergeMAMMessages: (conversationId, archivePage, rsm, complete, direction, isFetchLatest = false, preserveGapMarker = false, extras = undefined) => {
+        // XEP-0424: a retraction recorded earlier can target a message arriving in
+        // THIS page (the live pass missed it because nothing was resident). Patch
+        // the page BEFORE it merges, so the tombstone rides the same saveMessages
+        // write instead of racing it. Same array back when nothing matches.
+        const replay = resolvePendingRetractions(get(), conversationId, archivePage, { persist: false })
+        const mamMessages = replay.messages
+        if (replay.pendingRetractions) set({ pendingRetractions: replay.pendingRetractions })
+
         // Newest persisted timestamp (entity preview) — the seam-formation fallback
         // when the resident array is empty this run (fresh session, history on disk).
         const fallbackHeldTs = get().getConversationLastTimestamp(conversationId)
@@ -2521,6 +2631,9 @@ export const chatStore = createStore<ChatState>()(
         conversationGaps: state.conversationGaps,
         // Persist coverage records (contiguous-with-live bottom; Codex r3 #3)
         conversationCoverage: state.conversationCoverage,
+        // Persist XEP-0424 retractions still waiting for their target to load,
+        // so the tombstone lands even if the app restarts first
+        pendingRetractions: state.pendingRetractions,
       }),
     }
     )

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -5756,6 +5756,111 @@ describe('acknowledged non-anonymous rooms', () => {
   })
 })
 
+// XEP-0424 twin of the chatStore "pending retractions" suite: a retraction
+// landing on a room whose messages are not resident is replayed, not dropped.
+describe('roomStore pending retractions', () => {
+  const roomJid = 'retract@conference.example.com'
+
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    localStorageMock.clear()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      pendingRetractions: new Map(),
+    })
+    vi.clearAllMocks()
+    roomStore.getState().addRoom(createRoom(roomJid, { joined: true }))
+  })
+
+  function occupantMessage(id: string): RoomMessage {
+    return { ...createMessage(id, roomJid, 'edaveine', 'to retract'), occupantId: 'occ-1' }
+  }
+
+  it('tombstones the target when it arrives after the retraction', () => {
+    roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`, 'occ-1')
+
+    roomStore.getState().addMessage(roomJid, occupantMessage('m1'))
+
+    expect(roomStore.getState().rooms.get(roomJid)?.messages[0]).toMatchObject({
+      id: 'm1',
+      isRetracted: true,
+    })
+    expect(roomStore.getState().pendingRetractions.get(roomJid) ?? []).toHaveLength(0)
+  })
+
+  it('matches the author by occupant-id, not by nick', () => {
+    // Same nick, different occupant: a nick can be reassigned after its owner leaves.
+    roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`, 'occ-other')
+
+    roomStore.getState().addMessage(roomJid, occupantMessage('m1'))
+
+    expect(roomStore.getState().rooms.get(roomJid)?.messages[0].isRetracted).toBeUndefined()
+  })
+
+  it('falls back to the full room JID when neither side has an occupant-id', () => {
+    roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`)
+
+    roomStore.getState().addMessage(roomJid, createMessage('m1', roomJid, 'edaveine', 'to retract'))
+
+    expect(roomStore.getState().rooms.get(roomJid)?.messages[0]).toMatchObject({ isRetracted: true })
+  })
+
+  it('applies to a resident target without recording anything', () => {
+    roomStore.setState({ activeRoomJid: roomJid })
+    roomStore.getState().addMessage(roomJid, occupantMessage('m1'))
+
+    roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`, 'occ-1')
+
+    expect(roomStore.getState().rooms.get(roomJid)?.messages[0]).toMatchObject({ isRetracted: true })
+    expect(roomStore.getState().pendingRetractions.get(roomJid) ?? []).toHaveLength(0)
+  })
+
+  it('replays the record when the room hydrates from the cache', async () => {
+    roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`, 'occ-1')
+    vi.mocked(messageCache.getRoomMessages).mockResolvedValue([occupantMessage('m1')])
+
+    await roomStore.getState().loadMessagesFromCache(roomJid)
+
+    expect(roomStore.getState().rooms.get(roomJid)?.messages[0]).toMatchObject({ isRetracted: true })
+    expect(roomStore.getState().pendingRetractions.get(roomJid) ?? []).toHaveLength(0)
+    expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+      'm1',
+      expect.objectContaining({ isRetracted: true })
+    )
+  })
+
+  it('replays the record when the target arrives in a MAM page', () => {
+    roomStore.setState({ activeRoomJid: roomJid })
+    roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`, 'occ-1')
+
+    roomStore.getState().mergeRoomMAMMessages(roomJid, [occupantMessage('m1')], {}, true, 'backward')
+
+    expect(roomStore.getState().rooms.get(roomJid)?.messages[0]).toMatchObject({
+      id: 'm1',
+      isRetracted: true,
+    })
+    expect(roomStore.getState().pendingRetractions.get(roomJid) ?? []).toHaveLength(0)
+    // The tombstone rides the archive write instead of racing it.
+    expect(messageCache.saveRoomMessages).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'm1', isRetracted: true }),
+    ])
+  })
+
+  it('survives a reload through scoped localStorage', () => {
+    setStorageScopeJid('alice@example.com')
+    try {
+      roomStore.getState().recordPendingRetraction(roomJid, 'm1', `${roomJid}/edaveine`, 'occ-1')
+      expect(localStorageMock._store['fluux-room-pending-retractions:alice@example.com']).toBeDefined()
+    } finally {
+      _resetStorageScopeForTesting()
+    }
+  })
+})
+
 // Regression tests for chat/room parity drifts: each of these behaviors already
 // exists in chatStore and had silently diverged in roomStore (or vice versa).
 describe('roomStore parity drift regressions', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -29,6 +29,7 @@ import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { shouldUpdateLastMessage, shouldReplaceLastMessage, isPreviewableMessage, findLastNonIgnoredMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
+import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import { ignoreStore, isMessageFromIgnoredUser } from './ignoreStore'
 import { roomActivityTone } from './roomSelectors'
@@ -219,6 +220,34 @@ function loadCoverageFromStorage(jid?: string | null): Map<string, CoverageRecor
 function saveCoverageToStorage(coverage: Map<string, CoverageRecord>, jid?: string | null): void {
   try {
     localStorage.setItem(getRoomCoverageStorageKey(jid), serializeCoverage(coverage))
+  } catch {
+    // Ignore storage errors (quota exceeded, etc.)
+  }
+}
+
+/**
+ * localStorage persistence for XEP-0424 retractions still waiting for their
+ * target to load. Scoped per account like the gap/coverage maps.
+ */
+const ROOM_PENDING_RETRACTIONS_STORAGE_KEY_BASE = 'fluux-room-pending-retractions'
+
+function getRoomPendingRetractionsStorageKey(jid?: string | null): string {
+  return buildScopedStorageKey(ROOM_PENDING_RETRACTIONS_STORAGE_KEY_BASE, jid)
+}
+
+function loadPendingRetractionsFromStorage(jid?: string | null): Map<string, PendingRetraction[]> {
+  try {
+    const stored = localStorage.getItem(getRoomPendingRetractionsStorageKey(jid))
+    if (stored) return new Map(JSON.parse(stored) as [string, PendingRetraction[]][])
+  } catch {
+    // Ignore parse/storage errors
+  }
+  return new Map()
+}
+
+function savePendingRetractionsToStorage(pending: Map<string, PendingRetraction[]>, jid?: string | null): void {
+  try {
+    localStorage.setItem(getRoomPendingRetractionsStorageKey(jid), JSON.stringify([...pending.entries()]))
   } catch {
     // Ignore storage errors (quota exceeded, etc.)
   }
@@ -432,18 +461,66 @@ function commitRoomUpdate(
  * dedupe, merge/sort/trim, and refresh the sidebar preview. The only difference between the two
  * callers is WHICH cache slice they fetch (latest-N vs the slice around an anchor).
  */
+/**
+ * XEP-0424 authorship gate, room flavour. XEP-0421 occupant-id is the stable,
+ * unforgeable author identity and wins whenever BOTH sides carry one — a nick
+ * can be reassigned once its owner leaves. Mirrors Chat.isSameMucAuthor.
+ */
+const roomRetractionAuthor = (message: StoredRoomMessage, record: PendingRetraction): boolean =>
+  message.occupantId && record.actorOccupantId
+    ? message.occupantId === record.actorOccupantId
+    : message.from === record.actorJid
+
+/**
+ * Room twin of chatStore's resolvePendingRetractions: replay a room's pending
+ * retractions against a slice, writing every tombstone through to the durable
+ * cache. `persist: false` is for a message not yet saved — its own write carries
+ * the tombstone, and a concurrent update would race it.
+ */
+function resolveRoomPendingRetractions(
+  state: RoomState,
+  roomJid: string,
+  slice: StoredRoomMessage[],
+  options: { persist?: boolean } = {}
+): { messages: StoredRoomMessage[]; pendingRetractions?: RoomState['pendingRetractions'] } {
+  const pending = state.pendingRetractions.get(roomJid)
+  if (!pending || pending.length === 0) return { messages: slice }
+
+  const { messages, applied, remaining } = applyPendingRetractions(slice, pending, roomRetractionAuthor)
+  if (remaining.length === pending.length) return { messages }
+
+  if (options.persist !== false) {
+    for (const { messageId, retractedAt } of applied) {
+      void messageCache.updateRoomMessage(messageId, { isRetracted: true, retractedAt })
+      const retracted = findMessageById(messages, messageId)
+      if (retracted) void searchIndex.removeMessage(retracted)
+    }
+  }
+
+  const nextPending = new Map(state.pendingRetractions)
+  if (remaining.length === 0) nextPending.delete(roomJid)
+  else nextPending.set(roomJid, remaining)
+  savePendingRetractionsToStorage(nextPending)
+  return { messages, pendingRetractions: nextPending }
+}
+
 function mergeCachedRoomMessages(
   state: RoomState,
   roomJid: string,
   cachedMessages: RoomMessage[]
-): Pick<RoomState, 'rooms' | 'roomRuntime' | 'roomMeta'> | null {
+): Partial<Pick<RoomState, 'rooms' | 'roomRuntime' | 'roomMeta' | 'pendingRetractions'>> | null {
   const newRooms = new Map(state.rooms)
   const existing = newRooms.get(roomJid)
   if (!existing) return null
 
   // Shared timeline machine: dedupe (in-memory messages take precedence),
   // sort, and keep-newest trim.
-  const { merged } = timeline.latestSlice(existing.messages, cachedMessages, roomTimelineConfig())
+  const { merged: rawMerged } = timeline.latestSlice(existing.messages, cachedMessages, roomTimelineConfig())
+
+  // XEP-0424: a retraction recorded while this room was unloaded applies here,
+  // the moment its target becomes resident.
+  const resolvedRetractions = resolveRoomPendingRetractions(state, roomJid, rawMerged)
+  const merged = resolvedRetractions.messages
 
   // Sidebar preview via the shared policy: only replace when the merged set's
   // newest non-ignored message genuinely supersedes (or heals) the current
@@ -468,7 +545,12 @@ function mergeCachedRoomMessages(
     newMeta.set(roomJid, { ...existingMeta, lastMessage })
   }
 
-  return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta }
+  return {
+    rooms: newRooms,
+    roomRuntime: newRuntime,
+    roomMeta: newMeta,
+    ...(resolvedRetractions.pendingRetractions ? { pendingRetractions: resolvedRetractions.pendingRetractions } : {}),
+  }
 }
 
 /**
@@ -534,6 +616,12 @@ export interface RoomState {
   // Rooms the user has acknowledged as non-anonymous (issue #37) — warn once, not
   // on every reconnect. Persisted to localStorage separately and scoped per account.
   acknowledgedNonAnonymousRooms: Set<string>
+  // XEP-0424 retractions whose target was not resident when they arrived (only the
+  // ACTIVE room keeps messages in RAM, and a target older than the loaded slice is
+  // absent even there). Persisted (scoped, like roomGaps) so the tombstone still
+  // lands after a reload; each record clears the moment its target loads. Twin of
+  // chatStore.pendingRetractions — see shared/pendingRetractions.ts.
+  pendingRetractions: Map<string, PendingRetraction[]>
   // Target message to scroll to after navigation (ephemeral)
   targetMessageId: string | null
   // Session-only new-message divider per room (jid -> messageId). Derived at
@@ -574,6 +662,17 @@ export interface RoomState {
   updateMessage: (roomJid: string, messageId: string, updates: Partial<RoomMessage>) => void
   clearMessageStanzaId: (roomJid: string, stanzaId: string) => void
   getMessage: (roomJid: string, messageId: string) => RoomMessage | undefined
+  /**
+   * XEP-0424: apply an incoming retraction, deferring it when its target is not
+   * resident. Applies immediately (and writes through to the durable cache) when
+   * the target is in the window; otherwise records it and replays it the moment
+   * the target arrives live or loads from the cache. Only the message's own
+   * author can retract it — a mismatched actor is dropped, never tombstoned.
+   *
+   * @param actorJid - Full room JID (room@service/nick) the retraction came from.
+   * @param actorOccupantId - XEP-0421 occupant-id when advertised; preferred over the nick.
+   */
+  recordPendingRetraction: (roomJid: string, targetId: string, actorJid: string, actorOccupantId?: string) => void
   /**
    * Epoch ms of the room's persisted last-known message (the entity preview),
    * or undefined. Used as a last-resort forward catch-up cursor so a persisted
@@ -754,7 +853,8 @@ function createEmptyRoomState(
   roomGaps: Map<string, GapInterval> = new Map(),
   acknowledgedNonAnonymousRooms: Set<string> = new Set(),
   roomCoverage: Map<string, CoverageRecord> = new Map(),
-): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'roomCoverage' | 'acknowledgedNonAnonymousRooms' | 'targetMessageId' | 'firstNewMessageMarkers'> {
+  pendingRetractions: Map<string, PendingRetraction[]> = new Map(),
+): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'roomCoverage' | 'acknowledgedNonAnonymousRooms' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers'> {
   return {
     rooms: new Map(),
     roomEntities: new Map(),
@@ -769,6 +869,7 @@ function createEmptyRoomState(
     mamQueryStates: new Map(),
     roomGaps,
     roomCoverage,
+    pendingRetractions,
     acknowledgedNonAnonymousRooms,
     targetMessageId: null,
     firstNewMessageMarkers: new Map(),
@@ -777,7 +878,7 @@ function createEmptyRoomState(
 
 export const roomStore = createStore<RoomState>()(
   subscribeWithSelector((set, get) => ({
-  ...createEmptyRoomState(loadDraftsFromStorage(), loadVotedPollsFromStorage(), loadDismissedPollsFromStorage(), loadGapsFromStorage(), loadNonAnonAckFromStorage(), loadCoverageFromStorage()), // Restore drafts, poll state, history gaps, coverage, and non-anon acks from localStorage
+  ...createEmptyRoomState(loadDraftsFromStorage(), loadVotedPollsFromStorage(), loadDismissedPollsFromStorage(), loadGapsFromStorage(), loadNonAnonAckFromStorage(), loadCoverageFromStorage(), loadPendingRetractionsFromStorage()), // Restore drafts, poll state, history gaps, coverage, and non-anon acks from localStorage
 
   addRoom: (room) => {
     set((state) => {
@@ -1253,7 +1354,7 @@ export const roomStore = createStore<RoomState>()(
     // deferred commits must not land in the new account's maps.
     roomArchiveSaves.clear()
     roomCacheEpoch++
-    set(createEmptyRoomState(loadDraftsFromStorage(jid), loadVotedPollsFromStorage(jid), loadDismissedPollsFromStorage(jid), loadGapsFromStorage(jid), loadNonAnonAckFromStorage(jid), loadCoverageFromStorage(jid)))
+    set(createEmptyRoomState(loadDraftsFromStorage(jid), loadVotedPollsFromStorage(jid), loadDismissedPollsFromStorage(jid), loadGapsFromStorage(jid), loadNonAnonAckFromStorage(jid), loadCoverageFromStorage(jid), loadPendingRetractionsFromStorage(jid)))
   },
 
   reset: () => {
@@ -1284,9 +1385,16 @@ export const roomStore = createStore<RoomState>()(
     const room = get().rooms.get(roomJid)
 
     // Quick Chat rooms are transient: keep their messages in memory only
-    const messageToAdd: StoredRoomMessage = room?.isQuickChat
+    const incoming: StoredRoomMessage = room?.isQuickChat
       ? { ...message, noLocalStore: true }
       : message
+
+    // XEP-0424: a retraction can outrun its target (live retraction against a
+    // non-resident message, out-of-order delivery). Tombstone BEFORE the save
+    // below so it persists the tombstone — patching afterwards would race it.
+    const arrival = resolveRoomPendingRetractions(get(), roomJid, [incoming], { persist: false })
+    const messageToAdd = arrival.messages[0]
+    if (arrival.pendingRetractions) set({ pendingRetractions: arrival.pendingRetractions })
 
     // Save to IndexedDB only if the message is locally persistable
     if (!isNoLocalStore(messageToAdd)) {
@@ -1578,6 +1686,35 @@ export const roomStore = createStore<RoomState>()(
       }
 
       return result
+    })
+  },
+
+  recordPendingRetraction: (roomJid, targetId, actorJid, actorOccupantId) => {
+    const record: PendingRetraction = {
+      targetId,
+      actorJid,
+      ...(actorOccupantId ? { actorOccupantId } : {}),
+      retractedAt: Date.now(),
+    }
+    const resident = get().rooms.get(roomJid)?.messages
+    const target = resident ? findMessageById(resident, targetId) : undefined
+    if (target) {
+      // Resolved on the spot — updateMessage carries the write-through to
+      // IndexedDB and the search-index removal.
+      if (!target.isRetracted && roomRetractionAuthor(target, record)) {
+        get().updateMessage(roomJid, target.id, { isRetracted: true, retractedAt: new Date() })
+      }
+      return
+    }
+
+    set((state) => {
+      const existing = state.pendingRetractions.get(roomJid) ?? []
+      const next = addPendingRetraction(existing, record)
+      if (next === existing) return state
+      const nextPending = new Map(state.pendingRetractions)
+      nextPending.set(roomJid, next)
+      savePendingRetractionsToStorage(nextPending)
+      return { pendingRetractions: nextPending }
     })
   },
 
@@ -2702,7 +2839,19 @@ export const roomStore = createStore<RoomState>()(
     }))
   },
 
-  mergeRoomMAMMessages: (roomJid, mamMessages, rsm, complete, direction, preserveGapMarker = false, isFetchLatest = false, extras = undefined) => {
+  mergeRoomMAMMessages: (roomJid, archivePage, rsm, complete, direction, preserveGapMarker = false, isFetchLatest = false, extras = undefined) => {
+    // XEP-0424: a retraction recorded earlier can target a message arriving in
+    // THIS page (the live pass missed it because nothing was resident). Patch
+    // the page BEFORE it merges, so the tombstone rides the same saveRoomMessages
+    // write instead of racing it. Same array back when nothing matches.
+    // Guarded on the room existing: the merge below no-ops for an unknown room,
+    // and consuming the record against a page that is never stored would lose it.
+    const replay = get().rooms.has(roomJid)
+      ? resolveRoomPendingRetractions(get(), roomJid, archivePage, { persist: false })
+      : { messages: archivePage, pendingRetractions: undefined }
+    const mamMessages = replay.messages
+    if (replay.pendingRetractions) set({ pendingRetractions: replay.pendingRetractions })
+
     // Newest persisted timestamp (entity preview) — the seam-formation fallback
     // when the resident array is empty this run (fresh session, history on disk).
     const fallbackHeldTs = get().getRoomLastTimestamp(roomJid)

--- a/packages/fluux-sdk/src/stores/shared/pendingRetractions.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/pendingRetractions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  addPendingRetraction,
+  applyPendingRetractions,
+  PENDING_RETRACTION_CAP,
+  type PendingRetraction,
+} from './pendingRetractions'
+
+const AT = new Date('2026-07-22T03:53:00Z').getTime()
+
+function entry(targetId: string, actorJid = 'contact@example.com', retractedAt = AT): PendingRetraction {
+  return { targetId, actorJid, retractedAt }
+}
+
+function message(id: string, extra: Record<string, unknown> = {}) {
+  return { id, from: 'contact@example.com', body: 'hello', ...extra }
+}
+
+const isAuthor = (m: { from: string }, record: PendingRetraction) => m.from === record.actorJid
+
+describe('addPendingRetraction', () => {
+  it('appends a record', () => {
+    expect(addPendingRetraction([], entry('a'))).toEqual([entry('a')])
+  })
+
+  it('returns the same array when the target is already recorded', () => {
+    const existing = [entry('a')]
+    expect(addPendingRetraction(existing, entry('a'))).toBe(existing)
+  })
+
+  it('caps the list, dropping the oldest record', () => {
+    let list: PendingRetraction[] = []
+    for (let i = 0; i < PENDING_RETRACTION_CAP + 5; i++) {
+      list = addPendingRetraction(list, entry(`t${i}`))
+    }
+    expect(list).toHaveLength(PENDING_RETRACTION_CAP)
+    expect(list[0].targetId).toBe('t5')
+  })
+})
+
+describe('applyPendingRetractions', () => {
+  it('tombstones a target that is now present and reports it applied', () => {
+    const messages = [message('m1'), message('m2')]
+
+    const result = applyPendingRetractions(messages, [entry('m2')], isAuthor)
+
+    expect(result.messages[1]).toMatchObject({ id: 'm2', isRetracted: true, retractedAt: new Date(AT) })
+    expect(result.messages[0]).toBe(messages[0])
+    expect(result.applied).toEqual([{ messageId: 'm2', retractedAt: new Date(AT) }])
+    expect(result.remaining).toEqual([])
+  })
+
+  it('resolves the target through any id tier (stanza-id, origin-id)', () => {
+    const messages = [message('m1', { stanzaId: 'srv-1' }), message('m2', { originId: 'org-2' })]
+
+    const result = applyPendingRetractions(messages, [entry('srv-1'), entry('org-2')], isAuthor)
+
+    expect(result.messages[0]).toMatchObject({ isRetracted: true })
+    expect(result.messages[1]).toMatchObject({ isRetracted: true })
+    expect(result.remaining).toEqual([])
+  })
+
+  it('keeps a record pending when its target is not present', () => {
+    const messages = [message('m1')]
+
+    const result = applyPendingRetractions(messages, [entry('absent')], isAuthor)
+
+    expect(result.messages).toBe(messages)
+    expect(result.applied).toEqual([])
+    expect(result.remaining).toEqual([entry('absent')])
+  })
+
+  it('drops a record whose author does not match the target — never tombstones', () => {
+    const messages = [message('m1', { from: 'someone-else@example.com' })]
+
+    const result = applyPendingRetractions(messages, [entry('m1')], isAuthor)
+
+    expect(result.messages).toBe(messages)
+    expect(result.applied).toEqual([])
+    expect(result.remaining).toEqual([])
+  })
+
+  it('resolves an already-retracted target without rewriting the array', () => {
+    const messages = [message('m1', { isRetracted: true })]
+
+    const result = applyPendingRetractions(messages, [entry('m1')], isAuthor)
+
+    expect(result.messages).toBe(messages)
+    expect(result.applied).toEqual([])
+    expect(result.remaining).toEqual([])
+  })
+
+  it('returns the input array untouched when there is nothing pending', () => {
+    const messages = [message('m1')]
+
+    const result = applyPendingRetractions(messages, [], isAuthor)
+
+    expect(result.messages).toBe(messages)
+    expect(result.remaining).toEqual([])
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/pendingRetractions.ts
+++ b/packages/fluux-sdk/src/stores/shared/pendingRetractions.ts
@@ -1,0 +1,114 @@
+/**
+ * Pending retractions (XEP-0424) — shared by the chat and room stores.
+ *
+ * A retraction can arrive while its target is not in the resident window: only
+ * the ACTIVE conversation keeps its messages in RAM, and a target older than the
+ * loaded slice is absent even there. The live path used to give up in that case,
+ * which let the retraction's XEP-0428 fallback body fall through and surface as a
+ * normal message. Instead the retraction is recorded here and replayed the moment
+ * the target becomes resident (live arrival or a cache/MAM load), so the tombstone
+ * lands late rather than never.
+ *
+ * @module
+ */
+
+import { findMessageIndexById } from '../../utils/messageLookup'
+
+/** A retraction whose target was not resident when it arrived. */
+export interface PendingRetraction {
+  /** The `<retract id="…">` reference — any id tier of the target. */
+  targetId: string
+  /**
+   * Author the retraction claims to come from. XEP-0424 only lets a message be
+   * retracted by its own author, so this is re-checked when the target shows up.
+   */
+  actorJid: string
+  /**
+   * XEP-0421 occupant-id of the retracting author (MUC only). Preferred over
+   * {@link actorJid} when the target carries one too — a nick can be reassigned
+   * once its owner leaves, an occupant-id cannot.
+   */
+  actorOccupantId?: string
+  /** Epoch ms the retraction was received; becomes the target's `retractedAt`. */
+  retractedAt: number
+}
+
+/**
+ * Per-conversation record cap. Records only clear when their target loads, so a
+ * retraction for a message we never fetch would otherwise accumulate forever.
+ */
+export const PENDING_RETRACTION_CAP = 50
+
+/** Minimum message shape the replay needs: the id tiers plus the tombstone fields. */
+export interface RetractableMessage {
+  id: string
+  stanzaId?: string
+  originId?: string
+  correctionStanzaIds?: string[]
+  isRetracted?: boolean
+  retractedAt?: Date
+}
+
+/** Outcome of replaying a conversation's pending retractions against a slice. */
+export interface PendingRetractionResult<T> {
+  /** The patched array, or the input array itself when nothing changed. */
+  messages: T[]
+  /** Targets tombstoned by this pass — the caller writes these through to the cache. */
+  applied: Array<{ messageId: string; retractedAt: Date }>
+  /** Records whose target is still unknown; keep them for the next pass. */
+  remaining: PendingRetraction[]
+}
+
+/**
+ * Add a record, newest last. Idempotent per target, and capped so a retraction
+ * targeting a message we never load cannot grow the list without bound.
+ */
+export function addPendingRetraction(
+  list: PendingRetraction[],
+  entry: PendingRetraction
+): PendingRetraction[] {
+  // Same array back when the target is already recorded, so callers can skip the
+  // state write (a retraction re-delivered by carbons/MAM must not churn state).
+  if (list.some((r) => r.targetId === entry.targetId)) return list
+  return [...list, entry].slice(-PENDING_RETRACTION_CAP)
+}
+
+/**
+ * Replay pending retractions against a message slice.
+ *
+ * A record resolves as soon as its target is present — applied when the author
+ * matches, dropped otherwise (an unauthorized retraction must never tombstone,
+ * and re-checking it on every load would be pure churn).
+ */
+export function applyPendingRetractions<T extends RetractableMessage>(
+  messages: T[],
+  pending: readonly PendingRetraction[],
+  isAuthor: (message: T, record: PendingRetraction) => boolean
+): PendingRetractionResult<T> {
+  if (pending.length === 0) return { messages, applied: [], remaining: [] }
+
+  const applied: PendingRetractionResult<T>['applied'] = []
+  const remaining: PendingRetraction[] = []
+  let patched: T[] | null = null
+
+  for (const record of pending) {
+    const source: T[] = patched ?? messages
+    const index = findMessageIndexById(source, record.targetId)
+    if (index === -1) {
+      remaining.push(record)
+      continue
+    }
+
+    const target = source[index]
+    // Resolved either way from here: an unauthorized retraction is dropped, not
+    // retried, and an already-tombstoned target needs no second write.
+    if (target.isRetracted || !isAuthor(target, record)) continue
+
+    const retractedAt = new Date(record.retractedAt)
+    patched = [...source]
+    patched[index] = { ...target, isRetracted: true, retractedAt }
+    applied.push({ messageId: target.id, retractedAt })
+  }
+
+  return { messages: patched ?? messages, applied, remaining }
+}


### PR DESCRIPTION
A live XEP-0424 retraction was only claimed when its target resolved, and the target is looked up in the resident window — which is empty for every conversation but the active one, and misses any message older than the loaded slice. On a miss the stanza fell through to the message path and its fallback body was stored as a normal message: it rendered as a bubble, became the sidebar preview and counted as unread. Reported from a 1:1 chat showing a tombstone immediately followed by a stray "This message has been retracted by the sender." bubble.

The stanza is now always claimed, mirroring what the whisper and reactions paths already do. An unresolved retraction is recorded instead of dropped.

- New shared pure module `stores/shared/pendingRetractions.ts` (record/cap/replay, author gate injected), with `pendingRetractions` state on both stores: chat persists via `partialize`, rooms via the scoped key `fluux-room-pending-retractions`.
- Wired through new SDK events `chat:retraction-pending` / `room:retraction-pending` → `recordPendingRetraction`.
- Replayed at three points per store: `addMessage`, the cache→resident merge, and the MAM archive merge. The MAM hook patches the incoming page *before* the merge so the tombstone rides the same `saveMessages` write rather than racing it; the other paths write through to IndexedDB so the tombstone outlives the record.
- Only a message's own author may retract it: a mismatched actor resolves the record as dropped, never tombstoned. The room gate prefers the XEP-0421 occupant-id, mirroring `isSameMucAuthor`.