### PR TITLE
Route resident-top navigation through the positioning controller

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -226,19 +226,19 @@ describe('MessageList scroll behavior', () => {
         <MessageList messages={createTestMessages(10)} {...props} />,
       )
       const keydownAdds = addEventListener.mock.calls.filter(
-        ([eventName]) => eventName === 'keydown',
+        ([eventName]) => String(eventName) === 'keydown',
       ).length
       const keydownRemoves = removeEventListener.mock.calls.filter(
-        ([eventName]) => eventName === 'keydown',
+        ([eventName]) => String(eventName) === 'keydown',
       ).length
 
       rerender(<MessageList messages={createTestMessages(11)} {...props} />)
 
       expect(addEventListener.mock.calls.filter(
-        ([eventName]) => eventName === 'keydown',
+        ([eventName]) => String(eventName) === 'keydown',
       )).toHaveLength(keydownAdds)
       expect(removeEventListener.mock.calls.filter(
-        ([eventName]) => eventName === 'keydown',
+        ([eventName]) => String(eventName) === 'keydown',
       )).toHaveLength(keydownRemoves)
     })
 

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // fully-mounted DOM — still shipping until the old path is removed). Force the flag OFF;
 // virtualized scroll is verified via the scroll-hook unit tests + the real-engine pass.
 vi.mock('@/utils/featureFlags', () => ({ isFeatureEnabled: () => false }))
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import type { BaseMessage } from '@fluux/sdk'
 
@@ -137,6 +137,155 @@ describe('MessageList scroll behavior', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     window.requestAnimationFrame = originalRAF
+  })
+
+  describe('resident-top navigation', () => {
+    it.each([
+      {
+        label: 'Home',
+        key: 'Home',
+        modifiers: {},
+      },
+      {
+        label: 'Mod+ArrowUp',
+        key: 'ArrowUp',
+        modifiers: navigator.platform.includes('Mac')
+          ? { metaKey: true }
+          : { ctrlKey: true },
+      },
+    ])('starts one smooth $label navigation and only observes its progress afterward', ({
+      key,
+      modifiers,
+    }) => {
+      const callbacks: FrameRequestCallback[] = []
+      window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+        callbacks.push(callback)
+        return callbacks.length
+      }
+      render(
+        <MessageList
+          messages={createTestMessages(10)}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />,
+      )
+
+      const container = document.querySelector(
+        '[data-message-list]',
+      ) as HTMLDivElement
+      let scrollTop = 500
+      Object.defineProperties(container, {
+        scrollHeight: { value: 1000, configurable: true },
+        clientHeight: { value: 500, configurable: true },
+        scrollTop: {
+          get: () => scrollTop,
+          set: (value: number) => {
+            scrollTop = value
+          },
+          configurable: true,
+        },
+      })
+      const scrollTo = vi.fn()
+      container.scrollTo = scrollTo
+      const callbacksBeforeHome = callbacks.length
+
+      act(() => {
+        fireEvent.keyDown(window, { key, ...modifiers })
+      })
+
+      expect(scrollTo).toHaveBeenCalledTimes(1)
+      expect(scrollTo).toHaveBeenCalledWith({
+        top: 0,
+        behavior: 'smooth',
+      })
+      expect(callbacks).toHaveLength(callbacksBeforeHome + 1)
+
+      for (const nextScrollTop of [500, 20, 1, 0]) {
+        scrollTop = nextScrollTop
+        const callback = callbacks.pop()
+        expect(callback).toBeDefined()
+        act(() => {
+          callback!(0)
+        })
+      }
+
+      expect(scrollTo).toHaveBeenCalledTimes(1)
+      expect(callbacks).toHaveLength(callbacksBeforeHome)
+    })
+
+    it('does not rebind the global shortcut listener when messages append', () => {
+      const addEventListener = vi.spyOn(window, 'addEventListener')
+      const removeEventListener = vi.spyOn(window, 'removeEventListener')
+      const props = {
+        conversationId: 'conv-1',
+        clearFirstNewMessageId: vi.fn(),
+        renderMessage: (msg: BaseMessage) => <div key={msg.id}>{msg.body}</div>,
+      }
+      const { rerender } = render(
+        <MessageList messages={createTestMessages(10)} {...props} />,
+      )
+      const keydownAdds = addEventListener.mock.calls.filter(
+        ([eventName]) => eventName === 'keydown',
+      ).length
+      const keydownRemoves = removeEventListener.mock.calls.filter(
+        ([eventName]) => eventName === 'keydown',
+      ).length
+
+      rerender(<MessageList messages={createTestMessages(11)} {...props} />)
+
+      expect(addEventListener.mock.calls.filter(
+        ([eventName]) => eventName === 'keydown',
+      )).toHaveLength(keydownAdds)
+      expect(removeEventListener.mock.calls.filter(
+        ([eventName]) => eventName === 'keydown',
+      )).toHaveLength(keydownRemoves)
+    })
+
+    it('does not reinterpret Home reaching resident top as a load-older gesture', () => {
+      const callbacks: FrameRequestCallback[] = []
+      window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+        callbacks.push(callback)
+        return callbacks.length
+      }
+      const onScrollToTop = vi.fn()
+      render(
+        <MessageList
+          messages={createTestMessages(10)}
+          conversationId="conv-1"
+          clearFirstNewMessageId={vi.fn()}
+          onScrollToTop={onScrollToTop}
+          renderMessage={(msg) => <div key={msg.id}>{msg.body}</div>}
+        />,
+      )
+      const container = document.querySelector(
+        '[data-message-list]',
+      ) as HTMLDivElement
+      let scrollTop = 500
+      Object.defineProperties(container, {
+        scrollHeight: { value: 1000, configurable: true },
+        clientHeight: { value: 500, configurable: true },
+        scrollTop: {
+          get: () => scrollTop,
+          set: (value: number) => {
+            scrollTop = value
+          },
+          configurable: true,
+        },
+      })
+      container.scrollTo = vi.fn()
+
+      fireEvent.scroll(container)
+      fireEvent.keyDown(window, { key: 'Home' })
+      // Native smooth scrolling emits intermediate scroll events. They remain controller-owned
+      // and must not re-arm the "user travelled away from top" pagination latch.
+      scrollTop = 200
+      fireEvent.scroll(container)
+      scrollTop = 0
+      fireEvent.scroll(container)
+
+      expect(onScrollToTop).not.toHaveBeenCalled()
+    })
   })
 
   describe('typing indicator scroll', () => {

--- a/apps/fluux/src/components/conversation/MessageList.staticMode.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.staticMode.test.tsx
@@ -19,7 +19,7 @@
  * so the "all rows present" assertion fails.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { MessageList } from './MessageList'
 import { createTestMessages } from './MessageList.test-utils'
 import { scrollStateManager } from '@/utils/scrollStateManager'
@@ -90,5 +90,24 @@ describe('MessageList staticMode — non-virtualized render path (search/preview
     )
 
     expect(container.querySelectorAll('[data-message-id]')).toHaveLength(COUNT)
+  })
+
+  it('keeps Home navigation inside the isolated static preview scroller', () => {
+    const { container } = render(
+      <MessageList
+        messages={messages}
+        conversationId="static-conv"
+        renderMessage={renderMessage}
+        staticMode
+      />,
+    )
+    const scroller = container.querySelector('[data-message-list]') as HTMLDivElement
+    const scrollTo = vi.fn()
+    scroller.scrollTo = scrollTo
+
+    fireEvent.keyDown(window, { key: 'Home' })
+
+    expect(scrollTo).toHaveBeenCalledTimes(1)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
   })
 })

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -454,6 +454,34 @@ describe('positioning controller resident-top ownership', () => {
     expect(controller.snapshot().watermark).toBe(request!.generation)
   })
 
