### PR TITLE
Add generation-aware scroll positioning controller in shadow mode

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import { PositioningController, type PositionRequestDraft } from './positioningController'
+import {
+  deriveAtLiveEdge,
+  deriveEntryPositionFacts,
+  deriveGlobalLiveEdgeReachability,
+  deriveLiveEdgeNavigationFacts,
+  deriveTargetReachability,
+  readScrollGeometry,
+} from './scrollPositionFacts'
+import {
+  getScrollShadowSnapshot,
+  resetScrollShadowDiagnostics,
+} from './scrollPositionShadow'
+import {
+  messageFraction,
+  type BottomFractionAnchorPosition,
+  type LiveEdgePosition,
+} from './scrollPositionModel'
+import { recordedPositioningTraces } from './positioningController.traceFixtures'
+
+const conversationId = 'room@example.test'
+const liveEdge: LiveEdgePosition = { kind: 'live-edge', follow: true }
+
+function liveEntryFacts() {
+  return deriveEntryPositionFacts({
+    syncedLiveEdge: false,
+    savedAnchor: null,
+    savedOffsetPx: null,
+  })
+}
+
+function liveReachability() {
+  return deriveGlobalLiveEdgeReachability({
+    hasRows: true,
+    windowAtLiveEdge: true,
+  })
+}
+
+function observeLiveEntry(controller: PositioningController, id = conversationId) {
+  return controller.observeEntry({
+    event: 'entry',
+    conversationId: id,
+    entryFacts: liveEntryFacts(),
+    reachability: () => liveReachability(),
+    actual: { desired: liveEdge, phase: 'positioning' },
+  })
+}
+
+beforeEach(() => {
+  resetScrollShadowDiagnostics()
+})
+
+describe('positioning controller shadow mode', () => {
+  it('mints strictly increasing generations across controllers and conversation switches', () => {
+    const firstController = new PositioningController()
+    const first = observeLiveEntry(firstController)
+    const switched = observeLiveEntry(firstController, 'next-room@example.test')
+    const remountedController = new PositioningController()
+    const remounted = observeLiveEntry(remountedController)
+
+    // A per-instance counter reset would make the remounted generation equal the first.
+    expect(first?.generation).toBeGreaterThan(0)
+    expect(switched!.generation).toBeGreaterThan(first!.generation)
+    expect(remounted!.generation).toBeGreaterThan(switched!.generation)
+    expect(getScrollShadowSnapshot()).toMatchObject({
+      generationCount: 3,
+      divergenceCount: 0,
+    })
+  })
+
+  it('derives live-edge truth from current geometry, not a stale at-bottom latch', () => {
+    const geometry = readScrollGeometry({
+      scrollTop: 100,
+      scrollHeight: 1200,
+      clientHeight: 500,
+    } as HTMLElement)
+    const staleIsAtBottomLatch = true
+
+    // Control: using the stale latch would return true; geometry is 600px from the bottom.
+    expect(staleIsAtBottomLatch).toBe(true)
+    expect(geometry.distanceFromBottom).toBe(600)
+    expect(deriveAtLiveEdge(geometry, AT_BOTTOM_THRESHOLD)).toBe(false)
+  })
+
+  it('flags a legacy bottom reassert when neither the request nor live geometry owns it', () => {
+    const controller = new PositioningController()
+    const actualFollowsStaleLatch = controller.observeBottomReassert({
+      event: 'stale-latch',
+      conversationId,
+      geometryAtLiveEdge: false,
+      actualFollowsLive: true,
+    })
+
+    // A comparator that copied isAtBottomRef would accept this unsupported write.
+    expect(actualFollowsStaleLatch).toBe(false)
+    expect(getScrollShadowSnapshot().divergenceCount).toBe(1)
+
+    resetScrollShadowDiagnostics()
+    const measuredLiveEdge = controller.observeBottomReassert({
+      event: 'measured-live-edge',
+      conversationId,
+      geometryAtLiveEdge: true,
+      actualFollowsLive: true,
+    })
+    expect(measuredLiveEdge).toBe(true)
+    expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
+  })
+
+  it('rejects request/fact mismatches instead of converting them to warn-and-stop', () => {
+    const controller = new PositioningController()
+    const liveDraft: PositionRequestDraft = {
+      source: { kind: 'entry', reason: 'live-edge' },
+      desired: liveEdge,
+    }
+    const rejected = controller.observeRequest({
+      event: 'bad-live-facts',
+      conversationId,
+      draft: liveDraft,
+      reachability: {
+        kind: 'available',
+        index: 4,
+        mounted: true,
+        placement: 'viable',
+      },
+      actual: { desired: null, phase: 'idle' },
+    })
+
+    // A generic resolver would accept this and return unavailable(warn-and-stop).
+    expect(rejected).toBeNull()
+    expect(controller.snapshot().currentConversationId).toBeNull()
+    const anchoredController = new PositioningController()
+    const rejectedAnchor = anchoredController.observeRequest({
+      event: 'bad-anchor-facts',
+      conversationId,
+      draft: {
+        source: { kind: 'entry', reason: 'saved-position' },
+        desired: {
+          kind: 'anchor',
+          messageId: 'message-20',
+          placement: {
+            kind: 'bottom-fraction',
+            fraction: messageFraction(0.75),
+          },
+        },
+        onUnavailable: { kind: 'live-edge' },
+      },
+      reachability: liveReachability(),
+      actual: { desired: null, phase: 'idle' },
+    })
+    expect(rejectedAnchor).toBeNull()
+    expect(anchoredController.snapshot().currentConversationId).toBeNull()
+    expect(getScrollShadowSnapshot()).toMatchObject({
+      decisionCount: 2,
+      divergenceCount: 0,
+    })
+  })
+
+  it('preserves synced-live-edge precedence over a saved anchor on real entry facts', () => {
+    const trace = recordedPositioningTraces.syncedLiveEdgeEntry
+    const persisted: ScrollAnchor = trace.savedAnchor
+    const controller = new PositioningController()
+    const request = controller.observeEntry({
+      event: 'synced-entry',
+      conversationId: trace.conversationId,
+      entryFacts: deriveEntryPositionFacts({
+        syncedLiveEdge: true,
+        savedAnchor: persisted,
+        savedOffsetPx: trace.savedOffsetPx,
+        firstUnreadMessageId: trace.firstUnreadMessageId,
+      }),
+      reachability: () => liveReachability(),
+      actual: { desired: liveEdge, phase: 'positioning' },
+    })
+
+    // A saved-first implementation would select message-20 instead.
+    expect(request?.source).toEqual({ kind: 'entry', reason: 'synced-live-edge' })
+    expect(request?.desired).toEqual(liveEdge)
+    expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
+  })
+
+  it('allows outgoing send to supersede media preservation', () => {
+    const trace = recordedPositioningTraces.mediaThenOutgoing
+    const mediaAnchor: BottomFractionAnchorPosition = {
+      kind: 'anchor',
+      messageId: trace.anchor.messageId,
+      placement: {
+        kind: 'bottom-fraction',
+        fraction: messageFraction(trace.anchor.fraction),
+      },
+    }
+    const controller = new PositioningController()
+    observeLiveEntry(controller, trace.conversationId)
+    const mediaDraft: PositionRequestDraft = {
+      source: { kind: 'media-preservation', reason: 'remeasure' },
+      desired: mediaAnchor,
+      onUnavailable: { kind: 'warn-and-stop' },
+    }
+    controller.observeRequest({
+      event: 'media-preservation',
+      conversationId: trace.conversationId,
+      draft: mediaDraft,
+      reachability: {
+        kind: 'available',
+        index: trace.anchor.index,
+        mounted: true,
+        placement: 'viable',
+      },
+      actual: { desired: mediaAnchor, phase: 'positioning' },
+    })
+    const outgoing = controller.observeRequest({
+      event: 'outgoing-after-media',
+      conversationId: trace.conversationId,
+      draft: {
+        source: { kind: 'live-update', reason: 'outgoing-message' },
+        desired: liveEdge,
+      },
+      reachability: liveReachability(),
+      actual: { desired: liveEdge, phase: 'positioning' },
+    })
+
+    // Wrongly treating every preservation source as blocking would return null.
+    expect(outgoing?.source).toEqual({
+      kind: 'live-update',
+      reason: 'outgoing-message',
+    })
+    expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
+  })
+
+  it('releases outgoing suppression after the first saved-position write, before settle', () => {
+    const trace = recordedPositioningTraces.savedRestoreThenOutgoing
+    const traceAnchor: BottomFractionAnchorPosition = {
+      kind: 'anchor',
+      messageId: trace.anchor.messageId,
+      placement: {
+        kind: 'bottom-fraction',
+        fraction: messageFraction(trace.anchor.fraction),
+      },
+    }
+    const controller = new PositioningController()
+    const saved = controller.observeEntry({
+      event: 'saved-entry',
+      conversationId: trace.conversationId,
+      entryFacts: deriveEntryPositionFacts({
+        syncedLiveEdge: false,
+        savedAnchor: trace.anchor,
+        savedOffsetPx: trace.savedOffsetPx,
+      }),
+      reachability: () => ({
+        kind: 'available',
+        index: trace.anchor.index,
+        mounted: true,
+        placement: 'viable',
+      }),
+      actual: { desired: traceAnchor, phase: 'positioning' },
+    })
+    const dropped = controller.observeRequest({
+      event: 'outgoing-before-landing',
+      conversationId: trace.conversationId,
+      draft: {
+        source: { kind: 'live-update', reason: 'outgoing-message' },
+        desired: liveEdge,
+      },
+      reachability: liveReachability(),
+      actual: { desired: null, phase: 'idle' },
+    })
+    controller.markPositionApplied(trace.conversationId, saved!.generation)
+    const accepted = controller.observeRequest({
+      event: 'outgoing-after-landing',
+      conversationId: trace.conversationId,
+      draft: {
+        source: { kind: 'live-update', reason: 'outgoing-message' },
+        desired: liveEdge,
+      },
+      reachability: liveReachability(),
+      actual: { desired: liveEdge, phase: 'positioning' },
+    })
+
+    // Waiting for settled instead of position-applied would reject both attempts.
+    expect(dropped).toBeNull()
+    expect(accepted).not.toBeNull()
+    expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
+  })
+})
+
+describe('position fact adapters', () => {
+  it('derives mounted state from the current virtual window', () => {
+    const virtualizer = {
+      itemCount: 100,
+      getIndexForMessageId: () => 42,
+      getVirtualItems: () => [{ index: 42, start: 1000, size: 64, key: 'message-42' }],
+    } as unknown as MessageVirtualizer
+    const mounted = deriveTargetReachability({
+      messageId: 'message-42',
+      hasRows: true,
+      virtualizer,
+      loadAround: 'available',
+    })
+    virtualizer.getVirtualItems = () => []
+    const unmounted = deriveTargetReachability({
+      messageId: 'message-42',
+      hasRows: true,
+      virtualizer,
+      loadAround: 'available',
+    })
+
+    // Remembering a previous mount would return the same result for both current windows.
+    expect(mounted).toMatchObject({ kind: 'available', mounted: true })
+    expect(unmounted).toMatchObject({ kind: 'available', mounted: false })
+  })
+
+  it('derives FAB marker-first behavior from its current offset', () => {
+    const geometry = readScrollGeometry({
+      scrollTop: 500,
+      scrollHeight: 3000,
+      clientHeight: 600,
+    } as HTMLElement)
+    const below = deriveLiveEdgeNavigationFacts({
+      firstUnreadMessageId: 'message-50',
+      markerOffsetPx: 1400,
+      geometry,
+      virtualized: true,
+    })
+    const visible = deriveLiveEdgeNavigationFacts({
+      firstUnreadMessageId: 'message-50',
+      markerOffsetPx: 900,
+      geometry,
+      virtualized: true,
+    })
+
+    expect(below.unreadMarkerNeedsVisit).toBe(true)
+    expect(visible.unreadMarkerNeedsVisit).toBe(false)
+  })
+})

