### PR TITLE
refactor(scroll): migrate unread marker positioning to controller

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.fab.test.tsx
@@ -536,7 +536,9 @@ describe('MessageList FAB badge and scroll behavior', () => {
         Object.defineProperty(markerElement, 'offsetTop', { value: 800, configurable: true })
       }
 
-      simulateScrollUp(scrollCtx.container)
+      act(() => {
+        scrollCtx.container.dispatchEvent(new Event('scroll'))
+      })
 
       const fab = scrollCtx.container.parentElement?.querySelector('button[aria-label="chat.scrollToBottom"]') as HTMLButtonElement
       if (!fab) return
@@ -544,16 +546,10 @@ describe('MessageList FAB badge and scroll behavior', () => {
       act(() => { fireEvent.click(fab) })
 
       if (markerElement) {
-        // Should scroll to marker position (offsetTop - viewport/3 = 800 - 500/3 ≈ 633)
-        expect(scrollCtx.scrollToSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            top: expect.any(Number),
-            behavior: 'smooth',
-          })
-        )
-        // First call should NOT be to bottom
-        const firstCallTop = scrollCtx.scrollToSpy.mock.calls[0]?.[0]?.top
-        expect(firstCallTop).not.toBe(2000)
+        // Controller-owned convergence uses immediate writes so each frame observes the actual
+        // landing instead of repeatedly restarting a native smooth animation.
+        expect(scrollCtx.getScrollTop()).toBeCloseTo(800 - 500 / 3, 0)
+        expect(scrollCtx.scrollToSpy).not.toHaveBeenCalled()
       }
     })
 

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -9,8 +9,8 @@
  * `querySelector('[data-message-id]')` never finds it and the jump silently no-ops. jsdom
  * has no layout, so the pixel positioning is verified on a real engine; here we pin the
  * integration CONTRACTS that have no other automated guard:
- *  - unread-marker and scroll-to-bottom call `ensureMessageMounted(id)` to bring an
- *    off-window row in; targetMessageId jumps use getIndexForMessageId + scrollToIndex directly;
+ *  - unread-marker entry and the FAB marker-first leg route through the positioning controller,
+ *    whose executor uses getIndexForMessageId + scrollToIndex directly for an off-window row;
  *  - the MAM prepend restore reads the anchor offset from the VIRTUALIZER
  *    (`getOffsetForMessageId`), not `querySelector(anchor).offsetTop` — the anchor is
  *    windowed out on prepend, so the DOM read returns null and the old code fell back to
@@ -18,7 +18,7 @@
  */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, fireEvent, act } from '@testing-library/react'
+import { render, fireEvent, act, waitFor } from '@testing-library/react'
 import { MessageList, type MessageListProps } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
 import { scrollStateManager } from '@/utils/scrollStateManager'
@@ -33,6 +33,7 @@ const scrollToOffsetCalls: number[] = []
 // scrollToIndex(last,'end') (re-windows the virtualizer); a raw scrollTop write does not.
 // Lets a test prove the composer-resize correction routes through the virtualizer.
 const scrollToIndexCalls: Array<string | undefined> = []
+const scrollToIndexBehaviors: Array<ScrollBehavior | undefined> = []
 const scrollToIndexStartOffsets: number[] = []
 // Keys the fake virtualizer treats as OUTSIDE the mounted window: getVirtualItems() omits them (so
 // the restore's fraction-refine finds no measured size and must mount the row first via
@@ -82,8 +83,12 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
       const el = args.scrollRef.current
       if (el) el.scrollTop = offset
     },
