### PR TITLE
fix(linux): open the right notification settings pane per desktop

### DIFF
--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -1217,35 +1217,12 @@ fn log_to_terminal(level: String, message: String) {
 
 /// Open the operating system's notification settings.
 ///
-/// Uses a native process launch rather than the shell/opener plugins: their
-/// default scopes reject custom URL schemes (`x-apple.systempreferences:`,
-/// `ms-settings:`), and Linux has no notification-settings URL at all — it
-/// needs a control-center invocation. Best-effort; a failed launch is returned
-/// to the caller, which logs it.
+/// Platform dispatch and the Linux desktop detection live in
+/// `notifications::settings_pane`. A failed launch is returned to the caller,
+/// which surfaces it in the UI.
 #[tauri::command]
 fn open_notification_settings() -> Result<(), String> {
-    #[cfg(target_os = "macos")]
-    let result = std::process::Command::new("open")
-        .arg("x-apple.systempreferences:com.apple.Notifications-Settings.extension")
-        .spawn();
-
-    #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("cmd")
-        .args(["/C", "start", "", "ms-settings:notifications"])
-        .spawn();
-
-    #[cfg(target_os = "linux")]
-    let result = std::process::Command::new("gnome-control-center")
-        .arg("notifications")
-        .spawn();
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-    let result: std::io::Result<std::process::Child> = Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "unsupported platform",
-    ));
-
-    result.map(|_| ()).map_err(|e| e.to_string())
+    notifications::settings_pane::open()
 }
 
 /// Print startup diagnostics to stderr for debugging.

--- a/apps/fluux/src-tauri/src/notifications/mod.rs
+++ b/apps/fluux/src-tauri/src/notifications/mod.rs
@@ -10,6 +10,7 @@
 pub mod backend;
 #[cfg(target_os = "macos")]
 mod macos;
+pub mod settings_pane;
 
 #[cfg(target_os = "macos")]
 use backend::{AuthState, NativeNotification, NavTarget};

