### PR TITLE
fix(scroll): consume Escape in dropdown/sheet menus and the identity dialog

### DIFF
--- a/apps/fluux/src/components/IdentityChoiceDialog.test.tsx
+++ b/apps/fluux/src/components/IdentityChoiceDialog.test.tsx
@@ -302,4 +302,21 @@ describe('IdentityChoiceDialog', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(baseProps.onCancel).toHaveBeenCalledTimes(1)
   })
+
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // Regression (image-scroll-position-reset follow-up): this dialog can appear
+    // over the live app (App.tsx auto-init). Its Escape handling — backing out a
+    // sub-phase or cancelling from the chooser — must not also fire the window
+    // shortcut that scrolls the conversation to the bottom and marks it read.
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<IdentityChoiceDialog {...baseProps} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(baseProps.onCancel).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
 })

--- a/apps/fluux/src/components/IdentityChoiceDialog.tsx
+++ b/apps/fluux/src/components/IdentityChoiceDialog.tsx
@@ -94,6 +94,11 @@ export function IdentityChoiceDialog({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
+      // This dialog owns Escape while open (ModalOverlay's own handler is off via
+      // closeOnEscape={false}). Consume it so it can't also fire the window-level
+      // conversation shortcut (scroll-to-bottom / mark-read) behind the modal —
+      // the same leak useCloseOnEscape fixes for the shared overlays.
+      e.stopPropagation()
       // Escape backs out of the sub-phase to the chooser, NOT out of the
       // dialog entirely — Cancel is the only path that closes, to make
       // sure the user is making an explicit choice.

--- a/apps/fluux/src/components/OverflowMenu.test.tsx
+++ b/apps/fluux/src/components/OverflowMenu.test.tsx
@@ -49,6 +49,42 @@ describe('OverflowMenu', () => {
     expect(screen.queryByText('Archive')).not.toBeInTheDocument()
   })
 
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // Regression (image-scroll-position-reset follow-up): when this menu is used
+    // over a conversation (e.g. contact profile actions), closing it with Escape
+    // must not also fire the window shortcut that scrolls the conversation to the
+    // bottom and marks it read.
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<OverflowMenu ariaLabel="More actions" items={makeItems()} />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+      expect(screen.getByText('Archive')).toBeInTheDocument()
+
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+
+      expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('leaves Escape alone while closed (window handler still runs)', () => {
+    // The listener is gated on the open state: a closed menu must not swallow
+    // Escape meant for the conversation underneath.
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<OverflowMenu ariaLabel="More actions" items={makeItems()} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
   it('closes the menu when clicking outside', () => {
     render(
       <div>

--- a/apps/fluux/src/components/OverflowMenu.tsx
+++ b/apps/fluux/src/components/OverflowMenu.tsx
@@ -1,6 +1,7 @@
-import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react'
+import { Fragment, useRef, useState, type ReactNode } from 'react'
 import { MoreVertical, Check, type LucideIcon } from 'lucide-react'
 import { useClickOutside } from '@/hooks/useClickOutside'
+import { useCloseOnEscape } from '@/hooks/useCloseOnEscape'
 
 export interface OverflowMenuItem {
   /** Stable key for the list. */
@@ -68,17 +69,12 @@ export function OverflowMenu({
 
   useClickOutside(menuRef, () => setIsOpen(false), isOpen)
 
-  useEffect(() => {
-    if (!isOpen) return
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false)
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [isOpen])
-
   const toggle = () => setIsOpen((open) => !open)
   const close = () => setIsOpen(false)
+
+  // Consume Escape only while open so it can't also fire the window-level
+  // conversation shortcut (scroll-to-bottom / mark-read). See useCloseOnEscape.
+  useCloseOnEscape(close, isOpen)
 
   if (items.length === 0) return null
 

--- a/apps/fluux/src/components/header/HeaderOverflowKebab.test.tsx
+++ b/apps/fluux/src/components/header/HeaderOverflowKebab.test.tsx
@@ -49,6 +49,40 @@ describe('HeaderOverflowKebab', () => {
     expect(screen.queryByText('Invite')).not.toBeInTheDocument()
   })
 
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // Regression (image-scroll-position-reset follow-up): this kebab lives in the
+    // conversation/room header. Closing it with Escape must not also fire the
+    // window shortcut that scrolls the conversation to the bottom and marks it read.
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<HeaderOverflowKebab ariaLabel="More" entries={makeEntries()} />)
+      fireEvent.click(screen.getByLabelText('More'))
+      expect(screen.getByText('Search')).toBeInTheDocument()
+
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+
+      expect(screen.queryByText('Search')).not.toBeInTheDocument()
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('leaves Escape alone while closed (window handler still runs)', () => {
+    // The listener is gated on the open state: a closed kebab must not swallow
+    // Escape meant for the conversation underneath.
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<HeaderOverflowKebab ariaLabel="More" entries={makeEntries()} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
   it('touch: opens a bottom sheet, navigates into a submenu and back', () => {
     mockHasHover.mockReturnValue(false)
     const onMode = vi.fn()

--- a/apps/fluux/src/components/header/HeaderOverflowKebab.tsx
+++ b/apps/fluux/src/components/header/HeaderOverflowKebab.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { MoreVertical, ChevronLeft, ChevronRight, Check, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { BottomSheet } from '../ui/BottomSheet'
 import { useHasHover } from '@/hooks/useHasHover'
 import { useAnchoredMenu, useClickOutside } from '@/hooks'
+import { useCloseOnEscape } from '@/hooks/useCloseOnEscape'
 import type { HeaderActionGroup, HeaderActionItem } from './headerOverflow'
 
 export type OverflowEntry =
@@ -74,12 +75,9 @@ export function HeaderOverflowKebab({ ariaLabel, entries, triggerClassName }: He
 
   const close = () => { setIsOpen(false); setSheetView('root') }
 
-  useEffect(() => {
-    if (!isOpen) return
-    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') close() }
-    document.addEventListener('keydown', onEsc)
-    return () => document.removeEventListener('keydown', onEsc)
-  }, [isOpen])
+  // Consume Escape only while open so it can't also fire the window-level
+  // conversation shortcut (scroll-to-bottom / mark-read). See useCloseOnEscape.
+  useCloseOnEscape(close, isOpen)
 
   if (entries.length === 0) return null
 

--- a/apps/fluux/src/components/ui/BottomSheet.test.tsx
+++ b/apps/fluux/src/components/ui/BottomSheet.test.tsx
@@ -44,6 +44,27 @@ describe('BottomSheet', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // Regression (image-scroll-position-reset follow-up): a sheet opened over a
+    // conversation must not let Escape bubble to the window shortcut layer, which
+    // would scroll the conversation to the bottom and mark it read.
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(
+        <BottomSheet open onClose={onClose}>
+          x
+        </BottomSheet>,
+      )
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
   it('calls onClose when the backdrop is tapped', () => {
     const onClose = vi.fn()
     render(

--- a/apps/fluux/src/components/ui/BottomSheet.tsx
+++ b/apps/fluux/src/components/ui/BottomSheet.tsx
@@ -12,9 +12,10 @@
  * Used for touch action menus (e.g. per-message actions) where a centered modal
  * or a hover toolbar doesn't fit thumb ergonomics.
  */
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useFocusTrap } from '@/hooks/useFocusTrap'
+import { useCloseOnEscape } from '@/hooks/useCloseOnEscape'
 
 interface BottomSheetProps {
   /** Whether the sheet is open. Renders nothing when false. */
@@ -40,15 +41,9 @@ export function BottomSheet({
 }: BottomSheetProps) {
   const panelRef = useRef<HTMLDivElement>(null)
   useFocusTrap(panelRef, { active: open })
-
-  useEffect(() => {
-    if (!open) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [open, onClose])
+  // Consume Escape while open so it can't also fire the window-level conversation
+  // shortcut (scroll-to-bottom / mark-read) behind the sheet. See useCloseOnEscape.
+  useCloseOnEscape(onClose, open)
 
   if (!open || typeof document === 'undefined') return null
 

--- a/apps/fluux/src/hooks/useCloseOnEscape.test.tsx
+++ b/apps/fluux/src/hooks/useCloseOnEscape.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import { useCloseOnEscape } from './useCloseOnEscape'
 
-function Harness({ onClose }: { onClose: () => void }) {
-  useCloseOnEscape(onClose)
+function Harness({ onClose, enabled }: { onClose: () => void; enabled?: boolean }) {
+  useCloseOnEscape(onClose, enabled)
   return null
 }
 
@@ -31,6 +31,37 @@ describe('useCloseOnEscape', () => {
       fireEvent.keyDown(document.body, { key: 'Enter' })
       expect(onClose).not.toHaveBeenCalled()
       expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('does not attach while disabled (Escape flows through to window, onClose not called)', () => {
+    // Always-mounted overlays (dropdown/sheet menus) pass their open state as
+    // `enabled`. While closed the hook must NOT consume Escape, so the window
+    // handler still runs for anything else that cares about Escape.
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<Harness onClose={onClose} enabled={false} />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).not.toHaveBeenCalled()
+      expect(windowKeydown).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+
+  it('consumes Escape when explicitly enabled', () => {
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(<Harness onClose={onClose} enabled />)
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
     } finally {
       window.removeEventListener('keydown', windowKeydown)
     }

--- a/apps/fluux/src/hooks/useCloseOnEscape.ts
+++ b/apps/fluux/src/hooks/useCloseOnEscape.ts
@@ -16,9 +16,16 @@ import { useEffect } from 'react'
  * also running — the overlay "wins" the Escape, mirroring {@link useFocusTrap}'s
  * stacked-overlay behavior. Same-target listeners (e.g. a nested context menu on
  * `document`) are unaffected, so their own Escape handling still works.
+ *
+ * `enabled` (default `true`) gates the listener for overlays that stay mounted and
+ * toggle open/closed via state — dropdown and bottom-sheet menus. Pass the open
+ * flag so Escape is consumed ONLY while the overlay is open; when closed the event
+ * must flow through untouched (e.g. to the conversation's own Escape handling).
+ * Overlays that unmount when closed (lightboxes) can omit it.
  */
-export function useCloseOnEscape(onClose: () => void): void {
+export function useCloseOnEscape(onClose: () => void, enabled = true): void {
   useEffect(() => {
+    if (!enabled) return
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
       e.stopPropagation()
@@ -26,5 +33,5 @@ export function useCloseOnEscape(onClose: () => void): void {
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  }, [onClose, enabled])
 }


### PR DESCRIPTION
Follow-up to #1091. `HeaderOverflowKebab`, `BottomSheet` and `OverflowMenu` closed on Escape via their own `document` keydown listeners without `stopPropagation`, so dismissing them over a conversation also fired the window-level shortcut (`onConversationEscape` → scroll-to-bottom + mark-read). `IdentityChoiceDialog` (rendered over the live app from `App.tsx`) had the same leak.

- Migrate the three menus to `useCloseOnEscape`. Since they stay mounted and toggle open via state, the hook gains an `enabled` flag (`useCloseOnEscape(close, isOpen)`) so Escape is consumed only while open — a closed menu still lets Escape fall through.
- `IdentityChoiceDialog` re-routes Escape through its phases rather than plain-closing, so it gets an inline `e.stopPropagation()` after the Escape guard instead of the hook.
- Regression test per overlay (window-keydown spy must not fire after Escape), plus "leaves Escape alone while closed" control tests for the menus and `enabled` coverage on the hook.

Note: `ModalOverlay`'s default `closeOnEscape` handler has the same leak for every default modal (verify-peer, key-picker, …) and is best fixed centrally — tracked as a separate follow-up, out of scope here.