-    scrollToIndex: (_index: number, opts?: { align?: string }) => {
+    scrollToIndex: (
+      _index: number,
+      opts?: { align?: string; behavior?: ScrollBehavior },
+    ) => {
       scrollToIndexCalls.push(opts?.align)
+      scrollToIndexBehaviors.push(opts?.behavior)
       // Mounting a windowed-out row: scrollToIndex windows it into the measured set.
       const mountedKey = args.items[_index]?.key
       if (mountedKey) windowedOutKeys.delete(mountedKey)
@@ -137,7 +142,7 @@ function renderList(props: Partial<MessageListProps<BaseMessage>> = {}) {
   )
 }
 
-describe('MessageList — virtualized scroll integration (ensureMessageMounted)', () => {
+describe('MessageList — virtualized scroll integration', () => {
   beforeEach(() => {
     localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
     // jsdom doesn't implement Element.scrollTo; the scroll-to-bottom path calls it.
@@ -147,15 +152,18 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     getOffsetForMessageId.mockClear()
     getOffsetForMessageId.mockImplementation(() => 0)
     scrollToIndexCalls.length = 0
+    scrollToIndexBehaviors.length = 0
     scrollToOffsetCalls.length = 0
     scrollToIndexStartOffsets.length = 0
     windowedOutKeys.clear()
   })
   afterEach(() => localStorage.clear())
 
-  it('brings the unread-marker row into the window on conversation entry', () => {
+  it('positions the unread-marker row through the controller on conversation entry', async () => {
+    getOffsetForMessageId.mockImplementation((id) => (id === 'msg-40' ? 1600 : null))
     renderList({ firstNewMessageId: 'msg-40' })
-    expect(ensureMessageMounted).toHaveBeenCalledWith('msg-40')
+    await waitFor(() => expect(scrollToIndexCalls).toContain('start'))
+    expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-40')
   })
 
   it('centers the target row via scrollToIndex when a targetMessageId is set (reply / search jump)', () => {
@@ -173,12 +181,14 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-30')
   })
 
-  it('scrolls to the marker row via scrollToIndex when FAB is clicked with an unread marker', () => {
+  it('scrolls to the marker row via scrollToIndex when FAB is clicked with an unread marker', async () => {
     // FAB previously used ensureMessageMounted + querySelector + offsetTop (which fails when the
-    // marker is windowed out). New path: getIndexForMessageId + scrollToIndex('start', smooth),
-    // no DOM dependency. align:'start' clamps to the bottom when the marker is the last message,
-    // keeping a just-arrived new message fully visible (do not shift up by vh/3 — see the marker
-    // loop). ensureMessageMounted is no longer called for the FAB.
+    // marker is windowed out). New path: getIndexForMessageId + controller-owned
+    // scrollToIndex('start'), with no DOM dependency. The measured convergence loop deliberately
+    // uses immediate writes: repeatedly restarting native smooth scrolling would make immediate
+    // scrollTop samples lie about convergence. align:'start' clamps to the bottom when the marker
+    // is the last message, keeping a just-arrived new message fully visible. ensureMessageMounted
+    // is no longer called for the FAB.
     getOffsetForMessageId.mockImplementation((id) => (id === 'msg-40' ? 1600 : null))
     const { container, getByLabelText } = renderList({ firstNewMessageId: 'msg-40' })
     const scroller = container.querySelector('[data-message-list]') as HTMLElement
@@ -186,9 +196,11 @@ describe('MessageList — virtualized scroll integration (ensureMessageMounted)'
     Object.defineProperty(scroller, 'scrollTop', { value: 0, writable: true, configurable: true })
 
     scrollToIndexCalls.length = 0
+    scrollToIndexBehaviors.length = 0
     ensureMessageMounted.mockClear()
     fireEvent.click(getByLabelText('chat.scrollToBottom'))
-    expect(scrollToIndexCalls).toContain('start')
+    await waitFor(() => expect(scrollToIndexCalls).toContain('start'))
+    expect(scrollToIndexBehaviors).not.toContain('smooth')
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-40')
   })
 

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -3,9 +3,12 @@ import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManag
 import type { MessageVirtualizer } from './messageVirtualizer'
 import {
   PositioningController,
+  type PositionExecutionLease,
   type PositionRequestDraft,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
+  type UnreadMarkerExecutor,
+  type UnreadMarkerFrameResult,
 } from './positioningController'
 import {
   deriveAtLiveEdge,
@@ -639,6 +642,259 @@ describe('positioning controller saved-position ownership', () => {
     expect(signal!.aborted).toBe(true)
     expect(controller.savedPositionStatus(conversationId)).toBeNull()
     expect(reconcile).not.toHaveBeenCalled()
+  })
+})
+
+describe('positioning controller unread-marker ownership', () => {
+  function unreadFacts() {
+    return deriveEntryPositionFacts({
+      syncedLiveEdge: false,
+      savedAnchor: null,
+      savedOffsetPx: null,
+      firstUnreadMessageId: 'first-unread',
+      unreadMarkerAlign: 'start',
+    })
+  }
+
+  function unreadHarness(
+    initialReachability: ReturnType<UnreadMarkerExecutor['reachability']> = {
+      kind: 'target-absent',
+      loadAround: 'unavailable',
+    },
+  ) {
+    const callbacks: Array<() => void> = []
+    let frameResult: UnreadMarkerFrameResult = { kind: 'waiting' }
+    let scrollTop = 0
+    const finish = vi.fn()
+    const recordFrame = vi.fn()
+    const leases: PositionExecutionLease[] = []
+    const positionFrame = vi.fn(() => frameResult)
+    const applyLiveEdge = vi.fn(() => true)
+    const executor: UnreadMarkerExecutor = {
+      reachability: () => initialReachability,
+      beginLoop: (lease) => {
+        leases.push(lease)
+        return {
+          schedule: (callback) => callbacks.push(callback),
+          recordFrame,
+          finish,
+        }
+      },
+      readScrollTop: () => scrollTop,
+      positionFrame,
+      applyLiveEdge,
+    }
+    return {
+      executor,
+      callbacks,
+      finish,
+      recordFrame,
+      leases,
+      positionFrame,
+      applyLiveEdge,
+      setFrameResult: (result: UnreadMarkerFrameResult) => {
+        frameResult = result
+        if (result.kind === 'positioned') scrollTop = result.scrollTop
+      },
+      setScrollTop: (value: number) => {
+        scrollTop = value
+      },
+      runFrame: () => {
+        const callback = callbacks.shift()
+        expect(callback).toBeDefined()
+        callback!()
+      },
+    }
+  }
+
+  it('keeps an absent marker pending during local hydration, then converges it', () => {
+    const harness = unreadHarness()
+    const controller = new PositioningController()
+    const request = controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: harness.executor,
+    })
+
+    expect(request).not.toBeNull()
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'pending',
+      reason: 'target-not-indexed',
+    })
+    harness.runFrame()
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.callbacks).toHaveLength(1)
+
+    harness.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 800,
+      atLiveEdge: false,
+    })
+    for (let frame = 0; frame < 9; frame += 1) harness.runFrame()
+
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.applyLiveEdge).not.toHaveBeenCalled()
+  })
+
+  it('promotes a marker that never hydrates to live edge under a new generation', () => {
+    const harness = unreadHarness()
+    const controller = new PositioningController()
+    const request = controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: harness.executor,
+    })
+
+    for (let frame = 0; frame <= 120; frame += 1) harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(120)
+    expect(harness.applyLiveEdge).toHaveBeenCalledWith(
+      'unread-marker-unavailable',
+      expect.objectContaining({ conversationId }),
+    )
+    expect(controller.snapshot().active?.request).toMatchObject({
+      generation: expect.any(Number),
+      source: {
+        kind: 'fallback',
+        reason: 'unread-marker-unavailable',
+      },
+      desired: { kind: 'live-edge', follow: true },
+    })
+    expect(controller.snapshot().watermark).toBeGreaterThan(request!.generation)
+  })
+
+  it('drops a queued marker frame after switching conversations', () => {
+    const harness = unreadHarness()
+    const controller = new PositioningController()
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    observeLiveEntry(controller, 'next-room@example.test')
+    staleFrame()
+
+    expect(harness.positionFrame).not.toHaveBeenCalled()
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(controller.snapshot().currentConversationId).toBe('next-room@example.test')
+  })
+
+  it('cancels unread reconciliation immediately on genuine user input', () => {
+    const harness = unreadHarness()
+    const controller = new PositioningController()
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    controller.observeUserInput(conversationId)
+    staleFrame()
+
+    expect(harness.positionFrame).not.toHaveBeenCalled()
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+  })
+
+  it('treats geometry takeover as cancellation rather than a settled marker', () => {
+    const harness = unreadHarness({
+      kind: 'available',
+      index: 12,
+      mounted: true,
+      placement: 'viable',
+    })
+    harness.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 800,
+      atLiveEdge: false,
+    })
+    const controller = new PositioningController()
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: harness.executor,
+    })
+
+    harness.runFrame()
+    harness.setScrollTop(1200)
+    harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(controller.snapshot().active).toBeNull()
+    expect(controller.snapshot().lateMdsEligibleFor).toBeNull()
+  })
+
+  it('supersedes entry with pill navigation before the first frame and writes once per frame', () => {
+    const entry = unreadHarness()
+    const pill = unreadHarness({
+      kind: 'available',
+      index: 12,
+      mounted: false,
+      placement: 'viable',
+    })
+    pill.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 900,
+      atLiveEdge: false,
+    })
+    const controller = new PositioningController()
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: entry.executor,
+    })
+    const staleEntryFrame = entry.callbacks.shift()!
+    controller.beginUnreadMarkerNavigation({
+      conversationId,
+      navigationFacts: {
+        firstUnreadMessageId: 'first-unread',
+        unreadMarkerNeedsVisit: true,
+        unreadMarkerAlign: 'start',
+      },
+      executor: pill.executor,
+    })
+
+    staleEntryFrame()
+    pill.runFrame()
+
+    expect(entry.positionFrame).not.toHaveBeenCalled()
+    expect(entry.finish).toHaveBeenCalledTimes(1)
+    expect(pill.positionFrame).toHaveBeenCalledTimes(1)
+    expect(pill.callbacks).toHaveLength(1)
+  })
+
+  it('promotes an executor-declared near-top target without issuing another marker frame', () => {
+    const harness = unreadHarness({
+      kind: 'available',
+      index: 1,
+      mounted: true,
+      // Preflight geometry is only a hint. The final near-top decision belongs to the owned frame
+      // reconciler after row measurement, so this must not synchronously promote the fallback.
+      placement: 'use-unavailable-policy',
+    })
+    harness.setFrameResult({ kind: 'unavailable' })
+    const controller = new PositioningController()
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: unreadFacts(),
+      executor: harness.executor,
+    })
+
+    expect(harness.callbacks).toHaveLength(1)
+    expect(harness.applyLiveEdge).not.toHaveBeenCalled()
+    harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.callbacks).toHaveLength(0)
+    expect(harness.applyLiveEdge).toHaveBeenCalledWith(
+      'unread-marker-unavailable',
+      expect.any(Object),
+    )
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -17,6 +17,8 @@ import {
   type PositioningPhase,
   type ReachabilityFacts,
   type SavedPositionRequest,
+  type UnreadMarkerFallbackRequest,
+  type UnreadMarkerRequest,
   type UnavailablePolicy,
 } from './scrollPositionModel'
 import {
@@ -39,7 +41,7 @@ export type SavedPositionLoadAroundStatus =
   | 'exhausted'
   | 'unavailable'
 
-export interface SavedPositionExecutionLease {
+export interface PositionExecutionLease {
   conversationId: string
   generation: number
   operation: number
@@ -48,6 +50,8 @@ export interface SavedPositionExecutionLease {
   markApplied: () => boolean
   settle: () => boolean
 }
+
+export type SavedPositionExecutionLease = PositionExecutionLease
 
 export interface SavedPositionExecutor {
   reachability: (
@@ -69,6 +73,37 @@ export interface SavedPositionExecutor {
   ) => boolean
 }
 
+export interface UnreadMarkerFrameLoop {
+  schedule: (callback: () => void) => void
+  recordFrame: (wrote: boolean) => void
+  finish: () => void
+}
+
+export type UnreadMarkerFrameResult =
+  | { kind: 'waiting' }
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      atLiveEdge: boolean
+    }
+
+export interface UnreadMarkerExecutor {
+  reachability: (desired: UnreadMarkerRequest['desired']) => ReachabilityFacts
+  beginLoop: (lease: PositionExecutionLease) => UnreadMarkerFrameLoop | null
+  readScrollTop: () => number | null
+  positionFrame: (
+    request: UnreadMarkerRequest,
+    lease: PositionExecutionLease,
+  ) => UnreadMarkerFrameResult
+  applyLiveEdge: (
+    reason:
+      | 'unread-marker-unavailable'
+      | 'unread-marker-resolved-at-live-edge',
+    lease: PositionExecutionLease,
+  ) => boolean
+}
+
 interface SavedPositionExecutionState {
   request: SavedPositionRequest
   executor: SavedPositionExecutor
@@ -78,6 +113,24 @@ interface SavedPositionExecutionState {
   loadingAround: boolean
   lastRecenterVersion: string | null
 }
+
+interface UnreadMarkerExecutionState {
+  request: UnreadMarkerRequest | UnreadMarkerFallbackRequest
+  executor: UnreadMarkerExecutor
+  operation: number
+  abortController: AbortController | null
+  loop: UnreadMarkerFrameLoop | null
+  framesLeft: number
+  stableFrames: number
+  landedTarget: number | null
+  resolved: boolean
+  resolvedAtLiveEdge: boolean
+}
+
+const UNREAD_MARKER_REASSERT_FRAMES = 120
+const UNREAD_MARKER_STABLE_FRAMES = 8
+const UNREAD_MARKER_DRIFT_PX = 16
+const UNREAD_MARKER_TAKEOVER_DRIFT_PX = 300
 
 let nextPositionGeneration = 1
 
@@ -120,6 +173,7 @@ export function reachabilityMatchesRequest(
 export class PositioningController {
   private model: PositioningModel = initialPositioningModel()
   private savedExecution: SavedPositionExecutionState | null = null
+  private unreadExecution: UnreadMarkerExecutionState | null = null
 
   snapshot(): PositioningModel {
     return this.model
@@ -159,6 +213,7 @@ export class PositioningController {
     const accepted = acceptPositionRequest(this.model, request)
     if (accepted === this.model) return null
     this.cancelSavedExecution()
+    this.cancelUnreadExecution()
     this.model = advancePhaseIfCurrent(
       accepted,
       input.conversationId,
@@ -222,6 +277,58 @@ export class PositioningController {
     return status !== null &&
       status.phase.kind !== 'position-applied' &&
       status.phase.kind !== 'settled'
+  }
+
+  beginUnreadMarkerEntry(input: {
+    conversationId: string
+    entryFacts: EntryPositionFacts
+    executor: UnreadMarkerExecutor
+  }): UnreadMarkerRequest | null {
+    return runScrollShadowSafely({
+      event: 'unread-marker-entry',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const selection = selectEntryPosition(input.entryFacts)
+        if (
+          selection.source.kind !== 'entry' ||
+          selection.source.reason !== 'unread-marker'
+        ) {
+          return null
+        }
+        return this.beginUnreadMarkerRequest(
+          input.conversationId,
+          selection as PositionRequestDraft,
+          input.executor,
+        )
+      },
+    })
+  }
+
+  beginUnreadMarkerNavigation(input: {
+    conversationId: string
+    navigationFacts: LiveEdgeNavigationFacts
+    executor: UnreadMarkerExecutor
+  }): UnreadMarkerRequest | null {
+    return runScrollShadowSafely({
+      event: 'unread-marker-navigation',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const selection = selectLiveEdgeNavigation(input.navigationFacts)
+        if (
+          selection.source.kind !== 'user-navigation' ||
+          selection.source.reason !== 'unread-marker'
+        ) {
+          return null
+        }
+        return this.beginUnreadMarkerRequest(
+          input.conversationId,
+          selection as PositionRequestDraft,
+          input.executor,
+        )
+      },
+    })
   }
 
   observeEntry(input: {
@@ -294,7 +401,7 @@ export class PositioningController {
           generation,
           phase,
         )
-        this.cancelSavedExecutionIfSuperseded()
+        this.cancelExecutionsIfSuperseded()
         compareShadowDecision({
           event: input.event,
           conversationId: input.conversationId,
@@ -443,7 +550,7 @@ export class PositioningController {
           conversationId,
           generation,
         )
-        this.cancelSavedExecutionIfSuperseded()
+        this.cancelExecutionsIfSuperseded()
       },
     })
   }
@@ -475,7 +582,7 @@ export class PositioningController {
           input.atLiveEdge,
           rearmRequest,
         )
-        this.cancelSavedExecutionIfSuperseded()
+        this.cancelExecutionsIfSuperseded()
       },
     })
   }
@@ -491,8 +598,363 @@ export class PositioningController {
           conversationId,
           generation,
         )
-        this.cancelSavedExecutionIfSuperseded()
+        this.cancelExecutionsIfSuperseded()
       },
+    })
+  }
+
+  private beginUnreadMarkerRequest(
+    conversationId: string,
+    draft: PositionRequestDraft,
+    executor: UnreadMarkerExecutor,
+  ): UnreadMarkerRequest | null {
+    const generation = mintPositionGeneration()
+    const request = withIdentity(
+      conversationId,
+      generation,
+      draft,
+    ) as UnreadMarkerRequest
+    const reachability = executor.reachability(request.desired)
+    if (!reachabilityMatchesRequest(request, reachability)) return null
+
+    const accepted = acceptPositionRequest(this.model, request)
+    if (accepted === this.model) return null
+    this.cancelSavedExecution()
+    this.cancelUnreadExecution()
+    this.model = advancePhaseIfCurrent(
+      accepted,
+      conversationId,
+      generation,
+      this.resolveUnreadMarkerReachability(request, reachability),
+    )
+    const execution: UnreadMarkerExecutionState = {
+      request,
+      executor,
+      operation: 0,
+      abortController: null,
+      loop: null,
+      framesLeft: UNREAD_MARKER_REASSERT_FRAMES,
+      stableFrames: 0,
+      landedTarget: null,
+      resolved: false,
+      resolvedAtLiveEdge: false,
+    }
+    this.unreadExecution = execution
+
+    if (this.model.active?.phase.kind === 'unavailable') {
+      this.promoteUnreadFallback(execution, 'unread-marker-unavailable')
+    } else {
+      this.startUnreadMarkerLoop(execution)
+    }
+    return request
+  }
+
+  private resolveUnreadMarkerReachability(
+    request: UnreadMarkerRequest,
+    facts: ReachabilityFacts,
+  ): PositioningPhase {
+    // Unread hydration intentionally waits for the ordinary resident window instead of issuing a
+    // deep load-around. The bounded frame budget below eventually promotes an honest live-edge
+    // fallback if cache hydration never makes the marker reachable.
+    if (facts.kind === 'empty-window') {
+      return { kind: 'pending', reason: 'empty-window' }
+    }
+    if (facts.kind === 'target-absent') {
+      return { kind: 'pending', reason: 'target-not-indexed' }
+    }
+    // A reachable unread row still has to pass the executor's live geometry check. In
+    // particular, `placement: use-unavailable-policy` is only a preflight hint that the row may
+    // sit in the top third; row measurement can change that answer before the first frame. Let the
+    // owned reconciler observe the frame and promote the fallback itself instead of bottom-pinning
+    // synchronously during the entry layout effect.
+    if (facts.kind === 'available') return { kind: 'reconciling' }
+    return resolveReachability(request, facts)
+  }
+
+  private startUnreadMarkerLoop(
+    execution: UnreadMarkerExecutionState,
+  ): void {
+    if (!this.isUnreadExecutionCurrent(execution)) return
+    const lease = this.beginUnreadOperation(execution)
+    const loop = runScrollShadowSafely<UnreadMarkerFrameLoop | null>({
+      event: 'unread-marker-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      if (loop) {
+        runScrollShadowSafely({
+          event: 'unread-marker-loop-stale-finish',
+          conversationId: execution.request.conversationId,
+          fallback: undefined,
+          observe: () => loop.finish(),
+        })
+      }
+      return
+    }
+    if (!loop) {
+      this.promoteUnreadFallback(execution, 'unread-marker-unavailable')
+      return
+    }
+    execution.loop = loop
+    this.scheduleUnreadMarkerFrame(execution, lease)
+  }
+
+  private driveUnreadMarkerFrame(
+    execution: UnreadMarkerExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (
+      execution.request.source.kind === 'fallback' ||
+      execution.framesLeft-- <= 0
+    ) {
+      if (execution.resolvedAtLiveEdge) {
+        this.promoteUnreadFallback(
+          execution,
+          'unread-marker-resolved-at-live-edge',
+        )
+      } else if (execution.resolved) {
+        this.finishUnreadExecution(execution, true)
+      } else {
+        this.promoteUnreadFallback(execution, 'unread-marker-unavailable')
+      }
+      return
+    }
+
+    const currentScrollTop = runScrollShadowSafely<number | null>({
+      event: 'unread-marker-read-scroll-top',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.readScrollTop(),
+    })
+    if (
+      currentScrollTop !== null &&
+      execution.landedTarget !== null &&
+      Math.abs(currentScrollTop - execution.landedTarget) >
+        UNREAD_MARKER_TAKEOVER_DRIFT_PX
+    ) {
+      const { conversationId, generation } = execution.request
+      this.model = cancelReconciliationForUserInput(
+        this.model,
+        conversationId,
+        generation,
+      )
+      this.finishUnreadExecution(execution, false)
+      return
+    }
+
+    const result = runScrollShadowSafely<UnreadMarkerFrameResult>({
+      event: 'unread-marker-frame',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.positionFrame(
+        execution.request as UnreadMarkerRequest,
+        lease,
+      ),
+    })
+    if (!lease.isCurrent()) return
+
+    if (result.kind === 'waiting') {
+      this.recordUnreadMarkerFrame(execution, false)
+      this.scheduleUnreadMarkerFrame(execution, lease)
+      return
+    }
+    if (result.kind === 'unavailable') {
+      this.promoteUnreadFallback(execution, 'unread-marker-unavailable')
+      return
+    }
+
+    execution.resolved = true
+    lease.markApplied()
+    if (!lease.isCurrent()) return
+    execution.resolvedAtLiveEdge ||= result.atLiveEdge
+
+    let wrote = false
+    if (
+      execution.landedTarget !== null &&
+      Math.abs(result.scrollTop - execution.landedTarget) <=
+        UNREAD_MARKER_DRIFT_PX
+    ) {
+      execution.stableFrames += 1
+      if (execution.stableFrames >= UNREAD_MARKER_STABLE_FRAMES) {
+        if (execution.resolvedAtLiveEdge) {
+          this.promoteUnreadFallback(
+            execution,
+            'unread-marker-resolved-at-live-edge',
+          )
+        } else {
+          this.finishUnreadExecution(execution, true)
+        }
+        return
+      }
+    } else {
+      wrote = true
+      execution.stableFrames = 0
+    }
+    execution.landedTarget = result.scrollTop
+    this.recordUnreadMarkerFrame(execution, wrote)
+    this.scheduleUnreadMarkerFrame(execution, lease)
+  }
+
+  private scheduleUnreadMarkerFrame(
+    execution: UnreadMarkerExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'unread-marker-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveUnreadMarkerFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      this.promoteUnreadFallback(execution, 'unread-marker-unavailable')
+    }
+  }
+
+  private recordUnreadMarkerFrame(
+    execution: UnreadMarkerExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'unread-marker-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private promoteUnreadFallback(
+    execution: UnreadMarkerExecutionState,
+    reason:
+      | 'unread-marker-unavailable'
+      | 'unread-marker-resolved-at-live-edge',
+  ): void {
+    if (!this.isUnreadExecutionCurrent(execution)) return
+    this.finishUnreadLoop(execution)
+    execution.abortController?.abort()
+
+    const generation = mintPositionGeneration()
+    const request = withIdentity(
+      execution.request.conversationId,
+      generation,
+      {
+        source: { kind: 'fallback', reason },
+        desired: { kind: 'live-edge', follow: true },
+      },
+    ) as UnreadMarkerFallbackRequest
+    const accepted = acceptPositionRequest(this.model, request)
+    if (accepted === this.model) {
+      this.cancelUnreadExecution()
+      return
+    }
+
+    execution.request = request
+    execution.operation += 1
+    execution.abortController = null
+    this.model = advancePhaseIfCurrent(
+      accepted,
+      request.conversationId,
+      request.generation,
+      { kind: 'reconciling' },
+    )
+    const lease = this.beginUnreadOperation(execution)
+    const applied = runScrollShadowSafely({
+      event: reason,
+      conversationId: request.conversationId,
+      fallback: false,
+      observe: () => execution.executor.applyLiveEdge(reason, lease),
+    })
+    if (!lease.isCurrent()) return
+    if (applied) lease.markApplied()
+    this.finishUnreadExecution(execution, false)
+  }
+
+  private beginUnreadOperation(
+    execution: UnreadMarkerExecutionState,
+  ): PositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.unreadExecution === execution &&
+      execution.operation === operation &&
+      execution.request.conversationId === conversationId &&
+      execution.request.generation === generation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isUnreadExecutionCurrent(
+    execution: UnreadMarkerExecutionState,
+  ): boolean {
+    return (
+      this.unreadExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
+  }
+
+  private finishUnreadExecution(
+    execution: UnreadMarkerExecutionState,
+    settle: boolean,
+  ): void {
+    if (settle && this.isUnreadExecutionCurrent(execution)) {
+      const active = this.model.active
+      if (active) {
+        this.model = advancePhaseIfCurrent(
+          this.model,
+          active.request.conversationId,
+          active.request.generation,
+          { kind: 'settled' },
+        )
+      }
+    }
+    this.finishUnreadLoop(execution)
+    execution.abortController?.abort()
+    if (this.unreadExecution === execution) this.unreadExecution = null
+  }
+
+  private finishUnreadLoop(execution: UnreadMarkerExecutionState): void {
+    const loop = execution.loop
+    execution.loop = null
+    if (!loop) return
+    runScrollShadowSafely({
+      event: 'unread-marker-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => loop.finish(),
     })
   }
 
@@ -742,16 +1204,31 @@ export class PositioningController {
     )
   }
 
