### PR TITLE
fix(scroll): consume Escape in default ModalOverlay so closing a dialog can't reset conversation scroll

### DIFF
--- a/apps/fluux/src/components/ModalOverlay.escape.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.escape.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { ModalOverlay } from './ModalOverlay'
+
+// Skip the exit animation so the transition-aware `close` invokes onClose
+// synchronously (useModalTransition otherwise defers it behind MODAL_EXIT_MS).
+beforeEach(() => document.documentElement.setAttribute('data-motion', 'reduced'))
+afterEach(() => {
+  document.documentElement.removeAttribute('data-motion')
+  cleanup()
+})
+
+describe('ModalOverlay Escape handling', () => {
+  it('closes on Escape (default closeOnEscape)', () => {
+    const onClose = vi.fn()
+    render(
+      <ModalOverlay onClose={onClose}>
+        <button type="button">ok</button>
+      </ModalOverlay>,
+    )
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('consumes Escape so it never reaches the window-level shortcut handler', () => {
+    // Regression guard (mirrors AvatarLightbox / ImageLightbox): closing a default
+    // ModalOverlay modal with Escape must not ALSO fire the app's window-level
+    // conversation shortcut (scroll-to-bottom + mark-read), which listens on window.
+    // Without stopPropagation the Escape both closes the modal AND snaps a reader
+    // who scrolled up into history back to the newest message.
+    const onClose = vi.fn()
+    const windowKeydown = vi.fn()
+    window.addEventListener('keydown', windowKeydown)
+    try {
+      render(
+        <ModalOverlay onClose={onClose}>
+          <button type="button">ok</button>
+        </ModalOverlay>,
+      )
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(windowKeydown).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', windowKeydown)
+    }
+  })
+})

--- a/apps/fluux/src/components/ModalOverlay.tsx
+++ b/apps/fluux/src/components/ModalOverlay.tsx
@@ -118,7 +118,14 @@ export function ModalOverlay({
   useEffect(() => {
     if (!closeOnEscape || !dismissable) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close()
+      if (e.key !== 'Escape') return
+      // CONSUME the Escape (mirroring useCloseOnEscape) so it cannot also reach
+      // the app's window-level shortcut handler, whose Escape branch falls
+      // through to onConversationEscape (scroll-to-bottom + mark-read). Without
+      // this, closing any default ModalOverlay modal opened over a conversation
+      // would snap a reader scrolled up into history back to the newest message.
+      e.stopPropagation()
+      close()
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)


### PR DESCRIPTION
The default `closeOnEscape=true` document handler in `ModalOverlay` closed the modal but did not `stopPropagation`, so the same Escape reached the window-level shortcut handler, whose Escape branch falls through to `onConversationEscape` (scroll-to-bottom + mark-read). Every default `ModalOverlay` dialog (verify-peer, key-picker, confirm, backup/restore, …) opened over a conversation therefore snapped a reader scrolled up into history back to the newest message on close — the same bug class fixed for the lightboxes in #1091.

Fix: add `e.stopPropagation()` before `close()` in that handler, mirroring `useCloseOnEscape`. Single central fix covering every default modal at once. The `closeOnEscape={false}` callers (CommandPalette, IdentityChoiceDialog, ShortcutHelp) already consume Escape themselves or intentionally delegate to the window hierarchy.

Regression test `ModalOverlay.escape.test.tsx` mirrors `AvatarLightbox.test.tsx`: a control asserting the modal closes on Escape, plus a break check asserting a window-level keydown spy never fires.