### PR TITLE
Migrate saved-position restoration to the positioning controller

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -1,7 +1,12 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
 import type { MessageVirtualizer } from './messageVirtualizer'
-import { PositioningController, type PositionRequestDraft } from './positioningController'
+import {
+  PositioningController,
+  type PositionRequestDraft,
+  type SavedPositionExecutionLease,
+  type SavedPositionExecutor,
+} from './positioningController'
 import {
   deriveAtLiveEdge,
   deriveEntryPositionFacts,
@@ -17,8 +22,10 @@ import {
 } from './scrollPositionShadow'
 import {
   messageFraction,
+  pixelOffset,
   type BottomFractionAnchorPosition,
   type LiveEdgePosition,
+  type SavedPositionRequest,
 } from './scrollPositionModel'
 import { recordedPositioningTraces } from './positioningController.traceFixtures'
 
@@ -333,6 +340,305 @@ describe('positioning controller shadow mode', () => {
 
     controller.deactivate(conversationId, current!.generation)
     expect(controller.snapshot().currentConversationId).toBeNull()
+  })
+})
+
+describe('positioning controller saved-position ownership', () => {
+  const savedAnchor: ScrollAnchor = {
+    messageId: 'saved-message',
+    fraction: 0.5,
+  }
+
+  function savedFacts(savedOffsetPx = 900) {
+    return deriveEntryPositionFacts({
+      syncedLiveEdge: false,
+      savedAnchor,
+      savedOffsetPx,
+    })
+  }
+
+  it('loads an off-window anchor exactly once and resumes when that load settles', async () => {
+    let anchorAvailable = false
+    let resolveLoad!: () => void
+    const loadPromise = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    const reconcile = vi.fn(() => true)
+    const loadAround = vi.fn(() => loadPromise)
+    const executor: SavedPositionExecutor = {
+      reachability: (desired, loadStatus) =>
+        desired.kind === 'anchor' && !anchorAvailable
+          ? { kind: 'target-absent', loadAround: loadStatus }
+          : {
+              kind: 'available',
+              index: 4,
+              mounted: true,
+              placement: 'viable',
+            },
+      loadAround,
+      reconcile,
+    }
+    const controller = new PositioningController()
+    const request = controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor,
+    })
+
+    expect(request).not.toBeNull()
+    expect(loadAround).toHaveBeenCalledTimes(1)
+    expect(reconcile).not.toHaveBeenCalled()
+    expect(controller.isSavedPositionPending(conversationId)).toBe(true)
+
+    controller.refreshSavedPosition({
+      conversationId,
+      generation: request!.generation,
+      executor,
+    })
+    expect(loadAround).toHaveBeenCalledTimes(1)
+
+    anchorAvailable = true
+    resolveLoad()
+    await loadPromise
+    await Promise.resolve()
+
+    expect(reconcile).toHaveBeenCalledTimes(1)
+    expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
+      kind: 'position-applied',
+    })
+  })
+
+  it('drops a late around-load completion after switching conversations', async () => {
+    let resolveLoad!: () => void
+    const loadPromise = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    const reconcile = vi.fn(() => true)
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: {
+        reachability: (_desired, loadStatus) => ({
+          kind: 'target-absent',
+          loadAround: loadStatus,
+        }),
+        loadAround: () => loadPromise,
+        reconcile,
+      },
+    })
+
+    observeLiveEntry(controller, 'next-room@example.test')
+    resolveLoad()
+    await loadPromise
+    await Promise.resolve()
+
+    expect(reconcile).not.toHaveBeenCalled()
+    expect(controller.snapshot().currentConversationId).toBe('next-room@example.test')
+    expect(controller.savedPositionStatus(conversationId)).toBeNull()
+  })
+
+  it('invalidates an older same-generation reconciliation operation', () => {
+    const leases: SavedPositionExecutionLease[] = []
+    const executor: SavedPositionExecutor = {
+      reachability: () => ({
+        kind: 'available',
+        index: 4,
+        mounted: true,
+        placement: 'viable',
+      }),
+      reconcile: (_request, lease) => {
+        leases.push(lease)
+        return true
+      },
+    }
+    const controller = new PositioningController()
+    const request = controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor,
+    })
+    controller.refreshSavedPosition({
+      conversationId,
+      generation: request!.generation,
+      executor,
+    })
+
+    expect(leases).toHaveLength(2)
+    expect(leases[0].generation).toBe(leases[1].generation)
+    expect(leases[0].operation).toBeLessThan(leases[1].operation)
+    expect(leases[0].isCurrent()).toBe(false)
+    expect(leases[1].isCurrent()).toBe(true)
+  })
+
+  it('cancels saved reconciliation immediately on genuine user input', () => {
+    let lease: SavedPositionExecutionLease | null = null
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: {
+        reachability: () => ({
+          kind: 'available',
+          index: 4,
+          mounted: true,
+          placement: 'viable',
+        }),
+        reconcile: (_request, currentLease) => {
+          lease = currentLease
+          return true
+        },
+      },
+    })
+
+    controller.observeUserInput(conversationId)
+
+    expect(lease).not.toBeNull()
+    expect(lease!.isCurrent()).toBe(false)
+    expect(controller.savedPositionStatus(conversationId)).toBeNull()
+  })
+
+  it('promotes an unavailable anchor to its legacy offset under a new generation', () => {
+    let reconciled: SavedPositionRequest | null = null
+    const controller = new PositioningController()
+    const initial = controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(700),
+      executor: {
+        reachability: (desired) =>
+          desired.kind === 'anchor'
+            ? { kind: 'target-absent', loadAround: 'unavailable' }
+            : {
+                kind: 'available',
+                index: 0,
+                mounted: true,
+                placement: 'viable',
+              },
+        reconcile: (request) => {
+          reconciled = request
+          return true
+        },
+      },
+    })
+
+    expect(reconciled).not.toBeNull()
+    expect(reconciled!.generation).toBeGreaterThan(initial!.generation)
+    expect(reconciled!.source).toEqual({
+      kind: 'fallback',
+      reason: 'saved-position-unavailable',
+    })
+    expect(reconciled!.desired).toEqual({
+      kind: 'legacy-offset',
+      offsetPx: pixelOffset(700),
+    })
+  })
+
+  it('uses the request fallback when anchor reconciliation itself cannot land', () => {
+    const desiredKinds: string[] = []
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(650),
+      executor: {
+        reachability: () => ({
+          kind: 'available',
+          index: 3,
+          mounted: true,
+          placement: 'viable',
+        }),
+        reconcile: (request) => {
+          desiredKinds.push(request.desired.kind)
+          return request.desired.kind === 'legacy-offset'
+        },
+      },
+    })
+
+    // A generic reconcile-failure fallback would skip the usable legacy offset and go live.
+    expect(desiredKinds).toEqual(['anchor', 'legacy-offset'])
+    expect(controller.savedPositionStatus(conversationId)?.request.desired).toEqual({
+      kind: 'legacy-offset',
+      offsetPx: pixelOffset(650),
+    })
+  })
+
+  it('recenters a slid-up window before applying a saved live-edge fallback', () => {
+    let atGlobalLiveEdge = false
+    const recenter = vi.fn(() => 'requested' as const)
+    const reconcile = vi.fn(() => true)
+    const executor = (version: string): SavedPositionExecutor => ({
+      reachability: (desired) => {
+        if (desired.kind === 'anchor') {
+          return { kind: 'target-absent', loadAround: 'unavailable' }
+        }
+        return {
+          kind: 'global-live-edge',
+          state: atGlobalLiveEdge
+            ? { kind: 'resident-tail', index: 9, mounted: true }
+            : { kind: 'recenter-available' },
+        }
+      },
+      recenterVersion: version,
+      recenterLiveEdge: recenter,
+      reconcile,
+    })
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: deriveEntryPositionFacts({
+        syncedLiveEdge: false,
+        savedAnchor,
+        savedOffsetPx: null,
+      }),
+      executor: executor('slid:idle:10'),
+    })
+
+    expect(recenter).toHaveBeenCalledTimes(1)
+    expect(reconcile).not.toHaveBeenCalled()
+
+    const pending = controller.savedPositionStatus(conversationId)!
+    atGlobalLiveEdge = true
+    controller.refreshSavedPosition({
+      conversationId,
+      generation: pending.request.generation,
+      executor: executor('live:idle:20'),
+    })
+
+    expect(reconcile).toHaveBeenCalledTimes(1)
+    expect(controller.savedPositionStatus(conversationId)?.request.desired).toEqual(liveEdge)
+  })
+
+  it('aborts pending saved work when the active generation is deactivated', () => {
+    let signal: AbortSignal | null = null
+    let resolveLoad!: () => void
+    const loadPromise = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    const reconcile = vi.fn(() => true)
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: {
+        reachability: (_desired, loadStatus) => ({
+          kind: 'target-absent',
+          loadAround: loadStatus,
+        }),
+        loadAround: (_messageId, currentSignal) => {
+          signal = currentSignal
+          return loadPromise
+        },
+        reconcile,
+      },
+    })
+    const generation = controller.snapshot().watermark
+
+    controller.deactivate(conversationId, generation)
+    resolveLoad()
+
+    expect(signal).not.toBeNull()
+    expect(signal!.aborted).toBe(true)
+    expect(controller.savedPositionStatus(conversationId)).toBeNull()
+    expect(reconcile).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -4,6 +4,7 @@ import {
   cancelReconciliationForUserInput,
   deactivateConversation,
   initialPositioningModel,
+  isCurrentGeneration,
   resolveReachability,
   selectEntryPosition,
   selectLiveEdgeNavigation,
@@ -13,7 +14,10 @@ import {
   type LiveEdgeNavigationFacts,
   type PositionRequest,
   type PositioningModel,
+  type PositioningPhase,
   type ReachabilityFacts,
+  type SavedPositionRequest,
+  type UnavailablePolicy,
 } from './scrollPositionModel'
 import {
   compareShadowDecision,
@@ -28,6 +32,52 @@ type PositionRequestDraft = PositionRequest extends infer Request
     ? Omit<Request, 'generation' | 'conversationId'>
     : never
   : never
+
+export type SavedPositionLoadAroundStatus =
+  | 'available'
+  | 'loading'
+  | 'exhausted'
+  | 'unavailable'
+
+export interface SavedPositionExecutionLease {
+  conversationId: string
+  generation: number
+  operation: number
+  signal: AbortSignal
+  isCurrent: () => boolean
+  markApplied: () => boolean
+  settle: () => boolean
+}
+
+export interface SavedPositionExecutor {
+  reachability: (
+    desired: SavedPositionRequest['desired'],
+    loadAround: SavedPositionLoadAroundStatus,
+  ) => ReachabilityFacts
+  loadAround?: (
+    messageId: string,
+    signal: AbortSignal,
+  ) => Promise<unknown> | unknown
+  /** Changes whenever another forward-window request may be issued safely. */
+  recenterVersion?: string
+  recenterLiveEdge?: (
+    signal: AbortSignal,
+  ) => 'requested' | 'waiting' | 'unavailable'
+  reconcile: (
+    request: SavedPositionRequest,
+    lease: SavedPositionExecutionLease,
+  ) => boolean
+}
+
+interface SavedPositionExecutionState {
+  request: SavedPositionRequest
+  executor: SavedPositionExecutor
+  operation: number
+  abortController: AbortController | null
+  aroundAttempted: boolean
+  loadingAround: boolean
+  lastRecenterVersion: string | null
+}
 
 let nextPositionGeneration = 1
 
@@ -69,9 +119,109 @@ export function reachabilityMatchesRequest(
 
 export class PositioningController {
   private model: PositioningModel = initialPositioningModel()
+  private savedExecution: SavedPositionExecutionState | null = null
 
   snapshot(): PositioningModel {
     return this.model
+  }
+
+  beginSavedPositionEntry(input: {
+    conversationId: string
+    entryFacts: EntryPositionFacts
+    executor: SavedPositionExecutor
+  }): SavedPositionRequest | null {
+    const selection = selectEntryPosition(input.entryFacts)
+    if (
+      selection.source.kind !== 'entry' ||
+      selection.source.reason !== 'saved-position'
+    ) {
+      return null
+    }
+
+    const generation = mintPositionGeneration()
+    const request = withIdentity(
+      input.conversationId,
+      generation,
+      selection as PositionRequestDraft,
+    ) as SavedPositionRequest
+    const initialReachability = runScrollShadowSafely<ReachabilityFacts | null>({
+      event: 'saved-position-entry-reachability',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => input.executor.reachability(
+        request.desired,
+        input.executor.loadAround ? 'available' : 'unavailable',
+      ),
+    })
+    if (!initialReachability) return null
+    if (!reachabilityMatchesRequest(request, initialReachability)) return null
+
+    const accepted = acceptPositionRequest(this.model, request)
+    if (accepted === this.model) return null
+    this.cancelSavedExecution()
+    this.model = advancePhaseIfCurrent(
+      accepted,
+      input.conversationId,
+      generation,
+      resolveReachability(request, initialReachability),
+    )
+    this.savedExecution = {
+      request,
+      executor: input.executor,
+      operation: 0,
+      abortController: null,
+      aroundAttempted: false,
+      loadingAround: false,
+      lastRecenterVersion: null,
+    }
+    this.driveSavedPosition()
+    return request
+  }
+
+  refreshSavedPosition(input: {
+    conversationId: string
+    generation: number
+    executor: SavedPositionExecutor
+  }): boolean {
+    const execution = this.savedExecution
+    if (
+      !execution ||
+      execution.request.conversationId !== input.conversationId ||
+      execution.request.generation !== input.generation ||
+      !isCurrentGeneration(this.model, input.conversationId, input.generation)
+    ) {
+      return false
+    }
+    execution.executor = input.executor
+    this.driveSavedPosition()
+    return true
+  }
+
+  savedPositionStatus(conversationId: string): {
+    request: SavedPositionRequest
+    phase: PositioningPhase
+  } | null {
+    const execution = this.savedExecution
+    const active = this.model.active
+    if (
+      !execution ||
+      !active ||
+      active.request !== execution.request ||
+      active.request.conversationId !== conversationId
+    ) {
+      return null
+    }
+    return {
+      request: execution.request,
+      phase: active.phase,
+    }
+  }
+
+  isSavedPositionPending(conversationId: string): boolean {
+    const status = this.savedPositionStatus(conversationId)
+    return status !== null &&
+      status.phase.kind !== 'position-applied' &&
+      status.phase.kind !== 'settled'
   }
 
   observeEntry(input: {
@@ -144,6 +294,7 @@ export class PositioningController {
           generation,
           phase,
         )
+        this.cancelSavedExecutionIfSuperseded()
         compareShadowDecision({
           event: input.event,
           conversationId: input.conversationId,
@@ -292,6 +443,7 @@ export class PositioningController {
           conversationId,
           generation,
         )
+        this.cancelSavedExecutionIfSuperseded()
       },
     })
   }
@@ -323,6 +475,7 @@ export class PositioningController {
           input.atLiveEdge,
           rearmRequest,
         )
+        this.cancelSavedExecutionIfSuperseded()
       },
     })
   }
