### PR TITLE
fix(cache): scope compound-index cursor ranges to one entity

### DIFF
--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1401,3 +1401,169 @@ describe('live paths — identity-resolving upsert + alias lookups + mutations',
     expect(around.some((m) => m.timestamp.getTime() === 1000)).toBe(true)
   })
 })
+
+/**
+ * Cursor-range scoping.
+ *
+ * `conv_timestamp` / `room_timestamp` are COMPOUND indexes keyed
+ * `[entityId, timestamp]`. A half-open range over a compound key is only
+ * half-scoped: `upperBound([id, t])` admits every row of every entity sorting
+ * BEFORE `id`, and `lowerBound([id, t])` admits every row of every entity
+ * sorting AFTER it. The read loop skips foreign rows but cannot stop on them —
+ * `results.length < limit` never trips once the walk has left the entity — so
+ * the cursor walks the rest of the store, one awaited `continue()` per row.
+ * That is the conversation-activation stall: `getMessagesAround` issues exactly
+ * these two shapes, and returning ~150 rows costs a scan of the whole archive.
+ *
+ * The returned ROWS are correct either way (the loop skips foreign rows), so
+ * asserting on them cannot catch this. These tests assert on the key range
+ * handed to `openCursor`: an unscoped range is one missing a bound, or one
+ * whose bounds straddle two different entity ids.
+ */
+describe('cursor ranges stay scoped to one entity', () => {
+  const FIRST = 'aaa@example.com'
+  const MIDDLE = 'mmm@example.com'
+  const LAST = 'zzz@example.com'
+  const PER = 200
+  const BASE = Date.UTC(2026, 0, 1)
+  const ANCHOR = 100
+
+  let ranges: IDBKeyRange[] = []
+  let realOpenCursor: typeof IDBIndex.prototype.openCursor
+  let scope = 0
+
+  beforeEach(() => {
+    // A distinct account scope per test = a distinct database name, so no test
+    // can read another's rows however the shared connection cache behaves.
+    _resetStorageScopeForTesting()
+    globalThis.indexedDB = new IDBFactory()
+    ;(messageCache as { _resetDBForTesting?: () => void })._resetDBForTesting?.()
+    setStorageScopeJid(`scope${scope++}@example.com`)
+
+    ranges = []
+    realOpenCursor = IDBIndex.prototype.openCursor
+    IDBIndex.prototype.openCursor = function (
+      this: IDBIndex,
+      query?: IDBValidKey | IDBKeyRange | null,
+      direction?: IDBCursorDirection,
+    ) {
+      if (query && typeof query === 'object' && 'lower' in query) ranges.push(query as IDBKeyRange)
+      else ranges.push({ lower: undefined, upper: undefined } as unknown as IDBKeyRange)
+      return realOpenCursor.call(this, query, direction)
+    }
+  })
+
+  afterEach(() => {
+    IDBIndex.prototype.openCursor = realOpenCursor
+  })
+
+  /**
+   * The range must pin BOTH ends to `entityId`. A bound that is absent, or that
+   * names a different entity, lets the cursor walk out of the entity's rows.
+   */
+  function expectScopedTo(range: IDBKeyRange | undefined, entityId: string): void {
+    expect(range).toBeDefined()
+    expect(Array.isArray(range!.lower)).toBe(true)
+    expect(Array.isArray(range!.upper)).toBe(true)
+    expect((range!.lower as unknown[])[0]).toBe(entityId)
+    expect((range!.upper as unknown[])[0]).toBe(entityId)
+  }
+
+  /** Seed and CONFIRM the rows landed — a silent seeding failure would make
+   *  the assertions below pass vacuously. */
+  async function seedChats(): Promise<void> {
+    for (const id of [FIRST, MIDDLE, LAST]) {
+      await messageCache.saveMessages(
+        Array.from({ length: PER }, (_, i) =>
+          createMockMessage(id, { id: `${id}-${i}`, timestamp: new Date(BASE + i * 60_000) })
+        )
+      )
+    }
+    for (const id of [FIRST, MIDDLE, LAST]) {
+      expect(await messageCache.getMessageCount(id)).toBe(PER)
+    }
+  }
+
+  async function seedRooms(): Promise<void> {
+    for (const jid of [FIRST, MIDDLE, LAST]) {
+      await messageCache.saveRoomMessages(
+        Array.from({ length: PER }, (_, i) =>
+          createMockRoomMessage(jid, { id: `${jid}-${i}`, timestamp: new Date(BASE + i * 60_000) })
+        )
+      )
+    }
+    for (const jid of [FIRST, MIDDLE, LAST]) {
+      expect(await messageCache.getRoomMessageCount(jid)).toBe(PER)
+    }
+  }
+
+  it('scopes an `after`-only read to the conversation', async () => {
+    await seedChats()
+
+    // The uncapped tail read `getMessagesAround` issues — so the read
+    // `activateConversation` issues whenever the read pointer sits below the
+    // latest-100 slice. FIRST sorts before every other conversation, so an
+    // unscoped lowerBound walk crosses all 400 of their rows.
+    ranges = []
+    const tail = await messageCache.getMessages(FIRST, {
+      after: new Date(BASE + ANCHOR * 60_000),
+    })
+
+    expect(tail).toHaveLength(PER - ANCHOR - 1)
+    expect(tail.every((m) => m.conversationId === FIRST)).toBe(true)
+    expectScopedTo(ranges[0], FIRST)
+  })
+
+  it('scopes a `before`-limited read to the conversation', async () => {
+    await seedChats()
+
+    // A limit the conversation cannot fill: only 10 rows sit at or before the
+    // cutoff, so the walk never satisfies `results.length < limit` and — with an
+    // unscoped upperBound — keeps descending through the 400 earlier-sorting rows.
+    ranges = []
+    const head = await messageCache.getMessages(LAST, {
+      before: new Date(BASE + 10 * 60_000),
+      limit: 51,
+    })
+
+    expect(head).toHaveLength(10)
+    expect(head.every((m) => m.conversationId === LAST)).toBe(true)
+    expectScopedTo(ranges[0], LAST)
+  })
+
+  it('scopes room reads the same way (room_timestamp is compound too)', async () => {
+    await seedRooms()
+
+    ranges = []
+    const tail = await messageCache.getRoomMessages(FIRST, {
+      after: new Date(BASE + ANCHOR * 60_000),
+    })
+    expect(tail).toHaveLength(PER - ANCHOR - 1)
+    expect(tail.every((m) => m.roomJid === FIRST)).toBe(true)
+    expectScopedTo(ranges[0], FIRST)
+
+    ranges = []
+    const head = await messageCache.getRoomMessages(LAST, {
+      before: new Date(BASE + 10 * 60_000),
+      limit: 51,
+    })
+    expect(head).toHaveLength(10)
+    expect(head.every((m) => m.roomJid === LAST)).toBe(true)
+    expectScopedTo(ranges[0], LAST)
+  })
+
+  it('leaves the already-scoped read shapes alone', async () => {
+    await seedChats()
+
+    ranges = []
+    await messageCache.getMessages(FIRST, { limit: 100, latest: true })
+    expectScopedTo(ranges[0], FIRST)
+
+    ranges = []
+    await messageCache.getMessages(FIRST, {
+      after: new Date(BASE),
+      before: new Date(BASE + 10 * 60_000),
+    })
+    expectScopedTo(ranges[0], FIRST)
+  })
+})

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -643,6 +643,35 @@ export interface GetMessagesOptions {
 }
 
 /**
+ * Key range over a `[entityId, timestamp]` compound index, pinned to one entity.
+ *
+ * BOTH ends must name the entity. A half-open range (`upperBound([id, t])` /
+ * `lowerBound([id, t])`) bounds only the timestamp: everything belonging to
+ * entities sorting before (resp. after) `id` is still inside it. The read loops
+ * skip foreign rows but cannot STOP on them — `results.length < limit` never
+ * trips once the walk has left the entity, and an unlimited read has no stop
+ * condition at all — so the cursor walks the rest of the store, one awaited
+ * `continue()` per row. On the activation path (`getMessagesAround` issues one
+ * range of each shape) that turns a ~150-row read into a full-archive scan.
+ *
+ * Bounds carry the caller's exclusivity: `before` is an exclusive upper bound,
+ * `after` an exclusive lower bound. The open end takes the same 0 /
+ * MAX_SAFE_INTEGER sentinels the unfiltered range already uses.
+ */
+function entityTimestampRange(
+  entityId: string,
+  before?: Date,
+  after?: Date
+): IDBKeyRange {
+  return IDBKeyRange.bound(
+    [entityId, after ? after.getTime() : 0],
+    [entityId, before ? before.getTime() : Number.MAX_SAFE_INTEGER],
+    !!after, // exclude the lower bound only when the caller gave one
+    !!before // ...same for the upper
+  )
+}
+
+/**
  * Get messages for a conversation with optional pagination.
  * Messages are returned in chronological order (oldest first).
  */