+  it('deactivates resident-top before its queued frame can observe the old conversation', () => {
+    const harness = residentTopHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginResidentTopNavigation({
+      conversationId,
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    controller.deactivate(conversationId, request!.generation)
+    staleFrame()
+
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.objectContaining({ generation: request!.generation }),
+      'superseded',
+    )
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+    expect(controller.snapshot()).toEqual(
+      expect.objectContaining({
+        currentConversationId: null,
+        active: null,
+        watermark: request!.generation,
+      }),
+    )
+  })
+
   it('finishes resident-top as superseded before a queued frame can settle it', () => {
     const harness = residentTopHarness()
     const controller = new PositioningController()

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -429,6 +429,95 @@ describe('positioning controller resident-top ownership', () => {
     expect(harness.recordFrame).toHaveBeenLastCalledWith(false)
     expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
   })
+
+  it('cancels resident-top observation on genuine user input', () => {
+    const harness = residentTopHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginResidentTopNavigation({
+      conversationId,
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    controller.observeUserInput(conversationId)
+    staleFrame()
+
+    expect(harness.start).toHaveBeenCalledTimes(1)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.objectContaining({ generation: request!.generation }),
+      'user-takeover',
+    )
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+    expect(controller.snapshot().active).toBeNull()
+    expect(controller.snapshot().watermark).toBe(request!.generation)
+  })
+
+  it('finishes resident-top as superseded before a queued frame can settle it', () => {
+    const harness = residentTopHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginResidentTopNavigation({
+      conversationId,
+      executor: harness.executor,
+    })
+    const staleFrame = harness.callbacks.shift()!
+
+    const newer = controller.beginLiveEdgeRequest({
+      conversationId,
+      source: { kind: 'user-navigation', reason: 'live-edge' },
+      executor: inertLiveEdgeExecutor(),
+    })
+    staleFrame()
+
+    expect(newer!.generation).toBeGreaterThan(request!.generation)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.objectContaining({ generation: request!.generation }),
+      'superseded',
+    )
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(harness.leases[0].isCurrent()).toBe(false)
+    expect(controller.snapshot().watermark).toBe(newer!.generation)
+  })
+
+  it('ends best-effort after 120 observations without restarting the smooth write', () => {
+    const harness = residentTopHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginResidentTopNavigation({
+      conversationId,
+      executor: harness.executor,
+    })
+
+    for (let frame = 0; frame < 120; frame += 1) {
+      harness.setScrollTop(500)
+      harness.runFrame()
+    }
+
+    expect(harness.start).toHaveBeenCalledTimes(1)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.objectContaining({ generation: request!.generation }),
+      'best-effort',
+    )
+    expect(harness.finish).toHaveBeenCalledTimes(1)
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+  })
+
+  it('does not retain a resident-top owner for an empty window', () => {
+    const harness = residentTopHarness({ kind: 'empty-window' })
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+
+    const request = controller.beginResidentTopNavigation({
+      conversationId,
+      executor: harness.executor,
+    })
+
+    expect(request).toBeNull()
+    expect(harness.start).not.toHaveBeenCalled()
+    expect(controller.snapshot().active?.request.desired).toEqual(liveEdge)
+  })
 })
 
 describe('positioning controller live-edge ownership', () => {

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -13,6 +13,7 @@ import {
   type MediaPreservationFrameResult,
   type PositionExecutionLease,
   type PositionRequestDraft,
+  type ResidentTopExecutor,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
   type SavedPositionFrameResult,
@@ -347,6 +348,86 @@ describe('positioning controller shadow mode', () => {
 
     controller.deactivate(conversationId, current!.generation)
     expect(controller.snapshot().currentConversationId).toBeNull()
+  })
+})
+
+describe('positioning controller resident-top ownership', () => {
+  function residentTopHarness(
+    initialReachability: ReachabilityFacts = {
+      kind: 'available',
+      index: 0,
+      mounted: true,
+      placement: 'viable',
+    },
+  ) {
+    const callbacks: Array<() => void> = []
+    const leases: PositionExecutionLease[] = []
+    const start = vi.fn(() => ({ kind: 'started' as const }))
+    const finish = vi.fn()
+    const recordFrame = vi.fn()
+    const complete = vi.fn()
+    let scrollTop = 640
+    const executor: ResidentTopExecutor = {
+      reachability: () => initialReachability,
+      beginLoop: (lease) => {
+        leases.push(lease)
+        return {
+          schedule: (callback) => callbacks.push(callback),
+          recordFrame,
+          finish,
+        }
+      },
+      start,
+      readScrollTop: () => scrollTop,
+      complete,
+    }
+    return {
+      executor,
+      callbacks,
+      leases,
+      start,
+      finish,
+      recordFrame,
+      complete,
+      setScrollTop: (value: number) => {
+        scrollTop = value
+      },
+      runFrame: () => {
+        const callback = callbacks.shift()
+        expect(callback).toBeDefined()
+        callback!()
+      },
+    }
+  }
+
+  it('starts one smooth navigation and only observes until resident top settles', () => {
+    const harness = residentTopHarness()
+    const controller = new PositioningController()
+    observeLiveEntry(controller)
+    const request = controller.beginResidentTopNavigation({
+      conversationId,
+      executor: harness.executor,
+    })
+
+    expect(request).not.toBeNull()
+    expect(harness.start).toHaveBeenCalledTimes(1)
+    expect(controller.snapshot().active?.phase).toEqual({
+      kind: 'position-applied',
+    })
+
+    for (const scrollTop of [640, 100, 1, 0]) {
+      harness.setScrollTop(scrollTop)
+      harness.runFrame()
+    }
+
+    expect(harness.start).toHaveBeenCalledTimes(1)
+    expect(harness.complete).toHaveBeenLastCalledWith(
+      expect.objectContaining({ desired: { kind: 'resident-top' } }),
+      'settled',
+    )
+    expect(harness.recordFrame).toHaveBeenCalledWith(true)
+    expect(harness.recordFrame).toHaveBeenLastCalledWith(false)
+    expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
   })
 })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -1226,6 +1226,11 @@ export class PositioningController {
           directionalExecution !== null &&
           directionalExecution.request.conversationId === conversationId &&
           this.isDirectionalHistoryExecutionCurrent(directionalExecution)
+        const residentTopExecution = this.residentTopExecution
+        const residentTopWasCurrent =
+          residentTopExecution !== null &&
+          residentTopExecution.request.conversationId === conversationId &&
+          this.isResidentTopExecutionCurrent(residentTopExecution)
         // A boundary wheel can start a directional load and be followed by more wheel events while
         // the network request is still pending. The former prepend loop armed user takeover only
         // after the batch landed and reconciliation began, so those pre-load events could not
@@ -1255,6 +1260,9 @@ export class PositioningController {
         }
         if (directionalWasCurrent) {
           this.cancelDirectionalHistoryExecution('user-takeover')
+        }
+        if (residentTopWasCurrent) {
+          this.cancelResidentTopExecution('user-takeover')
         }
         this.cancelExecutionsIfSuperseded()
       },
@@ -2203,11 +2211,7 @@ export class PositioningController {
     lease: PositionExecutionLease,
   ): void {
     if (!lease.isCurrent()) return
-    if (execution.framesLeft-- <= 0) {
-      lease.settle()
-      this.completeResidentTopExecution(execution, 'best-effort')
-      return
-    }
+    execution.framesLeft -= 1
 
     const scrollTop = runScrollShadowSafely<number | null>({
       event: 'resident-top-read-scroll-top',
@@ -2230,6 +2234,11 @@ export class PositioningController {
     if (execution.stableFrames >= RESIDENT_TOP_STABLE_FRAMES) {
       lease.settle()
       this.completeResidentTopExecution(execution, 'settled')
+      return
+    }
+    if (execution.framesLeft <= 0) {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'best-effort')
       return
     }
     this.scheduleResidentTopFrame(execution, lease)
@@ -3519,6 +3528,13 @@ export class PositioningController {
     ) {
       this.cancelExplicitTargetExecution()
     }
+    const residentTopExecution = this.residentTopExecution
+    if (
+      residentTopExecution &&
+      !this.isResidentTopExecutionCurrent(residentTopExecution)
+    ) {
+      this.cancelResidentTopExecution('superseded')
+    }
     const liveEdgeExecution = this.liveEdgeExecution
     if (
       liveEdgeExecution &&
@@ -3546,6 +3562,7 @@ export class PositioningController {
     this.cancelSavedExecution()
     this.cancelUnreadExecution()
     this.cancelExplicitTargetExecution()
+    this.cancelResidentTopExecution(outcome)
     this.cancelLiveEdgeExecution(outcome)
     this.cancelMediaPreservationExecution(outcome)
     this.cancelDirectionalHistoryExecution(outcome)
@@ -3573,6 +3590,15 @@ export class PositioningController {
       this.explicitTargetExecution.abortController?.abort()
     }
     this.explicitTargetExecution = null
+  }
+
+  private cancelResidentTopExecution(
+    outcome: ResidentTopCompletion,
+  ): void {
+    const execution = this.residentTopExecution
+    if (execution) {
+      this.completeResidentTopExecution(execution, outcome)
+    }
   }
 
   private cancelLiveEdgeExecution(outcome: LiveEdgeCompletion): void {

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -20,6 +20,7 @@ import {
   type PositioningModel,
   type PositioningPhase,
   type ReachabilityFacts,
+  type ResidentTopRequest,
   type SavedPositionRequest,
   type UnreadMarkerRequest,
   type UnavailablePolicy,
@@ -259,6 +260,30 @@ export interface ExplicitTargetExecutor {
   ) => void
 }
 
+export type ResidentTopCompletion =
+  | 'settled'
+  | 'best-effort'
+  | 'user-takeover'
+  | 'superseded'
+
+export type ResidentTopStartResult =
+  | { kind: 'started' }
+  | { kind: 'unavailable' }
+
+export interface ResidentTopExecutor {
+  reachability: () => ReachabilityFacts
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  start: (
+    request: ResidentTopRequest,
+    lease: PositionExecutionLease,
+  ) => ResidentTopStartResult
+  readScrollTop: () => number | null
+  complete: (
+    request: ResidentTopRequest,
+    outcome: ResidentTopCompletion,
+  ) => void
+}
+
 interface SavedPositionExecutionState {
   request: SavedPositionRequest
   executor: SavedPositionExecutor
@@ -300,6 +325,16 @@ interface ExplicitTargetExecutionState {
   applied: boolean
 }
 
+interface ResidentTopExecutionState {
+  request: ResidentTopRequest
+  executor: ResidentTopExecutor
+  operation: number
+  abortController: AbortController | null
+  loop: PositionFrameLoop | null
+  framesLeft: number
+  stableFrames: number
+}
+
 interface LiveEdgeExecutionState {
   request: LiveEdgeRequest
   executor: LiveEdgeExecutor
@@ -337,6 +372,9 @@ const EXPLICIT_TARGET_REASSERT_FRAMES = 30
 const EXPLICIT_TARGET_STABLE_FRAMES = 4
 const EXPLICIT_TARGET_DRIFT_PX = 16
 const EXPLICIT_TARGET_TAKEOVER_DRIFT_PX = 300
+const RESIDENT_TOP_OBSERVE_FRAMES = 120
+const RESIDENT_TOP_STABLE_FRAMES = 2
+const RESIDENT_TOP_TOLERANCE_PX = 1
 // Preserved from the former hook-local restore-anchor loop.
 const SAVED_POSITION_REASSERT_FRAMES = 90
 const SAVED_POSITION_STABLE_FRAMES = 8
@@ -399,6 +437,7 @@ export class PositioningController {
   private savedExecution: SavedPositionExecutionState | null = null
   private unreadExecution: UnreadMarkerExecutionState | null = null
   private explicitTargetExecution: ExplicitTargetExecutionState | null = null
+  private residentTopExecution: ResidentTopExecutionState | null = null
   private liveEdgeExecution: LiveEdgeExecutionState | null = null
   private mediaPreservationExecution: MediaPreservationExecutionState | null = null
   private directionalHistoryExecution: DirectionalHistoryExecutionState | null = null
@@ -886,6 +925,63 @@ export class PositioningController {
           selection as PositionRequestDraft,
           input.executor,
         )
+      },
+    })
+  }
+
+  beginResidentTopNavigation(input: {
+    conversationId: string
+    executor: ResidentTopExecutor
+  }): ResidentTopRequest | null {
+    return runScrollShadowSafely({
+      event: 'resident-top-begin',
+      conversationId: input.conversationId,
+      fallback: null,
+      observe: () => {
+        const generation = mintPositionGeneration()
+        const request = withIdentity(
+          input.conversationId,
+          generation,
+          {
+            source: { kind: 'user-navigation', reason: 'resident-top' },
+            desired: { kind: 'resident-top' },
+          },
+        ) as ResidentTopRequest
+        const reachability = runScrollShadowSafely<ReachabilityFacts | null>({
+          event: 'resident-top-reachability',
+          conversationId: input.conversationId,
+          fallback: null,
+          observe: () => input.executor.reachability(),
+        })
+        if (
+          !reachability ||
+          reachability.kind === 'empty-window' ||
+          !reachabilityMatchesRequest(request, reachability)
+        ) {
+          return null
+        }
+        const accepted = acceptPositionRequest(this.model, request)
+        if (accepted === this.model) return null
+
+        this.cancelAllExecutions('superseded')
+        this.model = advancePhaseIfCurrent(
+          accepted,
+          input.conversationId,
+          generation,
+          resolveReachability(request, reachability),
+        )
+        const execution: ResidentTopExecutionState = {
+          request,
+          executor: input.executor,
+          operation: 0,
+          abortController: null,
+          loop: null,
+          framesLeft: RESIDENT_TOP_OBSERVE_FRAMES,
+          stableFrames: 0,
+        }
+        this.residentTopExecution = execution
+        this.startResidentTopLoop(execution)
+        return request
       },
     })
   }
@@ -2044,6 +2140,206 @@ export class PositioningController {
   ): boolean {
     return (
       this.directionalHistoryExecution === execution &&
+      isCurrentGeneration(
+        this.model,
+        execution.request.conversationId,
+        execution.request.generation,
+      )
+    )
+  }
+
+  private startResidentTopLoop(
+    execution: ResidentTopExecutionState,
+  ): void {
+    if (!this.isResidentTopExecutionCurrent(execution) || execution.loop) {
+      return
+    }
+    execution.framesLeft = RESIDENT_TOP_OBSERVE_FRAMES
+    execution.stableFrames = 0
+    const lease = this.beginResidentTopOperation(execution)
+    const loop = runScrollShadowSafely<PositionFrameLoop | null>({
+      event: 'resident-top-loop-start',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.beginLoop(lease),
+    })
+    if (!lease.isCurrent()) {
+      if (loop) {
+        runScrollShadowSafely({
+          event: 'resident-top-loop-stale-finish',
+          conversationId: execution.request.conversationId,
+          fallback: undefined,
+          observe: () => loop.finish(),
+        })
+      }
+      return
+    }
+    if (!loop) {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'best-effort')
+      return
+    }
+    execution.loop = loop
+
+    const started = runScrollShadowSafely<ResidentTopStartResult>({
+      event: 'resident-top-start',
+      conversationId: execution.request.conversationId,
+      fallback: { kind: 'unavailable' },
+      observe: () => execution.executor.start(execution.request, lease),
+    })
+    if (!lease.isCurrent()) return
+    if (started.kind === 'unavailable') {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'best-effort')
+      return
+    }
+    this.recordResidentTopFrame(execution, true)
+    if (!lease.markApplied()) return
+    this.scheduleResidentTopFrame(execution, lease)
+  }
+
+  private driveResidentTopFrame(
+    execution: ResidentTopExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent()) return
+    if (execution.framesLeft-- <= 0) {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'best-effort')
+      return
+    }
+
+    const scrollTop = runScrollShadowSafely<number | null>({
+      event: 'resident-top-read-scroll-top',
+      conversationId: execution.request.conversationId,
+      fallback: null,
+      observe: () => execution.executor.readScrollTop(),
+    })
+    if (!lease.isCurrent()) return
+    if (scrollTop === null) {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'best-effort')
+      return
+    }
+
+    execution.stableFrames =
+      scrollTop <= RESIDENT_TOP_TOLERANCE_PX
+        ? execution.stableFrames + 1
+        : 0
+    this.recordResidentTopFrame(execution, false)
+    if (execution.stableFrames >= RESIDENT_TOP_STABLE_FRAMES) {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'settled')
+      return
+    }
+    this.scheduleResidentTopFrame(execution, lease)
+  }
+
+  private scheduleResidentTopFrame(
+    execution: ResidentTopExecutionState,
+    lease: PositionExecutionLease,
+  ): void {
+    if (!lease.isCurrent() || !execution.loop) return
+    const scheduled = runScrollShadowSafely({
+      event: 'resident-top-frame-schedule',
+      conversationId: execution.request.conversationId,
+      fallback: false,
+      observe: () => {
+        execution.loop?.schedule(
+          () => this.driveResidentTopFrame(execution, lease),
+        )
+        return true
+      },
+    })
+    if (!scheduled && lease.isCurrent()) {
+      lease.settle()
+      this.completeResidentTopExecution(execution, 'best-effort')
+    }
+  }
+
+  private recordResidentTopFrame(
+    execution: ResidentTopExecutionState,
+    wrote: boolean,
+  ): void {
+    runScrollShadowSafely({
+      event: 'resident-top-frame-monitor',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.recordFrame(wrote),
+    })
+  }
+
+  private finishResidentTopLoop(
+    execution: ResidentTopExecutionState,
+  ): void {
+    if (!execution.loop) return
+    runScrollShadowSafely({
+      event: 'resident-top-loop-finish',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.loop?.finish(),
+    })
+    execution.loop = null
+  }
+
+  private completeResidentTopExecution(
+    execution: ResidentTopExecutionState,
+    outcome: ResidentTopCompletion,
+  ): void {
+    this.finishResidentTopLoop(execution)
+    execution.abortController?.abort()
+    runScrollShadowSafely({
+      event: 'resident-top-complete',
+      conversationId: execution.request.conversationId,
+      fallback: undefined,
+      observe: () => execution.executor.complete(execution.request, outcome),
+    })
+    if (this.residentTopExecution === execution) {
+      this.residentTopExecution = null
+    }
+  }
+
+  private beginResidentTopOperation(
+    execution: ResidentTopExecutionState,
+  ): PositionExecutionLease {
+    execution.abortController?.abort()
+    const abortController = new AbortController()
+    execution.abortController = abortController
+    const operation = ++execution.operation
+    const { conversationId, generation } = execution.request
+    const isCurrent = () =>
+      !abortController.signal.aborted &&
+      this.residentTopExecution === execution &&
+      execution.operation === operation &&
+      execution.request.conversationId === conversationId &&
+      execution.request.generation === generation &&
+      isCurrentGeneration(this.model, conversationId, generation)
+    const advance = (phase: PositioningPhase) => {
+      if (!isCurrent()) return false
+      this.model = advancePhaseIfCurrent(
+        this.model,
+        conversationId,
+        generation,
+        phase,
+      )
+      return isCurrent()
+    }
+    return {
+      conversationId,
+      generation,
+      operation,
+      signal: abortController.signal,
+      isCurrent,
+      markApplied: () => advance({ kind: 'position-applied' }),
+      settle: () => advance({ kind: 'settled' }),
+    }
+  }
+
+  private isResidentTopExecutionCurrent(
+    execution: ResidentTopExecutionState,
+  ): boolean {
+    return (
+      this.residentTopExecution === execution &&
       isCurrentGeneration(
         this.model,
         execution.request.conversationId,

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -206,6 +206,11 @@ export type ExplicitTargetRequest = Extract<
   { source: { kind: 'user-navigation'; reason: 'message-target' } }
 >
 
+export type ResidentTopRequest = Extract<
+  PositionRequest,
+  { source: { kind: 'user-navigation'; reason: 'resident-top' } }
+>
+
 export type UnreadMarkerRequest = Extract<
   PositionRequest,
   | { source: { kind: 'entry'; reason: 'unread-marker' } }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3,9 +3,9 @@
  *
  * DESIGN PRINCIPLES:
  * 1. Production scroll state lives in REFS, not React state (prevents render loops)
- * 2. Saved-position, unread-marker, explicit-target, live-edge, media-preservation, and
- *    directional-history policy/retry ownership lives in PositioningController; browser writes
- *    stay imperative in leased hook executors
+ * 2. Saved-position, unread-marker, explicit-target, live-edge, media-preservation,
+ *    directional-history, and resident-top policy/retry ownership lives in
+ *    PositioningController; browser writes stay imperative in leased hook executors
  * 3. Only FAB visibility uses React state (it needs to trigger UI updates)
  * 4. The controller owns generations and migrated-position arbitration, not React state or geometry
  *
@@ -38,6 +38,7 @@ import {
   type LiveEdgeCompletion,
   type MediaPreservationExecutor,
   type PositionExecutionLease,
+  type ResidentTopExecutor,
   type SavedPositionExecutionLease,
   type SavedPositionExecutor,
   type UnreadMarkerExecutor,
@@ -152,11 +153,11 @@ const CONTENT_ARRIVAL_TRIGGERS: ReadonlySet<string> = new Set([
  *
  * Positioning callbacks close over `messageCount`, `firstMessageId`, and window state through their
  * executors, so their identity changes on every append. That is harmless for a direct call, but two
- * of them are published: `requestMessageTarget` is a context value read by EVERY message row, and
- * both are dependencies of the active-list registration. An unstable identity there re-renders every
- * mounted row on each append — context updates bypass `React.memo` — and re-registers the list.
- * Forwarding through a ref keeps behaviour identical (the newest implementation still runs) while
- * the published identity stays constant.
+ * of them are published: `requestMessageTarget` is a context value read by EVERY message row,
+ * `requestMessageTarget`/`scrollToBottom` feed the active-list registration, and the top/bottom
+ * callbacks feed global keyboard listeners. An unstable identity there re-renders mounted rows or
+ * rebinds listeners on each append. Forwarding through a ref keeps behaviour identical (the newest
+ * implementation still runs) while the published identity stays constant.
  */
 function useStableCallback<Args extends unknown[]>(
   callback: (...args: Args) => void,
@@ -1900,23 +1901,54 @@ export function useMessageListScroll({
   // list — and re-binds the ⌘/Ctrl+↓ listener — on every append.
   const scrollToBottom = useStableCallback(scrollToBottomImpl)
 
-  const scrollToTop = useCallback(() => {
+  const createResidentTopExecutor = useCallback((): ResidentTopExecutor => ({
+    reachability: () => deriveReachabilityForDesired({
+      desired: { kind: 'resident-top' },
+      hasRows: messageCount > 0 && firstMessageId !== undefined,
+      windowAtLiveEdge: windowAtLiveEdge !== false,
+      virtualizer: virtualizerRef.current,
+      scroller: scrollerRef.current,
+      loadAround: 'unavailable',
+      canRecenter: false,
+    }),
+    beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
+    start: (_request, lease) => {
+      const scroller = scrollerRef.current
+      if (!lease.isCurrent() || !scroller) return { kind: 'unavailable' }
+      scroller.scrollTo({ top: 0, behavior: 'smooth' })
+      return { kind: 'started' }
+    },
+    readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
+    complete: (request, outcome) => {
+      debugLog('RESIDENT TOP: controller completed', {
+        conversationId: request.conversationId,
+        generation: request.generation,
+        outcome,
+      })
+    },
+  }), [
+    beginControllerFrameLoop,
+    firstMessageId,
+    messageCount,
+    windowAtLiveEdge,
+  ])
+
+  const scrollToTopImpl = useCallback(() => {
     lastLoadTimeRef.current = Date.now() // prevent auto-load trigger
-    const scroller = scrollerRef.current
-    if (!scroller) return
-    const desired = { kind: 'resident-top' } as const
-    positioningControllerRef.current?.observeRequest({
-      event: 'home-key',
+    // `triggerLoadOlder` intentionally lets explicit user travel back to the boundary bypass its
+    // cooldown via this latch. Home is a positioning command, not that travel gesture: it starts
+    // away from the top, so leaving the latch armed would make the smooth arrival immediately
+    // prepend history and supersede the resident-top request. A later genuine move away from the
+    // top re-arms the latch in handleScroll.
+    scrolledAwayFromTopRef.current = false
+    positioningControllerRef.current?.beginResidentTopNavigation({
       conversationId,
-      draft: {
-        source: { kind: 'user-navigation', reason: 'resident-top' },
-        desired,
-      },
-      reachability: shadowReachabilityRef.current(desired),
-      actual: { desired, phase: 'positioning' },
+      executor: createResidentTopExecutor(),
     })
-    scroller.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [conversationId])
+  }, [conversationId, createResidentTopExecutor])
+  // Published to MessageList's keyboard listeners. Keep the shell stable while the executor factory
+  // tracks row/window facts so normal appends do not churn global keydown subscriptions.
+  const scrollToTop = useStableCallback(scrollToTopImpl)
 
   // Re-pin to the bottom when the VIEWPORT itself shrinks (or grows) under a list
   // that is following along — most importantly when the mobile on-screen keyboard
@@ -2474,8 +2506,12 @@ export function useMessageListScroll({
       )
     }
 
-    // Track if user scrolled away from top (allows re-trigger of load)
-    if (scrollTop > 50) scrolledAwayFromTopRef.current = true
+    // Track if the USER scrolled away from top (allows a later return to re-trigger load). A
+    // controller-owned animation can cross this threshold too — most notably Home's smooth trip
+    // from the bottom — but that is not evidence of a separate pagination gesture.
+    if (!programmaticScroll && scrollTop > 50) {
+      scrolledAwayFromTopRef.current = true
+    }
     // Mirror for the newer direction (sliding window): away from the resident bottom.
     if (distFromBottom > 50) scrolledAwayFromBottomRef.current = true
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1935,6 +1935,13 @@ export function useMessageListScroll({
 
   const scrollToTopImpl = useCallback(() => {
     lastLoadTimeRef.current = Date.now() // prevent auto-load trigger
+    if (staticMode) {
+      // Search/stranger previews intentionally own neither a controller conversation nor live-list
+      // persistence. Preserve their isolated one-shot Home behavior inside this scroller; routing
+      // it into the live-list controller would reject the request after preventDefault().
+      scrollerRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+      return
+    }
     // `triggerLoadOlder` intentionally lets explicit user travel back to the boundary bypass its
     // cooldown via this latch. Home is a positioning command, not that travel gesture: it starts
     // away from the top, so leaving the latch armed would make the smooth arrival immediately
@@ -1945,7 +1952,7 @@ export function useMessageListScroll({
       conversationId,
       executor: createResidentTopExecutor(),
     })
-  }, [conversationId, createResidentTopExecutor])
+  }, [conversationId, createResidentTopExecutor, staticMode])
   // Published to MessageList's keyboard listeners. Keep the shell stable while the executor factory
   // tracks row/window facts so normal appends do not churn global keydown subscriptions.
   const scrollToTop = useStableCallback(scrollToTopImpl)

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -1,8 +1,8 @@
 # Message-list scroll positioning contract
 
 Status: core migration complete. Saved-position restoration, unread-marker positioning, explicit
-message targets, live-edge pinning, media remeasurement preservation, and directional history
-preservation are authoritative controller slices.
+message targets, live-edge pinning, media remeasurement preservation, directional history
+preservation, and resident-top navigation are authoritative controller slices.
 
 ## Purpose
 
@@ -44,7 +44,7 @@ cancellation, 2px target-shift correction, 5px clamp recovery, and bounded dista
 fallback. Boundary input while the load is still pending retains the captured anchor because no
 pixel owner exists yet; takeover becomes cancellable after the initial positioning write, matching
 the former loop's timing. Explicit competing requests still supersede pending directional history.
-All six authoritative slices share the same controller-owned
+All seven authoritative slices share the same controller-owned
 `PositionFrameLoop` shape. The saved executor retains the existing fractional-anchor
 measurement write, 90-frame budget, 8-frame stability window, and 8px tolerance; only scheduling,
 convergence state, and lifecycle ownership moved out of the hook-local loop. Unlike unread-marker
@@ -63,12 +63,18 @@ than competing lifecycle owners. A settled or best-effort generation flushes any
 repaint; user takeover or supersession deliberately discards that debt so it cannot repaint after
 the reader takes control or leak into unrelated content.
 
-Residual shadow observations cover the still-direct resident-top command and entry staging before
-an explicit target. A shared error boundary catches and counts adapter, validator,
-controller-driver, and executor errors; failure must degrade according to the active request's
-source-specific policy and must never escape into the scroll effect or event handler. The demo
-scroll-invariant suite fails if either `divergenceCount` or `instrumentationErrorCount` is non-zero.
-Retained diagnostic samples are capped, not the pass criterion.
+Resident-top navigation starts one native smooth write from its leased executor, then observes
+`scrollTop` without reissuing the target. It settles after two frames within 1px of the resident
+top, or releases best-effort after 120 observation frames without snapping. Home resets the prior
+top-boundary travel latch, and its controller-owned progress cannot recreate user pagination
+evidence; a later genuine user move away from the top can still re-arm ordinary load-older.
+
+Residual shadow observations cover entry staging before an explicit target. A shared error boundary
+catches and counts adapter, validator, controller-driver, and executor errors; failure must degrade
+according to the active request's source-specific policy and must never escape into the scroll
+effect or event handler. The demo scroll-invariant suite fails if either `divergenceCount` or
+`instrumentationErrorCount` is non-zero. Retained diagnostic samples are capped, not the pass
+criterion.
 
 For residual shadow observations, zero divergences means the model agrees with the hand-authored
 semantic `actual` label at each observation site: desired position plus the coarse
@@ -302,16 +308,17 @@ abort valid deep growth and media-settle runs.
 | Media at live edge | Existing live edge | Debounced measurement stimulus |
 | Media while reading history | Fixed bottom-relative fractional anchor | Preserve the reading point through remeasurement |
 | Load older/newer | Fixed top-relative offset anchor | Wait for the directional window change; if the anchor disappears, preserve captured distance from bottom and clamp |
-| Home / resident-top command | Resident top | May subsequently trigger ordinary load-older |
+| Home / resident-top command | Resident top | Does not itself trigger load-older; later genuine user travel can re-arm ordinary boundary loading |
 | Reaction, typing, resize, MAM completion | Current live edge, when active | Geometry stimulus, not a new position request |
 
 The FAB/End choice is made from current geometry, not a remembered click state. If the unread marker
 is already visible or above the viewport, the same activation goes directly to live edge.
 
-## Current owners to migrate
+## Ownership boundary
 
 The controller-owned mechanisms retain leased browser reconcilers for saved anchors, unread markers,
-explicit center-aligned targets, live edge, media preservation, and directional history. These
+explicit center-aligned targets, live edge, media preservation, directional history, and resident
+top. These
 reconcilers implement measurement convergence; they are not separate positioning authorities.
 There is no independent positioning frame-loop implementation left inside `useMessageListScroll`.
 
@@ -320,10 +327,6 @@ already create a controller-owned live-edge request, scroller resize is observed
 list's controller-backed correction path, and room media now receives the same list-owned callback
 as 1:1 media. That callback is published through a stable shell so current executor/window changes
 do not invalidate every memoized row. These stimuli no longer add a second pixel writer.
-
-One positioning owner remains outside the shared single-flight ref:
-
-- resident-top's direct writer.
 
 Two visually similar scroll operations are explicitly outside this migration:
 
@@ -398,7 +401,8 @@ kinetic scrolling and stale-paint behavior.
 5. [x] Migrate directional history preservation last, retaining kinetic cancellation, full-budget
    late-measurement tracking, distance-from-bottom fallback, and clamp recovery; delete the private
    prepend/window-shift loop.
-6. Route or isolate the remaining owners outside `useMessageListScroll`.
+6. [x] Route resident-top through the controller and document the two isolated, non-competing
+   preview/selection scroll contexts.
 7. Split persistence, user-intent tracking, history windowing, and reconciliation out of the
    orchestration hook.
 

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -338,7 +338,8 @@ Two visually similar scroll operations are explicitly outside this migration:
   active-list registry holds only one entry, requests from inside any list route by **containment**
   (`messageTargetContext`), not by registration order; previews therefore do not register at all.
   The registry remains for callers with no enclosing list that mean the live conversation
-  (`PollBanner`, find-on-page).
+  (`PollBanner`, find-on-page). Its Home shortcut likewise retains one isolated smooth write because
+  static previews deliberately have no active controller conversation to accept that command.
 - Keyboard selection in `useMessageSelection` uses
   `scrollIntoView({ block: 'nearest' })` only to keep the selected row visible. It is viewport
   maintenance, not a semantic message-position request, and remains intentionally direct.

--- a/docs/superpowers/plans/2026-07-27-resident-top-controller.md
+++ b/docs/superpowers/plans/2026-07-27-resident-top-controller.md
@@ -1,0 +1,554 @@
+# Resident-Top Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete scroll-positioning migration step 6 by moving Home / resident-top navigation from a hook-owned smooth write to a generation-aware controller-owned one-shot animation with leased observation.
+
+**Architecture:** Add a seventh authoritative execution slice to `PositioningController`. Its executor starts the native smooth animation once, while the shared `PositionFrameLoop` only observes progress and settles, cancels, or times out the generation. `useMessageListScroll` remains the browser adapter and publishes a stable Home command.
+
+**Tech Stack:** TypeScript, React, Vitest, Testing Library, Playwright, Chromium, WebKit.
+
+## Global Constraints
+
+- Preserve `scrollTo({ top: 0, behavior: 'smooth' })`; never restart it from an animation frame.
+- Settle after two consecutive observations at `scrollTop <= 1`.
+- Stop best-effort after 120 frames without forcing a snap.
+- Native user input, conversation deactivation, and newer requests cancel stale work before it can settle.
+- Preserve the existing `lastLoadTimeRef.current = Date.now()` history-load guard.
+- Do not add an unleased emergency scroll write.
+- Keep Home / Mod+ArrowUp listener and consumer identities stable across appends and window changes.
+- Step 7 hook decomposition is outside this change.
+
+---
+
+### Task 1: Define and drive the resident-top controller slice
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/scrollPositionModel.ts`
+- Modify: `apps/fluux/src/components/conversation/positioningController.ts`
+- Test: `apps/fluux/src/components/conversation/positioningController.test.ts`
+
+**Interfaces:**
+- Consumes: existing `PositionExecutionLease`, `PositionFrameLoop`, `ReachabilityFacts`, `acceptPositionRequest`, `resolveReachability`, and module-private `mintPositionGeneration`.
+- Produces:
+  - `ResidentTopRequest`
+  - `ResidentTopCompletion`
+  - `ResidentTopStartResult`
+  - `ResidentTopExecutor`
+  - `PositioningController.beginResidentTopNavigation(input)`
+
+- [ ] **Step 1: Write the failing single-write and convergence tests**
+
+In `positioningController.test.ts`, import the not-yet-existing resident-top
+types and add a harness with literal geometry:
+
+```ts
+function residentTopHarness(
+  initialReachability: ReachabilityFacts = {
+    kind: 'available',
+    index: 0,
+    mounted: true,
+    placement: 'viable',
+  },
+) {
+  const callbacks: Array<() => void> = []
+  const leases: PositionExecutionLease[] = []
+  const start = vi.fn(() => ({ kind: 'started' as const }))
+  const finish = vi.fn()
+  const recordFrame = vi.fn()
+  const complete = vi.fn()
+  let scrollTop = 640
+  const executor: ResidentTopExecutor = {
+    reachability: () => initialReachability,
+    beginLoop: (lease) => {
+      leases.push(lease)
+      return {
+        schedule: (callback) => callbacks.push(callback),
+        recordFrame,
+        finish,
+      }
+    },
+    start,
+    readScrollTop: () => scrollTop,
+    complete,
+  }
+  return {
+    executor,
+    callbacks,
+    leases,
+    start,
+    finish,
+    recordFrame,
+    complete,
+    setScrollTop: (value: number) => { scrollTop = value },
+    runFrame: () => callbacks.shift()!(),
+  }
+}
+```
+
+Add a test that begins navigation, observes `640`, `100`, `1`, and `0`, and asserts:
+
+```ts
+expect(harness.start).toHaveBeenCalledTimes(1)
+expect(harness.complete).toHaveBeenLastCalledWith(
+  expect.objectContaining({ desired: { kind: 'resident-top' } }),
+  'settled',
+)
+expect(harness.recordFrame).toHaveBeenCalledWith(true)
+expect(harness.recordFrame).toHaveBeenLastCalledWith(false)
+expect(controller.snapshot().active?.phase).toEqual({ kind: 'settled' })
+```
+
+The test must fail because `ResidentTopExecutor` and
+`beginResidentTopNavigation` do not exist. It would also fail if a frame
+restarted the smooth write or if one top observation settled too early.
+
+- [ ] **Step 2: Run the controller test and verify RED**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/positioningController.test.ts
+```
+
+Expected: TypeScript/Vitest failure naming the missing resident-top controller API.
+
+- [ ] **Step 3: Implement the minimal resident-top lifecycle**
+
+First add the request alias beside the other exported aliases in
+`scrollPositionModel.ts`:
+
+```ts
+export type ResidentTopRequest = Extract<
+  PositionRequest,
+  { source: { kind: 'user-navigation'; reason: 'resident-top' } }
+>
+```
+
+Then in `positioningController.ts`, add:
+
+```ts
+export type ResidentTopCompletion =
+  | 'settled'
+  | 'best-effort'
+  | 'user-takeover'
+  | 'superseded'
+
+export type ResidentTopStartResult =
+  | { kind: 'started' }
+  | { kind: 'unavailable' }
+
+export interface ResidentTopExecutor {
+  reachability: () => ReachabilityFacts
+  beginLoop: (lease: PositionExecutionLease) => PositionFrameLoop | null
+  start: (
+    request: ResidentTopRequest,
+    lease: PositionExecutionLease,
+  ) => ResidentTopStartResult
+  readScrollTop: () => number | null
+  complete: (
+    request: ResidentTopRequest,
+    outcome: ResidentTopCompletion,
+  ) => void
+}
+```
+
+Add `ResidentTopExecutionState` with `request`, `executor`, `operation`, `abortController`, `loop`, `framesLeft`, and `stableFrames`; add:
+
+```ts
+const RESIDENT_TOP_OBSERVE_FRAMES = 120
+const RESIDENT_TOP_STABLE_FRAMES = 2
+const RESIDENT_TOP_TOLERANCE_PX = 1
+```
+
+Implement `beginResidentTopNavigation` so it:
+
+1. reads reachability inside `runScrollShadowSafely`;
+2. rejects `empty-window` and mismatched facts before accepting;
+3. creates `{ source: { kind: 'user-navigation', reason: 'resident-top' }, desired: { kind: 'resident-top' } }`;
+4. cancels all older executions;
+5. advances to `resolveReachability`;
+6. creates the resident execution and starts a leased loop;
+7. invokes `executor.start` once, records that initial write, marks applied, and schedules observation.
+
+The frame driver must decrement the 120-frame budget, call only `readScrollTop`, record `false`, and settle after two consecutive values `<= 1`. Budget exhaustion completes `best-effort`. A null reading or unavailable start completes best-effort without a fallback write.
+
+- [ ] **Step 4: Run the controller test and verify GREEN**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/positioningController.test.ts
+```
+
+Expected: all controller tests pass, including the one-shot smooth start control.
+
+- [ ] **Step 5: Commit the first controller increment**
+
+```bash
+git add apps/fluux/src/components/conversation/scrollPositionModel.ts \
+  apps/fluux/src/components/conversation/positioningController.ts \
+  apps/fluux/src/components/conversation/positioningController.test.ts
+git commit -m "Add resident-top controller execution"
+```
+
+---
+
+### Task 2: Protect resident-top cancellation, supersession, and timeout
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/positioningController.ts`
+- Test: `apps/fluux/src/components/conversation/positioningController.test.ts`
+
+**Interfaces:**
+- Consumes: `ResidentTopExecutionState` and `beginResidentTopNavigation` from Task 1.
+- Produces: resident-top participation in `observeUserInput`, `cancelExecutionsIfSuperseded`, `cancelAllExecutions`, and conversation deactivation.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Add four tests using the real controller and resident harness:
+
+1. `observeUserInput(conversationId)` followed by a queued frame leaves `start` at one call, calls `complete(request, 'user-takeover')`, finishes the loop, and leaves the lease stale.
+2. A later `beginLiveEdgeRequest` followed by the queued resident frame calls `complete(request, 'superseded')` and cannot settle the older generation.
+3. 120 non-top observations complete `best-effort`, call `start` once, and never mutate observed geometry.
+4. `beginResidentTopNavigation` with `{ kind: 'empty-window' }` returns `null` and leaves no active resident-top request.
+
+Each test must assert the final controller phase/watermark as well as completion. These controls fail if resident-top is omitted from any shared cancellation path or if timeout performs a second write.
+
+- [ ] **Step 2: Run the lifecycle tests and verify RED**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/positioningController.test.ts
+```
+
+Expected: failures showing resident-top execution remains current after user input/supersession or lacks best-effort completion.
+
+- [ ] **Step 3: Implement shared cancellation participation**
+
+Add resident-top currentness, lease, finish, completion, and cancellation helpers following the existing live-edge/media shapes:
+
+```ts
+private cancelResidentTopExecution(outcome: ResidentTopCompletion): void
+private isResidentTopExecutionCurrent(
+  execution: ResidentTopExecutionState,
+): boolean
+private beginResidentTopOperation(
+  execution: ResidentTopExecutionState,
+): PositionExecutionLease
+```
+
+Capture `residentTopWasCurrent` before `cancelReconciliationForUserInput`, then cancel it with `user-takeover`. Include resident-top in `cancelExecutionsIfSuperseded` and `cancelAllExecutions('superseded')`. `deactivate` already calls `cancelExecutionsIfSuperseded`, so its stale queued frame must fail the lease without a separate direct path.
+
+- [ ] **Step 4: Run the controller tests and verify GREEN**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/positioningController.test.ts
+```
+
+Expected: all tests pass and every stale-frame control observes `lease.isCurrent() === false`.
+
+- [ ] **Step 5: Commit lifecycle coverage**
+
+```bash
+git add apps/fluux/src/components/conversation/positioningController.ts \
+  apps/fluux/src/components/conversation/positioningController.test.ts
+git commit -m "Cancel stale resident-top positioning"
+```
+
+---
+
+### Task 3: Route Home navigation through the controller
+
+**Files:**
+- Modify: `apps/fluux/src/components/conversation/useMessageListScroll.ts`
+- Modify: `apps/fluux/src/components/conversation/MessageList.scroll.test.tsx`
+- Modify: `scripts/scroll-invariants.ts`
+- Modify: `docs/superpowers/specs/2026-07-27-resident-top-controller-design.md`
+
+**Interfaces:**
+- Consumes: `ResidentTopExecutor` and `beginResidentTopNavigation`.
+- Produces: `createResidentTopExecutor()` and stable `scrollToTop`.
+
+- [ ] **Step 1: Write the failing runtime hook tests**
+
+In `MessageList.scroll.test.tsx`, add a Home test using the real `MessageList` and scroller:
+
+```ts
+fireEvent.keyDown(window, { key: 'Home' })
+expect(scroller.scrollTo).toHaveBeenCalledTimes(1)
+expect(scroller.scrollTo).toHaveBeenCalledWith({
+  top: 0,
+  behavior: 'smooth',
+})
+```
+
+Assert that the rAF harness has queued the controller observation loop, then
+advance it while setting `scroller.scrollTop` through `500`, `20`, `1`, and
+`0`; assert there is still exactly one `scrollTo` call. The current direct
+implementation queues no resident-top observation frame, so this is the RED
+control. Dispatch a wheel event in a sibling test before the queued frame and
+assert the stale callback does not add a write or settle into a live owner.
+
+In `scripts/scroll-invariants.ts`, add the real-engine Home scenario before the
+hook cutover. Enable scroll debug capture, start away from resident top, invoke
+Home through the focused message list, wait for `scrollTop <= 1`, and require
+one runtime `RESIDENT TOP: controller completed` trace with zero divergence and
+instrumentation errors. The current direct path reaches top but emits no
+controller completion, so the test must fail on both engines.
+
+- [ ] **Step 2: Run the hook tests and verify RED**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/MessageList.scroll.test.tsx
+cd ../..
+npx playwright test \
+  --config playwright.scroll.config.ts \
+  --grep "Home reaches resident top"
+```
+
+Expected: the Vitest progress test fails because the current direct call has no
+controller-owned observation, and Playwright fails because no resident-top
+controller completion trace exists.
+
+- [ ] **Step 3: Implement the hook adapter**
+
+Import `ResidentTopExecutor`. Add:
+
+```ts
+const createResidentTopExecutor = useCallback((): ResidentTopExecutor => ({
+  reachability: () => deriveReachabilityForDesired({
+    desired: { kind: 'resident-top' },
+    hasRows: messageCount > 0 && firstMessageId !== undefined,
+    windowAtLiveEdge: windowAtLiveEdge !== false,
+    virtualizer: virtualizerRef.current,
+    scroller: scrollerRef.current,
+    loadAround: 'unavailable',
+    canRecenter: false,
+  }),
+  beginLoop: (lease) => beginControllerFrameLoop('resident-top', lease),
+  start: (_request, lease) => {
+    const scroller = scrollerRef.current
+    if (!lease.isCurrent() || !scroller) return { kind: 'unavailable' }
+    scroller.scrollTo({ top: 0, behavior: 'smooth' })
+    return { kind: 'started' }
+  },
+  readScrollTop: () => scrollerRef.current?.scrollTop ?? null,
+  complete: (request, outcome) => {
+    debugLog('RESIDENT TOP: controller completed', {
+      conversationId: request.conversationId,
+      generation: request.generation,
+      outcome,
+    })
+  },
+}), [
+  beginControllerFrameLoop,
+  firstMessageId,
+  messageCount,
+  windowAtLiveEdge,
+])
+```
+
+Replace the old shadow block and direct write with:
+
+```ts
+const scrollToTopImpl = useCallback(() => {
+  lastLoadTimeRef.current = Date.now()
+  positioningControllerRef.current?.beginResidentTopNavigation({
+    conversationId,
+    executor: createResidentTopExecutor(),
+  })
+}, [conversationId, createResidentTopExecutor])
+
+```
+
+The only smooth write now lives inside the leased executor start method. Update the design spec's test paragraph to say runtime behavior, not source-text matching.
+
+- [ ] **Step 4: Run hook and real-engine tests and verify GREEN**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/MessageList.scroll.test.tsx
+cd ../..
+npx playwright test \
+  --config playwright.scroll.config.ts \
+  --grep "Home reaches resident top"
+```
+
+Expected: hook tests pass, resident-top issues one smooth write, and Playwright
+reports 2/2 with controller completion traces.
+
+- [ ] **Step 5: Write the failing callback-stability test**
+
+Capture `scrollToTop` from the hook consumer, rerender with an appended
+message/current window change, and assert the same function identity. The
+minimal cutover above closes over `createResidentTopExecutor`, so this test must
+fail until a stable shell is published. The realistic mutation caught is
+removing the stable shell and rebinding the global keyboard listener on every
+append.
+
+- [ ] **Step 6: Run the stability test and verify RED**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run src/components/conversation/MessageList.scroll.test.tsx
+```
+
+Expected: the new identity assertion fails while the resident-top behavior
+tests remain green.
+
+- [ ] **Step 7: Publish the stable command and verify GREEN**
+
+Add:
+
+```ts
+const scrollToTop = useStableCallback(scrollToTopImpl)
+```
+
+Then run:
+
+```bash
+cd apps/fluux
+npx vitest run \
+  src/components/conversation/MessageList.scroll.test.tsx \
+  src/components/roomRowPresenceMemo.test.tsx
+```
+
+Expected: all tests pass and appends do not invalidate the Home command or
+mounted room rows.
+
+- [ ] **Step 8: Commit the hook cutover**
+
+```bash
+git add apps/fluux/src/components/conversation/useMessageListScroll.ts \
+  apps/fluux/src/components/conversation/MessageList.scroll.test.tsx \
+  scripts/scroll-invariants.ts \
+  docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+git commit -m "Route Home positioning through the controller"
+```
+
+---
+
+### Task 4: Add real-engine coverage and close migration step 6
+
+**Files:**
+- Modify: `docs/2026-07-23-scroll-positioning-contract.md`
+- Modify: `docs/superpowers/plans/2026-07-27-resident-top-controller.md`
+
+**Interfaces:**
+- Consumes: controller-owned Home behavior and invariant from Task 3.
+- Produces: completed step-6 contract.
+
+- [ ] **Step 1: Update the positioning contract**
+
+In `docs/2026-07-23-scroll-positioning-contract.md`:
+
+- change step 6 to `[x]`;
+- replace “One positioning owner remains” with a statement that all live-list semantic positioning owners are controller-owned;
+- document resident-top as a one-shot smooth write plus leased observation, with no per-frame reassert;
+- retain the two isolated-context bullets unchanged;
+- update “all six authoritative slices” to “all seven authoritative slices”.
+
+- [ ] **Step 2: Mark completed plan checkboxes**
+
+As each step is completed, replace its `- [ ]` with `- [x]` in this plan so the committed plan accurately records execution.
+
+- [ ] **Step 3: Run focused controller, hook, and real-engine tests**
+
+Run:
+
+```bash
+cd apps/fluux
+npx vitest run \
+  src/components/conversation/positioningController.test.ts \
+  src/components/conversation/MessageList.scroll.test.tsx \
+  src/components/roomRowPresenceMemo.test.tsx
+cd ../..
+npx playwright test \
+  --config playwright.scroll.config.ts \
+  --grep "Home reaches resident top"
+```
+
+Expected: all focused Vitest tests pass and Playwright reports 2/2.
+
+- [ ] **Step 4: Commit the contract**
+
+```bash
+git add docs/2026-07-23-scroll-positioning-contract.md \
+  docs/superpowers/plans/2026-07-27-resident-top-controller.md
+git commit -m "Complete scroll positioning migration step 6"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:**
+- Verify only; modify production files only if a failing check exposes a real defect and add a failing regression test before the fix.
+
+**Interfaces:**
+- Consumes: complete branch state from Tasks 1–4.
+- Produces: evidence that the exact branch is ready for review.
+
+- [ ] **Step 1: Run the full unit/integration suite**
+
+```bash
+npm test
+```
+
+Expected: all SDK and app tests pass; existing environment warnings do not change the exit code.
+
+- [ ] **Step 2: Run static checks**
+
+```bash
+npm run typecheck
+npm run lint
+git diff --check origin/main...HEAD
+```
+
+Expected: typecheck passes, lint has zero errors, and the diff check is clean.
+
+- [ ] **Step 3: Run the complete scroll-invariant suite**
+
+```bash
+npm run test:scroll
+```
+
+Expected: all existing 52 scenarios plus the two new engine cases pass.
+
+- [ ] **Step 4: Audit ownership and scope**
+
+Review:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+git status -sb
+```
+
+Confirm the hook has no shadow `home-key` observation or direct Home write outside `ResidentTopExecutor.start`, static preview and selection scrolling are unchanged, and no unrelated files are present.
+
+- [ ] **Step 5: Commit any final plan-state update**
+
+If marking Task 5 checkboxes changes the plan:
+
+```bash
+git add docs/superpowers/plans/2026-07-27-resident-top-controller.md
+git commit -m "Record resident-top migration validation"
+```
+
+Otherwise leave the verified branch unchanged.

--- a/docs/superpowers/plans/2026-07-27-resident-top-controller.md
+++ b/docs/superpowers/plans/2026-07-27-resident-top-controller.md
@@ -314,7 +314,7 @@ npx vitest run src/components/conversation/MessageList.scroll.test.tsx
 cd ../..
 npx playwright test \
   --config playwright.scroll.config.ts \
-  --grep "Home reaches resident top"
+  --grep "Home issues one smooth write"
 ```
 
 Expected: the Vitest progress test fails because the current direct call has no
@@ -384,7 +384,7 @@ npx vitest run src/components/conversation/MessageList.scroll.test.tsx
 cd ../..
 npx playwright test \
   --config playwright.scroll.config.ts \
-  --grep "Home reaches resident top"
+  --grep "Home issues one smooth write"
 ```
 
 Expected: hook tests pass, resident-top issues one smooth write, and Playwright
@@ -480,7 +480,7 @@ npx vitest run \
 cd ../..
 npx playwright test \
   --config playwright.scroll.config.ts \
-  --grep "Home reaches resident top"
+  --grep "Home issues one smooth write"
 ```
 
 Expected: all focused Vitest tests pass and Playwright reports 2/2.

--- a/docs/superpowers/plans/2026-07-27-resident-top-controller.md
+++ b/docs/superpowers/plans/2026-07-27-resident-top-controller.md
@@ -555,7 +555,7 @@ Otherwise leave the verified branch unchanged.
 
 Validation recorded on 2026-07-27:
 
-- `npm test`: SDK 5,325 passed; app 5,338 passed and 22 skipped.
+- `npm test`: SDK 5,325 passed; app 5,339 passed and 22 skipped.
 - `npm run typecheck`: passed for both workspaces.
 - `npm run lint`: zero errors; 34 pre-existing warnings.
 - `npm run test:scroll`: 54/54 passed across Chromium and WebKit.

--- a/docs/superpowers/plans/2026-07-27-resident-top-controller.md
+++ b/docs/superpowers/plans/2026-07-27-resident-top-controller.md
@@ -555,7 +555,7 @@ Otherwise leave the verified branch unchanged.
 
 Validation recorded on 2026-07-27:
 
-- `npm test`: SDK 5,325 passed; app 5,339 passed and 22 skipped.
+- `npm test`: SDK 5,325 passed; app 5,341 passed and 22 skipped.
 - `npm run typecheck`: passed for both workspaces.
 - `npm run lint`: zero errors; 34 pre-existing warnings.
 - `npm run test:scroll`: 54/54 passed across Chromium and WebKit.

--- a/docs/superpowers/plans/2026-07-27-resident-top-controller.md
+++ b/docs/superpowers/plans/2026-07-27-resident-top-controller.md
@@ -37,7 +37,7 @@
   - `ResidentTopExecutor`
   - `PositioningController.beginResidentTopNavigation(input)`
 
-- [ ] **Step 1: Write the failing single-write and convergence tests**
+- [x] **Step 1: Write the failing single-write and convergence tests**
 
 In `positioningController.test.ts`, import the not-yet-existing resident-top
 types and add a harness with literal geometry:
@@ -103,7 +103,7 @@ The test must fail because `ResidentTopExecutor` and
 `beginResidentTopNavigation` do not exist. It would also fail if a frame
 restarted the smooth write or if one top observation settled too early.
 
-- [ ] **Step 2: Run the controller test and verify RED**
+- [x] **Step 2: Run the controller test and verify RED**
 
 Run:
 
@@ -114,7 +114,7 @@ npx vitest run src/components/conversation/positioningController.test.ts
 
 Expected: TypeScript/Vitest failure naming the missing resident-top controller API.
 
-- [ ] **Step 3: Implement the minimal resident-top lifecycle**
+- [x] **Step 3: Implement the minimal resident-top lifecycle**
 
 First add the request alias beside the other exported aliases in
 `scrollPositionModel.ts`:
@@ -174,7 +174,7 @@ Implement `beginResidentTopNavigation` so it:
 
 The frame driver must decrement the 120-frame budget, call only `readScrollTop`, record `false`, and settle after two consecutive values `<= 1`. Budget exhaustion completes `best-effort`. A null reading or unavailable start completes best-effort without a fallback write.
 
-- [ ] **Step 4: Run the controller test and verify GREEN**
+- [x] **Step 4: Run the controller test and verify GREEN**
 
 Run:
 
@@ -185,7 +185,7 @@ npx vitest run src/components/conversation/positioningController.test.ts
 
 Expected: all controller tests pass, including the one-shot smooth start control.
 
-- [ ] **Step 5: Commit the first controller increment**
+- [x] **Step 5: Commit the first controller increment**
 
 ```bash
 git add apps/fluux/src/components/conversation/scrollPositionModel.ts \
@@ -206,7 +206,7 @@ git commit -m "Add resident-top controller execution"
 - Consumes: `ResidentTopExecutionState` and `beginResidentTopNavigation` from Task 1.
 - Produces: resident-top participation in `observeUserInput`, `cancelExecutionsIfSuperseded`, `cancelAllExecutions`, and conversation deactivation.
 
-- [ ] **Step 1: Write failing lifecycle tests**
+- [x] **Step 1: Write failing lifecycle tests**
 
 Add four tests using the real controller and resident harness:
 
@@ -217,7 +217,7 @@ Add four tests using the real controller and resident harness:
 
 Each test must assert the final controller phase/watermark as well as completion. These controls fail if resident-top is omitted from any shared cancellation path or if timeout performs a second write.
 
-- [ ] **Step 2: Run the lifecycle tests and verify RED**
+- [x] **Step 2: Run the lifecycle tests and verify RED**
 
 Run:
 
@@ -228,7 +228,7 @@ npx vitest run src/components/conversation/positioningController.test.ts
 
 Expected: failures showing resident-top execution remains current after user input/supersession or lacks best-effort completion.
 
-- [ ] **Step 3: Implement shared cancellation participation**
+- [x] **Step 3: Implement shared cancellation participation**
 
 Add resident-top currentness, lease, finish, completion, and cancellation helpers following the existing live-edge/media shapes:
 
@@ -244,7 +244,7 @@ private beginResidentTopOperation(
 
 Capture `residentTopWasCurrent` before `cancelReconciliationForUserInput`, then cancel it with `user-takeover`. Include resident-top in `cancelExecutionsIfSuperseded` and `cancelAllExecutions('superseded')`. `deactivate` already calls `cancelExecutionsIfSuperseded`, so its stale queued frame must fail the lease without a separate direct path.
 
-- [ ] **Step 4: Run the controller tests and verify GREEN**
+- [x] **Step 4: Run the controller tests and verify GREEN**
 
 Run:
 
@@ -255,7 +255,7 @@ npx vitest run src/components/conversation/positioningController.test.ts
 
 Expected: all tests pass and every stale-frame control observes `lease.isCurrent() === false`.
 
-- [ ] **Step 5: Commit lifecycle coverage**
+- [x] **Step 5: Commit lifecycle coverage**
 
 ```bash
 git add apps/fluux/src/components/conversation/positioningController.ts \
@@ -277,7 +277,7 @@ git commit -m "Cancel stale resident-top positioning"
 - Consumes: `ResidentTopExecutor` and `beginResidentTopNavigation`.
 - Produces: `createResidentTopExecutor()` and stable `scrollToTop`.
 
-- [ ] **Step 1: Write the failing runtime hook tests**
+- [x] **Step 1: Write the failing runtime hook tests**
 
 In `MessageList.scroll.test.tsx`, add a Home test using the real `MessageList` and scroller:
 
@@ -304,7 +304,7 @@ one runtime `RESIDENT TOP: controller completed` trace with zero divergence and
 instrumentation errors. The current direct path reaches top but emits no
 controller completion, so the test must fail on both engines.
 
-- [ ] **Step 2: Run the hook tests and verify RED**
+- [x] **Step 2: Run the hook tests and verify RED**
 
 Run:
 
@@ -321,7 +321,7 @@ Expected: the Vitest progress test fails because the current direct call has no
 controller-owned observation, and Playwright fails because no resident-top
 controller completion trace exists.
 
-- [ ] **Step 3: Implement the hook adapter**
+- [x] **Step 3: Implement the hook adapter**
 
 Import `ResidentTopExecutor`. Add:
 
@@ -374,7 +374,7 @@ const scrollToTopImpl = useCallback(() => {
 
 The only smooth write now lives inside the leased executor start method. Update the design spec's test paragraph to say runtime behavior, not source-text matching.
 
-- [ ] **Step 4: Run hook and real-engine tests and verify GREEN**
+- [x] **Step 4: Run hook and real-engine tests and verify GREEN**
 
 Run:
 
@@ -390,7 +390,7 @@ npx playwright test \
 Expected: hook tests pass, resident-top issues one smooth write, and Playwright
 reports 2/2 with controller completion traces.
 
-- [ ] **Step 5: Write the failing callback-stability test**
+- [x] **Step 5: Write the failing callback-stability test**
 
 Capture `scrollToTop` from the hook consumer, rerender with an appended
 message/current window change, and assert the same function identity. The
@@ -399,7 +399,7 @@ fail until a stable shell is published. The realistic mutation caught is
 removing the stable shell and rebinding the global keyboard listener on every
 append.
 
-- [ ] **Step 6: Run the stability test and verify RED**
+- [x] **Step 6: Run the stability test and verify RED**
 
 Run:
 
@@ -411,7 +411,7 @@ npx vitest run src/components/conversation/MessageList.scroll.test.tsx
 Expected: the new identity assertion fails while the resident-top behavior
 tests remain green.
 
-- [ ] **Step 7: Publish the stable command and verify GREEN**
+- [x] **Step 7: Publish the stable command and verify GREEN**
 
 Add:
 
@@ -431,7 +431,7 @@ npx vitest run \
 Expected: all tests pass and appends do not invalidate the Home command or
 mounted room rows.
 
-- [ ] **Step 8: Commit the hook cutover**
+- [x] **Step 8: Commit the hook cutover**
 
 ```bash
 git add apps/fluux/src/components/conversation/useMessageListScroll.ts \
@@ -453,7 +453,7 @@ git commit -m "Route Home positioning through the controller"
 - Consumes: controller-owned Home behavior and invariant from Task 3.
 - Produces: completed step-6 contract.
 
-- [ ] **Step 1: Update the positioning contract**
+- [x] **Step 1: Update the positioning contract**
 
 In `docs/2026-07-23-scroll-positioning-contract.md`:
 
@@ -463,11 +463,11 @@ In `docs/2026-07-23-scroll-positioning-contract.md`:
 - retain the two isolated-context bullets unchanged;
 - update “all six authoritative slices” to “all seven authoritative slices”.
 
-- [ ] **Step 2: Mark completed plan checkboxes**
+- [x] **Step 2: Mark completed plan checkboxes**
 
 As each step is completed, replace its `- [ ]` with `- [x]` in this plan so the committed plan accurately records execution.
 
-- [ ] **Step 3: Run focused controller, hook, and real-engine tests**
+- [x] **Step 3: Run focused controller, hook, and real-engine tests**
 
 Run:
 
@@ -485,7 +485,7 @@ npx playwright test \
 
 Expected: all focused Vitest tests pass and Playwright reports 2/2.
 
-- [ ] **Step 4: Commit the contract**
+- [x] **Step 4: Commit the contract**
 
 ```bash
 git add docs/2026-07-23-scroll-positioning-contract.md \
@@ -504,7 +504,7 @@ git commit -m "Complete scroll positioning migration step 6"
 - Consumes: complete branch state from Tasks 1–4.
 - Produces: evidence that the exact branch is ready for review.
 
-- [ ] **Step 1: Run the full unit/integration suite**
+- [x] **Step 1: Run the full unit/integration suite**
 
 ```bash
 npm test
@@ -512,7 +512,7 @@ npm test
 
 Expected: all SDK and app tests pass; existing environment warnings do not change the exit code.
 
-- [ ] **Step 2: Run static checks**
+- [x] **Step 2: Run static checks**
 
 ```bash
 npm run typecheck
@@ -522,7 +522,7 @@ git diff --check origin/main...HEAD
 
 Expected: typecheck passes, lint has zero errors, and the diff check is clean.
 
-- [ ] **Step 3: Run the complete scroll-invariant suite**
+- [x] **Step 3: Run the complete scroll-invariant suite**
 
 ```bash
 npm run test:scroll
@@ -530,7 +530,7 @@ npm run test:scroll
 
 Expected: all existing 52 scenarios plus the two new engine cases pass.
 
-- [ ] **Step 4: Audit ownership and scope**
+- [x] **Step 4: Audit ownership and scope**
 
 Review:
 
@@ -542,7 +542,7 @@ git status -sb
 
 Confirm the hook has no shadow `home-key` observation or direct Home write outside `ResidentTopExecutor.start`, static preview and selection scrolling are unchanged, and no unrelated files are present.
 
-- [ ] **Step 5: Commit any final plan-state update**
+- [x] **Step 5: Commit any final plan-state update**
 
 If marking Task 5 checkboxes changes the plan:
 
@@ -552,3 +552,13 @@ git commit -m "Record resident-top migration validation"
 ```
 
 Otherwise leave the verified branch unchanged.
+
+Validation recorded on 2026-07-27:
+
+- `npm test`: SDK 5,325 passed; app 5,338 passed and 22 skipped.
+- `npm run typecheck`: passed for both workspaces.
+- `npm run lint`: zero errors; 34 pre-existing warnings.
+- `npm run test:scroll`: 54/54 passed across Chromium and WebKit.
+- Ownership audit: the only live-list resident-top write is
+  `ResidentTopExecutor.start`; static preview center positioning and keyboard
+  selection remain explicitly isolated.

--- a/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+++ b/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
@@ -145,3 +145,8 @@ non-competing contexts.
 
 Step 7—splitting persistence, user intent, history windowing, and browser
 reconciliation out of `useMessageListScroll`—is explicitly outside this PR.
+
+Static preview lists remain an isolated exception: they do not activate a
+controller conversation, so their Home shortcut retains its prior one-shot
+smooth write within the preview scroller. It cannot compete with live-list
+positioning or persistence.

--- a/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+++ b/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
@@ -4,22 +4,26 @@
 
 Complete scroll-positioning migration step 6 by making the generation-aware
 positioning controller the sole owner of the live message list's Home /
-resident-top navigation. Preserve the current smooth animation and history-load
-timing while deleting the hook's direct positioning owner and its shadow-only
-observation.
+resident-top navigation. Preserve the current smooth animation and intended
+history-load guard while deleting the hook's direct positioning owner and its
+shadow-only observation.
 
 ## Current behavior
 
 `useMessageListScroll.scrollToTop` currently:
 
-1. sets `lastLoadTimeRef.current` to prevent the Home action itself from being
-   mistaken for an ordinary load-older trigger;
+1. sets `lastLoadTimeRef.current` intending to prevent the Home action itself
+   from being mistaken for an ordinary load-older trigger;
 2. records a shadow `resident-top` request;
 3. directly calls `scroller.scrollTo({ top: 0, behavior: 'smooth' })`.
 
 The semantic request already exists in `scrollPositionModel`, but the controller
 does not execute it. This is the last live-list position outside the controller's
-shared generation and single-flight lifecycle.
+shared generation and single-flight lifecycle. The old history guard is also
+incomplete: `scrolledAwayFromTopRef` bypasses the cooldown, and native smooth
+scroll progress re-arms it before Home reaches zero. A deep Home jump can
+therefore be mistaken for a load-older gesture and immediately repositioned by
+directional-history preservation.
 
 ## Chosen approach
 
@@ -81,9 +85,12 @@ write.
   the controller-owned executor;
 - reports `scroller.scrollTop` without mutating it during observation.
 
-`lastLoadTimeRef.current = Date.now()` remains before the controller request, so
-the existing load-older guard is unchanged. Ordinary later top-boundary
-navigation can still trigger the existing history-loading path.
+`lastLoadTimeRef.current = Date.now()` remains before the controller request.
+Home also clears the prior `scrolledAwayFromTopRef` evidence, and
+controller-owned scroll events cannot re-arm that user-intent latch. This makes
+the existing guard effective for Home itself. A later genuine user move away
+from the top re-arms the latch, so ordinary later top-boundary navigation can
+still trigger the existing history-loading path.
 
 The published `scrollToTop` command will use a stable callback shell. The
 executor legitimately closes over current conversation/window facts, but those
@@ -118,9 +125,10 @@ animation in the frame loop.
 
 Hook tests must prove through runtime behavior that Home and Mod+ArrowUp route
 through the controller, preserve `behavior: 'smooth'`, issue exactly one write,
-and keep the published callback stable across message/window updates. These
-tests must fail if the deleted shadow-plus-direct-write path is restored; they
-must not merely grep implementation text.
+keep the published callback stable across message/window updates, and do not
+reinterpret smooth-scroll progress as load-older intent. These tests must fail
+if the deleted shadow-plus-direct-write path is restored; they must not merely
+grep implementation text.
 
 The Playwright scroll-invariant suite will add a real-engine Home scenario for
 Chromium and WebKit: start away from resident top, invoke Home, observe smooth

--- a/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+++ b/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
@@ -116,10 +116,11 @@ Each behavior test must have a plausible wrong implementation that would make it
 fail. The single-write test is the control against restarting the smooth
 animation in the frame loop.
 
-Hook tests must prove that Home and Mod+ArrowUp route through the controller,
-preserve `behavior: 'smooth'`, and keep the published callback stable across
-message/window updates. A source-level ownership test must fail against the
-deleted shadow-plus-direct-write shape.
+Hook tests must prove through runtime behavior that Home and Mod+ArrowUp route
+through the controller, preserve `behavior: 'smooth'`, issue exactly one write,
+and keep the published callback stable across message/window updates. These
+tests must fail if the deleted shadow-plus-direct-write path is restored; they
+must not merely grep implementation text.
 
 The Playwright scroll-invariant suite will add a real-engine Home scenario for
 Chromium and WebKit: start away from resident top, invoke Home, observe smooth

--- a/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+++ b/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
@@ -1,0 +1,138 @@
+# Resident-Top Controller Migration Design
+
+## Goal
+
+Complete scroll-positioning migration step 6 by making the generation-aware
+positioning controller the sole owner of the live message list's Home /
+resident-top navigation. Preserve the current smooth animation and history-load
+timing while deleting the hook's direct positioning owner and its shadow-only
+observation.
+
+## Current behavior
+
+`useMessageListScroll.scrollToTop` currently:
+
+1. sets `lastLoadTimeRef.current` to prevent the Home action itself from being
+   mistaken for an ordinary load-older trigger;
+2. records a shadow `resident-top` request;
+3. directly calls `scroller.scrollTo({ top: 0, behavior: 'smooth' })`.
+
+The semantic request already exists in `scrollPositionModel`, but the controller
+does not execute it. This is the last live-list position outside the controller's
+shared generation and single-flight lifecycle.
+
+## Chosen approach
+
+Add an authoritative resident-top controller slice with a leased observation
+loop.
+
+The executor issues exactly one smooth write after the request is accepted. The
+controller then observes `scrollTop` on animation frames until the browser has
+remained within 1 pixel of resident top for two consecutive frames. The loop
+must never reissue the smooth write: restarting a native animation on every
+frame would recreate scroll fighting.
+
+The observation budget is 120 frames. If the browser does not reach resident
+top within that budget, the controller completes best-effort and does not snap.
+This preserves the current one-shot behavior and avoids a late visible jump.
+
+Instant per-frame convergence is rejected because it would remove the existing
+Home animation. A controller method that merely wraps the current direct call
+is also rejected because it would not own cancellation, supersession, or
+completion.
+
+## Controller contract
+
+`scrollPositionModel` will export `ResidentTopRequest`, the existing
+`user-navigation/resident-top` member of `PositionRequest`.
+
+`positioningController` will expose:
+
+- `ResidentTopExecutor`, with reachability, leased loop creation, one-shot
+  smooth start, current `scrollTop` observation, and completion reporting;
+- `beginResidentTopNavigation`, which mints and accepts the request, resolves
+  current reachability, cancels older executions, starts the smooth write once,
+  and schedules observation;
+- a resident-top execution state holding its request, operation/abort state,
+  frame loop, remaining budget, and stable-frame count.
+
+The request uses the same module-private monotonic generation allocator and
+`PositionExecutionLease` contract as the six existing authoritative slices.
+A newer positioning request, conversation deactivation, or native user input
+aborts the resident-top loop. Stale callbacks must fail their lease check before
+they can observe, settle, or complete anything.
+
+An empty resident window is treated as unavailable for this explicit command:
+the current one-shot write would have no useful effect, and retaining an
+unrefreshable pending resident-top request could incorrectly supersede later
+content behavior.
+
+Completion outcomes are `settled`, `best-effort`, `user-takeover`, and
+`superseded`. Completion is diagnostic and must not introduce another pixel
+write.
+
+## Hook adapter
+
+`useMessageListScroll` will build a resident-top executor that:
+
+- derives reachability from the current first resident row;
+- uses `beginControllerFrameLoop('resident-top', lease)`;
+- calls `scroller.scrollTo({ top: 0, behavior: 'smooth' })` exactly once from
+  the controller-owned executor;
+- reports `scroller.scrollTop` without mutating it during observation.
+
+`lastLoadTimeRef.current = Date.now()` remains before the controller request, so
+the existing load-older guard is unchanged. Ordinary later top-boundary
+navigation can still trigger the existing history-loading path.
+
+The published `scrollToTop` command will use a stable callback shell. The
+executor legitimately closes over current conversation/window facts, but those
+changes must not rebind the global Home / Mod+ArrowUp listener or invalidate
+consumers on every append.
+
+The old `observeRequest({ event: 'home-key', ... })` block and the hook-level
+direct `scrollTo` call are deleted.
+
+## Failure behavior
+
+All controller/executor calls remain inside the existing scroll instrumentation
+boundary. Invalid reachability or a missing scroller results in a no-op request,
+not an exception escaping the keyboard handler. A failed request does not fall
+back to an unleased direct write, because that would retain the competing
+position owner this migration is meant to remove.
+
+## Tests
+
+Controller tests must prove:
+
+- a resident-top request performs one smooth start and only observes afterward;
+- changing observed positions converge and settle without additional writes;
+- native user input cancels the current generation and stale frames do nothing;
+- a newer request supersedes resident-top before its next frame;
+- budget exhaustion completes best-effort without a forced snap;
+- an empty window does not leave an active resident-top owner.
+
+Each behavior test must have a plausible wrong implementation that would make it
+fail. The single-write test is the control against restarting the smooth
+animation in the frame loop.
+
+Hook tests must prove that Home and Mod+ArrowUp route through the controller,
+preserve `behavior: 'smooth'`, and keep the published callback stable across
+message/window updates. A source-level ownership test must fail against the
+deleted shadow-plus-direct-write shape.
+
+The Playwright scroll-invariant suite will add a real-engine Home scenario for
+Chromium and WebKit: start away from resident top, invoke Home, observe smooth
+progress to the resident top, and assert no scroll divergence or instrumentation
+error. Existing 52 scenarios remain the regression gate.
+
+## Documentation and completion
+
+The scroll-positioning contract will mark step 6 complete, remove resident-top
+from the remaining-owner list, and state that all live-list semantic positions
+are controller-owned. `SearchContextView` positioning and keyboard-selection
+`scrollIntoView({ block: 'nearest' })` remain documented as isolated,
+non-competing contexts.
+
+Step 7—splitting persistence, user intent, history windowing, and browser
+reconciliation out of `useMessageListScroll`—is explicitly outside this PR.

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -439,6 +439,71 @@ async function activateChat(page: Page, jid: string): Promise<void> {
 
 // ── Invariant tests ───────────────────────────────────────────────────────────
 
+test.describe('Controller-owned resident-top navigation', () => {
+  test('Home issues one smooth write, then the controller observes it to settlement', async ({
+    page,
+  }) => {
+    const trace: string[] = []
+    page.on('console', (message) => {
+      const text = message.text()
+      if (text.includes('RESIDENT TOP: controller completed')) trace.push(text)
+    })
+
+    await loadDemo(page)
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).__fluuxScrollDebug?.(true)
+    })
+    await navigateToStressRoom(page)
+    // Start materially away from resident top without turning this into a deep virtualized-list
+    // animation test. The approved contract deliberately allows a native smooth scroll that a
+    // browser interrupts during deep re-windowing to time out best-effort without a corrective
+    // snap; the controller unit test covers that 120-frame path.
+    await setScrollTop(page, 800)
+    await page.waitForTimeout(300)
+
+    const initialScrollTop = await getScrollTop(page)
+    expect(initialScrollTop, 'precondition: resident window must start below its top').toBeGreaterThan(1)
+
+    await page.evaluate(() => {
+      const scroller = document.querySelector('[data-message-list]') as HTMLDivElement | null
+      if (!scroller) return
+      const nativeScrollTo = scroller.scrollTo.bind(scroller)
+      const writes: ScrollToOptions[] = []
+      ;(
+        window as Window & {
+          __fluuxResidentTopWrites?: ScrollToOptions[]
+        }
+      ).__fluuxResidentTopWrites = writes
+      scroller.scrollTo = ((...args: Parameters<HTMLDivElement['scrollTo']>) => {
+        const first = args[0]
+        if (typeof first === 'object') writes.push({ ...first })
+        return nativeScrollTo(...args)
+      }) as HTMLDivElement['scrollTo']
+    })
+
+    const scroller = page.locator('[data-message-list]').first()
+    await scroller.focus()
+    await page.keyboard.press('Home')
+
+    await expect.poll(() => getScrollTop(page), {
+      timeout: 5000,
+      message: 'Home navigation must reach the resident-window top',
+    }).toBeLessThanOrEqual(1)
+    await expect.poll(() => trace.length, {
+      timeout: 5000,
+      message: `resident-top controller did not settle: ${JSON.stringify(trace)}`,
+    }).toBe(1)
+
+    const writes = await page.evaluate(() => (
+      window as Window & {
+        __fluuxResidentTopWrites?: ScrollToOptions[]
+      }
+    ).__fluuxResidentTopWrites ?? [])
+    expect(writes).toEqual([{ top: 0, behavior: 'smooth' }])
+  })
+})
+
 test.describe('Virtualization scroll invariants', () => {
 
   // ── 1: Prepend holds position ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add resident-top/Home as the seventh authoritative positioning-controller slice
- start the native smooth scroll exactly once, then observe it under a generation-aware lease until settled or best-effort timeout
- cancel stale resident-top work on user takeover, supersession, and conversation deactivation
- keep the published Home callback stable across message/window updates
- prevent smooth Home progress from being mistaken for a load-older gesture
- preserve the explicitly isolated one-shot Home behavior in static search/stranger previews
- mark scroll-positioning migration step 6 complete and document the remaining isolated contexts

## Why

Home was the last live message-list semantic position still writing directly outside the controller. It could race other positioning generations, and its intended history-load cooldown was bypassed because smooth-scroll progress re-armed the top-boundary travel latch. This moves the live-list command under the same single-flight lifecycle as the other positioning mechanisms without restarting the browser animation on every frame.

## Behavior

- Home and Mod+ArrowUp retain one native `behavior: 'smooth'` write.
- The controller only observes afterward: two consecutive frames within 1px settle the request.
- A 120-frame timeout completes best-effort without a corrective snap.
- Empty resident windows are rejected without retaining an owner.
- Static preview lists remain isolated from the live-list controller and keep their prior one-shot Home scroll.