### PR TITLE
fix(mam): bootstrap the coverage record from a completed forward catch-up

### DIFF
--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -288,9 +288,9 @@ export function createStoreBindings(
     stores.chat.setMAMError(conversationId, error)
   })
 
-  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications }) => {
+  on('chat:mam-messages', ({ conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
     const stores = getStores()
-    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications })
+    stores.chat.mergeMAMMessages(conversationId, messages, rsm, complete, direction, isFetchLatest, preserveGapMarker, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
   })
 
   // A purged id-exact anchor (item-not-found degrade): strip the matching
@@ -464,9 +464,9 @@ export function createStoreBindings(
     stores.room.setRoomMAMError(roomJid, error)
   })
 
-  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications }) => {
+  on('room:mam-messages', ({ roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter }) => {
     const stores = getStores()
-    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications })
+    stores.room.mergeRoomMAMMessages(roomJid, messages, rsm, complete, direction, preserveGapMarker, isFetchLatest, { initialBefore, fetchLatestTopId, sawCoverageTop, walkCarriedModifications, initialAfter })
   })
 
   // Room twin of chat:mam-anchor-purged (see above).

--- a/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Chat.mam.test.ts
@@ -2622,7 +2622,8 @@ describe('XMPPClient MAM', () => {
         rsm: expect.any(Object),
         complete: true, // complete from server
         direction: 'forward', // direction - store will only set isCaughtUpToLive, not isHistoryComplete
-        isFetchLatest: false // forward queries are never fetch-latest candidates
+        isFetchLatest: false, // forward queries are never fetch-latest candidates
+        walkCarriedModifications: false // clean walk — may anchor a coverage bootstrap
       })
     })
 
@@ -3510,7 +3511,8 @@ describe('XMPPClient MAM', () => {
         rsm: expect.any(Object),
         complete: true, // complete from server
         direction: 'forward', // direction - store will only set isCaughtUpToLive, not isHistoryComplete
-        isFetchLatest: false // forward query, never a fetch-latest
+        isFetchLatest: false, // forward query, never a fetch-latest
+        walkCarriedModifications: false // clean walk — may anchor a coverage bootstrap
       })
     })
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -412,6 +412,14 @@ export class MAM extends BaseModule {
       // single pass (so cross-page corrections/reactions land), then emit.
       const unresolved = this.applyModifications(allMessages, modifications, (msg, from) => msg.from === from)
 
+      // Reported for BOTH directions: coverage never certifies over a walk whose
+      // modification cache-writes are fire-and-forget (Codex r4 #2), and that
+      // holds for the forward bootstrap anchor just as it does for a backward
+      // extent. `modifications` accumulates across every page of this query.
+      const walkCarriedModifications =
+        modifications.retractions.length + modifications.corrections.length +
+        modifications.fastenings.length + modifications.reactions.length > 0
+
       this.deps.emitSDK('chat:mam-messages', {
         conversationId,
         messages: allMessages,
@@ -420,14 +428,16 @@ export class MAM extends BaseModule {
         direction,
         preserveGapMarker,
         isFetchLatest: direction === 'backward' && !before,
+        walkCarriedModifications,
         ...(direction === 'backward' ? {
           initialBefore: before,
           fetchLatestTopId,
           sawCoverageTop,
-          walkCarriedModifications:
-            modifications.retractions.length + modifications.corrections.length +
-            modifications.fastenings.length + modifications.reactions.length > 0,
-        } : {}),
+        } : {
+          // The cursor this walk resumed from — anchors the coverage bottom
+          // when the catch-up reports complete (mamCoverage.ts).
+          initialAfter: after,
+        }),
       })
 
       // Modifications whose target is not in this batch belong to a message
