### PR TITLE
fix(modal): drop the focus ring from the modal panel

### DIFF
--- a/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.focustrap.test.tsx
@@ -38,4 +38,18 @@ describe('ModalOverlay focus trap', () => {
     expect(document.activeElement).toBe(panel)
     expect(document.activeElement).not.toBe(getByText('link'))
   })
+
+  it('opts the panel out of the global focus ring', () => {
+    // The panel is a tabindex=-1 focus target, not a control: focusing it (on
+    // open, or via useRestoreFocus after a window refocus) must not draw the
+    // app-wide `.user-interacted *:focus` outline around the whole dialog.
+    const { getByText, container } = render(
+      <ModalOverlay onClose={vi.fn()} initialFocus="panel">
+        <button type="button">alpha</button>
+      </ModalOverlay>,
+    )
+    expect(container.querySelector('.fluux-glass')?.className).toContain('no-focus-ring')
+    // Content controls keep theirs: the selector excludes only the class holder.
+    expect(getByText('alpha').className).not.toContain('no-focus-ring')
+  })
 })

--- a/apps/fluux/src/components/ModalOverlay.tsx
+++ b/apps/fluux/src/components/ModalOverlay.tsx
@@ -158,7 +158,14 @@ export function ModalOverlay({
         ref={panelRef}
         {...panelProps}
         onKeyDown={onPanelKeyDown ? (e) => onPanelKeyDown(e, { close }) : undefined}
-        className={`relative z-10 fluux-glass rounded-lg w-full ${width} mx-4 ${panelClass} ${panelClassName ?? ''}`}
+        // `no-focus-ring` opts the panel out of the global `.user-interacted
+        // *:focus` outline. The panel is a tabindex=-1 focus TARGET, not an
+        // interactive control: `initialFocus='panel'` and useRestoreFocus (after
+        // an OS window blur→refocus) both land focus here, and a 2px ring around
+        // the whole dialog communicates nothing — the scrim and the elevated
+        // glass surface already say where you are. Children keep their rings:
+        // the selector excludes only the element carrying the class.
+        className={`relative z-10 fluux-glass no-focus-ring rounded-lg w-full ${width} mx-4 ${panelClass} ${panelClassName ?? ''}`}
       >
         {typeof children === 'function' ? children({ close }) : children}
       </div>


### PR DESCRIPTION
Modals were drawing a 2px focus ring around the entire dialog. The ring came from the app-wide `.user-interacted *:focus` rule in `index.css`, which fires on anything focused, including the modal panel itself.

The panel picks up focus in two normal cases: `initialFocus='panel'` (read-only modals such as the room info sheet, where landing on the first focusable child would ring a content link instead) and `useRestoreFocus` reclaiming focus after an OS window blur/refocus, which affects every modal.

A `tabindex="-1"` container is a focus target, not an interactive control. There is nothing to activate, so the ring communicates nothing, and the scrim plus the elevated glass surface already say where you are. This is also what the ARIA APG dialog pattern assumes.

The panel now carries `no-focus-ring`. The global selector excludes only the element holding the class, so content controls keep their rings and the focus trap is unchanged. Fixing it in `ModalOverlay` covers every modal at once, since it is the single source of truth for modal chrome.

Verified in demo mode: the ring is gone, `document.activeElement` is still the panel, and its computed outline is `none` with `.user-interacted` present.