### PR TITLE
chore(lint): enforce react/button-has-type

### DIFF
--- a/apps/fluux/eslint.config.js
+++ b/apps/fluux/eslint.config.js
@@ -2,6 +2,7 @@ import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactCompiler from 'eslint-plugin-react-compiler'
+import react from 'eslint-plugin-react'
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -10,6 +11,7 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-compiler': reactCompiler,
+      react,
     },
     languageOptions: {
       parserOptions: {
@@ -24,6 +26,16 @@ export default tseslint.config(
 
       // React Compiler
       'react-compiler/react-compiler': 'warn',
+
+      // A <button> with no type attribute defaults to type="submit". Inside a
+      // <form> that silently triggers the form's onSubmit - which is how the
+      // backup dialog's Copy button ended up publishing the OpenPGP key.
+      // Only this rule is enabled from eslint-plugin-react; the recommended
+      // preset is deliberately not used here.
+      // eslint-plugin-react 7.37.5 still caps its eslint peer at ^9.7, so the
+      // root package.json overrides that peer to ^10 - the rule itself runs
+      // fine on eslint 10. Drop the override once upstream supports it.
+      'react/button-has-type': 'error',
 
       // Allow unused vars prefixed with underscore
       '@typescript-eslint/no-unused-vars': [

--- a/apps/fluux/package.json
+++ b/apps/fluux/package.json
@@ -66,6 +66,7 @@
     "autoprefixer": "^10.4.16",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.0.0",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "fake-indexeddb": "^6.2.5",

--- a/apps/fluux/src/components/AboutModal.tsx
+++ b/apps/fluux/src/components/AboutModal.tsx
@@ -44,6 +44,7 @@ export function AboutModal({ onClose }: AboutModalProps) {
           </p>
           <Tooltip content={copied ? t('common.copied') : t('about.copyVersionInfo')}>
             <button
+              type="button"
               onClick={copyVersionInfo}
               className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover"
             >

--- a/apps/fluux/src/components/AddUserModal.test.tsx
+++ b/apps/fluux/src/components/AddUserModal.test.tsx
@@ -76,6 +76,7 @@ function AddUserModal({ vhost, onSubmit, onClose }: AddUserModalProps) {
         <div className="flex items-center justify-between px-4 py-3 border-b border-fluux-hover">
           <h2 className="text-lg font-semibold text-fluux-text">admin.addUser.title</h2>
           <button
+            type="button"
             onClick={onClose}
             className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover"
             title="common.close"

--- a/apps/fluux/src/components/AdminBreadcrumb.tsx
+++ b/apps/fluux/src/components/AdminBreadcrumb.tsx
@@ -21,6 +21,7 @@ export function AdminBreadcrumb({ crumbs }: AdminBreadcrumbProps) {
             )}
             {!isLast && crumb.onClick ? (
               <button
+                type="button"
                 onClick={crumb.onClick}
                 className={`text-sm text-fluux-muted hover:text-fluux-text transition-colors ${
                   index === 0 ? 'shrink-0 whitespace-nowrap' : 'truncate max-w-[120px]'

--- a/apps/fluux/src/components/AdminCommandForm.tsx
+++ b/apps/fluux/src/components/AdminCommandForm.tsx
@@ -233,6 +233,7 @@ export function AdminCommandResult({ form, note, onClose }: AdminCommandResultPr
 
       <div className="flex justify-end pt-4 mt-4 border-t border-fluux-bg">
         <button
+          type="button"
           onClick={onClose}
           className="px-4 py-2 text-sm text-fluux-text-on-accent bg-fluux-brand hover:bg-fluux-brand/90 rounded-lg transition-colors"
         >

--- a/apps/fluux/src/components/AdminDashboard.tsx
+++ b/apps/fluux/src/components/AdminDashboard.tsx
@@ -107,6 +107,7 @@ function CategoryButton({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className={`w-full px-3 py-2 flex items-center gap-2 rounded-lg transition-colors
                  ${isActive

--- a/apps/fluux/src/components/AdminRoomView.tsx
+++ b/apps/fluux/src/components/AdminRoomView.tsx
@@ -95,6 +95,7 @@ export function AdminRoomView({
       <div className="flex items-center gap-3 mb-6">
         <Tooltip content={t('common.close')} position="right">
           <button
+            type="button"
             onClick={onBack}
             className="p-1.5 text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover
                        rounded-lg transition-colors"
@@ -159,6 +160,7 @@ export function AdminRoomView({
           <div className="space-y-2">
             {/* Destroy Room */}
             <button
+              type="button"
               onClick={() => setShowDeleteConfirm(true)}
               disabled={isExecuting}
               className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg

--- a/apps/fluux/src/components/AdminUserView.tsx
+++ b/apps/fluux/src/components/AdminUserView.tsx
@@ -90,6 +90,7 @@ export function AdminUserView({
       <div className="flex items-center gap-3 mb-6">
         <Tooltip content={t('common.close')} position="right">
           <button
+            type="button"
             onClick={onBack}
             className="p-1.5 text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover
                        rounded-lg transition-colors"

--- a/apps/fluux/src/components/AdminView.tsx
+++ b/apps/fluux/src/components/AdminView.tsx
@@ -439,6 +439,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
             headerAction={
               <Tooltip content={t('admin.userList.addUser')} position="left">
                 <button
+                  type="button"
                   onClick={handleAddUser}
                   className="p-1.5 text-fluux-muted hover:text-fluux-brand hover:bg-fluux-hover
                              rounded-lg transition-colors tap-target"
@@ -555,6 +556,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
         {/* Back button - mobile only */}
         {onBack && (
           <button
+            type="button"
             onClick={handleHeaderBack}
             className="p-1 -ms-1 me-2 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back')}
@@ -565,6 +567,7 @@ export function AdminView({ activeCategory, onBack }: AdminViewProps) {
         <AdminBreadcrumb crumbs={buildCrumbs()} />
         {onBack && (
           <button
+            type="button"
             onClick={() => setSectionsSheetOpen(true)}
             className="p-1 -me-1 ms-auto rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('admin.openSections')}

--- a/apps/fluux/src/components/AvatarCropModal.tsx
+++ b/apps/fluux/src/components/AvatarCropModal.tsx
@@ -372,6 +372,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
           <h2 className="text-lg font-semibold text-fluux-text">{t('avatar.uploadTitle')}</h2>
           <Tooltip content={t('common.close')}>
             <button
+              type="button"
               onClick={close}
               className="p-1 text-fluux-muted hover:text-fluux-text rounded"
             >
@@ -405,6 +406,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
               {/* Webcam controls */}
               <div className="flex items-center gap-4">
                 <button
+                  type="button"
                   onClick={capturePhoto}
                   disabled={!webcamReady}
                   className="flex items-center gap-2 px-4 py-2 bg-fluux-brand hover:bg-fluux-brand-hover text-fluux-text-on-accent rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -413,6 +415,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
                   {t('avatar.takePhoto')}
                 </button>
                 <button
+                  type="button"
                   onClick={exitWebcamMode}
                   className="flex items-center gap-2 px-4 py-2 text-fluux-muted hover:text-fluux-text rounded transition-colors"
                 >
@@ -502,6 +505,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
               {/* Zoom controls */}
               <div className="flex items-center gap-3">
                 <button
+                  type="button"
                   onClick={handleZoomOut}
                   disabled={zoom <= MIN_ZOOM}
                   className="p-2 text-fluux-muted hover:text-fluux-text disabled:opacity-50 disabled:cursor-not-allowed"
@@ -515,6 +519,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
                   />
                 </div>
                 <button
+                  type="button"
                   onClick={handleZoomIn}
                   disabled={zoom >= MAX_ZOOM}
                   className="p-2 text-fluux-muted hover:text-fluux-text disabled:opacity-50 disabled:cursor-not-allowed"
@@ -527,6 +532,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
               <div className="flex items-center gap-4">
                 <Tooltip content={t('avatar.resetZoom')}>
                   <button
+                    type="button"
                     onClick={handleReset}
                     disabled={zoom === 1 && offset.x === 0 && offset.y === 0}
                     className="flex items-center gap-1 text-sm text-fluux-muted hover:text-fluux-text disabled:opacity-50 disabled:cursor-not-allowed"
@@ -536,6 +542,7 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
                   </button>
                 </Tooltip>
                 <button
+                  type="button"
                   onClick={() => {
                     if (imageUrl) URL.revokeObjectURL(imageUrl)
                     setImageUrl(null)
@@ -569,12 +576,14 @@ export function AvatarCropModal({ isOpen, onClose, onSave }: AvatarCropModalProp
         {/* Footer */}
         <div className="flex justify-end gap-3 p-4 border-t border-fluux-bg">
           <button
+            type="button"
             onClick={close}
             className="px-4 py-2 text-fluux-text hover:bg-fluux-hover rounded transition-colors"
           >
             {t('common.cancel')}
           </button>
           <button
+            type="button"
             onClick={handleSave}
             disabled={!imageUrl || saving}
             className="px-4 py-2 bg-fluux-brand hover:bg-fluux-brand-hover text-fluux-text-on-accent rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/apps/fluux/src/components/BrowseRoomsModal.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.tsx
@@ -310,6 +310,7 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
               />
               <Tooltip content={t('rooms.discover')}>
                 <button
+                  type="button"
                   onClick={handleCustomServiceSubmit}
                   disabled={!customService.trim()}
                   aria-label={t('rooms.discover')}
@@ -321,6 +322,7 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
               </Tooltip>
               <Tooltip content={t('common.cancel')}>
                 <button
+                  type="button"
                   onClick={() => {
                     setShowCustomInput(false)
                     setCustomService('')
@@ -454,6 +456,7 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
                       </span>
                     ) : (
                       <button
+                        type="button"
                         onClick={(e) => {
                           e.stopPropagation()
                           void handleJoinRoom(room.jid)

--- a/apps/fluux/src/components/ChatHeader.tsx
+++ b/apps/fluux/src/components/ChatHeader.tsx
@@ -97,6 +97,7 @@ export function ChatHeader({
       {/* Back button - mobile only */}
       {onBack && (
         <button
+          type="button"
           onClick={onBack}
           className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
           aria-label={t('conversations.backToConversations')}
@@ -158,6 +159,7 @@ export function ChatHeader({
         {onSearchInConversation && (
           <div className={inlineClass('search')}>
             <button
+              type="button"
               onClick={onSearchInConversation}
               className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
               aria-label={t('chat.searchInConversation', 'Search in conversation')}

--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -93,7 +93,7 @@ function HistoryProbe() {
   return (
     <>
       <span data-testid="probe-path">{location.pathname}</span>
-      <button data-testid="probe-back" onClick={() => navigate(-1)}>back</button>
+      <button type="button" data-testid="probe-back" onClick={() => navigate(-1)}>back</button>
     </>
   )
 }
@@ -479,8 +479,8 @@ vi.mock('./Sidebar', () => ({
             the URL moves to a detail route without any click handler updating the store */}
         <NavLink to="/messages/bob@example.com" data-testid="deep-conversation-link">Deep Conversation</NavLink>
         <NavLink to="/rooms/lobby@conference.example.com" data-testid="deep-room-link">Deep Room</NavLink>
-        <button data-testid="select-contact" onClick={() => onSelectContact(mockContact)}>Select Contact</button>
-        <button data-testid="start-chat" onClick={() => onStartChat(mockContact)}>Start Chat</button>
+        <button type="button" data-testid="select-contact" onClick={() => onSelectContact(mockContact)}>Select Contact</button>
+        <button type="button" data-testid="start-chat" onClick={() => onStartChat(mockContact)}>Start Chat</button>
       </div>
     )
   },
@@ -490,8 +490,9 @@ vi.mock('./ChatView', () => ({
   ChatView: ({ onBack, onShowProfile }: { onBack: () => void; onShowProfile?: (jid: string) => void }) => (
     <div data-testid="chat-view">
       <span>Conversation: {getMockState().activeConversationId}</span>
-      <button data-testid="chat-back" onClick={onBack}>Back</button>
+      <button type="button" data-testid="chat-back" onClick={onBack}>Back</button>
       <button
+        type="button"
         data-testid="chat-show-profile"
         onClick={() => {
           const id = getMockState().activeConversationId
@@ -508,7 +509,7 @@ vi.mock('./RoomView', () => ({
   RoomView: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="room-view">
       <span>Room: {getMockState().activeRoomJid}</span>
-      <button data-testid="room-back" onClick={onBack}>Back</button>
+      <button type="button" data-testid="room-back" onClick={onBack}>Back</button>
     </div>
   ),
 }))
@@ -517,7 +518,7 @@ vi.mock('./ContactProfileView', () => ({
   ContactProfileView: ({ contact, onClose }: { contact: Contact; onClose: () => void }) => (
     <div data-testid="contact-profile-view">
       <span>Contact: {contact.name}</span>
-      <button data-testid="contact-back" onClick={onClose}>Back</button>
+      <button type="button" data-testid="contact-back" onClick={onClose}>Back</button>
     </div>
   ),
 }))
@@ -530,7 +531,7 @@ vi.mock('./AdminView', () => ({
   AdminView: ({ onBack }: { onBack?: () => void }) => (
     <div data-testid="admin-view">
       Admin
-      <button data-testid="admin-back" onClick={() => onBack?.()}>back</button>
+      <button type="button" data-testid="admin-back" onClick={() => onBack?.()}>back</button>
     </div>
   ),
 }))
@@ -558,7 +559,7 @@ vi.mock('./ToastContainer', () => ({
 vi.mock('./CreateRoomModal', () => ({
   CreateRoomModal: ({ onClose }: { onClose: () => void }) => (
     <div data-testid="create-room-modal">
-      <button data-testid="create-room-close" onClick={onClose}>Close</button>
+      <button type="button" data-testid="create-room-close" onClick={onClose}>Close</button>
     </div>
   ),
 }))

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -1161,6 +1161,7 @@ function EmptyState({ sidebarView, primaryAction }: { sidebarView: SidebarView; 
       {hint && <p className="max-w-sm mt-2 text-sm opacity-80">{hint}</p>}
       {primaryAction && (
         <button
+          type="button"
           onClick={primaryAction.onClick}
           className="mt-5 inline-flex items-center gap-2 px-4 py-2 bg-fluux-brand hover:bg-fluux-brand-hover text-fluux-text-on-accent text-sm font-medium rounded-lg transition-colors"
         >

--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -379,6 +379,7 @@ const { MockMessageComposer } = vi.hoisted(() => {
           onChange: () => {},
         }),
         React.createElement('button', {
+          type: 'button',
           'data-testid': 'send-button',
           onClick: () => onSend('test message'),
         }, 'Send')

--- a/apps/fluux/src/components/CommandPalette.tsx
+++ b/apps/fluux/src/components/CommandPalette.tsx
@@ -659,6 +659,7 @@ function CommandPaletteContent({
 
                   return (
                     <button
+                      type="button"
                       key={item.id}
                       data-selected={isSelected}
                       onClick={item.action}

--- a/apps/fluux/src/components/ConfirmDialog.tsx
+++ b/apps/fluux/src/components/ConfirmDialog.tsx
@@ -32,6 +32,7 @@ export function ConfirmDialog({
           <p className="text-sm text-fluux-muted mb-4">{message}</p>
           <div className="flex gap-2 justify-end">
             <button
+              type="button"
               onClick={close}
               className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active
                          rounded-lg transition-colors"
@@ -39,6 +40,7 @@ export function ConfirmDialog({
               {t('common.cancel')}
             </button>
             <button
+              type="button"
               onClick={onConfirm}
               className={`px-4 py-2 text-sm text-white ${confirmColors}
                          rounded-lg transition-colors`}

--- a/apps/fluux/src/components/ContactProfileView.tsx
+++ b/apps/fluux/src/components/ContactProfileView.tsx
@@ -206,6 +206,7 @@ export function ContactProfileView({
         >
           {onBack && (
             <button
+              type="button"
               onClick={onBack}
               className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
               aria-label={t('common.back')}

--- a/apps/fluux/src/components/DeleteOpenpgpKeyDialog.tsx
+++ b/apps/fluux/src/components/DeleteOpenpgpKeyDialog.tsx
@@ -119,6 +119,7 @@ export function DeleteOpenpgpKeyDialog({
 
         <div className="px-5 pb-5 pt-3 flex gap-2 justify-end">
           <button
+            type="button"
             onClick={onCancel}
             disabled={isRunning}
             className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors disabled:opacity-50"
@@ -126,6 +127,7 @@ export function DeleteOpenpgpKeyDialog({
             {t('common.cancel')}
           </button>
           <button
+            type="button"
             onClick={handleConfirm}
             disabled={isRunning}
             className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/apps/fluux/src/components/IdentityChoiceDialog.tsx
+++ b/apps/fluux/src/components/IdentityChoiceDialog.tsx
@@ -262,6 +262,7 @@ export function IdentityChoiceDialog({
         {phase === 'choose' && (
           <div className="px-5 pb-5 pt-3 flex justify-end">
             <button
+              type="button"
               onClick={onCancel}
               className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors"
             >
@@ -273,6 +274,7 @@ export function IdentityChoiceDialog({
         {phase === 'restoring' && (
           <div className="px-5 pb-5 pt-3 flex flex-wrap gap-2 justify-end">
             <button
+              type="button"
               onClick={() => {
                 setPhase('choose')
                 setPassphrase('')
@@ -283,6 +285,7 @@ export function IdentityChoiceDialog({
               {t('common.back')}
             </button>
             <button
+              type="button"
               onClick={handleConfirmRestore}
               disabled={!passphrase.trim()}
               className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-fluux-brand hover:opacity-90 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -295,6 +298,7 @@ export function IdentityChoiceDialog({
         {phase === 'confirm-replace' && (
           <div className="px-5 pb-5 pt-3 flex flex-wrap gap-2 justify-end">
             <button
+              type="button"
               onClick={() => {
                 setPhase('choose')
                 setError(null)
@@ -304,6 +308,7 @@ export function IdentityChoiceDialog({
               {t('common.back')}
             </button>
             <button
+              type="button"
               onClick={handleConfirmReplace}
               className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
             >
@@ -327,6 +332,7 @@ interface ChoiceButtonProps {
 function ChoiceButton({ icon, title, description, onClick, disabled, danger }: ChoiceButtonProps) {
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={disabled}
       className={`flex items-start gap-3 text-left px-3 py-3 rounded-lg border transition-colors ${

--- a/apps/fluux/src/components/ImageLightbox.tsx
+++ b/apps/fluux/src/components/ImageLightbox.tsx
@@ -89,6 +89,7 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
           <Download className="size-6" />
         </button>
         <button
+          type="button"
           onClick={onClose}
           className="p-2 text-white/70 hover:text-white rounded-full hover:bg-white/10 transition-colors"
           title={t('common.close')}

--- a/apps/fluux/src/components/InviteToRoomModal.test.tsx
+++ b/apps/fluux/src/components/InviteToRoomModal.test.tsx
@@ -37,18 +37,21 @@ vi.mock('./ContactSelector', () => ({
         <div data-testid="selected-count">{selectedContacts.length} selected</div>
         {/* Buttons to simulate selection for testing */}
         <button
+          type="button"
           data-testid="select-alice"
           onClick={() => onSelectionChange([...selectedContacts, 'alice@example.com'])}
         >
           Select Alice
         </button>
         <button
+          type="button"
           data-testid="select-bob"
           onClick={() => onSelectionChange([...selectedContacts, 'bob@example.com'])}
         >
           Select Bob
         </button>
         <button
+          type="button"
           data-testid="clear-selection"
           onClick={() => onSelectionChange([])}
         >

--- a/apps/fluux/src/components/InviteToRoomModal.tsx
+++ b/apps/fluux/src/components/InviteToRoomModal.tsx
@@ -106,6 +106,7 @@ function InviteToRoomModalContent({ onClose, room }: InviteToRoomModalProps) {
       {/* Footer */}
       <div className="flex justify-end gap-2 px-4 py-3 border-t border-fluux-hover">
         <button
+          type="button"
           onClick={onClose}
           className="px-4 py-2 text-sm text-fluux-muted hover:text-fluux-text
                      hover:bg-fluux-hover rounded transition-colors"
@@ -113,6 +114,7 @@ function InviteToRoomModalContent({ onClose, room }: InviteToRoomModalProps) {
           {t('common.cancel')}
         </button>
         <button
+          type="button"
           onClick={handleInvite}
           disabled={selectedContacts.length === 0}
           className="px-4 py-2 text-sm bg-fluux-brand text-fluux-text-on-accent rounded

--- a/apps/fluux/src/components/KeyChangeBanner.tsx
+++ b/apps/fluux/src/components/KeyChangeBanner.tsx
@@ -114,6 +114,7 @@ export function KeyChangeBanner({ peerJid, peerName }: KeyChangeBannerProps) {
           </p>
           <div className="flex flex-wrap gap-2 mt-2">
             <button
+              type="button"
               onClick={openVerify}
               disabled={busy}
               className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium bg-fluux-brand text-white hover:opacity-90 rounded transition-colors disabled:opacity-50"
@@ -122,6 +123,7 @@ export function KeyChangeBanner({ peerJid, peerName }: KeyChangeBannerProps) {
               {t('chat.keyChangeBanner.reVerify')}
             </button>
             <button
+              type="button"
               onClick={handleDismiss}
               disabled={busy}
               className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium bg-fluux-hover text-fluux-text hover:bg-fluux-active rounded transition-colors disabled:opacity-50"

--- a/apps/fluux/src/components/KeyPickerDialog.tsx
+++ b/apps/fluux/src/components/KeyPickerDialog.tsx
@@ -115,6 +115,7 @@ export function KeyPickerDialog({ candidates, onConfirm, onCancel }: KeyPickerDi
 
         <div className="px-5 pb-5 pt-3 flex gap-2 justify-end">
           <button
+            type="button"
             onClick={onCancel}
             disabled={isInstalling}
             className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors disabled:opacity-50"
@@ -122,6 +123,7 @@ export function KeyPickerDialog({ candidates, onConfirm, onCancel }: KeyPickerDi
             {t('common.cancel')}
           </button>
           <button
+            type="button"
             onClick={handleConfirm}
             disabled={!selected || isInstalling}
             className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-fluux-brand hover:opacity-90 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
+++ b/apps/fluux/src/components/MessageComposer.emojiAutocomplete.test.tsx
@@ -79,7 +79,7 @@ function SwappableDraftComposer() {
   const [value, setValue] = useState('')
   return (
     <>
-      <button onClick={() => setValue('see you at :heart_eyes later')}>swap-draft</button>
+      <button type="button" onClick={() => setValue('see you at :heart_eyes later')}>swap-draft</button>
       <MessageComposer
         placeholder="Type a message"
         onSend={vi.fn().mockResolvedValue(true)}

--- a/apps/fluux/src/components/MessageInput.memo.test.tsx
+++ b/apps/fluux/src/components/MessageInput.memo.test.tsx
@@ -59,7 +59,7 @@ function Harness() {
   const [, setTick] = useState(0)
   return (
     <>
-      <button onClick={() => setTick((t) => t + 1)}>tick</button>
+      <button type="button" onClick={() => setTick((t) => t + 1)}>tick</button>
       <MessageInput {...STABLE} />
     </>
   )

--- a/apps/fluux/src/components/ModalOverlay.backdroproot.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.backdroproot.test.tsx
@@ -42,7 +42,7 @@ describe('glass panel escapes the scrim backdrop root', () => {
   it('ModalOverlay renders the panel as a sibling of the scrim', () => {
     const { container } = render(
       <ModalOverlay onClose={vi.fn()}>
-        <button>ok</button>
+        <button type="button">ok</button>
       </ModalOverlay>,
     )
     expectPanelOutsideScrim(container)
@@ -51,7 +51,7 @@ describe('glass panel escapes the scrim backdrop root', () => {
   it('BottomSheet renders the panel as a sibling of the scrim', () => {
     render(
       <BottomSheet open onClose={vi.fn()} ariaLabel="actions">
-        <button>ok</button>
+        <button type="button">ok</button>
       </BottomSheet>,
     )
     // BottomSheet portals to document.body, so query from there.

--- a/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
@@ -9,8 +9,8 @@ describe('ModalOverlay focus trap', () => {
   it('wraps Tab within the panel', () => {
     const { getByText } = render(
       <ModalOverlay onClose={vi.fn()}>
-        <button>alpha</button>
-        <button>omega</button>
+        <button type="button">alpha</button>
+        <button type="button">omega</button>
       </ModalOverlay>,
     )
     const omega = getByText('omega')

--- a/apps/fluux/src/components/ModalShell.test.tsx
+++ b/apps/fluux/src/components/ModalShell.test.tsx
@@ -33,7 +33,7 @@ describe('ModalShell glass surface', () => {
   it('restores focus to its input when the window regains focus', () => {
     const { container } = render(
       <>
-        <button data-testid="outside">outside</button>
+        <button type="button" data-testid="outside">outside</button>
         <ModalShell title="X" onClose={() => {}}>
           <input data-testid="field" autoFocus />
         </ModalShell>

--- a/apps/fluux/src/components/ModalShell.tsx
+++ b/apps/fluux/src/components/ModalShell.tsx
@@ -42,6 +42,7 @@ export function ModalShell({
             <h2 className="text-lg font-semibold text-fluux-text">{title}</h2>
             <Tooltip content={t('common.close')}>
               <button
+                type="button"
                 onClick={close}
                 aria-label={t('common.close')}
                 // Escape closes the modal, so the X is a pointer-only affordance:

--- a/apps/fluux/src/components/OccupantModerationModal.tsx
+++ b/apps/fluux/src/components/OccupantModerationModal.tsx
@@ -180,6 +180,7 @@ export function OccupantModerationModal({
                 if (!label) return null
                 return (
                   <button
+                    type="button"
                     key={`role-${role}`}
                     disabled={loading}
                     onClick={() => void handleRoleAction(role)}
@@ -203,6 +204,7 @@ export function OccupantModerationModal({
             <div className="flex flex-wrap gap-2">
               {affButtons.map(aff => (
                 <button
+                  type="button"
                   key={`aff-${aff}`}
                   disabled={loading}
                   onClick={() => void handleAffAction(aff)}
@@ -240,6 +242,7 @@ export function OccupantModerationModal({
                 />
                 <div className="flex gap-2">
                   <button
+                    type="button"
                     disabled={loading}
                     onClick={() => {
                       if (confirmingAction === 'kick') void handleConfirmedKick()
@@ -251,6 +254,7 @@ export function OccupantModerationModal({
                     {confirmingAction === 'kick' ? t('rooms.kick') : t('rooms.ban')}
                   </button>
                   <button
+                    type="button"
                     onClick={() => { setConfirmingAction(null); setReason('') }}
                     className="px-3 py-1.5 text-sm rounded-md bg-fluux-hover/50 text-fluux-text
                       hover:bg-fluux-hover transition-colors"
@@ -263,6 +267,7 @@ export function OccupantModerationModal({
               <div className="flex flex-wrap gap-2">
                 {showKick && (
                   <button
+                    type="button"
                     disabled={loading}
                     onClick={() => setConfirmingAction('kick')}
                     className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md
@@ -275,6 +280,7 @@ export function OccupantModerationModal({
                 )}
                 {showBan && (
                   <button
+                    type="button"
                     disabled={loading}
                     onClick={() => setConfirmingAction('ban')}
                     className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md

--- a/apps/fluux/src/components/OccupantPanel.tsx
+++ b/apps/fluux/src/components/OccupantPanel.tsx
@@ -678,6 +678,7 @@ export function OccupantPanel({
         {fullScreen ? (
           <div className="flex items-center gap-2">
             <button
+              type="button"
               onClick={onClose}
               className="p-1 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
             >
@@ -690,6 +691,7 @@ export function OccupantPanel({
             <h3 className="font-semibold text-fluux-text">{t('rooms.members')}</h3>
             <Tooltip content={t('rooms.closePanel')} position="left">
               <button
+                type="button"
                 onClick={onClose}
                 aria-label={t('rooms.closePanel')}
                 className="p-1 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"

--- a/apps/fluux/src/components/OwnKeyConflictBanner.tsx
+++ b/apps/fluux/src/components/OwnKeyConflictBanner.tsx
@@ -136,6 +136,7 @@ export function OwnKeyConflictBanner() {
 
           <div className="flex flex-wrap gap-2 pt-1">
             <button
+              type="button"
               onClick={() => void handleOverwrite()}
               disabled={busy}
               className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium bg-fluux-brand text-white hover:opacity-90 rounded transition-colors disabled:opacity-50"
@@ -144,6 +145,7 @@ export function OwnKeyConflictBanner() {
               {t('settings.encryption.ownKeyConflict.overwriteServer')}
             </button>
             <button
+              type="button"
               onClick={() => setShowImportDialog(true)}
               disabled={busy}
               className="flex items-center gap-1.5 px-3 py-1 text-xs text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded transition-colors disabled:opacity-50"

--- a/apps/fluux/src/components/PollCreator.tsx
+++ b/apps/fluux/src/components/PollCreator.tsx
@@ -164,6 +164,7 @@ export function PollCreator({ onClose, onCreatePoll }: PollCreatorProps) {
               />
               {canRemoveOption && (
                 <button
+                  type="button"
                   onClick={() => removeOption(index)}
                   className="p-1 text-fluux-muted hover:text-red-500 transition-colors"
                   aria-label={t('poll.removeOption', 'Remove option')}
@@ -176,6 +177,7 @@ export function PollCreator({ onClose, onCreatePoll }: PollCreatorProps) {
 
           {canAddOption && (
             <button
+              type="button"
               onClick={addOption}
               className="flex items-center gap-1.5 text-sm text-fluux-brand hover:text-fluux-text transition-colors mt-1"
             >
@@ -231,12 +233,14 @@ export function PollCreator({ onClose, onCreatePoll }: PollCreatorProps) {
         {/* Actions */}
         <div className="flex justify-end gap-2 pt-2 border-t border-fluux-border">
           <button
+            type="button"
             onClick={onClose}
             className="px-4 py-2 text-sm text-fluux-muted hover:text-fluux-text transition-colors"
           >
             {t('common.cancel', 'Cancel')}
           </button>
           <button
+            type="button"
             onClick={handleSubmit}
             disabled={!isValid || sending}
             className="px-4 py-2 text-sm font-medium text-fluux-text-on-accent bg-fluux-brand rounded-md hover:bg-fluux-brand/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"

--- a/apps/fluux/src/components/RenderLoopBoundary.tsx
+++ b/apps/fluux/src/components/RenderLoopBoundary.tsx
@@ -192,6 +192,7 @@ export class RenderLoopBoundary extends Component<Props, State> {
               {isRenderLoop && (
                 <>
                   <button
+                    type="button"
                     onClick={this.handleCopy}
                     className="rounded border border-fluux-border px-4 py-2 text-fluux-text hover:bg-fluux-surface"
                   >
@@ -202,6 +203,7 @@ export class RenderLoopBoundary extends Component<Props, State> {
                         : 'Copy diagnostic info'}
                   </button>
                   <button
+                    type="button"
                     onClick={this.handleRetry}
                     className="rounded bg-fluux-brand px-4 py-2 text-fluux-text-on-accent hover:bg-fluux-brand/80"
                   >
@@ -210,6 +212,7 @@ export class RenderLoopBoundary extends Component<Props, State> {
                 </>
               )}
               <button
+                type="button"
                 onClick={this.handleReload}
                 className={`rounded px-4 py-2 ${isRenderLoop ? 'border border-fluux-border text-fluux-text hover:bg-fluux-surface' : 'bg-fluux-brand text-fluux-text-on-accent hover:bg-fluux-brand/80'}`}
               >
@@ -328,6 +331,7 @@ export function RenderLoopWarningBanner() {
           ⚠️ Render loop warning: {warning.componentName} ({warning.renderCount} renders/{warning.windowMs}ms)
         </div>
         <button
+          type="button"
           onClick={() => setDismissed(true)}
           className="shrink-0 rounded px-2 py-0.5 text-amber-200 hover:bg-amber-500/20"
           aria-label="Dismiss"
@@ -350,6 +354,7 @@ export function RenderLoopWarningBanner() {
         </pre>
       </details>
       <button
+        type="button"
         onClick={handleCopy}
         className="rounded border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-amber-200 hover:bg-amber-500/20"
       >

--- a/apps/fluux/src/components/RoomHatsModal.test.tsx
+++ b/apps/fluux/src/components/RoomHatsModal.test.tsx
@@ -102,7 +102,7 @@ vi.mock('./ModalShell', () => ({
   }) => (
     <div data-testid="modal-shell">
       <div data-testid="modal-title">{title}</div>
-      <button data-testid="modal-close" onClick={onClose}>Close</button>
+      <button type="button" data-testid="modal-close" onClick={onClose}>Close</button>
       {children}
     </div>
   ),
@@ -118,8 +118,8 @@ vi.mock('./ConfirmDialog', () => ({
     <div data-testid="confirm-dialog">
       <div data-testid="confirm-title">{title}</div>
       <div data-testid="confirm-message">{message}</div>
-      <button data-testid="confirm-yes" onClick={onConfirm}>Confirm</button>
-      <button data-testid="confirm-cancel" onClick={onCancel}>Cancel</button>
+      <button type="button" data-testid="confirm-yes" onClick={onConfirm}>Confirm</button>
+      <button type="button" data-testid="confirm-cancel" onClick={onCancel}>Cancel</button>
     </div>
   ),
 }))

--- a/apps/fluux/src/components/RoomHatsModal.tsx
+++ b/apps/fluux/src/components/RoomHatsModal.tsx
@@ -309,6 +309,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
               : (assignmentsLoaded ? assignments.length : undefined)
             return (
               <button
+                type="button"
                 key={tab}
                 onClick={() => handleTabChange(tab)}
                 className={`flex-1 flex items-center justify-center gap-1 px-2 py-1.5 text-xs font-medium rounded-md transition-all
@@ -343,6 +344,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
           />
           {search && (
             <button
+              type="button"
               onClick={() => setSearch('')}
               className="absolute end-2 top-1/2 -translate-y-1/2 text-fluux-muted hover:text-fluux-text"
             >
@@ -385,6 +387,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
                       <Loader2 className="size-4 animate-spin text-fluux-muted" />
                     ) : (
                       <button
+                        type="button"
                         onClick={() => setConfirmDelete(hat)}
                         className="p-1 text-fluux-muted hover:text-fluux-error transition-colors"
                         title={t('rooms.destroyHat')}
@@ -425,6 +428,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
                       <Loader2 className="size-4 animate-spin text-fluux-muted" />
                     ) : (
                       <button
+                        type="button"
                         onClick={() => void handleUnassign(a)}
                         className="text-xs text-fluux-muted hover:text-fluux-error transition-colors"
                       >
@@ -470,6 +474,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
               />
             </div>
             <button
+              type="button"
               onClick={() => void handleCreate()}
               disabled={!newTitle.trim() || !newUri.trim() || isCreating}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-fluux-text-on-accent
@@ -554,6 +559,7 @@ export function RoomHatsModal({ room, onClose }: RoomHatsModalProps) {
               )}
             </select>
             <button
+              type="button"
               onClick={() => void handleAssign()}
               disabled={jidSelection.length === 0 || !assignUri || isAssigning}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-fluux-text-on-accent

--- a/apps/fluux/src/components/RoomHeader.test.tsx
+++ b/apps/fluux/src/components/RoomHeader.test.tsx
@@ -62,35 +62,35 @@ vi.mock('./Avatar', () => ({
 // Mock AvatarCropModal
 vi.mock('./AvatarCropModal', () => ({
   AvatarCropModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
-    isOpen ? <div data-testid="avatar-crop-modal"><button onClick={onClose}>Close</button></div> : null
+    isOpen ? <div data-testid="avatar-crop-modal"><button type="button" onClick={onClose}>Close</button></div> : null
   ),
 }))
 
 // Mock InviteToRoomModal
 vi.mock('./InviteToRoomModal', () => ({
   InviteToRoomModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
-    isOpen ? <div data-testid="invite-modal"><button onClick={onClose}>Close</button></div> : null
+    isOpen ? <div data-testid="invite-modal"><button type="button" onClick={onClose}>Close</button></div> : null
   ),
 }))
 
 // Mock RoomConfigModal
 vi.mock('./RoomConfigModal', () => ({
   RoomConfigModal: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="room-config-modal"><button onClick={onClose}>Close</button></div>
+    <div data-testid="room-config-modal"><button type="button" onClick={onClose}>Close</button></div>
   ),
 }))
 
 // Mock RoomMembersModal
 vi.mock('./RoomMembersModal', () => ({
   RoomMembersModal: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="members-modal"><button onClick={onClose}>Close</button></div>
+    <div data-testid="members-modal"><button type="button" onClick={onClose}>Close</button></div>
   ),
 }))
 
 // Mock RoomHatsModal
 vi.mock('./RoomHatsModal', () => ({
   RoomHatsModal: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="hats-modal"><button onClick={onClose}>Close</button></div>
+    <div data-testid="hats-modal"><button type="button" onClick={onClose}>Close</button></div>
   ),
 }))
 

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -107,6 +107,7 @@ export function RoomHeader({
       {/* Back button - mobile only */}
       {onBack && (
         <button
+          type="button"
           onClick={onBack}
           className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
           aria-label={t('rooms.backToRooms')}
@@ -155,6 +156,7 @@ export function RoomHeader({
         <div className={inlineClass('wide')}>
           <Tooltip content={t('rooms.inviteMember')} position="bottom">
             <button
+              type="button"
               onClick={openInvite}
               className="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
               aria-label={t('rooms.inviteMember')}
@@ -181,6 +183,7 @@ export function RoomHeader({
           <div className={inlineClass('search')}>
             <Tooltip content={t('chat.searchInConversation', 'Search in conversation')} position="bottom">
               <button
+                type="button"
                 onClick={onSearchInConversation}
                 className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
                 aria-label={t('chat.searchInConversation', 'Search in conversation')}
@@ -213,6 +216,7 @@ export function RoomHeader({
         {/* Occupant toggle button */}
         <Tooltip content={showOccupants ? t('rooms.hideMembers') : t('rooms.showMembers')} position="bottom">
           <button
+            type="button"
             onClick={onToggleOccupants}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
                        ${showOccupants
@@ -232,7 +236,7 @@ export function RoomHeader({
       {avatarError && (
         <div className="absolute top-full inset-x-0 mt-1 mx-4 p-2 bg-fluux-red/20 border border-fluux-red/50 rounded text-fluux-error text-sm flex items-center justify-between z-40">
           <span>{avatarError}</span>
-          <button onClick={() => setAvatarError(null)} className="p-1 hover:bg-fluux-red/20 rounded">
+          <button type="button" onClick={() => setAvatarError(null)} className="p-1 hover:bg-fluux-red/20 rounded">
             <X className="size-4" />
           </button>
         </div>

--- a/apps/fluux/src/components/RoomListItem.tsx
+++ b/apps/fluux/src/components/RoomListItem.tsx
@@ -12,6 +12,7 @@ export function RoomListItem({
 }: RoomListItemProps) {
   return (
     <button
+      type="button"
       onClick={() => onSelect(room)}
       className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-fluux-hover
                  transition-colors text-start"

--- a/apps/fluux/src/components/RoomMembersModal.tsx
+++ b/apps/fluux/src/components/RoomMembersModal.tsx
@@ -232,6 +232,7 @@ export function RoomMembersModal({ room, onClose }: RoomMembersModalProps) {
             const count = getTabCount(tab)
             return (
               <button
+                type="button"
                 key={tab}
                 onClick={() => handleTabChange(tab)}
                 className={`flex-1 min-w-[calc(50%-2px)] flex items-center justify-center gap-1 px-2 py-1.5 text-xs font-medium rounded-md transition-all
@@ -267,6 +268,7 @@ export function RoomMembersModal({ room, onClose }: RoomMembersModalProps) {
           />
           {search && (
             <button
+              type="button"
               onClick={() => setSearch('')}
               className="absolute end-2 top-1/2 -translate-y-1/2 text-fluux-muted hover:text-fluux-text"
             >
@@ -354,6 +356,7 @@ export function RoomMembersModal({ room, onClose }: RoomMembersModalProps) {
               ))}
             </select>
             <button
+              type="button"
               onClick={handleAddMember}
               disabled={jidSelection.length === 0 || isAdding}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-fluux-text-on-accent
@@ -425,6 +428,7 @@ function AffiliationDropdown({
   return (
     <div ref={dropdownRef} className="relative">
       <button
+        type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-1 px-2 py-1 text-xs text-fluux-muted hover:text-fluux-text
                    bg-fluux-hover/50 hover:bg-fluux-hover rounded transition-colors"
@@ -436,6 +440,7 @@ function AffiliationDropdown({
         <div className="absolute end-0 top-full mt-1 fluux-popover rounded-lg py-1 z-50 min-w-36">
           {availableAffiliations.map(aff => (
             <button
+              type="button"
               key={aff}
               onClick={() => {
                 onSelect(aff)

--- a/apps/fluux/src/components/RoomMessageInput.memo.test.tsx
+++ b/apps/fluux/src/components/RoomMessageInput.memo.test.tsx
@@ -52,7 +52,7 @@ function Harness() {
   const [, setTick] = useState(0)
   return (
     <>
-      <button onClick={() => setTick((t) => t + 1)}>tick</button>
+      <button type="button" onClick={() => setTick((t) => t + 1)}>tick</button>
       <RoomMessageInput {...STABLE} />
     </>
   )

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -568,6 +568,7 @@ const { MockMessageComposer } = vi.hoisted(() => {
           onChange: () => {},
         }),
         React.createElement('button', {
+          type: 'button',
           'data-testid': 'send-button',
           onClick: () => onSend('test message'),
         }, 'Send')

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1662,12 +1662,14 @@ const RoomMessageBubbleWrapper = memo(function RoomMessageBubbleWrapper({
             )}
             <div className="flex gap-2 justify-end">
               <button
+                type="button"
                 onClick={close}
                 className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors"
               >
                 {t('common.cancel')}
               </button>
               <button
+                type="button"
                 onClick={() => {
                   setShowModerateConfirm(false)
                   const reason = moderateReason.trim() || undefined
@@ -2356,6 +2358,7 @@ function RoomJoinPrompt({
   return (
     <div className="p-4 border-t border-fluux-hover">
       <button
+        type="button"
         onClick={handleJoin}
         disabled={isJoining}
         className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-fluux-brand hover:bg-fluux-brand/90

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -334,6 +334,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
         {/* Back button - mobile */}
         {onBack && (
           <button
+            type="button"
             onClick={handleBack}
             className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back', 'Back')}
@@ -389,6 +390,7 @@ export function SearchContextView({ onBack }: { onBack?: () => void }) {
           <span className="text-sm">{t('search.previewBanner', 'You are viewing a search result preview')}</span>
         </div>
         <button
+          type="button"
           onClick={handleGoToMessage}
           className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md
                      bg-fluux-brand/10 text-fluux-brand hover:bg-fluux-brand/20 transition-colors flex-shrink-0"

--- a/apps/fluux/src/components/ServerOverview.tsx
+++ b/apps/fluux/src/components/ServerOverview.tsx
@@ -43,6 +43,7 @@ export function ServerOverview() {
             : null}
         </div>
         <button
+          type="button"
           onClick={() => { void fetchServerStats() }}
           disabled={isLoadingStats}
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-fluux-bg hover:bg-fluux-hover text-fluux-text disabled:opacity-50 transition-colors tap-target"
@@ -57,6 +58,7 @@ export function ServerOverview() {
         <div className="flex-1 flex flex-col items-center justify-center text-fluux-muted py-12">
           <p className="mb-3">{t('admin.overview.empty')}</p>
           <button
+            type="button"
             onClick={() => { void fetchServerStats() }}
             className="px-4 py-2 text-sm rounded-lg bg-fluux-brand text-fluux-text-on-accent hover:bg-fluux-brand/90 transition-colors"
           >

--- a/apps/fluux/src/components/SettingsView.tsx
+++ b/apps/fluux/src/components/SettingsView.tsx
@@ -85,6 +85,7 @@ export function SettingsView({ onBack }: SettingsViewProps) {
         {/* Back button - mobile only */}
         {onBack && (
           <button
+            type="button"
             onClick={onBack}
             className="p-1 -ms-1 me-2 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back')}

--- a/apps/fluux/src/components/ShortcutHelp.tsx
+++ b/apps/fluux/src/components/ShortcutHelp.tsx
@@ -46,6 +46,7 @@ export function ShortcutHelp({ shortcuts, onClose }: ShortcutHelpProps) {
           <h2 className="text-lg font-semibold text-fluux-text">{t('shortcuts.title')}</h2>
           <Tooltip content={t('common.close')} position="left">
             <button
+              type="button"
               onClick={close}
               className="p-1.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
               aria-label={t('common.close')}

--- a/apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
+++ b/apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
@@ -31,6 +31,7 @@ vi.mock('./sidebar-components', () => ({
   // exposes the archive toggle (aria-label reflects state) and calls back.
   MessagesHeaderActions: ({ showArchived, onToggleArchived }: { showArchived: boolean; onToggleArchived: () => void }) => (
     <button
+      type="button"
       aria-label={showArchived ? 'Show active conversations' : 'Show archived conversations'}
       onClick={onToggleArchived}
     />

--- a/apps/fluux/src/components/StrangerRequestPreviewView.tsx
+++ b/apps/fluux/src/components/StrangerRequestPreviewView.tsx
@@ -81,6 +81,7 @@ export function StrangerRequestPreviewView({
         {/* Back button — mobile */}
         {onBack && (
           <button
+            type="button"
             onClick={onBack}
             className="p-1 -ms-1 rounded hover:bg-fluux-hover md:hidden tap-target"
             aria-label={t('common.back', 'Back')}
@@ -132,6 +133,7 @@ export function StrangerRequestPreviewView({
       {/* Bottom action banner */}
       <div className="p-3 border-t border-fluux-hover flex items-center justify-end gap-2">
         <button
+          type="button"
           onClick={onBlock}
           className="px-4 py-2 text-sm font-medium rounded-md
                      text-fluux-muted hover:bg-fluux-hover transition-colors"
@@ -139,6 +141,7 @@ export function StrangerRequestPreviewView({
           {t('common.block', 'Block')}
         </button>
         <button
+          type="button"
           onClick={onIgnore}
           className="px-4 py-2 text-sm font-medium rounded-md
                      text-fluux-muted hover:bg-fluux-hover transition-colors"
@@ -146,6 +149,7 @@ export function StrangerRequestPreviewView({
           {t('common.ignore', 'Ignore')}
         </button>
         <button
+          type="button"
           onClick={onAccept}
           className="px-4 py-2 text-sm font-medium rounded-md
                      bg-fluux-brand text-white hover:bg-fluux-brand/90 transition-colors"

--- a/apps/fluux/src/components/TabBlockedScreen.tsx
+++ b/apps/fluux/src/components/TabBlockedScreen.tsx
@@ -38,6 +38,7 @@ export function TabBlockedScreen({ takenOver, onTakeOver }: TabBlockedScreenProp
           </p>
 
           <button
+            type="button"
             onClick={onTakeOver}
             className="w-full py-2.5 bg-fluux-brand hover:bg-fluux-brand-hover
                        text-fluux-text-on-accent font-medium rounded transition-colors

--- a/apps/fluux/src/components/ToastContainer.tsx
+++ b/apps/fluux/src/components/ToastContainer.tsx
@@ -45,6 +45,7 @@ export function ToastContainer() {
             <Icon className={`size-5 shrink-0 ${colors.icon}`} />
             <span className="text-sm text-fluux-text flex-1">{toast.message}</span>
             <button
+              type="button"
               onClick={(e) => { e.stopPropagation(); removeToast(toast.id) }}
               className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text shrink-0"
               aria-label={t('common.dismiss')}

--- a/apps/fluux/src/components/Tooltip.test.tsx
+++ b/apps/fluux/src/components/Tooltip.test.tsx
@@ -12,7 +12,7 @@ describe('Tooltip', () => {
     it('should not show tooltip initially', () => {
       render(
         <Tooltip content="Test tooltip">
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -23,7 +23,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={400}>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -45,7 +45,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={0}>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -67,7 +67,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={500}>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -94,7 +94,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={0}>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -118,7 +118,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={500}>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -149,7 +149,7 @@ describe('Tooltip', () => {
         <div>
           <div data-testid="unrelated-scroller">Some scrollable content</div>
           <Tooltip content="Test tooltip" delay={0}>
-            <button>Hover me</button>
+            <button type="button">Hover me</button>
           </Tooltip>
         </div>
       )
@@ -177,7 +177,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={0}>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -205,7 +205,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={0} disabled>
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -227,7 +227,7 @@ describe('Tooltip', () => {
         vi.useFakeTimers()
         render(
           <Tooltip content="Test tooltip" position={position} delay={0}>
-            <button>Hover me</button>
+            <button type="button">Hover me</button>
           </Tooltip>
         )
 
@@ -255,7 +255,7 @@ describe('Tooltip', () => {
           }
           delay={0}
         >
-          <button>Hover me</button>
+          <button type="button">Hover me</button>
         </Tooltip>
       )
 
@@ -276,7 +276,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={0}>
-          <button>Focus me</button>
+          <button type="button">Focus me</button>
         </Tooltip>
       )
 
@@ -294,7 +294,7 @@ describe('Tooltip', () => {
       vi.useFakeTimers()
       render(
         <Tooltip content="Test tooltip" delay={0}>
-          <button>Focus me</button>
+          <button type="button">Focus me</button>
         </Tooltip>
       )
 
@@ -323,7 +323,7 @@ describe('SimpleTooltip', () => {
     vi.useFakeTimers()
     render(
       <SimpleTooltip content="Simple tooltip" delay={0}>
-        <button>Hover me</button>
+        <button type="button">Hover me</button>
       </SimpleTooltip>
     )
 

--- a/apps/fluux/src/components/UpdateModal.tsx
+++ b/apps/fluux/src/components/UpdateModal.tsx
@@ -28,6 +28,7 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
           {!state.downloading && (
             <Tooltip content={t('common.close')}>
               <button
+                type="button"
                 onClick={close}
                 className="p-1 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover"
               >
@@ -98,6 +99,7 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
           <div className="flex gap-3">
             {state.downloaded ? (
               <button
+                type="button"
                 onClick={onRelaunch}
                 className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-fluux-brand text-fluux-text-on-accent rounded-lg hover:bg-fluux-brand/90 transition-colors"
               >
@@ -106,6 +108,7 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
               </button>
             ) : state.downloading ? (
               <button
+                type="button"
                 disabled
                 className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-fluux-muted/20 text-fluux-muted rounded-lg cursor-not-allowed"
               >
@@ -115,12 +118,14 @@ export function UpdateModal({ state, onDownload, onRelaunch, onDismiss }: Update
             ) : (
               <>
                 <button
+                  type="button"
                   onClick={close}
                   className="flex-1 px-4 py-2 text-fluux-muted hover:text-fluux-text border border-fluux-border rounded-lg hover:bg-fluux-hover transition-colors"
                 >
                   {t('update.later')}
                 </button>
                 <button
+                  type="button"
                   onClick={onDownload}
                   className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-fluux-brand text-fluux-text-on-accent rounded-lg hover:bg-fluux-brand/90 transition-colors"
                 >

--- a/apps/fluux/src/components/UserListItem.tsx
+++ b/apps/fluux/src/components/UserListItem.tsx
@@ -73,6 +73,7 @@ function UserListItemImpl({ user, onSelect, requestLastActivity }: UserListItemP
 
   return (
     <button
+      type="button"
       ref={rowRef}
       onClick={() => onSelect(user)}
       className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-fluux-hover

--- a/apps/fluux/src/components/VerifyPeerDialog.tsx
+++ b/apps/fluux/src/components/VerifyPeerDialog.tsx
@@ -224,6 +224,7 @@ export function VerifyPeerDialog({
             </div>
 
             <button
+              type="button"
               onClick={() => onConfirm(peerFingerprint)}
               className="w-full flex items-center justify-center gap-1.5 px-4 py-2 text-sm text-fluux-text border border-fluux-border hover:bg-fluux-hover rounded-lg transition-colors"
             >
@@ -239,6 +240,7 @@ export function VerifyPeerDialog({
           <div className={`flex gap-2 ${alreadyVerified && onRevoke ? 'justify-between' : 'justify-end'}`}>
             {alreadyVerified && onRevoke && (
               <button
+                type="button"
                 onClick={onRevoke}
                 className="flex items-center gap-1.5 px-4 py-2 text-sm text-fluux-error border border-fluux-red/50 hover:bg-fluux-red/10 rounded-lg transition-colors"
               >
@@ -248,12 +250,14 @@ export function VerifyPeerDialog({
             )}
             <div className="flex gap-2">
               <button
+                type="button"
                 onClick={onCancel}
                 className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active rounded-lg transition-colors"
               >
                 {t('common.cancel')}
               </button>
               <button
+                type="button"
                 onClick={() => onConfirm(peerFingerprint)}
                 disabled={!inputMatches}
                 className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-fluux-brand hover:opacity-90 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"

--- a/apps/fluux/src/components/XmppConsole.tsx
+++ b/apps/fluux/src/components/XmppConsole.tsx
@@ -537,6 +537,7 @@ export function XmppConsole() {
             {(['all', 'incoming', 'outgoing'] as DirectionFilter[]).map((dir) => (
               <Tooltip key={dir} content={dir === 'all' ? t('console.showAll') : dir === 'incoming' ? t('console.showReceived') : t('console.showSent')} position="bottom">
                 <button
+                  type="button"
                   onClick={() => setDirectionFilter(dir)}
                   className={`px-2 py-0.5 text-xs rounded transition-colors ${
                     directionFilter === dir
@@ -554,6 +555,7 @@ export function XmppConsole() {
             {(['message', 'presence', 'iq', 'sm', 'other', 'event'] as FilterType[]).map((type) => (
               <Tooltip key={type} content={enabledTypes.has(type) ? t('console.hideType', { type: type === 'event' ? 'events' : type + ' packets' }) : t('console.showType', { type: type === 'event' ? 'events' : type + ' packets' })} position="bottom">
                 <button
+                  type="button"
                   onClick={() => toggleType(type)}
                   className={`px-2 py-0.5 text-xs rounded transition-colors ${
                     enabledTypes.has(type)
@@ -578,6 +580,7 @@ export function XmppConsole() {
             />
             {searchQuery && (
               <button
+                type="button"
                 onClick={() => setSearchQuery('')}
                 className="absolute end-1.5 top-1/2 -translate-y-1/2 text-fluux-muted hover:text-fluux-text"
               >
@@ -587,6 +590,7 @@ export function XmppConsole() {
           </div>
           <Tooltip content={t('console.serverInfo')} position="bottom">
             <button
+              type="button"
               onClick={() => setShowServerInfo(true)}
               disabled={!serverInfo}
               className="p-1.5 text-fluux-muted hover:text-fluux-text hover:bg-fluux-bg/50 rounded disabled:opacity-50 disabled:cursor-not-allowed"
@@ -597,6 +601,7 @@ export function XmppConsole() {
           </Tooltip>
           <Tooltip content={t('console.export')} position="bottom">
             <button
+              type="button"
               onClick={handleExport}
               disabled={entries.length === 0}
               className="p-1.5 text-fluux-muted hover:text-fluux-text hover:bg-fluux-bg/50 rounded disabled:opacity-50 disabled:cursor-not-allowed"
@@ -607,6 +612,7 @@ export function XmppConsole() {
           </Tooltip>
           <Tooltip content={t('console.clear')} position="bottom">
             <button
+              type="button"
               onClick={clearEntries}
               className="p-1.5 text-fluux-muted hover:text-fluux-text hover:bg-fluux-bg/50 rounded"
               aria-label={t('console.clear')}
@@ -616,6 +622,7 @@ export function XmppConsole() {
           </Tooltip>
           <Tooltip content={t('console.close')} position="left">
             <button
+              type="button"
               onClick={toggle}
               className="p-1.5 text-fluux-muted hover:text-fluux-text hover:bg-fluux-bg/50 rounded"
               aria-label={t('console.close')}
@@ -692,6 +699,7 @@ export function XmppConsole() {
         {/* Floating "Go to Live" button */}
         {!autoScroll && filteredEntries.length > 0 && (
           <button
+            type="button"
             onClick={() => {
               setAutoScroll(true)
               setSelectedEntryId(null)
@@ -725,6 +733,7 @@ export function XmppConsole() {
           />
           <Tooltip content={t('console.sendStanza', { modifier: isMac ? '⌘' : 'Ctrl' })} position="top">
             <button
+              type="button"
               onClick={handleSend}
               disabled={!isConnected || !inputXml.trim()}
               className="px-4 bg-fluux-brand text-fluux-text-on-accent rounded hover:bg-fluux-brand/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
@@ -750,6 +759,7 @@ export function XmppConsole() {
                 <h2 className="text-lg font-semibold text-fluux-text">{t('console.serverInformation')}</h2>
               </div>
               <button
+                type="button"
                 onClick={() => setShowServerInfo(false)}
                 className="p-1 text-fluux-muted hover:text-fluux-text rounded"
               >
@@ -800,6 +810,7 @@ export function XmppConsole() {
             {/* Modal Footer */}
             <div className="px-4 py-3 border-t border-fluux-bg flex justify-end">
               <button
+                type="button"
                 onClick={() => setShowServerInfo(false)}
                 className="px-4 py-2 bg-fluux-bg text-fluux-text rounded hover:bg-fluux-bg/70 transition-colors"
               >

--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
             >
               <button
                 class="flex items-center gap-1 px-3 py-1.5 text-xs rounded-full transition-colors text-fluux-muted hover:text-fluux-text hover:bg-fluux-hover"
+                type="button"
               >
                 <span
                   data-testid="icon-chevron-up"
@@ -143,18 +144,21 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                         <button
                           aria-label="chat.reactWith"
                           class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          type="button"
                         >
                           👍
                         </button>
                         <button
                           aria-label="chat.reactWith"
                           class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          type="button"
                         >
                           ❤️
                         </button>
                         <button
                           aria-label="chat.reactWith"
                           class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          type="button"
                         >
                           😂
                         </button>
@@ -167,6 +171,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                           <button
                             aria-label="chat.moreReactions"
                             class="p-1.5 transition-colors hover:bg-fluux-hover"
+                            type="button"
                           >
                             <span
                               data-testid="icon-emoji"
@@ -181,6 +186,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                           <button
                             aria-label="chat.reply"
                             class="p-1.5 transition-colors hover:bg-fluux-hover"
+                            type="button"
                           >
                             <span
                               data-testid="icon-reply"
@@ -196,6 +202,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                             aria-label="chat.forwardMessage"
                             class="p-1.5 transition-colors opacity-50 cursor-not-allowed hover:bg-fluux-hover"
                             disabled=""
+                            type="button"
                           >
                             <span
                               data-testid="icon-forward"
@@ -214,6 +221,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                               aria-label="chat.moreOptions"
                               class="p-1.5 transition-colors hover:bg-fluux-hover opacity-50 cursor-not-allowed"
                               disabled=""
+                              type="button"
                             >
                               <span
                                 data-testid="icon-more"
@@ -309,18 +317,21 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                         <button
                           aria-label="chat.reactWith"
                           class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          type="button"
                         >
                           👍
                         </button>
                         <button
                           aria-label="chat.reactWith"
                           class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          type="button"
                         >
                           ❤️
                         </button>
                         <button
                           aria-label="chat.reactWith"
                           class="px-2 py-1.5 leading-none transition-colors text-base hover:bg-fluux-hover "
+                          type="button"
                         >
                           😂
                         </button>
@@ -333,6 +344,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                           <button
                             aria-label="chat.moreReactions"
                             class="p-1.5 transition-colors hover:bg-fluux-hover"
+                            type="button"
                           >
                             <span
                               data-testid="icon-emoji"
@@ -347,6 +359,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                           <button
                             aria-label="chat.editMessage"
                             class="p-1.5 transition-colors hover:bg-fluux-hover"
+                            type="button"
                           >
                             <span
                               data-testid="icon-edit"
@@ -362,6 +375,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                             aria-label="chat.forwardMessage"
                             class="p-1.5 transition-colors opacity-50 cursor-not-allowed hover:bg-fluux-hover"
                             disabled=""
+                            type="button"
                           >
                             <span
                               data-testid="icon-forward"
@@ -379,6 +393,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
                             <button
                               aria-label="chat.moreOptions"
                               class="p-1.5 transition-colors hover:bg-fluux-hover "
+                              type="button"
                             >
                               <span
                                 data-testid="icon-more"
@@ -454,6 +469,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
               class="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
               data-fab="scroll-to-bottom"
               tabindex="-1"
+              type="button"
             >
               <span
                 data-testid="icon-chevron-down"
@@ -474,6 +490,7 @@ exports[`ChatView > Snapshots > should match snapshot with messages 1`] = `
       />
       <button
         data-testid="send-button"
+        type="button"
       >
         Send
       </button>
@@ -612,6 +629,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
               class="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
               data-fab="scroll-to-bottom"
               tabindex="-1"
+              type="button"
             >
               <span
                 data-testid="icon-chevron-down"
@@ -632,6 +650,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
       />
       <button
         data-testid="send-button"
+        type="button"
       >
         Send
       </button>

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
                   aria-haspopup="menu"
                   aria-label="rooms.notificationSettings"
                   class="flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
+                  type="button"
                 >
                   <span
                     data-testid="icon-bell-off"
@@ -74,6 +75,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
               <button
                 aria-label="rooms.inviteMember"
                 class="p-1.5 rounded-lg hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors tap-target"
+                type="button"
               >
                 <span
                   data-testid="icon-user-plus"
@@ -111,6 +113,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
               aria-label="rooms.showMembers"
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-colors tap-target
                        hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text"
+              type="button"
             >
               <span
                 data-testid="icon-users"
@@ -188,6 +191,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
                 class="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"
                 data-fab="scroll-to-bottom"
                 tabindex="-1"
+                type="button"
               >
                 <span
                   data-testid="icon-chevron-down"
@@ -205,6 +209,7 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
         <button
           class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-fluux-brand hover:bg-fluux-brand/90
                    disabled:opacity-50 disabled:cursor-not-allowed text-fluux-text-on-accent rounded-lg font-medium transition-colors"
+          type="button"
         >
           <span
             data-testid="icon-login"

--- a/apps/fluux/src/components/contact-profile/ContactSecurityDetail.tsx
+++ b/apps/fluux/src/components/contact-profile/ContactSecurityDetail.tsx
@@ -31,6 +31,7 @@ export function ContactSecurityDetail({
     >
       <div className="h-14 px-4 flex items-center gap-2 border-b border-fluux-bg flex-shrink-0">
         <button
+          type="button"
           onClick={onClose}
           className="p-1 -ms-1 rounded hover:bg-fluux-hover tap-target"
           aria-label={t('common.back')}

--- a/apps/fluux/src/components/conversation/CollapsibleContent.tsx
+++ b/apps/fluux/src/components/conversation/CollapsibleContent.tsx
@@ -112,6 +112,7 @@ export function CollapsibleContent({
 
       {/* Show more / Show less button - select-none prevents copying button text */}
       <button
+        type="button"
         onClick={() => toggle(messageId)}
         className="flex items-center gap-1 mt-1 text-sm text-fluux-muted hover:text-fluux-text transition-colors select-none"
       >

--- a/apps/fluux/src/components/conversation/FindOnPageBar.tsx
+++ b/apps/fluux/src/components/conversation/FindOnPageBar.tsx
@@ -71,6 +71,7 @@ export function FindOnPageBar({
           </span>
         )}
         <button
+          type="button"
           onClick={onPrev}
           disabled={totalMatches === 0}
           className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted disabled:opacity-30"
@@ -79,6 +80,7 @@ export function FindOnPageBar({
           <ChevronUp className="size-4" />
         </button>
         <button
+          type="button"
           onClick={onNext}
           disabled={totalMatches === 0}
           className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted disabled:opacity-30"
@@ -87,6 +89,7 @@ export function FindOnPageBar({
           <ChevronDown className="size-4" />
         </button>
         <button
+          type="button"
           onClick={onClose}
           className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted"
           title={t('common.close', 'Close (Esc)')}

--- a/apps/fluux/src/components/conversation/HistoryGapMarker.tsx
+++ b/apps/fluux/src/components/conversation/HistoryGapMarker.tsx
@@ -20,6 +20,7 @@ export function HistoryGapMarker({ onLoadMore, isLoading }: { onLoadMore: () => 
         <div className="flex-1 h-px bg-fluux-hover" />
       </div>
       <button
+        type="button"
         onClick={onLoadMore}
         disabled={isLoading}
         className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-full transition-colors ${

--- a/apps/fluux/src/components/conversation/MentionChip.tsx
+++ b/apps/fluux/src/components/conversation/MentionChip.tsx
@@ -17,10 +17,10 @@ export function MentionChip({ label, actionLabel, onAction, onDismiss, icon }: M
     <div className="mx-auto max-w-md flex items-center justify-center gap-2 text-xs text-fluux-muted bg-fluux-hover/60 rounded-full px-3 py-1">
       {icon}
       <span className="truncate">{label}</span>
-      <button onClick={onAction} className="font-medium text-fluux-brand hover:underline flex-shrink-0">
+      <button type="button" onClick={onAction} className="font-medium text-fluux-brand hover:underline flex-shrink-0">
         {actionLabel}
       </button>
-      <button onClick={onDismiss} aria-label={t('common.dismiss')} className="text-fluux-muted hover:text-fluux-text flex-shrink-0">
+      <button type="button" onClick={onDismiss} aria-label={t('common.dismiss')} className="text-fluux-muted hover:text-fluux-text flex-shrink-0">
         <X className="size-3" />
       </button>
     </div>

--- a/apps/fluux/src/components/conversation/MessageActionSheet.tsx
+++ b/apps/fluux/src/components/conversation/MessageActionSheet.tsx
@@ -117,6 +117,7 @@ export function MessageActionSheet({
               <div className="flex items-center gap-1 px-2 pb-1">
                 {TOOLBAR_REACTIONS.map((emoji) => (
                   <button
+                    type="button"
                     key={emoji}
                     onClick={() => react(emoji)}
                     className={`flex h-12 flex-1 items-center justify-center rounded-lg text-2xl transition-colors hover:bg-fluux-hover ${
@@ -128,6 +129,7 @@ export function MessageActionSheet({
                   </button>
                 ))}
                 <button
+                  type="button"
                   onClick={() => setShowEmojiPicker(true)}
                   className="flex h-12 flex-1 items-center justify-center rounded-lg transition-colors hover:bg-fluux-hover"
                   aria-label={t('chat.moreReactions')}

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -678,6 +678,7 @@ export const MessageBubble = memo(function MessageBubble({
         {/* Reply context - show what message this is replying to (hidden for retracted messages) */}
         {!message.isRetracted && replyContext && (
           <button
+            type="button"
             onClick={() => scrollToMessage(replyContext.messageId)}
             className="reply-quote-card flex items-start gap-1.5 py-1 pe-2 ps-2 mb-1.5 border-s-2 text-start min-w-0 bg-fluux-bg-secondary hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
             // When the row is selected the selection tint melts into the card fill
@@ -776,6 +777,7 @@ export const MessageBubble = memo(function MessageBubble({
               <span className="text-xs font-medium">{t('chat.deliveryFailed')}</span>
               <span className="text-xs text-fluux-muted">—</span>
               <button
+                type="button"
                 onClick={() => setShowErrorDetails(!showErrorDetails)}
                 className="text-xs text-fluux-muted hover:text-fluux-text cursor-pointer underline"
               >
@@ -785,6 +787,7 @@ export const MessageBubble = memo(function MessageBubble({
                 <>
                   <span className="text-xs text-fluux-muted">·</span>
                   <button
+                    type="button"
                     onClick={onRetry}
                     className="text-xs text-fluux-link hover:text-fluux-link-hover cursor-pointer underline flex items-center gap-1"
                   >

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -1912,7 +1912,7 @@ describe('MessageList scroll behavior', () => {
           renderMessage={(msg, _idx, _group, _showNew, onMediaLoad) => (
             <div key={msg.id}>
               {msg.body}
-              <button data-testid={`load-${msg.id}`} onClick={onMediaLoad}>Load</button>
+              <button type="button" data-testid={`load-${msg.id}`} onClick={onMediaLoad}>Load</button>
             </div>
           )}
         />
@@ -1967,7 +1967,7 @@ describe('MessageList scroll behavior', () => {
           renderMessage={(msg, _idx, _group, _showNew, onMediaLoad) => (
             <div key={msg.id}>
               {msg.body}
-              <button data-testid={`load-${msg.id}`} onClick={onMediaLoad}>Load</button>
+              <button type="button" data-testid={`load-${msg.id}`} onClick={onMediaLoad}>Load</button>
             </div>
           )}
         />
@@ -2022,7 +2022,7 @@ describe('MessageList scroll behavior', () => {
           renderMessage={(msg, _idx, _group, _showNew, onMediaLoad) => (
             <div key={msg.id}>
               {msg.body}
-              <button data-testid={`load-${msg.id}`} onClick={onMediaLoad}>Load</button>
+              <button type="button" data-testid={`load-${msg.id}`} onClick={onMediaLoad}>Load</button>
             </div>
           )}
         />

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -658,6 +658,7 @@ export function MessageList<T extends BaseMessage>({
         ) : onScrollToTop ? (
           <div data-row-kind="header" className="flex justify-center py-3">
             <button
+              type="button"
               onClick={handleLoadEarlier}
               disabled={isLoadingOlder}
               className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-full transition-colors ${
@@ -814,6 +815,7 @@ export function MessageList<T extends BaseMessage>({
           {!isHistoryComplete && onScrollToTop && (
             <div className="flex justify-center py-3">
               <button
+                type="button"
                 onClick={handleLoadEarlier}
                 disabled={isLoadingOlder}
                 className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-full transition-colors ${
@@ -923,6 +925,7 @@ export function MessageList<T extends BaseMessage>({
       >
         <Tooltip content={t('chat.scrollToBottom') + ` (${isMac ? '⌘↓' : 'Ctrl+↓'})`} position="left">
           <button
+            type="button"
             onClick={handleJumpToBottom}
             data-fab="scroll-to-bottom"
             className="size-10 rounded-full bg-fluux-float border border-fluux-border shadow-lg flex items-center justify-center text-fluux-muted hover:text-fluux-text hover:bg-fluux-float-hover transition-colors duration-200 hover:scale-105 active:scale-95"

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -232,7 +232,7 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
           messages={makeMessages(8)}
           conversationId="conv-media-load"
           renderMessage={(msg, _idx, _group, _showNew, onMediaLoad) => (
-            <button onClick={onMediaLoad}>media loaded {msg.id}</button>
+            <button type="button" onClick={onMediaLoad}>media loaded {msg.id}</button>
           )}
         />,
       )

--- a/apps/fluux/src/components/conversation/MessageReactions.tsx
+++ b/apps/fluux/src/components/conversation/MessageReactions.tsx
@@ -69,6 +69,7 @@ export const MessageReactions = memo(function MessageReactions({
           delay={300}
         >
           <button
+            type="button"
             onClick={onReaction ? (e: React.MouseEvent) => {
               // Burst only when adding a reaction, not removing
               if (!myReactions.includes(emoji)) {

--- a/apps/fluux/src/components/conversation/MessageToolbar.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.test.tsx
@@ -33,14 +33,14 @@ vi.mock('@/hooks', () => ({
 vi.mock('../EmojiPicker', () => ({
   default: ({ onSelect, onClose }: { onSelect: (emoji: string) => void; onClose: () => void }) => (
     <div data-testid="emoji-picker">
-      <button onClick={() => onSelect('🎉')} data-testid="emoji-picker-select">Select emoji</button>
-      <button onClick={onClose} data-testid="emoji-picker-close">Close</button>
+      <button type="button" onClick={() => onSelect('🎉')} data-testid="emoji-picker-select">Select emoji</button>
+      <button type="button" onClick={onClose} data-testid="emoji-picker-close">Close</button>
     </div>
   ),
   EmojiPicker: ({ onSelect, onClose }: { onSelect: (emoji: string) => void; onClose: () => void }) => (
     <div data-testid="emoji-picker">
-      <button onClick={() => onSelect('🎉')} data-testid="emoji-picker-select">Select emoji</button>
-      <button onClick={onClose} data-testid="emoji-picker-close">Close</button>
+      <button type="button" onClick={() => onSelect('🎉')} data-testid="emoji-picker-select">Select emoji</button>
+      <button type="button" onClick={onClose} data-testid="emoji-picker-close">Close</button>
     </div>
   ),
 }))

--- a/apps/fluux/src/components/conversation/MessageToolbar.tsx
+++ b/apps/fluux/src/components/conversation/MessageToolbar.tsx
@@ -167,6 +167,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       {/* Quick reaction emojis (hidden when reactions are disabled) */}
       {handleReaction && TOOLBAR_REACTIONS.map(emoji => (
         <button
+          type="button"
           key={emoji}
           onClick={(e: React.MouseEvent) => {
             if (!myReactions.includes(emoji)) {
@@ -194,6 +195,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       {handleReaction && (
       <div className="relative">
         <button
+          type="button"
           ref={reactionButtonRef}
           onClick={() => {
             if (!showReactionPicker && reactionButtonRef.current) {
@@ -229,6 +231,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       {canReply && (
         <Tooltip content={t('chat.reply')} position="top" disabled={showReactionPicker || showMoreMenu}>
           <button
+            type="button"
             onClick={onReply}
             className={`p-1.5 transition-colors ${showReactionPicker || showMoreMenu ? '' : 'hover:bg-fluux-hover'}`}
             aria-label={t('chat.reply')}
@@ -242,6 +245,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       {canEdit && (
         <Tooltip content={t('chat.editMessage')} position="top" disabled={showReactionPicker || showMoreMenu}>
           <button
+            type="button"
             onClick={onEdit}
             className={`p-1.5 transition-colors ${showReactionPicker || showMoreMenu ? '' : 'hover:bg-fluux-hover'}`}
             aria-label={t('chat.editMessage')}
@@ -254,6 +258,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       {/* Forward button (placeholder) */}
       <Tooltip content={t('chat.forwardMessage')} position="top" disabled={showReactionPicker || showMoreMenu}>
         <button
+          type="button"
           className={`p-1.5 transition-colors opacity-50 cursor-not-allowed ${showReactionPicker || showMoreMenu ? '' : 'hover:bg-fluux-hover'}`}
           aria-label={t('chat.forwardMessage')}
           disabled
@@ -266,6 +271,7 @@ export const MessageToolbar = memo(function MessageToolbar({
       <div className="inline-flex relative" ref={moreMenuRef}>
         <Tooltip content={t('chat.moreOptions')} position="top" disabled={showReactionPicker || showMoreMenu}>
           <button
+            type="button"
             ref={moreButtonRef}
             onClick={() => {
               if (!showMoreMenu && moreButtonRef.current) {
@@ -287,6 +293,7 @@ export const MessageToolbar = memo(function MessageToolbar({
         {showMoreMenu && canDelete && (
           <div className={`absolute end-0 min-w-[160px] fluux-popover rounded-lg z-30 overflow-hidden ${moreMenuDropUpRef.current ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
             <button
+              type="button"
               onClick={handleDelete}
               className="w-full px-3 py-2 text-sm text-start text-red-500 hover:bg-fluux-hover transition-colors flex items-center gap-2"
             >

--- a/apps/fluux/src/components/conversation/PollBanner.tsx
+++ b/apps/fluux/src/components/conversation/PollBanner.tsx
@@ -69,6 +69,7 @@ export const PollBanner = memo(function PollBanner({ messages, myNick, votedPoll
       <BarChart3 className="size-4 text-fluux-brand flex-shrink-0" />
 
       <button
+        type="button"
         onClick={() => scrollToMessage(latestPoll.id)}
         className="flex-1 min-w-0 text-start text-fluux-text hover:text-fluux-brand transition-colors truncate"
       >
@@ -81,6 +82,7 @@ export const PollBanner = memo(function PollBanner({ messages, myNick, votedPoll
       <ChevronDown className="size-4 text-fluux-muted flex-shrink-0" />
 
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation()
           onDismiss(latestPoll.id)

--- a/apps/fluux/src/components/conversation/PollCard.tsx
+++ b/apps/fluux/src/components/conversation/PollCard.tsx
@@ -129,6 +129,7 @@ export function PollCard({ poll, reactions, myReactions, onVote, onClosePoll, is
           )}
           {onClosePoll && !expired && !isClosed && (
             <button
+              type="button"
               onClick={async () => {
                 setClosing(true)
                 try {
@@ -179,6 +180,7 @@ function PollOption({ option, color, totalVoters, isMyVote, hasVoted, showResult
 
   return (
     <button
+      type="button"
       onClick={onVote ? () => onVote(option.emoji) : undefined}
       disabled={!onVote}
       className={`

--- a/apps/fluux/src/components/conversation/PollClosedCard.tsx
+++ b/apps/fluux/src/components/conversation/PollClosedCard.tsx
@@ -45,6 +45,7 @@ export function PollClosedCard({ pollClosed, closedAt }: PollClosedCardProps) {
       <div className="flex items-center gap-2">
         <BarChart3 className="size-4 text-fluux-muted flex-shrink-0" />
         <button
+          type="button"
           onClick={() => scrollToMessage(pollClosed.pollMessageId)}
           className="font-medium text-fluux-text text-sm hover:text-fluux-brand transition-colors text-start truncate"
           title={t('poll.scrollToOriginal', 'Scroll to original poll')}

--- a/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
+++ b/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
@@ -34,6 +34,7 @@ export function HeaderSubmenuButton({ ariaLabel, tooltip, icon: Icon, active, gr
     <div className="relative" ref={containerRef}>
       <Tooltip content={tooltip} position="bottom" disabled={open}>
         <button
+          type="button"
           ref={menu.triggerRef}
           onClick={() => setOpen((v) => !v)}
           aria-label={ariaLabel}

--- a/apps/fluux/src/components/settings-components/AppearanceSettings.tsx
+++ b/apps/fluux/src/components/settings-components/AppearanceSettings.tsx
@@ -55,6 +55,7 @@ function ThemeCard({
 
   return (
     <button
+      type="button"
       onClick={onSelect}
       className={`relative flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all text-start
         ${isActive
@@ -107,6 +108,7 @@ function AccentDot({
   const color = `hsl(${hsl.h}, ${hsl.s}%, ${hsl.l}%)`
   return (
     <button
+      type="button"
       onClick={onSelect}
       title={preset.name}
       className={`size-7 rounded-full shrink-0 transition-all ring-offset-2 ring-offset-fluux-bg
@@ -170,12 +172,14 @@ function SnippetEditorModal({
         {/* Actions */}
         <div className="flex justify-end gap-2">
           <button
+            type="button"
             onClick={onClose}
             className="px-3 py-1.5 text-sm text-fluux-muted hover:text-fluux-text rounded-lg hover:bg-fluux-hover transition-colors"
           >
             {t('common.cancel')}
           </button>
           <button
+            type="button"
             onClick={handleSave}
             disabled={!css.trim()}
             className="px-3 py-1.5 text-sm text-fluux-text-on-accent bg-fluux-brand hover:bg-fluux-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -319,6 +323,7 @@ export function AppearanceSettings() {
               ))}
             </div>
             <button
+              type="button"
               onClick={() => themeInputRef.current?.click()}
               className="flex items-center gap-1.5 text-xs text-fluux-muted hover:text-fluux-text transition-colors"
             >
@@ -340,6 +345,7 @@ export function AppearanceSettings() {
             <div className="flex flex-wrap gap-2 items-center">
               {/* Theme Default reset button */}
               <button
+                type="button"
                 onClick={() => clearAccentPreset()}
                 title={t('settings.accentThemeDefault')}
                 className={`size-7 rounded-full shrink-0 transition-all ring-offset-2 ring-offset-fluux-bg
@@ -374,6 +380,7 @@ export function AppearanceSettings() {
               <SettingsRow key={snippet.id} label={snippet.filename}>
                 <div className="flex items-center gap-1.5">
                   <button
+                    type="button"
                     onClick={() => setEditingSnippet(snippet)}
                     className="p-1 text-fluux-muted hover:text-fluux-text transition-colors"
                     title={t('settings.editSnippet')}
@@ -381,6 +388,7 @@ export function AppearanceSettings() {
                     <Pencil className="size-3.5" />
                   </button>
                   <button
+                    type="button"
                     onClick={() => removeSnippet(snippet.id)}
                     className="p-1 text-fluux-muted hover:text-fluux-error transition-colors"
                     title={t('settings.removeTheme')}
@@ -398,6 +406,7 @@ export function AppearanceSettings() {
           </SettingsGroup>
         )}
         <button
+          type="button"
           onClick={() => setShowNewSnippet(true)}
           className="flex items-center gap-1.5 text-xs text-fluux-muted hover:text-fluux-text transition-colors"
         >

--- a/apps/fluux/src/components/settings-components/BlockedUsersSettings.tsx
+++ b/apps/fluux/src/components/settings-components/BlockedUsersSettings.tsx
@@ -115,6 +115,7 @@ export function BlockedUsersSettings() {
                          focus:border-fluux-brand focus:outline-none transition-colors"
             />
             <button
+              type="button"
               onClick={handleAddBlock}
               disabled={isBlocking || !newJid.trim()}
               className="flex items-center gap-1.5 px-3 py-2 text-sm text-white
@@ -129,6 +130,7 @@ export function BlockedUsersSettings() {
               {t('settings.blocked.block')}
             </button>
             <button
+              type="button"
               onClick={handleCancelAdd}
               disabled={isBlocking}
               className="p-2 text-fluux-muted hover:text-fluux-text rounded-lg
@@ -143,6 +145,7 @@ export function BlockedUsersSettings() {
         </div>
       ) : (
         <button
+          type="button"
           onClick={() => setShowAddForm(true)}
           className="flex items-center gap-2 w-full mb-4 p-3 rounded-lg border border-dashed
                      border-fluux-hover text-fluux-muted hover:text-fluux-text
@@ -203,6 +206,7 @@ export function BlockedUsersSettings() {
                 {t('settings.blocked.confirmUnblockAll', { count: blockedJids.length })}
               </span>
               <button
+                type="button"
                 onClick={() => setShowUnblockAllConfirm(false)}
                 disabled={isUnblockingAll}
                 className="px-3 py-1.5 text-sm text-fluux-muted hover:text-fluux-text
@@ -211,6 +215,7 @@ export function BlockedUsersSettings() {
                 {t('common.cancel')}
               </button>
               <button
+                type="button"
                 onClick={handleUnblockAll}
                 disabled={isUnblockingAll}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-white
@@ -223,6 +228,7 @@ export function BlockedUsersSettings() {
             </div>
           ) : (
             <button
+              type="button"
               onClick={() => setShowUnblockAllConfirm(true)}
               className="text-sm text-fluux-error hover:text-fluux-error/80 transition-colors"
             >
@@ -258,6 +264,7 @@ function BlockedUserItem({ jid, isUnblocking, onUnblock }: BlockedUserItemProps)
         <p className="text-xs text-fluux-muted truncate">{jid}</p>
       </div>
       <button
+        type="button"
         onClick={onUnblock}
         disabled={isUnblocking}
         className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-text

--- a/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
+++ b/apps/fluux/src/components/settings-components/EncryptionSettings.tsx
@@ -1027,6 +1027,7 @@ export function EncryptionSettings() {
               {t('settings.encryption.lockedBannerBody')}
             </p>
             <button
+              type="button"
               onClick={() => openWebUnlockDialog()}
               className="flex-shrink-0 px-3 py-1.5 text-sm text-white bg-fluux-brand hover:opacity-90 rounded-lg transition-colors"
             >
@@ -1077,6 +1078,7 @@ export function EncryptionSettings() {
                     {formatFingerprintMultiline(fingerprint)}
                   </code>
                   <button
+                    type="button"
                     onClick={handleCopyFingerprint}
                     className="p-1.5 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover transition-colors tap-target"
                     title={t('settings.encryption.copyFingerprint')}
@@ -1118,6 +1120,7 @@ export function EncryptionSettings() {
               <p className="mt-1">{t('settings.encryption.limitationBackend')}</p>
             </div>
             <button
+              type="button"
               onClick={handleDismissLimitations}
               aria-label={t('common.close')}
               className="flex-shrink-0 p-0.5 text-fluux-muted hover:text-fluux-text rounded transition-colors tap-target"
@@ -1135,6 +1138,7 @@ export function EncryptionSettings() {
                 {t('settings.encryption.backupLabel')}
               </label>
               <button
+                type="button"
                 onClick={() => setBackupDescVisible((v) => !v)}
                 aria-label={t('settings.encryption.backupLabel')}
                 className="text-fluux-muted hover:text-fluux-text transition-colors"
@@ -1199,6 +1203,7 @@ export function EncryptionSettings() {
                     <div className="flex flex-wrap gap-2">
                       {backupProbe === 'unknown' && (
                         <button
+                          type="button"
                           onClick={() => setBackupProbeNonce((n) => n + 1)}
                           className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-hover hover:bg-fluux-active text-fluux-text rounded transition-colors"
                         >
@@ -1207,6 +1212,7 @@ export function EncryptionSettings() {
                         </button>
                       )}
                       <button
+                        type="button"
                         onClick={handleBackupRequest}
                         className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-hover hover:bg-fluux-active text-fluux-text rounded transition-colors"
                       >
@@ -1215,6 +1221,7 @@ export function EncryptionSettings() {
                       </button>
                       {(backupProbe === 'present' || backupProbe === 'unknown') && (
                         <button
+                          type="button"
                           onClick={() => setShowRestoreDialog(true)}
                           className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-hover hover:bg-fluux-active text-fluux-text rounded transition-colors"
                         >
@@ -1226,6 +1233,7 @@ export function EncryptionSettings() {
                   )}
                   <div className="flex flex-wrap gap-2 pt-2 border-t border-fluux-hover/60">
                     <button
+                      type="button"
                       onClick={() => setShowExportFileDialog(true)}
                       className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-hover hover:bg-fluux-active text-fluux-text rounded transition-colors"
                     >
@@ -1233,6 +1241,7 @@ export function EncryptionSettings() {
                       {t('settings.encryption.exportFileAction')}
                     </button>
                     <button
+                      type="button"
                       onClick={() => { void handleImportFileRequest() }}
                       className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-hover hover:bg-fluux-active text-fluux-text rounded transition-colors"
                     >
@@ -1255,6 +1264,7 @@ export function EncryptionSettings() {
                 {t('settings.encryption.rotateLabel')}
               </label>
               <button
+                type="button"
                 onClick={() => setRotateDescVisible((v) => !v)}
                 aria-label={t('settings.encryption.rotateLabel')}
                 className="text-fluux-muted hover:text-fluux-text transition-colors"
@@ -1268,6 +1278,7 @@ export function EncryptionSettings() {
               </p>
             )}
             <button
+              type="button"
               onClick={handleRotateRequest}
               disabled={isRotating}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-hover hover:bg-fluux-active text-fluux-text rounded transition-colors disabled:opacity-50 disabled:cursor-wait"
@@ -1291,6 +1302,7 @@ export function EncryptionSettings() {
         {pluginStatus === 'ready' && (
           <div className="pt-2 border-t border-fluux-hover">
             <button
+              type="button"
               onClick={() => setDangerZoneExpanded((v) => !v)}
               aria-expanded={dangerZoneExpanded}
               className="flex items-center gap-1.5 w-full text-left"
@@ -1310,6 +1322,7 @@ export function EncryptionSettings() {
                   {t('settings.encryption.deleteKeyDescription')}
                 </p>
                 <button
+                  type="button"
                   onClick={() => setShowDeleteConfirm(true)}
                   disabled={isDeleting}
                   className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-fluux-red/10 hover:bg-fluux-red/20 text-fluux-error rounded transition-colors disabled:opacity-50 disabled:cursor-wait"

--- a/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
+++ b/apps/fluux/src/components/settings-components/NotificationsSettings.tsx
@@ -212,6 +212,7 @@ export function NotificationsSettings() {
           {/* Web: request permission in-page */}
           {!isTauri() && notificationStatus === 'default' && (
             <button
+              type="button"
               onClick={handleRequestPermission}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
                          bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"
@@ -224,6 +225,7 @@ export function NotificationsSettings() {
           {/* macOS: trigger the native OS prompt when permission was never asked */}
           {isMac && notificationStatus === 'default' && (
             <button
+              type="button"
               onClick={handleRequestPermission}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
                          bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"
@@ -249,6 +251,7 @@ export function NotificationsSettings() {
             (notificationStatus === 'granted' || notificationStatus === 'denied') && (
               <>
                 <button
+                  type="button"
                   onClick={handleOpenNotificationSettings}
                   className="flex items-center gap-1.5 text-xs text-fluux-brand hover:text-fluux-text transition-colors"
                 >
@@ -288,6 +291,7 @@ export function NotificationsSettings() {
 
             {webPushStatus === 'available' && webPushEnabled && (
               <button
+                type="button"
                 onClick={() => requestWebPushRegistration(client)}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
                            bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"
@@ -299,6 +303,7 @@ export function NotificationsSettings() {
 
             {webPushStatus === 'registered' && (
               <button
+                type="button"
                 onClick={handleDisableWebPush}
                 disabled={disabling}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-red hover:text-fluux-red/80
@@ -311,6 +316,7 @@ export function NotificationsSettings() {
 
             {(webPushStatus === 'disabled' || !webPushEnabled) && webPushStatus !== 'registered' && webPushStatus !== 'available' && (
               <button
+                type="button"
                 onClick={() => enableWebPush(client)}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
                            bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"

--- a/apps/fluux/src/components/settings-components/SettingsSidebar.tsx
+++ b/apps/fluux/src/components/settings-components/SettingsSidebar.tsx
@@ -36,6 +36,7 @@ export function SettingsSidebar({ activeCategory, onCategoryChange }: SettingsSi
               return (
                 <li key={category.id}>
                   <button
+                    type="button"
                     onClick={() => onCategoryChange(category.id)}
                     className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-start transition-colors
                       ${isActive

--- a/apps/fluux/src/components/settings-components/StorageSettings.tsx
+++ b/apps/fluux/src/components/settings-components/StorageSettings.tsx
@@ -88,6 +88,7 @@ export function StorageSettings() {
 
         {/* Clear cache button */}
         <button
+          type="button"
           onClick={handleClear}
           disabled={isClearing || cacheSize === 0}
           className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors
@@ -129,6 +130,7 @@ export function StorageSettings() {
           )}
 
           <button
+            type="button"
             onClick={handleRebuildIndex}
             disabled={isRebuilding}
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors
@@ -157,6 +159,7 @@ export function StorageSettings() {
           description={t('settings.storage.logsDescription')}
         >
           <button
+            type="button"
             onClick={() => void handleOpenLogs()}
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-fluux-hover hover:bg-fluux-border text-fluux-text"
           >

--- a/apps/fluux/src/components/settings-components/UpdatesSettings.tsx
+++ b/apps/fluux/src/components/settings-components/UpdatesSettings.tsx
@@ -44,6 +44,7 @@ export function UpdatesSettings() {
             )}
             {update.downloaded ? (
               <button
+                type="button"
                 onClick={update.relaunchApp}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-text-on-accent
                            bg-fluux-brand hover:bg-fluux-brand/90 rounded-md transition-colors"
@@ -53,6 +54,7 @@ export function UpdatesSettings() {
               </button>
             ) : update.available && !update.downloading ? (
               <button
+                type="button"
                 onClick={update.downloadAndInstall}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-text-on-accent
                            bg-fluux-brand hover:bg-fluux-brand/90 rounded-md transition-colors"
@@ -66,6 +68,7 @@ export function UpdatesSettings() {
               </span>
             ) : !update.checking ? (
               <button
+                type="button"
                 onClick={update.checkForUpdate}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-fluux-brand hover:text-fluux-text
                            bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-md transition-colors"

--- a/apps/fluux/src/components/sidebar-components/ContactList.tsx
+++ b/apps/fluux/src/components/sidebar-components/ContactList.tsx
@@ -435,6 +435,7 @@ const ContactItem = memo(function ContactItem({
           style={{ left: menu.position.x, top: menu.position.y }}
         >
           <button
+            type="button"
             onClick={handleStartChat}
             className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
           >
@@ -442,6 +443,7 @@ const ContactItem = memo(function ContactItem({
             <span>{t('contacts.startChat')}</span>
           </button>
           <button
+            type="button"
             onClick={handleRename}
             className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
           >
@@ -452,6 +454,7 @@ const ContactItem = memo(function ContactItem({
             <>
               <div className="my-1 border-t border-fluux-hover" />
               <button
+                type="button"
                 onClick={handleManage}
                 className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
               >
@@ -462,6 +465,7 @@ const ContactItem = memo(function ContactItem({
           )}
           <div className="my-1 border-t border-fluux-hover" />
           <button
+            type="button"
             onClick={handleRemove}
             className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
           >

--- a/apps/fluux/src/components/sidebar-components/IconRailButton.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailButton.tsx
@@ -28,6 +28,7 @@ export function IconRailButton({
   return (
     <Tooltip content={label} position="right" delay={500}>
       <button
+        type="button"
         onClick={onClick}
         disabled={disabled}
         aria-label={label}

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -48,6 +48,7 @@ export function IconRailNavLink({
   return (
     <Tooltip content={label} position="right" delay={500}>
       <button
+        type="button"
         onClick={() => onNavigate(view)}
         aria-label={badgeLabel ?? label}
         data-nav={view}

--- a/apps/fluux/src/components/sidebar-components/MucInvitationItem.tsx
+++ b/apps/fluux/src/components/sidebar-components/MucInvitationItem.tsx
@@ -40,6 +40,7 @@ export function MucInvitationItem({ invitation, onAccept, onDecline }: MucInvita
           button so the row never overflows the narrow sidebar. */}
       <div className="flex items-stretch gap-1.5 mt-2">
         <button
+          type="button"
           onClick={onAccept}
           className="flex-1 min-w-0 px-2 py-1.5 bg-fluux-green text-white text-sm font-medium rounded hover:bg-fluux-green/80 transition-colors flex items-center justify-center gap-1"
         >
@@ -48,6 +49,7 @@ export function MucInvitationItem({ invitation, onAccept, onDecline }: MucInvita
         </button>
         <Tooltip content={t('events.decline')} position="top">
           <button
+            type="button"
             onClick={onDecline}
             className="flex-shrink-0 px-2.5 py-1.5 bg-fluux-muted/20 text-fluux-text rounded hover:bg-fluux-muted/30 transition-colors flex items-center justify-center"
             aria-label={t('events.decline')}

--- a/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
+++ b/apps/fluux/src/components/sidebar-components/PresenceSelector.tsx
@@ -125,6 +125,7 @@ export function PresenceSelector({ isOpen: isOpenProp, onOpenChange }: PresenceS
       {/* Trigger - styled as a distinct chip */}
       <Tooltip content={t('presence.changeStatus')} position="top" disabled={isOpen} className="min-w-0">
         <button
+          type="button"
           ref={menu.triggerRef}
           onClick={() => setIsOpen(!isOpen)}
           className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-full bg-fluux-hover hover:bg-fluux-bg border border-transparent hover:border-fluux-muted/30 transition-colors group min-w-0 max-w-full overflow-hidden"
@@ -148,6 +149,7 @@ export function PresenceSelector({ isOpen: isOpenProp, onOpenChange }: PresenceS
           {/* Presence options */}
           {presenceOptions.map((option, index) => (
             <button
+              type="button"
               key={option.value}
               onClick={() => void handleSelectPresence(option.value)}
               onMouseEnter={() => setFocusedIndex(index)}

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -514,6 +514,7 @@ export const RoomItem = memo(function RoomItem({
           {/* Join (only for non-joined rooms) */}
           {!room.joined && (
             <button
+              type="button"
               onClick={() => { menu.close(); onJoin(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
             >
@@ -525,6 +526,7 @@ export const RoomItem = memo(function RoomItem({
           {/* Edit bookmark (only for bookmarked rooms) */}
           {room.isBookmarked && (
             <button
+              type="button"
               onClick={() => { menu.close(); onEditBookmark(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
             >
@@ -536,6 +538,7 @@ export const RoomItem = memo(function RoomItem({
           {/* Toggle autojoin (only for bookmarked rooms) */}
           {room.isBookmarked && (
             <button
+              type="button"
               onClick={() => { menu.close(); onToggleAutojoin(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent transition-colors"
             >
@@ -561,6 +564,7 @@ export const RoomItem = memo(function RoomItem({
           {/* Leave room (only for joined rooms) */}
           {room.joined && (
             <button
+              type="button"
               onClick={() => { menu.close(); onLeave(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
             >
@@ -572,6 +576,7 @@ export const RoomItem = memo(function RoomItem({
           {/* Remove bookmark (only for bookmarked rooms) */}
           {room.isBookmarked && (
             <button
+              type="button"
               onClick={() => { menu.close(); onRemoveBookmark(roomJid) }}
               className="w-full px-3 py-2 flex items-center gap-3 text-start text-fluux-error hover:bg-fluux-red hover:text-white transition-colors"
             >

--- a/apps/fluux/src/components/sidebar-components/SearchView.tsx
+++ b/apps/fluux/src/components/sidebar-components/SearchView.tsx
@@ -141,6 +141,7 @@ export function SearchView() {
           />
           {query && (
             <button
+              type="button"
               onClick={clearSearch}
               className="absolute end-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-fluux-hover text-fluux-muted tap-target"
               aria-label={t('common.clear')}
@@ -154,6 +155,7 @@ export function SearchView() {
             <div className="absolute inset-x-0 top-full mt-1 fluux-popover rounded-md z-50 max-h-48 overflow-y-auto">
               {inPrefixSuggestions.map((s, i) => (
                 <button
+                  type="button"
                   key={s.id}
                   onClick={() => selectInPrefixSuggestion(s)}
                   className={`w-full px-3 py-1.5 text-start text-sm flex items-center gap-2 transition-colors
@@ -180,6 +182,7 @@ export function SearchView() {
             {t('search.scopeLabel', 'Searching in')} {getConversationName(searchScope)}
           </span>
           <button
+            type="button"
             onClick={() => setSearchScope(null)}
             className="p-0.5 rounded hover:bg-fluux-hover text-fluux-muted flex-shrink-0 tap-target"
             aria-label={t('search.clearScope', 'Search all conversations')}
@@ -195,6 +198,7 @@ export function SearchView() {
         <div className="flex items-center gap-1 px-3 pb-1">
           {filterOptions.map(({ key, label, icon: Icon }) => (
             <button
+              type="button"
               key={key}
               onClick={() => setSearchFilter(key)}
               className={`text-xs rounded-full px-2.5 py-0.5 transition-colors flex items-center gap-1 ${
@@ -253,6 +257,7 @@ export function SearchView() {
         {!isSearching && !isInPrefixActive && query && !isSearchingMAM && mamResults.length === 0 && (
           <div className="px-2 py-3">
             <button
+              type="button"
               onClick={searchMAM}
               className="w-full flex items-center justify-center gap-2 py-2 text-sm text-fluux-muted
                          hover:text-fluux-text hover:bg-fluux-hover rounded-md transition-colors"
@@ -306,6 +311,7 @@ export function SearchView() {
         {hasMoreMAMResults && !isSearchingMAM && (
           <div className="px-2 py-2">
             <button
+              type="button"
               onClick={loadMoreMAMResults}
               className="w-full flex items-center justify-center gap-2 py-1.5 text-xs text-fluux-muted
                          hover:text-fluux-text hover:bg-fluux-hover rounded-md transition-colors"
@@ -414,6 +420,7 @@ const SearchResultItem = memo(function SearchResultItem({ result, context, isAct
               {formatConversationTime(timestamp, t, currentLang, timeFormat)}
             </span>
             <button
+              type="button"
               onClick={(e) => onGoToMessage(e, result)}
               className="p-0.5 rounded opacity-0 group-hover/result:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-fluux-hover-strong"
               title="Go to message"

--- a/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/SidebarListMenu.tsx
@@ -234,7 +234,7 @@ export function MenuButton({ onClick, icon, label, variant = 'default', classNam
     : 'text-fluux-text hover:bg-fluux-brand hover:text-fluux-text-on-accent'
 
   return (
-    <button onClick={onClick} className={`${baseClasses} ${variantClasses} ${className}`}>
+    <button type="button" onClick={onClick} className={`${baseClasses} ${variantClasses} ${className}`}>
       {icon}
       <span>{label}</span>
     </button>

--- a/apps/fluux/src/components/sidebar-components/StrangerMessageItem.tsx
+++ b/apps/fluux/src/components/sidebar-components/StrangerMessageItem.tsx
@@ -62,6 +62,7 @@ export function StrangerMessageItem({ jid, messages, onSelect, onAccept, onIgnor
           Ignore/Block are icon buttons with tooltips. */}
       <div className="flex items-stretch gap-1.5 mt-2">
         <button
+          type="button"
           onClick={onAccept}
           className="flex-1 min-w-0 px-2 py-1.5 bg-fluux-brand text-fluux-text-on-accent text-sm font-medium rounded hover:bg-fluux-brand-hover transition-colors flex items-center justify-center gap-1"
         >
@@ -70,6 +71,7 @@ export function StrangerMessageItem({ jid, messages, onSelect, onAccept, onIgnor
         </button>
         <Tooltip content={t('common.ignore')} position="top">
           <button
+            type="button"
             onClick={onIgnore}
             className="flex-shrink-0 px-2.5 py-1.5 bg-fluux-muted/20 text-fluux-text rounded hover:bg-fluux-muted/30 transition-colors flex items-center justify-center"
             aria-label={t('common.ignore')}
@@ -79,6 +81,7 @@ export function StrangerMessageItem({ jid, messages, onSelect, onAccept, onIgnor
         </Tooltip>
         <Tooltip content={t('common.block')} position="top">
           <button
+            type="button"
             onClick={onBlock}
             className="flex-shrink-0 px-2.5 py-1.5 bg-fluux-red text-white rounded hover:bg-fluux-red/80 transition-colors flex items-center justify-center"
             aria-label={t('common.block')}

--- a/apps/fluux/src/components/sidebar-components/SubscriptionRequestItem.tsx
+++ b/apps/fluux/src/components/sidebar-components/SubscriptionRequestItem.tsx
@@ -28,6 +28,7 @@ export function SubscriptionRequestItem({ request, onAccept, onReject, onBlock }
           buttons so the row never overflows the narrow sidebar. */}
       <div className="flex items-stretch gap-1.5 mt-2">
         <button
+          type="button"
           onClick={onAccept}
           className="flex-1 min-w-0 px-2 py-1.5 bg-fluux-green text-white text-sm font-medium rounded hover:bg-fluux-green/80 transition-colors flex items-center justify-center gap-1"
         >
@@ -36,6 +37,7 @@ export function SubscriptionRequestItem({ request, onAccept, onReject, onBlock }
         </button>
         <Tooltip content={t('common.reject')} position="top">
           <button
+            type="button"
             onClick={onReject}
             className="flex-shrink-0 px-2.5 py-1.5 bg-fluux-muted/20 text-fluux-text rounded hover:bg-fluux-muted/30 transition-colors flex items-center justify-center"
             aria-label={t('common.reject')}
@@ -45,6 +47,7 @@ export function SubscriptionRequestItem({ request, onAccept, onReject, onBlock }
         </Tooltip>
         <Tooltip content={t('common.block')} position="top">
           <button
+            type="button"
             onClick={onBlock}
             className="flex-shrink-0 px-2.5 py-1.5 bg-fluux-red text-white rounded hover:bg-fluux-red/80 transition-colors flex items-center justify-center"
             aria-label={t('common.block')}

--- a/apps/fluux/src/components/sidebar-components/UserMenu.tsx
+++ b/apps/fluux/src/components/sidebar-components/UserMenu.tsx
@@ -72,6 +72,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
       <div className="relative flex-shrink-0" ref={menuRef}>
         <Tooltip content={t('common.options')} position="top" disabled={isOpen}>
           <button
+            type="button"
             ref={menu.triggerRef}
             onClick={() => setIsOpen(!isOpen)}
             className="p-2 text-fluux-muted hover:text-fluux-text rounded hover:bg-fluux-hover"
@@ -88,6 +89,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
             {/* Console toggle - hidden on mobile and behind advanced mode */}
             {!isMobile && advancedMode && (
               <button
+                type="button"
                 onClick={() => {
                   toggleConsole()
                   setIsOpen(false)
@@ -101,6 +103,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
 
             {/* What's New */}
             <button
+              type="button"
               onClick={() => {
                 setShowChangelog(true)
                 setIsOpen(false)
@@ -114,6 +117,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
             {/* Keyboard Shortcuts - hidden on mobile */}
             {!isMobile && (
               <button
+                type="button"
                 onClick={() => {
                   modalOpen('shortcutHelp')
                   setIsOpen(false)
@@ -139,6 +143,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
 
             {/* About */}
             <button
+              type="button"
               onClick={() => {
                 setShowAbout(true)
                 setIsOpen(false)
@@ -154,6 +159,7 @@ export function UserMenu({ onLogout }: UserMenuProps) {
 
             {/* Log out */}
             <button
+              type="button"
               onClick={() => {
                 setShowLogoutConfirm(true)
                 setIsOpen(false)
@@ -198,12 +204,14 @@ export function UserMenu({ onLogout }: UserMenuProps) {
               </label>
               <div className="flex gap-3">
                 <button
+                  type="button"
                   onClick={close}
                   className="flex-1 px-4 py-2 text-fluux-text bg-fluux-hover rounded hover:bg-fluux-hover/80 transition-colors"
                 >
                   {t('common.cancel')}
                 </button>
                 <button
+                  type="button"
                   onClick={() => {
                     setShowLogoutConfirm(false)
                     void onLogout(cleanLocalData)

--- a/apps/fluux/src/components/ui/BottomSheet.test.tsx
+++ b/apps/fluux/src/components/ui/BottomSheet.test.tsx
@@ -15,7 +15,7 @@ describe('BottomSheet', () => {
   it('renders children in a labelled dialog when open', () => {
     render(
       <BottomSheet open onClose={() => {}} ariaLabel="Actions">
-        <button>Do thing</button>
+        <button type="button">Do thing</button>
       </BottomSheet>,
     )
     const dialog = screen.getByRole('dialog')

--- a/apps/fluux/src/components/ui/ListEmpty.tsx
+++ b/apps/fluux/src/components/ui/ListEmpty.tsx
@@ -24,6 +24,7 @@ export function ListEmpty({ icon: Icon, title, description, action, className = 
       {description && <p className="text-xs opacity-75 mt-1 max-w-xs">{description}</p>}
       {action && (
         <button
+          type="button"
           onClick={action.onClick}
           className="mt-3 inline-flex items-center gap-1 px-3 py-1.5 text-xs text-fluux-brand bg-fluux-brand/10 hover:bg-fluux-brand/20 rounded-lg transition-colors"
         >

--- a/apps/fluux/src/demo/tutorial/DemoTooltip.tsx
+++ b/apps/fluux/src/demo/tutorial/DemoTooltip.tsx
@@ -227,6 +227,7 @@ export function DemoTooltip({ step, onSkip, onComplete }: DemoTooltipProps) {
         {/* Skip button */}
         {!completed && (
           <button
+            type="button"
             onClick={onSkip}
             style={{
               marginTop: 8,

--- a/apps/fluux/src/hooks/useContextMenu.test.tsx
+++ b/apps/fluux/src/hooks/useContextMenu.test.tsx
@@ -23,7 +23,7 @@ function TestComponent({ longPressDuration = 500 }: { longPressDuration?: number
           data-testid="menu"
           style={{ left: menu.position.x, top: menu.position.y }}
         >
-          <button data-testid="menu-item" onClick={menu.close}>
+          <button type="button" data-testid="menu-item" onClick={menu.close}>
             Close
           </button>
         </div>

--- a/apps/fluux/src/hooks/useFocusTrap.test.tsx
+++ b/apps/fluux/src/hooks/useFocusTrap.test.tsx
@@ -11,9 +11,9 @@ function Trap({ active = true }: { active?: boolean }) {
   useFocusTrap(ref, { active })
   return (
     <div ref={ref}>
-      <button>first</button>
-      <button>middle</button>
-      <button>last</button>
+      <button type="button">first</button>
+      <button type="button">middle</button>
+      <button type="button">last</button>
     </div>
   )
 }
@@ -77,9 +77,9 @@ describe('useFocusTrap', () => {
       useFocusTrap(containerRef, { initialFocusRef: initialRef })
       return (
         <div ref={containerRef}>
-          <button>first</button>
-          <button ref={initialRef}>second</button>
-          <button>third</button>
+          <button type="button">first</button>
+          <button type="button" ref={initialRef}>second</button>
+          <button type="button">third</button>
         </div>
       )
     }

--- a/apps/fluux/src/hooks/useRestoreFocus.test.tsx
+++ b/apps/fluux/src/hooks/useRestoreFocus.test.tsx
@@ -14,10 +14,10 @@ function Harness() {
   useRestoreFocus(containerRef, inputRef)
   return (
     <div>
-      <button data-testid="outside">outside</button>
+      <button type="button" data-testid="outside">outside</button>
       <div ref={containerRef} data-testid="modal">
         <input ref={inputRef} data-testid="field" />
-        <button data-testid="inside-btn">inside</button>
+        <button type="button" data-testid="inside-btn">inside</button>
       </div>
     </div>
   )

--- a/apps/fluux/src/hooks/useRoomJoinWarning.test.tsx
+++ b/apps/fluux/src/hooks/useRoomJoinWarning.test.tsx
@@ -23,7 +23,7 @@ function Harness({ onResult }: { onResult: (v: boolean) => void }) {
   const { confirmJoin, warningDialog } = useRoomJoinWarning()
   return (
     <div>
-      <button onClick={async () => onResult(await confirmJoin('room@conference.example.com'))}>go</button>
+      <button type="button" onClick={async () => onResult(await confirmJoin('room@conference.example.com'))}>go</button>
       {warningDialog}
     </div>
   )

--- a/apps/fluux/src/utils/messageStyles.tsx
+++ b/apps/fluux/src/utils/messageStyles.tsx
@@ -365,6 +365,7 @@ function CopyButton({ text, className = '' }: { text: string; className?: string
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       className={`p-1 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors ${className}`}
       title={copied ? 'Copied!' : 'Copy code'}
@@ -444,6 +445,7 @@ function CodeBlock({ code, language, keyProp }: { code: string; language?: strin
           )}
           <div className="flex items-center gap-0.5">
             <button
+              type="button"
               onClick={() => setExpanded(true)}
               className="p-1 rounded hover:bg-fluux-hover text-fluux-muted hover:text-fluux-text transition-colors"
               title="Expand code"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "autoprefixer": "^10.4.16",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.0.0",
+        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "fake-indexeddb": "^6.2.5",
@@ -6736,6 +6737,105 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -7363,6 +7463,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/conf": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
@@ -7798,6 +7905,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -8016,6 +8136,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
@@ -8046,6 +8194,19 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "hasown": "^2.0.2"
       },
       "engines": {
@@ -8191,6 +8352,39 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
     "node_modules/eslint-plugin-react-compiler": {
       "version": "19.1.0-rc.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.1.0-rc.2.tgz",
@@ -8230,6 +8424,61 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -9799,6 +10048,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -10003,6 +10270,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/keyv": {
@@ -10418,6 +10701,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -10883,6 +11179,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
@@ -10975,6 +11290,60 @@
         "es-object-atoms": "^1.0.0",
         "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11682,6 +12051,25 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -12869,6 +13257,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "node_modules/string.prototype.trim": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "zod-validation-error": "4.0.2",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "eslint-plugin-react": {
+      "eslint": "^10.0.0"
+    }
   }
 }

--- a/packages/fluux-sdk/src/hooks/useAdmin.ts
+++ b/packages/fluux-sdk/src/hooks/useAdmin.ts
@@ -82,9 +82,9 @@ import { USER_COMMANDS } from './adminCommands'
  *       {currentSession.form.fields.map(field => (
  *         <FormField key={field.var} field={field} />
  *       ))}
- *       {canGoBack && <button onClick={previousStep}>Back</button>}
+ *       {canGoBack && <button type="button" onClick={previousStep}>Back</button>}
  *       <button type="submit">Submit</button>
- *       <button onClick={cancelCommand}>Cancel</button>
+ *       <button type="button" onClick={cancelCommand}>Cancel</button>
  *     </form>
  *   )
  * }


### PR DESCRIPTION
A `<button>` with no `type` defaults to `type="submit"`. Inside a `<form>` that silently fires the form's `onSubmit` — how the backup passphrase dialog's Copy button ended up publishing the OpenPGP backup with the acknowledgment checkbox never ticked (#1083). This is the systemic guard that was left out of that PR.

## What changed

- Added `eslint-plugin-react` as an app devDependency and enabled **only** `react/button-has-type` as an error. The recommended preset is deliberately not used — it would surface a large volume of unrelated warnings.
- `eslint-plugin-react@7.37.5` still caps its `eslint` peer at `^9.7` while this repo is on ESLint 10, so the root `package.json` overrides that peer to `^10`. The rule itself runs correctly on ESLint 10; the override can go once upstream catches up.
- Fixed the 295 buttons the rule reported.

## No second instance of the bug

I checked whether any offender was actually submitting a form — by AST offset against every `<form>` region, by walking components rendered inside forms, and by checking for `form=` attributes and forms that render `{children}`. **None of the 295 was inside a form**, so all became `type="button"` and app behavior is unchanged. Two DOM snapshots pick up the new attribute; the diffs are additions of `type="button"` and nothing else.

The one real find is documentation: the SDK's `useAdmin` JSDoc example had `Back` and `Cancel` with no `type` next to a genuine `type="submit"` inside a `<form>`, teaching the exact bug to SDK consumers. Corrected here. ESLint never lints JSDoc, so no rule could have caught it.

## SDK config

Not added. The SDK ships no product JSX with buttons — its only non-test `.tsx` files are the providers and a test helper, none of which render one. Adding the plugin there would mean a devDependency and the peer override for zero product coverage.