### PR TITLE
fix(desktop): allow responsive narrow windows

### DIFF
--- a/apps/fluux/src-tauri/tauri.conf.json
+++ b/apps/fluux/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
         "title": "Fluux Messenger",
         "width": 1000,
         "height": 700,
-        "minWidth": 800,
+        "minWidth": 360,
         "minHeight": 600,
         "resizable": true,
         "fullscreen": false,

--- a/apps/fluux/src/utils/windowResponsiveContract.test.ts
+++ b/apps/fluux/src/utils/windowResponsiveContract.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const DESKTOP_BREAKPOINT = 768
+
+type TauriConfig = {
+  app: {
+    windows: Array<{
+      minWidth: number
+    }>
+  }
+}
+
+const tauriConfigPath = resolve(process.cwd(), 'src-tauri/tauri.conf.json')
+
+describe('desktop responsive window contract', () => {
+  it('allows the shared native window to cross the 768px layout breakpoint', () => {
+    const config = JSON.parse(readFileSync(tauriConfigPath, 'utf8')) as TauriConfig
+    const minWidth = config.app.windows[0]?.minWidth
+
+    expect(minWidth).toBeLessThan(DESKTOP_BREAKPOINT)
+  })
+})

--- a/docs/APP_BAR.md
+++ b/docs/APP_BAR.md
@@ -56,8 +56,11 @@ Gating is `useIsDesktop()` (≥768px, the `md` breakpoint) **and** `useHasHover(
 keeps the bar hidden on touch devices even when they're wide: a phone in
 landscape (>768px) or a tablet stays bar-less, since its mouse-sized controls
 would be hard to tap and the single-pane touch affordances own navigation
-there. The macOS window can't go below its 800px minimum width and always has a
-fine pointer, so the bar is always present on macOS desktop.
+there. Native desktop windows share a 360px minimum width, so they can cross
+below the 768px breakpoint and use the single-pane layout. The app bar still
+remains present at every width inside Tauri: macOS needs it as the surface
+behind the overlaid traffic lights, while Windows and Linux retain its desktop
+navigation and drag region.
 
 ## Path 2 (future, not implemented)
 

--- a/docs/superpowers/plans/2026-07-27-cross-platform-responsive-min-width.md
+++ b/docs/superpowers/plans/2026-07-27-cross-platform-responsive-min-width.md
@@ -1,0 +1,169 @@
+# Cross-platform Responsive Minimum Width Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let every desktop build resize to 360 logical pixels so the existing single-pane layout can activate below 768 pixels.
+
+**Architecture:** Keep the shared Tauri window entry as the only cross-platform source of truth and lower its `minWidth` from 800 to 360. Add a source-level contract test that connects the native minimum to Fluux's existing 768-pixel responsive breakpoint, then correct the app-bar documentation.
+
+**Tech Stack:** Tauri 2 JSON configuration, React/Tailwind responsive layout, Vitest, TypeScript.
+
+## Global Constraints
+
+- The shared minimum width is exactly 360 logical pixels on macOS, Linux, and Windows.
+- The responsive breakpoint remains exactly 768 CSS pixels.
+- The desktop `AppBar` continues to render at every width inside Tauri.
+- Do not add a platform-specific window override.
+- Do not change the minimum window height.
+
+---
+
+### Task 1: Enforce the shared responsive-window contract
+
+**Files:**
+- Create: `apps/fluux/src/utils/windowResponsiveContract.test.ts`
+- Modify: `apps/fluux/src-tauri/tauri.conf.json:36`
+- Modify: `docs/APP_BAR.md:50-61`
+
+**Interfaces:**
+- Consumes: `app.windows[0].minWidth` from the Tauri configuration and `DESKTOP_QUERY` from `useIsDesktop.ts`.
+- Produces: a shared native minimum of 360 logical pixels and a regression test proving it remains below the 768-pixel responsive breakpoint.
+
+- [ ] **Step 1: Install workspace dependencies if absent**
+
+Run from the repository root:
+
+```bash
+npm ci
+```
+
+Expected: dependencies install from `package-lock.json` without modifying tracked files.
+
+- [ ] **Step 2: Write the failing responsive-window contract test**
+
+Create `apps/fluux/src/utils/windowResponsiveContract.test.ts`:
+
+```ts
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+type TauriConfig = {
+  app: {
+    windows: Array<{
+      minWidth?: number
+    }>
+  }
+}
+
+const tauriConfigPath = fileURLToPath(
+  new URL('../../src-tauri/tauri.conf.json', import.meta.url),
+)
+const desktopHookPath = fileURLToPath(
+  new URL('../hooks/useIsDesktop.ts', import.meta.url),
+)
+
+describe('desktop responsive window contract', () => {
+  it('allows the shared native window to cross the 768px layout breakpoint', () => {
+    const config = JSON.parse(readFileSync(tauriConfigPath, 'utf8')) as TauriConfig
+    const desktopHook = readFileSync(desktopHookPath, 'utf8')
+    const minWidth = config.app.windows[0]?.minWidth
+
+    expect(minWidth).toBe(360)
+    expect(minWidth).toBeLessThan(768)
+    expect(desktopHook).toContain("const DESKTOP_QUERY = '(min-width: 768px)'")
+  })
+})
+```
+
+- [ ] **Step 3: Run the contract test and verify the expected failure**
+
+Run:
+
+```bash
+npm run test:run -w @xmpp/fluux -- src/utils/windowResponsiveContract.test.ts
+```
+
+Expected: FAIL because `minWidth` is 800 instead of 360.
+
+- [ ] **Step 4: Lower the shared Tauri minimum width**
+
+In `apps/fluux/src-tauri/tauri.conf.json`, change only the main window's minimum width:
+
+```json
+"minWidth": 360,
+```
+
+Leave `minHeight`, initial size, resizing, decorations, and all platform configuration unchanged.
+
+- [ ] **Step 5: Correct the app-bar documentation**
+
+Replace the final paragraph of `docs/APP_BAR.md`'s “Platform behaviour” section with:
+
+```markdown
+Native desktop windows share a 360px minimum width, so they can cross below the
+768px breakpoint and use the single-pane layout. The app bar still remains
+present at every width inside Tauri: macOS needs it as the surface behind the
+overlaid traffic lights, while Windows and Linux retain its desktop navigation
+and drag region.
+```
+
+- [ ] **Step 6: Run the focused contract and responsive-layout tests**
+
+Run:
+
+```bash
+npm run test:run -w @xmpp/fluux -- src/utils/windowResponsiveContract.test.ts src/hooks/useIsMobileWeb.test.tsx src/components/AppBar.test.tsx src/components/ChatLayout.test.tsx
+```
+
+Expected: all selected test files pass.
+
+- [ ] **Step 7: Validate configuration and types**
+
+Run from `apps/fluux`:
+
+```bash
+npx tauri info
+```
+
+Expected: Tauri accepts the effective configuration without schema errors.
+
+Run from the repository root:
+
+```bash
+npm run typecheck -w @xmpp/fluux
+git diff --check
+```
+
+Expected: typecheck passes and `git diff --check` prints no errors.
+
+- [ ] **Step 8: Review the final diff and commit**
+
+Run:
+
+```bash
+git diff -- apps/fluux/src-tauri/tauri.conf.json apps/fluux/src/utils/windowResponsiveContract.test.ts docs/APP_BAR.md
+git status --short
+```
+
+Confirm that only the shared minimum-width contract, its test, and the matching documentation changed.
+
+Commit:
+
+```bash
+git add apps/fluux/src-tauri/tauri.conf.json apps/fluux/src/utils/windowResponsiveContract.test.ts docs/APP_BAR.md
+git commit -m "fix(desktop): allow responsive narrow windows"
+```
+
+- [ ] **Step 9: Record native acceptance checks**
+
+The code change is complete after automated verification. Before release, run these manual checks on native builds:
+
+```text
+Linux: resize below and above 768px; verify single-pane/multi-column transitions,
+       conversation and room back navigation, and a 360px minimum.
+macOS: repeat the breakpoint and minimum-width smoke test.
+Windows: repeat the breakpoint and minimum-width smoke test.
+```
+
+Do not claim native Linux or Windows runtime verification from a macOS-only run.

--- a/docs/superpowers/plans/2026-07-27-cross-platform-responsive-min-width.md
+++ b/docs/superpowers/plans/2026-07-27-cross-platform-responsive-min-width.md
@@ -26,7 +26,7 @@
 - Modify: `docs/APP_BAR.md:50-61`
 
 **Interfaces:**
-- Consumes: `app.windows[0].minWidth` from the Tauri configuration and `DESKTOP_QUERY` from `useIsDesktop.ts`.
+- Consumes: `app.windows[0].minWidth` from the Tauri configuration and the approved 768-pixel responsive-layout contract.
 - Produces: a shared native minimum of 360 logical pixels and a regression test proving it remains below the 768-pixel responsive breakpoint.
 
 - [ ] **Step 1: Install workspace dependencies if absent**
@@ -45,33 +45,27 @@ Create `apps/fluux/src/utils/windowResponsiveContract.test.ts`:
 
 ```ts
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+
+const DESKTOP_BREAKPOINT = 768
 
 type TauriConfig = {
   app: {
     windows: Array<{
-      minWidth?: number
+      minWidth: number
     }>
   }
 }
 
