### PR TITLE
Stop persisting the duplicated conversations compat map

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.compatMap.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.compatMap.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Rebuild fidelity for the `conversations` compat map.
+ *
+ * The map is no longer persisted: `deserializeState` rebuilds it from
+ * `conversationEntities` + `conversationMeta` on every new-format load. That is
+ * only safe while the LIVE map is nothing more than that same rebuild. A
+ * conversation whose compat entry carries a field its metadata does not —
+ * updated in one map and left stale in the other — keeps working until the next
+ * launch, then silently loses the field.
+ *
+ * `shared/conversationMaps` makes that structural by deriving the compat entry
+ * rather than patching it, and its own suite tests the derivation. What THIS
+ * suite tests is that every write path actually goes through it: the matrix
+ * below drives real store actions and asserts the invariant after each one, so
+ * a future write site that reaches around the draft fails here.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { chatStore } from './chatStore'
+import type { Message, Conversation } from '../core/types/chat'
+import { _resetStorageScopeForTesting } from '../utils/storageScope'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+    removeItem: vi.fn((key: string) => { delete store[key] }),
+    clear: vi.fn(() => { store = {} }),
+    get _store() { return store },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    isMessageCacheAvailable: vi.fn().mockReturnValue(true),
+    deleteConversationMessages: vi.fn().mockResolvedValue(undefined),
+    deleteConversationMessagesBefore: vi.fn().mockResolvedValue(undefined),
+    saveMessage: vi.fn().mockResolvedValue(undefined),
+    saveMessages: vi.fn().mockResolvedValue(true),
+    getMessages: vi.fn().mockResolvedValue([]),
+    getMessagesAround: vi.fn().mockResolvedValue([]),
+    updateMessage: vi.fn().mockResolvedValue(undefined),
+    updateMessageReactions: vi.fn().mockResolvedValue(true),
+  }
+})
+
+const CONV = 'alice@example.com'
+const OTHER = 'bob@example.com'
+
+const BASE_TIME = new Date('2026-01-01T00:00:00Z').getTime()
+
+// Monotonic ids and timestamps, so preview-replacement rules ("is this newer?")
+// resolve deterministically rather than on same-millisecond ties.
+let clock = 0
+function msg(conversationId: string, body: string, overrides: Partial<Message> = {}): Message {
+  clock += 1000
+  return {
+    type: 'chat',
+    id: `m${clock}`,
+    conversationId,
+    from: conversationId,
+    body,
+    timestamp: new Date(BASE_TIME + clock),
+    isOutgoing: false,
+    ...overrides,
+  }
+}
+
+function conversation(id: string, name?: string): Conversation {
+  return { id, name: name ?? id, type: 'chat', unreadCount: 0 }
+}
+
+/**
+ * The invariant, stated exactly as `deserializeState` would apply it: the compat
+ * map must equal the entity/meta merge for EVERY conversation, in both
+ * directions. Containment is not enough — a field present in `conversations` and
+ * stale in `conversationMeta` satisfies a subset check and still loses data on
+ * the next reload.
+ */
+function expectRebuildFidelity(label: string): void {
+  const { conversationEntities, conversationMeta, conversations } = chatStore.getState()
+
+  const expected = new Map<string, Conversation>()
+  for (const [id, entity] of conversationEntities) {
+    const meta = conversationMeta.get(id)
+    if (meta) expected.set(id, { ...entity, ...meta })
+  }
+
+  expect(
+    { at: label, entries: Object.fromEntries(conversations) },
+    `compat map drifted from entities+meta after: ${label}`
+  ).toEqual({ at: label, entries: Object.fromEntries(expected) })
+}
+
+/** Fidelity must hold after the round-trip too, not only in memory. */
+async function expectSurvivesReload(label: string): Promise<void> {
+  const before = new Map(chatStore.getState().conversations)
+
+  const persisted = localStorageMock._store['xmpp-chat-storage']
+  expect(persisted, `nothing persisted at: ${label}`).toBeDefined()
+  chatStore.setState({
+    conversations: new Map(),
+    conversationMeta: new Map(),
+    conversationEntities: new Map(),
+  })
+  localStorageMock._store['xmpp-chat-storage'] = persisted
+  await chatStore.persist.rehydrate()
+
+  const after = chatStore.getState().conversations
+  expect(after.size, `conversation count changed across reload at: ${label}`).toBe(before.size)
+  for (const [id, conv] of before) {
+    // Dates round-trip through JSON as ISO strings; compare the JSON shape.
+    expect(JSON.parse(JSON.stringify(after.get(id))), `lost data across reload for ${id} at: ${label}`)
+      .toEqual(JSON.parse(JSON.stringify(conv)))
+  }
+}
+
+describe('conversations compat map stays a pure rebuild of entities + meta', () => {
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    localStorageMock.clear()
+    chatStore.getState().reset()
+    clock = 0
+  })
+
+  /**
+   * Every mutating path that used to hand-mirror a `conversations` write. Each
+   * case leaves the store in a state the invariant must hold over; they run in
+   * sequence against one store so later cases also see earlier state.
+   */
+  const matrix: Array<{ name: string; run: () => void | Promise<void> }> = [
+    {
+      name: 'addConversation',
+      run: () => {
+        chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+        chatStore.getState().addConversation(conversation(OTHER, 'Bob'))
+      },
+    },
+    {
+      name: 'addConversation carrying a pending remote-displayed marker',
+      run: () => {
+        chatStore.getState().addConversation({
+          ...conversation(CONV, 'Alice'),
+          pendingRemoteDisplayedStanzaId: 'stanza-1',
+        })
+      },
+    },
+    {
+      name: 'addMessage (incoming, updates preview + unread)',
+      run: () => {
+        chatStore.getState().addMessage(msg(CONV, 'first'))
+        chatStore.getState().addMessage(msg(CONV, 'second'))
+      },
+    },
+    {
+      name: 'updateConversationName (entity-side write)',
+      run: () => chatStore.getState().updateConversationName(CONV, 'Alice Renamed'),
+    },
+    {
+      name: 'setActiveConversation (activation zeroes the count)',
+      run: () => chatStore.getState().setActiveConversation(CONV),
+    },
+    {
+      name: 'markAsRead',
+      run: () => chatStore.getState().markAsRead(CONV),
+    },
+    {
+      name: 'markReadToNewest',
+      run: () => chatStore.getState().markReadToNewest(CONV),
+    },
+    {
+      name: 'advanceReadPointer / markMessageSeen',
+      run: () => {
+        const messages = chatStore.getState().messages.get(CONV) ?? []
+        if (messages.length > 0) chatStore.getState().advanceReadPointer(CONV, messages[messages.length - 1].id)
+      },
+    },
+    {
+      name: 'applyRemoteDisplayed with an unknown stanza-id (stashes pending)',
+      run: () => chatStore.getState().applyRemoteDisplayed(CONV, 'not-loaded-yet'),
+    },
+    {
+      name: 'applyRemoteDisplayed resolving a known stanza-id',
+      run: () => {
+        const stamped = msg(CONV, 'stamped', { stanzaId: 'srv-9' })
+        chatStore.getState().addMessage(stamped)
+        chatStore.getState().applyRemoteDisplayed(CONV, 'srv-9')
+      },
+    },
+    {
+      name: 'updateLastMessagePreview',
+      run: () => chatStore.getState().updateLastMessagePreview(CONV, msg(CONV, 'newest preview')),
+    },
+    {
+      name: 'refreshLastMessageContent (deferred-decrypt heal)',
+      run: () => {
+        const preview = chatStore.getState().conversationMeta.get(CONV)?.lastMessage
+        if (preview) chatStore.getState().refreshLastMessageContent(CONV, preview.id, { body: 'decrypted' })
+      },
+    },
+    {
+      name: 'updateMessage on the preview message',
+      run: () => {
+        const preview = chatStore.getState().conversationMeta.get(CONV)?.lastMessage
+        if (preview) chatStore.getState().updateMessage(CONV, preview.id, { body: 'edited' })
+      },
+    },
+    {
+      name: 'clearMessageStanzaId on the preview message',
+      run: () => chatStore.getState().clearMessageStanzaId(CONV, 'srv-9'),
+    },
+    {
+      name: 'removeMessage dropping the current preview',
+      run: () => {
+        const preview = chatStore.getState().conversationMeta.get(CONV)?.lastMessage
+        if (preview) chatStore.getState().removeMessage(CONV, preview.id)
+      },
+    },
+    {
+      name: 'mergeMAMMessages (active conversation)',
+      run: () => {
+        chatStore.getState().mergeMAMMessages(
+          CONV,
+          [msg(CONV, 'archived-1'), msg(CONV, 'archived-2')],
+          { first: 'a1', last: 'a2', count: 2 },
+          true,
+          'backward'
+        )
+      },
+    },
+    {
+      name: 'mergeMAMMessages (backgrounded conversation)',
+      run: () => {
+        chatStore.getState().mergeMAMMessages(
+          OTHER,
+          [msg(OTHER, 'bg-1'), msg(OTHER, 'bg-2')],
+          { first: 'b1', last: 'b2', count: 2 },
+          true,
+          'backward'
+        )
+      },
+    },
+    {
+      name: 'mergeServerConversations (adds new, syncs archived)',
+      run: () => {
+        chatStore.getState().mergeServerConversations([
+          { id: CONV, name: 'Alice', type: 'chat', archived: true },
+          { id: 'carol@example.com', name: 'Carol', type: 'chat', archived: false },
+        ])
+      },
+    },
+    {
+      name: 'recomputeUnreadForConversation',
+      run: async () => {
+        await chatStore.getState().recomputeUnreadForConversation(OTHER)
+      },
+    },
+    {
+      name: 'recordPendingRetraction',
+      run: () => chatStore.getState().recordPendingRetraction(CONV, 'absent-target', CONV),
+    },
+    {
+      name: 'setConversationHistoryFloor via re-add',
+      run: () => chatStore.getState().addConversation(conversation(CONV, 'Alice Renamed')),
+    },
+    {
+      name: 'deleteConversation',
+      run: () => chatStore.getState().deleteConversation('carol@example.com'),
+    },
+  ]
+
+  for (const { name, run } of matrix) {
+    it(`holds after ${name}`, async () => {
+      // Every case starts from a populated store so the write paths that
+      // require an existing conversation actually execute.
+      chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+      chatStore.getState().addConversation(conversation(OTHER, 'Bob'))
+      chatStore.getState().addMessage(msg(CONV, 'seed'))
+      chatStore.getState().addMessage(msg(OTHER, 'seed'))
+      expectRebuildFidelity('setup')
+
+      await run()
+
+      expectRebuildFidelity(name)
+    })
+  }
+
+  it('holds after the whole matrix runs in sequence, and survives a reload', async () => {
+    for (const { name, run } of matrix) {
+      await run()
+      expectRebuildFidelity(name)
+    }
+    await expectSurvivesReload('full matrix')
+  })
+
+  /**
+   * The invariant has a second half the merge check alone cannot see: an entry
+   * present in `conversations` for a conversation with no entity (or no meta)
+   * is dropped entirely by the rebuild. Asserting only over ids the rebuild
+   * emits would never notice one.
+   */
+  it('never holds a compat entry the rebuild would not emit', () => {
+    chatStore.getState().addConversation(conversation(CONV, 'Alice'))
+    chatStore.getState().addMessage(msg(CONV, 'hello'))
+    chatStore.getState().markAsRead(CONV)
+
+    const { conversationEntities, conversationMeta, conversations } = chatStore.getState()
+    for (const id of conversations.keys()) {
+      expect(conversationEntities.has(id), `compat entry ${id} has no entity`).toBe(true)
+      expect(conversationMeta.has(id), `compat entry ${id} has no metadata`).toBe(true)
+    }
+  })
+})