@@ -658,26 +687,9 @@ export async function getMessages(
     const tx = db.transaction(MESSAGES_STORE, 'readonly')
     const index = tx.store.index('conv_timestamp')
 
-    // Build key range based on options
-    let range: IDBKeyRange | undefined
-    if (before && after) {
-      range = IDBKeyRange.bound(
-        [conversationId, after.getTime()],
-        [conversationId, before.getTime()],
-        true, // exclude lower bound
-        true // exclude upper bound
-      )
-    } else if (before) {
-      range = IDBKeyRange.upperBound([conversationId, before.getTime()], true)
-    } else if (after) {
-      range = IDBKeyRange.lowerBound([conversationId, after.getTime()], true)
-    } else {
-      // All messages for this conversation
-      range = IDBKeyRange.bound(
-        [conversationId, 0],
-        [conversationId, Number.MAX_SAFE_INTEGER]
-      )
-    }
+    // Key range: always pinned to this conversation at BOTH ends, whichever
+    // subset of before/after the caller gave (see entityTimestampRange).
+    const range = entityTimestampRange(conversationId, before, after)
 
     const results: Message[] = []
 
@@ -1068,22 +1080,8 @@ export async function getRoomMessages(
     const tx = db.transaction(ROOM_MESSAGES_STORE, 'readonly')
     const index = tx.store.index('room_timestamp')
 
-    // Build key range
-    let range: IDBKeyRange | undefined
-    if (before && after) {
-      range = IDBKeyRange.bound(
-        [roomJid, after.getTime()],
-        [roomJid, before.getTime()],
-        true,
-        true
-      )
-    } else if (before) {
-      range = IDBKeyRange.upperBound([roomJid, before.getTime()], true)
-    } else if (after) {
-      range = IDBKeyRange.lowerBound([roomJid, after.getTime()], true)
-    } else {
-      range = IDBKeyRange.bound([roomJid, 0], [roomJid, Number.MAX_SAFE_INTEGER])
-    }
+    // Key range: pinned to this room at both ends (see entityTimestampRange).
+    const range = entityTimestampRange(roomJid, before, after)
 
     const results: RoomMessage[] = []
 


### PR DESCRIPTION
On mobile, tapping a conversation was unresponsive for several seconds after launching the client following a long absence.

`conv_timestamp` / `room_timestamp` are compound indexes keyed `[entityId, timestamp]`. `getMessages` / `getRoomMessages` built half-open ranges (`upperBound` / `lowerBound`) over them, which bound only the timestamp — every row of every entity sorting before (resp. after) the id stays inside the range. The read loops skip foreign rows but cannot *stop* on them (`results.length < limit` never trips once the walk has left the entity, and an unlimited read has no stop condition), so the cursor walked the rest of the archive, one awaited `cursor.continue()` per row.

That lands on the activation path: when the read pointer sits below the latest-100 slice — exactly the "not launched for a while" case — `activateConversation` calls `getMessagesAround`, which issues one range of each broken shape. With 2400 rows across 12 conversations, returning 150 messages cost 2350 cursor steps / 3.2s; it now costs 150 steps / 16ms. The old cost scaled with total archive size rather than rows returned, so it grew with everything the catch-up wrote.

Both ends of the range are now pinned to the entity via a shared `entityTimestampRange` helper, preserving each caller's exclusivity.

The returned rows were correct either way (the loops filter foreign rows), so row assertions cannot catch this — the tests assert on the key range handed to `openCursor`, with a control case for the already-scoped shapes.

Two adjacent findings measured but left out of scope: `hasActiveContent` ignores `activationPending`, so mobile taps have no loading state; and `chatStore`'s `persist` adapter re-serializes every conversation synchronously on every `set()`.