### PR TITLE
Fix XMPP URI handler registration on Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,11 @@ jobs:
             librsvg2-dev \
             patchelf \
             libxss-dev \
-            libdbus-1-dev
+            libdbus-1-dev \
+            desktop-file-utils
+
+      - name: Validate Linux packaging metadata
+        run: bash scripts/check-linux-packaging.sh
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,8 @@ jobs:
             patchelf \
             libxss-dev \
             devscripts \
-            debhelper
+            debhelper \
+            desktop-file-utils
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -476,7 +477,8 @@ jobs:
             librsvg2-dev \
             patchelf \
             libxss-dev \
-            rpm
+            rpm \
+            desktop-file-utils
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -561,7 +563,13 @@ jobs:
           sed -i "s/^Release:.*/Release:        ${RPM_RELEASE}%{?dist}/" ~/rpmbuild/SPECS/fluux-messenger.spec
 
           # Build RPM
-          rpmbuild -bb ~/rpmbuild/SPECS/fluux-messenger.spec --target ${{ matrix.rpm_arch }}
+          # The RPM is assembled on Ubuntu from a pre-built binary. APT has
+          # installed desktop-file-utils above so %install can validate the
+          # desktop entry; --nodeps only skips RPM-database BuildRequires
+          # resolution, which cannot see Debian packages.
+          rpmbuild -bb ~/rpmbuild/SPECS/fluux-messenger.spec \
+            --target ${{ matrix.rpm_arch }} \
+            --nodeps
 
           # Move RPM to dist
           mkdir -p dist