@@ -338,8 +491,267 @@ export class PositioningController {
           conversationId,
           generation,
         )
+        this.cancelSavedExecutionIfSuperseded()
       },
     })
+  }
+
+  private driveSavedPosition(): void {
+    const execution = this.savedExecution
+    if (!execution || !this.isSavedExecutionCurrent(execution)) return
+
+    const loadAround: SavedPositionLoadAroundStatus = execution.loadingAround
+      ? 'loading'
+      : execution.aroundAttempted
+        ? 'exhausted'
+        : execution.executor.loadAround
+          ? 'available'
+          : 'unavailable'
+    const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+      event: 'saved-position-reachability',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.reachability(
+        execution.request.desired,
+        loadAround,
+      ),
+    })
+    if (!reachability) {
+      this.promoteSavedFallback(execution, { kind: 'live-edge' })
+      return
+    }
+
+    const phase = resolveReachability(execution.request, reachability)
+    this.model = advancePhaseIfCurrent(
+      this.model,
+      execution.request.conversationId,
+      execution.request.generation,
+      phase,
+    )
+    if (!this.isSavedExecutionCurrent(execution)) return
+
+    switch (phase.kind) {
+      case 'resolving':
+      case 'pending':
+      case 'position-applied':
+      case 'settled':
+      case 'paused-user-input':
+        return
+      case 'recentering-live-edge':
+        this.recenterSavedLiveEdge(execution)
+        return
+      case 'loading-around':
+        this.startSavedAroundLoad(execution, phase.messageId)
+        return
+      case 'unavailable':
+        this.promoteSavedFallback(execution, phase.policy)
+        return
+      case 'mounting':
+      case 'reconciling': {
+        execution.loadingAround = false
+        const lease = this.beginSavedOperation(execution)
+        const applied = runScrollShadowSafely({
+          event: 'saved-position-reconcile',
+          conversationId: execution.request.conversationId,
+          fallback: false,
+          observe: () => execution.executor.reconcile(execution.request, lease),
+        })
+        if (!lease.isCurrent()) return
+        if (applied) {
+          lease.markApplied()
+        } else {
+          this.promoteSavedFallback(
+            execution,
+            execution.request.onUnavailable ?? { kind: 'live-edge' },
+          )
+        }
+      }
+    }
+  }
+
+  private startSavedAroundLoad(
+    execution: SavedPositionExecutionState,
+    messageId: string,
+  ): void {
+    if (execution.loadingAround || execution.aroundAttempted) return
+    execution.aroundAttempted = true
+    execution.loadingAround = true
+    const lease = this.beginSavedOperation(execution)
+    const load = execution.executor.loadAround
+      ? runScrollShadowSafely<Promise<unknown> | unknown | null>({
+          event: 'saved-position-load-around',
+          conversationId: execution.request.conversationId,
+          fallback: null,
+          observe: () => execution.executor.loadAround?.(messageId, lease.signal) ?? null,
+        })
+      : null
+    if (load === null) {
+      if (lease.isCurrent()) {
+        execution.loadingAround = false
+        this.driveSavedPosition()
+      }
+      return
+    }
+    void Promise.resolve(load)
+      .catch(() => undefined)
+      .finally(() => {
+        if (!lease.isCurrent()) return
+        execution.loadingAround = false
+        this.driveSavedPosition()
+      })
+  }
+
+  private recenterSavedLiveEdge(
+    execution: SavedPositionExecutionState,
+  ): void {
+    const recenter = execution.executor.recenterLiveEdge
+    const version = execution.executor.recenterVersion
+    if (!recenter || !version) {
+      this.finishAtBestAvailableLiveEdge(execution)
+      return
+    }
+    if (execution.lastRecenterVersion === version) return
+    execution.lastRecenterVersion = version
+    const lease = this.beginSavedOperation(execution)
+    const result = runScrollShadowSafely({
+      event: 'saved-position-recenter-live-edge',
+      conversationId: execution.request.conversationId,
+      fallback: 'unavailable' as const,
+      observe: () => recenter(lease.signal),
+    })
+    if (!lease.isCurrent()) return
+    if (result === 'unavailable') {
+      this.finishAtBestAvailableLiveEdge(execution)
+    }
+  }
+
+  private finishAtBestAvailableLiveEdge(
+    execution: SavedPositionExecutionState,
+  ): void {
+    if (!this.isSavedExecutionCurrent(execution)) return
+    const lease = this.beginSavedOperation(execution)
+    const applied = runScrollShadowSafely({
+      event: 'saved-position-live-edge-best-effort',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => execution.executor.reconcile(execution.request, lease),
+    })
+    if (!lease.isCurrent()) return
+    if (applied) {
+      lease.markApplied()
+    } else {
+      this.cancelSavedExecution()
+    }
+  }
+
+  private promoteSavedFallback(
+    execution: SavedPositionExecutionState,
+    policy: UnavailablePolicy,
+  ): void {
+    if (!this.isSavedExecutionCurrent(execution)) return
+    const desired =
+      policy.kind === 'legacy-offset'
+        ? { kind: 'legacy-offset' as const, offsetPx: policy.offsetPx }
+        : { kind: 'live-edge' as const, follow: true as const }
+    if (
+      execution.request.source.kind === 'fallback' &&
+      execution.request.desired.kind === 'live-edge'
+    ) {
+      this.finishAtBestAvailableLiveEdge(execution)
+      return
+    }
+
+    const generation = mintPositionGeneration()
+    const draft: PositionRequestDraft = {
+      source: { kind: 'fallback', reason: 'saved-position-unavailable' },
+      desired,
+    }
+    const request = withIdentity(
+      execution.request.conversationId,
+      generation,
+      draft,
+    ) as SavedPositionRequest
+    const accepted = acceptPositionRequest(this.model, request)
+    if (accepted === this.model) {
+      this.cancelSavedExecution()
+      return
+    }
+    execution.abortController?.abort()
+    execution.request = request
+    execution.operation += 1
+    execution.abortController = null
+    execution.loadingAround = false
+    execution.aroundAttempted = true
+    execution.lastRecenterVersion = null
+    this.model = accepted
+    this.driveSavedPosition()
+  }
+
+  private beginSavedOperation(
+    execution: SavedPositionExecutionState,
+  ): SavedPositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.savedExecution === execution &&
+      execution.operation === operation &&
+      execution.request.conversationId === conversationId &&
+      execution.request.generation === generation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      if (
+        phase.kind === 'position-applied' &&
+        this.model.active?.phase.kind === 'settled'
+      ) {
+        return true
+      }
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isSavedExecutionCurrent(
+    execution: SavedPositionExecutionState,
+  ): boolean {
+    return (
+      this.savedExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
+  }
+
+  private cancelSavedExecutionIfSuperseded(): void {
+    const execution = this.savedExecution
+    if (execution && !this.isSavedExecutionCurrent(execution)) {
+      this.cancelSavedExecution()
+    }
+  }
+
+  private cancelSavedExecution(): void {
+    this.savedExecution?.abortController?.abort()
+    this.savedExecution = null
   }
 }
 

