### PR TITLE
fix(e2ee): reconcile own key by subkey fingerprints, not raw bytes

### DIFF
--- a/apps/fluux/src-tauri/src/openpgp.rs
+++ b/apps/fluux/src-tauri/src/openpgp.rs
@@ -663,6 +663,13 @@ pub struct CertValidation {
     pub encryption_subkey_count: u32,
     /// Raw User ID strings from the certificate (e.g. `"xmpp:user@domain"`).
     pub user_ids: Vec<String>,
+    /// Upper-case hex fingerprints of every subkey, independent of usage flags,
+    /// policy, or expiry. Fingerprints identify the key material itself, so
+    /// stripping an expiration or re-signing a binding signature leaves them
+    /// unchanged while a rotation adds a new one. The own-key consistency
+    /// check compares these instead of raw bytes to tell "same key, different
+    /// bytes" apart from "a different key was published".
+    pub subkey_fingerprints: Vec<String>,
 }
 
 /// Validate a PGP public key and return its structural metrics.
@@ -701,10 +708,19 @@ pub fn validate_cert(public_armored: &str) -> Result<CertValidation> {
         .map(|ua| String::from_utf8_lossy(ua.userid().value()).into_owned())
         .collect();
 
+    // Every subkey fingerprint, unfiltered by policy or expiry: a re-signed or
+    // expiry-stripped export keeps the same set, a rotation grows it.
+    let subkey_fingerprints: Vec<String> = cert
+        .keys()
+        .subkeys()
+        .map(|ka| ka.key().fingerprint().to_hex())
+        .collect();
+
     Ok(CertValidation {
         fingerprint: cert.fingerprint().to_hex(),
         encryption_subkey_count,
         user_ids,
+        subkey_fingerprints,
     })
 }
 
@@ -2231,6 +2247,29 @@ mod tests {
             all_encryption_subkey_fingerprints(&published).len(),
             1,
             "published cert must expose only the current [E] (retired stripped)"
+        );
+    }
+
+    #[test]
+    fn validate_cert_reports_every_subkey_fingerprint() {
+        // The own-key consistency check (OpenPGPPluginBase) compares subkey
+        // fingerprints instead of raw bytes so a re-signed / expiry-stripped
+        // re-publish doesn't masquerade as a conflict. That only works if
+        // validate_cert actually surfaces them.
+        let state = new_state();
+        let bundle = state.ensure_key_sync("alice@example.com", "Alice").unwrap();
+        let cert = Cert::from_bytes(bundle.public_armored.as_bytes()).unwrap();
+        let expected: Vec<String> = cert
+            .keys()
+            .subkeys()
+            .map(|ka| ka.key().fingerprint().to_hex())
+            .collect();
+        assert!(!expected.is_empty(), "a generated cert must have a subkey");
+
+        let validation = validate_cert(&bundle.public_armored).unwrap();
+        assert_eq!(
+            validation.subkey_fingerprints, expected,
+            "validate_cert must report every subkey fingerprint"
         );
     }
 

--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -92,6 +92,7 @@ import {
 } from './verificationSync'
 import {
   fingerprintsEqual,
+  normalizeFingerprint,
   toXep0373Fingerprint,
   pubkeyMetadataFingerprintAttrs,
 } from './fingerprintCompare'
@@ -235,6 +236,15 @@ export interface CertValidation {
   fingerprint: string
   encryptionSubkeyCount: number
   userIds: string[]
+  /**
+   * Upper-case hex fingerprints of every subkey in the certificate,
+   * independent of usage flags or expiry. These identify the key material
+   * itself: stripping an expiration or re-signing a self-signature leaves
+   * them unchanged, while a genuine key rotation adds a new one. Used to
+   * tell "same key, different bytes" apart from "a different key was
+   * published" without a brittle raw-byte comparison.
+   */
+  subkeyFingerprints: string[]
 }
 
 interface PendingVerification {
@@ -1550,7 +1560,11 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     }
 
     const publishedArmored = parsePublicKeyDataItem(dataItems[0].payload)