--- a/apps/fluux/src-tauri/src/linux_deep_link.rs
+++ b/apps/fluux/src-tauri/src/linux_deep_link.rs
@@ -1,0 +1,156 @@
+//! Linux deep-link registration policy.
+//!
+//! Installed packages already export a canonical desktop entry advertising
+//! `x-scheme-handler/xmpp`. Registering again at application startup would
+//! create a second user-local desktop entry and run `xdg-mime default`, which
+//! can silently replace another XMPP client's user-selected association.
+//!
+//! Runtime registration remains useful for development and portable builds
+//! (including AppImages), where no package manager installed a desktop entry.
+
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+const DESKTOP_ENTRY_NAMES: [&str; 2] = ["fluux-messenger.desktop", "com.processone.fluux.desktop"];
+const XMPP_SCHEME_HANDLER: &str = "x-scheme-handler/xmpp";
+
+/// Pure decision boundary for runtime deep-link registration.
+///
+/// Debug and AppImage builds must register so links target the current
+/// executable. Flatpak and package-managed installs rely on their exported
+/// desktop entry. An otherwise unintegrated release binary is treated as a
+/// portable build and self-registers.
+pub fn should_register_at_runtime(
+    debug_build: bool,
+    appimage: bool,
+    flatpak: bool,
+    packaged_desktop_entry: bool,
+) -> bool {
+    debug_build || appimage || (!flatpak && !packaged_desktop_entry)
+}
+
+/// Returns whether this Linux process should create/update a user-local
+/// deep-link handler.
+#[cfg(target_os = "linux")]
+pub fn should_register_current_process(appimage: bool) -> bool {
+    should_register_at_runtime(
+        cfg!(debug_assertions),
+        appimage,
+        is_flatpak(),
+        packaged_desktop_entry_installed(),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn is_flatpak() -> bool {
+    std::env::var_os("FLATPAK_ID").is_some() || Path::new("/.flatpak-info").is_file()
+}
+
+#[cfg(target_os = "linux")]
+fn packaged_desktop_entry_installed() -> bool {
+    application_data_dirs().iter().any(|data_dir| {
+        DESKTOP_ENTRY_NAMES.iter().any(|name| {
+            let path = data_dir.join("applications").join(name);
+            std::fs::read_to_string(path)
+                .map(|contents| desktop_entry_supports_xmpp(&contents))
+                .unwrap_or(false)
+        })
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn application_data_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    if let Some(data_home) = std::env::var_os("XDG_DATA_HOME") {
+        dirs.push(PathBuf::from(data_home));
+    } else if let Some(home) = std::env::var_os("HOME") {
+        dirs.push(PathBuf::from(home).join(".local/share"));
+    }
+
+    if let Some(data_dirs) = std::env::var_os("XDG_DATA_DIRS") {
+        dirs.extend(std::env::split_paths(&data_dirs));
+    } else {
+        dirs.push(PathBuf::from("/usr/local/share"));
+        dirs.push(PathBuf::from("/usr/share"));
+    }
+
+    // The Flatpak desktop entry is installed inside /app and exported to the
+    // host by Flatpak. Keeping it in the search list also makes detection work
+    // in stripped-down test/container environments without FLATPAK_ID.
+    dirs.push(PathBuf::from("/app/share"));
+    dirs
+}
+
+fn desktop_entry_supports_xmpp(contents: &str) -> bool {
+    let mut handles_xmpp = false;
+    let mut accepts_uri = false;
+
+    for line in contents.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "MimeType" => {
+                handles_xmpp = value
+                    .split(';')
+                    .any(|mime_type| mime_type.trim() == XMPP_SCHEME_HANDLER);
+            }
+            "Exec" => {
+                accepts_uri = value
+                    .split_whitespace()
+                    .any(|arg| arg == "%u" || arg == "%U");
+            }
+            _ => {}
+        }
+    }
+
+    handles_xmpp && accepts_uri
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_and_appimage_builds_always_register() {
+        assert!(should_register_at_runtime(true, false, true, true));
+        assert!(should_register_at_runtime(false, true, true, true));
+    }
+
+    #[test]
+    fn packaged_and_flatpak_builds_do_not_replace_the_user_default() {
+        assert!(!should_register_at_runtime(false, false, false, true));
+        assert!(!should_register_at_runtime(false, false, true, false));
+    }
+
+    #[test]
+    fn unintegrated_release_binary_is_treated_as_portable() {
+        assert!(should_register_at_runtime(false, false, false, false));
+    }
+
+    #[test]
+    fn recognizes_xmpp_among_multiple_mime_types() {
+        assert!(desktop_entry_supports_xmpp(
+            "Exec=fluux-messenger %u\nMimeType=text/plain;x-scheme-handler/xmpp;\n"
+        ));
+        assert!(!desktop_entry_supports_xmpp(
+            "Exec=fluux-messenger %u\nMimeType=x-scheme-handler/mailto;\n"
+        ));
+    }
+
+    #[test]
+    fn rejects_handler_that_cannot_receive_a_uri() {
+        assert!(!desktop_entry_supports_xmpp(
+            "Exec=fluux-messenger\nMimeType=x-scheme-handler/xmpp;\n"
+        ));
+    }
+
+    #[test]
+    fn ignores_comments_and_similar_keys() {
+        assert!(!desktop_entry_supports_xmpp(
+            "Exec=fluux-messenger %u\n# MimeType=x-scheme-handler/xmpp;\nX-MimeType=x-scheme-handler/xmpp;\n"
+        ));
+    }
+}

--- a/apps/fluux/src-tauri/src/main.rs
+++ b/apps/fluux/src-tauri/src/main.rs
@@ -191,7 +191,7 @@ use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 };
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", all(debug_assertions, target_os = "windows")))]
 use tauri_plugin_deep_link::DeepLinkExt;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use tauri_plugin_opener::OpenerExt;
@@ -204,6 +204,12 @@ mod openpgp_backup;
 mod openpgp_storage;
 mod notifications;
 mod mcp;
+
+// Runtime deep-link registration is only required for Linux development and
+// portable distributions; package-managed installs export a canonical desktop
+// entry instead. The pure policy is compiled in tests on every platform.
+#[cfg(any(target_os = "linux", test))]
+mod linux_deep_link;
 
 // Linux tray-functionality detection (pure combiner compiled everywhere; the
 // DBus probe inside is Linux-only).
@@ -1787,16 +1793,37 @@ fn main() {
                 });
             }
 