--- a/apps/fluux/src/components/conversation/positioningController.traceFixtures.ts
+++ b/apps/fluux/src/components/conversation/positioningController.traceFixtures.ts
@@ -1,0 +1,41 @@
+/**
+ * Normalized semantic captures from real scroll traces.
+ *
+ * The raw traces contain timing, DOM, and paint data that the semantic controller deliberately
+ * does not consume. These fixtures retain only the facts presented at each arbitration seam.
+ */
+export const recordedPositioningTraces = {
+  savedRestoreThenOutgoing: {
+    provenance:
+      'Safari room-switch trace, 2026-07-23: RESTORE via virtualizer index before restore-anchor rAF settle',
+    conversationId: 'fluux-messenger@conference.process-one.net',
+    messageCount: 100,
+    savedOffsetPx: 4949,
+    anchor: {
+      messageId: 'f863062b-c179-49e4-956c-d12ab4c5f60b',
+      fraction: 0.9257401714932859,
+      index: 41,
+    },
+  },
+  mediaThenOutgoing: {
+    provenance:
+      'scroll-invariants invariant-11: media batch preserves stress-0-33 while scrolled up',
+    conversationId: 'stress-0@conference.fluux.chat',
+    anchor: {
+      messageId: 'stress-0-33',
+      fraction: 0.75,
+      index: 33,
+    },
+  },
+  syncedLiveEdgeEntry: {
+    provenance:
+      'useMessageListScroll synced-live-edge entry scenario: resolved remote pointer equals resident tail before entry arbitration',
+    conversationId: 'synced-live-edge',
+    savedOffsetPx: 200,
+    savedAnchor: {
+      messageId: 'msg-5',
+      fraction: 1,
+    },
+    firstUnreadMessageId: 'msg-6',
+  },
+} as const

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -1,0 +1,282 @@
+import {
+  acceptPositionRequest,
+  advancePhaseIfCurrent,
+  cancelReconciliationForUserInput,
+  deactivateConversation,
+  initialPositioningModel,
+  resolveReachability,
+  selectEntryPosition,
+  selectLiveEdgeNavigation,
+  settleUserPosition,
+  shouldReconcileAfterAppend,
+  type EntryPositionFacts,
+  type LiveEdgeNavigationFacts,
+  type PositionRequest,
+  type PositioningModel,
+  type ReachabilityFacts,
+} from './scrollPositionModel'
+import {
+  compareShadowDecision,
+  phaseCategory,
+  recordShadowGeneration,
+  type ShadowActualDecision,
+} from './scrollPositionShadow'
+
+type PositionRequestDraft = PositionRequest extends infer Request
+  ? Request extends PositionRequest
+    ? Omit<Request, 'generation' | 'conversationId'>
+    : never
+  : never
+
+let nextPositionGeneration = 1
+
+function mintPositionGeneration(): number {
+  const generation = nextPositionGeneration
+  if (!Number.isSafeInteger(generation)) {
+    throw new RangeError('scroll position generation exhausted')
+  }
+  nextPositionGeneration += 1
+  recordShadowGeneration(generation)
+  return generation
+}
+
+function withIdentity(
+  conversationId: string,
+  generation: number,
+  draft: PositionRequestDraft,
+): PositionRequest {
+  return { ...draft, conversationId, generation } as PositionRequest
+}
+
+export function reachabilityMatchesRequest(
+  request: PositionRequest,
+  facts: ReachabilityFacts,
+): boolean {
+  if (facts.kind === 'empty-window') return true
+  switch (request.desired.kind) {
+    case 'live-edge':
+      return facts.kind === 'global-live-edge'
+    case 'anchor':
+    case 'message':
+      return facts.kind === 'target-absent' || facts.kind === 'available'
+    case 'resident-top':
+      return facts.kind === 'available'
+    case 'legacy-offset':
+      return facts.kind === 'available'
+  }
+}
+
+export class PositioningController {
+  private model: PositioningModel = initialPositioningModel()
+
+  snapshot(): PositioningModel {
+    return this.model
+  }
+
+  observeEntry(input: {
+    event: string
+    conversationId: string
+    entryFacts: EntryPositionFacts
+    reachability: (desired: PositionRequest['desired']) => ReachabilityFacts
+    actual: ShadowActualDecision
+  }): PositionRequest | null {
+    const selection = selectEntryPosition(input.entryFacts)
+    const draft = selection as PositionRequestDraft
+    return this.observeRequest({
+      event: input.event,
+      conversationId: input.conversationId,
+      actual: input.actual,
+      draft: selection as PositionRequestDraft,
+      reachability: input.reachability(draft.desired),
+    })
+  }
+
+  observeRequest(input: {
+    event: string
+    conversationId: string
+    draft: PositionRequestDraft
+    reachability: ReachabilityFacts
+    actual: ShadowActualDecision
+  }): PositionRequest | null {
+    const generation = mintPositionGeneration()
+    const request = withIdentity(input.conversationId, generation, input.draft)
+    if (!reachabilityMatchesRequest(request, input.reachability)) {
+      compareShadowDecision({
+        event: `${input.event}:fact-mismatch`,
+        conversationId: input.conversationId,
+        generation,
+        expected: { desired: null, phase: 'idle' },
+        actual: input.actual,
+      })
+      return null
+    }
+
+    const previous = this.model
+    const accepted = acceptPositionRequest(previous, request)
+    if (accepted === previous) {
+      compareShadowDecision({
+        event: input.event,
+        conversationId: input.conversationId,
+        generation,
+        expected: { desired: null, phase: 'idle' },
+        actual: input.actual,
+      })
+      return null
+    }
+
+    const phase = resolveReachability(request, input.reachability)
+    this.model = advancePhaseIfCurrent(
+      accepted,
+      input.conversationId,
+      generation,
+      phase,
+    )
+    compareShadowDecision({
+      event: input.event,
+      conversationId: input.conversationId,
+      generation,
+      expected: {
+        desired: request.desired,
+        phase: phaseCategory(phase),
+      },
+      actual: input.actual,
+    })
+    return request
+  }
+
+  observeLiveEdgeNavigation(input: {
+    event: string
+    conversationId: string
+    navigationFacts: LiveEdgeNavigationFacts
+    reachability: (desired: PositionRequest['desired']) => ReachabilityFacts
+    actual: ShadowActualDecision
+  }): PositionRequest | null {
+    const draft = selectLiveEdgeNavigation(
+      input.navigationFacts,
+    ) as PositionRequestDraft
+    return this.observeRequest({
+      event: input.event,
+      conversationId: input.conversationId,
+      draft,
+      reachability: input.reachability(draft.desired),
+      actual: input.actual,
+    })
+  }
+
+  observeAppend(input: {
+    event: string
+    conversationId: string
+    actualFollowsLive: boolean
+  }): boolean {
+    const expectedFollowsLive = shouldReconcileAfterAppend(
+      this.model,
+      input.conversationId,
+    )
+    compareShadowDecision({
+      event: input.event,
+      conversationId: input.conversationId,
+      generation: this.model.active?.request.generation ?? null,
+      expected: {
+        desired: expectedFollowsLive
+          ? this.model.active?.request.desired ?? null
+          : null,
+        phase: expectedFollowsLive ? 'positioning' : 'idle',
+      },
+      actual: {
+        desired: input.actualFollowsLive
+          ? { kind: 'live-edge', follow: true }
+          : null,
+        phase: input.actualFollowsLive ? 'positioning' : 'idle',
+      },
+    })
+    return expectedFollowsLive
+  }
+
+  /**
+   * Mirror the legacy shared reassert gate without importing its at-bottom latch. A reassert is
+   * justified either by semantic follow-live ownership or by geometry that is currently at the
+   * live edge. The second clause preserves today's settle/repaint behavior while making a stale
+   * latch falsifiable in shadow mode.
+   */
+  observeBottomReassert(input: {
+    event: string
+    conversationId: string
+    geometryAtLiveEdge: boolean
+    actualFollowsLive: boolean
+  }): boolean {
+    const expectedFollowsLive =
+      shouldReconcileAfterAppend(this.model, input.conversationId) ||
+      input.geometryAtLiveEdge
+    compareShadowDecision({
+      event: input.event,
+      conversationId: input.conversationId,
+      generation: this.model.active?.request.generation ?? null,
+      expected: {
+        desired: expectedFollowsLive
+          ? { kind: 'live-edge', follow: true }
+          : null,
+        phase: expectedFollowsLive ? 'positioning' : 'idle',
+      },
+      actual: {
+        desired: input.actualFollowsLive
+          ? { kind: 'live-edge', follow: true }
+          : null,
+        phase: input.actualFollowsLive ? 'positioning' : 'idle',
+      },
+    })
+    return expectedFollowsLive
+  }
+
+  markPositionApplied(conversationId: string, generation: number): void {
+    this.model = advancePhaseIfCurrent(
+      this.model,
+      conversationId,
+      generation,
+      { kind: 'position-applied' },
+    )
+  }
+
+  observeUserInput(conversationId: string): void {
+    const generation = this.model.active?.request.generation
+    if (generation === undefined) return
+    this.model = cancelReconciliationForUserInput(
+      this.model,
+      conversationId,
+      generation,
+    )
+  }
+
+  observeSettledUserGeometry(input: {
+    conversationId: string
+    atLiveEdge: boolean
+  }): void {
+    const rearmRequest: Extract<
+      PositionRequest,
+      { source: { kind: 'user-navigation'; reason: 'live-edge' } }
+    > | undefined =
+      input.atLiveEdge && this.model.active === null
+        ? {
+            generation: mintPositionGeneration(),
+            conversationId: input.conversationId,
+            source: { kind: 'user-navigation', reason: 'live-edge' },
+            desired: { kind: 'live-edge', follow: true },
+          }
+        : undefined
+    this.model = settleUserPosition(
+      this.model,
+      input.conversationId,
+      input.atLiveEdge,
+      rearmRequest,
+    )
+  }
+
+  deactivate(conversationId: string): void {
+    this.model = deactivateConversation(
+      this.model,
+      conversationId,
+      this.model.watermark,
+    )
+  }
+}
+
+export type { PositionRequestDraft }

