### PR TITLE
Unify saved-position restoration on the controller frame loop

### DIFF
--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -9,6 +9,7 @@ import {
   type PositionRequestDraft,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
+  type SavedPositionFrameResult,
   type UnreadMarkerExecutor,
   type UnreadMarkerFrameResult,
 } from './positioningController'
@@ -363,15 +364,86 @@ describe('positioning controller saved-position ownership', () => {
     })
   }
 
+  function immediateSavedExecutor(
+    overrides: Partial<SavedPositionExecutor> &
+      Pick<SavedPositionExecutor, 'reachability'>,
+  ): SavedPositionExecutor {
+    return {
+      beginLoop: () => null,
+      positionFrame: () => ({
+        kind: 'positioned',
+        scrollTop: 400,
+        reassert: false,
+      }),
+      complete: () => {},
+      ...overrides,
+    }
+  }
+
+  function savedLoopHarness() {
+    const callbacks: Array<() => void> = []
+    const finish = vi.fn()
+    const recordFrame = vi.fn()
+    const complete = vi.fn()
+    const leases: SavedPositionExecutionLease[] = []
+    let frameResult: SavedPositionFrameResult = {
+      kind: 'positioned',
+      scrollTop: 400,
+      reassert: true,
+    }
+    const positionFrame = vi.fn(() => frameResult)
+    const beginLoop = vi.fn((lease: SavedPositionExecutionLease) => {
+      leases.push(lease)
+      return {
+        schedule: (callback: () => void) => callbacks.push(callback),
+        recordFrame,
+        finish,
+      }
+    })
+    const executor = immediateSavedExecutor({
+      reachability: () => ({
+        kind: 'available',
+        index: 4,
+        mounted: true,
+        placement: 'viable',
+      }),
+      beginLoop,
+      positionFrame,
+      complete,
+    })
+    return {
+      executor,
+      callbacks,
+      finish,
+      recordFrame,
+      complete,
+      leases,
+      positionFrame,
+      beginLoop,
+      setFrameResult: (result: SavedPositionFrameResult) => {
+        frameResult = result
+      },
+      runFrame: () => {
+        const callback = callbacks.shift()
+        expect(callback).toBeDefined()
+        callback!()
+      },
+    }
+  }
+
   it('loads an off-window anchor exactly once and resumes when that load settles', async () => {
     let anchorAvailable = false
     let resolveLoad!: () => void
     const loadPromise = new Promise<void>((resolve) => {
       resolveLoad = resolve
     })
-    const reconcile = vi.fn(() => true)
+    const positionFrame = vi.fn(() => ({
+      kind: 'positioned' as const,
+      scrollTop: 400,
+      reassert: false,
+    }))
     const loadAround = vi.fn(() => loadPromise)
-    const executor: SavedPositionExecutor = {
+    const executor = immediateSavedExecutor({
       reachability: (desired, loadStatus) =>
         desired.kind === 'anchor' && !anchorAvailable
           ? { kind: 'target-absent', loadAround: loadStatus }
@@ -382,8 +454,8 @@ describe('positioning controller saved-position ownership', () => {
               placement: 'viable',
             },
       loadAround,
-      reconcile,
-    }
+      positionFrame,
+    })
     const controller = new PositioningController()
     const request = controller.beginSavedPositionEntry({
       conversationId,
@@ -393,7 +465,7 @@ describe('positioning controller saved-position ownership', () => {
 
     expect(request).not.toBeNull()
     expect(loadAround).toHaveBeenCalledTimes(1)
-    expect(reconcile).not.toHaveBeenCalled()
+    expect(positionFrame).not.toHaveBeenCalled()
     expect(controller.isSavedPositionPending(conversationId)).toBe(true)
 
     controller.refreshSavedPosition({
@@ -408,7 +480,7 @@ describe('positioning controller saved-position ownership', () => {
     await loadPromise
     await Promise.resolve()
 
-    expect(reconcile).toHaveBeenCalledTimes(1)
+    expect(positionFrame).toHaveBeenCalledTimes(1)
     expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
       kind: 'position-applied',
     })
@@ -419,19 +491,23 @@ describe('positioning controller saved-position ownership', () => {
     const loadPromise = new Promise<void>((resolve) => {
       resolveLoad = resolve
     })
-    const reconcile = vi.fn(() => true)
+    const positionFrame = vi.fn(() => ({
+      kind: 'positioned' as const,
+      scrollTop: 400,
+      reassert: false,
+    }))
     const controller = new PositioningController()
     controller.beginSavedPositionEntry({
       conversationId,
       entryFacts: savedFacts(),
-      executor: {
+      executor: immediateSavedExecutor({
         reachability: (_desired, loadStatus) => ({
           kind: 'target-absent',
           loadAround: loadStatus,
         }),
         loadAround: () => loadPromise,
-        reconcile,
-      },
+        positionFrame,
+      }),
     })
 
     observeLiveEntry(controller, 'next-room@example.test')
@@ -439,25 +515,29 @@ describe('positioning controller saved-position ownership', () => {
     await loadPromise
     await Promise.resolve()
 
-    expect(reconcile).not.toHaveBeenCalled()
+    expect(positionFrame).not.toHaveBeenCalled()
     expect(controller.snapshot().currentConversationId).toBe('next-room@example.test')
     expect(controller.savedPositionStatus(conversationId)).toBeNull()
   })
 
   it('invalidates an older same-generation reconciliation operation', () => {
     const leases: SavedPositionExecutionLease[] = []
-    const executor: SavedPositionExecutor = {
+    const executor = immediateSavedExecutor({
       reachability: () => ({
         kind: 'available',
         index: 4,
         mounted: true,
         placement: 'viable',
       }),
-      reconcile: (_request, lease) => {
+      positionFrame: (_request, lease) => {
         leases.push(lease)
-        return true
+        return {
+          kind: 'positioned',
+          scrollTop: 400,
+          reassert: false,
+        }
       },
-    }
+    })
     const controller = new PositioningController()
     const request = controller.beginSavedPositionEntry({
       conversationId,
@@ -483,18 +563,22 @@ describe('positioning controller saved-position ownership', () => {
     controller.beginSavedPositionEntry({
       conversationId,
       entryFacts: savedFacts(),
-      executor: {
+      executor: immediateSavedExecutor({
         reachability: () => ({
           kind: 'available',
           index: 4,
           mounted: true,
           placement: 'viable',
         }),
-        reconcile: (_request, currentLease) => {
+        positionFrame: (_request, currentLease) => {
           lease = currentLease
-          return true
+          return {
+            kind: 'positioned',
+            scrollTop: 400,
+            reassert: false,
+          }
         },
-      },
+      }),
     })
 
     controller.observeUserInput(conversationId)
@@ -510,7 +594,7 @@ describe('positioning controller saved-position ownership', () => {
     const initial = controller.beginSavedPositionEntry({
       conversationId,
       entryFacts: savedFacts(700),
-      executor: {
+      executor: immediateSavedExecutor({
         reachability: (desired) =>
           desired.kind === 'anchor'
             ? { kind: 'target-absent', loadAround: 'unavailable' }
@@ -520,11 +604,15 @@ describe('positioning controller saved-position ownership', () => {
                 mounted: true,
                 placement: 'viable',
               },
-        reconcile: (request) => {
+        positionFrame: (request) => {
           reconciled = request
-          return true
+          return {
+            kind: 'positioned',
+            scrollTop: 700,
+            reassert: false,
+          }
         },
-      },
+      }),
     })
 
     expect(reconciled).not.toBeNull()
@@ -545,18 +633,24 @@ describe('positioning controller saved-position ownership', () => {
     controller.beginSavedPositionEntry({
       conversationId,
       entryFacts: savedFacts(650),
-      executor: {
+      executor: immediateSavedExecutor({
         reachability: () => ({
           kind: 'available',
           index: 3,
           mounted: true,
           placement: 'viable',
         }),
-        reconcile: (request) => {
+        positionFrame: (request) => {
           desiredKinds.push(request.desired.kind)
           return request.desired.kind === 'legacy-offset'
+            ? {
+                kind: 'positioned',
+                scrollTop: 650,
+                reassert: false,
+              }
+            : { kind: 'unavailable' }
         },
-      },
+      }),
     })
 
     // A generic reconcile-failure fallback would skip the usable legacy offset and go live.
@@ -570,8 +664,12 @@ describe('positioning controller saved-position ownership', () => {
   it('recenters a slid-up window before applying a saved live-edge fallback', () => {
     let atGlobalLiveEdge = false
     const recenter = vi.fn(() => 'requested' as const)
-    const reconcile = vi.fn(() => true)
-    const executor = (version: string): SavedPositionExecutor => ({
+    const positionFrame = vi.fn(() => ({
+      kind: 'positioned' as const,
+      scrollTop: 900,
+      reassert: false,
+    }))
+    const executor = (version: string): SavedPositionExecutor => immediateSavedExecutor({
       reachability: (desired) => {
         if (desired.kind === 'anchor') {
           return { kind: 'target-absent', loadAround: 'unavailable' }
@@ -585,7 +683,7 @@ describe('positioning controller saved-position ownership', () => {
       },
       recenterVersion: version,
       recenterLiveEdge: recenter,
-      reconcile,
+      positionFrame,
     })
     const controller = new PositioningController()
     controller.beginSavedPositionEntry({
@@ -599,7 +697,7 @@ describe('positioning controller saved-position ownership', () => {
     })
 
     expect(recenter).toHaveBeenCalledTimes(1)
-    expect(reconcile).not.toHaveBeenCalled()
+    expect(positionFrame).not.toHaveBeenCalled()
 
     const pending = controller.savedPositionStatus(conversationId)!
     atGlobalLiveEdge = true
@@ -609,7 +707,7 @@ describe('positioning controller saved-position ownership', () => {
       executor: executor('live:idle:20'),
     })
 
-    expect(reconcile).toHaveBeenCalledTimes(1)
+    expect(positionFrame).toHaveBeenCalledTimes(1)
     expect(controller.savedPositionStatus(conversationId)?.request.desired).toEqual(liveEdge)
   })
 
@@ -619,12 +717,16 @@ describe('positioning controller saved-position ownership', () => {
     const loadPromise = new Promise<void>((resolve) => {
       resolveLoad = resolve
     })
-    const reconcile = vi.fn(() => true)
+    const positionFrame = vi.fn(() => ({
+      kind: 'positioned' as const,
+      scrollTop: 400,
+      reassert: false,
+    }))
     const controller = new PositioningController()
     controller.beginSavedPositionEntry({
       conversationId,
       entryFacts: savedFacts(),
-      executor: {
+      executor: immediateSavedExecutor({
         reachability: (_desired, loadStatus) => ({
           kind: 'target-absent',
           loadAround: loadStatus,
@@ -633,8 +735,8 @@ describe('positioning controller saved-position ownership', () => {
           signal = currentSignal
           return loadPromise
         },
-        reconcile,
-      },
+        positionFrame,
+      }),
     })
     const generation = controller.snapshot().watermark
 
@@ -644,7 +746,136 @@ describe('positioning controller saved-position ownership', () => {
     expect(signal).not.toBeNull()
     expect(signal!.aborted).toBe(true)
     expect(controller.savedPositionStatus(conversationId)).toBeNull()
-    expect(reconcile).not.toHaveBeenCalled()
+    expect(positionFrame).not.toHaveBeenCalled()
+  })
+
+  it('applies before the first scheduled frame and settles after eight stable frames', () => {
+    const harness = savedLoopHarness()
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: harness.executor,
+    })
+
+    // The entry layout effect keeps its pre-paint write; the shared owner schedules only settling.
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.beginLoop).toHaveBeenCalledTimes(1)
+    expect(harness.callbacks).toHaveLength(1)
+    expect(harness.complete).toHaveBeenCalledWith(
+      expect.objectContaining({ desired: expect.objectContaining({ kind: 'anchor' }) }),
+      'applied',
+    )
+
+    // The first scheduled result establishes the controller's landing sample. Eight subsequent
+    // stable samples are required, exactly matching the removed hook-local loop.
+    for (let frame = 0; frame < 9; frame += 1) harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(10)
+    expect(harness.recordFrame).toHaveBeenCalledTimes(8)
+    expect(harness.recordFrame).toHaveBeenNthCalledWith(1, true)
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      'settled',
+    )
+    expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
+      kind: 'settled',
+    })
+  })
+
+  it('finishes best-effort after exactly ninety non-converging settle frames', () => {
+    const harness = savedLoopHarness()
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: harness.executor,
+    })
+
+    for (let frame = 0; frame < 90; frame += 1) {
+      harness.setFrameResult({
+        kind: 'positioned',
+        scrollTop: 500 + frame * 20,
+        reassert: true,
+      })
+      harness.runFrame()
+    }
+    // The next scheduled callback observes the exhausted budget without issuing a 91st settle write.
+    harness.runFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(91)
+    expect(harness.recordFrame).toHaveBeenCalledTimes(90)
+    expect(harness.recordFrame).toHaveBeenCalledWith(true)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      'best-effort',
+    )
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
+      kind: 'settled',
+    })
+  })
+
+  it('drops a queued saved-position frame after switching conversations', () => {
+    const harness = savedLoopHarness()
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    observeLiveEntry(controller, 'next-room@example.test')
+    staleFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+    expect(controller.savedPositionStatus(conversationId)).toBeNull()
+  })
+
+  it('cancels the shared saved-position loop on genuine user input', () => {
+    const harness = savedLoopHarness()
+    const controller = new PositioningController()
+    controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    controller.observeUserInput(conversationId)
+    staleFrame()
+
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+    expect(controller.savedPositionStatus(conversationId)).toBeNull()
+  })
+
+  it('treats an anchor lost after the initial write as a settled best effort', () => {
+    const harness = savedLoopHarness()
+    const controller = new PositioningController()
+    const request = controller.beginSavedPositionEntry({
+      conversationId,
+      entryFacts: savedFacts(),
+      executor: harness.executor,
+    })
+
+    harness.setFrameResult({ kind: 'unavailable' })
+    harness.runFrame()
+
+    expect(controller.snapshot().watermark).toBe(request!.generation)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      'best-effort',
+    )
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(controller.savedPositionStatus(conversationId)?.phase).toEqual({
+      kind: 'settled',
+    })
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -60,6 +60,20 @@ export interface PositionFrameLoop {
   finish: () => void
 }
 
+export type SavedPositionFrameResult =
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      /** Whether measured geometry must be re-applied until it stabilises. */
+      reassert: boolean
+    }
+
+export type SavedPositionCompletion =
+  | 'applied'
+  | 'settled'
+  | 'best-effort'
+
 export interface SavedPositionExecutor {
   reachability: (
     desired: SavedPositionRequest['desired'],
@@ -74,10 +88,15 @@ export interface SavedPositionExecutor {
   recenterLiveEdge?: (
     signal: AbortSignal,
   ) => 'requested' | 'waiting' | 'unavailable'
-  reconcile: (
+  beginLoop: (lease: SavedPositionExecutionLease) => PositionFrameLoop | null
+  positionFrame: (
     request: SavedPositionRequest,
     lease: SavedPositionExecutionLease,
-  ) => boolean
+  ) => SavedPositionFrameResult
+  complete: (
+    request: SavedPositionRequest,
+    outcome: SavedPositionCompletion,
+  ) => void
 }
 
 export type UnreadMarkerFrameLoop = PositionFrameLoop
@@ -151,6 +170,10 @@ interface SavedPositionExecutionState {
   aroundAttempted: boolean
   loadingAround: boolean
   lastRecenterVersion: string | null
+  loop: PositionFrameLoop | null
+  framesLeft: number
+  stableFrames: number
+  landedTarget: number | null
 }
 
 interface UnreadMarkerExecutionState {
@@ -184,6 +207,10 @@ const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
 const EXPLICIT_TARGET_TAKEOVER_DRIFT_PX = 300
+// Preserved from the former hook-local restore-anchor loop.
+const SAVED_POSITION_REASSERT_FRAMES = 90
+const SAVED_POSITION_STABLE_FRAMES = 8
+const SAVED_POSITION_DRIFT_PX = 8
 const UNREAD_MARKER_REASSERT_FRAMES = 120
 const UNREAD_MARKER_STABLE_FRAMES = 8
 const UNREAD_MARKER_DRIFT_PX = 16
@@ -287,6 +314,10 @@ export class PositioningController {
       aroundAttempted: false,
       loadingAround: false,
       lastRecenterVersion: null,
+      loop: null,
+      framesLeft: SAVED_POSITION_REASSERT_FRAMES,
+      stableFrames: 0,
+      landedTarget: null,
     }
     this.driveSavedPosition()
     return request
@@ -1521,7 +1552,13 @@ export class PositioningController {
 
   private driveSavedPosition(): void {
     const execution = this.savedExecution
-    if (!execution || !this.isSavedExecutionCurrent(execution)) return
+    if (
+      !execution ||
+      !this.isSavedExecutionCurrent(execution) ||
+      execution.loop
+    ) {
+      return
+    }
 
     const loadAround: SavedPositionLoadAroundStatus = execution.loadingAround
       ? 'loading'
@@ -1572,24 +1609,203 @@ export class PositioningController {
       case 'mounting':
       case 'reconciling': {
         execution.loadingAround = false
-        const lease = this.beginSavedOperation(execution)
-        const applied = runScrollShadowSafely({
-          event: 'saved-position-reconcile',
-          conversationId: execution.request.conversationId,
-          fallback: false,
-          observe: () => execution.executor.reconcile(execution.request, lease),
-        })
-        if (!lease.isCurrent()) return
-        if (applied) {
-          lease.markApplied()
-        } else {
-          this.promoteSavedFallback(
-            execution,
-            execution.request.onUnavailable ?? { kind: 'live-edge' },
-          )
-        }
+        this.startSavedPositionLoop(execution)
       }
     }
+  }
+
+  private startSavedPositionLoop(
+    execution: SavedPositionExecutionState,
+  ): void {
+    if (
+      !this.isSavedExecutionCurrent(execution) ||
+      execution.loop
+    ) {
+      return
+    }
+
+    execution.framesLeft = SAVED_POSITION_REASSERT_FRAMES
+    execution.stableFrames = 0
+    execution.landedTarget = null
+    const lease = this.beginSavedOperation(execution)
+
+    // Preserve the pre-paint entry write: the first measured application happens synchronously
+    // from the conversation-entry layout effect. Only the subsequent measurement settle is
+    // scheduled through the shared frame-loop owner.
+    const initial = this.positionSavedFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (initial.kind === 'unavailable') {
+      if (
+        execution.request.source.kind === 'fallback' &&
+        execution.request.desired.kind === 'live-edge'
+      ) {
+        this.cancelSavedExecution()
+        return
+      }
+      this.promoteSavedFallback(
+        execution,
+        execution.request.onUnavailable ?? { kind: 'live-edge' },
+      )
+      return
+    }
+
+    lease.markApplied()
+    if (!lease.isCurrent()) return
+    this.completeSavedPosition(execution, 'applied')
+    if (!initial.reassert) return
+
+    const loop = runScrollShadowSafely<PositionFrameLoop | null>({
+      event: 'saved-position-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      if (loop) {
+        runScrollShadowSafely({
+          event: 'saved-position-loop-stale-finish',
+          conversationId: execution.request.conversationId,
+          fallback: undefined,
+          observe: () => loop.finish(),
+        })
+      }
+      return
+    }
+    if (!loop) {
+      this.settleSavedPosition(execution, lease, 'best-effort')
+      return
+    }
+    execution.loop = loop
+    this.scheduleSavedPositionFrame(execution, lease)
+  }
+
+  private driveSavedPositionFrame(
+    execution: SavedPositionExecutionState,
+    lease: SavedPositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (execution.framesLeft-- <= 0) {
+      this.settleSavedPosition(execution, lease, 'best-effort')
+      return
+    }
+
+    const result = this.positionSavedFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (result.kind === 'unavailable') {
+      // Once the initial anchor write landed, losing the row during re-windowing was historically
+      // a best-effort stop, not a new fallback request. Preserve that release seam.
+      this.settleSavedPosition(execution, lease, 'best-effort')
+      return
+    }
+    if (!result.reassert) {
+      this.settleSavedPosition(execution, lease, 'settled')
+      return
+    }
+
+    let wrote = false
+    if (
+      execution.landedTarget !== null &&
+      Math.abs(result.scrollTop - execution.landedTarget) <=
+        SAVED_POSITION_DRIFT_PX
+    ) {
+      execution.stableFrames += 1
+      if (execution.stableFrames >= SAVED_POSITION_STABLE_FRAMES) {
+        this.settleSavedPosition(execution, lease, 'settled')
+        return
+      }
+    } else {
+      wrote = true
+      execution.stableFrames = 0
+    }
+    execution.landedTarget = result.scrollTop
+    this.recordSavedPositionFrame(execution, wrote)
+    this.scheduleSavedPositionFrame(execution, lease)
+  }
+
+  private positionSavedFrame(
+    execution: SavedPositionExecutionState,
+    lease: SavedPositionExecutionLease,
+  ): SavedPositionFrameResult {
+    return runScrollShadowSafely<SavedPositionFrameResult>({
+      event: 'saved-position-frame',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.positionFrame(
+        execution.request,
+        lease,
+      ),
+    })
+  }
+
+  private scheduleSavedPositionFrame(
+    execution: SavedPositionExecutionState,
+    lease: SavedPositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'saved-position-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveSavedPositionFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      this.settleSavedPosition(execution, lease, 'best-effort')
+    }
+  }
+
+  private recordSavedPositionFrame(
+    execution: SavedPositionExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'saved-position-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private settleSavedPosition(
+    execution: SavedPositionExecutionState,
+    lease: SavedPositionExecutionLease,
+    outcome: Extract<SavedPositionCompletion, 'settled' | 'best-effort'>,
+  ): void {
+    if (!lease.isCurrent()) return
+    this.finishSavedLoop(execution)
+    this.completeSavedPosition(execution, outcome)
+    lease.settle()
+  }
+
+  private completeSavedPosition(
+    execution: SavedPositionExecutionState,
+    outcome: SavedPositionCompletion,
+  ): void {
+    runScrollShadowSafely({
+      event: 'saved-position-complete',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.executor.complete(
+        execution.request,
+        outcome,
+      ),
+    })
+  }
+
+  private finishSavedLoop(execution: SavedPositionExecutionState): void {
+    const loop = execution.loop
+    execution.loop = null
+    if (!loop) return
+    runScrollShadowSafely({
+      event: 'saved-position-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => loop.finish(),
+    })
   }
 
   private startSavedAroundLoad(
@@ -1652,19 +1868,7 @@ export class PositioningController {
     execution: SavedPositionExecutionState,
   ): void {
     if (!this.isSavedExecutionCurrent(execution)) return
-    const lease = this.beginSavedOperation(execution)
-    const applied = runScrollShadowSafely({
-      event: 'saved-position-live-edge-best-effort',
-      conversationId: execution.request.conversationId,
-      fallback: false,
-      observe: () => execution.executor.reconcile(execution.request, lease),
-    })
-    if (!lease.isCurrent()) return
-    if (applied) {
-      lease.markApplied()
-    } else {
-      this.cancelSavedExecution()
-    }
+    this.startSavedPositionLoop(execution)
   }
 
   private promoteSavedFallback(
@@ -1699,6 +1903,7 @@ export class PositioningController {
       this.cancelSavedExecution()
       return
     }
+    this.finishSavedLoop(execution)
     execution.abortController?.abort()
     execution.request = request
     execution.operation += 1
@@ -1706,6 +1911,9 @@ export class PositioningController {
     execution.loadingAround = false
     execution.aroundAttempted = true
     execution.lastRecenterVersion = null
+    execution.framesLeft = SAVED_POSITION_REASSERT_FRAMES
+    execution.stableFrames = 0
+    execution.landedTarget = null
     this.model = accepted
     this.driveSavedPosition()
   }
@@ -1787,7 +1995,10 @@ export class PositioningController {
   }
 
   private cancelSavedExecution(): void {
-    this.savedExecution?.abortController?.abort()
+    if (this.savedExecution) {
+      this.finishSavedLoop(this.savedExecution)
+      this.savedExecution.abortController?.abort()
+    }
     this.savedExecution = null
   }
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -120,16 +120,13 @@ const TARGET_HIGHLIGHT_MS = 1500
 // scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
 // one-shot scrollToIndex isn't enough. ~1s at 60fps comfortably covers the measurement settle.
 const BOTTOM_REASSERT_FRAMES = 60
-// Saved-position (content-anchor) restore needs the SAME measurement-aware re-assert as the marker
-// path. A one-shot scrollToIndex(anchor,'end') lands on the rows' ESTIMATED sizes; those rows then
-// measure TALLER over the next frames (media, wrapping), the content above the anchor grows, and the
-// anchor slides below the fold — the view drifts OLDER. handleScroll then saves that drifted position
-// and the (now older) bottom-visible message becomes the next anchor, so each re-open drifts further
-// back ("goes back in time on every open"). Re-pinning the anchor across frames lands it on settled
-// measurements, and registering the loop gates the save so the transient can't compound.
-const RESTORE_REASSERT_FRAMES = 90
-const RESTORE_STABLE_FRAMES = 8
-const RESTORE_DRIFT_PX = 8
+// Media decoded above a scrolled-up viewport changes the measured offsets after the batch snapshot.
+// Re-apply that snapshot's bottom-fraction anchor until measurements settle so the reading point
+// stays fixed. Saved-position restoration uses the same per-frame geometry, but its budget and
+// convergence state are controller-owned.
+const MEDIA_ANCHOR_REASSERT_FRAMES = 90
+const MEDIA_ANCHOR_STABLE_FRAMES = 8
+const MEDIA_ANCHOR_DRIFT_PX = 8
 // While re-pinning, treat the list as not-yet-pinned whenever it sits more than this many pixels
 // above the true bottom. The change-detection guard (re-pin only when scrollHeight moved) can miss
 // the frame where the last row's measurement settles — coalesced height deltas, or a height delta
@@ -1148,62 +1145,51 @@ export function useMessageListScroll({
     rememberBottomIntent()
   }, [conversationId, pinVirtualizedBottom, rememberBottomIntent])
 
-  // Re-pin a VIRTUALIZED list to a saved CONTENT ANCHOR and keep it pinned as rows measure — the
-  // restore counterpart of pinVirtualizedBottom. A one-shot scrollToIndex(anchor,'end') lands on the
-  // rows' estimated sizes; they then measure taller and the anchor drifts below the fold (see the
-  // RESTORE_* constants). Re-deriving the anchor's pixel target each frame (align:'end' + the saved
-  // fraction, both from CURRENT measurements) lands it on settled layout. Registering the loop in
-  // reassertLoopRef makes handleScroll treat these scrolls as programmatic — so the drifting
-  // transient is NOT saved (which is what made the drift compound across re-opens). Bails on a user
-  // scroll or a conversation switch; converges (and stops early) once the landing position is stable.
-  const pinVirtualizedAnchor = useCallback((
+  // Apply one virtualized bottom-fraction anchor write from CURRENT measurements. Saved-position
+  // restoration and media preservation deliberately share this browser geometry, but not ownership:
+  // the positioning controller schedules saved restore frames, while the retained media loop below
+  // remains outside the controller until the content-growth migration.
+  const applyVirtualizedAnchorFrame = useCallback((anchor: ScrollAnchor): number | null => {
+    const v = virtualizerRef.current
+    const s = scrollerRef.current
+    if (!v || !s) return null
+    const idx = v.getIndexForMessageId(anchor.messageId)
+    if (idx === null) return null
+    // Issue the fractional target as the ONLY scroll write per frame. The old code ALSO called
+    // scrollToIndex(idx,'end') every frame; the two targets differ by (1-fraction)*rowHeight, and
+    // for a tall anchor at a mid fraction that per-frame kick knocks the row across the
+    // virtualization window boundary — its height flips between estimate and measured, the offsets
+    // shift, and the loop never converges ([ScrollReassertLoop] 'restore-anchor', observed as a
+    // ~253px scrollTop ping-pong). scrollToOffset re-windows just like scrollToIndex, so the
+    // fractional write alone both positions the anchor AND keeps it mounted, so it settles.
+    const item =
+      anchor.fraction < 1 ? v.getVirtualItems().find((vi) => vi.index === idx) : undefined
+    const size = item?.size
+    const start = size ? v.getOffsetForMessageId(anchor.messageId) : null
+    if (size && start !== null) {
+      v.scrollToOffset(Math.max(0, start + anchor.fraction * size - s.clientHeight))
+    } else {
+      // Anchor not yet in the measured window (or fraction===1): mount it / pin its bottom to the
+      // viewport bottom. Once it measures in, later frames take the fractional branch above.
+      v.scrollToIndex(idx, { align: 'end' })
+    }
+    return s.scrollTop
+  }, [])
+
+  // Standalone media-preservation loop. Saved-position restoration no longer enters this owner.
+  const reassertMediaAnchor = useCallback((
     anchor: ScrollAnchor,
     anchorConvId: string,
-    lease?: SavedPositionExecutionLease,
   ): boolean => {
-    const scroller = scrollerRef.current
-    if (!virtualizerRef.current || !scroller || (lease && !lease.isCurrent())) {
-      return false
-    }
+    if (!virtualizerRef.current || !scrollerRef.current) return false
 
     supersedeReassertLoopRef.current()
 
-    // Re-derive and apply the anchor's pixel position from the CURRENT measured layout. Returns the
-    // resulting scrollTop, or null when the anchor row is no longer resolvable.
-    const applyAnchor = (): number | null => {
-      if (lease && !lease.isCurrent()) return null
-      const v = virtualizerRef.current
-      const s = scrollerRef.current
-      if (!v || !s) return null
-      const idx = v.getIndexForMessageId(anchor.messageId)
-      if (idx === null) return null
-      // Issue the fractional target as the ONLY scroll write per frame. The old code ALSO called
-      // scrollToIndex(idx,'end') every frame; the two targets differ by (1-fraction)*rowHeight, and
-      // for a tall anchor at a mid fraction that per-frame kick knocks the row across the
-      // virtualization window boundary — its height flips between estimate and measured, the offsets
-      // shift, and the loop never converges ([ScrollReassertLoop] 'restore-anchor', observed as a
-      // ~253px scrollTop ping-pong). scrollToOffset re-windows just like scrollToIndex, so the
-      // fractional write alone both positions the anchor AND keeps it mounted, so it settles.
-      const item =
-        anchor.fraction < 1 ? v.getVirtualItems().find((vi) => vi.index === idx) : undefined
-      const size = item?.size
-      const start = size ? v.getOffsetForMessageId(anchor.messageId) : null
-      if (size && start !== null) {
-        v.scrollToOffset(Math.max(0, start + anchor.fraction * size - s.clientHeight))
-      } else {
-        // Anchor not yet in the measured window (or fraction===1): mount it / pin its bottom to the
-        // viewport bottom. Once it measures in, later frames take the fractional branch above.
-        v.scrollToIndex(idx, { align: 'end' })
-      }
-      return s.scrollTop
-    }
-
-    // Immediate pin (pre-paint when called from the restore path's layout effect).
-    if (applyAnchor() === null) return false
+    if (applyVirtualizedAnchorFrame(anchor) === null) return false
 
     const startedAt = Date.now()
-    const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('restore-anchor', performance.now())
-    let framesLeft = RESTORE_REASSERT_FRAMES
+    const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('media-anchor', performance.now())
+    let framesLeft = MEDIA_ANCHOR_REASSERT_FRAMES
     let stableFrames = 0
     let landed = -1
     const finish = () => {
@@ -1211,38 +1197,33 @@ export function useMessageListScroll({
       if (reassertLoopRef.current?.handle === loop) {
         reassertLoopRef.current = null
       }
-      if (lease && !lease.isCurrent()) return
       // The loop just stopped owning scrollTop; keep the brief measurement settle that follows it
       // classified as programmatic so it can't open the save gate (see lastProgrammaticScrollAtRef).
       lastProgrammaticScrollAtRef.current = Date.now()
-      // Capture the settled position so a leave right after restore saves the anchor we LANDED on,
-      // not a mid-settle transient.
+      // Capture the settled position so a leave immediately after media decode saves the anchor we
+      // landed on, not a mid-settle transient.
       const s = scrollerRef.current
       if (s) {
         isAtBottomRef.current = (s.scrollHeight - s.scrollTop - s.clientHeight) < AT_BOTTOM_THRESHOLD
         rememberCurrentScrollSnapshot()
       }
-      lease?.settle()
     }
     const step = () => {
       const s = scrollerRef.current
       if (!s) { finish(); return }
       if (framesLeft-- <= 0) { finish(); return }
-      // Generation + operation ownership is authoritative. A late frame from a superseded restore
-      // must not write into a newer request in the same conversation.
-      if (lease && !lease.isCurrent()) { finish(); return }
       // Stale loop must never scroll the new conversation (prevConversationRef is set synchronously
       // at the end of the conversation-switch effect).
       if (prevConversationRef.current !== anchorConvId) { finish(); return }
       // User took over → stop fighting them.
       if (userScrollIntentAtRef.current > startedAt) { finish(); return }
 
-      const st = applyAnchor()
+      const st = applyVirtualizedAnchorFrame(anchor)
       if (st === null) { finish(); return }
 
       let wrote = false
-      if (landed >= 0 && Math.abs(st - landed) <= RESTORE_DRIFT_PX) {
-        if (++stableFrames >= RESTORE_STABLE_FRAMES) { finish(); return }
+      if (landed >= 0 && Math.abs(st - landed) <= MEDIA_ANCHOR_DRIFT_PX) {
+        if (++stableFrames >= MEDIA_ANCHOR_STABLE_FRAMES) { finish(); return }
       } else {
         wrote = true
         stableFrames = 0
@@ -1260,7 +1241,43 @@ export function useMessageListScroll({
     }
     register(step)
     return true
-  }, [isAtBottomRef, rememberCurrentScrollSnapshot])
+  }, [applyVirtualizedAnchorFrame, isAtBottomRef, rememberCurrentScrollSnapshot])
+
+  const beginControllerFrameLoop = useCallback((
+    label: string,
+    lease: PositionExecutionLease,
+  ) => {
+    if (!lease.isCurrent()) return null
+    supersedeReassertLoopRef.current()
+    const monitor = (reassertMonitorRef.current ??=
+      createReassertLoopMonitor()).begin(label, performance.now())
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      monitor.end()
+      const activeLoop = reassertLoopRef.current
+      if (activeLoop?.handle === monitor) {
+        cancelAnimationFrame(activeLoop.raf)
+        reassertLoopRef.current = null
+      }
+    }
+    return {
+      schedule: (callback: () => void) => {
+        if (finished || !lease.isCurrent()) return
+        // Register before scheduling so synchronous-rAF test harnesses cannot resurrect a loop that
+        // completed from inside the callback.
+        const entry = { raf: 0, handle: monitor }
+        reassertLoopRef.current = entry
+        entry.raf = requestAnimationFrame(callback)
+      },
+      recordFrame: (wrote: boolean) => {
+        const warning = monitor.frame(performance.now(), wrote)
+        if (warning) console.warn(warning)
+      },
+      finish,
+    }
+  }, [])
 
   const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
     reachability: (desired, loadAround) => {
@@ -1313,20 +1330,25 @@ export function useMessageListScroll({
           return 'requested'
         }
       : undefined,
-    reconcile: (request: SavedPositionRequest, lease: SavedPositionExecutionLease) => {
-      if (!lease.isCurrent()) return false
+    beginLoop: (lease) => beginControllerFrameLoop('restore-anchor', lease),
+    positionFrame: (request: SavedPositionRequest, lease: SavedPositionExecutionLease) => {
+      if (!lease.isCurrent()) return { kind: 'unavailable' }
       const scroller = scrollerRef.current
-      if (!scroller) return false
+      if (!scroller) return { kind: 'unavailable' }
 
       let restored = false
+      let reassert = false
       if (request.desired.kind === 'anchor') {
         const anchor: ScrollAnchor = {
           messageId: request.desired.messageId,
           fraction: request.desired.placement.fraction,
         }
-        restored = virtualizerRef.current
-          ? pinVirtualizedAnchor(anchor, conversationId, lease)
-          : restoreToAnchor(scroller, anchor)
+        if (virtualizerRef.current) {
+          restored = applyVirtualizedAnchorFrame(anchor) !== null
+          reassert = restored
+        } else {
+          restored = restoreToAnchor(scroller, anchor)
+        }
       } else if (request.desired.kind === 'legacy-offset') {
         const virtualizer = virtualizerRef.current
         if (virtualizer) {
@@ -1349,18 +1371,29 @@ export function useMessageListScroll({
         restored = true
       }
 
-      if (!restored || !lease.isCurrent()) return false
+      if (!restored || !lease.isCurrent()) return { kind: 'unavailable' }
+      return {
+        kind: 'positioned',
+        scrollTop: scroller.scrollTop,
+        reassert,
+      }
+    },
+    complete: (request, outcome) => {
+      const scroller = scrollerRef.current
+      if (!scroller) return
       isAtBottomRef.current = getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD
       rememberCurrentScrollSnapshot()
       lastProgrammaticScrollAtRef.current = Date.now()
-      debugLog('RESTORE: controller applied position', {
+      debugLog('RESTORE: controller completed position', {
         conversationId,
         generation: request.generation,
         desired: request.desired,
+        outcome,
       })
-      return true
     },
   }), [
+    applyVirtualizedAnchorFrame,
+    beginControllerFrameLoop,
     conversationId,
     firstMessageId,
     isAtBottomRef,
@@ -1368,47 +1401,10 @@ export function useMessageListScroll({
     lastMessageId,
     messageCount,
     onLoadNewer,
-    pinVirtualizedAnchor,
     reassertBottom,
     rememberCurrentScrollSnapshot,
     windowAtLiveEdge,
   ])
-
-  const beginControllerFrameLoop = useCallback((
-    label: string,
-    lease: PositionExecutionLease,
-  ) => {
-    if (!lease.isCurrent()) return null
-    supersedeReassertLoopRef.current()
-    const monitor = (reassertMonitorRef.current ??=
-      createReassertLoopMonitor()).begin(label, performance.now())
-    let finished = false
-    const finish = () => {
-      if (finished) return
-      finished = true
-      monitor.end()
-      const activeLoop = reassertLoopRef.current
-      if (activeLoop?.handle === monitor) {
-        cancelAnimationFrame(activeLoop.raf)
-        reassertLoopRef.current = null
-      }
-    }
-    return {
-      schedule: (callback: () => void) => {
-        if (finished || !lease.isCurrent()) return
-        // Register before scheduling so synchronous-rAF test harnesses cannot resurrect a loop that
-        // completed from inside the callback.
-        const entry = { raf: 0, handle: monitor }
-        reassertLoopRef.current = entry
-        entry.raf = requestAnimationFrame(callback)
-      },
-      recordFrame: (wrote: boolean) => {
-        const warning = monitor.frame(performance.now(), wrote)
-        if (warning) console.warn(warning)
-      },
-      finish,
-    }
-  }, [])
 
   const createUnreadMarkerExecutor = useCallback((): UnreadMarkerExecutor => ({
     reachability: (desired) => deriveReachabilityForDesired({
@@ -2135,7 +2131,7 @@ export function useMessageListScroll({
           wasAtBottom,
           anchorId: anchor.messageId,
         })
-        if (virtualizerRef.current) pinVirtualizedAnchor(anchor, conversationId)
+        if (virtualizerRef.current) reassertMediaAnchor(anchor, conversationId)
         else restoreToAnchor(currentScroller, anchor)
         if (request) {
           positioningControllerRef.current?.markPositionApplied(
@@ -2154,7 +2150,7 @@ export function useMessageListScroll({
       mediaLoadSnapshotRef.current = null
       mediaLoadDebounceRef.current = null
     }, MEDIA_LOAD_DEBOUNCE_MS)
-  }, [isAtBottomRef, reassertBottom, pinVirtualizedAnchor, conversationId])
+  }, [isAtBottomRef, reassertBottom, reassertMediaAnchor, conversationId])
 
   // ==========================================================================
   // SCROLL EVENT HANDLER

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -37,7 +37,10 @@ browser/virtualizer writes, and every frame must hold the current controller lea
 write. Saved-position, unread-marker, and explicit-target reconciliation now share the same
 controller-owned `PositionFrameLoop` shape. The saved executor retains the existing fractional-anchor
 measurement write, 90-frame budget, 8-frame stability window, and 8px tolerance; only scheduling,
-convergence state, and lifecycle ownership moved out of the hook-local loop.
+convergence state, and lifecycle ownership moved out of the hook-local loop. Unlike unread-marker
+and explicit-target loops, saved-position restoration deliberately has no fixed geometry-drift
+takeover threshold: legitimate deep-history measurement corrections can exceed 300px while rows
+settle, so user-input cancellation remains its takeover signal.
 
 Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
 native smooth animation is intentionally not retained: restarting a smooth animation while

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -34,9 +34,10 @@ frame scheduling, stale-work cancellation, convergence, and live-edge fallback. 
 message targets it owns supersession, one around-load attempt, mounting and center-position
 convergence, user takeover, and completion. Hook executors translate accepted requests into
 browser/virtualizer writes, and every frame must hold the current controller lease before it can
-write. `pinVirtualizedAnchor` remains the saved-position measurement reconciler; the controller-owned
-unread and explicit-target executors likewise retain their measurement settle behavior without
-retaining independent policy loops.
+write. Saved-position, unread-marker, and explicit-target reconciliation now share the same
+controller-owned `PositionFrameLoop` shape. The saved executor retains the existing fractional-anchor
+measurement write, 90-frame budget, 8-frame stability window, and 8px tolerance; only scheduling,
+convergence state, and lifecycle ownership moved out of the hook-local loop.
 
 Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
 native smooth animation is intentionally not retained: restarting a smooth animation while
@@ -68,9 +69,9 @@ The three previously prose-only fidelity seams are descriptive of current behavi
   only while entry restore is pending or a directional load has not completed its initial restore.
   A replay captured from the media-growth invariant proves that an outgoing live-edge request
   supersedes an active media anchor.
-- **`position-applied` is the current release seam, before measurement settle.** The saved executor
-  returns after its initial anchor/offset write, and the controller marks the lease applied before
-  the longer restore-anchor rAF loop converges. Directional restoration likewise sets
+- **`position-applied` is the current release seam, before measurement settle.** The saved controller
+  applies the initial anchor/offset write synchronously, marks the lease applied, and then schedules
+  the remaining restore-anchor frames through its shared loop. Directional restoration likewise sets
   `saved.restored` after its initial bounded write and before its measurement re-assert loop.
   Recorded restore facts prove an outgoing request is rejected before that signal and accepted
   immediately after it.


### PR DESCRIPTION
## Summary

- move saved-position measurement scheduling and convergence into the generation-aware positioning controller
- preserve the synchronous entry write and the existing 90-frame / 8-stable-frame / 8px restore contract
- leave browser and virtualizer anchor geometry in the hook executor
- separate the retained media-anchor loop from saved restoration and update the positioning contract
- add falsifiable lifecycle and convergence tests

## Why

Saved-position restoration was already controller-authoritative for intent, reachability, loading, fallback, and generation cancellation, but its executor still owned a private `requestAnimationFrame` loop. Unread-marker and explicit-target reconciliation use `PositionFrameLoop`, leaving two concurrency shapes before the live-edge and directional-history migrations.

This cutover gives saved restoration the same scheduling and lifecycle shape without changing placement geometry or pulling bottom/content-growth behavior into this PR.

## Behavior

No user-visible behavior change is intended. The initial saved-position write remains synchronous before paint, and virtualized measurement settling keeps the same budget and tolerance. Media preservation remains a separate owner until the content-growth migration.

## Validation

- Focused controller, restore, and virtualized suites: 3 files / 93 tests passed
- Full SDK suite: 204 files / 5,269 tests passed
- Full app suite: 407 files / 5,292 passed, 22 skipped
- Typecheck: passed
- Lint: passed with pre-existing warnings only
- Scroll invariants: 52/52 passed across Chromium and WebKit
- `git diff --check`: passed
