### PR TITLE
Migrate live-edge positioning to the controller

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  *
- * pinVirtualizedBottom cost-control behavior (the WebKitGTK freeze fixes):
+ * Live-edge executor cost-control behavior (the WebKitGTK freeze fixes):
  *
  * 1. CONVERGENCE EARLY-EXIT — the ~60-frame re-assert loop must stop once the
  *    geometry has been stable for a few consecutive frames instead of always
@@ -59,7 +59,7 @@ function makeMessages(count: number, prefix = 'msg'): BaseMessage[] {
   }))
 }
 
-describe('MessageList — pinVirtualizedBottom cost control', () => {
+describe('MessageList — live-edge executor cost control', () => {
   let realRaf: typeof requestAnimationFrame
   let rafQueue: FrameRequestCallback[]
   const flush = (frames: number) => { for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0)) }
@@ -211,8 +211,8 @@ describe('MessageList — pinVirtualizedBottom cost control', () => {
     const scroller = document.querySelector('[data-message-list]') as HTMLElement
 
     // Reproduce the reported state faithfully: the user has scrolled UP into history, but the
-    // follow flag is still latched `true`. That latch is the real bug — pinVirtualizedBottom's
-    // user-intent bail calls finish() WITHOUT re-deriving isAtBottomRef from geometry, so after a
+    // follow flag is still latched `true`. That latch was the real bug — the former pin loop's
+    // user-intent bail called finish() WITHOUT re-deriving isAtBottomRef from geometry, so after a
     // wheel-up mid-pin the flag stays true. With the old code (typing indicator inside the scroll
     // content, typingUsersCount driving the re-pin effect) each XEP-0085 composing/paused toggle
     // then re-pinned and hauled the viewport back to the bottom. The typing indicator now floats

--- a/apps/fluux/src/components/conversation/MessageList.pinBottomRepaint.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomRepaint.test.tsx
@@ -10,10 +10,10 @@
  * looked stranded, and toggling `overflow` (a forced reflow) made the already-correctly-positioned
  * message appear without any scroll.
  *
- * The fix: pinVirtualizedBottom calls forceRepaint() after every programmatic scroll — it toggles the
- * scroller's overflow (`hidden` → reflow via offsetHeight → restore). This test asserts the pin issues
- * that repaint after a send. jsdom has no compositor, so we can't observe the paint itself; instead we
- * count the forced-reflow reads of `offsetHeight`, which only forceRepaint performs on this path.
+ * The fix: the live-edge executor calls forceRepaint() after every programmatic scroll — it toggles
+ * the scroller's overflow (`hidden` → reflow via offsetHeight → restore). This test asserts the pin
+ * issues that repaint after a send. jsdom has no compositor, so we can't observe the paint itself;
+ * instead we count the forced-reflow reads of `offsetHeight`, which only forceRepaint performs here.
  */
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'

--- a/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
@@ -4,7 +4,8 @@
  * Single-flight invariant for the message-list rAF scroll re-assert loops.
  *
  * The list keeps the virtualized view pinned by re-asserting a scroll target across ~1s of
- * frames (`pinVirtualizedBottom` → bottom; the MAM-prepend `runMeasureAssert` → a history
+ * frames (the controller-owned live-edge executor → bottom; the MAM-prepend
+ * `runMeasureAssert` → a history
  * anchor). When two of these run at once they fight over scrollTop — the `[ScrollReassertLoop]`
  * overlap the reassert monitor warns about, observed in the wild as `(pin-bottom, pin-bottom)`.
  * pin-bottom was made single-flight against itself; this suite pins the FULL invariant: across
@@ -172,7 +173,7 @@ describe('MessageList — re-assert loops are single-flight (at most one active)
     flush(2) // prepend loop in-flight
 
     // A SENT (outgoing) message arrives while the prepend loop is still running -> the outgoing
-    // path forces a scroll-to-bottom (pinVirtualizedBottom). pin-bottom and prepend target
+    // path forces a controller-owned scroll-to-bottom. pin-bottom and prepend target
     // opposite positions, so they must not coexist.
     const sent: BaseMessage = {
       id: 'sent-1', from: 'me@example.com', body: 'my reply',

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -409,12 +409,14 @@ describe('MessageList — virtualized scroll integration', () => {
       set: (v: number) => { scrollTopVal = v },
       configurable: true,
     })
+    // The authoritative live-edge entry first requests the global tail from this slid-up window.
+    expect(onLoadNewer).toHaveBeenCalledTimes(1)
 
     // Near the bottom (distFromBottom = 800-600-200 = 0): a scroll fires triggerLoadNewer, which
     // captures the top-visible anchor and calls onLoadNewer.
     scrollTopVal = 600
     fireEvent.scroll(scroller)
-    expect(onLoadNewer).toHaveBeenCalledTimes(1)
+    expect(onLoadNewer).toHaveBeenCalledTimes(2)
 
     scrollToOffsetCalls.length = 0
     getOffsetForMessageId.mockClear()
@@ -445,11 +447,13 @@ describe('MessageList — virtualized scroll integration', () => {
     Object.defineProperty(scroller, 'scrollHeight', { get: () => 800, configurable: true })
     Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
     Object.defineProperty(scroller, 'scrollTop', { get: () => scrollTopVal, set: (v: number) => { scrollTopVal = v }, configurable: true })
+    // Entry owns global-live-edge reachability and asks for a newer slice before user scrolling.
+    expect(onLoadNewer).toHaveBeenCalledTimes(1)
 
     // Load-newer fires near the bottom → stashes an anchor (no message change here = tail no-op).
     scrollTopVal = 600
     fireEvent.scroll(scroller)
-    expect(onLoadNewer).toHaveBeenCalledTimes(1)
+    expect(onLoadNewer).toHaveBeenCalledTimes(2)
 
     // Tail reached: windowAtLiveEdge flips false→true → the stale anchor must be dropped.
     rerender(<MessageList messages={makeMessages(20)} windowAtLiveEdge={true} {...base} />)
@@ -933,7 +937,7 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     // row is NOT in the DOM, so the DOM anchor lookup (restoreToAnchor) fails. The restore must then
     // resolve the anchor through the virtualizer INDEX (getIndexForMessageId → scrollToIndex),
     // re-deriving its position from measurements — it must NOT go blank or fall back to
-    // pinVirtualizedBottom() (which would clear the saved state and stick the convo at the bottom).
+    // live-edge fallback (which would clear the saved state and stick the convo at the bottom).
     const { container, rerender } = render(
       <MessageList messages={makeMessages(50)} conversationId="conv-vi1" {...props} />,
     )

--- a/apps/fluux/src/components/conversation/pinBottomRun.test.ts
+++ b/apps/fluux/src/components/conversation/pinBottomRun.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit tests for the pin-bottom run helper: per-run convergence tracking, forced-work
- * accounting for the [PinLoopProbe] fluux.log line, and the repaint gating policy.
+ * Unit tests for the pin-bottom run helper: timing/probe accounting for the
+ * [PinLoopProbe] fluux.log line, and the repaint gating policy.
  *
  * Pure logic — timestamps and storage are passed in, no DOM.
  */
@@ -10,31 +10,6 @@ import {
   shouldForceRepaint,
   readPinRepaintMode,
 } from './pinBottomRun'
-
-describe('createPinRunTracker — convergence', () => {
-  it('settles after the configured number of consecutive stable (non-write) frames', () => {
-    const run = createPinRunTracker({ settledFrames: 3 })
-    expect(run.frame(false)).toBe('continue')
-    expect(run.frame(false)).toBe('continue')
-    expect(run.frame(false)).toBe('settled')
-  })
-
-  it('a write frame resets the stable streak', () => {
-    const run = createPinRunTracker({ settledFrames: 3 })
-    expect(run.frame(false)).toBe('continue')
-    expect(run.frame(false)).toBe('continue')
-    expect(run.frame(true)).toBe('continue') // height moved → re-pinned → not stable
-    expect(run.frame(false)).toBe('continue')
-    expect(run.frame(false)).toBe('continue')
-    expect(run.frame(false)).toBe('settled')
-  })
-
-  it('defaults to 8 stable frames (matches the marker/restore stability precedent)', () => {
-    const run = createPinRunTracker()
-    for (let i = 0; i < 7; i++) expect(run.frame(false)).toBe('continue')
-    expect(run.frame(false)).toBe('settled')
-  })
-})
 
 describe('createPinRunTracker — forced-work accounting', () => {
   it('accumulates ms by kind and reports the total', () => {
@@ -47,7 +22,7 @@ describe('createPinRunTracker — forced-work accounting', () => {
   })
 
   it('summary line carries trigger, frame/write counts and rounded per-kind ms', () => {
-    const run = createPinRunTracker({ settledFrames: 4 })
+    const run = createPinRunTracker()
     run.frame(true)
     run.frame(true)
     run.frame(false)

--- a/apps/fluux/src/components/conversation/pinBottomRun.ts
+++ b/apps/fluux/src/components/conversation/pinBottomRun.ts
@@ -1,5 +1,5 @@
 /**
- * Per-run helpers for `pinVirtualizedBottom` (useMessageListScroll).
+ * Per-run browser-work helpers for the controller-owned live-edge executor.
  *
  * On WebKitGTK the pin's forced layouts (`flushTailLayout`) and forced repaints
  * (`forceRepaint`'s overflow toggle) are the dominant main-thread cost in busy

--- a/apps/fluux/src/components/conversation/pinBottomRun.ts
+++ b/apps/fluux/src/components/conversation/pinBottomRun.ts
@@ -4,22 +4,13 @@
  * On WebKitGTK the pin's forced layouts (`flushTailLayout`) and forced repaints
  * (`forceRepaint`'s overflow toggle) are the dominant main-thread cost in busy
  * rooms — RenderCostProbe shows layoutPaint 189–359ms with react as low as 2ms.
- * These helpers make the pin loop (a) converge and stop early instead of always
- * burning its full frame budget, (b) skip the full-scroller repaint when the pin
- * did not actually move scrollTop, and (c) attribute the remaining forced work in
- * fluux.log with a single `[PinLoopProbe]` line per costly run.
+ * These helpers (a) skip the full-scroller repaint when the pin did not actually
+ * move scrollTop and (b) attribute the remaining forced work in fluux.log with a
+ * single `[PinLoopProbe]` line per costly run. Convergence belongs exclusively to
+ * the positioning controller; this tracker is timing/probe-only.
  *
  * Pure logic — timestamps and storage are passed in, unit-testable.
  */
-
-/**
- * Consecutive stable (non-write) frames before a pin run is declared settled and
- * its rAF loop stops. Matches the marker/restore stability precedent
- * (MARKER_STABLE_FRAMES / RESTORE_STABLE_FRAMES = 8): flushTailLayout forces
- * WebKit's late row measurements through on every frame, so 8 frames with no
- * height change and the list at the bottom means layout has genuinely settled.
- */
-const PIN_SETTLED_FRAMES = 8
 
 /**
  * When to force the full-scroller repaint (the `overflowY` toggle) after a pin:
@@ -65,12 +56,8 @@ export function shouldForceRepaint(
 export type PinWorkKind = 'flush' | 'scroll' | 'repaint'
 
 export interface PinRunTracker {
-  /**
-   * Record one loop frame. `wrote` is true when the frame re-pinned (height
-   * moved or the list was measurably off the bottom). Returns 'settled' once
-   * the run has been stable for the configured number of consecutive frames.
-   */
-  frame(wrote: boolean): 'continue' | 'settled'
+  /** Record one observed frame and whether it re-pinned. Probe-only; never controls settlement. */
+  frame(wrote: boolean): void
   /** Accumulate forced-work time (ms) of one kind. */
   addMs(kind: PinWorkKind, ms: number): void
   /** Total forced-work ms across all kinds. */
@@ -79,27 +66,16 @@ export interface PinRunTracker {
   summaryLine(trigger: string): string
 }
 
-export function createPinRunTracker(
-  opts: { settledFrames?: number } = {}
-): PinRunTracker {
-  const settledFrames = opts.settledFrames ?? PIN_SETTLED_FRAMES
-
+export function createPinRunTracker(): PinRunTracker {
   let frames = 0
   let writes = 0
-  let stableStreak = 0
   const ms: Record<PinWorkKind, number> = { flush: 0, scroll: 0, repaint: 0 }
   const totalForcedMs = () => ms.flush + ms.scroll + ms.repaint
 
   return {
-    frame(wrote: boolean): 'continue' | 'settled' {
+    frame(wrote: boolean): void {
       frames++
-      if (wrote) {
-        writes++
-        stableStreak = 0
-        return 'continue'
-      }
-      stableStreak++
-      return stableStreak >= settledFrames ? 'settled' : 'continue'
+      if (wrote) writes++
     },
 
     addMs(kind: PinWorkKind, value: number): void {

--- a/apps/fluux/src/components/conversation/pinRepaintBurst.ts
+++ b/apps/fluux/src/components/conversation/pinRepaintBurst.ts
@@ -1,5 +1,5 @@
 /**
- * Cross-run burst coalescing for `pinVirtualizedBottom`'s forced repaint.
+ * Cross-run burst coalescing for the live-edge executor's forced repaint.
  *
  * WHY THIS EXISTS
  * ---------------
@@ -52,7 +52,7 @@ export interface PinBurstSummary {
 export interface PinRepaintBurst {
   /**
    * Record a content-arrival pin (new-message / content-growth / media-load /
-   * reaction / mam-catchup-complete). Call at the top of `pinVirtualizedBottom`
+   * reaction / mam-catchup-complete). Call when the live-edge executor begins
    * for those triggers — BEFORE it supersedes the running loop — so every arrival
    * is counted even though its run may be immediately replaced.
    */

--- a/apps/fluux/src/components/conversation/pinRepaintBurst.ts
+++ b/apps/fluux/src/components/conversation/pinRepaintBurst.ts
@@ -33,9 +33,9 @@
 /**
  * Two content-arrival pins landing within this window count as a burst; while a
  * burst is live, forced repaints are suppressed. Sized a touch above the pin
- * loop's settle time (8 frames ≈ 133ms) so that "arrival stopped long enough for
- * the loop to converge" reliably implies "burst window expired", letting the
- * convergence own the single trailing repaint.
+ * controller's live-edge settle time (8 frames ≈ 133ms) so that "arrival stopped
+ * long enough for the controller to converge" reliably implies "burst window
+ * expired", letting controller convergence own the single trailing repaint.
  */
 export const PIN_BURST_WINDOW_MS = 200
 
@@ -74,7 +74,7 @@ export interface PinRepaintBurst {
    * exhausted path right before forcing the one final repaint.
    */
   settle(): PinBurstSummary
-  /** Drop all burst state (conversation switch, user-scroll takeover). */
+  /** Drop all burst state and owed paint (conversation switch, supersession, user takeover). */
   reset(): void
 }
 

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -5,6 +5,10 @@ import {
   PositioningController,
   type ExplicitTargetExecutor,
   type ExplicitTargetFrameResult,
+  type LiveEdgeExecutor,
+  type LiveEdgeFrameResult,
+  type MediaPreservationExecutor,
+  type MediaPreservationFrameResult,
   type PositionExecutionLease,
   type PositionRequestDraft,
   type SavedPositionExecutionLease,
@@ -52,6 +56,23 @@ function liveReachability() {
     hasRows: true,
     windowAtLiveEdge: true,
   })
+}
+
+function inertLiveEdgeExecutor(
+  positionFrame: LiveEdgeExecutor['positionFrame'] = () => ({
+    kind: 'positioned',
+    scrollTop: 1000,
+    atLiveEdge: true,
+    wrote: true,
+    reassert: false,
+  }),
+): LiveEdgeExecutor {
+  return {
+    reachability: liveReachability,
+    beginLoop: () => null,
+    positionFrame,
+    complete: () => {},
+  }
 }
 
 function observeLiveEntry(controller: PositioningController, id = conversationId) {
@@ -133,30 +154,6 @@ describe('positioning controller shadow mode', () => {
     expect(staleIsAtBottomLatch).toBe(true)
     expect(geometry.distanceFromBottom).toBe(600)
     expect(deriveAtLiveEdge(geometry, AT_BOTTOM_THRESHOLD)).toBe(false)
-  })
-
-  it('flags a legacy bottom reassert when neither the request nor live geometry owns it', () => {
-    const controller = new PositioningController()
-    const actualFollowsStaleLatch = controller.observeBottomReassert({
-      event: 'stale-latch',
-      conversationId,
-      geometryAtLiveEdge: false,
-      actualFollowsLive: true,
-    })
-
-    // A comparator that copied isAtBottomRef would accept this unsupported write.
-    expect(actualFollowsStaleLatch).toBe(false)
-    expect(getScrollShadowSnapshot().divergenceCount).toBe(1)
-
-    resetScrollShadowDiagnostics()
-    const measuredLiveEdge = controller.observeBottomReassert({
-      event: 'measured-live-edge',
-      conversationId,
-      geometryAtLiveEdge: true,
-      actualFollowsLive: true,
-    })
-    expect(measuredLiveEdge).toBe(true)
-    expect(getScrollShadowSnapshot().divergenceCount).toBe(0)
   })
 
   it('rejects request/fact mismatches instead of converting them to warn-and-stop', () => {
@@ -350,6 +347,250 @@ describe('positioning controller shadow mode', () => {
   })
 })
 
+describe('positioning controller live-edge ownership', () => {
+  function liveEdgeHarness(
+    reachability: ReachabilityFacts = liveReachability(),
+  ) {
+    const callbacks: Array<() => void> = []
+    const finish = vi.fn()
+    const recordFrame = vi.fn()
+    const complete = vi.fn()
+    const leases: PositionExecutionLease[] = []
+    let frameResult: LiveEdgeFrameResult = {
+      kind: 'positioned',
+      scrollTop: 1000,
+      atLiveEdge: true,
+      wrote: false,
+      reassert: true,
+    }
+    const positionFrame = vi.fn(() => frameResult)
+    const executor: LiveEdgeExecutor = {
+      reachability: () => reachability,
+      beginLoop: (lease) => {
+        leases.push(lease)
+        return {
+          schedule: (callback) => callbacks.push(callback),
+          recordFrame,
+          finish,
+        }
+      },
+      positionFrame,
+      complete,
+    }
+    return {
+      callbacks,
+      complete,
+      executor,
+      finish,
+      leases,
+      positionFrame,
+      recordFrame,
+      runFrame: () => {
+        const callback = callbacks.shift()
+        expect(callback).toBeDefined()
+        callback!()
+      },
+      setFrameResult: (result: LiveEdgeFrameResult) => {
+        frameResult = result
+      },
+    }
+  }
+
+  it('applies synchronously, then settles after exactly eight stable frames', () => {
+    const harness = liveEdgeHarness()
+    const controller = new PositioningController()
+    const request = controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })
+
+    expect(request).not.toBeNull()
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'position-applied',
+    })
+    for (let frame = 0; frame < 7; frame += 1) harness.runFrame()
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'position-applied',
+    })
+    harness.runFrame()
+
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+    expect(harness.recordFrame).toHaveBeenCalledTimes(8)
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.complete).toHaveBeenCalledWith(request, 'settled')
+  })
+
+  it('resets convergence when late measurement growth requires another pin', () => {
+    const harness = liveEdgeHarness()
+    const controller = new PositioningController()
+    controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })
+
+    for (let frame = 0; frame < 7; frame += 1) harness.runFrame()
+    harness.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 1200,
+      atLiveEdge: true,
+      wrote: true,
+      reassert: true,
+    })
+    harness.runFrame()
+    harness.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 1200,
+      atLiveEdge: true,
+      wrote: false,
+      reassert: true,
+    })
+    for (let frame = 0; frame < 7; frame += 1) harness.runFrame()
+    expect(controller.snapshot().active?.phase).not.toEqual({
+      kind: 'settled',
+    })
+    harness.runFrame()
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+  })
+
+  it('finishes best-effort after the exact 60-frame legacy budget', () => {
+    const harness = liveEdgeHarness()
+    harness.setFrameResult({
+      kind: 'positioned',
+      scrollTop: 1000,
+      atLiveEdge: false,
+      wrote: true,
+      reassert: true,
+    })
+    const controller = new PositioningController()
+    const request = controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })
+
+    for (let frame = 0; frame < 60; frame += 1) harness.runFrame()
+    expect(harness.positionFrame).toHaveBeenCalledTimes(61)
+    expect(harness.complete).not.toHaveBeenCalled()
+    harness.runFrame()
+    expect(harness.positionFrame).toHaveBeenCalledTimes(61)
+    expect(harness.complete).toHaveBeenCalledWith(request, 'best-effort')
+  })
+
+  it('restarts a content stimulus under the same generation and drops the stale frame', () => {
+    const first = liveEdgeHarness()
+    const second = liveEdgeHarness()
+    const controller = new PositioningController()
+    const request = controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: first.executor,
+    })!
+    const staleFrame = first.callbacks.shift()!
+
+    expect(controller.reconcileLiveEdge({
+      conversationId,
+      executor: second.executor,
+    })).toBe(true)
+    expect(controller.snapshot().active?.request.generation).toBe(
+      request.generation,
+    )
+    expect(first.complete).toHaveBeenCalledWith(request, 'restarted')
+    expect(second.positionFrame).toHaveBeenCalledTimes(1)
+
+    staleFrame()
+    expect(first.positionFrame).toHaveBeenCalledTimes(1)
+    expect(second.positionFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels immediately for user input and cannot be revived by a queued frame', () => {
+    const harness = liveEdgeHarness()
+    const controller = new PositioningController()
+    const request = controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: harness.executor,
+    })!
+    const staleFrame = harness.callbacks.shift()!
+
+    controller.observeUserInput(conversationId)
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'paused-user-input',
+    })
+    expect(harness.complete).toHaveBeenCalledWith(request, 'user-takeover')
+    staleFrame()
+    expect(harness.positionFrame).toHaveBeenCalledTimes(1)
+
+    controller.observeSettledUserGeometry({
+      conversationId,
+      atLiveEdge: false,
+    })
+    expect(controller.snapshot().active).toBeNull()
+  })
+
+  it('lets outgoing live edge supersede a controller-owned media anchor', () => {
+    const controller = new PositioningController()
+    controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: inertLiveEdgeExecutor(),
+    })
+    const callbacks: Array<() => void> = []
+    const mediaComplete = vi.fn()
+    const mediaPositionFrame = vi.fn(
+      (): MediaPreservationFrameResult => ({
+        kind: 'positioned',
+        scrollTop: 500,
+        reassert: true,
+      }),
+    )
+    const mediaExecutor: MediaPreservationExecutor = {
+      reachability: () => ({
+        kind: 'available',
+        index: 5,
+        mounted: true,
+        placement: 'viable',
+      }),
+      beginLoop: () => ({
+        schedule: (callback) => callbacks.push(callback),
+        recordFrame: vi.fn(),
+        finish: vi.fn(),
+      }),
+      positionFrame: mediaPositionFrame,
+      complete: mediaComplete,
+    }
+    const mediaRequest = controller.beginMediaPreservation({
+      conversationId,
+      desired: {
+        kind: 'anchor',
+        messageId: 'message-5',
+        placement: {
+          kind: 'bottom-fraction',
+          fraction: messageFraction(0.5),
+        },
+      },
+      executor: mediaExecutor,
+    })!
+    const staleMediaFrame = callbacks.shift()!
+    const outgoing = liveEdgeHarness()
+
+    controller.beginLiveEdgeRequest({
+      conversationId,
+      source: { kind: 'live-update', reason: 'outgoing-message' },
+      executor: outgoing.executor,
+    })
+    expect(mediaComplete).toHaveBeenCalledWith(
+      mediaRequest,
+      'superseded',
+    )
+    staleMediaFrame()
+    expect(mediaPositionFrame).toHaveBeenCalledTimes(1)
+    expect(outgoing.positionFrame).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('positioning controller saved-position ownership', () => {
   const savedAnchor: ScrollAnchor = {
     messageId: 'saved-message',
@@ -377,6 +618,7 @@ describe('positioning controller saved-position ownership', () => {
       }),
       complete: () => {},
       ...overrides,
+      liveEdge: overrides.liveEdge ?? inertLiveEdgeExecutor(),
     }
   }
 
@@ -667,10 +909,11 @@ describe('positioning controller saved-position ownership', () => {
     const positionFrame = vi.fn(() => ({
       kind: 'positioned' as const,
       scrollTop: 900,
+      atLiveEdge: true,
+      wrote: true,
       reassert: false,
     }))
-    const executor = (version: string): SavedPositionExecutor => immediateSavedExecutor({
-      reachability: (desired) => {
+    const reachability: SavedPositionExecutor['reachability'] = (desired) => {
         if (desired.kind === 'anchor') {
           return { kind: 'target-absent', loadAround: 'unavailable' }
         }
@@ -680,10 +923,17 @@ describe('positioning controller saved-position ownership', () => {
             ? { kind: 'resident-tail', index: 9, mounted: true }
             : { kind: 'recenter-available' },
         }
-      },
+      }
+    const executor = (version: string): SavedPositionExecutor => immediateSavedExecutor({
+      reachability,
       recenterVersion: version,
       recenterLiveEdge: recenter,
-      positionFrame,
+      liveEdge: {
+        ...inertLiveEdgeExecutor(positionFrame),
+        reachability: () => reachability(liveEdge, 'unavailable'),
+        recenterVersion: version,
+        recenter,
+      },
     })
     const controller = new PositioningController()
     controller.beginSavedPositionEntry({
@@ -699,16 +949,18 @@ describe('positioning controller saved-position ownership', () => {
     expect(recenter).toHaveBeenCalledTimes(1)
     expect(positionFrame).not.toHaveBeenCalled()
 
-    const pending = controller.savedPositionStatus(conversationId)!
+    const pending = controller.snapshot().active!
     atGlobalLiveEdge = true
-    controller.refreshSavedPosition({
+    controller.refreshLiveEdge({
       conversationId,
-      generation: pending.request.generation,
-      executor: executor('live:idle:20'),
+      executor: executor('live:idle:20').liveEdge,
     })
 
     expect(positionFrame).toHaveBeenCalledTimes(1)
-    expect(controller.savedPositionStatus(conversationId)?.request.desired).toEqual(liveEdge)
+    expect(controller.snapshot().active?.request.generation).toBe(
+      pending.request.generation,
+    )
+    expect(controller.snapshot().active?.request.desired).toEqual(liveEdge)
   })
 
   it('aborts pending saved work when the active generation is deactivated', () => {
@@ -903,8 +1155,15 @@ describe('positioning controller unread-marker ownership', () => {
     const recordFrame = vi.fn()
     const leases: PositionExecutionLease[] = []
     const positionFrame = vi.fn(() => frameResult)
-    const applyLiveEdge = vi.fn(() => true)
+    const applyLiveEdge = vi.fn(() => ({
+      kind: 'positioned' as const,
+      scrollTop: 1000,
+      atLiveEdge: true,
+      wrote: true,
+      reassert: false,
+    }))
     const executor: UnreadMarkerExecutor = {
+      liveEdge: inertLiveEdgeExecutor(applyLiveEdge),
       reachability: () => initialReachability,
       beginLoop: (lease) => {
         leases.push(lease)
@@ -916,7 +1175,6 @@ describe('positioning controller unread-marker ownership', () => {
       },
       readScrollTop: () => scrollTop,
       positionFrame,
-      applyLiveEdge,
     }
     return {
       executor,
@@ -984,7 +1242,13 @@ describe('positioning controller unread-marker ownership', () => {
 
     expect(harness.positionFrame).toHaveBeenCalledTimes(120)
     expect(harness.applyLiveEdge).toHaveBeenCalledWith(
-      'unread-marker-unavailable',
+      expect.objectContaining({
+        conversationId,
+        source: {
+          kind: 'fallback',
+          reason: 'unread-marker-unavailable',
+        },
+      }),
       expect.objectContaining({ conversationId }),
     )
     expect(controller.snapshot().active?.request).toMatchObject({
@@ -1126,7 +1390,12 @@ describe('positioning controller unread-marker ownership', () => {
     expect(harness.positionFrame).toHaveBeenCalledTimes(1)
     expect(harness.callbacks).toHaveLength(0)
     expect(harness.applyLiveEdge).toHaveBeenCalledWith(
-      'unread-marker-unavailable',
+      expect.objectContaining({
+        source: {
+          kind: 'fallback',
+          reason: 'unread-marker-unavailable',
+        },
+      }),
       expect.any(Object),
     )
   })
@@ -1447,6 +1716,7 @@ describe('positioning controller explicit-target ownership', () => {
     const markerCallbacks: Array<() => void> = []
     const markerFinish = vi.fn()
     const markerExecutor: UnreadMarkerExecutor = {
+      liveEdge: inertLiveEdgeExecutor(),
       reachability: () => ({
         kind: 'available',
         index: 3,
@@ -1460,7 +1730,6 @@ describe('positioning controller explicit-target ownership', () => {
       }),
       readScrollTop: () => 0,
       positionFrame: () => ({ kind: 'waiting' }),
-      applyLiveEdge: () => true,
     }
     const target = targetHarness()
     const controller = new PositioningController()
@@ -1493,6 +1762,7 @@ describe('positioning controller explicit-target ownership', () => {
     const target = targetHarness()
     const markerFinish = vi.fn()
     const markerExecutor: UnreadMarkerExecutor = {
+      liveEdge: inertLiveEdgeExecutor(),
       reachability: () => ({
         kind: 'available',
         index: 3,
@@ -1506,7 +1776,6 @@ describe('positioning controller explicit-target ownership', () => {
       }),
       readScrollTop: () => 0,
       positionFrame: () => ({ kind: 'waiting' }),
-      applyLiveEdge: () => true,
     }
     const controller = new PositioningController()
     observeLiveEntry(controller)

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -12,13 +12,14 @@ import {
   shouldReconcileAfterAppend,
   type EntryPositionFacts,
   type ExplicitTargetRequest,
+  type LiveEdgeRequest,
   type LiveEdgeNavigationFacts,
+  type MediaPreservationRequest,
   type PositionRequest,
   type PositioningModel,
   type PositioningPhase,
   type ReachabilityFacts,
   type SavedPositionRequest,
-  type UnreadMarkerFallbackRequest,
   type UnreadMarkerRequest,
   type UnavailablePolicy,
 } from './scrollPositionModel'
@@ -88,6 +89,7 @@ export interface SavedPositionExecutor {
   recenterLiveEdge?: (
     signal: AbortSignal,
   ) => 'requested' | 'waiting' | 'unavailable'
+  liveEdge: LiveEdgeExecutor
   beginLoop: (lease: SavedPositionExecutionLease) => PositionFrameLoop | null
   positionFrame: (
     request: SavedPositionRequest,
@@ -118,12 +120,73 @@ export interface UnreadMarkerExecutor {
     request: UnreadMarkerRequest,
     lease: PositionExecutionLease,
   ) => UnreadMarkerFrameResult
-  applyLiveEdge: (
-    reason:
-      | 'unread-marker-unavailable'
-      | 'unread-marker-resolved-at-live-edge',
+  liveEdge: LiveEdgeExecutor
+}
+
+export type LiveEdgeCompletion =
+  | 'settled'
+  | 'best-effort'
+  | 'restarted'
+  | 'user-takeover'
+  | 'superseded'
+
+export type LiveEdgeFrameResult =
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      atLiveEdge: boolean
+      /** True when geometry required another bottom write/check this frame. */
+      wrote: boolean
+      /** Virtualized rows still need the bounded measurement-settle loop. */
+      reassert: boolean
+    }
+
+export interface LiveEdgeExecutor {
+  reachability: () => ReachabilityFacts
+  /** Changes whenever another forward-window request may be issued safely. */
+  recenterVersion?: string
+  recenter?: (
+    signal: AbortSignal,
+  ) => 'requested' | 'waiting' | 'unavailable'
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  positionFrame: (
+    request: LiveEdgeRequest,
     lease: PositionExecutionLease,
-  ) => boolean
+  ) => LiveEdgeFrameResult
+  complete: (
+    request: LiveEdgeRequest,
+    outcome: LiveEdgeCompletion,
+  ) => void
+}
+
+export type MediaPreservationCompletion =
+  | 'settled'
+  | 'best-effort'
+  | 'user-takeover'
+  | 'superseded'
+
+export type MediaPreservationFrameResult =
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      reassert: boolean
+    }
+
+export interface MediaPreservationExecutor {
+  reachability: (
+    desired: MediaPreservationRequest['desired'],
+  ) => ReachabilityFacts
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  positionFrame: (
+    request: MediaPreservationRequest,
+    lease: PositionExecutionLease,
+  ) => MediaPreservationFrameResult
+  complete: (
+    request: MediaPreservationRequest,
+    outcome: MediaPreservationCompletion,
+  ) => void
 }
 
 export type ExplicitTargetCompletion =
@@ -177,7 +240,7 @@ interface SavedPositionExecutionState {
 }
 
 interface UnreadMarkerExecutionState {
-  request: UnreadMarkerRequest | UnreadMarkerFallbackRequest
+  request: UnreadMarkerRequest
   executor: UnreadMarkerExecutor
   operation: number
   abortController: AbortController | null
@@ -203,6 +266,29 @@ interface ExplicitTargetExecutionState {
   applied: boolean
 }
 
+interface LiveEdgeExecutionState {
+  request: LiveEdgeRequest
+  executor: LiveEdgeExecutor
+  operation: number
+  abortController: AbortController | null
+  lastRecenterVersion: string | null
+  loop: PositionFrameLoop | null
+  framesLeft: number
+  stableFrames: number
+  completed: boolean
+}
+
+interface MediaPreservationExecutionState {
+  request: MediaPreservationRequest
+  executor: MediaPreservationExecutor
+  operation: number
+  abortController: AbortController | null
+  loop: PositionFrameLoop | null
+  framesLeft: number
+  stableFrames: number
+  landedTarget: number | null
+}
+
 const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
@@ -215,6 +301,13 @@ const UNREAD_MARKER_REASSERT_FRAMES = 120
 const UNREAD_MARKER_STABLE_FRAMES = 8
 const UNREAD_MARKER_DRIFT_PX = 16
 const UNREAD_MARKER_TAKEOVER_DRIFT_PX = 300
+// Preserved from the former hook-local pinVirtualizedBottom loop.
+const LIVE_EDGE_REASSERT_FRAMES = 60
+const LIVE_EDGE_STABLE_FRAMES = 8
+// Preserved from the former standalone media-anchor loop.
+const MEDIA_PRESERVATION_REASSERT_FRAMES = 90
+const MEDIA_PRESERVATION_STABLE_FRAMES = 8
+const MEDIA_PRESERVATION_DRIFT_PX = 8
 
 let nextPositionGeneration = 1
 
@@ -259,6 +352,8 @@ export class PositioningController {
   private savedExecution: SavedPositionExecutionState | null = null
   private unreadExecution: UnreadMarkerExecutionState | null = null
   private explicitTargetExecution: ExplicitTargetExecutionState | null = null
+  private liveEdgeExecution: LiveEdgeExecutionState | null = null
+  private mediaPreservationExecution: MediaPreservationExecutionState | null = null
 
   snapshot(): PositioningModel {
     return this.model
@@ -297,9 +392,7 @@ export class PositioningController {
 
     const accepted = acceptPositionRequest(this.model, request)
     if (accepted === this.model) return null
-    this.cancelSavedExecution()
-    this.cancelUnreadExecution()
-    this.cancelExplicitTargetExecution()
+    this.cancelAllExecutions('superseded')
     this.model = advancePhaseIfCurrent(
       accepted,
       input.conversationId,
@@ -367,6 +460,203 @@ export class PositioningController {
     return status !== null &&
       status.phase.kind !== 'position-applied' &&
       status.phase.kind !== 'settled'
+  }
+
+  beginLiveEdgeEntry(input: {
+    conversationId: string
+    entryFacts: EntryPositionFacts
+    executor: LiveEdgeExecutor
+  }): LiveEdgeRequest | null {
+    return runScrollShadowSafely({
+      event: 'live-edge-entry',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const selection = selectEntryPosition(input.entryFacts)
+        if (selection.desired.kind !== 'live-edge') return null
+        return this.acceptLiveEdgeRequest(
+          input.conversationId,
+          (selection as Omit<
+            LiveEdgeRequest,
+            'conversationId' | 'generation'
+          >).source,
+          input.executor,
+        )
+      },
+    })
+  }
+
+  beginLiveEdgeNavigation(input: {
+    conversationId: string
+    navigationFacts: LiveEdgeNavigationFacts
+    executor: LiveEdgeExecutor
+  }): LiveEdgeRequest | null {
+    return runScrollShadowSafely({
+      event: 'live-edge-navigation',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const selection = selectLiveEdgeNavigation(input.navigationFacts)
+        if (selection.desired.kind !== 'live-edge') return null
+        return this.acceptLiveEdgeRequest(
+          input.conversationId,
+          (selection as Omit<
+            LiveEdgeRequest,
+            'conversationId' | 'generation'
+          >).source,
+          input.executor,
+        )
+      },
+    })
+  }
+
+  beginLiveEdgeRequest(input: {
+    conversationId: string
+    source: LiveEdgeRequest['source']
+    executor: LiveEdgeExecutor
+  }): LiveEdgeRequest | null {
+    return runScrollShadowSafely({
+      event: 'live-edge-request',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => this.acceptLiveEdgeRequest(
+        input.conversationId,
+        input.source,
+        input.executor,
+      ),
+    })
+  }
+
+  /**
+   * Re-open bottom reconciliation for appended or remeasured content without minting a competing
+   * request. The current live-edge generation remains the sole follow-live owner.
+   */
+  reconcileLiveEdge(input: {
+    conversationId: string
+    executor: LiveEdgeExecutor
+  }): boolean {
+    return runScrollShadowSafely({
+      event: 'live-edge-reconcile',
+      conversationId: input.conversationId,
+      fallback: false,
+      observe: () => {
+        if (!shouldReconcileAfterAppend(this.model, input.conversationId)) {
+          return false
+        }
+        const active = this.model.active
+        if (!active || active.request.desired.kind !== 'live-edge') return false
+        let execution = this.liveEdgeExecution
+        if (
+          !execution ||
+          execution.request !== active.request ||
+          !this.isLiveEdgeExecutionCurrent(execution)
+        ) {
+          this.cancelLiveEdgeExecution('superseded')
+          execution = this.createLiveEdgeExecution(
+            active.request as LiveEdgeRequest,
+            input.executor,
+          )
+          this.liveEdgeExecution = execution
+        } else {
+          this.finishLiveEdgeLoop(execution)
+          execution.abortController?.abort()
+          this.completeLiveEdge(execution, 'restarted')
+          execution.executor = input.executor
+          execution.operation += 1
+          execution.abortController = null
+          execution.lastRecenterVersion = null
+          execution.framesLeft = LIVE_EDGE_REASSERT_FRAMES
+          execution.stableFrames = 0
+          execution.completed = false
+        }
+        this.driveLiveEdge(execution)
+        return true
+      },
+    })
+  }
+
+  refreshLiveEdge(input: {
+    conversationId: string
+    executor: LiveEdgeExecutor
+  }): boolean {
+    const execution = this.liveEdgeExecution
+    if (
+      !execution ||
+      execution.request.conversationId !== input.conversationId ||
+      !this.isLiveEdgeExecutionCurrent(execution)
+    ) {
+      return false
+    }
+    if (!execution.loop) {
+      execution.executor = input.executor
+      const phase = this.model.active?.phase.kind
+      if (
+        phase === 'resolving' ||
+        phase === 'pending' ||
+        phase === 'recentering-live-edge' ||
+        phase === 'mounting' ||
+        phase === 'reconciling' ||
+        phase === 'unavailable'
+      ) {
+        this.driveLiveEdge(execution)
+      }
+    }
+    return true
+  }
+
+  beginMediaPreservation(input: {
+    conversationId: string
+    desired: MediaPreservationRequest['desired']
+    executor: MediaPreservationExecutor
+  }): MediaPreservationRequest | null {
+    return runScrollShadowSafely({
+      event: 'media-preservation-begin',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const generation = mintPositionGeneration()
+        const request = withIdentity(
+          input.conversationId,
+          generation,
+          {
+            source: { kind: 'media-preservation', reason: 'remeasure' },
+            desired: input.desired,
+            onUnavailable: { kind: 'warn-and-stop' },
+          },
+        ) as MediaPreservationRequest
+        const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+          event: 'media-preservation-reachability',
+          conversationId: input.conversationId,
+          fallback: null,
+          observe: () => input.executor.reachability(request.desired),
+        })
+        if (!reachability) return null
+        if (!reachabilityMatchesRequest(request, reachability)) return null
+        const accepted = acceptPositionRequest(this.model, request)
+        if (accepted === this.model) return null
+
+        this.cancelAllExecutions('superseded')
+        this.model = advancePhaseIfCurrent(
+          accepted,
+          input.conversationId,
+          generation,
+          resolveReachability(request, reachability),
+        )
+        const execution: MediaPreservationExecutionState = {
+          request,
+          executor: input.executor,
+          operation: 0,
+          abortController: null,
+          loop: null,
+          framesLeft: MEDIA_PRESERVATION_REASSERT_FRAMES,
+          stableFrames: 0,
+          landedTarget: null,
+        }
+        this.mediaPreservationExecution = execution
+        this.driveMediaPreservation(execution)
+        return request
+      },
+    })
   }
 
   beginUnreadMarkerEntry(input: {
@@ -465,9 +755,7 @@ export class PositioningController {
 
         const accepted = acceptPositionRequest(this.model, request)
         if (accepted === this.model) return null
-        this.cancelSavedExecution()
-        this.cancelUnreadExecution()
-        this.cancelExplicitTargetExecution()
+        this.cancelAllExecutions('superseded')
         this.model = advancePhaseIfCurrent(
           accepted,
           input.conversationId,
@@ -619,110 +907,6 @@ export class PositioningController {
     })
   }
 
-  observeLiveEdgeNavigation(input: {
-    event: string
-    conversationId: string
-    navigationFacts: LiveEdgeNavigationFacts
-    reachability: (desired: PositionRequest['desired']) => ReachabilityFacts
-    actual: ShadowActualDecision
-  }): PositionRequest | null {
-    return runScrollShadowSafely({
-      event: input.event,
-      conversationId: input.conversationId,
-      fallback: null,
-      observe: () => {
-        const draft = selectLiveEdgeNavigation(
-          input.navigationFacts,
-        ) as PositionRequestDraft
-        return this.observeRequest({
-          event: input.event,
-          conversationId: input.conversationId,
-          draft,
-          reachability: input.reachability(draft.desired),
-          actual: input.actual,
-        })
-      },
-    })
-  }
-
-  observeAppend(input: {
-    event: string
-    conversationId: string
-    actualFollowsLive: boolean
-  }): boolean {
-    return runScrollShadowSafely({
-      event: input.event,
-      conversationId: input.conversationId,
-      fallback: false,
-      observe: () => {
-        const expectedFollowsLive = shouldReconcileAfterAppend(
-          this.model,
-          input.conversationId,
-        )
-        compareShadowDecision({
-          event: input.event,
-          conversationId: input.conversationId,
-          generation: this.model.active?.request.generation ?? null,
-          expected: {
-            desired: expectedFollowsLive
-              ? this.model.active?.request.desired ?? null
-              : null,
-            phase: expectedFollowsLive ? 'positioning' : 'idle',
-          },
-          actual: {
-            desired: input.actualFollowsLive
-              ? { kind: 'live-edge', follow: true }
-              : null,
-            phase: input.actualFollowsLive ? 'positioning' : 'idle',
-          },
-        })
-        return expectedFollowsLive
-      },
-    })
-  }
-
-  /**
-   * Mirror the legacy shared reassert gate without importing its at-bottom latch. A reassert is
-   * justified either by semantic follow-live ownership or by geometry that is currently at the
-   * live edge. The second clause preserves today's settle/repaint behavior while making a stale
-   * latch falsifiable in shadow mode.
-   */
-  observeBottomReassert(input: {
-    event: string
-    conversationId: string
-    geometryAtLiveEdge: boolean
-    actualFollowsLive: boolean
-  }): boolean {
-    return runScrollShadowSafely({
-      event: input.event,
-      conversationId: input.conversationId,
-      fallback: false,
-      observe: () => {
-        const expectedFollowsLive =
-          shouldReconcileAfterAppend(this.model, input.conversationId) ||
-          input.geometryAtLiveEdge
-        compareShadowDecision({
-          event: input.event,
-          conversationId: input.conversationId,
-          generation: this.model.active?.request.generation ?? null,
-          expected: {
-            desired: expectedFollowsLive
-              ? { kind: 'live-edge', follow: true }
-              : null,
-            phase: expectedFollowsLive ? 'positioning' : 'idle',
-          },
-          actual: {
-            desired: input.actualFollowsLive
-              ? { kind: 'live-edge', follow: true }
-              : null,
-            phase: input.actualFollowsLive ? 'positioning' : 'idle',
-          },
-        })
-        return expectedFollowsLive
-      },
-    })
-  }
-
   markPositionApplied(conversationId: string, generation: number): void {
     runScrollShadowSafely({
       event: 'position-applied',
@@ -752,6 +936,16 @@ export class PositioningController {
           targetExecution !== null &&
           targetExecution.request.conversationId === conversationId &&
           this.isExplicitTargetExecutionCurrent(targetExecution)
+        const liveEdgeExecution = this.liveEdgeExecution
+        const liveEdgeWasCurrent =
+          liveEdgeExecution !== null &&
+          liveEdgeExecution.request.conversationId === conversationId &&
+          this.isLiveEdgeExecutionCurrent(liveEdgeExecution)
+        const mediaExecution = this.mediaPreservationExecution
+        const mediaWasCurrent =
+          mediaExecution !== null &&
+          mediaExecution.request.conversationId === conversationId &&
+          this.isMediaPreservationExecutionCurrent(mediaExecution)
         this.model = cancelReconciliationForUserInput(
           this.model,
           conversationId,
@@ -763,6 +957,12 @@ export class PositioningController {
             false,
             'user-takeover',
           )
+        }
+        if (liveEdgeWasCurrent) {
+          this.cancelLiveEdgeExecution('user-takeover')
+        }
+        if (mediaWasCurrent) {
+          this.cancelMediaPreservationExecution('user-takeover')
         }
         this.cancelExecutionsIfSuperseded()
       },
@@ -833,9 +1033,7 @@ export class PositioningController {
 
     const accepted = acceptPositionRequest(this.model, request)
     if (accepted === this.model) return null
-    this.cancelSavedExecution()
-    this.cancelUnreadExecution()
-    this.cancelExplicitTargetExecution()
+    this.cancelAllExecutions('superseded')
     this.model = advancePhaseIfCurrent(
       accepted,
       conversationId,
@@ -862,6 +1060,589 @@ export class PositioningController {
       this.startUnreadMarkerLoop(execution)
     }
     return request
+  }
+
+  private acceptLiveEdgeRequest(
+    conversationId: string,
+    source: LiveEdgeRequest['source'],
+    executor: LiveEdgeExecutor,
+  ): LiveEdgeRequest | null {
+    const generation = mintPositionGeneration()
+    const request = {
+      generation,
+      conversationId,
+      source,
+      desired: { kind: 'live-edge', follow: true },
+    } as LiveEdgeRequest
+    const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+      event: 'live-edge-reachability',
+      conversationId,
+      fallback: null,
+      observe: () => executor.reachability(),
+    })
+    if (!reachability || !reachabilityMatchesRequest(request, reachability)) {
+      return null
+    }
+    const accepted = acceptPositionRequest(this.model, request)
+    if (accepted === this.model) return null
+
+    this.cancelAllExecutions('superseded')
+    this.model = advancePhaseIfCurrent(
+      accepted,
+      conversationId,
+      generation,
+      resolveReachability(request, reachability),
+    )
+    const execution = this.createLiveEdgeExecution(request, executor)
+    this.liveEdgeExecution = execution
+    this.driveLiveEdge(execution)
+    return request
+  }
+
+  private createLiveEdgeExecution(
+    request: LiveEdgeRequest,
+    executor: LiveEdgeExecutor,
+  ): LiveEdgeExecutionState {
+    return {
+      request,
+      executor,
+      operation: 0,
+      abortController: null,
+      lastRecenterVersion: null,
+      loop: null,
+      framesLeft: LIVE_EDGE_REASSERT_FRAMES,
+      stableFrames: 0,
+      completed: false,
+    }
+  }
+
+  private driveLiveEdge(execution: LiveEdgeExecutionState): void {
+    if (!this.isLiveEdgeExecutionCurrent(execution)) return
+    if (execution.loop) return
+
+    const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+      event: 'live-edge-drive-reachability',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.reachability(),
+    })
+    if (
+      !reachability ||
+      !reachabilityMatchesRequest(execution.request, reachability)
+    ) {
+      this.settleLiveEdgeBestEffort(execution)
+      return
+    }
+    const phase = resolveReachability(execution.request, reachability)
+    this.model = advancePhaseIfCurrent(
+      this.model,
+      execution.request.conversationId,
+      execution.request.generation,
+      phase,
+    )
+    if (!this.isLiveEdgeExecutionCurrent(execution)) return
+
+    switch (phase.kind) {
+      case 'recentering-live-edge':
+        this.recenterLiveEdge(execution)
+        return
+      case 'mounting':
+      case 'reconciling':
+        this.startLiveEdgeLoop(execution)
+        return
+      case 'unavailable':
+        // Preserve the legacy best-resident-edge fallback when the sliding window cannot recenter.
+        this.startLiveEdgeLoop(execution)
+        return
+      case 'resolving':
+      case 'pending':
+      case 'loading-around':
+      case 'position-applied':
+      case 'settled':
+      case 'paused-user-input':
+        return
+    }
+  }
+
+  private recenterLiveEdge(execution: LiveEdgeExecutionState): void {
+    const recenter = execution.executor.recenter
+    const version = execution.executor.recenterVersion
+    if (!recenter || !version) {
+      this.startLiveEdgeLoop(execution)
+      return
+    }
+    if (execution.lastRecenterVersion === version) return
+    execution.lastRecenterVersion = version
+    const lease = this.beginLiveEdgeOperation(execution)
+    const result = runScrollShadowSafely({
+      event: 'live-edge-recenter',
+      conversationId: execution.request.conversationId,
+      fallback: 'unavailable' as const,
+      observe: () => recenter(lease.signal),
+    })
+    if (!lease.isCurrent()) return
+    if (result === 'unavailable') this.startLiveEdgeLoop(execution)
+  }
+
+  private startLiveEdgeLoop(execution: LiveEdgeExecutionState): void {
+    if (!this.isLiveEdgeExecutionCurrent(execution) || execution.loop) return
+    execution.framesLeft = LIVE_EDGE_REASSERT_FRAMES
+    execution.stableFrames = 0
+    execution.completed = false
+    const lease = this.beginLiveEdgeOperation(execution)
+
+    // Preserve the immediate write used by entry, FAB, outgoing send, and layout stimuli. Only
+    // virtualized measurement settling moves to scheduled controller frames.
+    const initial = this.positionLiveEdgeFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (initial.kind === 'unavailable') {
+      this.settleLiveEdgeBestEffort(execution, lease)
+      return
+    }
+    lease.markApplied()
+    if (!lease.isCurrent()) return
+    if (!initial.reassert) {
+      this.settleLiveEdge(execution, lease, 'settled')
+      return
+    }
+
+    const loop = runScrollShadowSafely<PositionFrameLoop | null>({
+      event: 'live-edge-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      loop?.finish()
+      return
+    }
+    if (!loop) {
+      this.settleLiveEdge(execution, lease, 'best-effort')
+      return
+    }
+    execution.loop = loop
+    this.scheduleLiveEdgeFrame(execution, lease)
+  }
+
+  private driveLiveEdgeFrame(
+    execution: LiveEdgeExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (execution.framesLeft-- <= 0) {
+      this.settleLiveEdge(execution, lease, 'best-effort')
+      return
+    }
+    const result = this.positionLiveEdgeFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (result.kind === 'unavailable') {
+      this.settleLiveEdge(execution, lease, 'best-effort')
+      return
+    }
+    if (!result.reassert) {
+      this.recordLiveEdgeFrame(execution, result.wrote)
+      this.settleLiveEdge(execution, lease, 'settled')
+      return
+    }
+
+    execution.stableFrames = result.wrote
+      ? 0
+      : execution.stableFrames + 1
+    this.recordLiveEdgeFrame(execution, result.wrote)
+    if (execution.stableFrames >= LIVE_EDGE_STABLE_FRAMES) {
+      this.settleLiveEdge(execution, lease, 'settled')
+      return
+    }
+    this.scheduleLiveEdgeFrame(execution, lease)
+  }
+
+  private positionLiveEdgeFrame(
+    execution: LiveEdgeExecutionState,
+    lease: PositionExecutionLease,
+  ): LiveEdgeFrameResult {
+    return runScrollShadowSafely<LiveEdgeFrameResult>({
+      event: 'live-edge-frame',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.positionFrame(
+        execution.request,
+        lease,
+      ),
+    })
+  }
+
+  private scheduleLiveEdgeFrame(
+    execution: LiveEdgeExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'live-edge-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveLiveEdgeFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      this.settleLiveEdge(execution, lease, 'best-effort')
+    }
+  }
+
+  private recordLiveEdgeFrame(
+    execution: LiveEdgeExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'live-edge-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private settleLiveEdgeBestEffort(
+    execution: LiveEdgeExecutionState,
+    existingLease?: PositionExecutionLease,
+  ): void {
+    if (!this.isLiveEdgeExecutionCurrent(execution)) return
+    const lease = existingLease ?? this.beginLiveEdgeOperation(execution)
+    this.settleLiveEdge(execution, lease, 'best-effort')
+  }
+
+  private settleLiveEdge(
+    execution: LiveEdgeExecutionState,
+    lease: PositionExecutionLease,
+    outcome: Extract<LiveEdgeCompletion, 'settled' | 'best-effort'>,
+  ): void {
+    if (!lease.isCurrent()) return
+    this.finishLiveEdgeLoop(execution)
+    this.completeLiveEdge(execution, outcome)
+    lease.settle()
+  }
+
+  private completeLiveEdge(
+    execution: LiveEdgeExecutionState,
+    outcome: LiveEdgeCompletion,
+  ): void {
+    if (execution.completed) return
+    execution.completed = true
+    runScrollShadowSafely({
+      event: 'live-edge-complete',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.executor.complete(
+        execution.request,
+        outcome,
+      ),
+    })
+  }
+
+  private finishLiveEdgeLoop(execution: LiveEdgeExecutionState): void {
+    const loop = execution.loop
+    execution.loop = null
+    if (!loop) return
+    runScrollShadowSafely({
+      event: 'live-edge-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => loop.finish(),
+    })
+  }
+
+  private beginLiveEdgeOperation(
+    execution: LiveEdgeExecutionState,
+  ): PositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.liveEdgeExecution === execution &&
+      execution.operation === operation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isLiveEdgeExecutionCurrent(
+    execution: LiveEdgeExecutionState,
+  ): boolean {
+    return (
+      this.liveEdgeExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
+  }
+
+  private driveMediaPreservation(
+    execution: MediaPreservationExecutionState,
+  ): void {
+    if (!this.isMediaPreservationExecutionCurrent(execution)) return
+    const phase = this.model.active?.phase
+    if (!phase) return
+    if (phase.kind === 'mounting' || phase.kind === 'reconciling') {
+      this.startMediaPreservationLoop(execution)
+      return
+    }
+    if (
+      phase.kind === 'unavailable' ||
+      phase.kind === 'pending'
+    ) {
+      const lease = this.beginMediaPreservationOperation(execution)
+      this.settleMediaPreservation(execution, lease, 'best-effort')
+    }
+  }
+
+  private startMediaPreservationLoop(
+    execution: MediaPreservationExecutionState,
+  ): void {
+    if (
+      !this.isMediaPreservationExecutionCurrent(execution) ||
+      execution.loop
+    ) {
+      return
+    }
+    execution.framesLeft = MEDIA_PRESERVATION_REASSERT_FRAMES
+    execution.stableFrames = 0
+    execution.landedTarget = null
+    const lease = this.beginMediaPreservationOperation(execution)
+    const initial = this.positionMediaPreservationFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (initial.kind === 'unavailable') {
+      this.settleMediaPreservation(execution, lease, 'best-effort')
+      return
+    }
+    lease.markApplied()
+    if (!lease.isCurrent()) return
+    if (!initial.reassert) {
+      this.settleMediaPreservation(execution, lease, 'settled')
+      return
+    }
+    const loop = runScrollShadowSafely<PositionFrameLoop | null>({
+      event: 'media-preservation-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      loop?.finish()
+      return
+    }
+    if (!loop) {
+      this.settleMediaPreservation(execution, lease, 'best-effort')
+      return
+    }
+    execution.loop = loop
+    this.scheduleMediaPreservationFrame(execution, lease)
+  }
+
+  private driveMediaPreservationFrame(
+    execution: MediaPreservationExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (execution.framesLeft-- <= 0) {
+      this.settleMediaPreservation(execution, lease, 'best-effort')
+      return
+    }
+    const result = this.positionMediaPreservationFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (result.kind === 'unavailable') {
+      this.settleMediaPreservation(execution, lease, 'best-effort')
+      return
+    }
+    if (!result.reassert) {
+      this.settleMediaPreservation(execution, lease, 'settled')
+      return
+    }
+    let wrote = false
+    if (
+      execution.landedTarget !== null &&
+      Math.abs(result.scrollTop - execution.landedTarget) <=
+        MEDIA_PRESERVATION_DRIFT_PX
+    ) {
+      execution.stableFrames += 1
+    } else {
+      wrote = true
+      execution.stableFrames = 0
+    }
+    execution.landedTarget = result.scrollTop
+    this.recordMediaPreservationFrame(execution, wrote)
+    if (
+      execution.stableFrames >= MEDIA_PRESERVATION_STABLE_FRAMES
+    ) {
+      this.settleMediaPreservation(execution, lease, 'settled')
+      return
+    }
+    this.scheduleMediaPreservationFrame(execution, lease)
+  }
+
+  private positionMediaPreservationFrame(
+    execution: MediaPreservationExecutionState,
+    lease: PositionExecutionLease,
+  ): MediaPreservationFrameResult {
+    return runScrollShadowSafely<MediaPreservationFrameResult>({
+      event: 'media-preservation-frame',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.positionFrame(
+        execution.request,
+        lease,
+      ),
+    })
+  }
+
+  private scheduleMediaPreservationFrame(
+    execution: MediaPreservationExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'media-preservation-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveMediaPreservationFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      this.settleMediaPreservation(execution, lease, 'best-effort')
+    }
+  }
+
+  private recordMediaPreservationFrame(
+    execution: MediaPreservationExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'media-preservation-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private settleMediaPreservation(
+    execution: MediaPreservationExecutionState,
+    lease: PositionExecutionLease,
+    outcome: Extract<
+      MediaPreservationCompletion,
+      'settled' | 'best-effort'
+    >,
+  ): void {
+    if (!lease.isCurrent()) return
+    this.finishMediaPreservationLoop(execution)
+    this.completeMediaPreservation(execution, outcome)
+    lease.settle()
+    execution.abortController?.abort()
+    if (this.mediaPreservationExecution === execution) {
+      this.mediaPreservationExecution = null
+    }
+  }
+
+  private completeMediaPreservation(
+    execution: MediaPreservationExecutionState,
+    outcome: MediaPreservationCompletion,
+  ): void {
+    runScrollShadowSafely({
+      event: 'media-preservation-complete',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.executor.complete(
+        execution.request,
+        outcome,
+      ),
+    })
+  }
+
+  private finishMediaPreservationLoop(
+    execution: MediaPreservationExecutionState,
+  ): void {
+    const loop = execution.loop
+    execution.loop = null
+    if (!loop) return
+    runScrollShadowSafely({
+      event: 'media-preservation-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => loop.finish(),
+    })
+  }
+
+  private beginMediaPreservationOperation(
+    execution: MediaPreservationExecutionState,
+  ): PositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.mediaPreservationExecution === execution &&
+      execution.operation === operation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isMediaPreservationExecutionCurrent(
+    execution: MediaPreservationExecutionState,
+  ): boolean {
+    return (
+      this.mediaPreservationExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
   }
 
   private driveExplicitTarget(
@@ -1298,10 +2079,7 @@ export class PositioningController {
     lease: PositionExecutionLease,
   ): void {
     if (!lease.isCurrent()) return
-    if (
-      execution.request.source.kind === 'fallback' ||
-      execution.framesLeft-- <= 0
-    ) {
+    if (execution.framesLeft-- <= 0) {
       if (execution.resolvedAtLiveEdge) {
         this.promoteUnreadFallback(
           execution,
@@ -1441,32 +2219,36 @@ export class PositioningController {
         source: { kind: 'fallback', reason },
         desired: { kind: 'live-edge', follow: true },
       },
-    ) as UnreadMarkerFallbackRequest
+    ) as LiveEdgeRequest
     const accepted = acceptPositionRequest(this.model, request)
     if (accepted === this.model) {
       this.cancelUnreadExecution()
       return
     }
-
-    execution.request = request
-    execution.operation += 1
-    execution.abortController = null
+    const liveExecutor = execution.executor.liveEdge
+    const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+      event: reason,
+      conversationId: request.conversationId,
+      fallback: null,
+      observe: () => liveExecutor.reachability(),
+    })
+    if (!reachability || !reachabilityMatchesRequest(request, reachability)) {
+      this.cancelUnreadExecution()
+      return
+    }
+    this.cancelUnreadExecution()
     this.model = advancePhaseIfCurrent(
       accepted,
       request.conversationId,
       request.generation,
-      { kind: 'reconciling' },
+      resolveReachability(request, reachability),
     )
-    const lease = this.beginUnreadOperation(execution)
-    const applied = runScrollShadowSafely({
-      event: reason,
-      conversationId: request.conversationId,
-      fallback: false,
-      observe: () => execution.executor.applyLiveEdge(reason, lease),
-    })
-    if (!lease.isCurrent()) return
-    if (applied) lease.markApplied()
-    this.finishUnreadExecution(execution, false)
+    const liveExecution = this.createLiveEdgeExecution(
+      request,
+      liveExecutor,
+    )
+    this.liveEdgeExecution = liveExecution
+    this.driveLiveEdge(liveExecution)
   }
 
   private beginUnreadOperation(
@@ -1884,23 +2666,65 @@ export class PositioningController {
       execution.request.source.kind === 'fallback' &&
       execution.request.desired.kind === 'live-edge'
     ) {
-      this.finishAtBestAvailableLiveEdge(execution)
+      const request = execution.request as LiveEdgeRequest
+      const liveExecutor = execution.executor.liveEdge
+      this.cancelSavedExecution()
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        request.conversationId,
+        request.generation,
+        { kind: 'reconciling' },
+      )
+      const liveExecution = this.createLiveEdgeExecution(
+        request,
+        liveExecutor,
+      )
+      this.liveEdgeExecution = liveExecution
+      this.driveLiveEdge(liveExecution)
       return
     }
 
     const generation = mintPositionGeneration()
-    const draft: PositionRequestDraft = {
+    const request: SavedPositionRequest = {
+      generation,
+      conversationId: execution.request.conversationId,
       source: { kind: 'fallback', reason: 'saved-position-unavailable' },
       desired,
-    }
-    const request = withIdentity(
-      execution.request.conversationId,
-      generation,
-      draft,
-    ) as SavedPositionRequest
+    } as SavedPositionRequest
     const accepted = acceptPositionRequest(this.model, request)
     if (accepted === this.model) {
       this.cancelSavedExecution()
+      return
+    }
+    if (request.desired.kind === 'live-edge') {
+      const liveRequest = request as LiveEdgeRequest
+      const liveExecutor = execution.executor.liveEdge
+      const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+        event: 'saved-position-live-edge-fallback',
+        conversationId: liveRequest.conversationId,
+        fallback: null,
+        observe: () => liveExecutor.reachability(),
+      })
+      if (
+        !reachability ||
+        !reachabilityMatchesRequest(liveRequest, reachability)
+      ) {
+        this.cancelSavedExecution()
+        return
+      }
+      this.cancelSavedExecution()
+      this.model = advancePhaseIfCurrent(
+        accepted,
+        liveRequest.conversationId,
+        liveRequest.generation,
+        resolveReachability(liveRequest, reachability),
+      )
+      const liveExecution = this.createLiveEdgeExecution(
+        liveRequest,
+        liveExecutor,
+      )
+      this.liveEdgeExecution = liveExecution
+      this.driveLiveEdge(liveExecution)
       return
     }
     this.finishSavedLoop(execution)
@@ -1992,6 +2816,28 @@ export class PositioningController {
     ) {
       this.cancelExplicitTargetExecution()
     }
+    const liveEdgeExecution = this.liveEdgeExecution
+    if (
+      liveEdgeExecution &&
+      !this.isLiveEdgeExecutionCurrent(liveEdgeExecution)
+    ) {
+      this.cancelLiveEdgeExecution('superseded')
+    }
+    const mediaExecution = this.mediaPreservationExecution
+    if (
+      mediaExecution &&
+      !this.isMediaPreservationExecutionCurrent(mediaExecution)
+    ) {
+      this.cancelMediaPreservationExecution('superseded')
+    }
+  }
+
+  private cancelAllExecutions(outcome: 'superseded'): void {
+    this.cancelSavedExecution()
+    this.cancelUnreadExecution()
+    this.cancelExplicitTargetExecution()
+    this.cancelLiveEdgeExecution(outcome)
+    this.cancelMediaPreservationExecution(outcome)
   }
 
   private cancelSavedExecution(): void {
@@ -2016,6 +2862,28 @@ export class PositioningController {
       this.explicitTargetExecution.abortController?.abort()
     }
     this.explicitTargetExecution = null
+  }
+
+  private cancelLiveEdgeExecution(outcome: LiveEdgeCompletion): void {
+    const execution = this.liveEdgeExecution
+    if (execution) {
+      this.finishLiveEdgeLoop(execution)
+      execution.abortController?.abort()
+      this.completeLiveEdge(execution, outcome)
+    }
+    this.liveEdgeExecution = null
+  }
+
+  private cancelMediaPreservationExecution(
+    outcome: MediaPreservationCompletion,
+  ): void {
+    const execution = this.mediaPreservationExecution
+    if (execution) {
+      this.finishMediaPreservationLoop(execution)
+      execution.abortController?.abort()
+      this.completeMediaPreservation(execution, outcome)
+    }
+    this.mediaPreservationExecution = null
   }
 }
 

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -4,7 +4,7 @@
  *
  * Background: useMessageListScroll keeps the virtualized list pinned to the
  * right place by RE-ASSERTING a scroll target across several frames as rows
- * measure asynchronously — `pinVirtualizedBottom` (stick to bottom), the
+ * measure asynchronously — the live-edge executor (stick to bottom), the
  * controller-owned unread-marker reconciliation, and the MAM-prepend
  * `runMeasureAssert` (anchor restore). Each is a `requestAnimationFrame` loop
  * that calls the virtualizer's `scrollToOffset`/`scrollToIndex`, which re-windows

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -176,7 +176,14 @@ export type PositionRequest =
         kind: 'fallback'
         reason: 'saved-position-unavailable'
       },
-      LiveEdgePosition | LegacyOffsetPosition
+      LiveEdgePosition
+    >
+  | Request<
+      {
+        kind: 'fallback'
+        reason: 'saved-position-unavailable'
+      },
+      LegacyOffsetPosition
     >
   | Request<
       {
@@ -215,6 +222,16 @@ export type UnreadMarkerFallbackRequest = Extract<
         | 'unread-marker-resolved-at-live-edge'
     }
   }
+>
+
+export type LiveEdgeRequest = Extract<
+  PositionRequest,
+  { desired: LiveEdgePosition }
+>
+
+export type MediaPreservationRequest = Extract<
+  PositionRequest,
+  { source: { kind: 'media-preservation'; reason: 'remeasure' } }
 >
 
 export type PositionRequestSource = PositionRequest['source']

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.test.tsx
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.test.tsx
@@ -158,7 +158,7 @@ describe('useTanstackMessageVirtualizer', () => {
 
   it('scrollToIndex re-windows via @tanstack\'s offset callback with isScrolling=false (bottom-stick on WebKit)', () => {
     // Same scrollOffset-desync as scrollToOffset, on the stick-to-bottom path. @tanstack's
-    // scrollToIndex (used by pinVirtualizedBottom for both send and receive, the FAB, and
+    // scrollToIndex (used by the live-edge executor for both send and receive, the FAB, and
     // ensureMessageMounted) sets the DOM scrollTop via _scrollToOffset but leaves its reactive
     // scrollOffset stale until the native 'scroll' event fires. On Tauri WebKit that event is
     // withheld/coalesced for a programmatic scroll, so the mounted window never re-syncs and a

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -258,7 +258,7 @@ export function useTanstackMessageVirtualizer({
       // leaves its reactive scrollOffset stale until the scroll element's native 'scroll' event
       // fires. On Tauri WebKit that event is withheld/coalesced for a programmatic scroll, so the
       // mounted window never re-windows and a just-appended bottom row (new message — send OR
-      // receive, via pinVirtualizedBottom) is never windowed in: the view fails to stick to the
+      // receive, via the live-edge executor) is never windowed in: the view fails to stick to the
       // bottom. Push the landed scrollTop straight into @tanstack's offset callback with
       // isScrolling=false (non-sync, plain rerender — NOT a synthetic scroll event, which would
       // flushSync mid-commit) to re-window before paint. Chromium fires the native event promptly

--- a/apps/fluux/src/components/conversation/useMessageListScroll.loadNewer.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.loadNewer.test.tsx
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  *
- * Sliding window: the load-newer scroll trigger. When the resident window is slid up
- * (windowAtLiveEdge === false), scrolling back down to the resident bottom must fetch the
- * next-newer cache slice; at the live edge the trigger is inert (bottom-stick unchanged).
+ * Sliding window: authoritative live-edge entry recenters immediately when the resident window is
+ * slid up. The older scroll trigger still fetches the next-newer cache slice after a reader moves
+ * back down to the resident bottom; at the global live edge it remains inert.
  */
 import React from 'react'
 import { render, act } from '@testing-library/react'
@@ -89,8 +89,9 @@ describe('useMessageListScroll load-newer trigger', () => {
   it('fires onLoadNewer when scrolled to the resident bottom of a slid-up window', () => {
     const onLoadNewer = vi.fn()
     const h = mount({ onLoadNewer, windowAtLiveEdge: false, initialScrollTop: 0 })
+    expect(onLoadNewer).toHaveBeenCalledTimes(1) // live-edge entry recenter
     scrollAt(h, 500) // distFromBottom 0
-    expect(onLoadNewer).toHaveBeenCalledTimes(1)
+    expect(onLoadNewer).toHaveBeenCalledTimes(2)
   })
 
   it('does NOT fire at the live edge (windowAtLiveEdge true) — bottom-stick territory', () => {
@@ -117,7 +118,8 @@ describe('useMessageListScroll load-newer trigger', () => {
   it('does NOT fire when the reader is not near the resident bottom', () => {
     const onLoadNewer = vi.fn()
     const h = mount({ onLoadNewer, windowAtLiveEdge: false, initialScrollTop: 0 })
+    expect(onLoadNewer).toHaveBeenCalledTimes(1) // live-edge entry recenter
     scrollAt(h, 100) // distFromBottom 400
-    expect(onLoadNewer).not.toHaveBeenCalled()
+    expect(onLoadNewer).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,9 +3,9 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Saved-position, unread-marker, and explicit-target policy/retry ownership lives in
- *    PositioningController; browser writes stay imperative in hook executors while the remaining
- *    mechanisms migrate
+ * 2. Saved-position, unread-marker, explicit-target, live-edge, and media-preservation
+ *    policy/retry ownership lives in PositioningController; browser writes stay imperative in
+ *    leased hook executors while directional history remains to migrate
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
  * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
@@ -33,6 +33,9 @@ import { notifyUserInput } from '@/utils/renderLoopDetector'
 import {
   PositioningController,
   type ExplicitTargetExecutor,
+  type LiveEdgeExecutor,
+  type LiveEdgeCompletion,
+  type MediaPreservationExecutor,
   type PositionExecutionLease,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
@@ -50,6 +53,8 @@ import {
   pixelOffset,
   type DesiredPosition,
   type ExplicitTargetRequest,
+  type LiveEdgeRequest,
+  type MediaPreservationRequest,
   type ReachabilityFacts,
   type SavedPositionRequest,
   type UnreadMarkerRequest,
@@ -115,18 +120,6 @@ const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load even
 // How long a jumped-to message keeps its highlight tint, for both the controller-owned live path
 // and the scoped static-preview path (they must flash identically).
 const TARGET_HIGHLIGHT_MS = 1500
-// Frames to keep re-pinning a virtualized list to the bottom after a scroll-to-bottom. Rows
-// start at the fixed estimateSize and re-measure asynchronously over several frames (taller →
-// scrollHeight grows and clips the last message; shorter → it floats above empty space), so a
-// one-shot scrollToIndex isn't enough. ~1s at 60fps comfortably covers the measurement settle.
-const BOTTOM_REASSERT_FRAMES = 60
-// Media decoded above a scrolled-up viewport changes the measured offsets after the batch snapshot.
-// Re-apply that snapshot's bottom-fraction anchor until measurements settle so the reading point
-// stays fixed. Saved-position restoration uses the same per-frame geometry, but its budget and
-// convergence state are controller-owned.
-const MEDIA_ANCHOR_REASSERT_FRAMES = 90
-const MEDIA_ANCHOR_STABLE_FRAMES = 8
-const MEDIA_ANCHOR_DRIFT_PX = 8
 // While re-pinning, treat the list as not-yet-pinned whenever it sits more than this many pixels
 // above the true bottom. The change-detection guard (re-pin only when scrollHeight moved) can miss
 // the frame where the last row's measurement settles — coalesced height deltas, or a height delta
@@ -451,7 +444,7 @@ export function useMessageListScroll({
   const storeTargetRequestRef = useRef<ExplicitTargetRequest | null>(null)
 
   // Latest MAM-loading state (forward catch-up on entry, or backward "load older" pagination) for
-  // the active conversation, read imperatively inside pinVirtualizedBottom's stable useCallback —
+  // the active conversation, read imperatively inside the live-edge executor —
   // see the repaint-suppression note in writePin below. Updated synchronously in the render body
   // (same pattern as virtualizerRef) so it is never stale when the pin loop reads it mid-run.
   const isLoadingOlderRef = useRef(isLoadingOlder)
@@ -496,9 +489,9 @@ export function useMessageListScroll({
   // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
   const unmountDeactivationTokenRef = useRef<object | null>(null)
   // Generation-aware semantic controller. Saved-position restoration, unread-marker positioning,
-  // and explicit message targets are authoritative; the remaining mechanisms still report shadow
-  // decisions. Pixel writes stay in hook executors, while the module-private generation allocator
-  // survives StrictMode remounts.
+  // explicit targets, live edge, and media preservation are authoritative. Directional history
+  // still reports shadow decisions. Pixel writes stay in hook executors, while the module-private
+  // generation allocator survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -508,6 +501,9 @@ export function useMessageListScroll({
       observe: () => new PositioningController(),
     })
   }
+  const reconcileLiveEdgeRef = useRef<(trigger: string) => boolean>(
+    () => false,
+  )
   const shadowReachabilityRef = useRef<(desired: DesiredPosition) => ReachabilityFacts>(
     () => ({ kind: 'empty-window' }),
   )
@@ -687,33 +683,9 @@ export function useMessageListScroll({
       const element = contentRef.current
       if (!scroller || !element || contentObserverRef.current) return
 
-      const { staticMode, isAtBottomRef, virtualizer } = latestRef.current
-
-      // On mount: if we should be at bottom, scroll there immediately.
-      //
-      // NON-VIRTUALIZED ONLY. Under virtualization the conversation-switch layout effect (which
-      // also runs on this same fresh mount — MessageList is keyed by conversation id, so every
-      // entry remounts and prevConversationRef starts null) owns the initial bottom positioning
-      // via pinVirtualizedBottom() → scrollToIndex(last,'end'). That target is MEASUREMENT-AWARE;
-      // this legacy raw `scrollTop = scrollHeight` predates virtualization and lands on the
-      // @tanstack spacer's ESTIMATED total instead — a different pixel. Running both on entry (the
-      // raw write here, plus its one-frame-later rAF, against the pin's scrollToIndex) positions
-      // the view twice at two slightly different bottoms, so it visibly nudges up/down before it
-      // settles. Gating on !virtualizer leaves the non-virtualized path byte-identical while
-      // letting the (virtualization-aware) switch effect be the single source of bottom positioning
-      // — the same migration already applied to the switch effect's own else branch.
-      if (isAtBottomRef.current && !staticMode && !virtualizer) {
-        void scroller.offsetHeight // Force reflow
-        scroller.scrollTop = scroller.scrollHeight
-        requestAnimationFrame(() => {
-          // Guard: useLayoutEffect may have set isAtBottomRef=false if restoring
-          // a mid-conversation scroll position (e.g. returning from Settings).
-          // Re-check here so we don't override the position restore.
-          if (scrollerRef.current && isAtBottomRef.current) {
-            scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
-          }
-        })
-      }
+      // Conversation entry owns initial bottom placement through the controller's live-edge
+      // executor. In particular, its non-virtualized switch path retains the historical immediate
+      // plus deferred repair, so this observer must not issue a second pair of mount-time writes.
 
       // Set up content ResizeObserver
       let lastHeight = scroller.scrollHeight
@@ -789,11 +761,8 @@ export function useMessageListScroll({
 
         const { staticMode, isAtBottomRef } = latestRef.current
 
-        // Content grew and we were at bottom -> stay at bottom. Route through the shared
-        // reassertBottom (the same helper the new-message / typing / composer-resize sites use)
-        // so there is one place that decides how to land at the bottom. Virtualized is already
-        // excluded above, so this only ever takes the raw-scrollTop branch — but keeping it
-        // funnelled means a future change to the pin logic can't miss this site.
+        // Content grew and we were at bottom -> stay at bottom. Re-open the current live-edge
+        // generation so the controller remains the only owner even on the non-virtualized path.
         if (newHeight > lastHeight && isAtBottomRef.current && !staticMode) {
           debugLog('RESIZE SCROLL TO BOTTOM', {
             newHeight,
@@ -801,7 +770,7 @@ export function useMessageListScroll({
             isAtBottom: isAtBottomRef.current,
             scrollTopBefore: currentScrollTop,
           })
-          reassertBottom('content-growth')
+          reconcileLiveEdgeRef.current('content-growth')
         } else if (newHeight !== lastHeight) {
           debugLog('RESIZE NO SCROLL', {
             newHeight,
@@ -883,272 +852,9 @@ export function useMessageListScroll({
 
   const { setScrollContainerRef, setContentRef } = stableSettersRef.current
 
-  // Pin a VIRTUALIZED list to the bottom and keep it pinned as rows measure.
-  //
-  // scrollToIndex(last, 'end') uses the virtualizer's current (estimated) layout. Rows then
-  // mount and re-measure over the next several frames; scrollHeight grows (rows taller than the
-  // estimate → last message clipped below the fold) or shrinks (shorter → empty space below the
-  // content). The content ResizeObserver that re-pins for the non-virtualized path is disabled
-  // under virtualization (its feedback loops with the @tanstack spacer churn — PR #646), so we
-  // re-assert across frames here instead.
-  //
-  // Runs entirely in rAF (NOT useLayoutEffect) to avoid the scroll→rerender→scrollTop-override
-  // oscillation. Re-pins only when scrollHeight actually changed since the previous frame, and
-  // yields the moment the user takes over (deliberate scroll intent, or simply scrolling away
-  // from the bottom). No-op for the non-virtualized path — callers keep their direct scrollTop.
-  const pinVirtualizedBottom = useCallback((trigger: string = 'unknown') => {
-    const virt = virtualizerRef.current
-    const scroller = scrollerRef.current
-    if (!virt || !scroller || virt.itemCount === 0) return
-
-    // Single-flight: supersede any re-assert loop still running (pin-bottom OR prepend) so two
-    // never run at once and fight over scrollTop (the overlap the reassert monitor warns about,
-    // and the suspected cause of a just-sent message not sticking to the bottom on WebKit). This
-    // call restarts with a fresh settle window. reassertBottom fires from several sites
-    // (new-message, typing, composer/viewport resize, media load) that can land within the ~1s
-    // window — and a send can land mid-prepend — so re-entry is routine.
-    supersedeReassertLoopRef.current()
-
-    // Repaint-burst coalescing. A content-arrival trigger (new message / reaction / media / catch-up)
-    // landing in quick succession with others is a BURST: its per-arrival forced repaint is the
-    // WebKitGTK freeze. note() it BEFORE the loop so writePin below can suppress the intermediate
-    // repaints (position still written, layout stays correct) and let convergence force one trailing
-    // repaint. User/layout triggers (switch, fab, resize) are not content and never suppress.
-    const burst = (pinRepaintBurstRef.current ??= createPinRepaintBurst())
-    if (CONTENT_ARRIVAL_TRIGGERS.has(trigger)) burst.note(performance.now())
-
-    // Per-run forced-work accounting + convergence tracking. On WebKitGTK the forced layouts and
-    // repaints below are the dominant main-thread cost in busy rooms (RenderCostProbe layoutPaint
-    // 189–359ms with react as low as 2ms) — the tracker attributes them in fluux.log.
-    const run = createPinRunTracker()
-    const repaintMode = readPinRepaintMode(
-      typeof window === 'undefined' ? undefined : window.localStorage
-    )
-
-    // Prompt WebKit's LATE row measure. Rows are absolutely positioned, so scrollHeight is the spacer's
-    // declared height (= @tanstack getTotalSize), which grows only once a just-added row's ResizeObserver
-    // delivers — and WebKit (Safari + Tauri) delivers that late. Reading a row's getBoundingClientRect
-    // forces the layout that makes the observer deliver, so scrollHeight catches up before we read it in
-    // the re-pin below. Strictly read-only; a no-op on Chromium. (NB: this only fixes the scrollHeight
-    // *value*; the actual send-stick was a stale PAINT — see forceRepaint below.)
-    const flushTailLayout = () => {
-      const ss = scrollerRef.current
-      if (!ss) return
-      const started = performance.now()
-      ss.getBoundingClientRect()
-      const rows = ss.querySelectorAll('[data-message-id]')
-      for (let i = Math.max(0, rows.length - 3); i < rows.length; i++) {
-        rows[i].getBoundingClientRect()
-      }
-      run.addMs('flush', performance.now() - started)
-    }
-
-    // THE ACTUAL SEND-STICK FIX — force a repaint after a programmatic scroll. On the Tauri WKWebView,
-    // setting scrollTop (via scrollToIndex) updates the LAYOUT correctly — scrollTop, the row rects and
-    // distFromBottom all land at the bottom — but the compositor does NOT repaint, so the pixels on
-    // screen keep showing the OLD position and the just-sent message looks stranded below the fold until
-    // a real user scroll forces a recomposite. This is why every geometry probe read "at bottom": the
-    // layout IS at the bottom; only the paint is stale (confirmed on-device — toggling overflow made the
-    // already-correctly-positioned message appear without any scroll). Toggling overflow forces the
-    // scroll container to re-layout and repaint at the current position; `overflowY = ''` yields the
-    // property back to the CSS class (overflow-y-auto) and scrollTop is preserved. A cheap extra reflow
-    // on Chromium, which repaints on its own — but a FULL re-layout + repaint of the scroller on
-    // WebKitGTK, which is why writePin gates it on the scroll actually having moved.
-    const forceRepaint = () => {
-      const ss = scrollerRef.current
-      if (!ss) return
-      const started = performance.now()
-      ss.style.overflowY = 'hidden'
-      void ss.offsetHeight // forced reflow → WebKit repaints the scrolled content
-      ss.style.overflowY = ''
-      run.addMs('repaint', performance.now() - started)
-    }
-
-    // Forced repaint, coalesced across a content-arrival BURST. When the pin would normally repaint
-    // but a burst is in flight (this arrival plus others within PIN_BURST_WINDOW_MS), skip it and
-    // record the debt: the position is already written so the layout is correct — only the paint is
-    // deferred to the single trailing repaint that convergence forces once arrival quiesces. This
-    // collapses a burst's N WebKitGTK repaints (~50–150ms each) to ~1. The 'always'/'off' A/B
-    // overrides stay unconditional (they must, to measure the un-coalesced cost on-device).
-    const repaintCoalesced = (moved: boolean) => {
-      if (!shouldForceRepaint(moved, repaintMode, isLoadingOlderRef.current)) return
-      if (repaintMode === 'on-write' && burst.suppress(performance.now())) {
-        burst.markSuppressed()
-        return
-      }
-      forceRepaint()
-    }
-
-    // Pin write + gated repaint. The stale-paint bug is specific to a PROGRAMMATIC SCROLL, so when
-    // scrollToIndex lands on the scrollTop the scroller already had (a no-op re-assert — typing
-    // toggles, resize re-pins) there is nothing stale to draw and the expensive repaint is skipped.
-    // `fluux:pin-repaint` = 'always' | 'off' overrides the gate for on-device A/B on Linux.
-    let wroteAny = false
-    const writePin = (): boolean => {
-      const ss = scrollerRef.current
-      const v = virtualizerRef.current
-      if (!ss || !v || v.itemCount === 0) return false
-      const before = ss.scrollTop
-      const started = performance.now()
-      v.scrollToIndex(v.itemCount - 1, { align: 'end' })
-      run.addMs('scroll', performance.now() - started)
-      const moved = ss.scrollTop !== before
-      if (moved) wroteAny = true
-      repaintCoalesced(moved)
-      return moved
-    }
-
-    // Flush a repaint debt owed by burst coalescing: force the single trailing repaint that draws the
-    // final settled position, and emit the [PinBurstProbe] line attributing how many repaints were
-    // coalesced (each ~50–150ms of WebKitGTK freeze avoided). No-op when nothing was suppressed.
-    const flushOwedRepaint = () => {
-      if (!burst.owed()) return
-      forceRepaint()
-      console.warn(pinBurstProbeLine(trigger, burst.settle()))
-    }
-
-    // Immediate pin (pre-paint when called from a layout effect).
-    flushTailLayout()
-    writePin()
-    debugLog('PIN start', {
-      trigger,
-      itemCount: virt.itemCount,
-      distFromBottom: scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
-    })
-
-    const startedAt = Date.now()
-    const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('pin-bottom', performance.now())
-    pinBottomActiveRef.current = true
-    let framesLeft = BOTTOM_REASSERT_FRAMES
-    let lastHeight = scroller.scrollHeight
-    const finish = () => {
-      loop.end()
-      reassertLoopRef.current = null
-      pinBottomActiveRef.current = false
-      // One rate-limited fluux.log line attributing this run's forced work (flush/scroll/repaint),
-      // so the next on-device freeze report says which pin trigger paid what.
-      const probe = (pinRunProbeRef.current ??= createRenderCostProbe({ thresholdMs: PIN_PROBE_THRESHOLD_MS }))
-      if (probe.record(run.totalForcedMs(), performance.now())) {
-        console.warn(run.summaryLine(trigger))
-      }
-    }
-    const step = () => {
-      const s = scrollerRef.current
-      if (framesLeft-- <= 0) {
-        // Loop ran its full budget without converging. Re-derive isAtBottom from geometry (accurate —
-        // the position is correct even when WebKit withheld the paint) and force one final repaint —
-        // if anything was written — so the settled position is actually drawn. Still suppressed while
-        // a MAM catch-up is in flight: more content is coming, so this isn't the settled position yet —
-        // the catch-up-complete effect below forces the real final repaint once it finishes.
-        if (s) {
-          flushTailLayout()
-          const dist = s.scrollHeight - s.scrollTop - s.clientHeight
-          isAtBottomRef.current = dist < AT_BOTTOM_THRESHOLD
-          // One final repaint draws the settled position. A burst debt takes precedence (it forces the
-          // repaint AND logs the coalesced count) and subsumes the normal on-write repaint, so at most
-          // one overflow toggle fires here.
-          if (burst.owed()) flushOwedRepaint()
-          else if (shouldForceRepaint(wroteAny, repaintMode, isLoadingOlderRef.current)) forceRepaint()
-          debugLog('PIN settled (frames exhausted)', { distFromBottom: dist })
-        }
-        finish()
-        return
-      }
-      const v = virtualizerRef.current
-      if (!s || !v || v.itemCount === 0) { finish(); return }
-      // The ONLY reason to stop pinning is a genuine user takeover — a FAB tap or a wheel scroll, both
-      // of which stamp userScrollIntentAtRef AFTER we started. We do NOT bail on a position-derived
-      // `!isAtBottomRef.current`: on WebKit a tall bottom row's post-paint growth fires extra `scroll`
-      // events reporting a large distFromBottom that the height-unchanged discriminator can't always
-      // catch, and flipping isAtBottom false used to strand the send. The pin keeps converging on
-      // geometry and yields only to real input intent.
-      if (userScrollIntentAtRef.current > startedAt) {
-        debugLog('PIN bail (user scroll intent)', {
-          distFromBottom: s.scrollHeight - s.scrollTop - s.clientHeight,
-        })
-        // User took over: the bottom-pin debt is void (their scroll itself repaints), so drop it
-        // rather than force a trailing repaint that would fight the position they scrolled to.
-        burst.reset()
-        finish()
-        return
-      }
-      // Force the tail rows to lay out this frame so WebKit's late ResizeObserver delivers and
-      // scrollHeight grows to include a just-added row before we read it below.
-      flushTailLayout()
-      const h = s.scrollHeight
-      // Re-pin when the layout grew/shrank OR we're still measurably short of the bottom. Idempotent
-      // once pinned; the repaint is gated inside writePin on the scroll actually moving.
-      const dist = h - s.scrollTop - s.clientHeight
-      let wrote = false
-      if (h !== lastHeight || dist > BOTTOM_PIN_TOLERANCE) {
-        debugLog('PIN re-assert', { distFromBottom: dist, heightChanged: h !== lastHeight })
-        lastHeight = h
-        writePin()
-        wrote = true
-      }
-      const warning = loop.frame(performance.now(), wrote)
-      if (warning) console.warn(warning)
-      // CONVERGENCE EARLY-EXIT: once the geometry has been stable for a few consecutive frames the
-      // measurement settle is over — running out the remaining budget would only burn one forced
-      // layout per frame (the WebKitGTK freeze pattern). Late media loads re-pin via their own site.
-      if (run.frame(wrote) === 'settled') {
-        isAtBottomRef.current = dist < AT_BOTTOM_THRESHOLD
-        // Arrival has quiesced (8 stable frames): flush any repaint the burst coalescer deferred, so
-        // the final bottom position is drawn exactly once. Non-burst runs already painted per-frame,
-        // so owed() is false and this is a no-op.
-        flushOwedRepaint()
-        debugLog('PIN settled (converged)', {
-          distFromBottom: dist,
-          framesUsed: BOTTOM_REASSERT_FRAMES - framesLeft,
-        })
-        finish()
-        return
-      }
-      reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
-    }
-    reassertLoopRef.current = { raf: requestAnimationFrame(step), handle: loop }
-  }, [isAtBottomRef])
-
-  // Re-pin the list to the bottom after a layout change that grows the content or shrinks the
-  // scroller while the user is following along: typing indicator, reactions on the last message,
-  // or a composer banner appearing/disappearing (attachment preview, whisper marker, reply/edit
-  // preview). Routes through the virtualizer when active so the mounted window re-windows before
-  // paint (a raw scrollTop write leaves @tanstack's offset stale → blank/clipped); otherwise a
-  // direct scrollTop write. Callers must have already confirmed the user is at/near the bottom.
-  const reassertBottom = useCallback((trigger: string = 'unknown') => {
-    // The saved-position executor calls this only after installing its generation-bearing fallback
-    // request. Every other bottom write must agree with semantic follow-live ownership or current
-    // live geometry; unlike the live loop, the shadow check never trusts isAtBottomRef by itself.
-    if (trigger !== 'restore-fallback') {
-      const scroller = scrollerRef.current
-      runScrollShadowSafely({
-        event: `reassert:${trigger}`,
-        conversationId: prevConversationRef.current ?? conversationId,
-        fallback: undefined,
-        observe: () => {
-          positioningControllerRef.current?.observeBottomReassert({
-            event: `reassert:${trigger}`,
-            conversationId: prevConversationRef.current ?? conversationId,
-            geometryAtLiveEdge:
-              !!scroller && deriveAtLiveEdge(readScrollGeometry(scroller)),
-            actualFollowsLive: true,
-          })
-        },
-      })
-    }
-    if (virtualizerRef.current) {
-      pinVirtualizedBottom(trigger)
-    } else {
-      const s = scrollerRef.current
-      if (s) s.scrollTop = s.scrollHeight
-    }
-    rememberBottomIntent()
-  }, [conversationId, pinVirtualizedBottom, rememberBottomIntent])
-
   // Apply one virtualized bottom-fraction anchor write from CURRENT measurements. Saved-position
-  // restoration and media preservation deliberately share this browser geometry, but not ownership:
-  // the positioning controller schedules saved restore frames, while the retained media loop below
-  // remains outside the controller until the content-growth migration.
+  // restoration and media preservation share this browser geometry while the positioning controller
+  // owns both frame-loop lifecycles.
   const applyVirtualizedAnchorFrame = useCallback((anchor: ScrollAnchor): number | null => {
     const v = virtualizerRef.current
     const s = scrollerRef.current
@@ -1175,73 +881,6 @@ export function useMessageListScroll({
     }
     return s.scrollTop
   }, [])
-
-  // Standalone media-preservation loop. Saved-position restoration no longer enters this owner.
-  const reassertMediaAnchor = useCallback((
-    anchor: ScrollAnchor,
-    anchorConvId: string,
-  ): boolean => {
-    if (!virtualizerRef.current || !scrollerRef.current) return false
-
-    supersedeReassertLoopRef.current()
-
-    if (applyVirtualizedAnchorFrame(anchor) === null) return false
-
-    const startedAt = Date.now()
-    const loop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('media-anchor', performance.now())
-    let framesLeft = MEDIA_ANCHOR_REASSERT_FRAMES
-    let stableFrames = 0
-    let landed = -1
-    const finish = () => {
-      loop.end()
-      if (reassertLoopRef.current?.handle === loop) {
-        reassertLoopRef.current = null
-      }
-      // The loop just stopped owning scrollTop; keep the brief measurement settle that follows it
-      // classified as programmatic so it can't open the save gate (see lastProgrammaticScrollAtRef).
-      lastProgrammaticScrollAtRef.current = Date.now()
-      // Capture the settled position so a leave immediately after media decode saves the anchor we
-      // landed on, not a mid-settle transient.
-      const s = scrollerRef.current
-      if (s) {
-        isAtBottomRef.current = (s.scrollHeight - s.scrollTop - s.clientHeight) < AT_BOTTOM_THRESHOLD
-        rememberCurrentScrollSnapshot()
-      }
-    }
-    const step = () => {
-      const s = scrollerRef.current
-      if (!s) { finish(); return }
-      if (framesLeft-- <= 0) { finish(); return }
-      // Stale loop must never scroll the new conversation (prevConversationRef is set synchronously
-      // at the end of the conversation-switch effect).
-      if (prevConversationRef.current !== anchorConvId) { finish(); return }
-      // User took over → stop fighting them.
-      if (userScrollIntentAtRef.current > startedAt) { finish(); return }
-
-      const st = applyVirtualizedAnchorFrame(anchor)
-      if (st === null) { finish(); return }
-
-      let wrote = false
-      if (landed >= 0 && Math.abs(st - landed) <= MEDIA_ANCHOR_DRIFT_PX) {
-        if (++stableFrames >= MEDIA_ANCHOR_STABLE_FRAMES) { finish(); return }
-      } else {
-        wrote = true
-        stableFrames = 0
-      }
-      landed = st
-
-      const warning = loop.frame(performance.now(), wrote)
-      if (warning) console.warn(warning)
-      register(step)
-    }
-    const register = (callback: () => void) => {
-      const entry = { raf: 0, handle: loop }
-      reassertLoopRef.current = entry
-      entry.raf = requestAnimationFrame(callback)
-    }
-    register(step)
-    return true
-  }, [applyVirtualizedAnchorFrame, isAtBottomRef, rememberCurrentScrollSnapshot])
 
   const beginControllerFrameLoop = useCallback((
     label: string,
@@ -1279,7 +918,351 @@ export function useMessageListScroll({
     }
   }, [])
 
+  const createLiveEdgeExecutor = useCallback((
+    trigger: string,
+    smoothNonVirtualized = false,
+  ): LiveEdgeExecutor => {
+    const burst = (pinRepaintBurstRef.current ??= createPinRepaintBurst())
+    const run = createPinRunTracker()
+    const repaintMode = readPinRepaintMode(
+      typeof window === 'undefined' ? undefined : window.localStorage,
+    )
+    let initialized = false
+    let lastHeight = 0
+    let wroteAny = false
+
+    const flushTailLayout = () => {
+      const scroller = scrollerRef.current
+      if (!scroller) return
+      const started = performance.now()
+      scroller.getBoundingClientRect()
+      const rows = scroller.querySelectorAll('[data-message-id]')
+      for (let i = Math.max(0, rows.length - 3); i < rows.length; i++) {
+        rows[i].getBoundingClientRect()
+      }
+      run.addMs('flush', performance.now() - started)
+    }
+
+    const forceRepaint = () => {
+      const scroller = scrollerRef.current
+      if (!scroller) return
+      const started = performance.now()
+      scroller.style.overflowY = 'hidden'
+      void scroller.offsetHeight
+      scroller.style.overflowY = ''
+      run.addMs('repaint', performance.now() - started)
+    }
+
+    const repaintCoalesced = (moved: boolean) => {
+      if (!shouldForceRepaint(moved, repaintMode, isLoadingOlderRef.current)) return
+      if (repaintMode === 'on-write' && burst.suppress(performance.now())) {
+        burst.markSuppressed()
+        return
+      }
+      forceRepaint()
+    }
+
+    const writeVirtualizedPin = (): boolean => {
+      const scroller = scrollerRef.current
+      const virtualizer = virtualizerRef.current
+      if (!scroller || !virtualizer || virtualizer.itemCount === 0) return false
+      const before = scroller.scrollTop
+      const started = performance.now()
+      virtualizer.scrollToIndex(virtualizer.itemCount - 1, { align: 'end' })
+      run.addMs('scroll', performance.now() - started)
+      const moved = scroller.scrollTop !== before
+      wroteAny ||= moved
+      repaintCoalesced(moved)
+      return moved
+    }
+
+    const flushOwedRepaint = () => {
+      if (!burst.owed()) return
+      forceRepaint()
+      console.warn(pinBurstProbeLine(trigger, burst.settle()))
+    }
+
+    return {
+      reachability: () => deriveReachabilityForDesired({
+        desired: { kind: 'live-edge', follow: true },
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+        virtualizer: virtualizerRef.current,
+        scroller: scrollerRef.current,
+        loadAround: 'unavailable',
+        canRecenter: Boolean(onLoadNewer),
+      }),
+      recenterVersion: [
+        windowAtLiveEdge === false ? 'slid' : 'live',
+        isLoadingNewer ? 'loading' : 'idle',
+        messageCount,
+        lastMessageId ?? '',
+      ].join(':'),
+      recenter: onLoadNewer
+        ? (signal) => {
+            if (signal.aborted) return 'unavailable'
+            if (isLoadingNewer) return 'waiting'
+            onLoadNewer()
+            return 'requested'
+          }
+        : undefined,
+      beginLoop: (lease) => {
+        const loop = beginControllerFrameLoop('pin-bottom', lease)
+        if (!loop) return null
+        pinBottomActiveRef.current = true
+        return {
+          ...loop,
+          finish: () => {
+            loop.finish()
+            pinBottomActiveRef.current = false
+          },
+        }
+      },
+      positionFrame: (
+        request: LiveEdgeRequest,
+        lease: PositionExecutionLease,
+      ) => {
+        if (
+          !lease.isCurrent() ||
+          activeConversationIdRef.current !== request.conversationId
+        ) {
+          return { kind: 'unavailable' }
+        }
+        const scroller = scrollerRef.current
+        if (!scroller) return { kind: 'unavailable' }
+        const virtualizer = virtualizerRef.current
+
+        if (!virtualizer) {
+          const firstFrame = !initialized
+          const before = scroller.scrollTop
+          if (smoothNonVirtualized && firstFrame) {
+            scroller.scrollTo({
+              top: scroller.scrollHeight,
+              behavior: 'smooth',
+            })
+          } else {
+            scroller.scrollTop = scroller.scrollHeight
+          }
+          initialized = true
+          rememberBottomIntent()
+          return {
+            kind: 'positioned',
+            scrollTop: scroller.scrollTop,
+            atLiveEdge: true,
+            wrote: scroller.scrollTop !== before,
+            // Conversation entry historically issued one deferred raw write after the immediate
+            // layout-effect write. Keep that exact two-write edge-case repair under controller
+            // scheduling; all other non-virtualized stimuli remain one-shot.
+            reassert: firstFrame && trigger === 'switch',
+          }
+        }
+        if (virtualizer.itemCount === 0) return { kind: 'unavailable' }
+
+        if (!initialized) {
+          initialized = true
+          if (CONTENT_ARRIVAL_TRIGGERS.has(trigger)) {
+            burst.note(performance.now())
+          }
+          flushTailLayout()
+          writeVirtualizedPin()
+          lastHeight = scroller.scrollHeight
+          rememberBottomIntent()
+          debugLog('PIN start', {
+            trigger,
+            itemCount: virtualizer.itemCount,
+            distFromBottom: getDistanceFromBottom(scroller),
+          })
+          return {
+            kind: 'positioned',
+            scrollTop: scroller.scrollTop,
+            atLiveEdge:
+              getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
+            wrote: true,
+            reassert: true,
+          }
+        }
+
+        flushTailLayout()
+        const height = scroller.scrollHeight
+        const distance = getDistanceFromBottom(scroller)
+        const needsWrite =
+          height !== lastHeight || distance > BOTTOM_PIN_TOLERANCE
+        if (needsWrite) {
+          debugLog('PIN re-assert', {
+            distFromBottom: distance,
+            heightChanged: height !== lastHeight,
+          })
+          lastHeight = height
+          writeVirtualizedPin()
+        }
+        run.frame(needsWrite)
+        return {
+          kind: 'positioned',
+          scrollTop: scroller.scrollTop,
+          atLiveEdge:
+            getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD,
+          wrote: needsWrite,
+          reassert: true,
+        }
+      },
+      complete: (
+        request: LiveEdgeRequest,
+        outcome: LiveEdgeCompletion,
+      ) => {
+        if (activeConversationIdRef.current !== request.conversationId) return
+        const scroller = scrollerRef.current
+        if (
+          outcome === 'user-takeover' ||
+          outcome === 'superseded'
+        ) {
+          burst.reset()
+        } else if (outcome === 'best-effort' && scroller) {
+          flushTailLayout()
+          if (burst.owed()) {
+            flushOwedRepaint()
+          } else if (
+            shouldForceRepaint(
+              wroteAny,
+              repaintMode,
+              isLoadingOlderRef.current,
+            )
+          ) {
+            forceRepaint()
+          }
+        } else if (outcome === 'settled') {
+          flushOwedRepaint()
+        }
+
+        if (scroller) {
+          isAtBottomRef.current =
+            getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD
+          lastProgrammaticScrollAtRef.current = Date.now()
+        }
+        const probe = (pinRunProbeRef.current ??= createRenderCostProbe({
+          thresholdMs: PIN_PROBE_THRESHOLD_MS,
+        }))
+        if (probe.record(run.totalForcedMs(), performance.now())) {
+          console.warn(run.summaryLine(trigger))
+        }
+        debugLog('PIN completed', {
+          trigger,
+          outcome,
+          distFromBottom: scroller ? getDistanceFromBottom(scroller) : null,
+        })
+      },
+    }
+  }, [
+    beginControllerFrameLoop,
+    firstMessageId,
+    isAtBottomRef,
+    isLoadingNewer,
+    lastMessageId,
+    messageCount,
+    onLoadNewer,
+    rememberBottomIntent,
+    windowAtLiveEdge,
+  ])
+
+  const reconcileLiveEdge = useCallback((trigger: string): boolean => {
+    const controller = positioningControllerRef.current
+    if (!controller) return false
+    return controller.reconcileLiveEdge({
+      conversationId,
+      executor: createLiveEdgeExecutor(trigger),
+    })
+  }, [conversationId, createLiveEdgeExecutor])
+  reconcileLiveEdgeRef.current = reconcileLiveEdge
+
+  // Controller/instrumentation failure boundary only. Normal bottom positioning always goes through
+  // a generation-bearing live-edge execution; this one-shot keeps the UI usable if that machinery
+  // cannot be constructed.
+  const emergencyLiveEdgeWrite = useCallback((
+    smoothNonVirtualized = false,
+  ) => {
+    const scroller = scrollerRef.current
+    const virtualizer = virtualizerRef.current
+    if (!scroller) return
+    if (virtualizer && virtualizer.itemCount > 0) {
+      virtualizer.scrollToIndex(virtualizer.itemCount - 1, { align: 'end' })
+    } else if (smoothNonVirtualized) {
+      scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
+    } else {
+      scroller.scrollTop = scroller.scrollHeight
+    }
+    rememberBottomIntent()
+  }, [rememberBottomIntent])
+
+  const createMediaPreservationExecutor = useCallback(
+    (): MediaPreservationExecutor => ({
+      reachability: (desired) => deriveReachabilityForDesired({
+        desired,
+        hasRows: messageCount > 0 && firstMessageId !== undefined,
+        windowAtLiveEdge: windowAtLiveEdge !== false,
+        virtualizer: virtualizerRef.current,
+        scroller: scrollerRef.current,
+        loadAround: 'unavailable',
+        canRecenter: false,
+      }),
+      beginLoop: (lease) => beginControllerFrameLoop('media-anchor', lease),
+      positionFrame: (
+        request: MediaPreservationRequest,
+        lease: PositionExecutionLease,
+      ) => {
+        if (
+          !lease.isCurrent() ||
+          activeConversationIdRef.current !== request.conversationId
+        ) {
+          return { kind: 'unavailable' }
+        }
+        const scroller = scrollerRef.current
+        if (!scroller) return { kind: 'unavailable' }
+        const anchor: ScrollAnchor = {
+          messageId: request.desired.messageId,
+          fraction: request.desired.placement.fraction,
+        }
+        if (virtualizerRef.current) {
+          const scrollTop = applyVirtualizedAnchorFrame(anchor)
+          return scrollTop === null
+            ? { kind: 'unavailable' }
+            : { kind: 'positioned', scrollTop, reassert: true }
+        }
+        return restoreToAnchor(scroller, anchor)
+          ? {
+              kind: 'positioned',
+              scrollTop: scroller.scrollTop,
+              reassert: false,
+            }
+          : { kind: 'unavailable' }
+      },
+      complete: (request, outcome) => {
+        if (activeConversationIdRef.current !== request.conversationId) return
+        const scroller = scrollerRef.current
+        if (scroller) {
+          isAtBottomRef.current =
+            getDistanceFromBottom(scroller) < AT_BOTTOM_THRESHOLD
+          rememberCurrentScrollSnapshot()
+        }
+        lastProgrammaticScrollAtRef.current = Date.now()
+        debugLog('MEDIA LOAD: controller completed preservation', {
+          conversationId: request.conversationId,
+          generation: request.generation,
+          outcome,
+        })
+      },
+    }),
+    [
+      applyVirtualizedAnchorFrame,
+      beginControllerFrameLoop,
+      firstMessageId,
+      isAtBottomRef,
+      messageCount,
+      rememberCurrentScrollSnapshot,
+      windowAtLiveEdge,
+    ],
+  )
+
   const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
+    liveEdge: createLiveEdgeExecutor('restore-fallback'),
     reachability: (desired, loadAround) => {
       const scroller = scrollerRef.current
       const virtualizer = virtualizerRef.current
@@ -1366,9 +1349,9 @@ export function useMessageListScroll({
           }
         }
       } else if (request.desired.kind === 'live-edge') {
-        isAtBottomRef.current = true
-        reassertBottom('restore-fallback')
-        restored = true
+        // Live-edge fallbacks transfer to the dedicated controller execution before this executor
+        // is driven. Treat a stale call as unavailable rather than creating a second scroll owner.
+        return { kind: 'unavailable' }
       }
 
       if (!restored || !lease.isCurrent()) return { kind: 'unavailable' }
@@ -1395,18 +1378,19 @@ export function useMessageListScroll({
     applyVirtualizedAnchorFrame,
     beginControllerFrameLoop,
     conversationId,
+    createLiveEdgeExecutor,
     firstMessageId,
     isAtBottomRef,
     isLoadingNewer,
     lastMessageId,
     messageCount,
     onLoadNewer,
-    reassertBottom,
     rememberCurrentScrollSnapshot,
     windowAtLiveEdge,
   ])
 
   const createUnreadMarkerExecutor = useCallback((): UnreadMarkerExecutor => ({
+    liveEdge: createLiveEdgeExecutor('marker-fallback'),
     reachability: (desired) => deriveReachabilityForDesired({
       desired,
       hasRows: messageCount > 0 && firstMessageId !== undefined,
@@ -1485,20 +1469,12 @@ export function useMessageListScroll({
       })
       return { kind: 'positioned', scrollTop, atLiveEdge }
     },
-    applyLiveEdge: (reason, lease) => {
-      if (!lease.isCurrent()) return false
-      isAtBottomRef.current = true
-      if (reason === 'unread-marker-unavailable') {
-        reassertBottom('marker-fallback')
-      }
-      return true
-    },
   }), [
     firstMessageId,
     beginControllerFrameLoop,
+    createLiveEdgeExecutor,
     isAtBottomRef,
     messageCount,
-    reassertBottom,
     windowAtLiveEdge,
   ])
 
@@ -1738,31 +1714,18 @@ export function useMessageListScroll({
       }
     }
 
-    positioningControllerRef.current?.observeLiveEdgeNavigation({
-      event: 'fab-live-edge',
+    const request = positioningControllerRef.current?.beginLiveEdgeNavigation({
       conversationId,
       navigationFacts,
-      reachability: (desired) => shadowReachabilityRef.current(desired),
-      actual: {
-        desired: { kind: 'live-edge', follow: true },
-        phase: 'positioning',
-      },
+      executor: createLiveEdgeExecutor('fab', true),
     })
-
-    const virtFab = latestRef.current.virtualizer
-    if (virtFab && virtFab.itemCount > 0) {
-      reassertBottom('fab')
-      return
-    }
-
-    rememberBottomIntent()
-    scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
+    if (!request) emergencyLiveEdgeWrite(true)
   }, [
     conversationId,
+    createLiveEdgeExecutor,
     createUnreadMarkerExecutor,
+    emergencyLiveEdgeWrite,
     firstNewMessageId,
-    reassertBottom,
-    rememberBottomIntent,
   ])
   // Also published to the active-list registry (ChatLayout's Escape handler reaches it there), so it
   // is stabilised for the same reason as requestMessageTarget: an unstable identity re-registers the
@@ -1801,7 +1764,9 @@ export function useMessageListScroll({
   useEffect(() => {
     if (staticMode) return
     const onViewportResize = () => {
-      if (isAtBottomRef.current) reassertBottom('viewport-resize')
+      if (isAtBottomRef.current) {
+        reconcileLiveEdgeRef.current('viewport-resize')
+      }
     }
     window.addEventListener('resize', onViewportResize)
     const vv = window.visualViewport
@@ -1810,7 +1775,7 @@ export function useMessageListScroll({
       window.removeEventListener('resize', onViewportResize)
       vv?.removeEventListener('resize', onViewportResize)
     }
-  }, [staticMode, isAtBottomRef, reassertBottom])
+  }, [staticMode, isAtBottomRef])
 
   // ==========================================================================
   // LOAD OLDER MESSAGES
@@ -2077,18 +2042,13 @@ export function useMessageListScroll({
 
       if (wasAtBottom) {
         if (!userScrolled) {
-          positioningControllerRef.current?.observeAppend({
-            event: 'media-live-edge',
-            conversationId,
-            actualFollowsLive: true,
-          })
           // User didn't scroll during the batch - scroll to bottom
           debugLog('MEDIA LOAD: batch complete, scrolling to bottom', {
             wasAtBottom,
             userScrolled,
             scrollHeight: currentScroller.scrollHeight,
           })
-          reassertBottom('media-load')
+          reconcileLiveEdge('media-load')
         } else {
           // User actively scrolled during the batch - respect their position
           debugLog('MEDIA LOAD: batch complete, user scrolled away', {
@@ -2097,12 +2057,12 @@ export function useMessageListScroll({
           })
         }
       } else if (!userScrolled && anchor) {
-        const request = runScrollShadowSafely({
+        runScrollShadowSafely({
           event: 'media-preservation',
           conversationId,
-          fallback: null,
+          fallback: undefined,
           observe: () => {
-            const desired: DesiredPosition = {
+            const desired: MediaPreservationRequest['desired'] = {
               kind: 'anchor',
               messageId: anchor.messageId,
               placement: {
@@ -2110,35 +2070,21 @@ export function useMessageListScroll({
                 fraction: messageFraction(anchor.fraction),
               },
             }
-            return positioningControllerRef.current?.observeRequest({
-              event: 'media-preservation',
+            positioningControllerRef.current?.beginMediaPreservation({
               conversationId,
-              draft: {
-                source: { kind: 'media-preservation', reason: 'remeasure' },
-                desired,
-                onUnavailable: { kind: 'warn-and-stop' },
-              },
-              reachability: shadowReachabilityRef.current(desired),
-              actual: { desired, phase: 'positioning' },
-            }) ?? null
+              desired,
+              executor: createMediaPreservationExecutor(),
+            })
           },
         })
         // Scrolled up and the user did NOT genuinely scroll during the batch: media that decoded
         // ABOVE the viewport grew the content and pushed the reading position down/out. Re-pin to the
         // anchor captured BEFORE the growth so the reader stays put (the conversation-switch + media
-        // "drifts back in time" bug). Mirrors the at-bottom reassertBottom, but for a held position.
+        // "drifts back in time" bug). Mirrors live-edge reconciliation, but for a held position.
         debugLog('MEDIA LOAD: batch complete, re-anchoring scrolled-up position', {
           wasAtBottom,
           anchorId: anchor.messageId,
         })
-        if (virtualizerRef.current) reassertMediaAnchor(anchor, conversationId)
-        else restoreToAnchor(currentScroller, anchor)
-        if (request) {
-          positioningControllerRef.current?.markPositionApplied(
-            conversationId,
-            request.generation,
-          )
-        }
       } else {
         debugLog('MEDIA LOAD: batch complete, was not at bottom (user scrolled / no anchor)', {
           wasAtBottom,
@@ -2150,7 +2096,12 @@ export function useMessageListScroll({
       mediaLoadSnapshotRef.current = null
       mediaLoadDebounceRef.current = null
     }, MEDIA_LOAD_DEBOUNCE_MS)
-  }, [isAtBottomRef, reassertBottom, reassertMediaAnchor, conversationId])
+  }, [
+    conversationId,
+    createMediaPreservationExecutor,
+    isAtBottomRef,
+    reconcileLiveEdge,
+  ])
 
   // ==========================================================================
   // SCROLL EVENT HANDLER
@@ -2561,7 +2512,7 @@ export function useMessageListScroll({
           // entry half-positioned. This is the only saved-position write outside the controller and
           // exists solely as its failure boundary.
           isAtBottomRef.current = true
-          reassertBottom('restore-fallback')
+          emergencyLiveEdgeWrite()
         }
       } else if (firstNewMessageId) {
         // Has unread messages — position the first-unread marker ~1/3 down from the top so the
@@ -2582,7 +2533,7 @@ export function useMessageListScroll({
           // Keep instrumentation/controller failures from stranding entry above an unresolved
           // divider. Normal marker unavailability is promoted by the controller itself.
           isAtBottomRef.current = true
-          reassertBottom('marker-fallback')
+          emergencyLiveEdgeWrite()
         }
       } else if (targetMessageId) {
         // Has a target message to scroll to — skip scroll-to-bottom.
@@ -2613,39 +2564,14 @@ export function useMessageListScroll({
         // Note: Async content loading (MAM) is handled by the separate "new message" effect
         // which triggers when messageCount changes.
         isAtBottomRef.current = true
-        if (entryFacts) {
-          positioningControllerRef.current?.observeEntry({
-            event: syncedLiveEdge ? 'entry-synced-live-edge' : 'entry-live-edge',
+        const request = entryFacts
+          ? positioningControllerRef.current?.beginLiveEdgeEntry({
             conversationId,
             entryFacts,
-            reachability: (desired) => shadowReachabilityRef.current(desired),
-            actual: {
-              desired: { kind: 'live-edge', follow: true },
-              phase: 'positioning',
-            },
+            executor: createLiveEdgeExecutor('switch'),
           })
-        }
-        const virtSwitch = latestRef.current.virtualizer
-        if (virtSwitch) {
-          // Virtualizer-native bottom: uses actual measured heights, not the estimated
-          // spacer height. This is the root cause of the "blank FAB" bug — estimated
-          // scrollHeight undershoots when bottom rows are taller than estimateSize.
-          // pinVirtualizedBottom re-asserts across frames as those rows measure, so the
-          // last message isn't left clipped (taller) or floating above empty space (shorter).
-          pinVirtualizedBottom('switch')
-        } else {
-          void scroller.offsetHeight  // Force layout calculation
-          scroller.scrollTop = scroller.scrollHeight
-          requestAnimationFrame(() => {
-            if (scrollerRef.current) {
-              scrollerRef.current.scrollTop = scrollerRef.current.scrollHeight
-              debugLog('CONVERSATION SWITCH: scrolled to bottom (deferred)', {
-                scrollTop: scrollerRef.current.scrollTop,
-                scrollHeight: scrollerRef.current.scrollHeight,
-              })
-            }
-          })
-        }
+          : null
+        if (!request) emergencyLiveEdgeWrite()
       }
     }
 
@@ -2658,7 +2584,20 @@ export function useMessageListScroll({
     prevLastMessageIdRef.current = lastMessageId
     previousReadPositionRef.current = readPointerId
 
-  }, [conversationId, messageCount, firstNewMessageId, targetMessageId, lastMessageId, readPointerId, isAtBottomRef, staticMode, createSavedPositionExecutor, createUnreadMarkerExecutor, pinVirtualizedBottom, reassertBottom])
+  }, [
+    conversationId,
+    createLiveEdgeExecutor,
+    createSavedPositionExecutor,
+    createUnreadMarkerExecutor,
+    emergencyLiveEdgeWrite,
+    firstNewMessageId,
+    isAtBottomRef,
+    lastMessageId,
+    messageCount,
+    readPointerId,
+    staticMode,
+    targetMessageId,
+  ])
 
   // Zero-unread twin of the divider-clear settle below. The old local position may be restored
   // before MAM resolves the other device's pointer to the newest downloaded row; with no divider,
@@ -2678,27 +2617,25 @@ export function useMessageListScroll({
       savedReadPositionId: pending.savedReadPositionId,
       readPointerId,
     })
-    positioningControllerRef.current?.observeRequest({
-      event: 'mds-live-edge',
+    const request = positioningControllerRef.current?.beginLiveEdgeRequest({
       conversationId,
-      draft: {
-        source: {
-          kind: 'late-mds-supersession',
-          reason: 'read-pointer-at-live-edge',
-        },
-        desired: { kind: 'live-edge', follow: true },
+      source: {
+        kind: 'late-mds-supersession',
+        reason: 'read-pointer-at-live-edge',
       },
-      reachability: shadowReachabilityRef.current({
-        kind: 'live-edge',
-        follow: true,
-      }),
-      actual: {
-        desired: { kind: 'live-edge', follow: true },
-        phase: 'positioning',
-      },
+      executor: createLiveEdgeExecutor('mds-live-edge'),
     })
-    reassertBottom('mds-live-edge')
-  }, [conversationId, firstNewMessageId, lastMessageId, readPointerId, staticMode, isAtBottomRef, reassertBottom])
+    if (!request) emergencyLiveEdgeWrite()
+  }, [
+    conversationId,
+    createLiveEdgeExecutor,
+    emergencyLiveEdgeWrite,
+    firstNewMessageId,
+    isAtBottomRef,
+    lastMessageId,
+    readPointerId,
+    staticMode,
+  ])
 
   // XEP-0490 settle window: the fresh-session read-sync seed can land just AFTER a
   // conversation is opened. The SDK's entry fold races the async PEP fetch, so at
@@ -2718,7 +2655,7 @@ export function useMessageListScroll({
   //    before this one runs),
   //  - only while the settle window is open (the user hasn't scrolled since entry),
   //  - never in static/preview mode.
-  // reassertBottom() supersedes the stale marker re-assert loop (single-flight).
+  // The newer live-edge generation supersedes the stale marker execution.
   const prevSettleRef = useRef({ conv: conversationId, divider: firstNewMessageId })
   useLayoutEffect(() => {
     const prev = prevSettleRef.current
@@ -2732,24 +2669,23 @@ export function useMessageListScroll({
       prevMarker: prev.divider,
     })
     isAtBottomRef.current = true
-    positioningControllerRef.current?.observeRequest({
-      event: 'mds-settle',
+    const request = positioningControllerRef.current?.beginLiveEdgeRequest({
       conversationId,
-      draft: {
-        source: { kind: 'late-mds-supersession', reason: 'divider-cleared' },
-        desired: { kind: 'live-edge', follow: true },
+      source: {
+        kind: 'late-mds-supersession',
+        reason: 'divider-cleared',
       },
-      reachability: shadowReachabilityRef.current({
-        kind: 'live-edge',
-        follow: true,
-      }),
-      actual: {
-        desired: { kind: 'live-edge', follow: true },
-        phase: 'positioning',
-      },
+      executor: createLiveEdgeExecutor('mds-settle'),
     })
-    reassertBottom('mds-settle')
-  }, [conversationId, firstNewMessageId, staticMode, isAtBottomRef, reassertBottom])
+    if (!request) emergencyLiveEdgeWrite()
+  }, [
+    conversationId,
+    createLiveEdgeExecutor,
+    emergencyLiveEdgeWrite,
+    firstNewMessageId,
+    isAtBottomRef,
+    staticMode,
+  ])
 
   // Refresh controller-owned saved positioning when cache/MAM rows or the active window change.
   // Async around-load completion also drives itself, covering an empty slice that changes no props.
@@ -2776,6 +2712,25 @@ export function useMessageListScroll({
     conversationId,
     createSavedPositionExecutor,
     firstMessageId,
+    lastMessageId,
+    messageCount,
+    staticMode,
+    windowAtLiveEdge,
+  ])
+
+  // Pending live-edge entry/recenter work resumes when cache rows or the sliding window changes.
+  // Settled follow-live requests are not restarted here; content stimuli call reconcileLiveEdge.
+  useLayoutEffect(() => {
+    if (staticMode) return
+    positioningControllerRef.current?.refreshLiveEdge({
+      conversationId,
+      executor: createLiveEdgeExecutor('refresh'),
+    })
+  }, [
+    conversationId,
+    createLiveEdgeExecutor,
+    firstMessageId,
+    isLoadingNewer,
     lastMessageId,
     messageCount,
     staticMode,
@@ -3267,24 +3222,10 @@ export function useMessageListScroll({
 
     if (positioningControllerRef.current?.isSavedPositionPending(conversationId)) {
       if (lastMessageIsOutgoing) {
-        positioningControllerRef.current?.observeRequest({
-          event: 'new-message-during-restore',
+        positioningControllerRef.current?.beginLiveEdgeRequest({
           conversationId,
-          draft: {
-            source: { kind: 'live-update', reason: 'outgoing-message' },
-            desired: { kind: 'live-edge', follow: true },
-          },
-          reachability: shadowReachabilityRef.current({
-            kind: 'live-edge',
-            follow: true,
-          }),
-          actual: { desired: null, phase: 'idle' },
-        })
-      } else {
-        positioningControllerRef.current?.observeAppend({
-          event: 'incoming-message-during-restore',
-          conversationId,
-          actualFollowsLive: false,
+          source: { kind: 'live-update', reason: 'outgoing-message' },
+          executor: createLiveEdgeExecutor('new-message'),
         })
       }
       debugLog('NEW MSG SKIP (restore pending)', {
@@ -3301,24 +3242,10 @@ export function useMessageListScroll({
     // Once restored, allow new message auto-scroll even during cooldown period
     if (prependRef.current && !prependRef.current.restored) {
       if (lastMessageIsOutgoing) {
-        positioningControllerRef.current?.observeRequest({
-          event: 'new-message-during-window-shift',
+        positioningControllerRef.current?.beginLiveEdgeRequest({
           conversationId,
-          draft: {
-            source: { kind: 'live-update', reason: 'outgoing-message' },
-            desired: { kind: 'live-edge', follow: true },
-          },
-          reachability: shadowReachabilityRef.current({
-            kind: 'live-edge',
-            follow: true,
-          }),
-          actual: { desired: null, phase: 'idle' },
-        })
-      } else {
-        positioningControllerRef.current?.observeAppend({
-          event: 'incoming-message-during-window-shift',
-          conversationId,
-          actualFollowsLive: false,
+          source: { kind: 'live-update', reason: 'outgoing-message' },
+          executor: createLiveEdgeExecutor('new-message'),
         })
       }
       debugLog('NEW MSG SKIP (prepend in progress)', {
@@ -3343,28 +3270,15 @@ export function useMessageListScroll({
     // from a scrolled-up position. An incoming message while scrolled up does NOT yank the reader.
     if (newBottomRow && (isAtBottomRef.current || lastMessageIsOutgoing)) {
       if (lastMessageIsOutgoing) {
-        positioningControllerRef.current?.observeRequest({
-          event: 'outgoing-message',
+        isAtBottomRef.current = true
+        const request = positioningControllerRef.current?.beginLiveEdgeRequest({
           conversationId,
-          draft: {
-            source: { kind: 'live-update', reason: 'outgoing-message' },
-            desired: { kind: 'live-edge', follow: true },
-          },
-          reachability: shadowReachabilityRef.current({
-            kind: 'live-edge',
-            follow: true,
-          }),
-          actual: {
-            desired: { kind: 'live-edge', follow: true },
-            phase: 'positioning',
-          },
+          source: { kind: 'live-update', reason: 'outgoing-message' },
+          executor: createLiveEdgeExecutor('new-message'),
         })
+        if (!request) emergencyLiveEdgeWrite()
       } else {
-        positioningControllerRef.current?.observeAppend({
-          event: 'incoming-message',
-          conversationId,
-          actualFollowsLive: true,
-        })
+        reconcileLiveEdge('new-message')
       }
       debugLog('NEW MSG SCROLL TO BOTTOM', {
         messageCount,
@@ -3377,14 +3291,7 @@ export function useMessageListScroll({
         distFromBottomBefore:
           scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight,
       })
-      isAtBottomRef.current = true // a send from a scrolled-up position lands us at the bottom
-      reassertBottom('new-message')
     } else if (newBottomRow) {
-      positioningControllerRef.current?.observeAppend({
-        event: 'incoming-message',
-        conversationId,
-        actualFollowsLive: false,
-      })
       debugLog('NEW MSG NO SCROLL (incoming, not at bottom)', {
         messageCount,
         prevCount: prevMessageCountRef.current,
@@ -3411,7 +3318,17 @@ export function useMessageListScroll({
 
     prevMessageCountRef.current = messageCount
     prevLastMessageIdRef.current = lastMessageId
-  }, [conversationId, messageCount, lastMessageId, isAtBottomRef, staticMode, lastMessageIsOutgoing, reassertBottom])
+  }, [
+    conversationId,
+    createLiveEdgeExecutor,
+    emergencyLiveEdgeWrite,
+    isAtBottomRef,
+    lastMessageId,
+    lastMessageIsOutgoing,
+    messageCount,
+    reconcileLiveEdge,
+    staticMode,
+  ])
 
   // ==========================================================================
   // EFFECT: Clean settle pin once a MAM catch-up completes
@@ -3431,9 +3348,9 @@ export function useMessageListScroll({
     const wasLoading = prevIsLoadingOlderRef.current
     prevIsLoadingOlderRef.current = isLoadingOlder
     if (wasLoading && !isLoadingOlder && isAtBottomRef.current && !staticMode) {
-      reassertBottom('mam-catchup-complete')
+      reconcileLiveEdge('mam-catchup-complete')
     }
-  }, [isLoadingOlder, isAtBottomRef, staticMode, reassertBottom])
+  }, [isLoadingOlder, isAtBottomRef, reconcileLiveEdge, staticMode])
 
   // ==========================================================================
   // EFFECT: Reset marker scroll tracking when firstNewMessageId changes
@@ -3457,7 +3374,7 @@ export function useMessageListScroll({
   // for a reaction on ANY resident row, not just the last one: a reaction in the middle of the
   // viewport would otherwise push everything below it (including the newest message) down.
   //
-  // We route through reassertBottom (the same multi-frame pinVirtualizedBottom convergence new
+  // We route through the controller-owned live-edge convergence that new
   // messages and the typing footer use) rather than a one-shot scrollToIndex, because the row's
   // ResizeObserver reports the grown height a frame or two AFTER the chip mounts — a single
   // synchronous pin would land on the pre-growth height and still let the bottom dip. The loop polls
@@ -3486,8 +3403,8 @@ export function useMessageListScroll({
     // A running pin loop already keeps the bottom pinned — don't stack a second one.
     if (pinBottomActiveRef.current) return
 
-    reassertBottom('reaction')
-  }, [reactionsSignature, conversationId, staticMode, reassertBottom])
+    reconcileLiveEdge('reaction')
+  }, [reactionsSignature, conversationId, reconcileLiveEdge, staticMode])
 
   // ==========================================================================
   // EFFECT: Typing indicator appears — reveal its footer clearance while sticked
@@ -3498,7 +3415,7 @@ export function useMessageListScroll({
   // few-pixel growth, the virtualized footer row needs a remeasure pass before the virtualizer's
   // computed end offset accounts for the taller padding — a one-shot scrollToIndex lands short (the
   // spacer hasn't caught up yet), leaving a residual gap under the pill. So this routes through the
-  // shared reassertBottom/pinVirtualizedBottom (the same multi-frame convergence new messages use)
+  // shared controller-owned live-edge loop (the same convergence new messages use)
   // instead of the reactions effect's single smooth nudge. Same two safeguards though: live-geometry
   // gate (not the latchable isAtBottomRef) and a same-conversation check. Only the false→true edge
   // nudges; typing stopping SHRINKS the footer, which the browser clamps scrollTop for on its own.
@@ -3517,8 +3434,8 @@ export function useMessageListScroll({
     // Live-geometry gate: only re-pin when genuinely at/near the bottom right now.
     if (getDistanceFromBottom(scroller) >= AT_BOTTOM_THRESHOLD) return
 
-    reassertBottom('typing')
-  }, [hasTypingIndicator, conversationId, staticMode, reassertBottom])
+    reconcileLiveEdge('typing')
+  }, [hasTypingIndicator, conversationId, reconcileLiveEdge, staticMode])
 
   // ==========================================================================
   // EFFECT: Container resize (composer grows/shrinks)
@@ -3555,9 +3472,11 @@ export function useMessageListScroll({
       const shrunk = lastHeight - newHeight
       if (shrunk > 0 && scrollerRef.current) {
         const wasNear = getDistanceFromBottom(scrollerRef.current) <= shrunk + AT_BOTTOM_THRESHOLD
-        // Route through reassertBottom so the virtualized path re-windows (scrollToIndex) rather
+        // Route through live-edge reconciliation so the virtualized path re-windows rather
         // than a raw scrollTop write that would leave the mounted window stale → blank/clipped.
-        if (wasNear) reassertBottom('container-shrink')
+        if (wasNear) {
+          reconcileLiveEdgeRef.current('container-shrink')
+        }
       } else if (
         newWidth !== null && lastWidth !== null && newWidth !== lastWidth &&
         scrollerRef.current && isAtBottomRef.current
@@ -3570,7 +3489,7 @@ export function useMessageListScroll({
         // drifted off the bottom. Re-assert while the user is following along, mirroring the
         // window-resize handler. The scroller's own width only changes on real layout changes,
         // not on row measurement, so this cannot feed back into the @tanstack spacer churn.
-        reassertBottom('width-change')
+        reconcileLiveEdgeRef.current('width-change')
       }
 
       lastHeight = newHeight
@@ -3603,11 +3522,10 @@ export function useMessageListScroll({
       observer.disconnect()
       if (rafId !== null) cancelAnimationFrame(rafId)
     }
-    // reassertBottom is stable (depends only on the stable pinVirtualizedBottom), so listing it
-    // re-creates the observer only on conversation change, same as conversationId alone.
+    // Re-create with the current conversation's live-edge executor.
     // isAtBottomRef is stable unless the caller passes a new externalIsAtBottomRef (same
     // rationale as the viewport-resize effect above).
-  }, [conversationId, reassertBottom, isAtBottomRef])
+  }, [conversationId, isAtBottomRef])
 
   // ==========================================================================
   // EFFECT: Keyboard shortcuts

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1115,6 +1115,8 @@ export function useMessageListScroll({
           outcome === 'user-takeover' ||
           outcome === 'superseded'
         ) {
+          // Cancellation abandons this executor's paint obligation. Carrying the debt into a newer
+          // generation could repaint after genuine user takeover or charge unrelated content.
           burst.reset()
         } else if (outcome === 'best-effort' && scroller) {
           flushTailLayout()

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -52,7 +52,9 @@ remeasurement moves the target makes convergence samples unreliable and recreate
 The live-edge executor retains its bottom-specific browser safeguards: tail-layout flushes for late
 WebKit measurement, the 4px missed-frame correction, repaint-burst coalescing, background-MAM
 repaint suppression, and the `overflowY` stale-paint repair. These remain executor mechanics rather
-than competing lifecycle owners.
+than competing lifecycle owners. A settled or best-effort generation flushes any owed trailing
+repaint; user takeover or supersession deliberately discards that debt so it cannot repaint after
+the reader takes control or leak into unrelated content.
 
 Directional-history preservation still runs the model beside `useMessageListScroll`: fact adapters
 read current virtualizer and DOM geometry, and observed decisions are compared with the model

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,8 +1,8 @@
 # Message-list scroll positioning contract
 
-Status: migration in progress. Saved-position restoration, unread-marker positioning, and explicit
-message targets are authoritative controller slices. Live-edge pinning and directional history
-preservation remain shadow-observed.
+Status: migration in progress. Saved-position restoration, unread-marker positioning, explicit
+message targets, live-edge pinning, and media remeasurement preservation are authoritative
+controller slices. Directional history preservation remains shadow-observed.
 
 ## Purpose
 
@@ -32,10 +32,13 @@ generation/operation cancellation, reachability, one around-load attempt, and ex
 legacy-offset/live-edge fallback. For unread markers it owns entry and jump-to-last-read requests,
 frame scheduling, stale-work cancellation, convergence, and live-edge fallback. For explicit
 message targets it owns supersession, one around-load attempt, mounting and center-position
-convergence, user takeover, and completion. Hook executors translate accepted requests into
-browser/virtualizer writes, and every frame must hold the current controller lease before it can
-write. Saved-position, unread-marker, and explicit-target reconciliation now share the same
-controller-owned `PositionFrameLoop` shape. The saved executor retains the existing fractional-anchor
+convergence, user takeover, and completion. For live edge it owns entry/FAB/outgoing generations,
+same-generation content stimuli, global-tail recentering, the 60-frame/8-stable-frame convergence
+budget, and user cancellation. Media growth while reading history is a separate fixed-anchor
+request with the former 90-frame/8-stable-frame/8px contract. Hook executors translate accepted
+requests into browser/virtualizer writes, and every frame must hold the current controller lease
+before it can write. All five authoritative slices share the same controller-owned
+`PositionFrameLoop` shape. The saved executor retains the existing fractional-anchor
 measurement write, 90-frame budget, 8-frame stability window, and 8px tolerance; only scheduling,
 convergence state, and lifecycle ownership moved out of the hook-local loop. Unlike unread-marker
 and explicit-target loops, saved-position restoration deliberately has no fixed geometry-drift
@@ -46,18 +49,24 @@ Explicit target convergence uses immediate center writes. The former reply/poll/
 native smooth animation is intentionally not retained: restarting a smooth animation while
 remeasurement moves the target makes convergence samples unreliable and recreates scroll fighting.
 
-The remaining live-edge and directional-history mechanisms run the model beside
-`useMessageListScroll`: fact adapters read current virtualizer and DOM geometry, and every observed
-live decision is compared with the model decision. The instrumentation runs in production so real
-traces can exercise it. A shared error boundary catches and counts adapter, validator,
+The live-edge executor retains its bottom-specific browser safeguards: tail-layout flushes for late
+WebKit measurement, the 4px missed-frame correction, repaint-burst coalescing, background-MAM
+repaint suppression, and the `overflowY` stale-paint repair. These remain executor mechanics rather
+than competing lifecycle owners.
+
+Directional-history preservation still runs the model beside `useMessageListScroll`: fact adapters
+read current virtualizer and DOM geometry, and observed decisions are compared with the model
+decision. The instrumentation runs in production so real traces can exercise it. A shared error
+boundary catches and counts adapter, validator,
 controller-driver, and executor errors; failure must degrade according to the active request's
 source-specific policy and must never escape into the scroll effect or event handler. The demo
 scroll-invariant suite fails if either `divergenceCount` or `instrumentationErrorCount` is non-zero.
 Retained diagnostic samples are capped, not the pass criterion.
 
-Zero divergences means the model agrees with the hand-authored semantic `actual` label at each
-observation site: desired position plus the coarse waiting/positioning/applied/paused/fallback/idle
-phase. It does **not** compare rendered pixels and must not be read as proof that the browser landed
+For the remaining shadow-observed slice, zero divergences means the model agrees with the
+hand-authored semantic `actual` label at each observation site: desired position plus the coarse
+waiting/positioning/applied/paused/fallback/idle phase. It does **not** compare rendered pixels and
+must not be read as proof that the browser landed
 or painted at the requested position, nor does it prove that every ownership site was observed.
 Pixel geometry, measurement convergence, and WebKit repaint remain covered by the scroll-invariant
 scenarios and the leased imperative reconcilers.
@@ -244,9 +253,8 @@ measurement, or MDS completion cannot revive cancelled work.
 
 ## Reconciler responsibilities
 
-The eventual single positioning reconciler owns the difficult runtime work below. None belongs in
-the pure model; the saved-position slice currently splits this work between controller lifecycle
-ownership and a leased hook executor:
+The controller-owned reconcilers own the difficult runtime work below. None belongs in the pure
+model; browser-specific geometry remains in leased hook executors:
 
 - resolve IDs against the loaded item set;
 - request an around slice and resume when it arrives;
@@ -264,6 +272,11 @@ ownership and a leased hook executor:
 
 In particular, the model describes **what position is wanted**. It does not make measurement settle
 or stale-paint reconciliation disappear.
+
+Live-edge reconciliation deliberately has no fixed geometry-drift takeover threshold. Large
+geometry changes are the content-growth condition it must absorb, so genuine user input or a newer
+generation is its takeover signal. Adding the 300px explicit-target/unread threshold here would
+abort valid deep growth and media-settle runs.
 
 ## Current behavior inventory
 
@@ -291,13 +304,10 @@ is already visible or above the viewport, the same activation goes directly to l
 ## Current owners to migrate
 
 The controller-owned mechanisms retain leased browser reconcilers for saved anchors, unread markers,
-and explicit center-aligned message targets. These reconcilers implement measurement convergence;
-they are not separate positioning authorities. The remaining independent implementations inside
-`useMessageListScroll` are:
-
-- `pinVirtualizedBottom`;
-- media-preservation reconciliation while reading history;
-- directional-load measurement reassertion.
+explicit center-aligned targets, live edge, and media preservation. These reconcilers implement
+measurement convergence; they are not separate positioning authorities. The only remaining
+independent frame-loop implementation inside `useMessageListScroll` is directional-load measurement
+reassertion.
 
 There are also positioning owners outside their shared single-flight ref:
 
@@ -372,7 +382,8 @@ kinetic scrolling and stale-paint behavior.
 3. [x] Migrate unread and explicit message targets: the controller owns their generations,
    supersession, reachability, frame convergence, and cancellation; their private loops and target
    around-load ref are deleted.
-4. Migrate live-edge pinning while retaining bottom-specific measurement/repaint safeguards.
+4. [x] Migrate live-edge pinning and media/content-growth preservation while retaining
+   bottom-specific measurement/repaint safeguards; delete both private hook-owned loops.
 5. Migrate directional history preservation last, retaining kinetic cancellation and clamp recovery.
 6. Route or isolate the remaining owners outside `useMessageListScroll`.
 7. Split persistence, user-intent tracking, history windowing, and reconciliation out of the


### PR DESCRIPTION
## Summary

- make the generation-aware positioning controller authoritative for live-edge bottom pinning and content-growth reconciliation
- migrate media-load anchor preservation into the same controller lifecycle
- delete the former hook-owned bottom-pin and media-preservation loops, plus the redundant non-virtualized mount writer
- retain bottom-specific browser mechanics in leased executors: late-tail layout flushes, missed-frame correction, repaint-burst coalescing, MAM repaint suppression, and the WebKit `overflowY` stale-paint repair
- update the positioning contract and add falsifiable controller/concurrency tests

## Why

Live-edge positioning still had multiple independent scroll owners after the saved-position, unread-marker, and explicit-target migrations. Content growth, media measurement, and late WebKit painting could therefore restart or overlap hook-local loops outside the controller's generation and cancellation rules.

This change makes the controller the single lifecycle owner while keeping browser-specific measurement and repaint work in leased executors. The old loops are removed rather than retained behind a wrapper.

## Behavior notes

- A live-edge entry into a slid-up resident window now requests newer slices immediately until the global tail is resident; the resident bottom is no longer mistaken for the global live edge.
- Live-edge reconciliation deliberately has no fixed 300px geometry-drift takeover threshold. Large geometry changes are the growth it must absorb, so genuine user input or a newer generation is the takeover signal.
- Non-virtualized conversation entry retains its historical immediate plus deferred bottom repair, but both writes are now controller-scheduled.