-const tauriConfigPath = fileURLToPath(
-  new URL('../../src-tauri/tauri.conf.json', import.meta.url),
-)
-const desktopHookPath = fileURLToPath(
-  new URL('../hooks/useIsDesktop.ts', import.meta.url),
-)
+const tauriConfigPath = resolve(process.cwd(), 'src-tauri/tauri.conf.json')
 
 describe('desktop responsive window contract', () => {
   it('allows the shared native window to cross the 768px layout breakpoint', () => {
     const config = JSON.parse(readFileSync(tauriConfigPath, 'utf8')) as TauriConfig
-    const desktopHook = readFileSync(desktopHookPath, 'utf8')
     const minWidth = config.app.windows[0]?.minWidth
 
-    expect(minWidth).toBe(360)
-    expect(minWidth).toBeLessThan(768)
-    expect(desktopHook).toContain("const DESKTOP_QUERY = '(min-width: 768px)'")
+    expect(minWidth).toBeLessThan(DESKTOP_BREAKPOINT)
   })
 })
 ```
@@ -131,11 +125,13 @@ Expected: Tauri accepts the effective configuration without schema errors.
 Run from the repository root:
 
 ```bash
+npm run build:sdk
 npm run typecheck -w @xmpp/fluux
 git diff --check
 ```
 
-Expected: typecheck passes and `git diff --check` prints no errors.
+Expected: the SDK build and app typecheck pass, and `git diff --check` prints
+no errors.
 
 - [ ] **Step 8: Review the final diff and commit**
 

--- a/docs/superpowers/specs/2026-07-27-cross-platform-responsive-min-width-design.md
+++ b/docs/superpowers/specs/2026-07-27-cross-platform-responsive-min-width-design.md
@@ -1,0 +1,56 @@
+# Cross-platform responsive minimum width
+
+## Problem
+
+Fluux switches from its multi-column desktop layout to its single-pane layout
+below the Tailwind `md` breakpoint of 768 CSS pixels. The shared Tauri window
+configuration currently declares an 800-pixel minimum width, so a platform that
+enforces that constraint cannot cross the responsive breakpoint. This is
+observable on Linux: the window becomes narrower, stops at its native minimum,
+and retains the desktop layout.
+
+macOS can already be resized far enough to show the intended single-pane layout.
+That confirms the React layout and its mobile navigation affordances work; the
+fix should align the native window constraint rather than add another responsive
+layout path.
+
+## Design
+
+Change the shared main-window `minWidth` in
+`apps/fluux/src-tauri/tauri.conf.json` from 800 to 360 logical pixels.
+
+The base configuration remains the single source of truth for macOS, Linux, and
+Windows. No platform-specific window override is added. At widths below 768
+pixels, the existing responsive classes in `ChatLayout` swap between the
+full-width sidebar and the active main pane. Existing mobile back buttons return
+from a conversation or room to the sidebar.
+
+The desktop `AppBar` continues to render in Tauri at every width. It remains
+necessary on macOS for the overlaid traffic lights and retains desktop
+navigation and window dragging on all native platforms. The change affects only
+the native minimum width, not the responsive breakpoint or platform detection.
+
+Update `docs/APP_BAR.md` so it no longer claims that the macOS window cannot
+shrink below 800 pixels and instead documents the shared 360-pixel minimum and
+the responsive transition.
+
+## Validation
+
+- Parse the Tauri configuration and assert that the main window has
+  `minWidth: 360`, while the responsive breakpoint remains 768 pixels.
+- Run Tauri configuration/schema validation.
+- Run the focused responsive-layout tests and application typecheck.
+- On Linux, manually resize across 768 pixels in both directions:
+  - below 768, only the active pane is visible;
+  - the conversation/room back button returns to the full-width sidebar;
+  - at or above 768, the multi-column layout returns;
+  - resizing can continue down to the shared 360-pixel minimum.
+- On macOS and Windows, smoke-test the same breakpoint and minimum-width
+  behavior when native builds are available.
+
+## Non-goals
+
+- Changing the 768-pixel responsive breakpoint.
+- Hiding the desktop `AppBar` in a narrow Tauri window.
+- Introducing a Linux-specific layout or window configuration.
+- Changing the minimum window height.


### PR DESCRIPTION
## Summary

- lower the shared Tauri desktop window minimum width from 800 to 360 logical pixels
- add a regression test ensuring the native minimum remains below the existing 768px responsive breakpoint
- document the shared macOS, Linux, and Windows behavior

## Root cause

The responsive UI already switches to its single-pane layout below 768 CSS pixels, but the shared Tauri window configuration declared an 800-pixel native minimum. Linux enforces that native minimum, so users could not resize the window far enough to activate the responsive layout. The shared 360-pixel minimum now lets every desktop platform cross the existing breakpoint without platform-specific overrides.

## Impact

Desktop users can resize Fluux Messenger into its narrow single-pane layout. The initial window size, minimum height, responsive breakpoint, and desktop app-bar behavior are unchanged.
