### PR TITLE
fix(logging): put the date before the .log extension

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1396,8 +1396,18 @@ fn main() {
             EnvFilter::new("fluux=info,webview=info,info")
         };
 
-        // File layer: daily-rotating log file, non-blocking writes
-        let file_appender = tracing_appender::rolling::daily(&log_dir, "fluux.log");
+        // File layer: daily-rotating log file, non-blocking writes.
+        // The date goes in the middle (fluux.2026-07-22.log) rather than at the
+        // end: with a trailing date the OS sees ".2026-07-22" as the extension,
+        // so Windows shows the file as unknown and refuses to open it on
+        // double-click. `rolling::daily()` produces that trailing form, hence
+        // the explicit builder.
+        let file_appender = tracing_appender::rolling::Builder::new()
+            .rotation(tracing_appender::rolling::Rotation::DAILY)
+            .filename_prefix("fluux")
+            .filename_suffix("log")
+            .build(&log_dir)
+            .expect("Initializing rolling file appender failed");
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
         let file_layer = tracing_subscriber::fmt::layer()
             .with_writer(non_blocking)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -6,7 +6,7 @@
 
 ## Log Files
 
-Fluux writes daily-rotating log files (`fluux.log`) automatically. These are useful for diagnosing connection issues, crashes, or unexpected behavior.
+Fluux writes daily-rotating log files automatically, named `fluux.YYYY-MM-DD.log` (one per day). These are useful for diagnosing connection issues, crashes, or unexpected behavior.
 
 ### Default Log Locations
 


### PR DESCRIPTION
`tracing_appender::rolling::daily()` appends the date after the whole filename, producing `fluux.log.2026-07-22`. The OS reads `.2026-07-22` as the extension, so Windows shows the log as an unknown file type and refuses to open it on double-click.

Switch to the explicit builder so the date lands in the middle — `fluux.2026-07-22.log`. Rotation cadence and the (absent) retention cap are unchanged. Verified against tracing-appender 0.2.5 by running the appender and reading back the filename it created.

Pre-existing `fluux.log.<date>` files keep their old names; nothing prunes them, so upgraded installs will show both styles side by side until deleted manually.