### PR TITLE
ci(windows): add on-demand Windows test build workflow

### DIFF
--- a/.github/workflows/windows-test-build.yml
+++ b/.github/workflows/windows-test-build.yml
@@ -1,0 +1,110 @@
+name: Windows Test Build
+
+# On-demand Windows installers for testing a branch before it is released.
+#
+# This mirrors the `build-windows` job in release.yml, minus everything that is
+# release-specific: no tag, no GitHub release, no Azure Trusted Signing, no
+# updater artifacts. The output is a plain Actions artifact you download and
+# install on a Windows machine.
+#
+# The build uses the production identity (com.processone.fluux, "Fluux
+# Messenger") rather than the .dev identity, so installing it over an existing
+# Fluux Messenger exercises the real WiX/NSIS upgrade path. It will replace an
+# installed release build.
+#
+# The installers are UNSIGNED — SmartScreen will warn on first run
+# ("More info" -> "Run anyway").
+#
+# Note: workflow_dispatch only appears in the Actions UI once this file is on
+# the default branch. Merge it to main first, then you can dispatch it against
+# any branch.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: windows-test-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Windows installers
+    runs-on: windows-latest
+    # Backstop against a hung build (default GitHub timeout is 6h). A cold
+    # cache is ~25min on Windows; a warm one is far less.
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/fluux/src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK
+        run: npm run build:sdk
+
+      - name: Disable updater artifacts
+        shell: bash
+        run: |
+          # tauri.conf.json sets createUpdaterArtifacts: true and configures an
+          # updater pubkey, so the bundler demands TAURI_SIGNING_PRIVATE_KEY.
+          # Test builds have no signing key and no latest.json to update from,
+          # so turn the artifacts off — same thing tauri-build.sh does locally.
+          sed -i 's/"createUpdaterArtifacts": true/"createUpdaterArtifacts": false/' \
+            apps/fluux/src-tauri/tauri.conf.json
+          grep -q '"createUpdaterArtifacts": false' apps/fluux/src-tauri/tauri.conf.json
+
+      - name: Build Tauri app
+        shell: bash
+        working-directory: apps/fluux
+        run: |
+          # bundle.targets is "all", which on Windows means both NSIS (.exe) and
+          # WiX (.msi) — the same pair the release builds.
+          npm run tauri build
+
+      - name: Summarize build
+        id: summary
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./apps/fluux/src-tauri/tauri.conf.json').version")
+          # Artifact names cannot contain "/", and this repo's branches are
+          # prefixed (mr/...), so flatten the ref before using it as a name.
+          SLUG=$(printf '%s' "$GITHUB_REF_NAME" | tr -c 'A-Za-z0-9._-' '-')
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Windows test build"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Branch | \`${GITHUB_REF_NAME}\` |"
+            echo "| Commit | \`$(git rev-parse --short HEAD)\` |"
+            echo "| Version | \`${VERSION}\` |"
+            echo ""
+            echo "Unsigned — SmartScreen will warn on first run."
+            echo "The app reports its commit hash in Settings, so you can confirm what you installed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v7
+        with:
+          name: fluux-windows-${{ steps.summary.outputs.slug }}-${{ github.sha }}
+          path: |
+            apps/fluux/src-tauri/target/release/bundle/nsis/*.exe
+            apps/fluux/src-tauri/target/release/bundle/msi/*.msi
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -97,6 +97,64 @@ This produces a set of PNG files in the `screenshots/` directory covering major 
 
 The script navigates the demo at `/demo.html?tutorial=false`, freezes the animation timeline, and captures each view at 1280×800. To add or modify screenshots, edit `scripts/screenshots.ts`.
 
+## Windows Test Builds
+
+Windows installers cannot be cross-compiled from macOS or Linux — the MSVC toolchain, WiX, and NSIS all require Windows. To try a branch on Windows before it is released, dispatch the **Windows Test Build** workflow (`.github/workflows/windows-test-build.yml`). It runs on `windows-latest`, builds both installers, and attaches them as a run artifact (14-day retention) — no tag and no GitHub release.
+
+### Triggering the build
+
+The workflow is manual-only (`workflow_dispatch`); nothing runs it automatically. Because GitHub only exposes `workflow_dispatch` from the default branch, **the workflow file must be on `main`** before you can dispatch it — including against a feature branch. Once it is there, the branch you pick is what gets built.
+
+From the command line:
+
+```bash
+gh workflow run windows-test-build.yml --ref my-feature-branch
+```
+
+Omit `--ref` to build `main`. The command confirms the dispatch but does not report a run ID, so list the runs to pick up the new one:
+
+```bash
+gh run list --workflow=windows-test-build.yml
+```
+
+Then follow it to completion (roughly 25 minutes on a cold Rust cache, much less once warm):
+
+```bash
+gh run watch <run-id>
+```
+
+From the web UI instead: **Actions** → **Windows Test Build** in the left sidebar → **Run workflow** → choose the branch → **Run workflow**.
+
+### Getting the installers
+
+When the run finishes, download the artifact into the current directory:
+
+```bash
+gh run download <run-id>
+```
+
+Or use the **Artifacts** section at the bottom of the run's summary page. Either way you get a zip named `fluux-windows-<branch>-<sha>` — with `/` flattened to `-`, so `mr/my-feature` becomes `mr-my-feature`, since artifact names cannot contain slashes. It holds two files:
+
+| File | Installer |
+|---|---|
+| `…_x64-setup.exe` | NSIS — per-user install, no admin prompt |
+| `…_x64_en-US.msi` | WiX — the MSI, for Group Policy or scripted deploys |
+
+These are Tauri's raw bundle names, so they still carry the `Fluux Messenger_<version>_` prefix; `scripts/rename-release-assets.js` only tidies names on published releases, and it does not run here.
+
+Copy either to the Windows machine and run it. The run summary page also records the branch, commit, and version that produced the build.
+
+Two things differ from a release build:
+
+| | Test build | Release build |
+|---|---|---|
+| Code signing | None — SmartScreen warns on first run ("More info" → "Run anyway") | Azure Trusted Signing |
+| Updater artifacts | Disabled (no signing key, no `latest.json` to serve) | `.sig` files published |
+
+Everything else matches `release.yml`, including the production identifier `com.processone.fluux` and the WiX `upgradeCode`. That means a test build installs *over* an installed Fluux Messenger and exercises the real upgrade path — which is usually what you want, but it does replace the release copy on that machine.
+
+The app reports its commit hash (embedded by `src-tauri/build.rs` as `GIT_HASH`), so you can confirm which build you actually installed. The version string still reads as the current `tauri.conf.json` version — Tauri v2 rejects non-`X.Y.Z` versions, so test builds are not separately stamped.
+
 ## Windows Installer Artwork
 
 The MSI and `.exe` installers carry four branded bitmaps. They are committed under `apps/fluux/src-tauri/installer/windows/` and referenced from `bundle.windows.wix` / `bundle.windows.nsis` in `tauri.conf.json`. They are **not** release-cadence assets — regenerate them only when the artwork itself changes.


### PR DESCRIPTION
Windows installers could previously only be produced by tagging a release — `build-windows` in `release.yml` fires on `v*` tags, and PR CI is Ubuntu-only. Testing a branch on Windows meant cutting a public prerelease.

This adds a `workflow_dispatch` job that builds any branch on `windows-latest` and attaches the NSIS `.exe` and WiX `.msi` as a run artifact (14-day retention). It mirrors the release recipe minus the release-specific parts: no tag, no GitHub release, no Azure Trusted Signing.

Two details worth reviewing:

- `tauri.conf.json` sets `createUpdaterArtifacts: true` alongside an updater `pubkey`, so the bundler hard-fails without `TAURI_SIGNING_PRIVATE_KEY`. Rather than wire the release secret into a test workflow, the job disables updater artifacts the same way `tauri-build.sh` already does locally — so it needs no secrets at all.
- The build keeps the production identifier and WiX `upgradeCode`, so installing over an existing Fluux exercises the real upgrade path. It will replace a release copy on that machine.

Also documents triggering and artifact download in `docs/DEVELOPER.md`.

Note: `workflow_dispatch` is only exposed from the default branch, so this has to merge before it can be dispatched against a feature branch. The workflow has not executed yet for that reason.