### PR TITLE
fix(scroll): stop overlay Escape from resetting the conversation scroll

### DIFF
--- a/apps/fluux/src/components/AvatarLightbox.test.tsx
+++ b/apps/fluux/src/components/AvatarLightbox.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { AvatarLightbox } from './AvatarLightbox'
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))
+vi.mock('./Avatar', () => ({ Avatar: () => null }))
+
+describe('AvatarLightbox Escape handling', () => {
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<AvatarLightbox identifier="user@x" onClose={onClose} />)
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // Same regression guard as ImageLightbox: closing the avatar view with Escape
+    // must not also fire the window-level conversation shortcut (scroll-to-bottom).
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<AvatarLightbox identifier="user@x" onClose={onClose} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+})

--- a/apps/fluux/src/components/AvatarLightbox.tsx
+++ b/apps/fluux/src/components/AvatarLightbox.tsx
@@ -2,11 +2,11 @@
  * Full-screen lightbox overlay for viewing avatars at a larger size.
  * Triggered by clicking on a message avatar in chat/room views.
  */
-import { useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Avatar } from './Avatar'
+import { useCloseOnEscape } from '@/hooks/useCloseOnEscape'
 
 interface AvatarLightboxProps {
   /** Avatar image URL (if available) */
@@ -24,14 +24,7 @@ interface AvatarLightboxProps {
 export function AvatarLightbox({ avatarUrl, identifier, name, fallbackColor, onClose }: AvatarLightboxProps) {
   const { t } = useTranslation()
 
-  // Close on Escape
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  useCloseOnEscape(onClose)
 
   return createPortal(
     <div

--- a/apps/fluux/src/components/ImageLightbox.test.tsx
+++ b/apps/fluux/src/components/ImageLightbox.test.tsx
@@ -67,6 +67,58 @@ describe('ImageLightbox allowFetch gating', () => {
   })
 })
 
+describe('ImageLightbox Escape handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAttachmentUrlSpy.mockReturnValue({ url: null, isLoading: false, error: null })
+    useCachedMediaUrlSpy.mockReturnValue({ cachedUrl: null, isPeeking: false })
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<ImageLightbox src="https://x/full.jpg" downloadUrl="https://x/full.jpg" onClose={onClose} />)
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // useKeyboardShortcuts listens on `window`; its Escape branch runs
+    // onConversationEscape → scrollToBottom(), snapping a reader who had scrolled
+    // up into history back to the newest message. The lightbox's own Escape (which
+    // closes it) must stop there — the same keypress must NOT also trigger that
+    // window-level handler. Regression guard for "opening an image resets my
+    // scroll position back to most recent".
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<ImageLightbox src="https://x/full.jpg" downloadUrl="https://x/full.jpg" onClose={onClose} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('does not intercept non-Escape keys (they still reach the window handler)', () => {
+    // Control: the consume behavior must be Escape-specific. A different key must
+    // pass through untouched, or the block above could be trivially satisfied by
+    // swallowing everything.
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<ImageLightbox src="https://x/full.jpg" downloadUrl="https://x/full.jpg" onClose={onClose} />)
+      fireEvent.keyDown(document.body, { key: 'a' })
+      expect(onClose).not.toHaveBeenCalled()
+      expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+})
+
 describe('ImageLightbox download button', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/fluux/src/components/ImageLightbox.tsx
+++ b/apps/fluux/src/components/ImageLightbox.tsx
@@ -2,9 +2,10 @@
  * Full-screen lightbox overlay for viewing image attachments.
  * Triggered by clicking on an image attachment in chat/room views.
  */
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useFocusTrap } from '@/hooks/useFocusTrap'
+import { useCloseOnEscape } from '@/hooks/useCloseOnEscape'
 import { X, Download, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { FileEncryption } from '@fluux/sdk'
@@ -40,14 +41,7 @@ export function ImageLightbox({ src, alt, downloadUrl, filename, encryption, pla
   const imageMenu = useContextMenu()
   const overlayRef = useRef<HTMLDivElement>(null)
   useFocusTrap(overlayRef)
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  useCloseOnEscape(onClose)
 
   const displaySrc = proxiedSrc ?? cachedFullRes ?? placeholderSrc
   // Already-resolved (decrypted or plaintext-proxied) full-res bytes, or null.

--- a/apps/fluux/src/hooks/useCloseOnEscape.test.tsx
+++ b/apps/fluux/src/hooks/useCloseOnEscape.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { useCloseOnEscape } from './useCloseOnEscape'
+
+function Harness({ onClose }: { onClose: () => void }) {
+  useCloseOnEscape(onClose)
+  return null
+}
+
+describe('useCloseOnEscape', () => {
+  it('calls onClose on Escape and stops the event reaching window', () => {
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<Harness onClose={onClose} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('ignores non-Escape keys and lets them bubble to window', () => {
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<Harness onClose={onClose} />)
+      fireEvent.keyDown(document.body, { key: 'Enter' })
+      expect(onClose).not.toHaveBeenCalled()
+      expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('detaches its listener on unmount (Escape no longer consumed)', () => {
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      const { unmount } = render(<Harness onClose={onClose} />)
+      unmount()
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).not.toHaveBeenCalled()
+      // With the overlay gone, Escape must flow through to the window handler again.
+      expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+})

--- a/apps/fluux/src/hooks/useCloseOnEscape.ts
+++ b/apps/fluux/src/hooks/useCloseOnEscape.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+
+/**
+ * Close an overlay when Escape is pressed, CONSUMING the event so it cannot also
+ * trigger the app's window-level keyboard shortcuts.
+ *
+ * The shortcut layer (useKeyboardShortcuts) listens on `window`; its Escape branch
+ * falls through to `onConversationEscape`, which marks the conversation read and
+ * calls `scrollToBottom()`. An overlay that closes on Escape via its own document
+ * listener but lets the event keep bubbling therefore fires BOTH: it closes AND
+ * snaps a reader who had scrolled up into history back to the newest message
+ * (the "opening an image resets my scroll position" report).
+ *
+ * The listener is attached to `document`, which sits inside `window` in the bubble
+ * path, so `stopPropagation()` here reliably prevents the window-level handler from
+ * also running — the overlay "wins" the Escape, mirroring {@link useFocusTrap}'s
+ * stacked-overlay behavior. Same-target listeners (e.g. a nested context menu on
+ * `document`) are unaffected, so their own Escape handling still works.
+ */
+export function useCloseOnEscape(onClose: () => void): void {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+}


### PR DESCRIPTION
## Summary

Closing an image (or avatar) lightbox with **Escape** also snapped the conversation back to the newest message when the reader had scrolled up into history — reported as "opening an image resets my scroll position back to most recent."

The lightbox closes via its own `document` keydown listener but did not stop the event, so the same Escape reached the window-level shortcut handler (`useKeyboardShortcuts`), whose Escape branch falls through to `onConversationEscape → scrollToBottom()`. One keypress both closed the overlay and yanked the view to the bottom. (Closing with the ✕ button or click-outside was unaffected.)

Adds a shared `useCloseOnEscape` hook that calls `stopPropagation()` before closing, used in `ImageLightbox` and `AvatarLightbox`. A plain Escape with no overlay open still runs the conversation catch-up (scroll to bottom).

## Follow-up

The same unguarded pattern exists in `HeaderOverflowKebab`, `ui/BottomSheet`, and `OverflowMenu` (tracked separately) — the new hook is the ready migration path.