### PR TITLE
fix(mam): stop the read-pointer probe from marking history complete

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2026,7 +2026,8 @@ export const chatStore = createStore<ChatState>()(
             rsm.first, // Pagination cursor for fetching older messages
             newestFetchedTimestamp,
             preserveGapMarker,
-            isFetchLatest
+            isFetchLatest,
+            mamState.isDisjointFromResidentWindow(rawExisting, extras?.initialBefore, isFetchLatest)
           )
 
           // Newest PROVEN in-memory boundary (resident extent). Undefined when the

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2305,6 +2305,71 @@ describe('roomStore', () => {
       expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
     })
 
+    it('does NOT mark the visible timeline complete when a Phase B deep probe reaches the archive start below the resident window', () => {
+      // Reproduces the "cannot scroll back past the activation slice" regression.
+      // The resident window is the latest-N activation slice (July). Phase B — a
+      // BACKGROUND read-pointer stitch — seeds from the true cache bottom
+      // (January, thousands of messages BELOW the resident window) and walks down
+      // until the server reports complete=true at the archive start.
+      //
+      // That completion is real, but it describes the ARCHIVE bottom, not the
+      // user's visible timeline. Folding it into isHistoryComplete makes the UI
+      // draw "Beginning of conversation" at the top of the July slice and disable
+      // load-more, stranding all the older history that is already cached.
+      const residentTop: RoomMessage = {
+        type: 'groupchat', id: 'july-top', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'resident window top', timestamp: new Date('2026-07-13T14:21:40Z'),
+        isOutgoing: false, stanzaId: 'july-top-archive-id',
+      }
+      roomStore.getState().addRoom(createRoom(jid, {
+        joined: true, messages: [residentTop], lastMessage: residentTop,
+      }))
+
+      // A Phase B page from January: it resumed from the cache-bottom cursor,
+      // NOT from the resident window's oldest message, and hit the archive start.
+      const januaryPage: RoomMessage = {
+        type: 'groupchat', id: 'jan-first', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'first message ever', timestamp: new Date('2026-01-26T15:12:00Z'),
+        isOutgoing: false, stanzaId: 'jan-first-archive-id',
+      }
+      roomStore.getState().mergeRoomMAMMessages(
+        jid, [januaryPage], { first: 'jan-first-archive-id' }, true, 'backward', false, false,
+        { initialBefore: 'cache-bottom-archive-id' }
+      )
+
+      // The user's timeline still starts at the July slice — older history exists
+      // both on the server and in the local cache, so load-more must stay enabled.
+      expect(roomStore.getState().getRoomMAMQueryState(jid).isHistoryComplete).toBe(false)
+    })
+
+    it('DOES mark the timeline complete when scroll-back resumes from the resident bottom and reaches the archive start', () => {
+      // Control for the Phase B case above: this is the genuine "user scrolled to
+      // the very beginning" path — fetchOlderHistory paginates from the resident
+      // window's own oldest archive id, so complete=true really does mean the
+      // visible timeline reached the start. The fix must not suppress this.
+      const residentBottom: RoomMessage = {
+        type: 'groupchat', id: 'oldest-resident', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'oldest resident', timestamp: new Date('2026-02-01T00:00:00Z'),
+        isOutgoing: false, stanzaId: 'oldest-resident-archive-id',
+      }
+      roomStore.getState().addRoom(createRoom(jid, {
+        joined: true, messages: [residentBottom], lastMessage: residentBottom,
+      }))
+
+      const firstEver: RoomMessage = {
+        type: 'groupchat', id: 'jan-first', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'first message ever', timestamp: new Date('2026-01-26T15:12:00Z'),
+        isOutgoing: false, stanzaId: 'jan-first-archive-id',
+      }
+      // Cursor IS the resident window's oldest archive id → contiguous page.
+      roomStore.getState().mergeRoomMAMMessages(
+        jid, [firstEver], { first: 'jan-first-archive-id' }, true, 'backward', false, false,
+        { initialBefore: 'oldest-resident-archive-id' }
+      )
+
+      expect(roomStore.getState().getRoomMAMQueryState(jid).isHistoryComplete).toBe(true)
+    })
+
     it('does NOT plant a seam for a plain backward pagination page (isFetchLatest omitted)', () => {
       const held: RoomMessage = {
         type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2905,7 +2905,8 @@ export const roomStore = createStore<RoomState>()(
         rsm.first, // Pagination cursor for fetching older messages
         newestFetchedTimestamp,
         preserveGapMarker,
-        isFetchLatest
+        isFetchLatest,
+        mamState.isDisjointFromResidentWindow(existingMessages, extras?.initialBefore, isFetchLatest)
       )
 
       // Newest PROVEN in-memory boundary (resident extent). Undefined when the

--- a/packages/fluux-sdk/src/stores/shared/mamState.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamState.ts
@@ -109,6 +109,35 @@ export function computeNewestFetchedTimestamp(
 }
 
 /**
+ * True when a backward page resumed from a cursor that is NOT in the resident
+ * window — i.e. the page is disjoint from, and below, what the user can
+ * currently scroll through.
+ *
+ * The read-pointer stitch (catch-up Phase B) seeds its walk from the persisted
+ * coverage bottom / gap edge / true cache bottom, which on an active entity sits
+ * far below the resident window (the activation slice is only the latest N).
+ * When that walk reaches the archive start the server reports `complete: true`,
+ * but that describes the ARCHIVE bottom — not the user's visible timeline. Only
+ * a page that resumed from the resident window's own bottom (ordinary
+ * scroll-back) proves the visible timeline reached the beginning.
+ *
+ * Conservative by construction: returns true only on positive proof of
+ * disjointness. A fetch-latest (`before:''`) swallows the live edge and is never
+ * disjoint; an absent cursor or an empty resident array carries no proof, so
+ * both preserve the previous behavior.
+ */
+export function isDisjointFromResidentWindow(
+  existing: Array<{ stanzaId?: string }>,
+  initialBefore: string | undefined,
+  isFetchLatest: boolean
+): boolean {
+  if (isFetchLatest) return false
+  if (!initialBefore) return false
+  if (existing.length === 0) return false
+  return !existing.some((m) => m.stanzaId === initialBefore)
+}
+
+/**
  * Create a new MAM states map with query completed state.
  *
  * @param states - Current MAM states map
@@ -120,6 +149,9 @@ export function computeNewestFetchedTimestamp(
  * @param preserveGapMarker - Leave forwardGapTimestamp untouched (bounded windowed queries)
  * @param isFetchLatest - A `before:''` fetch-latest merge: the window is the live edge by
  *   definition (SM/carbons own everything newer), regardless of `complete`.
+ * @param disjointFromResidentWindow - The backward page resumed from a cursor below the
+ *   resident window (see {@link isDisjointFromResidentWindow}); its `complete` describes
+ *   the archive bottom, not the user's visible timeline.
  */
 export function setMAMQueryCompleted(
   states: Map<string, MAMQueryState>,
@@ -129,13 +161,20 @@ export function setMAMQueryCompleted(
   oldestFetchedId?: string,
   newestFetchedTimestamp?: number,
   preserveGapMarker = false,
-  isFetchLatest = false
+  isFetchLatest = false,
+  disjointFromResidentWindow = false
 ): Map<string, MAMQueryState> {
   const newStates = new Map(states)
   const current = newStates.get(id) || DEFAULT_MAM_STATE
 
-  // Update the appropriate completion marker based on direction
-  const isHistoryComplete = direction === 'backward'
+  // Update the appropriate completion marker based on direction.
+  // A backward page that resumed BELOW the resident window (Phase B's
+  // read-pointer stitch) proves only that the ARCHIVE has nothing older than
+  // its own cursor — the user's timeline still starts at the resident top, and
+  // marking it complete would strand every older message (including history
+  // already sitting in the local cache) behind a "beginning of conversation"
+  // marker with load-more disabled.
+  const isHistoryComplete = direction === 'backward' && !disjointFromResidentWindow
     ? complete
     : current.isHistoryComplete
 


### PR DESCRIPTION
A room whose archive starts within reach of the local cache bottom would render "Beginning of conversation" at the top of its activation slice and disable load-more, stranding thousands of older messages that were already cached locally. Reported on a room created in January that would not scroll back past 13 July.

Catch-up Phase B (the XEP-0490 read-pointer stitch, background rooms only) seeds its backward walk from the true cache bottom — far below the resident window, which is only the latest 100 messages. Those are backward queries, so when the walk reached the archive start the server's `complete` was folded straight into `isHistoryComplete`, a flag the UI reads as "the user scrolled to the beginning". True about the archive bottom, false about the visible timeline.

`isHistoryComplete` now only absorbs `complete` from a backward page that resumed from the resident window's own bottom, which is what ordinary scroll-back does. The new predicate is conservative: it suppresses only on positive proof the cursor lies outside the resident window, so fetch-latest, absent cursors and empty resident arrays keep their previous behaviour. Applied to both stores — chat runs the same Phase B walk.