### PR TITLE
fix(shutdown): don't reconnect while quitting from the system tray

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1457,6 +1457,13 @@ fn main() {
     // timer) is allowed to complete and terminate the app.
     let graceful_shutdown_started = Arc::new(AtomicBool::new(false));
     let graceful_shutdown_flag_for_run = graceful_shutdown_started.clone();
+    // Tray "Quit" (and the Linux no-tray X-close) start the graceful shutdown
+    // themselves, so they must claim the flag too. Otherwise the frontend's
+    // follow-up `exit_app` looks like a *first* exit request to the run handler
+    // below, which prevents it — leaving the 2s fallback timer as the only way
+    // out, i.e. every tray quit force-killed instead of exiting cleanly.
+    // Underscore-prefixed: only the linux/windows cfg blocks below consume it.
+    let _graceful_shutdown_flag_for_setup = graceful_shutdown_started.clone();
 
     let app = tauri::Builder::default()
         // Single-instance guard MUST be the first plugin registered (Tauri
@@ -1874,6 +1881,7 @@ fn main() {
                     .tooltip("Fluux Messenger")
                     .on_menu_event({
                         let keepalive_flag = keepalive_flag_for_setup.clone();
+                        let graceful_shutdown_flag = _graceful_shutdown_flag_for_setup.clone();
                         let last_window_state = last_window_state.clone();
                         let window_hidden_to_tray = window_hidden_to_tray.clone();
                         move |app, event| match event.id.as_ref() {
@@ -1955,6 +1963,9 @@ fn main() {
                             }
                             "quit" => {
                                 keepalive_flag.store(false, Ordering::Relaxed);
+                                // Claim the shutdown so the frontend's exit_app
+                                // is treated as the second request and allowed.
+                                graceful_shutdown_flag.store(true, Ordering::Relaxed);
                                 let _ = app.emit("graceful-shutdown", ());
                                 let handle = app.clone();
                                 std::thread::spawn(move || {
@@ -2023,6 +2034,7 @@ fn main() {
                 let last_window_state_for_close = last_window_state.clone();
                 let window_hidden_to_tray_for_close = window_hidden_to_tray.clone();
                 let keepalive_flag_for_close = keepalive_flag_for_setup.clone();
+                let graceful_shutdown_flag_for_close = _graceful_shutdown_flag_for_setup.clone();
                 let app_handle_for_close = app.handle().clone();
                 main_window.on_window_event(move |event| {
                     if let WindowEvent::CloseRequested { api, .. } = event {
@@ -2041,6 +2053,7 @@ fn main() {
                             // Mirror the tray "Quit" menu item: stop keepalive,
                             // let the frontend disconnect XMPP, then force-exit.
                             keepalive_flag_for_close.store(false, Ordering::Relaxed);
+                            graceful_shutdown_flag_for_close.store(true, Ordering::Relaxed);
                             let _ = app_handle_for_close.emit("graceful-shutdown", ());
                             let handle = app_handle_for_close.clone();
                             std::thread::spawn(move || {
@@ -2085,6 +2098,7 @@ fn main() {
                     .tooltip("Fluux Messenger")
                     .on_menu_event({
                         let keepalive_flag = keepalive_flag_for_setup.clone();
+                        let graceful_shutdown_flag = _graceful_shutdown_flag_for_setup.clone();
                         let log_dir_for_tray = log_dir.clone();
                         move |app, event| match event.id.as_ref() {
                             "show" => {
@@ -2109,6 +2123,9 @@ fn main() {
                             "quit" => {
                                 // Stop the keepalive thread
                                 keepalive_flag.store(false, Ordering::Relaxed);
+                                // Claim the shutdown so the frontend's exit_app
+                                // is treated as the second request and allowed.
+                                graceful_shutdown_flag.store(true, Ordering::Relaxed);
                                 // Emit graceful shutdown event to frontend
                                 let _ = app.emit("graceful-shutdown", ());
                                 // Set a fallback timer to force exit after 2 seconds

--- a/apps/fluux/src/components/LoginScreen.shutdown.test.tsx
+++ b/apps/fluux/src/components/LoginScreen.shutdown.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { LoginScreen } from './LoginScreen'
+import { markConnectActive } from '@/utils/reconnectIntent'
+import { markShuttingDown, resetShutdownStateForTests } from '@/utils/appShutdown'
+
+const mockConnect = vi.fn().mockResolvedValue(undefined)
+
+// Tauri + saved keychain credentials => the keychain auto-connect effect arms.
+vi.mock('@fluux/sdk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@fluux/sdk')>()),
+  useConnectionStatus: () => ({ status: 'offline', error: null }),
+  useConnectionActions: () => ({ connect: mockConnect }),
+  deleteFastToken: vi.fn(),
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({ useWindowDrag: () => ({ dragRegionProps: {} }) }))
+vi.mock('@/hooks/useSessionPersistence', () => ({ saveSession: vi.fn() }))
+vi.mock('@/utils/xmppResource', () => ({ getResource: () => 'test-resource' }))
+vi.mock('@/utils/tauri', () => ({ isTauri: () => true }))
+vi.mock('@/utils/keychain', () => ({
+  hasSavedCredentials: () => true,
+  getCredentials: vi.fn().mockResolvedValue({
+    jid: 'user@example.com',
+    password: 'secret',
+    server: 'wss://example.com/ws',
+  }),
+  saveCredentials: vi.fn(),
+  deleteCredentials: vi.fn(),
+}))
+vi.mock('@/config/wellKnownServers', () => ({
+  getDomainFromJid: () => null,
+  getWebsocketUrlForDomain: () => null,
+}))
+vi.mock('@/stores/encryptionSettingsStore', () => ({ isOpenpgpEnabled: () => false }))
+
+/**
+ * Quitting the app (tray "Quit", Cmd+Q, close) makes `client.disconnect()` flip
+ * the store to 'disconnected', which routes App to a FRESH LoginScreen mount.
+ * Both of that mount's start-up effects used to fight the shutdown: the WRY
+ * reload workaround tore down the JS context before `exit_app` could run, and
+ * the keychain auto-connect opened a new XMPP session that the exit then killed.
+ */
+describe('LoginScreen — start-up effects during app shutdown', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    mockConnect.mockClear()
+    resetShutdownStateForTests()
+
+    // jsdom's window.location.reload is not writable; replace the accessor.
+    reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    })
+  })
+
+  // ── Positive controls ──────────────────────────────────────────────────────
+  // These prove both effects genuinely fire on a normal (non-shutdown) mount,
+  // so the "does NOT" assertions below are capable of failing.
+
+  it('auto-connects from the keychain on a normal disconnect (control)', async () => {
+    markConnectActive()
+
+    render(<LoginScreen />)
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalled())
+  })
+
+  it('reloads the webview on a normal post-online disconnect (control)', async () => {
+    markConnectActive()
+    sessionStorage.setItem('__wry_was_online', '1')
+
+    render(<LoginScreen />)
+
+    await waitFor(() => expect(reloadSpy).toHaveBeenCalled())
+  })
+
+  // ── The regression ─────────────────────────────────────────────────────────
+
+  // ★ Quitting must not open a fresh XMPP session that the exit kills seconds
+  // later, stranding a ghost session on the server.
+  it('does NOT auto-connect from the keychain while shutting down', async () => {
+    markConnectActive()
+    markShuttingDown()
+
+    render(<LoginScreen />)
+
+    // Give the credential-load + auto-connect effects time to run.
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(mockConnect).not.toHaveBeenCalled()
+  })
+
+  // ★ Reloading here would destroy the JS context that still owes the shutdown
+  // handler its `stop_xmpp_proxy` / `exit_app` invokes, so the app could only
+  // die via Rust's 2s force-exit fallback.
+  it('does NOT reload the webview while shutting down', async () => {
+    markConnectActive()
+    sessionStorage.setItem('__wry_was_online', '1')
+    markShuttingDown()
+
+    render(<LoginScreen />)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/components/LoginScreen.tsx
+++ b/apps/fluux/src/components/LoginScreen.tsx
@@ -14,6 +14,7 @@ import { getDomainFromJid, getWebsocketUrlForDomain } from '@/config/wellKnownSe
 import { useWindowDrag } from '@/hooks'
 import { isOpenpgpEnabled } from '@/stores/encryptionSettingsStore'
 import { getReconnectIntent } from '@/utils/reconnectIntent'
+import { isShuttingDown } from '@/utils/appShutdown'
 import { LoginErrorPanel } from './LoginErrorPanel'
 import { OverflowMenu } from './OverflowMenu'
 import { useAdvancedModeStore } from '@/stores/advancedModeStore'
@@ -104,6 +105,11 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
   // See: https://github.com/tauri-apps/wry/issues/184
   useEffect(() => {
     if (!isTauri()) return
+    // Not while quitting: this mount is the app tearing down, not a live
+    // disconnect the user has to keep interacting with. Reloading here destroys
+    // the JS context that still owes the shutdown handler its `stop_xmpp_proxy`
+    // / `exit_app` calls, downgrading a clean quit to Rust's 2s force-exit.
+    if (isShuttingDown()) return
     const flag = sessionStorage.getItem('__wry_was_online')
     if (!flag) return
 
@@ -321,6 +327,11 @@ export function LoginScreen({ claimConnection }: LoginScreenProps) {
     // race and the keychain entry survived. Mirrors the gate in
     // useSessionPersistence — the reconnect intent is the single source of truth.
     if (getReconnectIntent() === 'logged-out') return
+    // Quitting is not logging out, so the intent above is still 'active' — but
+    // a connection opened now is killed by the exit seconds later, leaving a
+    // ghost session on the server until it times out. `hasAutoConnected` cannot
+    // catch this: shutdown routes here as a *fresh mount*, so the ref is reset.
+    if (isShuttingDown()) return
 
     // Mark as auto-connected to prevent loops
     hasAutoConnected.current = true

--- a/apps/fluux/src/hooks/useTauriCloseHandler.test.tsx
+++ b/apps/fluux/src/hooks/useTauriCloseHandler.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useTauriCloseHandler } from './useTauriCloseHandler'
+import { isShuttingDown, resetShutdownStateForTests } from '@/utils/appShutdown'
+
+// Captures the `graceful-shutdown` callback Rust would invoke on quit.
+let shutdownHandler: (() => Promise<void>) | null = null
+const mockListen = vi.fn(async (event: string, cb: () => Promise<void>) => {
+  if (event === 'graceful-shutdown') shutdownHandler = cb
+  return () => {}
+})
+const mockInvoke = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: (...a: unknown[]) => mockListen(...(a as [string, () => Promise<void>])) }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }))
+
+// Records whether shutdown was already marked at the moment disconnect ran.
+let shuttingDownAtDisconnect: boolean | null = null
+const mockDisconnect = vi.fn(async () => {
+  shuttingDownAtDisconnect = isShuttingDown()
+})
+
+vi.mock('@fluux/sdk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@fluux/sdk')>()),
+  useXMPPContext: () => ({ client: { disconnect: mockDisconnect } }),
+}))
+
+describe('useTauriCloseHandler — shutdown marking', () => {
+  beforeEach(() => {
+    shutdownHandler = null
+    shuttingDownAtDisconnect = null
+    mockDisconnect.mockClear()
+    mockInvoke.mockClear()
+    resetShutdownStateForTests()
+    // The hook only registers on desktop platforms.
+    Object.defineProperty(navigator, 'platform', {
+      configurable: true,
+      value: 'Win32',
+    })
+  })
+
+  // ★ The flag must be set BEFORE disconnect(), because disconnect()
+  // synchronously flips the store to 'disconnected' — which is exactly what
+  // remounts LoginScreen and arms its reload / auto-connect effects. Marking it
+  // after the await would be too late to suppress them.
+  it('marks shutdown before disconnecting', async () => {
+    renderHook(() => useTauriCloseHandler())
+
+    await waitFor(() => expect(shutdownHandler).not.toBeNull())
+
+    // Control: nothing has marked shutdown before the event arrives.
+    expect(isShuttingDown()).toBe(false)
+
+    await shutdownHandler!()
+
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(shuttingDownAtDisconnect).toBe(true)
+  })
+
+  it('still tears down the proxy and exits after disconnect', async () => {
+    renderHook(() => useTauriCloseHandler())
+
+    await waitFor(() => expect(shutdownHandler).not.toBeNull())
+    await shutdownHandler!()
+
+    expect(mockInvoke).toHaveBeenCalledWith('stop_xmpp_proxy')
+    expect(mockInvoke).toHaveBeenCalledWith('exit_app')
+  })
+})

--- a/apps/fluux/src/hooks/useTauriCloseHandler.ts
+++ b/apps/fluux/src/hooks/useTauriCloseHandler.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useXMPPContext } from '@fluux/sdk'
+import { markShuttingDown } from '@/utils/appShutdown'
 
 /**
  * Set up Tauri app close handlers for graceful XMPP disconnect.
@@ -42,6 +43,14 @@ export function useTauriCloseHandler(): void {
         unlistenShutdown = await listen('graceful-shutdown', async () => {
           if (isClosing) return
           isClosing = true
+
+          // Mark shutdown BEFORE disconnecting. `disconnect()` synchronously
+          // flips the store to 'disconnected', which routes App to a fresh
+          // LoginScreen mount; without this flag set first, that mount would
+          // reload the webview (killing the JS context before `exit_app` runs)
+          // and auto-connect from the keychain — a pointless new XMPP session
+          // that the exit kills moments later.
+          markShuttingDown()
 
           await disconnectBestEffort()
           await invoke('stop_xmpp_proxy').catch(() => {})

--- a/apps/fluux/src/utils/appShutdown.ts
+++ b/apps/fluux/src/utils/appShutdown.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for "is the app shutting down?".
+ *
+ * Quitting is not logging out, so `reconnectIntent` stays `'active'` across a
+ * quit (we *want* the next launch to reconnect). That left the shutdown window
+ * with no signal at all, and the app's auto-reconnect machinery happily fired
+ * inside it:
+ *
+ * Rust emits `graceful-shutdown` (tray Quit, Cmd+Q, window close) ->
+ * `useTauriCloseHandler` calls `client.disconnect()` -> `disconnect()`
+ * synchronously flips the connection store to `'disconnected'` -> `App` routes
+ * to `LoginScreen` -> that is a *fresh mount* (LoginScreen is unmounted while
+ * online), so its mount effects ran with all their once-per-instance refs
+ * reset: the WRY reload workaround reloaded the webview (destroying the JS
+ * context before `exit_app` could be invoked, so the app only died via Rust's
+ * 2s force-exit fallback) and the keychain auto-connect opened a brand-new XMPP
+ * session that was then killed mid-login, stranding a ghost session on the
+ * server.
+ *
+ * This flag is deliberately **in-memory only**. It marks a one-way transition
+ * that ends in process exit, so it must never survive into the next launch —
+ * persisting it (localStorage/sessionStorage) would risk stranding a future
+ * start-up with auto-reconnect disabled. Losing it on a webview reload is fine
+ * because the guards below exist precisely to prevent that reload.
+ */
+
+let shuttingDown = false
+
+/**
+ * Record that the app has begun its shutdown sequence. Call this FIRST in the
+ * `graceful-shutdown` handler — synchronously, before `client.disconnect()` —
+ * so the status change disconnect() emits is already seen as "shutting down"
+ * by every effect that reacts to it.
+ */
+export function markShuttingDown(): void {
+  shuttingDown = true
+}
+
+/**
+ * Whether the app is tearing down. Auto-reconnect engines and the WRY reload
+ * workaround must no-op while this is true: any connection opened here is
+ * killed seconds later by the exit, and any reload prevents a clean exit.
+ */
+export function isShuttingDown(): boolean {
+  return shuttingDown
+}
+
+/** Test-only: reset the module state between cases. */
+export function resetShutdownStateForTests(): void {
+  shuttingDown = false
+}


### PR DESCRIPTION
Right-clicking the system tray and choosing **Quit** triggered a full reconnect before the app actually exited.

`client.disconnect()` synchronously flips the connection store to `disconnected`, which routes `App` to a **fresh** `LoginScreen` mount (it is unmounted while online). That reset every once-per-instance ref guard, so the mount both reloaded the webview — destroying the JS context before `stop_xmpp_proxy`/`exit_app` could run — and auto-connected from the keychain, opening an XMPP session the exit then killed mid-login, leaving a ghost session on the server.

Quitting is not logging out, so `reconnectIntent` correctly stays `active` and nothing signalled teardown. This adds an in-memory `appShutdown` flag (mirroring the existing `reconnectIntent` idiom), set before disconnect, and gates both `LoginScreen` start-up effects on it. It is deliberately not persisted — a stuck flag would disable auto-reconnect on a future launch.

Also fixes a second defect on the same path: the tray quit handlers never claimed `graceful_shutdown_started`, so the frontend's `exit_app` looked like a *first* exit request and was blocked by `prevent_exit()`. Every tray quit died via the 2s force-exit fallback instead of exiting cleanly.

Verified by removing both guards and confirming only the two regression tests fail while their positive controls still pass. The Windows tray block was type-checked by temporarily widening its `cfg`; runtime behaviour on Windows still needs a manual confirmation that quit is now immediate.