### PR TITLE
Canonicalize the room message store (read-state B0)

### DIFF
--- a/apps/fluux/src/hooks/useReactionNotifications.test.tsx
+++ b/apps/fluux/src/hooks/useReactionNotifications.test.tsx
@@ -276,7 +276,7 @@ describe('useReactionNotifications — room reaction resolution', () => {
     renderHook(() => useReactionNotifications())
     await roomHandler()({ roomJid: ROOM, messageId: 'r-old', reactorNick: 'Alice', emojis: ['🔥'], isLive: true })
 
-    expect(mockGetCachedRoomMessage).toHaveBeenCalledWith('r-old')
+    expect(mockGetCachedRoomMessage).toHaveBeenCalledWith(ROOM, 'r-old')
     expect(mockAddToast).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/fluux/src/hooks/useReactionNotifications.ts
+++ b/apps/fluux/src/hooks/useReactionNotifications.ts
@@ -139,7 +139,7 @@ export function useReactionNotifications(): void {
       const roomMessages = room.messages
       let message = state.getMessage(roomJid, messageId)
       if (!message) {
-        message = (await getCachedRoomMessage(messageId)) ?? (await getCachedRoomMessageByStanzaId(roomJid, messageId)) ?? undefined
+        message = (await getCachedRoomMessage(roomJid, messageId)) ?? (await getCachedRoomMessageByStanzaId(roomJid, messageId)) ?? undefined
       }
       if (!message || message.nick !== room.nickname) return
 

--- a/apps/fluux/src/hooks/useReactionNotifications.ts
+++ b/apps/fluux/src/hooks/useReactionNotifications.ts
@@ -139,7 +139,7 @@ export function useReactionNotifications(): void {
       const roomMessages = room.messages
       let message = state.getMessage(roomJid, messageId)
       if (!message) {
-        message = (await getCachedRoomMessage(messageId)) ?? (await getCachedRoomMessageByStanzaId(messageId)) ?? undefined
+        message = (await getCachedRoomMessage(messageId)) ?? (await getCachedRoomMessageByStanzaId(roomJid, messageId)) ?? undefined
       }
       if (!message || message.nick !== room.nickname) return
 

--- a/docs/superpowers/plans/2026-07-23-read-state-b0-room-store-canonicalization.md
+++ b/docs/superpowers/plans/2026-07-23-read-state-b0-room-store-canonicalization.md
@@ -1,0 +1,768 @@
+# PR B0 — Room message store canonicalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every *logical* room message exactly one cached row, matched across all its copies by the room-scoped XEP-0359 identity hierarchy, with every id/stanza/origin alias still resolvable — so PR B's unread count has one unambiguous archive position per message and no existing lookup breaks.
+
+**Architecture:** A logical room message appears as several stanzas — optimistic echo (`originId`, no `stanzaId`, a client `id` the MUC may *rewrite*), reflection, MAM copy — sharing no single stable field and sometimes carrying different timestamps. They are matched only through the tiered identity the store already uses (`stanzaId → originId → from+id`), **scoped by room** because stanza/origin values are not globally unique. B0 centralizes that identity; makes the live write path and a streaming migration resolve an incoming message against every existing row via all tiers; and merges matches into one canonical row with a **commutative, associative, field-complete** merge (total-order content selection so ties only occur when rows are identical). The row carries `identityKeys[]` and `ids[]` multi-entry indexes so no alias is lost; every mutation entry point resolves through them. A `room_ts_from_id` index gives PR B its ordered walk. The migration streams and aborts atomically.
+
+**Tech Stack:** TypeScript, `idb`, Vitest, `fake-indexeddb`.
+
+**Spec:** [docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md](../specs/2026-07-22-read-state-model-consolidation-design.md) — precursor PR **B0** in the `A → B0 → B → C` stack.
+**Issue:** [#1081](https://github.com/processone/fluux-messenger/issues/1081)
+
+## Global Constraints
+
+- **Identity is the room-scoped XEP-0359 tier hierarchy.** Two copies are the same logical message iff they share **any** of `stanzaId`, `originId`, `from+id`. Every tier key is prefixed with the room JID: `stanzaId`/`originId` are assigned per-archive and can collide across rooms, and the `identityKeys` index spans the whole store — an unscoped key would merge messages across rooms. Separator is `U+0000` (JIDs/ids/stanzaIds cannot contain it; `:` and spaces appear in nicks).
+- **No alias is dropped.** The merged row keeps `identityKeys[]` (union of every tier key) and `ids[]` (union of every client `id`), each a multi-entry index. `getRoomMessage`, `getRoomMessageByStanzaId`, `updateRoomMessage`, `updateRoomMessageReactions`, `deleteRoomMessage` resolve through those — a caller holding a pre-merge id (`roomStore.ts:600/1563/1720/1809/3046`) still finds the row.
+- **The merge is commutative and associative.** `merge(a,b)` deep-equals `merge(b,a)`; any 3-row grouping/order yields one result. The content owner is chosen by a *total* order ending in a stable immutable-content-projection serialization (never the whole row, whose merged fields would break associativity), so a tie occurs only when the content is identical; every other field uses a symmetric operator (min-of-defined, OR, set-union, stanza-preferring timestamp). No edit, poll closure, retraction, reaction, moderation, or alias from either copy is lost.
+- **Mutation entry points go through the identity model.** A non-identity update (reactions, retraction) is authoritative — resolve by `ids`, apply, put under the same key (no merge, so a removal is not undone). An update that *adds* identity fields (`{stanzaId, originId}`) must recompute `identityKeys`/`cacheKey`, re-key, and merge with any row that already carries the new identity.
+- **Ordering is the `room_ts_from_id` index** (`[roomJid, timestamp, from, id]`), never a key string's lexical order.
+- **The finder scans, never `.get()`.** `identityKeys` is non-unique; use `index.getAll(key)` so every match (non-unique tiers, bridges) is found.
+- **The migration is explicit-abort and streaming.** idb does **not** await the async `upgrade` callback, so a rejected promise is not a reliable abort *and* rethrowing risks an unhandled rejection. Use a **synchronous** `upgrade` callback that fires the migration promise with `.catch(() => transaction.abort())` — the abort rejects `openDB`. Cursor the source one row at a time; never `getAll()` the archive. Do not `deleteObjectStore` the legacy store from the async continuation (illegal outside the sync handler) — `clear()` it instead. `fake-indexeddb` cannot prove browser abort semantics: the abort is explicit, and a real-browser check is a manual pre-merge gate.
+- SDK tests are pure Vitest against `fake-indexeddb`. One small app-side change: `getRoomMessageByStanzaId` gains a `roomJid` parameter (stanza IDs collide across rooms), so its one app caller (`useReactionNotifications.ts`) is updated to pass it — see Task 4.
+- Before any commit: `npm test` clean (no failures **and no stderr noise**), `npm run typecheck`, lint. `npm run test:scroll` (repo root) is a required gate on the write/read tasks.
+- SSH commit signing is broken here; use `--no-gpg-sign` if it fails and say so. No Claude footer.
+- **Hollow tests are this codebase's recurring defect.** Every task names a control with an explicit break step; the break's fixture must actually reach the code path it targets.
+
+## File Structure
+
+**Created:** `packages/fluux-sdk/src/utils/roomMessageIdentity.ts` (+ `.test.ts`) — the one identity definition.
+**Modified:** `packages/fluux-sdk/src/utils/messageCache.ts` (+ `.test.ts`); `packages/fluux-sdk/src/stores/roomStore.ts:444-450` (delegate `getRoomMessageKeys`).
+
+---
+
+### Task 1: Centralize the room-scoped XEP-0359 identity
+
+**Files:** create `roomMessageIdentity.ts` + test; modify `roomStore.ts:444-450`.
+
+**Interfaces produced:**
+- `RoomIdentityFields = { roomJid; from; id; stanzaId?; originId? }`
+- `roomIdentityKeys(m): string[]` — every room-scoped tier key, most-specific first.
+- `roomCanonicalKey(m): string` — the highest tier (= `roomIdentityKeys(m)[0]`).
+
+**Control:** a `roomCanonicalKey` returning the `from+id` tier fails "prefers stanzaId then originId"; an unscoped key (dropping the `room:` prefix) fails "keys are room-scoped".
+
+- [ ] **Step 1: Write the failing tests** — create `packages/fluux-sdk/src/utils/roomMessageIdentity.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
+
+const base = { roomJid: 'r@c', from: 'r@c/alice', id: 'origin-1' }
+const NUL = '\u0000'
+
+describe('roomIdentityKeys', () => {
+  it('returns all tiers most-specific first, each room-scoped', () => {
+    expect(roomIdentityKeys({ ...base, stanzaId: 'S', originId: 'O' })).toEqual([
+      `room${NUL}r@c${NUL}stanzaId${NUL}S`,
+      `room${NUL}r@c${NUL}originId${NUL}O`,
+      `room${NUL}r@c${NUL}from${NUL}r@c/alice${NUL}id${NUL}origin-1`,
+    ])
+  })
+  it('always includes the from+id fallback tier', () => {
+    expect(roomIdentityKeys(base)).toEqual([`room${NUL}r@c${NUL}from${NUL}r@c/alice${NUL}id${NUL}origin-1`])
+  })
+  // Control: an unscoped implementation (no room: prefix) fails this — two rooms
+  // sharing a stanzaId would then collide in the identityKeys index.
+  it('scopes stanzaId by room, so equal values in different rooms differ', () => {
+    const a = roomIdentityKeys({ roomJid: 'A@c', from: 'A@c/x', id: 'i', stanzaId: '1' })[0]
+    const b = roomIdentityKeys({ roomJid: 'B@c', from: 'B@c/x', id: 'i', stanzaId: '1' })[0]
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('roomCanonicalKey', () => {
+  it('prefers stanzaId', () => { expect(roomCanonicalKey({ ...base, stanzaId: 'S', originId: 'O' })).toBe(`room${NUL}r@c${NUL}stanzaId${NUL}S`) })
+  it('falls back to originId', () => { expect(roomCanonicalKey({ ...base, originId: 'O' })).toBe(`room${NUL}r@c${NUL}originId${NUL}O`) })
+  it('falls back to from+id', () => { expect(roomCanonicalKey(base)).toBe(`room${NUL}r@c${NUL}from${NUL}r@c/alice${NUL}id${NUL}origin-1`) })
+  it('is always the first identity key', () => { const m = { ...base, stanzaId: 'S' }; expect(roomCanonicalKey(m)).toBe(roomIdentityKeys(m)[0]) })
+})
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd packages/fluux-sdk && npx vitest run src/utils/roomMessageIdentity.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement** — create `packages/fluux-sdk/src/utils/roomMessageIdentity.ts`:
+
+```ts
+/**
+ * The one definition of a room message's identity (XEP-0359), shared by the
+ * resident-window dedup (`roomStore.getRoomMessageKeys`) and the message cache.
+ * One logical message appears as several stanzas (optimistic echo, MUC reflection,
+ * MAM copy) with no single stable field. They are matched through a tiered
+ * identity, most-specific first: stanzaId, then originId, then from+id. Two copies
+ * are the same logical message iff they share ANY of these keys.
+ */
+export interface RoomIdentityFields {
+  roomJid: string
+  from: string
+  id: string
+  stanzaId?: string
+  originId?: string
+}
+
+// U+0000 separator: JIDs/ids/stanzaIds cannot contain it, so joins never collide.
+const S = '\u0000'
+
+/**
+ * Room-scope a tier key. stanzaId/originId are assigned per-archive and can repeat
+ * across rooms; the identityKeys index spans the whole store, so an unscoped key
+ * would let the finder merge messages from different rooms.
+ */
+function scoped(roomJid: string, tier: string): string {
+  return `room${S}${roomJid}${S}${tier}`
+}
+
+/** Every identity key the message carries, most-specific first. For matching. */
+export function roomIdentityKeys(m: RoomIdentityFields): string[] {
+  const keys: string[] = []
+  if (m.stanzaId) keys.push(scoped(m.roomJid, `stanzaId${S}${m.stanzaId}`))
+  if (m.originId) keys.push(scoped(m.roomJid, `originId${S}${m.originId}`))
+  keys.push(scoped(m.roomJid, `from${S}${m.from}${S}id${S}${m.id}`))
+  return keys
+}
+
+/** The single canonical key — the highest tier present. For the primary key. */
+export function roomCanonicalKey(m: RoomIdentityFields): string {
+  return roomIdentityKeys(m)[0]
+}
+```
+
+- [ ] **Step 4: Delegate `roomStore.getRoomMessageKeys`** — import `roomIdentityKeys` from `../utils/roomMessageIdentity` and replace the body of `getRoomMessageKeys` (roomStore.ts:444-450) with `return roomIdentityKeys(m)`. (The old inline version used an unscoped `:` join; delegating both centralizes the definition and room-scopes the timeline dedup, which is strictly safer — only this one function produces the keys it compares.)
+
+- [ ] **Step 5: Run + controls** — `npx vitest run src/utils/roomMessageIdentity.test.ts src/stores/roomStore.mds.test.ts`. Then: (1) make `roomCanonicalKey` return `roomIdentityKeys(m).at(-1)!` (the from+id tier) → "prefers stanzaId"/"falls back to originId" MUST fail; (2) make `scoped` return `tier` (drop the room prefix) → "scopes stanzaId by room" MUST fail. Revert each, confirm green.
+
+- [ ] **Step 6: Full suite + commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger/.claude/worktrees/windows-minimize-tray-setting-779fba
+npm run build:sdk && npm run typecheck && npm test
+git add packages/fluux-sdk/src/utils/roomMessageIdentity.ts packages/fluux-sdk/src/utils/roomMessageIdentity.test.ts packages/fluux-sdk/src/stores/roomStore.ts
+git commit -m "refactor(cache): centralize the room-scoped XEP-0359 message identity"
+```
+
+---
+
+### Task 2: Canonical serializer + commutative, field-complete, total-order merge
+
+**Files:** modify `messageCache.ts` (`StoredRoomMessage` line 62; `serializeRoomMessage` line 219; remove `getRoomMessageCacheKey` lines 30-45; add `mergeRoomRows` near `decryptionRank` line 257); test.
+
+**Interfaces produced:**
+- `StoredRoomMessage` gains `identityKeys: string[]`, `ids: string[]` (exported).
+- `serializeRoomMessage(m)` sets `cacheKey = roomCanonicalKey(m)`, `identityKeys = roomIdentityKeys(m)`, `ids = [m.id]`.
+- `mergeRoomRows(a, b): StoredRoomMessage` — commutative, associative, field-complete.
+
+- [ ] **Step 1: Write the failing tests** — append to `messageCache.test.ts`. Fixtures build `identityKeys`/`cacheKey` via the real helpers so scoping stays correct:
+
+```ts
+import { mergeRoomRows } from './messageCache'
+import type { StoredRoomMessage } from './messageCache'
+import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
+
+const rrow = (over: Partial<StoredRoomMessage> = {}): StoredRoomMessage => {
+  const base = { type: 'groupchat', id: 'origin-1', roomJid: 'r@c', from: 'r@c/alice', body: 'hi', timestamp: 1000, isOutgoing: false, ...over } as StoredRoomMessage
+  return { ...base, cacheKey: roomCanonicalKey(base), identityKeys: roomIdentityKeys(base), ids: [base.id], ...over } as StoredRoomMessage
+}
+const both = (a: StoredRoomMessage, b: StoredRoomMessage) => [mergeRoomRows(a, b), mergeRoomRows(b, a)]
+
+describe('mergeRoomRows — commutative, associative, field-complete', () => {
+  it('never downgrades decrypted content, both orders', () => {
+    for (const m of both(rrow({ body: 'plaintext' }), rrow({ body: '', unsupportedEncryption: { kind: 'x' } as never }))) expect(m.body).toBe('plaintext')
+  })
+  it('keeps an edit from either row', () => {
+    for (const m of both(rrow({ body: 'v1' }), rrow({ body: 'v2', isEdited: true, originalBody: 'v1' }))) { expect(m.isEdited).toBe(true); expect(m.body).toBe('v2') }
+  })
+  it('keeps a poll closure from either row', () => {
+    for (const m of both(rrow({}), rrow({ pollClosed: { by: 'alice' } as never, pollClosedAt: 8000 }))) expect(m.pollClosed).toBeTruthy()
+  })
+  it('prefers the stanza-bearing timestamp, both orders', () => {
+    for (const m of both(rrow({ timestamp: 5000 }), rrow({ timestamp: 4000, stanzaId: 'S' }))) expect(m.timestamp).toBe(4000)
+  })
+  it('unions reactions', () => {
+    for (const m of both(rrow({ reactions: { a: ['alice'] } }), rrow({ reactions: { a: ['bob'], b: ['c'] } }))) { expect(new Set(m.reactions!.a)).toEqual(new Set(['alice','bob'])); expect(m.reactions!.b).toEqual(['c']) }
+  })
+  it('preserves a retraction from either row', () => {
+    const [m] = both(rrow({}), rrow({ isRetracted: true, retractedAt: 7000 })); expect(m.isRetracted).toBe(true); expect(m.retractedAt).toBe(7000)
+  })
+  it('clears a delivery error when either copy delivered cleanly', () => {
+    expect(both(rrow({ deliveryError: { text: 'x' } as never }), rrow({}))[0].deliveryError).toBeUndefined()
+  })
+  it('unions identityKeys/ids and recomputes cacheKey to the highest tier', () => {
+    const echo = rrow({ originId: 'O', id: 'client-1' })
+    const refl = rrow({ originId: 'O', stanzaId: 'S', id: 'server-9' })
+    const [m] = both(echo, refl)
+    expect(m.cacheKey).toBe(roomCanonicalKey({ roomJid: 'r@c', from: 'r@c/alice', id: 'server-9', stanzaId: 'S', originId: 'O' }))
+    expect(new Set(m.ids)).toEqual(new Set(['client-1','server-9']))
+  })
+
+  it('is commutative on a mixed pair with EQUAL ids', () => {
+    const a = rrow({ body: 'plain', originId: 'O', id: 'client-1', timestamp: 5000, reactions: { a: ['alice'] } })
+    const b = rrow({ body: '', unsupportedEncryption: { kind: 'x' } as never, stanzaId: 'S', id: 'client-1', timestamp: 4000, reactions: { a: ['bob'] } })
+    expect(mergeRoomRows(a, b)).toEqual(mergeRoomRows(b, a))
+  })
+
+  // The tie the old contentOwner got wrong: identical id/body/rank/edit, DIFFERENT attachment.
+  it('is commutative when rows tie on rank/body/id but differ in attachment', () => {
+    const a = rrow({ id: 'x', body: 'same', attachment: { url: 'a://1' } as never })
+    const b = rrow({ id: 'x', body: 'same', attachment: { url: 'a://2' } as never })
+    expect(mergeRoomRows(a, b)).toEqual(mergeRoomRows(b, a))
+  })
+
+  it('is associative and order-independent across three rows', () => {
+    const a = rrow({ originId: 'O', id: 'c1', timestamp: 5000, reactions: { a: ['a'] } })
+    const b = rrow({ stanzaId: 'S', id: 'c2', timestamp: 4000, reactions: { r: ['b'] } })
+    const c = rrow({ body: 'edited', isEdited: true, id: 'c1', timestamp: 4500, reactions: { a: ['d'] } })
+    const rs = [mergeRoomRows(mergeRoomRows(a,b),c), mergeRoomRows(a,mergeRoomRows(b,c)), mergeRoomRows(mergeRoomRows(b,a),c), mergeRoomRows(mergeRoomRows(c,b),a)]
+    for (const r of rs) expect(r).toEqual(rs[0])
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure** — `npx vitest run src/utils/messageCache.test.ts -t "commutative, associative, field-complete"` → FAIL.
+
+- [ ] **Step 3: Implement the serializer + merge**
+
+Export the type (`export interface StoredRoomMessage`), add `identityKeys: string[]` and `ids: string[]` to it, and import at the top of `messageCache.ts`: `import { roomCanonicalKey, roomIdentityKeys } from './roomMessageIdentity'`. Update `serializeRoomMessage` (line 219) to set `cacheKey: roomCanonicalKey(message), identityKeys: roomIdentityKeys(message), ids: [message.id],` and **delete** the now-unused `getRoomMessageCacheKey` (lines 30-45).
+
+Add after `decryptionRank` (line 264):
+
+```ts
+function unionSorted(a: string[] = [], b: string[] = []): string[] { return [...new Set([...a, ...b])].sort() }
+function minStr(a?: string, b?: string): string | undefined { if (a == null) return b; if (b == null) return a; return a <= b ? a : b }
+function minNum(a?: number, b?: number): number | undefined { if (a == null) return b; if (b == null) return a; return Math.min(a, b) }
+function mergeReactions(a?: Record<string, string[]>, b?: Record<string, string[]>): Record<string, string[]> | undefined {
+  if (!a) return b; if (!b) return a
+  const out: Record<string, string[]> = {}
+  for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) out[k] = unionSorted(a[k], b[k])
+  return out
+}
+
+/** Deterministic, key-sorted serialization — a stable total order over any row. */
+function stableStringify(v: unknown): string {
+  // JSON.stringify(undefined) is `undefined`, not a string — return a token so the
+  // declared `string` return holds (undefined-valued fields do occur in the projection).
+  if (v === undefined) return '␀undefined'
+  if (v === null || typeof v !== 'object') return JSON.stringify(v)
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`
+  const o = v as Record<string, unknown>
+  return `{${Object.keys(o).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`).join(',')}}`
+}
+
+/**
+ * Choose the CONTENT-owner row by a strict TOTAL order, so the choice is the same
+ * regardless of argument order AND a tie happens only when the rows are identical.
+ * Higher decryption rank, then edited, then non-empty body, then — the fix — a
+ * full stable serialization, so two rows differing in attachment / poll / reply /
+ * encryption metadata still resolve deterministically instead of picking `a`.
+ */
+/**
+ * The IMMUTABLE content projection — everything EXCEPT the fields merged
+ * separately (aliases, timestamp, reactions, retraction, moderation, poll
+ * closure, delivery error, cacheKey). The tiebreak must serialize only this,
+ * because those excluded fields CHANGE during a merge: an intermediate merged
+ * row acquires unioned aliases/reactions and a min timestamp, so serializing the
+ * whole row would make contentOwner(merge(a,b), c) differ from
+ * contentOwner(a, merge(b,c)) — destroying associativity. The content projection
+ * is identical between a merged row and its content-winner, so max over it is
+ * genuinely associative.
+ */
+function contentProjection(m: StoredRoomMessage): unknown {
+  const {
+    stanzaId: _s, originId: _o, timestamp: _t, reactions: _r, identityKeys: _ik, ids: _ids,
+    isRetracted: _rt, retractedAt: _ra, isModerated: _m, moderatedBy: _mb, moderationReason: _mr,
+    pollClosed: _pc, pollClosedAt: _pca, deliveryError: _de, cacheKey: _ck, ...content
+  } = m
+  return content
+}
+
+function contentOwner(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+  const ra: number[] = [decryptionRank(a), a.isEdited ? 1 : 0, a.body ? 1 : 0]
+  const rb: number[] = [decryptionRank(b), b.isEdited ? 1 : 0, b.body ? 1 : 0]
+  for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) return ra[i] > rb[i] ? a : b
+  // Tiebreak over the IMMUTABLE content only, so max is associative (see contentProjection).
+  return stableStringify(contentProjection(a)) <= stableStringify(contentProjection(b)) ? a : b
+}
+
+/**
+ * Merge two stored rows that are the same logical room message into one.
+ * COMMUTATIVE and ASSOCIATIVE. The correlated content block comes from
+ * {@link contentOwner} (total order); every other field uses a symmetric operator,
+ * so no edit, poll closure, retraction, reaction, moderation, or alias is lost.
+ */
+export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+  const owner = contentOwner(a, b)
+  const aSid = a.stanzaId != null, bSid = b.stanzaId != null
+  const timestamp = aSid !== bSid ? (aSid ? a.timestamp : b.timestamp) : Math.min(a.timestamp, b.timestamp)
+  const retracted = !!(a.isRetracted || b.isRetracted)
+  const moderated = !!(a.isModerated || b.isModerated)
+  // Poll closure: symmetric even when both closed with different records.
+  const pollClosed = a.pollClosed && b.pollClosed
+    ? (stableStringify(a.pollClosed) <= stableStringify(b.pollClosed) ? a.pollClosed : b.pollClosed)
+    : (a.pollClosed ?? b.pollClosed)
+
+  const merged: StoredRoomMessage = {
+    ...owner,
+    stanzaId: minStr(a.stanzaId, b.stanzaId),
+    originId: minStr(a.originId, b.originId),
+    timestamp,
+    reactions: mergeReactions(a.reactions, b.reactions),
+    identityKeys: unionSorted(a.identityKeys, b.identityKeys),
+    ids: unionSorted(a.ids, b.ids),
+    deliveryError: a.deliveryError && b.deliveryError ? (stableStringify(a.deliveryError) <= stableStringify(b.deliveryError) ? a.deliveryError : b.deliveryError) : undefined,
+    ...(retracted ? { isRetracted: true, retractedAt: minNum(a.retractedAt, b.retractedAt) } : {}),
+    ...(moderated ? { isModerated: true, moderatedBy: minStr(a.moderatedBy, b.moderatedBy), moderationReason: minStr(a.moderationReason, b.moderationReason) } : {}),
+    ...(pollClosed ? { pollClosed, pollClosedAt: minNum(a.pollClosedAt, b.pollClosedAt) } : {}),
+  }
+  merged.cacheKey = roomCanonicalKey(merged)
+  merged.identityKeys = unionSorted(merged.identityKeys, roomIdentityKeys(merged))
+  return merged
+}
+```
+
+Notes: the `...owner` spread carries every correlated content field (attachment, poll, replyTo, mentions, encryption, nick, occupantId, flags, systemEvent, …) — that is what makes the merge field-complete without enumerating them; `contentOwner`'s total order guarantees the block is chosen deterministically. `timestamp`/`retractedAt`/`pollClosedAt` are epoch-ms numbers.
+
+- [ ] **Step 4: Run to verify pass** — `npx vitest run src/utils/messageCache.test.ts -t "commutative, associative, field-complete"` → PASS.
+
+- [ ] **Step 5: Verify the controls bite** (each break must reach the path it targets):
+1. Replace `contentOwner`'s last two lines with `return a` → the **"ties on rank/body/id but differ in attachment"** test MUST fail (this fixture reaches the tiebreak — unlike a rank/body-differing fixture, which would not). Revert.
+2. Drop `.sort()` from `unionSorted` → the associativity test MUST fail. Revert.
+3. Make `contentOwner` serialize the whole row (`stableStringify(a)` / `stableStringify(b)`) instead of `contentProjection(...)` → the associativity test MUST fail (an intermediate merge changes reactions/aliases/timestamp, so grouping changes the winner). Revert.
+4. Force `timestamp = a.timestamp` → the stanza-timestamp test MUST fail. Revert.
+4. Change `pollClosed` to `a.pollClosed ? a.pollClosed : b.pollClosed` for the both-closed case (order-dependent) → add/asssert a both-closed-different test fails; or fold into the attachment-tie test by giving both rows different `pollClosed`. Revert, confirm green.
+
+- [ ] **Step 6: Full suite + commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger/.claude/worktrees/windows-minimize-tray-setting-779fba
+npm run typecheck && npm test
+git add packages/fluux-sdk/src/utils/messageCache.ts packages/fluux-sdk/src/utils/messageCache.test.ts
+git commit -m "feat(cache): canonical room serializer and total-order commutative merge"
+```
+
+---
+
+### Task 3: Schema v4 — alias indexes, identity-resolving upsert, streaming explicit-abort migration
+
+**Files:** modify `messageCache.ts` (`DB_VERSION` 18, `ROOM_MESSAGES_STORE` 20, `MessageCacheSchema` 92-102, `upgrade` 146-184); add `findRoomRowsByIdentity`, `upsertRoomRowByIdentity`, `migrateRoomStoreToCanonical`, `_setMigrationFaultForTesting`; test.
+
+**Interfaces produced:** `upsertRoomRowByIdentity(store, message)` (used by the migration and Task 4's write path); a v4 DB whose canonical room store has `identityKeys` + `ids` **multi-entry** indexes plus `roomJid`/`stanzaId`/`originId`/`timestamp`/`room_timestamp`/`room_ts_from_id`.
+
+**Store rename:** stream the legacy `'room-messages'` into a fresh destination store, then `clear()` the legacy store:
+
+```ts
+const ROOM_MESSAGES_STORE = 'room-messages-canonical'
+const LEGACY_ROOM_MESSAGES_STORE = 'room-messages'
+```
+
+**Controls:** (1) the straddle migration — an `originId`-keyed echo at `t1` and a `stanzaId`-keyed reflection of the same message (shared `originId`, rewritten `id`) at `t2` — collapses to one row with **both ids resolvable**; a finder that `.get()`s one tier, or an upsert treating rows as new, fails it. (2) a migration that throws leaves the DB at v3.
+
+- [ ] **Step 1: Write the failing migration + alias + abort tests** — append to `messageCache.test.ts`:
+
+```ts
+import { openDB } from 'idb'
+
+describe('v4 migration — identity-resolving canonicalization (streaming)', () => {
+  const JID = 'me@example.com', ROOM = 'r@c', FROM = 'r@c/alice'
+  const dbName = `fluux-message-cache:${JID}`
+  async function seedV3(rows: Array<Record<string, unknown>>) {
+    const db = await openDB(dbName, 3, {
+      upgrade(d) {
+        if (!d.objectStoreNames.contains('messages')) {
+          const s = d.createObjectStore('messages', { keyPath: 'id' })
+          for (const [n, kp] of [['conversationId','conversationId'],['stanzaId','stanzaId'],['timestamp','timestamp'],['conv_timestamp',['conversationId','timestamp']],['encryptedPayload','encryptedPayload']] as const) s.createIndex(n, kp as never)
+        }
+        const r = d.createObjectStore('room-messages', { keyPath: 'cacheKey' })
+        for (const [n, kp] of [['roomJid','roomJid'],['stanzaId','stanzaId'],['timestamp','timestamp'],['room_timestamp',['roomJid','timestamp']],['id','id']] as const) r.createIndex(n, kp as never)
+      },
+    })
+    const tx = db.transaction('room-messages', 'readwrite')
+    for (const row of rows) await tx.objectStore('room-messages').put(row as never)
+    await tx.done; db.close()
+  }
+  beforeEach(() => { globalThis.indexedDB = new IDBFactory(); messageCache._resetDBForTesting(); _resetStorageScopeForTesting(); setStorageScopeJid(JID) })
+
+  it('collapses an originId echo pair (rewritten id) into one row; both ids + stanzaId resolvable', async () => {
+    await seedV3([
+      { cacheKey: 'k1', originId: 'O', type: 'groupchat', id: 'client-1', roomJid: ROOM, from: FROM, body: 'hi', timestamp: 1000, isOutgoing: true },
+      { cacheKey: 'k2', stanzaId: 'S', originId: 'O', type: 'groupchat', id: 'server-9', roomJid: ROOM, from: FROM, body: 'hi', timestamp: 2000, isOutgoing: true },
+    ])
+    const mine = (await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')
+    expect(mine).toHaveLength(1)
+    expect(mine[0].timestamp.getTime()).toBe(2000)
+    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
+  })
+
+  it('does not merge identical stanzaIds across different rooms', async () => {
+    await seedV3([
+      { cacheKey: 'a', stanzaId: '1', type: 'groupchat', id: 'i', roomJid: 'A@c', from: 'A@c/x', body: 'a', timestamp: 1000, isOutgoing: false },
+      { cacheKey: 'b', stanzaId: '1', type: 'groupchat', id: 'i', roomJid: 'B@c', from: 'B@c/x', body: 'b', timestamp: 1000, isOutgoing: false },
+    ])
+    expect(await messageCache.getRoomMessages('A@c', {})).toHaveLength(1)
+    expect(await messageCache.getRoomMessages('B@c', {})).toHaveLength(1)
+  })
+
+  it('does not downgrade a decrypted body during migration', async () => {
+    await seedV3([
+      { cacheKey: 'x', stanzaId: 'S1', type: 'groupchat', id: 'o2', roomJid: ROOM, from: FROM, body: '', unsupportedEncryption: { kind: 'x' }, timestamp: 3000, isOutgoing: false },
+      { cacheKey: 'y', stanzaId: 'S1', type: 'groupchat', id: 'o2', roomJid: ROOM, from: FROM, body: 'decrypted', timestamp: 3000, isOutgoing: false },
+    ])
+    expect((await messageCache.getRoomMessages(ROOM, {})).find((m) => m.stanzaId === 'S1')!.body).toBe('decrypted')
+  })
+
+  it('aborts the whole upgrade if the migration throws — DB stays at v3', async () => {
+    await seedV3([{ cacheKey: 'z', stanzaId: 'S9', type: 'groupchat', id: 'o9', roomJid: ROOM, from: FROM, body: 'x', timestamp: 5000, isOutgoing: false }])
+    messageCache._setMigrationFaultForTesting(true)
+    await expect(messageCache.getRoomMessages(ROOM, {})).resolves.toEqual([])
+    messageCache._setMigrationFaultForTesting(false); messageCache._resetDBForTesting()
+    const raw = await openDB(dbName)
+    expect(raw.version).toBe(3)
+    expect(raw.objectStoreNames.contains('room-messages-canonical')).toBe(false)
+    expect(await raw.get('room-messages', 'z')).toBeTruthy()
+    raw.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure** — `npx vitest run src/utils/messageCache.test.ts -t "identity-resolving canonicalization"` → FAIL.
+
+- [ ] **Step 3: Fault flag + finder + upsert**
+
+```ts
+let migrationFaultForTesting = false
+/** @internal test seam — force the v4 migration to throw, to verify it aborts. */
+export function _setMigrationFaultForTesting(on: boolean): void { migrationFaultForTesting = on }
+
+type RoomStoreLike = {
+  put(v: StoredRoomMessage): Promise<unknown>
+  delete(key: string): Promise<void>
+  index(name: 'identityKeys'): { getAll(key: string): Promise<StoredRoomMessage[]> }
+}
+
+/** Every existing row sharing ANY identity tier with `m`, de-duped by cacheKey. Scans (not .get). */
+async function findRoomRowsByIdentity(store: RoomStoreLike, m: StoredRoomMessage): Promise<StoredRoomMessage[]> {
+  const found = new Map<string, StoredRoomMessage>()
+  for (const key of m.identityKeys) for (const row of await store.index('identityKeys').getAll(key)) found.set(row.cacheKey, row)
+  return [...found.values()]
+}
+
+/**
+ * Core: resolve every existing row sharing any tier with `incoming` (echo,
+ * live/MAM, bridge), merge them and `incoming` into one, delete the losers, put
+ * the survivor. `incoming` is an already-serialized StoredRoomMessage, so callers
+ * that need to PRESERVE accumulated aliases (updateRoomMessage) union them in
+ * first. `excludeKey` skips a specific existing row from the merge — used when the
+ * caller already holds that row's data in `incoming` and must not merge its
+ * pre-update copy back in (which the union would do, re-adding a removed reaction).
+ */
+async function upsertStoredRoomRow(
+  store: RoomStoreLike,
+  incoming: StoredRoomMessage,
+  excludeKey?: string
+): Promise<void> {
+  const matches = (await findRoomRowsByIdentity(store, incoming)).filter((r) => r.cacheKey !== excludeKey)
+  let merged = incoming
+  for (const row of matches) merged = mergeRoomRows(merged, row)
+  const survivorKey = merged.cacheKey
+  if (excludeKey && excludeKey !== survivorKey) await store.delete(excludeKey)
+  for (const row of matches) if (row.cacheKey !== survivorKey) await store.delete(row.cacheKey)
+  await store.put(merged)
+}
+
+/** Insert or merge a live-arriving message by identity. */
+async function upsertRoomRowByIdentity(store: RoomStoreLike, message: RoomMessage): Promise<void> {
+  await upsertStoredRoomRow(store, serializeRoomMessage(message))
+}
+```
+
+- [ ] **Step 4: Version, schema, and the synchronous-callback explicit-abort migration**
+
+Set `DB_VERSION = 4`; add the store constants above. In `MessageCacheSchema`, the canonical room store's `indexes`:
+
+```ts
+    indexes: {
+      roomJid: string
+      stanzaId: string
+      originId: string
+      identityKeys: string // multiEntry over identityKeys[]
+      ids: string          // multiEntry over ids[]
+      timestamp: number
+      room_timestamp: [string, number]
+      room_ts_from_id: [string, number, string, string]
+    }
+```
+
+Keep the `upgrade` callback **synchronous** (do not make it `async`). Replace the room portion (166-183):
+
+```ts
+      if (!db.objectStoreNames.contains(ROOM_MESSAGES_STORE)) {
+        const s = db.createObjectStore(ROOM_MESSAGES_STORE, { keyPath: 'cacheKey' })
+        s.createIndex('roomJid', 'roomJid', { unique: false })
+        s.createIndex('stanzaId', 'stanzaId', { unique: false })
+        s.createIndex('originId', 'originId', { unique: false })
+        s.createIndex('identityKeys', 'identityKeys', { unique: false, multiEntry: true })
+        s.createIndex('ids', 'ids', { unique: false, multiEntry: true })
+        s.createIndex('timestamp', 'timestamp', { unique: false })
+        s.createIndex('room_timestamp', ['roomJid', 'timestamp'], { unique: false })
+        s.createIndex('room_ts_from_id', ['roomJid', 'timestamp', 'from', 'id'], { unique: false })
+
+        if (db.objectStoreNames.contains(LEGACY_ROOM_MESSAGES_STORE)) {
+          // idb does NOT await this callback, and rethrowing would be an unhandled
+          // rejection. Fire the migration and, on ANY failure, explicitly abort the
+          // version-change transaction (which rejects openDB). The transaction stays
+          // alive meanwhile via the migration's chained requests, and openDB resolves
+          // only after it commits. Do not deleteObjectStore here (illegal from the
+          // async continuation) — the migration clear()s the legacy store instead.
+          migrateRoomStoreToCanonical(transaction).catch(() => transaction.abort())
+        }
+      }
+```
+
+Add the streaming migration (it `clear()`s, not `deleteObjectStore`s, the legacy store):
+
+```ts
+async function migrateRoomStoreToCanonical(transaction: { objectStore(name: string): any }): Promise<void> {
+  const legacy = transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE)
+  const dest = transaction.objectStore(ROOM_MESSAGES_STORE) as unknown as RoomStoreLike
+  let cursor = await legacy.openCursor()
+  while (cursor) {
+    if (migrationFaultForTesting) throw new Error('migration fault (test)')
+    await upsertRoomRowByIdentity(dest, deserializeRoomMessage(cursor.value))
+    cursor = await cursor.continue()
+  }
+  await legacy.clear() // legacy store now empty; a future version bump can drop it synchronously
+}
+```
+
+Typing note: `transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE)` references a store not in the current schema — cast the name locally (`as never`) or add a minimal legacy entry to `MessageCacheSchema`.
+
+- [ ] **Step 5: Run to verify pass** — `npx vitest run src/utils/messageCache.test.ts -t "identity-resolving canonicalization"` → PASS.
+
+- [ ] **Step 6: Verify the controls bite**
+1. In `upsertRoomRowByIdentity`, force `const matches = []` → the straddle test finds two rows → `toHaveLength(1)` MUST fail. Revert.
+2. In `findRoomRowsByIdentity`, scan only `m.identityKeys[0]` → the straddle pair (sharing only the `originId` tier, the 2nd key) MUST fail. Revert.
+3. Replace `.catch(() => transaction.abort())` with `.catch(() => {})` (swallow) → the abort test MUST fail or flake. If it does not flip reliably under `fake-indexeddb`, that is the limitation Codex named — keep the explicit abort and record real-browser abort as a manual pre-merge check. Revert, confirm green.
+
+- [ ] **Step 7: Full suite + scroll gate + commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger/.claude/worktrees/windows-minimize-tray-setting-779fba
+npm run build:sdk && npm run typecheck && npm test && npm run test:scroll
+git add packages/fluux-sdk/src/utils/messageCache.ts packages/fluux-sdk/src/utils/messageCache.test.ts
+git commit -m "feat(cache): v4 identity-resolving room store, alias indexes, abortable streaming migration"
+```
+
+---
+
+### Task 4: Route every write/read/mutation path through the identity model
+
+**Files:** modify `messageCache.ts` — `saveRoomMessages` (761-778); `getRoomMessage` (784-796); `getRoomMessageByStanzaId` (801-814, **signature +roomJid**); `updateRoomMessage` (939+); `updateRoomMessageReactions` (983+); `deleteRoomMessage` (1034-1047); `getRoomMessagesAround` dedup (909); `roomMessageIdentity.ts` (add `roomStanzaKey`, `roomOriginKey`); `apps/fluux/src/hooks/useReactionNotifications.ts:142` (pass `roomJid`); test.
+
+**Controls:** a blind-`put` `saveRoomMessages` fails "optimistic then reflection converge"; a `getRoomMessage` on the old single `id` index fails "discarded id resolves"; an `updateRoomMessage({stanzaId})` that only puts-back fails "adding a stanzaId re-keys and merges".
+
+- [ ] **Step 1: Write the failing tests** — append to `messageCache.test.ts`:
+
+```ts
+describe('live paths — identity-resolving upsert + alias lookups + mutations', () => {
+  const ROOM = 'r@c', FROM = 'r@c/alice'
+  const mk = (over: Partial<RoomMessage> = {}): RoomMessage => ({ type: 'groupchat', id: 'client-1', roomJid: ROOM, from: FROM, body: 'hello', timestamp: new Date(5000), isOutgoing: true, originId: 'O', ...over }) as RoomMessage
+
+  it('merges a reflection (rewritten id + stanzaId) into the optimistic echo', async () => {
+    await messageCache.saveRoomMessage(mk())
+    await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S', timestamp: new Date(4000) }))
+    const mine = (await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')
+    expect(mine).toHaveLength(1); expect(mine[0].timestamp.getTime()).toBe(4000)
+  })
+  it('the discarded optimistic id still resolves after the merge', async () => {
+    await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
+    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
+  })
+  it('updateRoomMessage that ADDS a stanzaId re-keys and merges with any matching row', async () => {
+    // A separate MAM copy already carries stanzaId S...
+    await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
+    // ...and the optimistic row is only now confirmed via an identity-adding update.
+    await messageCache.saveRoomMessage(mk()) // optimistic: originId O, no stanzaId
+    await messageCache.updateRoomMessage('client-1', { stanzaId: 'S', originId: 'O' })
+    expect((await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')).toHaveLength(1)
+  })
+  it('updateRoomMessage that ADDS an originId (canonical key UNCHANGED) still merges a row already at that originId', async () => {
+    // Row 1 has stanzaId S, no originId → canonical key stanzaId:S.
+    await messageCache.saveRoomMessage(mk({ id: 'a1', stanzaId: 'S', originId: undefined }))
+    // Row 2 is a separate copy already carrying originId O (no stanzaId).
+    await messageCache.saveRoomMessage(mk({ id: 'a2', originId: 'O', stanzaId: undefined }))
+    // Confirm row 1 also carries originId O — its canonical key stays stanzaId:S,
+    // so a key-only identityChanged check would MISS this and leave two rows.
+    await messageCache.updateRoomMessage('a1', { originId: 'O' })
+    expect((await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.stanzaId === 'S' || m.originId === 'O')).toHaveLength(1)
+    expect(await messageCache.getRoomMessage('a1')).not.toBeNull()          // every alias
+    expect(await messageCache.getRoomMessage('a2')).not.toBeNull()          // preserved
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
+  })
+  it('removes a deliberately cleared stale stanzaId alias (clearMessageStanzaId)', async () => {
+    await messageCache.saveRoomMessage(mk({ stanzaId: 'stale-S' })) // has stanzaId + originId O + id client-1
+    await messageCache.updateRoomMessage('client-1', { stanzaId: undefined }) // revoke the stanzaId
+    // The scoped stanza alias must be GONE — else a later message with 'stale-S' merges wrongly.
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'stale-S')).toBeNull()
+    // ...but the message itself, and its other aliases, remain.
+    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessages(ROOM, {})).toHaveLength(1)
+  })
+  it('updateRoomMessageReactions resolves a pre-merge id and is authoritative (does not un-remove)', async () => {
+    await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
+    await messageCache.updateRoomMessageReactions('client-1', 'r@c/bob', ['👍'])
+    expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍']).toContain('r@c/bob')
+    await messageCache.updateRoomMessageReactions('client-1', 'r@c/bob', []) // removal
+    expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍'] ?? []).not.toContain('r@c/bob')
+  })
+  it('getRoomMessagesAround returns each logical message once', async () => {
+    await messageCache.saveRoomMessage(mk({ stanzaId: 'S' }))
+    expect((await messageCache.getRoomMessagesAround(ROOM, 'client-1', { before: 5, after: 5 })).filter((m) => m.originId === 'O')).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure** — `npx vitest run src/utils/messageCache.test.ts -t "live paths"` → FAIL.
+
+- [ ] **Step 3: Rewire the paths**
+
+**`saveRoomMessages`** (761-778) — sequential upsert (a same-batch optimistic+reflection pair must merge; each upsert must see the prior write):
+
+```ts
+export async function saveRoomMessages(messages: RoomMessage[]): Promise<boolean> {
+  if (messages.length === 0) return true
+  try {
+    const db = await getDB(getStorageScopeJid())
+    const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
+    const store = tx.objectStore(ROOM_MESSAGES_STORE)
+    for (const msg of messages) await upsertRoomRowByIdentity(store, msg)
+    await tx.done
+    return true
+  } catch (error) {
+    if (isIndexedDBAvailable()) console.warn('Failed to save room messages:', error)
+    return false
+  }
+}
+```
+
+**Reads:** `getRoomMessage(id)` → `db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', id)` (id is not unique across rooms — same as the old `id`-index behaviour, first match).
+
+`getRoomMessageByStanzaId` must become **room-scoped** — `stanzaId` collides across rooms, so the global `stanzaId` index can return the wrong room's message. Change the signature to `getRoomMessageByStanzaId(roomJid, stanzaId)` and query the room-scoped alias: `db.getFromIndex(ROOM_MESSAGES_STORE, 'identityKeys', roomStanzaKey(roomJid, stanzaId))`, where `roomStanzaKey` is a small exported helper added to `roomMessageIdentity.ts`:
+
+```ts
+/** The room-scoped stanzaId identity key (for getRoomMessageByStanzaId and revocation). */
+export function roomStanzaKey(roomJid: string, stanzaId: string): string {
+  return scoped(roomJid, `stanzaId${S}${stanzaId}`)
+}
+/** The room-scoped originId identity key (for revocation). */
+export function roomOriginKey(roomJid: string, originId: string): string {
+  return scoped(roomJid, `originId${S}${originId}`)
+}
+```
+
+Two callers pass the change through — both already have the room JID:
+- `getRoomMessagesAround(roomJid, anchorMessageId)` (messageCache.ts:892) → `getRoomMessageByStanzaId(roomJid, anchorMessageId)`.
+- **App-side** `apps/fluux/src/hooks/useReactionNotifications.ts:142` (inside a `room:reactions` handler that has `roomJid` in scope) → `getCachedRoomMessageByStanzaId(roomJid, messageId)`.
+
+`getRoomMessagesAround`'s dedup (909) → `roomCanonicalKey(m)`.
+
+**Non-identity mutations** — `updateRoomMessageReactions(id, ...)` and `deleteRoomMessage(id)`: resolve the row via the `ids` index (`getFromIndex(ROOM_MESSAGES_STORE, 'ids', id)`), then put/delete by the returned `cacheKey`. Reactions are authoritative (apply the reaction change to the found row and put under the same key — do NOT route through `mergeRoomRows`, whose union would un-remove a removed reaction).
+
+**`updateRoomMessage(id, updates)`** — resolve via `ids`; apply updates to a working copy; then branch:
+- If no identity **field** changed: `put` under the same key, keeping the existing `ids`/`identityKeys`.
+- If an identity field changed — note the canonical key may or may not differ (adding an `originId` to a `stanzaId` row does not), which is why the branch keys off the FIELDS. Two shapes:
+  - **Expansion** (a new `stanzaId`/`originId`, or a changed `id`): union the existing aliases into the updated row, then re-key and merge any *other* row already at the new identity.
+  - **Revocation** (an explicit `{ stanzaId: undefined }`, which `clearMessageStanzaId` sends): the scalar is gone *and* its scoped alias must be **removed** — not unioned back — or `getRoomMessageByStanzaId` keeps resolving the dead id and a later message carrying that stanzaId is wrongly merged in.
+
+  Both route through `upsertStoredRoomRow(store, row, existing.cacheKey)` (the `excludeKey` overwrites the same key when it is unchanged, re-keys and deletes the stale row when it changed). Concretely:
+
+```ts
+export async function updateRoomMessage(id: string, updates: Partial<RoomMessage>): Promise<void> {
+  try {
+    const db = await getDB(getStorageScopeJid())
+    const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
+    const store = tx.objectStore(ROOM_MESSAGES_STORE)
+    const existing = await store.index('ids').get(id)
+    if (!existing) { await tx.done; return }
+    const updated = { ...deserializeRoomMessage(existing), ...updates } as RoomMessage
+    // Compare identity FIELDS, not just the canonical key: adding an originId to a
+    // row that already has a stanzaId (or changing the id) leaves the canonical key
+    // unchanged yet still expands the identity — a row now matching the new tier must
+    // be merged in. Key-only comparison would take the non-identity branch and miss it.
+    const identityChanged =
+      updated.id !== existing.id ||
+      updated.from !== existing.from ||
+      updated.roomJid !== existing.roomJid ||
+      updated.stanzaId !== existing.stanzaId ||
+      updated.originId !== existing.originId
+    if (!identityChanged) {
+      const row = serializeRoomMessage(updated)
+      row.identityKeys = existing.identityKeys // unchanged
+      row.ids = existing.ids
+      await store.put(row)
+    } else {
+      // An identity field changed. Union the existing row's accumulated aliases in
+      // (do NOT delete-then-upsert — a deleted row cannot be rediscovered, and
+      // re-serialization resets ids/identityKeys). But a REVOCATION ({ stanzaId:
+      // undefined }) must REMOVE the cleared scoped alias, not union it back:
+      const revoked: string[] = []
+      if ('stanzaId' in updates && updated.stanzaId == null && existing.stanzaId) revoked.push(roomStanzaKey(existing.roomJid, existing.stanzaId))
+      if ('originId' in updates && updated.originId == null && existing.originId) revoked.push(roomOriginKey(existing.roomJid, existing.originId))
+
+      const row = serializeRoomMessage(updated) // ids=[updated.id]; identityKeys reflect current fields (a revoked tier is already absent)
+      row.ids = unionSorted(existing.ids, row.ids)
+      row.identityKeys = unionSorted(existing.identityKeys, row.identityKeys).filter((k) => !revoked.includes(k))
+      // excludeKey = old cacheKey: overwrites when the canonical key is unchanged,
+      // re-keys + deletes the stale row when it changed; either way the pre-update
+      // copy is not merged back in. The finder uses row.identityKeys (revoked tier
+      // absent), so a row legitimately still carrying that stanzaId is NOT pulled in.
+      await upsertStoredRoomRow(store as never, row, existing.cacheKey)
+    }
+    await tx.done
+  } catch (error) {
+    if (isIndexedDBAvailable()) console.warn('Failed to update room message:', error)
+  }
+}
+```
+
+(`unionSorted` and `upsertStoredRoomRow` are defined in Task 3. The existing row's aliases are preserved in `row` before re-keying; `excludeKey` removes the stale row without folding its pre-update content back in; any *other* row already at the new identity is merged in — that is a genuine duplicate.)
+
+- [ ] **Step 4: Run to verify pass** — `npx vitest run src/utils/messageCache.test.ts -t "live paths"` → PASS.
+
+- [ ] **Step 5: Verify the controls bite**
+1. Revert `saveRoomMessages` to `await Promise.all(messages.map((m) => store.put(serializeRoomMessage(m))))` → "merges a reflection" MUST fail. Revert.
+2. Point `getRoomMessage` back at a single `id` index → "discarded id resolves" MUST fail. Revert.
+3. In `updateRoomMessage`, take the `!identityChanged` branch unconditionally (never re-key) → "adds a stanzaId re-keys and merges" MUST fail (two rows). Revert.
+4. Revert `identityChanged` to the key-only check (`roomCanonicalKey(updated) !== existing.cacheKey`) → the "ADDS an originId (canonical key UNCHANGED)" test MUST fail (two rows), since adding an originId to a stanzaId row leaves the canonical key unchanged. Revert.
+5. Drop the `.filter((k) => !revoked.includes(k))` (restore the unconditional alias union) → the "removes a deliberately cleared stale stanzaId alias" test MUST fail (`getRoomMessageByStanzaId` still resolves the dead id). Revert, confirm green.
+
+- [ ] **Step 6: Full suite + scroll gate + commit**
+
+```bash
+cd /Users/mremond/AIProjects/fluux-messenger/.claude/worktrees/windows-minimize-tray-setting-779fba
+npm run build:sdk && npm run typecheck && npm test && npm run test:scroll
+git add packages/fluux-sdk/src/utils/messageCache.ts packages/fluux-sdk/src/utils/messageCache.test.ts
+git commit -m "feat(cache): route all room writes/reads/mutations through the identity model"
+```
+
+---
+
+## Definition of done for PR B0
+
+- One room-scoped identity definition, used by `roomStore.getRoomMessageKeys` and the cache.
+- One cache row per logical message — live optimistic+reflection, live+MAM, migrated legacy DB — and messages with equal stanza/origin values in *different rooms* stay separate.
+- The merge is provably commutative and associative including the identical-except-a-field tie (Task 2), losing no edit/poll-closure/retraction/reaction/moderation/alias.
+- Every id/stanza/origin alias resolves after a merge (Task 3/4), so all mutation entry points — `updateRoomMessage` (identity **expansion** *and* **revocation** of a cleared `stanzaId`), `updateRoomMessageReactions`, `deleteRoomMessage` — work on a pre-merge id, and a deliberately cleared alias stops resolving.
+- The migration streams, scans (not `.get()`), and **explicitly aborts** on failure, leaving the DB at v3. Real-browser abort is a manual pre-merge check.
+- `npm test`, typecheck, lint, `npm run test:scroll` pass; every control verified to bite.
+
+## What PR B0 deliberately does NOT do
+
+- No unread counting / `readState` / pointer `archiveOrderKey` — that is PR B, built on the single-row store this PR guarantees.
+- No chat-store change (chat keys by a stable, unique `id`).
+
+## Scope note
+
+This grew during review into an identity-resolving, alias-preserving upsert, because a MUC rewrites the client id on echo (copies share only `originId`), stanza/origin values collide across rooms, and existing mutation callers hold pre-merge ids. That is inherent to the correctness goal (one logical message = one row, no lookup broken) and is why B0 is its own isolated precursor PR.

--- a/docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md
@@ -32,7 +32,9 @@ occupant-id edges) then destroys the position permanently.
 The cache can already answer the question. `messageCache` carries compound indexes
 `conv_timestamp` (`[conversationId, timestamp]`) and `room_timestamp`
 (`[roomJid, timestamp]`), so "count the non-outgoing messages after this point" is a
-single indexed range walk over the *whole* archive — exact, not window-limited.
+single indexed range walk over the *complete local archive* — exact over what is cached,
+not window-limited (the reconciled PR B design adds a coverage gate so a *partial* local
+archive never overwrites a good count).
 
 The pattern already exists, hand-built for one call site. `applyRemoteDisplayed` runs an
 async exact recount over `MAM_POINTER_RECOUNT_CACHE_LIMIT` cached messages
@@ -97,8 +99,10 @@ therefore in scope, in PR A.
    records when the entity entered our world, once, at creation. Joining a room with 10k
    messages of history yields zero unread without anyone touching the pointer.
 
-6. **Three stacked PRs, one whole-slice review.** Individually-correct steps can fail to
-   compose; the final review reads the combined diff.
+6. **Four stacked PRs — `A → B0 → B → C` — with a whole-slice review.** (Three when this
+   was written; PR B's storage invariant now needs the room-store normalization B0, so B0
+   was inserted before B.) Individually-correct steps can fail to compose; the later PRs get
+   a combined whole-slice review.
 
 ## Data model
 
@@ -111,13 +115,45 @@ interface ReadPointer {
   messageId: string
   /** Timestamp OF that message — denormalised so ordering stays sync and O(1). */
   timestamp: Date
+  /**
+   * A **stable** logical ordering key for that message — the tiebreak that makes
+   * a `(timestamp, archiveOrderKey)` position total. Added in PR B (see the
+   * reconciled design): without it the count cannot locate the pointer's exact
+   * position after the resident array is evicted.
+   *
+   * It is NOT the cache primary key. A room message's `cacheKey` is mutable —
+   * first `roomJid:from:id`, then the server `stanzaId` once it arrives, and the
+   * two raw rows can even carry different timestamps (see the total-order section
+   * and precursor PR B0). The key is instead derived from fields that never change,
+   * and is **structured** — not a delimiter-joined string, whose lexical order need
+   * not match the tuple order and could collide on the delimiter:
+   *   - chat: `{ kind: 'chat', id }`
+   *   - room: `{ kind: 'room', from, id }` (stanza-id independent)
+   *
+   * Absent on a migrated pointer that names no trustworthy message — those fall
+   * back to the strict-after-timestamp count.
+   */
+  archiveOrderKey?: ArchiveOrderKey
 }
+
+type ArchiveOrderKey =
+  | { kind: 'chat'; id: string }
+  | { kind: 'room'; from: string; id: string }
 ```
 
 `lastSeenMessageId` and `lastReadAt` collapse into `readPointer?: ReadPointer` on
 `conversationMeta` / `roomMeta`. Making it one object is the structural fix: today nothing
 stops a writer from moving one field and not the other, which is exactly how they drifted.
 You cannot write half of an object.
+
+(`archiveOrderKey` is PR B's addition to this PR-A-created shape — additive and optional, so
+it needs no data migration: a persisted pointer without it uses the timestamp fallback until
+a writer replaces it. Populating it is not one edit but several — the shared
+`makeReadPointer` cannot infer a room's `(from, id)` from a `PointerSource { id, timestamp }`,
+so it takes an explicit order key (or splits into chat/room constructors), and every
+serialization surface must round-trip the field: chat `conversationMeta` persistence, room
+`readStateStorage`, the SDK `stateSnapshot`, and their deserializers, each with a round-trip
+test.)
 
 To be precise about decision 3: the *field name* `lastReadAt` disappears, but the value it
 was supposed to hold survives — corrected — as `readPointer.timestamp`. Nothing is lost;
@@ -128,9 +164,12 @@ A second, separate field — `historyFloor?: Date` — is the joined/created wat
 not a read position but an entity-lifecycle fact: written once at entity creation, never
 again.
 
-Every derivation uses **`floor = max(readPointer.timestamp, historyFloor)`** — one
-comparison between two timestamps, which is the entire reason for denormalising the
-timestamp onto the pointer.
+Every derivation uses **`floor = readPointer ? readPointer.timestamp : historyFloor`** —
+pointer-wins-else-floor. (The earlier draft of this line said `max(readPointer.timestamp,
+historyFloor)`; PR B found that unsafe — a migrated pre-existing conversation is stamped
+`historyFloor = now`, so `max` would resolve to *now* and zero its unread. See the
+reconciled PR B design. The denormalised timestamp is still the point: the comparison stays
+synchronous and O(1).)
 
 ### Room read-state persistence (new)
 
@@ -154,7 +193,7 @@ from, so they start from an empty read-state store and populate going forward:
 | `lastSeenMessageId` + `lastReadAt` | `{ messageId: lastSeenMessageId, timestamp: lastReadAt }` |
 | `lastSeenMessageId` only | `{ messageId, timestamp }` resolved from the cache |
 | `lastReadAt` only | newest cached message **at or before** that timestamp |
-| neither | no pointer — `historyFloor` takes over |
+| neither | no pointer — `historyFloor` takes over (**exception:** a restored *non-zero* persisted count defers instead of deriving — see the reconciled PR B design's pointerless-with-count rule) |
 
 The `lastReadAt`-only case is the delicate one, and it errs in the safe direction. Since
 today's `lastReadAt` means "newest *loaded* message when I last activated", resolving it
@@ -169,13 +208,16 @@ Split by testability — the decision logic stays pure and I/O is isolated.
 | Module | Purpose | Sync? |
 |---|---|---|
 | `stores/shared/readState.ts` *(new)* | Pure core: `countUnreadInSlice(messages, floor, opts)`, `deriveDivider(messages, floor, opts)`. No I/O. | sync |
-| `stores/shared/readStateArchive.ts` *(new)* | Cache-backed exact derivation over the whole archive via the `conv_timestamp` / `room_timestamp` range indexes, filtered by `isRenderableStoredMessage`, early-out at the display cap. | async |
+| ~~`stores/shared/readStateArchive.ts`~~ *(superseded)* | The cache-backed exact count instead lands in `messageCache.ts` as `countUnreadInArchive` — the DB handle, compound index, and stored-message deserialization already live there. See the reconciled PR B design. | async |
 | `stores/shared/notificationState.ts` *(shrinks)* | Keeps arrival / notify / badge logic. Loses `recomputeCountsFromPointer`, `onActivate`'s fallback ladder, `onMarkAsRead`'s `advanceSeenTo`. | sync |
 
 ## Data flow
 
-**One recompute entry point.** `recomputeUnread(entityId)` is the sole writer of
-`unreadCount` / `mentionsCount`. Triggers:
+**One recompute entry point.** `recomputeUnread(entityId)` is the sole *authoritative*
+writer of `unreadCount` / `mentionsCount`. (This is the end state, after PR C. Through PR B,
+`recomputeCountsFromPointer` still writes a provisional count that `recomputeUnread`
+immediately overwrites — see the reconciled PR B design for that two-phase intermediate.)
+Triggers:
 
 - rehydrate / app start (batched, per entity)
 - a forward MAM merge for that entity
@@ -237,9 +279,10 @@ Dead guards are their own liability, so each is decided explicitly:
 ## Failure modes
 
 **Never write a count from a failed read.** If the IndexedDB read fails or the cache is
-unavailable, the derivation falls back to counting the resident slice (a lower bound) and
-*leaves the persisted count in place* rather than zeroing it. A zero badge produced by a
-failed read is indistinguishable from "you are caught up" — the same shape as the B3
+unavailable, the derivation returns `unavailable` and the store *leaves the persisted count
+in place* — it does **not** count the resident slice or write anything (see the reconciled
+PR B design: the store writes only on an `exact` outcome). A zero badge produced by a failed
+read would be indistinguishable from "you are caught up" — the same shape as the B3
 false-"compromised" defect in the OpenPGP work.
 
 **Unresolvable floor degrades toward more unread, not less.** Pointer message absent from
@@ -286,11 +329,13 @@ anything touching the loaded window.
 
 ## Staging
 
-Three stacked PRs off `main`, reviewed as one slice at the end.
+Four stacked PRs off `main` — `A → B0 → B → C` — with a whole-slice review of the later ones.
 
-**PR A — `ReadPointer` + `historyFloor` + persistence + migration.** Everything computes
-exactly as today, just reading `readPointer.messageId` / `.timestamp` instead of two
-independent fields, plus the new room read-state store and the chat migration.
+**PR A — `ReadPointer` + `historyFloor` + persistence + migration. Implementation complete,
+PR [#1089](https://github.com/processone/fluux-messenger/pull/1089) open.**
+Everything computes exactly as today, just reading `readPointer.messageId` / `.timestamp`
+instead of two independent fields, plus the new room read-state store and the chat
+migration.
 
 Not strictly behaviour-neutral, by the decision above: rooms start remembering their read
 position across restarts, which they never did. That is the one intended behaviour change
@@ -301,18 +346,268 @@ comment, which currently claims a persistence that does not exist.
 The pointer object must come first: the archive count needs a *timestamp* floor, and
 before migration the only timestamp available is the `lastReadAt` that lies.
 
-**PR B — the derivation.** `readState.ts` + `readStateArchive.ts` + `recomputeUnread`,
-count derived against the floor. Deletes both per-store async recount blocks and
-`recomputeCountsFromPointer`.
+**PR B0 — room message store canonicalization** (precursor to PR B; see its own plan,
+`plans/2026-07-23-read-state-b0-*`). Canonicalize the room message store on the **XEP-0359
+identity hierarchy** (`stanzaId → originId → from+id`), not `(roomJid, from, id)` alone — a
+MUC rewrites the client `id` on echo, so an optimistic copy and its reflection share only
+`originId`. An identity-resolving upsert matches an incoming message against every existing
+row via all tiers and merges them into one canonical row with a **commutative, field-complete**
+merge; the row keeps `identityKeys[]` and `ids[]` multi-entry indexes so no alias is lost
+(existing mutation callers hold pre-merge ids), plus the `room_ts_from_id` = `[roomJid,
+timestamp, from, id]` order index. A streaming, explicitly-abortable migration replays every
+existing user's cache through that same upsert. Its own PR because it is a store migration
+with whole-room-cache blast radius, independently reviewable, and a prerequisite for PR B: it
+guarantees one logical message = one row = one archive position, so the count needs no dedup.
+It also retires the existing "double row in the raw cache" edge at its source.
+
+**PR B — the derivation.** See the reconciled design below — the original sketch here
+(`readStateArchive.ts`, "deletes `recomputeCountsFromPointer`") predated PR A and no longer
+holds. In short: the count becomes exact over the complete local archive via a new
+`messageCache` primitive; the
+pure floor/predicate logic lives in `readState.ts`; `recomputeCountsFromPointer` stays as
+the provisional count and pointer writer (its count output is ignored). PR B **changes
+where the count comes from**; PR C removes the pointer writes.
 
 **PR C — the writers.** Pointer reduced to the four writers; `onActivate`'s ladder
-deleted; divider derived from the floor; gate 3 removed and gate 4 re-justified;
-`resolveSeenStanzaId` cache-resolved; dead code removed.
+deleted; `recomputeCountsFromPointer` and its guards deleted (the derivation no longer
+needs its count, so only its pointer-writes remain to remove); divider derived from the
+floor; gate 3 removed and gate 4 re-justified; `resolveSeenStanzaId` cache-resolved; dead
+code removed.
+
+## PR B — reconciled design (post-PR-A, assuming B0)
+
+The sections above were written before PR A executed. PR A shifted the ground under PR B's
+sketch, so this section supersedes the "PR B" bullet in Staging and the `readStateArchive`
+row in Modules. The decisions here were brainstormed against the merged PR A code.
+
+**What PR A changed that matters.** `recomputeCountsFromPointer` now does three jobs at
+once: it counts unread, it writes the pointer (the outgoing-boundary advance and the
+fresh-entity snap), **and** it carries the two forward-only data-loss guards
+(`hasPendingRemoteMarker`, `hasUnmigratedLegacyReadState`). The original plan to "delete
+this whole function in PR B" would relocate those guards in the same PR that introduces the
+new derivation. A `recomputeUnreadForConversation` scaffold and two slice-limited async
+"exact recount" blocks (`MAM_POINTER_RECOUNT_CACHE_LIMIT`) already exist — PR B generalises
+those, it does not add a parallel mechanism.
+
+**Decision — the PR B/C boundary.** PR B changes *where the count comes from*; PR C removes
+the pointer writes. `recomputeCountsFromPointer` stays exactly as-is through PR B — still
+writing the pointer, still carrying the guards — but its count *output* is ignored once the
+archive derivation lands. This keeps the two PRs cleanly separable (B = the count source, C
+= the pointer writers) and never relocates the data-loss guards in the same step that
+changes the count model. PR C then deletes the function; by then only its pointer-writes
+remain to remove.
+
+**Decision — the floor formula.** `floor = readPointer ? readPointer.timestamp :
+historyFloor`, **not** `max(...)`. A pre-#1081 conversation is stamped `historyFloor = now`
+when it flows through `setConversations` (`chatStore.ts`), so `max(lastReadAt, now)` would
+resolve to *now* and zero every migrated conversation's unread. Pointer-wins handles the
+successfully-migrated case (floor = `lastReadAt`, which is at-or-behind the true position,
+so it over-counts slightly — the safe direction). The `historyFloor = now` value is
+therefore **never used as a floor for a migrated entity** and is left in place; making it
+honest is inert-but-worth-cleaning follow-up in the migration's domain, not PR B.
+
+**Decision — the un-migrated / pending branch defers.** With no pointer, the derivation
+must distinguish "genuinely fresh" (floor = `historyFloor` = real creation time → zero,
+correct) from "un-migrated legacy state, or a pending remote marker" (floor would be the
+bogus `historyFloor = now` → zero → *under*-count, unsafe). The derivation mirrors
+`recomputeCountsFromPointer`'s guards: when the entity has un-migrated legacy state or a
+pending marker, it **defers** — leaves the persisted count in place rather than deriving a
+zero it cannot trust. A cheap registry read, same signals the pointer path already uses.
+
+**Decision — one total order, `(timestamp, primaryKey)`, shared by the pointer side and the
+count.** A timestamp alone is not a position: two messages can share a millisecond, and
+today three places disagree on how to break that tie. The resident array
+(`messageArrayUtils.ts`) sorts by `timestamp` only — ties fall in merge order, which is not
+even stable across re-merges. `isAhead` refuses to advance on an equal millisecond. The
+IndexedDB compound index orders ties by primary key. So a naive "count messages after
+`floor.timestamp`" **under-counts**: with the pointer at `m1 @ t` and an unread `m2 @ t`,
+the pointer will not advance (equal ms) yet an `after t` query also excludes `m2` — badge
+says zero while `m2` is unread. That is the *unsafe* direction.
+
+The fix is a single total order, **stanza-id-independent** so a room pointer stays resolvable
+across a stanza-id arrival: chat `(timestamp, id)`, room `(timestamp, from, id)` scoped by
+`roomJid`. (Not `(timestamp, cacheKey)` — `cacheKey` swaps from `roomJid:from:id` to the
+`stanzaId` when the server assigns one; `(from, id)` never changes.)
+
+**A logical room message must be one row, not two — normalised in a precursor PR (B0).** The
+deeper hazard is not just the *key* swap but that the two raw rows carry *different
+timestamps*: a live message keeps its receipt time, its later MAM copy the archive `<delay>`
+time, and the cache stores each under its own primary key. So a single cursor cannot dedupe
+them by adjacency (they are not adjacent), and the same logical message has *two* archive
+positions that can fall on opposite sides of the pointer — counted twice, or counted after
+the floor while its already-read twin sits below it. Cursor-level dedup cannot fix this; the
+storage must. **PR B0 (see its own plan) canonicalizes the room store on the XEP-0359
+identity hierarchy (`stanzaId → originId → from+id`) — an identity-resolving upsert merges
+every copy of a logical message into one canonical row (commutatively, field-complete), keeps
+`identityKeys[]` + `ids[]` multi-entry indexes so no alias is lost, and streams an
+explicitly-abortable migration over existing caches.** After B0, one logical message = one
+row = one position, and everything below needs no dedup:
+
+- **The room order is a clean cursor walk** over `room_ts_from_id` = `[roomJid, timestamp,
+  from, id]` (added in B0 alongside the re-key). Chat's existing `conv_timestamp` already
+  orders by `(conversationId, timestamp)` tie-broken by the `id` primary key — no new index.
+- **Resident sort gains the tiebreak** — `messageArrayUtils` compares `id` (chat) /
+  `(from, id)` (room) when timestamps are equal. Array index then equals archive order, so
+  the viewport observer (which advances the pointer by array index) walks a same-ms run in
+  the same order the count uses.
+- **The count counts strictly after the pointer's *position*, not its timestamp** — the
+  cursor compares each entry's `(timestamp, from, id)` against the pointer's
+  `(timestamp, archiveOrderKey)` and counts renderable non-outgoing entries strictly after
+  it, so `m2` is counted. When the pointer has no `archiveOrderKey` (a migrated `lastReadAt`),
+  fall back to strict-after-timestamp — over-counts there (safe), and the tie edge is moot
+  because `lastReadAt` is not a message's exact position.
+- **The order key must be persisted on the pointer, not recovered from memory.** The whole
+  reason the count exists is that a backgrounded entity's resident array is *evicted* — so
+  "locate the pointer by the resident message's fields" fails exactly when it is needed, and
+  a room's `id` alone is not unique within the room. So the pointer persists a **structured**
+  `archiveOrderKey`, not a delimiter-joined string (whose lexical order need not match the
+  tuple order and could collide on a delimiter):
+
+  ```ts
+  type ArchiveOrderKey =
+    | { kind: 'chat'; id: string }
+    | { kind: 'room'; from: string; id: string }
+  ```
+
+  The comparator orders structurally (timestamp, then the key's fields), so no string-ordering
+  assumption is load-bearing. This is the one point where the total order reaches back into
+  PR A's data model.
+- **`isAhead` is left ms-only for PR C, which then aligns it to this same total order.** The
+  count and the resident advance do not route through `isAhead` (it drives `advance()` for
+  the MDS regressive-publish guard), so through PR B leaving it strict only means a
+  *published* marker won't cross a same-ms run — a bounded under-advance in the safe
+  direction. PR C aligns `isAhead` and the XEP-0490 comparison to `(timestamp, archiveOrderKey)`
+  as part of its writer work (persisting `archiveOrderKey` in PR B is what makes that possible);
+  this is a deferral of the edit, not of the decision.
+
+Tests must cover several incoming **and** outgoing messages sharing one millisecond, chat
+and room: the badge counts the same-ms unread, and the pointer advances through the run
+rather than stalling.
+
+**Decision — the count is only as exact as the local archive is *complete*, so it gates on
+coverage.** "Archive-exact" is exact over what IndexedDB *holds*, which is not the same as
+what the server has. IndexedDB can open cleanly while the archive is partial: MAM catch-up
+still running, a known history gap below the live edge, only the newest window cached, or a
+partial clear. Deriving then would count fewer messages than exist and **overwrite a correct
+persisted count with a smaller one or zero** — the unsafe direction, and the worst-timed
+trigger (cold-start rehydrate) fires exactly before catch-up has run.
+
+The derivation therefore gates on coverage, mirroring the publisher's existing
+`mdsSideEffects.archiveIsTrustworthy`: it counts only when the local archive is *contiguous
+from the floor to the live edge*. That maps onto the coverage records already maintained
+(`conversationCoverage` / `roomCoverage`, the "contiguous-with-live bottom"). Note the record
+stores a `bottomId`, not a timestamp — so the gate resolves `bottomId` through the cache to
+its full `(timestamp, orderKey)` position and compares *that* with the floor: trustworthy
+when the floor is at or above the resolved bottom **and** the entity is caught up to live. A
+deep gap *below* the floor is fine; we only count above it. If `bottomId` fails to resolve
+(the record points at a message no longer cached), the derivation returns `deferred` and the
+now-stale coverage record is invalidated so catch-up rebuilds it. When coverage is not yet
+trustworthy the derivation **defers** (keeps the persisted count), and the existing
+forward-MAM-merge trigger re-runs it once catch-up fills the range.
+
+**Decision — pointerless with a non-zero persisted count also defers.** A genuine pre-#1081
+conversation can have `unreadCount > 0`, no `lastSeenMessageId`, and no `lastReadAt` — e.g.
+an inactive conversation that received its first message but was never opened, so no read
+position was ever recorded. The migration table classifies it as "neither" → no pointer, and
+it is stamped `historyFloor = now`, so a naive derivation would compute zero and **erase a
+real unread count**. It is not in the un-migrated registry (it has no legacy fields to
+migrate), so the earlier defer signals miss it. The general safety net: **whenever there is
+no pointer and the persisted count is non-zero, defer** — the count came from somewhere real
+(incremental `+1`s) and there is no floor we can trust to re-derive it. Deriving is allowed
+pointerless only when the persisted count is already zero (nothing to erase; a genuinely
+fresh entity correctly stays zero). This subsumes the un-migrated case without depending on
+registry membership.
+
+**The derivation returns an explicit outcome, not a count-or-not.** `recomputeUnread`
+resolves to `{ kind: 'exact', unread, mentions } | { kind: 'deferred' } | { kind:
+'unavailable' }`. The store writes the count **only on `exact`**. `deferred` (coverage not
+trustworthy, or pointerless-with-count, or un-migrated / pending marker) and `unavailable`
+(IndexedDB error / cache absent) both leave the persisted count untouched — there is no
+"count the resident slice as a lower bound" path, which was ambiguous about what the slice
+value was even for. Every non-exact outcome keeps the last trustworthy value and waits for a
+later trigger.
+
+**Modules.**
+
+| Module | Purpose | Sync? |
+|---|---|---|
+| `messageCache.ts` *(+2 fns)* | `countUnreadInArchive(conversationId, {pointer, floor, cap})` and a room twin `countRoomUnreadInArchive` returning `{unread, mentions}`. A cursor from the floor timestamp forward — chat over `conv_timestamp`, room over the `room_ts_from_id` index B0 added — counting `!isOutgoing && isRenderableStoredMessage` strictly after the pointer's **position** in `(timestamp, orderKey)` order (matching the row's stable `(from, id)` / `id` against the pointer's persisted `archiveOrderKey`; strict-after-timestamp fallback when it is absent), early-out at `cap` (999). No dedup — B0 guarantees one row per logical message. Only touches the index range at/after the floor → O(unread)-capped over the *local* archive. A cursor, not `index.count()`, which can neither filter nor honor the tiebreak. | async |
+| `stores/shared/readState.ts` *(new, pure)* | `computeFloor(pointer, historyFloor)`; the derivation's outcome + defer logic (`exact | deferred | unavailable`, and the coverage / pointerless-with-count / un-migrated / pending-marker defer conditions); the `(timestamp, archiveOrderKey)` comparator used by the resident sort and the count; re-exports the single `isRenderableStoredMessage` predicate that both the cache walk and the live `+1` path use, so they cannot drift. | sync |
+| `chatStore` / `roomStore` | `recomputeUnreadForConversation` rewritten to gate on coverage, compute the floor (pure), call `countUnreadInArchive`, and write the count **only on an `exact` outcome**; a new parallel `recomputeUnreadForRoom` (rooms inline their recount today). | async |
+
+**Data flow — two-phase.** At every count-writing site: (1) `recomputeCountsFromPointer`
+runs unchanged, writing an immediate **provisional** count (no flash) and advancing the
+pointer; (2) a trigger schedules `recomputeUnread(entity)`, which reads the now-current
+pointer, checks coverage, computes the floor, calls `countUnreadInArchive`, and — **only on
+an `exact` outcome** — overwrites the provisional count with the archive-derived one; a
+`deferred` or `unavailable` outcome leaves the persisted count in place. Triggers: cold-start
+rehydrate (batched per entity — typically `deferred` under the coverage gate until catch-up
+runs, which is the point), a forward MAM merge past the floor, a pointer advance or inbound
+marker that advanced it, and a deferred-decrypt drop / retraction (the E2EE phantom-badge
+path already calls `recomputeUnreadForConversation`). The `+1` fast path in
+`onMessageReceived` stays synchronous but gains a renderability guard — it increments only
+for a message the shared predicate accepts, closing the phantom-badge class at the source.
+
+**PR B is not behaviour-neutral, and that is the point.** Backgrounded conversations with
+deep unread stop under-counting; badges become archive-accurate. The regression tests
+assert exactly that gap: backgrounded+deep-pointer → exact; migrated pointer → over-counts,
+never zero (the `max()` bug this replaces); un-migrated → deferred not zeroed; fresh
+deep-backfill room → zero; `+1` on a non-renderable message → no increment; cap at 999;
+**several incoming and outgoing messages sharing one millisecond → the same-ms unread is
+counted and the pointer advances through the run** (the tie bug), chat and room;
+**IndexedDB opens but holds only part of the unread range (mid-catch-up / gap below live) →
+`deferred`, persisted count untouched, never zeroed** (the partial-archive trap);
+**pointerless conversation with a non-zero persisted count → `deferred`, count preserved**;
+**a same-ms pointer absent from memory after restart → located via persisted `archiveOrderKey`,
+not a resident lookup**; **two room messages sharing an `id` but different `(from)` senders →
+counted as two distinct positions** (the room-id-not-unique case); **a pointer created before
+its `stanzaId` arrives → still resolvable after restart / MAM reconciliation** (the stable
+`(from, id)` key survives the stanza-id swap). The duplicate-row cases — including the
+decisive straddle migration (fallback row at `t1`, stanza row for the same `(from, id)` at
+`t2`, on opposite sides of the floor → after upgrade one canonical row, counted once) — are
+**B0's** tests, since B0 is what guarantees the single row PR B's count relies on. Every
+control gets a deliberate-break verification (this PR's recurring defect is hollow tests).
+Gates: `npm test`, typecheck, lint, and `npm run test:scroll` (the recount blocks live in the
+MAM merge path, and the resident sort tiebreak touches the loaded window).
+
+**One PR-A cleanup folded in:** PR A shipped a `readFloor()` helper in `readPointer.ts` that
+does `max(pointer.timestamp, historyFloor)` — the very formula this design rejects. It has no
+production caller but *is* exported from `index.ts`, so the wrong version sits on the SDK's
+public surface. PR B deletes it (and its export) in favour of `computeFloor`, so no reader —
+inside or outside the SDK — can pick it up.
+
+**PR B0 task order** (the precursor). New canonical room key + `room_ts_from_id` index on a
+fresh object store → the upgrade that copies existing rows into it, merging duplicate
+`(roomJid, from, id)` rows into one and picking the canonical timestamp → route every room
+cache read/write/`getByStanzaId`/merge path through the new key → migration + interop tests,
+including the decisive straddle case (fallback row at `t1`, stanza row for the same
+`(from, id)` at `t2`, straddling the floor → after upgrade one canonical row, counted once).
+
+**PR B task order** (on a store B0 has normalised). Pure `readState` core (the
+`(timestamp, archiveOrderKey)` comparator, `computeFloor`, the outcome/defer logic) and delete
+PR A's `readFloor` → persist `archiveOrderKey` (the explicit-structured-order-key constructor
+change, plus chat persistence, room `readStateStorage`, `stateSnapshot`, their deserializers,
+and round-trip tests) → resident-sort tiebreak in `messageArrayUtils` (isolated,
+`test:scroll`-gated, lands before anything depends on the shared order) → cache primitive
+(count-after-position, coverage-gated) → chat `recomputeUnread` rewrite + coverage gate +
+triggers → room `recomputeUnreadForRoom` + triggers → `+1` renderability guard → delete the
+now-dead slice-limited recount internals (and `MAM_POINTER_RECOUNT_CACHE_LIMIT` if nothing
+else uses it).
 
 ## Risks
 
 - **Deep-history rooms.** The cursor walk over a large unread range, bounded by the cap.
   `npm run test:scroll` is a required gate.
+- **PR B0 recreates the room store with whole-room-cache blast radius.** It streams every
+  existing user's rows through the identity upsert into a fresh canonical store, collapsing
+  the duplicate rows one logical message can hold. This is the riskiest change in the whole
+  effort — hence its own PR — and must be exercised against a populated pre-upgrade DB holding
+  known echo/stanza duplicate rows, asserting one row survives with the archived timestamp and
+  every id/stanza/origin alias still resolves. Two idb-specific hazards the plan pins down:
+  the async `upgrade` callback is not awaited by idb, so the migration **explicitly** calls
+  `transaction.abort()` on failure rather than relying on a rejected promise; and
+  `fake-indexeddb` cannot prove browser abort semantics, so a real-browser abort check is a
+  manual pre-merge gate.
 - **Multi-device read sync.** The publish path changes shape; the seed/echo-suppression
   logic in `mdsSideEffects` must keep working across the pointer refactor.
 - **The migration is forward-only, like the bug.** A migration that over-advances is as

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -1523,7 +1523,7 @@ describe('roomStore', () => {
 
       expect(roomStore.getState().rooms.get(ROOM)?.messages[0].stanzaId).toBeUndefined()
       expect(roomStore.getState().roomMeta.get(ROOM)?.lastMessage?.stanzaId).toBeUndefined()
-      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith('m1', { stanzaId: undefined })
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(ROOM, 'm1', { stanzaId: undefined }, `${ROOM}/me`)
     })
 
     it('is a no-op when no message carries the given stanzaId', () => {
@@ -5403,7 +5403,7 @@ describe('roomStore', () => {
       const updated = roomStore.getState().rooms.get(roomJid)?.messages[0]
       expect(updated?.isRetracted).toBe(true)
       // Verify IndexedDB update uses actual message id, not the stanza-id
-      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith('client-id-1', { isRetracted: true })
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(roomJid, 'client-id-1', { isRetracted: true }, `${roomJid}/alice`)
     })
 
     it('should update message found by originId when a correction references the origin-id', () => {
@@ -5424,7 +5424,7 @@ describe('roomStore', () => {
       expect(updated?.isEdited).toBe(true)
       expect(updated?.body).toBe('Hello (fixed)')
       // IndexedDB update still keyed by the actual stored message id.
-      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith('muc-rewritten-id', { isEdited: true, body: 'Hello (fixed)' })
+      expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(roomJid, 'muc-rewritten-id', { isEdited: true, body: 'Hello (fixed)' }, `${roomJid}/alice`)
     })
 
     it('should not touch an origin-id carrier when another message owns the id (no over-match)', () => {
@@ -5960,8 +5960,10 @@ describe('roomStore pending retractions', () => {
     expect(roomStore.getState().rooms.get(roomJid)?.messages[0]).toMatchObject({ isRetracted: true })
     expect(roomStore.getState().pendingRetractions.get(roomJid) ?? []).toHaveLength(0)
     expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+      roomJid,
       'm1',
-      expect.objectContaining({ isRetracted: true })
+      expect.objectContaining({ isRetracted: true }),
+      expect.any(String)
     )
   })
 
@@ -6052,8 +6054,10 @@ describe('roomStore parity drift regressions', () => {
       expect(roomStore.getState().roomRuntime.get(roomJid)?.messages[0]?.stanzaId).toBe('archive-123')
       // The backfill must also persist so the cursor survives a reload.
       expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+        roomJid,
         'orig-1',
-        expect.objectContaining({ stanzaId: 'archive-123' })
+        expect.objectContaining({ stanzaId: 'archive-123' }),
+        `${roomJid}/testuser`
       )
     })
   })
@@ -6189,8 +6193,10 @@ describe('roomStore parity drift regressions', () => {
       expect(messages[0].stanzaId).toBe('arch-merge')
       expect(roomStore.getState().roomRuntime.get(roomJid)?.messages[0]?.stanzaId).toBe('arch-merge')
       expect(messageCache.updateRoomMessage).toHaveBeenCalledWith(
+        roomJid,
         'own-1',
-        expect.objectContaining({ stanzaId: 'arch-merge' })
+        expect.objectContaining({ stanzaId: 'arch-merge' }),
+        `${roomJid}/testuser`
       )
     })
   })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -15,6 +15,7 @@ import type {
 import { isNoLocalStore, type StoredRoomMessage } from '../core/types/message-internal'
 import { setTypingTimeout, clearTypingTimeout } from './typingTimeout'
 import { findMessageById, findMessageIndexById } from '../utils/messageLookup'
+import { roomIdentityKeys } from '../utils/roomMessageIdentity'
 import { getBareJid } from '../core/jid'
 import { logInfo } from '../core/logger'
 import * as messageCache from '../utils/messageCache'
@@ -442,11 +443,7 @@ const EMPTY_SET: Set<string> = new Set()
  * - from+id: stanza attribute combo (fallback for legacy/bridge messages)
  */
 function getRoomMessageKeys(m: RoomMessage): string[] {
-  const keys: string[] = []
-  if (m.stanzaId) keys.push(`stanzaId:${m.stanzaId}`)
-  if (m.originId) keys.push(`originId:${m.originId}`)
-  keys.push(`from:${m.from}:id:${m.id}`)
-  return keys
+  return roomIdentityKeys(m)
 }
 
 /** Timeline config for the shared resident-window machine (see shared/messageTimeline.ts). */

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -1721,7 +1721,7 @@ export const roomStore = createStore<RoomState>()(
         // Message not in memory — update reactions directly in IndexedDB cache
         // so the correct state is restored when the message is loaded later
         logInfo(`Reaction for message ${messageId} not in memory — updating in cache`)
-        void messageCache.updateRoomMessageReactions(messageId, reactorNick, emojis)
+        void messageCache.updateRoomMessageReactions(roomJid, messageId, reactorNick, emojis)
       }
 
       newRooms.set(roomJid, { ...existing, messages: newMessages })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -594,8 +594,8 @@ function resolveRoomPendingRetractions(
 
   if (options.persist !== false) {
     for (const { messageId, retractedAt } of applied) {
-      void messageCache.updateRoomMessage(messageId, { isRetracted: true, retractedAt })
       const retracted = findMessageById(messages, messageId)
+      void messageCache.updateRoomMessage(roomJid, messageId, { isRetracted: true, retractedAt }, retracted?.from)
       if (retracted) void searchIndex.removeMessage(retracted)
     }
   }
@@ -1557,7 +1557,7 @@ export const roomStore = createStore<RoomState>()(
       if (append.kind === 'duplicate-backfilled') {
         // Persist the backfilled archive ids so pagination cursors survive a reload.
         for (const p of append.patched) {
-          void messageCache.updateRoomMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+          void messageCache.updateRoomMessage(roomJid, p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) }, p.from)
         }
         newRooms.set(roomJid, { ...existing, messages: append.messages })
         const patchedRuntime = new Map(state.roomRuntime)
@@ -1714,9 +1714,9 @@ export const roomStore = createStore<RoomState>()(
 
       // Update IndexedDB (non-blocking) — use actual message id, not the lookup key
       if (updatedMessage) {
-        void messageCache.updateRoomMessage(updatedMessage.id, {
+        void messageCache.updateRoomMessage(roomJid, updatedMessage.id, {
           reactions: updatedMessage.reactions,
-        })
+        }, updatedMessage.from)
       } else {
         // Message not in memory — update reactions directly in IndexedDB cache
         // so the correct state is restored when the message is loaded later
@@ -1756,7 +1756,7 @@ export const roomStore = createStore<RoomState>()(
 
       // Update IndexedDB (non-blocking) — use actual message id, not the lookup key
       if (updatedMessage) {
-        void messageCache.updateRoomMessage(updatedMessage.id, updates)
+        void messageCache.updateRoomMessage(roomJid, updatedMessage.id, updates, updatedMessage.from)
 
         // Update search index: re-index if body changed, remove if retracted
         if (updates.isRetracted) {
@@ -1803,7 +1803,7 @@ export const roomStore = createStore<RoomState>()(
       const { stanzaId: _staleStanzaId, ...updatedMessage } = existing.messages[targetIdx]
       newMessages[targetIdx] = updatedMessage
 
-      void messageCache.updateRoomMessage(existing.messages[targetIdx].id, { stanzaId: undefined })
+      void messageCache.updateRoomMessage(roomJid, existing.messages[targetIdx].id, { stanzaId: undefined }, existing.messages[targetIdx].from)
 
       const newRooms = new Map(state.rooms)
       newRooms.set(roomJid, { ...existing, messages: newMessages })
@@ -3040,7 +3040,7 @@ export const roomStore = createStore<RoomState>()(
       )
       // Persist backfilled archive ids so pagination cursors survive a reload.
       for (const p of patched) {
-        void messageCache.updateRoomMessage(p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) })
+        void messageCache.updateRoomMessage(roomJid, p.id, { stanzaId: p.stanzaId!, ...(p.originId ? { originId: p.originId } : {}) }, p.from)
       }
       mergedForMarker = merged
 

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -4,9 +4,12 @@ import { IDBFactory } from 'fake-indexeddb'
 import type { Message, RoomMessage } from '../core/types'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
 import { selectCatchUpQuery } from './mamCatchUpUtils'
+import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
 
 // Must import after fake-indexeddb/auto
 import * as messageCache from './messageCache'
+import { mergeRoomRows } from './messageCache'
+import type { StoredRoomMessage } from './messageCache'
 
 /**
  * Create a mock Message for testing
@@ -1011,5 +1014,70 @@ describe('messageCache', () => {
       // ...and NOT on the blank row's (newer) timestamp.
       expect(query).not.toEqual(selectCatchUpQuery([{ timestamp: blankTs }], { sessionStartTime }))
     })
+  })
+})
+
+const rrow = (over: Partial<StoredRoomMessage> = {}): StoredRoomMessage => {
+  const base = { type: 'groupchat', id: 'origin-1', roomJid: 'r@c', from: 'r@c/alice', body: 'hi', timestamp: 1000, isOutgoing: false, ...over } as StoredRoomMessage
+  return { ...base, cacheKey: roomCanonicalKey(base), identityKeys: roomIdentityKeys(base), ids: [base.id], ...over } as StoredRoomMessage
+}
+const both = (a: StoredRoomMessage, b: StoredRoomMessage) => [mergeRoomRows(a, b), mergeRoomRows(b, a)]
+
+describe('mergeRoomRows — commutative, associative, field-complete', () => {
+  it('never downgrades decrypted content, both orders', () => {
+    for (const m of both(rrow({ body: 'plaintext' }), rrow({ body: '', unsupportedEncryption: { kind: 'x' } as never }))) expect(m.body).toBe('plaintext')
+  })
+  it('keeps an edit from either row', () => {
+    for (const m of both(rrow({ body: 'v1' }), rrow({ body: 'v2', isEdited: true, originalBody: 'v1' }))) { expect(m.isEdited).toBe(true); expect(m.body).toBe('v2') }
+  })
+  it('keeps a poll closure from either row', () => {
+    for (const m of both(rrow({}), rrow({ pollClosed: { by: 'alice' } as never, pollClosedAt: 8000 }))) expect(m.pollClosed).toBeTruthy()
+  })
+  it('resolves a both-closed-with-different-records tie order-independently', () => {
+    const [m1, m2] = both(
+      rrow({ pollClosed: { by: 'alice' } as never, pollClosedAt: 8000 }),
+      rrow({ pollClosed: { by: 'bob' } as never, pollClosedAt: 9000 })
+    )
+    expect(m1).toEqual(m2)
+  })
+  it('prefers the stanza-bearing timestamp, both orders', () => {
+    for (const m of both(rrow({ timestamp: 5000 }), rrow({ timestamp: 4000, stanzaId: 'S' }))) expect(m.timestamp).toBe(4000)
+  })
+  it('unions reactions', () => {
+    for (const m of both(rrow({ reactions: { a: ['alice'] } }), rrow({ reactions: { a: ['bob'], b: ['c'] } }))) { expect(new Set(m.reactions!.a)).toEqual(new Set(['alice','bob'])); expect(m.reactions!.b).toEqual(['c']) }
+  })
+  it('preserves a retraction from either row', () => {
+    const [m] = both(rrow({}), rrow({ isRetracted: true, retractedAt: 7000 })); expect(m.isRetracted).toBe(true); expect(m.retractedAt).toBe(7000)
+  })
+  it('clears a delivery error when either copy delivered cleanly', () => {
+    expect(both(rrow({ deliveryError: { text: 'x' } as never }), rrow({}))[0].deliveryError).toBeUndefined()
+  })
+  it('unions identityKeys/ids and recomputes cacheKey to the highest tier', () => {
+    const echo = rrow({ originId: 'O', id: 'client-1' })
+    const refl = rrow({ originId: 'O', stanzaId: 'S', id: 'server-9' })
+    const [m] = both(echo, refl)
+    expect(m.cacheKey).toBe(roomCanonicalKey({ roomJid: 'r@c', from: 'r@c/alice', id: 'server-9', stanzaId: 'S', originId: 'O' }))
+    expect(new Set(m.ids)).toEqual(new Set(['client-1','server-9']))
+  })
+
+  it('is commutative on a mixed pair with EQUAL ids', () => {
+    const a = rrow({ body: 'plain', originId: 'O', id: 'client-1', timestamp: 5000, reactions: { a: ['alice'] } })
+    const b = rrow({ body: '', unsupportedEncryption: { kind: 'x' } as never, stanzaId: 'S', id: 'client-1', timestamp: 4000, reactions: { a: ['bob'] } })
+    expect(mergeRoomRows(a, b)).toEqual(mergeRoomRows(b, a))
+  })
+
+  // The tie the old contentOwner got wrong: identical id/body/rank/edit, DIFFERENT attachment.
+  it('is commutative when rows tie on rank/body/id but differ in attachment', () => {
+    const a = rrow({ id: 'x', body: 'same', attachment: { url: 'a://1' } as never })
+    const b = rrow({ id: 'x', body: 'same', attachment: { url: 'a://2' } as never })
+    expect(mergeRoomRows(a, b)).toEqual(mergeRoomRows(b, a))
+  })
+
+  it('is associative and order-independent across three rows', () => {
+    const a = rrow({ originId: 'O', id: 'c1', timestamp: 5000, reactions: { a: ['a'] } })
+    const b = rrow({ stanzaId: 'S', id: 'c2', timestamp: 4000, reactions: { r: ['b'] } })
+    const c = rrow({ body: 'edited', isEdited: true, id: 'c1', timestamp: 4500, reactions: { a: ['d'] } })
+    const rs = [mergeRoomRows(mergeRoomRows(a,b),c), mergeRoomRows(a,mergeRoomRows(b,c)), mergeRoomRows(mergeRoomRows(b,a),c), mergeRoomRows(mergeRoomRows(c,b),a)]
+    for (const r of rs) expect(r).toEqual(rs[0])
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1041,6 +1041,15 @@ describe('mergeRoomRows — commutative, associative, field-complete', () => {
     )
     expect(m1).toEqual(m2)
   })
+  it('resolves a both-carry-a-different-deliveryError tie order-independently', () => {
+    const [m1, m2] = both(
+      rrow({ deliveryError: { text: 'x' } as never }),
+      rrow({ deliveryError: { text: 'y' } as never })
+    )
+    // Both present → deterministic stableStringify-min pick, same in both orders.
+    expect(m1).toEqual(m2)
+    expect(m1.deliveryError).toEqual({ text: 'x' })
+  })
   it('prefers the stanza-bearing timestamp, both orders', () => {
     for (const m of both(rrow({ timestamp: 5000 }), rrow({ timestamp: 4000, stanzaId: 'S' }))) expect(m.timestamp).toBe(4000)
   })
@@ -1120,6 +1129,42 @@ describe('mergeRoomRows — commutative, associative, field-complete', () => {
 
     for (const field of ['body', 'id', 'attachment']) {
       expect(projectedKeys).toContain(field)
+    }
+  })
+
+  // A control that BITES the load-bearing invariant: contentOwner's tiebreak must
+  // serialize the content PROJECTION, not the whole row. The associativity test
+  // above can't catch a regression to whole-row serialization (its isEdited:true row
+  // dominates by rank, so the tiebreak never runs) and the contentProjection test
+  // only checks the projection's SHAPE, not that contentOwner CONSUMES it — so
+  // mutating contentOwner to `stableStringify(a) <= stableStringify(b)` (whole row)
+  // passes both while reintroducing the associativity bug. Here three rows tie on
+  // rank (all decrypted, non-empty body, isEdited:false) and differ ONLY in
+  // `reactions` (a MERGED field — unioned during a merge) and `systemEvent` (a
+  // CONTENT field, which contentOwner must own). The projection EXCLUDES reactions,
+  // so its tiebreak sees only systemEvent and keeps row a's in EVERY grouping. A
+  // whole-row tiebreak lets the unioned reactions (and the merged rows' extra keys)
+  // decide first; because c's reactions are exactly a's ∪ b's keys, that choice
+  // becomes grouping-dependent — e.g. (a∘b)∘c keeps a's systemEvent while a∘(b∘c)
+  // keeps c's. Verified: the whole-row mutation makes this test FAIL.
+  it('resolves the content winner from the projection, not the whole row (associativity control)', () => {
+    const evt = (n: string) => ({ kind: 'nick-changed', oldNick: 'o', newNick: n }) as never
+    const a = rrow({ body: 'same', reactions: { '1': ['n'] }, systemEvent: evt('a') })
+    const b = rrow({ body: 'same', reactions: { '2': ['n'] }, systemEvent: evt('b') })
+    const c = rrow({ body: 'same', reactions: { '1': ['n'], '2': ['n'] }, systemEvent: evt('c') })
+    const groupings = [
+      mergeRoomRows(mergeRoomRows(a, b), c),
+      mergeRoomRows(a, mergeRoomRows(b, c)),
+      mergeRoomRows(mergeRoomRows(b, a), c),
+      mergeRoomRows(mergeRoomRows(c, b), a),
+      mergeRoomRows(mergeRoomRows(a, c), b),
+      mergeRoomRows(c, mergeRoomRows(a, b)),
+    ]
+    for (const g of groupings) {
+      // Projection tiebreak keeps row a's systemEvent in every grouping (a's is the
+      // lexicographically-smallest projection). A whole-row tiebreak diverges here.
+      expect(g.systemEvent).toEqual(a.systemEvent)
+      expect(g).toEqual(groupings[0])
     }
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -523,7 +523,7 @@ describe('messageCache', () => {
 
         await messageCache.saveRoomMessage(message)
 
-        const byStanzaId = await messageCache.getRoomMessageByStanzaId('room-stanza-123')
+        const byStanzaId = await messageCache.getRoomMessageByStanzaId(roomJid, 'room-stanza-123')
         expect(byStanzaId).not.toBeNull()
         expect(byStanzaId?.id).toBe('room-stanza')
       })
@@ -1154,11 +1154,9 @@ describe('v4 migration — identity-resolving canonicalization (streaming)', () 
     expect(mine[0].timestamp.getTime()).toBe(2000)
     expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
     expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
-    // NOTE: getRoomMessageByStanzaId stays single-arg (stanzaId) in this task — the
-    // brief's 2-arg room-scoped form is Task 4 read-path wiring (its 3 callers are
-    // 1-arg today). A single-room fixture with a unique stanzaId validates the same
-    // "merged row resolvable by its stanzaId" behaviour.
-    expect(await messageCache.getRoomMessageByStanzaId('S')).not.toBeNull()
+    // Task 4 room-scoped getRoomMessageByStanzaId(roomJid, stanzaId): the merged row
+    // stays resolvable by its stanzaId within its own room.
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
   })
 
   it('does not merge identical stanzaIds across different rooms', async () => {
@@ -1188,5 +1186,68 @@ describe('v4 migration — identity-resolving canonicalization (streaming)', () 
     expect(raw.objectStoreNames.contains('room-messages-canonical')).toBe(false)
     expect(await raw.get('room-messages', 'z')).toBeTruthy()
     raw.close()
+  })
+})
+
+describe('live paths — identity-resolving upsert + alias lookups + mutations', () => {
+  const ROOM = 'r@c', FROM = 'r@c/alice'
+  const mk = (over: Partial<RoomMessage> = {}): RoomMessage => ({ type: 'groupchat', id: 'client-1', roomJid: ROOM, from: FROM, body: 'hello', timestamp: new Date(5000), isOutgoing: true, originId: 'O', ...over }) as RoomMessage
+  beforeEach(() => { globalThis.indexedDB = new IDBFactory(); messageCache._resetDBForTesting(); _resetStorageScopeForTesting() })
+
+  it('merges a reflection (rewritten id + stanzaId) into the optimistic echo', async () => {
+    await messageCache.saveRoomMessage(mk())
+    await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S', timestamp: new Date(4000) }))
+    const mine = (await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')
+    expect(mine).toHaveLength(1); expect(mine[0].timestamp.getTime()).toBe(4000)
+  })
+  it('the discarded optimistic id still resolves after the merge', async () => {
+    await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
+    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
+  })
+  it('updateRoomMessage that ADDS a stanzaId re-keys and merges with any matching row', async () => {
+    // A separate MAM copy already carries stanzaId S and NO originId — so it shares
+    // no identity tier with the optimistic echo (originId O, id client-1) and the two
+    // stay SEPARATE at save time. If the MAM copy also carried originId O they would
+    // merge on save, making updateRoomMessage a no-op and the re-key branch untested.
+    await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S', originId: undefined }))
+    // ...and the optimistic row is only now confirmed via an identity-adding update.
+    await messageCache.saveRoomMessage(mk()) // optimistic: originId O, no stanzaId
+    await messageCache.updateRoomMessage('client-1', { stanzaId: 'S', originId: 'O' })
+    expect((await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')).toHaveLength(1)
+  })
+  it('updateRoomMessage that ADDS an originId (canonical key UNCHANGED) still merges a row already at that originId', async () => {
+    // Row 1 has stanzaId S, no originId → canonical key stanzaId:S.
+    await messageCache.saveRoomMessage(mk({ id: 'a1', stanzaId: 'S', originId: undefined }))
+    // Row 2 is a separate copy already carrying originId O (no stanzaId).
+    await messageCache.saveRoomMessage(mk({ id: 'a2', originId: 'O', stanzaId: undefined }))
+    // Confirm row 1 also carries originId O — its canonical key stays stanzaId:S,
+    // so a key-only identityChanged check would MISS this and leave two rows.
+    await messageCache.updateRoomMessage('a1', { originId: 'O' })
+    expect((await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.stanzaId === 'S' || m.originId === 'O')).toHaveLength(1)
+    expect(await messageCache.getRoomMessage('a1')).not.toBeNull()          // every alias
+    expect(await messageCache.getRoomMessage('a2')).not.toBeNull()          // preserved
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
+  })
+  it('removes a deliberately cleared stale stanzaId alias (clearMessageStanzaId)', async () => {
+    await messageCache.saveRoomMessage(mk({ stanzaId: 'stale-S' })) // has stanzaId + originId O + id client-1
+    await messageCache.updateRoomMessage('client-1', { stanzaId: undefined }) // revoke the stanzaId
+    // The scoped stanza alias must be GONE — else a later message with 'stale-S' merges wrongly.
+    expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'stale-S')).toBeNull()
+    // ...but the message itself, and its other aliases, remain.
+    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessages(ROOM, {})).toHaveLength(1)
+  })
+  it('updateRoomMessageReactions resolves a pre-merge id and is authoritative (does not un-remove)', async () => {
+    await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
+    await messageCache.updateRoomMessageReactions('client-1', 'r@c/bob', ['👍'])
+    expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍']).toContain('r@c/bob')
+    await messageCache.updateRoomMessageReactions('client-1', 'r@c/bob', []) // removal
+    expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍'] ?? []).not.toContain('r@c/bob')
+  })
+  it('getRoomMessagesAround returns each logical message once', async () => {
+    await messageCache.saveRoomMessage(mk({ stanzaId: 'S' }))
+    expect((await messageCache.getRoomMessagesAround(ROOM, 'client-1', { before: 5, after: 5 })).filter((m) => m.originId === 'O')).toHaveLength(1)
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1241,13 +1241,35 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
   })
   it('updateRoomMessageReactions resolves a pre-merge id and is authoritative (does not un-remove)', async () => {
     await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
-    await messageCache.updateRoomMessageReactions('client-1', 'r@c/bob', ['👍'])
+    await messageCache.updateRoomMessageReactions(ROOM, 'client-1', 'r@c/bob', ['👍'])
     expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍']).toContain('r@c/bob')
-    await messageCache.updateRoomMessageReactions('client-1', 'r@c/bob', []) // removal
+    await messageCache.updateRoomMessageReactions(ROOM, 'client-1', 'r@c/bob', []) // removal
     expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍'] ?? []).not.toContain('r@c/bob')
   })
   it('getRoomMessagesAround returns each logical message once', async () => {
     await messageCache.saveRoomMessage(mk({ stanzaId: 'S' }))
     expect((await messageCache.getRoomMessagesAround(ROOM, 'client-1', { before: 5, after: 5 })).filter((m) => m.originId === 'O')).toHaveLength(1)
+  })
+  it('updateRoomMessageReactions on a stanza-id fallback is room-scoped — a same-stanzaId message in another room is untouched', async () => {
+    // Two DIFFERENT rooms each cache a message under the SAME server-assigned
+    // stanzaId (stanzaIds are per-archive, so this collision is routine). Neither
+    // row is reachable via the `ids` index for this reaction (the reaction only
+    // knows the stanza-id), so the lookup MUST fall through to the room-scoped
+    // stanza alias — a global stanzaId index would resolve to whichever row it
+    // hits first, independent of which room the reaction actually belongs to.
+    const ROOM_B = 'other-room@c', FROM_B = 'other-room@c/carol'
+    await messageCache.saveRoomMessage(mk({ id: 'a-room-msg', stanzaId: 'DUP', originId: undefined }))
+    await messageCache.saveRoomMessage({
+      type: 'groupchat', id: 'b-room-msg', roomJid: ROOM_B, from: FROM_B, body: 'hi',
+      timestamp: new Date(5000), isOutgoing: false, stanzaId: 'DUP',
+    } as RoomMessage)
+
+    const ok = await messageCache.updateRoomMessageReactions(ROOM, 'DUP', 'r@c/bob', ['🔥'])
+    expect(ok).toBe(true)
+
+    const roomAMsg = (await messageCache.getRoomMessages(ROOM, {})).find((m) => m.id === 'a-room-msg')
+    const roomBMsg = (await messageCache.getRoomMessages(ROOM_B, {})).find((m) => m.id === 'b-room-msg')
+    expect(roomAMsg!.reactions?.['🔥']).toContain('r@c/bob')
+    expect(roomBMsg!.reactions).toBeUndefined()
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1317,4 +1317,26 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
     expect(roomAMsg!.reactions?.['🔥']).toContain('r@c/bob')
     expect(roomBMsg!.reactions).toBeUndefined()
   })
+  it('updateRoomMessageReactions is room-scoped on the CLIENT-id path — a same-id message in another room is untouched', async () => {
+    // Two rooms each cache a message under the SAME client id (ids collide across
+    // rooms just like stanzaIds). Here the reaction references that client id, so
+    // it resolves through the store-wide `ids` index — which must be filtered to
+    // this room. ROOM_B sorts before ROOM by cacheKey, so an unscoped
+    // getFromIndex('ids', …) returns ROOM_B's row first and writes the reaction to
+    // the wrong room.
+    const ROOM_B = 'other-room@c', FROM_B = 'other-room@c/carol'
+    await messageCache.saveRoomMessage(mk({ id: 'SAME', originId: undefined }))
+    await messageCache.saveRoomMessage({
+      type: 'groupchat', id: 'SAME', roomJid: ROOM_B, from: FROM_B, body: 'hi',
+      timestamp: new Date(5000), isOutgoing: false,
+    } as RoomMessage)
+
+    const ok = await messageCache.updateRoomMessageReactions(ROOM, 'SAME', 'r@c/bob', ['🔥'])
+    expect(ok).toBe(true)
+
+    const roomAMsg = (await messageCache.getRoomMessages(ROOM, {})).find((m) => m.id === 'SAME')
+    const roomBMsg = (await messageCache.getRoomMessages(ROOM_B, {})).find((m) => m.id === 'SAME')
+    expect(roomAMsg!.reactions?.['🔥']).toContain('r@c/bob')
+    expect(roomBMsg!.reactions).toBeUndefined()
+  })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import 'fake-indexeddb/auto'
 import { IDBFactory } from 'fake-indexeddb'
+import { openDB } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
 import { _resetStorageScopeForTesting, setStorageScopeJid } from './storageScope'
 import { selectCatchUpQuery } from './mamCatchUpUtils'
@@ -1120,5 +1121,72 @@ describe('mergeRoomRows — commutative, associative, field-complete', () => {
     for (const field of ['body', 'id', 'attachment']) {
       expect(projectedKeys).toContain(field)
     }
+  })
+})
+
+describe('v4 migration — identity-resolving canonicalization (streaming)', () => {
+  const JID = 'me@example.com', ROOM = 'r@c', FROM = 'r@c/alice'
+  const dbName = `fluux-message-cache:${JID}`
+  async function seedV3(rows: Array<Record<string, unknown>>) {
+    const db = await openDB(dbName, 3, {
+      upgrade(d) {
+        if (!d.objectStoreNames.contains('messages')) {
+          const s = d.createObjectStore('messages', { keyPath: 'id' })
+          for (const [n, kp] of [['conversationId','conversationId'],['stanzaId','stanzaId'],['timestamp','timestamp'],['conv_timestamp',['conversationId','timestamp']],['encryptedPayload','encryptedPayload']] as const) s.createIndex(n, kp as never)
+        }
+        const r = d.createObjectStore('room-messages', { keyPath: 'cacheKey' })
+        for (const [n, kp] of [['roomJid','roomJid'],['stanzaId','stanzaId'],['timestamp','timestamp'],['room_timestamp',['roomJid','timestamp']],['id','id']] as const) r.createIndex(n, kp as never)
+      },
+    })
+    const tx = db.transaction('room-messages', 'readwrite')
+    for (const row of rows) await tx.objectStore('room-messages').put(row as never)
+    await tx.done; db.close()
+  }
+  beforeEach(() => { globalThis.indexedDB = new IDBFactory(); messageCache._resetDBForTesting(); _resetStorageScopeForTesting(); setStorageScopeJid(JID) })
+
+  it('collapses an originId echo pair (rewritten id) into one row; both ids + stanzaId resolvable', async () => {
+    await seedV3([
+      { cacheKey: 'k1', originId: 'O', type: 'groupchat', id: 'client-1', roomJid: ROOM, from: FROM, body: 'hi', timestamp: 1000, isOutgoing: true },
+      { cacheKey: 'k2', stanzaId: 'S', originId: 'O', type: 'groupchat', id: 'server-9', roomJid: ROOM, from: FROM, body: 'hi', timestamp: 2000, isOutgoing: true },
+    ])
+    const mine = (await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')
+    expect(mine).toHaveLength(1)
+    expect(mine[0].timestamp.getTime()).toBe(2000)
+    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
+    // NOTE: getRoomMessageByStanzaId stays single-arg (stanzaId) in this task — the
+    // brief's 2-arg room-scoped form is Task 4 read-path wiring (its 3 callers are
+    // 1-arg today). A single-room fixture with a unique stanzaId validates the same
+    // "merged row resolvable by its stanzaId" behaviour.
+    expect(await messageCache.getRoomMessageByStanzaId('S')).not.toBeNull()
+  })
+
+  it('does not merge identical stanzaIds across different rooms', async () => {
+    await seedV3([
+      { cacheKey: 'a', stanzaId: '1', type: 'groupchat', id: 'i', roomJid: 'A@c', from: 'A@c/x', body: 'a', timestamp: 1000, isOutgoing: false },
+      { cacheKey: 'b', stanzaId: '1', type: 'groupchat', id: 'i', roomJid: 'B@c', from: 'B@c/x', body: 'b', timestamp: 1000, isOutgoing: false },
+    ])
+    expect(await messageCache.getRoomMessages('A@c', {})).toHaveLength(1)
+    expect(await messageCache.getRoomMessages('B@c', {})).toHaveLength(1)
+  })
+
+  it('does not downgrade a decrypted body during migration', async () => {
+    await seedV3([
+      { cacheKey: 'x', stanzaId: 'S1', type: 'groupchat', id: 'o2', roomJid: ROOM, from: FROM, body: '', unsupportedEncryption: { kind: 'x' }, timestamp: 3000, isOutgoing: false },
+      { cacheKey: 'y', stanzaId: 'S1', type: 'groupchat', id: 'o2', roomJid: ROOM, from: FROM, body: 'decrypted', timestamp: 3000, isOutgoing: false },
+    ])
+    expect((await messageCache.getRoomMessages(ROOM, {})).find((m) => m.stanzaId === 'S1')!.body).toBe('decrypted')
+  })
+
+  it('aborts the whole upgrade if the migration throws — DB stays at v3', async () => {
+    await seedV3([{ cacheKey: 'z', stanzaId: 'S9', type: 'groupchat', id: 'o9', roomJid: ROOM, from: FROM, body: 'x', timestamp: 5000, isOutgoing: false }])
+    messageCache._setMigrationFaultForTesting(true)
+    await expect(messageCache.getRoomMessages(ROOM, {})).resolves.toEqual([])
+    messageCache._setMigrationFaultForTesting(false); messageCache._resetDBForTesting()
+    const raw = await openDB(dbName)
+    expect(raw.version).toBe(3)
+    expect(raw.objectStoreNames.contains('room-messages-canonical')).toBe(false)
+    expect(await raw.get('room-messages', 'z')).toBeTruthy()
+    raw.close()
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -510,7 +510,7 @@ describe('messageCache', () => {
 
         await messageCache.saveRoomMessage(message)
 
-        const retrieved = await messageCache.getRoomMessage('room-1')
+        const retrieved = await messageCache.getRoomMessage(roomJid, 'room-1')
         expect(retrieved).not.toBeNull()
         expect(retrieved?.id).toBe('room-1')
       })
@@ -616,12 +616,12 @@ describe('messageCache', () => {
         const message = createMockRoomMessage(roomJid, { id: 'room-update', body: 'Original' })
         await messageCache.saveRoomMessage(message)
 
-        await messageCache.updateRoomMessage('room-update', {
+        await messageCache.updateRoomMessage(roomJid, 'room-update', {
           body: 'Updated',
           isEdited: true,
         })
 
-        const retrieved = await messageCache.getRoomMessage('room-update')
+        const retrieved = await messageCache.getRoomMessage(roomJid, 'room-update')
         expect(retrieved?.body).toBe('Updated')
         expect(retrieved?.isEdited).toBe(true)
       })
@@ -632,9 +632,9 @@ describe('messageCache', () => {
         const message = createMockRoomMessage(roomJid, { id: 'room-delete' })
         await messageCache.saveRoomMessage(message)
 
-        await messageCache.deleteRoomMessage('room-delete')
+        await messageCache.deleteRoomMessage(roomJid, 'room-delete')
 
-        const retrieved = await messageCache.getRoomMessage('room-delete')
+        const retrieved = await messageCache.getRoomMessage(roomJid, 'room-delete')
         expect(retrieved).toBeNull()
       })
     })
@@ -1197,8 +1197,8 @@ describe('v4 migration — identity-resolving canonicalization (streaming)', () 
     const mine = (await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')
     expect(mine).toHaveLength(1)
     expect(mine[0].timestamp.getTime()).toBe(2000)
-    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
-    expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
+    expect(await messageCache.getRoomMessage(ROOM, 'client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage(ROOM, 'server-9')).not.toBeNull()
     // Task 4 room-scoped getRoomMessageByStanzaId(roomJid, stanzaId): the merged row
     // stays resolvable by its stanzaId within its own room.
     expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
@@ -1247,8 +1247,8 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
   })
   it('the discarded optimistic id still resolves after the merge', async () => {
     await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
-    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
-    expect(await messageCache.getRoomMessage('server-9')).not.toBeNull()
+    expect(await messageCache.getRoomMessage(ROOM, 'client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage(ROOM, 'server-9')).not.toBeNull()
     expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
   })
   it('updateRoomMessage that ADDS a stanzaId re-keys and merges with any matching row', async () => {
@@ -1259,7 +1259,7 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
     await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S', originId: undefined }))
     // ...and the optimistic row is only now confirmed via an identity-adding update.
     await messageCache.saveRoomMessage(mk()) // optimistic: originId O, no stanzaId
-    await messageCache.updateRoomMessage('client-1', { stanzaId: 'S', originId: 'O' })
+    await messageCache.updateRoomMessage(ROOM, 'client-1', { stanzaId: 'S', originId: 'O' })
     expect((await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.originId === 'O')).toHaveLength(1)
   })
   it('updateRoomMessage that ADDS an originId (canonical key UNCHANGED) still merges a row already at that originId', async () => {
@@ -1269,27 +1269,27 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
     await messageCache.saveRoomMessage(mk({ id: 'a2', originId: 'O', stanzaId: undefined }))
     // Confirm row 1 also carries originId O — its canonical key stays stanzaId:S,
     // so a key-only identityChanged check would MISS this and leave two rows.
-    await messageCache.updateRoomMessage('a1', { originId: 'O' })
+    await messageCache.updateRoomMessage(ROOM, 'a1', { originId: 'O' })
     expect((await messageCache.getRoomMessages(ROOM, {})).filter((m) => m.stanzaId === 'S' || m.originId === 'O')).toHaveLength(1)
-    expect(await messageCache.getRoomMessage('a1')).not.toBeNull()          // every alias
-    expect(await messageCache.getRoomMessage('a2')).not.toBeNull()          // preserved
+    expect(await messageCache.getRoomMessage(ROOM, 'a1')).not.toBeNull()          // every alias
+    expect(await messageCache.getRoomMessage(ROOM, 'a2')).not.toBeNull()          // preserved
     expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'S')).not.toBeNull()
   })
   it('removes a deliberately cleared stale stanzaId alias (clearMessageStanzaId)', async () => {
     await messageCache.saveRoomMessage(mk({ stanzaId: 'stale-S' })) // has stanzaId + originId O + id client-1
-    await messageCache.updateRoomMessage('client-1', { stanzaId: undefined }) // revoke the stanzaId
+    await messageCache.updateRoomMessage(ROOM, 'client-1', { stanzaId: undefined }) // revoke the stanzaId
     // The scoped stanza alias must be GONE — else a later message with 'stale-S' merges wrongly.
     expect(await messageCache.getRoomMessageByStanzaId(ROOM, 'stale-S')).toBeNull()
     // ...but the message itself, and its other aliases, remain.
-    expect(await messageCache.getRoomMessage('client-1')).not.toBeNull()
+    expect(await messageCache.getRoomMessage(ROOM, 'client-1')).not.toBeNull()
     expect(await messageCache.getRoomMessages(ROOM, {})).toHaveLength(1)
   })
   it('updateRoomMessageReactions resolves a pre-merge id and is authoritative (does not un-remove)', async () => {
     await messageCache.saveRoomMessage(mk()); await messageCache.saveRoomMessage(mk({ id: 'server-9', stanzaId: 'S' }))
     await messageCache.updateRoomMessageReactions(ROOM, 'client-1', 'r@c/bob', ['👍'])
-    expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍']).toContain('r@c/bob')
+    expect((await messageCache.getRoomMessage(ROOM, 'server-9'))!.reactions?.['👍']).toContain('r@c/bob')
     await messageCache.updateRoomMessageReactions(ROOM, 'client-1', 'r@c/bob', []) // removal
-    expect((await messageCache.getRoomMessage('server-9'))!.reactions?.['👍'] ?? []).not.toContain('r@c/bob')
+    expect((await messageCache.getRoomMessage(ROOM, 'server-9'))!.reactions?.['👍'] ?? []).not.toContain('r@c/bob')
   })
   it('getRoomMessagesAround returns each logical message once', async () => {
     await messageCache.saveRoomMessage(mk({ stanzaId: 'S' }))
@@ -1338,5 +1338,66 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
     const roomBMsg = (await messageCache.getRoomMessages(ROOM_B, {})).find((m) => m.id === 'SAME')
     expect(roomAMsg!.reactions?.['🔥']).toContain('r@c/bob')
     expect(roomBMsg!.reactions).toBeUndefined()
+  })
+  it('getRoomMessage is room-scoped — a same-id message in another room is not returned', async () => {
+    // Same client id in two rooms; the store-wide `ids` index must be filtered to
+    // the requested room. ROOM_B sorts before ROOM by cacheKey, so an unscoped
+    // index `get` would return ROOM_B's row for a ROOM lookup.
+    const ROOM_B = 'other-room@c'
+    await messageCache.saveRoomMessage(mk({ id: 'SAME', originId: undefined }))
+    await messageCache.saveRoomMessage({
+      type: 'groupchat', id: 'SAME', roomJid: ROOM_B, from: `${ROOM_B}/carol`, body: 'decoy',
+      timestamp: new Date(5000), isOutgoing: false,
+    } as RoomMessage)
+    expect((await messageCache.getRoomMessage(ROOM, 'SAME'))!.from).toBe(FROM)
+    expect((await messageCache.getRoomMessage(ROOM_B, 'SAME'))!.from).toBe(`${ROOM_B}/carol`)
+  })
+  it('updateRoomMessage is room-scoped — a same-id message in another room is not mutated', async () => {
+    // A retraction (non-identity update) targeting ROOM must not land on ROOM_B's
+    // same-id message. The assertions read each room through the room-scoped
+    // getRoomMessages cursor, independent of the id resolver under test.
+    const ROOM_B = 'other-room@c'
+    await messageCache.saveRoomMessage(mk({ id: 'SAME', originId: undefined }))
+    await messageCache.saveRoomMessage({
+      type: 'groupchat', id: 'SAME', roomJid: ROOM_B, from: `${ROOM_B}/carol`, body: 'hi',
+      timestamp: new Date(5000), isOutgoing: false,
+    } as RoomMessage)
+
+    await messageCache.updateRoomMessage(ROOM, 'SAME', { isRetracted: true })
+
+    const a = (await messageCache.getRoomMessages(ROOM, {})).find((m) => m.id === 'SAME')
+    const b = (await messageCache.getRoomMessages(ROOM_B, {})).find((m) => m.id === 'SAME')
+    expect(a!.isRetracted).toBe(true)
+    expect(b!.isRetracted).toBeFalsy()
+  })
+  it('deleteRoomMessage is room-scoped — a same-id message in another room survives', async () => {
+    const ROOM_B = 'other-room@c'
+    await messageCache.saveRoomMessage(mk({ id: 'SAME', originId: undefined }))
+    await messageCache.saveRoomMessage({
+      type: 'groupchat', id: 'SAME', roomJid: ROOM_B, from: `${ROOM_B}/carol`, body: 'keep',
+      timestamp: new Date(5000), isOutgoing: false,
+    } as RoomMessage)
+
+    await messageCache.deleteRoomMessage(ROOM, 'SAME') // delete THIS room's copy
+
+    expect((await messageCache.getRoomMessages(ROOM_B, {})).some((m) => m.id === 'SAME')).toBe(true)
+    expect((await messageCache.getRoomMessages(ROOM, {})).some((m) => m.id === 'SAME')).toBe(false)
+  })
+  it('getRoomMessagesAround resolves the anchor in the REQUESTED room, not a same-id decoy elsewhere', async () => {
+    // ROOM holds the real anchor (t=1000) plus later fillers. ROOM_B holds a same-id
+    // decoy far in the future (t=10000) whose cacheKey sorts first. An unscoped anchor
+    // lookup builds the window around t=10000, dropping the real anchor at t=1000.
+    const ROOM_B = 'other-room@c'
+    await messageCache.saveRoomMessage(mk({ id: 'ANCH', originId: undefined, timestamp: new Date(1000) }))
+    for (const [i, t] of [[1, 2000], [2, 3000], [3, 4000], [4, 5000]] as const) {
+      await messageCache.saveRoomMessage(mk({ id: `f${i}`, originId: undefined, timestamp: new Date(t) }))
+    }
+    await messageCache.saveRoomMessage({
+      type: 'groupchat', id: 'ANCH', roomJid: ROOM_B, from: `${ROOM_B}/carol`, body: 'decoy',
+      timestamp: new Date(10000), isOutgoing: false,
+    } as RoomMessage)
+
+    const around = await messageCache.getRoomMessagesAround(ROOM, 'ANCH', { before: 2, after: 2 })
+    expect(around.some((m) => m.timestamp.getTime() === 1000)).toBe(true)
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -8,7 +8,7 @@ import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
 
 // Must import after fake-indexeddb/auto
 import * as messageCache from './messageCache'
-import { mergeRoomRows } from './messageCache'
+import { mergeRoomRows, _contentProjectionForTesting } from './messageCache'
 import type { StoredRoomMessage } from './messageCache'
 
 /**
@@ -1079,5 +1079,46 @@ describe('mergeRoomRows — commutative, associative, field-complete', () => {
     const c = rrow({ body: 'edited', isEdited: true, id: 'c1', timestamp: 4500, reactions: { a: ['d'] } })
     const rs = [mergeRoomRows(mergeRoomRows(a,b),c), mergeRoomRows(a,mergeRoomRows(b,c)), mergeRoomRows(mergeRoomRows(b,a),c), mergeRoomRows(mergeRoomRows(c,b),a)]
     for (const r of rs) expect(r).toEqual(rs[0])
+  })
+
+  // Direct contract check on the tiebreak's serialized input. The associativity test above
+  // can't discriminate the projection from a whole-row serialization — its fixture's
+  // isEdited:true row dominates by rank at every grouping, so the tiebreak is never reached.
+  // This asserts the CONTRACT contentProjection relies on directly: every field mergeRoomRows
+  // computes separately must be absent (those fields change value during a merge, which is
+  // exactly what would break associativity if they leaked into the tiebreak serialization),
+  // and representative immutable content fields must remain present.
+  it('contentProjection omits every separately-merged field and keeps immutable content', () => {
+    const row = rrow({
+      stanzaId: 'S1',
+      originId: 'O1',
+      timestamp: 1234,
+      reactions: { thumbsup: ['alice'] },
+      isRetracted: true,
+      retractedAt: 5678,
+      isModerated: true,
+      moderatedBy: 'mod-nick',
+      moderationReason: 'spam',
+      pollClosed: { by: 'alice' } as never,
+      pollClosedAt: 9999,
+      deliveryError: { text: 'failed' } as never,
+      body: 'hello world',
+      id: 'client-1',
+      attachment: { url: 'a://file' } as never,
+    })
+    const proj = _contentProjectionForTesting(row) as Record<string, unknown>
+    const projectedKeys = Object.keys(proj)
+
+    for (const field of [
+      'stanzaId', 'originId', 'timestamp', 'reactions', 'identityKeys', 'ids',
+      'isRetracted', 'retractedAt', 'isModerated', 'moderatedBy', 'moderationReason',
+      'pollClosed', 'pollClosedAt', 'deliveryError', 'cacheKey',
+    ]) {
+      expect(projectedKeys).not.toContain(field)
+    }
+
+    for (const field of ['body', 'id', 'attachment']) {
+      expect(projectedKeys).toContain(field)
+    }
   })
 })

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -289,6 +289,25 @@ async function findRoomRowsByIdentity(
 }
 
 /**
+ * Resolve the one cached row carrying client `id` WITHIN a room. The `ids` index is
+ * store-wide and non-unique — client ids repeat across rooms, and per XEP-0359 an id
+ * is unique only per (room, sender) — so a plain index `get` returns the
+ * globally-first match and can land in the wrong room. Fetch every id match and keep
+ * the one in this room; when the caller knows the sender, also match `from`. Returns
+ * undefined when no row in the room carries the id. Shared by every room-aware
+ * by-id lookup (getRoomMessage, updateRoomMessage, deleteRoomMessage).
+ */
+async function findRoomRowById(
+  idsIndex: { getAll(key: string): Promise<StoredRoomMessage[]> },
+  roomJid: string,
+  id: string,
+  from?: string
+): Promise<StoredRoomMessage | undefined> {
+  const matches = await idsIndex.getAll(id)
+  return matches.find((r) => r.roomJid === roomJid && (from === undefined || r.from === from))
+}
+
+/**
  * Core: resolve every existing row sharing any tier with `incoming` (echo,
  * live/MAM, bridge), merge them and `incoming` into one, delete the losers, put
  * the survivor. `incoming` is an already-serialized StoredRoomMessage, so callers
@@ -988,16 +1007,17 @@ export async function saveRoomMessages(messages: RoomMessage[]): Promise<boolean
 }
 
 /**
- * Get a room message by its client-generated ID.
- * Note: IDs may not be unique across senders. Uses the id index to find the first match.
+ * Get a room message by its client-generated ID, scoped to a room.
+ *
+ * Client ids repeat across rooms (and, per XEP-0359, are unique only per sender), so
+ * the store-wide `ids` index is filtered to `roomJid` — pass `from` to also pin the
+ * sender. A MERGED row carries every absorbed client id in `ids[]`, so it stays
+ * findable by ANY of them. See {@link findRoomRowById}.
  */
-export async function getRoomMessage(id: string): Promise<RoomMessage | null> {
+export async function getRoomMessage(roomJid: string, id: string, from?: string): Promise<RoomMessage | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    // Resolve via the `ids` multiEntry index: a MERGED row carries every absorbed
-    // client id in `ids[]`, so it stays findable by ANY of them — not only the
-    // survivor's own `id` (which a single-`id` index lookup would miss).
-    const stored = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', id)
+    const stored = await findRoomRowById(db.transaction(ROOM_MESSAGES_STORE).store.index('ids'), roomJid, id, from)
     return stored ? deserializeRoomMessage(stored) : null
   } catch (error) {
     if (isIndexedDBAvailable()) {
@@ -1108,7 +1128,7 @@ export async function getRoomMessagesAround(
 ): Promise<RoomMessage[]> {
   const { before = 50, after } = options
 
-  let anchor = await getRoomMessage(anchorMessageId)
+  let anchor = await getRoomMessage(roomJid, anchorMessageId)
   if (!anchor) anchor = await getRoomMessageByStanzaId(roomJid, anchorMessageId)
   if (!anchor) return []
 
@@ -1153,8 +1173,10 @@ export async function getRoomMessageCount(roomJid: string): Promise<number> {
 }
 
 /**
- * Update specific fields of a room message, resolving the row through the `ids`
- * alias index so a caller holding a pre-merge id still finds it.
+ * Update specific fields of a room message, resolving the row through the room-scoped
+ * `ids` alias so a caller holding a pre-merge id still finds it. Client ids repeat
+ * across rooms, so the lookup is confined to `roomJid` (and `from` when the caller
+ * knows the sender) — otherwise the update could mutate another room's message.
  *
  * When an update carries an identity FIELD it splits two ways:
  *   - Expansion (a new stanzaId/originId, or a changed id) — the existing row's
@@ -1166,14 +1188,16 @@ export async function getRoomMessageCount(roomJid: string): Promise<number> {
  *     merged in.
  */
 export async function updateRoomMessage(
+  roomJid: string,
   id: string,
-  updates: Partial<RoomMessage>
+  updates: Partial<RoomMessage>,
+  from?: string
 ): Promise<void> {
   try {
     const db = await getDB(getStorageScopeJid())
     const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(ROOM_MESSAGES_STORE)
-    const existing = await store.index('ids').get(id)
+    const existing = await findRoomRowById(store.index('ids'), roomJid, id, from)
     if (!existing) { await tx.done; return }
     const updated = { ...deserializeRoomMessage(existing), ...updates } as RoomMessage
     // Compare identity FIELDS, not just the canonical key: adding an originId to a
@@ -1285,18 +1309,19 @@ export async function updateRoomMessageReactions(
 }
 
 /**
- * Delete a room message by ID.
- * Resolves the row through the `ids` alias index (so a pre-merge id still finds a
- * merged row), then deletes by its cacheKey (the primary key).
+ * Delete a room message by ID, scoped to a room.
+ * Resolves the row through the room-scoped `ids` alias (so a pre-merge id still finds
+ * a merged row, and a colliding id in another room is not deleted), then deletes by
+ * its cacheKey (the primary key). Pass `from` to also pin the sender.
  */
-export async function deleteRoomMessage(id: string): Promise<void> {
+export async function deleteRoomMessage(roomJid: string, id: string, from?: string): Promise<void> {
   try {
     const db = await getDB(getStorageScopeJid())
-    // Resolve via the `ids` multiEntry index to find the cacheKey.
-    const existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', id)
-    if (!existing) return
+    const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
+    const existing = await findRoomRowById(tx.store.index('ids'), roomJid, id, from)
     // Delete using the cacheKey (the actual primary key)
-    await db.delete(ROOM_MESSAGES_STORE, existing.cacheKey)
+    if (existing) await tx.store.delete(existing.cacheKey)
+    await tx.done
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to delete room message:', error)

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -1220,7 +1220,8 @@ export async function updateRoomMessage(
 /**
  * Update reactions for a room message in IndexedDB.
  * Used as a fallback when the message is not currently loaded in memory.
- * Looks up by client ID or room-scoped stanza-id (reactions may reference either).
+ * Resolves the target strictly within `roomJid` — a reaction may reference either
+ * a room-scoped stanza-id or a client id, and BOTH repeat across rooms.
  *
  * @returns true if the message was found and updated, false otherwise.
  */
@@ -1233,16 +1234,18 @@ export async function updateRoomMessageReactions(
   try {
     const db = await getDB(getStorageScopeJid())
 
-    // Resolve via the `ids` multiEntry index (a merged row is findable by EVERY
-    // absorbed client id), then fall back to the room-scoped `identityKeys` alias:
-    // a MUC reaction references the server stanza-id, which is not a client id in
-    // `ids`. stanzaIds are assigned per-archive and repeat across rooms, so an
-    // unscoped stanzaId lookup could resolve to a DIFFERENT room's message —
-    // scoping through roomStanzaKey confines it to this room (mirrors
-    // getRoomMessageByStanzaId).
-    let existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', messageId)
+    // Both resolution paths must be confined to THIS room, or a collision in
+    // another room wins. A MUC reaction references the server stanza-id, which
+    // repeats across rooms (per-archive) — so we resolve it through the
+    // room-scoped `identityKeys` alias (roomStanzaKey), a single indexed get.
+    // The `ids` multiEntry index is store-wide and non-unique, and cacheKeys sort
+    // by room JID, so getFromIndex('ids', …) could return a DIFFERENT room's
+    // message when a client id collides; take every id match and keep the one in
+    // this room. (Mirrors getRoomMessageByStanzaId's room-scoping.)
+    let existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'identityKeys', roomStanzaKey(roomJid, messageId))
     if (!existing) {
-      existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'identityKeys', roomStanzaKey(roomJid, messageId))
+      const idMatches = await db.getAllFromIndex(ROOM_MESSAGES_STORE, 'ids', messageId)
+      existing = idMatches.find((row) => row.roomJid === roomJid)
     }
     if (!existing) return false
 

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -81,7 +81,6 @@ interface MessageCacheSchema extends DBSchema {
     value: StoredRoomMessage
     indexes: {
       roomJid: string
-      originId: string
       // multiEntry over identityKeys[] — the finder resolves every identity tier here.
       identityKeys: string
       // multiEntry over ids[] — a merged row is findable by EVERY absorbed client id.
@@ -161,11 +160,12 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
       if (!db.objectStoreNames.contains(ROOM_MESSAGES_STORE)) {
         const s = db.createObjectStore(ROOM_MESSAGES_STORE, { keyPath: 'cacheKey' })
         s.createIndex('roomJid', 'roomJid', { unique: false })
-        // No unscoped `stanzaId` index: stanzaIds are assigned per-archive and repeat
-        // across rooms, so a scalar index on it would let a lookup cross rooms. Every
-        // stanzaId query goes through the room-scoped `identityKeys` alias instead
-        // (see roomStanzaKey / getRoomMessageByStanzaId / updateRoomMessageReactions).
-        s.createIndex('originId', 'originId', { unique: false })
+        // No unscoped `stanzaId` or `originId` scalar index: stanzaIds/originIds are
+        // assigned per-archive and repeat across rooms, so a scalar index on either
+        // would let a lookup cross rooms — and nothing queries them anyway. Every
+        // stanzaId/originId query goes through the room-scoped `identityKeys` alias
+        // instead (see roomStanzaKey / roomOriginKey / getRoomMessageByStanzaId /
+        // updateRoomMessageReactions).
         s.createIndex('identityKeys', 'identityKeys', { unique: false, multiEntry: true })
         s.createIndex('ids', 'ids', { unique: false, multiEntry: true })
         s.createIndex('timestamp', 'timestamp', { unique: false })
@@ -182,11 +182,14 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
           // alive meanwhile via the migration's chained requests, and openDB resolves
           // only after it commits. Do not deleteObjectStore here (illegal from the
           // async continuation) — the migration clear()s the legacy store instead.
-          migrateRoomStoreToCanonical(transaction).catch(() => {
-            // Aborting rejects openDB (getDB's caller handles that) AND rejects
-            // transaction.done with AbortError; nothing awaits `done`, so attach a
-            // no-op catch first to keep the abort from surfacing as an unhandled
-            // rejection, then abort.
+          migrateRoomStoreToCanonical(transaction).catch((err) => {
+            // Log before aborting: this streaming rewrite of the whole room archive
+            // is the riskiest path in the upgrade, and the abort otherwise swallows
+            // the cause silently. Then: aborting rejects openDB (getDB's caller
+            // handles that) AND rejects transaction.done with AbortError; nothing
+            // awaits `done`, so attach a no-op catch first to keep the abort from
+            // surfacing as an unhandled rejection, then abort.
+            console.error('v4 room-store migration aborted:', err)
             transaction.done.catch(() => {})
             transaction.abort()
           })
@@ -380,18 +383,17 @@ function stableStringify(v: unknown): string {
   // declared `string` return holds (undefined-valued fields do occur in the projection).
   if (v === undefined) return '␀undefined'
   if (v === null || typeof v !== 'object') return JSON.stringify(v)
+  // Date/Map/Set are objects but carry no own enumerable keys, so the object branch
+  // below would collapse each to `{}` — making two values that differ only in such a
+  // field stringify equal and breaking COMMUTATIVITY (not just the tiebreak). Not live
+  // today (no content-projection field is a Date), but normalize Date defensively.
+  // Map/Set remain hazards: content-projection fields must stay JSON-plain.
+  if (v instanceof Date) return v.toISOString()
   if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`
   const o = v as Record<string, unknown>
   return `{${Object.keys(o).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`).join(',')}}`
 }
 
-/**
- * Choose the CONTENT-owner row by a strict TOTAL order, so the choice is the same
- * regardless of argument order AND a tie happens only when the rows are identical.
- * Higher decryption rank, then edited, then non-empty body, then — the fix — a
- * full stable serialization, so two rows differing in attachment / poll / reply /
- * encryption metadata still resolve deterministically instead of picking `a`.
- */
 /**
  * The IMMUTABLE content projection — everything EXCEPT the fields merged
  * separately (aliases, timestamp, reactions, retraction, moderation, poll
@@ -412,6 +414,18 @@ function contentProjection(m: StoredRoomMessage): unknown {
   return content
 }
 
+/**
+ * Choose the CONTENT-owner row by a strict TOTAL order, so the choice is the same
+ * regardless of argument order AND a tie happens only when the rows are identical.
+ * Higher decryption rank, then edited, then non-empty body, then — the fix — a
+ * stable serialization of the CONTENT PROJECTION (not the whole row), so two rows
+ * differing in attachment / poll / reply / encryption metadata still resolve
+ * deterministically instead of picking `a`. Serializing the projection rather than
+ * the whole row is the LOAD-BEARING invariant for associativity: the fields
+ * {@link contentProjection} excludes (aliases, reactions, timestamp, retraction,
+ * moderation, poll closure, delivery error) CHANGE during a merge, so a whole-row
+ * serialization would make the winner grouping-dependent (see contentProjection).
+ */
 function contentOwner(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
   const ra: number[] = [decryptionRank(a), a.isEdited ? 1 : 0, a.body ? 1 : 0]
   const rb: number[] = [decryptionRank(b), b.isEdited ? 1 : 0, b.body ? 1 : 0]

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -1282,3 +1282,13 @@ export function _resetDBForTesting(): void {
   dbPromise = null
   dbNameForPromise = null
 }
+
+/**
+ * Expose {@link contentProjection} so tests can assert its contract directly
+ * (which fields it omits/includes) rather than only exercising it indirectly
+ * through {@link mergeRoomRows}. For testing only.
+ * @internal
+ */
+export function _contentProjectionForTesting(m: StoredRoomMessage): unknown {
+  return contentProjection(m)
+}

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -16,9 +16,16 @@ import { roomCanonicalKey, roomIdentityKeys } from './roomMessageIdentity'
 const DB_NAME = 'fluux-message-cache'
 // v3: add a SPARSE index on `encryptedPayload` so deferred decryption can list
 // only the messages still awaiting a key — without scanning the whole archive.
-const DB_VERSION = 3
+// v4: canonicalize the room archive — one cached row per logical message. A fresh
+// canonically-keyed store (identityKeys[]/ids[] multiEntry + room_ts_from_id order
+// index) replaces the old room store; the v4 upgrade streams every legacy row
+// through the identity-resolving upsert into it and aborts atomically on failure.
+const DB_VERSION = 4
 const MESSAGES_STORE = 'messages'
-const ROOM_MESSAGES_STORE = 'room-messages'
+// The canonical room store (v4+). Keyed by the highest-tier identity key.
+const ROOM_MESSAGES_STORE = 'room-messages-canonical'
+// The pre-v4 room store. Read + cleared by the v4 migration only; never written live.
+const LEGACY_ROOM_MESSAGES_STORE = 'room-messages'
 
 /**
  * Stored message format with timestamps as numbers for efficient indexing.
@@ -70,14 +77,23 @@ interface MessageCacheSchema extends DBSchema {
     }
   }
   [ROOM_MESSAGES_STORE]: {
-    key: string // cacheKey (stanzaId or roomJid:from:id)
+    key: string // cacheKey — the canonical (highest-tier) identity key
     value: StoredRoomMessage
     indexes: {
       roomJid: string
       stanzaId: string
+      originId: string
+      // multiEntry over identityKeys[] — the finder resolves every identity tier here.
+      identityKeys: string
+      // multiEntry over ids[] — a merged row is findable by EVERY absorbed client id.
+      ids: string
       timestamp: number
       room_timestamp: [string, number]
-      id: string // Index on client ID for lookup
+      // Stable room order key (roomJid, timestamp, from, id) for Task 4's read path.
+      room_ts_from_id: [string, number, string, string]
+      // Kept single-`id` index so the by-id update/delete/reaction paths resolve
+      // unchanged until Task 4 migrates them to identity-resolution.
+      id: string
     }
   }
 }
@@ -143,23 +159,40 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
         }
       }
 
-      // Room messages store
-      // Version 2: Changed keyPath from 'id' to 'cacheKey' to fix duplicate messages
-      // issue where different senders could have the same message ID.
-      if (oldVersion < 2 && db.objectStoreNames.contains(ROOM_MESSAGES_STORE)) {
-        // Delete old store - data will be re-fetched from MAM
-        db.deleteObjectStore(ROOM_MESSAGES_STORE)
-      }
-
+      // Room messages store (v4 canonical). A fresh canonically-keyed store replaces
+      // the pre-v4 room store; when the legacy store is present, the migration streams
+      // every legacy row through the identity-resolving upsert into it.
       if (!db.objectStoreNames.contains(ROOM_MESSAGES_STORE)) {
-        const roomStore = db.createObjectStore(ROOM_MESSAGES_STORE, { keyPath: 'cacheKey' })
-        roomStore.createIndex('roomJid', 'roomJid', { unique: false })
-        roomStore.createIndex('stanzaId', 'stanzaId', { unique: false })
-        roomStore.createIndex('timestamp', 'timestamp', { unique: false })
-        roomStore.createIndex('room_timestamp', ['roomJid', 'timestamp'], {
-          unique: false,
-        })
-        roomStore.createIndex('id', 'id', { unique: false })
+        const s = db.createObjectStore(ROOM_MESSAGES_STORE, { keyPath: 'cacheKey' })
+        s.createIndex('roomJid', 'roomJid', { unique: false })
+        s.createIndex('stanzaId', 'stanzaId', { unique: false })
+        s.createIndex('originId', 'originId', { unique: false })
+        s.createIndex('identityKeys', 'identityKeys', { unique: false, multiEntry: true })
+        s.createIndex('ids', 'ids', { unique: false, multiEntry: true })
+        s.createIndex('timestamp', 'timestamp', { unique: false })
+        s.createIndex('room_timestamp', ['roomJid', 'timestamp'], { unique: false })
+        s.createIndex('room_ts_from_id', ['roomJid', 'timestamp', 'from', 'id'], { unique: false })
+        s.createIndex('id', 'id', { unique: false })
+
+        // `as never`: the legacy store is not in the v4 schema, so idb's typed
+        // objectStoreNames.contains() would reject its name — but it can still be
+        // present in an upgrading DB, which is exactly what we test for here.
+        if (db.objectStoreNames.contains(LEGACY_ROOM_MESSAGES_STORE as never)) {
+          // idb does NOT await this callback, and rethrowing would be an unhandled
+          // rejection. Fire the migration and, on ANY failure, explicitly abort the
+          // version-change transaction (which rejects openDB). The transaction stays
+          // alive meanwhile via the migration's chained requests, and openDB resolves
+          // only after it commits. Do not deleteObjectStore here (illegal from the
+          // async continuation) — the migration clear()s the legacy store instead.
+          migrateRoomStoreToCanonical(transaction).catch(() => {
+            // Aborting rejects openDB (getDB's caller handles that) AND rejects
+            // transaction.done with AbortError; nothing awaits `done`, so attach a
+            // no-op catch first to keep the abort from surfacing as an unhandled
+            // rejection, then abort.
+            transaction.done.catch(() => {})
+            transaction.abort()
+          })
+        }
       }
     },
   })
@@ -218,6 +251,94 @@ function deserializeRoomMessage(stored: StoredRoomMessage): RoomMessage {
     retractedAt: stored.retractedAt ? new Date(stored.retractedAt) : undefined,
     pollClosedAt: stored.pollClosedAt ? new Date(stored.pollClosedAt) : undefined,
   }
+}
+
+// =============================================================================
+// v4 room-store canonicalization (identity-resolving upsert + streaming migration)
+// =============================================================================
+
+let migrationFaultForTesting = false
+/** @internal test seam — force the v4 migration to throw, to verify it aborts. */
+export function _setMigrationFaultForTesting(on: boolean): void {
+  migrationFaultForTesting = on
+}
+
+/** The minimal room-store surface the identity-resolving upsert needs. */
+type RoomStoreLike = {
+  put(v: StoredRoomMessage): Promise<unknown>
+  delete(key: string): Promise<void>
+  index(name: 'identityKeys'): { getAll(key: string): Promise<StoredRoomMessage[]> }
+}
+
+/**
+ * Every existing row sharing ANY identity tier with `m`, de-duped by cacheKey.
+ * SCANS the multiEntry `identityKeys` index across every one of `m`'s keys (never
+ * `.get()`): a non-unique tier or a gateway bridge can leave the same logical
+ * message under several rows, and only a scan of all tiers finds them all.
+ */
+async function findRoomRowsByIdentity(
+  store: RoomStoreLike,
+  m: StoredRoomMessage
+): Promise<StoredRoomMessage[]> {
+  const found = new Map<string, StoredRoomMessage>()
+  for (const key of m.identityKeys) {
+    for (const row of await store.index('identityKeys').getAll(key)) found.set(row.cacheKey, row)
+  }
+  return [...found.values()]
+}
+
+/**
+ * Core: resolve every existing row sharing any tier with `incoming` (echo,
+ * live/MAM, bridge), merge them and `incoming` into one, delete the losers, put
+ * the survivor. `incoming` is an already-serialized StoredRoomMessage, so callers
+ * that need to PRESERVE accumulated aliases (updateRoomMessage) union them in
+ * first. `excludeKey` skips a specific existing row from the merge — used when the
+ * caller already holds that row's data in `incoming` and must not merge its
+ * pre-update copy back in (which the union would do, re-adding a removed reaction).
+ */
+async function upsertStoredRoomRow(
+  store: RoomStoreLike,
+  incoming: StoredRoomMessage,
+  excludeKey?: string
+): Promise<void> {
+  const matches = (await findRoomRowsByIdentity(store, incoming)).filter((r) => r.cacheKey !== excludeKey)
+  let merged = incoming
+  for (const row of matches) merged = mergeRoomRows(merged, row)
+  const survivorKey = merged.cacheKey
+  if (excludeKey && excludeKey !== survivorKey) await store.delete(excludeKey)
+  for (const row of matches) if (row.cacheKey !== survivorKey) await store.delete(row.cacheKey)
+  await store.put(merged)
+}
+
+/** Insert or merge a live-arriving message by identity (migration + Task 4 write path). */
+async function upsertRoomRowByIdentity(store: RoomStoreLike, message: RoomMessage): Promise<void> {
+  await upsertStoredRoomRow(store, serializeRoomMessage(message))
+}
+
+/** Minimal cursor view over the legacy room store during migration. */
+type LegacyRoomCursor = { value: StoredRoomMessage; continue(): Promise<LegacyRoomCursor | null> }
+/** Minimal legacy-store view: stream every row out, then empty. */
+type LegacyRoomStore = { openCursor(): Promise<LegacyRoomCursor | null>; clear(): Promise<void> }
+/** Minimal version-change transaction view the streaming migration needs. */
+type MigrationTransaction = { objectStore(name: string): unknown }
+
+/**
+ * Stream every legacy room row through the identity-resolving upsert into the
+ * canonical store, one cursor step at a time (never `getAll()` the whole archive
+ * into memory), then empty the legacy store. Runs inside the v4 version-change
+ * transaction; any throw is caught by the caller, which aborts that transaction
+ * atomically — so a partial rewrite can never be observed.
+ */
+async function migrateRoomStoreToCanonical(transaction: MigrationTransaction): Promise<void> {
+  const legacy = transaction.objectStore(LEGACY_ROOM_MESSAGES_STORE) as LegacyRoomStore
+  const dest = transaction.objectStore(ROOM_MESSAGES_STORE) as RoomStoreLike
+  let cursor = await legacy.openCursor()
+  while (cursor) {
+    if (migrationFaultForTesting) throw new Error('migration fault (test)')
+    await upsertRoomRowByIdentity(dest, deserializeRoomMessage(cursor.value))
+    cursor = await cursor.continue()
+  }
+  await legacy.clear() // legacy store now empty; a future version bump can drop it synchronously
 }
 
 // =============================================================================
@@ -857,8 +978,10 @@ export async function saveRoomMessages(messages: RoomMessage[]): Promise<boolean
 export async function getRoomMessage(id: string): Promise<RoomMessage | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    // Use the id index since the primary key is now cacheKey
-    const stored = await db.getFromIndex(ROOM_MESSAGES_STORE, 'id', id)
+    // Resolve via the `ids` multiEntry index: a MERGED row carries every absorbed
+    // client id in `ids[]`, so it stays findable by ANY of them — not only the
+    // survivor's own `id` (which a single-`id` index lookup would miss).
+    const stored = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', id)
     return stored ? deserializeRoomMessage(stored) : null
   } catch (error) {
     if (isIndexedDBAvailable()) {

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -11,6 +11,7 @@ import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
 import { getStorageScopeJid } from './storageScope'
 import { isRenderableStoredMessage } from './messageRenderability'
+import { roomCanonicalKey, roomIdentityKeys } from './roomMessageIdentity'
 
 const DB_NAME = 'fluux-message-cache'
 // v3: add a SPARSE index on `encryptedPayload` so deferred decryption can list
@@ -18,31 +19,6 @@ const DB_NAME = 'fluux-message-cache'
 const DB_VERSION = 3
 const MESSAGES_STORE = 'messages'
 const ROOM_MESSAGES_STORE = 'room-messages'
-
-/**
- * Generate a unique cache key for a room message.
- * Uses stanzaId if available (globally unique from server),
- * otherwise falls back to roomJid:from:id (unique per sender).
- *
- * This fixes the duplicate message issue where different senders
- * could have the same message ID (XMPP IDs are only unique per sender).
- */
-function getRoomMessageCacheKey(message: {
-  stanzaId?: string
-  roomJid: string
-  from: string
-  id: string
-}): string {
-  // Prefer stanzaId - it's globally unique (XEP-0359)
-  if (message.stanzaId) {
-    return message.stanzaId
-  }
-  // Fallback: composite key using roomJid:from:id
-  // Known cosmetic edge: an id-less cached copy and its stanzaId-carrying
-  // re-fetch land under different keys (double row in the raw cache); the
-  // rehydrate merge dedupes them by from:id, so the UI shows one row.
-  return `${message.roomJid}:${message.from}:${message.id}`
-}
 
 /**
  * Stored message format with timestamps as numbers for efficient indexing.
@@ -59,10 +35,14 @@ interface StoredMessage extends Omit<Message, 'timestamp' | 'retractedAt' | 'rep
 /**
  * Stored room message format with timestamps as numbers for efficient indexing.
  */
-interface StoredRoomMessage
+export interface StoredRoomMessage
   extends Omit<RoomMessage, 'timestamp' | 'retractedAt' | 'pollClosedAt' | 'replyTo'> {
-  /** Cache key used as the primary key in IndexedDB */
+  /** Cache key used as the primary key in IndexedDB — the canonical (highest-tier) identity key. */
   cacheKey: string
+  /** Every room-scoped identity tier this row is known under (see {@link roomIdentityKeys}). */
+  identityKeys: string[]
+  /** Every client-generated `id` this row has absorbed (a merged row may carry more than one). */
+  ids: string[]
   /** Timestamp as milliseconds since epoch for indexing */
   timestamp: number
   /** Retracted timestamp as milliseconds if message was retracted */
@@ -219,7 +199,9 @@ function deserializeMessage(stored: StoredMessage): Message {
 function serializeRoomMessage(message: RoomMessage): StoredRoomMessage {
   return {
     ...message,
-    cacheKey: getRoomMessageCacheKey(message),
+    cacheKey: roomCanonicalKey(message),
+    identityKeys: roomIdentityKeys(message),
+    ids: [message.id],
     timestamp: message.timestamp.getTime(),
     retractedAt: message.retractedAt?.getTime(),
     pollClosedAt: message.pollClosedAt?.getTime(),
@@ -261,6 +243,97 @@ function decryptionRank(msg: {
   if (msg.encryptedPayload) return 1
   if (msg.unsupportedEncryption) return 0
   return 2
+}
+
+function unionSorted(a: string[] = [], b: string[] = []): string[] { return [...new Set([...a, ...b])].sort() }
+function minStr(a?: string, b?: string): string | undefined { if (a == null) return b; if (b == null) return a; return a <= b ? a : b }
+function minNum(a?: number, b?: number): number | undefined { if (a == null) return b; if (b == null) return a; return Math.min(a, b) }
+function mergeReactions(a?: Record<string, string[]>, b?: Record<string, string[]>): Record<string, string[]> | undefined {
+  if (!a) return b; if (!b) return a
+  const out: Record<string, string[]> = {}
+  for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) out[k] = unionSorted(a[k], b[k])
+  return out
+}
+
+/** Deterministic, key-sorted serialization — a stable total order over any row. */
+function stableStringify(v: unknown): string {
+  // JSON.stringify(undefined) is `undefined`, not a string — return a token so the
+  // declared `string` return holds (undefined-valued fields do occur in the projection).
+  if (v === undefined) return '␀undefined'
+  if (v === null || typeof v !== 'object') return JSON.stringify(v)
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`
+  const o = v as Record<string, unknown>
+  return `{${Object.keys(o).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`).join(',')}}`
+}
+
+/**
+ * Choose the CONTENT-owner row by a strict TOTAL order, so the choice is the same
+ * regardless of argument order AND a tie happens only when the rows are identical.
+ * Higher decryption rank, then edited, then non-empty body, then — the fix — a
+ * full stable serialization, so two rows differing in attachment / poll / reply /
+ * encryption metadata still resolve deterministically instead of picking `a`.
+ */
+/**
+ * The IMMUTABLE content projection — everything EXCEPT the fields merged
+ * separately (aliases, timestamp, reactions, retraction, moderation, poll
+ * closure, delivery error, cacheKey). The tiebreak must serialize only this,
+ * because those excluded fields CHANGE during a merge: an intermediate merged
+ * row acquires unioned aliases/reactions and a min timestamp, so serializing the
+ * whole row would make contentOwner(merge(a,b), c) differ from
+ * contentOwner(a, merge(b,c)) — destroying associativity. The content projection
+ * is identical between a merged row and its content-winner, so max over it is
+ * genuinely associative.
+ */
+function contentProjection(m: StoredRoomMessage): unknown {
+  const {
+    stanzaId: _s, originId: _o, timestamp: _t, reactions: _r, identityKeys: _ik, ids: _ids,
+    isRetracted: _rt, retractedAt: _ra, isModerated: _m, moderatedBy: _mb, moderationReason: _mr,
+    pollClosed: _pc, pollClosedAt: _pca, deliveryError: _de, cacheKey: _ck, ...content
+  } = m
+  return content
+}
+
+function contentOwner(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+  const ra: number[] = [decryptionRank(a), a.isEdited ? 1 : 0, a.body ? 1 : 0]
+  const rb: number[] = [decryptionRank(b), b.isEdited ? 1 : 0, b.body ? 1 : 0]
+  for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) return ra[i] > rb[i] ? a : b
+  // Tiebreak over the IMMUTABLE content only, so max is associative (see contentProjection).
+  return stableStringify(contentProjection(a)) <= stableStringify(contentProjection(b)) ? a : b
+}
+
+/**
+ * Merge two stored rows that are the same logical room message into one.
+ * COMMUTATIVE and ASSOCIATIVE. The correlated content block comes from
+ * {@link contentOwner} (total order); every other field uses a symmetric operator,
+ * so no edit, poll closure, retraction, reaction, moderation, or alias is lost.
+ */
+export function mergeRoomRows(a: StoredRoomMessage, b: StoredRoomMessage): StoredRoomMessage {
+  const owner = contentOwner(a, b)
+  const aSid = a.stanzaId != null, bSid = b.stanzaId != null
+  const timestamp = aSid !== bSid ? (aSid ? a.timestamp : b.timestamp) : Math.min(a.timestamp, b.timestamp)
+  const retracted = !!(a.isRetracted || b.isRetracted)
+  const moderated = !!(a.isModerated || b.isModerated)
+  // Poll closure: symmetric even when both closed with different records.
+  const pollClosed = a.pollClosed && b.pollClosed
+    ? (stableStringify(a.pollClosed) <= stableStringify(b.pollClosed) ? a.pollClosed : b.pollClosed)
+    : (a.pollClosed ?? b.pollClosed)
+
+  const merged: StoredRoomMessage = {
+    ...owner,
+    stanzaId: minStr(a.stanzaId, b.stanzaId),
+    originId: minStr(a.originId, b.originId),
+    timestamp,
+    reactions: mergeReactions(a.reactions, b.reactions),
+    identityKeys: unionSorted(a.identityKeys, b.identityKeys),
+    ids: unionSorted(a.ids, b.ids),
+    deliveryError: a.deliveryError && b.deliveryError ? (stableStringify(a.deliveryError) <= stableStringify(b.deliveryError) ? a.deliveryError : b.deliveryError) : undefined,
+    ...(retracted ? { isRetracted: true, retractedAt: minNum(a.retractedAt, b.retractedAt) } : {}),
+    ...(moderated ? { isModerated: true, moderatedBy: minStr(a.moderatedBy, b.moderatedBy), moderationReason: minStr(a.moderationReason, b.moderationReason) } : {}),
+    ...(pollClosed ? { pollClosed, pollClosedAt: minNum(a.pollClosedAt, b.pollClosedAt) } : {}),
+  }
+  merged.cacheKey = roomCanonicalKey(merged)
+  merged.identityKeys = unionSorted(merged.identityKeys, roomIdentityKeys(merged))
+  return merged
 }
 
 /**
@@ -902,11 +975,11 @@ export async function getRoomMessagesAround(
     ...(after !== undefined ? { limit: after } : {}),
   })
 
-  // Dedupe by the same key the cache uses (room ids are not unique across senders).
+  // Dedupe by the same canonical identity key the cache uses (room ids are not unique across senders).
   const seen = new Set<string>()
   const merged: RoomMessage[] = []
   for (const m of [...olderAndAnchor, ...newer]) {
-    const key = getRoomMessageCacheKey(m)
+    const key = roomCanonicalKey(m)
     if (seen.has(key)) continue
     seen.add(key)
     merged.push(m)

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -81,7 +81,6 @@ interface MessageCacheSchema extends DBSchema {
     value: StoredRoomMessage
     indexes: {
       roomJid: string
-      stanzaId: string
       originId: string
       // multiEntry over identityKeys[] — the finder resolves every identity tier here.
       identityKeys: string
@@ -162,7 +161,10 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
       if (!db.objectStoreNames.contains(ROOM_MESSAGES_STORE)) {
         const s = db.createObjectStore(ROOM_MESSAGES_STORE, { keyPath: 'cacheKey' })
         s.createIndex('roomJid', 'roomJid', { unique: false })
-        s.createIndex('stanzaId', 'stanzaId', { unique: false })
+        // No unscoped `stanzaId` index: stanzaIds are assigned per-archive and repeat
+        // across rooms, so a scalar index on it would let a lookup cross rooms. Every
+        // stanzaId query goes through the room-scoped `identityKeys` alias instead
+        // (see roomStanzaKey / getRoomMessageByStanzaId / updateRoomMessageReactions).
         s.createIndex('originId', 'originId', { unique: false })
         s.createIndex('identityKeys', 'identityKeys', { unique: false, multiEntry: true })
         s.createIndex('ids', 'ids', { unique: false, multiEntry: true })
@@ -1204,11 +1206,12 @@ export async function updateRoomMessage(
 /**
  * Update reactions for a room message in IndexedDB.
  * Used as a fallback when the message is not currently loaded in memory.
- * Looks up by client ID or stanza-id (reactions may reference either).
+ * Looks up by client ID or room-scoped stanza-id (reactions may reference either).
  *
  * @returns true if the message was found and updated, false otherwise.
  */
 export async function updateRoomMessageReactions(
+  roomJid: string,
   messageId: string,
   reactorNick: string,
   emojis: string[],
@@ -1217,11 +1220,15 @@ export async function updateRoomMessageReactions(
     const db = await getDB(getStorageScopeJid())
 
     // Resolve via the `ids` multiEntry index (a merged row is findable by EVERY
-    // absorbed client id), then fall back to the stanzaId scalar index: a MUC
-    // reaction references the server stanza-id, which is not a client id in `ids`.
+    // absorbed client id), then fall back to the room-scoped `identityKeys` alias:
+    // a MUC reaction references the server stanza-id, which is not a client id in
+    // `ids`. stanzaIds are assigned per-archive and repeat across rooms, so an
+    // unscoped stanzaId lookup could resolve to a DIFFERENT room's message —
+    // scoping through roomStanzaKey confines it to this room (mirrors
+    // getRoomMessageByStanzaId).
     let existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', messageId)
     if (!existing) {
-      existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'stanzaId', messageId)
+      existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'identityKeys', roomStanzaKey(roomJid, messageId))
     }
     if (!existing) return false
 

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -11,7 +11,7 @@ import { openDB, type IDBPDatabase, type DBSchema } from 'idb'
 import type { Message, RoomMessage } from '../core/types'
 import { getStorageScopeJid } from './storageScope'
 import { isRenderableStoredMessage } from './messageRenderability'
-import { roomCanonicalKey, roomIdentityKeys } from './roomMessageIdentity'
+import { roomCanonicalKey, roomIdentityKeys, roomStanzaKey, roomOriginKey } from './roomMessageIdentity'
 
 const DB_NAME = 'fluux-message-cache'
 // v3: add a SPARSE index on `encryptedPayload` so deferred decryption can list
@@ -91,9 +91,6 @@ interface MessageCacheSchema extends DBSchema {
       room_timestamp: [string, number]
       // Stable room order key (roomJid, timestamp, from, id) for Task 4's read path.
       room_ts_from_id: [string, number, string, string]
-      // Kept single-`id` index so the by-id update/delete/reaction paths resolve
-      // unchanged until Task 4 migrates them to identity-resolution.
-      id: string
     }
   }
 }
@@ -172,7 +169,6 @@ function getDB(scopeJid: string | null = getStorageScopeJid()): Promise<IDBPData
         s.createIndex('timestamp', 'timestamp', { unique: false })
         s.createIndex('room_timestamp', ['roomJid', 'timestamp'], { unique: false })
         s.createIndex('room_ts_from_id', ['roomJid', 'timestamp', 'from', 'id'], { unique: false })
-        s.createIndex('id', 'id', { unique: false })
 
         // `as never`: the legacy store is not in the v4 schema, so idb's typed
         // objectStoreNames.contains() would reject its name — but it can still be
@@ -960,7 +956,11 @@ export async function saveRoomMessages(messages: RoomMessage[]): Promise<boolean
     const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
     const store = tx.objectStore(ROOM_MESSAGES_STORE)
 
-    await Promise.all(messages.map((msg) => store.put(serializeRoomMessage(msg))))
+    // Sequential, NOT Promise.all: each upsert resolves existing rows by identity
+    // and merges, so a same-batch optimistic+reflection pair must collapse into one
+    // row — the second upsert has to observe the first's write. Concurrent puts would
+    // each see an empty store and leave two rows.
+    for (const msg of messages) await upsertRoomRowByIdentity(store as never, msg)
     await tx.done
     return true
   } catch (error) {
@@ -992,14 +992,22 @@ export async function getRoomMessage(id: string): Promise<RoomMessage | null> {
 }
 
 /**
- * Get a room message by its stanzaId.
+ * Get a room message by its stanzaId, scoped to a room.
+ *
+ * stanzaIds are assigned per-archive and repeat across rooms, so the global
+ * `stanzaId` index could return a different room's message. Resolving through the
+ * room-scoped `identityKeys` alias ({@link roomStanzaKey}) confines the lookup to
+ * this room, and also finds a MERGED row (which carries the stanza tier in its
+ * `identityKeys[]` even when the survivor's own `stanzaId` scalar came from a
+ * different copy).
  */
 export async function getRoomMessageByStanzaId(
+  roomJid: string,
   stanzaId: string
 ): Promise<RoomMessage | null> {
   try {
     const db = await getDB(getStorageScopeJid())
-    const stored = await db.getFromIndex(ROOM_MESSAGES_STORE, 'stanzaId', stanzaId)
+    const stored = await db.getFromIndex(ROOM_MESSAGES_STORE, 'identityKeys', roomStanzaKey(roomJid, stanzaId))
     return stored ? deserializeRoomMessage(stored) : null
   } catch (error) {
     if (isIndexedDBAvailable()) {
@@ -1085,7 +1093,7 @@ export async function getRoomMessagesAround(
   const { before = 50, after } = options
 
   let anchor = await getRoomMessage(anchorMessageId)
-  if (!anchor) anchor = await getRoomMessageByStanzaId(anchorMessageId)
+  if (!anchor) anchor = await getRoomMessageByStanzaId(roomJid, anchorMessageId)
   if (!anchor) return []
 
   const t = anchor.timestamp.getTime()
@@ -1129,8 +1137,17 @@ export async function getRoomMessageCount(roomJid: string): Promise<number> {
 }
 
 /**
- * Update specific fields of a room message.
- * Note: Looks up by client-generated ID using the id index.
+ * Update specific fields of a room message, resolving the row through the `ids`
+ * alias index so a caller holding a pre-merge id still finds it.
+ *
+ * When an update carries an identity FIELD it splits two ways:
+ *   - Expansion (a new stanzaId/originId, or a changed id) — the existing row's
+ *     accumulated aliases are unioned into the updated row, then it is re-keyed
+ *     and any OTHER row already at the new identity tier is merged in.
+ *   - Revocation ({ stanzaId: undefined }, as clearMessageStanzaId sends) — the
+ *     cleared tier's scoped alias is REMOVED from identityKeys, so a later message
+ *     carrying that stanzaId no longer resolves to this row and is not wrongly
+ *     merged in.
  */
 export async function updateRoomMessage(
   id: string,
@@ -1138,30 +1155,45 @@ export async function updateRoomMessage(
 ): Promise<void> {
   try {
     const db = await getDB(getStorageScopeJid())
-    // Look up by id index since primary key is now cacheKey
-    const existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'id', id)
-    if (!existing) return
+    const tx = db.transaction(ROOM_MESSAGES_STORE, 'readwrite')
+    const store = tx.objectStore(ROOM_MESSAGES_STORE)
+    const existing = await store.index('ids').get(id)
+    if (!existing) { await tx.done; return }
+    const updated = { ...deserializeRoomMessage(existing), ...updates } as RoomMessage
+    // Compare identity FIELDS, not just the canonical key: adding an originId to a
+    // row that already has a stanzaId (or changing the id) leaves the canonical key
+    // unchanged yet still expands the identity — a row now matching the new tier must
+    // be merged in. Key-only comparison would take the non-identity branch and miss it.
+    const identityChanged =
+      updated.id !== existing.id ||
+      updated.from !== existing.from ||
+      updated.roomJid !== existing.roomJid ||
+      updated.stanzaId !== existing.stanzaId ||
+      updated.originId !== existing.originId
+    if (!identityChanged) {
+      const row = serializeRoomMessage(updated)
+      row.identityKeys = existing.identityKeys // unchanged
+      row.ids = existing.ids
+      await store.put(row)
+    } else {
+      // An identity field changed. Union the existing row's accumulated aliases in
+      // (do NOT delete-then-upsert — a deleted row cannot be rediscovered, and
+      // re-serialization resets ids/identityKeys). But a REVOCATION ({ stanzaId:
+      // undefined }) must REMOVE the cleared scoped alias, not union it back:
+      const revoked: string[] = []
+      if ('stanzaId' in updates && updated.stanzaId == null && existing.stanzaId) revoked.push(roomStanzaKey(existing.roomJid, existing.stanzaId))
+      if ('originId' in updates && updated.originId == null && existing.originId) revoked.push(roomOriginKey(existing.roomJid, existing.originId))
 
-    const updated = {
-      ...existing,
-      ...updates,
-      // Preserve the cacheKey - it must match the original
-      cacheKey: existing.cacheKey,
-      timestamp:
-        updates.timestamp instanceof Date
-          ? updates.timestamp.getTime()
-          : existing.timestamp,
-      retractedAt:
-        updates.retractedAt instanceof Date
-          ? updates.retractedAt.getTime()
-          : updates.retractedAt ?? existing.retractedAt,
-      pollClosedAt:
-        updates.pollClosedAt instanceof Date
-          ? updates.pollClosedAt.getTime()
-          : updates.pollClosedAt ?? existing.pollClosedAt,
+      const row = serializeRoomMessage(updated) // ids=[updated.id]; identityKeys reflect current fields (a revoked tier is already absent)
+      row.ids = unionSorted(existing.ids, row.ids)
+      row.identityKeys = unionSorted(existing.identityKeys, row.identityKeys).filter((k) => !revoked.includes(k))
+      // excludeKey = old cacheKey: overwrites when the canonical key is unchanged,
+      // re-keys + deletes the stale row when it changed; either way the pre-update
+      // copy is not merged back in. The finder uses row.identityKeys (revoked tier
+      // absent), so a row legitimately still carrying that stanzaId is NOT pulled in.
+      await upsertStoredRoomRow(store as never, row, existing.cacheKey)
     }
-
-    await db.put(ROOM_MESSAGES_STORE, updated)
+    await tx.done
   } catch (error) {
     if (isIndexedDBAvailable()) {
       console.warn('Failed to update room message:', error)
@@ -1184,8 +1216,10 @@ export async function updateRoomMessageReactions(
   try {
     const db = await getDB(getStorageScopeJid())
 
-    // Try by id index first, then by stanzaId index
-    let existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'id', messageId)
+    // Resolve via the `ids` multiEntry index (a merged row is findable by EVERY
+    // absorbed client id), then fall back to the stanzaId scalar index: a MUC
+    // reaction references the server stanza-id, which is not a client id in `ids`.
+    let existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', messageId)
     if (!existing) {
       existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'stanzaId', messageId)
     }
@@ -1208,6 +1242,9 @@ export async function updateRoomMessageReactions(
       newReactions[emoji].push(reactorNick)
     }
 
+    // Authoritative: apply the change to the found row and put under its OWN
+    // cacheKey — never route through mergeRoomRows, whose reaction-union would
+    // resurrect a reactor this call just removed.
     const updated = {
       ...existing,
       reactions: Object.keys(newReactions).length > 0 ? newReactions : undefined,
@@ -1225,13 +1262,14 @@ export async function updateRoomMessageReactions(
 
 /**
  * Delete a room message by ID.
- * Note: Looks up by client-generated ID using the id index, then deletes by cacheKey.
+ * Resolves the row through the `ids` alias index (so a pre-merge id still finds a
+ * merged row), then deletes by its cacheKey (the primary key).
  */
 export async function deleteRoomMessage(id: string): Promise<void> {
   try {
     const db = await getDB(getStorageScopeJid())
-    // Look up by id index to find the cacheKey
-    const existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'id', id)
+    // Resolve via the `ids` multiEntry index to find the cacheKey.
+    const existing = await db.getFromIndex(ROOM_MESSAGES_STORE, 'ids', id)
     if (!existing) return
     // Delete using the cacheKey (the actual primary key)
     await db.delete(ROOM_MESSAGES_STORE, existing.cacheKey)

--- a/packages/fluux-sdk/src/utils/roomMessageIdentity.test.ts
+++ b/packages/fluux-sdk/src/utils/roomMessageIdentity.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { roomIdentityKeys, roomCanonicalKey } from './roomMessageIdentity'
+
+const base = { roomJid: 'r@c', from: 'r@c/alice', id: 'origin-1' }
+const NUL = '\u0000'
+
+describe('roomIdentityKeys', () => {
+  it('returns all tiers most-specific first, each room-scoped', () => {
+    expect(roomIdentityKeys({ ...base, stanzaId: 'S', originId: 'O' })).toEqual([
+      `room${NUL}r@c${NUL}stanzaId${NUL}S`,
+      `room${NUL}r@c${NUL}originId${NUL}O`,
+      `room${NUL}r@c${NUL}from${NUL}r@c/alice${NUL}id${NUL}origin-1`,
+    ])
+  })
+  it('always includes the from+id fallback tier', () => {
+    expect(roomIdentityKeys(base)).toEqual([`room${NUL}r@c${NUL}from${NUL}r@c/alice${NUL}id${NUL}origin-1`])
+  })
+  // Control: an unscoped implementation (no room: prefix) fails this — two rooms
+  // sharing a stanzaId would then collide in the identityKeys index.
+  it('scopes stanzaId by room, so equal values in different rooms differ', () => {
+    const a = roomIdentityKeys({ roomJid: 'A@c', from: 'A@c/x', id: 'i', stanzaId: '1' })[0]
+    const b = roomIdentityKeys({ roomJid: 'B@c', from: 'B@c/x', id: 'i', stanzaId: '1' })[0]
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('roomCanonicalKey', () => {
+  it('prefers stanzaId', () => { expect(roomCanonicalKey({ ...base, stanzaId: 'S', originId: 'O' })).toBe(`room${NUL}r@c${NUL}stanzaId${NUL}S`) })
+  it('falls back to originId', () => { expect(roomCanonicalKey({ ...base, originId: 'O' })).toBe(`room${NUL}r@c${NUL}originId${NUL}O`) })
+  it('falls back to from+id', () => { expect(roomCanonicalKey(base)).toBe(`room${NUL}r@c${NUL}from${NUL}r@c/alice${NUL}id${NUL}origin-1`) })
+  it('is always the first identity key', () => { const m = { ...base, stanzaId: 'S' }; expect(roomCanonicalKey(m)).toBe(roomIdentityKeys(m)[0]) })
+})

--- a/packages/fluux-sdk/src/utils/roomMessageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/roomMessageIdentity.ts
@@ -1,0 +1,41 @@
+/**
+ * The one definition of a room message's identity (XEP-0359), shared by the
+ * resident-window dedup (`roomStore.getRoomMessageKeys`) and the message cache.
+ * One logical message appears as several stanzas (optimistic echo, MUC reflection,
+ * MAM copy) with no single stable field. They are matched through a tiered
+ * identity, most-specific first: stanzaId, then originId, then from+id. Two copies
+ * are the same logical message iff they share ANY of these keys.
+ */
+export interface RoomIdentityFields {
+  roomJid: string
+  from: string
+  id: string
+  stanzaId?: string
+  originId?: string
+}
+
+// U+0000 separator: JIDs/ids/stanzaIds cannot contain it, so joins never collide.
+const S = '\u0000'
+
+/**
+ * Room-scope a tier key. stanzaId/originId are assigned per-archive and can repeat
+ * across rooms; the identityKeys index spans the whole store, so an unscoped key
+ * would let the finder merge messages from different rooms.
+ */
+function scoped(roomJid: string, tier: string): string {
+  return `room${S}${roomJid}${S}${tier}`
+}
+
+/** Every identity key the message carries, most-specific first. For matching. */
+export function roomIdentityKeys(m: RoomIdentityFields): string[] {
+  const keys: string[] = []
+  if (m.stanzaId) keys.push(scoped(m.roomJid, `stanzaId${S}${m.stanzaId}`))
+  if (m.originId) keys.push(scoped(m.roomJid, `originId${S}${m.originId}`))
+  keys.push(scoped(m.roomJid, `from${S}${m.from}${S}id${S}${m.id}`))
+  return keys
+}
+
+/** The single canonical key — the highest tier present. For the primary key. */
+export function roomCanonicalKey(m: RoomIdentityFields): string {
+  return roomIdentityKeys(m)[0]
+}

--- a/packages/fluux-sdk/src/utils/roomMessageIdentity.ts
+++ b/packages/fluux-sdk/src/utils/roomMessageIdentity.ts
@@ -39,3 +39,18 @@ export function roomIdentityKeys(m: RoomIdentityFields): string[] {
 export function roomCanonicalKey(m: RoomIdentityFields): string {
   return roomIdentityKeys(m)[0]
 }
+
+/**
+ * The room-scoped stanzaId identity key — the single tier a stanzaId contributes.
+ * Used by getRoomMessageByStanzaId (room-scoped lookup) and by updateRoomMessage
+ * revocation (removing the cleared alias). Matches the key roomIdentityKeys emits
+ * for the same stanzaId, so the two always agree.
+ */
+export function roomStanzaKey(roomJid: string, stanzaId: string): string {
+  return scoped(roomJid, `stanzaId${S}${stanzaId}`)
+}
+
+/** The room-scoped originId identity key (for revocation). Mirrors {@link roomStanzaKey}. */
+export function roomOriginKey(roomJid: string, originId: string): string {
+  return scoped(roomJid, `originId${S}${originId}`)
+}


### PR DESCRIPTION
Precursor to PR B of the read-state model consolidation (#1081). PR B derives unread counts from the room archive, which requires a stable one-row-per-message cache. Today room cache keys are unstable — a MUC rewrites the client `id` on echo, and stanza/origin ids collide across rooms — so an optimistic copy and its reflection can land as two rows. This PR makes "one logical message = one cache row" a structural guarantee.

## What changed

- **One identity definition** (`roomMessageIdentity.ts`): room-scoped XEP-0359 tier keys (stanzaId → originId → from+id), most-specific-first. Room-scoping prevents cross-room merges (ids are assigned per-archive).
- **Total-order commutative + associative merge** (`mergeRoomRows`): content owner chosen by a total order ending in a stable serialization of an *immutable content projection* (not the whole row, whose merged fields change during merge and would break associativity). Symmetric operators throughout (min-of-defined, OR, sorted set-union, stanza-preferring timestamp).
- **Identity-resolving upsert** shared by live writes and migration: an incoming row merges into any existing row sharing any alias. `identityKeys[]` + `ids[]` multiEntry indexes keep every alias resolvable after a merge; identity updates distinguish expansion (union aliases) from revocation (`clearMessageStanzaId` removes the scoped alias).
- **Schema v4** with an atomic streaming migration from the legacy room store, explicit abort on any per-row failure (rolls back to v3).
- All room write/read/mutation paths (`getRoomMessage`, update, delete, reactions, `getRoomMessageByStanzaId`) routed through the identity model; unused scalar `id`/`stanzaId`/`originId` room-store indexes dropped.

## Pre-merge gate

**Manual real-browser smoke test of the v4 version-change migration is required before merge.** `fake-indexeddb` validates the abort/rollback path but cannot prove the auto-commit timing of a real version-change transaction (cursor over the legacy store interleaved with put/delete into the canonical store).
