### PR TITLE
fix(e2ee): stop the backup dialog's Copy button from publishing the key

### DIFF
--- a/apps/fluux/src/components/BackupPassphraseDialog.test.tsx
+++ b/apps/fluux/src/components/BackupPassphraseDialog.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * BackupPassphraseDialog: the acknowledgment gate must survive the
+ * password-manager <form> wrapper.
+ *
+ * Every control in this dialog sits inside a <form> that exists only so
+ * password managers detect the generated passphrase. An untyped <button>
+ * inside a form defaults to type="submit", so Copy and Regenerate used to
+ * submit it — publishing the backup (or starting a key rotation) on the
+ * first click, with the "I saved this passphrase" checkbox never ticked.
+ * Disabling the confirm button does not help: `disabled` on one submit
+ * button has no effect on another one in the same form.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { BackupPassphraseDialog } from './BackupPassphraseDialog'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+const PASSPHRASE = 'alpha bravo charlie delta echo foxtrot golf hotel'
+
+vi.mock('@/e2ee/passphraseGenerator', () => ({
+  USE_V6_KEYS: true,
+  generateBackupPassphrase: vi.fn(() => Promise.resolve(PASSPHRASE)),
+  generateBackupCode: vi.fn(() => 'AAAA-BBBB-CCCC'),
+}))
+
+const writeText = vi.fn(() => Promise.resolve())
+
+beforeEach(() => {
+  writeText.mockClear()
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  })
+})
+
+const noop = () => {}
+
+/** Render and wait for the async passphrase draw to land. */
+async function renderDialog(onConfirm: () => Promise<void>) {
+  const view = render(<BackupPassphraseDialog onConfirm={onConfirm} onCancel={noop} />)
+  await screen.findByText('alpha')
+  return view
+}
+
+const copyButton = () => screen.getByRole('button', { name: 'settings.encryption.backupCopy' })
+const regenButton = () => screen.getByRole('button', { name: 'settings.encryption.backupRegenerate' })
+
+describe('BackupPassphraseDialog acknowledgment gate', () => {
+  it('copies without confirming: the passphrase reaches the clipboard and onConfirm does not fire', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    await renderDialog(onConfirm)
+
+    fireEvent.click(copyButton())
+
+    // The click really landed and the handler really ran — without this the
+    // onConfirm assertion below would pass even if the button were missing.
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(PASSPHRASE))
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('leaves the acknowledgment checkbox unticked and the confirm button disabled after a copy', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    const { container } = await renderDialog(onConfirm)
+
+    fireEvent.click(copyButton())
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+    expect(
+      screen.getByRole('button', { name: 'settings.encryption.backupPublish' }),
+    ).toBeDisabled()
+  })
+
+  it('regenerates without confirming: a fresh passphrase is drawn and onConfirm does not fire', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    await renderDialog(onConfirm)
+
+    // Tick the box first: this is the state in which an accidental submit
+    // would sail straight through the gate and publish the STALE passphrase.
+    fireEvent.click(screen.getByRole('checkbox'))
+    fireEvent.click(regenButton())
+
+    // Regenerating clears the acknowledgment, which is the observable proof
+    // that handleRegenerate ran.
+    await waitFor(() => expect(screen.getByRole('checkbox')).not.toBeChecked())
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('confirms only through the explicit confirm button (control: onConfirm is reachable)', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    await renderDialog(onConfirm)
+
+    fireEvent.click(screen.getByRole('checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: 'settings.encryption.backupPublish' }))
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(PASSPHRASE))
+  })
+})

--- a/apps/fluux/src/components/BackupPassphraseDialog.tsx
+++ b/apps/fluux/src/components/BackupPassphraseDialog.tsx
@@ -190,7 +190,14 @@ export function BackupPassphraseDialog({
         </div>
 
         <div className="flex gap-2 mb-4">
+          {/*
+            type="button" is load-bearing: everything here lives inside the
+            password-manager <form>, so an untyped button defaults to submit
+            and publishes the backup on the first click. Disabling the confirm
+            button does NOT stop a second submit button from submitting.
+          */}
           <button
+            type="button"
             onClick={handleCopy}
             disabled={isPublishing || !passphrase}
             className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors disabled:opacity-50"
@@ -211,6 +218,7 @@ export function BackupPassphraseDialog({
             disabled={isPublishing}
           />
           <button
+            type="button"
             onClick={handleRegenerate}
             disabled={isPublishing || !passphrase}
             className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors disabled:opacity-50"


### PR DESCRIPTION
Every control in `BackupPassphraseDialog` sits inside the `<form>` that exists only so password managers detect the generated passphrase. The Copy and Regenerate buttons carried no `type` attribute, so HTML defaulted them to `type="submit"` — clicking either one submitted the form.

That bypassed the acknowledgment gate entirely: `disabled={!acknowledged}` on the confirm button has no effect on a *second* submit button in the same form. Clicking Copy published the server backup, started a key rotation, or fired the file export depending on the call site, with the "I saved this passphrase" checkbox never ticked. Regenerate was worse — it ran both its own handler and the submit, publishing the stale passphrase held in `handleConfirm`'s closure.

Reported as "clicking Copy auto-checks the box and closes the modal". The checkbox was never checked; the modal closed because the parent closed it on a successful publish.

Copy now only copies and Regenerate only redraws, matching the treatment already used in `RestorePassphraseDialog` and `UnlockEncryptionDialog`. Adds the dialog's first test file, covering both buttons plus a control case proving `onConfirm` stays reachable through the confirm button.