@@ -512,6 +522,11 @@ export class MAM extends BaseModule {
     // signal on the first, signal-only page targets a message only fetched by
     // a later retry page — per-page resolution would drop it.
     const backwardModifications: MAMModifications = { retractions: [], corrections: [], fastenings: [], reactions: [] }
+    // Forward pages scope their modifications per page (see below), so the
+    // walk-level fact has to be accumulated separately: the coverage bootstrap
+    // is anchored by the page that reports `complete`, and it must know whether
+    // ANY earlier page of the same walk carried modifications (Codex r4 #2).
+    let forwardWalkCarriedModifications = false
 
     const room = this.deps.stores?.room.getRoom(roomJid)
     const myNickname = room?.nickname || ''
@@ -612,6 +627,10 @@ export class MAM extends BaseModule {
           }
 
           if (isForward) {
+            forwardWalkCarriedModifications ||=
+              modifications.retractions.length + modifications.corrections.length +
+              modifications.fastenings.length + modifications.reactions.length > 0
+
             // Apply modifications to collected messages (full JID comparison for rooms)
             // normalizeReactor extracts nick from full MUC JID for consistent reactor identifiers
             const unresolved = this.applyModifications(
@@ -632,6 +651,10 @@ export class MAM extends BaseModule {
               direction: 'forward',
               preserveGapMarker,
               isFetchLatest: false,
+              // The cursor the WALK resumed from (not this page's), so the
+              // completing page can anchor a coverage bottom (mamCoverage.ts).
+              initialAfter: after,
+              walkCarriedModifications: forwardWalkCarriedModifications,
             })
           }
 

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -242,6 +242,9 @@ export interface ChatEvents {
      *  cache effects are fire-and-forget, so coverage must not certify over
      *  them (Codex r4 #2). */
     walkCarriedModifications?: boolean
+    /** FORWARD only: the `after` cursor the catch-up resumed from. With
+     *  `complete`, it anchors the coverage bottom (mamCoverage.ts). */
+    initialAfter?: string
   }
 
   /**
@@ -480,6 +483,9 @@ export interface RoomEvents {
      *  cache effects are fire-and-forget, so coverage must not certify over
      *  them (Codex r4 #2). */
     walkCarriedModifications?: boolean
+    /** FORWARD only: the `after` cursor the catch-up resumed from. With
+     *  `complete`, it anchors the coverage bottom (mamCoverage.ts). */
+    initialAfter?: string
   }
 
   /**

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -2118,6 +2118,8 @@ export const chatStore = createStore<ChatState>()(
             initialBefore: extras?.initialBefore,
             sawCoverageTop: extras?.sawCoverageTop ?? false,
             walkCarriedModifications: extras?.walkCarriedModifications ?? false,
+            complete,
+            initialAfter: extras?.initialAfter,
           })
           const prevCoverage = state.conversationCoverage.get(conversationId)
           const deferCoverageCommit =

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2305,6 +2305,39 @@ describe('roomStore', () => {
       expect(roomStore.getState().roomGaps.has(jid)).toBe(false)
     })
 
+    it('seeds and persists the coverage record when a forward catch-up completes', async () => {
+      // End-to-end wiring for the bootstrap: before this, a record could only be
+      // born from a `before:''` fetch-latest, which only happens on an entity's
+      // first-ever sync — so every already-cached room never got one and Phase B
+      // fell back to the raw cache bottom.
+      const held: RoomMessage = {
+        type: 'groupchat', id: 'held', roomJid: jid, from: `${jid}/a`, nick: 'a',
+        body: 'held', timestamp: new Date('2026-07-20T00:00:00Z'), isOutgoing: false,
+        stanzaId: 'local-edge',
+      }
+      roomStore.getState().addRoom(createRoom(jid, { joined: true, messages: [held], lastMessage: held }))
+      expect(roomStore.getState().getRoomCoverage(jid)).toBeUndefined()
+
+      const fetched: RoomMessage = {
+        type: 'groupchat', id: 'caught-up', roomJid: jid, from: `${jid}/b`, nick: 'b',
+        body: 'caught up', timestamp: new Date('2026-07-21T00:00:00Z'), isOutgoing: false,
+        stanzaId: 'newer',
+      }
+      // Forward catch-up resumed from 'local-edge' and reached live.
+      roomStore.getState().mergeRoomMAMMessages(
+        jid, [fetched], { first: 'newer' }, true, 'forward', false, false,
+        { initialAfter: 'local-edge' }
+      )
+
+      await vi.waitFor(() => {
+        expect(roomStore.getState().getRoomCoverage(jid)).toEqual({ bottomId: 'local-edge' })
+      })
+      // ...and it reached localStorage, so it survives the next fresh session.
+      const persisted = Object.entries(localStorageMock._store)
+        .find(([k]) => k.startsWith('fluux-room-coverage'))
+      expect(persisted?.[1]).toContain('local-edge')
+    })
+
     it('does NOT mark the visible timeline complete when a Phase B deep probe reaches the archive start below the resident window', () => {
       // Reproduces the "cannot scroll back past the activation slice" regression.
       // The resident window is the latest-N activation slice (July). Phase B — a

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2998,6 +2998,8 @@ export const roomStore = createStore<RoomState>()(
         initialBefore: extras?.initialBefore,
         sawCoverageTop: extras?.sawCoverageTop ?? false,
         walkCarriedModifications: extras?.walkCarriedModifications ?? false,
+        complete,
+        initialAfter: extras?.initialAfter,
       })
       const prevCoverage = state.roomCoverage.get(roomJid)
       const deferCoverageCommit =

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -97,6 +97,63 @@ describe('syncCoverageAfterArchiveMerge', () => {
     ).toBe(coverage)
   })
 
+  describe('forward-catch-up bootstrap', () => {
+    // Without this, a record can only be BORN by a `before:''` fetch-latest,
+    // which selectCatchUpQuery only issues when the cache is EMPTY — an
+    // entity's first-ever sync. Every entity cached before the record shipped
+    // therefore never gets one, and Phase B permanently falls back to the
+    // cache-bottom probe. A forward catch-up that reports complete proves
+    // [resume cursor → live] is contiguous, which is exactly a coverage bottom.
+    const fwd = (over: Partial<ArchiveMergeCoverageInput> = {}) =>
+      base({ direction: 'forward', isFetchLatest: false, ...over })
+
+    it('a completed forward catch-up seeds the record from its resume cursor', () => {
+      const out = syncCoverageAfterArchiveMerge(fwd({ complete: true, initialAfter: 'local-edge' }))
+      expect(out.get('a@b')).toEqual({ bottomId: 'local-edge' })
+    })
+
+    it('an INCOMPLETE forward catch-up seeds nothing (it never reached live)', () => {
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: false, initialAfter: 'local-edge' }))
+      ).toBe(coverage)
+    })
+
+    it('a completed forward catch-up never shallows an existing, deeper record', () => {
+      const coverage = new Map([['a@b', { bottomId: 'much-deeper', topId: 'top' }]])
+      expect(
+        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true, initialAfter: 'local-edge' }))
+      ).toBe(coverage)
+    })
+
+    it('a completed forward catch-up with no resume cursor seeds nothing', () => {
+      // `start`-filtered or cursorless catch-up: no archive id to anchor on.
+      const coverage = new Map<string, CoverageRecord>()
+      expect(syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true }))).toBe(coverage)
+    })
+
+    it('a completed forward catch-up that carried modifications never seeds', () => {
+      // Same invariant the backward branch enforces (Codex r4 #2): the walk's
+      // modification cache-writes are fire-and-forget, so nothing it touched is
+      // durably confirmed enough to certify coverage.
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(
+          fwd({ coverage, complete: true, initialAfter: 'local-edge', walkCarriedModifications: true })
+        )
+      ).toBe(coverage)
+    })
+
+    it('a bounded windowed forward query never seeds (proves nothing about live)', () => {
+      const coverage = new Map<string, CoverageRecord>()
+      expect(
+        syncCoverageAfterArchiveMerge(
+          fwd({ coverage, complete: true, initialAfter: 'local-edge', preserveGapMarker: true })
+        )
+      ).toBe(coverage)
+    })
+  })
+
   it('empty fetch-latest with no rsm.first (empty archive) is a no-op', () => {
     const coverage = new Map<string, CoverageRecord>()
     expect(syncCoverageAfterArchiveMerge(base({ coverage }))).toBe(coverage)

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -39,6 +39,9 @@ export interface MergeArchiveExtras {
   /** The walk carried corrections/retractions/reactions/fastenings, whose
    *  cache effects are fire-and-forget — certification is blocked (r4 #2). */
   walkCarriedModifications?: boolean
+  /** FORWARD only: the `after` cursor the catch-up resumed from — the bootstrap
+   *  anchor when that catch-up reports complete. */
+  initialAfter?: string
 }
 
 /** Serialize the coverage map for localStorage (`[id, CoverageRecord][]`). */
