### PR TITLE
Polish room header menu chevron behavior

### DIFF
--- a/apps/fluux/src/components/RoomHeader.test.tsx
+++ b/apps/fluux/src/components/RoomHeader.test.tsx
@@ -381,7 +381,28 @@ describe('RoomHeader', () => {
         />
       )
 
-      expect(screen.getByLabelText('Hide members')).toBeInTheDocument()
+      const toggle = screen.getByLabelText('Hide members')
+      expect(toggle).toBeInTheDocument()
+      expect(toggle.querySelector('.lucide-chevron-right')).not.toHaveClass('rotate-180')
+    })
+
+    it('points the chevron toward the closed members panel', () => {
+      render(
+        <RoomHeader
+          room={createRoom()}
+          showOccupants={false}
+          onToggleOccupants={mockOnToggleOccupants}
+          setRoomNotifyAll={mockSetRoomNotifyAll}
+          setRoomAvatar={mockSetRoomAvatar}
+          clearRoomAvatar={mockClearRoomAvatar}
+          submitRoomConfig={mockSubmitRoomConfig}
+          setSubject={mockSetSubject}
+          destroyRoom={mockDestroyRoom}
+        />
+      )
+
+      const toggle = screen.getByLabelText('Show members')
+      expect(toggle.querySelector('.lucide-chevron-right')).toHaveClass('rotate-180')
     })
   })
 

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -227,7 +227,7 @@ export function RoomHeader({
           >
             <Users className="size-4" />
             <span className="text-sm font-medium">{uniqueOccupantCount}</span>
-            <ChevronRight className={`size-4 transition-transform ${showOccupants ? 'rotate-180' : ''}`} />
+            <ChevronRight className={`size-4 transition-transform ${showOccupants ? '' : 'rotate-180'}`} />
           </button>
         </Tooltip>
       </div>

--- a/apps/fluux/src/components/header/HeaderSubmenuButton.test.tsx
+++ b/apps/fluux/src/components/header/HeaderSubmenuButton.test.tsx
@@ -13,10 +13,14 @@ describe('HeaderSubmenuButton', () => {
   }
 
   it('opens the dropdown and lists the group items', () => {
-    render(<HeaderSubmenuButton ariaLabel="Notify" tooltip="Notify" icon={Bell} group={group} />)
+    const { container } = render(<HeaderSubmenuButton ariaLabel="Notify" tooltip="Notify" icon={Bell} group={group} />)
     fireEvent.click(screen.getByLabelText('Notify'))
     expect(screen.getByText('Mentions only')).toBeInTheDocument()
     expect(screen.getByText('All messages')).toBeInTheDocument()
+    expect(container.querySelector('.lucide-chevron-down')).toHaveClass(
+      '[transition-duration:var(--fluux-duration-fast)]',
+    )
+    expect(screen.getByRole('menu')).toHaveClass('header-submenu-in')
   })
 
   it('fires an item onSelect and closes', () => {

--- a/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
+++ b/apps/fluux/src/components/header/HeaderSubmenuButton.tsx
@@ -43,7 +43,7 @@ export function HeaderSubmenuButton({ ariaLabel, tooltip, icon: Icon, active, gr
           className={className ?? `flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors tap-target ${active ? on : idle}`}
         >
           <Icon className="size-4" />
-          <ChevronDown className={`size-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+          <ChevronDown className={`size-3 transition-transform [transition-duration:var(--fluux-duration-fast)] [transition-timing-function:var(--fluux-ease-standard)] ${open ? 'rotate-180' : ''}`} />
         </button>
       </Tooltip>
 
@@ -52,7 +52,7 @@ export function HeaderSubmenuButton({ ariaLabel, tooltip, icon: Icon, active, gr
           ref={menu.menuRef}
           role="menu"
           style={{ left: menu.position.x, top: menu.position.y }}
-          className="fixed w-64 max-w-[calc(100vw-1rem)] fluux-popover rounded-lg z-30 py-1"
+          className="header-submenu-in fixed w-64 max-w-[calc(100vw-1rem)] fluux-popover rounded-lg z-30 py-1"
         >
           {group.items.map((item) => {
             const ItemIcon = item.icon

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -571,6 +571,25 @@
     box-shadow: var(--fluux-shadow-overlay);
   }
 
+  /* Let a submenu trigger's chevron finish turning before the panel unfolds.
+     clip-path preserves the panel's measured size, so anchored positioning does
+     not jump while the reveal runs. */
+  @keyframes header-submenu-in {
+    from {
+      opacity: 0;
+      clip-path: inset(0 0 100% 0);
+    }
+    to {
+      opacity: 1;
+      clip-path: inset(0);
+    }
+  }
+
+  .header-submenu-in {
+    animation: header-submenu-in var(--fluux-duration-fast) var(--fluux-ease-emphasized)
+      var(--fluux-duration-fast) backwards;
+  }
+
   /* Frosted-glass panel surface (modals + command palette). Solid theme-derived
      fallback by default; frosted where the browser supports backdrop-filter +
      color-mix (~88% opaque, readability first); [data-transparency="reduced"]
@@ -820,6 +839,10 @@ html {
   scroll-behavior: auto !important;
 }
 
+[data-motion="reduced"] .header-submenu-in {
+  animation-delay: 0ms !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root:not([data-motion="full"]),
   :root:not([data-motion="full"]) *,
@@ -829,6 +852,10 @@ html {
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
     scroll-behavior: auto !important;
+  }
+
+  :root:not([data-motion="full"]) .header-submenu-in {
+    animation-delay: 0ms !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- rotate the room-management submenu chevron before revealing its panel
- reveal the submenu only after the chevron transition, while preserving anchored positioning
- orient the members-panel chevron toward the action it performs: left to open the closed right-side panel, right to close it
- skip the submenu reveal delay when reduced motion is enabled

## Why

The management menu appeared at the same time as its chevron rotated, making the motion read in the wrong order. The members toggle also pointed away from the direction in which the side panel would open or close.

## Impact

Room header controls now follow a consistent directional convention and provide a more natural two-step menu animation without changing their behavior or accessibility semantics.