-  private cancelSavedExecutionIfSuperseded(): void {
+  private cancelExecutionsIfSuperseded(): void {
     const execution = this.savedExecution
     if (execution && !this.isSavedExecutionCurrent(execution)) {
       this.cancelSavedExecution()
+    }
+    const unreadExecution = this.unreadExecution
+    if (
+      unreadExecution &&
+      !this.isUnreadExecutionCurrent(unreadExecution)
+    ) {
+      this.cancelUnreadExecution()
     }
   }
 
   private cancelSavedExecution(): void {
     this.savedExecution?.abortController?.abort()
     this.savedExecution = null
+  }
+
+  private cancelUnreadExecution(): void {
+    if (this.unreadExecution) {
+      this.finishUnreadLoop(this.unreadExecution)
+      this.unreadExecution.abortController?.abort()
+    }
+    this.unreadExecution = null
   }
 }
 

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -5,7 +5,7 @@
  * Background: useMessageListScroll keeps the virtualized list pinned to the
  * right place by RE-ASSERTING a scroll target across several frames as rows
  * measure asynchronously — `pinVirtualizedBottom` (stick to bottom), the
- * conversation-switch `stepToMarker` (unread marker), and the MAM-prepend
+ * controller-owned unread-marker reconciliation, and the MAM-prepend
  * `runMeasureAssert` (anchor restore). Each is a `requestAnimationFrame` loop
  * that calls the virtualizer's `scrollToOffset`/`scrollToIndex`, which re-windows
  * and re-renders.

