### PR TITLE
fix(notifications): surface plugin notification failures on Windows/Linux

### DIFF
--- a/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
@@ -101,12 +101,38 @@ describe('useDesktopNotifications posting + guard', () => {
     expect(sendNotification).not.toHaveBeenCalled()
   })
 
-  it('posts via the plugin (sendNotification) on non-macOS Tauri', async () => {
+  // Windows/Linux go through the plugin command directly rather than the
+  // plugin's sendNotification() wrapper, which discards the invoke promise and
+  // hid every failure. See utils/postPluginNotification.
+  it('posts via the plugin notify command on non-macOS Tauri', async () => {
     isMacOSDesktop.mockResolvedValue(false)
     renderHook(() => useDesktopNotifications())
     await handlers.onConversationMessage?.({ id: 'alice@example.com', name: 'Alice' }, { from: 'alice@example.com' })
-    expect(sendNotification).toHaveBeenCalled()
+    expect(invoke).toHaveBeenCalledWith('plugin:notification|notify', {
+      options: {
+        title: 'Alice',
+        body: 'body text',
+        attachments: undefined,
+        extra: { navType: 'conversation', navTarget: 'alice@example.com' },
+      },
+    })
+    expect(sendNotification).not.toHaveBeenCalled()
     expect(invoke).not.toHaveBeenCalledWith('post_notification', expect.anything())
+  })
+
+  it('posts a room via the plugin notify command on non-macOS Tauri', async () => {
+    isMacOSDesktop.mockResolvedValue(false)
+    renderHook(() => useDesktopNotifications())
+    await handlers.onRoomMessage?.({ jid: 'team@conf.example.com', name: 'Team' }, { nick: 'bob' })
+    expect(invoke).toHaveBeenCalledWith('plugin:notification|notify', {
+      options: {
+        title: 'bob @ Team',
+        body: 'body text',
+        attachments: undefined,
+        extra: { navType: 'room', navTarget: 'team@conf.example.com' },
+      },
+    })
+    expect(sendNotification).not.toHaveBeenCalled()
   })
 
   it('does NOT call onAction on macOS desktop (mobile-only guard)', async () => {

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -4,7 +4,7 @@ import { rosterStore, usePresence, useConnectionStatus, getLocalPart } from '@fl
 import type { Conversation, Message, Room, RoomMessage } from '@fluux/sdk'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
-import { sendNotification, onAction } from '@tauri-apps/plugin-notification'
+import { onAction } from '@tauri-apps/plugin-notification'
 import type { Options as NotificationOptions } from '@tauri-apps/plugin-notification'
 import { isMacOSDesktop } from '@/utils/tauriPlatform'
 import { useNotificationEvents } from './useNotificationEvents'
@@ -22,6 +22,7 @@ import { showWebNotification } from '@/utils/webNotification'
 import { webTag } from '@/utils/notificationNavigation'
 import { routeNotificationTarget } from '@/utils/notificationRouting'
 import { dismissNotification } from '@/utils/dismissNotification'
+import { postPluginNotification } from '@/utils/postPluginNotification'
 import { createNotificationCoalescer } from './notificationCoalescer'
 
 /** Duration of the post-reconnect window during which offline-delivery
@@ -169,7 +170,7 @@ export function useDesktopNotifications(): void {
           avatarPath: avatarUrl?.startsWith('file://') ? avatarUrl.replace(/^file:\/\//, '') : null,
         })
       } else {
-        sendNotification({
+        await postPluginNotification({
           title,
           body,
           attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,
@@ -228,7 +229,7 @@ export function useDesktopNotifications(): void {
           avatarPath: avatarUrl?.startsWith('file://') ? avatarUrl.replace(/^file:\/\//, '') : null,
         })
       } else {
-        sendNotification({
+        await postPluginNotification({
           title,
           body,
           attachments: avatarUrl ? [{ id: 'avatar', url: avatarUrl }] : undefined,

--- a/apps/fluux/src/hooks/useEventsDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useEventsDesktopNotifications.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react'
 import { useEvents, usePresence, getLocalPart } from '@fluux/sdk'
-import { sendNotification } from '@tauri-apps/plugin-notification'
 import {
   useNotificationPermission,
   getNotificationPermissionGranted,
   isTauri,
 } from './useNotificationPermission'
+import { postPluginNotification } from '@/utils/postPluginNotification'
 
 /**
  * Hook to show desktop notifications for new events (subscription requests).
@@ -39,7 +39,7 @@ export function useEventsDesktopNotifications(): void {
         const body = `${senderName} wants to add you as a contact`
 
         if (isTauri) {
-          sendNotification({ title, body })
+          void postPluginNotification({ title, body })
         } else {
           if (typeof Notification === 'undefined') continue
 

--- a/apps/fluux/src/utils/postPluginNotification.test.ts
+++ b/apps/fluux/src/utils/postPluginNotification.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke }))
+
+import { postPluginNotification } from './postPluginNotification'
+
+describe('postPluginNotification', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('invokes the plugin notify command with the options verbatim', async () => {
+    invoke.mockResolvedValue(null)
+
+    await postPluginNotification({
+      title: 'Alice',
+      body: 'hello',
+      extra: { navType: 'conversation', navTarget: 'alice@example.com' },
+    })
+
+    expect(invoke).toHaveBeenCalledWith('plugin:notification|notify', {
+      options: {
+        title: 'Alice',
+        body: 'hello',
+        extra: { navType: 'conversation', navTarget: 'alice@example.com' },
+      },
+    })
+  })
+
+  // The defect this module exists to fix: the plugin's own sendNotification()
+  // is synchronous and drops the invoke promise, so a rejected notify command
+  // left no trace anywhere. Logging it puts the failure in fluux.log, which
+  // main.rs feeds from the webview console.
+  it('logs a rejected notify command instead of swallowing it', async () => {
+    invoke.mockRejectedValue(new Error('notification.notify not allowed by ACL'))
+
+    await postPluginNotification({ title: 'Alice', body: 'hello' })
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const logged = errorSpy.mock.calls[0].join(' ')
+    expect(logged).toContain('not allowed by ACL')
+  })
+
+  it('does not reject when the command fails, so callers stay fire-and-forget', async () => {
+    invoke.mockRejectedValue(new Error('boom'))
+
+    await expect(postPluginNotification({ title: 'Alice' })).resolves.toBeUndefined()
+  })
+
+  // Control: a successful post must stay silent, or the assertion above would
+  // pass for a module that logs unconditionally.
+  it('logs nothing when the command succeeds', async () => {
+    invoke.mockResolvedValue(null)
+
+    await postPluginNotification({ title: 'Alice', body: 'hello' })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/fluux/src/utils/postPluginNotification.ts
+++ b/apps/fluux/src/utils/postPluginNotification.ts
@@ -1,0 +1,36 @@
+import { invoke } from '@tauri-apps/api/core'
+import type { Options } from '@tauri-apps/plugin-notification'
+
+/**
+ * Post a notification through the Tauri notification plugin (Windows/Linux;
+ * macOS uses the native `post_notification` command instead).
+ *
+ * Calls the plugin command directly rather than going through the plugin's
+ * `sendNotification()`: that wrapper is synchronous (`(options) => void`) and
+ * builds `new window.Notification(...)`, whose injected shim starts the invoke
+ * inside a floating async IIFE and drops the promise. A rejected command — ACL
+ * denial, a payload that fails to deserialize into `NotificationData` — was
+ * therefore swallowed with no trace on any platform. Awaiting it here puts the
+ * failure on the console, which main.rs forwards into fluux.log so it shows up
+ * in bug reports.
+ *
+ * The payload is what the shim would have sent: `{ options }` with `title`
+ * already merged in by the caller.
+ *
+ * Scope note: this can only observe failures up to the command boundary. The
+ * plugin's Rust side spawns the real D-Bus/WinRT call and discards its
+ * `Result`, so the command resolves before the OS has seen anything — a
+ * notification the OS accepts and then withdraws still looks like success from
+ * here. Closing that gap needs a Linux backend under `src-tauri/notifications/`
+ * alongside the macOS one.
+ *
+ * Never rejects: callers post notifications fire-and-forget, and a failed
+ * banner must not break message handling.
+ */
+export async function postPluginNotification(options: Options): Promise<void> {
+  try {
+    await invoke('plugin:notification|notify', { options })
+  } catch (error) {
+    console.error('[Notifications] Plugin notification failed:', error)
+  }
+}


### PR DESCRIPTION
While investigating #1051 (no notifications on Linux Mint / Cinnamon), the blocker turned out to be that the Windows/Linux notification path fails completely silently.

The plugin's `sendNotification()` is synchronous and builds `new window.Notification(...)`, whose injected shim starts the invoke inside a floating async IIFE and drops the promise. A rejected `notify` command — ACL denial, a payload that fails to deserialize into `NotificationData` — left no trace anywhere, so a user's log tells us nothing about whether a notification was even attempted.

This posts through the plugin command directly and awaits it, logging failures. `main.rs` forwards webview console output into `fluux.log`, so failures now land in the log users attach to bug reports. The payload is byte-identical to what the shim sent, so OS-side behavior is unchanged.

Applies to all three call sites: conversation, room, and subscription-request notifications.