### PR TITLE
Migrate explicit message targets to the positioning controller

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -19,7 +19,8 @@ import { renderQuotePreview } from '@/utils/messageStyles'
 import { EncryptedPlaceholder } from './EncryptedPlaceholder'
 import { UnsupportedEncryptionNotice } from './UnsupportedEncryptionNotice'
 import { MessageReactions } from './MessageReactions'
-import { scrollToMessage, isActionMessage, type WhisperThreadPosition } from './messageGrouping'
+import { isActionMessage, type WhisperThreadPosition } from './messageGrouping'
+import { useRequestMessageTarget } from './messageTargetContext'
 import { useOwnGroupWidth } from './messageGroupWidth'
 import { resolveDisplayTrust } from './messageTrust'
 import { trustVisual } from '@/e2ee/trustVisual'
@@ -340,6 +341,9 @@ export const MessageBubble = memo(function MessageBubble({
   ownGroupKey,
 }: MessageBubbleProps) {
   const { t } = useTranslation()
+  // Route jumps to the list this row is rendered in, so a click inside a search/activity preview
+  // positions that preview instead of no-opping or scrolling the live conversation.
+  const requestMessageTarget = useRequestMessageTarget()
   const [showReactionPicker, setShowReactionPickerState] = useState(false)
   const [showMoreMenu, setShowMoreMenu] = useState(false)
   const [showAvatarLightbox, setShowAvatarLightbox] = useState(false)
@@ -679,7 +683,7 @@ export const MessageBubble = memo(function MessageBubble({
         {!message.isRetracted && replyContext && (
           <button
             type="button"
-            onClick={() => scrollToMessage(replyContext.messageId)}
+            onClick={() => requestMessageTarget(replyContext.messageId)}
             className="reply-quote-card flex items-start gap-1.5 py-1 pe-2 ps-2 mb-1.5 border-s-2 text-start min-w-0 bg-fluux-bg-secondary hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
             // When the row is selected the selection tint melts into the card fill
             // (light themes); a full frame in the sender's colour keeps the card

--- a/apps/fluux/src/components/conversation/MessageList.targetRouting.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.targetRouting.test.tsx
@@ -15,6 +15,7 @@
  * clicking, so it fails against the registry-routed implementation instead of passing vacuously.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { memo } from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import { createTestMessages } from './MessageList.test-utils'
@@ -57,6 +58,19 @@ function JumpRow({ id, to }: { id: string; to: string }) {
 
 const messages = createTestMessages(8)
 const renderMessage = (m: { id: string }) => <JumpRow id={m.id} to="msg-5" />
+
+/** Memoized twin of JumpRow: MessageBubble is memoized too, so rows must survive an append. */
+const rowRenderCounts = new Map<string, number>()
+const CountingJumpRow = memo(function CountingJumpRow({ id }: { id: string }) {
+  rowRenderCounts.set(id, (rowRenderCounts.get(id) ?? 0) + 1)
+  const requestMessageTarget = useRequestMessageTarget()
+  return (
+    <button type="button" data-testid={`count-${id}`} onClick={() => requestMessageTarget('msg-0')}>
+      {id}
+    </button>
+  )
+})
+const renderCountingMessage = (m: { id: string }) => <CountingJumpRow id={m.id} />
 
 describe('MessageList explicit-target routing (containment, not registration order)', () => {
   let scrolled: Element[]
@@ -141,5 +155,83 @@ describe('MessageList explicit-target routing (containment, not registration ord
     )
     // A preview must not occupy the single global slot, or it would displace the live list.
     expect(getActiveMessageListController()).toBeNull()
+  })
+})
+
+describe('MessageList explicit-target provider identity', () => {
+  beforeEach(() => {
+    scrollStateManager.reset()
+    setActiveMessageListController(null)
+    rowRenderCounts.clear()
+    // jsdom has no layout, so the real virtualizer would window this live list down to no rows at
+    // all. Force the non-virtualized path to get mounted rows to count; the callback identity this
+    // test pins is shared by both paths.
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'false')
+  })
+
+  afterEach(() => {
+    setActiveMessageListController(null)
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('does not rerender memoized target consumers when a message is appended', () => {
+    const all = createTestMessages(6)
+    const resident = all.slice(0, 5)
+
+    const { rerender } = render(
+      <MessageList
+        messages={resident}
+        conversationId="live-conv"
+        renderMessage={renderCountingMessage}
+      />,
+    )
+    const before = new Map(rowRenderCounts)
+    expect(before.size).toBe(resident.length)
+
+    rerender(
+      <MessageList
+        messages={all}
+        conversationId="live-conv"
+        renderMessage={renderCountingMessage}
+      />,
+    )
+
+    // requestMessageTarget closes over messageCount through its executor. Publishing it raw made
+    // the context value change on every append, and a context update bypasses React.memo — so each
+    // arriving message rerendered every mounted row.
+    for (const message of resident) {
+      expect(rowRenderCounts.get(message.id)).toBe(before.get(message.id))
+    }
+    // Control: the appended row really did mount, so the assertion above is not passing because
+    // nothing rendered at all.
+    expect(rowRenderCounts.get('msg-5')).toBe(1)
+  })
+
+  it('does not re-register the active list when a message is appended', () => {
+    const all = createTestMessages(6)
+    const resident = all.slice(0, 5)
+
+    const { rerender } = render(
+      <MessageList
+        messages={resident}
+        conversationId="live-conv"
+        renderMessage={renderCountingMessage}
+      />,
+    )
+    const registered = getActiveMessageListController()
+    expect(registered).not.toBeNull()
+
+    rerender(
+      <MessageList
+        messages={all}
+        conversationId="live-conv"
+        renderMessage={renderCountingMessage}
+      />,
+    )
+
+    // Both published callbacks are identity-stable, so the registration effect must not re-run.
+    // If either tracked messageCount again, this would be a different controller object.
+    expect(getActiveMessageListController()).toBe(registered)
   })
 })

--- a/apps/fluux/src/components/conversation/MessageList.targetRouting.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.targetRouting.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+/**
+ * Routing guard: an explicit message target belongs to the list the click happened IN.
+ *
+ * Reply quotes and poll cards render inside a message list, and several lists can be mounted at
+ * once — the live conversation plus one non-virtualized preview per search/activity result. When
+ * those clicks were routed through the module-level active-list registry (which holds exactly one
+ * list), the destination depended on whichever list registered most recently:
+ *
+ *   - preview holding the registry → its own handler discarded the target (staticMode no-op);
+ *   - live list holding the registry → a click inside the PREVIEW scrolled the live conversation.
+ *
+ * Both are the same defect: registration order is not containment. These tests pin the fix from
+ * both directions, and the second one deliberately lets the LIVE list win the registry before
+ * clicking, so it fails against the registry-routed implementation instead of passing vacuously.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import { createTestMessages } from './MessageList.test-utils'
+import { useRequestMessageTarget } from './messageTargetContext'
+import {
+  setActiveMessageListController,
+  getActiveMessageListController,
+} from './activeMessageListController'
+import { scrollStateManager } from '@/utils/scrollStateManager'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(),
+    selectionCount: 0,
+    isSelecting: false,
+    selectAll: vi.fn(),
+    extendTo: vi.fn(),
+    clearSelection: vi.fn(),
+    copySelected: vi.fn(),
+  })),
+}))
+
+/**
+ * Stands in for a reply quote / poll card: it resolves its handler exactly the way MessageBubble
+ * and PollClosedCard do, so these tests exercise the real provider wiring rather than a stub.
+ */
+function JumpRow({ id, to }: { id: string; to: string }) {
+  const requestMessageTarget = useRequestMessageTarget()
+  return (
+    <button type="button" data-testid={`jump-${id}`} onClick={() => requestMessageTarget(to)}>
+      {id}
+    </button>
+  )
+}
+
+const messages = createTestMessages(8)
+const renderMessage = (m: { id: string }) => <JumpRow id={m.id} to="msg-5" />
+
+describe('MessageList explicit-target routing (containment, not registration order)', () => {
+  let scrolled: Element[]
+  let originalScrollIntoView: typeof Element.prototype.scrollIntoView
+
+  beforeEach(() => {
+    scrollStateManager.reset()
+    setActiveMessageListController(null)
+    scrolled = []
+    originalScrollIntoView = Element.prototype.scrollIntoView
+    // jsdom has no layout and no scrollIntoView; record the receiving element so we can assert
+    // WHICH list's row was positioned, not merely that something scrolled.
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrolled.push(this)
+    } as typeof Element.prototype.scrollIntoView
+  })
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView
+    setActiveMessageListController(null)
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('positions a preview click inside that preview instead of discarding it', () => {
+    const { container } = render(
+      <MessageList
+        messages={messages}
+        conversationId="preview-conv"
+        renderMessage={renderMessage}
+        staticMode
+      />,
+    )
+
+    fireEvent.click(container.querySelector('[data-testid="jump-msg-1"]')!)
+
+    const targetRow = container.querySelector('[data-message-id="msg-5"]')
+    expect(targetRow).not.toBeNull()
+    // Previously the staticMode branch returned early, so nothing scrolled at all.
+    expect(scrolled).toEqual([targetRow])
+    expect(targetRow!.classList.contains('message-highlight')).toBe(true)
+  })
+
+  it('never routes a preview click to the live conversation that holds the registry', () => {
+    const { container } = render(
+      <MessageList
+        messages={messages}
+        conversationId="preview-conv"
+        renderMessage={renderMessage}
+        staticMode
+      />,
+    )
+
+    // The live conversation list re-registers after the preview mounted — the ordering that made
+    // registry routing send preview clicks into the live conversation.
+    const liveList = { requestMessageTarget: vi.fn(), scrollToBottom: vi.fn() }
+    setActiveMessageListController(liveList)
+
+    fireEvent.click(container.querySelector('[data-testid="jump-msg-1"]')!)
+
+    expect(liveList.requestMessageTarget).not.toHaveBeenCalled()
+    // ...and the click still did its job inside the preview, so this is not passing by inaction.
+    expect(scrolled).toEqual([container.querySelector('[data-message-id="msg-5"]')])
+  })
+
+  it('registers the live list in the shared registry but never a preview', () => {
+    const { unmount } = render(
+      <MessageList messages={messages} conversationId="live-conv" renderMessage={renderMessage} />,
+    )
+    // Callers with no enclosing list (PollBanner, find-on-page) still reach the live conversation.
+    expect(getActiveMessageListController()).not.toBeNull()
+    unmount()
+
+    setActiveMessageListController(null)
+    render(
+      <MessageList
+        messages={messages}
+        conversationId="preview-conv"
+        renderMessage={renderMessage}
+        staticMode
+      />,
+    )
+    // A preview must not occupy the single global slot, or it would displace the live list.
+    expect(getActiveMessageListController()).toBeNull()
+  })
+})

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -42,6 +42,7 @@ import {
   getActiveMessageListController,
   type ActiveMessageListController,
 } from './activeMessageListController'
+import { MessageTargetProvider } from './messageTargetContext'
 import { useRowMetrics, ROW_METRICS_FALLBACK } from './useRowMetrics'
 import { estimateRowHeight } from './rowHeightEstimator'
 import { isEstimateDebugEnabled, estimateDebugLog } from '@/utils/scrollDebug'
@@ -553,11 +554,14 @@ export function MessageList<T extends BaseMessage>({
     setScrollContainerRefFromHook(element)
   }
 
-  // Register this list so outside code can submit reply/poll/find targets to the same
-  // generation-aware owner as store-driven search/activity jumps. ChatLayout's Escape handler
-  // also reaches the list's scroll-to-bottom action here. Identity-checked cleanup ensures a fast
-  // conversation switch cannot clear the new list's registration.
+  // Register this list so code with no enclosing list (PollBanner above the list, find-on-page at
+  // the layout level) and ChatLayout's Escape handler can reach the LIVE conversation. Previews are
+  // excluded on purpose: several static lists can be mounted at once, and this registry holds only
+  // one, so letting them register would make routing depend on which list rendered most recently.
+  // Callers rendered INSIDE a list route by containment instead (see messageTargetContext).
+  // Identity-checked cleanup ensures a fast conversation switch cannot clear the new registration.
   useEffect(() => {
+    if (staticMode) return
     const controller: ActiveMessageListController = {
       requestMessageTarget,
       scrollToBottom,
@@ -566,7 +570,7 @@ export function MessageList<T extends BaseMessage>({
     return () => {
       if (getActiveMessageListController() === controller) setActiveMessageListController(null)
     }
-  }, [requestMessageTarget, scrollToBottom])
+  }, [requestMessageTarget, scrollToBottom, staticMode])
 
   // Dev-only: expose the full load-earlier trigger (saves anchor + calls onScrollToTop)
   // so tests can fire it without scrolling to 0, which would change findAnchorElement's
@@ -751,6 +755,7 @@ export function MessageList<T extends BaseMessage>({
   }
 
   return (
+    <MessageTargetProvider value={requestMessageTarget}>
     <MessageWidthProvider containerRef={scrollContainerRef}>
     <OwnGroupWidthProvider>
     <div className="relative flex-1 flex flex-col min-h-0">
@@ -938,5 +943,6 @@ export function MessageList<T extends BaseMessage>({
     </div>
     </OwnGroupWidthProvider>
     </MessageWidthProvider>
+    </MessageTargetProvider>
   )
 }

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -516,6 +516,7 @@ export function MessageList<T extends BaseMessage>({
     handleLoadEarlier,
     handleMediaLoad,
     scrollToBottom,
+    requestMessageTarget,
     showScrollToBottom,
     markerAboveViewport,
     bottomVisibleMessageId,
@@ -552,28 +553,20 @@ export function MessageList<T extends BaseMessage>({
     setScrollContainerRefFromHook(element)
   }
 
-  // Register this list so outside code can reach it without threading a prop through
-  // every caller: scrollToMessage (reply-quote taps, find-on-page, poll and reaction
-  // jumps) windows an off-screen row in before its DOM read, and ChatLayout's Escape
-  // handler (spec §3 step 3, conversation catch-up) triggers the same scroll-to-bottom
-  // as the ⌘/Ctrl+↓ shortcut and FAB. hasMessage/ensureMessageMounted are virtualized-only
-  // (non-virtualized lists keep every row mounted, so scrollToMessage's plain DOM path
-  // works unchanged); scrollToBottom is always available. Identity-checked cleanup so a
-  // fast conversation switch can't clear the newly mounted list's registration.
+  // Register this list so outside code can submit reply/poll/find targets to the same
+  // generation-aware owner as store-driven search/activity jumps. ChatLayout's Escape handler
+  // also reaches the list's scroll-to-bottom action here. Identity-checked cleanup ensures a fast
+  // conversation switch cannot clear the new list's registration.
   useEffect(() => {
     const controller: ActiveMessageListController = {
-      hasMessage: (id) => activeVirtualizer ? activeVirtualizer.getIndexForMessageId(id) !== null : false,
-      ensureMessageMounted: (id) => { void activeVirtualizer?.ensureMessageMounted(id) },
-      // Reuse the same cache-slice loader as the targetMessageId jump so scrollToMessage can reach a
-      // target that scrolled out of the loaded item set entirely (issue #955: reply-quote / poll).
-      loadAround: onLoadAround,
+      requestMessageTarget,
       scrollToBottom,
     }
     setActiveMessageListController(controller)
     return () => {
       if (getActiveMessageListController() === controller) setActiveMessageListController(null)
     }
-  }, [activeVirtualizer, scrollToBottom, onLoadAround])
+  }, [requestMessageTarget, scrollToBottom])
 
   // Dev-only: expose the full load-earlier trigger (saves anchor + calls onScrollToTop)
   // so tests can fire it without scrolling to 0, which would change findAnchorElement's

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -22,6 +22,7 @@ import { render, fireEvent, act, waitFor } from '@testing-library/react'
 import { MessageList, type MessageListProps } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
 import { scrollStateManager } from '@/utils/scrollStateManager'
+import { scrollToMessage } from './messageGrouping'
 
 const ensureMessageMounted = vi.fn((_id: string) => Promise.resolve())
 const getOffsetForMessageId = vi.fn((_id: string): number | null => 0)
@@ -166,7 +167,7 @@ describe('MessageList — virtualized scroll integration', () => {
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-40')
   })
 
-  it('centers the target row via scrollToIndex when a targetMessageId is set (reply / search jump)', () => {
+  it('centers the target row via scrollToIndex when a targetMessageId is set (reply / search jump)', async () => {
     // targetMessageId (reply-to jump, search result open) resolves the row through the virtualizer
     // index (works for unmounted rows — no DOM query, no async waits) and centers it via
     // scrollToIndex('center'). Center — not align:'start' — so the row does NOT sit flush against
@@ -176,9 +177,18 @@ describe('MessageList — virtualized scroll integration', () => {
     // used for this path.
     scrollToIndexCalls.length = 0
     renderList({ targetMessageId: 'msg-30' })
-    expect(scrollToIndexCalls).toContain('center')
+    await waitFor(() => expect(scrollToIndexCalls).toContain('center'))
     expect(scrollToIndexCalls).not.toContain('start') // not tucked flush against the top edge
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-30')
+  })
+
+  it('routes reply, poll, and find-on-page jumps through the active list controller', async () => {
+    renderList()
+    scrollToIndexCalls.length = 0
+
+    act(() => scrollToMessage('msg-30'))
+
+    await waitFor(() => expect(scrollToIndexCalls).toContain('center'))
   })
 
   it('scrolls to the marker row via scrollToIndex when FAB is clicked with an unread marker', async () => {
@@ -554,6 +564,30 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
   }
 
   const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div> }
+
+  it('does not highlight a target cancelled before its first position write', () => {
+    const onConsumed = vi.fn()
+    const { container } = render(
+      <MessageList
+        messages={makeMessages(50)}
+        conversationId="conv-target-takeover"
+        targetMessageId="msg-30"
+        onTargetMessageConsumed={onConsumed}
+        {...props}
+      />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+
+    fireEvent.wheel(scroller, { deltaY: -20 })
+
+    expect(onConsumed).toHaveBeenCalledTimes(1)
+    expect(
+      container
+        .querySelector('[data-message-id="msg-30"]')
+        ?.classList.contains('message-highlight'),
+    ).toBe(false)
+    expect(scrollToIndexCalls).not.toContain('center')
+  })
 
   it('reasserts target-message jumps while virtualized rows settle', () => {
     // Reply/search/activity jumps used to call scrollToIndex('center') once. If rows above the
@@ -1196,7 +1230,7 @@ describe('MessageList — target-message highlight survives the target clear (vi
   }
 
   it('applies .message-highlight to the target row even though consuming it clears the target', () => {
-    // Hold scrollTop steady so the reassert loop reaches TARGET_STABLE_FRAMES and consumes.
+    // Hold scrollTop steady so the controller reaches its stable-frame threshold and consumes.
     scrollToIndexStartOffsets.push(1200, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400, 1400)
     const { container } = render(<Harness />)
     const scroller = container.querySelector('[data-message-list]') as HTMLElement

--- a/apps/fluux/src/components/conversation/PollClosedCard.tsx
+++ b/apps/fluux/src/components/conversation/PollClosedCard.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BarChart3, Lock } from 'lucide-react'
 import { generateConsistentColorHexSync, type PollClosedData } from '@fluux/sdk'
-import { scrollToMessage } from './messageGrouping'
+import { useRequestMessageTarget } from './messageTargetContext'
 
 export interface PollClosedCardProps {
   pollClosed: PollClosedData
@@ -22,6 +22,8 @@ function getResultColor(label: string, emoji: string): string {
 
 export function PollClosedCard({ pollClosed, closedAt }: PollClosedCardProps) {
   const { t } = useTranslation()
+  // Rendered inside a message row, so the jump belongs to the enclosing list (see MessageBubble).
+  const requestMessageTarget = useRequestMessageTarget()
 
   const totalVotes = useMemo(
     () => pollClosed.results.reduce((sum, r) => sum + r.count, 0),
@@ -46,7 +48,7 @@ export function PollClosedCard({ pollClosed, closedAt }: PollClosedCardProps) {
         <BarChart3 className="size-4 text-fluux-muted flex-shrink-0" />
         <button
           type="button"
-          onClick={() => scrollToMessage(pollClosed.pollMessageId)}
+          onClick={() => requestMessageTarget(pollClosed.pollMessageId)}
           className="font-medium text-fluux-text text-sm hover:text-fluux-brand transition-colors text-start truncate"
           title={t('poll.scrollToOriginal', 'Scroll to original poll')}
         >

--- a/apps/fluux/src/components/conversation/activeMessageListController.ts
+++ b/apps/fluux/src/components/conversation/activeMessageListController.ts
@@ -1,34 +1,21 @@
 /**
  * Registry for the currently-mounted conversation message list, so code outside the
- * list (DOM-based jump helpers, and ChatLayout's Escape handler) can reach the active
+ * list (message-target helpers and ChatLayout's Escape handler) can reach the active
  * list without threading it through every caller.
  *
- * Why this exists: under virtualization the target row of an in-conversation jump may be OUTSIDE
- * the mounted DOM window, so a raw `querySelector('[data-message-id]')` finds nothing and the jump
- * silently no-ops. The active list registers a tiny controller here; the helper asks it to window
- * the row in first, then the DOM read + scrollIntoView succeed. Non-virtualized lists keep every
- * row mounted, so `hasMessage`/`ensureMessageMounted` are no-ops there — the helper's plain DOM
- * path works unchanged. `scrollToBottom` is registered regardless of virtualization (see
- * `scrollToMessage` in messageGrouping.ts for the jump consumer, and ChatLayout's
- * `onConversationEscape` for the scroll-to-bottom consumer).
+ * Why this exists: positioning ownership lives with the active message list. Callers such as reply
+ * quotes, poll banners, and find-on-page submit a semantic target through `requestMessageTarget`;
+ * they must not start independent DOM/rAF scroll implementations outside the generation-aware
+ * positioning controller. `scrollToBottom` is registered for ChatLayout's conversation-level
+ * Escape handling.
  *
  * There is a single active conversation list at a time (ChatView / RoomView render one), so a
  * module-level singleton is sufficient. The list clears its registration on unmount (identity-
  * checked, so a fast conversation switch can't clobber the newly mounted list's registration).
  */
 export interface ActiveMessageListController {
-  /** True when `id` is in the loaded item set (resolvable by the virtualizer index), whether or
-   *  not its row is currently mounted. Always false for non-virtualized lists. */
-  hasMessage(id: string): boolean
-  /** Window the (possibly unmounted) row for `id` into the virtualizer's mounted set so a
-   *  subsequent DOM query can find it. No-op when `id` isn't in the item set. */
-  ensureMessageMounted(id: string): void
-  /** Pull the cache slice around `id` into the loaded item set, for a target that scrolled
-   *  so far out of the window it isn't even resolvable by the virtualizer index yet
-   *  (`hasMessage` is false). Reuses the same load-around path as the targetMessageId jump.
-   *  Resolves once the slice is merged. Absent on lists with no load-around wiring (older
-   *  callers, non-virtualized). `id` must be a LOCAL message id — see `scrollToMessage`. */
-  loadAround?(id: string): Promise<unknown> | void
+  /** Submit an explicit message target to the active list's positioning controller. */
+  requestMessageTarget(id: string): void
   /** Scroll the active list to the newest message (same action as the ⌘/Ctrl+↓ shortcut
    *  and the scroll-to-bottom FAB). */
   scrollToBottom(): void

--- a/apps/fluux/src/components/conversation/activeMessageListController.ts
+++ b/apps/fluux/src/components/conversation/activeMessageListController.ts
@@ -12,6 +12,11 @@
  * There is a single active conversation list at a time (ChatView / RoomView render one), so a
  * module-level singleton is sufficient. The list clears its registration on unmount (identity-
  * checked, so a fast conversation switch can't clobber the newly mounted list's registration).
+ *
+ * Static previews (SearchContextView, StrangerRequestPreviewView) deliberately do NOT register:
+ * several of them can be mounted at once beside the live list, and this registry holds only one,
+ * so registering them would make routing depend on render order. Callers rendered inside any list
+ * route by containment through `messageTargetContext` instead.
  */
 export interface ActiveMessageListController {
   /** Submit an explicit message target to the active list's positioning controller. */

--- a/apps/fluux/src/components/conversation/messageGrouping.test.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.test.ts
@@ -1,12 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { groupMessagesByDate, shouldShowAvatar, ownGroupKey, whisperThreadPosition, whisperCounterpartPresent, scrollToMessage, isActionMessage, canClosePoll } from './messageGrouping'
 import { setActiveMessageListController } from './activeMessageListController'
-
-// Mock CSS.escape since it's not available in JSDOM
-// This implementation matches the browser's CSS.escape behavior
-vi.stubGlobal('CSS', {
-  escape: (str: string) => str.replace(/([/@+=])/g, '\\$1'),
-})
 
 describe('groupMessagesByDate', () => {
   it('should group messages by date', () => {
@@ -483,226 +477,31 @@ describe('whisperCounterpartPresent', () => {
 })
 
 describe('scrollToMessage', () => {
-  let mockElement: {
-    scrollIntoView: ReturnType<typeof vi.fn>
-    classList: {
-      add: ReturnType<typeof vi.fn>
-      remove: ReturnType<typeof vi.fn>
-    }
-  }
-  let querySelectorSpy: ReturnType<typeof vi.spyOn>
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
-
-  beforeEach(() => {
-    vi.useFakeTimers()
-    mockElement = {
-      scrollIntoView: vi.fn(),
-      classList: {
-        add: vi.fn(),
-        remove: vi.fn(),
-      },
-    }
-    querySelectorSpy = vi.spyOn(document, 'querySelector')
-    vi.spyOn(document, 'querySelectorAll').mockReturnValue([] as unknown as NodeListOf<Element>)
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-  })
-
   afterEach(() => {
-    vi.useRealTimers()
+    setActiveMessageListController(null)
     vi.restoreAllMocks()
   })
 
-  it('should scroll to message element and add highlight class', () => {
-    querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
+  it('delegates the exact reference to the active list target owner', () => {
+    const requestMessageTarget = vi.fn()
+    const scrollToBottom = vi.fn()
+    setActiveMessageListController({ requestMessageTarget, scrollToBottom })
 
-    scrollToMessage('msg-123')
+    scrollToMessage('stanza+/id=123')
 
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="msg-123"]')
-    expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'center',
-    })
-    expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
+    expect(requestMessageTarget).toHaveBeenCalledTimes(1)
+    expect(requestMessageTarget).toHaveBeenCalledWith('stanza+/id=123')
+    expect(scrollToBottom).not.toHaveBeenCalled()
   })
 
-  it('should remove highlight class after 1.5 seconds', () => {
-    querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
+  it('is a safe no-op when there is no active message list', () => {
+    setActiveMessageListController(null)
+    const querySelector = vi.spyOn(document, 'querySelector')
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame')
 
-    scrollToMessage('msg-123')
-
-    // Highlight should not be removed yet
-    expect(mockElement.classList.remove).not.toHaveBeenCalled()
-
-    // Advance time by 1.5 seconds
-    vi.advanceTimersByTime(1500)
-
-    expect(mockElement.classList.remove).toHaveBeenCalledWith('message-highlight')
-  })
-
-  it('should not throw if message element is not found', () => {
-    querySelectorSpy.mockReturnValue(null)
-
-    // Should not throw
-    expect(() => scrollToMessage('non-existent-id')).not.toThrow()
-
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="non-existent-id"]')
-    expect(mockElement.scrollIntoView).not.toHaveBeenCalled()
-
-    // scrollToMessage retries several times via requestAnimationFrame before warning.
-    // Flush all pending rAF callbacks (jsdom polyfills rAF as setTimeout ~16ms/frame).
-    vi.advanceTimersByTime(300)
-
-    // Should log warning for debugging after retries exhausted
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      '[scrollToMessage] Message not found in DOM: id="non-existent-id"'
-    )
-  })
-
-  it('windows an off-screen (virtualized) target in via the active controller, then scrolls to it', () => {
-    // The target row is NOT in the DOM until the active list mounts it — the failure mode a plain
-    // querySelector retry can never recover from. scrollToMessage must ask the controller to window
-    // it in, then scroll once it mounts.
-    let mounted = false
-    querySelectorSpy.mockImplementation(() => (mounted ? (mockElement as unknown as Element) : null))
-    const ensureMessageMounted = vi.fn(() => { mounted = true })
-    setActiveMessageListController({ hasMessage: () => true, ensureMessageMounted, scrollToBottom: vi.fn() })
-    try {
-      scrollToMessage('windowed-out-id')
-
-      // Not in the DOM on the first pass → controller asked to window it in (exactly once).
-      expect(ensureMessageMounted).toHaveBeenCalledTimes(1)
-      expect(ensureMessageMounted).toHaveBeenCalledWith('windowed-out-id')
-
-      // Next frame: the row is now mounted → scrolled + highlighted, no warning.
-      vi.advanceTimersByTime(50)
-      expect(mockElement.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
-      expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
-      expect(consoleWarnSpy).not.toHaveBeenCalled()
-    } finally {
-      setActiveMessageListController(null)
-    }
-  })
-
-  it('does not ask the controller to mount an id it does not have (no churn on a truly missing id)', () => {
-    querySelectorSpy.mockReturnValue(null)
-    const ensureMessageMounted = vi.fn()
-    setActiveMessageListController({ hasMessage: () => false, ensureMessageMounted, scrollToBottom: vi.fn() })
-    try {
-      scrollToMessage('unknown-id')
-      vi.advanceTimersByTime(300)
-      expect(ensureMessageMounted).not.toHaveBeenCalled()
-      expect(consoleWarnSpy).toHaveBeenCalled()
-    } finally {
-      setActiveMessageListController(null)
-    }
-  })
-
-  it('requests a cache slice for an out-of-window target, then windows + scrolls once it loads', async () => {
-    // The target scrolled far out of the loaded window, so it is not even in the virtualizer's
-    // item set (hasMessage === false) — ensureMessageMounted alone can never recover it (this is
-    // issue #955: reply-quote and poll jumps silently no-op). scrollToMessage must pull the cache
-    // slice around the id via loadAround, wait past its default retry budget for the async fetch,
-    // then window + scroll as usual once the row enters the item set.
-    let loaded = false
-    let mounted = false
-    querySelectorSpy.mockImplementation(() => (mounted ? (mockElement as unknown as Element) : null))
-    // Resolve well past the default ~130ms retry window so the widened budget is exercised.
-    const loadAround = vi.fn(
-      () => new Promise<void>(resolve => setTimeout(() => { loaded = true; resolve() }, 300)),
-    )
-    const ensureMessageMounted = vi.fn(() => { mounted = true })
-    setActiveMessageListController({
-      hasMessage: () => loaded,
-      ensureMessageMounted,
-      loadAround,
-      scrollToBottom: vi.fn(),
-    })
-    try {
-      scrollToMessage('far-out-id')
-
-      // First pass: not in the item set → cache slice requested exactly once.
-      expect(loadAround).toHaveBeenCalledTimes(1)
-      expect(loadAround).toHaveBeenCalledWith('far-out-id')
-
-      // Slice loads (async) → id enters the item set → row windowed in → scrolled + highlighted.
-      await vi.advanceTimersByTimeAsync(500)
-      expect(ensureMessageMounted).toHaveBeenCalledWith('far-out-id')
-      expect(mockElement.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
-      expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
-      expect(consoleWarnSpy).not.toHaveBeenCalled()
-
-      // The slice is requested once, not per retry frame.
-      expect(loadAround).toHaveBeenCalledTimes(1)
-    } finally {
-      setActiveMessageListController(null)
-    }
-  })
-
-  it('should handle special characters in message ID by escaping them', () => {
-    querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
-
-    scrollToMessage('msg-with-special/chars@123')
-
-    // CSS.escape escapes special characters like / and @ with backslashes
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="msg-with-special\\/chars\\@123"]')
-    expect(mockElement.scrollIntoView).toHaveBeenCalled()
-  })
-
-  it('should escape base64 encoded message IDs', () => {
-    querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
-
-    // Base64 IDs often contain +, /, and = characters
-    scrollToMessage('abc+def/ghi=jkl')
-
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="abc\\+def\\/ghi\\=jkl"]')
-    expect(mockElement.scrollIntoView).toHaveBeenCalled()
-  })
-
-  it('should resolve a message by its stanza-id when the local id does not match', () => {
-    // Regression: MUC replies (XEP-0461) reference the room-assigned stanza-id, but
-    // DOM rows are keyed by local message id. When the reply context froze the raw
-    // stanza-id (target not in the lookup at render time), scrollToMessage must fall
-    // through to data-stanza-id to find the row instead of giving up.
-    querySelectorSpy.mockImplementation((sel: string) =>
-      sel === '[data-stanza-id="2026-06-08-b9469e60caa58b7f"]'
-        ? (mockElement as unknown as Element)
-        : null
-    )
-
-    scrollToMessage('2026-06-08-b9469e60caa58b7f')
-
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="2026-06-08-b9469e60caa58b7f"]')
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-stanza-id="2026-06-08-b9469e60caa58b7f"]')
-    expect(mockElement.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'center',
-    })
-    expect(mockElement.classList.add).toHaveBeenCalledWith('message-highlight')
-  })
-
-  it('should resolve a message by its origin-id when neither local id nor stanza-id match', () => {
-    // XEP-0308 corrections reference the sender-assigned origin-id.
-    querySelectorSpy.mockImplementation((sel: string) =>
-      sel === '[data-origin-id="origin-xyz"]' ? (mockElement as unknown as Element) : null
-    )
-
-    scrollToMessage('origin-xyz')
-
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-origin-id="origin-xyz"]')
-    expect(mockElement.scrollIntoView).toHaveBeenCalled()
-  })
-
-  it('should prefer the local-id match over stanza-id / origin-id', () => {
-    // The strong local-id tier wins so a sender-controlled origin-id can never shadow
-    // a real id match on a different row.
-    querySelectorSpy.mockReturnValue(mockElement as unknown as Element)
-
-    scrollToMessage('local-1')
-
-    // First lookup is by data-message-id; since it matches, the fallbacks are skipped.
-    expect(querySelectorSpy).toHaveBeenCalledWith('[data-message-id="local-1"]')
-    expect(querySelectorSpy).not.toHaveBeenCalledWith('[data-stanza-id="local-1"]')
-    expect(mockElement.scrollIntoView).toHaveBeenCalled()
+    expect(() => scrollToMessage('missing-target')).not.toThrow()
+    expect(querySelector).not.toHaveBeenCalled()
+    expect(requestFrame).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -272,87 +272,13 @@ export function whisperCounterpartPresent(
 }
 
 /**
- * Scrolls to a message element and highlights it temporarily.
- * Used when clicking on reply context to jump to the original message.
+ * Ask the active message list to position and highlight a message.
  *
- * @param messageId - The ID of the message to scroll to (matches data-message-id attribute)
+ * The active list owns target resolution, loading, browser reconciliation, and cancellation. This
+ * helper intentionally performs no DOM lookup or scroll write of its own.
+ *
+ * @param messageId - Local, stanza, or origin ID understood by the active list's target resolver.
  */
 export function scrollToMessage(messageId: string): void {
-  // Use CSS.escape to handle special characters in message IDs (e.g., +, /, =)
-  // Some clients use base64-encoded IDs that contain these characters
-  const escapedId = CSS.escape(messageId)
-
-  // A reply/reaction/correction references its target by whichever id tier the
-  // sender chose: XEP-0461 replies in a MUC reference the room-assigned stanza-id,
-  // XEP-0308 corrections reference the sender's origin-id. The DOM keys each row by
-  // the local message id but also exposes data-stanza-id / data-origin-id, so resolve
-  // against every tier — the reference passed here may not have been mapped back to a
-  // local id (e.g. the target wasn't in the lookup when the reply row last rendered).
-  function findElement(): Element | null {
-    return (
-      document.querySelector(`[data-message-id="${escapedId}"]`) ??
-      document.querySelector(`[data-stanza-id="${escapedId}"]`) ??
-      document.querySelector(`[data-origin-id="${escapedId}"]`)
-    )
-  }
-
-  let requestedMount = false
-  let requestedLoad = false
-
-  // A windowed-in row needs a few frames to mount + measure (covers a first-render race and an
-  // in-window re-window). A cache-slice fetch (loadAround) is asynchronous and much slower, so the
-  // retry budget widens to this once a load is requested — otherwise the loop would exhaust and warn
-  // before the slice lands.
-  const LOAD_AROUND_RETRY_FRAMES = 60
-
-  function tryScroll(retriesLeft: number) {
-    const element = findElement()
-    if (element) {
-      // scrollIntoView uses the real measured layout, so it lands precisely even when the row was
-      // just windowed in via an estimate-based scrollToIndex below (which self-corrects here).
-      element.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      element.classList.add('message-highlight')
-      setTimeout(() => element.classList.remove('message-highlight'), 1500)
-      return
-    }
-    // Under virtualization the target row may be OUTSIDE the mounted window, so the DOM query above
-    // finds nothing (retrying alone never helps — the row is never rendered). Two cases:
-    //   1. The row IS in the loaded item set (hasMessage) but its virtual row is unmounted — ask the
-    //      active list to window it in once, then keep retrying while it mounts and measures.
-    //   2. The row scrolled so far out that it isn't in the item set at all (issue #955: reply-quote
-    //      and poll jumps) — pull the cache slice around it via loadAround once, widen the retry
-    //      window to cover the async fetch, then case 1 windows it in once hasMessage flips true.
-    // Both are no-ops / absent for non-virtualized lists, where every row is already in the DOM.
-    //
-    // KNOWN EDGE: loadAround anchors on a LOCAL message id (getMessagesAround is keyed by it). A
-    // reply that references an OUT-OF-WINDOW target by its stanza-id / origin-id (XEP-0461/0308) has
-    // no local id to anchor the slice, so case 2 can't fetch it — the load falls through and the
-    // jump warns. In-window stanza/origin targets still resolve via findElement's 3-tier DOM query
-    // above. This covers reply-by-local-id and poll jumps (both carry local ids); a stanza→local map
-    // for out-of-window stanza/origin refs is future work.
-    const controller = getActiveMessageListController()
-    if (controller?.hasMessage(messageId)) {
-      if (!requestedMount) {
-        controller.ensureMessageMounted(messageId)
-        requestedMount = true
-      }
-    } else if (!requestedLoad && controller?.loadAround) {
-      requestedLoad = true
-      void Promise.resolve(controller.loadAround(messageId))
-      retriesLeft = Math.max(retriesLeft, LOAD_AROUND_RETRY_FRAMES)
-    }
-    if (retriesLeft > 0) {
-      // Element may not be in the DOM yet (first render, a row still being windowed in, or a cache
-      // slice still loading). Retry after the next frame.
-      requestAnimationFrame(() => tryScroll(retriesLeft - 1))
-    } else {
-      // Debug: message not found in DOM, log to help diagnose issues
-      console.warn(`[scrollToMessage] Message not found in DOM: id="${messageId}"`)
-      const allMsgEls = document.querySelectorAll('[data-message-id]')
-      const ids = Array.from(allMsgEls).slice(-20).map(el => el.getAttribute('data-message-id'))
-      console.warn(`[scrollToMessage] Last ${ids.length} message IDs in DOM:`, ids)
-    }
-  }
-
-  tryScroll(8)
+  getActiveMessageListController()?.requestMessageTarget(messageId)
 }

--- a/apps/fluux/src/components/conversation/messageGrouping.ts
+++ b/apps/fluux/src/components/conversation/messageGrouping.ts
@@ -272,10 +272,15 @@ export function whisperCounterpartPresent(
 }
 
 /**
- * Ask the active message list to position and highlight a message.
+ * Ask the LIVE conversation list to position and highlight a message.
  *
  * The active list owns target resolution, loading, browser reconciliation, and cancellation. This
  * helper intentionally performs no DOM lookup or scroll write of its own.
+ *
+ * Only for callers with no enclosing message list that genuinely mean the live conversation
+ * (PollBanner above the list, find-on-page at the layout level). Anything rendered INSIDE a list —
+ * reply quotes, poll cards — must use `useRequestMessageTarget` so the click routes to the list it
+ * happened in; otherwise a click inside a search/activity preview scrolls the live conversation.
  *
  * @param messageId - Local, stanza, or origin ID understood by the active list's target resolver.
  */

--- a/apps/fluux/src/components/conversation/messageTargetContext.ts
+++ b/apps/fluux/src/components/conversation/messageTargetContext.ts
@@ -1,0 +1,39 @@
+/**
+ * Routes an explicit message target to the list that CONTAINS the caller.
+ *
+ * Reply quotes and poll cards render inside a message list, but several lists can be mounted at
+ * once: the live conversation plus one non-virtualized preview per search/activity result
+ * (SearchContextView, StrangerRequestPreviewView). The module-level
+ * {@link getActiveMessageListController} registry holds only ONE list, so routing a click through
+ * it is decided by whichever list registered most recently — which means a click inside a preview
+ * could either no-op (preview registered) or scroll the LIVE conversation (live list registered).
+ *
+ * Containment, not registration order, is the correct routing rule: a click belongs to the list it
+ * happened in. Callers rendered inside a list therefore read the enclosing list's handler from this
+ * context. The registry remains for callers that legitimately have no enclosing list and mean the
+ * live conversation (PollBanner above the list, find-on-page at the layout level).
+ */
+import { createContext, useCallback, useContext } from 'react'
+import { getActiveMessageListController } from './activeMessageListController'
+
+const MessageTargetContext = createContext<((messageReference: string) => void) | null>(null)
+
+export const MessageTargetProvider = MessageTargetContext.Provider
+
+/**
+ * Resolve the target handler for the enclosing message list, falling back to the active-list
+ * registry when the caller is rendered outside any list.
+ */
+export function useRequestMessageTarget(): (messageReference: string) => void {
+  const enclosing = useContext(MessageTargetContext)
+  return useCallback(
+    (messageReference: string) => {
+      if (enclosing) {
+        enclosing(messageReference)
+        return
+      }
+      getActiveMessageListController()?.requestMessageTarget(messageReference)
+    },
+    [enclosing],
+  )
+}

--- a/apps/fluux/src/components/conversation/messageTargetElement.test.ts
+++ b/apps/fluux/src/components/conversation/messageTargetElement.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { findMessageTargetElement } from './messageTargetElement'
+
+describe('findMessageTargetElement', () => {
+  it('resolves local, stanza, and origin ids within the supplied list only', () => {
+    const outside = document.createElement('div')
+    outside.innerHTML = '<div data-message-id="shared"></div>'
+    document.body.append(outside)
+
+    const root = document.createElement('div')
+    root.innerHTML = [
+      '<div data-message-id="local/id" data-stanza-id="stanza+id" data-origin-id="origin=id"></div>',
+      '<div data-message-id="shared"></div>',
+    ].join('')
+
+    expect(findMessageTargetElement(root, 'local/id')?.dataset.messageId).toBe('local/id')
+    expect(findMessageTargetElement(root, 'stanza+id')?.dataset.messageId).toBe('local/id')
+    expect(findMessageTargetElement(root, 'origin=id')?.dataset.messageId).toBe('local/id')
+    expect(findMessageTargetElement(root, 'shared')?.parentElement).toBe(root)
+
+    outside.remove()
+  })
+
+  it('prefers the local id tier when aliases collide', () => {
+    const root = document.createElement('div')
+    root.innerHTML = [
+      '<div data-stanza-id="same" data-message-id="stanza-row"></div>',
+      '<div data-message-id="same"></div>',
+      '<div data-origin-id="same" data-message-id="origin-row"></div>',
+    ].join('')
+
+    expect(findMessageTargetElement(root, 'same')?.dataset.messageId).toBe('same')
+  })
+})

--- a/apps/fluux/src/components/conversation/messageTargetElement.ts
+++ b/apps/fluux/src/components/conversation/messageTargetElement.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve a message reference inside one conversation list.
+ *
+ * Replies and corrections may carry the local id, the room-assigned stanza id, or the sender's
+ * origin id. Keeping this lookup scoped to the active scroller prevents a mounted preview from
+ * stealing a live-conversation jump.
+ */
+export function findMessageTargetElement(
+  root: ParentNode,
+  messageReference: string,
+): HTMLElement | null {
+  const escaped = CSS.escape(messageReference)
+  return (
+    root.querySelector<HTMLElement>(`[data-message-id="${escaped}"]`) ??
+    root.querySelector<HTMLElement>(`[data-stanza-id="${escaped}"]`) ??
+    root.querySelector<HTMLElement>(`[data-origin-id="${escaped}"]`)
+  )
+}

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -3,6 +3,8 @@ import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManag
 import type { MessageVirtualizer } from './messageVirtualizer'
 import {
   PositioningController,
+  type ExplicitTargetExecutor,
+  type ExplicitTargetFrameResult,
   type PositionExecutionLease,
   type PositionRequestDraft,
   type SavedPositionExecutionLease,
@@ -27,6 +29,7 @@ import {
   messageFraction,
   pixelOffset,
   type BottomFractionAnchorPosition,
+  type ReachabilityFacts,
   type LiveEdgePosition,
   type SavedPositionRequest,
 } from './scrollPositionModel'
@@ -895,6 +898,411 @@ describe('positioning controller unread-marker ownership', () => {
       'unread-marker-unavailable',
       expect.any(Object),
     )
+  })
+})
+
+describe('positioning controller explicit-target ownership', () => {
+  function targetHarness(options: {
+    reachability?: (
+      loadStatus: Parameters<ExplicitTargetExecutor['reachability']>[1],
+    ) => ReachabilityFacts
+    loadAround?: ExplicitTargetExecutor['loadAround']
+  } = {}) {
+    const callbacks: Array<() => void> = []
+    const finish = vi.fn()
+    const recordFrame = vi.fn()
+    const complete = vi.fn()
+    const leases: PositionExecutionLease[] = []
+    let frameResult: ExplicitTargetFrameResult = { kind: 'waiting' }
+    let scrollTop = 0
+    const positionFrame = vi.fn(() => frameResult)
+    const beginLoop = vi.fn((lease: PositionExecutionLease) => {
+      leases.push(lease)
+      return {
+        schedule: (callback: () => void) => callbacks.push(callback),
+        recordFrame,
+        finish,
+      }
+    })
+    const executor: ExplicitTargetExecutor = {
+      reachability: (_desired, loadStatus) =>
+        options.reachability?.(loadStatus) ?? {
+          kind: 'available',
+          index: 12,
+          mounted: true,
+          placement: 'viable',
+        },
+      loadAround: options.loadAround,
+      beginLoop,
+      readScrollTop: () => scrollTop,
+      positionFrame,
+      complete,
+    }
+    return {
+      executor,
+      callbacks,
+      finish,
+      recordFrame,
+      complete,
+      leases,
+      positionFrame,
+      beginLoop,
+      setFrameResult: (result: ExplicitTargetFrameResult) => {
+        frameResult = result
+        if (result.kind === 'positioned') scrollTop = result.scrollTop
+      },
+      setScrollTop: (value: number) => {
+        scrollTop = value
+      },
+      runFrame: () => {
+        const callback = callbacks.shift()
+        expect(callback).toBeDefined()
+        callback!()
+      },
+    }
+  }
+
+  it('loads an absent target once and re-drives it when the load completes', async () => {
+    let available = false
+    let resolveLoad!: () => void
+    const loadPromise = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    const loadAround = vi.fn(() => loadPromise)
+    const harness = targetHarness({
+      reachability: (loadStatus) =>
+        available
+          ? {
+              kind: 'available',
+              index: 12,
+              mounted: false,
+              placement: 'viable',
+            }
+          : { kind: 'target-absent', loadAround: loadStatus },
+      loadAround,
+    })
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'target-a',
+      executor: harness.executor,
+    })
+    const refreshed = controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'target-a',
+      executor: harness.executor,
+    })
+
+    expect(refreshed?.generation).toBe(request?.generation)
+    expect(loadAround).toHaveBeenCalledTimes(1)
+    expect(harness.beginLoop).not.toHaveBeenCalled()
+
+    available = true
+    resolveLoad()
+    await loadPromise
+    await Promise.resolve()
+
+    expect(harness.beginLoop).toHaveBeenCalledTimes(1)
+    expect(harness.callbacks).toHaveLength(1)
+  })
+
+  it('keeps an exhausted wait target pending without repeating its around load', async () => {
+    const loadAround = vi.fn().mockResolvedValue(undefined)
+    const harness = targetHarness({
+      reachability: (loadStatus) => ({
+        kind: 'target-absent',
+        loadAround: loadStatus,
+      }),
+      loadAround,
+    })
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'missing-target',
+      executor: harness.executor,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.snapshot().active).toMatchObject({
+      request: { generation: request!.generation },
+      phase: { kind: 'pending', reason: 'target-not-indexed' },
+    })
+    controller.refreshExplicitTarget({
+      conversationId,
+      generation: request!.generation,
+      executor: harness.executor,
+    })
+    expect(loadAround).toHaveBeenCalledTimes(1)
+    expect(harness.complete).not.toHaveBeenCalled()
+  })
+
+  it('settles after four stable frames and records every actual write', () => {
+    const harness = targetHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'stable-target',
+      executor: harness.executor,
+    })
+
+    for (const scrollTop of [100, 115, 116, 117, 118]) {
+      harness.setFrameResult({
+        kind: 'positioned',
+        scrollTop,
+        wrote: true,
+      })
+      harness.runFrame()
+    }
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(5)
+    expect(harness.recordFrame).toHaveBeenCalledTimes(5)
+    expect(harness.recordFrame).toHaveBeenCalledWith(true)
+    expect(harness.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        desired: expect.objectContaining({ messageId: 'stable-target' }),
+      }),
+      'settled',
+      true,
+    )
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+  })
+
+  it('completes best-effort after exactly thirty non-converging writes', () => {
+    const harness = targetHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'moving-target',
+      executor: harness.executor,
+    })
+
+    for (let frame = 0; frame < 30; frame += 1) {
+      harness.setFrameResult({
+        kind: 'positioned',
+        scrollTop: frame * 20,
+        wrote: true,
+      })
+      harness.runFrame()
+    }
+    expect(harness.complete).not.toHaveBeenCalled()
+    harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(30)
+    expect(harness.recordFrame).toHaveBeenCalledTimes(30)
+    expect(harness.complete).toHaveBeenCalledWith(
+      expect.any(Object),
+      'best-effort',
+      true,
+    )
+  })
+
+  it('reports user takeover and invalidates the queued target frame', () => {
+    const harness = targetHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'cancelled-target',
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    controller.observeUserInput(conversationId)
+    staleFrame()
+
+    expect(harness.positionFrame).not.toHaveBeenCalled()
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+    expect(harness.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        desired: expect.objectContaining({ messageId: 'cancelled-target' }),
+      }),
+      'user-takeover',
+      false,
+    )
+  })
+
+  it('treats a 301px geometry drift as user takeover', () => {
+    const harness = targetHarness()
+    harness.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 100,
+      wrote: true,
+    })
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'dragged-away-target',
+      executor: harness.executor,
+    })
+    harness.runFrame()
+    harness.setScrollTop(401)
+    harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.complete).toHaveBeenCalledWith(
+      expect.any(Object),
+      'user-takeover',
+      true,
+    )
+    expect(controller.snapshot().active).toBeNull()
+  })
+
+  it('silently supersedes target A with B and drops A queued work', () => {
+    const targetA = targetHarness()
+    const targetB = targetHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'target-a',
+      executor: targetA.executor,
+    })
+    const staleFrame = targetA.callbacks.shift()!
+    const targetBRequest = controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'target-b',
+      executor: targetB.executor,
+    })
+
+    staleFrame()
+
+    expect(targetA.finish).toHaveBeenCalledTimes(1)
+    expect(targetA.positionFrame).not.toHaveBeenCalled()
+    expect(targetA.complete).not.toHaveBeenCalled()
+    expect(targetB.callbacks).toHaveLength(1)
+    expect(controller.snapshot().active?.request).toBe(targetBRequest)
+  })
+
+  it('drops an around-load completion after switching rooms without completing the target', async () => {
+    let resolveLoad!: () => void
+    const loadPromise = new Promise<void>((resolve) => {
+      resolveLoad = resolve
+    })
+    const harness = targetHarness({
+      reachability: (loadStatus) => ({
+        kind: 'target-absent',
+        loadAround: loadStatus,
+      }),
+      loadAround: () => loadPromise,
+    })
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'old-room-target',
+      executor: harness.executor,
+    })
+
+    observeLiveEntry(controller, 'next-room@example.test')
+    resolveLoad()
+    await loadPromise
+    await Promise.resolve()
+
+    expect(harness.beginLoop).not.toHaveBeenCalled()
+    expect(harness.complete).not.toHaveBeenCalled()
+    expect(controller.snapshot().currentConversationId).toBe(
+      'next-room@example.test',
+    )
+  })
+
+  it('lets a target supersede unread entry without completing the marker or target', () => {
+    const markerCallbacks: Array<() => void> = []
+    const markerFinish = vi.fn()
+    const markerExecutor: UnreadMarkerExecutor = {
+      reachability: () => ({
+        kind: 'available',
+        index: 3,
+        mounted: true,
+        placement: 'viable',
+      }),
+      beginLoop: () => ({
+        schedule: (callback) => markerCallbacks.push(callback),
+        recordFrame: vi.fn(),
+        finish: markerFinish,
+      }),
+      readScrollTop: () => 0,
+      positionFrame: () => ({ kind: 'waiting' }),
+      applyLiveEdge: () => true,
+    }
+    const target = targetHarness()
+    const controller = new PositioningController()
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: deriveEntryPositionFacts({
+        syncedLiveEdge: false,
+        savedAnchor: null,
+        savedOffsetPx: null,
+        firstUnreadMessageId: 'first-unread',
+        unreadMarkerAlign: 'start',
+      }),
+      executor: markerExecutor,
+    })
+    const staleMarkerFrame = markerCallbacks.shift()!
+
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'explicit-target',
+      executor: target.executor,
+    })
+    staleMarkerFrame()
+
+    expect(markerFinish).toHaveBeenCalledTimes(1)
+    expect(target.complete).not.toHaveBeenCalled()
+    expect(target.callbacks).toHaveLength(1)
+  })
+
+  it('lets a newer unread entry silently cancel an explicit target', () => {
+    const target = targetHarness()
+    const markerFinish = vi.fn()
+    const markerExecutor: UnreadMarkerExecutor = {
+      reachability: () => ({
+        kind: 'available',
+        index: 3,
+        mounted: true,
+        placement: 'viable',
+      }),
+      beginLoop: () => ({
+        schedule: vi.fn(),
+        recordFrame: vi.fn(),
+        finish: markerFinish,
+      }),
+      readScrollTop: () => 0,
+      positionFrame: () => ({ kind: 'waiting' }),
+      applyLiveEdge: () => true,
+    }
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    controller.beginExplicitTarget({
+      conversationId,
+      messageId: 'superseded-target',
+      executor: target.executor,
+    })
+    const staleTargetFrame = target.callbacks.shift()!
+
+    controller.beginUnreadMarkerEntry({
+      conversationId,
+      entryFacts: deriveEntryPositionFacts({
+        syncedLiveEdge: false,
+        savedAnchor: null,
+        savedOffsetPx: null,
+        firstUnreadMessageId: 'first-unread',
+        unreadMarkerAlign: 'start',
+      }),
+      executor: markerExecutor,
+    })
+    staleTargetFrame()
+
+    expect(target.finish).toHaveBeenCalledTimes(1)
+    expect(target.positionFrame).not.toHaveBeenCalled()
+    expect(target.complete).not.toHaveBeenCalled()
+    expect(markerFinish).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -11,6 +11,7 @@ import {
   settleUserPosition,
   shouldReconcileAfterAppend,
   type EntryPositionFacts,
+  type ExplicitTargetRequest,
   type LiveEdgeNavigationFacts,
   type PositionRequest,
   type PositioningModel,
@@ -53,6 +54,12 @@ export interface PositionExecutionLease {
 
 export type SavedPositionExecutionLease = PositionExecutionLease
 
+export interface PositionFrameLoop {
+  schedule: (callback: () => void) => void
+  recordFrame: (wrote: boolean) => void
+  finish: () => void
+}
+
 export interface SavedPositionExecutor {
   reachability: (
     desired: SavedPositionRequest['desired'],
@@ -73,11 +80,7 @@ export interface SavedPositionExecutor {
   ) => boolean
 }
 
-export interface UnreadMarkerFrameLoop {
-  schedule: (callback: () => void) => void
-  recordFrame: (wrote: boolean) => void
-  finish: () => void
-}
+export type UnreadMarkerFrameLoop = PositionFrameLoop
 
 export type UnreadMarkerFrameResult =
   | { kind: 'waiting' }
@@ -104,6 +107,42 @@ export interface UnreadMarkerExecutor {
   ) => boolean
 }
 
+export type ExplicitTargetCompletion =
+  | 'settled'
+  | 'best-effort'
+  | 'user-takeover'
+
+export type ExplicitTargetFrameResult =
+  | { kind: 'waiting' }
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      wrote: boolean
+    }
+
+export interface ExplicitTargetExecutor {
+  reachability: (
+    desired: ExplicitTargetRequest['desired'],
+    loadAround: SavedPositionLoadAroundStatus,
+  ) => ReachabilityFacts
+  loadAround?: (
+    messageId: string,
+    signal: AbortSignal,
+  ) => Promise<unknown> | unknown
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  readScrollTop: () => number | null
+  positionFrame: (
+    request: ExplicitTargetRequest,
+    lease: PositionExecutionLease,
+  ) => ExplicitTargetFrameResult
+  complete: (
+    request: ExplicitTargetRequest,
+    outcome: ExplicitTargetCompletion,
+    applied: boolean,
+  ) => void
+}
+
 interface SavedPositionExecutionState {
   request: SavedPositionRequest
   executor: SavedPositionExecutor
@@ -127,6 +166,24 @@ interface UnreadMarkerExecutionState {
   resolvedAtLiveEdge: boolean
 }
 
+interface ExplicitTargetExecutionState {
+  request: ExplicitTargetRequest
+  executor: ExplicitTargetExecutor
+  operation: number
+  abortController: AbortController | null
+  aroundAttempted: boolean
+  loadingAround: boolean
+  loop: PositionFrameLoop | null
+  framesLeft: number
+  stableFrames: number
+  landedTarget: number | null
+  applied: boolean
+}
+
+const EXPLICIT_TARGET_REASSERT_FRAMES = 30
+const EXPLICIT_TARGET_STABLE_FRAMES = 4
+const EXPLICIT_TARGET_DRIFT_PX = 16
+const EXPLICIT_TARGET_TAKEOVER_DRIFT_PX = 300
 const UNREAD_MARKER_REASSERT_FRAMES = 120
 const UNREAD_MARKER_STABLE_FRAMES = 8
 const UNREAD_MARKER_DRIFT_PX = 16
@@ -174,6 +231,7 @@ export class PositioningController {
   private model: PositioningModel = initialPositioningModel()
   private savedExecution: SavedPositionExecutionState | null = null
   private unreadExecution: UnreadMarkerExecutionState | null = null
+  private explicitTargetExecution: ExplicitTargetExecutionState | null = null
 
   snapshot(): PositioningModel {
     return this.model
@@ -214,6 +272,7 @@ export class PositioningController {
     if (accepted === this.model) return null
     this.cancelSavedExecution()
     this.cancelUnreadExecution()
+    this.cancelExplicitTargetExecution()
     this.model = advancePhaseIfCurrent(
       accepted,
       input.conversationId,
@@ -329,6 +388,118 @@ export class PositioningController {
         )
       },
     })
+  }
+
+  beginExplicitTarget(input: {
+    conversationId: string
+    messageId: string
+    executor: ExplicitTargetExecutor
+  }): ExplicitTargetRequest | null {
+    return runScrollShadowSafely({
+      event: 'explicit-target-begin',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const current = this.explicitTargetExecution
+        if (
+          current &&
+          this.isExplicitTargetExecutionCurrent(current) &&
+          current.request.conversationId === input.conversationId &&
+          current.request.desired.messageId === input.messageId
+        ) {
+          current.executor = input.executor
+          this.driveExplicitTarget(current)
+          return current.request
+        }
+
+        const generation = mintPositionGeneration()
+        const request = withIdentity(
+          input.conversationId,
+          generation,
+          {
+            source: { kind: 'user-navigation', reason: 'message-target' },
+            desired: {
+              kind: 'message',
+              messageId: input.messageId,
+              align: 'center',
+            },
+            onUnavailable: { kind: 'wait' },
+          },
+        ) as ExplicitTargetRequest
+        const reachability = input.executor.reachability(
+          request.desired,
+          input.executor.loadAround ? 'available' : 'unavailable',
+        )
+        if (!reachabilityMatchesRequest(request, reachability)) return null
+
+        const accepted = acceptPositionRequest(this.model, request)
+        if (accepted === this.model) return null
+        this.cancelSavedExecution()
+        this.cancelUnreadExecution()
+        this.cancelExplicitTargetExecution()
+        this.model = advancePhaseIfCurrent(
+          accepted,
+          input.conversationId,
+          generation,
+          resolveReachability(request, reachability),
+        )
+        const execution: ExplicitTargetExecutionState = {
+          request,
+          executor: input.executor,
+          operation: 0,
+          abortController: null,
+          aroundAttempted: false,
+          loadingAround: false,
+          loop: null,
+          framesLeft: EXPLICIT_TARGET_REASSERT_FRAMES,
+          stableFrames: 0,
+          landedTarget: null,
+          applied: false,
+        }
+        this.explicitTargetExecution = execution
+        this.driveExplicitTarget(execution)
+        return request
+      },
+    })
+  }
+
+  refreshExplicitTarget(input: {
+    conversationId: string
+    generation: number
+    executor: ExplicitTargetExecutor
+  }): boolean {
+    const execution = this.explicitTargetExecution
+    if (
+      !execution ||
+      execution.request.conversationId !== input.conversationId ||
+      execution.request.generation !== input.generation ||
+      !this.isExplicitTargetExecutionCurrent(execution)
+    ) {
+      return false
+    }
+    execution.executor = input.executor
+    this.driveExplicitTarget(execution)
+    return true
+  }
+
+  cancelExplicitTarget(conversationId: string, generation: number): boolean {
+    const execution = this.explicitTargetExecution
+    if (
+      !execution ||
+      execution.request.conversationId !== conversationId ||
+      execution.request.generation !== generation ||
+      !this.isExplicitTargetExecutionCurrent(execution)
+    ) {
+      return false
+    }
+    this.model = advancePhaseIfCurrent(
+      this.model,
+      conversationId,
+      generation,
+      { kind: 'settled' },
+    )
+    this.cancelExplicitTargetExecution()
+    return true
   }
 
   observeEntry(input: {
@@ -545,11 +716,23 @@ export class PositioningController {
       observe: () => {
         const generation = this.model.active?.request.generation
         if (generation === undefined) return
+        const targetExecution = this.explicitTargetExecution
+        const targetWasCurrent =
+          targetExecution !== null &&
+          targetExecution.request.conversationId === conversationId &&
+          this.isExplicitTargetExecutionCurrent(targetExecution)
         this.model = cancelReconciliationForUserInput(
           this.model,
           conversationId,
           generation,
         )
+        if (targetWasCurrent && targetExecution) {
+          this.finishExplicitTargetExecution(
+            targetExecution,
+            false,
+            'user-takeover',
+          )
+        }
         this.cancelExecutionsIfSuperseded()
       },
     })
@@ -621,6 +804,7 @@ export class PositioningController {
     if (accepted === this.model) return null
     this.cancelSavedExecution()
     this.cancelUnreadExecution()
+    this.cancelExplicitTargetExecution()
     this.model = advancePhaseIfCurrent(
       accepted,
       conversationId,
@@ -647,6 +831,383 @@ export class PositioningController {
       this.startUnreadMarkerLoop(execution)
     }
     return request
+  }
+
+  private driveExplicitTarget(
+    execution: ExplicitTargetExecutionState,
+  ): void {
+    if (
+      !this.isExplicitTargetExecutionCurrent(execution) ||
+      execution.loop
+    ) {
+      return
+    }
+
+    const loadAround: SavedPositionLoadAroundStatus = execution.loadingAround
+      ? 'loading'
+      : execution.aroundAttempted
+        ? 'exhausted'
+        : execution.executor.loadAround
+          ? 'available'
+          : 'unavailable'
+    const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+      event: 'explicit-target-reachability',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.reachability(
+        execution.request.desired,
+        loadAround,
+      ),
+    })
+    if (!reachability) return
+
+    const phase = resolveReachability(execution.request, reachability)
+    this.model = advancePhaseIfCurrent(
+      this.model,
+      execution.request.conversationId,
+      execution.request.generation,
+      phase,
+    )
+    if (!this.isExplicitTargetExecutionCurrent(execution)) return
+
+    switch (phase.kind) {
+      case 'loading-around':
+        this.startExplicitTargetAroundLoad(execution, phase.messageId)
+        return
+      case 'mounting':
+      case 'reconciling':
+        execution.loadingAround = false
+        this.startExplicitTargetLoop(execution)
+        return
+      case 'unavailable':
+        // Explicit navigation has `onUnavailable: wait`; retain the request so a later resident
+        // window refresh can make it reachable.
+        this.model = advancePhaseIfCurrent(
+          this.model,
+          execution.request.conversationId,
+          execution.request.generation,
+          { kind: 'pending', reason: 'target-not-indexed' },
+        )
+        return
+      case 'resolving':
+      case 'pending':
+      case 'recentering-live-edge':
+      case 'position-applied':
+      case 'settled':
+      case 'paused-user-input':
+        return
+    }
+  }
+
+  private startExplicitTargetAroundLoad(
+    execution: ExplicitTargetExecutionState,
+    messageId: string,
+  ): void {
+    if (execution.loadingAround || execution.aroundAttempted) return
+    execution.aroundAttempted = true
+    execution.loadingAround = true
+    const lease = this.beginExplicitTargetOperation(execution)
+    const load = execution.executor.loadAround
+      ? runScrollShadowSafely<Promise<unknown> | unknown | null>({
+          event: 'explicit-target-load-around',
+          conversationId: execution.request.conversationId,
+          fallback: null,
+          observe: () =>
+            execution.executor.loadAround?.(messageId, lease.signal) ?? null,
+        })
+      : null
+    if (load === null) {
+      if (lease.isCurrent()) {
+        execution.loadingAround = false
+        this.driveExplicitTarget(execution)
+      }
+      return
+    }
+    void Promise.resolve(load)
+      .catch(() => undefined)
+      .finally(() => {
+        if (!lease.isCurrent()) return
+        execution.loadingAround = false
+        this.driveExplicitTarget(execution)
+      })
+  }
+
+  private startExplicitTargetLoop(
+    execution: ExplicitTargetExecutionState,
+  ): void {
+    if (
+      !this.isExplicitTargetExecutionCurrent(execution) ||
+      execution.loop
+    ) {
+      return
+    }
+    execution.framesLeft = EXPLICIT_TARGET_REASSERT_FRAMES
+    execution.stableFrames = 0
+    execution.landedTarget = null
+    execution.applied = false
+    const lease = this.beginExplicitTargetOperation(execution)
+    const loop = runScrollShadowSafely<PositionFrameLoop | null>({
+      event: 'explicit-target-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      if (loop) {
+        runScrollShadowSafely({
+          event: 'explicit-target-loop-stale-finish',
+          conversationId: execution.request.conversationId,
+          fallback: undefined,
+          observe: () => loop.finish(),
+        })
+      }
+      return
+    }
+    if (!loop) {
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+        { kind: 'pending', reason: 'target-not-indexed' },
+      )
+      return
+    }
+    execution.loop = loop
+    this.scheduleExplicitTargetFrame(execution, lease)
+  }
+
+  private driveExplicitTargetFrame(
+    execution: ExplicitTargetExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (execution.framesLeft-- <= 0) {
+      if (execution.applied) {
+        this.finishExplicitTargetExecution(
+          execution,
+          true,
+          'best-effort',
+        )
+      } else {
+        this.finishExplicitTargetLoop(execution)
+        this.model = advancePhaseIfCurrent(
+          this.model,
+          execution.request.conversationId,
+          execution.request.generation,
+          { kind: 'pending', reason: 'target-not-indexed' },
+        )
+      }
+      return
+    }
+
+    const currentScrollTop = runScrollShadowSafely<number | null>({
+      event: 'explicit-target-read-scroll-top',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.readScrollTop(),
+    })
+    if (
+      currentScrollTop !== null &&
+      execution.landedTarget !== null &&
+      Math.abs(currentScrollTop - execution.landedTarget) >
+        EXPLICIT_TARGET_TAKEOVER_DRIFT_PX
+    ) {
+      const { conversationId, generation } = execution.request
+      this.model = cancelReconciliationForUserInput(
+        this.model,
+        conversationId,
+        generation,
+      )
+      this.finishExplicitTargetExecution(
+        execution,
+        false,
+        'user-takeover',
+      )
+      return
+    }
+
+    const result = runScrollShadowSafely<ExplicitTargetFrameResult>({
+      event: 'explicit-target-frame',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.positionFrame(
+        execution.request,
+        lease,
+      ),
+    })
+    if (!lease.isCurrent()) return
+
+    if (result.kind === 'waiting') {
+      this.recordExplicitTargetFrame(execution, false)
+      this.scheduleExplicitTargetFrame(execution, lease)
+      return
+    }
+    if (result.kind === 'unavailable') {
+      this.finishExplicitTargetLoop(execution)
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+        { kind: 'pending', reason: 'target-not-indexed' },
+      )
+      return
+    }
+
+    execution.applied = true
+    lease.markApplied()
+    if (!lease.isCurrent()) return
+
+    if (
+      execution.landedTarget !== null &&
+      Math.abs(result.scrollTop - execution.landedTarget) <=
+        EXPLICIT_TARGET_DRIFT_PX
+    ) {
+      execution.stableFrames += 1
+      if (execution.stableFrames >= EXPLICIT_TARGET_STABLE_FRAMES) {
+        this.recordExplicitTargetFrame(execution, result.wrote)
+        this.finishExplicitTargetExecution(execution, true, 'settled')
+        return
+      }
+    } else {
+      execution.stableFrames = 0
+    }
+    execution.landedTarget = result.scrollTop
+    this.recordExplicitTargetFrame(execution, result.wrote)
+    this.scheduleExplicitTargetFrame(execution, lease)
+  }
+
+  private scheduleExplicitTargetFrame(
+    execution: ExplicitTargetExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'explicit-target-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveExplicitTargetFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      this.finishExplicitTargetLoop(execution)
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+        { kind: 'pending', reason: 'target-not-indexed' },
+      )
+    }
+  }
+
+  private recordExplicitTargetFrame(
+    execution: ExplicitTargetExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'explicit-target-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private beginExplicitTargetOperation(
+    execution: ExplicitTargetExecutionState,
+  ): PositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.explicitTargetExecution === execution &&
+      execution.operation === operation &&
+      execution.request.conversationId === conversationId &&
+      execution.request.generation === generation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isExplicitTargetExecutionCurrent(
+    execution: ExplicitTargetExecutionState,
+  ): boolean {
+    return (
+      this.explicitTargetExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
+  }
+
+  private finishExplicitTargetExecution(
+    execution: ExplicitTargetExecutionState,
+    settle: boolean,
+    outcome?: ExplicitTargetCompletion,
+  ): void {
+    if (settle && this.isExplicitTargetExecutionCurrent(execution)) {
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+        { kind: 'settled' },
+      )
+    }
+    this.finishExplicitTargetLoop(execution)
+    execution.abortController?.abort()
+    if (this.explicitTargetExecution === execution) {
+      this.explicitTargetExecution = null
+    }
+    if (outcome) {
+      runScrollShadowSafely({
+        event: 'explicit-target-complete',
+        conversationId: execution.request.conversationId,
+        fallback: undefined,
+        observe: () => execution.executor.complete(
+          execution.request,
+          outcome,
+          execution.applied,
+        ),
+      })
+    }
+  }
+
+  private finishExplicitTargetLoop(
+    execution: ExplicitTargetExecutionState,
+  ): void {
+    const loop = execution.loop
+    execution.loop = null
+    if (!loop) return
+    runScrollShadowSafely({
+      event: 'explicit-target-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => loop.finish(),
+    })
   }
 
   private resolveUnreadMarkerReachability(
@@ -1216,6 +1777,13 @@ export class PositioningController {
     ) {
       this.cancelUnreadExecution()
     }
+    const targetExecution = this.explicitTargetExecution
+    if (
+      targetExecution &&
+      !this.isExplicitTargetExecutionCurrent(targetExecution)
+    ) {
+      this.cancelExplicitTargetExecution()
+    }
   }
 
   private cancelSavedExecution(): void {
@@ -1229,6 +1797,14 @@ export class PositioningController {
       this.unreadExecution.abortController?.abort()
     }
     this.unreadExecution = null
+  }
+
+  private cancelExplicitTargetExecution(): void {
+    if (this.explicitTargetExecution) {
+      this.finishExplicitTargetLoop(this.explicitTargetExecution)
+      this.explicitTargetExecution.abortController?.abort()
+    }
+    this.explicitTargetExecution = null
   }
 }
 

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -194,6 +194,11 @@ export type SavedPositionRequest = Extract<
   | { source: { kind: 'fallback'; reason: 'saved-position-unavailable' } }
 >
 