--- a/apps/fluux/src/components/conversation/scrollPositionFacts.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionFacts.ts
@@ -42,6 +42,7 @@ export function deriveEntryPositionFacts(input: {
   savedAnchor: ScrollAnchor | null
   savedOffsetPx: number | null
   firstUnreadMessageId?: string
+  unreadMarkerAlign?: 'start' | 'top-third'
 }): EntryPositionFacts {
   const savedAnchor: BottomFractionAnchorPosition | undefined = input.savedAnchor
     ? {
@@ -61,6 +62,9 @@ export function deriveEntryPositionFacts(input: {
       : { savedOffsetPx: pixelOffset(input.savedOffsetPx) }),
     ...(input.firstUnreadMessageId
       ? { firstUnreadMessageId: input.firstUnreadMessageId }
+      : {}),
+    ...(input.unreadMarkerAlign
+      ? { unreadMarkerAlign: input.unreadMarkerAlign }
       : {}),
   }
 }

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -130,7 +130,7 @@ type EntryRequest =
     >
   | Request<
       { kind: 'entry'; reason: 'unread-marker' },
-      MessagePosition<'start'>,
+      MessagePosition<'start' | 'top-third'>,
       Extract<UnavailablePolicy, { kind: 'live-edge' }>
     >
   | Request<{ kind: 'entry'; reason: 'live-edge' }, LiveEdgePosition>
@@ -192,6 +192,24 @@ export type SavedPositionRequest = Extract<
   PositionRequest,
   | { source: { kind: 'entry'; reason: 'saved-position' } }
   | { source: { kind: 'fallback'; reason: 'saved-position-unavailable' } }
+>
+
+export type UnreadMarkerRequest = Extract<
+  PositionRequest,
+  | { source: { kind: 'entry'; reason: 'unread-marker' } }
+  | { source: { kind: 'user-navigation'; reason: 'unread-marker' } }
+>
+
+export type UnreadMarkerFallbackRequest = Extract<
+  PositionRequest,
+  {
+    source: {
+      kind: 'fallback'
+      reason:
+        | 'unread-marker-unavailable'
+        | 'unread-marker-resolved-at-live-edge'
+    }
+  }
 >
 
 export type PositionRequestSource = PositionRequest['source']
@@ -269,6 +287,7 @@ export interface EntryPositionFacts {
   savedAnchor?: BottomFractionAnchorPosition
   savedOffsetPx?: PixelOffset
   firstUnreadMessageId?: string
+  unreadMarkerAlign?: 'start' | 'top-third'
 }
 
 export type EntryPositionSelection =
@@ -284,7 +303,7 @@ export type EntryPositionSelection =
     }
   | {
       source: { kind: 'entry'; reason: 'unread-marker' }
-      desired: MessagePosition<'start'>
+      desired: MessagePosition<'start' | 'top-third'>
       onUnavailable: Extract<UnavailablePolicy, { kind: 'live-edge' }>
     }
   | {
@@ -636,7 +655,7 @@ export function selectEntryPosition(facts: EntryPositionFacts): EntryPositionSel
       desired: {
         kind: 'message',
         messageId: facts.firstUnreadMessageId,
-        align: 'start',
+        align: facts.unreadMarkerAlign ?? 'start',
       },
       onUnavailable: { kind: 'live-edge' },
     }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,10 +3,10 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Saved-position policy/retry ownership lives in PositioningController; browser writes stay
