### PR TITLE
fix(e2ee): stop turning OMEMO key transports into phantom messages

### DIFF
--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.test.ts
@@ -809,6 +809,117 @@ describe('recordUnclaimedEME', () => {
 })
 
 // ---------------------------------------------------------------------------
+// XEP-0384 "empty" OMEMO messages (KeyTransportElement)
+// ---------------------------------------------------------------------------
+
+describe('recordUnclaimedEME — payload-less OMEMO (empty message)', () => {
+  /**
+   * An OMEMO element carrying a <header> but no <payload>. Per XEP-0384 these
+   * are "empty OMEMO messages, which are used in various places throughout the
+   * protocol purely to manage sessions and not to transfer content" — session
+   * completion acks and ratchet heartbeats. They carry nothing a user ever
+   * typed and MUST NOT surface as a message.
+   *
+   * Shape copied verbatim (minus base64 bulk) from a stanza a Conversations
+   * client sent after our device announced itself — see the phantom-message
+   * report where Conversations itself rendered nothing for these.
+   */
+  function emptyOmemoStanza(namespace = 'eu.siacs.conversations.axolotl'): Element {
+    return xml(
+      'message',
+      { from: 'ralphm@example.com/Conversations.cMny', type: 'chat' },
+      xml(
+        'encrypted',
+        { xmlns: namespace },
+        xml('header', { sid: '600125587' }, xml('key', { rid: '445710346' }, 'Mwoh'), xml('iv', {}, '4pEg')),
+      ),
+      xml('store', { xmlns: 'urn:xmpp:hints' }),
+    ) as Element
+  }
+
+  /** The same envelope, but a real message: <header> AND <payload>. */
+  function payloadOmemoStanza(): Element {
+    return xml(
+      'message',
+      { from: 'ralphm@example.com/Conversations.cMny', type: 'chat' },
+      xml(
+        'encrypted',
+        { xmlns: 'eu.siacs.conversations.axolotl' },
+        xml('header', { sid: '600125587' }, xml('key', { rid: '445710346' }, 'Mwoh'), xml('iv', {}, '4pEg')),
+        xml('payload', {}, 'zqPUb2xwZQ'),
+      ),
+    ) as Element
+  }
+
+  it('drops an empty OMEMO message instead of tagging it unsupported', () => {
+    const stanza = emptyOmemoStanza()
+
+    expect(recordUnclaimedEME(stanza, true).kind).toBe('none')
+    expect(readStashedUnsupportedEncryption(stanza)).toBeUndefined()
+  })
+
+  it('drops an empty OMEMO message rather than stashing it for retry', () => {
+    // No plugin registered yet. There is still nothing to show once it
+    // decrypts, so stashing would only manufacture a placeholder in the
+    // meantime.
+    const stanza = emptyOmemoStanza()
+
+    expect(recordUnclaimedEME(stanza, false).kind).toBe('none')
+    expect(readStashedEncryptedPayload(stanza)).toBeUndefined()
+  })
+
+  it('drops an empty OMEMO 2 message', () => {
+    const stanza = emptyOmemoStanza('urn:xmpp:omemo:2')
+
+    expect(recordUnclaimedEME(stanza, true).kind).toBe('none')
+    expect(readStashedUnsupportedEncryption(stanza)).toBeUndefined()
+  })
+
+  // --- controls: the drop must not widen beyond empty OMEMO -----------------
+
+  it('still reports unsupported for an OMEMO message that carries a payload', () => {
+    const stanza = payloadOmemoStanza()
+
+    const disposition = recordUnclaimedEME(stanza, true)
+    expect(disposition.kind).toBe('unsupported')
+    expect(readStashedUnsupportedEncryption(stanza)).toEqual({
+      namespace: 'eu.siacs.conversations.axolotl',
+      name: 'OMEMO',
+    })
+  })
+
+  it('still reports unsupported for OpenPGP, which has no <payload> child by design', () => {
+    // <openpgp> wraps base64 directly. A blanket "no <payload> means empty"
+    // rule would silently swallow every OX message — the drop is keyed on the
+    // OMEMO <header>/<payload> shape, not on the absence of a payload alone.
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/r', id: 'pgp2', type: 'chat' },
+      xml('openpgp', { xmlns: 'urn:xmpp:openpgp:0' }, 'cipher'),
+      xml('encryption', { xmlns: 'urn:xmpp:eme:0', namespace: 'urn:xmpp:openpgp:0', name: 'OpenPGP' }),
+    ) as Element
+
+    const disposition = recordUnclaimedEME(stanza, true)
+    expect(disposition.kind).toBe('unsupported')
+    if (disposition.kind === 'unsupported') {
+      expect(disposition.info.name).toBe('OpenPGP')
+    }
+  })
+
+  it('still reports unsupported for an OMEMO element with neither header nor payload', () => {
+    // Malformed, not an empty message: nothing identifies it as key transport,
+    // so it keeps the visible "unsupported" treatment rather than vanishing.
+    const stanza = xml(
+      'message',
+      { from: 'peer@example.com/r', type: 'chat' },
+      xml('encrypted', { xmlns: 'eu.siacs.conversations.axolotl' }, 'cipher'),
+    ) as Element
+
+    expect(recordUnclaimedEME(stanza, true).kind).toBe('unsupported')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // decryptStanzaInPlace: unsupported protocol with a registered plugin
 // ---------------------------------------------------------------------------
 

--- a/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
+++ b/packages/fluux-sdk/src/core/e2ee/stanzaDecrypt.ts
@@ -567,6 +567,52 @@ function findEncryptionTarget(
 }
 
 /**
+ * OMEMO namespaces whose `<encrypted>` element follows the
+ * `<header>` + optional `<payload>` shape. Both the legacy siacs namespace and
+ * OMEMO 2 use it; OpenPGP (`<openpgp>` wrapping base64 directly) does not.
+ */
+const OMEMO_NAMESPACES = new Set(['eu.siacs.conversations.axolotl', 'urn:xmpp:omemo:2'])
+
+/** Does `el` have a direct child element named `name`, whatever its namespace? */
+function hasChildElement(el: Element, name: string): boolean {
+  return el.children.some(
+    (child) => typeof child !== 'string' && (child as Element).name === name,
+  )
+}
+
+/**
+ * Whether this is an XEP-0384 **empty OMEMO message** — an `<encrypted>` with a
+ * `<header>` but no `<payload>`.
+ *
+ * The spec calls them "empty OMEMO messages, which are used in various places
+ * throughout the protocol purely to manage sessions and not to transfer
+ * content": the ack a device sends back to confirm a session was established,
+ * and the heartbeats that forward the ratchet. They encrypt 32 zero-bytes, not
+ * anything a human wrote, and every real client consumes them silently (Gajim:
+ * `if properties.omemo.payload is None: # Key Transport message`).
+ *
+ * They carry the `<store/>` hint, so they land in MAM and are replayed on every
+ * catch-up. Without this check a build with no OMEMO plugin classifies each one
+ * as an unsupported protocol and manufactures a "message encrypted with OMEMO"
+ * placeholder — a bubble, a preview and an unread badge for something the
+ * sender's client never displayed. Reported in the field as "phantom OMEMO
+ * messages": a burst of them arrives across many contacts at once, right after
+ * our account announces a new OMEMO device and each peer builds its session.
+ *
+ * Gated on the `<header>` being present: an element with neither header nor
+ * payload is malformed rather than empty, and keeps the visible unsupported
+ * treatment instead of disappearing.
+ *
+ * Note this only ever runs for stanzas **no plugin claimed**. Once an OMEMO
+ * plugin is registered it claims the stanza first and reports `control-message`
+ * from `decrypt`, which the main path already consumes without a body.
+ */
+function isEmptyOmemoElement(namespace: string, child: Element | null): boolean {
+  if (!child || !OMEMO_NAMESPACES.has(namespace)) return false
+  return hasChildElement(child, 'header') && !hasChildElement(child, 'payload')
+}
+
+/**
  * Classify and tag an encryption-tagged stanza that no plugin claimed, mutating
  * the stanza with the appropriate stash. See {@link UnclaimedEMEDisposition}.
  *
@@ -584,6 +630,13 @@ export function recordUnclaimedEME(
 ): UnclaimedEMEDisposition {
   const target = findEncryptionTarget(stanza)
   if (!target) return { kind: 'none' }
+
+  // Session bookkeeping, not a message — drop before either branch below can
+  // turn it into a placeholder. See {@link isEmptyOmemoElement}.
+  if (isEmptyOmemoElement(target.namespace, target.child)) {
+    logInfo(`E2EE: dropped empty OMEMO message (ns=${target.namespace})`)
+    return { kind: 'none' }
+  }
 
   const state = unclaimedPluginState(pluginState)
   if (state.hasPlugins && !state.hasPluginForNamespace(target.namespace)) {

--- a/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.e2ee.test.ts
@@ -483,6 +483,48 @@ describe('MAM E2EE wiring', () => {
     expect(msg.body).toBe('')
   })
 
+  it('drops an archived empty OMEMO message (XEP-0384 key transport) entirely', async () => {
+    // Counterpart to the two #135 tests above: those keep a *real* OMEMO
+    // message that merely lacks a fallback body. This one carries no <payload>
+    // at all — an XEP-0384 empty message, sent purely to establish a session or
+    // forward the ratchet. It has the <store/> hint so it lands in MAM and is
+    // replayed on every catch-up.
+    //
+    // Field report ("phantom OMEMO messages"): a burst of these arrived from
+    // several contacts at once after the account announced a new OMEMO device,
+    // and each became a "Message encrypted: OMEMO not supported" bubble with an
+    // unread badge. Conversations, which sent them, showed nothing.
+    const forwardedMessage = xml(
+      'message',
+      { from: PEER + '/Conversations.cMny', to: ME, type: 'chat' },
+      xml('encrypted', { xmlns: 'eu.siacs.conversations.axolotl' },
+        xml('header', { sid: '600125587' },
+          xml('key', { rid: '445710346' }, 'Mwoh'),
+          xml('iv', {}, '4pEg'),
+        ),
+      ),
+      xml('store', { xmlns: 'urn:xmpp:hints' }),
+    )
+    const archiveEntry = buildMAMResult({
+      archiveId: 'arch-omemo-keytransport',
+      forwardedMessage,
+    })
+
+    const resultPromise = harness.mam.queryArchive({ with: PEER, max: 10 })
+    await harness.iqPending()
+    const entries = [...harness.collectors.entries()]
+    if (entries.length === 0) throw new Error('No collector registered')
+    const [queryId, collector] = entries[0]
+    archiveEntry.getChild('result', 'urn:xmpp:mam:2')!.attrs.queryid = queryId
+    collector(archiveEntry)
+    harness.resolveNextIQ(
+      xml('iq', {}, xml('fin', { xmlns: 'urn:xmpp:mam:2', complete: 'true' })),
+    )
+    const result = await resultPromise
+
+    expect(result.messages).toHaveLength(0)
+  })
+
   it('surfaces a bodiless OMEMO MUC archive entry instead of dropping it (issue #135, rooms)', async () => {
     // parseRoomArchiveMessage has the same "no body, no attachment → drop" gate
     // as the 1:1 path. An OMEMO room message whose sender omitted the optional


### PR DESCRIPTION
An OMEMO `<encrypted>` element with a `<header>` but no `<payload>` is an XEP-0384 empty message — a session-completion ack or ratchet heartbeat. It carries nothing a user wrote, and every real client consumes it silently.

`recordUnclaimedEME` classified by namespace alone, so a build with no OMEMO plugin tagged each one `unsupportedEncryption`. That tag is deliberately allowed past the no-body gate (issue #135), so each empty message became a bubble, a sidebar preview and an unread badge. They carry the `<store/>` hint, so MAM replays them on every catch-up — and they arrive in a burst across many contacts at once, right after an account announces a new OMEMO device and each peer builds its session. Reported from the field, cross-checked against Conversations (which sent them and displayed nothing).

They are now dropped before both the `unsupported` and the `retry` branch. The claimed path already had this concept — a plugin reporting `control-message` yields no plaintext and no body is synthesized — only the unclaimed path was missing it, so the bug is invisible on `features/omemo` and only bites builds without OMEMO.

The drop is gated on the OMEMO namespaces and on `<header>` present with `<payload>` absent. Both gates matter: `<openpgp>` wraps base64 with no `<payload>` child, so a blanket rule would swallow every OX message; and an element with neither header nor payload is malformed rather than empty.

Note: already-stored placeholders cannot be cleaned up retroactively. For an unsupported protocol we keep no ciphertext, so a stored phantom is byte-identical to a genuine bodiless OMEMO message (#135) — `unsupportedEncryption` plus an empty body. Existing rows need a cache clear.