+export type ExplicitTargetRequest = Extract<
+  PositionRequest,
+  { source: { kind: 'user-navigation'; reason: 'message-target' } }
+>
+
 export type UnreadMarkerRequest = Extract<
   PositionRequest,
   | { source: { kind: 'entry'; reason: 'unread-marker' } }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -155,6 +155,25 @@ const CONTENT_ARRIVAL_TRIGGERS: ReadonlySet<string> = new Set([
   'mam-catchup-complete',
 ])
 
+/**
+ * Freeze a callback's identity while always invoking its latest version.
+ *
+ * Positioning callbacks close over `messageCount`, `firstMessageId`, and window state through their
+ * executors, so their identity changes on every append. That is harmless for a direct call, but two
+ * of them are published: `requestMessageTarget` is a context value read by EVERY message row, and
+ * both are dependencies of the active-list registration. An unstable identity there re-renders every
+ * mounted row on each append — context updates bypass `React.memo` — and re-registers the list.
+ * Forwarding through a ref keeps behaviour identical (the newest implementation still runs) while
+ * the published identity stays constant.
+ */
+function useStableCallback<Args extends unknown[]>(
+  callback: (...args: Args) => void,
+): (...args: Args) => void {
+  const latest = useRef(callback)
+  latest.current = callback
+  return useCallback((...args: Args) => latest.current(...args), [])
+}
+
 // ============================================================================
 // KINETIC SCROLL
 // ============================================================================
