### PR TITLE
feat(sidebar): show the unread count in the room row tooltip

### DIFF
--- a/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { Room } from '@fluux/sdk'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    isMessageFromIgnoredUser: () => false,
+    roomActivityTone: () => 'neutral',
+    generateConsistentColorHexSync: () => '#123456',
+  }
+})
+
+const h = vi.hoisted(() => ({ room: null as Room | null }))
+
+vi.mock('@fluux/sdk/react', () => ({
+  useRoomStore: (selector: (s: {
+    getRoom: (jid: string) => Room | null
+    drafts: Map<string, string>
+  }) => unknown) => selector({ getRoom: () => h.room, drafts: new Map() }),
+  useChatStore: (selector: (s: unknown) => unknown) => selector({}),
+  useIgnoreStore: (selector: (s: { ignoredUsers: Record<string, unknown[]> }) => unknown) =>
+    selector({ ignoredUsers: {} }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useContextMenu: () => ({
+    isOpen: false,
+    longPressTriggered: { current: false },
+    handleContextMenu: () => {},
+    handleTouchStart: () => {},
+    handleTouchEnd: () => {},
+    position: { x: 0, y: 0 },
+    menuRef: { current: null },
+    close: () => {},
+  }),
+  useListKeyboardNav: () => ({}),
+  useRouteSync: () => ({}),
+}))
+
+vi.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { timeFormat: string; densityMode: string }) => unknown) =>
+    selector({ timeFormat: '24h', densityMode: 'comfortable' }),
+}))
+
+// Unlike the typing test's mock, this one RENDERS `content`. The assertions are
+// about what RoomsList hands to Tooltip; hover/delay behaviour is Tooltip's own
+// test's job. Rendering every instance also lets us count them, which is how we
+// prove the activity dot no longer carries a tooltip of its own.
+vi.mock('../Tooltip', () => ({
+  Tooltip: ({ children, content }: { children: React.ReactNode; content: React.ReactNode }) => (
+    <>
+      {children}
+      <div data-testid="tooltip-content">{content}</div>
+    </>
+  ),
+}))
+
+// Import AFTER mocks so RoomItem picks them up.
+import { RoomItem } from './RoomsList'
+
+const makeRoom = (over: Partial<Room> = {}): Room =>
+  ({
+    jid: 'team@conference.fluux.chat',
+    name: 'Team',
+    joined: true,
+    isJoining: false,
+    nickname: 'me',
+    nickToJidCache: new Map(),
+    occupants: new Map([['alice', {}], ['bob', {}]]),
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set<string>(),
+    lastMessage: null,
+    avatar: undefined,
+    subject: undefined,
+    autojoin: false,
+    isBookmarked: false,
+    ...over,
+  }) as unknown as Room
+
+const noop = () => {}
+const renderRoom = (room: Room) => {
+  h.room = room
+  return render(
+    <RoomItem
+      roomJid={room.jid}
+      isActive={false}
+      isSelected={false}
+      isKeyboardNav={false}
+      onSelect={noop}
+      onActivate={noop}
+      onJoin={noop}
+      onLeave={noop}
+      onEditBookmark={noop}
+      onRemoveBookmark={noop}
+      onToggleAutojoin={noop}
+    />,
+  )
+}
+
+describe('RoomItem tooltip', () => {
+  it('puts the unread headline above the occupant detail line', () => {
+    renderRoom(makeRoom({ unreadCount: 37 }))
+    const tooltip = screen.getByTestId('tooltip-content')
+    // t is mocked to echo the key, so the headline renders as the bare key.
+    expect(tooltip.textContent).toContain('rooms.unreadMessages')
+    expect(tooltip.textContent).toContain('2 rooms.users • me')
+  })
+
+  it('still shows the unread headline when the room also has mentions', () => {
+    // The regression this feature exists to prevent: the old activity-dot
+    // tooltip was gated on mentionsCount === 0, which hid the total unread
+    // exactly when the room was busiest. Only a render test can catch a
+    // reintroduced gate — roomTooltipParts cannot even see mentionsCount.
+    renderRoom(makeRoom({ unreadCount: 37, mentionsCount: 3 }))
+    expect(screen.getByTestId('tooltip-content').textContent).toContain('rooms.unreadMessages')
+  })
+
+  it('shows only the detail line when the room is fully read', () => {
+    renderRoom(makeRoom({ unreadCount: 0 }))
+    const tooltip = screen.getByTestId('tooltip-content')
+    expect(tooltip.textContent).not.toContain('rooms.unreadMessages')
+    expect(tooltip.textContent).toContain('2 rooms.users • me')
+  })
+
+  it('gives the activity dot no tooltip of its own', () => {
+    // A room with unread and no mentions is precisely the state that used to
+    // render a second, nested Tooltip around the dot.
+    renderRoom(makeRoom({ unreadCount: 37, mentionsCount: 0 }))
+    expect(screen.getAllByTestId('tooltip-content')).toHaveLength(1)
+  })
+})

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -13,6 +13,7 @@ import { useChatStore, useRoomStore, useIgnoreStore } from '@fluux/sdk/react'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { shouldReplaceOnSelect } from '@/utils/navigationHistory'
 import { visibleRoomTypingNicks } from '@/utils/roomTyping'
+import { roomTooltipParts } from '@/utils/roomTooltip'
 import { EditBookmarkModal } from '../EditBookmarkModal'
 import { Tooltip } from '../Tooltip'
 import { TypingIndicator } from '../conversation/TypingIndicator'