--- a/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.mds.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { chatStore } from './chatStore'
 import { connectionStore } from './connectionStore'
 import { chatSelectors } from './chatSelectors'
-import type { Message } from '../core/types/chat'
+import type { Message, ConversationEntity, ConversationMetadata } from '../core/types/chat'
 
 // Mock messageCache: the deep-pointer activation tests need getMessagesAround to
 // return a controlled around-slice; everything else is a harmless stub.
@@ -79,6 +79,26 @@ function seedMessages(cid: string, messages: Message[]): void {
   })
 }
 
+/**
+ * Seed a conversation across all three maps, with the compat entry DERIVED from
+ * the entity and the metadata — the same rule the store itself now follows (see
+ * shared/conversationMaps) and the same one `deserializeState` applies on
+ * reload.
+ *
+ * Written out here rather than delegating to the production draft, so a bug in
+ * that module cannot quietly make these fixtures agree with it. Fixtures that
+ * set `conversations` without `conversationEntities` build a state the store can
+ * no longer reach, and assertions over the compat map then prove nothing.
+ */
+function seedConversation(cid: string, meta: ConversationMetadata): void {
+  const entity: ConversationEntity = { id: cid, name: cid, type: 'chat' }
+  chatStore.setState((state) => ({
+    conversationEntities: new Map(state.conversationEntities).set(cid, entity),
+    conversationMeta: new Map(state.conversationMeta).set(cid, meta),
+    conversations: new Map(state.conversations).set(cid, { ...entity, ...meta }),
+  }))
+}
+
 describe('chatStore.applyRemoteDisplayed', () => {
   beforeEach(() => chatStore.getState().reset())
 
@@ -88,13 +108,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     seedMessages(cid, messages)
 
     // Simulate conversation present in conversationMeta with m1 as last seen.
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m1') })
 
     chatStore.getState().applyRemoteDisplayed(cid, 's3')
 
@@ -109,13 +123,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')]
     seedMessages(cid, messages)
 
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m3') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m3') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m3') })
 
     chatStore.getState().applyRemoteDisplayed(cid, 's1') // behind → must be ignored
 
@@ -127,13 +135,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
     const cid = 'juliet@capulet.example'
     seedMessages(cid, [msg('m1', 's1')])
 
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0 })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0 })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0 })
 
     chatStore.getState().applyRemoteDisplayed(cid, 's-future')
 
@@ -150,19 +152,10 @@ describe('chatStore.applyRemoteDisplayed', () => {
     // Local position is already at m3 (past s2), yet a stale pending marker for
     // s2 lingers — e.g. set before the message loaded, then resolved by a local
     // advance that didn't go through applyRemoteDisplayed.
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m3'), pendingRemoteDisplayedStanzaId: 's2' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, {
-        id: cid,
-        name: cid,
-        type: 'chat',
-        unreadCount: 0,
-        readPointer: pointerAt('m3'),
-        pendingRemoteDisplayedStanzaId: 's2',
-      })
-      return { conversationMeta: newMeta, conversations: newConvs }
+    seedConversation(cid, {
+      unreadCount: 0,
+      readPointer: pointerAt('m3'),
+      pendingRemoteDisplayedStanzaId: 's2',
     })
 
     // s2's message IS present but the read pointer is already ahead → no advance.
@@ -184,13 +177,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
 
     // Backgrounded conversation: NO resident messages (evicted); the marker
     // arrives with the just-merged messages (the mergeMAMMessages override path).
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 3, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 3, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 3, readPointer: pointerAt('m1') })
 
     chatStore.getState().applyRemoteDisplayed(cid, 's4', messages)
 
@@ -216,13 +203,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
 
     // Non-active, non-resident conversation with a pending deep pointer
     // (new-device sync: no local read state yet).
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0 })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0 })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0 })
     chatStore.getState().applyRemoteDisplayed(cid, 's-ptr')
     expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s-ptr')
 
@@ -264,13 +245,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
       return { ...msg(id, stanzaId), timestamp: ts }
     }
 
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0 })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0 })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0 })
     chatStore.getState().applyRemoteDisplayed(cid, 's-ptr')
 
     const page = [timedMsg('p0', 's-ptr', t(41)), timedMsg('p1', 'sp1', t(42))]
@@ -313,13 +288,7 @@ describe('chatStore.applyRemoteDisplayed', () => {
 
     // Seed initial message m1/s1 and set up conversation meta with the read pointer at m1
     seedMessages(cid, [timedMsg('m1', 's1', t0)])
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m1') })
 
     // Remote marker for s5 arrives before m5 is loaded → stored as pending
     chatStore.getState().applyRemoteDisplayed(cid, 's5')
@@ -349,13 +318,7 @@ describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
   it('advances the read pointer to the newest loaded message when at the live edge', () => {
     const cid = 'juliet@capulet.example'
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 2, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 2, readPointer: pointerAt('m1') })
 
     chatStore.getState().markAsRead(cid)
 
@@ -370,14 +333,11 @@ describe('chatStore.markAsRead — read-pointer advance for XEP-0490 sync', () =
   it('does NOT advance the read pointer when the window is slid up into history', () => {
     const cid = 'juliet@capulet.example'
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
+    seedConversation(cid, { unreadCount: 2, readPointer: pointerAt('m1') })
     chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 2, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, readPointer: pointerAt('m1') })
       const newEdge = new Map(state.windowAtLiveEdge)
       newEdge.set(cid, false)
-      return { conversationMeta: newMeta, conversations: newConvs, windowAtLiveEdge: newEdge }
+      return { windowAtLiveEdge: newEdge }
     })
 
     chatStore.getState().markAsRead(cid)
@@ -395,13 +355,7 @@ describe('chatStore — new-message divider is session-only', () => {
     // m1 outgoing-read baseline, then two incoming unread messages.
     const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')]
     seedMessages(cid, messages)
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 2, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 2, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 2, readPointer: pointerAt('m1') })
 
     chatStore.getState().setActiveConversation(cid)
 
@@ -418,16 +372,9 @@ describe('chatStore — new-message divider is session-only', () => {
 
     // Seed conversation A with one read message and one unread message.
     seedMessages(cidA, [msg('a1', 'sa1'), msg('a2', 'sa2')])
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cidA, { unreadCount: 1, readPointer: pointerAt('a1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cidA, { id: cidA, name: cidA, type: 'chat', unreadCount: 1, readPointer: pointerAt('a1') })
-      // Seed conversation B with no unread so its activation sets no marker.
-      newMeta.set(cidB, { unreadCount: 0 })
-      newConvs.set(cidB, { id: cidB, name: cidB, type: 'chat', unreadCount: 0 })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cidA, { unreadCount: 1, readPointer: pointerAt('a1') })
+    // Seed conversation B with no unread so its activation sets no marker.
+    seedConversation(cidB, { unreadCount: 0 })
     seedMessages(cidB, [msg('b1', 'sb1')])
 
     // Activate A — should park the divider at a2.
@@ -444,13 +391,7 @@ describe('chatStore — new-message divider is session-only', () => {
   it('never writes the divider to persisted storage', () => {
     const cid = 'juliet@capulet.example'
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 1, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 1, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 1, readPointer: pointerAt('m1') })
     chatStore.getState().setActiveConversation(cid)
     expect(chatStore.getState().firstNewMessageMarkers.get(cid)).toBe('m2')
 
@@ -477,14 +418,11 @@ describe('chatStore.applyRemoteDisplayed — late marker corrects the ACTIVE div
 
     // Post-activation state: local read stale at m2, divider parked at m3 (first unread),
     // conversation is the active one. No pending marker yet (seed hasn't landed).
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2') })
     chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2') })
       const newMarkers = new Map(state.firstNewMessageMarkers)
       newMarkers.set(cid, 'm3')
-      return { conversationMeta: newMeta, conversations: newConvs, firstNewMessageMarkers: newMarkers, activeConversationId: cid }
+      return { firstNewMessageMarkers: newMarkers, activeConversationId: cid }
     })
 
     // The MDS seed lands late: the other device had read to s4 (the last message).
@@ -502,15 +440,12 @@ describe('chatStore.applyRemoteDisplayed — late marker corrects the ACTIVE div
     const messages = [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3'), msg('m4', 's4')]
     seedMessages(cid, messages)
 
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2') })
     chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2') })
       const newMarkers = new Map(state.firstNewMessageMarkers)
       newMarkers.set(cid, 'm3')
       // Some OTHER conversation is active, not cid.
-      return { conversationMeta: newMeta, conversations: newConvs, firstNewMessageMarkers: newMarkers, activeConversationId: 'romeo@montague.example' }
+      return { firstNewMessageMarkers: newMarkers, activeConversationId: 'romeo@montague.example' }
     })
 
     chatStore.getState().applyRemoteDisplayed(cid, 's4')
@@ -533,13 +468,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
 
     // Local read is stale at m2; a remote device read up to s4, seeded as pending
     // before the messages were loaded (the fresh-session MDS seed ordering).
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's4' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's4' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's4' })
 
     await chatStore.getState().activateConversation(cid)
 
@@ -560,13 +489,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     seedMessages(cid, messages)
 
     // First open: local read stale at m2, a remote device read up to s3 (pending) → folds to m3.
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
 
     await chatStore.getState().activateConversation(cid)
     expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
@@ -600,13 +523,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     seedMessages(cid, messages)
 
     // First open: local read stale at m2, a remote device read up to s3 (pending) → folds to m3.
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's3' })
 
     await chatStore.getState().activateConversation(cid)
     expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m3')
@@ -635,13 +552,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
     const early = [timed('m1', 's1', 1), timed('m2', 's2', 2)]
     seedMessages(cid, early)
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m1'), pendingRemoteDisplayedStanzaId: 's9' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m1'), pendingRemoteDisplayedStanzaId: 's9' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m1'), pendingRemoteDisplayedStanzaId: 's9' })
 
     await chatStore.getState().activateConversation(cid)
     // Unresolvable → stash survives, pointer untouched.
