### PR TITLE
fix(notifications): stop losing the user's read position (#1076)

### DIFF
--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -32,6 +32,7 @@ import { MediaAutoloadProvider } from '@/contexts'
 import { computeMediaAutoload } from '@/utils/mediaAutoload'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { auroraSenderColor } from '@/utils/senderColor'
+import { registerViewportBottomRef } from '@/utils/viewportAtBottom'
 import { ReactionMentions } from './conversation/ReactionMentions'
 import { reactionMentionStore } from '@/stores/reactionMentionStore'
 import { EasterEggMentions } from './conversation/EasterEggMentions'
@@ -155,6 +156,16 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   // Scroll ref for programmatic scrolling and keyboard navigation
   const scrollRef = useRef<HTMLElement>(null)
   const isAtBottomRef = useRef(true)
+
+  // Publish the viewport-at-bottom truth so the global focus handler can tell a
+  // genuine "user is looking at the newest message" from a view merely parked at
+  // the live edge (issue #1076). Registers the ref object, so the scroll hook's
+  // many writes to `.current` need no notification.
+  useEffect(() => {
+    const id = activeConversation?.id
+    if (!id) return
+    return registerViewportBottomRef('conversation', id, isAtBottomRef)
+  }, [activeConversation?.id])
 
   // Scroll to bottom (used after sending a message)
   const scrollToBottom = useCallback(() => {

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -41,6 +41,7 @@ import { computeMediaAutoload } from '@/utils/mediaAutoload'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { getRoomJoinErrorMessage } from '@/utils/roomJoinError'
 import { auroraSenderColor, nickColorSeed } from '@/utils/senderColor'
+import { registerViewportBottomRef } from '@/utils/viewportAtBottom'
 import { ReactionMentions } from './conversation/ReactionMentions'
 import { reactionMentionStore } from '@/stores/reactionMentionStore'
 import { EasterEggMentions } from './conversation/EasterEggMentions'
@@ -255,6 +256,15 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // Scroll ref for programmatic scrolling and keyboard navigation
   const scrollRef = useRef<HTMLElement>(null)
   const isAtBottomRef = useRef(true)
+
+  // Publish the viewport-at-bottom truth so the global focus handler can tell a
+  // genuine "user is looking at the newest message" from a view merely parked at
+  // the live edge (issue #1076). Registers the ref object, so the scroll hook's
+  // many writes to `.current` need no notification.
+  useEffect(() => {
+    if (!activeRoomJid) return
+    return registerViewportBottomRef('room', activeRoomJid, isAtBottomRef)
+  }, [activeRoomJid])
 
   // Composer handle ref for focusing after staging attachment
   const composerHandleRef = useRef<MessageComposerHandle>(null)

--- a/apps/fluux/src/hooks/useWindowVisibility.test.tsx
+++ b/apps/fluux/src/hooks/useWindowVisibility.test.tsx
@@ -21,6 +21,10 @@ vi.mock('@fluux/sdk', () => ({
 vi.mock('@/utils/dismissNotification', () => ({ dismissNotification }))
 
 import { useWindowVisibility } from './useWindowVisibility'
+import { registerViewportBottomRef, _resetViewportRegistryForTesting } from '@/utils/viewportAtBottom'
+
+const CONV = 'alice@example.com'
+const ROOM = 'team@conf.example.com'
 
 describe('useWindowVisibility', () => {
   beforeEach(() => {
@@ -29,24 +33,75 @@ describe('useWindowVisibility', () => {
     state.activeConversationId = null
     state.activeRoomJid = null
     vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    _resetViewportRegistryForTesting()
   })
 
   it('dismisses the active conversation notification on focus regain', () => {
-    state.activeConversationId = 'alice@example.com'
+    state.activeConversationId = CONV
     renderHook(() => useWindowVisibility())
-    expect(markConvRead).toHaveBeenCalledWith('alice@example.com')
-    expect(dismissNotification).toHaveBeenCalledWith('conversation', 'alice@example.com')
+    expect(dismissNotification).toHaveBeenCalledWith('conversation', CONV)
   })
 
   it('dismisses the active room notification on focus regain', () => {
-    state.activeRoomJid = 'team@conf.example.com'
+    state.activeRoomJid = ROOM
     renderHook(() => useWindowVisibility())
-    expect(markRoomRead).toHaveBeenCalledWith('team@conf.example.com')
-    expect(dismissNotification).toHaveBeenCalledWith('room', 'team@conf.example.com')
+    expect(dismissNotification).toHaveBeenCalledWith('room', ROOM)
   })
 
   it('does nothing when there is no active conversation or room', () => {
     renderHook(() => useWindowVisibility())
     expect(dismissNotification).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Focus regain is not evidence of reading (issue #1076).
+  //
+  // Gajim gates the same transition on view_is_at_bottom(); we gated it on
+  // windowAtLiveEdge, which is true for any backgrounded view parked at the
+  // tail. One alt-tab therefore marked a whole room read, advanced the read
+  // pointer to the newest message and destroyed the "new messages" divider.
+  // -------------------------------------------------------------------------
+
+  it('marks the active room read when the viewport is at the bottom', () => {
+    state.activeRoomJid = ROOM
+    registerViewportBottomRef('room', ROOM, { current: true })
+    renderHook(() => useWindowVisibility())
+    expect(markRoomRead).toHaveBeenCalledWith(ROOM)
+  })
+
+  it('does not mark the active room read when the viewport is scrolled up', () => {
+    state.activeRoomJid = ROOM
+    registerViewportBottomRef('room', ROOM, { current: false })
+    renderHook(() => useWindowVisibility())
+    expect(markRoomRead).not.toHaveBeenCalled()
+  })
+
+  it('marks the active conversation read when the viewport is at the bottom', () => {
+    state.activeConversationId = CONV
+    registerViewportBottomRef('conversation', CONV, { current: true })
+    renderHook(() => useWindowVisibility())
+    expect(markConvRead).toHaveBeenCalledWith(CONV)
+  })
+
+  it('does not mark the active conversation read when the viewport is scrolled up', () => {
+    state.activeConversationId = CONV
+    registerViewportBottomRef('conversation', CONV, { current: false })
+    renderHook(() => useWindowVisibility())
+    expect(markConvRead).not.toHaveBeenCalled()
+  })
+
+  it('does not mark read when no viewport is registered for the active view', () => {
+    state.activeRoomJid = ROOM
+    renderHook(() => useWindowVisibility())
+    expect(markRoomRead).not.toHaveBeenCalled()
+  })
+
+  it('reads the ref live, so a scroll after registration is respected', () => {
+    state.activeRoomJid = ROOM
+    const ref = { current: true }
+    registerViewportBottomRef('room', ROOM, ref)
+    ref.current = false // user scrolled up before refocusing
+    renderHook(() => useWindowVisibility())
+    expect(markRoomRead).not.toHaveBeenCalled()
   })
 })

--- a/apps/fluux/src/hooks/useWindowVisibility.ts
+++ b/apps/fluux/src/hooks/useWindowVisibility.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { connectionStore, chatStore, roomStore } from '@fluux/sdk'
 import { dismissNotification } from '@/utils/dismissNotification'
+import { isViewportAtBottom } from '@/utils/viewportAtBottom'
 
 /**
  * Hook to track window focus and update the SDK store.
@@ -24,16 +25,31 @@ export function useWindowVisibility(): void {
       // Update store directly without going through React state
       connectionStore.getState().setWindowVisible(isFocused)
 
-      // When window becomes visible again, mark active entities as read
+      // When the window regains focus, mark active entities as read — but ONLY when
+      // their viewport is actually showing the newest message (issue #1076).
+      //
+      // Focusing the app is not evidence of reading: the last-open view is usually
+      // just whatever was open when the user left. markAsRead advances the read
+      // pointer to the live edge, which drops the "new messages" divider and gets
+      // published over XEP-0490, so an unconditional call here silently discards a
+      // read position the user never caught up to. Gajim gates the same transition
+      // on view_is_at_bottom(); this is that gate.
+      //
+      // The notification dismissal stays unconditional — the user IS at the app now,
+      // so the OS-level alert has served its purpose either way.
       if (!wasFocused && isFocused) {
         const activeConversationId = chatStore.getState().activeConversationId
         if (activeConversationId) {
-          chatStore.getState().markAsRead(activeConversationId)
+          if (isViewportAtBottom('conversation', activeConversationId)) {
+            chatStore.getState().markAsRead(activeConversationId)
+          }
           void dismissNotification('conversation', activeConversationId)
         }
         const activeRoomJid = roomStore.getState().activeRoomJid
         if (activeRoomJid) {
-          roomStore.getState().markAsRead(activeRoomJid)
+          if (isViewportAtBottom('room', activeRoomJid)) {
+            roomStore.getState().markAsRead(activeRoomJid)
+          }
           void dismissNotification('room', activeRoomJid)
         }
       }

--- a/apps/fluux/src/utils/viewportAtBottom.test.ts
+++ b/apps/fluux/src/utils/viewportAtBottom.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  registerViewportBottomRef,
+  isViewportAtBottom,
+  _resetViewportRegistryForTesting,
+} from './viewportAtBottom'
+
+const ROOM = 'team@conf.example.com'
+const CONV = 'alice@example.com'
+
+describe('viewportAtBottom', () => {
+  beforeEach(() => {
+    _resetViewportRegistryForTesting()
+  })
+
+  // A read position must never be invented for a view we cannot see. An unknown
+  // id is the state during mount, after unmount, and for every backgrounded view.
+  it('reports false for an unregistered view', () => {
+    expect(isViewportAtBottom('room', ROOM)).toBe(false)
+  })
+
+  it('reads the ref live rather than snapshotting at registration', () => {
+    const ref = { current: true }
+    registerViewportBottomRef('room', ROOM, ref)
+    expect(isViewportAtBottom('room', ROOM)).toBe(true)
+
+    // The scroll hook mutates .current from many call sites and notifies nobody.
+    ref.current = false
+    expect(isViewportAtBottom('room', ROOM)).toBe(false)
+  })
+
+  it('stops reporting once the view unregisters', () => {
+    const unregister = registerViewportBottomRef('room', ROOM, { current: true })
+    unregister()
+    expect(isViewportAtBottom('room', ROOM)).toBe(false)
+  })
+
+  it('namespaces rooms and conversations that share an id', () => {
+    registerViewportBottomRef('room', 'shared@example.com', { current: true })
+    registerViewportBottomRef('conversation', 'shared@example.com', { current: false })
+
+    expect(isViewportAtBottom('room', 'shared@example.com')).toBe(true)
+    expect(isViewportAtBottom('conversation', 'shared@example.com')).toBe(false)
+  })
+
+  it('replaces the registration when a view remounts', () => {
+    registerViewportBottomRef('room', ROOM, { current: false })
+    registerViewportBottomRef('room', ROOM, { current: true })
+    expect(isViewportAtBottom('room', ROOM)).toBe(true)
+  })
+
+  // React runs the new effect before the old cleanup on a remount. A naive
+  // delete would then drop the LIVE registration and silently disable the gate.
+  it('ignores a stale unregister after a remount replaced the ref', () => {
+    const staleUnregister = registerViewportBottomRef('room', ROOM, { current: false })
+    registerViewportBottomRef('room', ROOM, { current: true })
+
+    staleUnregister()
+
+    expect(isViewportAtBottom('room', ROOM)).toBe(true)
+  })
+
+  it('keeps other views registered when one unregisters', () => {
+    registerViewportBottomRef('room', ROOM, { current: true })
+    const unregisterConv = registerViewportBottomRef('conversation', CONV, { current: true })
+
+    unregisterConv()
+
+    expect(isViewportAtBottom('conversation', CONV)).toBe(false)
+    expect(isViewportAtBottom('room', ROOM)).toBe(true)
+  })
+})

--- a/apps/fluux/src/utils/viewportAtBottom.ts
+++ b/apps/fluux/src/utils/viewportAtBottom.ts
@@ -1,0 +1,55 @@
+/**
+ * Viewport-at-bottom registry.
+ *
+ * `windowAtLiveEdge` (SDK) says where the *loaded message window* sits; it is true
+ * for any backgrounded conversation parked at the tail, because that is how the
+ * window is built. It is therefore NOT evidence that the user saw anything.
+ *
+ * The only real evidence is the scroll viewport: is the newest message actually on
+ * screen? That truth lives in `isAtBottomRef`, a ref owned by ChatView/RoomView and
+ * maintained by `useMessageListScroll`. `useWindowVisibility` is a global hook with
+ * no access to it, so the views register their ref here and it reads it on focus
+ * regain — mirroring Gajim's `view_is_at_bottom()` gate on the same transition.
+ *
+ * The ref OBJECT is registered, not its value: the scroll hook mutates
+ * `.current` from ~24 call sites, and reading through the ref means none of them
+ * need to notify anyone.
+ *
+ * Unknown id → `false`. A read position must never be invented for a view we
+ * cannot see.
+ */
+
+export type ViewportKind = 'conversation' | 'room'
+
+interface BooleanRef {
+  current: boolean
+}
+
+const refs = new Map<string, BooleanRef>()
+
+function key(kind: ViewportKind, id: string): string {
+  return `${kind}:${id}`
+}
+
+/**
+ * Register a view's at-bottom ref. Returns an unregister function for effect
+ * cleanup. Re-registering the same key replaces the previous ref (view remount).
+ */
+export function registerViewportBottomRef(kind: ViewportKind, id: string, ref: BooleanRef): () => void {
+  const k = key(kind, id)
+  refs.set(k, ref)
+  return () => {
+    // Only drop it if we still own the slot — a remount may have replaced it.
+    if (refs.get(k) === ref) refs.delete(k)
+  }
+}
+
+/** Is this view's viewport currently showing the newest message? */
+export function isViewportAtBottom(kind: ViewportKind, id: string): boolean {
+  return refs.get(key(kind, id))?.current ?? false
+}
+
+/** Test-only: drop all registrations. */
+export function _resetViewportRegistryForTesting(): void {
+  refs.clear()
+}

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -132,6 +132,22 @@ function addConversation(id: string): void {
   chatStore.getState().addConversation({ id, name: id, type: 'chat', unreadCount: 0 })
 }
 
+/** Force a conversation's MAM query state (catch-up gate input). */
+function setConvMamState(cid: string, patch: Partial<{ isLoading: boolean; hasQueried: boolean; isCaughtUpToLive: boolean }>): void {
+  chatStore.setState((state) => {
+    const next = new Map(state.mamQueryStates)
+    next.set(cid, {
+      isLoading: false,
+      hasQueried: false,
+      error: null,
+      isHistoryComplete: false,
+      isCaughtUpToLive: false,
+      ...patch,
+    } as never)
+    return { mamQueryStates: next }
+  })
+}
+
 describe('setupMdsSideEffects', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -567,6 +583,88 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(client.mds.retractDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Catch-up gate — Gajim's `if not MAM.is_catch_up_finished(contact): return`.
+//
+// Publishing a read position derived from a half-downloaded archive broadcasts a
+// wrong "read up to here" to every other device, and MDS positions are
+// forward-only — the real position is then unrecoverable. Wait until the archive
+// for that entity is actually caught up before speaking for the user.
+// ---------------------------------------------------------------------------
+
+describe('setupMdsSideEffects catch-up gate', () => {
+  const cid = 'juliet@capulet.example'
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    connectionStore.getState().reset()
+    chatStore.getState().reset()
+    roomStore.getState().reset()
+    localStorageMock.clear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  async function armed() {
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    seedMeta(cid, 'm1')
+    return { client, cleanup }
+  }
+
+  it('does not publish while a MAM query is still in flight', async () => {
+    const { client, cleanup } = await armed()
+    setConvMamState(cid, { isLoading: true, hasQueried: true })
+
+    chatStore.getState().updateLastSeenMessageId(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('does not publish when the archive was queried but is not caught up to live', async () => {
+    const { client, cleanup } = await armed()
+    setConvMamState(cid, { hasQueried: true, isCaughtUpToLive: false })
+
+    chatStore.getState().updateLastSeenMessageId(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('publishes once the archive is caught up to live', async () => {
+    const { client, cleanup } = await armed()
+    setConvMamState(cid, { hasQueried: true, isCaughtUpToLive: true })
+
+    chatStore.getState().updateLastSeenMessageId(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    cleanup()
+  })
+
+  // No-regression guarantee: an entity that never ran a MAM query (a conversation
+  // created live, mid-session) has no incomplete archive to misreport, so the gate
+  // must not silence it — that would break read sync for new conversations.
+  it('publishes for an entity that has never run a MAM query', async () => {
+    const { client, cleanup } = await armed()
+
+    chatStore.getState().updateLastSeenMessageId(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })
 })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -166,6 +166,13 @@ export function setupMdsSideEffects(
       // below) or a redundant re-enqueue. The local marker is forward-only, so
       // re-asserting a value the node already has is always pointless.
       if (lastKnownNodeStanzaId.get(jid) === stanzaId) continue
+      // Re-check the catch-up gate at FLUSH time, not just at enqueue: the
+      // debounce window is long enough for a catch-up to start after the
+      // position was buffered, and it is the publish itself that must never
+      // speak from a partial archive. Dropping the entry is safe — the local
+      // pointer lives in localStorage and is re-considered on the next advance
+      // or the next fresh-session seed.
+      if (!archiveIsTrustworthy(jid)) continue
       const by = stanzaIdBy(jid)
       if (!by) continue // own JID unknown (should not happen while online) — retry next advance
       try {
@@ -177,9 +184,34 @@ export function setupMdsSideEffects(
     }
   }
 
+  /**
+   * Is this entity's archive complete enough to speak for the user?
+   *
+   * Mirrors Gajim's `if not MAM.is_catch_up_finished(contact): return` guard.
+   * A read position derived mid-catch-up is computed against a partial window,
+   * and MDS positions are forward-only — publishing a wrong one makes every
+   * other device adopt it and leaves the real position unrecoverable.
+   *
+   * An entity that has NEVER been queried is allowed through: a conversation or
+   * room created live during the session has no half-downloaded archive to
+   * misreport, and gating it would silence read sync for new conversations
+   * entirely.
+   */
+  function archiveIsTrustworthy(jid: string): boolean {
+    const mam = isRoom(jid)
+      ? roomStore.getState().getRoomMAMQueryState(jid)
+      : chatStore.getState().getMAMQueryState(jid)
+    if (!mam.hasQueried && !mam.isLoading) return true // never queried — nothing partial
+    return !mam.isLoading && mam.isCaughtUpToLive
+  }
+
   /** Consider a conversation/room for publishing if its read position advanced. */
   function consider(jid: string): void {
     if (!syncEnabled) return
+    // Catch-up gate: never publish a position derived from a partial archive.
+    // Skipping is safe — localStorage holds the local pointer and the next
+    // advance (or the next fresh-session seed) re-considers it once caught up.
+    if (!archiveIsTrustworthy(jid)) return
 
     const seenId = isRoom(jid)
       ? roomStore.getState().roomMeta.get(jid)?.lastSeenMessageId

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { chatStore } from './chatStore'
+import { connectionStore } from './connectionStore'
 import { chatSelectors } from './chatSelectors'
 import type { Message } from '../core/types/chat'
 
@@ -795,5 +796,121 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBeUndefined()
     expect(chatSelectors.firstNewMessageIsProvisionalFor(cid)(chatStore.getState())).toBe(false)
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fresh-instance catch-up ordering (issue #1076) — twin of the roomStore case.
+//
+// A new instance has no local read state, so the marker from the client the user
+// left arrives before any message can resolve it and lands pending. The catch-up
+// merge recomputed counts first, and the fresh-entity guard snapped the pointer
+// to the newest message — past the marker, which the forward-only fold then
+// discarded.
+// ---------------------------------------------------------------------------
+
+describe('chatStore fresh-instance catch-up preserves the remote read position', () => {
+  const cid = 'juliet@capulet.example'
+
+  beforeEach(() => chatStore.getState().reset())
+
+  /** Register the conversation with NO read state at all (fresh instance). */
+  function seedFreshConversation(): void {
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0 })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0 })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+  }
+
+  const archive = () => Array.from({ length: 10 }, (_, i) => msg(`m${i + 1}`, `s${i + 1}`))
+
+  it('keeps the pointer at the marker instead of snapping to newest', () => {
+    seedFreshConversation()
+    chatStore.getState().applyRemoteDisplayed(cid, 's3') // nothing loaded → pending
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s3')
+
+    chatStore.getState().mergeMAMMessages(cid, archive(), {}, true, 'forward')
+
+    const meta = chatStore.getState().conversationMeta.get(cid)
+    expect(meta?.lastSeenMessageId).toBe('m3')
+    expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
+  })
+
+  it('counts the messages after the marker as unread', () => {
+    seedFreshConversation()
+    chatStore.getState().applyRemoteDisplayed(cid, 's3')
+
+    chatStore.getState().mergeMAMMessages(cid, archive(), {}, true, 'forward')
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.unreadCount).toBe(7)
+  })
+
+  // Control: no remote marker ⇒ a fresh conversation is still caught up.
+  it('still treats a fresh conversation with no remote marker as caught up', () => {
+    seedFreshConversation()
+
+    chatStore.getState().mergeMAMMessages(cid, archive(), {}, true, 'forward')
+
+    const meta = chatStore.getState().conversationMeta.get(cid)
+    expect(meta?.unreadCount).toBe(0)
+    expect(meta?.lastSeenMessageId).toBe('m10')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateLastSeenMessageId presence gate (issue #1076) — twin of the roomStore case.
+// ---------------------------------------------------------------------------
+
+describe('chatStore.updateLastSeenMessageId presence gate', () => {
+  const cid = 'juliet@capulet.example'
+
+  beforeEach(() => {
+    chatStore.getState().reset()
+    connectionStore.getState().setWindowVisible(true)
+  })
+
+  function seedWithPointer(lastSeenMessageId: string): void {
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
+    chatStore.setState((state) => {
+      const newMeta = new Map(state.conversationMeta)
+      newMeta.set(cid, { unreadCount: 0, lastSeenMessageId })
+      const newConvs = new Map(state.conversations)
+      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, lastSeenMessageId })
+      return { conversationMeta: newMeta, conversations: newConvs }
+    })
+  }
+
+  it('advances the read pointer when the window is focused', () => {
+    seedWithPointer('m1')
+    connectionStore.getState().setWindowVisible(true)
+    chatStore.getState().updateLastSeenMessageId(cid, 'm3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
+  })
+
+  it('does not advance the read pointer while the window is unfocused', () => {
+    seedWithPointer('m1')
+    connectionStore.getState().setWindowVisible(false)
+    chatStore.getState().updateLastSeenMessageId(cid, 'm3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m1')
+  })
+
+  it('leaves the combined conversations map untouched while unfocused', () => {
+    seedWithPointer('m1')
+    connectionStore.getState().setWindowVisible(false)
+    chatStore.getState().updateLastSeenMessageId(cid, 'm3')
+    expect(chatStore.getState().conversations.get(cid)?.lastSeenMessageId).toBe('m1')
+  })
+
+  it('resumes advancing once the window regains focus', () => {
+    seedWithPointer('m1')
+    connectionStore.getState().setWindowVisible(false)
+    chatStore.getState().updateLastSeenMessageId(cid, 'm2')
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m1')
+    connectionStore.getState().setWindowVisible(true)
+    chatStore.getState().updateLastSeenMessageId(cid, 'm3')
+    expect(chatStore.getState().conversationMeta.get(cid)?.lastSeenMessageId).toBe('m3')
   })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1340,6 +1340,11 @@ export const chatStore = createStore<ChatState>()(
       },
 
       updateLastSeenMessageId: (conversationId, messageId) => {
+        // Presence gate (issue #1076) — see the roomStore twin. The viewport
+        // observer reports what is PAINTED, and the list auto-scrolls to arriving
+        // messages whether or not the user is at the window. Rendered is not seen.
+        if (!connectionStore.getState().windowVisible) return
+
         set((state) => {
           const meta = state.conversationMeta.get(conversationId)
           const conv = state.conversations.get(conversationId)
@@ -2221,7 +2226,12 @@ export const chatStore = createStore<ChatState>()(
                 lastSeenMessageId: meta.lastSeenMessageId,
                 firstNewMessageId: state.firstNewMessageMarkers.get(conversationId),
               }
-              const recomputed = notifState.recomputeCountsFromPointer(pointerState, mergedForMarker)
+              const recomputed = notifState.recomputeCountsFromPointer(pointerState, mergedForMarker, {
+                // A stashed XEP-0490 marker is resolved after this set(), and that
+                // fold is forward-only — so the guard must not snap the pointer
+                // past it first (issue #1076).
+                hasPendingRemoteMarker: meta.pendingRemoteDisplayedStanzaId !== undefined,
+              })
               // Same-reference return = nothing changed; skip the map churn.
               if (recomputed !== pointerState) hydrated = recomputed
             }

--- a/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.mds.test.ts
@@ -4,6 +4,7 @@ import { roomSelectors } from './roomSelectors'
 import type { Room, RoomMessage } from '../core/types/room'
 import { getLocalPart } from '../core/jid'
 import { _resetStorageScopeForTesting } from '../utils/storageScope'
+import { connectionStore } from './connectionStore'
 
 // Mock localStorage (required because roomStore uses persist middleware)
 const localStorageMock = (() => {
@@ -704,5 +705,216 @@ describe('roomStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
 
     expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m1')
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateLastSeenMessageId — presence gate (issue #1076)
+//
+// The viewport observer equated "rendered on screen" with "read". Combined with
+// auto-scroll-on-new-message, a backgrounded client marked every arriving message
+// read in real time: the pointer rode the live edge, the "new messages" divider
+// never survived, and the position was published over XEP-0490. A message painted
+// while the user is in another app has not been seen.
+// ---------------------------------------------------------------------------
+
+describe('roomStore.updateLastSeenMessageId presence gate', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    connectionStore.getState().setWindowVisible(true)
+    vi.clearAllMocks()
+  })
+
+  it('advances the read pointer when the window is focused', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    connectionStore.getState().setWindowVisible(true)
+    roomStore.getState().updateLastSeenMessageId(ROOM, 'm3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m3')
+  })
+
+  it('does not advance the read pointer while the window is unfocused', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    connectionStore.getState().setWindowVisible(false)
+    roomStore.getState().updateLastSeenMessageId(ROOM, 'm3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m1')
+  })
+
+  it('resumes advancing once the window regains focus', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1), rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)], 'm1')
+    connectionStore.getState().setWindowVisible(false)
+    roomStore.getState().updateLastSeenMessageId(ROOM, 'm2')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m1')
+    connectionStore.getState().setWindowVisible(true)
+    roomStore.getState().updateLastSeenMessageId(ROOM, 'm3')
+    expect(roomStore.getState().roomMeta.get(ROOM)?.lastSeenMessageId).toBe('m3')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fresh-instance catch-up ordering (issue #1076)
+//
+// A new install / new device / cleared cache has NO local read state for a room.
+// The MDS marker from the client the user left always arrives before the room has
+// messages to resolve it against, so it lands in pendingRemoteDisplayedStanzaId.
+// The catch-up merge then recomputed counts FIRST — and its fresh-entity guard
+// ("no pointer, no lastReadAt ⇒ caught up") snapped the pointer to the newest
+// message. The pending fold that runs afterwards is forward-only, so the user's
+// real position was already behind it and got discarded.
+// ---------------------------------------------------------------------------
+
+describe('roomStore fresh-instance catch-up preserves the remote read position', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    connectionStore.getState().setWindowVisible(true)
+    vi.clearAllMocks()
+  })
+
+  /** 10 archived messages, m1..m10 / s1..s10. */
+  const archive = () => Array.from({ length: 10 }, (_, i) => rmsg(`m${i + 1}`, `s${i + 1}`, i + 1))
+
+  it('keeps the pointer at the marker instead of snapping to newest', () => {
+    seedRoom(ROOM, []) // fresh instance: no messages, no pointer, no lastReadAt
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's3') // non-resident → pending
+    expect(roomStore.getState().roomMeta.get(ROOM)?.pendingRemoteDisplayedStanzaId).toBe('s3')
+
+    roomStore.getState().mergeRoomMAMMessages(ROOM, archive(), {}, true, 'forward')
+
+    const meta = roomStore.getState().roomMeta.get(ROOM)
+    expect(meta?.lastSeenMessageId).toBe('m3')
+    expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
+  })
+
+  it('counts the messages after the marker as unread', () => {
+    seedRoom(ROOM, [])
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's3')
+
+    roomStore.getState().mergeRoomMAMMessages(ROOM, archive(), {}, true, 'forward')
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(7)
+  })
+
+  // Control: a genuinely fresh room with NO remote marker must still be treated as
+  // caught up, or every new join would manufacture unread debt from its history.
+  it('still treats a fresh room with no remote marker as caught up', () => {
+    seedRoom(ROOM, [])
+
+    roomStore.getState().mergeRoomMAMMessages(ROOM, archive(), {}, true, 'forward')
+
+    const meta = roomStore.getState().roomMeta.get(ROOM)
+    expect(meta?.unreadCount).toBe(0)
+    expect(meta?.lastSeenMessageId).toBe('m10')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pending-marker guard: edges around the fresh-instance fix (issue #1076).
+// ---------------------------------------------------------------------------
+
+describe('roomStore pending-marker guard edges', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    roomStore.setState({
+      rooms: new Map(),
+      roomEntities: new Map(),
+      roomMeta: new Map(),
+      roomRuntime: new Map(),
+      activeRoomJid: null,
+      drafts: new Map(),
+      mamQueryStates: new Map(),
+      roomGaps: new Map(),
+      firstNewMessageMarkers: new Map(),
+    })
+    connectionStore.getState().setWindowVisible(true)
+    vi.clearAllMocks()
+  })
+
+  // The guard must not strand a room forever: when the marker's message is NOT in
+  // the delivered page it stays pending (rather than snapping the pointer past it),
+  // and a later page carrying that message still resolves it.
+  it('holds the position pending when the marker is not in the delivered page', () => {
+    seedRoom(ROOM, [])
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's-deep')
+
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [rmsg('m8', 's8', 8), rmsg('m9', 's9', 9)],
+      {}, true, 'forward'
+    )
+
+    const meta = roomStore.getState().roomMeta.get(ROOM)
+    expect(meta?.pendingRemoteDisplayedStanzaId).toBe('s-deep')
+    expect(meta?.lastSeenMessageId).toBe(undefined)
+  })
+
+  it('resolves that held position once a later page carries the marker message', () => {
+    seedRoom(ROOM, [])
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's-deep')
+    roomStore.getState().mergeRoomMAMMessages(ROOM, [rmsg('m9', 's9', 9)], {}, true, 'forward')
+
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [rmsg('m5', 's-deep', 5), rmsg('m6', 's6', 6)],
+      {}, true, 'forward'
+    )
+
+    const meta = roomStore.getState().roomMeta.get(ROOM)
+    expect(meta?.lastSeenMessageId).toBe('m5')
+    expect(meta?.pendingRemoteDisplayedStanzaId).toBe(undefined)
+  })
+
+  // The guard is scoped to the fresh-entity branch — a room that already has a
+  // local pointer must keep counting from it, pending marker or not.
+  it('counts from the existing local pointer when one is already set', () => {
+    seedRoom(ROOM, [rmsg('m1', 's1', 1)], 'm1')
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's-future')
+
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [rmsg('m2', 's2', 2), rmsg('m3', 's3', 3)],
+      {}, true, 'forward'
+    )
+
+    expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
+  })
+
+  it('counts mentions after the resolved marker, not from the start of the page', () => {
+    seedRoom(ROOM, [])
+    roomStore.getState().applyRemoteDisplayed(ROOM, 's2')
+
+    const page = [
+      rmsg('m1', 's1', 1),
+      { ...rmsg('m2', 's2', 2), isMention: true } as RoomMessage,
+      { ...rmsg('m3', 's3', 3), isMention: true } as RoomMessage,
+      rmsg('m4', 's4', 4),
+    ]
+    roomStore.getState().mergeRoomMAMMessages(ROOM, page, {}, true, 'forward')
+
+    const meta = roomStore.getState().roomMeta.get(ROOM)
+    expect(meta?.lastSeenMessageId).toBe('m2')
+    expect(meta?.unreadCount).toBe(2)
+    // m2's mention is at/behind the read position — only m3's counts.
+    expect(meta?.mentionsCount).toBe(1)
   })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2028,6 +2028,14 @@ export const roomStore = createStore<RoomState>()(
   },
 
   updateLastSeenMessageId: (roomJid, messageId) => {
+    // Presence gate (issue #1076): the viewport observer reports what is PAINTED,
+    // and the list auto-scrolls to arriving messages whether or not the user is
+    // at the window. Without this check a backgrounded client marks every new
+    // message read in real time — the pointer rides the live edge, the "new
+    // messages" divider never survives to the next open, and the bogus position
+    // is published to other devices over XEP-0490. Rendered is not seen.
+    if (!connectionStore.getState().windowVisible) return
+
     set((state) => {
       const existing = state.rooms.get(roomJid)
       const meta = state.roomMeta.get(roomJid)
@@ -3111,7 +3119,13 @@ export const roomStore = createStore<RoomState>()(
               firstNewMessageId: state.firstNewMessageMarkers.get(roomJid),
             },
             mergedForMarker,
-            { countMentions: true }
+            {
+              countMentions: true,
+              // A stashed XEP-0490 marker is resolved just below (after this
+              // set()), and that fold is forward-only — so the guard must not
+              // snap the pointer past it first (issue #1076).
+              hasPendingRemoteMarker: existingMeta.pendingRemoteDisplayedStanzaId !== undefined,
+            }
           )
           newMeta.set(roomJid, {
             ...newMeta.get(roomJid)!,

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -1137,6 +1137,15 @@ describe('recomputeCountsFromPointer', () => {
     ...opts,
   })
 
+  it('does not claim caught-up while an XEP-0490 marker is still pending', () => {
+    const state = createInitialNotificationState()
+    const messages = [msg('a', 30), msg('b', 20), msg('c', 10)]
+    const out = recomputeCountsFromPointer(state, messages, { hasPendingRemoteMarker: true })
+    // Untouched: the pending fold owns resolving this position.
+    expect(out).toBe(state)
+    expect(out.lastSeenMessageId).toBeUndefined()
+  })
+
   it('fresh entity (no pointer, no lastReadAt) is caught up: snaps pointer to newest, zero counts', () => {
     const state = createInitialNotificationState()
     const messages = [msg('a', 30), msg('b', 20), msg('c', 10)]

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -464,6 +464,13 @@ export function onMessageSeen(
 export interface RecomputeCountsOptions {
   /** Count `isMention` messages into mentionsCount (rooms). */
   countMentions?: boolean
+  /**
+   * True when an XEP-0490 marker for this entity is stashed but not yet resolved
+   * (`pendingRemoteDisplayedStanzaId`). Such an entity has a read position — we
+   * simply cannot express it as a local message id yet — so the fresh-entity
+   * guard below must NOT claim it is caught up. See {@link recomputeCountsFromPointer}.
+   */
+  hasPendingRemoteMarker?: boolean
 }
 
 /**
@@ -477,6 +484,14 @@ export interface RecomputeCountsOptions {
  * counts stay zero. History replay of a newly joined room, or a new device
  * with no MDS position, never manufactures unread debt.
  *
+ * The guard does NOT apply while an XEP-0490 marker is still pending
+ * (`hasPendingRemoteMarker`). On a fresh instance the marker from the user's
+ * other client always arrives before the room has any messages to resolve it
+ * against, so it sits stashed while this runs. Snapping the pointer to newest
+ * then would put it PAST the marker, and the fold that follows is forward-only —
+ * silently discarding the position the user actually left off at. Leaving the
+ * state untouched lets that fold resolve the marker and the counts follow.
+ *
  * An outgoing message inside the counted range is a read boundary (the user
  * replied, here or on another device): counting restarts after the last one
  * and the pointer advances to it.
@@ -486,10 +501,13 @@ export function recomputeCountsFromPointer(
   messages: NotificationMessage[],
   options?: RecomputeCountsOptions
 ): EntityNotificationState {
-  const { countMentions = false } = options ?? {}
+  const { countMentions = false, hasPendingRemoteMarker = false } = options ?? {}
   if (messages.length === 0) return state
 
   if (!state.lastSeenMessageId && !state.lastReadAt) {
+    // An unresolved remote marker IS read state — defer to the fold that will
+    // resolve it rather than claiming this entity is caught up.
+    if (hasPendingRemoteMarker) return state
     const newest = messages[messages.length - 1]
     if (state.unreadCount === 0 && state.mentionsCount === 0 && state.lastSeenMessageId === newest.id) {
       return state


### PR DESCRIPTION
Fixes #1076 — rooms showed no unread count and no reading marker while Gajim/Conversations showed both.

Three independent defects, each of which advances or discards the read pointer without the user having read anything. Because the pointer is forward-only, every one of them is unrecoverable once it fires.

**Presence gate.** The viewport observer equated "painted" with "read", and the message list auto-scrolls to arriving messages whether or not the window is focused — so a backgrounded client marked every new message read in real time. `updateLastSeenMessageId` now returns early while the window is unfocused.

**Focus-regain gate.** `markAsRead` ran unconditionally for the active view on every focus, gated only on `windowAtLiveEdge`, which is true for any backgrounded view parked at the tail. It now requires the viewport to genuinely show the newest message — Gajim's `view_is_at_bottom()`. Views publish that via a small ref registry, since `useWindowVisibility` is global and has no access to the scroll state.

**Catch-up ordering.** On an instance with no local read state, the XEP-0490 marker from the client the user left always arrives before the room has messages to resolve it against, so it lands pending. The catch-up merge recomputed counts first, and the fresh-entity guard snapped the pointer to the newest message — past the marker, which the forward-only fold then discarded. `recomputeCountsFromPointer` now treats an unresolved pending marker as read state.

**Catch-up publish gate.** Mirrors Gajim's `is_catch_up_finished()`. A position derived from a partial archive is no longer published to the user's other devices. Checked at flush time as well as enqueue — the debounce is long enough for a catch-up to start in between. Entities that never ran a MAM query are unaffected, so read sync still works for conversations created live.