@@ -65,6 +68,12 @@ export interface ArchiveMergeCoverageInput {
   direction: 'backward' | 'forward'
   /** The query was a `before:''` fetch-latest. */
   isFetchLatest: boolean
+  /** The server reported the walk exhausted its direction. On a forward
+   *  catch-up this means the walk reached the live edge. */
+  complete?: boolean
+  /** The `after` cursor a forward catch-up resumed from (the local downloaded
+   *  edge). Undefined for `start`-filtered or cursorless catch-ups. */
+  initialAfter?: string
   /** Bounded windowed query — proves nothing about live contiguity. */
   preserveGapMarker: boolean
   /** rsm.first of the merge's LAST page (deepest entry seen, signals included). */
@@ -90,19 +99,47 @@ export interface ArchiveMergeCoverageInput {
  *   give-up with zero displayable messages) → replace with the walk extent;
  * - plain backward page → extend the bottom ONLY when the query resumed
  *   id-exactly from it (initialBefore === bottomId);
- * - forward merges and preserveGapMarker (bounded windowed) queries prove
- *   nothing about the live-contiguous bottom → no-op.
+ * - COMPLETED forward catch-up with a resume cursor → seed the bottom from that
+ *   cursor when no record exists yet (bootstrap, see below);
+ * - incomplete forward merges and preserveGapMarker (bounded windowed) queries
+ *   prove nothing about the live-contiguous bottom → no-op.
  *
  * Copy-on-write: returns the SAME map reference when nothing changes.
  */
 export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput): Map<string, CoverageRecord> {
   const {
-    coverage, id, direction, isFetchLatest, preserveGapMarker,
+    coverage, id, direction, isFetchLatest, preserveGapMarker, complete, initialAfter,
     rsmFirst, fetchLatestTopId, initialBefore, sawCoverageTop, walkCarriedModifications,
   } = input
   if (preserveGapMarker) return coverage
-  if (direction !== 'backward') return coverage
+  // Applies to BOTH directions: a walk whose corrections/retractions/reactions
+  // were written fire-and-forget is not durably confirmed, so it may not certify
+  // coverage — the forward bootstrap anchor included (Codex r4 #2).
   if (walkCarriedModifications) return coverage
+
+  if (direction !== 'backward') {
+    // Bootstrap. Without this the record can only be born in the fetch-latest
+    // branch below, and `selectCatchUpQuery` only issues a `before:''`
+    // fetch-latest when the cache is EMPTY — an entity's first-ever sync. Every
+    // entity already cached when this feature shipped would therefore never get
+    // a record (the plain-backward branch requires one to exist), leaving Phase
+    // B permanently seeded from the raw cache bottom instead of a proven edge.
+    //
+    // A forward catch-up that resumed at `initialAfter` and came back complete
+    // has downloaded everything from that cursor to the live edge — which is
+    // precisely "oldest entry proven contiguous with live". The claim is
+    // deliberately conservative: it anchors on the cursor we resumed from, never
+    // on how deep the cache happens to reach, and it never overwrites an
+    // existing record, so a bottom already proven deeper always wins. Erring
+    // shallow only costs Phase B a re-walk of covered ground; erring deep would
+    // skip real history, and this path cannot do that.
+    if (!complete || !initialAfter) return coverage
+    if (coverage.get(id)) return coverage
+    const next = new Map(coverage)
+    next.set(id, { bottomId: initialAfter })
+    return next
+  }
+
   const existing = coverage.get(id)
 
   if (isFetchLatest) {


### PR DESCRIPTION
Follow-up to #1084 (now merged). That fixed the symptom — Phase B's deep probe wrongly marking the visible timeline complete. This fixes the upstream cause: Phase B was seeding from the raw cache bottom in the first place because the coverage record from #1040 is never certified.

A record can only be **born** in the fetch-latest branch of `syncCoverageAfterArchiveMerge`, and `selectCatchUpQuery` only issues a `before:''` fetch-latest when the cache is **empty** — an entity's first-ever sync. Once an entity has cached history, catch-up always picks a forward `after` query, and the plain-backward branch can only *extend* a record that already exists. So every entity cached before the feature shipped never gets one, with no backfill path.

Measured on a real profile: of ~12 rooms and dozens of conversations, exactly one carried a record — a conversation created that same day holding two messages. `edaveine` (8,526 messages back to 2017) and every room had none. The session log shows 9 forward and 16 cursored-backward queries, and zero fetch-latest.

A forward catch-up that resumed at `after` and came back `complete` has downloaded everything from that cursor to the live edge, which is exactly "oldest entry proven contiguous with live". Seed the bottom from it when no record exists.

The claim is deliberately conservative: it anchors on the resume cursor rather than however deep the cache happens to reach, and it never overwrites an existing record, so a deeper proven bottom always wins. Erring shallow only costs Phase B a re-walk of covered ground; erring deep would skip real history, and this path cannot do that. Bounded windowed queries (`preserveGapMarker`) and incomplete catch-ups still seed nothing.

The r4 #2 modification gate now applies to **both** directions rather than backward only, so the bootstrap anchor is held to the same durability bar as a backward extent. Forward pages scope their modifications per page, so the walk-level fact is accumulated separately — the page reporting `complete` needs to know whether any earlier page of the same walk carried modifications, not just its own.

Two exact-payload assertions in `Chat.mam.test.ts` were updated for the added `walkCarriedModifications` field; the behaviour they guard is unchanged.