### PR TITLE
feat(rooms): add "Show room info" tooltip on the room header name

### DIFF
--- a/apps/fluux/src/components/RoomHeader.test.tsx
+++ b/apps/fluux/src/components/RoomHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { RoomHeader } from './RoomHeader'
 import type { Room, RoomOccupant } from '@fluux/sdk'
 
@@ -25,6 +25,7 @@ vi.mock('react-i18next', () => ({
         'rooms.kickBanMembers': 'Kick/ban members',
         'rooms.hideMembers': 'Hide members',
         'rooms.showMembers': 'Show members',
+        'rooms.showRoomInfo': 'Show room info',
         'rooms.avatarClearFailed': 'Failed to clear avatar',
         'rooms.avatarChangeFailed': 'Failed to change avatar',
         'rooms.manageHats': 'Manage Hats',
@@ -178,6 +179,55 @@ describe('RoomHeader', () => {
       )
 
       expect(screen.getByText('My Room')).toBeInTheDocument()
+    })
+
+    it('labels the room name button as the room info trigger', () => {
+      render(
+        <RoomHeader
+          room={createRoom({ name: 'My Room' })}
+          showOccupants={false}
+          onToggleOccupants={mockOnToggleOccupants}
+          setRoomNotifyAll={mockSetRoomNotifyAll}
+          setRoomAvatar={mockSetRoomAvatar}
+          clearRoomAvatar={mockClearRoomAvatar}
+          submitRoomConfig={mockSubmitRoomConfig}
+          setSubject={mockSetSubject}
+          destroyRoom={mockDestroyRoom}
+        />
+      )
+
+      expect(screen.getByLabelText('Show room info: My Room')).toBeInTheDocument()
+    })
+
+    it('shows a "Show room info" tooltip when hovering the room name', async () => {
+      vi.useFakeTimers()
+      try {
+        render(
+          <RoomHeader
+            room={createRoom({ name: 'My Room' })}
+            showOccupants={false}
+            onToggleOccupants={mockOnToggleOccupants}
+            setRoomNotifyAll={mockSetRoomNotifyAll}
+            setRoomAvatar={mockSetRoomAvatar}
+            clearRoomAvatar={mockClearRoomAvatar}
+            submitRoomConfig={mockSubmitRoomConfig}
+            setSubject={mockSetSubject}
+            destroyRoom={mockDestroyRoom}
+          />
+        )
+
+        // The tooltip listens on the wrapper around the trigger button
+        const infoButton = screen.getByLabelText('Show room info: My Room')
+        fireEvent.mouseEnter(infoButton.parentElement!)
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000)
+        })
+
+        expect(screen.getByRole('tooltip')).toHaveTextContent('Show room info')
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('carries the aurora horizon hairline', () => {

--- a/apps/fluux/src/components/RoomHeader.tsx
+++ b/apps/fluux/src/components/RoomHeader.tsx
@@ -124,18 +124,22 @@ export function RoomHeader({
         size="header"
       />
 
-      {/* Name and info — opens Room Info modal with the full topic and details */}
-      <button
-        type="button"
-        onClick={() => setShowInfoModal(true)}
-        aria-label={`${t('rooms.showRoomInfo', 'Room info')}: ${room.name}`}
-        className="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
-      >
-        <span className="block font-semibold text-fluux-text truncate leading-tight">{room.name}</span>
-        <p className="text-xs text-fluux-muted truncate">
-          {room.subject?.trim() ? renderTextWithLinks(room.subject) : room.jid}
-        </p>
-      </button>
+      {/* Name and info — opens Room Info modal with the full topic and details.
+          The tooltip wrapper carries the flex sizing so the button still fills
+          the free space between the avatar and the trailing action cluster. */}
+      <Tooltip content={t('rooms.showRoomInfo')} position="bottom" className="flex flex-1 min-w-0">
+        <button
+          type="button"
+          onClick={() => setShowInfoModal(true)}
+          aria-label={`${t('rooms.showRoomInfo')}: ${room.name}`}
+          className="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+        >
+          <span className="block font-semibold text-fluux-text truncate leading-tight">{room.name}</span>
+          <p className="text-xs text-fluux-muted truncate">
+            {room.subject?.trim() ? renderTextWithLinks(room.subject) : room.jid}
+          </p>
+        </button>
+      </Tooltip>
 
       {/* Trailing action cluster — grouped tightly on mobile (gap-1) so the
           kebab and members pill read as one unit; desktop keeps the header's md

--- a/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/RoomView.test.tsx.snap
@@ -17,22 +17,26 @@ exports[`RoomView > Snapshots > should match snapshot for non-joined room 1`] = 
           data-name="Test Room"
           data-testid="avatar"
         />
-        <button
-          aria-label="rooms.showRoomInfo: Test Room"
-          class="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
-          type="button"
+        <div
+          class="flex flex-1 min-w-0"
         >
-          <span
-            class="block font-semibold text-fluux-text truncate leading-tight"
+          <button
+            aria-label="rooms.showRoomInfo: Test Room"
+            class="flex-1 min-w-0 text-start rounded-md px-1 -mx-1 py-0.5 hover:bg-fluux-hover transition-colors"
+            type="button"
           >
-            Test Room
-          </span>
-          <p
-            class="text-xs text-fluux-muted truncate"
-          >
-            room@conference.example.com
-          </p>
-        </button>
+            <span
+              class="block font-semibold text-fluux-text truncate leading-tight"
+            >
+              Test Room
+            </span>
+            <p
+              class="text-xs text-fluux-muted truncate"
+            >
+              room@conference.example.com
+            </p>
+          </button>
+        </div>
         <div
           class="flex items-center gap-1 md:gap-3"
         >

--- a/apps/fluux/src/i18n/locales/ar.json
+++ b/apps/fluux/src/i18n/locales/ar.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "انضم لتحميل الرسائل",
         "notificationSettings": "إعدادات الإشعارات",
         "roomActions": "إجراءات الغرفة",
+        "showRoomInfo": "إظهار معلومات الغرفة",
         "mentionsOnly": "الإشارات فقط",
         "defaultBehavior": "السلوك الافتراضي",
         "allMessages": "جميع الرسائل",

--- a/apps/fluux/src/i18n/locales/be.json
+++ b/apps/fluux/src/i18n/locales/be.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Далучайцеся, каб загрузіць паведамленні",
         "notificationSettings": "Налады апавяшчэнняў",
         "roomActions": "Дзеянні пакоя",
+        "showRoomInfo": "Паказаць звесткі пра пакой",
         "mentionsOnly": "Толькі згадванні",
         "defaultBehavior": "Поведінка па змаўчанні",
         "allMessages": "Усе паведамленні",

--- a/apps/fluux/src/i18n/locales/bg.json
+++ b/apps/fluux/src/i18n/locales/bg.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Присъединете се за зареждане на съобщения",
         "notificationSettings": "Настройки за известия",
         "roomActions": "Действия в стаята",
+        "showRoomInfo": "Показване на информация за стаята",
         "mentionsOnly": "Само споменавания",
         "defaultBehavior": "Поведение по подразбиране",
         "allMessages": "Всички съобщения",

--- a/apps/fluux/src/i18n/locales/ca.json
+++ b/apps/fluux/src/i18n/locales/ca.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Uneix-te per carregar els missatges",
         "notificationSettings": "Configuració de notificacions",
         "roomActions": "Accions de la sala",
+        "showRoomInfo": "Mostra la informació de la sala",
         "mentionsOnly": "Només mencions",
         "defaultBehavior": "Comportament per defecte",
         "allMessages": "Tots els missatges",

--- a/apps/fluux/src/i18n/locales/cs.json
+++ b/apps/fluux/src/i18n/locales/cs.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Vstupte pro načtení zpráv",
         "notificationSettings": "Nastavení oznámení",
         "roomActions": "Akce místnosti",
+        "showRoomInfo": "Zobrazit informace o místnosti",
         "mentionsOnly": "Pouze zmínky",
         "defaultBehavior": "Výchozí chování",
         "allMessages": "Všechny zprávy",

--- a/apps/fluux/src/i18n/locales/da.json
+++ b/apps/fluux/src/i18n/locales/da.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Deltag for at indlæse beskeder",
         "notificationSettings": "Notifikationsindstillinger",
         "roomActions": "Rumshandlinger",
+        "showRoomInfo": "Vis rumoplysninger",
         "mentionsOnly": "Kun omtaler",
         "defaultBehavior": "Standardadfærd",
         "allMessages": "Alle beskeder",

--- a/apps/fluux/src/i18n/locales/de.json
+++ b/apps/fluux/src/i18n/locales/de.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Beitreten um Nachrichten zu laden",
         "notificationSettings": "Benachrichtigungseinstellungen",
         "roomActions": "Raumaktionen",
+        "showRoomInfo": "Rauminformationen anzeigen",
         "mentionsOnly": "Nur Erwähnungen",
         "defaultBehavior": "Standardverhalten",
         "allMessages": "Alle Nachrichten",

--- a/apps/fluux/src/i18n/locales/el.json
+++ b/apps/fluux/src/i18n/locales/el.json
@@ -251,6 +251,7 @@
         "joinToLoadHistory": "Μπείτε για φόρτωση μηνυμάτων",
         "notificationSettings": "Ρυθμίσεις ειδοποιήσεων",
         "roomActions": "Ενέργειες δωματίου",
+        "showRoomInfo": "Εμφάνιση πληροφοριών δωματίου",
         "mentionsOnly": "Μόνο αναφορές",
         "defaultBehavior": "Προεπιλεγμένη συμπεριφορά",
         "allMessages": "Όλα τα μηνύματα",

--- a/apps/fluux/src/i18n/locales/en.json
+++ b/apps/fluux/src/i18n/locales/en.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Join to load messages",
         "notificationSettings": "Notification settings",
         "roomActions": "Room actions",
+        "showRoomInfo": "Show room info",
         "mentionsOnly": "Mentions only",
         "defaultBehavior": "Default behavior",
         "allMessages": "All messages",

--- a/apps/fluux/src/i18n/locales/es.json
+++ b/apps/fluux/src/i18n/locales/es.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Unete para cargar mensajes",
         "notificationSettings": "Ajustes de notificaciones",
         "roomActions": "Acciones de la sala",
+        "showRoomInfo": "Mostrar información de la sala",
         "mentionsOnly": "Solo menciones",
         "defaultBehavior": "Comportamiento predeterminado",
         "allMessages": "Todos los mensajes",

--- a/apps/fluux/src/i18n/locales/et.json
+++ b/apps/fluux/src/i18n/locales/et.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Liitu sõnumite laadimiseks",
         "notificationSettings": "Teavituste seaded",
         "roomActions": "Ruumi toimingud",
+        "showRoomInfo": "Näita toa teavet",
         "mentionsOnly": "Ainult mainimised",
         "defaultBehavior": "Vaikekäitumine",
         "allMessages": "Kõik sõnumid",

--- a/apps/fluux/src/i18n/locales/fi.json
+++ b/apps/fluux/src/i18n/locales/fi.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Liity ladataksesi viestit",
         "notificationSettings": "Ilmoitusasetukset",
         "roomActions": "Huoneen toiminnot",
+        "showRoomInfo": "Näytä huoneen tiedot",
         "mentionsOnly": "Vain maininnat",
         "defaultBehavior": "Oletuskäyttäytyminen",
         "allMessages": "Kaikki viestit",

--- a/apps/fluux/src/i18n/locales/fr.json
+++ b/apps/fluux/src/i18n/locales/fr.json
@@ -251,6 +251,7 @@
         "joinToLoadHistory": "Rejoindre pour charger les messages",
         "notificationSettings": "Paramètres de notification",
         "roomActions": "Actions du salon",
+        "showRoomInfo": "Afficher les informations du salon",
         "mentionsOnly": "Mentions uniquement",
         "defaultBehavior": "Comportement par défaut",
         "allMessages": "Tous les messages",

--- a/apps/fluux/src/i18n/locales/ga.json
+++ b/apps/fluux/src/i18n/locales/ga.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Téigh isteach le teachtaireachtaí a luchtú",
         "notificationSettings": "Socruithe fógraí",
         "roomActions": "Gníomhartha seomra",
+        "showRoomInfo": "Taispeáin eolas an tseomra",
         "mentionsOnly": "Tagairtí amháin",
         "defaultBehavior": "Iompraíocht réamhshocraithe",
         "allMessages": "Gach teachtaireacht",

--- a/apps/fluux/src/i18n/locales/he.json
+++ b/apps/fluux/src/i18n/locales/he.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "הצטרף לטעינת הודעות",
         "notificationSettings": "הגדרות התראות",
         "roomActions": "פעולות חדר",
+        "showRoomInfo": "הצגת פרטי החדר",
         "mentionsOnly": "אזכורים בלבד",
         "defaultBehavior": "ברירת מחדל",
         "allMessages": "כל ההודעות",

--- a/apps/fluux/src/i18n/locales/hr.json
+++ b/apps/fluux/src/i18n/locales/hr.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Pridružite se za učitavanje poruka",
         "notificationSettings": "Postavke obavijesti",
         "roomActions": "Radnje sobe",
+        "showRoomInfo": "Prikaži informacije o sobi",
         "mentionsOnly": "Samo spominjanja",
         "defaultBehavior": "Zadano ponašanje",
         "allMessages": "Sve poruke",

--- a/apps/fluux/src/i18n/locales/hu.json
+++ b/apps/fluux/src/i18n/locales/hu.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Csatlakozzon az üzenetek betöltéséhez",
         "notificationSettings": "Értesítési beállítások",
         "roomActions": "Szoba műveletek",
+        "showRoomInfo": "Szobainformációk megjelenítése",
         "mentionsOnly": "Csak említések",
         "defaultBehavior": "Alapértelmezett viselkedés",
         "allMessages": "Minden üzenet",

--- a/apps/fluux/src/i18n/locales/is.json
+++ b/apps/fluux/src/i18n/locales/is.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Gangt inn til að hlaða skilaboðum",
         "notificationSettings": "Tilkynningastillingar",
         "roomActions": "Herbergisaðgerðir",
+        "showRoomInfo": "Sýna upplýsingar um herbergi",
         "mentionsOnly": "Aðeins tilvísanir",
         "defaultBehavior": "Sjálfgefin hegðun",
         "allMessages": "Öll skilaboð",

--- a/apps/fluux/src/i18n/locales/it.json
+++ b/apps/fluux/src/i18n/locales/it.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Entra per caricare i messaggi",
         "notificationSettings": "Impostazioni notifiche",
         "roomActions": "Azioni stanza",
+        "showRoomInfo": "Mostra informazioni stanza",
         "mentionsOnly": "Solo menzioni",
         "defaultBehavior": "Comportamento predefinito",
         "allMessages": "Tutti i messaggi",

--- a/apps/fluux/src/i18n/locales/lt.json
+++ b/apps/fluux/src/i18n/locales/lt.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Prisijunkite įkelti žinutes",
         "notificationSettings": "Pranešimų nustatymai",
         "roomActions": "Kambario veiksmai",
+        "showRoomInfo": "Rodyti kambario informaciją",
         "mentionsOnly": "Tik paminėjimai",
         "defaultBehavior": "Numatytoji elgsena",
         "allMessages": "Visos žinutės",

--- a/apps/fluux/src/i18n/locales/lv.json
+++ b/apps/fluux/src/i18n/locales/lv.json
@@ -251,6 +251,7 @@
         "joinToLoadHistory": "Pievienojieties, lai ielādētu ziņojumus",
         "notificationSettings": "Paziņojumu iestatījumi",
         "roomActions": "Istabas darbības",
+        "showRoomInfo": "Rādīt istabas informāciju",
         "mentionsOnly": "Tikai pieminējumi",
         "defaultBehavior": "Noklusējuma uzvedība",
         "allMessages": "Visi ziņojumi",

--- a/apps/fluux/src/i18n/locales/mt.json
+++ b/apps/fluux/src/i18n/locales/mt.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Idħol biex tgħabbi l-messaġġi",
         "notificationSettings": "Settings tan-notifiki",
         "roomActions": "Azzjonijiet tal-kamra",
+        "showRoomInfo": "Uri informazzjoni tal-kamra",
         "mentionsOnly": "Mentions biss",
         "defaultBehavior": "Imġiba default",
         "allMessages": "Il-messaġġi kollha",

--- a/apps/fluux/src/i18n/locales/nb.json
+++ b/apps/fluux/src/i18n/locales/nb.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Bli med for å laste meldinger",
         "notificationSettings": "Varslingsinnstillinger",
         "roomActions": "Romhandlinger",
+        "showRoomInfo": "Vis rominformasjon",
         "mentionsOnly": "Kun omtaler",
         "defaultBehavior": "Standardoppførsel",
         "allMessages": "Alle meldinger",

--- a/apps/fluux/src/i18n/locales/nl.json
+++ b/apps/fluux/src/i18n/locales/nl.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Join om berichten te laden",
         "notificationSettings": "Meldingsinstellingen",
         "roomActions": "Kameraacties",
+        "showRoomInfo": "Groepsinfo tonen",
         "mentionsOnly": "Alleen vermeldingen",
         "defaultBehavior": "Standaardgedrag",
         "allMessages": "Alle berichten",

--- a/apps/fluux/src/i18n/locales/pl.json
+++ b/apps/fluux/src/i18n/locales/pl.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Dołącz, aby załadować wiadomości",
         "notificationSettings": "Ustawienia powiadomień",
         "roomActions": "Akcje pokoju",
+        "showRoomInfo": "Pokaż informacje o pokoju",
         "mentionsOnly": "Tylko wzmianki",
         "defaultBehavior": "Domyślne zachowanie",
         "allMessages": "Wszystkie wiadomości",

--- a/apps/fluux/src/i18n/locales/pt.json
+++ b/apps/fluux/src/i18n/locales/pt.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Entre para carregar mensagens",
         "notificationSettings": "Definições de notificações",
         "roomActions": "Ações da sala",
+        "showRoomInfo": "Mostrar informações da sala",
         "mentionsOnly": "Apenas menções",
         "defaultBehavior": "Comportamento por defeito",
         "allMessages": "Todas as mensagens",

--- a/apps/fluux/src/i18n/locales/ro.json
+++ b/apps/fluux/src/i18n/locales/ro.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Intră pentru a încărca mesajele",
         "notificationSettings": "Setări de notificare",
         "roomActions": "Acțiuni cameră",
+        "showRoomInfo": "Arată informațiile camerei",
         "mentionsOnly": "Doar mențiuni",
         "defaultBehavior": "Comportament implicit",
         "allMessages": "Toate mesajele",

--- a/apps/fluux/src/i18n/locales/ru.json
+++ b/apps/fluux/src/i18n/locales/ru.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Войдите, чтобы загрузить сообщения",
         "notificationSettings": "Настройки уведомлений",
         "roomActions": "Действия комнаты",
+        "showRoomInfo": "Показать информацию о конференции",
         "mentionsOnly": "Только упоминания",
         "defaultBehavior": "Поведение по умолчанию",
         "allMessages": "Все сообщения",

--- a/apps/fluux/src/i18n/locales/sk.json
+++ b/apps/fluux/src/i18n/locales/sk.json
@@ -251,6 +251,7 @@
         "joinToLoadHistory": "Pripojte sa pre načítanie správ",
         "notificationSettings": "Nastavenia oznámení",
         "roomActions": "Akcie miestnosti",
+        "showRoomInfo": "Zobraziť informácie o miestnosti",
         "mentionsOnly": "Len zmienky",
         "defaultBehavior": "Predvolené správanie",
         "allMessages": "Všetky správy",

--- a/apps/fluux/src/i18n/locales/sl.json
+++ b/apps/fluux/src/i18n/locales/sl.json
@@ -252,6 +252,7 @@
         "joinToLoadHistory": "Pridružite se za nalaganje sporočil",
         "notificationSettings": "Nastavitve obvestil",
         "roomActions": "Dejanja sobe",
+        "showRoomInfo": "Prikaži informacije o sobi",
         "mentionsOnly": "Samo omembe",
         "defaultBehavior": "Privzeto vedenje",
         "allMessages": "Vsa sporočila",

--- a/apps/fluux/src/i18n/locales/sv.json
+++ b/apps/fluux/src/i18n/locales/sv.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Gå med för att ladda meddelanden",
         "notificationSettings": "Aviseringsinställningar",
         "roomActions": "Rumsåtgärder",
+        "showRoomInfo": "Visa rumsinformation",
         "mentionsOnly": "Endast omnämnanden",
         "defaultBehavior": "Standardbeteende",
         "allMessages": "Alla meddelanden",

--- a/apps/fluux/src/i18n/locales/uk.json
+++ b/apps/fluux/src/i18n/locales/uk.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "Приєднайтеся, щоб завантажити повідомлення",
         "notificationSettings": "Налаштування сповіщень",
         "roomActions": "Дії кімнати",
+        "showRoomInfo": "Показати відомості про кімнату",
         "mentionsOnly": "Тільки згадування",
         "defaultBehavior": "Поведінка за замовчуванням",
         "allMessages": "Всі повідомлення",

--- a/apps/fluux/src/i18n/locales/zh-CN.json
+++ b/apps/fluux/src/i18n/locales/zh-CN.json
@@ -250,6 +250,7 @@
         "joinToLoadHistory": "加入即可加载消息",
         "notificationSettings": "通知设置",
         "roomActions": "房间操作",
+        "showRoomInfo": "显示房间信息",
         "mentionsOnly": "仅提及",
         "defaultBehavior": "默认行为",
         "allMessages": "所有消息",


### PR DESCRIPTION
The room name in the room header opens the Room Info modal, but nothing hinted at that. Every other control in the header carries a tooltip, so the name was the odd one out.

The name button is now wrapped in the shared `Tooltip` showing "Show room info", positioned below the header like its neighbours. The tooltip wrapper carries the flex sizing so the button still fills the space between the avatar and the trailing action cluster — the rendered layout is unchanged apart from that wrapper.

A new `rooms.showRoomInfo` key backs both the tooltip and the button aria-label (which previously used an inline English fallback), translated in all 33 locales following each one's existing wording for "room" (nl uses "Groep", ru uses "конференция", and so on).