### PR TITLE
Inset the tap-to-load media placeholder

### DIFF
--- a/apps/fluux/src/components/DeferredMediaPlaceholder.test.tsx
+++ b/apps/fluux/src/components/DeferredMediaPlaceholder.test.tsx
@@ -21,6 +21,21 @@ describe('DeferredMediaPlaceholder', () => {
     expect(screen.queryByText(/MB/)).not.toBeInTheDocument()
   })
 
+  it('insets the box variant so a long name never runs flush against the frame', () => {
+    render(
+      <DeferredMediaPlaceholder
+        variant="box"
+        icon={ImageIcon}
+        label="Load image"
+        name="zb2rhYRAjkYZ7qdWwhv7qdz6qVukFezQxwNSYgXHunKWCgaBc"
+        onLoad={() => {}}
+      />,
+    )
+    // The name truncates at the box width, so without horizontal padding the
+    // ellipsised text starts on the border itself.
+    expect(screen.getByRole('button').className).toMatch(/(^|\s)px-3(\s|$)/)
+  })
+
   it('shows the file name as a hint, alongside the label and size, when name is given', () => {
     render(
       <DeferredMediaPlaceholder variant="box" icon={ImageIcon} label="Load image" name="screenshot.png" sizeLabel="12.7 KB" onLoad={() => {}} />,

--- a/apps/fluux/src/components/DeferredMediaPlaceholder.tsx
+++ b/apps/fluux/src/components/DeferredMediaPlaceholder.tsx
@@ -31,7 +31,7 @@ export function DeferredMediaPlaceholder({
       <button
         type="button"
         onClick={onLoad}
-        className="mt-2 w-full flex flex-col items-center justify-center gap-2 rounded-lg bg-fluux-hover/60 border border-fluux-border hover:bg-fluux-hover transition-colors text-fluux-muted"
+        className="mt-2 w-full flex flex-col items-center justify-center gap-2 px-3 rounded-lg bg-fluux-hover/60 border border-fluux-border hover:bg-fluux-hover transition-colors text-fluux-muted"
         style={{
           aspectRatio: aspectRatio ?? 4 / 3,
           maxWidth: maxWidthPx ? `${maxWidthPx}px` : '384px',


### PR DESCRIPTION
The box variant of `DeferredMediaPlaceholder` had no horizontal padding. A long attachment name (a CID, for instance) truncates at the box width, so the ellipsised text ran flush against the frame with no gutter, as reported in user feedback.

Adds `px-3` to the box container, so the name truncates inside the padding and sits 12px off the border. This matches the gutter already used by the sibling "image unavailable" box and by the card variant, so all three attachment states are now consistent.

Verified in demo mode with media auto-download set to "never" and a CID-style file name: the truncated name now sits 13px from the frame (12px padding plus the 1px border) on both sides.