### PR TITLE
Migrate directional history positioning to the controller

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
@@ -4,9 +4,9 @@
  * Single-flight invariant for the message-list rAF scroll re-assert loops.
  *
  * The list keeps the virtualized view pinned by re-asserting a scroll target across ~1s of
- * frames (the controller-owned live-edge executor → bottom; the MAM-prepend
- * `runMeasureAssert` → a history
- * anchor). When two of these run at once they fight over scrollTop — the `[ScrollReassertLoop]`
+ * frames (the controller-owned live-edge executor → bottom; the controller-owned directional
+ * executor → a history anchor). When two of these run at once they fight over scrollTop — the
+ * `[ScrollReassertLoop]`
  * overlap the reassert monitor warns about, observed in the wild as `(pin-bottom, pin-bottom)`.
  * pin-bottom was made single-flight against itself; this suite pins the FULL invariant: across
  * any rapid multi-trigger sequence, at most ONE re-assert loop is ever active — including the
@@ -64,6 +64,7 @@ vi.mock('@/hooks', () => ({
 }))
 
 const getOffsetForMessageId = vi.fn((_id: string): number | null => 0)
+const scrollToOffsetCalls: number[] = []
 vi.mock('./tanstackMessageVirtualizer', () => ({
   useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
     getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
@@ -72,7 +73,11 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
     getOffsetForMessageId,
     ensureMessageMounted: vi.fn(() => Promise.resolve()),
     measureElement: () => {},
-    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    scrollToOffset: (offset: number) => {
+      scrollToOffsetCalls.push(offset)
+      const el = args.scrollRef.current
+      if (el) el.scrollTop = offset
+    },
     scrollToIndex: (index: number, opts?: { align?: string }) => {
       const el = args.scrollRef.current
       if (!el) return
@@ -111,6 +116,7 @@ describe('MessageList — re-assert loops are single-flight (at most one active)
     loopTracker.active = 0
     loopTracker.peak = 0
     loopTracker.begins = []
+    scrollToOffsetCalls.length = 0
     getOffsetForMessageId.mockClear()
     getOffsetForMessageId.mockImplementation(() => 0)
   })
@@ -128,6 +134,12 @@ describe('MessageList — re-assert loops are single-flight (at most one active)
       set: (v: number) => { scrollTopVal = v },
       configurable: true,
     })
+    return {
+      get: () => scrollTopVal,
+      set: (value: number) => {
+        scrollTopVal = value
+      },
+    }
   }
 
   const props = {
@@ -144,14 +156,13 @@ describe('MessageList — re-assert loops are single-flight (at most one active)
     instrumentScroller(scroller, 5000)
     rafQueue.length = 0
 
-    // First load-older -> older messages prepended -> prepend restore begins runMeasureAssert.
+    // First load-older -> older messages prepended -> the controller begins its directional loop.
     fireEvent.click(getByText('chat.loadEarlierMessages'))
     rerender(<MessageList messages={[...makeMessages(10, 'older1'), ...makeMessages(50)]} conversationId="conv-pp" {...props} />)
     flush(2) // a couple of frames pass; the first loop still has ~58 frames left
 
     // Second load-older BEFORE the first settles -> a second prepend restore. It must supersede
-    // the first, not run alongside it (the documented prime suspect: runMeasureAssert had no
-    // cleanup and no early-stable exit).
+    // the first, not run alongside it. Each accepted generation has an exact cancellation lease.
     fireEvent.click(getByText('chat.loadEarlierMessages'))
     rerender(<MessageList messages={[...makeMessages(10, 'older2'), ...makeMessages(10, 'older1'), ...makeMessages(50)]} conversationId="conv-pp" {...props} />)
 
@@ -167,7 +178,7 @@ describe('MessageList — re-assert loops are single-flight (at most one active)
     instrumentScroller(scroller, 5000)
     rafQueue.length = 0
 
-    // Load older -> prepend restore begins runMeasureAssert (the 'prepend' loop).
+    // Load older -> the directional controller begins the monitor's 'prepend' loop.
     fireEvent.click(getByText('chat.loadEarlierMessages'))
     rerender(<MessageList messages={[...makeMessages(10, 'older1'), ...makeMessages(50)]} conversationId="conv-mix" {...props} />)
     flush(2) // prepend loop in-flight
@@ -183,5 +194,41 @@ describe('MessageList — re-assert loops are single-flight (at most one active)
 
     expect(loopTracker.begins).toContain('pin-bottom')
     expect(loopTracker.peak).toBeLessThanOrEqual(1)
+  })
+
+  it('re-pins the directional anchor after a content-shrink clamp without treating it as takeover', () => {
+    getOffsetForMessageId.mockImplementation((id) =>
+      id === 'msg-0' ? 0 : null,
+    )
+    const { container, getByText, rerender } = render(
+      <MessageList
+        messages={makeMessages(50)}
+        conversationId="conv-clamp"
+        {...props}
+      />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLElement
+    const geometry = instrumentScroller(scroller, 5000)
+    rafQueue.length = 0
+
+    fireEvent.click(getByText('chat.loadEarlierMessages'))
+    getOffsetForMessageId.mockImplementation((id) =>
+      id === 'msg-0' ? 1000 : null,
+    )
+    rerender(
+      <MessageList
+        messages={[...makeMessages(10, 'older'), ...makeMessages(50)]}
+        conversationId="conv-clamp"
+        {...props}
+      />,
+    )
+    expect(scrollToOffsetCalls).toContain(1000)
+
+    scrollToOffsetCalls.length = 0
+    geometry.set(4500) // browser clamp after content shrink; no genuine input event
+    flush(1)
+
+    expect(scrollToOffsetCalls).toContain(1000)
+    expect(geometry.get()).toBe(1000)
   })
 })

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -3,6 +3,8 @@ import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManag
 import type { MessageVirtualizer } from './messageVirtualizer'
 import {
   PositioningController,
+  type DirectionalHistoryExecutor,
+  type DirectionalHistoryFrameResult,
   type ExplicitTargetExecutor,
   type ExplicitTargetFrameResult,
   type LiveEdgeExecutor,
@@ -34,6 +36,7 @@ import {
   messageFraction,
   pixelOffset,
   type BottomFractionAnchorPosition,
+  type DirectionalHistoryRequest,
   type ReachabilityFacts,
   type LiveEdgePosition,
   type SavedPositionRequest,
@@ -588,6 +591,292 @@ describe('positioning controller live-edge ownership', () => {
     staleMediaFrame()
     expect(mediaPositionFrame).toHaveBeenCalledTimes(1)
     expect(outgoing.positionFrame).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('positioning controller directional-history ownership', () => {
+  function directionalHarness(
+    overrides: {
+      reachability?: ReachabilityFacts
+      frameResult?: DirectionalHistoryFrameResult
+    } = {},
+  ) {
+    const callbacks: Array<() => void> = []
+    const finish = vi.fn()
+    const recordFrame = vi.fn()
+    const complete = vi.fn()
+    const leases: PositionExecutionLease[] = []
+    let frameResult: DirectionalHistoryFrameResult =
+      overrides.frameResult ?? {
+        kind: 'positioned',
+        scrollTop: 400,
+        wrote: false,
+        reassert: true,
+      }
+    const positionFrame = vi.fn(() => frameResult)
+    const executor: DirectionalHistoryExecutor = {
+      reachability: () => overrides.reachability ?? {
+        kind: 'available',
+        index: 5,
+        mounted: false,
+        placement: 'viable',
+      },
+      beginLoop: (lease) => {
+        leases.push(lease)
+        return {
+          schedule: (callback) => callbacks.push(callback),
+          recordFrame,
+          finish,
+        }
+      },
+      positionFrame,
+      complete,
+    }
+    return {
+      callbacks,
+      complete,
+      executor,
+      finish,
+      leases,
+      positionFrame,
+      recordFrame,
+      runFrame: () => {
+        const callback = callbacks.shift()
+        expect(callback).toBeDefined()
+        callback!()
+      },
+      setFrameResult: (result: DirectionalHistoryFrameResult) => {
+        frameResult = result
+      },
+    }
+  }
+
+  function beginDirectional(
+    controller: PositioningController,
+    executor: DirectionalHistoryExecutor,
+    messageId = 'top-visible',
+  ): DirectionalHistoryRequest {
+    return controller.beginDirectionalHistory({
+      conversationId,
+      desired: {
+        kind: 'anchor',
+        messageId,
+        placement: {
+          kind: 'top-offset',
+          offsetPx: pixelOffset(-12),
+        },
+      },
+      distanceFromBottom: pixelOffset(640),
+      executor,
+    })!
+  }
+
+  it('owns the pending window shift, then releases outgoing suppression after the pre-paint write', () => {
+    const history = directionalHarness()
+    const outgoingPositionFrame = vi.fn(
+      (): LiveEdgeFrameResult => ({
+        kind: 'positioned',
+        scrollTop: 1000,
+        atLiveEdge: true,
+        wrote: true,
+        reassert: false,
+      }),
+    )
+    const outgoingExecutor = inertLiveEdgeExecutor(outgoingPositionFrame)
+    const controller = new PositioningController()
+    controller.beginLiveEdgeEntry({
+      conversationId,
+      entryFacts: liveEntryFacts(),
+      executor: inertLiveEdgeExecutor(),
+    })
+    const request = beginDirectional(controller, history.executor)
+
+    expect(controller.snapshot().active).toEqual({
+      request,
+      phase: { kind: 'pending', reason: 'window-shift' },
+    })
+    expect(controller.beginLiveEdgeRequest({
+      conversationId,
+      source: { kind: 'live-update', reason: 'outgoing-message' },
+      executor: outgoingExecutor,
+    })).toBeNull()
+    expect(outgoingPositionFrame).not.toHaveBeenCalled()
+
+    expect(controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: request.generation,
+      executor: history.executor,
+    })).toBe(true)
+    expect(history.positionFrame).toHaveBeenCalledTimes(1)
+    expect(history.complete).toHaveBeenCalledWith(request, 'applied')
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'position-applied',
+    })
+
+    expect(controller.beginLiveEdgeRequest({
+      conversationId,
+      source: { kind: 'live-update', reason: 'outgoing-message' },
+      executor: outgoingExecutor,
+    })).not.toBeNull()
+    expect(history.complete).toHaveBeenLastCalledWith(request, 'superseded')
+    expect(outgoingPositionFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains the exact sixty-frame late-measurement budget without an early-stable exit', () => {
+    const history = directionalHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = beginDirectional(controller, history.executor)
+    controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: request.generation,
+      executor: history.executor,
+    })
+
+    for (let frame = 0; frame < 60; frame += 1) history.runFrame()
+    expect(history.positionFrame).toHaveBeenCalledTimes(61)
+    expect(history.recordFrame).toHaveBeenCalledTimes(60)
+    expect(history.complete).not.toHaveBeenCalledWith(request, 'best-effort')
+    history.runFrame()
+
+    expect(history.positionFrame).toHaveBeenCalledTimes(61)
+    expect(history.complete).toHaveBeenLastCalledWith(request, 'best-effort')
+    expect(history.finish).toHaveBeenCalledTimes(1)
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+  })
+
+  it('cancels on genuine user input and rejects the already-queued frame', () => {
+    const history = directionalHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = beginDirectional(controller, history.executor)
+    controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: request.generation,
+      executor: history.executor,
+    })
+    const staleFrame = history.callbacks.shift()!
+
+    controller.observeUserInput(conversationId)
+    staleFrame()
+
+    expect(history.finish).toHaveBeenCalledTimes(1)
+    expect(history.positionFrame).toHaveBeenCalledTimes(1)
+    expect(history.complete).toHaveBeenLastCalledWith(
+      request,
+      'user-takeover',
+    )
+    expect(controller.snapshot().active).toBeNull()
+  })
+
+  it('retains the captured anchor through boundary input while the history load is pending', () => {
+    const history = directionalHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = beginDirectional(controller, history.executor)
+
+    controller.observeUserInput(conversationId)
+
+    expect(history.complete).not.toHaveBeenCalled()
+    expect(controller.snapshot().active).toEqual({
+      request,
+      phase: { kind: 'pending', reason: 'window-shift' },
+    })
+    expect(controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: request.generation,
+      executor: history.executor,
+    })).toBe(true)
+    expect(history.positionFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies the distance-from-bottom fallback once when the anchor was evicted', () => {
+    const history = directionalHarness({
+      reachability: {
+        kind: 'target-absent',
+        loadAround: 'unavailable',
+      },
+      frameResult: {
+        kind: 'positioned',
+        scrollTop: 120,
+        wrote: true,
+        reassert: false,
+      },
+    })
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = beginDirectional(
+      controller,
+      history.executor,
+      'evicted-anchor',
+    )
+
+    expect(controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: request.generation,
+      executor: history.executor,
+    })).toBe(true)
+    expect(history.positionFrame).toHaveBeenCalledTimes(1)
+    expect(history.complete.mock.calls).toEqual([
+      [request, 'applied'],
+      [request, 'settled'],
+    ])
+    expect(history.callbacks).toHaveLength(0)
+  })
+
+  it('supersedes an unresolved load with a newer directional generation', () => {
+    const first = directionalHarness()
+    const second = directionalHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const firstRequest = beginDirectional(
+      controller,
+      first.executor,
+      'first-anchor',
+    )
+    const secondRequest = beginDirectional(
+      controller,
+      second.executor,
+      'second-anchor',
+    )
+
+    expect(first.complete).toHaveBeenCalledWith(firstRequest, 'superseded')
+    expect(controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: firstRequest.generation,
+      executor: first.executor,
+    })).toBe(false)
+    expect(controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: secondRequest.generation,
+      executor: second.executor,
+    })).toBe(true)
+    expect(first.positionFrame).not.toHaveBeenCalled()
+    expect(second.positionFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a pending anchor when a forward load reaches the live edge without shifting', () => {
+    const history = directionalHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = beginDirectional(controller, history.executor)
+
+    expect(controller.cancelDirectionalHistoryWithoutShift({
+      conversationId,
+      generation: request.generation,
+    })).toBe(true)
+    expect(history.complete).toHaveBeenCalledWith(
+      request,
+      'no-window-shift',
+    )
+    expect(controller.isDirectionalHistoryPending(conversationId)).toBe(false)
+    expect(controller.snapshot().active).toBeNull()
+    expect(controller.reconcileDirectionalHistory({
+      conversationId,
+      generation: request.generation,
+      executor: history.executor,
+    })).toBe(false)
+    expect(history.positionFrame).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -10,6 +10,7 @@ import {
   selectLiveEdgeNavigation,
   settleUserPosition,
   shouldReconcileAfterAppend,
+  type DirectionalHistoryRequest,
   type EntryPositionFacts,
   type ExplicitTargetRequest,
   type LiveEdgeRequest,
@@ -189,6 +190,39 @@ export interface MediaPreservationExecutor {
   ) => void
 }
 
+export type DirectionalHistoryCompletion =
+  | 'applied'
+  | 'settled'
+  | 'best-effort'
+  | 'user-takeover'
+  | 'superseded'
+  | 'no-window-shift'
+
+export type DirectionalHistoryFrameResult =
+  | { kind: 'unavailable' }
+  | {
+      kind: 'positioned'
+      scrollTop: number
+      wrote: boolean
+      /** False for a one-shot distance-from-bottom fallback or non-virtualized placement. */
+      reassert: boolean
+    }
+
+export interface DirectionalHistoryExecutor {
+  reachability: (
+    desired: DirectionalHistoryRequest['desired'],
+  ) => ReachabilityFacts
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  positionFrame: (
+    request: DirectionalHistoryRequest,
+    lease: PositionExecutionLease,
+  ) => DirectionalHistoryFrameResult
+  complete: (
+    request: DirectionalHistoryRequest,
+    outcome: DirectionalHistoryCompletion,
+  ) => void
+}
+
 export type ExplicitTargetCompletion =
   | 'settled'
   | 'best-effort'
@@ -289,6 +323,16 @@ interface MediaPreservationExecutionState {
   landedTarget: number | null
 }
 
+interface DirectionalHistoryExecutionState {
+  request: DirectionalHistoryRequest
+  executor: DirectionalHistoryExecutor
+  operation: number
+  abortController: AbortController | null
+  loop: PositionFrameLoop | null
+  framesLeft: number
+  applied: boolean
+}
+
 const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
@@ -308,6 +352,9 @@ const LIVE_EDGE_STABLE_FRAMES = 8
 const MEDIA_PRESERVATION_REASSERT_FRAMES = 90
 const MEDIA_PRESERVATION_STABLE_FRAMES = 8
 const MEDIA_PRESERVATION_DRIFT_PX = 8
+// Preserved from the former hook-local prepend/window-shift loop. It intentionally has no
+// early-stable exit because virtualizer measurements can arrive late after several quiet frames.
+const DIRECTIONAL_HISTORY_REASSERT_FRAMES = 60
 
 let nextPositionGeneration = 1
 
@@ -354,6 +401,7 @@ export class PositioningController {
   private explicitTargetExecution: ExplicitTargetExecutionState | null = null
   private liveEdgeExecution: LiveEdgeExecutionState | null = null
   private mediaPreservationExecution: MediaPreservationExecutionState | null = null
+  private directionalHistoryExecution: DirectionalHistoryExecutionState | null = null
 
   snapshot(): PositioningModel {
     return this.model
@@ -659,6 +707,137 @@ export class PositioningController {
     })
   }
 
+  beginDirectionalHistory(input: {
+    conversationId: string
+    desired: DirectionalHistoryRequest['desired']
+    distanceFromBottom: Extract<
+      DirectionalHistoryRequest['onUnavailable'],
+      { kind: 'distance-from-bottom' }
+    >['distancePx']
+    executor: DirectionalHistoryExecutor
+  }): DirectionalHistoryRequest | null {
+    return runScrollShadowSafely({
+      event: 'directional-history-begin',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const generation = mintPositionGeneration()
+        const request = withIdentity(
+          input.conversationId,
+          generation,
+          {
+            source: { kind: 'history-preservation', reason: 'window-shift' },
+            desired: input.desired,
+            onUnavailable: {
+              kind: 'distance-from-bottom',
+              distancePx: input.distanceFromBottom,
+            },
+          },
+        ) as DirectionalHistoryRequest
+        const accepted = acceptPositionRequest(this.model, request)
+        if (accepted === this.model) return null
+
+        this.cancelAllExecutions('superseded')
+        this.model = advancePhaseIfCurrent(
+          accepted,
+          input.conversationId,
+          generation,
+          { kind: 'pending', reason: 'window-shift' },
+        )
+        this.directionalHistoryExecution = {
+          request,
+          executor: input.executor,
+          operation: 0,
+          abortController: null,
+          loop: null,
+          framesLeft: DIRECTIONAL_HISTORY_REASSERT_FRAMES,
+          applied: false,
+        }
+        return request
+      },
+    })
+  }
+
+  reconcileDirectionalHistory(input: {
+    conversationId: string
+    generation: number
+    executor: DirectionalHistoryExecutor
+  }): boolean {
+    return runScrollShadowSafely({
+      event: 'directional-history-reconcile',
+      conversationId: input.conversationId,
+      fallback: false,
+      observe: () => {
+        const execution = this.directionalHistoryExecution
+        if (
+          !execution ||
+          execution.request.conversationId !== input.conversationId ||
+          execution.request.generation !== input.generation ||
+          !this.isDirectionalHistoryExecutionCurrent(execution)
+        ) {
+          return false
+        }
+        execution.executor = input.executor
+        const reachability = execution.executor.reachability(
+          execution.request.desired,
+        )
+        if (!reachabilityMatchesRequest(execution.request, reachability)) {
+          this.cancelDirectionalHistoryExecution('superseded')
+          return false
+        }
+        const phase = resolveReachability(execution.request, reachability)
+        this.model = advancePhaseIfCurrent(
+          this.model,
+          input.conversationId,
+          input.generation,
+          phase,
+        )
+        if (
+          phase.kind !== 'mounting' &&
+          phase.kind !== 'reconciling' &&
+          phase.kind !== 'unavailable'
+        ) {
+          return false
+        }
+        this.startDirectionalHistoryLoop(execution)
+        return execution.applied
+      },
+    })
+  }
+
+  cancelDirectionalHistoryWithoutShift(input: {
+    conversationId: string
+    generation: number
+  }): boolean {
+    const execution = this.directionalHistoryExecution
+    if (
+      !execution ||
+      execution.request.conversationId !== input.conversationId ||
+      execution.request.generation !== input.generation ||
+      !this.isDirectionalHistoryExecutionCurrent(execution)
+    ) {
+      return false
+    }
+    this.cancelDirectionalHistoryExecution('no-window-shift')
+    if (
+      this.model.active?.request.conversationId === input.conversationId &&
+      this.model.active.request.generation === input.generation
+    ) {
+      this.model = { ...this.model, active: null }
+    }
+    return true
+  }
+
+  isDirectionalHistoryPending(conversationId: string): boolean {
+    const execution = this.directionalHistoryExecution
+    return Boolean(
+      execution &&
+      execution.request.conversationId === conversationId &&
+      this.isDirectionalHistoryExecutionCurrent(execution) &&
+      !execution.applied,
+    )
+  }
+
   beginUnreadMarkerEntry(input: {
     conversationId: string
     entryFacts: EntryPositionFacts
@@ -946,6 +1125,20 @@ export class PositioningController {
           mediaExecution !== null &&
           mediaExecution.request.conversationId === conversationId &&
           this.isMediaPreservationExecutionCurrent(mediaExecution)
+        const directionalExecution = this.directionalHistoryExecution
+        const directionalWasCurrent =
+          directionalExecution !== null &&
+          directionalExecution.request.conversationId === conversationId &&
+          this.isDirectionalHistoryExecutionCurrent(directionalExecution)
+        // A boundary wheel can start a directional load and be followed by more wheel events while
+        // the network request is still pending. The former prepend loop armed user takeover only
+        // after the batch landed and reconciliation began, so those pre-load events could not
+        // discard the saved anchor. Preserve that contract: there is no pixel owner to take over
+        // until the synchronous initial write has run. Explicit competing position requests still
+        // supersede this pending generation through normal request arbitration.
+        if (directionalWasCurrent && directionalExecution && !directionalExecution.applied) {
+          return
+        }
         this.model = cancelReconciliationForUserInput(
           this.model,
           conversationId,
@@ -963,6 +1156,9 @@ export class PositioningController {
         }
         if (mediaWasCurrent) {
           this.cancelMediaPreservationExecution('user-takeover')
+        }
+        if (directionalWasCurrent) {
+          this.cancelDirectionalHistoryExecution('user-takeover')
         }
         this.cancelExecutionsIfSuperseded()
       },
@@ -1637,6 +1833,217 @@ export class PositioningController {
   ): boolean {
     return (
       this.mediaPreservationExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
+  }
+
+  private startDirectionalHistoryLoop(
+    execution: DirectionalHistoryExecutionState,
+  ): void {
+    if (
+      !this.isDirectionalHistoryExecutionCurrent(execution) ||
+      execution.loop ||
+      execution.applied
+    ) {
+      return
+    }
+    execution.framesLeft = DIRECTIONAL_HISTORY_REASSERT_FRAMES
+    const lease = this.beginDirectionalHistoryOperation(execution)
+    const initial = this.positionDirectionalHistoryFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (initial.kind === 'unavailable') {
+      this.settleDirectionalHistory(execution, lease, 'best-effort')
+      return
+    }
+
+    execution.applied = true
+    lease.markApplied()
+    if (!lease.isCurrent()) return
+    this.completeDirectionalHistory(execution, 'applied')
+    if (!initial.reassert) {
+      this.settleDirectionalHistory(execution, lease, 'settled')
+      return
+    }
+
+    const loop = runScrollShadowSafely<PositionFrameLoop | null>({
+      event: 'directional-history-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      loop?.finish()
+      return
+    }
+    if (!loop) {
+      this.settleDirectionalHistory(execution, lease, 'best-effort')
+      return
+    }
+    execution.loop = loop
+    this.scheduleDirectionalHistoryFrame(execution, lease)
+  }
+
+  private driveDirectionalHistoryFrame(
+    execution: DirectionalHistoryExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (execution.framesLeft-- <= 0) {
+      this.settleDirectionalHistory(execution, lease, 'best-effort')
+      return
+    }
+    const result = this.positionDirectionalHistoryFrame(execution, lease)
+    if (!lease.isCurrent()) return
+    if (result.kind === 'unavailable') {
+      this.settleDirectionalHistory(execution, lease, 'best-effort')
+      return
+    }
+    this.recordDirectionalHistoryFrame(execution, result.wrote)
+    if (!result.reassert) {
+      this.settleDirectionalHistory(execution, lease, 'settled')
+      return
+    }
+    this.scheduleDirectionalHistoryFrame(execution, lease)
+  }
+
+  private positionDirectionalHistoryFrame(
+    execution: DirectionalHistoryExecutionState,
+    lease: PositionExecutionLease,
+  ): DirectionalHistoryFrameResult {
+    return runScrollShadowSafely<DirectionalHistoryFrameResult>({
+      event: 'directional-history-frame',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.positionFrame(
+        execution.request,
+        lease,
+      ),
+    })
+  }
+
+  private scheduleDirectionalHistoryFrame(
+    execution: DirectionalHistoryExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'directional-history-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveDirectionalHistoryFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      this.settleDirectionalHistory(execution, lease, 'best-effort')
+    }
+  }
+
+  private recordDirectionalHistoryFrame(
+    execution: DirectionalHistoryExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'directional-history-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private settleDirectionalHistory(
+    execution: DirectionalHistoryExecutionState,
+    lease: PositionExecutionLease,
+    outcome: Extract<
+      DirectionalHistoryCompletion,
+      'settled' | 'best-effort'
+    >,
+  ): void {
+    if (!lease.isCurrent()) return
+    this.finishDirectionalHistoryLoop(execution)
+    this.completeDirectionalHistory(execution, outcome)
+    lease.settle()
+    execution.abortController?.abort()
+    if (this.directionalHistoryExecution === execution) {
+      this.directionalHistoryExecution = null
+    }
+  }
+
+  private completeDirectionalHistory(
+    execution: DirectionalHistoryExecutionState,
+    outcome: DirectionalHistoryCompletion,
+  ): void {
+    runScrollShadowSafely({
+      event: 'directional-history-complete',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.executor.complete(
+        execution.request,
+        outcome,
+      ),
+    })
+  }
+
+  private finishDirectionalHistoryLoop(
+    execution: DirectionalHistoryExecutionState,
+  ): void {
+    const loop = execution.loop
+    execution.loop = null
+    if (!loop) return
+    runScrollShadowSafely({
+      event: 'directional-history-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => loop.finish(),
+    })
+  }
+
+  private beginDirectionalHistoryOperation(
+    execution: DirectionalHistoryExecutionState,
+  ): PositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.directionalHistoryExecution === execution &&
+      execution.operation === operation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isDirectionalHistoryExecutionCurrent(
+    execution: DirectionalHistoryExecutionState,
+  ): boolean {
+    return (
+      this.directionalHistoryExecution === execution &&
       isCurrentGeneration(
         this.model,
         execution.request.conversationId,
@@ -2830,6 +3237,13 @@ export class PositioningController {
     ) {
       this.cancelMediaPreservationExecution('superseded')
     }
+    const directionalExecution = this.directionalHistoryExecution
+    if (
+      directionalExecution &&
+      !this.isDirectionalHistoryExecutionCurrent(directionalExecution)
+    ) {
+      this.cancelDirectionalHistoryExecution('superseded')
+    }
   }
 
   private cancelAllExecutions(outcome: 'superseded'): void {
@@ -2838,6 +3252,7 @@ export class PositioningController {
     this.cancelExplicitTargetExecution()
     this.cancelLiveEdgeExecution(outcome)
     this.cancelMediaPreservationExecution(outcome)
+    this.cancelDirectionalHistoryExecution(outcome)
   }
 
   private cancelSavedExecution(): void {
@@ -2884,6 +3299,18 @@ export class PositioningController {
       this.completeMediaPreservation(execution, outcome)
     }
     this.mediaPreservationExecution = null
+  }
+
+  private cancelDirectionalHistoryExecution(
+    outcome: DirectionalHistoryCompletion,
+  ): void {
+    const execution = this.directionalHistoryExecution
+    if (execution) {
+      this.finishDirectionalHistoryLoop(execution)
+      execution.abortController?.abort()
+      this.completeDirectionalHistory(execution, outcome)
+    }
+    this.directionalHistoryExecution = null
   }
 }
 

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -5,8 +5,8 @@
  * Background: useMessageListScroll keeps the virtualized list pinned to the
  * right place by RE-ASSERTING a scroll target across several frames as rows
  * measure asynchronously — the live-edge executor (stick to bottom), the
- * controller-owned unread-marker reconciliation, and the MAM-prepend
- * `runMeasureAssert` (anchor restore). Each is a `requestAnimationFrame` loop
+ * controller-owned unread-marker reconciliation, and the directional-history
+ * executor (anchor restore). Each is a `requestAnimationFrame` loop
  * that calls the virtualizer's `scrollToOffset`/`scrollToIndex`, which re-windows
  * and re-renders.
  *
@@ -22,10 +22,8 @@
  *     instead of settling, e.g. two anchors disagree by more than the tolerance
  *     and it ping-pongs.
  *  2. OVERLAP — two re-assert loops are alive at the same time and fight over
- *     scrollTop. The prime suspect: `runMeasureAssert` has no cleanup and no
- *     early-stable exit, so a second MAM prepend (fast scroll-up through history)
- *     starts a second loop against a different anchor while the first ~1s loop is
- *     still running.
+ *     scrollTop. This historically happened when a second MAM prepend started an
+ *     unleased loop against a different anchor while the first ~1s loop remained.
  *
  * Like resizeLoopMonitor/slowCorrectionMonitor this NEVER cancels or throttles a
  * loop; it only emits a single rate-limited log line so the loop class finally

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -234,6 +234,11 @@ export type MediaPreservationRequest = Extract<
   { source: { kind: 'media-preservation'; reason: 'remeasure' } }
 >
 
+export type DirectionalHistoryRequest = Extract<
+  PositionRequest,
+  { source: { kind: 'history-preservation'; reason: 'window-shift' } }
+>
+
 export type PositionRequestSource = PositionRequest['source']
 
 /**
@@ -247,7 +252,12 @@ export type PositioningPhase =
   | { kind: 'resolving' }
   | {
       kind: 'pending'
-      reason: 'empty-window' | 'around-load' | 'live-edge-recenter' | 'target-not-indexed'
+      reason:
+        | 'empty-window'
+        | 'around-load'
+        | 'live-edge-recenter'
+        | 'target-not-indexed'
+        | 'window-shift'
     }
   | { kind: 'loading-around'; messageId: string }
   | { kind: 'recentering-live-edge' }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,9 +3,9 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Saved-position, unread-marker, explicit-target, live-edge, and media-preservation
- *    policy/retry ownership lives in PositioningController; browser writes stay imperative in
- *    leased hook executors while directional history remains to migrate
+ * 2. Saved-position, unread-marker, explicit-target, live-edge, media-preservation, and
+ *    directional-history policy/retry ownership lives in PositioningController; browser writes
+ *    stay imperative in leased hook executors
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
  * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
@@ -32,6 +32,7 @@ import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
 import {
   PositioningController,
+  type DirectionalHistoryExecutor,
   type ExplicitTargetExecutor,
   type LiveEdgeExecutor,
   type LiveEdgeCompletion,
@@ -51,6 +52,7 @@ import {
 import {
   messageFraction,
   pixelOffset,
+  type DirectionalHistoryRequest,
   type DesiredPosition,
   type ExplicitTargetRequest,
   type LiveEdgeRequest,
@@ -345,6 +347,17 @@ export interface UseMessageListScrollResult {
   scrollToMarker: () => void
 }
 
+interface DirectionalHistorySnapshot {
+  anchorMessageId: string
+  anchorOffsetFromTop: number
+  distanceFromBottom: number
+  oldFirstId: string
+  oldMessageCount: number
+  generation?: number
+  restored?: boolean
+  restoredAt?: number
+}
+
 // ============================================================================
 // HOOK
 // ============================================================================
@@ -388,15 +401,13 @@ export function useMessageListScroll({
   const resizeMonitorRef = useRef<ReturnType<typeof createResizeLoopMonitor> | null>(null)
   // Diagnostic-only monitor for SLOW corrections (reflow cost, not fire rate).
   const slowCorrectionMonitorRef = useRef<ReturnType<typeof createSlowCorrectionMonitor> | null>(null)
-  // Diagnostic-only monitor for the rAF scroll re-assert loops (pin-bottom / marker / prepend):
+  // Diagnostic-only monitor for the controller-owned rAF scroll re-assert loops:
   // surfaces a non-converging loop or two overlapping loops fighting over scrollTop on WebKit
   // (frame-coupled, so invisible to the headless harness and the other monitors). Never cancels.
   const reassertMonitorRef = useRef<ReturnType<typeof createReassertLoopMonitor> | null>(null)
-  // In-flight scroll re-assert loop (rAF id + monitor handle), SHARED across pin-bottom and the
-  // MAM-prepend re-assert. Starting any re-assert loop supersedes whatever is in-flight, so only
-  // one ever runs: two loops fight over scrollTop (the overlap the monitor warns about), and
-  // pin-bottom vs prepend target opposite positions (bottom vs a history anchor). Single-flight:
-  // latest call wins with a fresh settle window.
+  // In-flight controller-owned scroll re-assert loop (rAF id + monitor handle). Starting any loop
+  // supersedes whatever is in flight so bottom, message, restore, media, and history targets cannot
+  // fight over scrollTop. Single-flight: latest accepted generation wins with a fresh budget.
   const reassertLoopRef = useRef<{ raf: number; handle: ReassertLoopHandle } | null>(null)
   // True while a pin-bottom re-assert loop is in flight. The typing/reactions re-pin defers to an
   // active loop (it re-checks scrollHeight every frame and picks the change up itself) instead of
@@ -455,6 +466,8 @@ export function useMessageListScroll({
   activeConversationIdRef.current = conversationId
   const prevConversationRef = useRef<string | null>(null)
   const prevMessageCountRef = useRef(0)
+  const messageCountRef = useRef(messageCount)
+  messageCountRef.current = messageCount
   const prevLastMessageIdRef = useRef<string | undefined>(lastMessageId)
   const hasInitializedRef = useRef(false)
   const pendingSyncedLiveEdgeRef = useRef<{
@@ -488,10 +501,9 @@ export function useMessageListScroll({
   // React StrictMode replays layout-effect cleanup/setup without unmounting the DOM. Defer controller
   // deactivation by one microtask and cancel it if setup replays, while real unmount still aborts.
   const unmountDeactivationTokenRef = useRef<object | null>(null)
-  // Generation-aware semantic controller. Saved-position restoration, unread-marker positioning,
-  // explicit targets, live edge, and media preservation are authoritative. Directional history
-  // still reports shadow decisions. Pixel writes stay in hook executors, while the module-private
-  // generation allocator survives StrictMode remounts.
+  // Generation-aware semantic controller. All live-conversation positioning slices, including
+  // directional history, are authoritative. Pixel writes stay in hook executors, while the
+  // module-private generation allocator survives StrictMode remounts.
   const positioningControllerRef = useRef<PositioningController | null | undefined>(undefined)
   if (positioningControllerRef.current === undefined) {
     positioningControllerRef.current = runScrollShadowSafely({
@@ -530,17 +542,7 @@ export function useMessageListScroll({
   // When we load older messages, we save the anchor element position BEFORE the load,
   // then restore it AFTER React renders the new messages.
   // Using element-based positioning is more reliable than pure scroll math.
-  const prependRef = useRef<{
-    // Element-based: ID and offset of the anchor element (first visible message)
-    anchorMessageId: string
-    anchorOffsetFromTop: number
-    // Fallback: distance from bottom (in case element isn't found)
-    distanceFromBottom: number
-    oldFirstId: string
-    oldMessageCount: number
-    restored?: boolean  // Set after restore, cleared after cooldown
-    restoredAt?: number // Timestamp of restore
-  } | null>(null)
+  const prependRef = useRef<DirectionalHistorySnapshot | null>(null)
 
   // Throttling/cooldown
   const lastSaveTimeRef = useRef(0)
@@ -553,9 +555,8 @@ export function useMessageListScroll({
   // Tracks the previous windowAtLiveEdge so we can detect the false→true transition (returning to
   // the live edge) and drop a stale prepend/append anchor — see the effect below.
   const prevWindowAtLiveEdgeRef = useRef(windowAtLiveEdge)
-  // Timestamp of the last DELIBERATE user scroll (FAB click / wheel). The prepend re-assert
-  // loop yields to a deliberate scroll recorded after it starts, but keeps re-pinning the
-  // anchor through a content-shrink clamp (which records no such intent).
+  // Timestamp of the last DELIBERATE user scroll (FAB click / wheel). The controller receives the
+  // same input directly; this timestamp also supports marker clearing and resize heuristics.
   const userScrollIntentAtRef = useRef(0)
 
   // Media load batching (for images, videos, link previews)
@@ -738,7 +739,11 @@ export function useMessageListScroll({
         const currentScrollTop = currentScroller.scrollTop
 
         // Skip during prepend that's actively in progress (not yet restored)
-        if (prependRef.current && !prependRef.current.restored) {
+        if (
+          positioningControllerRef.current?.isDirectionalHistoryPending(
+            activeConversationIdRef.current,
+          )
+        ) {
           debugLog('RESIZE SKIP (prepend in progress)', {
             newHeight,
             lastHeight,
@@ -1263,6 +1268,168 @@ export function useMessageListScroll({
     ],
   )
 
+  const createDirectionalHistoryExecutor = useCallback(
+    (saved: DirectionalHistorySnapshot): DirectionalHistoryExecutor => {
+      let initialized = false
+      let previousTarget = 0
+      let usedFallback = false
+
+      return {
+        reachability: (desired) => {
+          const scroller = scrollerRef.current
+          const virtualizer = virtualizerRef.current
+          return deriveReachabilityForDesired({
+            desired,
+            hasRows: Boolean(
+              (virtualizer && virtualizer.itemCount > 0) ||
+              scroller?.querySelector('[data-message-id]'),
+            ),
+            windowAtLiveEdge: true,
+            virtualizer,
+            scroller,
+            loadAround: 'unavailable',
+            canRecenter: false,
+          })
+        },
+        beginLoop: (lease) => beginControllerFrameLoop('prepend', lease),
+        positionFrame: (
+          request: DirectionalHistoryRequest,
+          lease: PositionExecutionLease,
+        ) => {
+          if (
+            !lease.isCurrent() ||
+            activeConversationIdRef.current !== request.conversationId
+          ) {
+            return { kind: 'unavailable' }
+          }
+          const scroller = scrollerRef.current
+          if (!scroller) return { kind: 'unavailable' }
+          const virtualizer = virtualizerRef.current
+
+          if (!initialized) {
+            // Preserve the pre-paint WebKit momentum cancellation from the former layout effect.
+            void scroller.offsetHeight
+            cancelKineticScroll(scroller)
+          }
+
+          let target: number | null = null
+          let usedMethod = 'none'
+          if (request.desired.messageId) {
+            const virtualOffset =
+              virtualizer?.getOffsetForMessageId(
+                request.desired.messageId,
+              ) ?? null
+            if (virtualOffset !== null) {
+              target =
+                virtualOffset - request.desired.placement.offsetPx
+              usedMethod = 'virtualizer-offset'
+            } else {
+              const anchorElement = scroller.querySelector(
+                `[data-message-id="${CSS.escape(request.desired.messageId)}"]`,
+              ) as HTMLElement | null
+              if (anchorElement) {
+                target =
+                  anchorElement.offsetTop -
+                  request.desired.placement.offsetPx
+                usedMethod = 'element-based'
+              }
+            }
+          }
+
+          if (target === null) {
+            if (initialized) {
+              // The former loop kept its full late-measurement budget if an already-applied anchor
+              // temporarily disappeared. Do not switch fallback policy after the initial landing.
+              return {
+                kind: 'positioned',
+                scrollTop: scroller.scrollTop,
+                wrote: false,
+                reassert: Boolean(virtualizer && !usedFallback),
+              }
+            }
+            target =
+              scroller.scrollHeight -
+              scroller.clientHeight -
+              request.onUnavailable.distancePx
+            usedMethod = 'distance-from-bottom'
+            usedFallback = true
+          }
+
+          const maxScrollTop = Math.max(
+            0,
+            scroller.scrollHeight - scroller.clientHeight,
+          )
+          const boundedTarget = Math.max(
+            0,
+            Math.min(target, maxScrollTop),
+          )
+          const targetMoved =
+            initialized && Math.abs(boundedTarget - previousTarget) > 2
+          const geometryDrift =
+            initialized && Math.abs(scroller.scrollTop - boundedTarget) > 5
+          const shouldWrite = !initialized || targetMoved || geometryDrift
+          if (shouldWrite) {
+            if (virtualizer) {
+              virtualizer.scrollToOffset(boundedTarget)
+            } else {
+              scroller.scrollTop = boundedTarget
+            }
+          }
+          previousTarget = boundedTarget
+          initialized = true
+
+          debugLog('DIRECTIONAL HISTORY POSITION', {
+            generation: request.generation,
+            usedMethod,
+            target: boundedTarget,
+            targetMoved,
+            geometryDrift,
+            wrote: shouldWrite,
+          })
+          return {
+            kind: 'positioned',
+            scrollTop: scroller.scrollTop,
+            wrote: shouldWrite,
+            reassert: Boolean(virtualizer && !usedFallback),
+          }
+        },
+        complete: (request, outcome) => {
+          if (activeConversationIdRef.current !== request.conversationId) return
+          if (outcome === 'applied') {
+            saved.restored = true
+            saved.restoredAt = Date.now()
+            lastRestoreTimeRef.current = saved.restoredAt
+            prevMessageCountRef.current = messageCountRef.current
+            lastProgrammaticScrollAtRef.current = saved.restoredAt
+            setTimeout(() => {
+              if (
+                prependRef.current === saved &&
+                prependRef.current.restoredAt === saved.restoredAt
+              ) {
+                debugLog('DIRECTIONAL HISTORY CLEAR')
+                prependRef.current = null
+              }
+            }, PREPEND_COOLDOWN_MS)
+          } else if (
+            !saved.restored &&
+            prependRef.current === saved
+          ) {
+            prependRef.current = null
+          }
+          if (outcome !== 'applied') {
+            lastProgrammaticScrollAtRef.current = Date.now()
+          }
+          debugLog('DIRECTIONAL HISTORY COMPLETE', {
+            generation: request.generation,
+            outcome,
+            restored: Boolean(saved.restored),
+          })
+        },
+      }
+    },
+    [beginControllerFrameLoop],
+  )
+
   const createSavedPositionExecutor = useCallback((): SavedPositionExecutor => ({
     liveEdge: createLiveEdgeExecutor('restore-fallback'),
     reachability: (desired, loadAround) => {
@@ -1655,9 +1822,8 @@ export function useMessageListScroll({
     const scroller = scrollerRef.current
     if (!scroller) return
 
-    // FAB / scroll-to-bottom is a deliberate user action — record it so the prepend re-assert
-    // loop yields instead of fighting it back to the anchor (it can fire while the loop runs:
-    // entering at the top triggers a load-older, then the user clicks the FAB).
+    // FAB / scroll-to-bottom is deliberate user input. Record it for the marker/resize heuristics;
+    // observeUserInput separately cancels any controller-owned history loop.
     userScrollIntentAtRef.current = Date.now()
     // Deliberate user action → open the save gate so the resulting position persists.
     userHasScrolledSinceEntryRef.current = true
@@ -1884,6 +2050,43 @@ export function useMessageListScroll({
     return null
   }
 
+  const beginDirectionalHistoryLoad = (
+    scroller: HTMLDivElement,
+  ): {
+    saved: DirectionalHistorySnapshot
+    anchor: { id: string; offsetFromTop: number } | null
+  } => {
+    const anchor = findAnchorElement()
+    const saved: DirectionalHistorySnapshot = {
+      anchorMessageId: anchor?.id ?? '',
+      anchorOffsetFromTop: anchor?.offsetFromTop ?? 0,
+      distanceFromBottom: getDistanceFromBottom(scroller),
+      oldFirstId: firstMessageId ?? '',
+      oldMessageCount: messageCount,
+    }
+    prependRef.current = saved
+    const request = runScrollShadowSafely({
+      event: 'directional-history-capture',
+      conversationId,
+      fallback: null,
+      observe: () => positioningControllerRef.current?.beginDirectionalHistory({
+        conversationId,
+        desired: {
+          kind: 'anchor',
+          messageId: saved.anchorMessageId,
+          placement: {
+            kind: 'top-offset',
+            offsetPx: pixelOffset(saved.anchorOffsetFromTop),
+          },
+        },
+        distanceFromBottom: pixelOffset(saved.distanceFromBottom),
+        executor: createDirectionalHistoryExecutor(saved),
+      }) ?? null,
+    })
+    saved.generation = request?.generation
+    return { saved, anchor }
+  }
+
   const triggerLoadOlder = () => {
     if (!canLoadMore) return
     const scroller = scrollerRef.current
@@ -1905,21 +2108,11 @@ export function useMessageListScroll({
       lastLoadTimeRef.current = now
       scrolledAwayFromTopRef.current = false
 
-      const distFromBottom = getDistanceFromBottom(scroller)
-      const anchor = findAnchorElement()
-
-      // SAVE position before load - we'll restore this distance after messages render
-      prependRef.current = {
-        anchorMessageId: anchor?.id || '',
-        anchorOffsetFromTop: anchor?.offsetFromTop || 0,
-        distanceFromBottom: distFromBottom,
-        oldFirstId: firstMessageId || '',
-        oldMessageCount: messageCount,
-      }
+      const { saved, anchor } = beginDirectionalHistoryLoad(scroller)
 
       debugLog('PREPEND START', {
         anchor,
-        distanceFromBottom: distFromBottom,
+        distanceFromBottom: saved.distanceFromBottom,
         scrollHeight: scroller.scrollHeight,
         scrollTop: scroller.scrollTop,
         clientHeight: scroller.clientHeight,
@@ -1949,14 +2142,7 @@ export function useMessageListScroll({
     lastLoadTimeRef.current = now
     scrolledAwayFromBottomRef.current = false
 
-    const anchor = findAnchorElement()
-    prependRef.current = {
-      anchorMessageId: anchor?.id || '',
-      anchorOffsetFromTop: anchor?.offsetFromTop || 0,
-      distanceFromBottom: getDistanceFromBottom(scroller),
-      oldFirstId: firstMessageId || '',
-      oldMessageCount: messageCount,
-    }
+    beginDirectionalHistoryLoad(scroller)
 
     onLoadNewer?.()
   }
@@ -1968,21 +2154,11 @@ export function useMessageListScroll({
 
     lastLoadTimeRef.current = Date.now()
 
-    const distFromBottom = getDistanceFromBottom(scroller)
-    const anchor = findAnchorElement()
-
-    // SAVE position before load
-    prependRef.current = {
-      anchorMessageId: anchor?.id || '',
-      anchorOffsetFromTop: anchor?.offsetFromTop || 0,
-      distanceFromBottom: distFromBottom,
-      oldFirstId: firstMessageId || '',
-      oldMessageCount: messageCount,
-    }
+    const { saved, anchor } = beginDirectionalHistoryLoad(scroller)
 
     debugLog('LOAD EARLIER', {
       anchor,
-      distanceFromBottom: distFromBottom,
+      distanceFromBottom: saved.distanceFromBottom,
       scrollHeight: scroller.scrollHeight,
       scrollTop: scroller.scrollTop,
       clientHeight: scroller.clientHeight,
@@ -2317,9 +2493,8 @@ export function useMessageListScroll({
   }
 
   const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
-    // A wheel is a deliberate user scroll — record it so the prepend re-assert loop yields if
-    // the user keeps scrolling after a load (rather than fighting a content-shrink clamp). The
-    // wheel that triggers the load itself is recorded BEFORE the loop starts, so it won't bail.
+    // A wheel cancels any older controller generation before a new directional request is captured
+    // below; later wheel input cancels that new request.
     userScrollIntentAtRef.current = Date.now()
     // Genuine user scroll → open the save gate (see userHasScrolledSinceEntryRef). Mirrors the
     // native wheel listener; kept here so it fires even when wheel arrives via the React handler.
@@ -2884,12 +3059,20 @@ export function useMessageListScroll({
   // clears the already-`restored` ref harmlessly.
   useEffect(() => {
     if (windowAtLiveEdge === true && prevWindowAtLiveEdgeRef.current === false) {
-      if (prependRef.current && !prependRef.current.restored) {
-        prependRef.current = null
+      const saved = prependRef.current
+      if (saved && !saved.restored) {
+        if (saved.generation !== undefined) {
+          positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift({
+            conversationId,
+            generation: saved.generation,
+          })
+        } else {
+          prependRef.current = null
+        }
       }
     }
     prevWindowAtLiveEdgeRef.current = windowAtLiveEdge
-  }, [windowAtLiveEdge])
+  }, [conversationId, windowAtLiveEdge])
 
   // EFFECT: Prepend complete (older messages loaded)
   // ==========================================================================
@@ -2928,291 +3111,31 @@ export function useMessageListScroll({
       return
     }
 
-    // Force reflow first to ensure browser has calculated new layout
-    void scroller.offsetHeight
-
-    const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
-
-    // Try element-based positioning first (more reliable)
-    let newScrollTop: number | null = null
-    let usedMethod = 'none'
-
-    if (saved.anchorMessageId) {
-      // Virtualized: read the anchor's offset from the CURRENT render's virtualizer
-      // (virtualizerRef, updated synchronously in the render body). Using
-      // latestRef.current.virtualizer here would give the STALE pre-prepend indexById
-      // because latestRef is updated in useEffect (after paint) — too late for this
-      // useLayoutEffect (before paint). The current virtualizer has the new indexById
-      // with post-prepend indices, giving the correct anchor offset.
-      const virtualOffset =
-        virtualizerRef.current?.getOffsetForMessageId(saved.anchorMessageId) ?? null
-
-      if (virtualOffset != null) {
-        newScrollTop = virtualOffset - saved.anchorOffsetFromTop
-        usedMethod = 'virtualizer-offset'
-
-        debugLog('PREPEND RESTORE (virtualizer offset)', {
-          anchorMessageId: saved.anchorMessageId,
-          virtualOffset,
-          savedOffsetFromTop: saved.anchorOffsetFromTop,
-          newScrollTop,
-          maxScrollTop,
-        })
-      } else {
-        const anchorElement = scroller.querySelector(
-          `[data-message-id="${saved.anchorMessageId}"]`
-        ) as HTMLElement | null
-
-        if (anchorElement) {
-          // Position the anchor element at the same offset from viewport top as before
-          newScrollTop = anchorElement.offsetTop - saved.anchorOffsetFromTop
-          usedMethod = 'element-based'
-
-          debugLog('PREPEND RESTORE (element-based)', {
-            anchorMessageId: saved.anchorMessageId,
-            anchorOffsetTop: anchorElement.offsetTop,
-            savedOffsetFromTop: saved.anchorOffsetFromTop,
-            newScrollTop,
-            maxScrollTop,
-          })
-        }
-      }
-    }
-
-    // Fallback to distance-from-bottom math if element not found
-    if (newScrollTop === null) {
-      newScrollTop = scroller.scrollHeight - scroller.clientHeight - saved.distanceFromBottom
-      usedMethod = 'math-fallback'
-
-      debugLog('PREPEND RESTORE (math-based fallback)', {
-        newScrollTop,
-        scrollHeight: scroller.scrollHeight,
-        clientHeight: scroller.clientHeight,
-        savedDistanceFromBottom: saved.distanceFromBottom,
-        maxScrollTop,
+    if (saved.generation === undefined) {
+      debugLog('DIRECTIONAL HISTORY DROPPED (controller unavailable)', {
+        oldFirstId: saved.oldFirstId,
+        firstMessageId,
       })
+      prependRef.current = null
+      return
     }
 
-    // BOUNDS CHECK: Ensure scroll position is valid
-    // This prevents blank window when scroll position is out of range
-    const boundedScrollTop = Math.max(0, Math.min(newScrollTop, maxScrollTop))
-
-    if (boundedScrollTop !== newScrollTop) {
-      debugLog('PREPEND RESTORE BOUNDS CLAMPED', {
-        original: newScrollTop,
-        bounded: boundedScrollTop,
-        maxScrollTop,
-        usedMethod,
-      })
-    }
-
-    debugLog('PREPEND RESTORE FINAL', {
-      newScrollTop: boundedScrollTop,
-      usedMethod,
-      oldFirstId: saved.oldFirstId,
-      newFirstId: firstMessageId,
-      messageCount,
-      scrollHeightBefore: scroller.scrollHeight,
-      scrollTopBefore: scroller.scrollTop,
-      maxScrollTop,
-    })
-
-    const shadowWindowShiftRequest = runScrollShadowSafely({
-      event: 'window-shift-preservation',
+    // The controller performs the first write synchronously in this layout effect, preserving the
+    // pre-paint landing. Its leased executor retains kinetic cancellation, anchor/fallback geometry,
+    // clamp recovery, and the full late-measurement frame budget.
+    positioningControllerRef.current?.reconcileDirectionalHistory({
       conversationId,
-      fallback: null,
-      observe: () => {
-        if (!saved.anchorMessageId) return null
-        const desired: DesiredPosition = {
-          kind: 'anchor',
-          messageId: saved.anchorMessageId,
-          placement: {
-            kind: 'top-offset',
-            offsetPx: pixelOffset(saved.anchorOffsetFromTop),
-          },
-        }
-        return positioningControllerRef.current?.observeRequest({
-          event: 'window-shift-preservation',
-          conversationId,
-          draft: {
-            source: { kind: 'history-preservation', reason: 'window-shift' },
-            desired,
-            onUnavailable: {
-              kind: 'distance-from-bottom',
-              distancePx: pixelOffset(saved.distanceFromBottom),
-            },
-          },
-          reachability: shadowReachabilityRef.current(desired),
-          actual: {
-            desired,
-            phase: usedMethod === 'math-fallback' ? 'fallback' : 'positioning',
-          },
-        }) ?? null
-      },
+      generation: saved.generation,
+      executor: createDirectionalHistoryExecutor(saved),
     })
 
-    // Cancel any parked kinetic (momentum) scroll BEFORE positioning. On a fast scroll-up
-    // fling the user reaches the top boundary with residual velocity that WebKit parks and
-    // then resumes once we prepend older messages — overshooting the restored anchor and
-    // landing in an unmounted region (blank window) or driving scrollTop out of bounds (jump
-    // to bottom). Toggling overflow off, forcing a reflow, and turning it back on cancels
-    // WebKit's momentum animation. This runs inside the useLayoutEffect (pre-paint), so there
-    // is no visible scrollbar flash. Programmatic scrolls carry no momentum, so this is inert
-    // in the Playwright/preview harness — the fix is only observable on real hardware.
-    cancelKineticScroll(scroller)
-
-    // Set via the virtualizer's own scroll path so @tanstack's internal state stays
-    // consistent and it does not re-process this as an external scroll event.
-    // For the non-virtualized path, write scrollTop directly as before.
-    // Use virtualizerRef (updated in render body) NOT latestRef (updated in useEffect,
-    // which runs after paint — too late for this useLayoutEffect).
-    const virtRestore = virtualizerRef.current
-    if (virtRestore) {
-      virtRestore.scrollToOffset(boundedScrollTop)
-    } else {
-      scroller.scrollTop = boundedScrollTop
-    }
-
-    // Verify it was applied (browser may have clamped further)
-    const actualScrollTop = scroller.scrollTop
-    if (Math.abs(actualScrollTop - boundedScrollTop) > 1) {
-      debugLog('PREPEND RESTORE MISMATCH', {
-        requested: boundedScrollTop,
-        actual: actualScrollTop,
-        diff: actualScrollTop - boundedScrollTop,
-      })
-    }
-
-    debugLog('PREPEND RESTORE APPLIED', {
-      scrollTopAfter: actualScrollTop,
-      scrollHeightAfter: scroller.scrollHeight,
-    })
-
-    // Mark as restored but keep the ref for a cooldown period
-    saved.restored = true
-    saved.restoredAt = Date.now()
-    lastRestoreTimeRef.current = Date.now()
-    if (shadowWindowShiftRequest) {
-      positioningControllerRef.current?.markPositionApplied(
-        conversationId,
-        shadowWindowShiftRequest.generation,
-      )
-    }
-
-    // Account for the prepended rows in the new-message baseline. This layout effect runs BEFORE
-    // the new-message effect in the same commit and flips `restored` true, so that effect no
-    // longer takes its `!restored` skip branch. Without syncing the count here it would compare
-    // the post-prepend messageCount against the STALE pre-prepend count, misread the load-older as
-    // a new message, and (in a short conversation, where the top is still within AT_BOTTOM_THRESHOLD
-    // so isAtBottom stays true) pin the view to the bottom — the reported "scroll up to the top
-    // jumps back to the bottom". A genuine new message arriving later still grows the count past
-    // this and scrolls normally.
-    prevMessageCountRef.current = messageCount
-
-    // Measurement-aware re-assert loop: tanstack's estimated sizes for prepended rows
-    // may differ from actual heights. As ResizeObserver reports measurements,
-    // getOffsetForMessageId(anchor) shifts upward. Re-apply the anchor-based target
-    // on each frame until it stabilises (max 20 frames ≈ 333ms at 60fps).
-    //
-    // Runs entirely in rAF — NOT in useLayoutEffect — to avoid the scroll→rerender→
-    // scrollTop-override oscillation (PR #646). The initial scroll was momentum-corrected
-    // by frame 0; subsequent frames track measurement drift only.
-    // Measurement-aware re-assert: tanstack estimated 64px per prepended row; actual
-    // heights may differ. ResizeObserver fires asynchronously — often AFTER the first
-    // rAF. Run unconditionally for 20 frames (≈333ms) so we track every measurement
-    // update and keep the anchor at its correct viewport offset.
-    //
-    // Runs in rAF only (not useLayoutEffect) to avoid the scroll→rerender→override
-    // oscillation from PR #646.
-    // Measurement-aware re-assert: tanstack estimated 64px per prepended row; actual
-    // heights may differ. ResizeObserver fires asynchronously — often AFTER the first
-    // rAF. Run for up to 20 frames (≈333ms) so every measurement update is tracked.
-    //
-    // Runs in rAF only (not useLayoutEffect) to avoid the scroll→rerender→override
-    // oscillation from PR #646.
-    //
-    // Large external scrolls (FAB, keyboard, conversation switch) are detected as
-    // |scrollTop − prevTarget| > 200px and cancel the loop immediately.
-    // Measurement-aware re-assert: tanstack estimated 64px per prepended row; actual
-    // heights may differ. ResizeObserver fires asynchronously over many frames. Keep
-    // tracking until stable for STABLE_FRAMES consecutive frames (max MAX_FRAMES total).
-    //
-    // Runs in rAF only (not useLayoutEffect) to avoid the scroll→rerender→override
-    // oscillation from PR #646.
-    //
-    // Large external scrolls (FAB click, keyboard nav) cancel the loop immediately.
-    const anchorForAssert = saved.anchorMessageId
-    const offsetForAssert = saved.anchorOffsetFromTop
-    // Hard stop after 60 frames (≈1 second). No early-stable exit: ResizeObserver
-    // callbacks can arrive late (beyond a 5-frame window). A big one-frame drift is
-    // re-pinned once (clamp recovery) and only treated as a genuine external scroll —
-    // FAB / keyboard / user fling — if it persists the next frame.
-    const MAX_FRAMES = 60
-    let framesLeft = MAX_FRAMES
-    let prevTarget = boundedScrollTop
-    // Snapshot the loop start. A deliberate user scroll (FAB / wheel) recorded AFTER this means
-    // the user took over → yield. A content-shrink clamp records no intent, so the loop keeps
-    // re-pinning the anchor through it (clamp recovery — the "jump to bottom" fix).
-    const assertStartedAt = Date.now()
-    // Single-flight (shared with pin-bottom): supersede any re-assert loop still in-flight so two
-    // never run at once. This loop has no early-stable exit, so a second MAM prepend (fast
-    // scroll-up through history) would otherwise start a second 'prepend' loop against a different
-    // anchor while this one runs; and a pin-bottom from a send can land mid-prepend. Both fight
-    // over scrollTop. The latest re-assert wins.
-    supersedeReassertLoopRef.current()
-    const assertLoop = (reassertMonitorRef.current ??= createReassertLoopMonitor()).begin('prepend', performance.now())
-    const finishAssert = () => {
-      assertLoop.end()
-      reassertLoopRef.current = null
-    }
-    const runMeasureAssert = () => {
-      if (framesLeft-- <= 0) { finishAssert(); return }
-      // Deliberate user scroll (FAB / wheel) since the loop started → the user took over;
-      // stop re-pinning and yield. A content-shrink clamp does NOT set this, so we keep going.
-      if (userScrollIntentAtRef.current > assertStartedAt) {
-        debugLog('PREPEND ASSERT CANCELLED (user scroll intent)', { scrollTop: scrollerRef.current?.scrollTop })
-        finishAssert()
-        return
-      }
-      let wrote = false
-      const virt = virtualizerRef.current
-      const s = scrollerRef.current
-      if (virt && s) {
-        const currentOffset = virt.getOffsetForMessageId(anchorForAssert)
-        if (currentOffset != null) {
-          const newTarget = Math.max(0, Math.round(currentOffset - offsetForAssert))
-          const scrollDrift = s.scrollTop - newTarget
-          if (Math.abs(newTarget - prevTarget) > 2) {
-            // Measurements shifted since last frame — update scroll to match
-            debugLog('PREPEND MEASURE ASSERT', { newTarget, prevTarget, delta: newTarget - prevTarget })
-            virt.scrollToOffset(newTarget)
-            prevTarget = newTarget
-            wrote = true
-          } else if (Math.abs(scrollDrift) > 5) {
-            // scrollTop diverged from the (stable) anchor target — a content-shrink clamp
-            // pinned us to the bottom, or the browser nudged us. Re-pin the anchor. We do NOT
-            // bail on a big drift here: that previously mistook the clamp for a user scroll and
-            // left the view stuck at the bottom (the reported "jump to bottom"). Genuine user
-            // scrolls are handled by the intent check at the top of the loop instead.
-            virt.scrollToOffset(newTarget)
-            wrote = true
-          }
-        }
-      }
-      const warning = assertLoop.frame(performance.now(), wrote)
-      if (warning) console.warn(warning)
-      reassertLoopRef.current = { raf: requestAnimationFrame(runMeasureAssert), handle: assertLoop }
-    }
-    reassertLoopRef.current = { raf: requestAnimationFrame(runMeasureAssert), handle: assertLoop }
-
-    // Clear after cooldown
-    setTimeout(() => {
-      if (prependRef.current?.restoredAt === saved.restoredAt) {
-        debugLog('PREPEND CLEAR')
-        prependRef.current = null
-      }
-    }, PREPEND_COOLDOWN_MS)
-  }, [conversationId, messageCount, firstMessageId, staticMode])
+  }, [
+    conversationId,
+    createDirectionalHistoryExecutor,
+    firstMessageId,
+    messageCount,
+    staticMode,
+  ])
 
   // ==========================================================================
   // EFFECT: New message arrives
@@ -3240,9 +3163,13 @@ export function useMessageListScroll({
       return
     }
 
-    // Don't interfere with prepend that's actively in progress (not yet restored)
-    // Once restored, allow new message auto-scroll even during cooldown period
-    if (prependRef.current && !prependRef.current.restored) {
+    // Don't interfere while a controller-owned directional restore is still waiting to land.
+    // Once applied, allow new-message auto-scroll even during the snapshot cooldown period.
+    if (
+      positioningControllerRef.current?.isDirectionalHistoryPending(
+        conversationId,
+      )
+    ) {
       if (lastMessageIsOutgoing) {
         positioningControllerRef.current?.beginLiveEdgeRequest({
           conversationId,

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,12 +1,12 @@
 # Message-list scroll positioning contract
 
-Status: migration in progress. Saved-position restoration, unread-marker positioning, explicit
-message targets, live-edge pinning, and media remeasurement preservation are authoritative
-controller slices. Directional history preservation remains shadow-observed.
+Status: core migration complete. Saved-position restoration, unread-marker positioning, explicit
+message targets, live-edge pinning, media remeasurement preservation, and directional history
+preservation are authoritative controller slices.
 
 ## Purpose
 
-Message-list positioning currently has several independent implementations for live-edge pinning,
+Message-list positioning historically had several independent implementations for live-edge pinning,
 saved-position restoration, unread markers, explicit message targets, directional history loads,
 and media re-anchoring. Most are individually justified, but they share `scrollTop`, virtualizer
 measurements, cancellation, persistence gates, and WebKit workarounds. Correctness therefore depends
@@ -37,7 +37,14 @@ same-generation content stimuli, global-tail recentering, the 60-frame/8-stable-
 budget, and user cancellation. Media growth while reading history is a separate fixed-anchor
 request with the former 90-frame/8-stable-frame/8px contract. Hook executors translate accepted
 requests into browser/virtualizer writes, and every frame must hold the current controller lease
-before it can write. All five authoritative slices share the same controller-owned
+before it can write. Directional history is accepted before a load begins, remains pending until
+the first resident ID changes, then performs its pre-paint anchor/fallback write and the former
+full 60-frame late-measurement budget under one lease. Its executor retains WebKit kinetic-scroll
+cancellation, 2px target-shift correction, 5px clamp recovery, and bounded distance-from-bottom
+fallback. Boundary input while the load is still pending retains the captured anchor because no
+pixel owner exists yet; takeover becomes cancellable after the initial positioning write, matching
+the former loop's timing. Explicit competing requests still supersede pending directional history.
+All six authoritative slices share the same controller-owned
 `PositionFrameLoop` shape. The saved executor retains the existing fractional-anchor
 measurement write, 90-frame budget, 8-frame stability window, and 8px tolerance; only scheduling,
 convergence state, and lifecycle ownership moved out of the hook-local loop. Unlike unread-marker
@@ -56,17 +63,15 @@ than competing lifecycle owners. A settled or best-effort generation flushes any
 repaint; user takeover or supersession deliberately discards that debt so it cannot repaint after
 the reader takes control or leak into unrelated content.
 
-Directional-history preservation still runs the model beside `useMessageListScroll`: fact adapters
-read current virtualizer and DOM geometry, and observed decisions are compared with the model
-decision. The instrumentation runs in production so real traces can exercise it. A shared error
-boundary catches and counts adapter, validator,
+Residual shadow observations cover the still-direct resident-top command and entry staging before
+an explicit target. A shared error boundary catches and counts adapter, validator,
 controller-driver, and executor errors; failure must degrade according to the active request's
 source-specific policy and must never escape into the scroll effect or event handler. The demo
 scroll-invariant suite fails if either `divergenceCount` or `instrumentationErrorCount` is non-zero.
 Retained diagnostic samples are capped, not the pass criterion.
 
-For the remaining shadow-observed slice, zero divergences means the model agrees with the
-hand-authored semantic `actual` label at each observation site: desired position plus the coarse
+For residual shadow observations, zero divergences means the model agrees with the hand-authored
+semantic `actual` label at each observation site: desired position plus the coarse
 waiting/positioning/applied/paused/fallback/idle phase. It does **not** compare rendered pixels and
 must not be read as proof that the browser landed
 or painted at the requested position, nor does it prove that every ownership site was observed.
@@ -306,10 +311,9 @@ is already visible or above the viewport, the same activation goes directly to l
 ## Current owners to migrate
 
 The controller-owned mechanisms retain leased browser reconcilers for saved anchors, unread markers,
-explicit center-aligned targets, live edge, and media preservation. These reconcilers implement
-measurement convergence; they are not separate positioning authorities. The only remaining
-independent frame-loop implementation inside `useMessageListScroll` is directional-load measurement
-reassertion.
+explicit center-aligned targets, live edge, media preservation, and directional history. These
+reconcilers implement measurement convergence; they are not separate positioning authorities.
+There is no independent positioning frame-loop implementation left inside `useMessageListScroll`.
 
 There are also positioning owners outside their shared single-flight ref:
 
@@ -362,8 +366,8 @@ Required controls include:
   conversations;
 - outgoing send cannot steal ownership from pending saved/directional preservation;
 - outgoing send may proceed after the preservation position is first applied, before full settle;
-- input cancels reconciliation while settled bottom geometry independently preserves, clears, or
-  re-arms follow-live;
+- input cancels active reconciliation while pending directional-history loads retain their captured
+  anchor; settled bottom geometry independently preserves, clears, or re-arms follow-live;
 - deactivation blocks callbacks from an unmounted conversation;
 - cancellation and settlement preserve the generation watermark;
 - incompatible provenance/position pairs fail compile-time controls.
@@ -386,7 +390,9 @@ kinetic scrolling and stale-paint behavior.
    around-load ref are deleted.
 4. [x] Migrate live-edge pinning and media/content-growth preservation while retaining
    bottom-specific measurement/repaint safeguards; delete both private hook-owned loops.
-5. Migrate directional history preservation last, retaining kinetic cancellation and clamp recovery.
+5. [x] Migrate directional history preservation last, retaining kinetic cancellation, full-budget
+   late-measurement tracking, distance-from-bottom fallback, and clamp recovery; delete the private
+   prepend/window-shift loop.
 6. Route or isolate the remaining owners outside `useMessageListScroll`.
 7. Split persistence, user-intent tracking, history windowing, and reconciliation out of the
    orchestration hook.


### PR DESCRIPTION
## Summary

- move MAM prepend and sliding-window position preservation into the generation-aware positioning controller
- accept the directional-history intent before loading, then perform the first anchor/fallback write synchronously when the resident window changes
- retain the existing 60-frame late-measurement budget, WebKit kinetic-scroll cancellation, 2px target correction, 5px clamp recovery, and distance-from-bottom fallback
- delete the hook-owned directional-history `requestAnimationFrame` loop so all six positioning slices now share one controller-owned execution shape
- add falsifiable coverage for pending loads, supersession, takeover, stale callbacks, fallback, the exact frame budget, and content-shrink clamp recovery
- update the positioning contract to mark migration 5 complete

## Why

Directional history was the last independent scroll-positioning owner in `useMessageListScroll`. It could still compete structurally with the controller-owned saved-position, unread-marker, explicit-target, live-edge, and media-preservation mechanisms.

The controller now owns the intent, generation, cancellation, and frame lifecycle while the hook executor remains responsible only for browser and virtualizer measurements/writes. Boundary wheel input during an unresolved history load deliberately retains the captured anchor because no pixel owner exists yet; takeover becomes cancellable after the initial positioning write, matching the former loop's behavior. Explicit competing requests still supersede the pending generation normally.

## Behavior

No user-visible behavior change is intended. Pre-paint landing, anchor preservation, bounded fallback, late row measurement handling, WebKit momentum cancellation, and content-shrink clamp recovery remain intact. The reassert loop intentionally keeps its full 60-frame budget without an early-stable exit.