### PR TITLE
Define scroll positioning contract

### DIFF
--- a/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
@@ -1,0 +1,690 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import {
+  acceptPositionRequest,
+  advancePhaseIfCurrent,
+  cancelReconciliationForUserInput,
+  deactivateConversation,
+  initialPositioningModel,
+  isCurrentGeneration,
+  messageFraction,
+  pixelOffset,
+  resolveReachability,
+  selectEntryPosition,
+  selectLiveEdgeNavigation,
+  settleUserPosition,
+  shouldReconcileAfterAppend,
+  type BottomFractionAnchorPosition,
+  type PixelOffset,
+  type PositionRequest,
+} from './scrollPositionModel'
+
+const conversationId = 'room@example.test'
+const otherConversationId = 'other-room@example.test'
+const liveEdge = { kind: 'live-edge', follow: true } as const
+const savedAnchor: BottomFractionAnchorPosition = {
+  kind: 'anchor',
+  messageId: 'last-message',
+  placement: {
+    kind: 'bottom-fraction',
+    fraction: messageFraction(1),
+  },
+}
+
+type SavedEntryRequest = Extract<
+  PositionRequest,
+  {
+    source: { kind: 'entry'; reason: 'saved-position' }
+    desired: BottomFractionAnchorPosition
+  }
+>
+
+function savedRequest(generation: number): SavedEntryRequest {
+  return {
+    generation,
+    conversationId,
+    source: { kind: 'entry', reason: 'saved-position' },
+    desired: savedAnchor,
+    onUnavailable: { kind: 'live-edge' },
+  }
+}
+
+function liveEntry(generation: number, id = conversationId): PositionRequest {
+  return {
+    generation,
+    conversationId: id,
+    source: { kind: 'entry', reason: 'live-edge' },
+    desired: liveEdge,
+  }
+}
+
+function explicitMessage(generation: number): PositionRequest {
+  return {
+    generation,
+    conversationId,
+    source: { kind: 'user-navigation', reason: 'message-target' },
+    desired: {
+      kind: 'message',
+      messageId: 'explicit-target',
+      align: 'center',
+    },
+    onUnavailable: { kind: 'wait' },
+  }
+}
+
+function lateMds(generation: number, id = conversationId): PositionRequest {
+  return {
+    generation,
+    conversationId: id,
+    source: {
+      kind: 'late-mds-supersession',
+      reason: 'read-pointer-at-live-edge',
+    },
+    desired: liveEdge,
+  }
+}
+
+function outgoingMessage(generation: number): PositionRequest {
+  return {
+    generation,
+    conversationId,
+    source: { kind: 'live-update', reason: 'outgoing-message' },
+    desired: liveEdge,
+  }
+}
+
+describe('scroll position model', () => {
+  it('couples provenance to compatible desired-position types', () => {
+    type InvalidLateMdsAnchor = {
+      generation: number
+      conversationId: string
+      source: {
+        kind: 'late-mds-supersession'
+        reason: 'read-pointer-at-live-edge'
+      }
+      desired: BottomFractionAnchorPosition
+    }
+    type InvalidOutgoingResidentTop = {
+      generation: number
+      conversationId: string
+      source: { kind: 'live-update'; reason: 'outgoing-message' }
+      desired: { kind: 'resident-top' }
+    }
+    type ValidSavedFallback = {
+      generation: number
+      conversationId: string
+      source: { kind: 'fallback'; reason: 'saved-position-unavailable' }
+      desired: { kind: 'legacy-offset'; offsetPx: PixelOffset }
+    }
+
+    // These compile-time controls fail if PositionRequest is widened back into independent source
+    // and desired fields. The valid control prevents an accidentally impossible fallback contract.
+    expectTypeOf<InvalidLateMdsAnchor>().not.toMatchTypeOf<PositionRequest>()
+    expectTypeOf<InvalidOutgoingResidentTop>().not.toMatchTypeOf<PositionRequest>()
+    expectTypeOf<ValidSavedFallback>().toMatchTypeOf<PositionRequest>()
+  })
+
+  it('validates fractional anchor bounds instead of leaving incompatible geometry implicit', () => {
+    expect(messageFraction(0)).toBe(0)
+    expect(messageFraction(1)).toBe(1)
+    expect(() => messageFraction(-0.01)).toThrow(RangeError)
+    expect(() => messageFraction(1.01)).toThrow(RangeError)
+    expect(() => messageFraction(Number.NaN)).toThrow(RangeError)
+    expect(() => messageFraction(Number.POSITIVE_INFINITY)).toThrow(RangeError)
+    expect(pixelOffset(-12.5)).toBe(-12.5)
+    expect(() => pixelOffset(Number.NEGATIVE_INFINITY)).toThrow(RangeError)
+  })
+
+  it('follows appends only for live-edge policy, never for fixed positions at the tail', () => {
+    const nonFollowingRequests: PositionRequest[] = [
+      {
+        generation: 2,
+        conversationId,
+        source: { kind: 'media-preservation', reason: 'remeasure' },
+        desired: savedAnchor,
+        onUnavailable: { kind: 'warn-and-stop' },
+      },
+      {
+        generation: 3,
+        conversationId,
+        source: { kind: 'user-navigation', reason: 'message-target' },
+        desired: { kind: 'message', messageId: 'last-message', align: 'center' },
+        onUnavailable: { kind: 'wait' },
+      },
+      {
+        generation: 4,
+        conversationId,
+        source: { kind: 'user-navigation', reason: 'resident-top' },
+        desired: { kind: 'resident-top' },
+      },
+    ]
+    nonFollowingRequests.forEach((request) => {
+      const live = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+      expect(shouldReconcileAfterAppend(live, conversationId)).toBe(true)
+      const model = acceptPositionRequest(live, request)
+      expect(shouldReconcileAfterAppend(model, conversationId)).toBe(false)
+    })
+
+    const legacyEntry: PositionRequest = {
+      generation: 5,
+      conversationId,
+      source: { kind: 'entry', reason: 'saved-position' },
+      desired: { kind: 'legacy-offset', offsetPx: pixelOffset(50) },
+    }
+    const model = acceptPositionRequest(initialPositioningModel(), legacyEntry)
+    expect(shouldReconcileAfterAppend(model, conversationId)).toBe(false)
+  })
+
+  it('distinguishes empty, loadable, unavailable, unmounted, and mounted targets', () => {
+    const request = savedRequest(1)
+    expect(resolveReachability(request, { kind: 'empty-window' })).toEqual({
+      kind: 'pending',
+      reason: 'empty-window',
+    })
+    expect(
+      resolveReachability(request, { kind: 'target-absent', loadAround: 'available' }),
+    ).toEqual({
+      kind: 'loading-around',
+      messageId: 'last-message',
+    })
+    expect(
+      resolveReachability(request, { kind: 'target-absent', loadAround: 'loading' }),
+    ).toEqual({
+      kind: 'pending',
+      reason: 'around-load',
+    })
+    expect(
+      resolveReachability(request, { kind: 'target-absent', loadAround: 'unavailable' }),
+    ).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'live-edge' },
+    })
+    expect(
+      resolveReachability(request, {
+        kind: 'available',
+        index: 42,
+        mounted: false,
+        placement: 'viable',
+      }),
+    ).toEqual({
+      kind: 'mounting',
+      index: 42,
+      messageId: 'last-message',
+    })
+    expect(
+      resolveReachability(request, {
+        kind: 'available',
+        index: 42,
+        mounted: true,
+        placement: 'viable',
+      }),
+    ).toEqual({ kind: 'reconciling' })
+  })
+
+  it('keeps unavailable behavior request-specific instead of applying one generic fallback', () => {
+    const absent = { kind: 'target-absent', loadAround: 'exhausted' } as const
+    const savedWithLegacy: PositionRequest = {
+      ...savedRequest(1),
+      onUnavailable: {
+        kind: 'legacy-offset',
+        offsetPx: pixelOffset(1234),
+        otherwise: 'live-edge',
+      },
+    }
+    const explicit = explicitMessage(2)
+    const preservation: PositionRequest = {
+      generation: 3,
+      conversationId,
+      source: { kind: 'media-preservation', reason: 'remeasure' },
+      desired: savedAnchor,
+      onUnavailable: { kind: 'warn-and-stop' },
+    }
+
+    expect(resolveReachability(savedWithLegacy, absent)).toEqual({
+      kind: 'unavailable',
+      policy: {
+        kind: 'legacy-offset',
+        offsetPx: pixelOffset(1234),
+        otherwise: 'live-edge',
+      },
+    })
+    expect(resolveReachability(explicit, absent)).toEqual({
+      kind: 'pending',
+      reason: 'target-not-indexed',
+    })
+    expect(resolveReachability(preservation, absent)).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'warn-and-stop' },
+    })
+  })
+
+  it('preserves directional history with distance-from-bottom while media failure stops', () => {
+    const absent = { kind: 'target-absent', loadAround: 'unavailable' } as const
+    const directional: PositionRequest = {
+      generation: 2,
+      conversationId,
+      source: { kind: 'history-preservation', reason: 'window-shift' },
+      desired: {
+        kind: 'anchor',
+        messageId: 'top-visible',
+        placement: { kind: 'top-offset', offsetPx: pixelOffset(-18) },
+      },
+      onUnavailable: {
+        kind: 'distance-from-bottom',
+        distancePx: pixelOffset(640),
+      },
+    }
+    const media: PositionRequest = {
+      generation: 3,
+      conversationId,
+      source: { kind: 'media-preservation', reason: 'remeasure' },
+      desired: savedAnchor,
+      onUnavailable: { kind: 'warn-and-stop' },
+    }
+
+    expect(resolveReachability(directional, absent)).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'distance-from-bottom', distancePx: pixelOffset(640) },
+    })
+    expect(resolveReachability(media, absent)).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'warn-and-stop' },
+    })
+  })
+
+  it('falls back from a mounted unread marker whose start placement would hit resident top', () => {
+    const request: PositionRequest = {
+      generation: 1,
+      conversationId,
+      source: { kind: 'entry', reason: 'unread-marker' },
+      desired: {
+        kind: 'message',
+        messageId: 'first-unread',
+        align: 'start',
+      },
+      onUnavailable: { kind: 'live-edge' },
+    }
+
+    expect(
+      resolveReachability(request, {
+        kind: 'available',
+        index: 0,
+        mounted: true,
+        placement: 'use-unavailable-policy',
+      }),
+    ).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'live-edge' },
+    })
+    expect(
+      resolveReachability(request, {
+        kind: 'available',
+        index: 0,
+        mounted: false,
+        placement: 'use-unavailable-policy',
+      }),
+    ).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'live-edge' },
+    })
+    expect(
+      resolveReachability(request, {
+        kind: 'available',
+        index: 10,
+        mounted: true,
+        placement: 'viable',
+      }),
+    ).toEqual({ kind: 'reconciling' })
+  })
+
+  it('reconciles a raw legacy offset without mounting an unrelated row', () => {
+    const legacy: PositionRequest = {
+      generation: 1,
+      conversationId,
+      source: { kind: 'entry', reason: 'saved-position' },
+      desired: { kind: 'legacy-offset', offsetPx: pixelOffset(400) },
+    }
+    expect(
+      resolveReachability(legacy, {
+        kind: 'available',
+        index: 99,
+        mounted: false,
+        placement: 'viable',
+      }),
+    ).toEqual({ kind: 'reconciling' })
+    expect(
+      resolveReachability(liveEntry(1), {
+        kind: 'global-live-edge',
+        state: { kind: 'resident-tail', index: 99, mounted: false },
+      }),
+    ).toEqual({ kind: 'mounting', index: 99 })
+  })
+
+  it('recenters a slid-up window before mounting and reconciling the global live edge', () => {
+    const request = liveEntry(1)
+    expect(
+      resolveReachability(request, {
+        kind: 'global-live-edge',
+        state: { kind: 'recenter-available' },
+      }),
+    ).toEqual({ kind: 'recentering-live-edge' })
+    expect(
+      resolveReachability(request, {
+        kind: 'global-live-edge',
+        state: { kind: 'recentering' },
+      }),
+    ).toEqual({ kind: 'pending', reason: 'live-edge-recenter' })
+    expect(
+      resolveReachability(request, {
+        kind: 'global-live-edge',
+        state: { kind: 'resident-tail', index: 99, mounted: false },
+      }),
+    ).toEqual({ kind: 'mounting', index: 99 })
+    expect(
+      resolveReachability(request, {
+        kind: 'global-live-edge',
+        state: { kind: 'resident-tail', index: 99, mounted: true },
+      }),
+    ).toEqual({ kind: 'reconciling' })
+  })
+
+  it('selects synced live edge ahead of saved state and saved state ahead of unread', () => {
+    const ordinary = selectEntryPosition({
+      syncedLiveEdge: false,
+      savedAnchor,
+      savedOffsetPx: pixelOffset(1234),
+      firstUnreadMessageId: 'first-unread',
+    })
+    const synced = selectEntryPosition({
+      syncedLiveEdge: true,
+      savedAnchor,
+      savedOffsetPx: pixelOffset(1234),
+      firstUnreadMessageId: 'first-unread',
+    })
+
+    expect(ordinary).toEqual({
+      source: { kind: 'entry', reason: 'saved-position' },
+      desired: savedAnchor,
+      onUnavailable: {
+        kind: 'legacy-offset',
+        offsetPx: 1234,
+        otherwise: 'live-edge',
+      },
+    })
+    expect(synced).toEqual({
+      source: { kind: 'entry', reason: 'synced-live-edge' },
+      desired: liveEdge,
+    })
+  })
+
+  it('preserves raw-only legacy saves instead of silently choosing unread or live edge', () => {
+    const withUnread = selectEntryPosition({
+      syncedLiveEdge: false,
+      savedOffsetPx: pixelOffset(1234),
+      firstUnreadMessageId: 'first-unread',
+    })
+    const withoutUnread = selectEntryPosition({
+      syncedLiveEdge: false,
+      savedOffsetPx: pixelOffset(1234),
+    })
+
+    const expected = {
+      source: { kind: 'entry', reason: 'saved-position' },
+      desired: { kind: 'legacy-offset', offsetPx: pixelOffset(1234) },
+    }
+    expect(withUnread).toEqual(expected)
+    expect(withoutUnread).toEqual(expected)
+  })
+
+  it('uses unread only without saved state, then falls back to live edge', () => {
+    const unread = selectEntryPosition({
+      syncedLiveEdge: false,
+      firstUnreadMessageId: 'first-unread',
+    })
+    const noUnread = selectEntryPosition({ syncedLiveEdge: false })
+
+    expect(unread).toEqual({
+      source: { kind: 'entry', reason: 'unread-marker' },
+      desired: {
+        kind: 'message',
+        messageId: 'first-unread',
+        align: 'start',
+      },
+      onUnavailable: { kind: 'live-edge' },
+    })
+    expect(noUnread).toEqual({
+      source: { kind: 'entry', reason: 'live-edge' },
+      desired: liveEdge,
+    })
+  })
+
+  it('preserves FAB/End marker-first navigation only while the marker still needs a visit', () => {
+    const marker = selectLiveEdgeNavigation({
+      firstUnreadMessageId: 'first-unread',
+      unreadMarkerNeedsVisit: true,
+      unreadMarkerAlign: 'top-third',
+    })
+    const live = selectLiveEdgeNavigation({
+      firstUnreadMessageId: 'first-unread',
+      unreadMarkerNeedsVisit: false,
+      unreadMarkerAlign: 'top-third',
+    })
+
+    expect(marker).toEqual({
+      source: { kind: 'user-navigation', reason: 'unread-marker' },
+      desired: {
+        kind: 'message',
+        messageId: 'first-unread',
+        align: 'top-third',
+      },
+      onUnavailable: { kind: 'live-edge' },
+    })
+    expect(live).toEqual({
+      source: { kind: 'user-navigation', reason: 'live-edge' },
+      desired: liveEdge,
+    })
+  })
+
+  it('accepts only newer generations and ignores stale phase completion and cancellation', () => {
+    const first = acceptPositionRequest(initialPositioningModel(), savedRequest(1))
+    const secondRequest = explicitMessage(2)
+    const second = acceptPositionRequest(first, secondRequest)
+
+    expect(acceptPositionRequest(second, savedRequest(1))).toBe(second)
+    expect(
+      advancePhaseIfCurrent(second, conversationId, 1, { kind: 'reconciling' }),
+    ).toBe(second)
+    expect(cancelReconciliationForUserInput(second, conversationId, 1)).toBe(second)
+    expect(
+      cancelReconciliationForUserInput(second, otherConversationId, 2),
+    ).toBe(second)
+    expect(
+      advancePhaseIfCurrent(second, conversationId, 2, { kind: 'reconciling' }),
+    ).toEqual({
+      ...second,
+      active: {
+        request: secondRequest,
+        phase: { kind: 'reconciling' },
+      },
+    })
+  })
+
+  it('lets late MDS supersede only the provisional entry for the current conversation', () => {
+    const entry = acceptPositionRequest(initialPositioningModel(), savedRequest(1))
+    const mdsRequest = lateMds(2)
+    const superseded = acceptPositionRequest(entry, mdsRequest)
+
+    expect(superseded.active).toEqual({
+      request: mdsRequest,
+      phase: { kind: 'resolving' },
+    })
+    expect(superseded.lateMdsEligibleFor).toBeNull()
+  })
+
+  it('does not let delayed MDS revive a room after entry into another room', () => {
+    const roomA = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const roomBRequest = liveEntry(2, otherConversationId)
+    const roomB = acceptPositionRequest(roomA, roomBRequest)
+    const delayedRoomA = acceptPositionRequest(roomB, lateMds(3))
+    const staleMedia: PositionRequest = {
+      generation: 3,
+      conversationId,
+      source: { kind: 'media-preservation', reason: 'remeasure' },
+      desired: savedAnchor,
+      onUnavailable: { kind: 'warn-and-stop' },
+    }
+
+    expect(delayedRoomA).toBe(roomB)
+    expect(acceptPositionRequest(roomB, staleMedia)).toBe(roomB)
+    expect(roomB.currentConversationId).toBe(otherConversationId)
+    expect(roomB.active?.request).toEqual(roomBRequest)
+    expect(shouldReconcileAfterAppend(roomB, conversationId)).toBe(false)
+    expect(shouldReconcileAfterAppend(roomB, otherConversationId)).toBe(true)
+  })
+
+  it('independently closes late-MDS eligibility on takeover, navigation, and outgoing send', () => {
+    const takeoverEntry = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const cancelled = cancelReconciliationForUserInput(
+      takeoverEntry,
+      conversationId,
+      1,
+    )
+    expect(takeoverEntry.lateMdsEligibleFor).toBe(conversationId)
+    expect(acceptPositionRequest(cancelled, lateMds(2))).toBe(cancelled)
+
+    const navigationEntry = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const explicit = acceptPositionRequest(navigationEntry, explicitMessage(2))
+    expect(navigationEntry.lateMdsEligibleFor).toBe(conversationId)
+    expect(acceptPositionRequest(explicit, lateMds(3))).toBe(explicit)
+
+    const outgoingEntry = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const outgoing = acceptPositionRequest(outgoingEntry, outgoingMessage(2))
+    expect(outgoingEntry.lateMdsEligibleFor).toBe(conversationId)
+    expect(outgoing.active?.request).toEqual(outgoingMessage(2))
+    expect(acceptPositionRequest(outgoing, lateMds(3))).toBe(outgoing)
+  })
+
+  it('drops outgoing pin attempts while restore or directional preservation owns position', () => {
+    const restore = acceptPositionRequest(initialPositioningModel(), savedRequest(1))
+    const restorePending = advancePhaseIfCurrent(restore, conversationId, 1, {
+      kind: 'loading-around',
+      messageId: 'last-message',
+    })
+    expect(acceptPositionRequest(restorePending, outgoingMessage(2))).toBe(
+      restorePending,
+    )
+    const restoreReleased = advancePhaseIfCurrent(restorePending, conversationId, 1, {
+      kind: 'position-applied',
+    })
+    expect(acceptPositionRequest(restoreReleased, outgoingMessage(2)).active?.request).toEqual(
+      outgoingMessage(2),
+    )
+
+    const live = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const historyRequest: PositionRequest = {
+      generation: 2,
+      conversationId,
+      source: { kind: 'history-preservation', reason: 'window-shift' },
+      desired: {
+        kind: 'anchor',
+        messageId: 'top-visible',
+        placement: { kind: 'top-offset', offsetPx: pixelOffset(-10) },
+      },
+      onUnavailable: {
+        kind: 'distance-from-bottom',
+        distancePx: pixelOffset(500),
+      },
+    }
+    const history = acceptPositionRequest(live, historyRequest)
+    const historyPending = advancePhaseIfCurrent(history, conversationId, 2, {
+      kind: 'mounting',
+      index: 4,
+      messageId: 'top-visible',
+    })
+    expect(acceptPositionRequest(historyPending, outgoingMessage(3))).toBe(
+      historyPending,
+    )
+
+    const historyReleased = advancePhaseIfCurrent(historyPending, conversationId, 2, {
+      kind: 'position-applied',
+    })
+    expect(acceptPositionRequest(historyReleased, outgoingMessage(3)).active?.request).toEqual(
+      outgoingMessage(3),
+    )
+  })
+
+  it('cancels reconciliation separately from follow-live settled geometry', () => {
+    const entry = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const cancelled = cancelReconciliationForUserInput(entry, conversationId, 1)
+
+    // Input at the threshold cancels the current write loop but does not yet prove the reader left.
+    expect(cancelled.active).toEqual({
+      request: liveEntry(1),
+      phase: { kind: 'paused-user-input' },
+    })
+    expect(shouldReconcileAfterAppend(cancelled, conversationId)).toBe(false)
+
+    const stayedAtEdge = settleUserPosition(cancelled, conversationId, true)
+    const leftEdge = settleUserPosition(cancelled, conversationId, false)
+    const rearmRequest: PositionRequest = {
+      generation: 2,
+      conversationId,
+      source: { kind: 'user-navigation', reason: 'live-edge' },
+      desired: liveEdge,
+    }
+    const returnedToEdge = settleUserPosition(
+      leftEdge,
+      conversationId,
+      true,
+      rearmRequest,
+    )
+    expect(shouldReconcileAfterAppend(stayedAtEdge, conversationId)).toBe(true)
+    expect(shouldReconcileAfterAppend(leftEdge, conversationId)).toBe(false)
+    expect(shouldReconcileAfterAppend(returnedToEdge, conversationId)).toBe(true)
+    expect(returnedToEdge.active).toEqual({
+      request: rearmRequest,
+      phase: { kind: 'settled' },
+    })
+    expect(settleUserPosition(cancelled, otherConversationId, false)).toBe(cancelled)
+  })
+
+  it('retains the watermark after cancellation and settlement', () => {
+    const active = acceptPositionRequest(initialPositioningModel(), liveEntry(7))
+    const settled = advancePhaseIfCurrent(active, conversationId, 7, { kind: 'settled' })
+    const cancelled = cancelReconciliationForUserInput(settled, conversationId, 7)
+
+    expect(settled.watermark).toBe(7)
+    expect(acceptPositionRequest(settled, liveEntry(7))).toBe(settled)
+    expect(cancelled.watermark).toBe(7)
+    expect(cancelled.active?.phase).toEqual({ kind: 'paused-user-input' })
+    expect(
+      advancePhaseIfCurrent(cancelled, conversationId, 7, { kind: 'settled' }),
+    ).toBe(cancelled)
+    expect(isCurrentGeneration(cancelled, conversationId, 7)).toBe(true)
+    expect(acceptPositionRequest(settled, liveEntry(8)).watermark).toBe(8)
+  })
+
+  it('deactivates an unmounted conversation without letting stale cleanup clear a newer entry', () => {
+    const roomA = acceptPositionRequest(initialPositioningModel(), liveEntry(1))
+    const inactive = deactivateConversation(roomA, conversationId, 1)
+    expect(inactive).toEqual({
+      ...roomA,
+      currentConversationId: null,
+      active: null,
+      lateMdsEligibleFor: null,
+    })
+    expect(acceptPositionRequest(inactive, lateMds(2))).toBe(inactive)
+
+    const roomB = acceptPositionRequest(inactive, liveEntry(2, otherConversationId))
+    expect(deactivateConversation(roomB, conversationId, 1)).toBe(roomB)
+    expect(deactivateConversation(roomB, otherConversationId, 1)).toBe(roomB)
+  })
+
+  it('rejects non-positive, fractional, and non-finite generations', () => {
+    const initial = initialPositioningModel()
+    expect(acceptPositionRequest(initial, liveEntry(0))).toBe(initial)
+    expect(acceptPositionRequest(initial, liveEntry(1.5))).toBe(initial)
+    expect(acceptPositionRequest(initial, liveEntry(Number.POSITIVE_INFINITY))).toBe(
+      initial,
+    )
+  })
+})

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -1,0 +1,662 @@
+/**
+ * Pure semantic model for message-list positioning.
+ *
+ * This module answers:
+ *   - what position the UI wants,
+ *   - whether that position is reachable yet,
+ *   - which request supersedes an older one, and
+ *   - how user takeover affects reconciliation and follow-live policy.
+ *
+ * It deliberately does NOT implement pixel reconciliation, measurement settling, rAF ownership,
+ * scroll-event classification, or WebKit repaint correction. Those remain the hard responsibilities
+ * of the positioning reconciler.
+ */
+
+declare const messageFractionBrand: unique symbol
+declare const pixelOffsetBrand: unique symbol
+
+/** A validated point within a message: 0 is its top and 1 is its bottom. */
+export type MessageFraction = number & { readonly [messageFractionBrand]: true }
+
+export function messageFraction(value: number): MessageFraction {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError('message fraction must be a finite number between 0 and 1')
+  }
+  return value as MessageFraction
+}
+
+/** A finite CSS-pixel measurement. Negative values are valid where the geometry permits them. */
+export type PixelOffset = number & { readonly [pixelOffsetBrand]: true }
+
+export function pixelOffset(value: number): PixelOffset {
+  if (!Number.isFinite(value)) {
+    throw new RangeError('pixel offset must be finite')
+  }
+  return value as PixelOffset
+}
+
+export type LiveEdgePosition = {
+  /** Follow future rows and bottom-of-list UI, not merely the current last row. */
+  kind: 'live-edge'
+  follow: true
+}
+
+export type BottomFractionAnchorPosition = {
+  kind: 'anchor'
+  messageId: string
+  placement: {
+    /**
+     * Keep this message point at the viewport bottom:
+     * rowTop + fraction * rowHeight = scrollTop + viewportHeight.
+     */
+    kind: 'bottom-fraction'
+    fraction: MessageFraction
+  }
+}
+
+export type TopOffsetAnchorPosition = {
+  kind: 'anchor'
+  messageId: string
+  placement: {
+    /**
+     * Keep the row's top at this viewport-top offset:
+     * rowTop - scrollTop = offsetPx. Negative offsets are valid.
+     */
+    kind: 'top-offset'
+    offsetPx: PixelOffset
+  }
+}
+
+export type MessagePosition<
+  Align extends 'start' | 'top-third' | 'center' | 'end' =
+    | 'start'
+    | 'top-third'
+    | 'center'
+    | 'end',
+> = {
+  kind: 'message'
+  messageId: string
+  align: Align
+}
+
+export type LegacyOffsetPosition = {
+  /**
+   * Transitional support for saved states that predate content anchors. New code must never persist
+   * this as the semantic position.
+   */
+  kind: 'legacy-offset'
+  offsetPx: PixelOffset
+}
+
+export type DesiredPosition =
+  | LiveEdgePosition
+  | BottomFractionAnchorPosition
+  | TopOffsetAnchorPosition
+  | MessagePosition
+  | { kind: 'resident-top' }
+  | LegacyOffsetPosition
+
+export type UnavailablePolicy =
+  | { kind: 'wait' }
+  | { kind: 'live-edge' }
+  | { kind: 'legacy-offset'; offsetPx: PixelOffset; otherwise: 'live-edge' }
+  | { kind: 'distance-from-bottom'; distancePx: PixelOffset }
+  | { kind: 'warn-and-stop' }
+
+type Request<
+  Source,
+  Desired extends DesiredPosition,
+  Unavailable extends UnavailablePolicy | undefined = undefined,
+> = {
+  /** Monotonic token. Async work from an older generation must never affect the active request. */
+  generation: number
+  conversationId: string
+  source: Source
+  desired: Desired
+} & (Unavailable extends UnavailablePolicy
+  ? { onUnavailable: Unavailable }
+  : { onUnavailable?: never })
+
+type EntryRequest =
+  | Request<
+      { kind: 'entry'; reason: 'saved-position' },
+      BottomFractionAnchorPosition,
+      Extract<UnavailablePolicy, { kind: 'live-edge' | 'legacy-offset' }>
+    >
+  | Request<{ kind: 'entry'; reason: 'saved-position' }, LegacyOffsetPosition>
+  | Request<
+      { kind: 'entry'; reason: 'unread-marker' },
+      MessagePosition<'start'>,
+      Extract<UnavailablePolicy, { kind: 'live-edge' }>
+    >
+  | Request<{ kind: 'entry'; reason: 'live-edge' }, LiveEdgePosition>
+  | Request<{ kind: 'entry'; reason: 'synced-live-edge' }, LiveEdgePosition>
+
+type UserNavigationRequest =
+  | Request<
+      { kind: 'user-navigation'; reason: 'message-target' },
+      MessagePosition<'center'>,
+      Extract<UnavailablePolicy, { kind: 'wait' }>
+    >
+  | Request<
+      { kind: 'user-navigation'; reason: 'unread-marker' },
+      MessagePosition<'start' | 'top-third'>,
+      Extract<UnavailablePolicy, { kind: 'live-edge' }>
+    >
+  | Request<{ kind: 'user-navigation'; reason: 'live-edge' }, LiveEdgePosition>
+  | Request<{ kind: 'user-navigation'; reason: 'resident-top' }, { kind: 'resident-top' }>
+
+export type PositionRequest =
+  | EntryRequest
+  | UserNavigationRequest
+  | Request<{ kind: 'live-update'; reason: 'outgoing-message' }, LiveEdgePosition>
+  | Request<
+      { kind: 'history-preservation'; reason: 'window-shift' },
+      TopOffsetAnchorPosition,
+      Extract<UnavailablePolicy, { kind: 'distance-from-bottom' }>
+    >
+  | Request<
+      { kind: 'media-preservation'; reason: 'remeasure' },
+      BottomFractionAnchorPosition,
+      Extract<UnavailablePolicy, { kind: 'warn-and-stop' }>
+    >
+  | Request<
+      {
+        kind: 'late-mds-supersession'
+        reason: 'read-pointer-at-live-edge' | 'divider-cleared'
+      },
+      LiveEdgePosition
+    >
+  | Request<
+      {
+        kind: 'fallback'
+        reason: 'saved-position-unavailable'
+      },
+      LiveEdgePosition | LegacyOffsetPosition
+    >
+  | Request<
+      {
+        kind: 'fallback'
+        reason: 'unread-marker-unavailable'
+      },
+      LiveEdgePosition
+    >
+
+export type PositionRequestSource = PositionRequest['source']
+
+/**
+ * Reachability/convergence lifecycle for one request.
+ *
+ * `pending`, `loading-around`, `mounting`, and `unavailable` make off-window/deep-history targets
+ * explicit. `reconciling` says the semantic position is resolvable; the browser reconciler still
+ * owns measured geometry, one-write-per-frame enforcement, convergence, and repaint behavior.
+ */
+export type PositioningPhase =
+  | { kind: 'resolving' }
+  | {
+      kind: 'pending'
+      reason: 'empty-window' | 'around-load' | 'live-edge-recenter' | 'target-not-indexed'
+    }
+  | { kind: 'loading-around'; messageId: string }
+  | { kind: 'recentering-live-edge' }
+  | { kind: 'mounting'; index: number; messageId?: string }
+  | { kind: 'unavailable'; policy: UnavailablePolicy }
+  | { kind: 'paused-user-input' }
+  | { kind: 'reconciling' }
+  | { kind: 'position-applied' }
+  | { kind: 'settled' }
+
+export interface PositioningModel {
+  /** Highest accepted generation, retained after settle/cancellation to reject stale completions. */
+  watermark: number
+  /** Only an entry request changes the displayed conversation. */
+  currentConversationId: string | null
+  active: {
+    request: PositionRequest
+    phase: PositioningPhase
+  } | null
+  /**
+   * Entry may be provisionally corrected by one late MDS request. User takeover, explicit
+   * navigation, outgoing send, or an accepted MDS correction closes that entry window.
+   */
+  lateMdsEligibleFor: string | null
+}
+
+/**
+ * Contradictory states (for example absent-but-mounted) are unrepresentable. For live edge,
+ * `available` describes the current tail row; for resident top it describes the first resident row.
+ */
+export type ReachabilityFacts =
+  | { kind: 'empty-window' }
+  | {
+      kind: 'target-absent'
+      loadAround: 'available' | 'loading' | 'exhausted' | 'unavailable'
+    }
+  | {
+      kind: 'available'
+      index: number
+      mounted: boolean
+      /** Some placements are intentionally abandoned even after the row becomes reachable. */
+      placement: 'viable' | 'use-unavailable-policy'
+    }
+  | {
+      kind: 'global-live-edge'
+      state:
+        | { kind: 'resident-tail'; index: number; mounted: boolean }
+        | { kind: 'recenter-available' }
+        | { kind: 'recentering' }
+        | { kind: 'unavailable' }
+    }
+
+export interface EntryPositionFacts {
+  /**
+   * The already-resolved remote read pointer says the local saved position is obsolete. This is
+   * evaluated before the ordinary saved/unread/live entry priority.
+   */
+  syncedLiveEdge: boolean
+  savedAnchor?: BottomFractionAnchorPosition
+  savedOffsetPx?: PixelOffset
+  firstUnreadMessageId?: string
+}
+
+export type EntryPositionSelection =
+  | {
+      source: { kind: 'entry'; reason: 'saved-position' }
+      desired: BottomFractionAnchorPosition
+      onUnavailable: Extract<UnavailablePolicy, { kind: 'live-edge' | 'legacy-offset' }>
+    }
+  | {
+      source: { kind: 'entry'; reason: 'saved-position' }
+      desired: LegacyOffsetPosition
+    }
+  | {
+      source: { kind: 'entry'; reason: 'unread-marker' }
+      desired: MessagePosition<'start'>
+      onUnavailable: Extract<UnavailablePolicy, { kind: 'live-edge' }>
+    }
+  | {
+      source: { kind: 'entry'; reason: 'live-edge' }
+      desired: LiveEdgePosition
+    }
+  | {
+      source: { kind: 'entry'; reason: 'synced-live-edge' }
+      desired: LiveEdgePosition
+    }
+
+export interface LiveEdgeNavigationFacts {
+  firstUnreadMessageId?: string
+  /**
+   * Computed from live geometry by the adapter. Virtualized callers treat an unknown marker offset
+   * as needing a visit; non-virtualized callers only set this when the row exists below the
+   * viewport.
+   */
+  unreadMarkerNeedsVisit: boolean
+  unreadMarkerAlign: 'start' | 'top-third'
+}
+
+export type LiveEdgeNavigationSelection =
+  | {
+      source: { kind: 'user-navigation'; reason: 'unread-marker' }
+      desired: MessagePosition<'start' | 'top-third'>
+      onUnavailable: Extract<UnavailablePolicy, { kind: 'live-edge' }>
+    }
+  | {
+      source: { kind: 'user-navigation'; reason: 'live-edge' }
+      desired: LiveEdgePosition
+    }
+
+export const initialPositioningModel = (): PositioningModel => ({
+  watermark: 0,
+  currentConversationId: null,
+  active: null,
+  lateMdsEligibleFor: null,
+})
+
+export function isCurrentGeneration(
+  model: PositioningModel,
+  conversationId: string,
+  generation: number,
+): boolean {
+  return (
+    model.active?.request.conversationId === conversationId &&
+    model.active.request.generation === generation
+  )
+}
+
+/**
+ * Accept a newer request and supersede the previous one.
+ *
+ * Entry chooses the displayed conversation. Automatic late MDS may only correct that same
+ * conversation while its provisional entry window is still eligible. Other requests cannot
+ * resurrect a conversation that is no longer displayed.
+ */
+export function acceptPositionRequest(
+  model: PositioningModel,
+  request: PositionRequest,
+): PositioningModel {
+  if (
+    !Number.isSafeInteger(request.generation) ||
+    request.generation <= model.watermark ||
+    request.generation <= 0
+  ) {
+    return model
+  }
+
+  const isEntry = request.source.kind === 'entry'
+  const isLateMds = request.source.kind === 'late-mds-supersession'
+  if (
+    (!isEntry && request.conversationId !== model.currentConversationId) ||
+    (isLateMds && model.lateMdsEligibleFor !== request.conversationId)
+  ) {
+    return model
+  }
+
+  const active = model.active
+  const preservationPending =
+    active !== null &&
+    active.phase.kind !== 'position-applied' &&
+    active.phase.kind !== 'settled' &&
+    ((active.request.source.kind === 'entry' &&
+      active.request.source.reason === 'saved-position') ||
+      active.request.source.kind === 'history-preservation')
+  if (request.source.kind === 'live-update' && preservationPending) {
+    // Current behavior drops this pin attempt; it does not queue an ownership change behind restore.
+    return model
+  }
+
+  const closesMdsWindow =
+    isLateMds ||
+    request.source.kind === 'user-navigation' ||
+    request.source.kind === 'live-update'
+
+  return {
+    watermark: request.generation,
+    currentConversationId: isEntry ? request.conversationId : model.currentConversationId,
+    active: {
+      request,
+      phase: { kind: 'resolving' },
+    },
+    lateMdsEligibleFor: isEntry
+      ? request.source.reason === 'synced-live-edge'
+        ? null
+        : request.conversationId
+      : closesMdsWindow
+        ? null
+        : model.lateMdsEligibleFor,
+  }
+}
+
+/** Advance only the active conversation/generation; stale async work is an exact no-op. */
+export function advancePhaseIfCurrent(
+  model: PositioningModel,
+  conversationId: string,
+  generation: number,
+  phase: PositioningPhase,
+): PositioningModel {
+  if (!isCurrentGeneration(model, conversationId, generation) || !model.active) return model
+  if (model.active.phase.kind === 'paused-user-input') return model
+  return {
+    ...model,
+    active: {
+      ...model.active,
+      phase,
+    },
+  }
+}
+
+/**
+ * Genuine input cancels the current reconciliation run and closes the late-MDS entry window. A
+ * live-edge request remains generation-bearing in a paused phase until settled geometry says
+ * whether the reader left it. Fixed-position requests are cancelled immediately.
+ */
+export function cancelReconciliationForUserInput(
+  model: PositioningModel,
+  conversationId: string,
+  generation: number,
+): PositioningModel {
+  if (!isCurrentGeneration(model, conversationId, generation)) return model
+  return {
+    ...model,
+    active:
+      model.active?.request.desired.kind === 'live-edge'
+        ? {
+            ...model.active,
+            phase: { kind: 'paused-user-input' },
+          }
+        : null,
+    lateMdsEligibleFor: null,
+  }
+}
+
+/**
+ * Resolve a paused live-edge request from settled user geometry. Remaining at the edge preserves
+ * its generation; leaving cancels it. Manually returning after another request requires a new,
+ * generation-bearing live-edge request supplied by the adapter.
+ */
+export function settleUserPosition(
+  model: PositioningModel,
+  conversationId: string,
+  atLiveEdge: boolean,
+  rearmRequest?: Extract<
+    PositionRequest,
+    { source: { kind: 'user-navigation'; reason: 'live-edge' } }
+  >,
+): PositioningModel {
+  if (conversationId !== model.currentConversationId) return model
+  const active = model.active
+  if (
+    active?.request.desired.kind === 'live-edge' &&
+    active.phase.kind === 'paused-user-input'
+  ) {
+    return atLiveEdge
+      ? {
+          ...model,
+          active: {
+            ...active,
+            phase: { kind: 'settled' },
+          },
+        }
+      : { ...model, active: null }
+  }
+  if (!atLiveEdge || !rearmRequest) return model
+  const rearmed = acceptPositionRequest(model, rearmRequest)
+  return rearmed === model || !rearmed.active
+    ? model
+    : {
+        ...rearmed,
+        active: {
+          ...rearmed.active,
+          phase: { kind: 'settled' },
+        },
+      }
+}
+
+/**
+ * Clear semantic ownership when the list unmounts or navigation leaves conversations. The
+ * generation guard prevents a stale cleanup from deactivating a newer entry.
+ */
+export function deactivateConversation(
+  model: PositioningModel,
+  conversationId: string,
+  generation: number,
+): PositioningModel {
+  if (
+    model.currentConversationId !== conversationId ||
+    model.watermark !== generation
+  ) {
+    return model
+  }
+  return {
+    ...model,
+    currentConversationId: null,
+    active: null,
+    lateMdsEligibleFor: null,
+  }
+}
+
+/**
+ * Resolve semantic reachability without reading DOM/layout geometry.
+ *
+ * The request's unavailable policy preserves source-specific behavior: saved restore can use a
+ * legacy offset then live edge, unread falls back to live edge, explicit targets wait, directional
+ * history preserves distance from bottom, and media-preservation failures stop with a warning.
+ */
+export function resolveReachability(
+  request: PositionRequest,
+  facts: ReachabilityFacts,
+): PositioningPhase {
+  if (facts.kind === 'empty-window') return { kind: 'pending', reason: 'empty-window' }
+
+  if (facts.kind === 'target-absent') {
+    const desired = request.desired
+    if (desired.kind !== 'anchor' && desired.kind !== 'message') {
+      return { kind: 'reconciling' }
+    }
+    if (facts.loadAround === 'available') {
+      return { kind: 'loading-around', messageId: desired.messageId }
+    }
+    if (facts.loadAround === 'loading') {
+      return { kind: 'pending', reason: 'around-load' }
+    }
+    return request.onUnavailable?.kind === 'wait'
+      ? { kind: 'pending', reason: 'target-not-indexed' }
+      : {
+          kind: 'unavailable',
+          policy: request.onUnavailable ?? { kind: 'warn-and-stop' },
+        }
+  }
+
+  if (request.desired.kind === 'live-edge') {
+    if (facts.kind !== 'global-live-edge') {
+      return { kind: 'unavailable', policy: { kind: 'warn-and-stop' } }
+    }
+    const state = facts.state
+    if (state.kind === 'recenter-available') {
+      return { kind: 'recentering-live-edge' }
+    }
+    if (state.kind === 'recentering') {
+      return { kind: 'pending', reason: 'live-edge-recenter' }
+    }
+    if (state.kind === 'unavailable') {
+      return { kind: 'unavailable', policy: { kind: 'warn-and-stop' } }
+    }
+    return state.mounted
+      ? { kind: 'reconciling' }
+      : { kind: 'mounting', index: state.index }
+  }
+
+  if (request.desired.kind === 'legacy-offset') {
+    return { kind: 'reconciling' }
+  }
+
+  if (facts.kind === 'global-live-edge') {
+    return { kind: 'unavailable', policy: { kind: 'warn-and-stop' } }
+  }
+
+  if (facts.placement === 'use-unavailable-policy') {
+    return request.onUnavailable?.kind === 'wait'
+      ? { kind: 'pending', reason: 'target-not-indexed' }
+      : {
+          kind: 'unavailable',
+          policy: request.onUnavailable ?? { kind: 'warn-and-stop' },
+        }
+  }
+
+  if (!facts.mounted) {
+    const desired = request.desired
+    return {
+      kind: 'mounting',
+      index: facts.index,
+      ...(desired.kind === 'anchor' || desired.kind === 'message'
+        ? { messageId: desired.messageId }
+        : {}),
+    }
+  }
+
+  return { kind: 'reconciling' }
+}
+
+/** Select exactly one provisional position for conversation entry. */
+export function selectEntryPosition(facts: EntryPositionFacts): EntryPositionSelection {
+  if (facts.syncedLiveEdge) {
+    return {
+      source: { kind: 'entry', reason: 'synced-live-edge' },
+      desired: { kind: 'live-edge', follow: true },
+    }
+  }
+
+  if (facts.savedAnchor) {
+    return {
+      source: { kind: 'entry', reason: 'saved-position' },
+      desired: facts.savedAnchor,
+      onUnavailable:
+        facts.savedOffsetPx === undefined
+          ? { kind: 'live-edge' }
+          : {
+              kind: 'legacy-offset',
+              offsetPx: facts.savedOffsetPx,
+              otherwise: 'live-edge',
+            },
+    }
+  }
+
+  if (facts.savedOffsetPx !== undefined) {
+    return {
+      source: { kind: 'entry', reason: 'saved-position' },
+      desired: { kind: 'legacy-offset', offsetPx: facts.savedOffsetPx },
+    }
+  }
+
+  if (facts.firstUnreadMessageId) {
+    return {
+      source: { kind: 'entry', reason: 'unread-marker' },
+      desired: {
+        kind: 'message',
+        messageId: facts.firstUnreadMessageId,
+        align: 'start',
+      },
+      onUnavailable: { kind: 'live-edge' },
+    }
+  }
+
+  return {
+    source: { kind: 'entry', reason: 'live-edge' },
+    desired: { kind: 'live-edge', follow: true },
+  }
+}
+
+/**
+ * Preserve FAB/End two-step behavior. The adapter decides from current geometry whether the unread
+ * marker is still below the viewport; the pure arbiter chooses marker first or live edge.
+ */
+export function selectLiveEdgeNavigation(
+  facts: LiveEdgeNavigationFacts,
+): LiveEdgeNavigationSelection {
+  if (facts.firstUnreadMessageId && facts.unreadMarkerNeedsVisit) {
+    return {
+      source: { kind: 'user-navigation', reason: 'unread-marker' },
+      desired: {
+        kind: 'message',
+        messageId: facts.firstUnreadMessageId,
+        align: facts.unreadMarkerAlign,
+      },
+      onUnavailable: { kind: 'live-edge' },
+    }
+  }
+  return {
+    source: { kind: 'user-navigation', reason: 'live-edge' },
+    desired: { kind: 'live-edge', follow: true },
+  }
+}
+
+/** Appended content re-opens reconciliation only while follow-live policy remains armed. */
+export function shouldReconcileAfterAppend(
+  model: PositioningModel,
+  conversationId: string,
+): boolean {
+  return (
+    model.currentConversationId === conversationId &&
+    model.active?.request.desired.kind === 'live-edge' &&
+    model.active.phase.kind !== 'paused-user-input'
+  )
+}

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,0 +1,298 @@
+# Message-list scroll positioning contract
+
+Status: migration contract. The model and tests introduced with this document are pure and do not
+change production scroll behavior.
+
+## Purpose
+
+Message-list positioning currently has several independent implementations for live-edge pinning,
+saved-position restoration, unread markers, explicit message targets, directional history loads,
+and media re-anchoring. Most are individually justified, but they share `scrollTop`, virtualizer
+measurements, cancellation, persistence gates, and WebKit workarounds. Correctness therefore depends
+on effect ordering and on every implementation honoring the same implicit rules.
+
+The migration goal is one positioning authority. This document defines the semantic request and
+lifecycle contract that authority will consume.
+
+It intentionally separates two concerns:
+
+1. **Position policy:** what position is wanted, whether it is reachable, which newer request
+   supersedes an older one, and when user input cancels automatic positioning.
+2. **Browser reconciliation:** how estimated and measured geometry converges on that position,
+   including WebKit layout/repaint behavior.
+
+The first concern can be pure and deterministic. The second remains the hard browser-specific work;
+centralizing it later must not erase or weaken its current safeguards.
+
+## Non-goals for this stage
+
+- Replacing any production rAF loop.
+- Changing entry priority, marker placement, saved scroll data, or history loading.
+- Removing measurement settle windows, tolerances, or WebKit repaint workarounds.
+- Treating a one-shot scroll as sufficient under virtualization.
+- Making raw `scrollTop` a new durable position type.
+- Migrating static search-context lists in the first controller slice. They do not use the live-list
+  positioning hook today and must remain isolated until explicitly brought under this contract.
+
+## Desired positions
+
+`DesiredPosition` has four durable semantic variants plus one migration bridge:
+
+- **Live edge:** keep following appended messages and bottom-of-list UI until genuine user takeover.
+- **Fixed anchor:** keep a point in one message at a stable viewport placement. Its placement is a
+  discriminated type, so the two geometries cannot be mixed:
+  - `bottom-fraction`: saved reading position and media preservation. The fraction is validated in
+    `[0, 1]`, where `0` is the row top and `1` its bottom. The exact equation is
+    `rowTop + fraction * rowHeight = scrollTop + viewportHeight`;
+  - `top-offset`: directional history preservation. The equation is
+    `rowTop - scrollTop = offsetPx`; negative offsets are valid when the top-visible row begins
+    above the viewport.
+- **Message target:** place a message at start, top-third, center, or end for
+  unread/reply/search/activity navigation.
+- **Resident top:** move to the top of the currently loaded window; ordinary history loading may
+  follow.
+- **Legacy offset:** transitional support for anchorless persisted `scrollTop` from existing saved
+  states. New code must not persist it as the semantic position.
+
+Live edge is the only follow-live variant. A fixed anchor on the newest message with fraction `1`
+does **not** follow later appends.
+
+A saved content anchor remains authoritative. Its raw pixel value is a source-specific fallback
+when that anchor is unavailable. An old saved state containing only the raw value selects the
+transitional legacy-offset position and still outranks unread/live-edge entry, preserving current
+behavior.
+
+## Request provenance
+
+Every position request carries:
+
+- a positive, safe-integer monotonic generation;
+- the conversation id;
+- a semantic source;
+- the desired position.
+
+The request is a discriminated union: provenance and desired position must agree. For example, a
+late-MDS request can only want live edge, history preservation can only want a top-offset anchor,
+and outgoing-message provenance cannot request resident top. A fallback that changes the desired
+position also gets honest fallback provenance; it does not retain the source of the failed target.
+
+Sources distinguish:
+
+- provisional conversation entry, including distinct synced-live-edge provenance that tells the
+  adapter to discard obsolete saved state;
+- explicit user navigation;
+- an outgoing message that deliberately returns the sender to live edge;
+- directional history preservation;
+- media remeasurement preservation;
+- late XEP-0490/MDS supersession.
+
+Incoming messages, reactions, typing, composer/container/viewport resize, media measurement, and MAM
+completion are normally **reconciliation stimuli for the current request**, not new competing
+requests. An outgoing send is different: current behavior deliberately moves a reader out of
+history, so it creates a live-edge request. The attempt is dropped while a directional-load or
+entry-restore preservation step is still pending, matching the existing send-stick suppression;
+the preservation owner releases after its first position is applied, not after the entire
+measurement-settle loop. Later ordinary stimuli handle content from any dropped attempt.
+
+## Entry arbitration and later supersession
+
+Entry selects exactly one provisional request:
+
+1. already-resolved synced live edge invalidates stale local state;
+2. saved fixed anchor, or transitional raw-only saved offset;
+3. first unread message;
+4. live edge.
+
+An explicit reply/search/activity target is not folded into this priority table. It is a separate,
+newer request and supersedes the provisional entry request.
+
+The entry choice is not final. XEP-0490/MDS state can resolve after entry:
+
+- a remote read pointer reaches the live edge; or
+- a stale unread divider clears.
+
+Before genuine user takeover, either event may issue a newer live-edge request, but only for the
+currently displayed conversation and only while that provisional entry remains eligible. After
+takeover, explicit navigation, outgoing send, or one accepted MDS correction, the late-MDS entry
+window closes. A delayed result from the room just left must never reactivate it. A later explicit
+user request remains allowed but does not reopen MDS eligibility.
+
+Source priority chooses the one provisional entry request. After entry, generation order governs
+permitted supersession; a newer generation alone does not bypass current-conversation or MDS
+eligibility guards. Async work tagged with a stale generation is ignored.
+
+User input and follow-live are separate facts. Genuine input cancels the current reconciliation
+run immediately. A live-edge request retains its generation in a paused-user-input phase until
+settled geometry shows whether the reader left the edge; stale callbacks cannot resume that pause.
+Input that remains within the bottom threshold settles the same request and keeps following.
+Manually returning to the bottom after another position was cancelled creates a fresh
+generation-bearing live-edge request without reopening late-MDS eligibility.
+
+When the message list unmounts or navigation leaves conversations, a generation-guarded deactivation
+clears the current conversation, active request, and MDS eligibility while retaining the watermark.
+Callbacks from the unmounted conversation are then rejected.
+
+## Reachability lifecycle
+
+The semantic lifecycle is:
+
+```text
+request
+  -> resolving
+      -> pending(empty-window)
+      -> loading-around(message)
+      -> pending(around-load)
+      -> pending(target-not-indexed)
+      -> unavailable(source-specific policy)
+      -> recentering-live-edge
+      -> mounting(index)
+      -> reconciling
+      -> position-applied
+      -> paused-user-input
+      -> settled
+```
+
+These states have distinct meanings:
+
+- An empty hydrating window is not evidence that a saved target is missing.
+- A target absent from a populated item set distinguishes an available around request, a request
+  already loading, and an exhausted/unavailable loader. An empty completed slice cannot trigger the
+  same load forever.
+- If no around-loader can satisfy it, behavior comes from request provenance rather than a generic
+  fallback: saved restore uses legacy offset then live edge, unread uses live edge, explicit targets
+  wait, directional history uses captured distance-from-bottom and clamps, and media preservation
+  warns and stops.
+- A loaded/indexed message can still be absent from the measured virtual window.
+- Live edge can likewise require mounting the tail of a slid-up virtual window; merely having rows
+  does not prove that the global tail is resident. A FAB/live-edge request first recenters a
+  slid-up window, then mounts and reconciles the global tail.
+- A mounted unread marker near the resident start can still reject start placement and use its
+  live-edge fallback, avoiding a scroll-to-zero that spuriously loads older history.
+- Mounting a row and positioning it are separate phases. They must not emit competing targets in
+  the same frame.
+- Reconciling means the semantic target is reachable; it does not mean layout has stabilized.
+
+The generation watermark survives settlement and cancellation. A stale cache load, mount callback,
+measurement, or MDS completion cannot revive cancelled work.
+
+## Reconciler responsibilities
+
+The future single positioning reconciler owns the difficult runtime work below. None belongs in the
+pure model:
+
+- resolve IDs against the loaded item set;
+- request an around slice and resume when it arrives;
+- mount an off-window virtual row;
+- translate current measured geometry into the requested placement;
+- perform at most one positioning target per frame;
+- re-resolve as estimated rows acquire measured sizes;
+- apply purpose-appropriate drift tolerances, stable-frame counts, and hard frame budgets;
+- recover when coalesced height deltas hide the final bottom-pin correction;
+- distinguish growth-driven programmatic scroll events from genuine takeover;
+- keep transient programmatic positions out of saved reading state;
+- cancel WebKit kinetic scrolling around directional history loads;
+- force/coalesce WebKit repaint when layout is correct but painted pixels are stale;
+- guarantee single-flight ownership and cancel stale generations.
+
+In particular, the model describes **what position is wanted**. It does not make measurement settle
+or stale-paint reconciliation disappear.
+
+## Current behavior inventory
+
+| Current trigger | Semantic position | Reachability / supersession notes |
+| --- | --- | --- |
+| Entry with saved state | Fixed bottom-relative fractional anchor | Empty window waits; absent target can load around; indexed target may need mounting |
+| Entry with raw-only legacy state | Transitional legacy offset | Still outranks unread/live edge; not persisted by new semantic code |
+| Entry with unread | Message at start | Cache hydration and virtual mounting may delay resolution |
+| Entry without restore/unread | Live edge | Remains follow-live until user leaves it |
+| Explicit reply/search/activity target | Message at center | Newer request supersedes provisional entry; missing target can load around |
+| Jump-to-last-read | Message at start | Reuses unread-marker placement |
+| FAB or live-edge keyboard command | Unread marker, then live edge | If the marker is still below the viewport, first activation visits it (virtualized start alignment; current non-virtualized path uses top-third); a later activation goes live |
+| Outgoing message | Live edge | Deliberately supersedes a fixed historical position after its first landing releases preservation ownership; it need not wait for full convergence |
+| Incoming message | Existing live edge only | Must not make a fixed anchor follow |
+| Late MDS live-edge state | Live edge | Newer automatic request only before user takeover |
+| Media at live edge | Existing live edge | Debounced measurement stimulus |
+| Media while reading history | Fixed bottom-relative fractional anchor | Preserve the reading point through remeasurement |
+| Load older/newer | Fixed top-relative offset anchor | Wait for the directional window change; if the anchor disappears, preserve captured distance from bottom and clamp |
+| Home / resident-top command | Resident top | May subsequently trigger ordinary load-older |
+| Reaction, typing, resize, MAM completion | Current live edge, when active | Geometry stimulus, not a new position request |
+
+The FAB/End choice is made from current geometry, not a remembered click state. If the unread marker
+is already visible or above the viewport, the same activation goes directly to live edge.
+
+## Current owners to migrate
+
+`useMessageListScroll` currently contains separate implementations for:
+
+- `pinVirtualizedBottom`;
+- `pinVirtualizedAnchor`;
+- `runMarkerReassertLoop`;
+- the explicit target-message loop;
+- directional-load measurement reassertion.
+
+There are also positioning owners outside their shared single-flight ref:
+
+- send/composer resize writes in `ChatView` and `RoomView`;
+- `scrollToMessage` through `activeMessageListController`;
+- keyboard selection navigation in `useMessageSelection` (`scrollIntoView({ block: 'nearest' })`);
+- resident-top's direct writer;
+- non-virtualized marker/target/restore writers inside `useMessageListScroll`;
+- static search-context positioning.
+
+A later migration is incomplete until each in-scope owner either routes through the controller or is
+explicitly documented as an isolated, non-competing context. New controller code must replace and
+delete old owners rather than wrap them indefinitely.
+
+## Test standard
+
+Pure-model tests use paired controls that differ by one semantic fact. Every test must identify a
+plausible incorrect implementation that would make it fail.
+
+Required controls include:
+
+- live edge follows an append; an anchor on the same tail message does not;
+- message target, resident top, and legacy offset do not follow appends either;
+- empty window, target absent with loader, target absent without loader, indexed/unmounted, and
+  mounted resolve to different phases;
+- load-around available, in-flight, and exhausted resolve differently;
+- source-specific target-unavailable policies remain different;
+- an unmounted live-edge tail mounts before reconciliation;
+- a slid-up window recenters before treating its resident bottom as the global live edge;
+- a legacy raw offset reconciles without mounting an unrelated row;
+- a mounted unread marker at the resident start takes its live-edge fallback;
+- already-resolved synced live edge changes the entry selection from saved anchor to live edge;
+- saved anchor and raw-only legacy state beat unread; unread beats ordinary live-edge fallback;
+- FAB/End chooses the unread marker only while live geometry says it still needs a visit;
+- a newer explicit target supersedes the provisional entry generation;
+- stale generation phase completion is ignored while current generation completion succeeds;
+- stale input cancellation is ignored;
+- late MDS supersedes eligible entry but is rejected after takeover/navigation and after switching
+  conversations;
+- outgoing send cannot steal ownership from pending saved/directional preservation;
+- outgoing send may proceed after the preservation position is first applied, before full settle;
+- input cancels reconciliation while settled bottom geometry independently preserves, clears, or
+  re-arms follow-live;
+- deactivation blocks callbacks from an unmounted conversation;
+- cancellation and settlement preserve the generation watermark;
+- incompatible provenance/position pairs fail compile-time controls.
+
+Tests must assert complete results where practical. A test that only repeats fixture arithmetic or
+asserts that an enum contains the value supplied by the fixture does not protect behavior.
+
+Pixel convergence remains a real-engine concern. When runtime migration begins, mechanism-level unit
+tests must be paired with Chromium/WebKit scroll invariants and real desktop WebKit validation for
+kinetic scrolling and stale-paint behavior.
+
+## Incremental migration after this contract
+
+1. Introduce one generation-aware reconciliation controller without changing existing positioning.
+2. Migrate saved-anchor restoration, then delete its private loop.
+3. Migrate unread and explicit message targets, then delete their private loops.
+4. Migrate live-edge pinning while retaining bottom-specific measurement/repaint safeguards.
+5. Migrate directional history preservation last, retaining kinetic cancellation and clamp recovery.
+6. Route or isolate the remaining owners outside `useMessageListScroll`.
+7. Split persistence, user-intent tracking, history windowing, and reconciliation out of the
+   orchestration hook.
+
+Each migration must preserve observable behavior, add a falsifiable regression control, and remove
+one previous source of scroll authority.


### PR DESCRIPTION
## Summary

- define a DOM-free semantic model for message-list positioning requests, arbitration, reachability, fallbacks, and user takeover
- distinguish follow-live policy from fixed anchors and browser reconciliation
- document the current positioning owners, preserved edge cases, and incremental migration sequence
- add 22 falsifiable model controls, including raw legacy restore, late MDS eligibility, load-around/recenter states, preservation ownership, and global live-edge behavior

## Why

Scroll positioning behavior is currently distributed across several loops and direct writers. Their intent, pending states, and supersession rules are implicit, which makes individually justified fixes interact unpredictably.

This PR establishes the behavior contract for a staged simplification. It intentionally does **not** change production scroll behavior or replace the measurement-settle and WebKit repaint reconciliation mechanisms.

## Validation

- `npm run typecheck`
- `npm run lint` (existing repository warnings only)
- `npm test`: 5,127 SDK tests and 5,239 app tests passed; 22 app tests skipped
- focused positioning model suite: 22 tests passed
- `npm run test:scroll`: 52/52 Chromium and WebKit invariants passed