--- a/apps/fluux/src/components/conversation/scrollPositionFacts.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionFacts.ts
@@ -168,6 +168,7 @@ export function deriveReachabilityForDesired(input: {
   scroller?: HTMLElement | null
   loadAround: 'available' | 'loading' | 'exhausted' | 'unavailable'
   canRecenter?: boolean
+  legacyOffsetViable?: boolean
 }): ReachabilityFacts {
   if (input.desired.kind === 'live-edge') {
     return deriveGlobalLiveEdgeReachability(input)
@@ -215,6 +216,10 @@ export function deriveReachabilityForDesired(input: {
     mounted: input.virtualizer
       ? isVirtualIndexMounted(input.virtualizer, index)
       : true,
-    placement: 'viable',
+    placement:
+      input.desired.kind === 'legacy-offset' &&
+      input.legacyOffsetViable === false
+        ? 'use-unavailable-policy'
+        : 'viable',
   }
 }

--- a/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.test.ts
@@ -169,6 +169,7 @@ describe('scroll position model', () => {
       conversationId,
       source: { kind: 'entry', reason: 'saved-position' },
       desired: { kind: 'legacy-offset', offsetPx: pixelOffset(50) },
+      onUnavailable: { kind: 'live-edge' },
     }
     const model = acceptPositionRequest(initialPositioningModel(), legacyEntry)
     expect(shouldReconcileAfterAppend(model, conversationId)).toBe(false)
@@ -342,6 +343,7 @@ describe('scroll position model', () => {
       conversationId,
       source: { kind: 'entry', reason: 'saved-position' },
       desired: { kind: 'legacy-offset', offsetPx: pixelOffset(400) },
+      onUnavailable: { kind: 'live-edge' },
     }
     expect(
       resolveReachability(legacy, {
@@ -351,6 +353,17 @@ describe('scroll position model', () => {
         placement: 'viable',
       }),
     ).toEqual({ kind: 'reconciling' })
+    expect(
+      resolveReachability(legacy, {
+        kind: 'available',
+        index: 99,
+        mounted: false,
+        placement: 'use-unavailable-policy',
+      }),
+    ).toEqual({
+      kind: 'unavailable',
+      policy: { kind: 'live-edge' },
+    })
     expect(
       resolveReachability(liveEntry(1), {
         kind: 'global-live-edge',
@@ -430,6 +443,7 @@ describe('scroll position model', () => {
     const expected = {
       source: { kind: 'entry', reason: 'saved-position' },
       desired: { kind: 'legacy-offset', offsetPx: pixelOffset(1234) },
+      onUnavailable: { kind: 'live-edge' },
     }
     expect(withUnread).toEqual(expected)
     expect(withoutUnread).toEqual(expected)

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -123,7 +123,11 @@ type EntryRequest =
       BottomFractionAnchorPosition,
       Extract<UnavailablePolicy, { kind: 'live-edge' | 'legacy-offset' }>
     >
-  | Request<{ kind: 'entry'; reason: 'saved-position' }, LegacyOffsetPosition>
+  | Request<
+      { kind: 'entry'; reason: 'saved-position' },
+      LegacyOffsetPosition,
+      Extract<UnavailablePolicy, { kind: 'live-edge' }>
+    >
   | Request<
       { kind: 'entry'; reason: 'unread-marker' },
       MessagePosition<'start'>,
@@ -183,6 +187,12 @@ export type PositionRequest =
       },
       LiveEdgePosition
     >
+
+export type SavedPositionRequest = Extract<
+  PositionRequest,
+  | { source: { kind: 'entry'; reason: 'saved-position' } }
+  | { source: { kind: 'fallback'; reason: 'saved-position-unavailable' } }
+>
 
 export type PositionRequestSource = PositionRequest['source']
 
@@ -270,6 +280,7 @@ export type EntryPositionSelection =
   | {
       source: { kind: 'entry'; reason: 'saved-position' }
       desired: LegacyOffsetPosition
+      onUnavailable: Extract<UnavailablePolicy, { kind: 'live-edge' }>
     }
   | {
       source: { kind: 'entry'; reason: 'unread-marker' }
@@ -548,6 +559,15 @@ export function resolveReachability(
   }
 
   if (request.desired.kind === 'legacy-offset') {
+    if (
+      facts.kind !== 'available' ||
+      facts.placement === 'use-unavailable-policy'
+    ) {
+      return {
+        kind: 'unavailable',
+        policy: request.onUnavailable ?? { kind: 'live-edge' },
+      }
+    }
     return { kind: 'reconciling' }
   }
 
@@ -606,6 +626,7 @@ export function selectEntryPosition(facts: EntryPositionFacts): EntryPositionSel
     return {
       source: { kind: 'entry', reason: 'saved-position' },
       desired: { kind: 'legacy-offset', offsetPx: facts.savedOffsetPx },
+      onUnavailable: { kind: 'live-edge' },
     }
   }
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -34,6 +34,7 @@ interface HarnessHandle {
 interface HookHarnessProps {
   conversationId: string
   ids: string[]
+  messageCount?: number
   firstNewMessageId?: string
   readPointerId?: string
   clearFirstNewMessageId?: () => void
@@ -68,6 +69,7 @@ function seedSavedAnchor(
 function HookHarness({
   conversationId,
   ids,
+  messageCount,
   firstNewMessageId,
   readPointerId,
   clearFirstNewMessageId,
@@ -85,7 +87,7 @@ function HookHarness({
 
   const api = useMessageListScroll({
     conversationId,
-    messageCount: ids.length,
+    messageCount: messageCount ?? ids.length,
     firstMessageId: ids[0],
     firstNewMessageId,
     readPointerId,
@@ -209,6 +211,33 @@ describe('useMessageListScroll saved-position restore', () => {
 
     expect(handle?.scrollTopSets).toContain(200)
     expect(handle?.scrollTopSets).not.toContain(1000)
+  })
+
+  it('waits for the first resident row even when the store count is already populated', () => {
+    seedSavedScrollPosition('room-first-row-pending', 200)
+    let handle: HarnessHandle | undefined
+    const view = render(
+      <HookHarness
+        conversationId="room-first-row-pending"
+        ids={[]}
+        messageCount={3}
+        onReady={(next) => { handle = next }}
+      />,
+    )
+
+    expect(handle?.scrollTopSets).not.toContain(200)
+    expect(handle?.scrollTopSets).not.toContain(1000)
+
+    view.rerender(
+      <HookHarness
+        conversationId="room-first-row-pending"
+        ids={['msg-0', 'msg-1', 'msg-2']}
+        messageCount={3}
+        onReady={(next) => { handle = next }}
+      />,
+    )
+
+    expect(handle?.scrollTopSets).toContain(200)
   })
 
   it('can restore the same scrolled-up room again without an intervening scroll event', () => {
@@ -401,37 +430,45 @@ describe('useMessageListScroll saved-position restore', () => {
   // an OLD message that the latest-N rehydration didn't load, so restore can't resolve it. It must
   // request the cache slice AROUND the anchor (onLoadAround) rather than fall back to the saved
   // scrollTop on the short list (which landed near the top at the load-more trigger — the bug).
-  it('requests the cache slice around a saved anchor that is not in the loaded set', () => {
+  it('requests one cache slice and falls back when the anchor remains unavailable', async () => {
     seedSavedAnchor('around-missing', 'old-anchor')
     const onLoadAround = vi.fn().mockResolvedValue([])
+    let handle: HarnessHandle | undefined
 
     render(
       <HookHarness
         conversationId="around-missing"
         ids={['msg-0', 'msg-1', 'msg-2']}
         onLoadAround={onLoadAround}
-        onReady={() => {}}
+        onReady={(next) => { handle = next }}
       />,
     )
 
     expect(onLoadAround).toHaveBeenCalledWith('old-anchor')
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(onLoadAround).toHaveBeenCalledTimes(1)
+    expect(handle?.scrollTopSets).toContain(200)
   })
 
-  it('continues the live restore when malformed shadow facts are rejected', () => {
+  it('degrades a malformed anchor to its finite saved offset', () => {
     seedSavedAnchor('around-invalid-shadow', 'old-anchor', 200, Number.NaN)
     const onLoadAround = vi.fn().mockResolvedValue([])
+    let handle: HarnessHandle | undefined
 
     render(
       <HookHarness
         conversationId="around-invalid-shadow"
         ids={['msg-0', 'msg-1', 'msg-2']}
         onLoadAround={onLoadAround}
-        onReady={() => {}}
+        onReady={(next) => { handle = next }}
       />,
     )
 
-    // The production restore still requests its missing anchor; only the shadow observation skips.
-    expect(onLoadAround).toHaveBeenCalledWith('old-anchor')
+    expect(onLoadAround).not.toHaveBeenCalled()
+    expect(handle?.scrollTopSets).toContain(200)
     expect(getScrollShadowSnapshot()).toMatchObject({
       instrumentationErrorCount: 1,
       instrumentationErrors: [{
@@ -439,6 +476,71 @@ describe('useMessageListScroll saved-position restore', () => {
         conversationId: 'around-invalid-shadow',
       }],
     })
+  })
+
+  it('does not let a late around-load completion write into the next conversation', async () => {
+    seedSavedAnchor('around-stale', 'old-anchor', 200)
+    let resolveLoad!: () => void
+    const onLoadAround = vi.fn(() => new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    }))
+    let handle: HarnessHandle | undefined
+    const view = render(
+      <HookHarness
+        conversationId="around-stale"
+        ids={['msg-0', 'msg-1', 'msg-2']}
+        onLoadAround={onLoadAround}
+        onReady={(next) => { handle = next }}
+      />,
+    )
+    expect(onLoadAround).toHaveBeenCalledTimes(1)
+
+    view.rerender(
+      <HookHarness
+        conversationId="around-next"
+        ids={['next-0', 'next-1']}
+        onLoadAround={onLoadAround}
+        onReady={(next) => { handle = next }}
+      />,
+    )
+    handle?.scrollTopSets.splice(0)
+
+    await act(async () => {
+      resolveLoad()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(handle?.scrollTopSets).not.toContain(200)
+    expect(handle?.getScrollTop()).toBe(1000)
+  })
+
+  it('does not resume a pending around-load after the message list unmounts', async () => {
+    seedSavedAnchor('around-unmount', 'old-anchor', 200)
+    let resolveLoad!: () => void
+    const onLoadAround = vi.fn(() => new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    }))
+    let handle: HarnessHandle | undefined
+    const view = render(
+      <HookHarness
+        conversationId="around-unmount"
+        ids={['msg-0', 'msg-1', 'msg-2']}
+        onLoadAround={onLoadAround}
+        onReady={(next) => { handle = next }}
+      />,
+    )
+    expect(onLoadAround).toHaveBeenCalledTimes(1)
+
+    view.unmount()
+    handle?.scrollTopSets.splice(0)
+    await act(async () => {
+      resolveLoad()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(handle?.scrollTopSets).toHaveLength(0)
   })
 
   it('does not request a slice when the saved anchor is already in the loaded set', () => {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,9 +3,10 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Existing scroll operations remain IMPERATIVE during the shadow-controller migration
+ * 2. Saved-position policy/retry ownership lives in PositioningController; browser writes stay
+ *    imperative in its hook executor while the remaining mechanisms migrate incrementally
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
- * 4. The semantic controller observes decisions only; it never writes scrollTop
+ * 4. The controller owns generations and saved-position arbitration, not React state or geometry
  *
  * BEHAVIORS:
  * - Initial load: scroll to bottom
@@ -28,7 +29,12 @@ import { isProgrammaticScroll } from './scrollGate'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
-import { PositioningController, type PositionRequestDraft } from './positioningController'
+import {
+  PositioningController,
+  type PositionRequestDraft,
+  type SavedPositionExecutionLease,
+  type SavedPositionExecutor,
+} from './positioningController'
 import {
   deriveAtLiveEdge,
   deriveEntryPositionFacts,
@@ -41,6 +47,7 @@ import {
   pixelOffset,
   type DesiredPosition,
   type ReachabilityFacts,
+  type SavedPositionRequest,
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
 
@@ -335,8 +342,6 @@ export interface UseMessageListScrollResult {
   scrollToMarker: () => void
 }
 
-type RestoreSavedPositionResult = 'restored' | 'pending' | 'bottom'
-
 // ============================================================================
 // HOOK
 // ============================================================================
@@ -423,6 +428,10 @@ export function useMessageListScroll({
   // useEffect = after paint, too late for the prepend restore useLayoutEffect).
   const virtualizerRef = useRef<MessageVirtualizer | undefined>(undefined)
   virtualizerRef.current = virtualizer
+  // Saved-position entry runs in a layout effect, before latestRef's passive update. Keep the
+  // loader synchronous with the render so a conversation switch cannot invoke the room we left.
+  const onLoadAroundRef = useRef(onLoadAround)
+  onLoadAroundRef.current = onLoadAround
 
   // Latest MAM-loading state (forward catch-up on entry, or backward "load older" pagination) for
   // the active conversation, read imperatively inside pinVirtualizedBottom's stable useCallback —
@@ -432,11 +441,12 @@ export function useMessageListScroll({
   isLoadingOlderRef.current = isLoadingOlder
 
   // Track conversation
+  const activeConversationIdRef = useRef(conversationId)
+  activeConversationIdRef.current = conversationId
   const prevConversationRef = useRef<string | null>(null)
   const prevMessageCountRef = useRef(0)
   const prevLastMessageIdRef = useRef<string | undefined>(lastMessageId)
   const hasInitializedRef = useRef(false)
-  const pendingRestoreConversationRef = useRef<string | null>(null)
   const pendingSyncedLiveEdgeRef = useRef<{
     conversationId: string
     savedReadPositionId: string | undefined
@@ -465,15 +475,12 @@ export function useMessageListScroll({
   // Teardown for the native user-input listeners attached to the scroller (set them via addEventListener
   // so touch/keyboard scrolls — which don't go through the React onWheel handler — also count).
   const userInputCleanupRef = useRef<(() => void) | null>(null)
-  // Per-anchor status for the on-demand "load the cache slice around the anchor" request used when
-  // a saved content anchor (or navigation target) is older than the latest-N slice loaded on
-  // activation. 'loading' → request in flight (stay pending); 'done' → attempted (resolved by the
-  // index path, or the anchor wasn't in the cache → fall through to the legacy fallback). Keyed by
-  // `${conversationId}:${anchorMessageId}` and cleared on conversation switch so returning to the
-  // same conversation re-requests. Prevents re-issuing the load on every retry frame.
-  const aroundLoadStatusRef = useRef<Map<string, 'loading' | 'done'>>(new Map())
-  // Shadow-only semantic controller. It owns no React state and performs no scroll writes.
-  // The module-private generation allocator survives controller remounts (including StrictMode).
+  // React StrictMode replays layout-effect cleanup/setup without unmounting the DOM. Defer controller
+  // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
+  const unmountDeactivationTokenRef = useRef<object | null>(null)
+  // Generation-aware semantic controller. Saved-position restoration is its first authoritative
+  // slice; the other positioning mechanisms still report shadow decisions. Pixel writes remain in
+  // the hook executor, while the module-private generation allocator survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -492,21 +499,7 @@ export function useMessageListScroll({
       conversationId,
       fallback: { kind: 'empty-window' },
       observe: () => {
-        const anchorId =
-          desired.kind === 'anchor' || desired.kind === 'message'
-            ? desired.messageId
-            : null
-        const aroundStatus = anchorId
-          ? aroundLoadStatusRef.current.get(`${conversationId}:${anchorId}`)
-          : undefined
-        const loadAround =
-          aroundStatus === 'loading'
-            ? 'loading'
-            : aroundStatus === 'done'
-              ? 'exhausted'
-              : onLoadAround
-                ? 'available'
-                : 'unavailable'
+        const loadAround = onLoadAround ? 'available' : 'unavailable'
         return deriveReachabilityForDesired({
           desired,
           hasRows: messageCount > 0,
@@ -523,10 +516,6 @@ export function useMessageListScroll({
   // message older than the loaded window). Prevents re-issuing the load while the target effect
   // re-fires waiting for the slice to merge.
   const targetAroundRequestedRef = useRef<string | null>(null)
-  // Stable indirection so the async around-load completion can re-run restore without making
-  // restoreSavedPosition a dependency of itself.
-  const restoreSavedPositionRef = useRef<((source: 'entry' | 'retry') => RestoreSavedPositionResult) | null>(null)
-
   // Track prepend (loading older messages)
   // When we load older messages, we save the anchor element position BEFORE the load,
   // then restore it AFTER React renders the new messages.
@@ -851,7 +840,13 @@ export function useMessageListScroll({
         userInputCleanupRef.current?.()
         userInputCleanupRef.current = null
         if (el) {
-          const markUserScrolled = () => { userHasScrolledSinceEntryRef.current = true }
+          const markUserScrolled = () => {
+            userHasScrolledSinceEntryRef.current = true
+            userScrollIntentAtRef.current = Date.now()
+            positioningControllerRef.current?.observeUserInput(
+              activeConversationIdRef.current,
+            )
+          }
           el.addEventListener('wheel', markUserScrolled, { passive: true })
           el.addEventListener('touchstart', markUserScrolled, { passive: true })
           el.addEventListener('keydown', markUserScrolled)
@@ -1107,10 +1102,9 @@ export function useMessageListScroll({
   // paint (a raw scrollTop write leaves @tanstack's offset stale → blank/clipped); otherwise a
   // direct scrollTop write. Callers must have already confirmed the user is at/near the bottom.
   const reassertBottom = useCallback((trigger: string = 'unknown') => {
-    // Entry restore calls this before its shadow entry request is installed; that decision is
-    // compared by the entry adapter immediately after restoreSavedPosition returns. Every other
-    // bottom write must agree with either semantic follow-live ownership or current live geometry;
-    // unlike the live loop, the shadow check never trusts isAtBottomRef by itself.
+    // The saved-position executor calls this only after installing its generation-bearing fallback
+    // request. Every other bottom write must agree with semantic follow-live ownership or current
+    // live geometry; unlike the live loop, the shadow check never trusts isAtBottomRef by itself.
     if (trigger !== 'restore-fallback') {
       const scroller = scrollerRef.current
       runScrollShadowSafely({
@@ -1145,15 +1139,22 @@ export function useMessageListScroll({
   // reassertLoopRef makes handleScroll treat these scrolls as programmatic — so the drifting
   // transient is NOT saved (which is what made the drift compound across re-opens). Bails on a user
   // scroll or a conversation switch; converges (and stops early) once the landing position is stable.
-  const pinVirtualizedAnchor = useCallback((anchor: ScrollAnchor, anchorConvId: string) => {
+  const pinVirtualizedAnchor = useCallback((
+    anchor: ScrollAnchor,
+    anchorConvId: string,
+    lease?: SavedPositionExecutionLease,
+  ): boolean => {
     const scroller = scrollerRef.current
-    if (!virtualizerRef.current || !scroller) return
+    if (!virtualizerRef.current || !scroller || (lease && !lease.isCurrent())) {
+      return false
+    }
 
     supersedeReassertLoopRef.current()
 
     // Re-derive and apply the anchor's pixel position from the CURRENT measured layout. Returns the
     // resulting scrollTop, or null when the anchor row is no longer resolvable.
     const applyAnchor = (): number | null => {
+      if (lease && !lease.isCurrent()) return null
       const v = virtualizerRef.current
       const s = scrollerRef.current
       if (!v || !s) return null
@@ -1181,7 +1182,7 @@ export function useMessageListScroll({
     }
 
     // Immediate pin (pre-paint when called from the restore path's layout effect).
-    applyAnchor()
+    if (applyAnchor() === null) return false
 
     const startedAt = Date.now()
     const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('restore-anchor', performance.now())
@@ -1190,7 +1191,10 @@ export function useMessageListScroll({
     let landed = -1
     const finish = () => {
       loop.end()
-      reassertLoopRef.current = null
+      if (reassertLoopRef.current?.handle === loop) {
+        reassertLoopRef.current = null
+      }
+      if (lease && !lease.isCurrent()) return
       // The loop just stopped owning scrollTop; keep the brief measurement settle that follows it
       // classified as programmatic so it can't open the save gate (see lastProgrammaticScrollAtRef).
       lastProgrammaticScrollAtRef.current = Date.now()
@@ -1201,11 +1205,15 @@ export function useMessageListScroll({
         isAtBottomRef.current = (s.scrollHeight - s.scrollTop - s.clientHeight) < AT_BOTTOM_THRESHOLD
         rememberCurrentScrollSnapshot()
       }
+      lease?.settle()
     }
     const step = () => {
       const s = scrollerRef.current
       if (!s) { finish(); return }
       if (framesLeft-- <= 0) { finish(); return }
+      // Generation + operation ownership is authoritative. A late frame from a superseded restore
+      // must not write into a newer request in the same conversation.
+      if (lease && !lease.isCurrent()) { finish(); return }
       // Stale loop must never scroll the new conversation (prevConversationRef is set synchronously
       // at the end of the conversation-switch effect).
       if (prevConversationRef.current !== anchorConvId) { finish(); return }
@@ -1226,9 +1234,15 @@ export function useMessageListScroll({
 
       const warning = loop.frame(performance.now(), wrote)
       if (warning) console.warn(warning)
-      reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
+      register(step)
     }
-    reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
+    const register = (callback: () => void) => {
+      const entry = { raf: 0, handle: loop }
+      reassertLoopRef.current = entry
+      entry.raf = requestAnimationFrame(callback)
+    }
+    register(step)
+    return true
   }, [isAtBottomRef, rememberCurrentScrollSnapshot])
 
   // Scroll to (and keep re-asserting toward) the first-new-message marker, re-assert-loop style —
@@ -1380,155 +1394,117 @@ export function useMessageListScroll({
     registerMarkerLoop(stepToMarker)
   }, [isAtBottomRef, reassertBottom])
 
-  const restoreSavedPosition = useCallback((source: 'entry' | 'retry'): RestoreSavedPositionResult => {
-    const scroller = scrollerRef.current
-    if (!scroller) return 'pending'
+  const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
+    reachability: (desired, loadAround) => {
+      const scroller = scrollerRef.current
+      const virtualizer = virtualizerRef.current
+      const legacyOffsetViable =
+        desired.kind !== 'legacy-offset' ||
+        Boolean(
+          virtualizer ||
+          (
+            scroller &&
+            scroller.scrollHeight - scroller.clientHeight > 0 &&
+            desired.offsetPx >= 0 &&
+            desired.offsetPx <= scroller.scrollHeight - scroller.clientHeight
+          )
+        )
+      return deriveReachabilityForDesired({
+        desired,
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+        virtualizer,
+        scroller,
+        loadAround,
+        canRecenter: Boolean(onLoadNewer),
+        legacyOffsetViable,
+      })
+    },
+    loadAround: onLoadAroundRef.current
+      ? (messageId, signal) => {
+          if (signal.aborted) return
+          isAtBottomRef.current = false
+          debugLog('RESTORE: anchor not loaded, requesting cache slice around it', {
+            messageId,
+            conversationId,
+          })
+          return onLoadAroundRef.current?.(messageId)
+        }
+      : undefined,
+    recenterVersion: [
+      windowAtLiveEdge === false ? 'slid' : 'live',
+      isLoadingNewer ? 'loading' : 'idle',
+      messageCount,
+      lastMessageId ?? '',
+    ].join(':'),
+    recenterLiveEdge: onLoadNewer
+      ? (signal) => {
+          if (signal.aborted) return 'unavailable'
+          if (isLoadingNewer) return 'waiting'
+          onLoadNewer()
+          return 'requested'
+        }
+      : undefined,
+    reconcile: (request: SavedPositionRequest, lease: SavedPositionExecutionLease) => {
+      if (!lease.isCurrent()) return false
+      const scroller = scrollerRef.current
+      if (!scroller) return false
 
-    const savedPos = scrollStateManager.getSavedScrollTop(conversationId)
-    const savedAnchor = scrollStateManager.getSavedAnchor(conversationId)
-    const hasSavedState = savedPos !== null || savedAnchor !== null
+      let restored = false
+      if (request.desired.kind === 'anchor') {
+        const anchor: ScrollAnchor = {
+          messageId: request.desired.messageId,
+          fraction: request.desired.placement.fraction,
+        }
+        restored = virtualizerRef.current
+          ? pinVirtualizedAnchor(anchor, conversationId, lease)
+          : restoreToAnchor(scroller, anchor)
+      } else if (request.desired.kind === 'legacy-offset') {
+        const virtualizer = virtualizerRef.current
+        if (virtualizer) {
+          virtualizer.scrollToOffset(request.desired.offsetPx)
+          restored = true
+        } else {
+          const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
+          if (
+            maxScrollTop > 0 &&
+            request.desired.offsetPx >= 0 &&
+            request.desired.offsetPx <= maxScrollTop
+          ) {
+            scroller.scrollTop = request.desired.offsetPx
+            restored = true
+          }
+        }
+      } else if (request.desired.kind === 'live-edge') {
+        isAtBottomRef.current = true
+        reassertBottom('restore-fallback')
+        restored = true
+      }
 
-    if (!hasSavedState) {
-      // No saved scrolled-up position → caller scrolls to bottom. This is the silent path behind a
-      // "jumps to bottom on return" report: it means the leave-side SAVE did not persist a
-      // scrolled-up anchor (saved as wasAtBottom, throttled-out, or cleared as stale). Log it so the
-      // trace shows restore was ASKED to restore but had nothing to restore TO — distinct from a
-      // restore that ran and landed wrong.
-      debugLog('RESTORE: no saved state, scrolling to bottom', { source, conversationId })
-      return 'bottom'
-    }
-
-    // Rooms often mount once with a loading/empty message set, then hydrate from
-    // cache/MAM. A saved scrolled-up position is still valid, just not restorable
-    // until there is at least one row/virtualizer item to target.
-    if (messageCount === 0 || !firstMessageId) {
-      isAtBottomRef.current = false
-      debugLog('RESTORE pending (no rows yet)', { source, savedPos, savedAnchor })
-      return 'pending'
-    }
-
-    const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
-    const virtRestore = virtualizerRef.current
-    const finishRestore = (
-      action: string,
-      data: Record<string, unknown>
-    ): RestoreSavedPositionResult => {
+      if (!restored || !lease.isCurrent()) return false
       isAtBottomRef.current = getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD
       rememberCurrentScrollSnapshot()
-      // We just wrote scrollTop programmatically; the measurement settle that follows must not be
-      // mistaken for a user scroll and open the save gate (see lastProgrammaticScrollAtRef).
       lastProgrammaticScrollAtRef.current = Date.now()
-      debugLog(action, { source, ...data })
-      return 'restored'
-    }
-
-    // The saved anchor message is not in the currently-loaded window (the user had scrolled deep
-    // into history, so it sits OLDER than the latest-N slice rehydrated on activation). Request the
-    // cache slice that CONTAINS it; the merge grows messageCount, which re-runs this restore via the
-    // retry effect, and the anchor then resolves through the virtualizer-index path below. Without
-    // this the restore fell through to the saved scrollTop on the short rehydrated list and landed
-    // near the top at the load-more trigger — the reported bug. Returns true while the load should
-    // hold the restore in 'pending'; false when there's no loader or the load already completed
-    // without recovering the anchor (then the legacy fallbacks run).
-    const requestAnchorAroundLoad = (anchorMessageId: string): boolean => {
-      const loader = latestRef.current.onLoadAround
-      if (!loader) return false
-      const key = `${conversationId}:${anchorMessageId}`
-      const status = aroundLoadStatusRef.current.get(key)
-      if (status === 'done') return false
-      if (status === 'loading') return true
-      aroundLoadStatusRef.current.set(key, 'loading')
-      isAtBottomRef.current = false
-      debugLog('RESTORE: anchor not loaded, requesting cache slice around it', { source, anchorMessageId, conversationId })
-      void Promise.resolve(loader(anchorMessageId)).finally(() => {
-        aroundLoadStatusRef.current.set(key, 'done')
-        // The merge bumps messageCount → the retry effect re-runs restore. Force one attempt too,
-        // covering the empty-slice case (anchor not in cache → no count change → no retry) so the
-        // restore can fall through to its bottom fallback instead of hanging in 'pending'.
-        if (pendingRestoreConversationRef.current === conversationId) {
-          restoreSavedPositionRef.current?.('retry')
-        }
+      debugLog('RESTORE: controller applied position', {
+        conversationId,
+        generation: request.generation,
+        desired: request.desired,
       })
       return true
-    }
-
-    // THE CONTENT ANCHOR IS AUTHORITATIVE. The saved fraction anchor — re-derived from the anchor
-    // message's CURRENT measured height on every restore — is correct in every case: identical
-    // layout, MAM prepend, font-size change, view-density change, or a viewport-width change (which
-    // rewraps bubbles and so invalidates any saved pixel). We therefore try the anchor FIRST and
-    // UNCONDITIONALLY — no "layout unchanged" height/width gate. The saved scrollTop is only a pixel
-    // PROXY that holds when the layout is byte-identical; it is demoted to a last-resort fallback,
-    // used solely when there is NO usable anchor (a legacy save with no captured anchor, or an
-    // anchor message that is no longer in the loaded set). Pixel correctness is covered by the
-    // real-engine scroll-invariants e2e — jsdom/happy-dom have no layout, so the captured fraction
-    // degenerates (last row, fraction 1) and cannot be exercised in a unit test.
-    if (savedAnchor && restoreToAnchor(scroller, savedAnchor)) {
-      if (virtRestore) virtRestore.scrollToOffset(scroller.scrollTop)
-      return finishRestore('RESTORE via anchor', { savedAnchor })
-    }
-
-    if (virtRestore && savedAnchor) {
-      const anchorIndex = virtRestore.getIndexForMessageId(savedAnchor.messageId)
-      if (anchorIndex !== null) {
-        // Position the anchor's bottom at the viewport bottom (align:'end') refined to the saved
-        // fraction, and KEEP it pinned across frames as the just-windowed rows measure taller. A
-        // one-shot landing here drifts older (and compounds across re-opens) because it lands on
-        // estimated sizes — see pinVirtualizedAnchor / the RESTORE_* constants.
-        pinVirtualizedAnchor(savedAnchor, conversationId)
-        return finishRestore('RESTORE via virtualizer index', { savedAnchor, anchorIndex })
-      }
-
-      // Anchor is older than the loaded window — pull in the slice that contains it, then retry.
-      if (requestAnchorAroundLoad(savedAnchor.messageId)) {
-        return 'pending'
-      }
-
-      if (savedPos !== null) {
-        virtRestore.scrollToOffset(savedPos)
-        return finishRestore('RESTORE via savedPos (virt, anchor not indexed)', { savedPos })
-      }
-
-      debugLog('RESTORE: anchor not indexed, no savedPos, scrolling to bottom', { source, savedAnchor })
-      reassertBottom('restore-fallback')
-      return 'bottom'
-    }
-
-    // Non-virtualized: all loaded rows are in the DOM, so a missing anchor row means the anchor
-    // isn't loaded. Pull in its slice and retry before falling back to the saved scrollTop.
-    if (!virtRestore && savedAnchor && requestAnchorAroundLoad(savedAnchor.messageId)) {
-      return 'pending'
-    }
-
-    if (virtRestore && savedPos !== null) {
-      // Virtualized, no anchor: use savedPos without bounds check because the
-      // initial estimated scrollHeight may be smaller than the real saved offset.
-      virtRestore.scrollToOffset(savedPos)
-      return finishRestore('RESTORE via savedPos (virtualized, no anchor)', { savedPos })
-    }
-
-    if (savedPos !== null && savedPos <= maxScrollTop && maxScrollTop > 0) {
-      scroller.scrollTop = savedPos
-      return finishRestore('RESTORE via savedPos', { savedPos })
-    }
-
-    debugLog('RESTORE out of bounds / anchor missing, scrolling to bottom', {
-      source, savedPos, maxScrollTop, scrollHeight: scroller.scrollHeight,
-    })
-    reassertBottom('restore-fallback')
-    return 'bottom'
-  }, [
+    },
+  }), [
     conversationId,
     firstMessageId,
     isAtBottomRef,
+    isLoadingNewer,
+    lastMessageId,
     messageCount,
+    onLoadNewer,
     pinVirtualizedAnchor,
     reassertBottom,
     rememberCurrentScrollSnapshot,
+    windowAtLiveEdge,
   ])
-
-  // Stable handle so the async around-load completion can re-run restore (see
-  // requestAnchorAroundLoad) without restoreSavedPosition depending on itself. Updated each render.
-  restoreSavedPositionRef.current = restoreSavedPosition
 
   // ==========================================================================
   // SCROLL ACTIONS
@@ -2333,10 +2309,7 @@ export function useMessageListScroll({
     lastScrollDataRef.current = null
     lastAnchorRef.current = null
     prependRef.current = null
-    pendingRestoreConversationRef.current = null
     pendingSyncedLiveEdgeRef.current = null
-    // Returning to this conversation later must be free to re-request its anchor slice.
-    aroundLoadStatusRef.current.clear()
     // Fresh entry: the saved position is locked until the user genuinely scrolls (see the ref).
     userHasScrolledSinceEntryRef.current = false
     prevScrollHeightRef.current = null
@@ -2412,36 +2385,36 @@ export function useMessageListScroll({
           firstUnreadMessageId: firstNewMessageId,
         }),
       })
+      // Observation validators must never strand production positioning. If a transient saved
+      // anchor is malformed (for example a zero-height row produced NaN), retain a finite legacy
+      // offset when possible and otherwise let the controller choose its live-edge fallback.
+      const savedExecutionFacts = entryFacts ?? runScrollShadowSafely({
+        event: 'entry-fallback-facts',
+        conversationId,
+        fallback: null,
+        observe: () => deriveEntryPositionFacts({
+          syncedLiveEdge,
+          savedAnchor: null,
+          savedOffsetPx: savedPos !== null && Number.isFinite(savedPos) ? savedPos : null,
+          firstUnreadMessageId: firstNewMessageId,
+        }),
+      })
 
       if (action === 'restore-position') {
-        const restoreResult = restoreSavedPosition('entry')
-        pendingRestoreConversationRef.current =
-          restoreResult === 'pending' ? conversationId : null
-        const request = entryFacts
-          ? positioningControllerRef.current?.observeEntry({
-              event: 'entry-restore',
+        isAtBottomRef.current = false
+        const request = savedExecutionFacts
+          ? positioningControllerRef.current?.beginSavedPositionEntry({
               conversationId,
-              entryFacts,
-              reachability: (desired) => shadowReachabilityRef.current(desired),
-              actual: {
-                desired: entryFacts.savedAnchor ??
-                  (entryFacts.savedOffsetPx !== undefined
-                    ? { kind: 'legacy-offset', offsetPx: entryFacts.savedOffsetPx }
-                    : { kind: 'live-edge', follow: true }),
-                phase:
-                  restoreResult === 'pending'
-                    ? 'waiting'
-                    : restoreResult === 'bottom'
-                      ? 'fallback'
-                      : 'positioning',
-              },
+              entryFacts: savedExecutionFacts,
+              executor: createSavedPositionExecutor(),
             })
           : null
-        if (restoreResult === 'restored' && request) {
-          positioningControllerRef.current?.markPositionApplied(
-            conversationId,
-            request.generation,
-          )
+        if (!request) {
+          // Controller construction/instrumentation failure must degrade safely instead of leaving
+          // entry half-positioned. This is the only saved-position write outside the controller and
+          // exists solely as its failure boundary.
+          isAtBottomRef.current = true
+          reassertBottom('restore-fallback')
         }
       } else if (firstNewMessageId) {
         // Has unread messages — position the first-unread marker ~1/3 down from the top so the
@@ -2568,7 +2541,7 @@ export function useMessageListScroll({
     prevLastMessageIdRef.current = lastMessageId
     previousReadPositionRef.current = readPointerId
 
-  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, readPointerId, isAtBottomRef, staticMode, pinVirtualizedBottom, reassertBottom, restoreSavedPosition, runMarkerReassertLoop])
+  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, readPointerId, isAtBottomRef, staticMode, createSavedPositionExecutor, pinVirtualizedBottom, reassertBottom, runMarkerReassertLoop])
 
   // Zero-unread twin of the divider-clear settle below. The old local position may be restored
   // before MAM resolves the other device's pointer to the newest downloaded row; with no divider,
@@ -2581,7 +2554,6 @@ export function useMessageListScroll({
     if (readPointerId !== lastMessageId || readPointerId === pending.savedReadPositionId) return
 
     pendingSyncedLiveEdgeRef.current = null
-    pendingRestoreConversationRef.current = null
     scrollStateManager.clearSavedScrollState(conversationId)
     isAtBottomRef.current = true
     debugLog('MDS LIVE EDGE: late synced read supersedes restored position', {
@@ -2662,35 +2634,36 @@ export function useMessageListScroll({
     reassertBottom('mds-settle')
   }, [conversationId, firstNewMessageId, staticMode, isAtBottomRef, reassertBottom])
 
-  // Retry a saved-position restore that entered before any rows were mounted.
-  // This is common for rooms: the MessageList mounts in a loading state, then
-  // cache/MAM rows arrive in the same conversation id. Until the restore lands,
-  // keep isAtBottom=false so the async message-count growth does not auto-pin.
+  // Refresh controller-owned saved positioning when cache/MAM rows or the active window change.
+  // Async around-load completion also drives itself, covering an empty slice that changes no props.
   useLayoutEffect(() => {
     if (staticMode) return
-    if (pendingRestoreConversationRef.current !== conversationId) return
-
-    const restoreResult = restoreSavedPosition('retry')
-    if (restoreResult !== 'pending') {
-      pendingRestoreConversationRef.current = null
-      if (restoreResult === 'restored') {
-        const active = runScrollShadowSafely({
-          event: 'restore-retry-snapshot',
-          conversationId,
-          fallback: null,
-          observe: () => positioningControllerRef.current?.snapshot().active ?? null,
-        })
-        if (active?.request.conversationId === conversationId) {
-          positioningControllerRef.current?.markPositionApplied(
-            conversationId,
-            active.request.generation,
-          )
-        }
-      }
+    const controller = positioningControllerRef.current
+    const status = controller?.savedPositionStatus(conversationId)
+    if (!controller || !status) return
+    if (
+      status.phase.kind === 'position-applied' ||
+      status.phase.kind === 'settled'
+    ) {
+      return
+    }
+    if (controller.refreshSavedPosition({
+      conversationId,
+      generation: status.request.generation,
+      executor: createSavedPositionExecutor(),
+    })) {
       prevMessageCountRef.current = messageCount
       prevLastMessageIdRef.current = lastMessageId
     }
-  }, [conversationId, messageCount, lastMessageId, staticMode, restoreSavedPosition])
+  }, [
+    conversationId,
+    createSavedPositionExecutor,
+    firstMessageId,
+    lastMessageId,
+    messageCount,
+    staticMode,
+    windowAtLiveEdge,
+  ])
 
   // Cleanup: properly leave conversation in scrollStateManager only when the message list
   // actually unmounts. The conversation-switch effect above intentionally has broad deps
@@ -2698,7 +2671,24 @@ export function useMessageListScroll({
   // there would also run on same-conversation updates and mark the singleton manager "left"
   // while the room is still mounted.
   useLayoutEffect(() => {
+    unmountDeactivationTokenRef.current = null
     return () => {
+      const activeConversationId = prevConversationRef.current
+      const controller = positioningControllerRef.current
+      if (controller && activeConversationId) {
+        const token = {}
+        unmountDeactivationTokenRef.current = token
+        queueMicrotask(() => {
+          if (unmountDeactivationTokenRef.current !== token) return
+          const controllerSnapshot = controller.snapshot()
+          if (controllerSnapshot.currentConversationId === activeConversationId) {
+            controller.deactivate(
+              activeConversationId,
+              controllerSnapshot.watermark,
+            )
+          }
+        })
+      }
       if (prevConversationRef.current) {
         // Same gate as the conversation-switch leave: only persist the live scroll data when the
         // user genuinely scrolled this visit; otherwise keep the existing saved anchor (markAsLeft)
@@ -3323,7 +3313,7 @@ export function useMessageListScroll({
     const scroller = scrollerRef.current
     if (!scroller || !hasInitializedRef.current || staticMode) return
 
-    if (pendingRestoreConversationRef.current === conversationId) {
+    if (positioningControllerRef.current?.isSavedPositionPending(conversationId)) {
       if (lastMessageIsOutgoing) {
         positioningControllerRef.current?.observeRequest({
           event: 'new-message-during-restore',

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,7 +1,7 @@
 # Message-list scroll positioning contract
 
-Status: migration in progress. The pure model is connected to a generation-aware shadow controller,
-but existing positioning loops still own every scroll write.
+Status: migration in progress. Saved-position restoration is the first authoritative controller
+slice; unread, explicit targets, live-edge pinning, and directional history remain shadow-observed.
 
 ## Purpose
 
@@ -24,16 +24,22 @@ It intentionally separates two concerns:
 The first concern can be pure and deterministic. The second remains the hard browser-specific work;
 centralizing it later must not erase or weaken its current safeguards.
 
-## Shadow-controller fidelity findings
+## Controller migration and fidelity findings
 
-The first migration step runs the model beside `useMessageListScroll` without moving a scroll write.
-Fact adapters read current virtualizer, persisted-state, and DOM geometry; the controller is held in
-a ref and owns no React state. Every observed live decision is compared with the model decision.
-The shadow runs in production so real traces can exercise it. A shared instrumentation boundary
-therefore catches and counts adapter, validator, and controller errors; an observation failure must
-never escape into the live scroll effect or event handler. The demo scroll-invariant suite fails if
-either `divergenceCount` or `instrumentationErrorCount` is non-zero. The retained lists are capped
-diagnostic samples, not the pass criterion.
+The controller is held in a ref and owns no React state. For saved positions it now owns entry
+selection, generation/operation cancellation, reachability, one around-load attempt, and explicit
+legacy-offset/live-edge fallback. A hook executor still translates the accepted request into
+browser/virtualizer writes. `pinVirtualizedAnchor` remains the measurement reconciler, but every
+frame must hold the current controller lease before it can write.
+
+The remaining mechanisms run the model beside `useMessageListScroll`: fact adapters read current
+virtualizer and DOM geometry, and every observed live decision is compared with the model decision.
+The instrumentation runs in production so real traces can exercise it. A shared error boundary
+catches and counts adapter, validator, controller-driver, and executor errors; failure must degrade
+to a safe saved-position fallback and must never escape into the scroll effect or event handler.
+The demo scroll-invariant suite fails if either `divergenceCount` or
+`instrumentationErrorCount` is non-zero. Retained diagnostic samples are capped, not the pass
+criterion.
 
 Zero divergences means the model agrees with the hand-authored semantic `actual` label at each
 observation site: desired position plus the coarse waiting/positioning/applied/paused/fallback/idle
@@ -52,22 +58,23 @@ The three previously prose-only fidelity seams are descriptive of current behavi
   only while entry restore is pending or a directional load has not completed its initial restore.
   A replay captured from the media-growth invariant proves that an outgoing live-edge request
   supersedes an active media anchor.
-- **`position-applied` is the current release seam, before measurement settle.** Saved entry restore
-  returns after its initial anchor/offset write and is marked applied before the longer
-  restore-anchor rAF loop converges. Directional restoration likewise sets `saved.restored` after
-  the initial bounded write and before its measurement re-assert loop. Recorded restore facts prove
-  an outgoing request is rejected before that signal and accepted immediately after it.
+- **`position-applied` is the current release seam, before measurement settle.** The saved executor
+  returns after its initial anchor/offset write, and the controller marks the lease applied before
+  the longer restore-anchor rAF loop converges. Directional restoration likewise sets
+  `saved.restored` after its initial bounded write and before its measurement re-assert loop.
+  Recorded restore facts prove an outgoing request is rejected before that signal and accepted
+  immediately after it.
 - **Already-resolved synced live edge wins synchronously.** The entry effect compares the remote
-  read pointer with the resident tail and clears obsolete saved state before calling
-  `restoreSavedPosition`. Late `mds-live-edge` and `mds-settle` remain separate supersession paths
-  only for remote state that arrives after entry.
+  read pointer with the resident tail and clears obsolete saved state before beginning the
+  controller request. Late `mds-live-edge` and `mds-settle` remain separate supersession paths only
+  for remote state that arrives after entry.
 
 These checks establish policy fidelity; they do not claim that jsdom can prove pixel convergence or
 WebKit paint correctness.
 
 ## Non-goals for this stage
 
-- Replacing any production rAF loop.
+- Replacing browser measurement/repaint rAF loops in the saved-position policy migration.
 - Changing entry priority, marker placement, saved scroll data, or history loading.
 - Removing measurement settle windows, tolerances, or WebKit repaint workarounds.
 - Treating a one-shot scroll as sufficient under virtualization.
@@ -173,6 +180,11 @@ When the message list unmounts or navigation leaves conversations, a generation-
 clears the current conversation, active request, and MDS eligibility while retaining the watermark.
 Callbacks from the unmounted conversation are then rejected.
 
+Saved live-edge fallback also respects sliding-window reachability. The leased executor requests
+newer resident slices until the global tail becomes resident; only then may it apply the live-edge
+position. If no forward-window port exists, it explicitly lands at the best resident edge and ends
+ownership rather than leaving restoration permanently pending.
+
 ## Reachability lifecycle
 
 The semantic lifecycle is:
@@ -218,8 +230,9 @@ measurement, or MDS completion cannot revive cancelled work.
 
 ## Reconciler responsibilities
 
-The future single positioning reconciler owns the difficult runtime work below. None belongs in the
-pure model:
+The eventual single positioning reconciler owns the difficult runtime work below. None belongs in
+the pure model; the saved-position slice currently splits this work between controller lifecycle
+ownership and a leased hook executor:
 
 - resolve IDs against the loaded item set;
 - request an around slice and resume when it arrives;
@@ -266,7 +279,7 @@ is already visible or above the viewport, the same activation goes directly to l
 `useMessageListScroll` currently contains separate implementations for:
 
 - `pinVirtualizedBottom`;
-- `pinVirtualizedAnchor`;
+- leased `pinVirtualizedAnchor` measurement convergence for the controller-owned saved request;
 - `runMarkerReassertLoop`;
 - the explicit target-message loop;
 - directional-load measurement reassertion.
@@ -277,7 +290,7 @@ There are also positioning owners outside their shared single-flight ref:
 - `scrollToMessage` through `activeMessageListController`;
 - keyboard selection navigation in `useMessageSelection` (`scrollIntoView({ block: 'nearest' })`);
 - resident-top's direct writer;
-- non-virtualized marker/target/restore writers inside `useMessageListScroll`;
+- non-virtualized marker/target writers inside `useMessageListScroll`;
 - static search-context positioning.
 
 A later migration is incomplete until each in-scope owner either routes through the controller or is
@@ -327,7 +340,9 @@ kinetic scrolling and stale-paint behavior.
 ## Incremental migration after this contract
 
 1. Introduce one generation-aware reconciliation controller without changing existing positioning.
-2. Migrate saved-anchor restoration, then delete its private loop.
+2. [x] Migrate saved-anchor restoration: delete the legacy restore dispatcher, pending ref, and
+   around-load status map; retain the measurement loop only as a generation/operation-leased
+   reconciler.
 3. Migrate unread and explicit message targets, then delete their private loops.
 4. Migrate live-edge pinning while retaining bottom-specific measurement/repaint safeguards.
 5. Migrate directional history preservation last, retaining kinetic cancellation and clamp recovery.


### PR DESCRIPTION
## What changed

- make `PositioningController` authoritative for saved-position entry selection, reachability, around-load retry, fallback, and cancellation
- issue generation- and operation-scoped execution leases so stale async completions and rAF frames cannot write
- retain `pinVirtualizedAnchor` as the measurement/WebKit reconciler, but require a current lease on every restore frame
- delete the legacy `restoreSavedPosition` dispatcher, pending-restore ref, and around-load status map
- recenter slid-up windows before applying a saved live-edge fallback
- abort pending saved work on conversation switch, genuine user input, and real component unmount
- update the positioning contract to describe the first authoritative migration slice

## Why

Saved-position restoration previously split policy and lifecycle state across the shadow controller and a separate hook implementation. That left two descriptions of ownership and made stale around-load completions, empty results, and conversation changes depend on effect/ref ordering.

This is the first incremental migration from the scroll-positioning plan. It moves the saved-position mechanism into the controller without pretending the difficult browser work disappeared: current measurement settling, single-target-per-frame behavior, save gating, and WebKit safeguards remain in the leased hook executor.

## Behavioral safeguards

- anchor remains authoritative; a finite legacy offset is the declared fallback, then live edge
- empty hydration waits for the first resident row
- an off-window anchor requests exactly one around slice per attempt, including the empty-slice completion path
- an outgoing send remains suppressed only until the first restore write is applied, not through the full measurement settle
- stale room, operation, load, and animation-frame work is rejected
- StrictMode effect replay does not masquerade as a real unmount