@@ -1621,7 +1640,7 @@ export function useMessageListScroll({
     windowAtLiveEdge,
   ])
 
-  const requestMessageTarget = useCallback((messageReference: string) => {
+  const requestMessageTargetImpl = useCallback((messageReference: string) => {
     if (staticMode) {
       // Search/activity previews mount their own non-virtualized list beside the live conversation.
       // They own no positioning controller and must never drive one, but their reply/poll rows are
@@ -1650,12 +1669,15 @@ export function useMessageListScroll({
     isAtBottomRef,
     staticMode,
   ])
+  // Published to every message row through MessageTargetProvider and to the active-list registry,
+  // so its identity must not track messageCount/window state (see useStableCallback).
+  const requestMessageTarget = useStableCallback(requestMessageTargetImpl)
 
   // ==========================================================================
   // SCROLL ACTIONS
   // ==========================================================================
 
-  const scrollToBottom = useCallback(() => {
+  const scrollToBottomImpl = useCallback(() => {
     const scroller = scrollerRef.current
     if (!scroller) return
 
@@ -1746,6 +1768,10 @@ export function useMessageListScroll({
     reassertBottom,
     rememberBottomIntent,
   ])
+  // Also published to the active-list registry (ChatLayout's Escape handler reaches it there), so it
+  // is stabilised for the same reason as requestMessageTarget: an unstable identity re-registers the
+  // list — and re-binds the ⌘/Ctrl+↓ listener — on every append.
+  const scrollToBottom = useStableCallback(scrollToBottomImpl)
 
   const scrollToTop = useCallback(() => {
     lastLoadTimeRef.current = Date.now() // prevent auto-load trigger

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -112,6 +112,9 @@ const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-loa
 const SAVE_THROTTLE_MS = 100 // minimum time between position saves
 const PREPEND_COOLDOWN_MS = 500 // time to keep prepend flag after restore (prevents re-trigger)
 const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
+// How long a jumped-to message keeps its highlight tint, for both the controller-owned live path
+// and the scoped static-preview path (they must flash identically).
+const TARGET_HIGHLIGHT_MS = 1500
 // Frames to keep re-pinning a virtualized list to the bottom after a scroll-to-bottom. Rows
 // start at the fixed estimateSize and re-measure asynchronously over several frames (taller →
 // scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
@@ -1598,7 +1601,7 @@ export function useMessageListScroll({
         : null
       if (element && applied) {
         element.classList.add('message-highlight')
-        setTimeout(() => element.classList.remove('message-highlight'), 1500)
+        setTimeout(() => element.classList.remove('message-highlight'), TARGET_HIGHLIGHT_MS)
       }
       debugLog('TARGET MESSAGE: controller completed', {
         conversationId: request.conversationId,
@@ -1619,7 +1622,22 @@ export function useMessageListScroll({
   ])
 
   const requestMessageTarget = useCallback((messageReference: string) => {
-    if (staticMode) return
+    if (staticMode) {
+      // Search/activity previews mount their own non-virtualized list beside the live conversation.
+      // They own no positioning controller and must never drive one, but their reply/poll rows are
+      // still clickable — so resolve inside THIS scroller only. Never the document: a preview must
+      // not steal (or be stolen by) another list's copy of the same message id. Every row is in the
+      // DOM here (staticMode forces the non-virtualized path), so one measured write is enough and
+      // no generation, frame loop, or around-load is involved.
+      const scroller = scrollerRef.current
+      if (!scroller) return
+      const element = findMessageTargetElement(scroller, messageReference)
+      if (!element) return
+      element.scrollIntoView({ block: 'center' })
+      element.classList.add('message-highlight')
+      setTimeout(() => element.classList.remove('message-highlight'), TARGET_HIGHLIGHT_MS)
+      return
+    }
     isAtBottomRef.current = false
     positioningControllerRef.current?.beginExplicitTarget({
       conversationId,

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,8 +3,9 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Saved-position and unread-marker policy/retry ownership lives in PositioningController;
- *    browser writes stay imperative in hook executors while the remaining mechanisms migrate
+ * 2. Saved-position, unread-marker, and explicit-target policy/retry ownership lives in
+ *    PositioningController; browser writes stay imperative in hook executors while the remaining
+ *    mechanisms migrate
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
  * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
@@ -31,7 +32,7 @@ import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
 import {
   PositioningController,
-  type PositionRequestDraft,
+  type ExplicitTargetExecutor,
   type PositionExecutionLease,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
@@ -48,11 +49,13 @@ import {
   messageFraction,
   pixelOffset,
   type DesiredPosition,
+  type ExplicitTargetRequest,
   type ReachabilityFacts,
   type SavedPositionRequest,
   type UnreadMarkerRequest,
 } from './scrollPositionModel'
 import { runScrollShadowSafely } from './scrollPositionShadow'
+import { findMessageTargetElement } from './messageTargetElement'
 
 // ============================================================================
 // DEBUG
@@ -114,11 +117,6 @@ const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load even
 // scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
 // one-shot scrollToIndex isn't enough. ~1s at 60fps comfortably covers the measurement settle.
 const BOTTOM_REASSERT_FRAMES = 60
-// Target jumps (reply/search/activity) need the same measurement-aware behavior as unread-marker
-// entry, but for a shorter window: the target row is explicitly requested and should settle fast.
-const TARGET_REASSERT_FRAMES = 30
-const TARGET_STABLE_FRAMES = 4
-const TARGET_DRIFT_PX = 16
 // Saved-position (content-anchor) restore needs the SAME measurement-aware re-assert as the marker
 // path. A one-shot scrollToIndex(anchor,'end') lands on the rows' ESTIMATED sizes; those rows then
 // measure TALLER over the next frames (media, wrapping), the content above the anchor grows, and the
@@ -317,6 +315,8 @@ export interface UseMessageListScrollResult {
   handleMediaLoad: () => void
   scrollToBottom: () => void
   scrollToTop: () => void
+  /** Submit a reply/poll/find target to the generation-aware positioning controller. */
+  requestMessageTarget: (messageReference: string) => void
   showScrollToBottom: boolean
   /** Whether the first-new-message divider is currently scrolled above the viewport. Drives the
    *  jump-to-last-read pill. */
@@ -423,6 +423,13 @@ export function useMessageListScroll({
   // loader synchronous with the render so a conversation switch cannot invoke the room we left.
   const onLoadAroundRef = useRef(onLoadAround)
   onLoadAroundRef.current = onLoadAround
+  // Explicit-target completion may run after the render that submitted it. Keep the current target
+  // and callback synchronous so a stale generation can never clear a newer search/activity target.
+  const targetMessageIdRef = useRef(targetMessageId)
+  targetMessageIdRef.current = targetMessageId
+  const onTargetMessageConsumedRef = useRef(onTargetMessageConsumed)
+  onTargetMessageConsumedRef.current = onTargetMessageConsumed
+  const storeTargetRequestRef = useRef<ExplicitTargetRequest | null>(null)
 
   // Latest MAM-loading state (forward catch-up on entry, or backward "load older" pagination) for
   // the active conversation, read imperatively inside pinVirtualizedBottom's stable useCallback —
@@ -469,8 +476,8 @@ export function useMessageListScroll({
   // React StrictMode replays layout-effect cleanup/setup without unmounting the DOM. Defer controller
   // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
   const unmountDeactivationTokenRef = useRef<object | null>(null)
-  // Generation-aware semantic controller. Saved-position restoration and unread-marker
-  // reconciliation are authoritative; the remaining positioning mechanisms still report shadow
+  // Generation-aware semantic controller. Saved-position restoration, unread-marker positioning,
+  // and explicit message targets are authoritative; the remaining mechanisms still report shadow
   // decisions. Pixel writes stay in hook executors, while the module-private generation allocator
   // survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
@@ -504,10 +511,6 @@ export function useMessageListScroll({
       },
     })
   }
-  // Last target message id we requested an around-load for (search / activity navigation to a
-  // message older than the loaded window). Prevents re-issuing the load while the target effect
-  // re-fires waiting for the slice to merge.
-  const targetAroundRequestedRef = useRef<string | null>(null)
   // Track prepend (loading older messages)
   // When we load older messages, we save the anchor element position BEFORE the load,
   // then restore it AFTER React renders the new messages.
@@ -1349,6 +1352,42 @@ export function useMessageListScroll({
     windowAtLiveEdge,
   ])
 
+  const beginControllerFrameLoop = useCallback((
+    label: string,
+    lease: PositionExecutionLease,
+  ) => {
+    if (!lease.isCurrent()) return null
+    supersedeReassertLoopRef.current()
+    const monitor = (reassertMonitorRef.current ??=
+      createReassertLoopMonitor()).begin(label, performance.now())
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      monitor.end()
+      const activeLoop = reassertLoopRef.current
+      if (activeLoop?.handle === monitor) {
+        cancelAnimationFrame(activeLoop.raf)
+        reassertLoopRef.current = null
+      }
+    }
+    return {
+      schedule: (callback: () => void) => {
+        if (finished || !lease.isCurrent()) return
+        // Register before scheduling so synchronous-rAF test harnesses cannot resurrect a loop that
+        // completed from inside the callback.
+        const entry = { raf: 0, handle: monitor }
+        reassertLoopRef.current = entry
+        entry.raf = requestAnimationFrame(callback)
+      },
+      recordFrame: (wrote: boolean) => {
+        const warning = monitor.frame(performance.now(), wrote)
+        if (warning) console.warn(warning)
+      },
+      finish,
+    }
+  }, [])
+
   const createUnreadMarkerExecutor = useCallback((): UnreadMarkerExecutor => ({
     reachability: (desired) => deriveReachabilityForDesired({
       desired,
@@ -1359,38 +1398,8 @@ export function useMessageListScroll({
       loadAround: 'unavailable',
       canRecenter: false,
     }),
-    beginLoop: (lease: PositionExecutionLease) => {
-      if (!lease.isCurrent()) return null
-      supersedeReassertLoopRef.current()
-      const monitor = (reassertMonitorRef.current ??=
-        createReassertLoopMonitor()).begin('marker', performance.now())
-      let finished = false
-      const finish = () => {
-        if (finished) return
-        finished = true
-        monitor.end()
-        const activeLoop = reassertLoopRef.current
-        if (activeLoop?.handle === monitor) {
-          cancelAnimationFrame(activeLoop.raf)
-          reassertLoopRef.current = null
-        }
-      }
-      return {
-        schedule: (callback) => {
-          if (finished || !lease.isCurrent()) return
-          // Register before scheduling so synchronous-rAF test harnesses cannot resurrect a loop
-          // that completed from inside the callback.
-          const entry = { raf: 0, handle: monitor }
-          reassertLoopRef.current = entry
-          entry.raf = requestAnimationFrame(callback)
-        },
-        recordFrame: (wrote) => {
-          const warning = monitor.frame(performance.now(), wrote)
-          if (warning) console.warn(warning)
-        },
-        finish,
-      }
-    },
+    beginLoop: (lease: PositionExecutionLease) =>
+      beginControllerFrameLoop('marker', lease),
     readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
     positionFrame: (
       request: UnreadMarkerRequest,
@@ -1468,10 +1477,160 @@ export function useMessageListScroll({
     },
   }), [
     firstMessageId,
+    beginControllerFrameLoop,
     isAtBottomRef,
     messageCount,
     reassertBottom,
     windowAtLiveEdge,
+  ])
+
+  const createExplicitTargetExecutor = useCallback((
+    messageReference: string,
+    consumeStoreTarget: boolean,
+  ): ExplicitTargetExecutor => ({
+    reachability: (desired, loadAround) => {
+      const scroller = scrollerRef.current
+      const virtualizer = virtualizerRef.current
+      const element = scroller
+        ? findMessageTargetElement(scroller, desired.messageId)
+        : null
+      if (element) {
+        return {
+          kind: 'available',
+          index: virtualizer?.getIndexForMessageId(desired.messageId) ?? 0,
+          mounted: true,
+          placement: 'viable',
+        }
+      }
+      const facts = deriveReachabilityForDesired({
+        desired,
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+        virtualizer,
+        scroller,
+        loadAround,
+        canRecenter: false,
+      })
+      // Unlike ordinary entry hydration, an explicit target is meaningful even when the resident
+      // window is empty: it can name the cache slice that must be loaded.
+      return facts.kind === 'empty-window'
+        ? { kind: 'target-absent', loadAround }
+        : facts
+    },
+    loadAround: onLoadAroundRef.current
+      ? (messageId, signal) => {
+          if (
+            signal.aborted ||
+            activeConversationIdRef.current !== conversationId
+          ) {
+            return
+          }
+          isAtBottomRef.current = false
+          debugLog('TARGET MESSAGE: requesting cache slice around target', {
+            conversationId,
+            messageId,
+          })
+          return onLoadAroundRef.current?.(messageId)
+        }
+      : undefined,
+    beginLoop: (lease) => beginControllerFrameLoop('target', lease),
+    readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
+    positionFrame: (
+      request: ExplicitTargetRequest,
+      lease: PositionExecutionLease,
+    ) => {
+      if (!lease.isCurrent()) return { kind: 'unavailable' }
+      const scroller = scrollerRef.current
+      if (!scroller) return { kind: 'unavailable' }
+
+      // The request may be submitted during entry. Wait for the passive handoff so a stale
+      // virtualizer from the room we left cannot receive the first center write.
+      const latest = latestRef.current
+      if (latest.conversationId !== request.conversationId) {
+        return { kind: 'waiting' }
+      }
+
+      const targetId = request.desired.messageId
+      const virtualizer = latest.virtualizer
+      const index = virtualizer?.getIndexForMessageId(targetId) ?? null
+      const element = findMessageTargetElement(scroller, targetId)
+      if (index === null && !element) return { kind: 'waiting' }
+      if (!lease.isCurrent()) return { kind: 'unavailable' }
+
+      if (index !== null && virtualizer) {
+        virtualizer.scrollToIndex(index, { align: 'center' })
+      } else {
+        element?.scrollIntoView({ block: 'center' })
+      }
+      const scrollTop = scroller.scrollTop
+      const distanceFromBottom =
+        scroller.scrollHeight - scrollTop - scroller.clientHeight
+      isAtBottomRef.current = distanceFromBottom < AT_BOTTOM_THRESHOLD
+      debugLog('TARGET MESSAGE: controller positioned frame', {
+        conversationId: request.conversationId,
+        generation: request.generation,
+        targetId,
+        index,
+        scrollTop,
+        distanceFromBottom,
+      })
+      return { kind: 'positioned', scrollTop, wrote: true }
+    },
+    complete: (request, outcome, applied) => {
+      if (
+        activeConversationIdRef.current !== request.conversationId ||
+        request.desired.messageId !== messageReference
+      ) {
+        return
+      }
+      if (
+        consumeStoreTarget &&
+        targetMessageIdRef.current !== request.desired.messageId
+      ) {
+        return
+      }
+
+      const element = scrollerRef.current
+        ? findMessageTargetElement(
+            scrollerRef.current,
+            request.desired.messageId,
+          )
+        : null
+      if (element && applied) {
+        element.classList.add('message-highlight')
+        setTimeout(() => element.classList.remove('message-highlight'), 1500)
+      }
+      debugLog('TARGET MESSAGE: controller completed', {
+        conversationId: request.conversationId,
+        generation: request.generation,
+        targetId: request.desired.messageId,
+        outcome,
+        highlighted: Boolean(element && applied),
+      })
+      if (consumeStoreTarget) onTargetMessageConsumedRef.current?.()
+    },
+  }), [
+    beginControllerFrameLoop,
+    conversationId,
+    firstMessageId,
+    isAtBottomRef,
+    messageCount,
+    windowAtLiveEdge,
+  ])
+
+  const requestMessageTarget = useCallback((messageReference: string) => {
+    if (staticMode) return
+    isAtBottomRef.current = false
+    positioningControllerRef.current?.beginExplicitTarget({
+      conversationId,
+      messageId: messageReference,
+      executor: createExplicitTargetExecutor(messageReference, false),
+    })
+  }, [
+    conversationId,
+    createExplicitTargetExecutor,
+    isAtBottomRef,
+    staticMode,
   ])
 
   // ==========================================================================
@@ -2392,11 +2551,11 @@ export function useMessageListScroll({
         // to bottom when content grows (messages loading from IndexedDB).
         isAtBottomRef.current = false
         debugLog('CONVERSATION SWITCH: has targetMessageId, deferring to target scroll', { targetMessageId })
-        if (entryFacts) {
+        if (entryExecutionFacts) {
           positioningControllerRef.current?.observeEntry({
             event: 'entry-before-explicit-target',
             conversationId,
-            entryFacts,
+            entryFacts: entryExecutionFacts,
             reachability: (desired) => shadowReachabilityRef.current(desired),
             actual: {
               desired: { kind: 'live-edge', follow: true },
@@ -2645,216 +2804,51 @@ export function useMessageListScroll({
     }
   }, [])
 
-  // ==========================================================================
-  // EFFECT: Scroll to target message (from activity log click, etc.)
-  // ==========================================================================
-  //
-  // When targetMessageId is set (e.g., user clicked a reaction in the activity log),
-  // scroll to that specific message. Uses the same data-message-id attribute pattern
-  // as the unread marker scroll. Clears the target after consumption.
-
+  // Store-driven search/activity/reaction targets use the same controller execution as reply,
+  // poll, and find-on-page requests. Re-renders refresh the executor for the existing generation;
+  // load-around completion also re-drives it without relying on messageCount changing.
   useEffect(() => {
+    const previous = storeTargetRequestRef.current
     if (!targetMessageId || staticMode) {
-      // Target cleared (consumed or navigated away): allow a future jump to the same id to
-      // re-request its slice (it may have been evicted again in the meantime).
-      if (!targetMessageId) targetAroundRequestedRef.current = null
+      if (previous) {
+        positioningControllerRef.current?.cancelExplicitTarget(
+          previous.conversationId,
+          previous.generation,
+        )
+        storeTargetRequestRef.current = null
+      }
       return
     }
-    const scroller = scrollerRef.current
-    if (!scroller) return
 
-    const virt = latestRef.current.virtualizer
-    const escapedId = CSS.escape(targetMessageId)
-    const shadowTargetDesired = {
-      kind: 'message',
+    isAtBottomRef.current = false
+    const executor = createExplicitTargetExecutor(targetMessageId, true)
+    if (
+      previous &&
+      previous.conversationId === conversationId &&
+      previous.desired.messageId === targetMessageId &&
+      positioningControllerRef.current?.refreshExplicitTarget({
+        conversationId,
+        generation: previous.generation,
+        executor,
+      })
+    ) {
+      return
+    }
+
+    const request = positioningControllerRef.current?.beginExplicitTarget({
+      conversationId,
       messageId: targetMessageId,
-      align: 'center',
-    } as const
-    const shadowTargetDraft: PositionRequestDraft = {
-      source: { kind: 'user-navigation', reason: 'message-target' },
-      desired: shadowTargetDesired,
-      onUnavailable: { kind: 'wait' },
-    }
-
-    const highlight = (el: Element) => {
-      el.classList.add('message-highlight')
-      setTimeout(() => el.classList.remove('message-highlight'), 1500)
-    }
-
-    if (virt) {
-      // Virtualized: resolve the row by index (works whether or not the row is mounted)
-      // and let the virtualizer window it in. No DOM query or retry timeouts needed.
-      // messageCount is in deps so this effect re-fires if the message isn't in the list
-      // yet (e.g., search opens a conversation before messages finish loading from cache).
-      const idx = virt.getIndexForMessageId(targetMessageId)
-      if (idx === null) {
-        positioningControllerRef.current?.observeRequest({
-          event: 'explicit-target-waiting',
-          conversationId,
-          draft: shadowTargetDraft,
-          reachability: shadowReachabilityRef.current(shadowTargetDesired),
-          actual: { desired: shadowTargetDesired, phase: 'waiting' },
-        })
-        // The target isn't in the loaded window — pull in the cache slice that contains it (search /
-        // activity jump to a message older than the latest-N slice). The merge grows messageCount,
-        // re-firing this effect with the target now resolvable. Request once per target.
-        const loader = latestRef.current.onLoadAround
-        if (loader && targetAroundRequestedRef.current !== targetMessageId) {
-          targetAroundRequestedRef.current = targetMessageId
-          debugLog('TARGET MESSAGE: not loaded, requesting cache slice around it', { targetMessageId })
-          void Promise.resolve(loader(targetMessageId))
-        } else {
-          debugLog('TARGET MESSAGE: not in item set yet, waiting for load', { targetMessageId })
-        }
-        return
-      }
-      const targetConvId = conversationId
-      positioningControllerRef.current?.observeRequest({
-        event: 'explicit-target',
-        conversationId,
-        draft: shadowTargetDraft,
-        reachability: shadowReachabilityRef.current(shadowTargetDesired),
-        actual: { desired: shadowTargetDesired, phase: 'positioning' },
-      })
-      const startedAt = Date.now()
-      supersedeReassertLoopRef.current()
-      const targetLoop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('target', performance.now())
-      let framesLeft = TARGET_REASSERT_FRAMES
-      let stableFrames = 0
-      let landedTarget = -1
-      let targetRafId: number | null = null
-      let finished = false
-      let consumed = false
-
-      const finishTarget = () => {
-        if (finished) return
-        finished = true
-        targetLoop.end()
-        if (reassertLoopRef.current?.handle === targetLoop) {
-          if (targetRafId !== null) cancelAnimationFrame(targetRafId)
-          reassertLoopRef.current = null
-        }
-      }
-
-      const consumeAndHighlight = () => {
-        if (consumed) return
-        consumed = true
-        // Apply the highlight synchronously BEFORE clearing the target (mirrors the non-virtualized
-        // branch below). onTargetMessageConsumed clears targetMessageId, which re-runs this effect and
-        // fires its cleanup in the same tick; a deferred (rAF) highlight got cancelled by that cleanup
-        // before it could paint, so the "go to message" flash silently vanished. The reassert loop has
-        // already settled the target row into the window, so it is mounted and queryable now.
-        const el = scrollerRef.current?.querySelector(`[data-message-id="${escapedId}"]`)
-        if (el) highlight(el)
-        onTargetMessageConsumed?.()
-      }
-
-      const stepToTarget = () => {
-        if (framesLeft-- <= 0) {
-          finishTarget()
-          consumeAndHighlight()
-          return
-        }
-        const s = scrollerRef.current
-        const v = latestRef.current.virtualizer
-        if (!s || !v) { finishTarget(); return }
-        if (prevConversationRef.current !== targetConvId) { finishTarget(); return }
-        if (userScrollIntentAtRef.current > startedAt) {
-          finishTarget()
-          consumeAndHighlight()
-          return
-        }
-
-        const currentIdx = v.getIndexForMessageId(targetMessageId)
-        if (currentIdx === null) {
-          finishTarget()
-          return
-        }
-
-        // Center the target rather than pinning it to the top edge (align:'start'), which tucks it
-        // under the sticky date header where it reads as misaligned and the highlight flash is easy
-        // to miss. scrollToIndex('center') windows the (possibly far-out-of-window) row in, measures
-        // it, and clamps internally — so a near-bottom target stays visible instead of being scrolled
-        // past the fold (the failure mode of a manual getOffsetForMessageId − clientHeight/3 shift,
-        // since getOffsetForMessageId returns an offset already clamped to the scrollable range).
-        // Re-asserting each frame converges as rows settle. Matches the reply-scroll block:'center'.
-        v.scrollToIndex(currentIdx, { align: 'center' })
-        const st = s.scrollTop
-        const distFromBottom = s.scrollHeight - st - s.clientHeight
-        isAtBottomRef.current = distFromBottom < AT_BOTTOM_THRESHOLD
-
-        let wrote = false
-        if (landedTarget >= 0 && Math.abs(st - landedTarget) <= TARGET_DRIFT_PX) {
-          if (++stableFrames >= TARGET_STABLE_FRAMES) {
-            finishTarget()
-            consumeAndHighlight()
-            return
-          }
-        } else {
-          wrote = true
-          stableFrames = 0
-          debugLog('TARGET MESSAGE: reasserting virtualizer index', {
-            targetMessageId,
-            idx: currentIdx,
-            scrollTop: st,
-            distFromBottom,
-            isAtBottom: isAtBottomRef.current,
-          })
-        }
-        landedTarget = st
-
-        const warning = targetLoop.frame(performance.now(), wrote)
-        if (warning) console.warn(warning)
-        targetRafId = requestAnimationFrame(stepToTarget)
-        reassertLoopRef.current = { raf: targetRafId, handle: targetLoop }
-      }
-
-      debugLog('TARGET MESSAGE: scrolling via virtualizer index', { targetMessageId, idx })
-      stepToTarget()
-
-      return () => {
-        finishTarget()
-      }
-    } else {
-      // Non-virtualized: all rows are always in the DOM.
-      const el = scroller.querySelector(`[data-message-id="${escapedId}"]`)
-      if (!el) {
-        positioningControllerRef.current?.observeRequest({
-          event: 'explicit-target-waiting',
-          conversationId,
-          draft: shadowTargetDraft,
-          reachability: shadowReachabilityRef.current(shadowTargetDesired),
-          actual: { desired: shadowTargetDesired, phase: 'waiting' },
-        })
-        const loader = latestRef.current.onLoadAround
-        if (loader && targetAroundRequestedRef.current !== targetMessageId) {
-          targetAroundRequestedRef.current = targetMessageId
-          debugLog('TARGET MESSAGE: not loaded (non-virtualized), requesting cache slice around it', { targetMessageId })
-          void Promise.resolve(loader(targetMessageId))
-        } else {
-          debugLog('TARGET MESSAGE: element not found (non-virtualized), waiting for load', { targetMessageId })
-        }
-        return
-      }
-      // Center the target (matches the virtualized path above and the reply-scroll convention);
-      // the browser clamps scrollTop, so a near-bottom target stays fully visible.
-      ;(el as HTMLElement).scrollIntoView({ block: 'center' })
-      positioningControllerRef.current?.observeRequest({
-        event: 'explicit-target',
-        conversationId,
-        draft: shadowTargetDraft,
-        reachability: shadowReachabilityRef.current(shadowTargetDesired),
-        actual: { desired: shadowTargetDesired, phase: 'positioning' },
-      })
-      isAtBottomRef.current = (scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight) < AT_BOTTOM_THRESHOLD
-      highlight(el)
-      debugLog('TARGET MESSAGE: scrolled to target (center)', { targetMessageId })
-      onTargetMessageConsumed?.()
-    }
-
-    // messageCount is in deps so this re-fires when messages load from async sources
-    // (e.g., IndexedDB in search context view)
-  }, [targetMessageId, messageCount, conversationId, isAtBottomRef, onTargetMessageConsumed, staticMode])
+      executor,
+    }) ?? null
+    storeTargetRequestRef.current = request
+  }, [
+    targetMessageId,
+    messageCount,
+    conversationId,
+    createExplicitTargetExecutor,
+    isAtBottomRef,
+    staticMode,
+  ])
 
   // ==========================================================================
   // EFFECT: Cleanup on unmount
@@ -3630,6 +3624,7 @@ export function useMessageListScroll({
     handleMediaLoad,
     scrollToBottom,
     scrollToTop,
+    requestMessageTarget,
     showScrollToBottom,
     markerAboveViewport,
     bottomVisibleMessageId,

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,7 +1,8 @@
 # Message-list scroll positioning contract
 
-Status: migration in progress. Saved-position restoration is the first authoritative controller
-slice; unread, explicit targets, live-edge pinning, and directional history remain shadow-observed.
+Status: migration in progress. Saved-position restoration, unread-marker positioning, and explicit
+message targets are authoritative controller slices. Live-edge pinning and directional history
+preservation remain shadow-observed.
 
 ## Purpose
 
@@ -26,27 +27,36 @@ centralizing it later must not erase or weaken its current safeguards.
 
 ## Controller migration and fidelity findings
 
-The controller is held in a ref and owns no React state. For saved positions it now owns entry
-selection, generation/operation cancellation, reachability, one around-load attempt, and explicit
-legacy-offset/live-edge fallback. A hook executor still translates the accepted request into
-browser/virtualizer writes. `pinVirtualizedAnchor` remains the measurement reconciler, but every
-frame must hold the current controller lease before it can write.
+The controller is held in a ref and owns no React state. For saved positions it owns entry selection,
+generation/operation cancellation, reachability, one around-load attempt, and explicit
+legacy-offset/live-edge fallback. For unread markers it owns entry and jump-to-last-read requests,
+frame scheduling, stale-work cancellation, convergence, and live-edge fallback. For explicit
+message targets it owns supersession, one around-load attempt, mounting and center-position
+convergence, user takeover, and completion. Hook executors translate accepted requests into
+browser/virtualizer writes, and every frame must hold the current controller lease before it can
+write. `pinVirtualizedAnchor` remains the saved-position measurement reconciler; the controller-owned
+unread and explicit-target executors likewise retain their measurement settle behavior without
+retaining independent policy loops.
 
-The remaining mechanisms run the model beside `useMessageListScroll`: fact adapters read current
-virtualizer and DOM geometry, and every observed live decision is compared with the model decision.
-The instrumentation runs in production so real traces can exercise it. A shared error boundary
-catches and counts adapter, validator, controller-driver, and executor errors; failure must degrade
-to a safe saved-position fallback and must never escape into the scroll effect or event handler.
-The demo scroll-invariant suite fails if either `divergenceCount` or
-`instrumentationErrorCount` is non-zero. Retained diagnostic samples are capped, not the pass
-criterion.
+Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
+native smooth animation is intentionally not retained: restarting a smooth animation while
+remeasurement moves the target makes convergence samples unreliable and recreates scroll fighting.
+
+The remaining live-edge and directional-history mechanisms run the model beside
+`useMessageListScroll`: fact adapters read current virtualizer and DOM geometry, and every observed
+live decision is compared with the model decision. The instrumentation runs in production so real
+traces can exercise it. A shared error boundary catches and counts adapter, validator,
+controller-driver, and executor errors; failure must degrade according to the active request's
+source-specific policy and must never escape into the scroll effect or event handler. The demo
+scroll-invariant suite fails if either `divergenceCount` or `instrumentationErrorCount` is non-zero.
+Retained diagnostic samples are capped, not the pass criterion.
 
 Zero divergences means the model agrees with the hand-authored semantic `actual` label at each
 observation site: desired position plus the coarse waiting/positioning/applied/paused/fallback/idle
 phase. It does **not** compare rendered pixels and must not be read as proof that the browser landed
 or painted at the requested position, nor does it prove that every ownership site was observed.
 Pixel geometry, measurement convergence, and WebKit repaint remain covered by the scroll-invariant
-scenarios and the unchanged imperative implementation.
+scenarios and the leased imperative reconcilers.
 
 Generation allocation is module-private and shared by controller instances. Each mounted
 message-list owns its controller model, but a remount (including StrictMode effect replay) cannot
@@ -74,7 +84,7 @@ WebKit paint correctness.
 
 ## Non-goals for this stage
 
-- Replacing browser measurement/repaint rAF loops in the saved-position policy migration.
+- Replacing browser measurement/repaint safeguards while migrating positioning policy.
 - Changing entry priority, marker placement, saved scroll data, or history loading.
 - Removing measurement settle windows, tolerances, or WebKit repaint workarounds.
 - Treating a one-shot scroll as sufficient under virtualization.
@@ -276,22 +286,28 @@ is already visible or above the viewport, the same activation goes directly to l
 
 ## Current owners to migrate
 
-`useMessageListScroll` currently contains separate implementations for:
+The controller-owned mechanisms retain leased browser reconcilers for saved anchors, unread markers,
+and explicit center-aligned message targets. These reconcilers implement measurement convergence;
+they are not separate positioning authorities. The remaining independent implementations inside
+`useMessageListScroll` are:
 
 - `pinVirtualizedBottom`;
-- leased `pinVirtualizedAnchor` measurement convergence for the controller-owned saved request;
-- `runMarkerReassertLoop`;
-- the explicit target-message loop;
+- media-preservation reconciliation while reading history;
 - directional-load measurement reassertion.
 
 There are also positioning owners outside their shared single-flight ref:
 
 - send/composer resize writes in `ChatView` and `RoomView`;
-- `scrollToMessage` through `activeMessageListController`;
-- keyboard selection navigation in `useMessageSelection` (`scrollIntoView({ block: 'nearest' })`);
 - resident-top's direct writer;
-- non-virtualized marker/target writers inside `useMessageListScroll`;
-- static search-context positioning.
+
+Two visually similar scroll operations are explicitly outside this migration:
+
+- `SearchContextView` is a static preview with its own scroller and no live-conversation persistence,
+  follow-live, unread, or history-window ownership. Its persistent-highlight positioning loop remains
+  isolated from the live message-list controller.
+- Keyboard selection in `useMessageSelection` uses
+  `scrollIntoView({ block: 'nearest' })` only to keep the selected row visible. It is viewport
+  maintenance, not a semantic message-position request, and remains intentionally direct.
 
 A later migration is incomplete until each in-scope owner either routes through the controller or is
 explicitly documented as an isolated, non-competing context. New controller code must replace and
@@ -343,7 +359,9 @@ kinetic scrolling and stale-paint behavior.
 2. [x] Migrate saved-anchor restoration: delete the legacy restore dispatcher, pending ref, and
    around-load status map; retain the measurement loop only as a generation/operation-leased
    reconciler.
-3. Migrate unread and explicit message targets, then delete their private loops.
+3. [x] Migrate unread and explicit message targets: the controller owns their generations,
+   supersession, reachability, frame convergence, and cancellation; their private loops and target
+   around-load ref are deleted.
 4. Migrate live-edge pinning while retaining bottom-specific measurement/repaint safeguards.
 5. Migrate directional history preservation last, retaining kinetic cancellation and clamp recovery.
 6. Route or isolate the remaining owners outside `useMessageListScroll`.

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -304,7 +304,13 @@ Two visually similar scroll operations are explicitly outside this migration:
 
 - `SearchContextView` is a static preview with its own scroller and no live-conversation persistence,
   follow-live, unread, or history-window ownership. Its persistent-highlight positioning loop remains
-  isolated from the live message-list controller.
+  isolated from the live message-list controller. Its rows are still interactive, so a reply/poll
+  click inside a preview resolves within that preview's own scroller — never the document, and never
+  the live conversation. Because several previews can be mounted beside the live list while the
+  active-list registry holds only one entry, requests from inside any list route by **containment**
+  (`messageTargetContext`), not by registration order; previews therefore do not register at all.
+  The registry remains for callers with no enclosing list that mean the live conversation
+  (`PollBanner`, find-on-page).
 - Keyboard selection in `useMessageSelection` uses
   `scrollIntoView({ block: 'nearest' })` only to keep the selected row visible. It is viewport
   maintenance, not a semantic message-position request, and remains intentionally direct.


### PR DESCRIPTION
## Summary

- make the generation-aware positioning controller authoritative for explicit message targets
- own target load-around single-flight, pending/exhausted state, measured center convergence, user takeover, and stale async cancellation in the controller
- route search/activity targets and reply, poll, and find-on-page jumps through the same active-list executor
- delete the old hook-local target loop/ref and the independent `messageGrouping.scrollToMessage` DOM/rAF writer
- scope local/stanza/origin-id lookup to the active conversation scroller and update the positioning contract

## Why

Explicit navigation still had two independent scroll owners: the `targetMessageId` effect and the reply/poll/find helper. Both could load, retry, write, and highlight without a shared generation, so stale work could survive a room switch or compete with another positioning request.

This slice leaves browser geometry in hook executors, but gives policy, arbitration, retry state, and lifecycle ownership to one controller execution. A newer target, room entry, unread request, saved restore, or genuine user takeover invalidates old work before another write can run.

## Behavior note

Reply/poll/find jumps now use immediate measured center writes instead of the former one-shot native smooth animation. Re-starting smooth animation during per-frame remeasurement makes convergence samples unreliable and recreates scroll fighting; the target is now guaranteed to settle before highlighting.