@@ -366,22 +367,19 @@ export const RoomItem = memo(function RoomItem({
     onActivate(roomJid)
   }
 
-  // Determine tooltip based on state
-  const getTooltipContent = () => {
-    if (room.isJoining) return t('rooms.joining')
-    if (room.joined) {
-      // Show user count and nickname in tooltip for joined rooms
-      const userCount = room.occupants.size
-      const userText = `${userCount} ${userCount === 1 ? t('rooms.user') : t('rooms.users')}`
-      if (room.nickname) {
-        return `${userText} • ${room.nickname}`
-      }
-      return userText
-    }
-    return t('rooms.doubleClickToJoin')
-  }
-
-  const tooltipContent = getTooltipContent()
+  // Tooltip: the unread count as a headline (the row itself only shows a dot,
+  // so this is the one place the number is legible), over the occupant/nickname
+  // detail line. With nothing unread this stays a bare string — byte-identical
+  // to the pre-headline tooltip.
+  const { headline, detail } = roomTooltipParts(room, t)
+  const tooltipContent = headline ? (
+    <div>
+      <div className="font-medium">{headline}</div>
+      <div className="text-xs text-fluux-muted">{detail}</div>
+    </div>
+  ) : (
+    detail
+  )
 
   return (
     <>
@@ -450,15 +448,15 @@ export const RoomItem = memo(function RoomItem({
             <p dir="auto" className={`truncate ${room.unreadCount > 0 ? 'font-semibold text-fluux-text' : 'font-medium'}`}>{room.name}</p>
             {/* Activity dot for unread (non-mention) activity. Red for a
                 notify-all room — the attention tier, matching the icon-rail
-                indicator and mention badge — grey for plain unread. */}
+                indicator and mention badge — grey for plain unread. The count
+                itself lives in the row tooltip; the dot carries no tooltip of
+                its own (nested inside the row's, it popped a second bubble). */}
             {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
-              <Tooltip content={`${room.unreadCount} unread`} position="top">
-                <div
-                  className={`size-2.5 rounded-full flex-shrink-0 ${
-                    roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
-                  }`}
-                />
-              </Tooltip>
+              <div
+                className={`size-2.5 rounded-full flex-shrink-0 ${
+                  roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
+                }`}
+              />
             )}
             {/* Mentions count badge — red, the loud "wants your attention" tier. */}
             {room.mentionsCount > 0 && (

--- a/apps/fluux/src/i18n/i18n.test.ts
+++ b/apps/fluux/src/i18n/i18n.test.ts
@@ -163,6 +163,25 @@ describe('i18n', () => {
       expect(testI18n.t('presence.yearsAgo', { count: 1 })).toBe('1y ago')
       expect(testI18n.t('presence.yearsAgo', { count: 3 })).toBe('3y ago')
     })
+
+    it('should use English singular and plural for unread messages', async () => {
+      await testI18n.changeLanguage('en')
+      expect(testI18n.t('rooms.unreadMessages', { count: 1 })).toBe('1 unread message')
+      expect(testI18n.t('rooms.unreadMessages', { count: 37 })).toBe('37 unread messages')
+    })
+
+    it('should use French singular and plural for unread messages', async () => {
+      await testI18n.changeLanguage('fr')
+      expect(testI18n.t('rooms.unreadMessages', { count: 1 })).toBe('1 message non lu')
+      expect(testI18n.t('rooms.unreadMessages', { count: 4 })).toBe('4 messages non lus')
+    })
+
+    it('should use correct Polish plural forms for unread messages', async () => {
+      await testI18n.changeLanguage('pl')
+      expect(testI18n.t('rooms.unreadMessages', { count: 1 })).toBe('1 nieprzeczytana wiadomość')
+      expect(testI18n.t('rooms.unreadMessages', { count: 3 })).toBe('3 nieprzeczytane wiadomości')
+      expect(testI18n.t('rooms.unreadMessages', { count: 12 })).toBe('12 nieprzeczytanych wiadomości')
+    })
   })
 
   describe('language switching', () => {

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -429,7 +429,13 @@
         "nickChanged": "أصبح {{oldNick}} يُعرف الآن باسم {{newNick}}",
         "nickEdgeWhitespace": "يحتوي الاسم على مسافات إضافية في الأطراف",
         "nickHiddenChars": "يحتوي الاسم على أحرف مخفية",
-        "mentionSuggestions": "اقتراحات الإشارات"
+        "mentionSuggestions": "اقتراحات الإشارات",
+        "unreadMessages_zero": "لا رسائل غير مقروءة",
+        "unreadMessages": "رسالة واحدة غير مقروءة",
+        "unreadMessages_two": "رسالتان غير مقروءتين",
+        "unreadMessages_few": "{{count}} رسائل غير مقروءة",
+        "unreadMessages_many": "{{count}} رسالة غير مقروءة",
+        "unreadMessages_other": "{{count}} رسالة غير مقروءة"
     },
     "events": {
         "invitedBy": "دعوة من {{name}}",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -429,7 +429,11 @@
         "nickChanged": "{{oldNick}} цяпер вядомы як {{newNick}}",
         "nickEdgeWhitespace": "Імя змяшчае лішнія прабелы па краях",
         "nickHiddenChars": "Імя змяшчае схаваныя сімвалы",
-        "mentionSuggestions": "Прапановы згадванняў"
+        "mentionSuggestions": "Прапановы згадванняў",
+        "unreadMessages": "{{count}} непрачытанае паведамленне",
+        "unreadMessages_few": "{{count}} непрачытаныя паведамленні",
+        "unreadMessages_many": "{{count}} непрачытаных паведамленняў",
+        "unreadMessages_other": "{{count}} непрачытанага паведамлення"
     },
     "events": {
         "invitedBy": "Запрошаны {{name}}",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} вече е познат като {{newNick}}",
         "nickEdgeWhitespace": "Името съдържа излишни интервали в краищата",
         "nickHiddenChars": "Името съдържа скрити знаци",
-        "mentionSuggestions": "Предложения за споменавания"
+        "mentionSuggestions": "Предложения за споменавания",
+        "unreadMessages": "{{count}} непрочетено съобщение",
+        "unreadMessages_other": "{{count}} непрочетени съобщения"
     },
     "events": {
         "invitedBy": "Поканен от {{name}}",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -431,7 +431,10 @@
         "nickChanged": "{{oldNick}} ara es coneix com a {{newNick}}",
         "nickEdgeWhitespace": "El nom té espais addicionals als extrems",
         "nickHiddenChars": "El nom conté caràcters ocults",
-        "mentionSuggestions": "Suggeriments de mencions"
+        "mentionSuggestions": "Suggeriments de mencions",
+        "unreadMessages": "{{count}} missatge sense llegir",
+        "unreadMessages_many": "{{count}} de missatges sense llegir",
+        "unreadMessages_other": "{{count}} missatges sense llegir"
     },
     "events": {
         "invitedBy": "Convidat per {{name}}",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -431,7 +431,11 @@
         "nickChanged": "{{oldNick}} je nyní znám jako {{newNick}}",
         "nickEdgeWhitespace": "Jméno obsahuje mezery na okrajích",
         "nickHiddenChars": "Jméno obsahuje skryté znaky",
-        "mentionSuggestions": "Návrhy zmínek"
+        "mentionSuggestions": "Návrhy zmínek",
+        "unreadMessages": "{{count}} nepřečtená zpráva",
+        "unreadMessages_few": "{{count}} nepřečtené zprávy",
+        "unreadMessages_many": "{{count}} nepřečtené zprávy",
+        "unreadMessages_other": "{{count}} nepřečtených zpráv"
     },
     "events": {
         "invitedBy": "Pozval(a) {{name}}",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} er nu kendt som {{newNick}}",
         "nickEdgeWhitespace": "Navnet har ekstra mellemrum i kanterne",
         "nickHiddenChars": "Navnet indeholder skjulte tegn",
-        "mentionSuggestions": "Omtaleforslag"
+        "mentionSuggestions": "Omtaleforslag",
+        "unreadMessages": "{{count}} ulæst besked",
+        "unreadMessages_other": "{{count}} ulæste beskeder"
     },
     "events": {
         "invitedBy": "Inviteret af {{name}}",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -431,7 +431,9 @@
         "nickChanged": "{{oldNick}} heißt jetzt {{newNick}}",
         "nickEdgeWhitespace": "Der Name hat zusätzliche Leerzeichen am Rand",
         "nickHiddenChars": "Der Name enthält versteckte Zeichen",
-        "mentionSuggestions": "Erwähnungsvorschläge"
+        "mentionSuggestions": "Erwähnungsvorschläge",
+        "unreadMessages": "{{count}} ungelesene Nachricht",
+        "unreadMessages_other": "{{count}} ungelesene Nachrichten"
     },
     "events": {
         "invitedBy": "Eingeladen von {{name}}",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -430,7 +430,9 @@
         "nickChanged": "{{oldNick}} είναι πλέον γνωστός ως {{newNick}}",
         "nickEdgeWhitespace": "Το όνομα έχει επιπλέον κενά στα άκρα",
         "nickHiddenChars": "Το όνομα περιέχει κρυφούς χαρακτήρες",
-        "mentionSuggestions": "Προτάσεις αναφορών"
+        "mentionSuggestions": "Προτάσεις αναφορών",
+        "unreadMessages": "{{count}} μη αναγνωσμένο μήνυμα",
+        "unreadMessages_other": "{{count}} μη αναγνωσμένα μηνύματα"
     },
     "events": {
         "invitedBy": "Πρόσκληση από {{name}}",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} is now known as {{newNick}}",
         "nickEdgeWhitespace": "Name has extra spaces at the edges",
         "nickHiddenChars": "Name contains hidden characters",
-        "mentionSuggestions": "Mention suggestions"
+        "mentionSuggestions": "Mention suggestions",
+        "unreadMessages": "{{count}} unread message",
+        "unreadMessages_other": "{{count}} unread messages"
     },
     "events": {
         "invitedBy": "Invited by {{name}}",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -431,7 +431,10 @@
         "nickChanged": "{{oldNick}} ahora se conoce como {{newNick}}",
         "nickEdgeWhitespace": "El nombre tiene espacios adicionales en los extremos",
         "nickHiddenChars": "El nombre contiene caracteres ocultos",
-        "mentionSuggestions": "Sugerencias de menciones"
+        "mentionSuggestions": "Sugerencias de menciones",
+        "unreadMessages": "{{count}} mensaje sin leer",
+        "unreadMessages_many": "{{count}} de mensajes sin leer",
+        "unreadMessages_other": "{{count}} mensajes sin leer"
     },
     "events": {
         "invitedBy": "Invitado por {{name}}",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -431,7 +431,9 @@
         "nickChanged": "{{oldNick}} on nüüd tuntud kui {{newNick}}",
         "nickEdgeWhitespace": "Nimel on servades lisatühikud",
         "nickHiddenChars": "Nimi sisaldab peidetud märke",
-        "mentionSuggestions": "Mainimiste soovitused"
+        "mentionSuggestions": "Mainimiste soovitused",
+        "unreadMessages": "{{count}} lugemata sõnum",
+        "unreadMessages_other": "{{count}} lugemata sõnumit"
     },
     "events": {
         "invitedBy": "Kutsuja {{name}}",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} tunnetaan nyt nimellä {{newNick}}",
         "nickEdgeWhitespace": "Nimessä on ylimääräisiä välilyöntejä reunoilla",
         "nickHiddenChars": "Nimi sisältää piilotettuja merkkejä",
-        "mentionSuggestions": "Mainintaehdotukset"
+        "mentionSuggestions": "Mainintaehdotukset",
+        "unreadMessages": "{{count}} lukematon viesti",
+        "unreadMessages_other": "{{count}} lukematonta viestiä"
     },
     "events": {
         "invitedBy": "Kutsuja: {{name}}",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -430,7 +430,10 @@
         "nickChanged": "{{oldNick}} est désormais connu sous le nom de {{newNick}}",
         "nickEdgeWhitespace": "Le nom comporte des espaces au début ou à la fin",
         "nickHiddenChars": "Le nom contient des caractères invisibles",
-        "mentionSuggestions": "Suggestions de mentions"
+        "mentionSuggestions": "Suggestions de mentions",
+        "unreadMessages": "{{count}} message non lu",
+        "unreadMessages_many": "{{count}} de messages non lus",
+        "unreadMessages_other": "{{count}} messages non lus"
     },
     "events": {
         "invitedBy": "Invité par {{name}}",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -429,7 +429,12 @@
         "nickChanged": "Tugtar {{newNick}} ar {{oldNick}} anois",
         "nickEdgeWhitespace": "Tá spásanna breise ag imill an ainm",
         "nickHiddenChars": "Tá carachtair fholaithe san ainm",
-        "mentionSuggestions": "Moltaí tagartha"
+        "mentionSuggestions": "Moltaí tagartha",
+        "unreadMessages": "{{count}} teachtaireacht gan léamh",
+        "unreadMessages_two": "{{count}} theachtaireacht gan léamh",
+        "unreadMessages_few": "{{count}} theachtaireacht gan léamh",
+        "unreadMessages_many": "{{count}} dteachtaireacht gan léamh",
+        "unreadMessages_other": "{{count}} teachtaireacht gan léamh"
     },
     "events": {
         "invitedBy": "Cuireadh ag {{name}}",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -429,7 +429,10 @@
         "nickChanged": "{{oldNick}} ידוע כעת בשם {{newNick}}",
         "nickEdgeWhitespace": "השם מכיל רווחים נוספים בקצוות",
         "nickHiddenChars": "השם מכיל תווים נסתרים",
-        "mentionSuggestions": "הצעות אזכור"
+        "mentionSuggestions": "הצעות אזכור",
+        "unreadMessages": "הודעה אחת שלא נקראה",
+        "unreadMessages_two": "2 הודעות שלא נקראו",
+        "unreadMessages_other": "{{count}} הודעות שלא נקראו"
     },
     "events": {
         "invitedBy": "הוזמן על ידי {{name}}",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -429,7 +429,10 @@
         "nickChanged": "{{oldNick}} sada je poznat kao {{newNick}}",
         "nickEdgeWhitespace": "Ime sadrži dodatne razmake na rubovima",
         "nickHiddenChars": "Ime sadrži skrivene znakove",
-        "mentionSuggestions": "Prijedlozi spominjanja"
+        "mentionSuggestions": "Prijedlozi spominjanja",
+        "unreadMessages": "{{count}} nepročitana poruka",
+        "unreadMessages_few": "{{count}} nepročitane poruke",
+        "unreadMessages_other": "{{count}} nepročitanih poruka"
     },
     "events": {
         "invitedBy": "Pozvao {{name}}",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} mostantól {{newNick}} néven ismert",
         "nickEdgeWhitespace": "A név szélein extra szóközök vannak",
         "nickHiddenChars": "A név rejtett karaktereket tartalmaz",
-        "mentionSuggestions": "Említésjavaslatok"
+        "mentionSuggestions": "Említésjavaslatok",
+        "unreadMessages": "{{count}} olvasatlan üzenet",
+        "unreadMessages_other": "{{count}} olvasatlan üzenet"
     },
     "events": {
         "invitedBy": "Meghívta: {{name}}",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} er nú þekktur sem {{newNick}}",
         "nickEdgeWhitespace": "Nafnið er með auka bil á endunum",
         "nickHiddenChars": "Nafnið inniheldur falda stafi",
-        "mentionSuggestions": "Tillögur að tilvísunum"
+        "mentionSuggestions": "Tillögur að tilvísunum",
+        "unreadMessages": "{{count}} ólesið skilaboð",
+        "unreadMessages_other": "{{count}} ólesin skilaboð"
     },
     "events": {
         "invitedBy": "Boðið af {{name}}",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -431,7 +431,10 @@
         "nickChanged": "{{oldNick}} ora è conosciuto come {{newNick}}",
         "nickEdgeWhitespace": "Il nome ha spazi aggiuntivi ai bordi",
         "nickHiddenChars": "Il nome contiene caratteri nascosti",
-        "mentionSuggestions": "Suggerimenti menzioni"
+        "mentionSuggestions": "Suggerimenti menzioni",
+        "unreadMessages": "{{count}} messaggio non letto",
+        "unreadMessages_many": "{{count}} di messaggi non letti",
+        "unreadMessages_other": "{{count}} messaggi non letti"
     },
     "events": {
         "invitedBy": "Invitato da {{name}}",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -429,7 +429,11 @@
         "nickChanged": "{{oldNick}} dabar žinomas kaip {{newNick}}",
         "nickEdgeWhitespace": "Varde yra papildomų tarpų kraštuose",
         "nickHiddenChars": "Varde yra paslėptų simbolių",
-        "mentionSuggestions": "Paminėjimų pasiūlymai"
+        "mentionSuggestions": "Paminėjimų pasiūlymai",
+        "unreadMessages": "{{count}} neperskaitytas pranešimas",
+        "unreadMessages_few": "{{count}} neperskaityti pranešimai",
+        "unreadMessages_many": "{{count}} neperskaityto pranešimo",
+        "unreadMessages_other": "{{count}} neperskaitytų pranešimų"
     },
     "events": {
         "invitedBy": "Pakvietė {{name}}",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -430,7 +430,10 @@
         "nickChanged": "{{oldNick}} tagad zināms kā {{newNick}}",
         "nickEdgeWhitespace": "Vārdam ir papildu atstarpes malās",
         "nickHiddenChars": "Vārds satur slēptas rakstzīmes",
-        "mentionSuggestions": "Pieminējumu ieteikumi"
+        "mentionSuggestions": "Pieminējumu ieteikumi",
+        "unreadMessages_zero": "{{count}} neizlasītu ziņojumu",
+        "unreadMessages": "{{count}} neizlasīts ziņojums",
+        "unreadMessages_other": "{{count}} neizlasīti ziņojumi"
     },
     "events": {
         "invitedBy": "Uzaicināja {{name}}",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -431,7 +431,12 @@
         "nickChanged": "{{oldNick}} issa magħruf bħala {{newNick}}",
         "nickEdgeWhitespace": "L-isem għandu spazji żejda fit-truf",
         "nickHiddenChars": "L-isem fih karattri moħbija",
-        "mentionSuggestions": "Suġġerimenti ta' msemmija"
+        "mentionSuggestions": "Suġġerimenti ta' msemmija",
+        "unreadMessages": "{{count}} messaġġ mhux moqri",
+        "unreadMessages_two": "{{count}} messaġġi mhux moqrija",
+        "unreadMessages_few": "{{count}} messaġġi mhux moqrija",
+        "unreadMessages_many": "{{count}} messaġġ mhux moqri",
+        "unreadMessages_other": "{{count}} messaġġ mhux moqri"
     },
     "events": {
         "invitedBy": "Mistieden minn {{name}}",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} er nå kjent som {{newNick}}",
         "nickEdgeWhitespace": "Navnet har ekstra mellomrom i kantene",
         "nickHiddenChars": "Navnet inneholder skjulte tegn",
-        "mentionSuggestions": "Omtaleforslag"
+        "mentionSuggestions": "Omtaleforslag",
+        "unreadMessages": "{{count}} ulest melding",
+        "unreadMessages_other": "{{count}} uleste meldinger"
     },
     "events": {
         "invitedBy": "Invitert av {{name}}",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} heet nu {{newNick}}",
         "nickEdgeWhitespace": "De naam heeft extra spaties aan de randen",
         "nickHiddenChars": "De naam bevat verborgen tekens",
