### PR TITLE
Align room unread indicators with timestamps

### DIFF
--- a/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
@@ -136,3 +136,31 @@ describe('RoomItem tooltip', () => {
     expect(screen.getAllByTestId('tooltip-content')).toHaveLength(1)
   })
 })
+
+describe('RoomItem unread activity dot', () => {
+  it('renders a larger dot after the timestamp at the fixed metadata edge', () => {
+    const { container } = renderRoom(makeRoom({
+      unreadCount: 37,
+      mentionsCount: 0,
+      lastMessage: {
+        type: 'groupchat',
+        id: 'm1',
+        roomJid: 'team@conference.fluux.chat',
+        from: 'team@conference.fluux.chat/alice',
+        body: 'hello',
+        timestamp: new Date('2026-07-24T12:00:00Z'),
+        isOutgoing: false,
+        nick: 'alice',
+      },
+    }))
+
+    const metadata = container.querySelector('.ms-auto') as HTMLElement
+    const timestamp = metadata.querySelector('.text-xs') as HTMLElement
+    const dot = metadata.querySelector('.bg-fluux-gray') as HTMLElement
+
+    expect(timestamp).not.toBeNull()
+    expect(dot).not.toBeNull()
+    expect(timestamp.compareDocumentPosition(dot) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(dot.className).toContain('size-3')
+  })
+})

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tooltip.test.tsx
@@ -137,7 +137,7 @@ describe('RoomItem tooltip', () => {
   })
 })
 
