### PR TITLE
Make scroll shadow instrumentation fail-safe

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   getScrollShadowSnapshot,
   resetScrollShadowDiagnostics,
+  runScrollShadowSafely,
 } from './scrollPositionShadow'
 import {
   messageFraction,
@@ -54,6 +55,41 @@ beforeEach(() => {
 })
 
 describe('positioning controller shadow mode', () => {
+  it('swallows and counts invalid shadow facts without blocking the live path', () => {
+    const valid = runScrollShadowSafely({
+      event: 'valid-entry-facts',
+      conversationId,
+      fallback: null,
+      observe: () => liveEntryFacts(),
+    })
+    expect(valid).not.toBeNull()
+    expect(getScrollShadowSnapshot().instrumentationErrorCount).toBe(0)
+
+    const invalid = runScrollShadowSafely({
+      event: 'invalid-entry-facts',
+      conversationId,
+      fallback: null,
+      observe: () => deriveEntryPositionFacts({
+        syncedLiveEdge: false,
+        savedAnchor: {
+          messageId: 'zero-height-row',
+          fraction: Number.NaN,
+        },
+        savedOffsetPx: null,
+      }),
+    })
+
+    // Calling the strict fact adapter directly would throw and abort the entry effect.
+    expect(invalid).toBeNull()
+    expect(getScrollShadowSnapshot()).toMatchObject({
+      instrumentationErrorCount: 1,
+      instrumentationErrors: [{
+        event: 'invalid-entry-facts',
+        conversationId,
+      }],
+    })
+  })
+
   it('mints strictly increasing generations across controllers and conversation switches', () => {
     const firstController = new PositioningController()
     const first = observeLiveEntry(firstController)
@@ -175,7 +211,7 @@ describe('positioning controller shadow mode', () => {
       actual: { desired: liveEdge, phase: 'positioning' },
     })
 
-    // A saved-first implementation would select message-20 instead.
+    // A saved-first implementation would select the trace's msg-5 anchor instead.
     expect(request?.source).toEqual({ kind: 'entry', reason: 'synced-live-edge' })
     expect(request?.desired).toEqual(liveEdge)
     expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
@@ -282,6 +318,21 @@ describe('positioning controller shadow mode', () => {
     expect(dropped).toBeNull()
     expect(accepted).not.toBeNull()
     expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
+  })
+
+  it('rejects stale deactivation generations', () => {
+    const controller = new PositioningController()
+    const first = observeLiveEntry(controller, 'first-room@example.test')
+    const current = observeLiveEntry(controller, conversationId)
+
+    controller.deactivate('first-room@example.test', first!.generation)
+    expect(controller.snapshot().currentConversationId).toBe(conversationId)
+
+    controller.deactivate(conversationId, first!.generation)
+    expect(controller.snapshot().currentConversationId).toBe(conversationId)
+
+    controller.deactivate(conversationId, current!.generation)
+    expect(controller.snapshot().currentConversationId).toBeNull()
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -19,6 +19,7 @@ import {
   compareShadowDecision,
   phaseCategory,
   recordShadowGeneration,
+  runScrollShadowSafely,
   type ShadowActualDecision,
 } from './scrollPositionShadow'
 
@@ -80,14 +81,21 @@ export class PositioningController {
     reachability: (desired: PositionRequest['desired']) => ReachabilityFacts
     actual: ShadowActualDecision
   }): PositionRequest | null {
-    const selection = selectEntryPosition(input.entryFacts)
-    const draft = selection as PositionRequestDraft
-    return this.observeRequest({
+    return runScrollShadowSafely({
       event: input.event,
       conversationId: input.conversationId,
-      actual: input.actual,
-      draft: selection as PositionRequestDraft,
-      reachability: input.reachability(draft.desired),
+      fallback: null,
+      observe: () => {
+        const selection = selectEntryPosition(input.entryFacts)
+        const draft = selection as PositionRequestDraft
+        return this.observeRequest({
+          event: input.event,
+          conversationId: input.conversationId,
+          actual: input.actual,
+          draft,
+          reachability: input.reachability(draft.desired),
+        })
+      },
     })
   }
 
@@ -98,50 +106,57 @@ export class PositioningController {
     reachability: ReachabilityFacts
     actual: ShadowActualDecision
   }): PositionRequest | null {
-    const generation = mintPositionGeneration()
-    const request = withIdentity(input.conversationId, generation, input.draft)
-    if (!reachabilityMatchesRequest(request, input.reachability)) {
-      compareShadowDecision({
-        event: `${input.event}:fact-mismatch`,
-        conversationId: input.conversationId,
-        generation,
-        expected: { desired: null, phase: 'idle' },
-        actual: input.actual,
-      })
-      return null
-    }
-
-    const previous = this.model
-    const accepted = acceptPositionRequest(previous, request)
-    if (accepted === previous) {
-      compareShadowDecision({
-        event: input.event,
-        conversationId: input.conversationId,
-        generation,
-        expected: { desired: null, phase: 'idle' },
-        actual: input.actual,
-      })
-      return null
-    }
-
-    const phase = resolveReachability(request, input.reachability)
-    this.model = advancePhaseIfCurrent(
-      accepted,
-      input.conversationId,
-      generation,
-      phase,
-    )
-    compareShadowDecision({
+    return runScrollShadowSafely({
       event: input.event,
       conversationId: input.conversationId,
-      generation,
-      expected: {
-        desired: request.desired,
-        phase: phaseCategory(phase),
+      fallback: null,
+      observe: () => {
+        const generation = mintPositionGeneration()
+        const request = withIdentity(input.conversationId, generation, input.draft)
+        if (!reachabilityMatchesRequest(request, input.reachability)) {
+          compareShadowDecision({
+            event: `${input.event}:fact-mismatch`,
+            conversationId: input.conversationId,
+            generation,
+            expected: { desired: null, phase: 'idle' },
+            actual: input.actual,
+          })
+          return null
+        }
+
+        const previous = this.model
+        const accepted = acceptPositionRequest(previous, request)
+        if (accepted === previous) {
+          compareShadowDecision({
+            event: input.event,
+            conversationId: input.conversationId,
+            generation,
+            expected: { desired: null, phase: 'idle' },
+            actual: input.actual,
+          })
+          return null
+        }
+
+        const phase = resolveReachability(request, input.reachability)
+        this.model = advancePhaseIfCurrent(
+          accepted,
+          input.conversationId,
+          generation,
+          phase,
+        )
+        compareShadowDecision({
+          event: input.event,
+          conversationId: input.conversationId,
+          generation,
+          expected: {
+            desired: request.desired,
+            phase: phaseCategory(phase),
+          },
+          actual: input.actual,
+        })
+        return request
       },
-      actual: input.actual,
     })
-    return request
   }
 
   observeLiveEdgeNavigation(input: {
@@ -151,15 +166,22 @@ export class PositioningController {
     reachability: (desired: PositionRequest['desired']) => ReachabilityFacts
     actual: ShadowActualDecision
   }): PositionRequest | null {
-    const draft = selectLiveEdgeNavigation(
-      input.navigationFacts,
-    ) as PositionRequestDraft
-    return this.observeRequest({
+    return runScrollShadowSafely({
       event: input.event,
       conversationId: input.conversationId,
-      draft,
-      reachability: input.reachability(draft.desired),
-      actual: input.actual,
+      fallback: null,
+      observe: () => {
+        const draft = selectLiveEdgeNavigation(
+          input.navigationFacts,
+        ) as PositionRequestDraft
+        return this.observeRequest({
+          event: input.event,
+          conversationId: input.conversationId,
+          draft,
+          reachability: input.reachability(draft.desired),
+          actual: input.actual,
+        })
+      },
     })
   }
 
@@ -168,28 +190,35 @@ export class PositioningController {
     conversationId: string
     actualFollowsLive: boolean
   }): boolean {
-    const expectedFollowsLive = shouldReconcileAfterAppend(
-      this.model,
-      input.conversationId,
-    )
-    compareShadowDecision({
+    return runScrollShadowSafely({
       event: input.event,
       conversationId: input.conversationId,
-      generation: this.model.active?.request.generation ?? null,
-      expected: {
-        desired: expectedFollowsLive
-          ? this.model.active?.request.desired ?? null
-          : null,
-        phase: expectedFollowsLive ? 'positioning' : 'idle',
-      },
-      actual: {
-        desired: input.actualFollowsLive
-          ? { kind: 'live-edge', follow: true }
-          : null,
-        phase: input.actualFollowsLive ? 'positioning' : 'idle',
+      fallback: false,
+      observe: () => {
+        const expectedFollowsLive = shouldReconcileAfterAppend(
+          this.model,
+          input.conversationId,
+        )
+        compareShadowDecision({
+          event: input.event,
+          conversationId: input.conversationId,
+          generation: this.model.active?.request.generation ?? null,
+          expected: {
+            desired: expectedFollowsLive
+              ? this.model.active?.request.desired ?? null
+              : null,
+            phase: expectedFollowsLive ? 'positioning' : 'idle',
+          },
+          actual: {
+            desired: input.actualFollowsLive
+              ? { kind: 'live-edge', follow: true }
+              : null,
+            phase: input.actualFollowsLive ? 'positioning' : 'idle',
+          },
+        })
+        return expectedFollowsLive
       },
     })
-    return expectedFollowsLive
   }
 
   /**
@@ -204,78 +233,113 @@ export class PositioningController {
     geometryAtLiveEdge: boolean
     actualFollowsLive: boolean
   }): boolean {
-    const expectedFollowsLive =
-      shouldReconcileAfterAppend(this.model, input.conversationId) ||
-      input.geometryAtLiveEdge
-    compareShadowDecision({
+    return runScrollShadowSafely({
       event: input.event,
       conversationId: input.conversationId,
-      generation: this.model.active?.request.generation ?? null,
-      expected: {
-        desired: expectedFollowsLive
-          ? { kind: 'live-edge', follow: true }
-          : null,
-        phase: expectedFollowsLive ? 'positioning' : 'idle',
-      },
-      actual: {
-        desired: input.actualFollowsLive
-          ? { kind: 'live-edge', follow: true }
-          : null,
-        phase: input.actualFollowsLive ? 'positioning' : 'idle',
+      fallback: false,
+      observe: () => {
+        const expectedFollowsLive =
+          shouldReconcileAfterAppend(this.model, input.conversationId) ||
+          input.geometryAtLiveEdge
+        compareShadowDecision({
+          event: input.event,
+          conversationId: input.conversationId,
+          generation: this.model.active?.request.generation ?? null,
+          expected: {
+            desired: expectedFollowsLive
+              ? { kind: 'live-edge', follow: true }
+              : null,
+            phase: expectedFollowsLive ? 'positioning' : 'idle',
+          },
+          actual: {
+            desired: input.actualFollowsLive
+              ? { kind: 'live-edge', follow: true }
+              : null,
+            phase: input.actualFollowsLive ? 'positioning' : 'idle',
+          },
+        })
+        return expectedFollowsLive
       },
     })
-    return expectedFollowsLive
   }
 
   markPositionApplied(conversationId: string, generation: number): void {
-    this.model = advancePhaseIfCurrent(
-      this.model,
+    runScrollShadowSafely({
+      event: 'position-applied',
       conversationId,
-      generation,
-      { kind: 'position-applied' },
-    )
+      fallback: undefined,
+      observe: () => {
+        this.model = advancePhaseIfCurrent(
+          this.model,
+          conversationId,
+          generation,
+          { kind: 'position-applied' },
+        )
+      },
+    })
   }
 
   observeUserInput(conversationId: string): void {
-    const generation = this.model.active?.request.generation
-    if (generation === undefined) return
-    this.model = cancelReconciliationForUserInput(
-      this.model,
+    runScrollShadowSafely({
+      event: 'user-input',
       conversationId,
-      generation,
-    )
+      fallback: undefined,
+      observe: () => {
+        const generation = this.model.active?.request.generation
+        if (generation === undefined) return
+        this.model = cancelReconciliationForUserInput(
+          this.model,
+          conversationId,
+          generation,
+        )
+      },
+    })
   }
 
   observeSettledUserGeometry(input: {
     conversationId: string
     atLiveEdge: boolean
   }): void {
-    const rearmRequest: Extract<
-      PositionRequest,
-      { source: { kind: 'user-navigation'; reason: 'live-edge' } }
-    > | undefined =
-      input.atLiveEdge && this.model.active === null
-        ? {
-            generation: mintPositionGeneration(),
-            conversationId: input.conversationId,
-            source: { kind: 'user-navigation', reason: 'live-edge' },
-            desired: { kind: 'live-edge', follow: true },
-          }
-        : undefined
-    this.model = settleUserPosition(
-      this.model,
-      input.conversationId,
-      input.atLiveEdge,
-      rearmRequest,
-    )
+    runScrollShadowSafely({
+      event: 'settled-user-geometry',
+      conversationId: input.conversationId,
+      fallback: undefined,
+      observe: () => {
+        const rearmRequest: Extract<
+          PositionRequest,
+          { source: { kind: 'user-navigation'; reason: 'live-edge' } }
+        > | undefined =
+          input.atLiveEdge && this.model.active === null
+            ? {
+                generation: mintPositionGeneration(),
+                conversationId: input.conversationId,
+                source: { kind: 'user-navigation', reason: 'live-edge' },
+                desired: { kind: 'live-edge', follow: true },
+              }
+            : undefined
+        this.model = settleUserPosition(
+          this.model,
+          input.conversationId,
+          input.atLiveEdge,
+          rearmRequest,
+        )
+      },
+    })
   }
 
-  deactivate(conversationId: string): void {
-    this.model = deactivateConversation(
-      this.model,
+  deactivate(conversationId: string, generation: number): void {
+    runScrollShadowSafely({
+      event: 'deactivate',
       conversationId,
-      this.model.watermark,
-    )
+      fallback: undefined,
+      observe: () => {
+        this.model = deactivateConversation(
+          this.model,
+          conversationId,
+          generation,
+        )
+      },
+    })
   }
 }
 

--- a/apps/fluux/src/components/conversation/scrollPositionShadow.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionShadow.ts
@@ -22,22 +22,33 @@ export interface ScrollShadowDivergence {
   actual: ShadowActualDecision
 }
 
+export interface ScrollShadowInstrumentationError {
+  event: string
+  conversationId: string
+  message: string
+}
+
 export interface ScrollShadowSnapshot {
   decisionCount: number
   divergenceCount: number
+  instrumentationErrorCount: number
   generationCount: number
   lastGeneration: number
   divergences: ScrollShadowDivergence[]
+  instrumentationErrors: ScrollShadowInstrumentationError[]
 }
 
 const MAX_RETAINED_DIVERGENCES = 50
+const MAX_RETAINED_INSTRUMENTATION_ERRORS = 50
 
 const diagnostics: ScrollShadowSnapshot = {
   decisionCount: 0,
   divergenceCount: 0,
+  instrumentationErrorCount: 0,
   generationCount: 0,
   lastGeneration: 0,
   divergences: [],
+  instrumentationErrors: [],
 }
 
 function cloneSnapshot(): ScrollShadowSnapshot {
@@ -48,19 +59,69 @@ function cloneSnapshot(): ScrollShadowSnapshot {
       expected: { ...item.expected },
       actual: { ...item.actual },
     })),
+    instrumentationErrors: diagnostics.instrumentationErrors.map((item) => ({
+      ...item,
+    })),
   }
 }
 
 export function resetScrollShadowDiagnostics(): void {
   diagnostics.decisionCount = 0
   diagnostics.divergenceCount = 0
+  diagnostics.instrumentationErrorCount = 0
   diagnostics.generationCount = 0
   diagnostics.lastGeneration = 0
   diagnostics.divergences = []
+  diagnostics.instrumentationErrors = []
 }
 
 export function getScrollShadowSnapshot(): ScrollShadowSnapshot {
   return cloneSnapshot()
+}
+
+/**
+ * Shadow observation must never interfere with the live scroll path it watches. Keep the error
+ * boundary here rather than scattering validator-specific guards through production call sites:
+ * branded fact constructors are deliberately strict, while malformed/transient geometry is a
+ * diagnostic failure that must be counted and skipped, not thrown through a React effect or event.
+ */
+export function runScrollShadowSafely<T>(input: {
+  event: string
+  conversationId: string
+  observe: () => T
+  fallback: T
+}): T {
+  try {
+    return input.observe()
+  } catch (error) {
+    let message = 'unknown shadow instrumentation error'
+    try {
+      message = error instanceof Error ? error.message : String(error)
+    } catch {
+      // Keep the boundary no-throw even for hostile error values.
+    }
+    const instrumentationError: ScrollShadowInstrumentationError = {
+      event: input.event,
+      conversationId: input.conversationId,
+      message,
+    }
+    diagnostics.instrumentationErrorCount += 1
+    diagnostics.instrumentationErrors.push(instrumentationError)
+    if (
+      diagnostics.instrumentationErrors.length >
+      MAX_RETAINED_INSTRUMENTATION_ERRORS
+    ) {
+      diagnostics.instrumentationErrors.shift()
+    }
+    if (isScrollDebugEnabled()) {
+      try {
+        console.warn('[ScrollShadow] instrumentation error', instrumentationError)
+      } catch {
+        // Console instrumentation must not punch through the shadow boundary either.
+      }
+    }
+    return input.fallback
+  }
 }
 
 export function recordShadowGeneration(generation: number): void {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -9,6 +9,10 @@ import {
   type UseMessageListScrollResult,
 } from './useMessageListScroll'
 import { scrollStateManager } from '@/utils/scrollStateManager'
+import {
+  getScrollShadowSnapshot,
+  resetScrollShadowDiagnostics,
+} from './scrollPositionShadow'
 
 class MockResizeObserver {
   constructor(private readonly callback: ResizeObserverCallback) {}
@@ -48,11 +52,16 @@ function seedSavedScrollPosition(conversationId: string, scrollTop = 200, readPo
 // Seed a saved CONTENT anchor whose scrollHeight differs from the harness scroller (1000) so the
 // exact-scrollTop fast-path is skipped and the anchor path runs — mirrors returning to a deeply
 // scrolled-back conversation whose tall window was evicted and rehydrated to a short latest slice.
-function seedSavedAnchor(conversationId: string, anchorMessageId: string, scrollTop = 200) {
+function seedSavedAnchor(
+  conversationId: string,
+  anchorMessageId: string,
+  scrollTop = 200,
+  fraction = 1,
+) {
   scrollStateManager.enterConversation(conversationId, 10)
   scrollStateManager.leaveConversation(conversationId, scrollTop, 5000, 500, {
     messageId: anchorMessageId,
-    fraction: 1,
+    fraction,
   })
 }
 
@@ -160,6 +169,7 @@ describe('useMessageListScroll saved-position restore', () => {
 
   beforeEach(() => {
     scrollStateManager.reset()
+    resetScrollShadowDiagnostics()
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
     realRaf = window.requestAnimationFrame
     window.requestAnimationFrame = (callback: FrameRequestCallback) => {
@@ -405,6 +415,30 @@ describe('useMessageListScroll saved-position restore', () => {
     )
 
     expect(onLoadAround).toHaveBeenCalledWith('old-anchor')
+  })
+
+  it('continues the live restore when malformed shadow facts are rejected', () => {
+    seedSavedAnchor('around-invalid-shadow', 'old-anchor', 200, Number.NaN)
+    const onLoadAround = vi.fn().mockResolvedValue([])
+
+    render(
+      <HookHarness
+        conversationId="around-invalid-shadow"
+        ids={['msg-0', 'msg-1', 'msg-2']}
+        onLoadAround={onLoadAround}
+        onReady={() => {}}
+      />,
+    )
+
+    // The production restore still requests its missing anchor; only the shadow observation skips.
+    expect(onLoadAround).toHaveBeenCalledWith('old-anchor')
+    expect(getScrollShadowSnapshot()).toMatchObject({
+      instrumentationErrorCount: 1,
+      instrumentationErrors: [{
+        event: 'entry-facts',
+        conversationId: 'around-invalid-shadow',
+      }],
+    })
   })
 
   it('does not request a slice when the saved anchor is already in the loaded set', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -42,6 +42,7 @@ import {
   type DesiredPosition,
   type ReachabilityFacts,
 } from './scrollPositionModel'
+import { runScrollShadowSafely } from './scrollPositionShadow'
 
 // ============================================================================
 // DEBUG
@@ -473,37 +474,49 @@ export function useMessageListScroll({
   const aroundLoadStatusRef = useRef<Map<string, 'loading' | 'done'>>(new Map())
   // Shadow-only semantic controller. It owns no React state and performs no scroll writes.
   // The module-private generation allocator survives controller remounts (including StrictMode).
-  const positioningControllerRef = useRef<PositioningController | null>(null)
-  if (!positioningControllerRef.current) {
-    positioningControllerRef.current = new PositioningController()
+  const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
+  if (positioningControllerRef.current === undefined) {
+    positioningControllerRef.current = runScrollShadowSafely({
+      event: 'controller-create',
+      conversationId,
+      fallback: null,
+      observe: () => new PositioningController(),
+    })
   }
   const shadowReachabilityRef = useRef<(desired: DesiredPosition) => ReachabilityFacts>(
     () => ({ kind: 'empty-window' }),
   )
   shadowReachabilityRef.current = (desired) => {
-    const anchorId =
-      desired.kind === 'anchor' || desired.kind === 'message'
-        ? desired.messageId
-        : null
-    const aroundStatus = anchorId
-      ? aroundLoadStatusRef.current.get(`${conversationId}:${anchorId}`)
-      : undefined
-    const loadAround =
-      aroundStatus === 'loading'
-        ? 'loading'
-        : aroundStatus === 'done'
-          ? 'exhausted'
-          : onLoadAround
-            ? 'available'
-            : 'unavailable'
-    return deriveReachabilityForDesired({
-      desired,
-      hasRows: messageCount > 0,
-      windowAtLiveEdge: windowAtLiveEdge !== false,
-      virtualizer: virtualizerRef.current,
-      scroller: scrollerRef.current,
-      loadAround,
-      canRecenter: true,
+    return runScrollShadowSafely({
+      event: 'reachability',
+      conversationId,
+      fallback: { kind: 'empty-window' },
+      observe: () => {
+        const anchorId =
+          desired.kind === 'anchor' || desired.kind === 'message'
+            ? desired.messageId
+            : null
+        const aroundStatus = anchorId
+          ? aroundLoadStatusRef.current.get(`${conversationId}:${anchorId}`)
+          : undefined
+        const loadAround =
+          aroundStatus === 'loading'
+            ? 'loading'
+            : aroundStatus === 'done'
+              ? 'exhausted'
+              : onLoadAround
+                ? 'available'
+                : 'unavailable'
+        return deriveReachabilityForDesired({
+          desired,
+          hasRows: messageCount > 0,
+          windowAtLiveEdge: windowAtLiveEdge !== false,
+          virtualizer: virtualizerRef.current,
+          scroller: scrollerRef.current,
+          loadAround,
+          canRecenter: true,
+        })
+      },
     })
   }
   // Last target message id we requested an around-load for (search / activity navigation to a
@@ -1100,12 +1113,19 @@ export function useMessageListScroll({
     // unlike the live loop, the shadow check never trusts isAtBottomRef by itself.
     if (trigger !== 'restore-fallback') {
       const scroller = scrollerRef.current
-      positioningControllerRef.current?.observeBottomReassert({
+      runScrollShadowSafely({
         event: `reassert:${trigger}`,
         conversationId: prevConversationRef.current ?? conversationId,
-        geometryAtLiveEdge:
-          !!scroller && deriveAtLiveEdge(readScrollGeometry(scroller)),
-        actualFollowsLive: true,
+        fallback: undefined,
+        observe: () => {
+          positioningControllerRef.current?.observeBottomReassert({
+            event: `reassert:${trigger}`,
+            conversationId: prevConversationRef.current ?? conversationId,
+            geometryAtLiveEdge:
+              !!scroller && deriveAtLiveEdge(readScrollGeometry(scroller)),
+            actualFollowsLive: true,
+          })
+        },
       })
     }
     if (virtualizerRef.current) {
@@ -1556,28 +1576,41 @@ export function useMessageListScroll({
       }
     }
 
-    const navigationFacts = deriveLiveEdgeNavigationFacts({
-      firstUnreadMessageId: markerResolvable ? firstNewMessageId : undefined,
-      markerOffsetPx,
-      geometry: readScrollGeometry(scroller),
-      virtualized: !!virt,
-    })
+    const viewportBottom = scroller.scrollTop + scroller.clientHeight
+    const markerNeedsVisit =
+      markerResolvable &&
+      (virt
+        ? markerOffsetPx === null || markerOffsetPx > viewportBottom
+        : markerOffsetPx !== null && markerOffsetPx > viewportBottom)
     const markerDesired =
-      firstNewMessageId && navigationFacts.unreadMarkerNeedsVisit
+      firstNewMessageId && markerNeedsVisit
         ? {
             kind: 'message' as const,
             messageId: firstNewMessageId,
-            align: navigationFacts.unreadMarkerAlign,
+            align: virt ? 'start' as const : 'top-third' as const,
           }
         : null
-    positioningControllerRef.current?.observeLiveEdgeNavigation({
+    runScrollShadowSafely({
       event: 'fab',
       conversationId,
-      navigationFacts,
-      reachability: (desired) => shadowReachabilityRef.current(desired),
-      actual: {
-        desired: markerDesired ?? { kind: 'live-edge', follow: true },
-        phase: 'positioning',
+      fallback: undefined,
+      observe: () => {
+        const navigationFacts = deriveLiveEdgeNavigationFacts({
+          firstUnreadMessageId: markerResolvable ? firstNewMessageId : undefined,
+          markerOffsetPx,
+          geometry: readScrollGeometry(scroller),
+          virtualized: !!virt,
+        })
+        positioningControllerRef.current?.observeLiveEdgeNavigation({
+          event: 'fab',
+          conversationId,
+          navigationFacts,
+          reachability: (desired) => shadowReachabilityRef.current(desired),
+          actual: {
+            desired: markerDesired ?? { kind: 'live-edge', follow: true },
+            phase: 'positioning',
+          },
+        })
       },
     })
 
@@ -1585,11 +1618,8 @@ export function useMessageListScroll({
       if (virt) {
         const markerIdx = virt.getIndexForMessageId(firstNewMessageId)
         if (markerIdx !== null) {
-          const viewportBottom = scroller.scrollTop + scroller.clientHeight
-          if (markerOffsetPx === null || markerOffsetPx > viewportBottom) {
-            virt.scrollToIndex(markerIdx, { align: 'start', behavior: 'smooth' })
-            return
-          }
+          virt.scrollToIndex(markerIdx, { align: 'start', behavior: 'smooth' })
+          return
         }
       } else {
         const messageElement = scroller.querySelector(
@@ -1597,11 +1627,8 @@ export function useMessageListScroll({
         )
         if (messageElement) {
           const elementTop = (messageElement as HTMLElement).offsetTop
-          const viewportBottom = scroller.scrollTop + scroller.clientHeight
-          if (elementTop > viewportBottom) {
-            scroller.scrollTo({ top: Math.max(0, elementTop - scroller.clientHeight / 3), behavior: 'smooth' })
-            return
-          }
+          scroller.scrollTo({ top: Math.max(0, elementTop - scroller.clientHeight / 3), behavior: 'smooth' })
+          return
         }
       }
     }
@@ -1949,24 +1976,31 @@ export function useMessageListScroll({
           })
         }
       } else if (!userScrolled && anchor) {
-        const desired: DesiredPosition = {
-          kind: 'anchor',
-          messageId: anchor.messageId,
-          placement: {
-            kind: 'bottom-fraction',
-            fraction: messageFraction(anchor.fraction),
-          },
-        }
-        const request = positioningControllerRef.current?.observeRequest({
+        const request = runScrollShadowSafely({
           event: 'media-preservation',
           conversationId,
-          draft: {
-            source: { kind: 'media-preservation', reason: 'remeasure' },
-            desired,
-            onUnavailable: { kind: 'warn-and-stop' },
+          fallback: null,
+          observe: () => {
+            const desired: DesiredPosition = {
+              kind: 'anchor',
+              messageId: anchor.messageId,
+              placement: {
+                kind: 'bottom-fraction',
+                fraction: messageFraction(anchor.fraction),
+              },
+            }
+            return positioningControllerRef.current?.observeRequest({
+              event: 'media-preservation',
+              conversationId,
+              draft: {
+                source: { kind: 'media-preservation', reason: 'remeasure' },
+                desired,
+                onUnavailable: { kind: 'warn-and-stop' },
+              },
+              reachability: shadowReachabilityRef.current(desired),
+              actual: { desired, phase: 'positioning' },
+            }) ?? null
           },
-          reachability: shadowReachabilityRef.current(desired),
-          actual: { desired, phase: 'positioning' },
         })
         // Scrolled up and the user did NOT genuinely scroll during the batch: media that decoded
         // ABOVE the viewport grew the content and pushed the reading position down/out. Re-pin to the
@@ -2128,9 +2162,16 @@ export function useMessageListScroll({
     if (genuineUserScroll) {
       userHasScrolledSinceEntryRef.current = true
       positioningControllerRef.current?.observeUserInput(conversationId)
-      positioningControllerRef.current?.observeSettledUserGeometry({
+      runScrollShadowSafely({
+        event: 'settled-user-geometry',
         conversationId,
-        atLiveEdge: deriveAtLiveEdge(readScrollGeometry(el)),
+        fallback: undefined,
+        observe: () => {
+          positioningControllerRef.current?.observeSettledUserGeometry({
+            conversationId,
+            atLiveEdge: deriveAtLiveEdge(readScrollGeometry(el)),
+          })
+        },
       })
     }
     prevScrollHeightRef.current = scrollHeight
@@ -2241,6 +2282,16 @@ export function useMessageListScroll({
     const scroller = scrollerRef.current
     if (!scroller) return
     if (prevConversationRef.current === conversationId) return
+    const previousShadowModel = runScrollShadowSafely({
+      event: 'deactivate-snapshot',
+      conversationId: prevConversationRef.current ?? conversationId,
+      fallback: null,
+      observe: () => positioningControllerRef.current?.snapshot() ?? null,
+    })
+    const previousShadowGeneration =
+      previousShadowModel?.currentConversationId === prevConversationRef.current
+        ? previousShadowModel.watermark
+        : null
 
     debugLog('CONVERSATION SWITCH', {
       from: prevConversationRef.current,
@@ -2265,9 +2316,13 @@ export function useMessageListScroll({
     } else if (prevConversationRef.current) {
       scrollStateManager.markAsLeft(prevConversationRef.current)
     }
-    if (prevConversationRef.current) {
+    if (
+      prevConversationRef.current &&
+      previousShadowGeneration !== null
+    ) {
       positioningControllerRef.current?.deactivate(
         prevConversationRef.current,
+        previousShadowGeneration,
       )
     }
 
@@ -2346,36 +2401,42 @@ export function useMessageListScroll({
       }
 
       debugLog('CONVERSATION ACTION', { action, savedPos, firstOpenThisSession, scrollHeight: scroller.scrollHeight })
-      const entryFacts = deriveEntryPositionFacts({
-        syncedLiveEdge,
-        savedAnchor,
-        savedOffsetPx: savedPos,
-        firstUnreadMessageId: firstNewMessageId,
+      const entryFacts = runScrollShadowSafely({
+        event: 'entry-facts',
+        conversationId,
+        fallback: null,
+        observe: () => deriveEntryPositionFacts({
+          syncedLiveEdge,
+          savedAnchor,
+          savedOffsetPx: savedPos,
+          firstUnreadMessageId: firstNewMessageId,
+        }),
       })
 
       if (action === 'restore-position') {
         const restoreResult = restoreSavedPosition('entry')
         pendingRestoreConversationRef.current =
           restoreResult === 'pending' ? conversationId : null
-        const actualDesired: DesiredPosition = entryFacts.savedAnchor ??
-          (entryFacts.savedOffsetPx !== undefined
-            ? { kind: 'legacy-offset', offsetPx: entryFacts.savedOffsetPx }
-            : { kind: 'live-edge', follow: true })
-        const request = positioningControllerRef.current?.observeEntry({
-          event: 'entry-restore',
-          conversationId,
-          entryFacts,
-          reachability: (desired) => shadowReachabilityRef.current(desired),
-          actual: {
-            desired: actualDesired,
-            phase:
-              restoreResult === 'pending'
-                ? 'waiting'
-                : restoreResult === 'bottom'
-                  ? 'fallback'
-                  : 'positioning',
-          },
-        })
+        const request = entryFacts
+          ? positioningControllerRef.current?.observeEntry({
+              event: 'entry-restore',
+              conversationId,
+              entryFacts,
+              reachability: (desired) => shadowReachabilityRef.current(desired),
+              actual: {
+                desired: entryFacts.savedAnchor ??
+                  (entryFacts.savedOffsetPx !== undefined
+                    ? { kind: 'legacy-offset', offsetPx: entryFacts.savedOffsetPx }
+                    : { kind: 'live-edge', follow: true }),
+                phase:
+                  restoreResult === 'pending'
+                    ? 'waiting'
+                    : restoreResult === 'bottom'
+                      ? 'fallback'
+                      : 'positioning',
+              },
+            })
+          : null
         if (restoreResult === 'restored' && request) {
           positioningControllerRef.current?.markPositionApplied(
             conversationId,
@@ -2403,22 +2464,24 @@ export function useMessageListScroll({
         }
         const markerReachability =
           shadowReachabilityRef.current(markerDesired)
-        positioningControllerRef.current?.observeEntry({
-          event: 'entry-unread',
-          conversationId,
-          entryFacts,
-          reachability: () => markerReachability,
-          actual: {
-            desired: markerDesired,
-            phase:
-              markerReachability.kind === 'available' &&
-              markerReachability.placement === 'use-unavailable-policy'
-                ? 'fallback'
-                : markerReachability.kind === 'available'
-                  ? 'positioning'
-                  : 'waiting',
-          },
-        })
+        if (entryFacts) {
+          positioningControllerRef.current?.observeEntry({
+            event: 'entry-unread',
+            conversationId,
+            entryFacts,
+            reachability: () => markerReachability,
+            actual: {
+              desired: markerDesired,
+              phase:
+                markerReachability.kind === 'available' &&
+                markerReachability.placement === 'use-unavailable-policy'
+                  ? 'fallback'
+                  : markerReachability.kind === 'available'
+                    ? 'positioning'
+                    : 'waiting',
+            },
+          })
+        }
         // Re-assert the marker position across frames. On entry the conversation's messages were
         // evicted on leave and rehydrate from cache ASYNCHRONOUSLY, and rows then measure over
         // several frames, so the marker offset is unresolved at first and sharpens as it settles.
@@ -2438,16 +2501,18 @@ export function useMessageListScroll({
         // to bottom when content grows (messages loading from IndexedDB).
         isAtBottomRef.current = false
         debugLog('CONVERSATION SWITCH: has targetMessageId, deferring to target scroll', { targetMessageId })
-        positioningControllerRef.current?.observeEntry({
-          event: 'entry-before-explicit-target',
-          conversationId,
-          entryFacts,
-          reachability: (desired) => shadowReachabilityRef.current(desired),
-          actual: {
-            desired: { kind: 'live-edge', follow: true },
-            phase: 'positioning',
-          },
-        })
+        if (entryFacts) {
+          positioningControllerRef.current?.observeEntry({
+            event: 'entry-before-explicit-target',
+            conversationId,
+            entryFacts,
+            reachability: (desired) => shadowReachabilityRef.current(desired),
+            actual: {
+              desired: { kind: 'live-edge', follow: true },
+              phase: 'positioning',
+            },
+          })
+        }
       } else {
         // No unread messages - scroll to bottom
         // We use both immediate and deferred scroll because:
@@ -2458,16 +2523,18 @@ export function useMessageListScroll({
         // Note: Async content loading (MAM) is handled by the separate "new message" effect
         // which triggers when messageCount changes.
         isAtBottomRef.current = true
-        positioningControllerRef.current?.observeEntry({
-          event: syncedLiveEdge ? 'entry-synced-live-edge' : 'entry-live-edge',
-          conversationId,
-          entryFacts,
-          reachability: (desired) => shadowReachabilityRef.current(desired),
-          actual: {
-            desired: { kind: 'live-edge', follow: true },
-            phase: 'positioning',
-          },
-        })
+        if (entryFacts) {
+          positioningControllerRef.current?.observeEntry({
+            event: syncedLiveEdge ? 'entry-synced-live-edge' : 'entry-live-edge',
+            conversationId,
+            entryFacts,
+            reachability: (desired) => shadowReachabilityRef.current(desired),
+            actual: {
+              desired: { kind: 'live-edge', follow: true },
+              phase: 'positioning',
+            },
+          })
+        }
         const virtSwitch = latestRef.current.virtualizer
         if (virtSwitch) {
           // Virtualizer-native bottom: uses actual measured heights, not the estimated
@@ -2607,7 +2674,12 @@ export function useMessageListScroll({
     if (restoreResult !== 'pending') {
       pendingRestoreConversationRef.current = null
       if (restoreResult === 'restored') {
-        const active = positioningControllerRef.current?.snapshot().active
+        const active = runScrollShadowSafely({
+          event: 'restore-retry-snapshot',
+          conversationId,
+          fallback: null,
+          observe: () => positioningControllerRef.current?.snapshot().active ?? null,
+        })
         if (active?.request.conversationId === conversationId) {
           positioningControllerRef.current?.markPositionApplied(
             conversationId,
@@ -3046,38 +3118,39 @@ export function useMessageListScroll({
       maxScrollTop,
     })
 
-    const shadowWindowShiftDesired: DesiredPosition | null =
-      saved.anchorMessageId
-        ? {
-            kind: 'anchor',
-            messageId: saved.anchorMessageId,
-            placement: {
-              kind: 'top-offset',
-              offsetPx: pixelOffset(saved.anchorOffsetFromTop),
-            },
-          }
-        : null
-    const shadowWindowShiftRequest = shadowWindowShiftDesired
-      ? positioningControllerRef.current?.observeRequest({
+    const shadowWindowShiftRequest = runScrollShadowSafely({
+      event: 'window-shift-preservation',
+      conversationId,
+      fallback: null,
+      observe: () => {
+        if (!saved.anchorMessageId) return null
+        const desired: DesiredPosition = {
+          kind: 'anchor',
+          messageId: saved.anchorMessageId,
+          placement: {
+            kind: 'top-offset',
+            offsetPx: pixelOffset(saved.anchorOffsetFromTop),
+          },
+        }
+        return positioningControllerRef.current?.observeRequest({
           event: 'window-shift-preservation',
           conversationId,
           draft: {
             source: { kind: 'history-preservation', reason: 'window-shift' },
-            desired: shadowWindowShiftDesired,
+            desired,
             onUnavailable: {
               kind: 'distance-from-bottom',
               distancePx: pixelOffset(saved.distanceFromBottom),
             },
           },
-          reachability: shadowReachabilityRef.current(
-            shadowWindowShiftDesired,
-          ),
+          reachability: shadowReachabilityRef.current(desired),
           actual: {
-            desired: shadowWindowShiftDesired,
+            desired,
             phase: usedMethod === 'math-fallback' ? 'fallback' : 'positioning',
           },
-        })
-      : null
+        }) ?? null
+      },
+    })
 
     // Cancel any parked kinetic (momentum) scroll BEFORE positioning. On a fast scroll-up
     // fling the user reaches the top boundary with residual velocity that WebKit parks and

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -29,7 +29,18 @@ centralizing it later must not erase or weaken its current safeguards.
 The first migration step runs the model beside `useMessageListScroll` without moving a scroll write.
 Fact adapters read current virtualizer, persisted-state, and DOM geometry; the controller is held in
 a ref and owns no React state. Every observed live decision is compared with the model decision.
-The demo scroll-invariant suite fails if its retained divergence list is non-empty.
+The shadow runs in production so real traces can exercise it. A shared instrumentation boundary
+therefore catches and counts adapter, validator, and controller errors; an observation failure must
+never escape into the live scroll effect or event handler. The demo scroll-invariant suite fails if
+either `divergenceCount` or `instrumentationErrorCount` is non-zero. The retained lists are capped
+diagnostic samples, not the pass criterion.
+
+Zero divergences means the model agrees with the hand-authored semantic `actual` label at each
+observation site: desired position plus the coarse waiting/positioning/applied/paused/fallback/idle
+phase. It does **not** compare rendered pixels and must not be read as proof that the browser landed
+or painted at the requested position, nor does it prove that every ownership site was observed.
+Pixel geometry, measurement convergence, and WebKit repaint remain covered by the scroll-invariant
+scenarios and the unchanged imperative implementation.
 
 Generation allocation is module-private and shared by controller instances. Each mounted
 message-list owns its controller model, but a remount (including StrictMode effect replay) cannot

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -91,15 +91,21 @@ test.afterEach(async ({ page }) => {
         __fluuxScrollShadow?: () => {
           divergenceCount: number
           divergences: unknown[]
+          instrumentationErrorCount: number
+          instrumentationErrors: unknown[]
         }
       }
     ).__fluuxScrollShadow?.()
   })
   expect(shadow, 'scroll shadow diagnostics must be installed').toBeDefined()
   expect(
-    shadow?.divergences,
-    `scroll shadow recorded ${shadow?.divergenceCount ?? 0} divergence(s)`,
-  ).toEqual([])
+    shadow?.divergenceCount,
+    `scroll shadow divergences: ${JSON.stringify(shadow?.divergences ?? [])}`,
+  ).toBe(0)
+  expect(
+    shadow?.instrumentationErrorCount,
+    `scroll shadow instrumentation errors: ${JSON.stringify(shadow?.instrumentationErrors ?? [])}`,
+  ).toBe(0)
 })
 
 /** Navigate to the stress room and wait for virtual rows to appear.


### PR DESCRIPTION
Follow-up to #1097.

This keeps the production shadow observer strictly passive:
- catches and counts adapter, validator, and controller instrumentation errors without interrupting live scroll behavior
- covers saved-anchor, media-preservation, reachability, and window-shift fact construction
- restores the FAB legacy geometry predicate as the production authority and compares shadow facts independently
- wires deactivation to a captured generation so stale deactivation can actually be rejected
- documents that zero divergences validates semantic labels, not rendered pixels
- makes the browser invariant harness fail on instrumentation errors as well as semantic divergences