-        "mentionSuggestions": "Vermeldingssuggesties"
+        "mentionSuggestions": "Vermeldingssuggesties",
+        "unreadMessages": "{{count}} ongelezen bericht",
+        "unreadMessages_other": "{{count}} ongelezen berichten"
     },
     "events": {
         "invitedBy": "Uitgenodigd door {{name}}",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -431,7 +431,11 @@
         "nickChanged": "{{oldNick}} jest teraz znany jako {{newNick}}",
         "nickEdgeWhitespace": "Nazwa ma dodatkowe spacje na brzegach",
         "nickHiddenChars": "Nazwa zawiera ukryte znaki",
-        "mentionSuggestions": "Podpowiedzi wzmianek"
+        "mentionSuggestions": "Podpowiedzi wzmianek",
+        "unreadMessages": "{{count}} nieprzeczytana wiadomość",
+        "unreadMessages_few": "{{count}} nieprzeczytane wiadomości",
+        "unreadMessages_many": "{{count}} nieprzeczytanych wiadomości",
+        "unreadMessages_other": "{{count}} nieprzeczytanej wiadomości"
     },
     "events": {
         "invitedBy": "Zaproszony przez {{name}}",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -431,7 +431,10 @@
         "nickChanged": "{{oldNick}} agora é conhecido como {{newNick}}",
         "nickEdgeWhitespace": "O nome tem espaços extra nas extremidades",
         "nickHiddenChars": "O nome contém caracteres ocultos",
-        "mentionSuggestions": "Sugestões de menções"
+        "mentionSuggestions": "Sugestões de menções",
+        "unreadMessages": "{{count}} mensagem não lida",
+        "unreadMessages_many": "{{count}} de mensagens não lidas",
+        "unreadMessages_other": "{{count}} mensagens não lidas"
     },
     "events": {
         "invitedBy": "Convidado por {{name}}",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -431,7 +431,10 @@
         "nickChanged": "{{oldNick}} este acum cunoscut ca {{newNick}}",
         "nickEdgeWhitespace": "Numele are spații suplimentare la margini",
         "nickHiddenChars": "Numele conține caractere ascunse",
-        "mentionSuggestions": "Sugestii de mențiuni"
+        "mentionSuggestions": "Sugestii de mențiuni",
+        "unreadMessages": "{{count}} mesaj necitit",
+        "unreadMessages_few": "{{count}} mesaje necitite",
+        "unreadMessages_other": "{{count}} de mesaje necitite"
     },
     "events": {
         "invitedBy": "Invitat de {{name}}",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -429,7 +429,11 @@
         "nickChanged": "{{oldNick}} теперь известен как {{newNick}}",
         "nickEdgeWhitespace": "Имя содержит лишние пробелы по краям",
         "nickHiddenChars": "Имя содержит скрытые символы",
-        "mentionSuggestions": "Предложения упоминаний"
+        "mentionSuggestions": "Предложения упоминаний",
+        "unreadMessages": "{{count}} непрочитанное сообщение",
+        "unreadMessages_few": "{{count}} непрочитанных сообщения",
+        "unreadMessages_many": "{{count}} непрочитанных сообщений",
+        "unreadMessages_other": "{{count}} непрочитанного сообщения"
     },
     "events": {
         "invitedBy": "Пригласил(а) {{name}}",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -430,7 +430,11 @@
         "nickChanged": "{{oldNick}} je teraz známy ako {{newNick}}",
         "nickEdgeWhitespace": "Meno obsahuje medzery na okrajoch",
         "nickHiddenChars": "Meno obsahuje skryté znaky",
-        "mentionSuggestions": "Návrhy zmienok"
+        "mentionSuggestions": "Návrhy zmienok",
+        "unreadMessages": "{{count}} neprečítaná správa",
+        "unreadMessages_few": "{{count}} neprečítané správy",
+        "unreadMessages_many": "{{count}} neprečítanej správy",
+        "unreadMessages_other": "{{count}} neprečítaných správ"
     },
     "events": {
         "invitedBy": "Pozval {{name}}",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -431,7 +431,11 @@
         "nickChanged": "{{oldNick}} je zdaj znan kot {{newNick}}",
         "nickEdgeWhitespace": "Ime ima dodatne presledke na robovih",
         "nickHiddenChars": "Ime vsebuje skrite znake",
-        "mentionSuggestions": "Predlogi omemb"
+        "mentionSuggestions": "Predlogi omemb",
+        "unreadMessages": "{{count}} neprebrano sporočilo",
+        "unreadMessages_two": "{{count}} neprebrani sporočili",
+        "unreadMessages_few": "{{count}} neprebrana sporočila",
+        "unreadMessages_other": "{{count}} neprebranih sporočil"
     },
     "events": {
         "invitedBy": "Povabil {{name}}",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} är nu känd som {{newNick}}",
         "nickEdgeWhitespace": "Namnet har extra mellanslag i kanterna",
         "nickHiddenChars": "Namnet innehåller dolda tecken",
