### PR TITLE
fix(muc): persist avatars by stable occupant id

### DIFF
--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -48,7 +48,11 @@ const createRoom = (overrides: Partial<Room> & { occupantsList?: RoomOccupant[] 
   const { occupantsList = [], ...rest } = overrides
   // Convert occupants array to Map keyed by nick
   const occupantsMap = new Map<string, RoomOccupant>()
+  const occupantIdToNick = new Map<string, string>()
   occupantsList.forEach(occ => occupantsMap.set(occ.nick, occ))
+  occupantsList.forEach(occ => {
+    if (occ.occupantId) occupantIdToNick.set(occ.occupantId, occ.nick)
+  })
 
   return {
     jid: 'room@conference.example.com',
@@ -57,6 +61,7 @@ const createRoom = (overrides: Partial<Room> & { occupantsList?: RoomOccupant[] 
     nickname: 'Me', // Our nick in the room
     messages: [],
     occupants: occupantsMap,
+    ...(occupantIdToNick.size > 0 && { occupantIdToNick }),
     typingUsers: new Set<string>(),
     unreadCount: 0,
     mentionsCount: 0,

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useId, useImperativeHandle, useMemo, memo, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { detectRenderLoop } from '@/utils/renderLoopDetector'
-import { useRoomActive, usePolls, useRoomModeration, useRoomManagement, useRoomEntity, useContactIdentities, getBareJid, generateConsistentColorHexSync, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, WhisperCounterpartGoneError, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
+import { useRoomActive, usePolls, useRoomModeration, useRoomManagement, useRoomEntity, useContactIdentities, getBareJid, generateConsistentColorHexSync, createMessageLookup, useReferencedMessage, isMessageFromIgnoredUser, isReplyToIgnoredUser, filterIgnoredReactions, canKick, canBan, getAvailableAffiliations, getAvailableRoles, getMyReactions, WhisperCounterpartGoneError, type RoomMessage, type Room, type RoomOccupant, type MentionReference, type ChatStateNotification, type ContactIdentity, type FileAttachment, type RoomAffiliation, type RoomRole, type PollData } from '@fluux/sdk'
 import { useConnectionStore, useIgnoreStore, useRoomStore } from '@fluux/sdk/react'
 import { ignoreStore, roomStore, type IgnoredUser } from '@fluux/sdk/stores'
 import { useMentionAutocomplete, useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useMessageHoverState, useDragAndDrop, useConversationDraft, useTimeFormat, useContextMenu, useWhisperCounterpartPresent, useRoomOccupantCountBelow, isSmallScreen } from '@/hooks'
@@ -994,6 +994,10 @@ export const RoomMessageList = memo(function RoomMessageList({
     return ids
   }, [messages])
 
+  // Resolve reply identities once per resident message window. The lookup
+  // includes stanza/origin aliases, matching reply resolution elsewhere.
+  const messagesById = useMemo(() => createMessageLookup(messages), [messages])
+
   // Set of known occupant nicknames for IRC-style mention highlighting.
   // Ref-stable across presence (show/status) churn — only changes when the nick
   // SET changes — so it does not bust every memoized row on each presence stanza.
@@ -1107,7 +1111,15 @@ export const RoomMessageList = memo(function RoomMessageList({
       // avatar is resolved here so it can be passed down as a memo-safe primitive.
       // replyNick may be undefined (no `to`); resolveReplyAvatar handles that safely.
       const replyNick = msg.replyTo.to ? msg.replyTo.to.split('/').pop() : undefined
-      const ra = resolveReplyAvatar(replyNick, room, contactsByJid, room.nickname, ownAvatar)
+      const replyOccupantId = messagesById.get(msg.replyTo.id)?.occupantId
+      const ra = resolveReplyAvatar(
+        replyNick,
+        room,
+        contactsByJid,
+        room.nickname,
+        ownAvatar,
+        replyOccupantId,
+      )
       replyAvatarUrl = ra.avatarUrl
       replyAvatarIdentifier = ra.avatarIdentifier
       replyBareJid = ra.senderBareJid

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -25,8 +25,9 @@ import {
 } from '@fluux/sdk'
 import { getMessages, getRoomMessages } from '@fluux/sdk/cache'
 import { getSearchClient } from '@fluux/sdk/stores'
-import { useConnectionStore } from '@fluux/sdk/react'
+import { useConnectionStore, useRoomStore } from '@fluux/sdk/react'
 import { MessageBubble, MessageList, shouldShowAvatar, buildReplyContext } from './conversation'
+import { resolveRoomAvatar } from './conversation/roomSenderResolution'
 import { useNavigateToTarget } from '@/hooks/useNavigateToTarget'
 import { useWindowDrag, useTimeFormat, useMode } from '@/hooks'
 import { auroraSenderColor } from '@/utils/senderColor'
@@ -446,6 +447,10 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
 }) {
   const { t } = useTranslation()
   const { formatTime, effectiveTimeFormat } = useTimeFormat()
+  const roomJid = isRoom
+    ? messages.find((message): message is RoomMessage => message.type === 'groupchat')?.roomJid
+    : undefined
+  const room = useRoomStore((state) => roomJid ? state.rooms.get(roomJid) : undefined)
 
   // Build message lookup for reply context
   const messagesById = createMessageLookup(messages as BaseMessage[])
@@ -467,15 +472,32 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
 
     if (isRoom && msg.type === 'groupchat') {
       const roomMsg = msg as RoomMessage
-      senderName = roomMsg.nick
-      avatarIdentifier = `${roomMsg.roomJid}/${roomMsg.nick}`
-      senderColor = auroraSenderColor(roomMsg.nick, isDarkMode ?? true)
+      const avatar = room
+        ? resolveRoomAvatar(
+            { nick: roomMsg.nick, occupantId: roomMsg.occupantId, isOwn: roomMsg.isOutgoing },
+            room,
+            contactsByJid,
+            ownAvatar,
+          )
+        : undefined
+      const contact = avatar?.senderBareJid
+        ? contactsByJid.get(avatar.senderBareJid)
+        : undefined
+      senderName = avatar?.matchedNick || contact?.name || roomMsg.nick
+      avatarIdentifier = avatar?.avatarIdentifier
+        || roomMsg.occupantId
+        || `${roomMsg.roomJid}/${roomMsg.nick}`
+      avatarUrl = avatar?.avatarUrl
+      senderColor = auroraSenderColor(
+        roomMsg.occupantId || avatar?.senderBareJid || roomMsg.nick,
+        isDarkMode ?? true,
+      )
+      senderJid = avatar?.senderBareJid
 
       // Check if it's own message
       if (roomMsg.isOutgoing) {
         senderName = ownNickname || roomMsg.nick
         senderColor = 'var(--fluux-text-self)'
-        avatarUrl = ownAvatar || undefined
       }
     } else {
       const senderBareJid = getBareJid(msg.from)
@@ -510,6 +532,23 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
         return auroraSenderColor(senderId, dark ?? true)
       },
       (originalMsg, fallbackId) => {
+        if (isRoom && room && originalMsg?.type === 'groupchat') {
+          const roomMessage = originalMsg as RoomMessage
+          const avatar = resolveRoomAvatar(
+            {
+              nick: roomMessage.nick,
+              occupantId: roomMessage.occupantId,
+              isOwn: roomMessage.isOutgoing,
+            },
+            room,
+            contactsByJid,
+            ownAvatar,
+          )
+          return {
+            avatarUrl: avatar.avatarUrl,
+            avatarIdentifier: avatar.avatarIdentifier,
+          }
+        }
         const senderId = (originalMsg ? getBareJid(originalMsg.from) : undefined) || (fallbackId ? getBareJid(fallbackId) : undefined)
         if (senderId === myBareJid) {
           return { avatarUrl: ownAvatar || undefined, avatarIdentifier: senderId || 'unknown' }

--- a/apps/fluux/src/components/SearchContextView.tsx
+++ b/apps/fluux/src/components/SearchContextView.tsx
@@ -30,7 +30,7 @@ import { MessageBubble, MessageList, shouldShowAvatar, buildReplyContext } from 
 import { resolveRoomAvatar } from './conversation/roomSenderResolution'
 import { useNavigateToTarget } from '@/hooks/useNavigateToTarget'
 import { useWindowDrag, useTimeFormat, useMode } from '@/hooks'
-import { auroraSenderColor } from '@/utils/senderColor'
+import { auroraSenderColor, nickColorSeed } from '@/utils/senderColor'
 import { ArrowLeft, ExternalLink, Search } from 'lucide-react'
 
 /** Number of messages to load on each side of the target */
@@ -487,9 +487,13 @@ export const SearchContextMessageList = memo(function SearchContextMessageList({
       avatarIdentifier = avatar?.avatarIdentifier
         || roomMsg.occupantId
         || `${roomMsg.roomJid}/${roomMsg.nick}`
-      avatarUrl = avatar?.avatarUrl
+      avatarUrl = roomMsg.isOutgoing ? (ownAvatar || undefined) : avatar?.avatarUrl
       senderColor = auroraSenderColor(
-        roomMsg.occupantId || avatar?.senderBareJid || roomMsg.nick,
+        nickColorSeed({
+          occupantId: roomMsg.occupantId,
+          bareJid: avatar?.senderBareJid,
+          nick: roomMsg.nick,
+        }),
         isDarkMode ?? true,
       )
       senderJid = avatar?.senderBareJid

--- a/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { selectSelfOccupant, stableNickSet, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './roomSenderResolution'
+import { selectSelfOccupant, stableNickSet, resolveRoomAvatar, resolveRoomSender, resolveReplyAvatar, resolveSenderColor, resolveNickColor } from './roomSenderResolution'
 import { auroraSenderColor } from '@/utils/senderColor'
 import type { RoomOccupant, Room, RoomMessage } from '@fluux/sdk'
 
@@ -39,6 +39,7 @@ describe('stableNickSet', () => {
 const room = (over: Partial<Room>): Room => ({
   jid: 'r@conf', nickname: 'me', joined: true, supportsReactions: true,
   occupants: new Map(), nickToJidCache: new Map(), nickToAvatarCache: new Map(),
+  occupantIdToJidCache: new Map(), occupantIdToAvatarCache: new Map(),
   ...over,
 } as Room)
 const msg = (over: Partial<RoomMessage>): RoomMessage =>
@@ -64,6 +65,73 @@ describe('resolveRoomSender', () => {
   it('reports avatarPresence offline when occupant absent (joined room)', () => {
     const s = resolveRoomSender(msg({ nick: 'ghost' }), room({}), new Map(), undefined)
     expect(s.avatarPresence).toBe('offline')
+  })
+  it('restores an offline anonymous sender avatar by room-scoped occupant-id', () => {
+    const r = room({
+      occupantIdToAvatarCache: new Map([['occ-alice', 'blob:stable']]),
+      nickToAvatarCache: new Map([['alice', 'blob:nick']]),
+    })
+    const s = resolveRoomSender(
+      msg({ nick: 'alice', occupantId: 'occ-alice' }),
+      r,
+      new Map(),
+      undefined,
+    )
+    expect(s.senderAvatar).toBe('blob:stable')
+    expect(s.avatarPresence).toBe('offline')
+  })
+  it('does not give a historical sender the avatar of a recycled nickname', () => {
+    const recycled = occ('alice', {
+      occupantId: 'occ-new-person',
+      avatar: 'blob:new-person',
+    })
+    const r = room({
+      occupants: new Map([['alice', recycled]]),
+      nickToAvatarCache: new Map([['alice', 'blob:unsafe-nick-cache']]),
+    })
+    const resolved = resolveRoomAvatar(
+      { nick: 'alice', occupantId: 'occ-old-person' },
+      r,
+      new Map(),
+    )
+    expect(resolved.occupant).toBeUndefined()
+    expect(resolved.avatarUrl).toBeUndefined()
+    expect(resolved.source).toBe('fallback')
+  })
+  it('follows a stable occupant-id across a nickname change', () => {
+    const renamed = occ('alice-new', {
+      occupantId: 'occ-alice',
+      avatar: 'blob:renamed',
+    })
+    const r = room({ occupants: new Map([['alice-new', renamed]]) })
+    const resolved = resolveRoomAvatar(
+      { nick: 'alice-old', occupantId: 'occ-alice' },
+      r,
+      new Map(),
+    )
+    expect(resolved.occupant).toBe(renamed)
+    expect(resolved.matchedNick).toBe('alice-new')
+    expect(resolved.avatarUrl).toBe('blob:renamed')
+  })
+  it('falls back through the stable JID alias in a non-anonymous room', () => {
+    const r = room({
+      occupantIdToJidCache: new Map([['occ-alice', 'alice@example.com']]),
+    })
+    const contacts = new Map([
+      ['alice@example.com', {
+        jid: 'alice@example.com',
+        name: 'Alice',
+        avatar: 'blob:contact',
+      } as any],
+    ])
+    const resolved = resolveRoomAvatar(
+      { nick: 'old-nick', occupantId: 'occ-alice' },
+      r,
+      contacts,
+    )
+    expect(resolved.avatarUrl).toBe('blob:contact')
+    expect(resolved.senderBareJid).toBe('alice@example.com')
+    expect(resolved.source).toBe('jid')
   })
   it('counterpartPresent is true for non-private messages', () => {
     const s = resolveRoomSender(msg({ isPrivate: false }), room({}), new Map(), undefined)

--- a/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.test.ts
@@ -39,7 +39,8 @@ describe('stableNickSet', () => {
 const room = (over: Partial<Room>): Room => ({
   jid: 'r@conf', nickname: 'me', joined: true, supportsReactions: true,
   occupants: new Map(), nickToJidCache: new Map(), nickToAvatarCache: new Map(),
-  occupantIdToJidCache: new Map(), occupantIdToAvatarCache: new Map(),
+  occupantIdToJidCache: new Map(), occupantIdToNick: new Map(),
+  occupantIdToAvatarCache: new Map(),
   ...over,
 } as Room)
 const msg = (over: Partial<RoomMessage>): RoomMessage =>
@@ -57,7 +58,10 @@ describe('resolveRoomSender', () => {
   })
   it('falls back to occupant-id match when nick is not a current occupant', () => {
     const bob = { nick: 'bob2', occupantId: 'oid-bob', role: 'participant', affiliation: 'none', show: 'online' } as any
-    const r = room({ occupants: new Map([['bob2', bob]]) })
+    const r = room({
+      occupants: new Map([['bob2', bob]]),
+      occupantIdToNick: new Map([['oid-bob', 'bob2']]),
+    })
     const s = resolveRoomSender(msg({ nick: 'bob', occupantId: 'oid-bob' }), r, new Map(), undefined)
     expect(s.occupant).toBe(bob)
     expect(s.resolvedSenderName).toBe('bob2')
@@ -103,7 +107,10 @@ describe('resolveRoomSender', () => {
       occupantId: 'occ-alice',
       avatar: 'blob:renamed',
     })
-    const r = room({ occupants: new Map([['alice-new', renamed]]) })
+    const r = room({
+      occupants: new Map([['alice-new', renamed]]),
+      occupantIdToNick: new Map([['occ-alice', 'alice-new']]),
+    })
     const resolved = resolveRoomAvatar(
       { nick: 'alice-old', occupantId: 'occ-alice' },
       r,
@@ -168,20 +175,20 @@ describe('resolveRoomSender', () => {
     const s = resolveRoomSender(msg({ isPrivate: true, whisperWith: 'alice' }), room({}), new Map(), undefined)
     expect(s.counterpartPresent).toBe(false)
   })
-  it('senderBareJid falls back via the occupant-id cache where senderBareJidForBan is undefined', () => {
-    // Message nick is NOT a current occupant, but occupant-id matches an occupant
-    // under a different nick; the JID for that nick lives only in nickToJidCache.
-    const bob = { nick: 'bob2', occupantId: 'oid-bob', role: 'participant', affiliation: 'none' } as any
+  it('keeps Ban available for a departed occupant through the stable JID alias', () => {
+    const self = { nick: 'me', role: 'moderator', affiliation: 'admin' } as any
     const r = room({
-      occupants: new Map([['bob2', bob]]),
-      // cache keyed by the occupant-id-matched nick, NOT message.nick
-      nickToJidCache: new Map([['bob2', 'bob@server']]),
+      occupantIdToJidCache: new Map([['oid-bob', 'bob@server']]),
     })
-    const s = resolveRoomSender(msg({ nick: 'bob', occupantId: 'oid-bob' }), r, new Map(), undefined)
-    // Ban path has no occupant-id fallback → undefined (occupant.jid absent, cache miss on message.nick)
-    expect(s.senderBareJidForBan).toBeUndefined()
-    // Superset JID resolves via the occupant-id-matched nick cache entry
+    const s = resolveRoomSender(
+      msg({ nick: 'departed-bob', occupantId: 'oid-bob' }),
+      r,
+      new Map(),
+      self,
+    )
+    expect(s.senderBareJidForBan).toBe('bob@server')
     expect(s.senderBareJid).toBe('bob@server')
+    expect(s.canBan).toBe(true)
   })
 })
 
@@ -208,6 +215,31 @@ describe('resolveReplyAvatar', () => {
       nickToAvatarCache: new Map([['alice', 'blob:cache']]),
     })
     expect(resolveReplyAvatar('alice', r, new Map(), 'me', undefined).avatarUrl).toBe('blob:cache')
+  })
+  it('uses the replied-to occupant-id instead of a recycled live nickname', () => {
+    const r = room({
+      occupants: new Map([[
+        'alice',
+        {
+          nick: 'alice',
+          occupantId: 'new-alice',
+          avatar: 'blob:new-alice',
+        } as any,
+      ]]),
+      occupantIdToNick: new Map([['new-alice', 'alice']]),
+      occupantIdToAvatarCache: new Map([['old-alice', 'blob:old-alice']]),
+    })
+
+    expect(
+      resolveReplyAvatar(
+        'alice',
+        r,
+        new Map(),
+        'me',
+        undefined,
+        'old-alice',
+      ).avatarUrl
+    ).toBe('blob:old-alice')
   })
   it('falls back to the contact avatar when occupant and cache have none', () => {
     const r = room({

--- a/apps/fluux/src/components/conversation/roomSenderResolution.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.ts
@@ -46,12 +46,19 @@ export function resolveRoomAvatar(
   let matchedNick: string | undefined
 
   if (subject.occupantId) {
-    for (const candidate of room.occupants.values()) {
-      if (candidate.occupantId === subject.occupantId) {
-        occupant = candidate
-        matchedNick = candidate.nick
-        break
-      }
+    const indexedNick = room.occupantIdToNick?.get(subject.occupantId)
+    const indexedOccupant = indexedNick
+      ? room.occupants.get(indexedNick)
+      : undefined
+    const sameNickOccupant = room.occupants.get(subject.nick)
+    const candidate = indexedOccupant?.occupantId === subject.occupantId
+      ? indexedOccupant
+      : sameNickOccupant?.occupantId === subject.occupantId
+        ? sameNickOccupant
+        : undefined
+    if (candidate) {
+      occupant = candidate
+      matchedNick = candidate.nick
     }
   } else {
     occupant = room.occupants.get(subject.nick)
@@ -156,10 +163,14 @@ export function resolveRoomSender(
   const canModerateMsg = !message.isOutgoing && selfOccupant && room.supportsModeration !== false
     ? canModerate(selfOccupant.role, selfOccupant.affiliation, occupant?.affiliation ?? 'none')
     : false
-  // senderBareJidForBan intentionally has NO occupant-id fallback — matches pre-refactor ban-permission behavior
+  // Ban only through an identity alias that cannot be captured by nickname
+  // recycling. XEP-0421 gives departed occupants a stable room-scoped alias;
+  // legacy messages retain the historical nick cache fallback.
   const senderBareJidForBan = occupant?.jid
     ? getBareJid(occupant.jid)
-    : (!message.occupantId ? room.nickToJidCache?.get(message.nick) : undefined)
+    : message.occupantId
+      ? room.occupantIdToJidCache?.get(message.occupantId)
+      : room.nickToJidCache?.get(message.nick)
   const canBanUser = !message.isOutgoing && selfOccupant && senderBareJidForBan
     ? canBan(selfOccupant.affiliation, occupant?.affiliation ?? 'none')
     : false

--- a/apps/fluux/src/components/conversation/roomSenderResolution.ts
+++ b/apps/fluux/src/components/conversation/roomSenderResolution.ts
@@ -19,19 +19,136 @@ export interface ResolvedRoomSender {
   counterpartPresent: boolean
 }
 
+export interface ResolvedRoomAvatar {
+  occupant: RoomOccupant | undefined
+  matchedNick: string | undefined
+  avatarUrl: string | undefined
+  avatarIdentifier: string
+  senderBareJid: string | undefined
+  source: 'own' | 'live' | 'occupant-id' | 'jid' | 'nick' | 'fallback'
+}
+
+/**
+ * Resolve one room actor through stable identity first.
+ *
+ * A nickname is only trusted when the message has no XEP-0421 identity, or
+ * when the live occupant under that nick proves the same occupant-id. This
+ * prevents historical messages from inheriting the avatar/JID of a different
+ * person who later recycled the nickname.
+ */
+export function resolveRoomAvatar(
+  subject: { nick: string; occupantId?: string; isOwn?: boolean },
+  room: Room,
+  contactsByJid: ReadonlyMap<string, ContactIdentity>,
+  ownAvatar?: string | null,
+): ResolvedRoomAvatar {
+  let occupant: RoomOccupant | undefined
+  let matchedNick: string | undefined
+
+  if (subject.occupantId) {
+    for (const candidate of room.occupants.values()) {
+      if (candidate.occupantId === subject.occupantId) {
+        occupant = candidate
+        matchedNick = candidate.nick
+        break
+      }
+    }
+  } else {
+    occupant = room.occupants.get(subject.nick)
+    matchedNick = occupant?.nick
+  }
+
+  const senderBareJid = occupant?.jid
+    ? getBareJid(occupant.jid)
+    : subject.occupantId
+      ? room.occupantIdToJidCache?.get(subject.occupantId)
+        || (occupant ? room.nickToJidCache?.get(occupant.nick) : undefined)
+      : room.nickToJidCache?.get(subject.nick)
+  const contactAvatar = senderBareJid
+    ? contactsByJid.get(senderBareJid)?.avatar
+    : undefined
+
+  if (subject.isOwn) {
+    return {
+      occupant,
+      matchedNick,
+      avatarUrl: ownAvatar || undefined,
+      avatarIdentifier: subject.occupantId || senderBareJid || subject.nick,
+      senderBareJid,
+      source: ownAvatar ? 'own' : 'fallback',
+    }
+  }
+
+  if (occupant?.avatar) {
+    return {
+      occupant,
+      matchedNick,
+      avatarUrl: occupant.avatar,
+      avatarIdentifier: subject.occupantId || senderBareJid || subject.nick,
+      senderBareJid,
+      source: 'live',
+    }
+  }
+
+  const stableAvatar = subject.occupantId
+    ? room.occupantIdToAvatarCache?.get(subject.occupantId)
+    : undefined
+  if (stableAvatar) {
+    return {
+      occupant,
+      matchedNick,
+      avatarUrl: stableAvatar,
+      avatarIdentifier: subject.occupantId!,
+      senderBareJid,
+      source: 'occupant-id',
+    }
+  }
+
+  if (contactAvatar) {
+    return {
+      occupant,
+      matchedNick,
+      avatarUrl: contactAvatar,
+      avatarIdentifier: senderBareJid || subject.occupantId || subject.nick,
+      senderBareJid,
+      source: 'jid',
+    }
+  }
+
+  // The nick cache is deliberately session-only. With XEP-0421 it is safe
+  // only when a live occupant proves that this nick still belongs to the same
+  // stable identity.
+  const nickCacheIsSafe = !subject.occupantId
+    || occupant?.occupantId === subject.occupantId
+  const nickAvatar = nickCacheIsSafe
+    ? room.nickToAvatarCache?.get(matchedNick || subject.nick)
+    : undefined
+
+  return {
+    occupant,
+    matchedNick,
+    avatarUrl: nickAvatar,
+    avatarIdentifier: subject.occupantId || senderBareJid || subject.nick,
+    senderBareJid,
+    source: nickAvatar ? 'nick' : 'fallback',
+  }
+}
+
 export function resolveRoomSender(
   message: RoomMessage,
   room: Room,
   contactsByJid: ReadonlyMap<string, ContactIdentity>,
   selfOccupant: RoomOccupant | undefined,
 ): ResolvedRoomSender {
-  let occupant = room.occupants.get(message.nick)
-  let occupantIdMatchNick: string | undefined
-  if (!occupant && message.occupantId) {
-    for (const occ of room.occupants.values()) {
-      if (occ.occupantId === message.occupantId) { occupant = occ; occupantIdMatchNick = occ.nick; break }
-    }
-  }
+  const avatar = resolveRoomAvatar(
+    { nick: message.nick, occupantId: message.occupantId, isOwn: message.isOutgoing },
+    room,
+    contactsByJid,
+  )
+  const occupant = avatar.occupant
+  const occupantIdMatchNick = avatar.matchedNick !== message.nick
+    ? avatar.matchedNick
+    : undefined
   // XEP-0425 §2: only offer moderation when the room advertises message-moderate:1
   // on its own disco#info. `room.supportsModeration` is tri-state — `false` means
   // disco confirmed it's unsupported (hide); `undefined` (disco unresolved) stays
@@ -42,24 +159,19 @@ export function resolveRoomSender(
   // senderBareJidForBan intentionally has NO occupant-id fallback — matches pre-refactor ban-permission behavior
   const senderBareJidForBan = occupant?.jid
     ? getBareJid(occupant.jid)
-    : room.nickToJidCache?.get(message.nick)
+    : (!message.occupantId ? room.nickToJidCache?.get(message.nick) : undefined)
   const canBanUser = !message.isOutgoing && selfOccupant && senderBareJidForBan
     ? canBan(selfOccupant.affiliation, occupant?.affiliation ?? 'none')
     : false
-  // reuse senderBareJidForBan, adding only the occupant-id fallback that the ban path intentionally excludes
-  const senderBareJid = senderBareJidForBan
-    || room.nickToJidCache?.get(occupantIdMatchNick ?? '')
+  const senderBareJid = avatar.senderBareJid
   const contact = senderBareJid ? contactsByJid.get(senderBareJid) : undefined
-  const cachedAvatar = room.nickToAvatarCache?.get(message.nick)
-    || room.nickToAvatarCache?.get(occupantIdMatchNick ?? '')
-  const senderAvatar = occupant?.avatar || cachedAvatar || contact?.avatar
   const resolvedSenderName = occupantIdMatchNick
     || (contact?.name && !occupant ? contact.name : null)
     || message.nick
   return {
     occupant,
     avatarPresence: room.joined ? (occupant ? getPresenceFromShow(occupant.show) : 'offline') : undefined,
-    senderAvatar, resolvedSenderName,
+    senderAvatar: avatar.avatarUrl, resolvedSenderName,
     senderRole: occupant?.role,
     senderAffiliation: occupant?.affiliation,
     senderBareJid,
@@ -76,20 +188,21 @@ export function resolveReplyAvatar(
   contactsByJid: ReadonlyMap<string, ContactIdentity>,
   myNick: string | undefined,
   ownAvatar: string | null | undefined,
+  occupantId?: string,
 ): { avatarUrl: string | undefined; avatarIdentifier: string; senderBareJid: string | undefined } {
-  if (nick === myNick && nick) {
-    return { avatarUrl: ownAvatar || undefined, avatarIdentifier: nick, senderBareJid: undefined }
+  if (!nick) {
+    return { avatarUrl: undefined, avatarIdentifier: occupantId || 'unknown', senderBareJid: undefined }
   }
-  const occupantForReply = nick ? room.occupants.get(nick) : undefined
-  const senderBareJid = occupantForReply?.jid
-    ? getBareJid(occupantForReply.jid)
-    : (nick ? room.nickToJidCache?.get(nick) : undefined)
-  const contactAvatar = senderBareJid ? contactsByJid.get(senderBareJid)?.avatar : undefined
-  const cachedReplyAvatar = nick ? room.nickToAvatarCache?.get(nick) : undefined
+  const avatar = resolveRoomAvatar(
+    { nick, occupantId, isOwn: nick === myNick },
+    room,
+    contactsByJid,
+    ownAvatar,
+  )
   return {
-    avatarUrl: occupantForReply?.avatar || cachedReplyAvatar || contactAvatar,
-    avatarIdentifier: nick || 'unknown',
-    senderBareJid,
+    avatarUrl: avatar.avatarUrl,
+    avatarIdentifier: avatar.avatarIdentifier,
+    senderBareJid: avatar.senderBareJid,
   }
 }
 

--- a/packages/fluux-sdk/src/bindings/storeBindings.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.test.ts
@@ -322,7 +322,14 @@ describe('createStoreBindings', () => {
         ])
       })
 
-      it('coalesces a restored offline occupant by stable occupant-id without a nick', () => {
+      it('coalesces live and restored updates by stable occupant-id while retaining the nick', () => {
+        mockClient.emit('room:occupant-avatar', {
+          roomJid: 'room@conference.example.com',
+          nick: 'Alice',
+          occupantId: 'offline-occ',
+          avatar: 'blob:live',
+          avatarHash: 'live-hash',
+        })
         mockClient.emit('room:occupant-avatar', {
           roomJid: 'room@conference.example.com',
           occupantId: 'offline-occ',
@@ -335,6 +342,7 @@ describe('createStoreBindings', () => {
         expect(mockStores.room.updateOccupantAvatars).toHaveBeenCalledWith(
           'room@conference.example.com',
           [{
+            nick: 'Alice',
             occupantId: 'offline-occ',
             avatar: 'blob:offline',
             avatarHash: 'offline-hash',

--- a/packages/fluux-sdk/src/bindings/storeBindings.test.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.test.ts
@@ -322,6 +322,26 @@ describe('createStoreBindings', () => {
         ])
       })
 
+      it('coalesces a restored offline occupant by stable occupant-id without a nick', () => {
+        mockClient.emit('room:occupant-avatar', {
+          roomJid: 'room@conference.example.com',
+          occupantId: 'offline-occ',
+          avatar: 'blob:offline',
+          avatarHash: 'offline-hash',
+        })
+
+        vi.runAllTimers()
+
+        expect(mockStores.room.updateOccupantAvatars).toHaveBeenCalledWith(
+          'room@conference.example.com',
+          [{
+            occupantId: 'offline-occ',
+            avatar: 'blob:offline',
+            avatarHash: 'offline-hash',
+          }],
+        )
+      })
+
       it('drops a pending flush when bindings are unsubscribed', () => {
         mockClient.emit('room:occupant-avatar', { roomJid: 'room@conference.example.com', nick: 'Alice', avatar: 'blob:alice', avatarHash: 'ha' })
 

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -363,23 +363,23 @@ export function createStoreBindings(
   const flushOccupantAvatars = () => {
     avatarFlushTimer = null
     const stores = getStores()
-    for (const [roomJid, byNick] of pendingOccupantAvatars) {
-      stores.room.updateOccupantAvatars(roomJid, [...byNick.values()])
+    for (const [roomJid, byIdentity] of pendingOccupantAvatars) {
+      stores.room.updateOccupantAvatars(roomJid, [...byIdentity.values()])
     }
     pendingOccupantAvatars.clear()
   }
 
   on('room:occupant-avatar', ({ roomJid, nick, occupantId, avatar, avatarHash }) => {
-    let byNick = pendingOccupantAvatars.get(roomJid)
-    if (!byNick) {
-      byNick = new Map()
-      pendingOccupantAvatars.set(roomJid, byNick)
+    let byIdentity = pendingOccupantAvatars.get(roomJid)
+    if (!byIdentity) {
+      byIdentity = new Map()
+      pendingOccupantAvatars.set(roomJid, byIdentity)
     }
     // Prefer the stable occupant-id as the coalescing key. Restored offline
     // identities deliberately have no nick, while live updates carry both.
     const identityKey = occupantId ? `id:${occupantId}` : `nick:${nick ?? ''}`
-    const previous = byNick.get(identityKey)
-    byNick.set(identityKey, {
+    const previous = byIdentity.get(identityKey)
+    byIdentity.set(identityKey, {
       ...previous,
       ...(nick !== undefined && { nick }),
       ...(occupantId !== undefined && { occupantId }),

--- a/packages/fluux-sdk/src/bindings/storeBindings.ts
+++ b/packages/fluux-sdk/src/bindings/storeBindings.ts
@@ -352,7 +352,12 @@ export function createStoreBindings(
   // resolution individually replaces the occupants Map N times in a burst and
   // re-renders every room subscriber once per avatar (render storm on join).
   const AVATAR_FLUSH_DELAY_MS = 200
-  const pendingOccupantAvatars = new Map<string, Map<string, { nick: string; avatar: string | null; avatarHash: string | null }>>()
+  const pendingOccupantAvatars = new Map<string, Map<string, {
+    nick?: string
+    occupantId?: string
+    avatar: string | null
+    avatarHash: string | null
+  }>>()
   let avatarFlushTimer: ReturnType<typeof setTimeout> | null = null
 
   const flushOccupantAvatars = () => {
@@ -364,13 +369,23 @@ export function createStoreBindings(
     pendingOccupantAvatars.clear()
   }
 
-  on('room:occupant-avatar', ({ roomJid, nick, avatar, avatarHash }) => {
+  on('room:occupant-avatar', ({ roomJid, nick, occupantId, avatar, avatarHash }) => {
     let byNick = pendingOccupantAvatars.get(roomJid)
     if (!byNick) {
       byNick = new Map()
       pendingOccupantAvatars.set(roomJid, byNick)
     }
-    byNick.set(nick, { nick, avatar, avatarHash })
+    // Prefer the stable occupant-id as the coalescing key. Restored offline
+    // identities deliberately have no nick, while live updates carry both.
+    const identityKey = occupantId ? `id:${occupantId}` : `nick:${nick ?? ''}`
+    const previous = byNick.get(identityKey)
+    byNick.set(identityKey, {
+      ...previous,
+      ...(nick !== undefined && { nick }),
+      ...(occupantId !== undefined && { occupantId }),
+      avatar,
+      avatarHash,
+    })
     if (avatarFlushTimer === null) {
       avatarFlushTimer = setTimeout(flushOccupantAvatars, AVATAR_FLUSH_DELAY_MS)
     }

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -1914,7 +1914,8 @@ describe('XMPPClient', () => {
         'room@conference.example.com',
         'TestUser',
         'abc123hash',
-        'realuser@example.com'
+        'realuser@example.com',
+        undefined,
       )
     })
 
@@ -2012,7 +2013,8 @@ describe('XMPPClient', () => {
         'room@conference.example.com',
         'TestUser',
         'newhash456',
-        'realuser@example.com'
+        'realuser@example.com',
+        undefined,
       )
     })
   })

--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -1918,6 +1918,45 @@ describe('XMPPClient', () => {
       )
     })
 
+    it('threads the room-scoped occupant-id into avatar persistence', () => {
+      const occupants = new Map()
+      occupants.set('TestUser', {
+        nick: 'TestUser',
+        occupantId: 'opaque-occ-id',
+        affiliation: 'member',
+        role: 'participant',
+      })
+      mockStores.room.getRoom.mockReturnValue(
+        createMockRoom('room@conference.example.com', {
+          name: 'Test Room',
+          joined: true,
+          occupants,
+        })
+      )
+
+      const fetchOccupantAvatarSpy = vi.spyOn(
+        xmppClient.profile,
+        'fetchOccupantAvatar'
+      ).mockResolvedValue()
+
+      ;(xmppClient as any).emit(
+        'occupantAvatarUpdate',
+        'room@conference.example.com',
+        'TestUser',
+        'abc123hash',
+        undefined,
+        'opaque-occ-id',
+      )
+
+      expect(fetchOccupantAvatarSpy).toHaveBeenCalledWith(
+        'room@conference.example.com',
+        'TestUser',
+        'abc123hash',
+        undefined,
+        'opaque-occ-id',
+      )
+    })
+
     it('should NOT call fetchOccupantAvatar if occupant already has same hash and avatar', async () => {
       // Mock room with occupant that already has the avatar
       const occupants = new Map()

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -768,10 +768,13 @@ export class XMPPClient {
           // Same hash and already have avatar blob - skip fetch
           return
         }
-        const fetch = occupantId
-          ? this.profile.fetchOccupantAvatar(roomJid, nick, hash, realJid, occupantId)
-          : this.profile.fetchOccupantAvatar(roomJid, nick, hash, realJid)
-        fetch.catch(() => {})
+        this.profile.fetchOccupantAvatar(
+          roomJid,
+          nick,
+          hash,
+          realJid,
+          occupantId,
+        ).catch(() => {})
       })
 
       // Listen for avatar metadata updates (XEP-0084)

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -760,7 +760,7 @@ export class XMPPClient {
 
       // Listen for MUC occupant avatar updates (XEP-0398)
       // Emitted by MUC module when an occupant's presence contains vcard-temp:x:update
-      this.on('occupantAvatarUpdate', (roomJid, nick, hash, realJid) => {
+      this.on('occupantAvatarUpdate', (roomJid, nick, hash, realJid, occupantId) => {
         // Only fetch if the avatar hash changed to avoid re-downloading on every presence
         const room = this.stores?.room.getRoom(roomJid)
         const occupant = room?.occupants.get(nick)
@@ -768,7 +768,10 @@ export class XMPPClient {
           // Same hash and already have avatar blob - skip fetch
           return
         }
-        this.profile.fetchOccupantAvatar(roomJid, nick, hash, realJid).catch(() => {})
+        const fetch = occupantId
+          ? this.profile.fetchOccupantAvatar(roomJid, nick, hash, realJid, occupantId)
+          : this.profile.fetchOccupantAvatar(roomJid, nick, hash, realJid)
+        fetch.catch(() => {})
       })
 
       // Listen for avatar metadata updates (XEP-0084)

--- a/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
@@ -94,7 +94,8 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
         'room@conference.example.org',
         'TestUser',
         'abc123avatarhash',
-        undefined // no real JID in semi-anonymous room
+        undefined, // no real JID in semi-anonymous room
+        undefined, // no occupant-id advertised
       )
     })
 
@@ -413,7 +414,8 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
         'room@conference.example.org',
         'TestUser',
         'abc123avatarhash',
-        undefined
+        undefined,
+        undefined,
       )
     })
 
@@ -471,7 +473,8 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
         'room@conference.example.org',
         'TestUser',
         'new-hash',
-        undefined
+        undefined,
+        undefined,
       )
     })
   })

--- a/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.occupant-avatar.test.ts
@@ -124,6 +124,10 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
             { name: 'photo', text: 'def456avatarhash' },
           ],
         },
+        {
+          name: 'occupant-id',
+          attrs: { xmlns: 'urn:xmpp:occupant-id:0', id: 'opaque-test-user' },
+        },
       ])
 
       mockStores.room.getRoom.mockReturnValue({
@@ -146,7 +150,8 @@ describe('MUC Occupant Avatars (XEP-0398)', () => {
         'room@conference.example.org',
         'TestUser',
         'def456avatarhash',
-        'realuser@example.org/resource' // real JID available
+        'realuser@example.org/resource',
+        'opaque-test-user',
       )
     })
 

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -324,7 +324,7 @@ export class MUC extends BaseModule {
         this.deps.emitSDK('room:self-occupant', { roomJid, occupant })
         this.deps.emitSDK('room:occupant-joined', { roomJid, occupant })
         if (avatarHash) {
-          this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
+          this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
         }
         return
       }
@@ -390,7 +390,7 @@ export class MUC extends BaseModule {
 
       // XEP-0398: Trigger avatar fetch if occupant has avatar hash (skip self - we use own avatar)
       if (avatarHash) {
-        this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
+        this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
       }
     } else {
       // Check if room is in joining state - buffer occupants to reduce re-renders
@@ -410,7 +410,7 @@ export class MUC extends BaseModule {
         if (avatarHash) {
           const existing = room?.occupants.get(nick)
           if (existing?.avatarHash !== avatarHash || !existing?.avatar) {
-            this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
+            this.emitOccupantAvatarUpdate(roomJid, nick, avatarHash, realJid, occupantId)
           }
         }
       }
@@ -426,6 +426,22 @@ export class MUC extends BaseModule {
     if (pending) {
       clearTimeout(pending.timeoutId)
       this.pendingJoins.delete(roomJid)
+    }
+  }
+
+  private emitOccupantAvatarUpdate(
+    roomJid: string,
+    nick: string,
+    avatarHash: string,
+    realJid?: string,
+    occupantId?: string,
+  ): void {
+    // Preserve the historical four-argument event shape for servers without
+    // XEP-0421 while threading the stable identity when it is advertised.
+    if (occupantId) {
+      this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId)
+    } else {
+      this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
     }
   }
 
@@ -556,7 +572,13 @@ export class MUC extends BaseModule {
       // XEP-0398: Trigger avatar fetch for all occupants with avatar hashes
       for (const occupant of occupants) {
         if (occupant.avatarHash) {
-          this.deps.emit('occupantAvatarUpdate', roomJid, occupant.nick, occupant.avatarHash, occupant.jid)
+          this.emitOccupantAvatarUpdate(
+            roomJid,
+            occupant.nick,
+            occupant.avatarHash,
+            occupant.jid,
+            occupant.occupantId,
+          )
         }
       }
     }

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -436,13 +436,7 @@ export class MUC extends BaseModule {
     realJid?: string,
     occupantId?: string,
   ): void {
-    // Preserve the historical four-argument event shape for servers without
-    // XEP-0421 while threading the stable identity when it is advertised.
-    if (occupantId) {
-      this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId)
-    } else {
-      this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid)
-    }
+    this.deps.emit('occupantAvatarUpdate', roomJid, nick, avatarHash, realJid, occupantId)
   }
 
   /**

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -64,6 +64,8 @@ vi.mock('../../utils/avatarCache', () => ({
   saveAvatarHash: vi.fn().mockResolvedValue(undefined),
   getAvatarHash: vi.fn().mockResolvedValue(null),
   getAllAvatarHashes: vi.fn().mockResolvedValue([]),
+  saveRoomOccupantAvatarHash: vi.fn().mockResolvedValue(undefined),
+  getRoomOccupantAvatarHashes: vi.fn().mockResolvedValue([]),
   refreshAllBlobUrls: vi.fn().mockResolvedValue(new Map()),
   // Negative cache functions
   hasNoAvatar: vi.fn().mockResolvedValue(false),
@@ -1398,6 +1400,41 @@ describe('XMPPClient Own Avatar', () => {
     })
 
     describe('fetchOccupantAvatar', () => {
+      it('records both stable aliases when cached bytes satisfy an occupant avatar', async () => {
+        const {
+          getCachedAvatar,
+          saveAvatarHash,
+          saveRoomOccupantAvatarHash,
+        } = await import('../../utils/avatarCache')
+        vi.mocked(getCachedAvatar).mockResolvedValueOnce('blob:shared-avatar')
+
+        await xmppClient.profile.fetchOccupantAvatar(
+          'room@conference.example.com',
+          'CurrentNick',
+          'shared-hash',
+          'person@example.com/resource',
+          'opaque-occupant-id',
+        )
+
+        expect(saveAvatarHash).toHaveBeenCalledWith(
+          'person@example.com',
+          'shared-hash',
+          'contact',
+        )
+        expect(saveRoomOccupantAvatarHash).toHaveBeenCalledWith(
+          'room@conference.example.com',
+          'opaque-occupant-id',
+          'shared-hash',
+        )
+        expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
+          roomJid: 'room@conference.example.com',
+          nick: 'CurrentNick',
+          occupantId: 'opaque-occupant-id',
+          avatar: 'blob:shared-avatar',
+          avatarHash: 'shared-hash',
+        })
+      })
+
       it('should clear negative cache and proceed when presence advertises avatar hash', async () => {
         mockXmppClientInstance.iqCaller.request.mockClear()
 
@@ -1626,6 +1663,35 @@ describe('XMPPClient Own Avatar', () => {
     })
 
     describe('restoreOccupantAvatarsFromCache', () => {
+      it('restores an offline anonymous occupant through its room-scoped occupant-id', async () => {
+        emitSDKSpy.mockClear()
+
+        const {
+          getRoomOccupantAvatarHashes,
+          getCachedAvatar,
+        } = await import('../../utils/avatarCache')
+        vi.mocked(getRoomOccupantAvatarHashes).mockResolvedValueOnce([
+          { occupantId: 'offline-opaque-id', hash: 'offline-hash' },
+        ])
+        vi.mocked(getCachedAvatar).mockResolvedValueOnce('blob:offline-avatar')
+
+        mockStores.room.getRoom.mockReturnValue({
+          jid: 'room@conference.example.com',
+          occupants: new Map(),
+        } as any)
+
+        await xmppClient.profile.restoreOccupantAvatarsFromCache(
+          'room@conference.example.com'
+        )
+
+        expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
+          roomJid: 'room@conference.example.com',
+          occupantId: 'offline-opaque-id',
+          avatar: 'blob:offline-avatar',
+          avatarHash: 'offline-hash',
+        })
+      })
+
       it('should restore cached avatar for occupant with real JID but no avatar', async () => {
         emitSDKSpy.mockClear()
 

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -66,6 +66,7 @@ vi.mock('../../utils/avatarCache', () => ({
   getAllAvatarHashes: vi.fn().mockResolvedValue([]),
   saveRoomOccupantAvatarHash: vi.fn().mockResolvedValue(undefined),
   getRoomOccupantAvatarHashes: vi.fn().mockResolvedValue([]),
+  groupRoomOccupantAvatarHashes: vi.fn().mockReturnValue(new Map()),
   refreshAllBlobUrls: vi.fn().mockResolvedValue(new Map()),
   // Negative cache functions
   hasNoAvatar: vi.fn().mockResolvedValue(false),
@@ -1038,6 +1039,65 @@ describe('XMPPClient Own Avatar', () => {
       expect(emitSDKSpy).not.toHaveBeenCalledWith('room:occupant-avatar', expect.objectContaining({ nick: 'Carol' }))
     })
 
+    it('groups persisted occupant aliases once for every joined room', async () => {
+      emitSDKSpy.mockClear()
+
+      const {
+        refreshAllBlobUrls,
+        getAllAvatarHashes,
+        getRoomOccupantAvatarHashes,
+        groupRoomOccupantAvatarHashes,
+      } = await import('../../utils/avatarCache')
+      const mappings = [
+        { jid: 'encoded-a', hash: 'hash-a', type: 'occupant' as const },
+        { jid: 'encoded-b', hash: 'hash-b', type: 'occupant' as const },
+      ]
+      vi.mocked(getAllAvatarHashes).mockClear()
+      vi.mocked(groupRoomOccupantAvatarHashes).mockClear()
+      vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([
+        ['hash-a', 'blob:fresh-a'],
+        ['hash-b', 'blob:fresh-b'],
+      ]))
+      vi.mocked(getAllAvatarHashes).mockResolvedValue(mappings)
+      vi.mocked(groupRoomOccupantAvatarHashes).mockReturnValueOnce(new Map([
+        ['room-a@conf.example.com', [{ occupantId: 'occ-a', hash: 'hash-a' }]],
+        ['room-b@conf.example.com', [{ occupantId: 'occ-b', hash: 'hash-b' }]],
+      ]))
+      vi.mocked(getRoomOccupantAvatarHashes).mockClear()
+
+      mockStores.room.joinedRooms.mockReturnValue([
+        {
+          jid: 'room-a@conf.example.com',
+          occupants: new Map(),
+          occupantIdToNick: new Map([['occ-a', 'Alice']]),
+        } as Room,
+        {
+          jid: 'room-b@conf.example.com',
+          occupants: new Map(),
+        } as Room,
+      ])
+
+      await xmppClient.profile.refreshAllAvatarBlobUrls()
+
+      expect(getAllAvatarHashes).toHaveBeenCalledTimes(1)
+      expect(groupRoomOccupantAvatarHashes).toHaveBeenCalledTimes(1)
+      expect(groupRoomOccupantAvatarHashes).toHaveBeenCalledWith(mappings)
+      expect(getRoomOccupantAvatarHashes).not.toHaveBeenCalled()
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
+        roomJid: 'room-a@conf.example.com',
+        nick: 'Alice',
+        occupantId: 'occ-a',
+        avatar: 'blob:fresh-a',
+        avatarHash: 'hash-a',
+      })
+      expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
+        roomJid: 'room-b@conf.example.com',
+        occupantId: 'occ-b',
+        avatar: 'blob:fresh-b',
+        avatarHash: 'hash-b',
+      })
+    })
+
     it('re-points a roster contact whose hash the mapping store missed', async () => {
       emitSDKSpy.mockClear()
 
@@ -1400,7 +1460,7 @@ describe('XMPPClient Own Avatar', () => {
     })
 
     describe('fetchOccupantAvatar', () => {
-      it('records both stable aliases when cached bytes satisfy an occupant avatar', async () => {
+      it('records only the room-scoped stable alias when cached bytes satisfy an occupant avatar', async () => {
         const {
           getCachedAvatar,
           saveAvatarHash,
@@ -1416,11 +1476,7 @@ describe('XMPPClient Own Avatar', () => {
           'opaque-occupant-id',
         )
 
-        expect(saveAvatarHash).toHaveBeenCalledWith(
-          'person@example.com',
-          'shared-hash',
-          'contact',
-        )
+        expect(saveAvatarHash).not.toHaveBeenCalled()
         expect(saveRoomOccupantAvatarHash).toHaveBeenCalledWith(
           'room@conference.example.com',
           'opaque-occupant-id',
@@ -1690,6 +1746,75 @@ describe('XMPPClient Own Avatar', () => {
           avatar: 'blob:offline-avatar',
           avatarHash: 'offline-hash',
         })
+      })
+
+      it('includes the live nick when a stable restore matches an online occupant', async () => {
+        emitSDKSpy.mockClear()
+
+        const {
+          getRoomOccupantAvatarHashes,
+          getCachedAvatar,
+        } = await import('../../utils/avatarCache')
+        vi.mocked(getRoomOccupantAvatarHashes).mockResolvedValueOnce([
+          { occupantId: 'online-opaque-id', hash: 'online-hash' },
+        ])
+        vi.mocked(getCachedAvatar).mockResolvedValueOnce('blob:online-avatar')
+
+        mockStores.room.getRoom.mockReturnValue({
+          jid: 'room@conference.example.com',
+          occupants: new Map([
+            ['Alice', {
+              nick: 'Alice',
+              occupantId: 'online-opaque-id',
+              affiliation: 'none',
+              role: 'participant',
+            }],
+          ]),
+          occupantIdToNick: new Map([['online-opaque-id', 'Alice']]),
+        } as any)
+
+        await xmppClient.profile.restoreOccupantAvatarsFromCache(
+          'room@conference.example.com'
+        )
+
+        expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
+          roomJid: 'room@conference.example.com',
+          nick: 'Alice',
+          occupantId: 'online-opaque-id',
+          avatar: 'blob:online-avatar',
+          avatarHash: 'online-hash',
+        })
+      })
+
+      it('restores optimistically while room anonymity disco is unresolved', async () => {
+        emitSDKSpy.mockClear()
+        ;(xmppClient.profile as any).deps.privacyOptions = {
+          disableOccupantAvatarsInAnonymousRooms: true,
+        }
+
+        const {
+          getRoomOccupantAvatarHashes,
+          getCachedAvatar,
+        } = await import('../../utils/avatarCache')
+        vi.mocked(getRoomOccupantAvatarHashes).mockResolvedValueOnce([
+          { occupantId: 'pending-disco-id', hash: 'pending-disco-hash' },
+        ])
+        vi.mocked(getCachedAvatar).mockResolvedValueOnce('blob:pending-disco')
+
+        mockStores.room.getRoom.mockReturnValue({
+          jid: 'room@conference.example.com',
+          isNonAnonymous: undefined,
+          occupants: new Map(),
+        } as any)
+
+        await xmppClient.profile.restoreOccupantAvatarsFromCache(
+          'room@conference.example.com'
+        )
+
+        expect(emitSDKSpy).toHaveBeenCalledWith(
+          'room:occupant-avatar',
+          expect.objectContaining({ occupantId: 'pending-disco-id' }),
+        )
       })
 
       it('should restore cached avatar for occupant with real JID but no avatar', async () => {

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -66,7 +66,7 @@ vi.mock('../../utils/avatarCache', () => ({
   getAllAvatarHashes: vi.fn().mockResolvedValue([]),
   saveRoomOccupantAvatarHash: vi.fn().mockResolvedValue(undefined),
   getRoomOccupantAvatarHashes: vi.fn().mockResolvedValue([]),
-  groupRoomOccupantAvatarHashes: vi.fn().mockReturnValue(new Map()),
+  seedRoomOccupantAvatarHashes: vi.fn().mockResolvedValue(new Map()),
   refreshAllBlobUrls: vi.fn().mockResolvedValue(new Map()),
   // Negative cache functions
   hasNoAvatar: vi.fn().mockResolvedValue(false),
@@ -1046,22 +1046,22 @@ describe('XMPPClient Own Avatar', () => {
         refreshAllBlobUrls,
         getAllAvatarHashes,
         getRoomOccupantAvatarHashes,
-        groupRoomOccupantAvatarHashes,
+        seedRoomOccupantAvatarHashes,
       } = await import('../../utils/avatarCache')
       const mappings = [
         { jid: 'encoded-a', hash: 'hash-a', type: 'occupant' as const },
         { jid: 'encoded-b', hash: 'hash-b', type: 'occupant' as const },
       ]
       vi.mocked(getAllAvatarHashes).mockClear()
-      vi.mocked(groupRoomOccupantAvatarHashes).mockClear()
+      vi.mocked(seedRoomOccupantAvatarHashes).mockClear()
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([
         ['hash-a', 'blob:fresh-a'],
         ['hash-b', 'blob:fresh-b'],
       ]))
       vi.mocked(getAllAvatarHashes).mockResolvedValue(mappings)
-      vi.mocked(groupRoomOccupantAvatarHashes).mockReturnValueOnce(new Map([
-        ['room-a@conf.example.com', [{ occupantId: 'occ-a', hash: 'hash-a' }]],
-        ['room-b@conf.example.com', [{ occupantId: 'occ-b', hash: 'hash-b' }]],
+      vi.mocked(seedRoomOccupantAvatarHashes).mockResolvedValueOnce(new Map([
+        ['room-a@conf.example.com', new Map([['occ-a', 'hash-a']])],
+        ['room-b@conf.example.com', new Map([['occ-b', 'hash-b']])],
       ]))
       vi.mocked(getRoomOccupantAvatarHashes).mockClear()
 
@@ -1080,8 +1080,8 @@ describe('XMPPClient Own Avatar', () => {
       await xmppClient.profile.refreshAllAvatarBlobUrls()
 
       expect(getAllAvatarHashes).toHaveBeenCalledTimes(1)
-      expect(groupRoomOccupantAvatarHashes).toHaveBeenCalledTimes(1)
-      expect(groupRoomOccupantAvatarHashes).toHaveBeenCalledWith(mappings)
+      expect(seedRoomOccupantAvatarHashes).toHaveBeenCalledTimes(1)
+      expect(seedRoomOccupantAvatarHashes).toHaveBeenCalledWith(mappings)
       expect(getRoomOccupantAvatarHashes).not.toHaveBeenCalled()
       expect(emitSDKSpy).toHaveBeenCalledWith('room:occupant-avatar', {
         roomJid: 'room-a@conf.example.com',

--- a/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.avatar.test.ts
@@ -64,6 +64,7 @@ vi.mock('../../utils/avatarCache', () => ({
   saveAvatarHash: vi.fn().mockResolvedValue(undefined),
   getAvatarHash: vi.fn().mockResolvedValue(null),
   getAllAvatarHashes: vi.fn().mockResolvedValue([]),
+  tryGetAllAvatarHashes: vi.fn().mockResolvedValue([]),
   saveRoomOccupantAvatarHash: vi.fn().mockResolvedValue(undefined),
   getRoomOccupantAvatarHashes: vi.fn().mockResolvedValue([]),
   seedRoomOccupantAvatarHashes: vi.fn().mockResolvedValue(new Map()),
@@ -948,12 +949,12 @@ describe('XMPPClient Own Avatar', () => {
     it('should refresh stale blob URLs for contacts and rooms', async () => {
       emitSDKSpy.mockClear()
 
-      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      const { refreshAllBlobUrls, tryGetAllAvatarHashes } = await import('../../utils/avatarCache')
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([
         ['hash-c1', 'blob:fresh-contact1'],
         ['hash-r1', 'blob:fresh-room1'],
       ]))
-      vi.mocked(getAllAvatarHashes).mockResolvedValue([
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue([
         { jid: 'alice@example.com', hash: 'hash-c1', type: 'contact' },
         { jid: 'room@conference.example.com', hash: 'hash-r1', type: 'room' },
       ])
@@ -980,9 +981,9 @@ describe('XMPPClient Own Avatar', () => {
     it('should skip entities not in store', async () => {
       emitSDKSpy.mockClear()
 
-      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      const { refreshAllBlobUrls, tryGetAllAvatarHashes } = await import('../../utils/avatarCache')
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash1', 'blob:url']]))
-      vi.mocked(getAllAvatarHashes).mockResolvedValue([
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue([
         { jid: 'unknown@example.com', hash: 'hash1', type: 'contact' },
       ])
       mockStores.roster.getContact.mockReturnValue(undefined)
@@ -1003,13 +1004,30 @@ describe('XMPPClient Own Avatar', () => {
       expect(emitSDKSpy).not.toHaveBeenCalled()
     })
 
+    it('does not seed a failed hash-store read as an empty snapshot', async () => {
+      const {
+        refreshAllBlobUrls,
+        tryGetAllAvatarHashes,
+        seedRoomOccupantAvatarHashes,
+      } = await import('../../utils/avatarCache')
+      vi.mocked(refreshAllBlobUrls).mockResolvedValue(
+        new Map([['hash-other', 'blob:fresh-other']])
+      )
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValueOnce(null)
+      vi.mocked(seedRoomOccupantAvatarHashes).mockClear()
+
+      await xmppClient.profile.refreshAllAvatarBlobUrls()
+
+      expect(seedRoomOccupantAvatarHashes).toHaveBeenCalledWith(null)
+    })
+
     it('should refresh stale blob URLs for MUC occupants', async () => {
       emitSDKSpy.mockClear()
 
-      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      const { refreshAllBlobUrls, tryGetAllAvatarHashes } = await import('../../utils/avatarCache')
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-o1', 'blob:fresh-occupant1']]))
       // Occupant avatars are NOT in the contact/room hash store, so this stays empty.
-      vi.mocked(getAllAvatarHashes).mockResolvedValue([])
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue([])
 
       // A joined room whose occupant's avatar blob URL went stale after wake.
       // refreshAllBlobUrls revoked the old blobs; occupants must be re-pointed.
@@ -1044,7 +1062,7 @@ describe('XMPPClient Own Avatar', () => {
 
       const {
         refreshAllBlobUrls,
-        getAllAvatarHashes,
+        tryGetAllAvatarHashes,
         getRoomOccupantAvatarHashes,
         seedRoomOccupantAvatarHashes,
       } = await import('../../utils/avatarCache')
@@ -1052,13 +1070,13 @@ describe('XMPPClient Own Avatar', () => {
         { jid: 'encoded-a', hash: 'hash-a', type: 'occupant' as const },
         { jid: 'encoded-b', hash: 'hash-b', type: 'occupant' as const },
       ]
-      vi.mocked(getAllAvatarHashes).mockClear()
+      vi.mocked(tryGetAllAvatarHashes).mockClear()
       vi.mocked(seedRoomOccupantAvatarHashes).mockClear()
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([
         ['hash-a', 'blob:fresh-a'],
         ['hash-b', 'blob:fresh-b'],
       ]))
-      vi.mocked(getAllAvatarHashes).mockResolvedValue(mappings)
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue(mappings)
       vi.mocked(seedRoomOccupantAvatarHashes).mockResolvedValueOnce(new Map([
         ['room-a@conf.example.com', new Map([['occ-a', 'hash-a']])],
         ['room-b@conf.example.com', new Map([['occ-b', 'hash-b']])],
@@ -1079,7 +1097,7 @@ describe('XMPPClient Own Avatar', () => {
 
       await xmppClient.profile.refreshAllAvatarBlobUrls()
 
-      expect(getAllAvatarHashes).toHaveBeenCalledTimes(1)
+      expect(tryGetAllAvatarHashes).toHaveBeenCalledTimes(1)
       expect(seedRoomOccupantAvatarHashes).toHaveBeenCalledTimes(1)
       expect(seedRoomOccupantAvatarHashes).toHaveBeenCalledWith(mappings)
       expect(getRoomOccupantAvatarHashes).not.toHaveBeenCalled()
@@ -1101,13 +1119,13 @@ describe('XMPPClient Own Avatar', () => {
     it('re-points a roster contact whose hash the mapping store missed', async () => {
       emitSDKSpy.mockClear()
 
-      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      const { refreshAllBlobUrls, tryGetAllAvatarHashes } = await import('../../utils/avatarCache')
       // A fresh URL exists for the contact's hash, but the IndexedDB mapping
       // store does NOT list this JID (e.g. the avatar arrived via MUC
       // vcard-temp presence, not a PEP/vCard fetch). The mapping loop misses it;
       // the roster-store safety net must still re-point its dead blob.
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-seb', 'blob:fresh-seb']]))
-      vi.mocked(getAllAvatarHashes).mockResolvedValue([])
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue([])
       mockStores.roster.sortedContacts.mockReturnValue([
         { jid: 'seb@example.com', name: 'Seb', presence: 'online', subscription: 'both', avatar: 'blob:dead-seb', avatarHash: 'hash-seb' },
       ])
@@ -1122,12 +1140,12 @@ describe('XMPPClient Own Avatar', () => {
     it('re-fetches a roster contact whose cached avatar bytes are gone', async () => {
       emitSDKSpy.mockClear()
 
-      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      const { refreshAllBlobUrls, tryGetAllAvatarHashes } = await import('../../utils/avatarCache')
       // Another contact is cached (so the size-0 short-circuit doesn't fire), but
       // Seb's hash has no fresh URL → his bytes were evicted from IndexedDB.
       // His pointer is a now-dead blob, so the safety net must re-fetch to heal.
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-other', 'blob:other']]))
-      vi.mocked(getAllAvatarHashes).mockResolvedValue([])
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue([])
       const fetchSpy = vi.spyOn(xmppClient.profile, 'fetchAvatarData').mockResolvedValue()
       mockStores.roster.sortedContacts.mockReturnValue([
         { jid: 'seb@example.com', name: 'Seb', presence: 'online', subscription: 'both', avatar: 'blob:dead-seb', avatarHash: 'hash-seb' },
@@ -1141,11 +1159,11 @@ describe('XMPPClient Own Avatar', () => {
     it('should re-point the current user\'s own avatar via connection:own-avatar', async () => {
       emitSDKSpy.mockClear()
 
-      const { refreshAllBlobUrls, getAllAvatarHashes } = await import('../../utils/avatarCache')
+      const { refreshAllBlobUrls, tryGetAllAvatarHashes } = await import('../../utils/avatarCache')
       vi.mocked(refreshAllBlobUrls).mockResolvedValue(new Map([['hash-self', 'blob:fresh-self']]))
       // The own avatar is stored in the hash store as a 'contact' under the
       // user's own bare JID (Profile.fetchOwnAvatar → saveAvatarHash(..., 'contact')).
-      vi.mocked(getAllAvatarHashes).mockResolvedValue([
+      vi.mocked(tryGetAllAvatarHashes).mockResolvedValue([
         { jid: 'user@example.com', hash: 'hash-self', type: 'contact' },
       ])
       // The user is not in their own roster, so getContact misses.

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -10,6 +10,7 @@ import {
   cacheAvatar,
   saveAvatarHash,
   getAllAvatarHashes,
+  tryGetAllAvatarHashes,
   saveRoomOccupantAvatarHash,
   getRoomOccupantAvatarHashes,
   seedRoomOccupantAvatarHashes,
@@ -1059,10 +1060,10 @@ export class Profile extends BaseModule {
       const currentJid = this.deps.getCurrentJid()
       const ownBareJid = currentJid ? getBareJid(currentJid) : null
 
-      const hashMappings = await getAllAvatarHashes()
+      const hashMappings = await tryGetAllAvatarHashes()
       const occupantMappingsByRoom =
         await seedRoomOccupantAvatarHashes(hashMappings)
-      for (const mapping of hashMappings) {
+      for (const mapping of hashMappings ?? []) {
         const url = freshUrls.get(mapping.hash)
         if (!url) continue
 

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -12,6 +12,7 @@ import {
   getAllAvatarHashes,
   saveRoomOccupantAvatarHash,
   getRoomOccupantAvatarHashes,
+  groupRoomOccupantAvatarHashes,
   hasNoAvatar,
   markNoAvatar,
   clearNoAvatar,
@@ -305,9 +306,6 @@ export class Profile extends BaseModule {
     // Check cache first using the hash
     const cachedUrl = await getCachedAvatar(avatarHash)
     if (cachedUrl) {
-      if (realJid) {
-        await saveAvatarHash(getBareJid(realJid), avatarHash, 'contact')
-      }
       if (occupantId) {
         await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
       }
@@ -1060,6 +1058,7 @@ export class Profile extends BaseModule {
       const ownBareJid = currentJid ? getBareJid(currentJid) : null
 
       const hashMappings = await getAllAvatarHashes()
+      const occupantMappingsByRoom = groupRoomOccupantAvatarHashes(hashMappings)
       for (const mapping of hashMappings) {
         const url = freshUrls.get(mapping.hash)
         if (!url) continue
@@ -1139,16 +1138,18 @@ export class Profile extends BaseModule {
         // live occupant map, but their room-scoped hash bindings are durable.
         if (
           this.deps.privacyOptions?.disableOccupantAvatarsInAnonymousRooms
-          && !room.isNonAnonymous
+          && room.isNonAnonymous === false
         ) {
           continue
         }
-        const stableMappings = await getRoomOccupantAvatarHashes(room.jid)
+        const stableMappings = occupantMappingsByRoom.get(getBareJid(room.jid)) ?? []
         for (const { occupantId, hash } of stableMappings) {
           const url = freshUrls.get(hash)
           if (!url) continue
+          const nick = room.occupantIdToNick?.get(occupantId)
           this.deps.emitSDK('room:occupant-avatar', {
             roomJid: room.jid,
+            ...(nick && { nick }),
             occupantId,
             avatar: url,
             avatarHash: hash,
@@ -1195,14 +1196,16 @@ export class Profile extends BaseModule {
       // room-scoped identity, including occupants who are already offline.
       const anonymousRestoreDisabled =
         this.deps.privacyOptions?.disableOccupantAvatarsInAnonymousRooms
-        && !room.isNonAnonymous
+        && room.isNonAnonymous === false
       if (!anonymousRestoreDisabled) {
         const stableMappings = await getRoomOccupantAvatarHashes(roomJid)
         for (const { occupantId, hash } of stableMappings) {
           const cachedUrl = await getCachedAvatar(hash)
           if (!cachedUrl) continue
+          const nick = room.occupantIdToNick?.get(occupantId)
           this.deps.emitSDK('room:occupant-avatar', {
             roomJid,
+            ...(nick && { nick }),
             occupantId,
             avatar: cachedUrl,
             avatarHash: hash,

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -296,9 +296,11 @@ export class Profile extends BaseModule {
     realJid?: string,
     occupantId?: string,
   ): Promise<void> {
-    // Check privacy options: if avatar fetching is disabled for anonymous rooms
-    // and we don't have a real JID (meaning we'd query via room@conf/nick),
-    // skip fetching to protect user privacy
+    // This gate intentionally uses per-presence evidence while restore uses the
+    // room's disco result: with the privacy option enabled, fetching/persistence
+    // is allowed only when this occupant exposes a real JID; restore is
+    // suppressed once disco confirms the room anonymous
+    // (`isNonAnonymous === false`).
     if (this.deps.privacyOptions?.disableOccupantAvatarsInAnonymousRooms && !realJid) {
       return
     }

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -12,7 +12,7 @@ import {
   getAllAvatarHashes,
   saveRoomOccupantAvatarHash,
   getRoomOccupantAvatarHashes,
-  groupRoomOccupantAvatarHashes,
+  seedRoomOccupantAvatarHashes,
   hasNoAvatar,
   markNoAvatar,
   clearNoAvatar,
@@ -1060,7 +1060,8 @@ export class Profile extends BaseModule {
       const ownBareJid = currentJid ? getBareJid(currentJid) : null
 
       const hashMappings = await getAllAvatarHashes()
-      const occupantMappingsByRoom = groupRoomOccupantAvatarHashes(hashMappings)
+      const occupantMappingsByRoom =
+        await seedRoomOccupantAvatarHashes(hashMappings)
       for (const mapping of hashMappings) {
         const url = freshUrls.get(mapping.hash)
         if (!url) continue
@@ -1144,8 +1145,9 @@ export class Profile extends BaseModule {
         ) {
           continue
         }
-        const stableMappings = occupantMappingsByRoom.get(getBareJid(room.jid)) ?? []
-        for (const { occupantId, hash } of stableMappings) {
+        const stableMappings = occupantMappingsByRoom.get(getBareJid(room.jid))
+        if (!stableMappings) continue
+        for (const [occupantId, hash] of stableMappings) {
           const url = freshUrls.get(hash)
           if (!url) continue
           const nick = room.occupantIdToNick?.get(occupantId)

--- a/packages/fluux-sdk/src/core/modules/Profile.ts
+++ b/packages/fluux-sdk/src/core/modules/Profile.ts
@@ -4,7 +4,22 @@ import { BaseModule } from './BaseModule'
 import { getBareJid, getLocalPart, getDomain } from '../jid'
 import type { VCardInfo } from '../types/roster'
 import { generateUUID } from '../../utils/uuid'
-import { getCachedAvatar, getAvatarHash, cacheAvatar, saveAvatarHash, getAllAvatarHashes, hasNoAvatar, markNoAvatar, clearNoAvatar, refreshAllBlobUrls, isPepForbiddenDomain, markPepForbiddenDomain, loadPepForbiddenDomains } from '../../utils/avatarCache'
+import {
+  getCachedAvatar,
+  getAvatarHash,
+  cacheAvatar,
+  saveAvatarHash,
+  getAllAvatarHashes,
+  saveRoomOccupantAvatarHash,
+  getRoomOccupantAvatarHashes,
+  hasNoAvatar,
+  markNoAvatar,
+  clearNoAvatar,
+  refreshAllBlobUrls,
+  isPepForbiddenDomain,
+  markPepForbiddenDomain,
+  loadPepForbiddenDomains,
+} from '../../utils/avatarCache'
 import { sniffImageMimeType } from '../../utils/imageType'
 import {
   NS_PUBSUB,
@@ -271,12 +286,14 @@ export class Profile extends BaseModule {
    * @param nick - The occupant's nickname
    * @param avatarHash - The avatar hash from XEP-0153 presence
    * @param realJid - The occupant's real JID (if available in non-anonymous rooms)
+   * @param occupantId - XEP-0421 identity, stable within roomJid
    */
   async fetchOccupantAvatar(
     roomJid: string,
     nick: string,
     avatarHash: string,
-    realJid?: string
+    realJid?: string,
+    occupantId?: string,
   ): Promise<void> {
     // Check privacy options: if avatar fetching is disabled for anonymous rooms
     // and we don't have a real JID (meaning we'd query via room@conf/nick),
@@ -288,9 +305,16 @@ export class Profile extends BaseModule {
     // Check cache first using the hash
     const cachedUrl = await getCachedAvatar(avatarHash)
     if (cachedUrl) {
+      if (realJid) {
+        await saveAvatarHash(getBareJid(realJid), avatarHash, 'contact')
+      }
+      if (occupantId) {
+        await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
+      }
       this.deps.emitSDK('room:occupant-avatar', {
         roomJid,
         nick,
+        ...(occupantId && { occupantId }),
         avatar: cachedUrl,
         avatarHash,
       })
@@ -329,9 +353,13 @@ export class Profile extends BaseModule {
             await clearNoAvatar(bareJid)
             // Persist JID→hash mapping so we can restore from cache on next session
             await saveAvatarHash(bareJid, avatarHash, 'contact')
+            if (occupantId) {
+              await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
+            }
             this.deps.emitSDK('room:occupant-avatar', {
               roomJid,
               nick,
+              ...(occupantId && { occupantId }),
               avatar: blobUrl,
               avatarHash,
             })
@@ -363,9 +391,13 @@ export class Profile extends BaseModule {
           await clearNoAvatar(bareJid)
           // Persist JID→hash mapping so we can restore from cache on next session
           await saveAvatarHash(bareJid, avatarHash, 'contact')
+          if (occupantId) {
+            await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
+          }
           this.deps.emitSDK('room:occupant-avatar', {
             roomJid,
             nick,
+            ...(occupantId && { occupantId }),
             avatar: blobUrl,
             avatarHash,
           })
@@ -396,9 +428,13 @@ export class Profile extends BaseModule {
         const mimeType = photo?.getChildText('TYPE') || 'image/png'
         const base64 = binval.replace(/\s/g, '')
         const blobUrl = await cacheAvatar(avatarHash, base64, mimeType)
+        if (occupantId) {
+          await saveRoomOccupantAvatarHash(roomJid, occupantId, avatarHash)
+        }
         this.deps.emitSDK('room:occupant-avatar', {
           roomJid,
           nick,
+          ...(occupantId && { occupantId }),
           avatar: blobUrl,
           avatarHash,
         })
@@ -1093,8 +1129,29 @@ export class Profile extends BaseModule {
           this.deps.emitSDK('room:occupant-avatar', {
             roomJid: room.jid,
             nick: occupant.nick,
+            ...(occupant.occupantId && { occupantId: occupant.occupantId }),
             avatar: url,
             avatarHash: occupant.avatarHash,
+          })
+        }
+
+        // Re-point offline XEP-0421 identities too. They are absent from the
+        // live occupant map, but their room-scoped hash bindings are durable.
+        if (
+          this.deps.privacyOptions?.disableOccupantAvatarsInAnonymousRooms
+          && !room.isNonAnonymous
+        ) {
+          continue
+        }
+        const stableMappings = await getRoomOccupantAvatarHashes(room.jid)
+        for (const { occupantId, hash } of stableMappings) {
+          const url = freshUrls.get(hash)
+          if (!url) continue
+          this.deps.emitSDK('room:occupant-avatar', {
+            roomJid: room.jid,
+            occupantId,
+            avatar: url,
+            avatarHash: hash,
           })
         }
       }
@@ -1127,6 +1184,26 @@ export class Profile extends BaseModule {
           this.deps.emitSDK('room:occupant-avatar', {
             roomJid,
             nick,
+            ...(occupant.occupantId && { occupantId: occupant.occupantId }),
+            avatar: cachedUrl,
+            avatarHash: hash,
+          })
+        }
+      }
+
+      // XEP-0421 is the durable path for anonymous rooms: hydrate every known
+      // room-scoped identity, including occupants who are already offline.
+      const anonymousRestoreDisabled =
+        this.deps.privacyOptions?.disableOccupantAvatarsInAnonymousRooms
+        && !room.isNonAnonymous
+      if (!anonymousRestoreDisabled) {
+        const stableMappings = await getRoomOccupantAvatarHashes(roomJid)
+        for (const { occupantId, hash } of stableMappings) {
+          const cachedUrl = await getCachedAvatar(hash)
+          if (!cachedUrl) continue
+          this.deps.emitSDK('room:occupant-avatar', {
+            roomJid,
+            occupantId,
             avatar: cachedUrl,
             avatarHash: hash,
           })

--- a/packages/fluux-sdk/src/core/types/client.ts
+++ b/packages/fluux-sdk/src/core/types/client.ts
@@ -192,7 +192,7 @@ export interface XMPPClientEvents {
   /** Room avatar updated */
   roomAvatarUpdate: (roomJid: string, photoHash: string) => void
   /** MUC occupant avatar hash received (XEP-0398) */
-  occupantAvatarUpdate: (roomJid: string, nick: string, hash: string, realJid?: string) => void
+  occupantAvatarUpdate: (roomJid: string, nick: string, hash: string, realJid?: string, occupantId?: string) => void
   /** Roster (contact list) fully loaded from server */
   rosterLoaded: () => void
 }

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -313,8 +313,19 @@ export interface RoomRuntime {
   occupants: Map<string, RoomOccupant>
   /** Cache of nick→bareJid for users who have left (non-anonymous rooms only) */
   nickToJidCache?: Map<string, string>
+  /**
+   * Session cache of XEP-0421 occupant-id→bareJid aliases.
+   * Unlike nickToJidCache, this remains safe when a nickname is recycled.
+   */
+  occupantIdToJidCache?: Map<string, string>
   /** Cache of nick→avatar blob URL for users who have left (preserves avatars across leave/join) */
   nickToAvatarCache?: Map<string, string>
+  /**
+   * Cache of room-scoped XEP-0421 occupant-id→avatar blob URL.
+   * Hydrated from IndexedDB on join so anonymous occupants keep their avatars
+   * across reconnects, nick changes, and application restarts.
+   */
+  occupantIdToAvatarCache?: Map<string, string>
   /** Affiliated members discovered via XEP-0045 admin query (includes offline members) */
   affiliatedMembers?: RoomMember[]
   /** Our own occupant info (when joined) */

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -318,6 +318,12 @@ export interface RoomRuntime {
    * Unlike nickToJidCache, this remains safe when a nickname is recycled.
    */
   occupantIdToJidCache?: Map<string, string>
+  /**
+   * Live XEP-0421 occupant-id→nick index.
+   * This only contains current occupants and makes stable-identity resolution
+   * an O(1) lookup on message render paths.
+   */
+  occupantIdToNick?: Map<string, string>
   /** Cache of nick→avatar blob URL for users who have left (preserves avatars across leave/join) */
   nickToAvatarCache?: Map<string, string>
   /**

--- a/packages/fluux-sdk/src/core/types/sdk-events.ts
+++ b/packages/fluux-sdk/src/core/types/sdk-events.ts
@@ -349,7 +349,10 @@ export interface RoomEvents {
   /** Occupant avatar updated (XEP-0398) */
   'room:occupant-avatar': {
     roomJid: string
-    nick: string
+    /** Present for a live occupant; omitted when restoring an offline occupant-id binding. */
+    nick?: string
+    /** XEP-0421 identity, scoped to roomJid. */
+    occupantId?: string
     avatar: string | null
     avatarHash: string | null
   }

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3061,14 +3061,14 @@ describe('roomStore', () => {
     it('applies multiple avatar updates in a single state notification', () => {
       roomStore.getState().addRoom(createRoom('test@conference.example.com'))
       roomStore.getState().batchAddOccupants('test@conference.example.com', [
-        { nick: 'alice', affiliation: 'member', role: 'participant', avatarHash: 'ha' },
+        { nick: 'alice', occupantId: 'occ-alice', affiliation: 'member', role: 'participant', avatarHash: 'ha' },
         { nick: 'bob', affiliation: 'member', role: 'participant', avatarHash: 'hb' },
       ])
 
       let notifications = 0
       const unsub = roomStore.subscribe(() => { notifications++ })
       roomStore.getState().updateOccupantAvatars('test@conference.example.com', [
-        { nick: 'alice', avatar: 'blob:alice', avatarHash: 'ha' },
+        { nick: 'alice', occupantId: 'occ-alice', avatar: 'blob:alice', avatarHash: 'ha' },
         { nick: 'bob', avatar: 'blob:bob', avatarHash: 'hb' },
       ])
       unsub()
@@ -3080,6 +3080,7 @@ describe('roomStore', () => {
       // nick→avatar cache must be updated so message rows keep avatars after occupants leave
       expect(room?.nickToAvatarCache?.get('alice')).toBe('blob:alice')
       expect(room?.nickToAvatarCache?.get('bob')).toBe('blob:bob')
+      expect(room?.occupantIdToAvatarCache?.get('occ-alice')).toBe('blob:alice')
     })
 
     it('skips unknown occupants while applying known ones', () => {
@@ -3096,6 +3097,46 @@ describe('roomStore', () => {
       const room = roomStore.getState().rooms.get('test@conference.example.com')
       expect(room?.occupants.get('alice')?.avatar).toBe('blob:alice')
       expect(room?.occupants.has('ghost')).toBe(false)
+    })
+
+    it('hydrates an offline occupant-id avatar without inventing a live occupant', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+
+      roomStore.getState().updateOccupantAvatars('test@conference.example.com', [
+        {
+          occupantId: 'offline-occ',
+          avatar: 'blob:offline',
+          avatarHash: 'offline-hash',
+        },
+      ])
+
+      const room = roomStore.getState().rooms.get('test@conference.example.com')
+      expect(room?.occupants.size).toBe(0)
+      expect(room?.occupantIdToAvatarCache?.get('offline-occ')).toBe('blob:offline')
+    })
+
+    it('does not apply a late avatar fetch to a recycled nickname', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'alice',
+        occupantId: 'new-person',
+        affiliation: 'member',
+        role: 'participant',
+      })
+
+      roomStore.getState().updateOccupantAvatars('test@conference.example.com', [
+        {
+          nick: 'alice',
+          occupantId: 'old-person',
+          avatar: 'blob:old-person',
+          avatarHash: 'old-hash',
+        },
+      ])
+
+      const room = roomStore.getState().rooms.get('test@conference.example.com')
+      expect(room?.occupants.get('alice')?.avatar).toBeUndefined()
+      expect(room?.nickToAvatarCache?.get('alice')).toBeUndefined()
+      expect(room?.occupantIdToAvatarCache?.get('old-person')).toBe('blob:old-person')
     })
 
     it('does nothing for an unknown room', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -3055,6 +3055,72 @@ describe('roomStore', () => {
       expect(occ?.avatar).toBeUndefined()
       expect(occ?.avatarHash).toBe('hash999')
     })
+
+    it('maintains an O(1) live occupant-id index across nick changes and leaves', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'alice-old',
+        occupantId: 'occ-alice',
+        affiliation: 'member',
+        role: 'participant',
+      })
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'alice-new',
+        occupantId: 'occ-alice',
+        affiliation: 'member',
+        role: 'participant',
+      })
+
+      expect(
+        roomStore.getState().rooms
+          .get('test@conference.example.com')
+          ?.occupantIdToNick?.get('occ-alice')
+      ).toBe('alice-new')
+
+      // A delayed unavailable presence for the old nick must not erase the
+      // current alias established by the nick-change presence.
+      roomStore.getState().removeOccupant(
+        'test@conference.example.com',
+        'alice-old',
+      )
+      expect(
+        roomStore.getState().rooms
+          .get('test@conference.example.com')
+          ?.occupantIdToNick?.get('occ-alice')
+      ).toBe('alice-new')
+
+      roomStore.getState().removeOccupant(
+        'test@conference.example.com',
+        'alice-new',
+      )
+      expect(
+        roomStore.getState().rooms
+          .get('test@conference.example.com')
+          ?.occupantIdToNick?.has('occ-alice')
+      ).toBe(false)
+    })
+
+    it('indexes occupants already present when a room is added', () => {
+      roomStore.getState().addRoom(createRoom(
+        'test@conference.example.com',
+        {
+          occupants: new Map([
+            ['Alice', {
+              nick: 'Alice',
+              occupantId: 'occ-alice',
+              affiliation: 'member',
+              role: 'participant',
+            }],
+          ]),
+        },
+      ))
+
+      expect(
+        roomStore.getState().rooms
+          .get('test@conference.example.com')
+          ?.occupantIdToNick?.get('occ-alice')
+      ).toBe('Alice')
+    })
   })
 
   describe('updateOccupantAvatars (batch)', () => {
@@ -3137,6 +3203,28 @@ describe('roomStore', () => {
       expect(room?.occupants.get('alice')?.avatar).toBeUndefined()
       expect(room?.nickToAvatarCache?.get('alice')).toBeUndefined()
       expect(room?.occupantIdToAvatarCache?.get('old-person')).toBe('blob:old-person')
+    })
+
+    it('threads occupant-id through the singular avatar update helper', () => {
+      roomStore.getState().addRoom(createRoom('test@conference.example.com'))
+      roomStore.getState().addOccupant('test@conference.example.com', {
+        nick: 'alice',
+        occupantId: 'occ-alice',
+        affiliation: 'member',
+        role: 'participant',
+      })
+
+      roomStore.getState().updateOccupantAvatar(
+        'test@conference.example.com',
+        'alice',
+        'blob:alice',
+        'hash-alice',
+        'occ-alice',
+      )
+
+      const room = roomStore.getState().rooms.get('test@conference.example.com')
+      expect(room?.occupants.get('alice')?.avatar).toBe('blob:alice')
+      expect(room?.occupantIdToAvatarCache?.get('occ-alice')).toBe('blob:alice')
     })
 
     it('does nothing for an unknown room', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -477,7 +477,8 @@ const ROOM_META_FIELDS = Object.keys({
 } satisfies Record<keyof RoomMetadata, true>) as readonly (keyof RoomMetadata)[]
 
 const ROOM_RUNTIME_FIELD_ROUTING = {
-  occupants: 'sync', nickToJidCache: 'sync', nickToAvatarCache: 'sync',
+  occupants: 'sync', nickToJidCache: 'sync', occupantIdToJidCache: 'sync',
+  nickToAvatarCache: 'sync', occupantIdToAvatarCache: 'sync',
   affiliatedMembers: 'sync', selfOccupant: 'sync', messages: 'sync',
   // A plain field update must never silently recenter the window — the
   // live-edge flag only changes through window operations (see
@@ -743,7 +744,7 @@ export interface RoomState {
   removeOccupant: (roomJid: string, nick: string) => void
   updateOccupantAvatar: (roomJid: string, nick: string, avatar: string | null, avatarHash: string | null) => void
   /** Batch variant of updateOccupantAvatar — one state update for N resolved avatars (e.g. after joining a large room) */
-  updateOccupantAvatars: (roomJid: string, updates: Array<{ nick: string; avatar: string | null; avatarHash: string | null }>) => void
+  updateOccupantAvatars: (roomJid: string, updates: Array<{ nick?: string; occupantId?: string; avatar: string | null; avatarHash: string | null }>) => void
   setSelfOccupant: (roomJid: string, occupant: RoomOccupant) => void
   mergeRoomMembers: (roomJid: string, members: Array<{ jid: string; nick?: string; affiliation: RoomAffiliation }>, contactAvatarLookup?: (jid: string) => string | null) => void
   /**
@@ -1031,6 +1032,10 @@ export const roomStore = createStore<RoomState>()(
       const runtime: RoomRuntime = {
         occupants: room.occupants,
         nickToJidCache: room.nickToJidCache,
+        occupantIdToJidCache: room.occupantIdToJidCache,
+        nickToAvatarCache: room.nickToAvatarCache,
+        occupantIdToAvatarCache: room.occupantIdToAvatarCache,
+        affiliatedMembers: room.affiliatedMembers,
         selfOccupant: room.selfOccupant,
         messages: room.messages,
         // A room upsert seeds the newest window → at the live edge by default.
@@ -1205,6 +1210,11 @@ export const roomStore = createStore<RoomState>()(
         nickToJidCache = new Map(nickToJidCache || [])
         nickToJidCache.set(merged.nick, getBareJid(merged.jid))
       }
+      let occupantIdToJidCache = existing.occupantIdToJidCache
+      if (merged.occupantId && merged.jid) {
+        occupantIdToJidCache = new Map(occupantIdToJidCache || [])
+        occupantIdToJidCache.set(merged.occupantId, getBareJid(merged.jid))
+      }
 
       // Update nick→avatar cache if occupant has avatar
       let nickToAvatarCache = existing.nickToAvatarCache
@@ -1212,14 +1222,33 @@ export const roomStore = createStore<RoomState>()(
         nickToAvatarCache = new Map(nickToAvatarCache || [])
         nickToAvatarCache.set(merged.nick, merged.avatar)
       }
+      let occupantIdToAvatarCache = existing.occupantIdToAvatarCache
+      if (merged.occupantId && merged.avatar) {
+        occupantIdToAvatarCache = new Map(occupantIdToAvatarCache || [])
+        occupantIdToAvatarCache.set(merged.occupantId, merged.avatar)
+      }
 
-      newRooms.set(roomJid, { ...existing, occupants: newOccupants, nickToJidCache, nickToAvatarCache })
+      newRooms.set(roomJid, {
+        ...existing,
+        occupants: newOccupants,
+        nickToJidCache,
+        occupantIdToJidCache,
+        nickToAvatarCache,
+        occupantIdToAvatarCache,
+      })
 
       // Update runtime
       const newRuntime = new Map(state.roomRuntime)
       const existingRuntime = newRuntime.get(roomJid)
       if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, occupants: newOccupants, nickToJidCache, nickToAvatarCache })
+        newRuntime.set(roomJid, {
+          ...existingRuntime,
+          occupants: newOccupants,
+          nickToJidCache,
+          occupantIdToJidCache,
+          nickToAvatarCache,
+          occupantIdToAvatarCache,
+        })
       }
 
       return { rooms: newRooms, roomRuntime: newRuntime }
@@ -1236,7 +1265,9 @@ export const roomStore = createStore<RoomState>()(
 
       const newOccupants = new Map(existing.occupants)
       let nickToJidCache = existing.nickToJidCache
+      let occupantIdToJidCache = existing.occupantIdToJidCache
       let nickToAvatarCache = existing.nickToAvatarCache
+      let occupantIdToAvatarCache = existing.occupantIdToAvatarCache
 
       // Add all occupants in a single update
       for (const occupant of occupants) {
@@ -1251,6 +1282,12 @@ export const roomStore = createStore<RoomState>()(
           }
           nickToJidCache.set(merged.nick, getBareJid(merged.jid))
         }
+        if (merged.occupantId && merged.jid) {
+          if (!occupantIdToJidCache || occupantIdToJidCache === existing.occupantIdToJidCache) {
+            occupantIdToJidCache = new Map(occupantIdToJidCache || [])
+          }
+          occupantIdToJidCache.set(merged.occupantId, getBareJid(merged.jid))
+        }
 
         // Update nick→avatar cache
         if (merged.avatar) {
@@ -1259,15 +1296,35 @@ export const roomStore = createStore<RoomState>()(
           }
           nickToAvatarCache.set(merged.nick, merged.avatar)
         }
+        if (merged.occupantId && merged.avatar) {
+          if (!occupantIdToAvatarCache || occupantIdToAvatarCache === existing.occupantIdToAvatarCache) {
+            occupantIdToAvatarCache = new Map(occupantIdToAvatarCache || [])
+          }
+          occupantIdToAvatarCache.set(merged.occupantId, merged.avatar)
+        }
       }
 
-      newRooms.set(roomJid, { ...existing, occupants: newOccupants, nickToJidCache, nickToAvatarCache })
+      newRooms.set(roomJid, {
+        ...existing,
+        occupants: newOccupants,
+        nickToJidCache,
+        occupantIdToJidCache,
+        nickToAvatarCache,
+        occupantIdToAvatarCache,
+      })
 
       // Update runtime
       const newRuntime = new Map(state.roomRuntime)
       const existingRuntime = newRuntime.get(roomJid)
       if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, occupants: newOccupants, nickToJidCache, nickToAvatarCache })
+        newRuntime.set(roomJid, {
+          ...existingRuntime,
+          occupants: newOccupants,
+          nickToJidCache,
+          occupantIdToJidCache,
+          nickToAvatarCache,
+          occupantIdToAvatarCache,
+        })
       }
 
       return { rooms: newRooms, roomRuntime: newRuntime }
@@ -1317,36 +1374,74 @@ export const roomStore = createStore<RoomState>()(
       let newOccupants: Map<string, RoomOccupant> | null = null
       // Update nick→avatar cache so avatars persist after occupants leave
       let nickToAvatarCache = existing.nickToAvatarCache
+      // Stable XEP-0421 cache survives nick changes and can be hydrated for
+      // occupants who are already offline when the room is joined.
+      let occupantIdToAvatarCache = existing.occupantIdToAvatarCache
+      let cacheChanged = false
 
-      for (const { nick, avatar, avatarHash } of updates) {
-        const occupant = (newOccupants ?? existing.occupants).get(nick)
-        if (!occupant) continue
+      for (const { nick, occupantId, avatar, avatarHash } of updates) {
+        const occupantAtNick = nick
+          ? (newOccupants ?? existing.occupants).get(nick)
+          : undefined
+        // An async avatar fetch may finish after the old occupant left and a
+        // different person recycled the nick. Never write the old avatar into
+        // that new live occupant.
+        const occupant = occupantId && occupantAtNick?.occupantId
+          && occupantAtNick.occupantId !== occupantId
+          ? undefined
+          : occupantAtNick
+        const stableOccupantId = occupantId ?? occupant?.occupantId
 
-        if (!newOccupants) newOccupants = new Map(existing.occupants)
-        newOccupants.set(nick, {
-          ...occupant,
-          avatar: avatar ?? undefined,
-          avatarHash: avatarHash ?? undefined,
-        })
+        if (occupant && nick) {
+          if (!newOccupants) newOccupants = new Map(existing.occupants)
+          newOccupants.set(nick, {
+            ...occupant,
+            avatar: avatar ?? undefined,
+            avatarHash: avatarHash ?? undefined,
+          })
+        }
 
-        if (avatar) {
+        if (avatar && nick && (occupant || !occupantId)) {
           if (!nickToAvatarCache || nickToAvatarCache === existing.nickToAvatarCache) {
             nickToAvatarCache = new Map(nickToAvatarCache || [])
           }
           nickToAvatarCache.set(nick, avatar)
+          cacheChanged = true
+        }
+
+        if (stableOccupantId) {
+          if (!occupantIdToAvatarCache || occupantIdToAvatarCache === existing.occupantIdToAvatarCache) {
+            occupantIdToAvatarCache = new Map(occupantIdToAvatarCache || [])
+          }
+          if (avatar) {
+            occupantIdToAvatarCache.set(stableOccupantId, avatar)
+          } else {
+            occupantIdToAvatarCache.delete(stableOccupantId)
+          }
+          cacheChanged = true
         }
       }
 
-      if (!newOccupants) return state
+      if (!newOccupants && !cacheChanged) return state
 
       const newRooms = new Map(state.rooms)
-      newRooms.set(roomJid, { ...existing, occupants: newOccupants, nickToAvatarCache })
+      newRooms.set(roomJid, {
+        ...existing,
+        occupants: newOccupants ?? existing.occupants,
+        nickToAvatarCache,
+        occupantIdToAvatarCache,
+      })
 
       // Update runtime (occupants + avatar cache)
       const newRuntime = new Map(state.roomRuntime)
       const existingRuntime = newRuntime.get(roomJid)
       if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, occupants: newOccupants, nickToAvatarCache })
+        newRuntime.set(roomJid, {
+          ...existingRuntime,
+          occupants: newOccupants ?? existingRuntime.occupants,
+          nickToAvatarCache,
+          occupantIdToAvatarCache,
+        })
       }
 
       return { rooms: newRooms, roomRuntime: newRuntime }

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -478,7 +478,7 @@ const ROOM_META_FIELDS = Object.keys({
 
 const ROOM_RUNTIME_FIELD_ROUTING = {
   occupants: 'sync', nickToJidCache: 'sync', occupantIdToJidCache: 'sync',
-  nickToAvatarCache: 'sync', occupantIdToAvatarCache: 'sync',
+  occupantIdToNick: 'sync', nickToAvatarCache: 'sync', occupantIdToAvatarCache: 'sync',
   affiliatedMembers: 'sync', selfOccupant: 'sync', messages: 'sync',
   // A plain field update must never silently recenter the window — the
   // live-edge flag only changes through window operations (see
@@ -742,7 +742,7 @@ export interface RoomState {
   addOccupant: (roomJid: string, occupant: RoomOccupant) => void
   batchAddOccupants: (roomJid: string, occupants: RoomOccupant[]) => void
   removeOccupant: (roomJid: string, nick: string) => void
-  updateOccupantAvatar: (roomJid: string, nick: string, avatar: string | null, avatarHash: string | null) => void
+  updateOccupantAvatar: (roomJid: string, nick: string, avatar: string | null, avatarHash: string | null, occupantId?: string) => void
   /** Batch variant of updateOccupantAvatar — one state update for N resolved avatars (e.g. after joining a large room) */
   updateOccupantAvatars: (roomJid: string, updates: Array<{ nick?: string; occupantId?: string; avatar: string | null; avatarHash: string | null }>) => void
   setSelfOccupant: (roomJid: string, occupant: RoomOccupant) => void
@@ -1012,6 +1012,13 @@ export const roomStore = createStore<RoomState>()(
       }
       const existingMeta = state.roomMeta.get(room.jid)
       const restoredReadState = persistedRoomReadState.get(room.jid)
+      const occupantIdToNick = room.occupantIdToNick ?? (() => {
+        const index = new Map<string, string>()
+        for (const occupant of room.occupants?.values() ?? []) {
+          if (occupant.occupantId) index.set(occupant.occupantId, occupant.nick)
+        }
+        return index.size > 0 ? index : undefined
+      })()
       const meta: RoomMetadata = {
         unreadCount: room.unreadCount,
         mentionsCount: room.mentionsCount,
@@ -1033,9 +1040,8 @@ export const roomStore = createStore<RoomState>()(
         occupants: room.occupants,
         nickToJidCache: room.nickToJidCache,
         occupantIdToJidCache: room.occupantIdToJidCache,
-        nickToAvatarCache: room.nickToAvatarCache,
+        occupantIdToNick,
         occupantIdToAvatarCache: room.occupantIdToAvatarCache,
-        affiliatedMembers: room.affiliatedMembers,
         selfOccupant: room.selfOccupant,
         messages: room.messages,
         // A room upsert seeds the newest window → at the live edge by default.
@@ -1048,6 +1054,7 @@ export const roomStore = createStore<RoomState>()(
       // fields, and an incoming Room carries none of them.
       newRooms.set(room.jid, {
         ...room,
+        ...(occupantIdToNick && { occupantIdToNick }),
         readPointer: meta.readPointer,
         historyFloor: meta.historyFloor,
       })
@@ -1201,8 +1208,21 @@ export const roomStore = createStore<RoomState>()(
 
       const newOccupants = new Map(existing.occupants)
       // Presence carries only the avatar hash — keep an already-fetched blob alive.
-      const merged = preserveOccupantAvatar(existing.occupants.get(occupant.nick), occupant)
+      const previousAtNick = existing.occupants.get(occupant.nick)
+      const merged = preserveOccupantAvatar(previousAtNick, occupant)
       newOccupants.set(merged.nick, merged)
+
+      let occupantIdToNick = existing.occupantIdToNick
+      const previousIdNeedsRemoval = previousAtNick?.occupantId
+        && previousAtNick.occupantId !== merged.occupantId
+        && occupantIdToNick?.get(previousAtNick.occupantId) === previousAtNick.nick
+      const currentIdNeedsUpdate = merged.occupantId
+        && occupantIdToNick?.get(merged.occupantId) !== merged.nick
+      if (previousIdNeedsRemoval || currentIdNeedsUpdate) {
+        occupantIdToNick = new Map(occupantIdToNick || [])
+        if (previousIdNeedsRemoval) occupantIdToNick.delete(previousAtNick.occupantId!)
+        if (merged.occupantId) occupantIdToNick.set(merged.occupantId, merged.nick)
+      }
 
       // Update nick→jid cache for non-anonymous rooms (when real JID is visible)
       let nickToJidCache = existing.nickToJidCache
@@ -1233,6 +1253,7 @@ export const roomStore = createStore<RoomState>()(
         occupants: newOccupants,
         nickToJidCache,
         occupantIdToJidCache,
+        occupantIdToNick,
         nickToAvatarCache,
         occupantIdToAvatarCache,
       })
@@ -1246,6 +1267,7 @@ export const roomStore = createStore<RoomState>()(
           occupants: newOccupants,
           nickToJidCache,
           occupantIdToJidCache,
+          occupantIdToNick,
           nickToAvatarCache,
           occupantIdToAvatarCache,
         })
@@ -1266,14 +1288,29 @@ export const roomStore = createStore<RoomState>()(
       const newOccupants = new Map(existing.occupants)
       let nickToJidCache = existing.nickToJidCache
       let occupantIdToJidCache = existing.occupantIdToJidCache
+      let occupantIdToNick = existing.occupantIdToNick
       let nickToAvatarCache = existing.nickToAvatarCache
       let occupantIdToAvatarCache = existing.occupantIdToAvatarCache
 
       // Add all occupants in a single update
       for (const occupant of occupants) {
         // Presence carries only the avatar hash — keep an already-fetched blob alive.
-        const merged = preserveOccupantAvatar(newOccupants.get(occupant.nick), occupant)
+        const previousAtNick = newOccupants.get(occupant.nick)
+        const merged = preserveOccupantAvatar(previousAtNick, occupant)
         newOccupants.set(merged.nick, merged)
+
+        const previousIdNeedsRemoval = previousAtNick?.occupantId
+          && previousAtNick.occupantId !== merged.occupantId
+          && occupantIdToNick?.get(previousAtNick.occupantId) === previousAtNick.nick
+        const currentIdNeedsUpdate = merged.occupantId
+          && occupantIdToNick?.get(merged.occupantId) !== merged.nick
+        if (previousIdNeedsRemoval || currentIdNeedsUpdate) {
+          if (!occupantIdToNick || occupantIdToNick === existing.occupantIdToNick) {
+            occupantIdToNick = new Map(occupantIdToNick || [])
+          }
+          if (previousIdNeedsRemoval) occupantIdToNick.delete(previousAtNick.occupantId!)
+          if (merged.occupantId) occupantIdToNick.set(merged.occupantId, merged.nick)
+        }
 
         // Update nick→jid cache for non-anonymous rooms
         if (merged.jid) {
@@ -1309,6 +1346,7 @@ export const roomStore = createStore<RoomState>()(
         occupants: newOccupants,
         nickToJidCache,
         occupantIdToJidCache,
+        occupantIdToNick,
         nickToAvatarCache,
         occupantIdToAvatarCache,
       })
@@ -1322,6 +1360,7 @@ export const roomStore = createStore<RoomState>()(
           occupants: newOccupants,
           nickToJidCache,
           occupantIdToJidCache,
+          occupantIdToNick,
           nickToAvatarCache,
           occupantIdToAvatarCache,
         })
@@ -1337,18 +1376,32 @@ export const roomStore = createStore<RoomState>()(
       const existing = newRooms.get(roomJid)
       if (!existing) return state
 
+      const leavingOccupant = existing.occupants.get(nick)
       const newOccupants = new Map(existing.occupants)
       newOccupants.delete(nick)
+      let occupantIdToNick = existing.occupantIdToNick
+      if (
+        leavingOccupant?.occupantId
+        && occupantIdToNick?.get(leavingOccupant.occupantId) === nick
+      ) {
+        occupantIdToNick = new Map(occupantIdToNick)
+        occupantIdToNick.delete(leavingOccupant.occupantId)
+      }
       // Also remove from typing users when they leave
       const newTypingUsers = new Set(existing.typingUsers)
       newTypingUsers.delete(nick)
-      newRooms.set(roomJid, { ...existing, occupants: newOccupants, typingUsers: newTypingUsers })
+      newRooms.set(roomJid, {
+        ...existing,
+        occupants: newOccupants,
+        occupantIdToNick,
+        typingUsers: newTypingUsers,
+      })
 
       // Update runtime (occupants)
       const newRuntime = new Map(state.roomRuntime)
       const existingRuntime = newRuntime.get(roomJid)
       if (existingRuntime) {
-        newRuntime.set(roomJid, { ...existingRuntime, occupants: newOccupants })
+        newRuntime.set(roomJid, { ...existingRuntime, occupants: newOccupants, occupantIdToNick })
       }
 
       // Update metadata (typingUsers)
@@ -1362,8 +1415,8 @@ export const roomStore = createStore<RoomState>()(
     })
   },
 
-  updateOccupantAvatar: (roomJid, nick, avatar, avatarHash) => {
-    get().updateOccupantAvatars(roomJid, [{ nick, avatar, avatarHash }])
+  updateOccupantAvatar: (roomJid, nick, avatar, avatarHash, occupantId) => {
+    get().updateOccupantAvatars(roomJid, [{ nick, occupantId, avatar, avatarHash }])
   },
 
   updateOccupantAvatars: (roomJid, updates) => {

--- a/packages/fluux-sdk/src/utils/avatarCache.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.test.ts
@@ -14,6 +14,8 @@ import {
   getAvatarResumeCount,
   saveRoomOccupantAvatarHash,
   getRoomOccupantAvatarHashes,
+  getAllAvatarHashes,
+  groupRoomOccupantAvatarHashes,
   _resetBlobUrlPoolForTesting,
   _resetDBForTesting,
 } from './avatarCache'
@@ -240,6 +242,29 @@ describe('avatarCache blob URL pool', () => {
       ).resolves.toEqual([
         { occupantId: 'opaque:id/with separators', hash: 'hash-b' },
       ])
+    })
+
+    it('groups every room from one occupant-mapping snapshot', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-a',
+      )
+      await saveRoomOccupantAvatarHash(
+        'room-b@conference.example.com',
+        'occupant-b',
+        'hash-b',
+      )
+
+      const mappings = await getAllAvatarHashes('occupant')
+      expect(groupRoomOccupantAvatarHashes(mappings)).toEqual(new Map([
+        ['room-a@conference.example.com', [
+          { occupantId: 'occupant-a', hash: 'hash-a' },
+        ]],
+        ['room-b@conference.example.com', [
+          { occupantId: 'occupant-b', hash: 'hash-b' },
+        ]],
+      ]))
     })
   })
 

--- a/packages/fluux-sdk/src/utils/avatarCache.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.test.ts
@@ -16,6 +16,7 @@ import {
   getRoomOccupantAvatarHashes,
   getAllAvatarHashes,
   groupRoomOccupantAvatarHashes,
+  seedRoomOccupantAvatarHashes,
   _resetBlobUrlPoolForTesting,
   _resetDBForTesting,
 } from './avatarCache'
@@ -258,13 +259,31 @@ describe('avatarCache blob URL pool', () => {
 
       const mappings = await getAllAvatarHashes('occupant')
       expect(groupRoomOccupantAvatarHashes(mappings)).toEqual(new Map([
-        ['room-a@conference.example.com', [
-          { occupantId: 'occupant-a', hash: 'hash-a' },
-        ]],
-        ['room-b@conference.example.com', [
-          { occupantId: 'occupant-b', hash: 'hash-b' },
-        ]],
+        ['room-a@conference.example.com', new Map([
+          ['occupant-a', 'hash-a'],
+        ])],
+        ['room-b@conference.example.com', new Map([
+          ['occupant-b', 'hash-b'],
+        ])],
       ]))
+    })
+
+    it('seeds room lookups from an existing full hash-store read', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-a',
+      )
+      const mappings = await getAllAvatarHashes()
+      const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll')
+
+      await seedRoomOccupantAvatarHashes(mappings)
+
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([{ occupantId: 'occupant-a', hash: 'hash-a' }])
+      expect(getAllSpy).not.toHaveBeenCalled()
+      getAllSpy.mockRestore()
     })
 
     it('shares one grouped read across room joins and updates it after writes', async () => {
@@ -298,6 +317,18 @@ describe('avatarCache blob URL pool', () => {
       await expect(
         getRoomOccupantAvatarHashes('room-c@conference.example.com')
       ).resolves.toEqual([{ occupantId: 'occupant-c', hash: 'hash-c' }])
+      expect(getAllSpy).toHaveBeenCalledTimes(1)
+
+      await saveRoomOccupantAvatarHash(
+        'room-c@conference.example.com',
+        'occupant-c',
+        'hash-c-updated',
+      )
+      await expect(
+        getRoomOccupantAvatarHashes('room-c@conference.example.com')
+      ).resolves.toEqual([
+        { occupantId: 'occupant-c', hash: 'hash-c-updated' },
+      ])
       expect(getAllSpy).toHaveBeenCalledTimes(1)
 
       await clearAllAvatarData()

--- a/packages/fluux-sdk/src/utils/avatarCache.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.test.ts
@@ -12,6 +12,8 @@ import {
   getBlobUrlPoolSize,
   bumpAvatarResumeCount,
   getAvatarResumeCount,
+  saveRoomOccupantAvatarHash,
+  getRoomOccupantAvatarHashes,
   _resetBlobUrlPoolForTesting,
   _resetDBForTesting,
 } from './avatarCache'
@@ -212,6 +214,32 @@ describe('avatarCache blob URL pool', () => {
       // Pool is cleared, IndexedDB is cleared — should get null
       const url = await getCachedAvatar('hash-abc')
       expect(url).toBeNull()
+    })
+  })
+
+  describe('room-scoped occupant-id mappings', () => {
+    it('restores a stable occupant mapping only in its own room', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'opaque:id/with separators',
+        'hash-a',
+      )
+      await saveRoomOccupantAvatarHash(
+        'room-b@conference.example.com',
+        'opaque:id/with separators',
+        'hash-b',
+      )
+
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([
+        { occupantId: 'opaque:id/with separators', hash: 'hash-a' },
+      ])
+      await expect(
+        getRoomOccupantAvatarHashes('room-b@conference.example.com')
+      ).resolves.toEqual([
+        { occupantId: 'opaque:id/with separators', hash: 'hash-b' },
+      ])
     })
   })
 

--- a/packages/fluux-sdk/src/utils/avatarCache.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.test.ts
@@ -266,6 +266,47 @@ describe('avatarCache blob URL pool', () => {
         ]],
       ]))
     })
+
+    it('shares one grouped read across room joins and updates it after writes', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-a',
+      )
+      await saveRoomOccupantAvatarHash(
+        'room-b@conference.example.com',
+        'occupant-b',
+        'hash-b',
+      )
+      const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll')
+
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([{ occupantId: 'occupant-a', hash: 'hash-a' }])
+      await expect(
+        getRoomOccupantAvatarHashes('room-b@conference.example.com')
+      ).resolves.toEqual([{ occupantId: 'occupant-b', hash: 'hash-b' }])
+      expect(getAllSpy).toHaveBeenCalledTimes(1)
+
+      // Writes after the first join update the loaded snapshot in place, so a
+      // later manual/autojoined room is visible without another full read.
+      await saveRoomOccupantAvatarHash(
+        'room-c@conference.example.com',
+        'occupant-c',
+        'hash-c',
+      )
+      await expect(
+        getRoomOccupantAvatarHashes('room-c@conference.example.com')
+      ).resolves.toEqual([{ occupantId: 'occupant-c', hash: 'hash-c' }])
+      expect(getAllSpy).toHaveBeenCalledTimes(1)
+
+      await clearAllAvatarData()
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([])
+      expect(getAllSpy).toHaveBeenCalledTimes(2)
+      getAllSpy.mockRestore()
+    })
   })
 
   describe('diagnostics', () => {

--- a/packages/fluux-sdk/src/utils/avatarCache.test.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.test.ts
@@ -286,6 +286,77 @@ describe('avatarCache blob URL pool', () => {
       getAllSpy.mockRestore()
     })
 
+    it('does not memoize a failed seed as a genuinely empty snapshot', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-a',
+      )
+      await seedRoomOccupantAvatarHashes(null)
+      const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll')
+
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([{ occupantId: 'occupant-a', hash: 'hash-a' }])
+      expect(getAllSpy).toHaveBeenCalledTimes(1)
+      getAllSpy.mockRestore()
+    })
+
+    it('retries after a transient occupant snapshot read failure', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-a',
+      )
+      const getAllSpy = vi.spyOn(IDBIndex.prototype, 'getAll')
+        .mockImplementationOnce(() => {
+          throw new Error('transient IndexedDB failure')
+        })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([])
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([{ occupantId: 'occupant-a', hash: 'hash-a' }])
+      expect(getAllSpy).toHaveBeenCalledTimes(2)
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to get avatar hash mappings:',
+        expect.any(Error)
+      )
+
+      warnSpy.mockRestore()
+      getAllSpy.mockRestore()
+    })
+
+    it('preserves write-through updates when a later seed is ignored', async () => {
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-a',
+      )
+      const staleMappings = await getAllAvatarHashes()
+      await seedRoomOccupantAvatarHashes(staleMappings)
+
+      await saveRoomOccupantAvatarHash(
+        'room-a@conference.example.com',
+        'occupant-a',
+        'hash-patched',
+      )
+      const ignoredMappings = staleMappings.map((mapping) => ({
+        ...mapping,
+        hash: 'hash-from-reseed',
+      }))
+      await seedRoomOccupantAvatarHashes(ignoredMappings)
+
+      await expect(
+        getRoomOccupantAvatarHashes('room-a@conference.example.com')
+      ).resolves.toEqual([
+        { occupantId: 'occupant-a', hash: 'hash-patched' },
+      ])
+    })
+
     it('shares one grouped read across room joins and updates it after writes', async () => {
       await saveRoomOccupantAvatarHash(
         'room-a@conference.example.com',

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -46,6 +46,9 @@ export interface RoomOccupantAvatarHashMapping {
   hash: string
 }
 
+export type RoomOccupantAvatarHashesByRoom =
+  Map<string, RoomOccupantAvatarHashMapping[]>
+
 const OCCUPANT_HASH_KEY_PREFIX = 'muc-occupant:'
 
 /**
@@ -397,17 +400,33 @@ export async function saveRoomOccupantAvatarHash(
 export async function getRoomOccupantAvatarHashes(
   roomJid: string
 ): Promise<RoomOccupantAvatarHashMapping[]> {
-  const bareRoomJid = getBareJid(roomJid)
   const mappings = await getAllAvatarHashes('occupant')
-  const result: RoomOccupantAvatarHashMapping[] = []
+  return groupRoomOccupantAvatarHashes(mappings).get(getBareJid(roomJid)) ?? []
+}
 
+/**
+ * Group persisted XEP-0421 avatar aliases from one hash-store read.
+ *
+ * Blob URL refresh runs across every joined room, so grouping once avoids one
+ * full IndexedDB index read and one full scan per room.
+ */
+export function groupRoomOccupantAvatarHashes(
+  mappings: readonly AvatarHashMapping[]
+): RoomOccupantAvatarHashesByRoom {
+  const byRoom: RoomOccupantAvatarHashesByRoom = new Map()
   for (const mapping of mappings) {
+    if (mapping.type !== 'occupant') continue
     const parsed = parseOccupantHashMappingKey(mapping.jid)
-    if (!parsed || parsed.roomJid !== bareRoomJid) continue
-    result.push({ occupantId: parsed.occupantId, hash: mapping.hash })
+    if (!parsed) continue
+    const roomMappings = byRoom.get(parsed.roomJid)
+    const entry = { occupantId: parsed.occupantId, hash: mapping.hash }
+    if (roomMappings) {
+      roomMappings.push(entry)
+    } else {
+      byRoom.set(parsed.roomJid, [entry])
+    }
   }
-
-  return result
+  return byRoom
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -368,14 +368,18 @@ export async function getAvatarHash(jid: string): Promise<string | null> {
 }
 
 /**
- * Get all avatar hash mappings, optionally filtered by type
+ * Read all avatar hash mappings, optionally filtered by type.
+ *
+ * Unlike the public compatibility wrapper below, this returns `null` when the
+ * IndexedDB read fails so memoized callers can distinguish a transient failure
+ * from a genuinely empty store.
  */
-export async function getAllAvatarHashes(
+export async function tryGetAllAvatarHashes(
   type?: AvatarEntityType
-): Promise<AvatarHashMapping[]> {
+): Promise<AvatarHashMapping[] | null> {
   try {
     const db = await getDB()
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const transaction = db.transaction(HASH_STORE_NAME, 'readonly')
       const store = transaction.objectStore(HASH_STORE_NAME)
 
@@ -397,8 +401,19 @@ export async function getAllAvatarHashes(
     if (isIndexedDBAvailable()) {
       console.warn('Failed to get avatar hash mappings:', error)
     }
-    return []
+    return null
   }
+}
+
+/**
+ * Get all avatar hash mappings, optionally filtered by type.
+ *
+ * Keep returning an empty array on storage errors for existing callers.
+ */
+export async function getAllAvatarHashes(
+  type?: AvatarEntityType
+): Promise<AvatarHashMapping[]> {
+  return (await tryGetAllAvatarHashes(type)) ?? []
 }
 
 /**
@@ -425,8 +440,18 @@ export async function getRoomOccupantAvatarHashes(
   roomJid: string
 ): Promise<RoomOccupantAvatarHashMapping[]> {
   if (!occupantMappingsByRoomPromise) {
-    occupantMappingsByRoomPromise = getAllAvatarHashes('occupant')
-      .then(groupRoomOccupantAvatarHashes)
+    const snapshotPromise = tryGetAllAvatarHashes('occupant').then((mappings) => {
+      if (mappings === null) {
+        // Do not turn a transient IndexedDB failure into a session-long empty
+        // snapshot. The current caller falls back, while the next join retries.
+        if (occupantMappingsByRoomPromise === snapshotPromise) {
+          occupantMappingsByRoomPromise = null
+        }
+        return new Map()
+      }
+      return groupRoomOccupantAvatarHashes(mappings)
+    })
+    occupantMappingsByRoomPromise = snapshotPromise
   }
   const mappingsByRoom = await occupantMappingsByRoomPromise
   const roomMappings = mappingsByRoom.get(getBareJid(roomJid))
@@ -469,14 +494,16 @@ export function groupRoomOccupantAvatarHashes(
  * a second grouping while preserving a snapshot that another caller loaded.
  */
 export async function seedRoomOccupantAvatarHashes(
-  mappings: readonly AvatarHashMapping[]
+  mappings: readonly AvatarHashMapping[] | null
 ): Promise<RoomOccupantAvatarHashesByRoom> {
-  if (!occupantMappingsByRoomPromise) {
+  if (!occupantMappingsByRoomPromise && mappings !== null) {
     occupantMappingsByRoomPromise = Promise.resolve(
       groupRoomOccupantAvatarHashes(mappings)
     )
   }
-  return occupantMappingsByRoomPromise
+  // `null` denotes a failed read. Reuse an existing good snapshot if present,
+  // but never memoize an empty replacement for the failed read.
+  return occupantMappingsByRoomPromise ?? new Map()
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -47,7 +47,7 @@ export interface RoomOccupantAvatarHashMapping {
 }
 
 export type RoomOccupantAvatarHashesByRoom =
-  Map<string, RoomOccupantAvatarHashMapping[]>
+  Map<string, Map<string, string>>
 
 const OCCUPANT_HASH_KEY_PREFIX = 'muc-occupant:'
 
@@ -326,18 +326,10 @@ export async function saveAvatarHash(
       if (parsed) {
         const byRoom = await occupantMappingsByRoomPromise
         const roomMappings = byRoom.get(parsed.roomJid)
-        const entry = { occupantId: parsed.occupantId, hash }
-        if (!roomMappings) {
-          byRoom.set(parsed.roomJid, [entry])
+        if (roomMappings) {
+          roomMappings.set(parsed.occupantId, hash)
         } else {
-          const existingIndex = roomMappings.findIndex(
-            (mapping) => mapping.occupantId === parsed.occupantId
-          )
-          if (existingIndex >= 0) {
-            roomMappings[existingIndex] = entry
-          } else {
-            roomMappings.push(entry)
-          }
+          byRoom.set(parsed.roomJid, new Map([[parsed.occupantId, hash]]))
         }
       }
     }
@@ -437,7 +429,10 @@ export async function getRoomOccupantAvatarHashes(
       .then(groupRoomOccupantAvatarHashes)
   }
   const mappingsByRoom = await occupantMappingsByRoomPromise
-  return [...(mappingsByRoom.get(getBareJid(roomJid)) ?? [])]
+  const roomMappings = mappingsByRoom.get(getBareJid(roomJid))
+  return roomMappings
+    ? [...roomMappings].map(([occupantId, hash]) => ({ occupantId, hash }))
+    : []
 }
 
 /**
@@ -455,14 +450,33 @@ export function groupRoomOccupantAvatarHashes(
     const parsed = parseOccupantHashMappingKey(mapping.jid)
     if (!parsed) continue
     const roomMappings = byRoom.get(parsed.roomJid)
-    const entry = { occupantId: parsed.occupantId, hash: mapping.hash }
     if (roomMappings) {
-      roomMappings.push(entry)
+      roomMappings.set(parsed.occupantId, mapping.hash)
     } else {
-      byRoom.set(parsed.roomJid, [entry])
+      byRoom.set(
+        parsed.roomJid,
+        new Map([[parsed.occupantId, mapping.hash]])
+      )
     }
   }
   return byRoom
+}
+
+/**
+ * Seed the shared occupant snapshot from a broader hash-store read.
+ *
+ * Blob URL refresh already reads every mapping, so reusing that result avoids
+ * a second grouping while preserving a snapshot that another caller loaded.
+ */
+export async function seedRoomOccupantAvatarHashes(
+  mappings: readonly AvatarHashMapping[]
+): Promise<RoomOccupantAvatarHashesByRoom> {
+  if (!occupantMappingsByRoomPromise) {
+    occupantMappingsByRoomPromise = Promise.resolve(
+      groupRoomOccupantAvatarHashes(mappings)
+    )
+  }
+  return occupantMappingsByRoomPromise
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -4,6 +4,8 @@
  * JID → hash mappings are also stored to enable restoration on app restart
  */
 
+import { getBareJid } from '../core/jid'
+
 const DB_NAME = 'fluux-avatar-cache'
 const DB_VERSION = 4
 const STORE_NAME = 'avatars'
@@ -31,12 +33,45 @@ interface CachedAvatar {
   timestamp: number // When cached
 }
 
-export type AvatarEntityType = 'contact' | 'room'
+export type AvatarEntityType = 'contact' | 'room' | 'occupant'
 
 export interface AvatarHashMapping {
   jid: string // JID (primary key)
   hash: string // SHA-1 hash
-  type: AvatarEntityType // 'contact' or 'room'
+  type: AvatarEntityType
+}
+
+export interface RoomOccupantAvatarHashMapping {
+  occupantId: string
+  hash: string
+}
+
+const OCCUPANT_HASH_KEY_PREFIX = 'muc-occupant:'
+
+/**
+ * XEP-0421 occupant identifiers are opaque and only stable within one room.
+ * Encode both components so an identifier can never collide with a JID mapping
+ * or with the same opaque value issued by another room.
+ */
+function occupantHashMappingKey(roomJid: string, occupantId: string): string {
+  return `${OCCUPANT_HASH_KEY_PREFIX}${encodeURIComponent(getBareJid(roomJid))}:${encodeURIComponent(occupantId)}`
+}
+
+function parseOccupantHashMappingKey(
+  key: string
+): { roomJid: string; occupantId: string } | null {
+  if (!key.startsWith(OCCUPANT_HASH_KEY_PREFIX)) return null
+  const encoded = key.slice(OCCUPANT_HASH_KEY_PREFIX.length)
+  const separator = encoded.indexOf(':')
+  if (separator < 0) return null
+  try {
+    return {
+      roomJid: decodeURIComponent(encoded.slice(0, separator)),
+      occupantId: decodeURIComponent(encoded.slice(separator + 1)),
+    }
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -337,6 +372,42 @@ export async function getAllAvatarHashes(
     }
     return []
   }
+}
+
+/**
+ * Persist the avatar hash advertised for one XEP-0421 identity.
+ *
+ * This deliberately stores a room-scoped opaque key rather than treating the
+ * occupant-id as a JID. The avatar blob itself remains globally deduplicated by
+ * hash in the avatars store.
+ */
+export async function saveRoomOccupantAvatarHash(
+  roomJid: string,
+  occupantId: string,
+  hash: string
+): Promise<void> {
+  await saveAvatarHash(
+    occupantHashMappingKey(roomJid, occupantId),
+    hash,
+    'occupant'
+  )
+}
+
+/** Return every persisted occupant-id→hash binding for one room. */
+export async function getRoomOccupantAvatarHashes(
+  roomJid: string
+): Promise<RoomOccupantAvatarHashMapping[]> {
+  const bareRoomJid = getBareJid(roomJid)
+  const mappings = await getAllAvatarHashes('occupant')
+  const result: RoomOccupantAvatarHashMapping[] = []
+
+  for (const mapping of mappings) {
+    const parsed = parseOccupantHashMappingKey(mapping.jid)
+    if (!parsed || parsed.roomJid !== bareRoomJid) continue
+    result.push({ occupantId: parsed.occupantId, hash: mapping.hash })
+  }
+
+  return result
 }
 
 /**

--- a/packages/fluux-sdk/src/utils/avatarCache.ts
+++ b/packages/fluux-sdk/src/utils/avatarCache.ts
@@ -106,6 +106,17 @@ let dbPromise: Promise<IDBDatabase> | null = null
 const blobUrlPool = new Map<string, string>()
 
 /**
+ * Lazily shared snapshot of durable XEP-0421 bindings.
+ *
+ * Room joins complete independently, so each `mucJoined` callback asks for one
+ * room. Sharing the grouped snapshot here turns an autojoin burst into one
+ * IndexedDB read without coupling the cache layer to join ordering. Successful
+ * writes update the loaded snapshot below; clearing avatar data drops it.
+ */
+let occupantMappingsByRoomPromise:
+  Promise<RoomOccupantAvatarHashesByRoom> | null = null
+
+/**
  * In-memory set of domains known to block PEP avatar access.
  * Populated from IndexedDB on load, updated on new forbidden responses.
  * Enables synchronous checks to skip PEP requests entirely.
@@ -309,6 +320,27 @@ export async function saveAvatarHash(
       request.onerror = () => reject(request.error)
       request.onsuccess = () => resolve()
     })
+
+    if (type === 'occupant' && occupantMappingsByRoomPromise) {
+      const parsed = parseOccupantHashMappingKey(jid)
+      if (parsed) {
+        const byRoom = await occupantMappingsByRoomPromise
+        const roomMappings = byRoom.get(parsed.roomJid)
+        const entry = { occupantId: parsed.occupantId, hash }
+        if (!roomMappings) {
+          byRoom.set(parsed.roomJid, [entry])
+        } else {
+          const existingIndex = roomMappings.findIndex(
+            (mapping) => mapping.occupantId === parsed.occupantId
+          )
+          if (existingIndex >= 0) {
+            roomMappings[existingIndex] = entry
+          } else {
+            roomMappings.push(entry)
+          }
+        }
+      }
+    }
   } catch (error) {
     // Only log if IndexedDB is available (skip in test environments)
     if (isIndexedDBAvailable()) {
@@ -400,8 +432,12 @@ export async function saveRoomOccupantAvatarHash(
 export async function getRoomOccupantAvatarHashes(
   roomJid: string
 ): Promise<RoomOccupantAvatarHashMapping[]> {
-  const mappings = await getAllAvatarHashes('occupant')
-  return groupRoomOccupantAvatarHashes(mappings).get(getBareJid(roomJid)) ?? []
+  if (!occupantMappingsByRoomPromise) {
+    occupantMappingsByRoomPromise = getAllAvatarHashes('occupant')
+      .then(groupRoomOccupantAvatarHashes)
+  }
+  const mappingsByRoom = await occupantMappingsByRoomPromise
+  return [...(mappingsByRoom.get(getBareJid(roomJid)) ?? [])]
 }
 
 /**
@@ -443,6 +479,7 @@ export async function clearAllAvatarHashes(): Promise<void> {
       request.onerror = () => reject(request.error)
       request.onsuccess = () => resolve()
     })
+    occupantMappingsByRoomPromise = null
   } catch (error) {
     // Only log if IndexedDB is available (skip in test environments)
     if (isIndexedDBAvailable()) {
@@ -762,6 +799,7 @@ export function _resetPepForbiddenDomainsForTesting(): void {
  */
 export function _resetDBForTesting(): void {
   dbPromise = null
+  occupantMappingsByRoomPromise = null
 }
 
 /**


### PR DESCRIPTION
## Summary

- propagate XEP-0421 occupant IDs through MUC avatar discovery and SDK events
- persist room-scoped occupant ID to avatar-hash mappings so historical messages keep avatars after the occupant leaves or the app restarts
- centralize room avatar resolution across conversation and search views
- preserve the stable bare-JID/contact-avatar fallback for non-anonymous rooms
- prevent recycled nicknames and late avatar fetches from assigning an old occupant's avatar to a new occupant

## Why

Room message avatars were primarily resolved from the current occupant list and session-scoped nickname caches. Once an occupant went offline, anonymous rooms had no stable JID fallback, and a recycled nickname could resolve to the wrong current occupant. XEP-0421 occupant IDs provide a stable, room-scoped identity for this purpose.

## User impact

Historical room messages can continue to render the correct avatar while their author is offline. This works through stable occupant IDs in anonymous rooms and through the existing bare-JID fallback in non-anonymous rooms.
