### PR TITLE
fix(chat): preserve quote framing in bulk selection

### DIFF
--- a/apps/fluux/src/components/conversation/MessageBubble.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.test.tsx
@@ -239,6 +239,7 @@ describe('MessageBubble', () => {
 
       const quote = screen.getByText('Original message').closest('button')!
       expect(quote).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' })
+      expect(quote.style.getPropertyValue('--fluux-quote-frame-color')).toBe('rgb(0, 255, 0)')
       expect(within(quote).getByText('Bob')).toHaveStyle({ color: 'rgb(0, 255, 0)' })
       // the leading reply arrow also follows the sender hue
       expect(quote.querySelector('svg')).toHaveStyle({ color: 'rgb(0, 255, 0)' })

--- a/apps/fluux/src/components/conversation/MessageBubble.tsx
+++ b/apps/fluux/src/components/conversation/MessageBubble.tsx
@@ -4,7 +4,7 @@
  * Uses composition to handle view-specific rendering while sharing
  * the common bubble structure.
  */
-import { useState, useMemo, useRef, useEffect, memo, type ReactNode } from 'react'
+import { useState, useMemo, useRef, useEffect, memo, type CSSProperties, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CornerUpRight, AlertCircle, RefreshCw, Shield, ShieldCheck, ShieldX, ShieldAlert, Ear, UserX } from 'lucide-react'
 import { formatMessagePreview, formatXMPPError, getBareJid, type BaseMessage, type MentionReference, type Contact, type ContactIdentity, type RoomRole, type RoomAffiliation } from '@fluux/sdk'
@@ -32,6 +32,17 @@ import { PollClosedCard } from './PollClosedCard'
 import { Tooltip } from '../Tooltip'
 import { MessageActionSheet } from './MessageActionSheet'
 import { computeMessageActions } from './messageActionCapabilities'
+
+type ReplyQuoteCardStyle = CSSProperties & {
+  '--fluux-quote-frame-color': string
+}
+
+function replyQuoteCardStyle(senderColor: string): ReplyQuoteCardStyle {
+  return {
+    borderColor: senderColor,
+    '--fluux-quote-frame-color': senderColor,
+  }
+}
 
 export interface MessageBubbleProps {
   // Core message data (using BaseMessage interface)
@@ -681,13 +692,10 @@ export const MessageBubble = memo(function MessageBubble({
             type="button"
             onClick={() => scrollToMessage(replyContext.messageId)}
             className="reply-quote-card flex items-start gap-1.5 py-1 pe-2 ps-2 mb-1.5 border-s-2 text-start min-w-0 bg-fluux-bg-secondary hover:bg-fluux-hover/50 rounded-e transition-colors cursor-pointer select-none"
-            // When the row is selected the selection tint melts into the card fill
-            // (light themes); a full frame in the sender's colour keeps the card
-            // distinct in every theme/mode without touching the fill. Issue #1008.
-            style={{
-              borderColor: replyContext.senderColor,
-              boxShadow: isSelected || showActionSheet ? `inset 0 0 0 1px ${replyContext.senderColor}` : undefined,
-            }}
+            // CSS applies the selected-state frame because selection can live on
+            // this message chrome (keyboard/action sheet) or the outer MessageList
+            // row (bulk copy). Expose the sender hue once so both paths stay equal.
+            style={replyQuoteCardStyle(replyContext.senderColor)}
           >
             <CornerUpRight
               className="rtl-mirror size-3.5 flex-shrink-0 mt-0.5"

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -686,6 +686,10 @@ export function MessageList<T extends BaseMessage>({
             data-message-id={msg.id}
             data-stanza-id={msg.stanzaId}
             data-origin-id={msg.originId}
+            // Bulk-copy selection lives on the virtualized row, outside
+            // MessageBubble. Share the same semantic marker as keyboard/action
+            // selection so nested quote/reply cards receive identical framing.
+            data-msg-selected={copySelectedIds.has(msg.id) ? '' : undefined}
             style={msg.id === lastSentMessageId ? { animation: 'message-send var(--fluux-duration-slow) var(--fluux-ease-standard)' } : undefined}
           >
             {msg.id === gapMarkerMessageId && onCatchUpHistory && (
@@ -867,6 +871,7 @@ export function MessageList<T extends BaseMessage>({
                     data-message-id={msg.id}
                     data-stanza-id={msg.stanzaId}
                     data-origin-id={msg.originId}
+                    data-msg-selected={copySelectedIds.has(msg.id) ? '' : undefined}
                     style={msg.id === lastSentMessageId ? { animation: 'message-send var(--fluux-duration-slow) var(--fluux-ease-standard)' } : undefined}
                   >
                     {showGapMarker && <HistoryGapMarker onLoadMore={onCatchUpHistory} isLoading={isCatchingUp ?? false} />}

--- a/apps/fluux/src/components/conversation/MessageList.virtualized.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualized.test.tsx
@@ -13,14 +13,18 @@ import { MessageList } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
 import type { MessageVirtualizer } from './messageVirtualizer'
 
+const rangeSelectionState = vi.hoisted(() => ({
+  selectedIds: new Set<string>(),
+}))
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }))
 vi.mock('@/hooks', () => ({
   useMessageCopyFormatter: vi.fn(),
   useMessageRangeSelection: vi.fn(() => ({
-    copySelectedIds: new Set<string>(),
-    selectionCount: 0,
+    copySelectedIds: rangeSelectionState.selectedIds,
+    selectionCount: rangeSelectionState.selectedIds.size,
     isSelecting: false,
     selectAll: vi.fn(),
     extendTo: vi.fn(),
@@ -89,6 +93,7 @@ describe('MessageList — virtualized render path (flag ON)', () => {
   beforeEach(() => {
     localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
     _capturedAdapterArgs = {}
+    rangeSelectionState.selectedIds = new Set<string>()
   })
   afterEach(() => localStorage.clear())
 
@@ -101,6 +106,18 @@ describe('MessageList — virtualized render path (flag ON)', () => {
     expect(screen.getByText('Body 0')).toBeInTheDocument()
     expect(screen.getByText('Body 2')).toBeInTheDocument()
     expect(container.querySelectorAll('[data-date-separator]')).toHaveLength(1)
+  })
+
+  it('marks bulk-copy rows with the shared selected-message styling hook', () => {
+    rangeSelectionState.selectedIds = new Set(['msg-1'])
+
+    const { container } = render(
+      <MessageList messages={makeMessages(3)} conversationId="conv-1" renderMessage={(msg) => <div>{msg.body}</div>} />,
+    )
+
+    expect(container.querySelector('[data-message-id="msg-1"]')).toHaveAttribute('data-msg-selected', '')
+    expect(container.querySelector('[data-message-id="msg-0"]')).not.toHaveAttribute('data-msg-selected')
+    expect(container.querySelector('[data-message-id="msg-2"]')).not.toHaveAttribute('data-msg-selected')
   })
 
   it('renders the load-earlier header item when history is incomplete', () => {

--- a/apps/fluux/src/index.css
+++ b/apps/fluux/src/index.css
@@ -1014,8 +1014,10 @@ html, body {
      2. An accent frame (inset ring) that stays high-contrast against both the
         fill and the selection tint in every theme and both modes — the frame is
         what guarantees the card is always readable as a distinct block.
-   The reply card carries its frame inline in the sender's colour (see
-   MessageBubble); the blockquote uses the brand accent it already borders with. */
+   The reply card exposes its sender colour through --fluux-quote-frame-color
+   (see MessageBubble); the blockquote uses the brand accent it already borders
+   with. MessageList also sets data-msg-selected on bulk-copy rows, so keyboard,
+   action-sheet, and copy-range selection share this exact treatment. */
 [data-msg-selected] .blockquote-decorated,
 [data-msg-selected] .reply-quote-card {
   background-image: linear-gradient(
@@ -1025,6 +1027,9 @@ html, body {
 }
 [data-msg-selected] .blockquote-decorated {
   box-shadow: inset 0 0 0 1px var(--fluux-brand);
+}
+[data-msg-selected] .reply-quote-card {
+  box-shadow: inset 0 0 0 1px var(--fluux-quote-frame-color, var(--fluux-brand));
 }
 
 /* Remove default focus outline */

--- a/apps/fluux/src/themes/quoteSelection.test.ts
+++ b/apps/fluux/src/themes/quoteSelection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const css = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8')
+
+describe('selected quote and reply framing', () => {
+  it('uses the shared selected-message marker for both card types', () => {
+    expect(css).toMatch(
+      /\[data-msg-selected\]\s+\.blockquote-decorated,\s*\[data-msg-selected\]\s+\.reply-quote-card\s*\{[\s\S]*?--fluux-quote-selected-overlay/,
+    )
+  })
+
+  it('frames reply cards with their sender colour', () => {
+    expect(css).toMatch(
+      /\[data-msg-selected\]\s+\.reply-quote-card\s*\{[\s\S]*?box-shadow:\s*inset 0 0 0 1px var\(--fluux-quote-frame-color,\s*var\(--fluux-brand\)\)/,
+    )
+  })
+})


### PR DESCRIPTION
## What

- propagate the shared `data-msg-selected` marker to bulk-selected message rows in both virtualized and non-virtualized lists
- centralize the sender-colored reply/quote frame through a CSS custom property
- add component, virtualization, and structural theme regression tests

## Why

The earlier selected-message styling covered keyboard and action-sheet selection inside `MessageBubble`, but bulk range selection is owned by the outer `MessageList` row. As a result, the selected quote/reply selectors never matched during bulk copy selection, so cards could blend into the selected message background—most visibly in Aurora light.

This is a follow-up to #1008.

## Impact

Quoted-message and reply cards retain a distinct overlay and sender-colored inset frame whenever their message is selected, across light and dark themes.