- *    imperative in its hook executor while the remaining mechanisms migrate incrementally
+ * 2. Saved-position and unread-marker policy/retry ownership lives in PositioningController;
+ *    browser writes stay imperative in hook executors while the remaining mechanisms migrate
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
- * 4. The controller owns generations and saved-position arbitration, not React state or geometry
+ * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
  * BEHAVIORS:
  * - Initial load: scroll to bottom
@@ -32,8 +32,10 @@ import { notifyUserInput } from '@/utils/renderLoopDetector'
 import {
   PositioningController,
   type PositionRequestDraft,
+  type PositionExecutionLease,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
+  type UnreadMarkerExecutor,
 } from './positioningController'
 import {
   deriveAtLiveEdge,
@@ -48,6 +50,7 @@ import {
   type DesiredPosition,
   type ReachabilityFacts,
   type SavedPositionRequest,
+  type UnreadMarkerRequest,
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
 
@@ -111,18 +114,6 @@ const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load even
 // scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
 // one-shot scrollToIndex isn't enough. ~1s at 60fps comfortably covers the measurement settle.
 const BOTTOM_REASSERT_FRAMES = 60
-// Frames to keep re-resolving the unread-marker offset after a conversation switch. On entry the
-// conversation's messages were evicted on leave and rehydrate from cache asynchronously, then the
-// rows measure over several frames, so the marker offset is unresolved at first and sharpens as it
-// settles. ~2s comfortably covers a cache page load + measurement; the loop stops early once the
-// target is stable, and bails immediately on a user scroll or a conversation switch.
-const MARKER_REASSERT_FRAMES = 120
-// Consecutive frames the marker target must hold steady before the re-assert loop stops early.
-const MARKER_STABLE_FRAMES = 8
-// Sub-row tolerance for the marker re-assert: only re-scroll when the resolved target moves more
-// than this (rows measuring jitter the offset by a few px every frame; a 1px threshold would
-// re-scroll — and re-render — every frame and never stabilize).
-const MARKER_DRIFT_PX = 16
 // Target jumps (reply/search/activity) need the same measurement-aware behavior as unread-marker
 // entry, but for a shorter window: the target row is explicitly requested and should settle fast.
 const TARGET_REASSERT_FRAMES = 30
@@ -478,9 +469,10 @@ export function useMessageListScroll({
   // React StrictMode replays layout-effect cleanup/setup without unmounting the DOM. Defer controller
   // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
   const unmountDeactivationTokenRef = useRef<object | null>(null)
-  // Generation-aware semantic controller. Saved-position restoration is its first authoritative
-  // slice; the other positioning mechanisms still report shadow decisions. Pixel writes remain in
-  // the hook executor, while the module-private generation allocator survives StrictMode remounts.
+  // Generation-aware semantic controller. Saved-position restoration and unread-marker
+  // reconciliation are authoritative; the remaining positioning mechanisms still report shadow
+  // decisions. Pixel writes stay in hook executors, while the module-private generation allocator
+  // survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -1245,155 +1237,6 @@ export function useMessageListScroll({
     return true
   }, [isAtBottomRef, rememberCurrentScrollSnapshot])
 
-  // Scroll to (and keep re-asserting toward) the first-new-message marker, re-assert-loop style —
-  // shared by the conversation-switch entry effect AND the jump-to-last-read pill's click handler,
-  // so there is exactly one marker-positioning routine (see the loop body comment at its original
-  // call site for the full rationale: unmounted rows resolve via getOffsetForMessageId/scrollToIndex,
-  // re-applied each frame as rows measure over several frames after cache rehydrate).
-  const runMarkerReassertLoop = useCallback((markerId: string, markerConvId: string) => {
-    const startedAt = Date.now()
-    // Single-flight (shared with pin-bottom / prepend): the marker positioning loop owns
-    // scrollTop while it runs, so it supersedes any in-flight re-assert and registers itself.
-    supersedeReassertLoopRef.current()
-    const markerLoop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('marker', performance.now())
-    const finishMarker = () => {
-      markerLoop.end()
-      reassertLoopRef.current = null
-    }
-    // Register the ref BEFORE scheduling the frame, then patch its `raf` id in place — rather than
-    // reassigning reassertLoopRef.current AFTER requestAnimationFrame returns. A mocked/synchronous
-    // rAF (test harnesses) invokes the callback inline, so an outer `ref.current = { raf:
-    // requestAnimationFrame(cb), ... }` evaluates the RHS (running the callback, possibly to
-    // completion — including a `finishMarker()` that nulls the ref) and THEN clobbers that null back
-    // to a stale non-null entry. Pre-registering means a same-tick finish's null assignment is never
-    // overwritten; the `raf` id patch only mutates the (by-then-detached) local object when that
-    // happens.
-    const registerMarkerLoop = (cb: () => void) => {
-      const entry: { raf: number; handle: typeof markerLoop } = { raf: 0, handle: markerLoop }
-      reassertLoopRef.current = entry
-      entry.raf = requestAnimationFrame(cb)
-    }
-    let framesLeft = MARKER_REASSERT_FRAMES
-    let stableFrames = 0
-    let landedTarget = -1
-    let resolved = false
-    let followLiveRecorded = false
-    const recordMarkerLiveEdge = (
-      reason:
-        | 'unread-marker-unavailable'
-        | 'unread-marker-resolved-at-live-edge',
-    ) => {
-      if (followLiveRecorded) return
-      followLiveRecorded = true
-      positioningControllerRef.current?.observeRequest({
-        event:
-          reason === 'unread-marker-unavailable'
-            ? 'marker-fallback'
-            : 'marker-resolved-at-live-edge',
-        conversationId: markerConvId,
-        draft: {
-          source: { kind: 'fallback', reason },
-          desired: { kind: 'live-edge', follow: true },
-        },
-        reachability: shadowReachabilityRef.current({
-          kind: 'live-edge',
-          follow: true,
-        }),
-        actual: {
-          desired: { kind: 'live-edge', follow: true },
-          phase: 'positioning',
-        },
-      })
-    }
-    const stepToMarker = () => {
-      if (framesLeft-- <= 0) {
-        // Marker never resolved at all (e.g. trimmed from the loaded set) — don't strand the
-        // view at the top; fall back to the bottom. End first so the handoff to reassertBottom
-        // (which begins a pin-bottom loop) is not miscounted as an overlap.
-        finishMarker()
-        if (!resolved) {
-          recordMarkerLiveEdge('unread-marker-unavailable')
-          reassertBottom('marker-fallback')
-        }
-        return
-      }
-      const s = scrollerRef.current
-      if (!s) { finishMarker(); return }
-      // Conversation switched away while this loop was still running → stop (a stale loop must
-      // never scroll the new conversation). prevConversationRef is set synchronously below.
-      if (prevConversationRef.current !== markerConvId) { finishMarker(); return }
-      // User took over (FAB/wheel) or scrolled away from where we landed → stop fighting them.
-      if (userScrollIntentAtRef.current > startedAt) { finishMarker(); return }
-      if (landedTarget >= 0 && Math.abs(s.scrollTop - landedTarget) > FAB_THRESHOLD) { finishMarker(); return }
-
-      const viewportHeight = s.clientHeight
-      const v = latestRef.current.virtualizer
-      const markerIndex = v ? v.getIndexForMessageId(markerId) : null
-      let offset: number | null = null
-      if (v) {
-        offset = v.getOffsetForMessageId(markerId)
-      } else {
-        const el = s.querySelector(`[data-message-id="${CSS.escape(markerId)}"]`) as HTMLElement | null
-        if (el) offset = el.offsetTop
-      }
-
-      let wrote = false
-      if (offset != null && (!v || markerIndex != null)) {
-        resolved = true
-        // Marker sits in the top third of the content (vh/3-from-top would be above the content
-        // top, so the only valid scroll target is 0). Scrolling to 0 would spuriously fire
-        // triggerLoadOlder (handleScroll keys load-older on scrollTop===0) and churn — the
-        // regression that consumed the older-message backlog on entry. This is the all/mostly-
-        // unread case; fall back to the bottom (the prior behavior) rather than paginating.
-        if (offset <= viewportHeight / 3) {
-          isAtBottomRef.current = true
-          finishMarker()
-          recordMarkerLiveEdge('unread-marker-unavailable')
-          reassertBottom('marker-fallback')
-          return
-        }
-        // Position the marker row via the virtualizer's measurement-aware scrollToIndex.
-        // A raw scrollToOffset to the ESTIMATED offset lands SHORT and never windows the marker
-        // row in, so its height never measures and the offset estimate never sharpens — the loop
-        // then sees a "stable" (wrong) target and stops with the marker stranded below the fold
-        // (the bug). scrollToIndex windows the marker region in (mount + measure), so each frame
-        // lands closer and re-asserting converges, exactly like pinVirtualizedBottom. align:'start'
-        // puts the divider near the top to read forward, and clamps to the bottom when the marker
-        // is the last message (so a single new message lands at the bottom, fully visible — do NOT
-        // shift up by viewportHeight/3 here: getOffsetForMessageId clamps to the scrollable range
-        // for a near-bottom marker, so the shift would scroll past the new message and hide it).
-        if (v) v.scrollToIndex(markerIndex!, { align: 'start' })
-        else s.scrollTop = Math.max(0, offset - viewportHeight / 3)
-
-        const st = s.scrollTop
-        // Converged when the landing position stops moving (rows have finished measuring).
-        if (landedTarget >= 0 && Math.abs(st - landedTarget) <= MARKER_DRIFT_PX) {
-          if (++stableFrames >= MARKER_STABLE_FRAMES) {
-            finishMarker()
-            return
-          }
-        } else {
-          wrote = true
-          stableFrames = 0
-          const distFromBottom = s.scrollHeight - st - viewportHeight
-          isAtBottomRef.current = distFromBottom < AT_BOTTOM_THRESHOLD
-          if (isAtBottomRef.current && !followLiveRecorded) {
-            recordMarkerLiveEdge('unread-marker-resolved-at-live-edge')
-          }
-          debugLog('CONVERSATION SWITCH: scrolling to new message marker', {
-            firstNewMessageId: markerId, markerIndex, offset, scrollTop: st,
-            distFromBottom, isAtBottom: isAtBottomRef.current,
-          })
-        }
-        landedTarget = st
-      }
-      const warning = markerLoop.frame(performance.now(), wrote)
-      if (warning) console.warn(warning)
-      registerMarkerLoop(stepToMarker)
-    }
-    registerMarkerLoop(stepToMarker)
-  }, [isAtBottomRef, reassertBottom])
-
   const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
     reachability: (desired, loadAround) => {
       const scroller = scrollerRef.current
@@ -1506,6 +1349,131 @@ export function useMessageListScroll({
     windowAtLiveEdge,
   ])
 
+  const createUnreadMarkerExecutor = useCallback((): UnreadMarkerExecutor => ({
+    reachability: (desired) => deriveReachabilityForDesired({
+      desired,
+      hasRows: messageCount > 0 && firstMessageId !== undefined,
+      windowAtLiveEdge: windowAtLiveEdge !== false,
+      virtualizer: virtualizerRef.current,
+      scroller: scrollerRef.current,
+      loadAround: 'unavailable',
+      canRecenter: false,
+    }),
+    beginLoop: (lease: PositionExecutionLease) => {
+      if (!lease.isCurrent()) return null
+      supersedeReassertLoopRef.current()
+      const monitor = (reassertMonitorRef.current ??=
+        createReassertLoopMonitor()).begin('marker', performance.now())
+      let finished = false
+      const finish = () => {
+        if (finished) return
+        finished = true
+        monitor.end()
+        const activeLoop = reassertLoopRef.current
+        if (activeLoop?.handle === monitor) {
+          cancelAnimationFrame(activeLoop.raf)
+          reassertLoopRef.current = null
+        }
+      }
+      return {
+        schedule: (callback) => {
+          if (finished || !lease.isCurrent()) return
+          // Register before scheduling so synchronous-rAF test harnesses cannot resurrect a loop
+          // that completed from inside the callback.
+          const entry = { raf: 0, handle: monitor }
+          reassertLoopRef.current = entry
+          entry.raf = requestAnimationFrame(callback)
+        },
+        recordFrame: (wrote) => {
+          const warning = monitor.frame(performance.now(), wrote)
+          if (warning) console.warn(warning)
+        },
+        finish,
+      }
+    },
+    readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
+    positionFrame: (
+      request: UnreadMarkerRequest,
+      lease: PositionExecutionLease,
+    ) => {
+      if (!lease.isCurrent()) return { kind: 'unavailable' }
+      const scroller = scrollerRef.current
+      if (!scroller) return { kind: 'unavailable' }
+
+      // Entry waits until the passive latest-value handoff has installed the new conversation's
+      // virtualizer. Reading the synchronous render ref here can act on a transient pre-paint
+      // window and advance viewport-derived read state before the new list is settled.
+      const latest = latestRef.current
+      if (latest.conversationId !== request.conversationId) {
+        return { kind: 'waiting' }
+      }
+      const virtualizer = latest.virtualizer
+      const markerId = request.desired.messageId
+      const markerIndex = virtualizer
+        ? virtualizer.getIndexForMessageId(markerId)
+        : null
+      let offset: number | null = null
+      if (virtualizer) {
+        if (markerIndex === null) return { kind: 'waiting' }
+        offset = virtualizer.getOffsetForMessageId(markerId)
+      } else {
+        const element = scroller.querySelector(
+          `[data-message-id="${CSS.escape(markerId)}"]`,
+        ) as HTMLElement | null
+        if (element) offset = element.offsetTop
+      }
+      if (offset === null) return { kind: 'waiting' }
+
+      // Avoid a target at scrollTop=0: handleScroll treats that as an explicit request for older
+      // history. For all/mostly-unread windows, preserve the established live-edge fallback.
+      if (offset <= scroller.clientHeight / 3) {
+        return { kind: 'unavailable' }
+      }
+      if (!lease.isCurrent()) return { kind: 'unavailable' }
+
+      if (virtualizer && markerIndex !== null) {
+        virtualizer.scrollToIndex(markerIndex, { align: 'start' })
+      } else {
+        const top =
+          request.desired.align === 'top-third'
+            ? Math.max(0, offset - scroller.clientHeight / 3)
+            : offset
+        scroller.scrollTop = top
+      }
+
+      const scrollTop = scroller.scrollTop
+      const distanceFromBottom =
+        scroller.scrollHeight - scrollTop - scroller.clientHeight
+      const atLiveEdge = distanceFromBottom < AT_BOTTOM_THRESHOLD
+      isAtBottomRef.current = atLiveEdge
+      debugLog('UNREAD MARKER: controller positioned frame', {
+        conversationId: request.conversationId,
+        generation: request.generation,
+        markerId,
+        markerIndex,
+        offset,
+        scrollTop,
+        distanceFromBottom,
+        atLiveEdge,
+      })
+      return { kind: 'positioned', scrollTop, atLiveEdge }
+    },
+    applyLiveEdge: (reason, lease) => {
+      if (!lease.isCurrent()) return false
+      isAtBottomRef.current = true
+      if (reason === 'unread-marker-unavailable') {
+        reassertBottom('marker-fallback')
+      }
+      return true
+    },
+  }), [
+    firstMessageId,
+    isAtBottomRef,
+    messageCount,
+    reassertBottom,
+    windowAtLiveEdge,
+  ])
+
   // ==========================================================================
   // SCROLL ACTIONS
   // ==========================================================================
@@ -1558,56 +1526,33 @@ export function useMessageListScroll({
       (virt
         ? markerOffsetPx === null || markerOffsetPx > viewportBottom
         : markerOffsetPx !== null && markerOffsetPx > viewportBottom)
-    const markerDesired =
-      firstNewMessageId && markerNeedsVisit
-        ? {
-            kind: 'message' as const,
-            messageId: firstNewMessageId,
-            align: virt ? 'start' as const : 'top-third' as const,
-          }
-        : null
-    runScrollShadowSafely({
-      event: 'fab',
-      conversationId,
-      fallback: undefined,
-      observe: () => {
-        const navigationFacts = deriveLiveEdgeNavigationFacts({
-          firstUnreadMessageId: markerResolvable ? firstNewMessageId : undefined,
-          markerOffsetPx,
-          geometry: readScrollGeometry(scroller),
-          virtualized: !!virt,
-        })
-        positioningControllerRef.current?.observeLiveEdgeNavigation({
-          event: 'fab',
-          conversationId,
-          navigationFacts,
-          reachability: (desired) => shadowReachabilityRef.current(desired),
-          actual: {
-            desired: markerDesired ?? { kind: 'live-edge', follow: true },
-            phase: 'positioning',
-          },
-        })
-      },
+    const navigationFacts = deriveLiveEdgeNavigationFacts({
+      firstUnreadMessageId: markerResolvable ? firstNewMessageId : undefined,
+      markerOffsetPx,
+      geometry: readScrollGeometry(scroller),
+      virtualized: !!virt,
     })
-
-    if (markerDesired && firstNewMessageId) {
-      if (virt) {
-        const markerIdx = virt.getIndexForMessageId(firstNewMessageId)
-        if (markerIdx !== null) {
-          virt.scrollToIndex(markerIdx, { align: 'start', behavior: 'smooth' })
-          return
-        }
-      } else {
-        const messageElement = scroller.querySelector(
-          `[data-message-id="${CSS.escape(firstNewMessageId)}"]`,
-        )
-        if (messageElement) {
-          const elementTop = (messageElement as HTMLElement).offsetTop
-          scroller.scrollTo({ top: Math.max(0, elementTop - scroller.clientHeight / 3), behavior: 'smooth' })
-          return
-        }
+    if (markerNeedsVisit) {
+      const request = positioningControllerRef.current?.beginUnreadMarkerNavigation({
+        conversationId,
+        navigationFacts,
+        executor: createUnreadMarkerExecutor(),
+      })
+      if (request) {
+        return
       }
     }
+
+    positioningControllerRef.current?.observeLiveEdgeNavigation({
+      event: 'fab-live-edge',
+      conversationId,
+      navigationFacts,
+      reachability: (desired) => shadowReachabilityRef.current(desired),
+      actual: {
+        desired: { kind: 'live-edge', follow: true },
+        phase: 'positioning',
+      },
+    })
 
     const virtFab = latestRef.current.virtualizer
     if (virtFab && virtFab.itemCount > 0) {
@@ -1619,6 +1564,7 @@ export function useMessageListScroll({
     scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
   }, [
     conversationId,
+    createUnreadMarkerExecutor,
     firstNewMessageId,
     reassertBottom,
     rememberBottomIntent,
@@ -2383,12 +2329,13 @@ export function useMessageListScroll({
           savedAnchor,
           savedOffsetPx: savedPos,
           firstUnreadMessageId: firstNewMessageId,
+          unreadMarkerAlign: virtualizerRef.current ? 'start' : 'top-third',
         }),
       })
       // Observation validators must never strand production positioning. If a transient saved
       // anchor is malformed (for example a zero-height row produced NaN), retain a finite legacy
       // offset when possible and otherwise let the controller choose its live-edge fallback.
-      const savedExecutionFacts = entryFacts ?? runScrollShadowSafely({
+      const entryExecutionFacts = entryFacts ?? runScrollShadowSafely({
         event: 'entry-fallback-facts',
         conversationId,
         fallback: null,
@@ -2397,15 +2344,16 @@ export function useMessageListScroll({
           savedAnchor: null,
           savedOffsetPx: savedPos !== null && Number.isFinite(savedPos) ? savedPos : null,
           firstUnreadMessageId: firstNewMessageId,
+          unreadMarkerAlign: virtualizerRef.current ? 'start' : 'top-third',
         }),
       })
 
       if (action === 'restore-position') {
         isAtBottomRef.current = false
-        const request = savedExecutionFacts
+        const request = entryExecutionFacts
           ? positioningControllerRef.current?.beginSavedPositionEntry({
               conversationId,
-              entryFacts: savedExecutionFacts,
+              entryFacts: entryExecutionFacts,
               executor: createSavedPositionExecutor(),
             })
           : null
@@ -2424,49 +2372,19 @@ export function useMessageListScroll({
         debugLog('CONVERSATION SWITCH: has unread, will scroll to marker', { firstNewMessageId })
         isAtBottomRef.current = false
 
-        const markerId = firstNewMessageId
-        const markerConvId = conversationId
-        // When virtualized, bring the (possibly unmounted) marker row into the window so the
-        // non-virtualized fallback path can find it too; the virtualized path below does not need
-        // it (getOffsetForMessageId resolves unmounted rows).
-        void latestRef.current.virtualizer?.ensureMessageMounted(markerId)
-        const markerDesired = {
-          kind: 'message' as const,
-          messageId: firstNewMessageId,
-          align: 'start' as const,
-        }
-        const markerReachability =
-          shadowReachabilityRef.current(markerDesired)
-        if (entryFacts) {
-          positioningControllerRef.current?.observeEntry({
-            event: 'entry-unread',
+        const request = entryExecutionFacts
+          ? positioningControllerRef.current?.beginUnreadMarkerEntry({
             conversationId,
-            entryFacts,
-            reachability: () => markerReachability,
-            actual: {
-              desired: markerDesired,
-              phase:
-                markerReachability.kind === 'available' &&
-                markerReachability.placement === 'use-unavailable-policy'
-                  ? 'fallback'
-                  : markerReachability.kind === 'available'
-                    ? 'positioning'
-                    : 'waiting',
-            },
+            entryFacts: entryExecutionFacts,
+            executor: createUnreadMarkerExecutor(),
           })
+          : null
+        if (!request) {
+          // Keep instrumentation/controller failures from stranding entry above an unresolved
+          // divider. Normal marker unavailability is promoted by the controller itself.
+          isAtBottomRef.current = true
+          reassertBottom('marker-fallback')
         }
-        // Re-assert the marker position across frames. On entry the conversation's messages were
-        // evicted on leave and rehydrate from cache ASYNCHRONOUSLY, and rows then measure over
-        // several frames, so the marker offset is unresolved at first and sharpens as it settles.
-        // The old code read the position from `querySelector(marker).offsetTop` — null for a row
-        // windowed OUT and 0 with no layout — and used a raw `scrollTop = scrollHeight` fallback
-        // that the virtualizer reverts to offset 0, parking the view at the TOP with the marker
-        // stranded below the fold. Resolving via getOffsetForMessageId (works for unmounted rows)
-        // and re-applying each frame lands at the marker once the region mounts. Mirrors
-        // pinVirtualizedBottom's re-assert loop; bails on user scroll or a conversation switch.
-        // Shared with the jump-to-last-read pill's click handler — see runMarkerReassertLoop's own
-        // comment.
-        runMarkerReassertLoop(markerId, markerConvId)
       } else if (targetMessageId) {
         // Has a target message to scroll to — skip scroll-to-bottom.
         // The targetMessageId effect will handle scrolling.
@@ -2541,7 +2459,7 @@ export function useMessageListScroll({
     prevLastMessageIdRef.current = lastMessageId
     previousReadPositionRef.current = readPointerId
 
-  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, readPointerId, isAtBottomRef, staticMode, createSavedPositionExecutor, pinVirtualizedBottom, reassertBottom, runMarkerReassertLoop])
+  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, readPointerId, isAtBottomRef, staticMode, createSavedPositionExecutor, createUnreadMarkerExecutor, pinVirtualizedBottom, reassertBottom])
 
   // Zero-unread twin of the divider-clear settle below. The old local position may be restored
   // before MAM resolves the other device's pointer to the newest downloaded row; with no divider,
@@ -3682,40 +3600,22 @@ export function useMessageListScroll({
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [scrollToBottom, scrollToTop])
 
-  // Public jump-to-last-read entry point: re-run the SAME re-assert loop the conversation-switch
-  // entry effect uses, targeting the CURRENT marker/conversation. No-op without a live marker.
+  // Public jump-to-last-read entry point: issue the same controller-owned unread request used by
+  // conversation entry. No-op without a live marker.
   const scrollToMarker = useCallback(() => {
     if (!firstNewMessageId) return
     userScrollIntentAtRef.current = Date.now()
     userHasScrolledSinceEntryRef.current = true
-    const desired = {
-      kind: 'message' as const,
-      messageId: firstNewMessageId,
-      align: virtualizerRef.current ? 'start' as const : 'top-third' as const,
-    }
-    const reachability = shadowReachabilityRef.current(desired)
-    positioningControllerRef.current?.observeRequest({
-      event: 'jump-to-last-read',
+    positioningControllerRef.current?.beginUnreadMarkerNavigation({
       conversationId,
-      draft: {
-        source: { kind: 'user-navigation', reason: 'unread-marker' },
-        desired,
-        onUnavailable: { kind: 'live-edge' },
+      navigationFacts: {
+        firstUnreadMessageId: firstNewMessageId,
+        unreadMarkerNeedsVisit: true,
+        unreadMarkerAlign: virtualizerRef.current ? 'start' : 'top-third',
       },
-      reachability,
-      actual: {
-        desired,
-        phase:
-          reachability.kind === 'available' &&
-          reachability.placement === 'use-unavailable-policy'
-            ? 'fallback'
-            : reachability.kind === 'available'
-              ? 'positioning'
-              : 'waiting',
-      },
+      executor: createUnreadMarkerExecutor(),
     })
-    runMarkerReassertLoop(firstNewMessageId, conversationId)
-  }, [firstNewMessageId, conversationId, runMarkerReassertLoop])
+  }, [firstNewMessageId, conversationId, createUnreadMarkerExecutor])
 
   // ==========================================================================
   // RETURN


### PR DESCRIPTION
## Summary

- migrate unread-marker entry, jump-to-last-read, and the FAB marker-first leg to the generation-aware positioning controller
- move hydration waiting, measurement convergence, stale-generation rejection, user takeover, and live-edge fallback policy into the controller
- delete the legacy marker reassert loop and the pre-controller `ensureMessageMounted` / direct FAB writers, leaving the hook executor responsible only for current browser geometry and one immediate write per frame
- gate passive virtualizer access by conversation and treat near-top placement as a frame-time geometry decision instead of a synchronous preflight fallback

This is migration 2 of the incremental scroll-positioning plan. It gives unread positioning one generation and one write authority without moving saved restoration, explicit targets, bottom pinning, or MAM prepend behavior back into wrappers.

Intentional UX change: FAB-to-unread and jump-to-last-read now snap instead of smooth-scrolling, ensuring measurement reconciliation reaches the correct marker without competing animations.