@@ -670,13 +581,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const latest = [timed('m10', 's10', 10), timed('m11', 's11', 11), timed('m12', 's12', 12)]
     // Resident window = latest slice; the read pointer (m2) is deeper than it.
     seedMessages(cid, latest)
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's5' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's5' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's5' })
     // The IndexedDB slice around the stale pointer contains the marker's message (m5).
     const aroundSlice = [
       timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3),
@@ -702,13 +607,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
     const messages = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m4', 's4', 4)]
     seedMessages(cid, messages)
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's0' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's0' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's0' })
 
     await chatStore.getState().activateConversation(cid)
 
@@ -728,13 +627,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const t = (n: number) => new Date(`2026-01-01T00:0${n}:00Z`)
     const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
     seedMessages(cid, [timed('m1', 's1', 1), timed('m2', 's2', 2)])
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m1') })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m1') })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m1') })
 
     await chatStore.getState().activateConversation(cid)
 
@@ -763,13 +656,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     // m4 is NOT loaded at activation (deep gap) — the marker for s4 can only stash.
     const loaded = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3), timed('m5', 's5', 5)]
     seedMessages(cid, loaded)
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's4' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's4' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m2'), pendingRemoteDisplayedStanzaId: 's4' })
 
     await chatStore.getState().activateConversation(cid)
     // Provisional divider from the stale local pointer (m2 → m3).
@@ -792,13 +679,7 @@ describe('chatStore.activateConversation — XEP-0490 divider sync', () => {
     const timed = (id: string, stanzaId: string, n: number): Message => ({ ...msg(id, stanzaId), timestamp: t(n) })
     const loaded = [timed('m1', 's1', 1), timed('m2', 's2', 2), timed('m3', 's3', 3)]
     seedMessages(cid, loaded)
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt('m1'), pendingRemoteDisplayedStanzaId: 's9' })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt('m1'), pendingRemoteDisplayedStanzaId: 's9' })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt('m1'), pendingRemoteDisplayedStanzaId: 's9' })
 
     await chatStore.getState().activateConversation(cid)
     expect(chatSelectors.firstNewMessageIdFor(cid)(chatStore.getState())).toBe('m2')
@@ -830,13 +711,7 @@ describe('chatStore fresh-instance catch-up preserves the remote read position',
 
   /** Register the conversation with NO read state at all (fresh instance). */
   function seedFreshConversation(): void {
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0 })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0 })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0 })
   }
 
   const archive = () => Array.from({ length: 10 }, (_, i) => msg(`m${i + 1}`, `s${i + 1}`))