-    if (publishedArmored !== null && !openPgpBlocksEqual(publishedArmored, bundle.publicArmored)) {
+    if (
+      publishedArmored !== null &&
+      !openPgpBlocksEqual(publishedArmored, bundle.publicArmored) &&
+      !(await this.certsShareSameKeyMaterial(publishedArmored, bundle.publicArmored))
+    ) {
       recordOwnKeyConflict({
         kind: 'subkey-mismatch',
         localFingerprint: bundle.fingerprint,
@@ -1561,6 +1575,43 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     }
 
     clearOwnKeyConflict()
+  }
+
+  /**
+   * Decide whether the server-published cert and the local cert carry the
+   * same key material, regardless of raw-byte differences.
+   *
+   * A byte comparison of two exports of the *same* certificate reports a
+   * difference for entirely benign reasons: PR #1087's expiry heal re-signs
+   * the primary (and subkey bindings) to drop the validity period, and
+   * re-exporting through another OpenPGP client reorders or minimizes packets.
+   * None of that changes a single component fingerprint — only a genuine
+   * rotation introduces a new subkey. Comparing the set of component
+   * fingerprints (primary + subkeys) is therefore the honest test for "did
+   * someone publish a different key?", and it stops a harmless re-publish from
+   * locking encryption behind a phantom `subkey-mismatch`.
+   *
+   * Falls back to `true` (treat as the same key) when either cert cannot be
+   * validated: an unparseable published cert is a distinct failure that the
+   * reconcile banner cannot resolve, and encryption must not be blocked on it.
+   */
+  private async certsShareSameKeyMaterial(
+    publishedArmored: string,
+    localArmored: string,
+  ): Promise<boolean> {
+    let published: CertValidation
+    let local: CertValidation
+    try {
+      published = await this.validateCert(publishedArmored)
+      local = await this.validateCert(localArmored)
+    } catch (err) {
+      this.requireCtx().logger.warn(
+        `${this.pluginName()}: could not compare published key material against ` +
+          `local; treating as unchanged: ${formatError(err)}`,
+      )
+      return true
+    }
+    return sameComponentFingerprints(published, local)
   }
 
   private async publishOwnPublicKeyData(bundle: KeyBundle): Promise<void> {
@@ -2482,6 +2533,20 @@ function openPgpBlocksEqual(a: string, b: string): boolean {
   const bRaw = dearmorOpenPgpBlock(b)
   if (aRaw && bRaw) return bytesEqual(aRaw, bRaw)
   return a.trim() === b.trim()
+}
+
+/**
+ * Two certs share the same key material when their component fingerprints —
+ * the primary plus every subkey — match. Fingerprints are immutable identifiers
+ * of key packets, so re-signing (expiry stripped, packets reordered) leaves
+ * them untouched while a rotation adds a new subkey fingerprint. Order- and
+ * case-insensitive so the two OpenPGP backends' differing hex casing can't
+ * fabricate a difference.
+ */
+function sameComponentFingerprints(a: CertValidation, b: CertValidation): boolean {
+  const componentKey = (v: CertValidation): string =>
+    [v.fingerprint, ...v.subkeyFingerprints].map(normalizeFingerprint).sort().join('|')
+  return componentKey(a) === componentKey(b)
 }
 
 function dearmorOpenPgpBlock(armored: string): Uint8Array | null {

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -256,10 +256,24 @@ function makeFakeRust() {
         return fp as T
       }
       case 'openpgp_validate_cert': {
-        const fp = extractFingerprint(args!.publicArmored as string)
+        const armored = args!.publicArmored as string
+        const fp = extractFingerprint(armored)
         if (!fp) throw new Error('not a recognizable OpenPGP public key')
-        const uid = extractUID(args!.publicArmored as string)
-        return { fingerprint: fp, encryptionSubkeyCount: 1, userIds: uid ? [uid] : [] } as T
+        const uid = extractUID(armored)
+        // Model a real cert's immutable subkey fingerprints. A rotation keeps
+        // every prior encryption subkey and adds a fresh one, so a rotated cert
+        // has a strictly larger set. Re-signing (e.g. stripping the primary's
+        // expiry) leaves the rotation counter — and therefore this set —
+        // untouched, mirroring how OpenPGP subkey fingerprints survive a
+        // self-signature rewrite.
+        const rotation = extractRotation(armored)
+        const subkeyFingerprints = Array.from({ length: rotation + 1 }, (_, i) => `${fp}-E${i}`)
+        return {
+          fingerprint: fp,
+          encryptionSubkeyCount: 1,
+          userIds: uid ? [uid] : [],
+          subkeyFingerprints,
+        } as T
       }
       case 'openpgp_has_persisted_key': {
         const jid = args!.accountJid as string
@@ -1057,6 +1071,64 @@ describe('SequoiaPgpPlugin', () => {
       expect(conflict!.localFingerprint).toBe(bundle.fingerprint)
       expect(conflict!.publishedDate).toBe('2024-06-01T00:00:00Z')
       expect(published).toHaveLength(0)
+    })
+
+    it('does NOT flag a conflict when the published cert differs in bytes but has the same subkey fingerprints (e.g. expiry stripped by the #1087 heal)', async () => {
+      const { ctx, peerPublish, published } = makeContext('me@example.com')
+      const bundle = await fake.invoke<KeyBundle>('openpgp_ensure_key', {
+        accountJid: 'me@example.com',
+        userId: 'xmpp:me@example.com',
+      })
+      // Same key material re-signed with the primary-key expiration stripped:
+      // identical primary fingerprint AND identical subkey fingerprints, but
+      // the self-signature packets — and therefore the raw bytes — differ.
+      // This is exactly what PR #1087's `strip_key_expiration` /
+      // `clearKeyExpiration` heal produces locally while the server still
+      // holds the pre-heal copy. A raw-byte comparison sees a difference;
+      // a subkey-fingerprint comparison correctly sees the same key.
+      const serverArmoredExpiryStripped = makeOpenPgpArmor(
+        'PGP PUBLIC KEY BLOCK',
+        readOpenPgpArmorPayloadForTest(bundle.publicArmored) + 'Expiry: stripped\n',
+      )
+      expect(serverArmoredExpiryStripped).not.toBe(bundle.publicArmored)
+
+      peerPublish('me@example.com', METADATA_NODE, {
+        id: 'current',
+        payload: {
+          name: 'public-keys-list',
+          attrs: { xmlns: OX_NS },
+          children: [
+            {
+              name: 'pubkey-metadata',
+              attrs: {
+                'v4-fingerprint': bundle.fingerprint,
+                'v6-fingerprint': bundle.fingerprint,
+                date: '2024-06-01T00:00:00Z',
+              },
+              children: [],
+            },
+          ],
+        },
+      })
+      peerPublish('me@example.com', dataNodeFor(bundle.fingerprint), {
+        id: 'current',
+        payload: {
+          name: 'pubkey',
+          attrs: { xmlns: OX_NS },
+          children: [
+            {
+              name: 'data',
+              attrs: {},
+              children: [encodeOpenPgpArmorForXep0373(serverArmoredExpiryStripped)],
+            },
+          ],
+        },
+      })
+      await plugin.init(ctx)
+      expect(getOwnKeyConflict()).toBeNull()
+      // With no real conflict, ensureIdentity must go on to (re)publish the
+      // local key so the byte divergence self-heals instead of deadlocking.
+      expect(published.length).toBeGreaterThan(0)
     })
 
     it('blocks encrypt() while an own-key conflict is live', async () => {

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.test.ts
@@ -791,6 +791,10 @@ describe('WebOpenPGPPlugin', () => {
       // ECC keys generate with one encryption subkey by default.
       expect(info.encryptionSubkeyCount).toBeGreaterThanOrEqual(1)
       expect(info.userIds).toContain('xmpp:alice@example.com')
+      // Subkey fingerprints feed the own-key consistency check's "same key,
+      // different bytes" test, so the real backend must surface them.
+      expect(info.subkeyFingerprints.length).toBeGreaterThanOrEqual(1)
+      expect(info.subkeyFingerprints).not.toContain(info.fingerprint)
     })
   })
 

--- a/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
+++ b/apps/fluux/src/e2ee/WebOpenPGPPlugin.ts
@@ -292,7 +292,11 @@ export class WebOpenPGPPlugin extends OpenPGPPluginBase {
       // No usable encryption-capable subkey (expired, revoked, or absent).
     }
     const userIds = key.getUserIDs()
-    return { fingerprint, encryptionSubkeyCount, userIds }
+    // Every subkey fingerprint, independent of usage/expiry — these identify
+    // the key material so the own-key consistency check can tell "same key,
+    // re-signed" from "a different key was published" (OpenPGPPluginBase).
+    const subkeyFingerprints = key.getSubkeys().map((sk) => sk.getFingerprint())
+    return { fingerprint, encryptionSubkeyCount, userIds, subkeyFingerprints }
   }
 
   protected async rotateKeyMaterial(_accountJid: string): Promise<KeyBundle> {


### PR DESCRIPTION
## Summary

Re-uploading an OpenPGP cert that hadn't actually changed could lock encryption behind a "reconcile server vs client" banner, even though the fingerprint was identical.

`checkOwnPublishedKeyConsistency` compared the server-published cert against the local cert with a **raw packet-byte equality test**. Two exports of the same key differ byte-for-byte for benign reasons:

- the #1087 expiry heal (`strip_key_expiration` / `clearKeyExpiration`) re-signs the primary and subkey bindings to drop the 3-year validity — same fingerprint, different self-signature packets;
- a re-export through another OpenPGP client (e.g. Gajim) reorders or minimizes packets.

Any of those falsely recorded a `subkey-mismatch`, threw `own-key-conflict` from `encrypt()`, and — because `ensureIdentity` returns early on a conflict — skipped the re-publish that would have healed the divergence, so re-uploading couldn't clear it.

## Fix

Compare the **set of component fingerprints** (primary + subkeys) instead of raw bytes. Fingerprints are immutable identifiers of the key material: re-signing leaves them untouched while a genuine rotation adds a new subkey fingerprint.

- `CertValidation` now carries `subkeyFingerprints`, populated by both backends (Rust `cert.keys().subkeys()`; web `key.getSubkeys()`).
- The primary-mismatch (tamper) branch and the byte-equal fast path are unchanged; a genuine remote rotation still raises the banner.
- An unparseable published cert is treated as "same key" so encryption is never blocked on something the reconcile banner can't resolve.