--- a/apps/fluux/src/components/conversation/scrollPositionFacts.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionFacts.ts
@@ -1,0 +1,220 @@
+import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
+import type { MessageVirtualizer } from './messageVirtualizer'
+import {
+  messageFraction,
+  pixelOffset,
+  type BottomFractionAnchorPosition,
+  type DesiredPosition,
+  type EntryPositionFacts,
+  type LiveEdgeNavigationFacts,
+  type ReachabilityFacts,
+} from './scrollPositionModel'
+
+export interface ScrollGeometrySnapshot {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  distanceFromBottom: number
+}
+
+export function readScrollGeometry(scroller: Pick<
+  HTMLElement,
+  'scrollTop' | 'scrollHeight' | 'clientHeight'
+>): ScrollGeometrySnapshot {
+  const { scrollTop, scrollHeight, clientHeight } = scroller
+  return {
+    scrollTop,
+    scrollHeight,
+    clientHeight,
+    distanceFromBottom: scrollHeight - scrollTop - clientHeight,
+  }
+}
+
+export function deriveAtLiveEdge(
+  geometry: ScrollGeometrySnapshot,
+  threshold = AT_BOTTOM_THRESHOLD,
+): boolean {
+  return geometry.distanceFromBottom < threshold
+}
+
+export function deriveEntryPositionFacts(input: {
+  syncedLiveEdge: boolean
+  savedAnchor: ScrollAnchor | null
+  savedOffsetPx: number | null
+  firstUnreadMessageId?: string
+}): EntryPositionFacts {
+  const savedAnchor: BottomFractionAnchorPosition | undefined = input.savedAnchor
+    ? {
+        kind: 'anchor',
+        messageId: input.savedAnchor.messageId,
+        placement: {
+          kind: 'bottom-fraction',
+          fraction: messageFraction(input.savedAnchor.fraction),
+        },
+      }
+    : undefined
+  return {
+    syncedLiveEdge: input.syncedLiveEdge,
+    ...(savedAnchor ? { savedAnchor } : {}),
+    ...(input.savedOffsetPx === null
+      ? {}
+      : { savedOffsetPx: pixelOffset(input.savedOffsetPx) }),
+    ...(input.firstUnreadMessageId
+      ? { firstUnreadMessageId: input.firstUnreadMessageId }
+      : {}),
+  }
+}
+
+export function deriveLiveEdgeNavigationFacts(input: {
+  firstUnreadMessageId?: string
+  markerOffsetPx: number | null
+  geometry: ScrollGeometrySnapshot
+  virtualized: boolean
+}): LiveEdgeNavigationFacts {
+  const markerNeedsVisit =
+    !!input.firstUnreadMessageId &&
+    (input.virtualized
+      ? input.markerOffsetPx === null ||
+        input.markerOffsetPx > input.geometry.scrollTop + input.geometry.clientHeight
+      : input.markerOffsetPx !== null &&
+        input.markerOffsetPx > input.geometry.scrollTop + input.geometry.clientHeight)
+  return {
+    ...(input.firstUnreadMessageId
+      ? { firstUnreadMessageId: input.firstUnreadMessageId }
+      : {}),
+    unreadMarkerNeedsVisit: markerNeedsVisit,
+    unreadMarkerAlign: input.virtualized ? 'start' : 'top-third',
+  }
+}
+
+function isVirtualIndexMounted(virtualizer: MessageVirtualizer, index: number): boolean {
+  return typeof virtualizer.getVirtualItems === 'function' &&
+    virtualizer.getVirtualItems().some((item) => item.index === index)
+}
+
+export function deriveTargetReachability(input: {
+  messageId: string
+  hasRows: boolean
+  virtualizer?: MessageVirtualizer
+  scroller?: HTMLElement | null
+  loadAround: 'available' | 'loading' | 'exhausted' | 'unavailable'
+  placementViable?: boolean
+}): ReachabilityFacts {
+  if (!input.hasRows) return { kind: 'empty-window' }
+  const index =
+    input.virtualizer &&
+    typeof input.virtualizer.getIndexForMessageId === 'function'
+      ? input.virtualizer.getIndexForMessageId(input.messageId)
+      : null
+  if (input.virtualizer) {
+    if (index === null) {
+      return { kind: 'target-absent', loadAround: input.loadAround }
+    }
+    return {
+      kind: 'available',
+      index,
+      mounted: isVirtualIndexMounted(input.virtualizer, index),
+      placement: input.placementViable === false ? 'use-unavailable-policy' : 'viable',
+    }
+  }
+  const element = input.scroller?.querySelector(
+    `[data-message-id="${CSS.escape(input.messageId)}"]`,
+  )
+  if (!element) return { kind: 'target-absent', loadAround: input.loadAround }
+  return {
+    kind: 'available',
+    index: 0,
+    mounted: true,
+    placement: input.placementViable === false ? 'use-unavailable-policy' : 'viable',
+  }
+}
+
+export function deriveGlobalLiveEdgeReachability(input: {
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+  virtualizer?: MessageVirtualizer
+  recentering?: boolean
+  canRecenter?: boolean
+}): ReachabilityFacts {
+  if (!input.hasRows) return { kind: 'empty-window' }
+  if (!input.windowAtLiveEdge) {
+    return {
+      kind: 'global-live-edge',
+      state: input.recentering
+        ? { kind: 'recentering' }
+        : input.canRecenter === false
+          ? { kind: 'unavailable' }
+          : { kind: 'recenter-available' },
+    }
+  }
+  const index = Math.max(0, (input.virtualizer?.itemCount ?? 1) - 1)
+  return {
+    kind: 'global-live-edge',
+    state: {
+      kind: 'resident-tail',
+      index,
+      mounted: input.virtualizer
+        ? isVirtualIndexMounted(input.virtualizer, index)
+        : true,
+    },
+  }
+}
+
+export function deriveReachabilityForDesired(input: {
+  desired: DesiredPosition
+  hasRows: boolean
+  windowAtLiveEdge: boolean
+  virtualizer?: MessageVirtualizer
+  scroller?: HTMLElement | null
+  loadAround: 'available' | 'loading' | 'exhausted' | 'unavailable'
+  canRecenter?: boolean
+}): ReachabilityFacts {
+  if (input.desired.kind === 'live-edge') {
+    return deriveGlobalLiveEdgeReachability(input)
+  }
+  if (input.desired.kind === 'anchor' || input.desired.kind === 'message') {
+    let placementViable = true
+    if (
+      input.desired.kind === 'message' &&
+      input.desired.align === 'start' &&
+      input.scroller
+    ) {
+      const virtualOffset =
+        input.virtualizer &&
+        typeof input.virtualizer.getOffsetForMessageId === 'function'
+          ? input.virtualizer.getOffsetForMessageId(input.desired.messageId)
+          : null
+      const offset =
+        virtualOffset ??
+        (
+          input.scroller.querySelector(
+            `[data-message-id="${CSS.escape(input.desired.messageId)}"]`,
+          ) as HTMLElement | null
+        )?.offsetTop ??
+        null
+      placementViable =
+        offset === null || offset > input.scroller.clientHeight / 3
+    }
+    return deriveTargetReachability({
+      messageId: input.desired.messageId,
+      hasRows: input.hasRows,
+      virtualizer: input.virtualizer,
+      scroller: input.scroller,
+      loadAround: input.loadAround,
+      placementViable,
+    })
+  }
+  if (!input.hasRows) return { kind: 'empty-window' }
+  const index = input.desired.kind === 'resident-top' ? 0 : Math.max(
+    0,
+    (input.virtualizer?.itemCount ?? 1) - 1,
+  )
+  return {
+    kind: 'available',
+    index,
+    mounted: input.virtualizer
+      ? isVirtualIndexMounted(input.virtualizer, index)
+      : true,
+    placement: 'viable',
+  }
+}

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -177,7 +177,9 @@ export type PositionRequest =
   | Request<
       {
         kind: 'fallback'
-        reason: 'unread-marker-unavailable'
+        reason:
+          | 'unread-marker-unavailable'
+          | 'unread-marker-resolved-at-live-edge'
       },
       LiveEdgePosition
     >

