### PR TITLE
fix(scroll): keep the save gate closed through a measurement settle

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -1732,6 +1732,55 @@ describe('MessageList scroll behavior', () => {
       }
     })
 
+    it('does not open the save gate on a measurement settle that outlives the programmatic window', () => {
+      // Save-gate settle drift: after a restore the list keeps re-measuring; on WebKit a measurement
+      // settle can fire 'scroll' events LATER than PROGRAMMATIC_SETTLE_MS (250ms) after the last
+      // programmatic write. The save gate's fallback heuristic — "not programmatic + height unchanged
+      // = a scrollbar drag" — then mistakes a mid-settle frame (whose height happens to equal the
+      // previous frame's) for a user drag, opens the gate, and persists a drifted anchor that creeps
+      // between room visits. A measurement settle CHANGES height across frames, so it must keep
+      // refreshing the programmatic window and never open the gate.
+      vi.useFakeTimers()
+      vi.setSystemTime(100_000)
+      const saveSpy = vi.spyOn(scrollStateManager, 'saveScrollPosition')
+      try {
+        const messages = createTestMessages(20)
+        const props = { clearFirstNewMessageId: vi.fn(), renderMessage: (m: BaseMessage) => <div key={m.id}>{m.body}</div> }
+        const { rerender } = render(<MessageList messages={messages} conversationId="conv-A" {...props} />)
+        const container = document.querySelector('.overflow-y-auto') as HTMLDivElement
+
+        let top = 250
+        let height = 2000
+        Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+        Object.defineProperty(container, 'scrollHeight', { get: () => height, configurable: true })
+        Object.defineProperty(container, 'scrollTop', { get: () => top, set: (v: number) => { top = v }, configurable: true })
+
+        // Genuine user scroll-up → saves conv-A's scrolled-up anchor (opens the gate via the wheel).
+        act(() => { container.dispatchEvent(new WheelEvent('wheel', { bubbles: true })); container.dispatchEvent(new Event('scroll')) })
+
+        // Switch away and back → restore sets lastProgrammaticScrollAt (starts the 250ms window) and
+        // resets "user scrolled since entry".
+        rerender(<MessageList messages={messages} conversationId="conv-B" {...props} />)
+        rerender(<MessageList messages={messages} conversationId="conv-A" {...props} />)
+
+        saveSpy.mockClear()
+
+        // >250ms after the restore, a measurement settle fires scroll events with NO wheel/touch: a
+        // frame at the current height, a frame where the height changes (rows re-measuring), then a
+        // frame back at a stable height with a drifted scrollTop.
+        vi.advanceTimersByTime(300)
+        act(() => { top = 300; container.dispatchEvent(new Event('scroll')) }) // establishes prev height
+        act(() => { height = 2100; top = 290; container.dispatchEvent(new Event('scroll')) }) // height changed
+        act(() => { top = 280; container.dispatchEvent(new Event('scroll')) }) // height stable, drifted
+
+        // The settle must NOT be mistaken for a user scroll and persisted.
+        expect(saveSpy).not.toHaveBeenCalled()
+      } finally {
+        saveSpy.mockRestore()
+        vi.useRealTimers()
+      }
+    })
+
     it('should scroll to bottom when returning to conversation that was at bottom', () => {
       const messages = createTestMessages(10)
       const scrollSpy = vi.fn()

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1906,14 +1906,27 @@ export function useMessageListScroll({
     // (the transient scrollTop:0 of the virtualized initial render was saved as a "scrolled-up"
     // position, poisoning the next re-entry into restore-position and bypassing the marker entirely).
 
+    // A height change between consecutive scroll events is a measurement settle (rows re-measuring,
+    // media decoding), never a user scroll — keep the programmatic-settle window alive across it.
+    // isProgrammaticScroll's window is anchored to the last programmatic WRITE, but a WebKit settle
+    // can fire 'scroll' events well beyond PROGRAMMATIC_SETTLE_MS after that write; once one of them
+    // happened to match the previous frame's height, the gate below mistook it for a scrollbar drag,
+    // opened, and persisted a drifted anchor that crept between room visits. Re-anchoring the window
+    // to the last measurement CHANGE covers a settle of any duration. A genuine scrollbar-drag leaves
+    // height unchanged, so it never refreshes the window and still opens the gate.
+    if (prevScrollHeightRef.current !== null && prevScrollHeightRef.current !== scrollHeight) {
+      lastProgrammaticScrollAtRef.current = Date.now()
+    }
+
     // Open the save gate when this is a genuine user scroll: content height UNCHANGED from the
     // previous scroll event (a media/measurement-driven shift changes the height; a wheel / touch /
     // scrollbar-drag does not). Complements the input-event listeners so scrollbar-drag — which
-    // fires no wheel/touch — also counts. Excluded: programmatic loop scrolls AND the brief
-    // post-restore / post-re-pin measurement settle (isProgrammaticScroll's window) — that settle is
-    // height-unchanged too, so without the window a SECOND settle event looked like a scrollbar drag,
-    // opened the gate, and persisted a drifted position that crept older on every re-open. Genuine
-    // user scrolls still open the gate via the input-event listeners / handleWheel, unaffected.
+    // fires no wheel/touch — also counts. Excluded: programmatic loop scrolls AND the
+    // post-restore / post-re-pin measurement settle (isProgrammaticScroll's window, refreshed on the
+    // height change just above) — that settle is height-unchanged on its final frames too, so without
+    // the window a settle frame looked like a scrollbar drag, opened the gate, and persisted a
+    // drifted position that crept older on every re-open. Genuine user scrolls still open the gate
+    // via the input-event listeners / handleWheel, unaffected.
     if (
       !isProgrammaticScroll(programmaticScroll, Date.now(), lastProgrammaticScrollAtRef.current) &&
       prevScrollHeightRef.current === scrollHeight


### PR DESCRIPTION
## Summary

Follow-up to #1092. Returning to a room could persist a **drifted** scroll anchor even after the restore-anchor loop was fixed to converge — a separate save-gate defect (flagged in review, reproduced here on merged `main`).

The save gate's scrollbar-drag fallback opens on `!programmatic && height-unchanged` (a scrollbar drag fires no wheel/touch and leaves height unchanged). But `isProgrammaticScroll`'s window is anchored to the last programmatic *write*, and on WebKit a measurement **settle** fires `scroll` events well beyond `PROGRAMMATIC_SETTLE_MS` (250 ms) after that write. Once a late settle frame happened to match the previous frame's height, the gate mistook it for a user drag, opened, and saved a drifted anchor — which then restored on the next visit ("position drifts between room visits").

**Fix:** re-anchor the programmatic-settle window to the last measurement *change*. A height change between consecutive `scroll` events is always a settle (rows re-measuring / media decoding), never a user scroll, so it refreshes the window and covers a settle of any duration. A genuine scrollbar-drag leaves height unchanged, so it never refreshes the window and still opens the gate. 4 lines in `handleScroll`.