@@ -888,13 +763,7 @@ describe('chatStore.advanceReadPointer presence gate', () => {
 
   function seedWithPointer(seenMessageId: string): void {
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2'), msg('m3', 's3')])
-    chatStore.setState((state) => {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(cid, { unreadCount: 0, readPointer: pointerAt(seenMessageId) })
-      const newConvs = new Map(state.conversations)
-      newConvs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer: pointerAt(seenMessageId) })
-      return { conversationMeta: newMeta, conversations: newConvs }
-    })
+    seedConversation(cid, { unreadCount: 0, readPointer: pointerAt(seenMessageId) })
   }
 
   it('advances the read pointer when the window is focused', () => {

--- a/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
@@ -97,9 +97,11 @@ function persistConversations(entries: Array<[string, LegacyMeta]>): void {
     STORAGE_KEY,
     JSON.stringify({
       state: {
+        // New-format blob: entities + meta only. The compat map is rebuilt from
+        // these on load and is no longer persisted, so writing one here would
+        // describe a shape the app never produces.
         conversationEntities: entries.map(([id]) => [id, { id, name: id, type: 'chat' }]),
         conversationMeta: entries.map(([id, m]) => [id, { unreadCount: 0, ...m }]),
-        conversations: entries.map(([id, m]) => [id, { id, name: id, type: 'chat', unreadCount: 0, ...m }]),
         archivedConversations: [],
       },
     })
@@ -243,7 +245,7 @@ describe('post-rehydrate readPointer backfill', () => {
 const LATE = 'late@example.com'
 
 /** One conversation's entry in one persisted map, as it actually sits on disk. */
-function diskEntry(map: 'conversationMeta' | 'conversations', id: string): Record<string, unknown> {
+function diskEntry(map: 'conversationMeta' | 'conversationEntities', id: string): Record<string, unknown> {
   const raw = localStorage.getItem(STORAGE_KEY)
   if (!raw) throw new Error(`diskEntry: nothing persisted under ${STORAGE_KEY}`)
   const entries = JSON.parse(raw).state[map] as Array<[string, Record<string, unknown>]>
@@ -253,13 +255,12 @@ function diskEntry(map: 'conversationMeta' | 'conversations', id: string): Recor
 }
 
 /**
- * The legacy pair on disk. Both persisted maps are read: `serializeState` writes
- * them separately, and either one going missing is the same loss.
+ * The legacy pair on disk. `conversationMeta` is the only persisted carrier: the
+ * `conversations` compat map is no longer written at all (it is rebuilt from
+ * entities + meta on load), so there is one place left for this to go missing.
  */
 function legacyOnDisk(id: string): { lastSeenMessageId?: unknown; lastReadAt?: unknown } {
   const meta = diskEntry('conversationMeta', id)
-  const conv = diskEntry('conversations', id)
-  expect([conv.lastSeenMessageId, conv.lastReadAt]).toEqual([meta.lastSeenMessageId, meta.lastReadAt])
   return { lastSeenMessageId: meta.lastSeenMessageId, lastReadAt: meta.lastReadAt }
 }
 
@@ -332,7 +333,8 @@ describe('unmigrated legacy read state survives the persist', () => {
       timestamp: at(2000).toISOString(),
     })
     expect('lastSeenMessageId' in diskEntry('conversationMeta', CONV)).toBe(false)
-    expect('lastSeenMessageId' in diskEntry('conversations', CONV)).toBe(false)
+    // The compat map is not on disk to check any more — nothing writes it.
+    expect('conversations' in JSON.parse(localStorage.getItem(STORAGE_KEY)!).state).toBe(false)
   })
 
   // A conversation the user reads normally gets its pointer from the store, not

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1773,9 +1773,10 @@ describe('chatStore', () => {
       const persisted = localStorageMock.setItem.mock.calls[localStorageMock.setItem.mock.calls.length - 1][1]
       const payload = JSON.parse(persisted)
       // What JSON.stringify actually writes for a `Date` inside the meta blob.
-      const isoPointer = { messageId: 'msg1', timestamp: '2025-01-10T10:00:00.000Z' }
-      payload.state.conversations[0][1].readPointer = isoPointer
-      payload.state.conversationMeta[0][1].readPointer = isoPointer
+      payload.state.conversationMeta[0][1].readPointer = {
+        messageId: 'msg1',
+        timestamp: '2025-01-10T10:00:00.000Z',
+      }
 
       chatStore.setState({ conversations: new Map(), conversationMeta: new Map(), conversationEntities: new Map() })
       localStorageMock._store['xmpp-chat-storage'] = JSON.stringify(payload)
@@ -1995,7 +1996,7 @@ describe('chatStore', () => {
   })
 
   describe('persistence', () => {
-    it('should serialize conversations Map to array', () => {
+    it('should serialize conversation Maps to arrays', () => {
       chatStore.getState().addConversation(createConversation('alice@example.com', 'Alice'))
       chatStore.getState().addConversation(createConversation('bob@example.com', 'Bob'))
 
@@ -2005,9 +2006,65 @@ describe('chatStore', () => {
       const lastCall = localStorageMock.setItem.mock.calls[localStorageMock.setItem.mock.calls.length - 1]
       const stored = JSON.parse(lastCall[1])
 
-      // Should be array of tuples, not a Map
-      expect(Array.isArray(stored.state.conversations)).toBe(true)
-      expect(stored.state.conversations.length).toBe(2)
+      // Should be arrays of tuples, not Maps
+      expect(Array.isArray(stored.state.conversationEntities)).toBe(true)
+      expect(stored.state.conversationEntities.length).toBe(2)
+      expect(Array.isArray(stored.state.conversationMeta)).toBe(true)
+      expect(stored.state.conversationMeta.length).toBe(2)
+    })
+
+    // The compat map is a view over the two maps above — `deserializeState`
+    // rebuilds it on load — so persisting it wrote the same data twice and
+    // doubled the cost of every write.
+    it('does not persist the conversations compat map', () => {
+      chatStore.getState().addConversation(createConversation('alice@example.com', 'Alice'))
+
+      const lastCall = localStorageMock.setItem.mock.calls[localStorageMock.setItem.mock.calls.length - 1]
+      expect('conversations' in JSON.parse(lastCall[1]).state).toBe(false)
+    })
+
+    // The compat map has to come back on rehydrate even though nothing wrote
+    // it, and it has to be exactly the entity/meta merge.
+    it('rebuilds the compat map on rehydrate from entities and meta alone', async () => {
+      const conv = { ...createConversation('alice@example.com', 'Alice'), unreadCount: 4 }
+      chatStore.getState().addConversation(conv)
+      const persisted = localStorageMock.setItem.mock.calls[localStorageMock.setItem.mock.calls.length - 1][1]
+
+      chatStore.setState({ conversations: new Map(), conversationMeta: new Map(), conversationEntities: new Map() })
+      localStorageMock._store['xmpp-chat-storage'] = persisted
+      localStorageMock.getItem.mockImplementation((key: string) => localStorageMock._store[key] || null)
+      await chatStore.persist.rehydrate()
+
+      const state = chatStore.getState()
+      const restored = state.conversations.get('alice@example.com')
+      expect(restored).toBeDefined()
+      expect(restored).toEqual({
+        ...state.conversationEntities.get('alice@example.com'),
+        ...state.conversationMeta.get('alice@example.com'),
+      })
+      expect(restored?.name).toBe('Alice')
+      expect(restored?.unreadCount).toBe(4)
+    })
+
+    // A blob written before the entity/meta split carries only `conversations`.
+    // Dropping the field from what we WRITE must not stop us READING those.
+    it('still restores a legacy blob that carries only the conversations map', async () => {
+      chatStore.setState({ conversations: new Map(), conversationMeta: new Map(), conversationEntities: new Map() })
+      localStorageMock._store['xmpp-chat-storage'] = JSON.stringify({
+        state: {
+          conversations: [
+            ['alice@example.com', { id: 'alice@example.com', name: 'Alice', type: 'chat', unreadCount: 2 }],
+          ],
+          archivedConversations: [],
+        },
+      })
+      localStorageMock.getItem.mockImplementation((key: string) => localStorageMock._store[key] || null)
+      await chatStore.persist.rehydrate()
+
+      const state = chatStore.getState()
+      expect(state.conversations.get('alice@example.com')?.name).toBe('Alice')
+      expect(state.conversationEntities.get('alice@example.com')?.name).toBe('Alice')
+      expect(state.conversationMeta.get('alice@example.com')?.unreadCount).toBe(2)
     })
 
     it('should NOT serialize messages to localStorage (they are in IndexedDB)', () => {
@@ -2063,15 +2120,14 @@ describe('chatStore', () => {
       // The persist middleware serializes the conversation
       const parsed = JSON.parse(serialized)
 
-      // Conversation should have lastMessage (updated when message was added)
-      const conversationData = parsed.state.conversations.find(
+      // The preview rides in conversationMeta — the only persisted carrier.
+      const metaData = parsed.state.conversationMeta.find(
         ([id]: [string, unknown]) => id === 'alice@example.com'
       )
-      expect(conversationData).toBeDefined()
-      // lastMessage is now stored on the conversation
-      expect(conversationData[1].lastMessage).toBeDefined()
-      expect(conversationData[1].lastMessage.id).toBe('test-msg')
-      expect(conversationData[1].lastMessage.body).toBe('Test')
+      expect(metaData).toBeDefined()
+      expect(metaData[1].lastMessage).toBeDefined()
+      expect(metaData[1].lastMessage.id).toBe('test-msg')
+      expect(metaData[1].lastMessage.body).toBe('Test')
     })
 
     // Deserialization used to zero the count, so a cold start flashed empty
@@ -2083,7 +2139,7 @@ describe('chatStore', () => {
 
       // The serialized data carries the count...
       const persisted = localStorageMock.setItem.mock.calls[localStorageMock.setItem.mock.calls.length - 1][1]
-      expect(JSON.parse(persisted).state.conversations[0][1].unreadCount).toBe(5)
+      expect(JSON.parse(persisted).state.conversationMeta[0][1].unreadCount).toBe(5)
 
       // ...and the restore keeps it. (Clearing the store re-persists an empty
       // payload, so the captured one has to be put back before rehydrating.)

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -16,6 +16,7 @@ import * as draftState from './shared/draftState'
 import * as timeline from './shared/messageTimeline'
 import { isPreviewableMessage, findLastPreviewableMessage, shouldReplaceLastMessage } from './shared/lastMessageUtils'
 import { derivePreviewAfterMerge } from './shared/previewState'
+import { draftConversationMaps, rebuildCompatEntry } from './shared/conversationMaps'
 import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
 import { advance, deserializeReadPointer, makeReadPointer, type ReadPointer } from './shared/readPointer'
@@ -86,7 +87,7 @@ function mergeCachedChatMessages(
   state: ChatState,
   conversationId: string,
   cachedMessages: Message[]
-): Partial<Pick<ChatState, 'messages' | 'conversationMeta' | 'conversations' | 'pendingRetractions'>> | null {
+): Partial<Pick<ChatState, 'messages' | 'conversationEntities' | 'conversationMeta' | 'conversations' | 'pendingRetractions'>> | null {
   const existingMessages = state.messages.get(conversationId) || []
 
   const { merged, newMessages } = timeline.latestSlice(
@@ -108,15 +109,13 @@ function mergeCachedChatMessages(
   // supersedes (or heals) the stored preview — e.g. opening a conversation
   // whose stored preview is a stuck placeholder heals it here.
   const meta = state.conversationMeta.get(conversationId)
-  const conv = state.conversations.get(conversationId)
   const { lastMessage, changed } = derivePreviewAfterMerge(meta?.lastMessage, trimmed, findLastPreviewableMessage)
   const retractionPatch = resolved.pendingRetractions ? { pendingRetractions: resolved.pendingRetractions } : {}
-  if (meta && conv && changed) {
-    const newMeta = new Map(state.conversationMeta)
-    newMeta.set(conversationId, { ...meta, lastMessage })
-    const newConversations = new Map(state.conversations)
-    newConversations.set(conversationId, { ...conv, lastMessage })
-    return { messages: newMessagesMap, conversationMeta: newMeta, conversations: newConversations, ...retractionPatch }
+  if (changed) {
+    const draft = draftConversationMaps(state)
+    if (draft.patchMeta(conversationId, { lastMessage })) {
+      return { messages: newMessagesMap, ...draft.commit(), ...retractionPatch }
+    }
   }
 
   return { messages: newMessagesMap, ...retractionPatch }
@@ -581,8 +580,11 @@ interface PersistedState {
   // New separated storage (Phase 6)
   conversationEntities?: [string, ConversationEntity][]
   conversationMeta?: [string, PersistedConversationMetadata][]
-  // Legacy combined storage for backward compatibility
-  conversations: [string, PersistedConversation][]
+  // Legacy combined storage, read-only: blobs written before the entity/meta
+  // split carry this and nothing else. Never written any more — the new-format
+  // load rebuilds the compat map from the two maps above, so persisting it was
+  // storing the same data a second time (halving every write to remove it).
+  conversations?: [string, PersistedConversation][]
   archivedConversations?: string[] // Optional for backwards compatibility
   drafts?: [string, string][] // Optional for backwards compatibility
   conversationGaps?: [string, GapInterval][] // Optional for backwards compatibility
@@ -622,15 +624,16 @@ function withUnmigratedReadState<T extends { readPointer?: ReadPointer }>(
 }
 
 // Serialize Maps to arrays for JSON storage
-function serializeState(state: Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'archivedConversations' | 'drafts'> & { conversationGaps?: Map<string, GapInterval>; conversationCoverage?: Map<string, CoverageRecord>; pendingRetractions?: Map<string, PendingRetraction[]> }, storageKey: string): PersistedState {
+function serializeState(state: Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'messages' | 'archivedConversations' | 'drafts'> & { conversationGaps?: Map<string, GapInterval>; conversationCoverage?: Map<string, CoverageRecord>; pendingRetractions?: Map<string, PendingRetraction[]> }, storageKey: string): PersistedState {
   // Un-migrated legacy read state belonging to THIS blob (see the map's doc).
   const legacy = unmigratedLegacyReadState.get(storageKey)
   return {
-    // Serialize separated maps (Phase 6)
+    // Serialize separated maps (Phase 6). The `conversations` compat map is
+    // deliberately NOT written: `deserializeState` rebuilds it from these two
+    // (see its new-format branch), and `shared/conversationMaps` guarantees the
+    // live map is nothing but that rebuild, so the copy was pure duplication.
     conversationEntities: Array.from(state.conversationEntities.entries()),
     conversationMeta: withUnmigratedReadState(state.conversationMeta, legacy),
-    // Also serialize combined map for backward compatibility
-    conversations: withUnmigratedReadState(state.conversations, legacy),
     // Messages are NOT stored in localStorage - they're in IndexedDB
     archivedConversations: Array.from(state.archivedConversations),
     drafts: Array.from(state.drafts.entries()),
@@ -702,33 +705,24 @@ export async function migrateReadPointer(
  * rehydrate, so it is at or behind the true position by construction — it can
  * only ever fill a gap, never push the pointer past something unread.
  *
- * `conversationMeta` and `conversations` are written in ONE `setState`, so the
- * conversation is never observable holding a pointer in one map and not the
- * other. Until this lands it simply looks un-migrated, which is a valid state.
+ * `conversationMeta` and `conversations` are written in ONE `setState` (see
+ * shared/conversationMaps), so the conversation is never observable holding a
+ * pointer in one map and not the other. Until this lands it simply looks
+ * un-migrated, which is a valid state.
  */
 function applyMigratedReadPointer(conversationId: string, migrated: ReadPointer): void {
   chatStore.setState((state) => {
     const meta = state.conversationMeta.get(conversationId)
-    const conv = state.conversations.get(conversationId)
     // Gone (deleted, logged out, account switched) — nothing to migrate into.
-    if (!meta && !conv) return {}
+    if (!meta) return {}
 
-    const current = meta?.readPointer ?? conv?.readPointer
+    const current = meta.readPointer
     const next = advance(current, migrated)
     if (next === current) return {}
 
-    const update: Partial<ChatState> = {}
-    if (meta) {
-      const newMeta = new Map(state.conversationMeta)
-      newMeta.set(conversationId, { ...meta, readPointer: next })
-      update.conversationMeta = newMeta
-    }
-    if (conv) {
-      const newConversations = new Map(state.conversations)
-      newConversations.set(conversationId, { ...conv, readPointer: next })
-      update.conversations = newConversations
-    }
-    return update
+    const draft = draftConversationMaps(state)
+    draft.patchMeta(conversationId, { readPointer: next })
+    return draft.commit()
   })
 }
 
@@ -897,18 +891,22 @@ function deserializeState(persisted: PersistedState, storageKey: string): Pick<C
       })
     )
 
-    // Rebuild combined map from separated maps
+    // Rebuild the combined map from the separated maps. This — not the blob —
+    // is where `conversations` comes from on every new-format load, which is
+    // why the map is no longer persisted at all. `shared/conversationMaps`
+    // holds the same expression and is the only writer while the store is live,
+    // so a restored map and a mutated one cannot disagree.
     conversations = new Map()
     for (const [id, entity] of conversationEntities) {
       const meta = conversationMeta.get(id)
       if (meta) {
-        conversations.set(id, { ...entity, ...meta })
+        conversations.set(id, rebuildCompatEntry(entity, meta))
       }
     }
   } else {
     // Legacy format: deserialize combined map and extract separated maps
     conversations = new Map(
-      persisted.conversations.map(([id, conv]) => {
+      (persisted.conversations ?? []).map(([id, conv]) => {
         captureLegacyReadState(id, conv)
         const { lastSeenMessageId: _seen, lastReadAt: _readAt, ...rest } = conv
         return [
@@ -1052,10 +1050,11 @@ function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatSt
     migrated.conversations = restored.conversations
     migrated.archivedConversations = restored.archivedConversations
 
+    // The blob written here carries entities + meta only; the new-format read
+    // branch rebuilds the compat map from them on the next load.
     const serialized = serializeState({
       conversationEntities: migrated.conversationEntities,
       conversationMeta: migrated.conversationMeta,
-      conversations: migrated.conversations,
       messages: migrated.messages,
       archivedConversations: migrated.archivedConversations,
       drafts: migrated.drafts,
@@ -1193,23 +1192,16 @@ export const chatStore = createStore<ChatState>()(
             const activated = notifState.onActivate(notifInput, messages, { treatDelayedAsNew: true })
 
             set((state) => {
-              const newMetaEntry = {
-                ...(meta ?? { unreadCount: 0, readPointer: undefined }),
-                unreadCount: activated.unreadCount,
-                readPointer: activated.readPointer,
-              }
-              const newMeta = new Map(state.conversationMeta)
-              newMeta.set(id, newMetaEntry)
-              const newConversations = new Map(state.conversations)
-              newConversations.set(id, {
-                ...conv,
+              const draft = draftConversationMaps(state)
+              draft.setMeta(id, {
+                ...(draft.getMeta(id) ?? { unreadCount: 0, readPointer: undefined }),
                 unreadCount: activated.unreadCount,
                 readPointer: activated.readPointer,
               })
               const newMarkers = new Map(state.firstNewMessageMarkers)
               if (activated.firstNewMessageId) newMarkers.set(id, activated.firstNewMessageId)
               else newMarkers.delete(id)
-              return { conversationMeta: newMeta, conversations: newConversations, activeConversationId: id, firstNewMessageMarkers: newMarkers }
+              return { ...draft.commit(), activeConversationId: id, firstNewMessageMarkers: newMarkers }
             })
             return
           }
@@ -1309,44 +1301,21 @@ export const chatStore = createStore<ChatState>()(
             // value comes back through `deserializeState`, so a conversation
             // re-added after a restart finds its original floor here.
             historyFloor: existingMeta?.historyFloor ?? conv.historyFloor ?? new Date(),
+            pendingRemoteDisplayedStanzaId: conv.pendingRemoteDisplayedStanzaId,
           }
 
-          const newEntities = new Map(state.conversationEntities)
-          newEntities.set(conv.id, entity)
-
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conv.id, meta)
-
-          // Also update combined map for backward compatibility
-          const newConversations = new Map(state.conversations)
-          newConversations.set(conv.id, { ...conv, historyFloor: meta.historyFloor })
-
-          return {
-            conversationEntities: newEntities,
-            conversationMeta: newMeta,
-            conversations: newConversations,
-          }
+          const draft = draftConversationMaps(state)
+          draft.upsert(conv.id, entity, meta)
+          return draft.commit()
         })
       },
 
       updateConversationName: (id, name) => {
         set((state) => {
-          const entity = state.conversationEntities.get(id)
-          if (!entity) return state
-
-          // Update entity (name is entity data)
-          const newEntities = new Map(state.conversationEntities)
-          newEntities.set(id, { ...entity, name })
-
-          // Update combined map
-          const conv = state.conversations.get(id)
-          if (conv) {
-            const newConversations = new Map(state.conversations)
-            newConversations.set(id, { ...conv, name })
-            return { conversationEntities: newEntities, conversations: newConversations }
-          }
-
-          return { conversationEntities: newEntities }
+          // Name is entity data; the compat entry follows from it.
+          const draft = draftConversationMaps(state)
+          if (!draft.patchEntity(id, { name })) return state
+          return draft.commit()
         })
       },
 
@@ -1360,16 +1329,9 @@ export const chatStore = createStore<ChatState>()(
         chatCacheEpoch++
 
         set((state) => {
-          // Remove from separated maps
-          const newEntities = new Map(state.conversationEntities)
-          newEntities.delete(id)
-
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.delete(id)
-
-          // Remove from combined map
-          const newConversations = new Map(state.conversations)
-          newConversations.delete(id)
+          // Remove from all three conversation maps
+          const draft = draftConversationMaps(state)
+          draft.remove(id)
 
           // Also delete all messages for this conversation from memory
           const newMessages = new Map(state.messages)
@@ -1389,9 +1351,7 @@ export const chatStore = createStore<ChatState>()(
           const newActiveId = state.activeConversationId === id ? null : state.activeConversationId
 
           return {
-            conversationEntities: newEntities,
-            conversationMeta: newMeta,
-            conversations: newConversations,
+            ...draft.commit(),
             messages: newMessages,
             archivedConversations: newArchived,
             conversationGaps: newGaps,
@@ -1494,19 +1454,8 @@ export const chatStore = createStore<ChatState>()(
                 ? msg
                 : meta.lastMessage
 
-            // Update metadata map
-            const newMeta = new Map(state.conversationMeta)
-            newMeta.set(msg.conversationId, {
-              ...meta,
-              unreadCount: notif.unreadCount,
-              lastMessage: previewMessage,
-              readPointer: notif.readPointer,
-            })
-
-            // Update combined map for backward compatibility
-            const newConversations = new Map(state.conversations)
-            newConversations.set(msg.conversationId, {
-              ...conv,
+            const draft = draftConversationMaps(state)
+            draft.patchMeta(msg.conversationId, {
               unreadCount: notif.unreadCount,
               lastMessage: previewMessage,
               readPointer: notif.readPointer,
@@ -1526,8 +1475,7 @@ export const chatStore = createStore<ChatState>()(
                 newArchived.delete(msg.conversationId)
                 return {
                   messages: newMessages,
-                  conversationMeta: newMeta,
-                  conversations: newConversations,
+                  ...draft.commit(),
                   archivedConversations: newArchived,
                   firstNewMessageMarkers: newMarkers,
                   lastArrivedMessage: newArrived,
@@ -1535,7 +1483,7 @@ export const chatStore = createStore<ChatState>()(
               }
             }
 
-            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers, lastArrivedMessage: newArrived }
+            return { messages: newMessages, ...draft.commit(), firstNewMessageMarkers: newMarkers, lastArrivedMessage: newArrived }
           }
 
           return { messages: newMessages, lastArrivedMessage: newArrived }
@@ -1575,18 +1523,14 @@ export const chatStore = createStore<ChatState>()(
           // Pure function returns the same reference when nothing changed.
           if (updated === notifInput) return {}
 
-          const newMetaEntry = {
-            ...(meta ?? { unreadCount: 0, readPointer: undefined }),
+          const draft = draftConversationMaps(state)
+          draft.setMeta(conversationId, {
+            ...(draft.getMeta(conversationId) ?? { unreadCount: 0, readPointer: undefined }),
             unreadCount: updated.unreadCount,
             readPointer: updated.readPointer,
-          }
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, newMetaEntry)
+          })
 
-          const newConversations = new Map(state.conversations)
-          newConversations.set(conversationId, { ...conv, unreadCount: updated.unreadCount, readPointer: updated.readPointer })
-
-          return { conversationMeta: newMeta, conversations: newConversations }
+          return draft.commit()
         })
       },
 
@@ -1612,21 +1556,17 @@ export const chatStore = createStore<ChatState>()(
             return state
           }
 
-          const read = {
+          const draft = draftConversationMaps(state)
+          draft.setMeta(conversationId, {
+            ...(draft.getMeta(conversationId) ?? { unreadCount: 0 }),
             readPointer: makeReadPointer(newest),
             unreadCount: 0,
-          }
-
-          const newMeta = new Map(state.conversationMeta)
-          if (meta) newMeta.set(conversationId, { ...meta, ...read })
-
-          const newConversations = new Map(state.conversations)
-          newConversations.set(conversationId, { ...existing, ...read })
+          })
 
           const newMarkers = new Map(state.firstNewMessageMarkers)
           newMarkers.delete(conversationId)
 
-          return { conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
+          return { ...draft.commit(), firstNewMessageMarkers: newMarkers }
         })
       },
 
@@ -1679,7 +1619,6 @@ export const chatStore = createStore<ChatState>()(
 
         set((state) => {
           const meta = state.conversationMeta.get(conversationId)
-          const conv = state.conversations.get(conversationId)
           if (!meta) return state
 
           const messages = state.messages.get(conversationId) || []
@@ -1700,16 +1639,9 @@ export const chatStore = createStore<ChatState>()(
           // reference) whenever it did not advance, and a fresh object when it did.
           if (updated.readPointer === meta.readPointer) return state
 
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, { ...meta, readPointer: updated.readPointer })
-
-          if (conv) {
-            const newConversations = new Map(state.conversations)
-            newConversations.set(conversationId, { ...conv, readPointer: updated.readPointer })
-            return { conversationMeta: newMeta, conversations: newConversations }
-          }
-
-          return { conversationMeta: newMeta }
+          const draft = draftConversationMaps(state)
+          draft.patchMeta(conversationId, { readPointer: updated.readPointer })
+          return draft.commit()
         })
       },
 
@@ -1719,7 +1651,6 @@ export const chatStore = createStore<ChatState>()(
         let advancedNonActive = false
         set((state) => {
           const meta = state.conversationMeta.get(conversationId)
-          const conv = state.conversations.get(conversationId)
           if (!meta) return state
 
           // A non-active conversation keeps no resident array (memory windowing), so
@@ -1752,8 +1683,8 @@ export const chatStore = createStore<ChatState>()(
                     pendingRemoteDisplayedStanzaId: undefined,
                   }
 
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, { ...meta, ...metaPatch })
+          const draft = draftConversationMaps(state)
+          draft.patchMeta(conversationId, metaPatch)
 
           // Inbound read-state sync (spec §4): a marker published by another
           // client clears this conversation's badge now, not on the next
@@ -1764,10 +1695,9 @@ export const chatStore = createStore<ChatState>()(
           // countMentions is omitted (default false) and mentionsCount is an
           // inert 0: conversations don't track mentions the way rooms do
           // (parity with the hydration path in mergeMAMMessages).
-          let recomputed: notifState.EntityNotificationState | undefined
           if (resolution.kind === 'advanced') {
             advancedNonActive = true
-            recomputed = notifState.recomputeCountsFromPointer(
+            const recomputed = notifState.recomputeCountsFromPointer(
               {
                 unreadCount: meta.unreadCount,
                 mentionsCount: 0,
@@ -1776,10 +1706,7 @@ export const chatStore = createStore<ChatState>()(
               },
               messages
             )
-            newMeta.set(conversationId, {
-              ...newMeta.get(conversationId)!,
-              unreadCount: recomputed.unreadCount,
-            })
+            draft.patchMeta(conversationId, { unreadCount: recomputed.unreadCount })
           }
 
           // The divider is recomputed only for the active conversation; inactive
@@ -1791,18 +1718,7 @@ export const chatStore = createStore<ChatState>()(
             else newMarkers.delete(conversationId)
           }
 
-          if (conv) {
-            // Keep the combined map coherent with conversationMeta.
-            const newConversations = new Map(state.conversations)
-            newConversations.set(conversationId, {
-              ...conv,
-              ...metaPatch,
-              // Keep the combined map coherent with the recomputed count.
-              ...(recomputed ? { unreadCount: recomputed.unreadCount } : {}),
-            })
-            return { conversationMeta: newMeta, conversations: newConversations, firstNewMessageMarkers: newMarkers }
-          }
-          return { conversationMeta: newMeta, firstNewMessageMarkers: newMarkers }
+          return { ...draft.commit(), firstNewMessageMarkers: newMarkers }
         })
 
         // EXACT badge recount for a non-resident conversation: the sync
@@ -1841,21 +1757,12 @@ export const chatStore = createStore<ChatState>()(
                   hasUnmigratedLegacyReadState: hasUnmigratedLegacyReadState(conversationId),
                 })
                 if (exact === pointerState) return state
-                const newMeta = new Map(state.conversationMeta)
-                newMeta.set(conversationId, {
-                  ...meta,
+                const draft = draftConversationMaps(state)
+                draft.patchMeta(conversationId, {
                   unreadCount: exact.unreadCount,
                   readPointer: exact.readPointer,
                 })
-                const conv = state.conversations.get(conversationId)
-                if (!conv) return { conversationMeta: newMeta }
-                const newConversations = new Map(state.conversations)
-                newConversations.set(conversationId, {
-                  ...conv,
-                  unreadCount: exact.unreadCount,
-                  readPointer: exact.readPointer,
-                })
-                return { conversationMeta: newMeta, conversations: newConversations }
+                return draft.commit()
               })
             } catch {
               // Cache read failed — keep the page-scoped count (an undercount,
@@ -1889,13 +1796,11 @@ export const chatStore = createStore<ChatState>()(
 
       mergeServerConversations: (convs) => {
         set((state) => {
-          const newEntities = new Map(state.conversationEntities)
-          const newMeta = new Map(state.conversationMeta)
-          const newConversations = new Map(state.conversations)
+          const draft = draftConversationMaps(state)
           const newArchived = new Set(state.archivedConversations)
 
           for (const serverConv of convs) {
-            if (newConversations.has(serverConv.id)) {
+            if (draft.getEntity(serverConv.id)) {
               // Existing conversation: sync archived status
               if (serverConv.archived) {
                 newArchived.add(serverConv.id)
@@ -1916,11 +1821,8 @@ export const chatStore = createStore<ChatState>()(
                 // it can never restamp an existing floor.
                 historyFloor: new Date(),
               }
-              const conv: Conversation = { ...entity, ...meta }
 
-              newEntities.set(serverConv.id, entity)
-              newMeta.set(serverConv.id, meta)
-              newConversations.set(serverConv.id, conv)
+              draft.upsert(serverConv.id, entity, meta)
 
               if (serverConv.archived) {
                 newArchived.add(serverConv.id)
@@ -1929,9 +1831,7 @@ export const chatStore = createStore<ChatState>()(
           }
 
           return {
-            conversationEntities: newEntities,
-            conversationMeta: newMeta,
-            conversations: newConversations,
+            ...draft.commit(),
             archivedConversations: newArchived,
           }
         })
@@ -2075,22 +1975,14 @@ export const chatStore = createStore<ChatState>()(
           // purely positional gate would leave the sidebar stuck on
           // "[OpenPGP-encrypted message]" after the real message decrypts.
           const meta = state.conversationMeta.get(conversationId)
-          const conv = state.conversations.get(conversationId)
           const isLastMessage = messageIndex === updatedConvMessages.length - 1
           const isPreviewMessage =
             !!meta?.lastMessage &&
             findMessageIndexById([meta.lastMessage], updatedMessage.id) !== -1
           if (isLastMessage || isPreviewMessage) {
-            if (meta && conv) {
-              // Update metadata map
-              const newMeta = new Map(state.conversationMeta)
-              newMeta.set(conversationId, { ...meta, lastMessage: updatedMessage })
-
-              // Update combined map
-              const newConversations = new Map(state.conversations)
-              newConversations.set(conversationId, { ...conv, lastMessage: updatedMessage })
-
-              return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+            const draft = draftConversationMaps(state)
+            if (draft.patchMeta(conversationId, { lastMessage: updatedMessage })) {
+              return { messages: newMessages, ...draft.commit() }
             }
           }
 
@@ -2115,19 +2007,15 @@ export const chatStore = createStore<ChatState>()(
           void messageCache.updateMessage(convMessages[messageIndex].id, { stanzaId: undefined })
 
           const meta = state.conversationMeta.get(conversationId)
-          const conv = state.conversations.get(conversationId)
           const wasLastMessage =
             !!meta?.lastMessage &&
             (meta.lastMessage.id === updatedMessage.id || meta.lastMessage.stanzaId === stanzaId)
 
-          if (meta && conv && wasLastMessage) {
-            const newMeta = new Map(state.conversationMeta)
-            newMeta.set(conversationId, { ...meta, lastMessage: updatedMessage })
-
-            const newConversations = new Map(state.conversations)
-            newConversations.set(conversationId, { ...conv, lastMessage: updatedMessage })
-
-            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+          if (wasLastMessage) {
+            const draft = draftConversationMaps(state)
+            if (draft.patchMeta(conversationId, { lastMessage: updatedMessage })) {
+              return { messages: newMessages, ...draft.commit() }
+            }
           }
 
           return { messages: newMessages }
@@ -2203,13 +2091,10 @@ export const chatStore = createStore<ChatState>()(
               (!!removed.originId && meta.lastMessage.originId === removed.originId))
 
           if (wasLastMessage) {
-            const conv = state.conversations.get(conversationId)
             const lastMessage = findLastPreviewableMessage(updatedConvMessages)
-            const newMeta = new Map(state.conversationMeta)
-            newMeta.set(conversationId, { ...meta!, lastMessage })
-            const newConversations = new Map(state.conversations)
-            if (conv) newConversations.set(conversationId, { ...conv, lastMessage })
-            return { messages: newMessages, conversationMeta: newMeta, conversations: newConversations }
+            const draft = draftConversationMaps(state)
+            draft.patchMeta(conversationId, { lastMessage })
+            return { messages: newMessages, ...draft.commit() }
           }
 
           return { messages: newMessages }
@@ -2262,21 +2147,12 @@ export const chatStore = createStore<ChatState>()(
           // Same-reference return = nothing changed; skip the map churn.
           if (recomputed === pointerState) return state
 
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, {
-            ...meta,
+          const draft = draftConversationMaps(state)
+          draft.patchMeta(conversationId, {
             unreadCount: recomputed.unreadCount,
             readPointer: recomputed.readPointer,
           })
-          const conv = state.conversations.get(conversationId)
-          if (!conv) return { conversationMeta: newMeta }
-          const newConversations = new Map(state.conversations)
-          newConversations.set(conversationId, {
-            ...conv,
-            unreadCount: recomputed.unreadCount,
-            readPointer: recomputed.readPointer,
-          })
-          return { conversationMeta: newMeta, conversations: newConversations }
+          return draft.commit()
         })
       },
 
@@ -2587,25 +2463,15 @@ export const chatStore = createStore<ChatState>()(
             }
 
             if (previewUpdate || hydrated) {
-              const newMeta = new Map(state.conversationMeta)
-              newMeta.set(conversationId, {
-                ...meta!,
+              const draft = draftConversationMaps(state)
+              draft.patchMeta(conversationId, {
                 ...(previewUpdate ? { lastMessage } : {}),
                 ...(hydrated ? {
                   unreadCount: hydrated.unreadCount,
                   readPointer: hydrated.readPointer,
                 } : {}),
               })
-              const newConversations = new Map(state.conversations)
-              newConversations.set(conversationId, {
-                ...conv!,
-                ...(previewUpdate ? { lastMessage } : {}),
-                ...(hydrated ? {
-                  unreadCount: hydrated.unreadCount,
-                  readPointer: hydrated.readPointer,
-                } : {}),
-              })
-              return { mamQueryStates: newStates, conversationMeta: newMeta, conversations: newConversations, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge }
+              return { mamQueryStates: newStates, ...draft.commit(), conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge }
             }
             return { mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge }
           }
@@ -2633,11 +2499,9 @@ export const chatStore = createStore<ChatState>()(
           }
 
           if (previewUpdate) {
-            const newMeta = new Map(state.conversationMeta)
-            newMeta.set(conversationId, { ...meta!, lastMessage })
-            const newConversations = new Map(state.conversations)
-            newConversations.set(conversationId, { ...conv!, lastMessage })
-            return { messages: newMessagesMap, mamQueryStates: newStates, conversationMeta: newMeta, conversations: newConversations, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
+            const draft = draftConversationMaps(state)
+            draft.patchMeta(conversationId, { lastMessage })
+            return { messages: newMessagesMap, mamQueryStates: newStates, ...draft.commit(), conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
           }
 
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
@@ -2697,15 +2561,9 @@ export const chatStore = createStore<ChatState>()(
           // Update if newer, or if the existing preview is a stuck placeholder
           if (!shouldReplaceLastMessage(meta.lastMessage, lastMessage)) return state
 
-          // Update metadata map
-          const newMeta = new Map(state.conversationMeta)
-          newMeta.set(conversationId, { ...meta, lastMessage })
-
-          // Update combined map for backward compatibility
-          const newConversations = new Map(state.conversations)
-          newConversations.set(conversationId, { ...conv, lastMessage })
-
-          return { conversationMeta: newMeta, conversations: newConversations }
+          const draft = draftConversationMaps(state)
+          draft.patchMeta(conversationId, { lastMessage })
+          return draft.commit()
         })
       },
 
@@ -2723,13 +2581,9 @@ export const chatStore = createStore<ChatState>()(
 
           const updated = { ...existing, ...updates }
 
-          const newMeta = new Map(state.conversationMeta)
-          if (meta) newMeta.set(conversationId, { ...meta, lastMessage: updated })
-
-          const newConversations = new Map(state.conversations)
-          if (conv) newConversations.set(conversationId, { ...conv, lastMessage: updated })
-
-          return { conversationMeta: newMeta, conversations: newConversations }
+          const draft = draftConversationMaps(state)
+          draft.patchMeta(conversationId, { lastMessage: updated })
+          return draft.commit()
         })
       },
 
@@ -2978,8 +2832,11 @@ export const chatStore = createStore<ChatState>()(
         // Persist separated maps (Phase 6)
         conversationEntities: state.conversationEntities,
         conversationMeta: state.conversationMeta,
-        // Also persist combined map for backward compatibility
-        conversations: state.conversations,
+        // Empty, like `messages` below: the partialized shape has to match what
+        // `getItem` hands back (deserializeState rebuilds the compat map, so it
+        // is present there), but `serializeState` no longer reads this field and
+        // nothing about it reaches disk.
+        conversations: new Map<string, Conversation>(),
         // Note: messages are NOT persisted in localStorage anymore - they're in IndexedDB
         // This allows unlimited message storage and efficient pagination
         messages: new Map(), // Empty - messages loaded from IndexedDB on demand

--- a/packages/fluux-sdk/src/stores/shared/conversationMaps.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/conversationMaps.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest'
+import type { Conversation, ConversationEntity, ConversationMetadata, Message } from '../../core/types/chat'
+import { draftConversationMaps, rebuildCompatEntry, type ConversationMaps } from './conversationMaps'
+
+function makeMessage(id: string, body = 'hi'): Message {
+  return {
+    type: 'chat',
+    id,
+    conversationId: 'alice@example.com',
+    from: 'alice@example.com',
+    body,
+    timestamp: new Date('2026-07-24T10:00:00Z'),
+    isOutgoing: false,
+  }
+}
+
+function makeMaps(
+  entries: Array<[string, ConversationEntity, ConversationMetadata]>
+): ConversationMaps {
+  const conversationEntities = new Map<string, ConversationEntity>()
+  const conversationMeta = new Map<string, ConversationMetadata>()
+  const conversations = new Map<string, Conversation>()
+  for (const [id, entity, meta] of entries) {
+    conversationEntities.set(id, entity)
+    conversationMeta.set(id, meta)
+    conversations.set(id, { ...entity, ...meta })
+  }
+  return { conversationEntities, conversationMeta, conversations }
+}
+
+const ALICE_ENTITY: ConversationEntity = { id: 'alice@example.com', name: 'Alice', type: 'chat' }
+const ALICE_META: ConversationMetadata = { unreadCount: 0 }
+
+/**
+ * The invariant that licenses dropping `conversations` from the persisted blob:
+ * every compat entry must equal what `deserializeState` would rebuild for it.
+ */
+function expectRebuildFidelity(maps: ConversationMaps): void {
+  const expected = new Map<string, Conversation>()
+  for (const [id, entity] of maps.conversationEntities) {
+    const meta = maps.conversationMeta.get(id)
+    if (meta) expected.set(id, { ...entity, ...meta })
+  }
+  expect(Object.fromEntries(maps.conversations)).toEqual(Object.fromEntries(expected))
+}
+
+describe('conversationMaps', () => {
+  describe('rebuildCompatEntry', () => {
+    it('merges entity and metadata fields', () => {
+      const message = makeMessage('m1')
+      expect(
+        rebuildCompatEntry(ALICE_ENTITY, { unreadCount: 3, lastMessage: message })
+      ).toEqual({
+        id: 'alice@example.com',
+        name: 'Alice',
+        type: 'chat',
+        unreadCount: 3,
+        lastMessage: message,
+      })
+    })
+  })
+
+  describe('patchMeta', () => {
+    it('writes the metadata map and derives the compat entry from it', () => {
+      const draft = draftConversationMaps(makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]]))
+      const message = makeMessage('m1')
+
+      expect(draft.patchMeta('alice@example.com', { lastMessage: message })).toBe(true)
+      const committed = draft.commit()
+
+      expect(committed.conversationMeta?.get('alice@example.com')).toEqual({
+        unreadCount: 0,
+        lastMessage: message,
+      })
+      expect(committed.conversations?.get('alice@example.com')).toEqual({
+        id: 'alice@example.com',
+        name: 'Alice',
+        type: 'chat',
+        unreadCount: 0,
+        lastMessage: message,
+      })
+    })
+
+    it('returns false and writes nothing when the conversation has no metadata', () => {
+      const draft = draftConversationMaps({
+        conversationEntities: new Map([['alice@example.com', ALICE_ENTITY]]),
+        conversationMeta: new Map(),
+        conversations: new Map(),
+      })
+
+      expect(draft.patchMeta('alice@example.com', { unreadCount: 5 })).toBe(false)
+      expect(draft.dirty).toBe(false)
+      expect(draft.commit()).toEqual({})
+    })
+
+    /**
+     * The drift the compat-map removal exists to make impossible: a field
+     * written into `conversations` alone vanishes on the next reload, because
+     * the rebuild only ever emits `{ ...entity, ...meta }`.
+     */
+    it('heals a pre-existing compat entry that drifted from its metadata', () => {
+      const maps = makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]])
+      // Simulate a legacy write site that patched only the compat map.
+      maps.conversations.set('alice@example.com', {
+        ...maps.conversations.get('alice@example.com')!,
+        pendingRemoteDisplayedStanzaId: 'orphaned',
+      })
+
+      const draft = draftConversationMaps(maps)
+      draft.patchMeta('alice@example.com', { unreadCount: 2 })
+      const committed = draft.commit()
+
+      expect(committed.conversations?.get('alice@example.com')).toEqual({
+        id: 'alice@example.com',
+        name: 'Alice',
+        type: 'chat',
+        unreadCount: 2,
+      })
+      expectRebuildFidelity({ ...maps, ...committed })
+    })
+  })
+
+  describe('setMeta', () => {
+    it('replaces metadata wholesale and re-derives the compat entry', () => {
+      const draft = draftConversationMaps(
+        makeMaps([['alice@example.com', ALICE_ENTITY, { unreadCount: 7, lastMessage: makeMessage('old') }]])
+      )
+
+      draft.setMeta('alice@example.com', { unreadCount: 0 })
+      const committed = draft.commit()
+
+      expect(committed.conversations?.get('alice@example.com')).toEqual({
+        id: 'alice@example.com',
+        name: 'Alice',
+        type: 'chat',
+        unreadCount: 0,
+      })
+      expect(committed.conversations?.get('alice@example.com')).not.toHaveProperty('lastMessage')
+    })
+
+    it('creates no compat entry when the conversation has no entity', () => {
+      const draft = draftConversationMaps({
+        conversationEntities: new Map(),
+        conversationMeta: new Map(),
+        conversations: new Map(),
+      })
+
+      draft.setMeta('ghost@example.com', { unreadCount: 1 })
+      const committed = draft.commit()
+
+      expect(committed.conversationMeta?.get('ghost@example.com')).toEqual({ unreadCount: 1 })
+      expect(committed.conversations?.has('ghost@example.com')).toBe(false)
+    })
+  })
+
+  describe('setEntity / patchEntity', () => {
+    it('re-derives the compat entry when an entity field changes', () => {
+      const draft = draftConversationMaps(
+        makeMaps([['alice@example.com', ALICE_ENTITY, { unreadCount: 4 }]])
+      )
+
+      expect(draft.patchEntity('alice@example.com', { name: 'Alice Smith' })).toBe(true)
+      const committed = draft.commit()
+
+      expect(committed.conversationEntities?.get('alice@example.com')?.name).toBe('Alice Smith')
+      expect(committed.conversations?.get('alice@example.com')).toEqual({
+        id: 'alice@example.com',
+        name: 'Alice Smith',
+        type: 'chat',
+        unreadCount: 4,
+      })
+    })
+
+    it('does not hand back a new metadata map when only the entity changed', () => {
+      const maps = makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]])
+      const draft = draftConversationMaps(maps)
+
+      draft.patchEntity('alice@example.com', { name: 'Renamed' })
+      const committed = draft.commit()
+
+      expect(committed.conversationMeta).toBeUndefined()
+      expect(committed.conversationEntities).toBeDefined()
+      expect(committed.conversations).toBeDefined()
+    })
+
+    it('returns false when the entity is absent', () => {
+      const draft = draftConversationMaps(makeMaps([]))
+      expect(draft.patchEntity('nobody@example.com', { name: 'X' })).toBe(false)
+      expect(draft.dirty).toBe(false)
+    })
+  })
+
+  describe('upsert', () => {
+    it('writes all three maps for a new conversation', () => {
+      const draft = draftConversationMaps(makeMaps([]))
+
+      draft.upsert('bob@example.com', { id: 'bob@example.com', name: 'Bob', type: 'chat' }, { unreadCount: 0 })
+      const committed = draft.commit()
+
+      expect(committed.conversationEntities?.get('bob@example.com')).toBeDefined()
+      expect(committed.conversationMeta?.get('bob@example.com')).toBeDefined()
+      expect(committed.conversations?.get('bob@example.com')).toEqual({
+        id: 'bob@example.com',
+        name: 'Bob',
+        type: 'chat',
+        unreadCount: 0,
+      })
+    })
+  })
+
+  describe('remove', () => {
+    it('deletes from all three maps', () => {
+      const draft = draftConversationMaps(makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]]))
+
+      draft.remove('alice@example.com')
+      const committed = draft.commit()
+
+      expect(committed.conversationEntities?.has('alice@example.com')).toBe(false)
+      expect(committed.conversationMeta?.has('alice@example.com')).toBe(false)
+      expect(committed.conversations?.has('alice@example.com')).toBe(false)
+    })
+
+    it('is a no-op for an unknown id', () => {
+      const draft = draftConversationMaps(makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]]))
+      draft.remove('nobody@example.com')
+      expect(draft.dirty).toBe(false)
+      expect(draft.commit()).toEqual({})
+    })
+  })
+
+  describe('copy-on-write', () => {
+    it('never mutates the source maps', () => {
+      const maps = makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]])
+      const draft = draftConversationMaps(maps)
+
+      draft.patchMeta('alice@example.com', { unreadCount: 9 })
+      draft.commit()
+
+      expect(maps.conversationMeta.get('alice@example.com')?.unreadCount).toBe(0)
+      expect(maps.conversations.get('alice@example.com')?.unreadCount).toBe(0)
+    })
+
+    it('returns an empty patch when nothing was written', () => {
+      const draft = draftConversationMaps(makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]]))
+      expect(draft.commit()).toEqual({})
+      expect(draft.dirty).toBe(false)
+    })
+
+    it('reads back its own uncommitted writes', () => {
+      const draft = draftConversationMaps(makeMaps([['alice@example.com', ALICE_ENTITY, ALICE_META]]))
+
+      draft.patchMeta('alice@example.com', { unreadCount: 1 })
+      expect(draft.getMeta('alice@example.com')?.unreadCount).toBe(1)
+
+      draft.patchMeta('alice@example.com', { unreadCount: 2 })
+      expect(draft.commit().conversationMeta?.get('alice@example.com')?.unreadCount).toBe(2)
+    })
+
+    it('keeps other conversations untouched', () => {
+      const maps = makeMaps([
+        ['alice@example.com', ALICE_ENTITY, ALICE_META],
+        ['bob@example.com', { id: 'bob@example.com', name: 'Bob', type: 'chat' }, { unreadCount: 3 }],
+      ])
+      const draft = draftConversationMaps(maps)
+
+      draft.patchMeta('alice@example.com', { unreadCount: 1 })
+      const committed = draft.commit()
+
+      expect(committed.conversations?.get('bob@example.com')).toBe(maps.conversations.get('bob@example.com'))
+      expectRebuildFidelity({ ...maps, ...committed })
+    })
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/conversationMaps.ts
+++ b/packages/fluux-sdk/src/stores/shared/conversationMaps.ts
@@ -1,0 +1,169 @@
+/**
+ * The single writer for chatStore's three conversation maps.
+ *
+ * `conversations` is a compat view of `conversationEntities` + `conversationMeta`
+ * — and only a view. {@link Conversation} extends both interfaces and adds
+ * nothing, and their field sets are disjoint, so `{ ...entity, ...meta }` is a
+ * TOTAL reconstruction: a compat entry can hold no information the other two
+ * maps do not already carry.
+ *
+ * `deserializeState` relies on exactly that, rebuilding the map with that
+ * expression on every reload rather than reading the persisted copy. Which
+ * means any field written into `conversations` alone — updated in one map and
+ * left stale in the other — survives in memory and then silently disappears on
+ * the next launch. Twenty-two call sites used to mirror each metadata write by
+ * hand, several of them naming a subset of the fields they had just changed;
+ * that mirroring is what this module replaces.
+ *
+ * The guarantee is structural rather than remembered: the compat entry is never
+ * patched, only DERIVED, with the same expression the rebuild uses. A new write
+ * site cannot reintroduce drift without bypassing the draft entirely.
+ *
+ * Copy-on-write: `commit()` hands back only the maps a caller actually touched,
+ * so a rename still returns the original `conversationMeta` reference and
+ * metadata subscribers do not re-render.
+ */
+
+import type { Conversation, ConversationEntity, ConversationMetadata } from '../../core/types/chat'
+
+/** The three maps this module owns, as they live on `ChatState`. */
+export interface ConversationMaps {
+  conversationEntities: Map<string, ConversationEntity>
+  conversationMeta: Map<string, ConversationMetadata>
+  conversations: Map<string, Conversation>
+}
+
+/**
+ * Build one conversation's compat entry. The single definition of the merge —
+ * `deserializeState`'s rebuild loop calls this too, so the live map and a
+ * restored one cannot disagree about the shape.
+ */
+export function rebuildCompatEntry(
+  entity: ConversationEntity,
+  meta: ConversationMetadata
+): Conversation {
+  return { ...entity, ...meta }
+}
+
+export interface ConversationMapsDraft {
+  /** Current entity, including this draft's own uncommitted writes. */
+  getEntity(id: string): ConversationEntity | undefined
+  /** Current metadata, including this draft's own uncommitted writes. */
+  getMeta(id: string): ConversationMetadata | undefined
+  /** Replace metadata wholesale. Fields absent from `meta` are dropped. */
+  setMeta(id: string, meta: ConversationMetadata): void
+  /**
+   * Merge `patch` over existing metadata. Returns false (writing nothing) when
+   * the conversation has no metadata — callers that must create it use
+   * {@link setMeta} with their own default.
+   */
+  patchMeta(id: string, patch: Partial<ConversationMetadata>): boolean
+  /** Replace the entity wholesale. */
+  setEntity(id: string, entity: ConversationEntity): void
+  /** Merge `patch` over an existing entity. Returns false when absent. */
+  patchEntity(id: string, patch: Partial<ConversationEntity>): boolean
+  /** Create or replace both halves of a conversation. */
+  upsert(id: string, entity: ConversationEntity, meta: ConversationMetadata): void
+  /** Drop a conversation from all three maps. */
+  remove(id: string): void
+  /** Whether any write landed; false means `commit()` returns an empty patch. */
+  readonly dirty: boolean
+  /**
+   * The state patch to return from `set()`. Contains only the maps that
+   * changed, so untouched maps keep their identity.
+   */
+  commit(): Partial<ConversationMaps>
+}
+
+/**
+ * Open a draft over `source`. Nothing is mutated: each map is cloned on its
+ * first write, and `commit()` returns the clones.
+ */
+export function draftConversationMaps(source: ConversationMaps): ConversationMapsDraft {
+  let entities: Map<string, ConversationEntity> | undefined
+  let meta: Map<string, ConversationMetadata> | undefined
+  let compat: Map<string, Conversation> | undefined
+
+  const entitiesNow = (): Map<string, ConversationEntity> => entities ?? source.conversationEntities
+  const metaNow = (): Map<string, ConversationMetadata> => meta ?? source.conversationMeta
+
+  const mutableEntities = (): Map<string, ConversationEntity> =>
+    (entities ??= new Map(source.conversationEntities))
+  const mutableMeta = (): Map<string, ConversationMetadata> =>
+    (meta ??= new Map(source.conversationMeta))
+  const mutableCompat = (): Map<string, Conversation> =>
+    (compat ??= new Map(source.conversations))
+
+  /**
+   * Re-derive one conversation's compat entry from whatever the entity and
+   * metadata maps now hold. A conversation missing either half has no compat
+   * entry at all — the same rule `deserializeState`'s rebuild applies, which is
+   * why an entry it would not reproduce can never exist here either.
+   */
+  const rederive = (id: string): void => {
+    const entity = entitiesNow().get(id)
+    const entryMeta = metaNow().get(id)
+    const next = entity && entryMeta ? rebuildCompatEntry(entity, entryMeta) : undefined
+    const map = mutableCompat()
+    if (next) map.set(id, next)
+    else map.delete(id)
+  }
+
+  return {
+    getEntity: (id) => entitiesNow().get(id),
+    getMeta: (id) => metaNow().get(id),
+
+    setMeta(id, value) {
+      mutableMeta().set(id, value)
+      rederive(id)
+    },
+
+    patchMeta(id, patch) {
+      const existing = metaNow().get(id)
+      if (!existing) return false
+      mutableMeta().set(id, { ...existing, ...patch })
+      rederive(id)
+      return true
+    },
+
+    setEntity(id, value) {
+      mutableEntities().set(id, value)
+      rederive(id)
+    },
+
+    patchEntity(id, patch) {
+      const existing = entitiesNow().get(id)
+      if (!existing) return false
+      mutableEntities().set(id, { ...existing, ...patch })
+      rederive(id)
+      return true
+    },
+
+    upsert(id, entity, value) {
+      mutableEntities().set(id, entity)
+      mutableMeta().set(id, value)
+      rederive(id)
+    },
+
+    remove(id) {
+      // Guard so a miss stays a no-op: cloning here would hand every caller a
+      // fresh map and re-render the sidebar for nothing.
+      if (!entitiesNow().has(id) && !metaNow().has(id) && !source.conversations.has(id)) return
+      mutableEntities().delete(id)
+      mutableMeta().delete(id)
+      mutableCompat().delete(id)
+    },
+
+    get dirty() {
+      return entities !== undefined || meta !== undefined || compat !== undefined
+    },
+
+    commit() {
+      const patch: Partial<ConversationMaps> = {}
+      if (entities) patch.conversationEntities = entities
+      if (meta) patch.conversationMeta = meta
+      if (compat) patch.conversations = compat
+      return patch
+    },
+  }
+}


### PR DESCRIPTION
`deserializeState` already rebuilt `conversations` from `conversationEntities` + `conversationMeta`, so the persisted copy was the same data a second time. Dropping it makes the blob **48.3% smaller** (measured, 100 conversations). Follow-up deferred from the localStorage persistence throttle design (§2.2).