--- a/apps/fluux/src/components/conversation/scrollPositionShadow.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionShadow.ts
@@ -1,0 +1,146 @@
+import { isScrollDebugEnabled } from '@/utils/scrollDebug'
+import type { DesiredPosition, PositioningPhase } from './scrollPositionModel'
+
+export type ShadowPhaseCategory =
+  | 'waiting'
+  | 'positioning'
+  | 'applied'
+  | 'paused'
+  | 'fallback'
+  | 'idle'
+
+export interface ShadowActualDecision {
+  desired: DesiredPosition | null
+  phase: ShadowPhaseCategory
+}
+
+export interface ScrollShadowDivergence {
+  event: string
+  conversationId: string
+  generation: number | null
+  expected: ShadowActualDecision
+  actual: ShadowActualDecision
+}
+
+export interface ScrollShadowSnapshot {
+  decisionCount: number
+  divergenceCount: number
+  generationCount: number
+  lastGeneration: number
+  divergences: ScrollShadowDivergence[]
+}
+
+const MAX_RETAINED_DIVERGENCES = 50
+
+const diagnostics: ScrollShadowSnapshot = {
+  decisionCount: 0,
+  divergenceCount: 0,
+  generationCount: 0,
+  lastGeneration: 0,
+  divergences: [],
+}
+
+function cloneSnapshot(): ScrollShadowSnapshot {
+  return {
+    ...diagnostics,
+    divergences: diagnostics.divergences.map((item) => ({
+      ...item,
+      expected: { ...item.expected },
+      actual: { ...item.actual },
+    })),
+  }
+}
+
+export function resetScrollShadowDiagnostics(): void {
+  diagnostics.decisionCount = 0
+  diagnostics.divergenceCount = 0
+  diagnostics.generationCount = 0
+  diagnostics.lastGeneration = 0
+  diagnostics.divergences = []
+}
+
+export function getScrollShadowSnapshot(): ScrollShadowSnapshot {
+  return cloneSnapshot()
+}
+
+export function recordShadowGeneration(generation: number): void {
+  diagnostics.generationCount += 1
+  if (generation <= diagnostics.lastGeneration) {
+    recordShadowDivergence({
+      event: 'generation-order',
+      conversationId: '',
+      generation,
+      expected: { desired: null, phase: 'applied' },
+      actual: { desired: null, phase: 'fallback' },
+    })
+    return
+  }
+  diagnostics.lastGeneration = generation
+}
+
+export function phaseCategory(phase: PositioningPhase | null): ShadowPhaseCategory {
+  if (!phase) return 'idle'
+  switch (phase.kind) {
+    case 'resolving':
+    case 'pending':
+    case 'loading-around':
+    case 'recentering-live-edge':
+      return 'waiting'
+    case 'mounting':
+    case 'reconciling':
+      return 'positioning'
+    case 'position-applied':
+    case 'settled':
+      return 'applied'
+    case 'paused-user-input':
+      return 'paused'
+    case 'unavailable':
+      return 'fallback'
+  }
+}
+
+function sameDesired(left: DesiredPosition | null, right: DesiredPosition | null): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+export function compareShadowDecision(input: {
+  event: string
+  conversationId: string
+  generation: number | null
+  expected: ShadowActualDecision
+  actual: ShadowActualDecision
+}): boolean {
+  diagnostics.decisionCount += 1
+  if (
+    sameDesired(input.expected.desired, input.actual.desired) &&
+    input.expected.phase === input.actual.phase
+  ) {
+    return true
+  }
+  recordShadowDivergence(input)
+  return false
+}
+
+function recordShadowDivergence(divergence: ScrollShadowDivergence): void {
+  diagnostics.divergenceCount += 1
+  diagnostics.divergences.push(divergence)
+  if (diagnostics.divergences.length > MAX_RETAINED_DIVERGENCES) {
+    diagnostics.divergences.shift()
+  }
+  if (isScrollDebugEnabled()) {
+    console.warn('[ScrollShadow] divergence', divergence)
+  }
+}
+
+declare global {
+  interface Window {
+    __fluuxScrollShadow?: (reset?: boolean) => ScrollShadowSnapshot
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.__fluuxScrollShadow = (reset = false) => {
+    if (reset) resetScrollShadowDiagnostics()
+    return getScrollShadowSnapshot()
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -2,10 +2,10 @@
  * useMessageListScroll - Simple, imperative scroll management
  *
  * DESIGN PRINCIPLES:
- * 1. All scroll state lives in REFS, not React state (prevents render loops)
- * 2. Scroll operations are IMPERATIVE (directly set scrollTop)
+ * 1. Production scroll state lives in REFS, not React state (prevents render loops)
+ * 2. Existing scroll operations remain IMPERATIVE during the shadow-controller migration
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
- * 4. Logic is LINEAR and SIMPLE - no state machines, no complex transitions
+ * 4. The semantic controller observes decisions only; it never writes scrollTop
  *
  * BEHAVIORS:
  * - Initial load: scroll to bottom
@@ -28,6 +28,20 @@ import { isProgrammaticScroll } from './scrollGate'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
+import { PositioningController, type PositionRequestDraft } from './positioningController'
+import {
+  deriveAtLiveEdge,
+  deriveEntryPositionFacts,
+  deriveLiveEdgeNavigationFacts,
+  deriveReachabilityForDesired,
+  readScrollGeometry,
+} from './scrollPositionFacts'
+import {
+  messageFraction,
+  pixelOffset,
+  type DesiredPosition,
+  type ReachabilityFacts,
+} from './scrollPositionModel'
 
 // ============================================================================
 // DEBUG
@@ -457,6 +471,41 @@ export function useMessageListScroll({
   // `${conversationId}:${anchorMessageId}` and cleared on conversation switch so returning to the
   // same conversation re-requests. Prevents re-issuing the load on every retry frame.
   const aroundLoadStatusRef = useRef<Map<string, 'loading' | 'done'>>(new Map())
+  // Shadow-only semantic controller. It owns no React state and performs no scroll writes.
+  // The module-private generation allocator survives controller remounts (including StrictMode).
+  const positioningControllerRef = useRef<PositioningController | null>(null)
+  if (!positioningControllerRef.current) {
+    positioningControllerRef.current = new PositioningController()
+  }
+  const shadowReachabilityRef = useRef<(desired: DesiredPosition) => ReachabilityFacts>(
+    () => ({ kind: 'empty-window' }),
+  )
+  shadowReachabilityRef.current = (desired) => {
+    const anchorId =
+      desired.kind === 'anchor' || desired.kind === 'message'
+        ? desired.messageId
+        : null
+    const aroundStatus = anchorId
+      ? aroundLoadStatusRef.current.get(`${conversationId}:${anchorId}`)
+      : undefined
+    const loadAround =
+      aroundStatus === 'loading'
+        ? 'loading'
+        : aroundStatus === 'done'
+          ? 'exhausted'
+          : onLoadAround
+            ? 'available'
+            : 'unavailable'
+    return deriveReachabilityForDesired({
+      desired,
+      hasRows: messageCount > 0,
+      windowAtLiveEdge: windowAtLiveEdge !== false,
+      virtualizer: virtualizerRef.current,
+      scroller: scrollerRef.current,
+      loadAround,
+      canRecenter: true,
+    })
+  }
   // Last target message id we requested an around-load for (search / activity navigation to a
   // message older than the loaded window). Prevents re-issuing the load while the target effect
   // re-fires waiting for the slice to merge.
@@ -1045,6 +1094,20 @@ export function useMessageListScroll({
   // paint (a raw scrollTop write leaves @tanstack's offset stale → blank/clipped); otherwise a
   // direct scrollTop write. Callers must have already confirmed the user is at/near the bottom.
   const reassertBottom = useCallback((trigger: string = 'unknown') => {
+    // Entry restore calls this before its shadow entry request is installed; that decision is
+    // compared by the entry adapter immediately after restoreSavedPosition returns. Every other
+    // bottom write must agree with either semantic follow-live ownership or current live geometry;
+    // unlike the live loop, the shadow check never trusts isAtBottomRef by itself.
+    if (trigger !== 'restore-fallback') {
+      const scroller = scrollerRef.current
+      positioningControllerRef.current?.observeBottomReassert({
+        event: `reassert:${trigger}`,
+        conversationId: prevConversationRef.current ?? conversationId,
+        geometryAtLiveEdge:
+          !!scroller && deriveAtLiveEdge(readScrollGeometry(scroller)),
+        actualFollowsLive: true,
+      })
+    }
     if (virtualizerRef.current) {
       pinVirtualizedBottom(trigger)
     } else {
@@ -1052,7 +1115,7 @@ export function useMessageListScroll({
       if (s) s.scrollTop = s.scrollHeight
     }
     rememberBottomIntent()
-  }, [pinVirtualizedBottom, rememberBottomIntent])
+  }, [conversationId, pinVirtualizedBottom, rememberBottomIntent])
 
   // Re-pin a VIRTUALIZED list to a saved CONTENT ANCHOR and keep it pinned as rows measure — the
   // restore counterpart of pinVirtualizedBottom. A one-shot scrollToIndex(anchor,'end') lands on the
@@ -1180,13 +1243,44 @@ export function useMessageListScroll({
     let stableFrames = 0
     let landedTarget = -1
     let resolved = false
+    let followLiveRecorded = false
+    const recordMarkerLiveEdge = (
+      reason:
+        | 'unread-marker-unavailable'
+        | 'unread-marker-resolved-at-live-edge',
+    ) => {
+      if (followLiveRecorded) return
+      followLiveRecorded = true
+      positioningControllerRef.current?.observeRequest({
+        event:
+          reason === 'unread-marker-unavailable'
+            ? 'marker-fallback'
+            : 'marker-resolved-at-live-edge',
+        conversationId: markerConvId,
+        draft: {
+          source: { kind: 'fallback', reason },
+          desired: { kind: 'live-edge', follow: true },
+        },
+        reachability: shadowReachabilityRef.current({
+          kind: 'live-edge',
+          follow: true,
+        }),
+        actual: {
+          desired: { kind: 'live-edge', follow: true },
+          phase: 'positioning',
+        },
+      })
+    }
     const stepToMarker = () => {
       if (framesLeft-- <= 0) {
         // Marker never resolved at all (e.g. trimmed from the loaded set) — don't strand the
         // view at the top; fall back to the bottom. End first so the handoff to reassertBottom
         // (which begins a pin-bottom loop) is not miscounted as an overlap.
         finishMarker()
-        if (!resolved) reassertBottom('marker-fallback')
+        if (!resolved) {
+          recordMarkerLiveEdge('unread-marker-unavailable')
+          reassertBottom('marker-fallback')
+        }
         return
       }
       const s = scrollerRef.current
@@ -1220,6 +1314,7 @@ export function useMessageListScroll({
         if (offset <= viewportHeight / 3) {
           isAtBottomRef.current = true
           finishMarker()
+          recordMarkerLiveEdge('unread-marker-unavailable')
           reassertBottom('marker-fallback')
           return
         }
@@ -1248,6 +1343,9 @@ export function useMessageListScroll({
           stableFrames = 0
           const distFromBottom = s.scrollHeight - st - viewportHeight
           isAtBottomRef.current = distFromBottom < AT_BOTTOM_THRESHOLD
+          if (isAtBottomRef.current && !followLiveRecorded) {
+            recordMarkerLiveEdge('unread-marker-resolved-at-live-edge')
+          }
           debugLog('CONVERSATION SWITCH: scrolling to new message marker', {
             firstNewMessageId: markerId, markerIndex, offset, scrollTop: st,
             distFromBottom, isAtBottom: isAtBottomRef.current,
@@ -1434,23 +1532,69 @@ export function useMessageListScroll({
     // single click always makes progress toward the bottom: no wasted click when the
     // user is already sitting at the marker (e.g. right after opening a conversation,
     // where the init effect auto-scrolls to the marker).
+    const virt = latestRef.current.virtualizer
+    let markerOffsetPx: number | null = null
+    let markerResolvable = false
     if (firstNewMessageId) {
-      const virt = latestRef.current.virtualizer
       // Two-step: scroll to the marker first, then bottom on a second click.
       // Virtualized: use getIndexForMessageId (works for unmounted rows) + scrollToIndex.
       // Non-virtualized: DOM querySelector + offsetTop (all rows are always mounted).
       if (virt) {
         const markerIdx = virt.getIndexForMessageId(firstNewMessageId)
         if (markerIdx !== null) {
-          const markerOffset = virt.getOffsetForMessageId(firstNewMessageId)
+          markerResolvable = true
+          markerOffsetPx = virt.getOffsetForMessageId(firstNewMessageId)
+        }
+      } else {
+        const messageElement = scroller.querySelector(
+          `[data-message-id="${CSS.escape(firstNewMessageId)}"]`,
+        ) as HTMLElement | null
+        if (messageElement) {
+          markerResolvable = true
+          markerOffsetPx = messageElement.offsetTop
+        }
+      }
+    }
+
+    const navigationFacts = deriveLiveEdgeNavigationFacts({
+      firstUnreadMessageId: markerResolvable ? firstNewMessageId : undefined,
+      markerOffsetPx,
+      geometry: readScrollGeometry(scroller),
+      virtualized: !!virt,
+    })
+    const markerDesired =
+      firstNewMessageId && navigationFacts.unreadMarkerNeedsVisit
+        ? {
+            kind: 'message' as const,
+            messageId: firstNewMessageId,
+            align: navigationFacts.unreadMarkerAlign,
+          }
+        : null
+    positioningControllerRef.current?.observeLiveEdgeNavigation({
+      event: 'fab',
+      conversationId,
+      navigationFacts,
+      reachability: (desired) => shadowReachabilityRef.current(desired),
+      actual: {
+        desired: markerDesired ?? { kind: 'live-edge', follow: true },
+        phase: 'positioning',
+      },
+    })
+
+    if (markerDesired && firstNewMessageId) {
+      if (virt) {
+        const markerIdx = virt.getIndexForMessageId(firstNewMessageId)
+        if (markerIdx !== null) {
           const viewportBottom = scroller.scrollTop + scroller.clientHeight
-          if (markerOffset === null || markerOffset > viewportBottom) {
+          if (markerOffsetPx === null || markerOffsetPx > viewportBottom) {
             virt.scrollToIndex(markerIdx, { align: 'start', behavior: 'smooth' })
             return
           }
         }
       } else {
-        const messageElement = scroller.querySelector(`[data-message-id="${CSS.escape(firstNewMessageId)}"]`)
+        const messageElement = scroller.querySelector(
+          `[data-message-id="${CSS.escape(firstNewMessageId)}"]`,
+        )
         if (messageElement) {
           const elementTop = (messageElement as HTMLElement).offsetTop
           const viewportBottom = scroller.scrollTop + scroller.clientHeight
@@ -1470,12 +1614,30 @@ export function useMessageListScroll({
 
     rememberBottomIntent()
     scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
-  }, [firstNewMessageId, reassertBottom, rememberBottomIntent])
+  }, [
+    conversationId,
+    firstNewMessageId,
+    reassertBottom,
+    rememberBottomIntent,
+  ])
 
   const scrollToTop = useCallback(() => {
     lastLoadTimeRef.current = Date.now() // prevent auto-load trigger
-    scrollerRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [])
+    const scroller = scrollerRef.current
+    if (!scroller) return
+    const desired = { kind: 'resident-top' } as const
+    positioningControllerRef.current?.observeRequest({
+      event: 'home-key',
+      conversationId,
+      draft: {
+        source: { kind: 'user-navigation', reason: 'resident-top' },
+        desired,
+      },
+      reachability: shadowReachabilityRef.current(desired),
+      actual: { desired, phase: 'positioning' },
+    })
+    scroller.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [conversationId])
 
   // Re-pin to the bottom when the VIEWPORT itself shrinks (or grows) under a list
   // that is following along — most importantly when the mobile on-screen keyboard
@@ -1767,6 +1929,11 @@ export function useMessageListScroll({
 
       if (wasAtBottom) {
         if (!userScrolled) {
+          positioningControllerRef.current?.observeAppend({
+            event: 'media-live-edge',
+            conversationId,
+            actualFollowsLive: true,
+          })
           // User didn't scroll during the batch - scroll to bottom
           debugLog('MEDIA LOAD: batch complete, scrolling to bottom', {
             wasAtBottom,
@@ -1782,6 +1949,25 @@ export function useMessageListScroll({
           })
         }
       } else if (!userScrolled && anchor) {
+        const desired: DesiredPosition = {
+          kind: 'anchor',
+          messageId: anchor.messageId,
+          placement: {
+            kind: 'bottom-fraction',
+            fraction: messageFraction(anchor.fraction),
+          },
+        }
+        const request = positioningControllerRef.current?.observeRequest({
+          event: 'media-preservation',
+          conversationId,
+          draft: {
+            source: { kind: 'media-preservation', reason: 'remeasure' },
+            desired,
+            onUnavailable: { kind: 'warn-and-stop' },
+          },
+          reachability: shadowReachabilityRef.current(desired),
+          actual: { desired, phase: 'positioning' },
+        })
         // Scrolled up and the user did NOT genuinely scroll during the batch: media that decoded
         // ABOVE the viewport grew the content and pushed the reading position down/out. Re-pin to the
         // anchor captured BEFORE the growth so the reader stays put (the conversation-switch + media
@@ -1792,6 +1978,12 @@ export function useMessageListScroll({
         })
         if (virtualizerRef.current) pinVirtualizedAnchor(anchor, conversationId)
         else restoreToAnchor(currentScroller, anchor)
+        if (request) {
+          positioningControllerRef.current?.markPositionApplied(
+            conversationId,
+            request.generation,
+          )
+        }
       } else {
         debugLog('MEDIA LOAD: batch complete, was not at bottom (user scrolled / no anchor)', {
           wasAtBottom,
@@ -1927,11 +2119,19 @@ export function useMessageListScroll({
     // the window a settle frame looked like a scrollbar drag, opened the gate, and persisted a
     // drifted position that crept older on every re-open. Genuine user scrolls still open the gate
     // via the input-event listeners / handleWheel, unaffected.
-    if (
-      !isProgrammaticScroll(programmaticScroll, Date.now(), lastProgrammaticScrollAtRef.current) &&
-      prevScrollHeightRef.current === scrollHeight
-    ) {
+    const genuineUserScroll =
+      !isProgrammaticScroll(
+        programmaticScroll,
+        Date.now(),
+        lastProgrammaticScrollAtRef.current,
+      ) && prevScrollHeightRef.current === scrollHeight
+    if (genuineUserScroll) {
       userHasScrolledSinceEntryRef.current = true
+      positioningControllerRef.current?.observeUserInput(conversationId)
+      positioningControllerRef.current?.observeSettledUserGeometry({
+        conversationId,
+        atLiveEdge: deriveAtLiveEdge(readScrollGeometry(el)),
+      })
     }
     prevScrollHeightRef.current = scrollHeight
 
@@ -2009,6 +2209,7 @@ export function useMessageListScroll({
     // Genuine user scroll → open the save gate (see userHasScrolledSinceEntryRef). Mirrors the
     // native wheel listener; kept here so it fires even when wheel arrives via the React handler.
     userHasScrolledSinceEntryRef.current = true
+    positioningControllerRef.current?.observeUserInput(conversationId)
     const { scrollTop, scrollHeight, clientHeight } = e.currentTarget
     const distFromBottom = scrollHeight - scrollTop - clientHeight
     if (scrollTop === 0 && e.deltaY < 0 && !staticMode) triggerLoadOlder()
@@ -2064,6 +2265,11 @@ export function useMessageListScroll({
     } else if (prevConversationRef.current) {
       scrollStateManager.markAsLeft(prevConversationRef.current)
     }
+    if (prevConversationRef.current) {
+      positioningControllerRef.current?.deactivate(
+        prevConversationRef.current,
+      )
+    }
 
     // ENTERING new conversation - reset state
     hasInitializedRef.current = false
@@ -2113,19 +2319,21 @@ export function useMessageListScroll({
       // Decide: restore position or scroll to bottom?
       let action = scrollStateManager.enterConversation(conversationId, messageCount)
       const savedPos = scrollStateManager.getSavedScrollTop(conversationId)
+      const savedAnchor = scrollStateManager.getSavedAnchor(conversationId)
       const savedReadPositionId = scrollStateManager.getSavedReadPositionId(conversationId)
+      const syncedLiveEdge =
+        action === 'restore-position' &&
+        firstNewMessageId === undefined &&
+        readPointerId !== undefined &&
+        readPointerId === lastMessageId &&
+        readPointerId !== savedReadPositionId
 
       if (action === 'restore-position') {
         pendingSyncedLiveEdgeRef.current = { conversationId, savedReadPositionId }
         // The remote pointer can resolve before this mount. When it now identifies the newest
         // downloaded row, a saved position tied to an older pointer must not win merely because
         // there was never an unread divider.
-        if (
-          firstNewMessageId === undefined &&
-          readPointerId !== undefined &&
-          readPointerId === lastMessageId &&
-          readPointerId !== savedReadPositionId
-        ) {
+        if (syncedLiveEdge) {
           scrollStateManager.clearSavedScrollState(conversationId)
           pendingSyncedLiveEdgeRef.current = null
           action = 'scroll-to-bottom'
@@ -2138,11 +2346,42 @@ export function useMessageListScroll({
       }
 
       debugLog('CONVERSATION ACTION', { action, savedPos, firstOpenThisSession, scrollHeight: scroller.scrollHeight })
+      const entryFacts = deriveEntryPositionFacts({
+        syncedLiveEdge,
+        savedAnchor,
+        savedOffsetPx: savedPos,
+        firstUnreadMessageId: firstNewMessageId,
+      })
 
       if (action === 'restore-position') {
         const restoreResult = restoreSavedPosition('entry')
         pendingRestoreConversationRef.current =
           restoreResult === 'pending' ? conversationId : null
+        const actualDesired: DesiredPosition = entryFacts.savedAnchor ??
+          (entryFacts.savedOffsetPx !== undefined
+            ? { kind: 'legacy-offset', offsetPx: entryFacts.savedOffsetPx }
+            : { kind: 'live-edge', follow: true })
+        const request = positioningControllerRef.current?.observeEntry({
+          event: 'entry-restore',
+          conversationId,
+          entryFacts,
+          reachability: (desired) => shadowReachabilityRef.current(desired),
+          actual: {
+            desired: actualDesired,
+            phase:
+              restoreResult === 'pending'
+                ? 'waiting'
+                : restoreResult === 'bottom'
+                  ? 'fallback'
+                  : 'positioning',
+          },
+        })
+        if (restoreResult === 'restored' && request) {
+          positioningControllerRef.current?.markPositionApplied(
+            conversationId,
+            request.generation,
+          )
+        }
       } else if (firstNewMessageId) {
         // Has unread messages — position the first-unread marker ~1/3 down from the top so the
         // user reads forward from where they left off. Mark NOT at bottom up front (mirrors the
@@ -2157,7 +2396,29 @@ export function useMessageListScroll({
         // non-virtualized fallback path can find it too; the virtualized path below does not need
         // it (getOffsetForMessageId resolves unmounted rows).
         void latestRef.current.virtualizer?.ensureMessageMounted(markerId)
-
+        const markerDesired = {
+          kind: 'message' as const,
+          messageId: firstNewMessageId,
+          align: 'start' as const,
+        }
+        const markerReachability =
+          shadowReachabilityRef.current(markerDesired)
+        positioningControllerRef.current?.observeEntry({
+          event: 'entry-unread',
+          conversationId,
+          entryFacts,
+          reachability: () => markerReachability,
+          actual: {
+            desired: markerDesired,
+            phase:
+              markerReachability.kind === 'available' &&
+              markerReachability.placement === 'use-unavailable-policy'
+                ? 'fallback'
+                : markerReachability.kind === 'available'
+                  ? 'positioning'
+                  : 'waiting',
+          },
+        })
         // Re-assert the marker position across frames. On entry the conversation's messages were
         // evicted on leave and rehydrate from cache ASYNCHRONOUSLY, and rows then measure over
         // several frames, so the marker offset is unresolved at first and sharpens as it settles.
@@ -2177,6 +2438,16 @@ export function useMessageListScroll({
         // to bottom when content grows (messages loading from IndexedDB).
         isAtBottomRef.current = false
         debugLog('CONVERSATION SWITCH: has targetMessageId, deferring to target scroll', { targetMessageId })
+        positioningControllerRef.current?.observeEntry({
+          event: 'entry-before-explicit-target',
+          conversationId,
+          entryFacts,
+          reachability: (desired) => shadowReachabilityRef.current(desired),
+          actual: {
+            desired: { kind: 'live-edge', follow: true },
+            phase: 'positioning',
+          },
+        })
       } else {
         // No unread messages - scroll to bottom
         // We use both immediate and deferred scroll because:
@@ -2187,6 +2458,16 @@ export function useMessageListScroll({
         // Note: Async content loading (MAM) is handled by the separate "new message" effect
         // which triggers when messageCount changes.
         isAtBottomRef.current = true
+        positioningControllerRef.current?.observeEntry({
+          event: syncedLiveEdge ? 'entry-synced-live-edge' : 'entry-live-edge',
+          conversationId,
+          entryFacts,
+          reachability: (desired) => shadowReachabilityRef.current(desired),
+          actual: {
+            desired: { kind: 'live-edge', follow: true },
+            phase: 'positioning',
+          },
+        })
         const virtSwitch = latestRef.current.virtualizer
         if (virtSwitch) {
           // Virtualizer-native bottom: uses actual measured heights, not the estimated
@@ -2241,6 +2522,25 @@ export function useMessageListScroll({
       savedReadPositionId: pending.savedReadPositionId,
       readPointerId,
     })
+    positioningControllerRef.current?.observeRequest({
+      event: 'mds-live-edge',
+      conversationId,
+      draft: {
+        source: {
+          kind: 'late-mds-supersession',
+          reason: 'read-pointer-at-live-edge',
+        },
+        desired: { kind: 'live-edge', follow: true },
+      },
+      reachability: shadowReachabilityRef.current({
+        kind: 'live-edge',
+        follow: true,
+      }),
+      actual: {
+        desired: { kind: 'live-edge', follow: true },
+        phase: 'positioning',
+      },
+    })
     reassertBottom('mds-live-edge')
   }, [conversationId, firstNewMessageId, lastMessageId, readPointerId, staticMode, isAtBottomRef, reassertBottom])
 
@@ -2276,6 +2576,22 @@ export function useMessageListScroll({
       prevMarker: prev.divider,
     })
     isAtBottomRef.current = true
+    positioningControllerRef.current?.observeRequest({
+      event: 'mds-settle',
+      conversationId,
+      draft: {
+        source: { kind: 'late-mds-supersession', reason: 'divider-cleared' },
+        desired: { kind: 'live-edge', follow: true },
+      },
+      reachability: shadowReachabilityRef.current({
+        kind: 'live-edge',
+        follow: true,
+      }),
+      actual: {
+        desired: { kind: 'live-edge', follow: true },
+        phase: 'positioning',
+      },
+    })
     reassertBottom('mds-settle')
   }, [conversationId, firstNewMessageId, staticMode, isAtBottomRef, reassertBottom])
 
@@ -2290,6 +2606,15 @@ export function useMessageListScroll({
     const restoreResult = restoreSavedPosition('retry')
     if (restoreResult !== 'pending') {
       pendingRestoreConversationRef.current = null
+      if (restoreResult === 'restored') {
+        const active = positioningControllerRef.current?.snapshot().active
+        if (active?.request.conversationId === conversationId) {
+          positioningControllerRef.current?.markPositionApplied(
+            conversationId,
+            active.request.generation,
+          )
+        }
+      }
       prevMessageCountRef.current = messageCount
       prevLastMessageIdRef.current = lastMessageId
     }
@@ -2360,6 +2685,16 @@ export function useMessageListScroll({
 
     const virt = latestRef.current.virtualizer
     const escapedId = CSS.escape(targetMessageId)
+    const shadowTargetDesired = {
+      kind: 'message',
+      messageId: targetMessageId,
+      align: 'center',
+    } as const
+    const shadowTargetDraft: PositionRequestDraft = {
+      source: { kind: 'user-navigation', reason: 'message-target' },
+      desired: shadowTargetDesired,
+      onUnavailable: { kind: 'wait' },
+    }
 
     const highlight = (el: Element) => {
       el.classList.add('message-highlight')
@@ -2373,6 +2708,13 @@ export function useMessageListScroll({
       // yet (e.g., search opens a conversation before messages finish loading from cache).
       const idx = virt.getIndexForMessageId(targetMessageId)
       if (idx === null) {
+        positioningControllerRef.current?.observeRequest({
+          event: 'explicit-target-waiting',
+          conversationId,
+          draft: shadowTargetDraft,
+          reachability: shadowReachabilityRef.current(shadowTargetDesired),
+          actual: { desired: shadowTargetDesired, phase: 'waiting' },
+        })
         // The target isn't in the loaded window — pull in the cache slice that contains it (search /
         // activity jump to a message older than the latest-N slice). The merge grows messageCount,
         // re-firing this effect with the target now resolvable. Request once per target.
@@ -2387,6 +2729,13 @@ export function useMessageListScroll({
         return
       }
       const targetConvId = conversationId
+      positioningControllerRef.current?.observeRequest({
+        event: 'explicit-target',
+        conversationId,
+        draft: shadowTargetDraft,
+        reachability: shadowReachabilityRef.current(shadowTargetDesired),
+        actual: { desired: shadowTargetDesired, phase: 'positioning' },
+      })
       const startedAt = Date.now()
       supersedeReassertLoopRef.current()
       const targetLoop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('target', performance.now())
@@ -2490,6 +2839,13 @@ export function useMessageListScroll({
       // Non-virtualized: all rows are always in the DOM.
       const el = scroller.querySelector(`[data-message-id="${escapedId}"]`)
       if (!el) {
+        positioningControllerRef.current?.observeRequest({
+          event: 'explicit-target-waiting',
+          conversationId,
+          draft: shadowTargetDraft,
+          reachability: shadowReachabilityRef.current(shadowTargetDesired),
+          actual: { desired: shadowTargetDesired, phase: 'waiting' },
+        })
         const loader = latestRef.current.onLoadAround
         if (loader && targetAroundRequestedRef.current !== targetMessageId) {
           targetAroundRequestedRef.current = targetMessageId
@@ -2503,6 +2859,13 @@ export function useMessageListScroll({
       // Center the target (matches the virtualized path above and the reply-scroll convention);
       // the browser clamps scrollTop, so a near-bottom target stays fully visible.
       ;(el as HTMLElement).scrollIntoView({ block: 'center' })
+      positioningControllerRef.current?.observeRequest({
+        event: 'explicit-target',
+        conversationId,
+        draft: shadowTargetDraft,
+        reachability: shadowReachabilityRef.current(shadowTargetDesired),
+        actual: { desired: shadowTargetDesired, phase: 'positioning' },
+      })
       isAtBottomRef.current = (scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight) < AT_BOTTOM_THRESHOLD
       highlight(el)
       debugLog('TARGET MESSAGE: scrolled to target (center)', { targetMessageId })
@@ -2683,6 +3046,39 @@ export function useMessageListScroll({
       maxScrollTop,
     })
 
+    const shadowWindowShiftDesired: DesiredPosition | null =
+      saved.anchorMessageId
+        ? {
+            kind: 'anchor',
+            messageId: saved.anchorMessageId,
+            placement: {
+              kind: 'top-offset',
+              offsetPx: pixelOffset(saved.anchorOffsetFromTop),
+            },
+          }
+        : null
+    const shadowWindowShiftRequest = shadowWindowShiftDesired
+      ? positioningControllerRef.current?.observeRequest({
+          event: 'window-shift-preservation',
+          conversationId,
+          draft: {
+            source: { kind: 'history-preservation', reason: 'window-shift' },
+            desired: shadowWindowShiftDesired,
+            onUnavailable: {
+              kind: 'distance-from-bottom',
+              distancePx: pixelOffset(saved.distanceFromBottom),
+            },
+          },
+          reachability: shadowReachabilityRef.current(
+            shadowWindowShiftDesired,
+          ),
+          actual: {
+            desired: shadowWindowShiftDesired,
+            phase: usedMethod === 'math-fallback' ? 'fallback' : 'positioning',
+          },
+        })
+      : null
+
     // Cancel any parked kinetic (momentum) scroll BEFORE positioning. On a fast scroll-up
     // fling the user reaches the top boundary with residual velocity that WebKit parks and
     // then resumes once we prepend older messages — overshooting the restored anchor and
@@ -2724,6 +3120,12 @@ export function useMessageListScroll({
     saved.restored = true
     saved.restoredAt = Date.now()
     lastRestoreTimeRef.current = Date.now()
+    if (shadowWindowShiftRequest) {
+      positioningControllerRef.current?.markPositionApplied(
+        conversationId,
+        shadowWindowShiftRequest.generation,
+      )
+    }
 
     // Account for the prepended rows in the new-message baseline. This layout effect runs BEFORE
     // the new-message effect in the same commit and flips `restored` true, so that effect no
@@ -2838,7 +3240,7 @@ export function useMessageListScroll({
         prependRef.current = null
       }
     }, PREPEND_COOLDOWN_MS)
-  }, [messageCount, firstMessageId, staticMode])
+  }, [conversationId, messageCount, firstMessageId, staticMode])
 
   // ==========================================================================
   // EFFECT: New message arrives
@@ -2849,6 +3251,27 @@ export function useMessageListScroll({
     if (!scroller || !hasInitializedRef.current || staticMode) return
 
     if (pendingRestoreConversationRef.current === conversationId) {
+      if (lastMessageIsOutgoing) {
+        positioningControllerRef.current?.observeRequest({
+          event: 'new-message-during-restore',
+          conversationId,
+          draft: {
+            source: { kind: 'live-update', reason: 'outgoing-message' },
+            desired: { kind: 'live-edge', follow: true },
+          },
+          reachability: shadowReachabilityRef.current({
+            kind: 'live-edge',
+            follow: true,
+          }),
+          actual: { desired: null, phase: 'idle' },
+        })
+      } else {
+        positioningControllerRef.current?.observeAppend({
+          event: 'incoming-message-during-restore',
+          conversationId,
+          actualFollowsLive: false,
+        })
+      }
       debugLog('NEW MSG SKIP (restore pending)', {
         messageCount,
         prevCount: prevMessageCountRef.current,
@@ -2862,6 +3285,27 @@ export function useMessageListScroll({
     // Don't interfere with prepend that's actively in progress (not yet restored)
     // Once restored, allow new message auto-scroll even during cooldown period
     if (prependRef.current && !prependRef.current.restored) {
+      if (lastMessageIsOutgoing) {
+        positioningControllerRef.current?.observeRequest({
+          event: 'new-message-during-window-shift',
+          conversationId,
+          draft: {
+            source: { kind: 'live-update', reason: 'outgoing-message' },
+            desired: { kind: 'live-edge', follow: true },
+          },
+          reachability: shadowReachabilityRef.current({
+            kind: 'live-edge',
+            follow: true,
+          }),
+          actual: { desired: null, phase: 'idle' },
+        })
+      } else {
+        positioningControllerRef.current?.observeAppend({
+          event: 'incoming-message-during-window-shift',
+          conversationId,
+          actualFollowsLive: false,
+        })
+      }
       debugLog('NEW MSG SKIP (prepend in progress)', {
         messageCount,
         prevCount: prevMessageCountRef.current,
@@ -2883,6 +3327,30 @@ export function useMessageListScroll({
     // (auto-follow) OR it's the user's own send — you always want to see what you just sent, even
     // from a scrolled-up position. An incoming message while scrolled up does NOT yank the reader.
     if (newBottomRow && (isAtBottomRef.current || lastMessageIsOutgoing)) {
+      if (lastMessageIsOutgoing) {
+        positioningControllerRef.current?.observeRequest({
+          event: 'outgoing-message',
+          conversationId,
+          draft: {
+            source: { kind: 'live-update', reason: 'outgoing-message' },
+            desired: { kind: 'live-edge', follow: true },
+          },
+          reachability: shadowReachabilityRef.current({
+            kind: 'live-edge',
+            follow: true,
+          }),
+          actual: {
+            desired: { kind: 'live-edge', follow: true },
+            phase: 'positioning',
+          },
+        })
+      } else {
+        positioningControllerRef.current?.observeAppend({
+          event: 'incoming-message',
+          conversationId,
+          actualFollowsLive: true,
+        })
+      }
       debugLog('NEW MSG SCROLL TO BOTTOM', {
         messageCount,
         prevCount: prevMessageCountRef.current,
@@ -2897,6 +3365,11 @@ export function useMessageListScroll({
       isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
       reassertBottom('new-message')
     } else if (newBottomRow) {
+      positioningControllerRef.current?.observeAppend({
+        event: 'incoming-message',
+        conversationId,
+        actualFollowsLive: false,
+      })
       debugLog('NEW MSG NO SCROLL (incoming, not at bottom)', {
         messageCount,
         prevCount: prevMessageCountRef.current,
@@ -3152,6 +3625,32 @@ export function useMessageListScroll({
     if (!firstNewMessageId) return
     userScrollIntentAtRef.current = Date.now()
     userHasScrolledSinceEntryRef.current = true
+    const desired = {
+      kind: 'message' as const,
+      messageId: firstNewMessageId,
+      align: virtualizerRef.current ? 'start' as const : 'top-third' as const,
+    }
+    const reachability = shadowReachabilityRef.current(desired)
+    positioningControllerRef.current?.observeRequest({
+      event: 'jump-to-last-read',
+      conversationId,
+      draft: {
+        source: { kind: 'user-navigation', reason: 'unread-marker' },
+        desired,
+        onUnavailable: { kind: 'live-edge' },
+      },
+      reachability,
+      actual: {
+        desired,
+        phase:
+          reachability.kind === 'available' &&
+          reachability.placement === 'use-unavailable-policy'
+            ? 'fallback'
+            : reachability.kind === 'available'
+              ? 'positioning'
+              : 'waiting',
+      },
+    })
     runMarkerReassertLoop(firstNewMessageId, conversationId)
   }, [firstNewMessageId, conversationId, runMarkerReassertLoop])
 

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,7 +1,7 @@
 # Message-list scroll positioning contract
 
-Status: migration contract. The model and tests introduced with this document are pure and do not
-change production scroll behavior.
+Status: migration in progress. The pure model is connected to a generation-aware shadow controller,
+but existing positioning loops still own every scroll write.
 
 ## Purpose
 
@@ -23,6 +23,36 @@ It intentionally separates two concerns:
 
 The first concern can be pure and deterministic. The second remains the hard browser-specific work;
 centralizing it later must not erase or weaken its current safeguards.
+
+## Shadow-controller fidelity findings
+
+The first migration step runs the model beside `useMessageListScroll` without moving a scroll write.
+Fact adapters read current virtualizer, persisted-state, and DOM geometry; the controller is held in
+a ref and owns no React state. Every observed live decision is compared with the model decision.
+The demo scroll-invariant suite fails if its retained divergence list is non-empty.
+
+Generation allocation is module-private and shared by controller instances. Each mounted
+message-list owns its controller model, but a remount (including StrictMode effect replay) cannot
+reuse a generation. No adapter or model helper can mint one.
+
+The three previously prose-only fidelity seams are descriptive of current behavior:
+
+- **Media preservation does not suppress an outgoing send.** The live new-message effect suppresses
+  only while entry restore is pending or a directional load has not completed its initial restore.
+  A replay captured from the media-growth invariant proves that an outgoing live-edge request
+  supersedes an active media anchor.
+- **`position-applied` is the current release seam, before measurement settle.** Saved entry restore
+  returns after its initial anchor/offset write and is marked applied before the longer
+  restore-anchor rAF loop converges. Directional restoration likewise sets `saved.restored` after
+  the initial bounded write and before its measurement re-assert loop. Recorded restore facts prove
+  an outgoing request is rejected before that signal and accepted immediately after it.
+- **Already-resolved synced live edge wins synchronously.** The entry effect compares the remote
+  read pointer with the resident tail and clears obsolete saved state before calling
+  `restoreSavedPosition`. Late `mds-live-edge` and `mds-settle` remain separate supersession paths
+  only for remote state that arrives after entry.
+
+These checks establish policy fidelity; they do not claim that jsdom can prove pixel convergence or
+WebKit paint correctness.
 
 ## Non-goals for this stage
 

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -74,7 +74,33 @@ async function loadDemo(page: Page): Promise<void> {
   await page.waitForSelector('[data-nav="messages"]', { timeout: 120_000 })
   // Extra wait for the setTimeout(0) stress seeding to complete
   await page.waitForTimeout(1200)
+  await page.evaluate(() => {
+    ;(
+      window as Window & {
+        __fluuxScrollShadow?: (reset?: boolean) => unknown
+      }
+    ).__fluuxScrollShadow?.(true)
+  })
 }
+
+test.afterEach(async ({ page }) => {
+  if (page.isClosed()) return
+  const shadow = await page.evaluate(() => {
+    return (
+      window as Window & {
+        __fluuxScrollShadow?: () => {
+          divergenceCount: number
+          divergences: unknown[]
+        }
+      }
+    ).__fluuxScrollShadow?.()
+  })
+  expect(shadow, 'scroll shadow diagnostics must be installed').toBeDefined()
+  expect(
+    shadow?.divergences,
+    `scroll shadow recorded ${shadow?.divergenceCount ?? 0} divergence(s)`,
+  ).toEqual([])
+})
 
 /** Navigate to the stress room and wait for virtual rows to appear.
  *


### PR DESCRIPTION
## Summary

- add a generation-aware positioning controller backed by the existing pure scroll-position model
- derive entry, reachability, live-edge, and mounted facts from current scroll/virtualizer geometry
- observe the existing entry, restore, marker, FAB, target, history, message, media, MDS, and user-takeover paths without taking ownership of any scroll write
- expose shadow diagnostics through `__fluuxScrollShadow()` and fail the scroll-invariant suite on any retained divergence
- replay normalized real traces for the media/outgoing, first-position-applied, and synced-live-edge fidelity seams
- update the positioning contract with the confirmed runtime findings

## Why

The scroll model introduced in the previous PR was still disconnected from production behavior. Its tests could validate the model internally, but could not prove that it described the decisions made by the live loops. This PR runs the model beside those loops and compares their decisions before any owner is migrated.

The controller is stored in a ref, owns no React state, and never calls `scrollToIndex`, `scrollToOffset`, `scrollTo`, or writes `scrollTop`. Existing measurement-settle, WebKit repaint, kinetic-scroll, and persistence behavior remains in charge.

## Fidelity findings

- media preservation does not suppress a later outgoing-send live-edge request
- saved and directional preservation release outgoing suppression after the initial position write, before their longer measurement-settle loops finish
- an already-resolved synced read pointer wins synchronously over saved state during entry
- legacy shared bottom reassertion can be justified by either semantic follow-live ownership or current measured live-edge geometry; the shadow path does not trust the `isAtBottomRef` latch alone

## Validation

- `npm test` — 404 app test files passed, 5,237 app tests passed; 203 SDK files and 5,210 SDK tests passed; 22 skipped
- `npm run typecheck`
- `npm run lint` — no errors or new warnings
- `npm run test:scroll` — 52/52 passed across Chromium and WebKit with zero shadow divergences
- `git diff --cached --check`
