### PR TITLE
fix(e2ee): merge into the shared OpenPGP public-keys-list instead of clobbering it (#1059)

### DIFF
--- a/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
+++ b/apps/fluux/src/e2ee/OpenPGPPluginBase.ts
@@ -94,9 +94,9 @@ import {
   fingerprintsEqual,
   normalizeFingerprint,
   toXep0373Fingerprint,
-  pubkeyMetadataFingerprintAttrs,
 } from './fingerprintCompare'
 import { accountUserId } from './openpgpUserId'
+import { mergePublicKeysList, OX_NAMESPACE as OX_WIRE_NAMESPACE } from './oxPublicKeysList'
 import { legacyNormalizeBackupPassphrase, prepareBackupPassphrase } from './backupPassphrase'
 import {
   clearKeyChangeAlert,
@@ -133,7 +133,8 @@ import { isSecretKeyUnavailableError } from './keyUnavailable'
 // XEP-0373 constants
 // ---------------------------------------------------------------------------
 
-const OX_NAMESPACE = 'urn:xmpp:openpgp:0'
+// Single source: `oxPublicKeysList` owns the OX wire format constants.
+const OX_NAMESPACE = OX_WIRE_NAMESPACE
 const PUBSUB_PUBLISH_OPTIONS_FEATURE = 'http://jabber.org/protocol/pubsub#publish-options'
 const PUBLIC_KEYS_METADATA_NODE = 'urn:xmpp:openpgp:0:public-keys'
 const SECRET_KEY_NODE = 'urn:xmpp:openpgp:0:secret-key'
@@ -946,7 +947,9 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
 
     try {
       await this.publishOwnPublicKeyData(bundle)
-      await this.publishOwnPublicKeyMetadata(bundle)
+      // The retired identity's fingerprints must leave the list — we just
+      // retracted their data nodes and forgot their secret material.
+      await this.publishOwnPublicKeyMetadata(bundle, publishedFingerprints)
     } catch (err) {
       ctx.logger.warn(
         `${this.pluginName()}: retire publish failed: ${formatError(err)}`,
@@ -1353,7 +1356,12 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
 
     try {
       await this.publishOwnPublicKeyData(bundle)
-      await this.publishOwnPublicKeyMetadata(bundle)
+      // The key we just replaced is no longer ours to decrypt with, so it must
+      // not stay advertised — but any SIBLING device's entry has to survive.
+      await this.publishOwnPublicKeyMetadata(
+        bundle,
+        previousFingerprint ? [previousFingerprint] : [],
+      )
       if (previousFingerprint) {
         await this.retractStalePublicKeyDataNode(previousFingerprint, bundle.fingerprint)
       }
@@ -1633,24 +1641,42 @@ export abstract class OpenPGPPluginBase implements E2EEPlugin {
     )
   }
 
-  private async publishOwnPublicKeyMetadata(bundle: KeyBundle): Promise<void> {
-    const payload: XMLElementData = {
-      name: 'public-keys-list',
-      attrs: { xmlns: OX_NAMESPACE },
-      children: [
-        {
-          name: 'pubkey-metadata',
-          attrs: {
-            // XEP-0373 §4.1: fingerprint string is upper-case hex. Emit only
-            // the version-appropriate attribute (v4 = 40 hex, v6 = 64 hex) so
-            // we never advertise a malformed v6 fingerprint for a v4 key.
-            ...pubkeyMetadataFingerprintAttrs(bundle.fingerprint),
-            date: new Date().toISOString(),
-          },
-          children: [],
-        },
-      ],
+  /**
+   * Advertise our key on `urn:xmpp:openpgp:0:public-keys`, MERGING into
+   * whatever is already there.
+   *
+   * XEP-0373 §4.2 makes this one item the account's whole key list, shared by
+   * every client. PubSub only offers a whole-item write, so we read first and
+   * carry foreign entries over — replacing the item would delete our sibling
+   * devices' keys, and peers that track the list (Gajim) would then stop
+   * encrypting to them (issue #1059).
+   *
+   * @param drop fingerprints to retire instead of carrying over — the identity
+   *             this publish replaces (restore / import / retire).
+   */
+  private async publishOwnPublicKeyMetadata(
+    bundle: KeyBundle,
+    drop: readonly string[] = [],
+  ): Promise<void> {
+    const ctx = this.requireCtx()
+    let existing: PEPItem[] = []
+    try {
+      existing = await ctx.xmpp.queryPEP(ctx.account.jid, PUBLIC_KEYS_METADATA_NODE, 1)
+    } catch (err) {
+      // Read failed (node absent on first publish, or a transient error).
+      // Publishing our own entry alone is still strictly better than not
+      // advertising at all — a sibling's next publish re-adds its entry.
+      ctx.logger.debug(
+        `${this.pluginName()}: could not read the published key list before merge: ${formatError(err)}`,
+      )
     }
+    const payload = mergePublicKeysList({
+      existing,
+      // XEP-0373 §4.1: fingerprint string is upper-case hex, emitted under the
+      // version-appropriate attribute (v4 = 40 hex, v6 = 64 hex).
+      own: { fingerprint: bundle.fingerprint, date: new Date().toISOString() },
+      drop,
+    })
     await this.publishWithPreconditionHeal(
       PUBLIC_KEYS_METADATA_NODE,
       { id: CURRENT_ITEM_ID, payload },

--- a/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
+++ b/apps/fluux/src/e2ee/SequoiaPgpPlugin.test.ts
@@ -493,6 +493,29 @@ function findChild(parent: XMLElementData, name: string): XMLElementData | undef
   )
 }
 
+/** Fingerprint standing in for another client of the SAME account. */
+const SIBLING_FP = 'AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555'
+
+/** Build one `<pubkey-metadata/>` entry for a `<public-keys-list/>`. */
+function pubkeyMetadata(fingerprint: string, date: string): XMLElementData {
+  return { name: 'pubkey-metadata', attrs: { 'v4-fingerprint': fingerprint, date }, children: [] }
+}
+
+/**
+ * Fingerprints advertised by the LAST metadata publish in `published`.
+ * Returns `null` when no metadata publish happened at all, so a test can
+ * tell "published nothing" apart from "published an empty list".
+ */
+function advertisedFingerprintsIn(
+  published: Array<{ node: string; item: PEPItem }>,
+): string[] | null {
+  const last = published.filter((p) => p.node === METADATA_NODE).at(-1)
+  if (!last) return null
+  return last.item.payload.children
+    .filter((c): c is XMLElementData => typeof c !== 'string' && c.name === 'pubkey-metadata')
+    .map((c) => c.attrs['v4-fingerprint'] ?? c.attrs['v6-fingerprint'])
+}
+
 /**
  * Mock-XMPP factory. The returned `peerPublish(peer, node, item)` stores
  * a PEPItem under a specific (jid, node) pair, letting tests simulate the
@@ -695,6 +718,41 @@ describe('SequoiaPgpPlugin', () => {
       // Only the metadata node would be reached if we hadn't short-
       // circuited; with the ordering guard, published stays empty.
       expect(published).toHaveLength(0)
+    })
+
+    it('keeps a sibling device\'s key in the shared public-keys-list (#1059)', async () => {
+      // XEP-0373 §4.2: `<public-keys-list>` enumerates EVERY key the account
+      // advertises, across all its clients. Replacing the whole item with our
+      // single entry deletes sibling clients' keys, and a spec-compliant peer
+      // (Gajim) then marks the missing fingerprint inactive and stops
+      // encrypting to it — so that device can no longer read its own account's
+      // messages. Republish must merge, not clobber.
+      const { ctx, published } = makeContext('me@example.com')
+      await plugin.init(ctx)
+      const ownFp = plugin.getOwnFingerprint()!
+
+      // A sibling client republishes the list with BOTH keys, as the spec
+      // intends. Written through publishPEP because that is what replaces the
+      // single `id: 'current'` item — `peerPublish` appends a second item,
+      // which no real server would hold under `maxItems: 1`.
+      await ctx.xmpp.publishPEP(METADATA_NODE, {
+        id: 'current',
+        payload: {
+          name: 'public-keys-list',
+          attrs: { xmlns: OX_NS },
+          children: [
+            pubkeyMetadata(ownFp, '2024-01-01T00:00:00Z'),
+            pubkeyMetadata(SIBLING_FP, '2024-01-02T00:00:00Z'),
+          ],
+        },
+      })
+
+      published.length = 0
+      await plugin.ensureIdentity()
+
+      expect(advertisedFingerprintsIn(published)).toEqual(
+        expect.arrayContaining([ownFp, SIBLING_FP]),
+      )
     })
 
     it('is idempotent across calls for the same account', async () => {
@@ -2689,6 +2747,54 @@ describe('SequoiaPgpPlugin', () => {
       // Unused to silence "published is declared but never read" from the
       // device A context.
       void publishedA
+    })
+
+    it('restore keeps a sibling key but retires the key it replaced (#1059)', async () => {
+      // The two halves of the merge, in one flow: restoring an identity must
+      // drop the ephemeral key this device just generated (peers must stop
+      // encrypting to a secret we discarded) WITHOUT taking the sibling
+      // client's entry down with it.
+      const { ctx: ctxA } = makeContext('me@example.com')
+      await plugin.init(ctxA)
+      const restoredFp = plugin.getOwnFingerprint()!
+      await plugin.backupSecretKey('shared-pp')
+      const backup = await plugin.fetchSecretKeyBackup()
+
+      fake.accounts.clear()
+      const pluginB = new SequoiaPgpPlugin({ invoke: fake.invoke })
+      const { ctx: ctxB, published: publishedB } = makeContext('me@example.com')
+      await pluginB.init(ctxB)
+      const ephemeralFp = pluginB.getOwnFingerprint()!
+      expect(ephemeralFp).not.toBe(restoredFp)
+
+      await ctxB.xmpp.publishPEP(SECRET_KEY_NODE, {
+        id: 'current',
+        payload: {
+          name: 'secretkey',
+          attrs: { xmlns: OX_NS },
+          children: [encodeOpenPgpArmorForXep0373(backup!)],
+        },
+      })
+      // A sibling client is listed alongside device B's ephemeral key.
+      await ctxB.xmpp.publishPEP(METADATA_NODE, {
+        id: 'current',
+        payload: {
+          name: 'public-keys-list',
+          attrs: { xmlns: OX_NS },
+          children: [
+            pubkeyMetadata(ephemeralFp, '2024-01-01T00:00:00Z'),
+            pubkeyMetadata(SIBLING_FP, '2024-01-02T00:00:00Z'),
+          ],
+        },
+      })
+
+      publishedB.length = 0
+      await pluginB.restoreSecretKey('shared-pp')
+
+      const advertised = advertisedFingerprintsIn(publishedB)
+      expect(advertised).toContain(restoredFp)
+      expect(advertised).toContain(SIBLING_FP)
+      expect(advertised).not.toContain(ephemeralFp)
     })
 
     it('opens a legacy-normalized backup with the displayed code and heals it (#1021)', async () => {

--- a/apps/fluux/src/e2ee/oxPublicKeysList.test.ts
+++ b/apps/fluux/src/e2ee/oxPublicKeysList.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import type { PEPItem, XMLElementData } from '@fluux/sdk'
+import { mergePublicKeysList } from './oxPublicKeysList'
+
+const OX_NS = 'urn:xmpp:openpgp:0'
+
+function meta(fingerprint: string, date: string, attr = 'v4-fingerprint'): XMLElementData {
+  return { name: 'pubkey-metadata', attrs: { [attr]: fingerprint, date }, children: [] }
+}
+
+function listItem(...children: XMLElementData[]): PEPItem {
+  return {
+    id: 'current',
+    payload: { name: 'public-keys-list', attrs: { xmlns: OX_NS }, children },
+  }
+}
+
+/** (fingerprint, date) pairs of the merged list, in emitted order. */
+function entriesOf(payload: XMLElementData): Array<[string, string]> {
+  return payload.children
+    .filter((c): c is XMLElementData => typeof c !== 'string')
+    .map((c) => [c.attrs['v4-fingerprint'] ?? c.attrs['v6-fingerprint'], c.attrs.date])
+}
+
+const OWN = 'FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000'
+const SIBLING = 'AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111'
+const NOW = '2026-07-22T10:00:00.000Z'
+
+describe('mergePublicKeysList', () => {
+  it('keeps a sibling client entry alongside our own', () => {
+    const payload = mergePublicKeysList({
+      existing: [listItem(meta(SIBLING, '2024-01-02T00:00:00Z'))],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    expect(entriesOf(payload)).toEqual([
+      [SIBLING, '2024-01-02T00:00:00Z'],
+      [OWN, NOW],
+    ])
+  })
+
+  it('emits a well-formed <public-keys-list/>', () => {
+    const payload = mergePublicKeysList({ existing: [], own: { fingerprint: OWN, date: NOW } })
+
+    expect(payload.name).toBe('public-keys-list')
+    expect(payload.attrs.xmlns).toBe(OX_NS)
+    expect(entriesOf(payload)).toEqual([[OWN, NOW]])
+  })
+
+  it('refreshes our own entry rather than duplicating it', () => {
+    const payload = mergePublicKeysList({
+      existing: [listItem(meta(OWN, '2020-01-01T00:00:00Z'), meta(SIBLING, '2024-01-02T00:00:00Z'))],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    expect(entriesOf(payload)).toEqual([
+      [SIBLING, '2024-01-02T00:00:00Z'],
+      [OWN, NOW],
+    ])
+  })
+
+  it('matches our own entry case-insensitively', () => {
+    // Sequoia emits upper-case, openpgp.js lower-case; a case-only difference
+    // must not advertise the same key twice.
+    const payload = mergePublicKeysList({
+      existing: [listItem(meta(OWN.toLowerCase(), '2020-01-01T00:00:00Z'))],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    expect(entriesOf(payload)).toEqual([[OWN, NOW]])
+  })
+
+  it('drops fingerprints the caller is retiring', () => {
+    // Restoring or replacing our identity must remove the key we no longer
+    // hold — otherwise peers keep encrypting to a secret we just discarded.
+    const RETIRED = 'BBBB2222BBBB2222BBBB2222BBBB2222BBBB2222'
+    const payload = mergePublicKeysList({
+      existing: [listItem(meta(RETIRED, '2023-01-01T00:00:00Z'), meta(SIBLING, '2024-01-02T00:00:00Z'))],
+      own: { fingerprint: OWN, date: NOW },
+      drop: [RETIRED.toLowerCase()],
+    })
+
+    expect(entriesOf(payload)).toEqual([
+      [SIBLING, '2024-01-02T00:00:00Z'],
+      [OWN, NOW],
+    ])
+  })
+
+  it('preserves a v6 sibling entry under its own attribute', () => {
+    const V6 = 'C'.repeat(64)
+    const payload = mergePublicKeysList({
+      existing: [listItem(meta(V6, '2024-01-02T00:00:00Z', 'v6-fingerprint'))],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    const sibling = payload.children[0] as XMLElementData
+    expect(sibling.attrs['v6-fingerprint']).toBe(V6)
+    expect(sibling.attrs['v4-fingerprint']).toBeUndefined()
+  })
+
+  it('ignores foreign children and entries with no fingerprint', () => {
+    const payload = mergePublicKeysList({
+      existing: [
+        listItem(
+          { name: 'pubkey-metadata', attrs: { date: '2024-01-02T00:00:00Z' }, children: [] },
+          { name: 'something-else', attrs: { 'v4-fingerprint': SIBLING }, children: [] },
+        ),
+      ],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    expect(entriesOf(payload)).toEqual([[OWN, NOW]])
+  })
+
+  it('ignores items that are not a <public-keys-list/>', () => {
+    const payload = mergePublicKeysList({
+      existing: [{ id: 'current', payload: { name: 'pubkey', attrs: { xmlns: OX_NS }, children: [] } }],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    expect(entriesOf(payload)).toEqual([[OWN, NOW]])
+  })
+
+  it('de-duplicates a fingerprint advertised twice by the server', () => {
+    const payload = mergePublicKeysList({
+      existing: [listItem(meta(SIBLING, '2024-01-02T00:00:00Z'), meta(SIBLING, '2024-05-05T00:00:00Z'))],
+      own: { fingerprint: OWN, date: NOW },
+    })
+
+    expect(entriesOf(payload)).toEqual([
+      [SIBLING, '2024-01-02T00:00:00Z'],
+      [OWN, NOW],
+    ])
+  })
+})

--- a/apps/fluux/src/e2ee/oxPublicKeysList.ts
+++ b/apps/fluux/src/e2ee/oxPublicKeysList.ts
@@ -1,0 +1,98 @@
+/**
+ * XEP-0373 `<public-keys-list/>` merge.
+ *
+ * The `urn:xmpp:openpgp:0:public-keys` node holds ONE item that enumerates
+ * every OpenPGP key the account advertises — across all of its clients, not
+ * just the one doing the publishing (XEP-0373 §4.2). Since PubSub gives us a
+ * whole-item write, republishing our own single entry deletes every sibling
+ * client's entry.
+ *
+ * That is not cosmetic. A spec-compliant peer treats the list as the set of
+ * ACTIVE keys: Gajim marks any previously-known fingerprint that is missing
+ * from the list `active=False`, and its recipient selection then skips it. So
+ * clobbering the list makes peers stop encrypting to our sibling devices, and
+ * those devices can no longer read their own account's messages (issue #1059).
+ *
+ * `mergePublicKeysList` is the read-modify-write half of the fix: hand it the
+ * items currently on the node and it returns the payload to publish, with
+ * foreign entries carried over verbatim.
+ */
+
+import type { PEPItem, XMLElementData } from '@fluux/sdk'
+import { normalizeFingerprint, pubkeyMetadataFingerprintAttrs } from './fingerprintCompare'
+
+/** The OX wire namespace, shared by every `urn:xmpp:openpgp:0` element. */
+export const OX_NAMESPACE = 'urn:xmpp:openpgp:0'
+
+const LIST_ELEMENT = 'public-keys-list'
+const ENTRY_ELEMENT = 'pubkey-metadata'
+
+/**
+ * Read the fingerprint an entry advertises, preferring `v6-fingerprint`.
+ *
+ * Mirrors the reader in `OpenPGPPluginBase.parseAdvertisedFingerprints`: a key
+ * publishes exactly one of the two attributes, matching its version.
+ */
+function entryFingerprint(entry: XMLElementData): string | null {
+  for (const name of ['v6-fingerprint', 'v4-fingerprint'] as const) {
+    const value = entry.attrs?.[name]
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+export interface MergePublicKeysListParams {
+  /** Items currently published on `urn:xmpp:openpgp:0:public-keys`. */
+  existing: PEPItem[]
+  /** Our own key: the entry this publish is asserting. */
+  own: { fingerprint: string; date: string }
+  /**
+   * Fingerprints to remove rather than carry over — the identity we just
+   * replaced. Without this a restore/import would leave the discarded key
+   * advertised and peers would keep encrypting to a secret we no longer hold.
+   */
+  drop?: readonly string[]
+}
+
+/**
+ * Build the `<public-keys-list/>` payload to publish: every foreign entry
+ * already on the node, in their original order, followed by ours.
+ *
+ * Our own entry is always re-emitted fresh (new `date`, version-appropriate
+ * fingerprint attribute) whether or not it was already listed, so the publish
+ * is idempotent and self-healing.
+ */
+export function mergePublicKeysList({
+  existing,
+  own,
+  drop = [],
+}: MergePublicKeysListParams): XMLElementData {
+  const ownFp = normalizeFingerprint(own.fingerprint)
+  const excluded = new Set([ownFp, ...drop.map(normalizeFingerprint)])
+  const seen = new Set<string>()
+  const children: XMLElementData[] = []
+
+  for (const item of existing) {
+    const list = item.payload
+    if (list.name !== LIST_ELEMENT || list.attrs?.xmlns !== OX_NAMESPACE) continue
+    for (const child of list.children) {
+      if (typeof child === 'string' || child.name !== ENTRY_ELEMENT) continue
+      const fingerprint = entryFingerprint(child)
+      if (!fingerprint) continue
+      const normalized = normalizeFingerprint(fingerprint)
+      if (excluded.has(normalized) || seen.has(normalized)) continue
+      seen.add(normalized)
+      // Carry the entry over verbatim: its `date` and fingerprint attribute
+      // belong to the client that published it, and we must not rewrite them.
+      children.push({ name: ENTRY_ELEMENT, attrs: { ...child.attrs }, children: [] })
+    }
+  }
+
+  children.push({
+    name: ENTRY_ELEMENT,
+    attrs: { ...pubkeyMetadataFingerprintAttrs(own.fingerprint), date: own.date },
+    children: [],
+  })
+
+  return { name: LIST_ELEMENT, attrs: { xmlns: OX_NAMESPACE }, children }
+}


### PR DESCRIPTION
Stops Fluux from deleting sibling clients' keys from the shared OpenPGP key list — the root cause of #1059, split out of #1115 so it can ship in a minor release without the multi-key trust-model change.

## The bug

`urn:xmpp:openpgp:0:public-keys` holds **one** item that enumerates *every* OpenPGP key an account advertises, across all of its clients (XEP-0373 §4.2). PubSub only offers a whole-item write, and we were publishing our single entry — deleting every sibling client's entry on every connection.

That is not cosmetic. A spec-compliant peer treats the list as the set of *active* keys: Gajim marks any previously-known fingerprint missing from the list `active=False` and stops encrypting to it. Gajim then re-appends its own entry, we clobber it again on the next connection, and the node ping-pongs — which is why the symptom looks intermittent while actually affecting all inbound traffic.

## The fix

`publishOwnPublicKeyMetadata` now reads the node and merges, carrying foreign entries over verbatim (their `date` and fingerprint attribute belong to the client that published them). A `drop` parameter retires the fingerprints of an identity we just replaced on restore/import, so we never keep advertising a secret we no longer hold.

If the read fails — node absent on first publish, or a transient error — we publish our own entry alone and log it. That is strictly better than not advertising, and a sibling's next publish re-adds its entry.

The merge logic lives in a new pure module, `oxPublicKeysList.ts`, with unit tests plus two integration tests through the plugin (steady-state publish and restore).

## Scope

Self-contained: no SDK change, no Rust change, no trust-model change. Single-key accounts are unaffected — with nothing else on the node, the merged list is exactly what we published before.

Complete fix only if the two clients **share** one key (XEP-0373 §5 secret-key sync). With genuinely distinct keys per client, the sibling's signature still fails to verify against our single cached key — that needs the multi-key verifier set in #1115.