-        "mentionSuggestions": "Omnämnandeförslag"
+        "mentionSuggestions": "Omnämnandeförslag",
+        "unreadMessages": "{{count}} oläst meddelande",
+        "unreadMessages_other": "{{count}} olästa meddelanden"
     },
     "events": {
         "invitedBy": "Inbjuden av {{name}}",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -429,7 +429,11 @@
         "nickChanged": "{{oldNick}} тепер відомий як {{newNick}}",
         "nickEdgeWhitespace": "Ім'я містить зайві пробіли по краях",
         "nickHiddenChars": "Ім'я містить приховані символи",
-        "mentionSuggestions": "Пропозиції згадувань"
+        "mentionSuggestions": "Пропозиції згадувань",
+        "unreadMessages": "{{count}} непрочитане повідомлення",
+        "unreadMessages_few": "{{count}} непрочитаних повідомлення",
+        "unreadMessages_many": "{{count}} непрочитаних повідомлень",
+        "unreadMessages_other": "{{count}} непрочитаного повідомлення"
     },
     "events": {
         "invitedBy": "Запрошено {{name}}",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -429,7 +429,9 @@
         "nickChanged": "{{oldNick}} 现在称为 {{newNick}}",
         "nickEdgeWhitespace": "名称的首尾包含多余的空格",
         "nickHiddenChars": "名称包含隐藏字符",
-        "mentionSuggestions": "提及建议"
+        "mentionSuggestions": "提及建议",
+        "unreadMessages": "{{count}} 条未读消息",
+        "unreadMessages_other": "{{count}} 条未读消息"
     },
     "events": {
         "invitedBy": "邀请者 {{name}}",

--- a/apps/fluux/src/utils/roomTooltip.test.ts
+++ b/apps/fluux/src/utils/roomTooltip.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { roomTooltipParts, type RoomTooltipRoom } from './roomTooltip'
+
+// Echoes the key back, with the interpolation options appended when present, so
+// assertions can check both WHICH key was chosen and WHAT was interpolated
+// without depending on real locale copy. Real plural resolution is covered in
+// i18n.test.ts against the actual locale files.
+const t = (key: string, options?: Record<string, unknown>) =>
+  options ? `${key}(${JSON.stringify(options)})` : key
+
+const occupants = (n: number) =>
+  new Map(Array.from({ length: n }, (_, i) => [`user${i}`, {}])) as RoomTooltipRoom['occupants']
+
+const makeRoom = (over: Partial<RoomTooltipRoom> = {}): RoomTooltipRoom => ({
+  joined: true,
+  isJoining: false,
+  unreadCount: 0,
+  occupants: occupants(2),
+  nickname: 'me',
+  ...over,
+})
+
+describe('roomTooltipParts', () => {
+  it('announces the unread count as the headline', () => {
+    const parts = roomTooltipParts(makeRoom({ unreadCount: 37 }), t)
+    expect(parts.headline).toBe('rooms.unreadMessages({"count":37})')
+  })
+
+  it('passes the raw count to the translator so i18next can pick the plural form', () => {
+    const spy = vi.fn((key: string) => key)
+    roomTooltipParts(makeRoom({ unreadCount: 1 }), spy)
+    expect(spy).toHaveBeenCalledWith('rooms.unreadMessages', { count: 1 })
+  })
+
+  it('has no headline when the room is fully read', () => {
+    expect(roomTooltipParts(makeRoom({ unreadCount: 0 }), t).headline).toBeNull()
+  })
+
+  it('composes occupant count and nickname into the detail line', () => {
+    expect(roomTooltipParts(makeRoom({ unreadCount: 37 }), t).detail).toBe('2 rooms.users • me')
+  })
+
+  it('drops the nickname segment when the room has no nickname', () => {
+    const parts = roomTooltipParts(makeRoom({ nickname: undefined }), t)
+    expect(parts.detail).toBe('2 rooms.users')
+  })
+
+  it('uses the singular occupant key for a room of one', () => {
+    expect(roomTooltipParts(makeRoom({ occupants: occupants(1) }), t).detail).toBe('1 rooms.user • me')
+  })
+
+  it('reports joining state with no headline, even with unread messages', () => {
+    // isJoining wins over joined — preserves the precedence of the previous
+    // getTooltipContent, which checked isJoining first.
+    const parts = roomTooltipParts(makeRoom({ isJoining: true, unreadCount: 37 }), t)
+    expect(parts).toEqual({ headline: null, detail: 'rooms.joining' })
+  })
+
+  it('prompts to join an unjoined room, with no headline', () => {
+    const parts = roomTooltipParts(makeRoom({ joined: false, unreadCount: 37 }), t)
+    expect(parts).toEqual({ headline: null, detail: 'rooms.doubleClickToJoin' })
+  })
+})

--- a/apps/fluux/src/utils/roomTooltip.ts
+++ b/apps/fluux/src/utils/roomTooltip.ts
@@ -1,0 +1,47 @@
+import type { Room } from '@fluux/sdk'
+
+// Matches the TranslateFn convention in messagePreviewText.ts / roomJoinError.ts.
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+/**
+ * The room fields the sidebar row tooltip needs.
+ *
+ * `mentionsCount` is deliberately absent. The unread headline must not be gated
+ * on it — the row's own `@N` badge already carries the mentions number, and a
+ * room WITH mentions is exactly the case where the total unread is otherwise
+ * invisible. Leaving the field out of the input type makes that gate
+ * unrepresentable here.
+ */
+export type RoomTooltipRoom = Pick<
+  Room,
+  'joined' | 'isJoining' | 'unreadCount' | 'occupants' | 'nickname'
+>
+
+export interface RoomTooltipParts {
+  /** "37 unread messages", or null when there is nothing unread to announce. */
+  headline: string | null
+  /** "12 users • MyNick" | "Joining..." | "Double-click to join" */
+  detail: string
+}
+
+/**
+ * Compose the sidebar room row tooltip.
+ *
+ * The detail line reproduces the tooltip as it was before the unread headline
+ * existed, including the manual singular/plural selection between `rooms.user`
+ * and `rooms.users`. The headline is the only new information, and it appears
+ * only for a joined room with unread messages.
+ */
+export function roomTooltipParts(room: RoomTooltipRoom, t: TranslateFn): RoomTooltipParts {
+  if (room.isJoining) return { headline: null, detail: t('rooms.joining') }
+  if (!room.joined) return { headline: null, detail: t('rooms.doubleClickToJoin') }
+
+  const userCount = room.occupants.size
+  const userText = `${userCount} ${userCount === 1 ? t('rooms.user') : t('rooms.users')}`
+  const detail = room.nickname ? `${userText} • ${room.nickname}` : userText
+
+  const headline =
+    room.unreadCount > 0 ? t('rooms.unreadMessages', { count: room.unreadCount }) : null
+
+  return { headline, detail }
+}

--- a/docs/superpowers/plans/2026-07-22-room-tooltip-unread-count.md
+++ b/docs/superpowers/plans/2026-07-22-room-tooltip-unread-count.md
@@ -1,0 +1,653 @@
+# Room Row Tooltip Unread Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the unread message count as a headline line in the sidebar room row tooltip, and delete the untranslated tooltip currently attached to the activity dot.
+
+**Architecture:** A new pure module `apps/fluux/src/utils/roomTooltip.ts` owns all tooltip string composition and state branching, replacing the inline `getTooltipContent` closure in `RoomsList`. It returns `{ headline, detail }`; `RoomsList` renders a single string when `headline` is `null` (today's exact behaviour) and a two-line node otherwise. The nested `Tooltip` around the activity dot is removed.
+
+**Tech Stack:** React 19, TypeScript, Vitest + @testing-library/react, i18next / react-i18next, Tailwind.
+
+**Spec:** [docs/superpowers/specs/2026-07-22-room-tooltip-unread-count-design.md](../specs/2026-07-22-room-tooltip-unread-count-design.md)
+
+## Global Constraints
+
+- The unread headline shows whenever `room.joined && room.unreadCount > 0`, **including when `mentionsCount > 0`**. It is never gated on mentions.
+- `mentionsCount` must not appear in `roomTooltipParts`' input type. Excluding it makes the old gate structurally unrepresentable.
+- The unread line is **not** colour-tinted. No `text-fluux-badge-strong`, no `roomActivityTone` in the tooltip.
+- The detail line keeps its existing manual `rooms.user` / `rooms.users` singular-plural selection. Do not migrate it to i18next plurals.
+- New i18n keys follow the established base-key convention: the **unsuffixed** key is the singular (i18next falls back to it when `_one` is absent), `_other` is the plural. Verified against a live i18next instance for `en` and `fr`.
+- All 33 locales must gain the new key. `apps/fluux/src/i18n/i18n.test.ts` enforces parity on unsuffixed keys and fails the build otherwise.
+- Locale files are written back with `json.dumps(d, ensure_ascii=False, indent=4) + "\n"`. Verified: all 33 files round-trip byte-identically under this format, so diffs stay minimal.
+- No em-dash connectors in translated copy.
+- Never include a Claude footer in commit messages.
+- Before each commit: tests pass with no stderr, `npm run typecheck` and `npm run lint` pass.
+
+---
+
+### Task 1: `roomTooltipParts` pure module
+
+**Files:**
+- Create: `apps/fluux/src/utils/roomTooltip.ts`
+- Test: `apps/fluux/src/utils/roomTooltip.test.ts`
+
+**Interfaces:**
+- Consumes: `Room` from `@fluux/sdk` (type only).
+- Produces:
+  - `type RoomTooltipRoom = Pick<Room, 'joined' | 'isJoining' | 'unreadCount' | 'occupants' | 'nickname'>`
+  - `interface RoomTooltipParts { headline: string | null; detail: string }`
+  - `function roomTooltipParts(room: RoomTooltipRoom, t: TranslateFn): RoomTooltipParts`
+  - i18n key used: `rooms.unreadMessages`, called as `t('rooms.unreadMessages', { count })`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/utils/roomTooltip.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { roomTooltipParts, type RoomTooltipRoom } from './roomTooltip'
+
+// Echoes the key back, with the interpolation options appended when present, so
+// assertions can check both WHICH key was chosen and WHAT was interpolated
+// without depending on real locale copy. Real plural resolution is covered in
+// i18n.test.ts against the actual locale files.
+const t = (key: string, options?: Record<string, unknown>) =>
+  options ? `${key}(${JSON.stringify(options)})` : key
+
+const occupants = (n: number) =>
+  new Map(Array.from({ length: n }, (_, i) => [`user${i}`, {}])) as RoomTooltipRoom['occupants']
+
+const makeRoom = (over: Partial<RoomTooltipRoom> = {}): RoomTooltipRoom => ({
+  joined: true,
+  isJoining: false,
+  unreadCount: 0,
+  occupants: occupants(2),
+  nickname: 'me',
+  ...over,
+})
+
+describe('roomTooltipParts', () => {
+  it('announces the unread count as the headline', () => {
+    const parts = roomTooltipParts(makeRoom({ unreadCount: 37 }), t)
+    expect(parts.headline).toBe('rooms.unreadMessages({"count":37})')
+  })
+
+  it('passes the raw count to the translator so i18next can pick the plural form', () => {
+    const spy = vi.fn((key: string) => key)
+    roomTooltipParts(makeRoom({ unreadCount: 1 }), spy)
+    expect(spy).toHaveBeenCalledWith('rooms.unreadMessages', { count: 1 })
+  })
+
+  it('has no headline when the room is fully read', () => {
+    expect(roomTooltipParts(makeRoom({ unreadCount: 0 }), t).headline).toBeNull()
+  })
+
+  it('composes occupant count and nickname into the detail line', () => {
+    expect(roomTooltipParts(makeRoom({ unreadCount: 37 }), t).detail).toBe('2 rooms.users • me')
+  })
+
+  it('drops the nickname segment when the room has no nickname', () => {
+    const parts = roomTooltipParts(makeRoom({ nickname: undefined }), t)
+    expect(parts.detail).toBe('2 rooms.users')
+  })
+
+  it('uses the singular occupant key for a room of one', () => {
+    expect(roomTooltipParts(makeRoom({ occupants: occupants(1) }), t).detail).toBe('1 rooms.user • me')
+  })
+
+  it('reports joining state with no headline, even with unread messages', () => {
+    // isJoining wins over joined — preserves the precedence of the previous
+    // getTooltipContent, which checked isJoining first.
+    const parts = roomTooltipParts(makeRoom({ isJoining: true, unreadCount: 37 }), t)
+    expect(parts).toEqual({ headline: null, detail: 'rooms.joining' })
+  })
+
+  it('prompts to join an unjoined room, with no headline', () => {
+    const parts = roomTooltipParts(makeRoom({ joined: false, unreadCount: 37 }), t)
+    expect(parts).toEqual({ headline: null, detail: 'rooms.doubleClickToJoin' })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/fluux && npx vitest run src/utils/roomTooltip.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./roomTooltip"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/fluux/src/utils/roomTooltip.ts`:
+
+```typescript
+import type { Room } from '@fluux/sdk'
+
+// Matches the TranslateFn convention in messagePreviewText.ts / roomJoinError.ts.
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+/**
+ * The room fields the sidebar row tooltip needs.
+ *
+ * `mentionsCount` is deliberately absent. The unread headline must not be gated
+ * on it — the row's own `@N` badge already carries the mentions number, and a
+ * room WITH mentions is exactly the case where the total unread is otherwise
+ * invisible. Leaving the field out of the input type makes that gate
+ * unrepresentable here.
+ */
+export type RoomTooltipRoom = Pick<
+  Room,
+  'joined' | 'isJoining' | 'unreadCount' | 'occupants' | 'nickname'
+>
+
+export interface RoomTooltipParts {
+  /** "37 unread messages", or null when there is nothing unread to announce. */
+  headline: string | null
+  /** "12 users • MyNick" | "Joining..." | "Double-click to join" */
+  detail: string
+}
+
+/**
+ * Compose the sidebar room row tooltip.
+ *
+ * The detail line reproduces the tooltip as it was before the unread headline
+ * existed, including the manual singular/plural selection between `rooms.user`
+ * and `rooms.users`. The headline is the only new information, and it appears
+ * only for a joined room with unread messages.
+ */
+export function roomTooltipParts(room: RoomTooltipRoom, t: TranslateFn): RoomTooltipParts {
+  if (room.isJoining) return { headline: null, detail: t('rooms.joining') }
+  if (!room.joined) return { headline: null, detail: t('rooms.doubleClickToJoin') }
+
+  const userCount = room.occupants.size
+  const userText = `${userCount} ${userCount === 1 ? t('rooms.user') : t('rooms.users')}`
+  const detail = room.nickname ? `${userText} • ${room.nickname}` : userText
+
+  const headline =
+    room.unreadCount > 0 ? t('rooms.unreadMessages', { count: room.unreadCount }) : null
+
+  return { headline, detail }
+}
+```
+
+- [ ] **Step 4: Run tests, typecheck and lint**
+
+```bash
+cd apps/fluux && npx vitest run src/utils/roomTooltip.test.ts && npm run typecheck && npm run lint
+```
+
+Expected: 8 tests PASS, no stderr, typecheck and lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fluux/src/utils/roomTooltip.ts apps/fluux/src/utils/roomTooltip.test.ts
+git commit -m "feat(sidebar): add roomTooltipParts helper for the room row tooltip"
+```
+
+---
+
+### Task 2: `rooms.unreadMessages` in all 33 locales
+
+**Files:**
+- Modify: `apps/fluux/src/i18n/locales/*.json` (all 33)
+- Modify: `apps/fluux/src/i18n/i18n.test.ts` (add plural assertions in the `plural forms` describe block)
+
+**Interfaces:**
+- Consumes: the key name `rooms.unreadMessages` chosen in Task 1.
+- Produces: `rooms.unreadMessages` (+ locale-appropriate plural suffixes) resolvable in every locale. Task 3 depends on nothing further from this task.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/fluux/src/i18n/i18n.test.ts`, inside the existing `describe('plural forms for months/years ago', ...)` block, add these tests after the last existing `it(...)`:
+
+```typescript
+  it('should use English singular and plural for unread messages', async () => {
+    await testI18n.changeLanguage('en')
+    expect(testI18n.t('rooms.unreadMessages', { count: 1 })).toBe('1 unread message')
+    expect(testI18n.t('rooms.unreadMessages', { count: 37 })).toBe('37 unread messages')
+  })
+
+  it('should use French singular and plural for unread messages', async () => {
+    await testI18n.changeLanguage('fr')
+    expect(testI18n.t('rooms.unreadMessages', { count: 1 })).toBe('1 message non lu')
+    expect(testI18n.t('rooms.unreadMessages', { count: 4 })).toBe('4 messages non lus')
+  })
+
+  it('should use correct Polish plural forms for unread messages', async () => {
+    await testI18n.changeLanguage('pl')
+    expect(testI18n.t('rooms.unreadMessages', { count: 1 })).toBe('1 nieprzeczytana wiadomość')
+    expect(testI18n.t('rooms.unreadMessages', { count: 3 })).toBe('3 nieprzeczytane wiadomości')
+    expect(testI18n.t('rooms.unreadMessages', { count: 12 })).toBe('12 nieprzeczytanych wiadomości')
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/fluux && npx vitest run src/i18n/i18n.test.ts
+```
+
+Expected: the three new tests FAIL, each returning the raw key `rooms.unreadMessages` instead of the copy. The parity tests still pass at this point (no key added yet).
+
+- [ ] **Step 3: Add the key to all 33 locales**
+
+Each locale gets the same set of plural suffixes it already uses for `chat.newMessagesCount` — that set was chosen per-language by a translator and is the correct CLDR shape for each.
+
+Run this script from the repository root:
+
+```python
+python3 - <<'PY'
+import json, pathlib
+
+TRANSLATIONS = {
+    'ar': {'_zero': 'لا رسائل غير مقروءة', '': 'رسالة واحدة غير مقروءة', '_two': 'رسالتان غير مقروءتين', '_few': '{{count}} رسائل غير مقروءة', '_many': '{{count}} رسالة غير مقروءة', '_other': '{{count}} رسالة غير مقروءة'},
+    'be': {'': '{{count}} непрачытанае паведамленне', '_few': '{{count}} непрачытаныя паведамленні', '_many': '{{count}} непрачытаных паведамленняў', '_other': '{{count}} непрачытанага паведамлення'},
+    'bg': {'': '{{count}} непрочетено съобщение', '_other': '{{count}} непрочетени съобщения'},
+    'ca': {'': '{{count}} missatge sense llegir', '_many': '{{count}} de missatges sense llegir', '_other': '{{count}} missatges sense llegir'},
+    'cs': {'': '{{count}} nepřečtená zpráva', '_few': '{{count}} nepřečtené zprávy', '_many': '{{count}} nepřečtené zprávy', '_other': '{{count}} nepřečtených zpráv'},
+    'da': {'': '{{count}} ulæst besked', '_other': '{{count}} ulæste beskeder'},
+    'de': {'': '{{count}} ungelesene Nachricht', '_other': '{{count}} ungelesene Nachrichten'},
+    'el': {'': '{{count}} μη αναγνωσμένο μήνυμα', '_other': '{{count}} μη αναγνωσμένα μηνύματα'},
+    'en': {'': '{{count}} unread message', '_other': '{{count}} unread messages'},
+    'es': {'': '{{count}} mensaje sin leer', '_many': '{{count}} de mensajes sin leer', '_other': '{{count}} mensajes sin leer'},
+    'et': {'': '{{count}} lugemata sõnum', '_other': '{{count}} lugemata sõnumit'},
+    'fi': {'': '{{count}} lukematon viesti', '_other': '{{count}} lukematonta viestiä'},
+    'fr': {'': '{{count}} message non lu', '_many': '{{count}} de messages non lus', '_other': '{{count}} messages non lus'},
+    'ga': {'': '{{count}} teachtaireacht gan léamh', '_two': '{{count}} theachtaireacht gan léamh', '_few': '{{count}} theachtaireacht gan léamh', '_many': '{{count}} dteachtaireacht gan léamh', '_other': '{{count}} teachtaireacht gan léamh'},
+    'he': {'': 'הודעה אחת שלא נקראה', '_two': '2 הודעות שלא נקראו', '_other': '{{count}} הודעות שלא נקראו'},
+    'hr': {'': '{{count}} nepročitana poruka', '_few': '{{count}} nepročitane poruke', '_other': '{{count}} nepročitanih poruka'},
+    'hu': {'': '{{count}} olvasatlan üzenet', '_other': '{{count}} olvasatlan üzenet'},
+    'is': {'': '{{count}} ólesið skilaboð', '_other': '{{count}} ólesin skilaboð'},
+    'it': {'': '{{count}} messaggio non letto', '_many': '{{count}} di messaggi non letti', '_other': '{{count}} messaggi non letti'},
+    'lt': {'': '{{count}} neperskaitytas pranešimas', '_few': '{{count}} neperskaityti pranešimai', '_many': '{{count}} neperskaityto pranešimo', '_other': '{{count}} neperskaitytų pranešimų'},
+    'lv': {'_zero': '{{count}} neizlasītu ziņojumu', '': '{{count}} neizlasīts ziņojums', '_other': '{{count}} neizlasīti ziņojumi'},
+    'mt': {'': '{{count}} messaġġ mhux moqri', '_two': '{{count}} messaġġi mhux moqrija', '_few': '{{count}} messaġġi mhux moqrija', '_many': '{{count}} messaġġ mhux moqri', '_other': '{{count}} messaġġ mhux moqri'},
+    'nb': {'': '{{count}} ulest melding', '_other': '{{count}} uleste meldinger'},
+    'nl': {'': '{{count}} ongelezen bericht', '_other': '{{count}} ongelezen berichten'},
+    'pl': {'': '{{count}} nieprzeczytana wiadomość', '_few': '{{count}} nieprzeczytane wiadomości', '_many': '{{count}} nieprzeczytanych wiadomości', '_other': '{{count}} nieprzeczytanej wiadomości'},
+    'pt': {'': '{{count}} mensagem não lida', '_many': '{{count}} de mensagens não lidas', '_other': '{{count}} mensagens não lidas'},
+    'ro': {'': '{{count}} mesaj necitit', '_few': '{{count}} mesaje necitite', '_other': '{{count}} de mesaje necitite'},
+    'ru': {'': '{{count}} непрочитанное сообщение', '_few': '{{count}} непрочитанных сообщения', '_many': '{{count}} непрочитанных сообщений', '_other': '{{count}} непрочитанного сообщения'},
+    'sk': {'': '{{count}} neprečítaná správa', '_few': '{{count}} neprečítané správy', '_many': '{{count}} neprečítanej správy', '_other': '{{count}} neprečítaných správ'},
+    'sl': {'': '{{count}} neprebrano sporočilo', '_two': '{{count}} neprebrani sporočili', '_few': '{{count}} neprebrana sporočila', '_other': '{{count}} neprebranih sporočil'},
+    'sv': {'': '{{count}} oläst meddelande', '_other': '{{count}} olästa meddelanden'},
+    'uk': {'': '{{count}} непрочитане повідомлення', '_few': '{{count}} непрочитаних повідомлення', '_many': '{{count}} непрочитаних повідомлень', '_other': '{{count}} непрочитаного повідомлення'},
+    'zh-CN': {'': '{{count}} 条未读消息', '_other': '{{count}} 条未读消息'},
+}
+
+base = pathlib.Path('apps/fluux/src/i18n/locales')
+for lang, forms in TRANSLATIONS.items():
+    path = base / f'{lang}.json'
+    data = json.loads(path.read_text(encoding='utf-8'))
+    for suffix, value in forms.items():
+        data['rooms'][f'unreadMessages{suffix}'] = value
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=4) + '\n', encoding='utf-8')
+    print(f'{lang}: +{len(forms)}')
+PY
+```
+
+Expected: 33 lines printed, one per locale.
+
+- [ ] **Step 4: Run the i18n suite**
+
+```bash
+cd apps/fluux && npx vitest run src/i18n/i18n.test.ts
+```
+
+Expected: PASS, including the three new plural tests and every existing parity test (`should have all English keys`, `should not have extra keys beyond English`, `should not have empty translation values`) across all 33 locales.
+
+- [ ] **Step 5: Confirm the diff is confined to the new key**
+
+```bash
+git diff --stat apps/fluux/src/i18n/locales
+```
+
+Expected: 33 files changed, each with a small insertion count matching its number of plural forms. If any file shows a large rewrite, the JSON round-trip format is wrong — stop and fix before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/fluux/src/i18n
+git commit -m "i18n: add rooms.unreadMessages in all locales"
+```
+
+---
+
+### Task 3: Render the two-line tooltip in `RoomsList`
+
+**Files:**
+- Modify: `apps/fluux/src/components/sidebar-components/RoomsList.tsx` (replace `getTooltipContent` at lines 369-384; the `Tooltip` at line 388; delete the dot `Tooltip` at lines 455-461)
+- Test: `apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `roomTooltipParts`, `RoomTooltipParts` from `@/utils/roomTooltip` (Task 1); `rooms.unreadMessages` (Task 2).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx`. This mirrors the mock setup of the existing `RoomsList.typing.test.tsx`, with one deliberate difference: the `Tooltip` mock renders its `content` prop unconditionally into the DOM. Hover timing is already covered by `Tooltip.test.tsx`; what needs proving here is *what RoomsList passes to Tooltip*.
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { Room } from '@fluux/sdk'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    isMessageFromIgnoredUser: () => false,
+    roomActivityTone: () => 'neutral',
+    generateConsistentColorHexSync: () => '#123456',
+  }
+})
+
+const h = vi.hoisted(() => ({ room: null as Room | null }))
+
+vi.mock('@fluux/sdk/react', () => ({
+  useRoomStore: (selector: (s: {
+    getRoom: (jid: string) => Room | null
+    drafts: Map<string, string>
+  }) => unknown) => selector({ getRoom: () => h.room, drafts: new Map() }),
+  useChatStore: (selector: (s: unknown) => unknown) => selector({}),
+  useIgnoreStore: (selector: (s: { ignoredUsers: Record<string, unknown[]> }) => unknown) =>
+    selector({ ignoredUsers: {} }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useContextMenu: () => ({
+    isOpen: false,
+    longPressTriggered: { current: false },
+    handleContextMenu: () => {},
+    handleTouchStart: () => {},
+    handleTouchEnd: () => {},
+    position: { x: 0, y: 0 },
+    menuRef: { current: null },
+    close: () => {},
+  }),
+  useListKeyboardNav: () => ({}),
+  useRouteSync: () => ({}),
+}))
+
+vi.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { timeFormat: string; densityMode: string }) => unknown) =>
+    selector({ timeFormat: '24h', densityMode: 'comfortable' }),
+}))
+
+// Unlike the typing test's mock, this one RENDERS `content`. The assertions are
+// about what RoomsList hands to Tooltip; hover/delay behaviour is Tooltip's own
+// test's job. Rendering every instance also lets us count them, which is how we
+// prove the activity dot no longer carries a tooltip of its own.
+vi.mock('../Tooltip', () => ({
+  Tooltip: ({ children, content }: { children: React.ReactNode; content: React.ReactNode }) => (
+    <>
+      {children}
+      <div data-testid="tooltip-content">{content}</div>
+    </>
+  ),
+}))
+
+// Import AFTER mocks so RoomItem picks them up.
+import { RoomItem } from './RoomsList'
+
+const makeRoom = (over: Partial<Room> = {}): Room =>
+  ({
+    jid: 'team@conference.fluux.chat',
+    name: 'Team',
+    joined: true,
+    isJoining: false,
+    nickname: 'me',
+    nickToJidCache: new Map(),
+    occupants: new Map([['alice', {}], ['bob', {}]]),
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set<string>(),
+    lastMessage: null,
+    avatar: undefined,
+    subject: undefined,
+    autojoin: false,
+    isBookmarked: false,
+    ...over,
+  }) as unknown as Room
+
+const noop = () => {}
+const renderRoom = (room: Room) => {
+  h.room = room
+  return render(
+    <RoomItem
+      roomJid={room.jid}
+      isActive={false}
+      isSelected={false}
+      isKeyboardNav={false}
+      onSelect={noop}
+      onActivate={noop}
+      onJoin={noop}
+      onLeave={noop}
+      onEditBookmark={noop}
+      onRemoveBookmark={noop}
+      onToggleAutojoin={noop}
+    />,
+  )
+}
+
+describe('RoomItem tooltip', () => {
+  it('puts the unread headline above the occupant detail line', () => {
+    renderRoom(makeRoom({ unreadCount: 37 }))
+    const tooltip = screen.getByTestId('tooltip-content')
+    // t is mocked to echo the key, so the headline renders as the bare key.
+    expect(tooltip.textContent).toContain('rooms.unreadMessages')
+    expect(tooltip.textContent).toContain('2 rooms.users • me')
+  })
+
+  it('still shows the unread headline when the room also has mentions', () => {
+    // The regression this feature exists to prevent: the old activity-dot
+    // tooltip was gated on mentionsCount === 0, which hid the total unread
+    // exactly when the room was busiest. Only a render test can catch a
+    // reintroduced gate — roomTooltipParts cannot even see mentionsCount.
+    renderRoom(makeRoom({ unreadCount: 37, mentionsCount: 3 }))
+    expect(screen.getByTestId('tooltip-content').textContent).toContain('rooms.unreadMessages')
+  })
+
+  it('shows only the detail line when the room is fully read', () => {
+    renderRoom(makeRoom({ unreadCount: 0 }))
+    const tooltip = screen.getByTestId('tooltip-content')
+    expect(tooltip.textContent).not.toContain('rooms.unreadMessages')
+    expect(tooltip.textContent).toContain('2 rooms.users • me')
+  })
+
+  it('gives the activity dot no tooltip of its own', () => {
+    // A room with unread and no mentions is precisely the state that used to
+    // render a second, nested Tooltip around the dot.
+    renderRoom(makeRoom({ unreadCount: 37, mentionsCount: 0 }))
+    expect(screen.getAllByTestId('tooltip-content')).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/fluux && npx vitest run src/components/sidebar-components/RoomsList.tooltip.test.tsx
+```
+
+Expected: FAIL. The first three tests fail because the tooltip text is the old single-line string with no `rooms.unreadMessages`; the last fails with `expected length 1, received 2` because the dot still has its own `Tooltip`.
+
+- [ ] **Step 3: Import the helper**
+
+In `apps/fluux/src/components/sidebar-components/RoomsList.tsx`, add the import next to the other `@/utils` imports (after the `import { visibleRoomTypingNicks } from '@/utils/roomTyping'` line):
+
+```typescript
+import { roomTooltipParts } from '@/utils/roomTooltip'
+```
+
+- [ ] **Step 4: Replace `getTooltipContent` with the helper**
+
+Replace this block (`RoomsList.tsx`, lines 369-384):
+
+```typescript
+  // Determine tooltip based on state
+  const getTooltipContent = () => {
+    if (room.isJoining) return t('rooms.joining')
+    if (room.joined) {
+      // Show user count and nickname in tooltip for joined rooms
+      const userCount = room.occupants.size
+      const userText = `${userCount} ${userCount === 1 ? t('rooms.user') : t('rooms.users')}`
+      if (room.nickname) {
+        return `${userText} • ${room.nickname}`
+      }
+      return userText
+    }
+    return t('rooms.doubleClickToJoin')
+  }
+
+  const tooltipContent = getTooltipContent()
+```
+
+with:
+
+```typescript
+  // Tooltip: the unread count as a headline (the row itself only shows a dot,
+  // so this is the one place the number is legible), over the occupant/nickname
+  // detail line. With nothing unread this stays a bare string — byte-identical
+  // to the pre-headline tooltip.
+  const { headline, detail } = roomTooltipParts(room, t)
+  const tooltipContent = headline ? (
+    <div>
+      <div className="font-medium">{headline}</div>
+      <div className="text-xs text-fluux-muted">{detail}</div>
+    </div>
+  ) : (
+    detail
+  )
+```
+
+- [ ] **Step 5: Remove the activity dot's nested tooltip**
+
+Replace this block (`RoomsList.tsx`, lines 451-462):
+
+```tsx
+            {/* Activity dot for unread (non-mention) activity. Red for a
+                notify-all room — the attention tier, matching the icon-rail
+                indicator and mention badge — grey for plain unread. */}
+            {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
+              <Tooltip content={`${room.unreadCount} unread`} position="top">
+                <div
+                  className={`size-2.5 rounded-full flex-shrink-0 ${
+                    roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
+                  }`}
+                />
+              </Tooltip>
+            )}
+```
+
+with:
+
+```tsx
+            {/* Activity dot for unread (non-mention) activity. Red for a
+                notify-all room — the attention tier, matching the icon-rail
+                indicator and mention badge — grey for plain unread. The count
+                itself lives in the row tooltip; the dot carries no tooltip of
+                its own (nested inside the row's, it popped a second bubble). */}
+            {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
+              <div
+                className={`size-2.5 rounded-full flex-shrink-0 ${
+                  roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
+                }`}
+              />
+            )}
+```
+
+- [ ] **Step 6: Run the new test**
+
+```bash
+cd apps/fluux && npx vitest run src/components/sidebar-components/RoomsList.tooltip.test.tsx
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 7: Run the affected suite, typecheck and lint**
+
+```bash
+scripts/test-affected.sh apps/fluux/src/components/sidebar-components/RoomsList.tsx apps/fluux/src/utils/roomTooltip.ts
+```
+
+Then:
+
+```bash
+npm run typecheck && npm run lint
+```
+
+Expected: all selected tests PASS with no stderr — in particular the existing `RoomsList.typing.test.tsx` must stay green. Typecheck and lint clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/fluux/src/components/sidebar-components/RoomsList.tsx apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
+git commit -m "feat(sidebar): show the unread count in the room row tooltip"
+```
+
+---
+
+### Task 4: Verify in the running app
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: PASS across both workspaces, no stderr.
+
+- [ ] **Step 2: Launch demo mode**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:5173/demo.html?tutorial=false`, go to the Rooms view.
+
+- [ ] **Step 3: Check the three states by hover**
+
+- A room with unread and no mentions → two-line tooltip, headline `N unread messages`, detail `N users • nick`. Hovering the grey/red dot itself must show **one** bubble, not two.
+- A room with mentions (`@N` badge on the row) → the tooltip still shows the unread headline.
+- A fully-read room → single-line tooltip, unchanged from before.
+
+- [ ] **Step 4: Check a non-English locale**
+
+Switch the language to French in Settings → and re-hover a room with unread messages. Expected: `4 messages non lus`, and `1 message non lu` for a single unread — no raw `rooms.unreadMessages` key on screen.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Two-line tooltip, headline + detail | 3 (steps 4) |
+| Headline only when `joined && unreadCount > 0` | 1 |
+| Headline shows even with mentions | 1 (type excludes `mentionsCount`), 3 (render test) |
+| Joining / not-joined unchanged | 1 |
+| Detail keeps manual `rooms.user`/`rooms.users` plural | 1 |
+| Dot tooltip deleted | 3 (step 5) |
+| No tint on the headline | 3 (step 4 — `font-medium` / `text-xs text-fluux-muted` only) |
+| Pure module in `utils/`, narrow `Pick<>` | 1 |
+| Bare string passed to `Tooltip` when headline is null | 3 (step 4) |
+| `unreadMessages` + `_other`, `chat.newMessagesCount` convention | 2 |
+| All 33 locales | 2 |
+| Pure-function unit tests | 1 |
+| Render test proving the wiring | 3 |
+
+The spec's `test-setup.ts` note does not apply: both new test files mock `react-i18next` locally (following `RoomsList.typing.test.tsx`), so the shared i18n subset is never consulted. Real copy is asserted in `i18n.test.ts` against the actual locale files instead, which is stronger.
+
+**Placeholder scan:** none — every step carries the literal code, the literal translation table, and an exact command with expected output.
+
+**Type consistency:** `roomTooltipParts` / `RoomTooltipRoom` / `RoomTooltipParts` and the `{ headline, detail }` shape are used identically in Tasks 1 and 3. The key `rooms.unreadMessages` is spelled the same in Tasks 1, 2 and 3.

--- a/docs/superpowers/specs/2026-07-22-room-tooltip-unread-count-design.md
+++ b/docs/superpowers/specs/2026-07-22-room-tooltip-unread-count-design.md
@@ -1,0 +1,134 @@
+# Room row tooltip: show the unread count
+
+## Problem
+
+In the sidebar Rooms list, a room with unread activity shows only a dot. The
+count is never rendered on the row — only mentions get a number, via the `@N`
+badge. So "3 unread" and "300 unread" look identical.
+
+The count is reachable today, but badly:
+
+- It lives in a second `Tooltip` wrapped around the 10px activity dot
+  (`RoomsList.tsx`), so you have to hover the dot itself, not the row.
+- That tooltip is nested *inside* the row tooltip, so hovering the dot pops two
+  bubbles at once.
+- Its content is a hardcoded English template literal, `` `${room.unreadCount} unread` ``
+  — untranslated in all 33 locales.
+- It is gated on `mentionsCount === 0`, matching the dot's own visibility rule.
+  When a room has mentions the dot is replaced by the `@N` badge, and the total
+  unread becomes completely unreachable — which is exactly the case where the
+  user most wants it.
+
+## Solution
+
+Fold the unread count into the room **row** tooltip as a headline line, and
+delete the dot's own tooltip.
+
+### Behaviour
+
+| Room state | Tooltip |
+|---|---|
+| Joined, `unreadCount > 0` | **`37 unread messages`** <br> `12 users • MyNick` |
+| Joined, `unreadCount === 0` | `12 users • MyNick` (single line — unchanged) |
+| Joining | `Joining...` (unchanged) |
+| Not joined | `Double-click to join` (unchanged) |
+
+The headline appears whenever `room.joined && room.unreadCount > 0`, **including
+when mentions exist**. Mentions get no line of their own: the `@N` badge on the
+row already carries that number, so the tooltip adds only what the row cannot
+show.
+
+The detail line keeps its current composition exactly: `N users`, plus
+` • <nickname>` when the room has a nickname. Its existing manual singular/plural
+selection between the `rooms.user` and `rooms.users` keys is carried over
+unchanged — migrating it to i18next plurals is not part of this change.
+
+The activity dot keeps its two-tier colour (`roomActivityTone`) and loses its
+`Tooltip` wrapper. The unread line is **not** tinted — the dot already carries
+the attention signal on the row, and coloured tooltip text reads as an alert.
+
+### Module boundary
+
+New pure module `apps/fluux/src/utils/roomTooltip.ts`, alongside the existing
+`roomTyping.ts` / `roomJoinError.ts` helpers:
+
+```ts
+export interface RoomTooltipParts {
+  /** "37 unread messages", or null when there is nothing unread to announce. */
+  headline: string | null
+  /** "12 users • MyNick" | "Joining..." | "Double-click to join" */
+  detail: string
+}
+
+export function roomTooltipParts(
+  room: Pick<Room, 'joined' | 'isJoining' | 'unreadCount' | 'occupants' | 'nickname'>,
+  t: TFunction,
+): RoomTooltipParts
+```
+
+The narrow `Pick<>` keeps the function testable with a plain object literal and
+no rendering. All string composition and all state branching live here; it
+replaces the inline `getTooltipContent` closure in `RoomsList`.
+
+Note that `mentionsCount` is deliberately **absent** from the `Pick<>`. The
+headline must not depend on it, and leaving it out of the input type makes the
+old `mentionsCount === 0` gate structurally unrepresentable in this module. The
+risk of reintroducing that gate therefore sits in the component, and is covered
+by a render test rather than a unit test.
+
+`RoomsList` keeps only presentation:
+
+- `headline === null` → pass the bare `detail` **string** to `Tooltip`, byte-for-byte
+  today's behaviour for the unchanged states.
+- otherwise → pass a two-line node: headline in `font-medium` (default text
+  colour), detail in `text-xs text-fluux-muted`. This is the hierarchy already
+  established by `ContactDevicesTooltip` in `sidebar-components/types.tsx`.
+
+### i18n
+
+Two new keys under `rooms`, following the `chat.newMessagesCount` convention
+already used in this codebase (base key = singular, `_other` = plural):
+
+```json
+"unreadMessages":       "{{count}} unread message",
+"unreadMessages_other": "{{count}} unread messages"
+```
+
+"unread messages" rather than a bare "unread": the bare adjective has no good
+translation in most of the 33 locales. All locales are translated in the same
+change, edited surgically (parse → mutate → `stringify(, , 4) + "\n"`).
+
+If the component-level test resolves these keys through the `test-setup.ts` i18n
+subset, both the base and `_other` forms must be added there — the existing
+`newMessagesCount` pair is the precedent.
+
+## Testing
+
+**`apps/fluux/src/utils/roomTooltip.test.ts`** — the pure function:
+
+- joined, unread > 0 → headline set, detail `"12 users • MyNick"`
+- joined, unread === 0 → headline `null`
+- singular (`count: 1`) vs plural
+- no nickname → detail is just `"12 users"`
+- `isJoining` → headline `null`, detail `"Joining..."`
+- not joined → headline `null`, detail `"Double-click to join"`
+
+**Render test in `RoomsList`**:
+
+- hover a room row with `unreadCount > 0` → both lines appear in the tooltip
+- hover a room row with `unreadCount > 0` **and** `mentionsCount > 0` → the
+  headline still appears. This is the regression the feature exists to prevent,
+  and it can only be caught here.
+- the activity dot no longer has its own tooltip
+
+The render test is not optional. The pure-function tests would all pass even if
+`RoomsList` never called `roomTooltipParts` — only the render test proves the
+wiring. `Tooltip` uses a show delay (700ms default on this row) so the test
+needs fake timers or an explicit advance.
+
+## Out of scope
+
+- The DM/conversation row tooltip. Those rows already render the unread count as
+  a numeric badge over the avatar, so a tooltip line would be redundant.
+- The icon rail tooltip (aggregate unread across a view).
+- Capping either badge at `99+`.


### PR DESCRIPTION
A room with unread activity only shows a dot in the sidebar, so "3 unread" and "300 unread" look identical. The count was reachable, but only by hovering the 10px dot itself — a second `Tooltip` nested inside the row's, rendering a hardcoded English `${room.unreadCount} unread`. It was also gated on `mentionsCount === 0`, so in a room with mentions the total unread was unreachable entirely.

The count now appears as a headline line in the room **row** tooltip, over the existing occupant/nickname line, and shows whenever the room is joined with unread messages — mentions included, since the row's `@N` badge already carries that number. The dot's own tooltip is gone, which also removes the double bubble you got when hovering it.

String composition moved out of the component into a pure `roomTooltipParts` helper in `apps/fluux/src/utils/`. `mentionsCount` is deliberately absent from its input type so the old gate cannot be reintroduced there. With nothing unread the helper returns a bare string and the tooltip renders exactly as before.

New `rooms.unreadMessages` key translated across all 33 locales, following the existing `chat.newMessagesCount` plural convention.