-            // Register xmpp: URI scheme for deep linking (RFC 5122)
-            // This allows the app to open when users click xmpp: links
-            // On macOS, URI schemes are registered via Info.plist at build time
-            // (configured in tauri.conf.json), so runtime registration is only
-            // needed on Linux and Windows.
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            // Ensure the statically configured xmpp: URI scheme (RFC 5122) is
+            // available when the app was not installed through a platform
+            // bundle. Windows installers own the production association; only
+            // debug builds register the current executable at runtime. Linux
+            // package/Flatpak installs export a canonical desktop entry, while
+            // development and portable/AppImage builds self-register.
+            #[cfg(any(
+                target_os = "linux",
+                all(debug_assertions, target_os = "windows")
+            ))]
             {
-                match app.deep_link().register("xmpp") {
-                    Ok(_) => tracing::info!("Deep link: registered xmpp: URI scheme"),
-                    Err(e) => tracing::warn!("Deep link: failed to register xmpp: URI scheme: {}", e),
+                #[cfg(target_os = "linux")]
+                let should_register =
+                    linux_deep_link::should_register_current_process(app.env().appimage.is_some());
+                #[cfg(all(debug_assertions, target_os = "windows"))]
+                let should_register = true;
+
+                if should_register {
+                    match app.deep_link().register_all() {
+                        Ok(_) => tracing::info!("Deep link: registered configured URI schemes"),
+                        Err(e) => {
+                            tracing::warn!(
+                                "Deep link: failed to register configured URI schemes: {}",
+                                e
+                            )
+                        }
+                    }
+                } else {
+                    tracing::info!(
+                        "Deep link: using the xmpp: handler exported by the Linux package"
+                    );
                 }
             }
 

--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -92,14 +92,18 @@
         "depends": [
           "libwebkit2gtk-4.1-0",
           "libgtk-3-0",
-          "libayatana-appindicator3-1"
+          "libayatana-appindicator3-1",
+          "xdg-utils",
+          "desktop-file-utils"
         ]
       },
       "rpm": {
         "depends": [
           "webkit2gtk4.1",
           "gtk3",
-          "libayatana-appindicator-gtk3"
+          "libayatana-appindicator-gtk3",
+          "xdg-utils",
+          "desktop-file-utils"
         ]
       }
     }

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -11,9 +11,8 @@ depends=(
     'gtk3'
     'glib2'
     'libayatana-appindicator'
-)
-optdepends=(
-    'xdg-utils: for opening URLs'
+    'xdg-utils'
+    'desktop-file-utils'
 )
 provides=('fluux-messenger')
 conflicts=('fluux-messenger')

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,7 +12,8 @@ Build-Depends: debhelper-compat (= 13),
                libayatana-appindicator3-dev,
                librsvg2-dev,
                libssl-dev,
-               pkg-config
+               pkg-config,
+               desktop-file-utils
 Standards-Version: 4.6.2
 Homepage: https://github.com/processone/fluux-messenger
 Vcs-Git: https://github.com/processone/fluux-messenger.git
@@ -25,7 +26,9 @@ Depends: ${misc:Depends},
          libwebkit2gtk-4.1-0,
          libgtk-3-0 | libgtk-3-0t64,
          libglib2.0-0 | libglib2.0-0t64,
-         libayatana-appindicator3-1
+         libayatana-appindicator3-1,
+         xdg-utils,
+         desktop-file-utils
 Description: Modern XMPP desktop client
  Fluux Messenger is a modern, user-friendly XMPP chat client built with
  Tauri and React. It provides a clean interface for real-time messaging

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -34,6 +34,8 @@ override_dh_auto_install:
 	# Install desktop file
 	install -Dm644 debian/fluux-messenger.desktop \
 		$(CURDIR)/debian/fluux-messenger/usr/share/applications/fluux-messenger.desktop
+	desktop-file-validate \
+		$(CURDIR)/debian/fluux-messenger/usr/share/applications/fluux-messenger.desktop
 	# Install icons
 	install -Dm644 apps/fluux/src-tauri/icons/32x32.png \
 		$(CURDIR)/debian/fluux-messenger/usr/share/icons/hicolor/32x32/apps/fluux-messenger.png

--- a/packaging/rpm/fluux-messenger.spec
+++ b/packaging/rpm/fluux-messenger.spec
@@ -7,11 +7,15 @@ License:        AGPL-3.0-or-later
 URL:            https://github.com/processone/fluux-messenger
 Source0:        fluux-messenger-%{version}.tar.gz
 
+BuildRequires:  desktop-file-utils
+
 # Runtime dependencies
 Requires:       webkit2gtk4.1
 Requires:       gtk3
 Requires:       glib2
 Requires:       libayatana-appindicator-gtk3
+Requires:       xdg-utils
+Requires:       desktop-file-utils
 
 # Disable automatic dependency generation (we use pre-built binary)
 AutoReqProv:    no