-describe('RoomItem unread activity dot', () => {
+describe('RoomItem unread indicators', () => {
   it('renders a larger dot after the timestamp at the fixed metadata edge', () => {
     const { container } = renderRoom(makeRoom({
       unreadCount: 37,
@@ -162,5 +162,30 @@ describe('RoomItem unread activity dot', () => {
     expect(dot).not.toBeNull()
     expect(timestamp.compareDocumentPosition(dot) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(dot.className).toContain('size-3')
+  })
+
+  it('renders the mention-count badge after the timestamp in the same metadata slot', () => {
+    const { container } = renderRoom(makeRoom({
+      unreadCount: 37,
+      mentionsCount: 3,
+      lastMessage: {
+        type: 'groupchat',
+        id: 'm1',
+        roomJid: 'team@conference.fluux.chat',
+        from: 'team@conference.fluux.chat/alice',
+        body: 'hello',
+        timestamp: new Date('2026-07-24T12:00:00Z'),
+        isOutgoing: false,
+        nick: 'alice',
+      },
+    }))
+
+    const metadata = container.querySelector('.ms-auto') as HTMLElement
+    const timestamp = metadata.querySelector('.text-xs') as HTMLElement
+    const badge = screen.getByText('@3')
+
+    expect(metadata.contains(badge)).toBe(true)
+    expect(timestamp.compareDocumentPosition(badge) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(metadata.querySelector('.size-3')).toBeNull()
   })
 })

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -446,12 +446,6 @@ export const RoomItem = memo(function RoomItem({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <p dir="auto" className={`truncate ${room.unreadCount > 0 ? 'font-semibold text-fluux-text' : 'font-medium'}`}>{room.name}</p>
-            {/* Mentions count badge — red, the loud "wants your attention" tier. */}
-            {room.mentionsCount > 0 && (
-              <span className="min-w-5 h-5 px-1.5 bg-fluux-badge-strong text-white text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
-                @{room.mentionsCount}
-              </span>
-            )}
             <div className="ms-auto flex flex-shrink-0 items-center gap-2">
               {/* Timestamp */}
               {lastMessage && (
@@ -472,6 +466,14 @@ export const RoomItem = memo(function RoomItem({
                     roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
                   }`}
                 />
+              )}
+              {/* Mentions count badge — red, the loud "wants your attention"
+                  variant of the unread indicator. It uses the same trailing
+                  slot as the plain activity dot. */}
+              {room.mentionsCount > 0 && (
+                <span className="min-w-5 h-5 px-1.5 bg-fluux-badge-strong text-white text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
+                  @{room.mentionsCount}
+                </span>
               )}
             </div>
           </div>

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -446,30 +446,34 @@ export const RoomItem = memo(function RoomItem({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <p dir="auto" className={`truncate ${room.unreadCount > 0 ? 'font-semibold text-fluux-text' : 'font-medium'}`}>{room.name}</p>
-            {/* Activity dot for unread (non-mention) activity. Red for a
-                notify-all room — the attention tier, matching the icon-rail
-                indicator and mention badge — grey for plain unread. The count
-                itself lives in the row tooltip; the dot carries no tooltip of
-                its own (nested inside the row's, it popped a second bubble). */}
-            {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
-              <div
-                className={`size-2.5 rounded-full flex-shrink-0 ${
-                  roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
-                }`}
-              />
-            )}
             {/* Mentions count badge — red, the loud "wants your attention" tier. */}
             {room.mentionsCount > 0 && (
               <span className="min-w-5 h-5 px-1.5 bg-fluux-badge-strong text-white text-xs font-bold rounded-full flex-shrink-0 flex items-center justify-center">
                 @{room.mentionsCount}
               </span>
             )}
-            {/* Timestamp */}
-            {lastMessage && (
-              <span className="text-xs text-fluux-muted flex-shrink-0 ms-auto">
-                {formatConversationTime(lastMessage.timestamp, t, currentLang, timeFormat)}
-              </span>
-            )}
+            <div className="ms-auto flex flex-shrink-0 items-center gap-2">
+              {/* Timestamp */}
+              {lastMessage && (
+                <span className="text-xs text-fluux-muted">
+                  {formatConversationTime(lastMessage.timestamp, t, currentLang, timeFormat)}
+                </span>
+              )}
+              {/* Activity dot for unread (non-mention) activity. Red for a
+                  notify-all room — the attention tier, matching the icon-rail
+                  indicator and mention badge — grey for plain unread. Keeping
+                  the fixed-size dot after the timestamp aligns it across rows.
+                  The count itself lives in the row tooltip; the dot carries no
+                  tooltip of its own (nested inside the row's, it popped a
+                  second bubble). */}
+              {room.joined && room.unreadCount > 0 && room.mentionsCount === 0 && (
+                <div
+                  className={`size-3 rounded-full flex-shrink-0 ${
+                    roomActivityTone(room) === 'accent' ? 'bg-fluux-badge-strong' : 'bg-fluux-gray'
+                  }`}
+                />
+              )}
+            </div>
           </div>
           {showTyping ? (
             <TypingIndicator variant="compact" typingUsers={typingNicks} />

--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -58,7 +58,7 @@ export const changelog: ChangelogEntry[] = [
           'The quoted-message and reply cards stay visually distinct when a message is selected',
           'Your own message group re-fits its width once an image inside it finishes loading',
           'The typing indicator is vertically centered between the last message and the composer',
-          'Group-chat unread activity dots now sit after the timestamp in a larger, vertically aligned indicator',
+          'Group-chat unread dots and mention badges now sit after the timestamp as vertically aligned activity indicators',
           'macOS: the traffic-light window buttons stay centered in the app bar',
           'Web: the notification permission card in Settings uses platform-neutral wording instead of "Desktop Notifications"',
         ],

--- a/apps/fluux/src/data/changelog.ts
+++ b/apps/fluux/src/data/changelog.ts
@@ -58,6 +58,7 @@ export const changelog: ChangelogEntry[] = [
           'The quoted-message and reply cards stay visually distinct when a message is selected',
           'Your own message group re-fits its width once an image inside it finishes loading',
           'The typing indicator is vertically centered between the last message and the composer',
+          'Group-chat unread activity dots now sit after the timestamp in a larger, vertically aligned indicator',
           'macOS: the traffic-light window buttons stay centered in the app bar',
           'Web: the notification permission card in Settings uses platform-neutral wording instead of "Desktop Notifications"',
         ],


### PR DESCRIPTION
## Summary

- move room unread indicators—the plain activity dot and `@N` mention badge—to the fixed metadata edge after the timestamp
- increase the plain dot from 10 px to 12 px for easier visual targeting
- add regression coverage for both unread-indicator variants
- document the sidebar refinement in the changelog

## Why

Unread dots and mention badges previously sat immediately after the room name, so their horizontal position varied with each name. Both represent unread-attention state at different strengths, so placing either variant after the timestamp keeps that metadata vertically aligned across room rows and matches the user feedback.

Typing indicators are unchanged. The existing precedence remains: a mention badge replaces the plain unread dot when mentions are present.