--- a/apps/fluux/src-tauri/src/notifications/settings_pane.rs
+++ b/apps/fluux/src-tauri/src/notifications/settings_pane.rs
@@ -1,0 +1,311 @@
+//! "Open system notification settings" — the OS notification pane shortcut.
+//!
+//! Uses a native process launch rather than the shell/opener plugins: their
+//! default scopes reject custom URL schemes (`x-apple.systempreferences:`,
+//! `ms-settings:`), and Linux has no notification-settings URL at all — it
+//! needs a control-center invocation.
+//!
+//! Linux has no single control center, so [`linux_candidates`] turns the
+//! desktop-environment hints into an ordered list of commands to try; it is a
+//! pure function, unit-tested on every platform. [`open`] is the I/O boundary
+//! that reads the environment and spawns.
+
+// The candidate table is compiled everywhere so its tests run on any dev
+// machine, but only the Linux build calls it.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+/// A launchable settings command: program plus its arguments.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Candidate {
+    pub program: &'static str,
+    pub args: &'static [&'static str],
+}
+
+const fn candidate(program: &'static str, args: &'static [&'static str]) -> Candidate {
+    Candidate { program, args }
+}
+
+/// Known desktops, each with the aliases that identify it and the commands
+/// that open its notification pane. Order within a desktop matters (Plasma 6
+/// ships `systemsettings`, Plasma 5 `systemsettings5`); order of the table is
+/// the fallback order used when the desktop is unknown.
+const DESKTOPS: &[(&[&str], &[Candidate])] = &[
+    (
+        &["gnome", "unity"],
+        &[candidate("gnome-control-center", &["notifications"])],
+    ),
+    (
+        &["cinnamon"],
+        &[candidate("cinnamon-settings", &["notifications"])],
+    ),
+    (
+        &["kde", "plasma"],
+        &[
+            candidate("systemsettings", &["kcm_notifications"]),
+            candidate("systemsettings5", &["kcm_notifications"]),
+        ],
+    ),
+    (&["xfce"], &[candidate("xfce4-notifyd-config", &[])]),
+    (
+        &["budgie"],
+        &[candidate("budgie-control-center", &["notifications"])],
+    ),
+    (&["lxqt"], &[candidate("lxqt-config-notificationd", &[])]),
+];
+
+/// Normalise one desktop token for matching: lowercase, drop the `X-` vendor
+/// prefix (`X-Cinnamon`), and reduce a `DESKTOP_SESSION` path to its basename
+/// (`/usr/share/xsessions/plasma`).
+fn normalize(token: &str) -> String {
+    let token = token.rsplit('/').next().unwrap_or(token);
+    let lower = token.trim().to_ascii_lowercase();
+    lower.strip_prefix("x-").unwrap_or(&lower).to_string()
+}
+
+/// True when a normalised token names this desktop. Prefix matching absorbs the
+/// session variants (`gnome-xorg`, `plasmawayland`, `budgie-desktop`); no alias
+/// is a prefix of another desktop's alias, so this cannot cross-match.
+fn matches(token: &str, aliases: &[&str]) -> bool {
+    aliases.iter().any(|alias| token.starts_with(alias))
+}
+
+/// The ordered commands to try for the given desktop hints.
+///
+/// `xdg_current_desktop` is the colon-separated, case-insensitive
+/// `XDG_CURRENT_DESKTOP` (e.g. `ubuntu:GNOME`); `desktop_session` is the
+/// `DESKTOP_SESSION` fallback for the sessions that leave the former unset.
+///
+/// The matched desktop's commands come first, followed by every other known
+/// command: the environment names the desktop but does not promise its binary
+/// is installed, so a failed spawn only means "not this one" and trying the
+/// rest still beats doing nothing.
+///
+/// When several tokens name a desktop, the earliest one wins — the desktop
+/// entry spec orders `XDG_CURRENT_DESKTOP` most-specific-first, so Budgie's
+/// `Budgie:GNOME` must open Budgie's pane, not GNOME's. `DESKTOP_SESSION` is
+/// appended last and therefore only breaks ties `XDG_CURRENT_DESKTOP` left open.
+pub fn linux_candidates(
+    xdg_current_desktop: Option<&str>,
+    desktop_session: Option<&str>,
+) -> Vec<Candidate> {
+    let tokens: Vec<String> = xdg_current_desktop
+        .into_iter()
+        .flat_map(|value| value.split(':'))
+        .chain(desktop_session)
+        .map(normalize)
+        .filter(|token| !token.is_empty())
+        .collect();
+
+    // Rank by the position of the first token naming this desktop; unmatched
+    // desktops sort last, keeping the table's order among themselves.
+    let mut ranked: Vec<_> = DESKTOPS
+        .iter()
+        .map(|(aliases, commands)| {
+            let rank = tokens
+                .iter()
+                .position(|token| matches(token, aliases))
+                .unwrap_or(usize::MAX);
+            (rank, commands)
+        })
+        .collect();
+    ranked.sort_by_key(|(rank, _)| *rank);
+
+    ranked
+        .into_iter()
+        .flat_map(|(_, commands)| commands.iter().copied())
+        .collect()
+}
+
+/// Open the OS notification settings. `Err` carries a message for the caller to
+/// log; the UI shows its own translated fallback text.
+pub fn open() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.Notifications-Settings.extension")
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", "ms-settings:notifications"])
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let xdg = std::env::var("XDG_CURRENT_DESKTOP").ok();
+        let session = std::env::var("DESKTOP_SESSION").ok();
+        let candidates = linux_candidates(xdg.as_deref(), session.as_deref());
+
+        for c in &candidates {
+            match std::process::Command::new(c.program).args(c.args).spawn() {
+                Ok(_) => return Ok(()),
+                // Usually ENOENT — this desktop's control center isn't
+                // installed. Keep going; the next candidate may be.
+                Err(e) => tracing::debug!(
+                    "notification settings: {} unavailable: {}",
+                    c.program,
+                    e
+                ),
+            }
+        }
+
+        Err(format!(
+            "no notification settings command available (tried: {})",
+            candidates
+                .iter()
+                .map(|c| c.program)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Err("unsupported platform".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn programs(xdg: Option<&str>, session: Option<&str>) -> Vec<&'static str> {
+        linux_candidates(xdg, session)
+            .into_iter()
+            .map(|c| c.program)
+            .collect()
+    }
+
+    #[test]
+    fn gnome_is_tried_first() {
+        assert_eq!(
+            programs(Some("GNOME"), None).first(),
+            Some(&"gnome-control-center")
+        );
+    }
+
+    #[test]
+    fn vendor_prefixed_and_multi_token_xdg_still_matches() {
+        // Ubuntu ships `ubuntu:GNOME`; Cinnamon ships `X-Cinnamon`.
+        assert_eq!(
+            programs(Some("ubuntu:GNOME"), None).first(),
+            Some(&"gnome-control-center")
+        );
+        assert_eq!(
+            programs(Some("X-Cinnamon"), None).first(),
+            Some(&"cinnamon-settings")
+        );
+    }
+
+    #[test]
+    fn kde_tries_plasma6_then_plasma5() {
+        let kde = programs(Some("KDE"), None);
+        assert_eq!(&kde[..2], &["systemsettings", "systemsettings5"]);
+    }
+
+    #[test]
+    fn each_desktop_leads_with_its_own_command() {
+        let cases = [
+            ("XFCE", "xfce4-notifyd-config"),
+            ("Budgie:GNOME", "budgie-control-center"),
+            ("LXQt", "lxqt-config-notificationd"),
+            ("Unity", "gnome-control-center"),
+        ];
+        for (xdg, expected) in cases {
+            assert_eq!(
+                programs(Some(xdg), None).first(),
+                Some(&expected),
+                "XDG_CURRENT_DESKTOP={xdg}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_most_specific_token_wins() {
+        // `XDG_CURRENT_DESKTOP` is ordered most-specific-first, and the
+        // GNOME-derived desktops advertise `GNOME` as a later token. Ranking by
+        // table order instead of token order sends these to GNOME's pane.
+        assert_eq!(
+            programs(Some("Budgie:GNOME"), None).first(),
+            Some(&"budgie-control-center")
+        );
+        assert_eq!(
+            programs(Some("Unity:Unity7:ubuntu"), None).first(),
+            Some(&"gnome-control-center")
+        );
+    }
+
+    #[test]
+    fn session_variants_match_by_prefix() {
+        assert_eq!(
+            programs(Some("plasmawayland"), None).first(),
+            Some(&"systemsettings")
+        );
+        assert_eq!(
+            programs(Some("budgie-desktop"), None).first(),
+            Some(&"budgie-control-center")
+        );
+    }
+
+    #[test]
+    fn desktop_session_is_the_fallback_when_xdg_is_unset() {
+        assert_eq!(
+            programs(None, Some("cinnamon")).first(),
+            Some(&"cinnamon-settings")
+        );
+        // Display managers hand out a full path.
+        assert_eq!(
+            programs(None, Some("/usr/share/xsessions/plasma")).first(),
+            Some(&"systemsettings")
+        );
+    }
+
+    #[test]
+    fn xdg_wins_over_desktop_session() {
+        // `DESKTOP_SESSION` is often the generic distro session name while
+        // `XDG_CURRENT_DESKTOP` names the actual desktop.
+        assert_eq!(
+            programs(Some("X-Cinnamon"), Some("lightdm-xsession")).first(),
+            Some(&"cinnamon-settings")
+        );
+    }
+
+    #[test]
+    fn unknown_or_absent_desktop_still_offers_every_candidate() {
+        for hints in [(None, None), (Some("Enlightenment"), Some("weird-session"))] {
+            let all = programs(hints.0, hints.1);
+            assert_eq!(all.len(), 7, "hints={hints:?}");
+            assert!(all.contains(&"gnome-control-center"), "hints={hints:?}");
+            assert!(all.contains(&"lxqt-config-notificationd"), "hints={hints:?}");
+        }
+    }
+
+    #[test]
+    fn matched_desktop_keeps_the_others_as_fallbacks() {
+        // The desktop env var doesn't promise the binary is installed, so the
+        // remaining commands must still be tried after the matched one.
+        let xfce = programs(Some("XFCE"), None);
+        assert_eq!(xfce.first(), Some(&"xfce4-notifyd-config"));
+        assert_eq!(xfce.len(), 7);
+        assert!(xfce[1..].contains(&"gnome-control-center"));
+    }
+
+    #[test]
+    fn no_alias_is_a_prefix_of_another_desktops_alias() {
+        // Guards the prefix matching in `matches`: adding an alias that is a
+        // prefix of another desktop's would silently mis-route.
+        let aliases: Vec<&str> = DESKTOPS.iter().flat_map(|(a, _)| a.iter().copied()).collect();
+        for (i, a) in aliases.iter().enumerate() {
+            for (j, b) in aliases.iter().enumerate() {
+                assert!(i == j || !b.starts_with(a), "alias {a:?} is a prefix of {b:?}");
+            }
+        }
+    }
+}

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.test.tsx
@@ -104,6 +104,39 @@ describe('NotificationsSettings — system notification settings link', () => {
     )
   })
 
+  it('reports the failure in the UI when no OS settings pane could be opened', async () => {
+    // Regression (#1072): on non-GNOME Linux the native command fails with
+    // ENOENT and the error died in console.error, so the button did nothing at
+    // all from the user's side. The failure must now be visible.
+    render(<NotificationsSettings />)
+    const link = await screen.findByRole('button', { name: LINK })
+    // Reject the click, not the initial permission probe that already ran.
+    mockInvoke.mockRejectedValueOnce(new Error('no notification settings command available'))
+
+    fireEvent.click(link)
+
+    expect(
+      await screen.findByText('settings.openSystemNotificationSettingsFailed'),
+    ).toBeInTheDocument()
+  })
+
+  it('clears a previous failure message when a later attempt succeeds', async () => {
+    render(<NotificationsSettings />)
+    const link = await screen.findByRole('button', { name: LINK })
+    mockInvoke.mockRejectedValueOnce(new Error('no notification settings command available'))
+
+    fireEvent.click(link)
+    await screen.findByText('settings.openSystemNotificationSettingsFailed')
+
+    fireEvent.click(link)
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('settings.openSystemNotificationSettingsFailed'),
+      ).not.toBeInTheDocument(),
+    )
+  })
+
   it('hides the link while permission was never requested (macOS default), offering Enable instead', async () => {
     mockPermState = 'default'
 

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -37,15 +37,21 @@ async function checkNotificationPermission(): Promise<NotificationStatus> {
   }
 }
 
-async function openNotificationSettings(): Promise<void> {
+/** Returns false when the OS pane could not be opened, so the UI can say so. */
+async function openNotificationSettings(): Promise<boolean> {
   try {
     // Go through a native command rather than the shell/opener plugins: their
     // default scopes reject custom URL schemes (x-apple.systempreferences:,
     // ms-settings:), and Linux needs a control-center invocation, not a URL.
     const { invoke } = await import('@tauri-apps/api/core')
     await invoke('open_notification_settings')
+    return true
   } catch (error) {
+    // Linux has no single control center: the command tries each desktop's
+    // settings binary and fails when none is installed. Swallowing that left
+    // the button silently dead (#1072), so the caller surfaces it.
     console.error('[Settings] Failed to open notification settings:', error)
+    return false
   }
 }
 
@@ -100,6 +106,7 @@ export function NotificationsSettings() {
   const [notificationStatus, setNotificationStatus] = useState<NotificationStatus>('checking')
   const [isMac, setIsMac] = useState(false)
   const [disabling, setDisabling] = useState(false)
+  const [openSettingsFailed, setOpenSettingsFailed] = useState(false)
 
   useEffect(() => {
     void isMacOSDesktop().then(setIsMac)
@@ -136,6 +143,10 @@ export function NotificationsSettings() {
   const handleRequestPermission = async () => {
     await requestNotificationPermission()
     setNotificationStatus(await checkNotificationPermission())
+  }
+
+  const handleOpenNotificationSettings = async () => {
+    setOpenSettingsFailed(!(await openNotificationSettings()))
   }
 
   const handleDisableWebPush = async () => {
@@ -214,13 +225,22 @@ export function NotificationsSettings() {
               is the correct first action. */}
           {isTauri() &&
             (notificationStatus === 'granted' || notificationStatus === 'denied') && (
-              <button
-                onClick={openNotificationSettings}
-                className="flex items-center gap-1.5 text-xs text-fluux-brand hover:text-fluux-text transition-colors"
-              >
-                <ExternalLink className="size-3.5" />
-                {t('settings.openSystemNotificationSettings')}
-              </button>
+              <>
+                <button
+                  onClick={handleOpenNotificationSettings}
+                  className="flex items-center gap-1.5 text-xs text-fluux-brand hover:text-fluux-text transition-colors"
+                >
+                  <ExternalLink className="size-3.5" />
+                  {t('settings.openSystemNotificationSettings')}
+                </button>
+                {/* Linux desktops without a known settings binary: say so
+                    rather than leaving the click with no visible effect. */}
+                {openSettingsFailed && (
+                  <p role="status" className="text-xs text-fluux-red">
+                    {t('settings.openSystemNotificationSettingsFailed')}
+                  </p>
+                )}
+              </>
             )}
         </div>
 

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -711,6 +711,7 @@
         "notificationDescriptionWeb": "تنبهك الإشعارات بالرسائل الجديدة عندما يكون التطبيق في الخلفية.",
         "requestPermission": "تفعيل",
         "openSystemNotificationSettings": "فتح إعدادات إشعارات النظام",
+        "openSystemNotificationSettingsFailed": "تعذّر فتح إعدادات إشعارات النظام. افتحها من إعدادات سطح المكتب لديك.",
         "webPushStatus": "إشعارات الويب الفورية",
         "webPush_unavailable": "غير مدعوم من الخادم",
         "webPush_available": "متاح, انقر للتفعيل",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Апавяшчэнні паведамляюць пра новыя паведамленні, калі дадатак у фоне.",
         "requestPermission": "Уключыць",
         "openSystemNotificationSettings": "Адкрыць сістэмныя налады апавяшчэнняў",
+        "openSystemNotificationSettingsFailed": "Не ўдалося адкрыць сістэмныя налады апавяшчэнняў. Адкрыйце іх у наладах працоўнага стала.",
         "webPushStatus": "Web push-апавяшчэнні",
         "webPush_unavailable": "Сервер не падтрымлівае",
         "webPush_available": "Даступна, націсніце, каб уключыць",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Известията ви уведомяват за нови съобщения, когато приложението е във фонов режим.",
         "requestPermission": "Активирай",
         "openSystemNotificationSettings": "Отвори системните настройки за известия",
+        "openSystemNotificationSettingsFailed": "Системните настройки за известия не можаха да бъдат отворени. Отворете ги от настройките на работния плот.",
         "webPushStatus": "Уеб push известия",
         "webPush_unavailable": "Не се поддържа от сървъра",
         "webPush_available": "Налично, натиснете за активиране",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "Les notificacions t'avisen de missatges nous quan l'aplicació està en segon pla.",
         "requestPermission": "Activa",
         "openSystemNotificationSettings": "Obre la configuració de notificacions del sistema",
+        "openSystemNotificationSettingsFailed": "No s'ha pogut obrir la configuració de notificacions del sistema. Obriu-la des de la configuració del vostre escriptori.",
         "webPushStatus": "Notificacions push web",
         "webPush_unavailable": "No compatible amb el servidor",
         "webPush_available": "Disponible, toca per activar",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -711,6 +711,7 @@
         "notificationDescriptionWeb": "Oznámení vás upozorní na nové zprávy, když je aplikace na pozadí.",
         "requestPermission": "Povolit",
         "openSystemNotificationSettings": "Otevřít systémové nastavení oznámení",
+        "openSystemNotificationSettingsFailed": "Systémové nastavení oznámení se nepodařilo otevřít. Otevřete je v nastavení svého prostředí.",
         "webPushStatus": "Webová push oznámení",
         "webPush_unavailable": "Server nepodporuje",
         "webPush_available": "K dispozici, klepněte pro aktivaci",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Notifikationer advarer dig om nye beskeder, når appen er i baggrunden.",
         "requestPermission": "Aktiver",
         "openSystemNotificationSettings": "Åbn systemets notifikationsindstillinger",
+        "openSystemNotificationSettingsFailed": "Systemets notifikationsindstillinger kunne ikke åbnes. Åbn dem via indstillingerne for dit skrivebord.",
         "webPushStatus": "Web-pushnotifikationer",
         "webPush_unavailable": "Ikke understøttet af serveren",
         "webPush_available": "Tilgængelig, tryk for at aktivere",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Benachrichtigungen informieren Sie über neue Nachrichten, wenn die App im Hintergrund ist.",
         "requestPermission": "Aktivieren",
         "openSystemNotificationSettings": "Systemeinstellungen für Benachrichtigungen öffnen",
+        "openSystemNotificationSettingsFailed": "Die Systemeinstellungen für Benachrichtigungen konnten nicht geöffnet werden. Bitte öffnen Sie sie über die Einstellungen Ihrer Arbeitsumgebung.",
         "webPushStatus": "Web-Push-Benachrichtigungen",
         "webPush_unavailable": "Vom Server nicht unterstützt",
         "webPush_available": "Verfügbar, tippen zum Aktivieren",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -708,6 +708,7 @@
         "notificationDescriptionWeb": "Οι ειδοποιήσεις σας ειδοποιούν για νέα μηνύματα όταν η εφαρμογή είναι στο παρασκήνιο.",
         "requestPermission": "Ενεργοποίηση",
         "openSystemNotificationSettings": "Άνοιγμα ρυθμίσεων ειδοποιήσεων συστήματος",
+        "openSystemNotificationSettingsFailed": "Δεν ήταν δυνατό το άνοιγμα των ρυθμίσεων ειδοποιήσεων συστήματος. Ανοίξτε τις από τις ρυθμίσεις της επιφάνειας εργασίας σας.",
         "webPushStatus": "Ειδοποιήσεις web push",
         "webPush_unavailable": "Δεν υποστηρίζεται από τον διακομιστή",
         "webPush_available": "Διαθέσιμο, πατήστε για ενεργοποίηση",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -899,6 +899,7 @@
         "notificationDescriptionWeb": "Notifications alert you to new messages when the app is in the background.",
         "requestPermission": "Enable",
         "openSystemNotificationSettings": "Open system notification settings",
+        "openSystemNotificationSettingsFailed": "Could not open the system notification settings. Please open them from your desktop settings.",
         "webPushStatus": "Web Push Notifications",
         "webPush_unavailable": "Not supported by server",
         "webPush_available": "Available, tap to enable",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "Las notificaciones te alertan de nuevos mensajes cuando la aplicacion esta en segundo plano.",
         "requestPermission": "Activar",
         "openSystemNotificationSettings": "Abrir los ajustes de notificaciones del sistema",
+        "openSystemNotificationSettingsFailed": "No se han podido abrir los ajustes de notificaciones del sistema. Ábrelos desde los ajustes de tu escritorio.",
         "webPushStatus": "Notificaciones push web",
         "webPush_unavailable": "No compatible con el servidor",
         "webPush_available": "Disponible, toca para activar",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Teavitused hoiatavad sind uute sõnumite eest, kui rakendus on taustal.",
         "requestPermission": "Luba",
         "openSystemNotificationSettings": "Ava süsteemi teavituste seaded",
+        "openSystemNotificationSettingsFailed": "Süsteemi teavituste sätteid ei õnnestunud avada. Ava need oma töölaua sätetest.",
         "webPushStatus": "Veebi push-teavitused",
         "webPush_unavailable": "Server ei toeta",
         "webPush_available": "Saadaval, puuduta lubamiseks",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Ilmoitukset hälyttävät uusista viesteistä, kun sovellus on taustalla.",
         "requestPermission": "Ota käyttöön",
         "openSystemNotificationSettings": "Avaa järjestelmän ilmoitusasetukset",
+        "openSystemNotificationSettingsFailed": "Järjestelmän ilmoitusasetuksia ei voitu avata. Avaa ne työpöytäsi asetuksista.",
         "webPushStatus": "Web-push-ilmoitukset",
         "webPush_unavailable": "Palvelin ei tue tätä",
         "webPush_available": "Käytettävissä, ota käyttöön napauttamalla",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -738,6 +738,7 @@
         "notificationDescriptionWeb": "Les notifications vous alertent des nouveaux messages lorsque l'application est en arrière-plan.",
         "requestPermission": "Activer",
         "openSystemNotificationSettings": "Ouvrir les réglages de notification du système",
+        "openSystemNotificationSettingsFailed": "Impossible d'ouvrir les réglages de notification du système. Ouvrez-les depuis les réglages de votre bureau.",
         "webPushStatus": "Notifications Web Push",
         "webPush_unavailable": "Non supporté par le serveur",
         "webPush_available": "Disponible, appuyez pour activer",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "Cuireann fógraí ar an eolas thú faoi theachtaireachtaí nua nuair atá an aip sa chúlra.",
         "requestPermission": "Cumasaigh",
         "openSystemNotificationSettings": "Oscail socruithe fógraí an chórais",
+        "openSystemNotificationSettingsFailed": "Níorbh fhéidir socruithe fógraí an chórais a oscailt. Oscail iad ó shocruithe do dheasca.",
         "webPushStatus": "Fógraí brú gréasáin",
         "webPush_unavailable": "Ní thacaíonn an freastalaí leis",
         "webPush_available": "Ar fáil, tapáil le cumasú",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -708,6 +708,7 @@
         "notificationDescriptionWeb": "התראות מתריעות על הודעות חדשות כשהאפליקציה ברקע.",
         "requestPermission": "אפשר",
         "openSystemNotificationSettings": "פתח את הגדרות ההתראות של המערכת",
+        "openSystemNotificationSettingsFailed": "לא ניתן היה לפתוח את הגדרות ההתראות של המערכת. פתח אותן מהגדרות שולחן העבודה שלך.",
         "webPushStatus": "התראות Web Push",
         "webPush_unavailable": "לא נתמך על ידי השרת",
         "webPush_available": "זמין - לחץ להפעלה",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -708,6 +708,7 @@
         "notificationDescriptionWeb": "Obavijesti vas upozoravaju na nove poruke kada je aplikacija u pozadini.",
         "requestPermission": "Omogući",
         "openSystemNotificationSettings": "Otvori postavke obavijesti sustava",
+        "openSystemNotificationSettingsFailed": "Sustavske postavke obavijesti nije moguće otvoriti. Otvorite ih u postavkama svoje radne površine.",
         "webPushStatus": "Web push obavijesti",
         "webPush_unavailable": "Poslužitelj ne podržava",
         "webPush_available": "Dostupno, dodirnite za omogućavanje",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Az értesítések figyelmeztetik az új üzenetekre, amikor az alkalmazás a háttérben fut.",
         "requestPermission": "Engedélyezés",
         "openSystemNotificationSettings": "Rendszerértesítési beállítások megnyitása",
+        "openSystemNotificationSettingsFailed": "A rendszerértesítési beállítások megnyitása nem sikerült. Nyissa meg őket az asztali környezet beállításaiban.",
         "webPushStatus": "Webes push értesítések",
         "webPush_unavailable": "A szerver nem támogatja",
         "webPush_available": "Elérhető, érintse meg az aktiváláshoz",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Tilkynningar láta þig vita af nýjum skilaboðum þegar forritið er í bakgrunni.",
         "requestPermission": "Virkja",
         "openSystemNotificationSettings": "Opna tilkynningastillingar kerfisins",
+        "openSystemNotificationSettingsFailed": "Ekki tókst að opna tilkynningastillingar kerfisins. Opnaðu þær í stillingum skjáborðsins.",
         "webPushStatus": "Vef push-tilkynningar",
         "webPush_unavailable": "Ekki stutt af þjóni",
         "webPush_available": "Tiltækt, ýttu til að virkja",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "Le notifiche ti avvisano dei nuovi messaggi quando l'app e in background.",
         "requestPermission": "Attiva",
         "openSystemNotificationSettings": "Apri le impostazioni di notifica del sistema",
+        "openSystemNotificationSettingsFailed": "Impossibile aprire le impostazioni di notifica del sistema. Aprile dalle impostazioni della tua scrivania.",
         "webPushStatus": "Notifiche push web",
         "webPush_unavailable": "Non supportato dal server",
         "webPush_available": "Disponibile, tocca per attivare",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Pranešimai įspėja apie naujas žinutes, kai programa veikia fone.",
         "requestPermission": "Įjungti",
         "openSystemNotificationSettings": "Atidaryti sistemos pranešimų nustatymus",
+        "openSystemNotificationSettingsFailed": "Nepavyko atidaryti sistemos pranešimų nustatymų. Atidarykite juos savo darbalaukio nustatymuose.",
         "webPushStatus": "Žiniatinklio push pranešimai",
         "webPush_unavailable": "Serveris nepalaiko",
         "webPush_available": "Galima, bakstelėkite, kad įjungtumėte",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Paziņojumi brīdina par jauniem ziņojumiem, kad lietotne ir fonā.",
         "requestPermission": "Iespējot",
         "openSystemNotificationSettings": "Atvērt sistēmas paziņojumu iestatījumus",
+        "openSystemNotificationSettingsFailed": "Neizdevās atvērt sistēmas paziņojumu iestatījumus. Atveriet tos savas darbvirsmas iestatījumos.",
         "webPushStatus": "Tīmekļa push paziņojumi",
         "webPush_unavailable": "Serveris neatbalsta",
         "webPush_available": "Pieejams, pieskarieties, lai iespējotu",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -712,6 +712,7 @@
         "notificationDescriptionWeb": "In-notifiki jallertak għal messaġġi ġodda meta l-app tkun fil-background.",
         "requestPermission": "Ixgħel",
         "openSystemNotificationSettings": "Iftaħ is-settings tan-notifiki tas-sistema",
+        "openSystemNotificationSettingsFailed": "Ma setgħux jinfetħu s-settings tan-notifiki tas-sistema. Iftaħhom mis-settings tad-desktop tiegħek.",
         "webPushStatus": "Notifiki Web Push",
         "webPush_unavailable": "Mhux appoġġjat mis-server",
         "webPush_available": "Disponibbli, miss biex tixgħel",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Varsler gir deg beskjed om nye meldinger når appen er i bakgrunnen.",
         "requestPermission": "Aktiver",
         "openSystemNotificationSettings": "Åpne systemets varslingsinnstillinger",
+        "openSystemNotificationSettingsFailed": "Kunne ikke åpne systemets varslingsinnstillinger. Åpne dem fra innstillingene for skrivebordet ditt.",
         "webPushStatus": "Web-pushvarsler",
         "webPush_unavailable": "Ikke støttet av serveren",
         "webPush_available": "Tilgjengelig, trykk for å aktivere",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Meldingen waarschuwen je voor nieuwe berichten wanneer de app op de achtergrond staat.",
         "requestPermission": "Inschakelen",
         "openSystemNotificationSettings": "Systeeminstellingen voor meldingen openen",
+        "openSystemNotificationSettingsFailed": "De systeeminstellingen voor meldingen konden niet worden geopend. Open ze via de instellingen van je bureaublad.",
         "webPushStatus": "Web-pushmeldingen",
         "webPush_unavailable": "Niet ondersteund door server",
         "webPush_available": "Beschikbaar, tik om in te schakelen",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -711,6 +711,7 @@
         "notificationDescriptionWeb": "Powiadomienia alertują o nowych wiadomościach, gdy aplikacja jest w tle.",
         "requestPermission": "Włącz",
         "openSystemNotificationSettings": "Otwórz systemowe ustawienia powiadomień",
+        "openSystemNotificationSettingsFailed": "Nie można otworzyć systemowych ustawień powiadomień. Otwórz je w ustawieniach swojego pulpitu.",
         "webPushStatus": "Powiadomienia web push",
         "webPush_unavailable": "Nieobsługiwane przez serwer",
         "webPush_available": "Dostępne, dotknij, aby włączyć",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "As notificações alertam-no para novas mensagens quando a aplicação está em segundo plano.",
         "requestPermission": "Ativar",
         "openSystemNotificationSettings": "Abrir as definições de notificações do sistema",
+        "openSystemNotificationSettingsFailed": "Não foi possível abrir as definições de notificações do sistema. Abra-as nas definições do seu ambiente de trabalho.",
         "webPushStatus": "Notificações push web",
         "webPush_unavailable": "Não suportado pelo servidor",
         "webPush_available": "Disponível, toque para ativar",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "Notificările te alertează despre mesaje noi când aplicația este în fundal.",
         "requestPermission": "Activează",
         "openSystemNotificationSettings": "Deschide setările de notificări ale sistemului",
+        "openSystemNotificationSettingsFailed": "Setările de notificări ale sistemului nu au putut fi deschise. Deschideți-le din setările desktopului.",
         "webPushStatus": "Notificări push web",
         "webPush_unavailable": "Nu este suportat de server",
         "webPush_available": "Disponibil, atinge pentru activare",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Уведомления оповещают о новых сообщениях, когда приложение свёрнуто.",
         "requestPermission": "Включить",
         "openSystemNotificationSettings": "Открыть системные настройки уведомлений",
+        "openSystemNotificationSettingsFailed": "Не удалось открыть системные настройки уведомлений. Откройте их в настройках рабочего стола.",
         "webPushStatus": "Web push-уведомления",
         "webPush_unavailable": "Не поддерживается сервером",
         "webPush_available": "Доступно, нажмите для включения",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -710,6 +710,7 @@
         "notificationDescriptionWeb": "Oznámenia vás upozornia na nové správy, keď je aplikácia na pozadí.",
         "requestPermission": "Povoliť",
         "openSystemNotificationSettings": "Otvoriť systémové nastavenia oznámení",
+        "openSystemNotificationSettingsFailed": "Systémové nastavenia oznámení sa nepodarilo otvoriť. Otvorte ich v nastaveniach svojho prostredia.",
         "webPushStatus": "Webové push notifikácie",
         "webPush_unavailable": "Server nepodporuje",
         "webPush_available": "K dispozícii, ťuknite pre aktiváciu",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -711,6 +711,7 @@
         "notificationDescriptionWeb": "Obvestila vas opozorijo na nova sporočila, ko je aplikacija v ozadju.",
         "requestPermission": "Omogoči",
         "openSystemNotificationSettings": "Odpri sistemske nastavitve obvestil",
+        "openSystemNotificationSettingsFailed": "Sistemskih nastavitev obvestil ni bilo mogoče odpreti. Odprite jih v nastavitvah svojega namizja.",
         "webPushStatus": "Spletna push obvestila",
         "webPush_unavailable": "Strežnik ne podpira",
         "webPush_available": "Na voljo, tapnite za vklop",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "Aviseringar meddelar dig om nya meddelanden när appen är i bakgrunden.",
         "requestPermission": "Aktivera",
         "openSystemNotificationSettings": "Öppna systemets aviseringsinställningar",
+        "openSystemNotificationSettingsFailed": "Det gick inte att öppna systemets aviseringsinställningar. Öppna dem från skrivbordets inställningar.",
         "webPushStatus": "Webb-pushnotiser",
         "webPush_unavailable": "Stöds inte av servern",
         "webPush_available": "Tillgängligt, tryck för att aktivera",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -709,6 +709,7 @@
         "notificationDescriptionWeb": "Сповіщення повідомляють про нові повідомлення, коли додаток у фоні.",
         "requestPermission": "Увімкнути",
         "openSystemNotificationSettings": "Відкрити системні налаштування сповіщень",
+        "openSystemNotificationSettingsFailed": "Не вдалося відкрити системні налаштування сповіщень. Відкрийте їх у налаштуваннях робочого столу.",
         "webPushStatus": "Web push-сповіщення",
         "webPush_unavailable": "Сервер не підтримує",
         "webPush_available": "Доступно, натисніть, щоб увімкнути",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -707,6 +707,7 @@
         "notificationDescriptionWeb": "当应用在后台时，通知会提醒您有新消息。",
         "requestPermission": "启用",
         "openSystemNotificationSettings": "打开系统通知设置",
+        "openSystemNotificationSettingsFailed": "无法打开系统通知设置。请从桌面环境的设置中打开。",
         "webPushStatus": "网页推送通知",
         "webPush_unavailable": "服务器不支持",
         "webPush_available": "可用，点击即可启用",


### PR DESCRIPTION
Fixes #1072.

`open_notification_settings` hardcoded `gnome-control-center`, so on Cinnamon, KDE, XFCE, Budgie and LXQt the spawn failed with `ENOENT` and the caller only logged it — the button did nothing at all. It is always visible on Linux, since the notification plugin reports permission as `granted` unconditionally on desktop.

The desktop is now detected from `XDG_CURRENT_DESKTOP` (colon-separated, case-insensitive, `X-` prefixed) with a `DESKTOP_SESSION` fallback. Its command is tried first, followed by every other known one: the env var names the desktop but does not promise its binary is installed, so a failed spawn only means "not this one". Match order follows token order rather than table order, because the spec lists the most specific desktop first — Budgie ships `Budgie:GNOME` and must not land on GNOME's pane.

When every candidate fails, the command reports it and the settings panel shows a message instead of silently doing nothing (new string translated across all 33 locales).

Platform dispatch moves out of `main.rs` into `notifications::settings_pane`, where candidate selection is a pure function unit-tested on every platform (11 tests), following the `linux_tray.rs` precedent.