@@ -41,6 +45,7 @@ install -Dm755 fluux-messenger %{buildroot}%{_bindir}/fluux-messenger
 
 # Install desktop file
 install -Dm644 fluux-messenger.desktop %{buildroot}%{_datadir}/applications/fluux-messenger.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/fluux-messenger.desktop
 
 # Install icons
 install -Dm644 icons/32x32.png %{buildroot}%{_datadir}/icons/hicolor/32x32/apps/fluux-messenger.png

--- a/scripts/check-linux-packaging.sh
+++ b/scripts/check-linux-packaging.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Validate the Linux desktop integration shared by Debian, RPM, AUR, Flatpak,
+# and portable release artifacts.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESKTOP_FILE="$ROOT_DIR/packaging/debian/fluux-messenger.desktop"
+
+fail() {
+    echo "Linux packaging check failed: $*" >&2
+    exit 1
+}
+
+require_literal() {
+    local file="$1"
+    local text="$2"
+    grep -Fq -- "$text" "$file" || fail "$file does not contain: $text"
+}
+
+command -v desktop-file-validate >/dev/null 2>&1 \
+    || fail "desktop-file-validate is missing (install desktop-file-utils)"
+
+desktop-file-validate "$DESKTOP_FILE"
+require_literal "$DESKTOP_FILE" "Exec=fluux-messenger %u"
+require_literal "$DESKTOP_FILE" "MimeType=x-scheme-handler/xmpp;"
+
+require_literal "$ROOT_DIR/packaging/debian/control" "         xdg-utils,"
+require_literal "$ROOT_DIR/packaging/debian/control" "         desktop-file-utils"
+require_literal "$ROOT_DIR/packaging/debian/control" "               desktop-file-utils"
+require_literal "$ROOT_DIR/packaging/debian/rules" "desktop-file-validate"
+
+require_literal "$ROOT_DIR/packaging/rpm/fluux-messenger.spec" "BuildRequires:  desktop-file-utils"
+require_literal "$ROOT_DIR/packaging/rpm/fluux-messenger.spec" "Requires:       xdg-utils"
+require_literal "$ROOT_DIR/packaging/rpm/fluux-messenger.spec" "Requires:       desktop-file-utils"
+require_literal "$ROOT_DIR/packaging/rpm/fluux-messenger.spec" \
+    "desktop-file-validate %{buildroot}%{_datadir}/applications/fluux-messenger.desktop"
+
+require_literal "$ROOT_DIR/packaging/aur/PKGBUILD" "    'xdg-utils'"
+require_literal "$ROOT_DIR/packaging/aur/PKGBUILD" "    'desktop-file-utils'"
+
+require_literal "$ROOT_DIR/packaging/flatpak/com.processone.fluux.yaml" \
+    "/app/share/applications/com.processone.fluux.desktop"
+
+require_literal "$ROOT_DIR/apps/fluux/src-tauri/tauri.conf.json" '"xdg-utils"'
+require_literal "$ROOT_DIR/apps/fluux/src-tauri/tauri.conf.json" '"desktop-file-utils"'
+
+echo "Linux packaging metadata is consistent."

--- a/scripts/test-deb-build.sh
+++ b/scripts/test-deb-build.sh
@@ -26,7 +26,8 @@ sudo apt-get install -y \
     librsvg2-dev \
     libssl-dev \
     pkg-config \
-    patchelf
+    patchelf \
+    desktop-file-utils
 
 # Check for Node.js
 if ! command -v node &> /dev/null; then


### PR DESCRIPTION
## Summary

- let Windows installers own the production `xmpp:` URI association while keeping runtime registration for debug builds
- avoid overwriting the user's Linux XMPP handler for package-managed and Flatpak installs, while retaining runtime integration for development, AppImage, and portable builds
- align Debian, RPM, and AUR dependencies and validate the desktop entry in CI and release builds

## Root cause

The URI scheme was declared in the bundle configuration and also force-registered on every application launch. On Windows, that could associate `xmpp:` with a development or otherwise transient executable instead of the installed application.

On Linux, unconditional runtime registration could create a second user-local desktop entry and make it the default even though the system package or Flatpak already exported the canonical handler. In addition, the release workflow assembles Linux packages after a `--no-bundle` build, so dependency declarations in `tauri.conf.json` alone did not reach every produced artifact.