### PR TITLE
fix(mobile): swap the pane as soon as a hydrating activation starts

### DIFF
--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -17,17 +17,36 @@ const {
   lastKeyboardShortcutsOptions,
   getMockState,
   setMockState,
+  subscribeMockState,
+  getMockStateVersion,
 } = vi.hoisted(() => {
   const state = {
     activeConversationId: null as string | null,
     activeRoomJid: null as string | null,
-    activationPending: false,
+    // Kept per store: ChatLayout ORs chatStore.activationPending with the
+    // roomStore one, so a single shared field could not tell which store drove
+    // the pane swap — and the room half would stay unfalsifiable.
+    chatActivationPending: false,
+    roomActivationPending: false,
     isArchivedResult: false,
     conversations: new Map<string, { id: string }>(),
     rooms: new Map<string, { jid: string; joined: boolean }>(),
     adminCategory: null as string | null,
     adminSession: null as unknown,
     adminIsAdmin: false,
+  }
+
+  // Minimal reactivity for the store mocks below (they subscribe through
+  // useSyncExternalStore). A store write that happens mid-flow — an effect
+  // flipping activationPending, a hydrating activation resolving — must
+  // re-render ChatLayout the way the real Zustand stores would. Without it an
+  // assertion made after the tap would silently read the pre-tap frame.
+  let version = 0
+  const listeners = new Set<() => void>()
+  const setMockState = (newState: Partial<typeof state>) => {
+    Object.assign(state, newState)
+    version += 1
+    for (const listener of listeners) listener()
   }
 
   const mockContact: Contact = {
@@ -38,20 +57,20 @@ const {
   }
 
   const mockSetActiveConversation = vi.fn((id: string | null) => {
-    state.activeConversationId = id
+    setMockState({ activeConversationId: id })
   })
 
   const mockSetActiveRoom = vi.fn((jid: string | null) => {
-    state.activeRoomJid = jid
+    setMockState({ activeRoomJid: jid })
   })
 
   // Hydrating activation actions (load message cache, then set active)
   const mockActivateConversation = vi.fn(async (id: string | null) => {
-    state.activeConversationId = id
+    setMockState({ activeConversationId: id })
   })
 
   const mockActivateRoom = vi.fn(async (jid: string | null) => {
-    state.activeRoomJid = jid
+    setMockState({ activeRoomJid: jid })
   })
 
   const mockMarkChatReadToNewest = vi.fn()
@@ -72,7 +91,14 @@ const {
     mockMarkRoomReadToNewest,
     lastKeyboardShortcutsOptions,
     getMockState: () => state,
-    setMockState: (newState: Partial<typeof state>) => Object.assign(state, newState),
+    setMockState,
+    subscribeMockState: (listener: () => void) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    getMockStateVersion: () => version,
   }
 })
 
@@ -270,7 +296,12 @@ vi.mock('@fluux/sdk', () => ({
 }))
 
 // Mock React store hooks (from @fluux/sdk/react)
-vi.mock('@fluux/sdk/react', () => ({
+vi.mock('@fluux/sdk/react', async () => {
+  const { useSyncExternalStore } = await import('react')
+  // Subscribe the mock store hooks to setMockState so a store write commits a
+  // re-render, like the real Zustand subscriptions do.
+  const useMockStoreSubscription = () => useSyncExternalStore(subscribeMockState, getMockStateVersion)
+  return {
   useChatStore: Object.assign(
     (selector: (state: {
       activeConversationId: string | null;
@@ -283,9 +314,10 @@ vi.mock('@fluux/sdk/react', () => ({
       updateConversationName: ReturnType<typeof vi.fn>;
       conversations: Map<string, unknown>;
     }) => unknown) => {
+      useMockStoreSubscription()
       const state = {
         activeConversationId: getMockState().activeConversationId,
-        activationPending: getMockState().activationPending,
+        activationPending: getMockState().chatActivationPending,
         setActiveConversation: mockSetActiveConversation,
         activateConversation: mockActivateConversation,
         addConversation: vi.fn(),
@@ -307,9 +339,11 @@ vi.mock('@fluux/sdk/react', () => ({
     }
   ),
   useRoomStore: Object.assign(
-    (selector: (state: { activeRoomJid: string | null; setActiveRoom: typeof mockSetActiveRoom; activateRoom: typeof mockActivateRoom; rooms: Map<string, unknown> }) => unknown) => {
+    (selector: (state: { activeRoomJid: string | null; activationPending: boolean; setActiveRoom: typeof mockSetActiveRoom; activateRoom: typeof mockActivateRoom; rooms: Map<string, unknown> }) => unknown) => {
+      useMockStoreSubscription()
       const state = {
         activeRoomJid: getMockState().activeRoomJid,
+        activationPending: getMockState().roomActivationPending,
         setActiveRoom: mockSetActiveRoom,
         activateRoom: mockActivateRoom,
         rooms: getMockState().rooms,
@@ -374,7 +408,8 @@ vi.mock('@fluux/sdk/react', () => ({
   useSearchStore: (selector: (state: { previewResult: null }) => unknown) => {
     return selector({ previewResult: null })
   },
-}))
+  }
+})
 
 // Mock app hooks
 vi.mock('@/hooks/useNotificationBadge', () => ({
@@ -1280,13 +1315,14 @@ describe('ChatLayout - activation gap (no empty-state flash)', () => {
     setMockState({
       activeConversationId: null,
       activeRoomJid: null,
-      activationPending: false,
+      chatActivationPending: false,
+      roomActivationPending: false,
       isArchivedResult: false,
     })
   })
 
   afterEach(() => {
-    setMockState({ activationPending: false })
+    setMockState({ chatActivationPending: false, roomActivationPending: false })
   })
 
   // Regression for the empty-screen flash on rail tab switch: while a hydrating
@@ -1294,17 +1330,135 @@ describe('ChatLayout - activation gap (no empty-state flash)', () => {
   // ids are null, so the render cascade would otherwise fall through to the
   // empty-state hero. It must hold a neutral surface instead.
   it('does not flash the empty-state hero while an activation is pending', () => {
-    setMockState({ activationPending: true })
+    setMockState({ chatActivationPending: true })
     render(<ChatLayoutWithRouter initialRoute="/messages" />)
 
     expect(screen.queryByText('Start a conversation')).toBeNull()
   })
 
   it('shows the empty-state hero once no activation is pending', () => {
-    setMockState({ activationPending: false })
+    setMockState({ chatActivationPending: false })
     render(<ChatLayoutWithRouter initialRoute="/messages" />)
 
     expect(screen.getByText('Start a conversation')).toBeInTheDocument()
+  })
+})
+
+// The mobile layout is a single pane: the sidebar column and the main pane swap
+// via `hidden md:flex` / `flex`, driven by hasActiveContent. A hydrating
+// activation sets the active id only AFTER the IndexedDB read resolves, so the
+// swap must be gated on the pending flag too — otherwise a tap on a
+// conversation row is dead on screen until the cache answers.
+describe('ChatLayout - mobile pane swap during a hydrating activation', () => {
+  /** The sidebar column and main pane, as the mobile single-pane swap sees them. */
+  const panes = () => ({
+    sidebar: screen.getByTestId('sidebar-pane'),
+    main: screen.getByRole('main'),
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setMockState({
+      activeConversationId: null,
+      activeRoomJid: null,
+      chatActivationPending: false,
+      roomActivationPending: false,
+      isArchivedResult: false,
+      conversations: new Map(),
+      rooms: new Map(),
+    })
+  })
+
+  afterEach(() => {
+    setMockState({ chatActivationPending: false, roomActivationPending: false })
+  })
+
+  it('hides the sidebar and shows the hydration surface before the tapped conversation resolves', async () => {
+    // Stand in for a slow cache read: flag the hydration window synchronously
+    // (as activateConversation does), then hold the active id back until the
+    // test releases it. This is the window the tap has to feel responsive in.
+    let releaseCacheRead: (() => void) | undefined
+    const cacheRead = new Promise<void>((resolve) => {
+      releaseCacheRead = resolve
+    })
+    mockActivateConversation.mockImplementationOnce(async (id: string | null) => {
+      setMockState({ chatActivationPending: true })
+      await cacheRead
+      setMockState({ activeConversationId: id, chatActivationPending: false })
+    })
+
+    render(<ChatLayoutWithRouter initialRoute="/messages" />)
+    // Sanity: nothing active yet, so mobile is showing the list.
+    expect(panes().sidebar).not.toHaveClass('hidden')
+
+    // Tap a conversation row (URL → store sync activates it).
+    fireEvent.click(screen.getByTestId('deep-conversation-link'))
+
+    await waitFor(() => {
+      expect(mockActivateConversation).toHaveBeenCalledWith('bob@example.com')
+    })
+
+    // Mid-flight: the activation has NOT resolved...
+    expect(getMockState().activeConversationId).toBeNull()
+    expect(screen.queryByTestId('chat-view')).not.toBeInTheDocument()
+    // ...yet the pane has already swapped and holds the neutral surface.
+    expect(panes().sidebar).toHaveClass('hidden')
+    expect(panes().main).not.toHaveClass('hidden')
+    expect(screen.getByTestId('view-loading-fallback')).toBeInTheDocument()
+    expect(screen.queryByText('Start a conversation')).toBeNull()
+
+    // Cache read resolves: straight from the surface to the conversation, and
+    // the pane stays swapped (no frame where the sidebar comes back).
+    releaseCacheRead?.()
+    expect(await screen.findByTestId('chat-view')).toBeInTheDocument()
+    expect(screen.queryByTestId('view-loading-fallback')).not.toBeInTheDocument()
+    expect(panes().sidebar).toHaveClass('hidden')
+  })
+
+  // Control for the assertions above: at the same point in the flow, with
+  // nothing pending, the sidebar keeps the screen. Without this a gate stuck at
+  // `true` would pass the test above.
+  it('keeps the sidebar when the tapped conversation never enters a pending window', async () => {
+    mockActivateConversation.mockImplementationOnce(async () => {
+      // No pending flag, no active id: the activation is a no-op.
+    })
+
+    render(<ChatLayoutWithRouter initialRoute="/messages" />)
+    fireEvent.click(screen.getByTestId('deep-conversation-link'))
+
+    await waitFor(() => {
+      expect(mockActivateConversation).toHaveBeenCalledWith('bob@example.com')
+    })
+
+    expect(panes().sidebar).not.toHaveClass('hidden')
+    expect(panes().main).toHaveClass('hidden')
+    expect(screen.queryByTestId('view-loading-fallback')).not.toBeInTheDocument()
+    expect(screen.getByText('Start a conversation')).toBeInTheDocument()
+  })
+
+  // Parity: ChatLayout ORs both stores' pending flags, so a room tap must swap
+  // the pane the same way a conversation tap does.
+  it('hides the sidebar while a room activation is pending', () => {
+    setMockState({ roomActivationPending: true })
+    render(<ChatLayoutWithRouter initialRoute="/rooms" />)
+
+    expect(panes().sidebar).toHaveClass('hidden')
+    expect(panes().main).not.toHaveClass('hidden')
+    expect(screen.getByTestId('view-loading-fallback')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /create a room/i })).not.toBeInTheDocument()
+  })
+
+  // The settings branch sits ABOVE the neutral surface in the render cascade,
+  // so counting a pending activation as content there would hand the mobile
+  // screen to a category-less SettingsView — the one view that deliberately
+  // lets the user pick from the sidebar first. Reachable by tapping Settings
+  // while a slow cache read is still in flight.
+  it('leaves the settings sidebar visible while an unrelated activation is pending', () => {
+    setMockState({ chatActivationPending: true })
+    render(<ChatLayoutWithRouter initialRoute="/settings" />)
+
+    expect(panes().sidebar).not.toHaveClass('hidden')
+    expect(panes().main).toHaveClass('hidden')
   })
 })
 
@@ -1314,7 +1468,8 @@ describe('ChatLayout - admin back navigation (mobile)', () => {
     setMockState({
       activeConversationId: null,
       activeRoomJid: null,
-      activationPending: false,
+      chatActivationPending: false,
+      roomActivationPending: false,
       isArchivedResult: false,
       conversations: new Map(),
       rooms: new Map(),
@@ -1371,7 +1526,8 @@ describe('ChatLayout - Escape marks the active conversation read (spec §3)', ()
     setMockState({
       activeConversationId: null,
       activeRoomJid: null,
-      activationPending: false,
+      chatActivationPending: false,
+      roomActivationPending: false,
       isArchivedResult: false,
       conversations: new Map(),
       rooms: new Map(),

--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -1448,6 +1448,35 @@ describe('ChatLayout - mobile pane swap during a hydrating activation', () => {
     expect(screen.queryByRole('button', { name: /create a room/i })).not.toBeInTheDocument()
   })
 
+  // Pending state belongs to the tab that owns the store. A chat activation in
+  // flight says nothing about the rooms list, so it must not blank it — the user
+  // tapped the Rooms rail and is owed the rooms list, not a skeleton. Same the
+  // other way round, and on the tabs that own neither store.
+  it.each([
+    ['/rooms', 'chatActivationPending', /create a room/i],
+    ['/messages', 'roomActivationPending', /start a conversation/i],
+  ] as const)('keeps the sidebar on %s while the other store has a pending activation', (route, pendingFlag, visibleAction) => {
+    setMockState({ [pendingFlag]: true })
+    render(<ChatLayoutWithRouter initialRoute={route} />)
+
+    expect(panes().sidebar).not.toHaveClass('hidden')
+    expect(panes().main).toHaveClass('hidden')
+    expect(screen.queryByTestId('view-loading-fallback')).not.toBeInTheDocument()
+    expect(screen.getByText(visibleAction)).toBeInTheDocument()
+  })
+
+  // Contacts and Search own neither activation store: a pending chat read is
+  // unrelated to what those tabs are showing, and neither has main-pane content
+  // of its own until the user picks something.
+  it.each(['/contacts', '/search'] as const)('keeps the sidebar on %s while a chat activation is pending', (route) => {
+    setMockState({ chatActivationPending: true })
+    render(<ChatLayoutWithRouter initialRoute={route} />)
+
+    expect(panes().sidebar).not.toHaveClass('hidden')
+    expect(panes().main).toHaveClass('hidden')
+    expect(screen.queryByTestId('view-loading-fallback')).not.toBeInTheDocument()
+  })
+
   // The settings branch sits ABOVE the neutral surface in the render cascade,
   // so counting a pending activation as content there would hand the mobile
   // screen to a category-less SettingsView — the one view that deliberately

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -111,7 +111,7 @@ function GlobalEffects() {
 /** Lightweight skeleton fallback for lazy-loaded views to prevent layout shift */
 function ViewLoadingFallback() {
   return (
-    <div className="h-full flex flex-col bg-fluux-chat">
+    <div className="h-full flex flex-col bg-fluux-chat" data-testid="view-loading-fallback">
       <div className="h-12 px-4 flex items-center border-b border-fluux-bg" />
       <div className="flex-1" />
     </div>
@@ -599,7 +599,16 @@ function ChatLayoutContent() {
   const adminHasMainContent = sidebarView === 'admin' && (adminSession || adminCategory === 'users' || adminCategory === 'rooms' || adminCategory === 'stats')
   // Settings: only show content when a category is explicitly selected (on mobile, let user choose from sidebar first)
   const settingsHasContent = sidebarView === 'settings' && !!settingsCategory
-  const hasActiveContent = !!(activeConversationId || activeRoomJid || selectedContact || adminHasMainContent || settingsHasContent || searchPreviewResult || previewJid)
+  // A hydrating activation counts as main-pane content: the active id lands only
+  // once the cache read resolves, so without this the mobile single-pane swap
+  // waits on IndexedDB and the tap on a conversation/room row looks dead. Same
+  // flag drives the neutral surface in the render cascade below, so the pane that
+  // opens is the one that holds it. Excluded on the settings/admin tabs: their
+  // branches sit above that surface in the cascade, so a pending activation there
+  // would hand the screen to a category-less view the user never selected — and
+  // those views intentionally let mobile pick from the sidebar first.
+  const activationHoldsMainPane = activationPending && sidebarView !== 'settings' && sidebarView !== 'admin'
+  const hasActiveContent = !!(activeConversationId || activeRoomJid || selectedContact || adminHasMainContent || settingsHasContent || searchPreviewResult || previewJid || activationHoldsMainPane)
 
   // Toggle shortcut help overlay
   const toggleShortcutHelp = () => {
@@ -947,7 +956,7 @@ function ChatLayoutContent() {
       <div className="flex flex-1 min-h-0">
         {/* Left Sidebar - Conversations */}
         {/* Hidden on mobile when conversation or room is active, full width on mobile */}
-        <div className={`${hasActiveContent ? 'hidden md:flex' : 'flex'} w-full md:w-auto`}>
+        <div className={`${hasActiveContent ? 'hidden md:flex' : 'flex'} w-full md:w-auto`} data-testid="sidebar-pane">
           <Sidebar
             onSelectContact={handleSelectContact}
             onStartChat={handleStartConversation}
@@ -1008,10 +1017,11 @@ function ChatLayoutContent() {
             <Suspense fallback={<ViewLoadingFallback />}>
               <SearchContextView onBack={() => searchStore.getState().setPreviewResult(null)} />
             </Suspense>
-          ) : activationPending ? (
+          ) : activationHoldsMainPane ? (
             // A hydrating activation is in flight (cache load before the active id
             // lands). Hold the neutral loading surface — matching the lazy views
             // above — so switching content tabs doesn't flash the empty-state hero.
+            // This is the surface the mobile pane swap above opens onto.
             <ViewLoadingFallback />
           ) : (
             <EmptyState

--- a/apps/fluux/src/components/ChatLayout.tsx
+++ b/apps/fluux/src/components/ChatLayout.tsx
@@ -202,11 +202,12 @@ function ChatLayoutContent() {
   const setActiveRoom = useRoomStore((s) => s.setActiveRoom)
   const activateRoom = useRoomStore((s) => s.activateRoom)
   // True while a hydrating activation is in flight (cache read before the active
-  // id lands). During this gap both active ids are null, so without it the main
-  // pane would flash the empty-state hero on every content-tab switch.
+  // id lands). During this gap the store's active id is still null, so without it
+  // the main pane would flash the empty-state hero on every content-tab switch.
+  // Kept per store, never ORed: each flag only describes the tab that owns it
+  // (see activationHoldsMainPane below).
   const chatActivationPending = useChatStore((s) => s.activationPending)
   const roomActivationPending = useRoomStore((s) => s.activationPending)
-  const activationPending = chatActivationPending || roomActivationPending
   const searchPreviewResult = useSearchStore((s) => s.previewResult)
   // Read-only message-request preview (transient; set by the Message-requests banner).
   const previewJid = useMessageRequestPreviewStore((s) => s.previewJid)
@@ -601,13 +602,16 @@ function ChatLayoutContent() {
   const settingsHasContent = sidebarView === 'settings' && !!settingsCategory
   // A hydrating activation counts as main-pane content: the active id lands only
   // once the cache read resolves, so without this the mobile single-pane swap
-  // waits on IndexedDB and the tap on a conversation/room row looks dead. Same
+  // waits on IndexedDB and the tap on a conversation/room row looks dead. The same
   // flag drives the neutral surface in the render cascade below, so the pane that
-  // opens is the one that holds it. Excluded on the settings/admin tabs: their
-  // branches sit above that surface in the cascade, so a pending activation there
-  // would hand the screen to a category-less view the user never selected — and
-  // those views intentionally let mobile pick from the sidebar first.
-  const activationHoldsMainPane = activationPending && sidebarView !== 'settings' && sidebarView !== 'admin'
+  // opens is the one that holds it.
+  // Scoped to the tab that OWNS the pending store: a chat read in flight says
+  // nothing about the rooms list, and counting it anywhere else would blank a
+  // sidebar the user just asked for (Rooms/Contacts/Search), or hand the screen
+  // to a category-less Settings/Admin view they never selected.
+  const activationHoldsMainPane =
+    (sidebarView === 'messages' && chatActivationPending) ||
+    (sidebarView === 'rooms' && roomActivationPending)
   const hasActiveContent = !!(activeConversationId || activeRoomJid || selectedContact || adminHasMainContent || settingsHasContent || searchPreviewResult || previewJid || activationHoldsMainPane)
 
   // Toggle shortcut help overlay


### PR DESCRIPTION
On a small screen the sidebar and main pane swap based on `hasActiveContent`, which was gated on the active conversation/room id. But `activateConversation`/`activateRoom` set that id only *after* awaiting the IndexedDB read — until then the id is still null, so a tap on a conversation or room row produced no visible feedback. The stores already set `activationPending` synchronously for exactly this reason; the layout just never read it.

`entityTimestampRange` cut those reads to ~16ms, so this isn't user-visible today — but with no loading state in the layout, any future slow read reappears as a dead tap.

One `activationHoldsMainPane` flag now drives both the pane swap and the neutral hydration surface, so the pane that opens is the one holding that surface. It is scoped to the tab that owns the pending store:

```ts
const activationHoldsMainPane =
  (sidebarView === 'messages' && chatActivationPending) ||
  (sidebarView === 'rooms' && roomActivationPending)
```

A chat read in flight says nothing about the rooms list, so counting either flag on a tab that doesn't own it would blank a sidebar the user just asked for (Rooms/Contacts/Search) or hand the screen to a category-less Settings/Admin view they never selected.

Two test-mock fixes were prerequisites, both of which would have left the new tests unable to fail:

- the `useChatStore`/`useRoomStore` mocks read a plain object with no subscription, so a store write from inside an effect committed no re-render — a mid-flight assertion would have re-read the pre-tap frame. They now subscribe via `useSyncExternalStore`.
- the room-store mock never exposed `activationPending`, so `roomActivationPending` was `undefined` in every test. Split into separate `chatActivationPending` / `roomActivationPending` fields.