### PR TITLE
fix(muc): join password-protected rooms after a restart (#1126)

### DIFF
--- a/apps/fluux/src/components/RoomPasswordDialog.tsx
+++ b/apps/fluux/src/components/RoomPasswordDialog.tsx
@@ -1,0 +1,76 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ModalOverlay } from './ModalOverlay'
+import { TextInput } from './ui/TextInput'
+
+interface RoomPasswordDialogProps {
+  /** Why we are asking: the initial request, or "incorrect password" on a retry. */
+  message: string
+  /** The entered password (never trimmed - room passwords are opaque strings). */
+  onSubmit: (password: string) => void
+  onCancel: () => void
+}
+
+/**
+ * Asks for a MUC room password after the server refused a join with
+ * `not-authorized`. Used by {@link useRoomPasswordPrompt} for every join path
+ * outside the Join Room modal (sidebar, room view, deep links).
+ */
+export function RoomPasswordDialog({ message, onSubmit, onCancel }: RoomPasswordDialogProps) {
+  const { t } = useTranslation()
+  const [password, setPassword] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <ModalOverlay onClose={onCancel} focusRef={inputRef} panelClassName="p-4">
+      {({ close }) => (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            onSubmit(password)
+          }}
+        >
+          <h3 className="text-lg font-semibold text-fluux-text mb-2">
+            {t('rooms.roomPassword')}
+          </h3>
+          {/* Carries the ask ("this room is password-protected…") or, on a retry,
+              the "incorrect password" hint - so the field needs no visible label
+              of its own on top of the title. */}
+          <p className="text-sm text-fluux-muted mb-4">{message}</p>
+
+          <TextInput
+            ref={inputRef}
+            id="room-password-prompt"
+            aria-label={t('rooms.roomPassword')}
+            type="password"
+            autoComplete="off"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 mb-4 bg-fluux-bg text-fluux-text rounded
+                       border border-transparent focus:border-fluux-brand
+                       placeholder:text-fluux-muted"
+          />
+
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={close}
+              className="px-4 py-2 text-sm text-fluux-text bg-fluux-hover hover:bg-fluux-active
+                         rounded-lg transition-colors"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={password.length === 0}
+              className="px-4 py-2 text-sm text-fluux-text-on-accent bg-fluux-brand hover:bg-fluux-brand/90
+                         disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+            >
+              {t('rooms.joinRoom')}
+            </button>
+          </div>
+        </form>
+      )}
+    </ModalOverlay>
+  )
+}

--- a/apps/fluux/src/components/RoomView.test.tsx
+++ b/apps/fluux/src/components/RoomView.test.tsx
@@ -214,6 +214,10 @@ vi.mock('@fluux/sdk', () => ({
     getRoomInfo: vi.fn().mockResolvedValue(null),
     acknowledgeNonAnonymousRoom: vi.fn(),
     isNonAnonymousRoomAcknowledged: () => false,
+    // The join prompt joins through useRoomPasswordPrompt (issue #1126), which
+    // sources its actions here rather than from the useRoomActive spread.
+    joinRoom: mockJoinRoom,
+    joinResult: mockJoinResult,
   }),
   useXMPP: () => ({
     client: { profile: { fetchVCard: vi.fn().mockResolvedValue(null) } },
@@ -665,6 +669,35 @@ describe('RoomView', () => {
         const toasts = useToastStore.getState().toasts
         expect(toasts.some((t) => t.type === 'error' && t.message === 'rooms.membersOnly')).toBe(true)
       })
+    })
+
+    // Issue #1126: a password-protected room used to dead-end here — the join
+    // failed and the user had nowhere to type the password.
+    it('asks for the room password when the server refuses the join', async () => {
+      const { useToastStore } = await import('@/stores/toastStore')
+      useToastStore.setState({ toasts: [] })
+      mockActiveRoom = createRoom({ joined: false })
+      mockJoinRoom.mockResolvedValue(undefined)
+      mockJoinResult
+        .mockRejectedValueOnce(new RoomJoinError('room@conference.example.com', 'not-authorized'))
+        .mockResolvedValue(undefined)
+
+      render(<RoomView />)
+      fireEvent.click(screen.getByText(/rooms.joinToParticipate/))
+
+      const input = await screen.findByLabelText('rooms.roomPassword')
+      fireEvent.change(input, { target: { value: ' s3cret ' } })
+      fireEvent.submit(input)
+
+      await waitFor(() => {
+        // Retried with the typed password, untrimmed (passwords are opaque).
+        expect(mockJoinRoom).toHaveBeenLastCalledWith(
+          'room@conference.example.com',
+          expect.any(String),
+          { password: ' s3cret ' },
+        )
+      })
+      expect(useToastStore.getState().toasts).toHaveLength(0)
     })
   })
 

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -36,6 +36,7 @@ import { CommandMenu } from './composer/CommandMenu'
 import { CommandHelpPanel } from './composer/CommandHelpPanel'
 import { visibleCommands } from '@/commands/registry'
 import { useRoomJoinWarning } from '@/hooks/useRoomJoinWarning'
+import { useRoomPasswordPrompt } from '@/hooks/useRoomPasswordPrompt'
 import { MediaAutoloadProvider } from '@/contexts'
 import { computeMediaAutoload } from '@/utils/mediaAutoload'
 import { useSettingsStore } from '@/stores/settingsStore'
@@ -97,7 +98,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // Active-room state + messaging/scroll actions. Poll / moderation /
   // management actions come from the focused hooks below (they subscribe to no
   // store, so they add no re-render triggers).
-  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, joinRoom, joinResult, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeMAMState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
+  const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeMAMState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
   const { sendPoll, votePoll, closePoll } = usePolls()
   const { moderateMessage, setAffiliation, setRole } = useRoomModeration()
   const { setRoomNotifyAll, setRoomAvatar, clearRoomAvatar, submitRoomConfig, setSubject, destroyRoom } = useRoomManagement()
@@ -112,6 +113,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   const { processMessageForLinkPreview } = useLinkPreview()
   const { resolvedMode } = useMode()
   const { confirmJoin, warningDialog } = useRoomJoinWarning()
+  const { joinRoomWithPassword, passwordDialog } = useRoomPasswordPrompt()
 
   // Handler to open search scoped to this room
   const handleSearchInConversation = activeRoom && onSearchInConversation
@@ -651,8 +653,8 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
               // Issue #37: warn before joining a room that would expose the user's real JID.
               if (await confirmJoin(activeRoom.jid)) {
                 try {
-                  await joinRoom(activeRoom.jid, activeRoom.nickname)
-                  await joinResult(activeRoom.jid)
+                  // Prompts for the room password when the server asks for one.
+                  await joinRoomWithPassword(activeRoom.jid, activeRoom.nickname)
                 } catch (err) {
                   addToast('error', getRoomJoinErrorMessage(t, err))
                 }
@@ -661,6 +663,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
           />
         )}
         {warningDialog}
+        {passwordDialog}
       </div>
 
       {/* Occupant panel (>=768px; <768 uses the full-screen panel in ChatLayout).

--- a/apps/fluux/src/components/sidebar-components/RoomInvitationsBanner.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomInvitationsBanner.test.tsx
@@ -15,7 +15,15 @@ let mucInvitations: Array<{ id: string; roomJid: string; from: string; password?
 vi.mock('@fluux/sdk', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@fluux/sdk')>()),
   useEvents: () => ({ mucInvitations, acceptInvitation, declineInvitation }),
-  useRoomActions: () => ({ getRoomInfo, acknowledgeNonAnonymousRoom: acknowledgeNonAnon, isNonAnonymousRoomAcknowledged: isNonAnonAck }),
+  useRoomActions: () => ({
+    getRoomInfo,
+    acknowledgeNonAnonymousRoom: acknowledgeNonAnon,
+    isNonAnonymousRoomAcknowledged: isNonAnonAck,
+    // useRoomPasswordPrompt sources its join actions here; the banner only uses
+    // its withPasswordPrompt wrapper, which drives acceptInvitation instead.
+    joinRoom: vi.fn(),
+    joinResult: vi.fn(),
+  }),
 }))
 vi.mock('@fluux/sdk/react', () => ({
   useChatStore: (sel: (s: { setActiveConversation: typeof setActiveConversation }) => unknown) => sel({ setActiveConversation }),
@@ -25,9 +33,16 @@ const navigateToRooms = vi.fn()
 vi.mock('@/hooks', () => ({ useRouteSync: () => ({ navigateToRooms }) }))
 
 import { RoomInvitationsBanner } from './RoomInvitationsBanner'
+import { RoomJoinError } from '@fluux/sdk'
+import { useToastStore } from '@/stores/toastStore'
 
 describe('RoomInvitationsBanner', () => {
-  beforeEach(() => { vi.clearAllMocks(); mucInvitations = [] })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mucInvitations = []
+    acceptInvitation.mockResolvedValue(undefined)
+    useToastStore.setState({ toasts: [] })
+  })
 
   it('renders nothing when there are no invitations', () => {
     const { container } = render(<RoomInvitationsBanner />)
@@ -44,5 +59,65 @@ describe('RoomInvitationsBanner', () => {
     fireEvent.click(screen.getByText('rooms.nonAnonWarningConfirm'))
     await waitFor(() => expect(acceptInvitation).toHaveBeenCalledWith('room@conf.example.com', undefined))
     expect(setActiveRoom).toHaveBeenCalledWith('room@conf.example.com')
+  })
+
+  // Issue #1126: an invitation to a password-protected room carries no password
+  // unless the inviter added one. Accepting used to fail silently AND drop the
+  // invitation, leaving no way back into the room.
+  describe('password-protected room', () => {
+    const invite = () => {
+      mucInvitations = [{ id: 'i1', roomJid: 'private@conf.example.com', from: 'friend@example.com' }]
+      getRoomInfo.mockResolvedValue({ isNonAnonymous: false, isPrivate: true })
+    }
+
+    it('asks for the password when the join is refused, then retries with it', async () => {
+      invite()
+      acceptInvitation
+        .mockRejectedValueOnce(new RoomJoinError('private@conf.example.com', 'not-authorized'))
+        .mockResolvedValue(undefined)
+
+      render(<RoomInvitationsBanner />)
+      fireEvent.click(screen.getByText('events.join'))
+
+      const input = await screen.findByLabelText('rooms.roomPassword')
+      fireEvent.change(input, { target: { value: 's3cret' } })
+      fireEvent.submit(input)
+
+      await waitFor(() =>
+        expect(acceptInvitation).toHaveBeenLastCalledWith('private@conf.example.com', 's3cret')
+      )
+      expect(setActiveRoom).toHaveBeenCalledWith('private@conf.example.com')
+      expect(useToastStore.getState().toasts).toHaveLength(0)
+    })
+
+    it('does not open the room when the password prompt is cancelled', async () => {
+      invite()
+      acceptInvitation.mockRejectedValue(new RoomJoinError('private@conf.example.com', 'not-authorized'))
+
+      render(<RoomInvitationsBanner />)
+      fireEvent.click(screen.getByText('events.join'))
+
+      fireEvent.click(await screen.findByText('common.cancel'))
+
+      await waitFor(() =>
+        expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+      )
+      expect(setActiveRoom).not.toHaveBeenCalled()
+      expect(useToastStore.getState().toasts).toHaveLength(0)
+    })
+
+    it('toasts a refusal a password cannot fix, without opening the room', async () => {
+      invite()
+      acceptInvitation.mockRejectedValue(new RoomJoinError('private@conf.example.com', 'registration-required'))
+
+      render(<RoomInvitationsBanner />)
+      fireEvent.click(screen.getByText('events.join'))
+
+      await waitFor(() =>
+        expect(useToastStore.getState().toasts.some((t) => t.message === 'rooms.membersOnly')).toBe(true)
+      )
+      expect(setActiveRoom).not.toHaveBeenCalled()
+      expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/fluux/src/components/sidebar-components/RoomInvitationsBanner.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomInvitationsBanner.tsx
@@ -3,6 +3,9 @@ import { useEvents } from '@fluux/sdk'
 import { useChatStore, useRoomStore } from '@fluux/sdk/react'
 import { useRouteSync } from '@/hooks'
 import { useRoomJoinWarning } from '@/hooks/useRoomJoinWarning'
+import { useRoomPasswordPrompt } from '@/hooks/useRoomPasswordPrompt'
+import { useToastStore } from '@/stores/toastStore'
+import { getRoomJoinErrorMessage } from '@/utils/roomJoinError'
 import { MucInvitationItem } from './MucInvitationItem'
 
 export function RoomInvitationsBanner() {
@@ -12,6 +15,8 @@ export function RoomInvitationsBanner() {
   const setActiveRoom = useRoomStore((s) => s.setActiveRoom)
   const { navigateToRooms } = useRouteSync()
   const { confirmJoin, warningDialog } = useRoomJoinWarning()
+  const { withPasswordPrompt, passwordDialog } = useRoomPasswordPrompt()
+  const addToast = useToastStore((s) => s.addToast)
 
   if (mucInvitations.length === 0) return null
 
@@ -19,7 +24,17 @@ export function RoomInvitationsBanner() {
   // room that would expose the user's real JID.
   const handleAccept = async (roomJid: string, password?: string) => {
     if (!(await confirmJoin(roomJid))) return
-    await acceptInvitation(roomJid, password)
+    try {
+      // Issue #1126: an invitation to a password-protected room carries no
+      // password unless the inviter added one. Ask for it rather than failing.
+      // acceptInvitation keeps the invitation when the join is refused, so a
+      // cancelled prompt (or any other error) leaves the banner intact to retry.
+      const joined = await withPasswordPrompt((typed) => acceptInvitation(roomJid, typed ?? password))
+      if (!joined) return
+    } catch (err) {
+      addToast('error', getRoomJoinErrorMessage(t, err))
+      return
+    }
     void setActiveConversation(null)
     void setActiveRoom(roomJid)
     navigateToRooms(roomJid)
@@ -41,6 +56,7 @@ export function RoomInvitationsBanner() {
         ))}
       </div>
       {warningDialog}
+      {passwordDialog}
     </div>
   )
 }

--- a/apps/fluux/src/components/sidebar-components/RoomsList.join.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.join.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Issue #1126: double-clicking a bookmarked, password-protected room in the
+ * sidebar is the exact path the bug was reported on. It used to join with no
+ * password, get refused, and (with the error swallowed) sit at "Joining…".
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { Room } from '@fluux/sdk'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+const h = vi.hoisted(() => ({
+  room: null as Room | null,
+  joinRoom: vi.fn(),
+  joinResult: vi.fn(),
+  activateRoom: vi.fn(),
+}))
+
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    roomActivityTone: () => 'neutral',
+    generateConsistentColorHexSync: () => '#123456',
+    roomStore: {
+      getState: () => ({
+        activeRoomJid: null,
+        getRoom: () => h.room,
+        activateRoom: h.activateRoom,
+      }),
+    },
+    useRoomActions: () => ({
+      joinRoom: h.joinRoom,
+      joinResult: h.joinResult,
+      leaveRoom: vi.fn(),
+      setBookmark: vi.fn(),
+      removeBookmark: vi.fn(),
+      setActiveRoom: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('@fluux/sdk/react', () => ({
+  useRoomStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      roomSidebarJids: () => [`bookmarked ${h.room?.jid ?? ''}`],
+      activeRoomJid: null,
+      getRoom: () => h.room,
+      drafts: new Map(),
+    }),
+  useChatStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setActiveConversation: vi.fn() }),
+  useIgnoreStore: (selector: (s: { ignoredUsers: Record<string, unknown[]> }) => unknown) =>
+    selector({ ignoredUsers: {} }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useContextMenu: () => ({
+    isOpen: false,
+    longPressTriggered: { current: false },
+    handleContextMenu: () => {},
+    handleTouchStart: () => {},
+    handleTouchEnd: () => {},
+    position: { x: 0, y: 0 },
+    menuRef: { current: null },
+    close: () => {},
+  }),
+  useListKeyboardNav: () => ({
+    selectedIndex: -1,
+    isKeyboardNav: false,
+    getItemProps: () => ({}),
+    getItemAttribute: () => ({}),
+    getContainerProps: () => ({}),
+  }),
+  useRouteSync: () => ({ navigateToRooms: vi.fn() }),
+}))
+
+vi.mock('@/stores/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { timeFormat: string; densityMode: string }) => unknown) =>
+    selector({ timeFormat: '24h', densityMode: 'comfortable' }),
+}))
+
+vi.mock('../Tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('./RoomInvitationsBanner', () => ({ RoomInvitationsBanner: () => null }))
+
+// Imported AFTER the mocks so the component picks them up.
+import { RoomsList } from './RoomsList'
+import { RoomJoinError } from '@fluux/sdk'
+import { useToastStore } from '@/stores/toastStore'
+
+const ROOM_JID = 'board@conference.example.com'
+
+const makeRoom = (over: Partial<Room> = {}): Room =>
+  ({
+    jid: ROOM_JID,
+    name: 'Board',
+    nickname: 'me',
+    joined: false,
+    isJoining: false,
+    isBookmarked: true,
+    autojoin: false,
+    occupants: new Map(),
+    messages: [],
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set<string>(),
+    lastMessage: null,
+    ...over,
+  }) as unknown as Room
+
+describe('RoomsList join', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useToastStore.setState({ toasts: [] })
+    h.room = makeRoom()
+    h.joinRoom.mockResolvedValue(undefined)
+    h.joinResult.mockResolvedValue(undefined)
+  })
+
+  it('asks for the password when the server refuses the join, then retries', async () => {
+    h.joinResult
+      .mockRejectedValueOnce(new RoomJoinError(ROOM_JID, 'not-authorized'))
+      .mockResolvedValue(undefined)
+
+    render(<RoomsList />)
+    fireEvent.doubleClick(screen.getByText('Board'))
+
+    const input = await screen.findByLabelText('rooms.roomPassword')
+    fireEvent.change(input, { target: { value: 's3cret' } })
+    fireEvent.submit(input)
+
+    await waitFor(() =>
+      expect(h.joinRoom).toHaveBeenLastCalledWith(ROOM_JID, 'me', { password: 's3cret' })
+    )
+    // Joined for real → the room is opened, and no error was surfaced.
+    await waitFor(() => expect(h.activateRoom).toHaveBeenCalledWith(ROOM_JID))
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('does not open a room the user cancelled the password prompt for', async () => {
+    h.joinResult.mockRejectedValue(new RoomJoinError(ROOM_JID, 'not-authorized'))
+
+    render(<RoomsList />)
+    fireEvent.doubleClick(screen.getByText('Board'))
+
+    fireEvent.click(await screen.findByText('common.cancel'))
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+    )
+    expect(h.activateRoom).not.toHaveBeenCalled()
+    // Cancelling is not a failure - no error toast.
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('still toasts a failure a password cannot fix', async () => {
+    h.joinResult.mockRejectedValue(new RoomJoinError(ROOM_JID, 'registration-required'))
+
+    render(<RoomsList />)
+    fireEvent.doubleClick(screen.getByText('Board'))
+
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts.some((t) => t.message === 'rooms.membersOnly')).toBe(true)
+    )
+    expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/components/sidebar-components/RoomsList.tsx
+++ b/apps/fluux/src/components/sidebar-components/RoomsList.tsx
@@ -23,6 +23,7 @@ import { formatConversationTime } from '@/utils/dateFormat'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useToastStore } from '@/stores/toastStore'
 import { getRoomJoinErrorMessage } from '@/utils/roomJoinError'
+import { useRoomPasswordPrompt } from '@/hooks/useRoomPasswordPrompt'
 import { CreateRoomModal } from '../CreateRoomModal'
 import {
   Hash,
@@ -61,7 +62,8 @@ export function RoomsList() {
   // a message to one room re-renders just that row. drafts/typing are likewise per-row.
   const sidebarEntries = useRoomStore(useShallow((s) => s.roomSidebarJids()))
   const activeRoomJid = useRoomStore((s) => s.activeRoomJid)
-  const { joinRoom, joinResult, leaveRoom, setBookmark, removeBookmark, setActiveRoom } = useRoomActions()
+  const { leaveRoom, setBookmark, removeBookmark, setActiveRoom } = useRoomActions()
+  const { joinRoomWithPassword, passwordDialog } = useRoomPasswordPrompt()
   const setActiveConversation = useChatStore((s) => s.setActiveConversation)
   const addToast = useToastStore((s) => s.addToast)
   const { navigateToRooms } = useRouteSync()
@@ -99,8 +101,8 @@ export function RoomsList() {
   // React.memo, re-rendering every row. Building the handlers once in a ref and
   // routing through a "latest" ref keeps their identity stable for the lifetime
   // of the list while always invoking the current actions.
-  const latestRef = useRef({ setActiveConversation, setActiveRoom, joinRoom, joinResult, leaveRoom, removeBookmark, setBookmark, navigateToRooms, setEditingRoomJid, addToast, t })
-  latestRef.current = { setActiveConversation, setActiveRoom, joinRoom, joinResult, leaveRoom, removeBookmark, setBookmark, navigateToRooms, setEditingRoomJid, addToast, t }
+  const latestRef = useRef({ setActiveConversation, setActiveRoom, joinRoomWithPassword, leaveRoom, removeBookmark, setBookmark, navigateToRooms, setEditingRoomJid, addToast, t })
+  latestRef.current = { setActiveConversation, setActiveRoom, joinRoomWithPassword, leaveRoom, removeBookmark, setBookmark, navigateToRooms, setEditingRoomJid, addToast, t }
 
   const handlersRef = useRef<{
     onSelect: (roomJid: string) => void
@@ -130,8 +132,8 @@ export function RoomsList() {
           void roomStore.getState().activateRoom(roomJid)
         } else {
           try {
-            await L.joinRoom(roomJid, room?.nickname ?? '')
-            await L.joinResult(roomJid)
+            // Prompts for the room password when the server asks for one.
+            if (!(await L.joinRoomWithPassword(roomJid, room?.nickname ?? ''))) return
           } catch (err) {
             // Do not activate/navigate into a room we failed to join.
             L.addToast('error', getRoomJoinErrorMessage(L.t, err))
@@ -147,8 +149,7 @@ export function RoomsList() {
         const room = roomStore.getState().getRoom(roomJid)
         void (async () => {
           try {
-            await L.joinRoom(roomJid, room?.nickname ?? '')
-            await L.joinResult(roomJid)
+            await L.joinRoomWithPassword(roomJid, room?.nickname ?? '')
           } catch (err) {
             L.addToast('error', getRoomJoinErrorMessage(L.t, err))
           }
@@ -281,6 +282,9 @@ export function RoomsList() {
       {showCreateRoom && (
         <CreateRoomModal onClose={() => setShowCreateRoom(false)} />
       )}
+
+      {/* Room password prompt (shown when a join is refused with 401) */}
+      {passwordDialog}
     </div>
   )
 }

--- a/apps/fluux/src/demo/constants.ts
+++ b/apps/fluux/src/demo/constants.ts
@@ -11,6 +11,11 @@ export const SELF_NICK = 'You'
 export const ROOM_JID = `team@${CONFERENCE}`
 export const DESIGN_ROOM_JID = `design@${CONFERENCE}`
 
+// Password-protected room: bookmarked but not joined, so the demo can exercise
+// the unlock path (issue #1126). The password is shown in the join prompt hint.
+export const BOARD_ROOM_JID = `board@${CONFERENCE}`
+export const BOARD_ROOM_PASSWORD = 'fluux'
+
 // Discoverable room JIDs (not pre-joined, visible in Browse Rooms)
 export const ENGINEERING_ROOM_JID = `engineering@${CONFERENCE}`
 export const RANDOM_ROOM_JID = `random@${CONFERENCE}`

--- a/apps/fluux/src/demo/demoData.ts
+++ b/apps/fluux/src/demo/demoData.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DemoData, DemoAnimationStep } from '@fluux/sdk/demo'
-import { SELF, DOMAIN, CONFERENCE } from './constants'
+import { SELF, DOMAIN, CONFERENCE, BOARD_ROOM_PASSWORD } from './constants'
 import { DEMO_CONTACTS, DEMO_PRESENCES } from './contacts'
 import { getDemoConversations, getDemoMessages } from './conversations'
 import { getDemoRooms } from './rooms'
@@ -23,7 +23,9 @@ export function buildDemoData(): DemoData {
     rooms: getDemoRooms(),
     subscriptionRequests: [`olivia@${DOMAIN}`, `alex@${DOMAIN}`],
     mucInvitations: [
-      { roomJid: `design-team@${CONFERENCE}`, from: `ava@${DOMAIN}`, reason: 'Join us for the redesign kickoff' },
+      // Password-protected, and the invitation carries no password: accepting it
+      // has to ask for one (issue #1126). Same password as the Board room.
+      { roomJid: `design-team@${CONFERENCE}`, from: `ava@${DOMAIN}`, reason: 'Join us for the redesign kickoff', requiredPassword: BOARD_ROOM_PASSWORD },
     ],
     strangerMessages: [
       { from: `recruiter@${DOMAIN}`, body: 'Hi! Are you open to new roles?' },

--- a/apps/fluux/src/demo/rooms/boardPrivate.ts
+++ b/apps/fluux/src/demo/rooms/boardPrivate.ts
@@ -1,0 +1,54 @@
+import type { RoomMessage } from '@fluux/sdk'
+import type { DemoRoomData } from '@fluux/sdk/demo'
+import { hoursAgo } from '@fluux/sdk/demo'
+import { DOMAIN, SELF_JID, SELF_NICK, BOARD_ROOM_JID, BOARD_ROOM_PASSWORD } from '../constants'
+
+/**
+ * A password-protected room the demo user has bookmarked but is NOT in
+ * (issue #1126): the state a private room is in right after a restart.
+ *
+ * Joining it exercises the whole unlock path offline — the simulated service
+ * refuses the join with a 401, the client asks for the password, and a correct
+ * one is remembered for the next join.
+ */
+export const BOARD_ROOM_MESSAGES: RoomMessage[] = [
+  {
+    type: 'groupchat', id: 'demo-board-1', from: `${BOARD_ROOM_JID}/Olivia`, nick: 'Olivia',
+    body: 'Agenda for Thursday is in the shared folder', timestamp: hoursAgo(30), isOutgoing: false, roomJid: BOARD_ROOM_JID,
+  },
+  {
+    type: 'groupchat', id: 'demo-board-2', from: `${BOARD_ROOM_JID}/${SELF_NICK}`, nick: SELF_NICK,
+    body: 'Thanks — I will add the hiring plan before the meeting', timestamp: hoursAgo(29.5), isOutgoing: true, roomJid: BOARD_ROOM_JID,
+  },
+]
+
+export function getBoardRoom(): DemoRoomData {
+  return {
+    room: {
+      jid: BOARD_ROOM_JID,
+      name: 'Board',
+      nickname: SELF_NICK,
+      // Bookmarked, but not currently joined: the room has to be unlocked.
+      joined: false,
+      isBookmarked: true,
+      autojoin: false,
+      isPrivate: true,
+      supportsMAM: true,
+      supportsReactions: true,
+      unreadCount: 0,
+      mentionsCount: 0,
+      typingUsers: new Set(),
+      occupants: new Map(),
+      messages: [],
+      lastMessage: BOARD_ROOM_MESSAGES.at(-1),
+    },
+    occupants: [
+      { nick: SELF_NICK, jid: SELF_JID, affiliation: 'member', role: 'participant' },
+      { nick: 'Olivia', jid: `olivia@${DOMAIN}`, affiliation: 'owner', role: 'moderator' },
+    ],
+    messages: BOARD_ROOM_MESSAGES,
+    // Deliberately NOT stored on the room: the client has to learn it from the
+    // user, exactly as it would after a fresh install.
+    requiredPassword: BOARD_ROOM_PASSWORD,
+  }
+}

--- a/apps/fluux/src/demo/rooms/index.ts
+++ b/apps/fluux/src/demo/rooms/index.ts
@@ -1,12 +1,14 @@
 import type { DemoRoomData } from '@fluux/sdk/demo'
 import { getTeamRoom } from './teamChat'
 import { getDesignRoom } from './designReview'
+import { getBoardRoom } from './boardPrivate'
 
 export { TEAM_ROOM_MESSAGES } from './teamChat'
 export { DESIGN_ROOM_MESSAGES } from './designReview'
+export { BOARD_ROOM_MESSAGES } from './boardPrivate'
 export { getDiscoverableRooms } from './discoverableRooms'
 export type { DiscoverableRoom } from './discoverableRooms'
 
 export function getDemoRooms(): DemoRoomData[] {
-  return [getTeamRoom(), getDesignRoom()]
+  return [getTeamRoom(), getDesignRoom(), getBoardRoom()]
 }

--- a/apps/fluux/src/hooks/useRoomPasswordPrompt.test.tsx
+++ b/apps/fluux/src/hooks/useRoomPasswordPrompt.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Issue #1126: joining a password-protected room from anywhere but the Join Room
+ * modal used to dead-end on the server's 401. These cover the prompt/retry loop.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RoomJoinError } from '@fluux/sdk'
+import { useRoomPasswordPrompt } from './useRoomPasswordPrompt'
+
+const mockJoinRoom = vi.fn()
+const mockJoinResult = vi.fn()
+
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    useRoomActions: () => ({ joinRoom: mockJoinRoom, joinResult: mockJoinResult }),
+  }
+})
+
+const ROOM = 'secret@conference.example.com'
+
+/** Drives the hook and records what the join resolved to. */
+function Harness({ onResult }: { onResult: (outcome: string) => void }) {
+  const { joinRoomWithPassword, passwordDialog } = useRoomPasswordPrompt()
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          joinRoomWithPassword(ROOM, 'mynick').then(
+            (joined) => onResult(joined ? 'joined' : 'cancelled'),
+            (err: unknown) => onResult(`threw:${(err as RoomJoinError).condition}`)
+          )
+        }}
+      >
+        join
+      </button>
+      {passwordDialog}
+    </div>
+  )
+}
+
+const clickJoin = () => fireEvent.click(screen.getByText('join'))
+const passwordField = () => screen.findByLabelText('rooms.roomPassword')
+const submit = async (password: string) => {
+  const input = await passwordField()
+  fireEvent.change(input, { target: { value: password } })
+  fireEvent.submit(input)
+}
+
+describe('useRoomPasswordPrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockJoinRoom.mockResolvedValue(undefined)
+    mockJoinResult.mockResolvedValue(undefined)
+  })
+
+  it('joins without prompting when the room takes no password', async () => {
+    const onResult = vi.fn()
+    render(<Harness onResult={onResult} />)
+    clickJoin()
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith('joined'))
+    expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+    expect(mockJoinRoom).toHaveBeenCalledWith(ROOM, 'mynick', undefined)
+  })
+
+  it('prompts on a 401 and retries with the password', async () => {
+    mockJoinResult
+      .mockRejectedValueOnce(new RoomJoinError(ROOM, 'not-authorized'))
+      .mockResolvedValue(undefined)
+    const onResult = vi.fn()
+    render(<Harness onResult={onResult} />)
+    clickJoin()
+
+    await submit('s3cret')
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith('joined'))
+    expect(mockJoinRoom).toHaveBeenLastCalledWith(ROOM, 'mynick', { password: 's3cret' })
+    // Dialog dismissed once we are in.
+    expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+  })
+
+  it('re-prompts with an "incorrect password" hint after a wrong password', async () => {
+    mockJoinResult.mockRejectedValue(new RoomJoinError(ROOM, 'not-authorized'))
+    render(<Harness onResult={vi.fn()} />)
+    clickJoin()
+
+    expect(await screen.findByText('rooms.passwordRequired')).toBeInTheDocument()
+    await submit('wrong')
+
+    expect(await screen.findByText('rooms.incorrectPassword')).toBeInTheDocument()
+    // Still asking, not bounced out to an error toast.
+    expect(await passwordField()).toBeInTheDocument()
+  })
+
+  it('reports a cancelled prompt as "not joined" rather than an error', async () => {
+    mockJoinResult.mockRejectedValue(new RoomJoinError(ROOM, 'not-authorized'))
+    const onResult = vi.fn()
+    render(<Harness onResult={onResult} />)
+    clickJoin()
+
+    fireEvent.click(await screen.findByText('common.cancel'))
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith('cancelled'))
+  })
+
+  it('rethrows failures that a password cannot fix', async () => {
+    mockJoinResult.mockRejectedValue(new RoomJoinError(ROOM, 'conflict'))
+    const onResult = vi.fn()
+    render(<Harness onResult={onResult} />)
+    clickJoin()
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith('threw:conflict'))
+    expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
+  })
+})

--- a/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
+++ b/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useRoomActions, RoomJoinError } from '@fluux/sdk'
+import { RoomPasswordDialog } from '@/components/RoomPasswordDialog'
+
+interface PendingPrompt {
+  /** Inline hint above the field: the initial ask, or "incorrect password" on a retry. */
+  message: string
+  /** Resolves with the entered password, or null when the user cancels. */
+  resolve: (password: string | null) => void
+}
+
+/**
+ * Joins a MUC room, asking for the room password when the server refuses the
+ * join with `not-authorized` (issue #1126).
+ *
+ * The SDK re-sends a password it already knows (bookmark or earlier join in this
+ * session), so this only prompts when we genuinely have none or it stopped
+ * working. A password that gets us in is stored in the room's XEP-0402 bookmark,
+ * so the next launch joins unattended.
+ *
+ * Resolves `true` when the room was joined and `false` when the user dismissed
+ * the prompt. Any other join failure (nickname conflict, banned, …) is rethrown
+ * for the caller's existing error handling.
+ *
+ * Render the returned `passwordDialog` in the component so the prompt can
+ * appear; it is `null` when nothing is pending.
+ *
+ * @example
+ * const { joinRoomWithPassword, passwordDialog } = useRoomPasswordPrompt()
+ * // in a handler:
+ * if (!(await joinRoomWithPassword(roomJid, nickname))) return
+ * // in JSX:
+ * {passwordDialog}
+ */
+export function useRoomPasswordPrompt() {
+  const { t } = useTranslation()
+  const { joinRoom, joinResult } = useRoomActions()
+  const [pending, setPending] = useState<PendingPrompt | null>(null)
+
+  const askForPassword = useCallback((message: string) => {
+    return new Promise<string | null>((resolve) => {
+      setPending({
+        message,
+        resolve: (password) => {
+          setPending(null)
+          resolve(password)
+        },
+      })
+    })
+  }, [])
+
+  const joinRoomWithPassword = useCallback(
+    async (roomJid: string, nickname: string): Promise<boolean> => {
+      const attempt = async (password?: string) => {
+        // Room passwords are opaque XMPP strings - never trim them.
+        await joinRoom(roomJid, nickname, password !== undefined ? { password } : undefined)
+        await joinResult(roomJid)
+      }
+
+      const isPasswordRefusal = (err: unknown) =>
+        err instanceof RoomJoinError && err.condition === 'not-authorized'
+
+      try {
+        await attempt()
+        return true
+      } catch (err) {
+        if (!isPasswordRefusal(err)) throw err
+      }
+
+      // Keep asking until we are in or the user gives up: a mistyped password
+      // should reopen the same prompt, not bounce the user out to a toast.
+      let message = t('rooms.passwordRequired')
+      for (;;) {
+        const password = await askForPassword(message)
+        if (password === null) return false
+        try {
+          await attempt(password)
+          return true
+        } catch (err) {
+          if (!isPasswordRefusal(err)) throw err
+          message = t('rooms.incorrectPassword')
+        }
+      }
+    },
+    [joinRoom, joinResult, askForPassword, t]
+  )
+
+  const passwordDialog = pending ? (
+    <RoomPasswordDialog
+      message={pending.message}
+      onSubmit={(password) => pending.resolve(password)}
+      onCancel={() => pending.resolve(null)}
+    />
+  ) : null
+
+  return { joinRoomWithPassword, passwordDialog }
+}

--- a/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
+++ b/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
@@ -11,8 +11,10 @@ interface PendingPrompt {
 }
 
 /**
- * Joins a MUC room, asking for the room password when the server refuses the
- * join with `not-authorized` (issue #1126).
+ * Gets the user into a MUC room, asking for the room password when the server
+ * refuses with `not-authorized` (issue #1126). `joinRoomWithPassword` covers a
+ * plain join; `withPasswordPrompt` wraps any other way in (accepting an
+ * invitation, …).
  *
  * The SDK re-sends a password it already knows (bookmark or earlier join in this
  * session), so this only prompts when we genuinely have none or it stopped
@@ -26,12 +28,16 @@ interface PendingPrompt {
  * Render the returned `passwordDialog` in the component so the prompt can
  * appear; it is `null` when nothing is pending.
  *
- * @example
+ * @example Joining a room
  * const { joinRoomWithPassword, passwordDialog } = useRoomPasswordPrompt()
  * // in a handler:
  * if (!(await joinRoomWithPassword(roomJid, nickname))) return
  * // in JSX:
  * {passwordDialog}
+ *
+ * @example Any other way into a room (accepting an invitation, …)
+ * const { withPasswordPrompt, passwordDialog } = useRoomPasswordPrompt()
+ * if (!(await withPasswordPrompt((password) => acceptInvitation(roomJid, password)))) return
  */
 export function useRoomPasswordPrompt() {
   const { t } = useTranslation()
@@ -50,14 +56,17 @@ export function useRoomPasswordPrompt() {
     })
   }, [])
 
-  const joinRoomWithPassword = useCallback(
-    async (roomJid: string, nickname: string): Promise<boolean> => {
-      const attempt = async (password?: string) => {
-        // Room passwords are opaque XMPP strings - never trim them.
-        await joinRoom(roomJid, nickname, password !== undefined ? { password } : undefined)
-        await joinResult(roomJid)
-      }
-
+  /**
+   * Run `attempt`, asking for the room password if the server refuses with
+   * `not-authorized` and retrying until it succeeds or the user gives up.
+   *
+   * `attempt` receives the password the user typed (undefined on the first,
+   * unprompted try) and must reject with a {@link RoomJoinError} carrying the
+   * server's outcome — i.e. it has to await the join result, not just send the
+   * join. Anything else it throws is rethrown untouched.
+   */
+  const withPasswordPrompt = useCallback(
+    async (attempt: (password?: string) => Promise<void>): Promise<boolean> => {
       const isPasswordRefusal = (err: unknown) =>
         err instanceof RoomJoinError && err.condition === 'not-authorized'
 
@@ -83,7 +92,18 @@ export function useRoomPasswordPrompt() {
         }
       }
     },
-    [joinRoom, joinResult, askForPassword, t]
+    [askForPassword, t]
+  )
+
+  /** {@link withPasswordPrompt} over a plain room join. */
+  const joinRoomWithPassword = useCallback(
+    (roomJid: string, nickname: string) =>
+      withPasswordPrompt(async (password) => {
+        // Room passwords are opaque XMPP strings - never trim them.
+        await joinRoom(roomJid, nickname, password !== undefined ? { password } : undefined)
+        await joinResult(roomJid)
+      }),
+    [withPasswordPrompt, joinRoom, joinResult]
   )
 
   const passwordDialog = pending ? (
@@ -94,5 +114,5 @@ export function useRoomPasswordPrompt() {
     />
   ) : null
 
-  return { joinRoomWithPassword, passwordDialog }
+  return { joinRoomWithPassword, withPasswordPrompt, passwordDialog }
 }

--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -30,7 +30,11 @@ The demo populates the UI with:
   - PDF attachment
   - Video attachment
   - Link preview with Open Graph metadata (XEP-0422 Message Fastening)
-- **1 group chat room** ("Team Chat") with 4 occupants, reactions, and replies
+- **Group chat rooms**: "Team Chat" (4 occupants, reactions, replies) and "Design Review"
+- **1 password-protected room** ("Board"), bookmarked but not joined. The simulated
+  service refuses a join without the password (`fluux`) exactly as a real one does,
+  so the unlock path — 401, password prompt, retry, and remembering the password for
+  the next join — can be exercised without a server.
 - **Live animations** that start after page load: typing indicators, incoming messages, and emoji reactions
 
 ## Recording a Demo Video

--- a/packages/fluux-sdk/src/core/XMPPClient.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.ts
@@ -729,7 +729,14 @@ export class XMPPClient {
       // Route to modules (order matters - first handler to return true wins)
       // PubSub before Chat so PubSub events aren't treated as chat messages
       // Blocking before Roster so blocklist pushes are handled correctly
-      const modules = [this.pubsub, this.blocking, this.poll, this.chat, this.roster, this.muc, this.profile, this.discovery, this.lastActivity]
+      // MUC before Roster so join/nick-change error presences reach failJoin():
+      // Roster claims EVERY presence type='error', and a MUC join error (401
+      // password required, 409 conflict, …) echoes <x muc>, not muc#user, so it
+      // is indistinguishable from a contact presence error at that layer. MUC
+      // only claims presence it recognises (muc#user, or an error matching an
+      // in-flight join/nick change), so regular contact presence still falls
+      // through to Roster.
+      const modules = [this.pubsub, this.blocking, this.poll, this.chat, this.muc, this.roster, this.profile, this.discovery, this.lastActivity]
       for (const module of modules) {
         if (module.handle(stanza)) break
       }

--- a/packages/fluux-sdk/src/core/modules/MUC.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.test.ts
@@ -8,10 +8,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { MUC } from './MUC'
 import {
   createMockElement,
+  createMockRoom,
   createMockStores,
   createMockPresenceReader,
 } from '../test-utils'
 import type { ModuleDependencies } from './BaseModule'
+import type { Room } from '../types/room'
 
 describe('MUC Module', () => {
   let muc: MUC
@@ -784,6 +786,171 @@ describe('MUC Module', () => {
           nick: 'mynick',
           autojoin: true,
         })
+      })
+    })
+  })
+
+  // Issue #1126: a password-protected room could only be entered by typing the
+  // password again in the Join Room modal. It was never stored, never reused by
+  // the secondary join paths, and an unrelated bookmark write dropped one another
+  // client had stored.
+  describe('room password', () => {
+    const ROOM = 'secret@conference.example.org'
+
+    /** The <password/> the join presence actually carried, if any. */
+    const sentJoinPassword = () =>
+      mockSendStanza.mock.calls[0][0].getChild('x', 'http://jabber.org/protocol/muc')?.getChildText('password')
+
+    /** The <password/> of the bookmark we published, if any. */
+    const publishedPassword = (call = 0) =>
+      mockSendIQ.mock.calls[call][0]
+        .children[0].children[0].children[0].children[0]
+        .children.find((c: { name: string }) => c.name === 'password')?.children[0]
+
+    const selfPresence = (nick: string) =>
+      createMockElement('presence', { from: `${ROOM}/${nick}` }, [
+        {
+          name: 'x',
+          attrs: { xmlns: 'http://jabber.org/protocol/muc#user' },
+          children: [
+            { name: 'item', attrs: { affiliation: 'member', role: 'participant' } },
+            { name: 'status', attrs: { code: '110' } },
+          ],
+        },
+      ])
+
+    const storedRoom = (overrides: Partial<Room> = {}) =>
+      createMockRoom(ROOM, { name: 'Secret', nickname: 'mynick', isBookmarked: true, autojoin: false, ...overrides })
+
+    describe('joinRoom', () => {
+      it('reuses the password we already know for the room', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom({ password: 'from-bookmark' }))
+
+        await muc.joinRoom(ROOM, 'mynick')
+
+        expect(sentJoinPassword()).toBe('from-bookmark')
+      })
+
+      it('prefers an explicitly supplied password over the stored one', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom({ password: 'stale' }))
+
+        await muc.joinRoom(ROOM, 'mynick', { password: 'typed-just-now' })
+
+        expect(sentJoinPassword()).toBe('typed-just-now')
+      })
+
+      it('sends no password when none is known', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom())
+
+        await muc.joinRoom(ROOM, 'mynick')
+
+        expect(sentJoinPassword()).toBeNull()
+      })
+
+      it('re-sends the resolved password on the join retry', async () => {
+        vi.useFakeTimers()
+        try {
+          mockStores.room.getRoom.mockReturnValue(storedRoom({ password: 'from-bookmark' }))
+          await muc.joinRoom(ROOM, 'mynick')
+          mockSendStanza.mockClear()
+
+          // No self-presence: the 30s timeout fires and retries the join.
+          await vi.advanceTimersByTimeAsync(31000)
+
+          expect(sentJoinPassword()).toBe('from-bookmark')
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+    })
+
+    describe('setBookmark', () => {
+      it('keeps the stored password when the caller does not supply one', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom({ password: 'keep-me' }))
+        mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+        // e.g. toggling autojoin from the sidebar, which knows nothing about passwords
+        await muc.setBookmark(ROOM, { name: 'Secret', nick: 'mynick', autojoin: true })
+
+        expect(publishedPassword()).toBe('keep-me')
+      })
+
+      it('clears the password when explicitly given an empty one', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom({ password: 'keep-me' }))
+        mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+        await muc.setBookmark(ROOM, { name: 'Secret', nick: 'mynick', password: '' })
+
+        expect(publishedPassword()).toBeUndefined()
+        expect(mockEmitSDK).toHaveBeenCalledWith('room:bookmark', {
+          roomJid: ROOM,
+          bookmark: expect.objectContaining({ password: undefined }),
+        })
+      })
+    })
+
+    describe('on a successful join', () => {
+      it('stores a working password and writes it to the bookmark', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom())
+        mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+        await muc.joinRoom(ROOM, 'mynick', { password: 'correct-horse' })
+        muc.handle(selfPresence('mynick'))
+
+        expect(mockEmitSDK).toHaveBeenCalledWith('room:updated', {
+          roomJid: ROOM,
+          updates: { password: 'correct-horse' },
+        })
+        // joinRoom's disco#info is call 0; the bookmark publish follows it.
+        expect(publishedPassword(1)).toBe('correct-horse')
+      })
+
+      it('does not re-publish the bookmark when the password is unchanged', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom({ password: 'correct-horse' }))
+        mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+        await muc.joinRoom(ROOM, 'mynick')
+        mockSendIQ.mockClear()
+        muc.handle(selfPresence('mynick'))
+
+        expect(mockSendIQ).not.toHaveBeenCalled()
+      })
+
+      it('does not touch a quick chat', async () => {
+        mockStores.room.getRoom.mockReturnValue(storedRoom({ isBookmarked: false, isQuickChat: true }))
+        mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+        await muc.joinRoom(ROOM, 'mynick', { password: 'correct-horse', isQuickChat: true })
+        mockSendIQ.mockClear()
+        muc.handle(selfPresence('mynick'))
+
+        expect(mockSendIQ).not.toHaveBeenCalled()
+      })
+    })
+
+    it('never stores a password the server refused', async () => {
+      mockStores.room.getRoom.mockReturnValue(storedRoom())
+      mockSendIQ.mockResolvedValue(createMockElement('iq', { type: 'result' }))
+
+      await muc.joinRoom(ROOM, 'mynick', { password: 'wrong' })
+      const result = muc.joinResult(ROOM)
+      mockSendIQ.mockClear()
+      mockEmitSDK.mockClear()
+
+      muc.handle(createMockElement('presence', { from: `${ROOM}/mynick`, type: 'error' }, [
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc' } },
+        {
+          name: 'error',
+          attrs: { type: 'auth' },
+          children: [{ name: 'not-authorized', attrs: { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' } }],
+        },
+      ]))
+
+      await expect(result).rejects.toMatchObject({ condition: 'not-authorized' })
+      expect(mockSendIQ).not.toHaveBeenCalled()
+      expect(mockEmitSDK).not.toHaveBeenCalledWith('room:updated', {
+        roomJid: ROOM,
+        updates: expect.objectContaining({ password: expect.anything() }),
       })
     })
   })

--- a/packages/fluux-sdk/src/core/modules/MUC.ts
+++ b/packages/fluux-sdk/src/core/modules/MUC.ts
@@ -329,6 +329,11 @@ export class MUC extends BaseModule {
         return
       }
 
+      // The password this join actually got in with — read before clearPendingJoin
+      // drops the pending entry. Only recorded on success, so a wrong password is
+      // never persisted (and never re-sent on the next join).
+      const acceptedPassword = this.pendingJoins.get(roomJid)?.options?.password
+
       // Clear the join timeout - we successfully joined
       this.clearPendingJoin(roomJid)
       this.settleJoinSuccess(roomJid)
@@ -348,16 +353,40 @@ export class MUC extends BaseModule {
 
       this.deps.emit('mucJoined', roomJid, nick)
 
-      // Auto-bookmark the room if not already bookmarked (skip quick chats - they're transient)
+      // Remember a working room password (skip quick chats - they're transient) so
+      // later sessions can rejoin unattended: keep it in the store for this session
+      // and in the bookmark's XEP-0402 <password/> across restarts (issue #1126).
       const room = this.deps.stores?.room.getRoom(roomJid)
-      if (room && !room.isBookmarked && !room.isQuickChat) {
-        this.setBookmark(roomJid, {
-          name: room.name,
-          nick: nick,
-          autojoin: false,
-        }).catch(() => {
-          // Ignore bookmark errors - room join was still successful
-        })
+      if (room && !room.isQuickChat) {
+        const passwordIsNew = !!acceptedPassword && acceptedPassword !== room.password
+        if (passwordIsNew) {
+          // SDK event only - binding calls store.updateRoom
+          this.deps.emitSDK('room:updated', { roomJid, updates: { password: acceptedPassword } })
+        }
+
+        // Auto-bookmark the room if not already bookmarked; if it IS bookmarked,
+        // only re-publish when we learned a new password (setBookmark preserves
+        // the stored one, so the other fields have to be carried over here).
+        if (!room.isBookmarked) {
+          this.setBookmark(roomJid, {
+            name: room.name,
+            nick: nick,
+            autojoin: false,
+            password: acceptedPassword,
+          }).catch(() => {
+            // Ignore bookmark errors - room join was still successful
+          })
+        } else if (passwordIsNew) {
+          this.setBookmark(roomJid, {
+            name: room.name,
+            nick: nick,
+            autojoin: room.autojoin,
+            password: acceptedPassword,
+            notifyAll: room.notifyAllPersistent,
+          }).catch(() => {
+            // Ignore bookmark errors - room join was still successful
+          })
+        }
       }
 
       // Re-query room capabilities if initial disco#info failed before join.
@@ -647,7 +676,10 @@ export class MUC extends BaseModule {
    * @param nickname - Your nickname in the room
    * @param options - Optional join settings
    * @param options.maxHistory - Number of history messages to request (default: 50, use 0 for none)
-   * @param options.password - Room password if required
+   * @param options.password - Room password. Defaults to the password already
+   *   known for the room (from its bookmark or an earlier successful join), so
+   *   callers only pass one the user just typed. A password that works is saved
+   *   to the room's bookmark.
    * @param options.isQuickChat - Mark this as a temporary quick chat room
    *
    * @example
@@ -692,6 +724,14 @@ export class MUC extends BaseModule {
 
     // Register (or reuse, on retry) the awaitable outcome for joinResult().
     this.getOrCreateJoinDeferred(roomJid)
+
+    // Fall back to the password we already know for this room (XEP-0402
+    // <password/>, kept in the store by fetchBookmarks and by a successful
+    // password join). Without this only the connect-time autojoin could enter a
+    // password-protected room: every other entry point — sidebar double-click,
+    // the room-view join prompt, /join, deep links — passes no options and would
+    // be refused with 401 after a restart (issue #1126).
+    const password = options?.password ?? existingRoom?.password
 
     const isQuickChat = options?.isQuickChat ?? existingRoom?.isQuickChat
 
@@ -770,8 +810,8 @@ export class MUC extends BaseModule {
     const maxHistory = supportsMAM ? 0 : (options?.maxHistory ?? 50)
     xChildren.push(xml('history', { maxstanzas: maxHistory.toString() }))
 
-    if (options?.password) {
-      xChildren.push(xml('password', {}, options.password))
+    if (password) {
+      xChildren.push(xml('password', {}, password))
     }
 
     const presenceChildren: Element[] = [
@@ -801,8 +841,10 @@ export class MUC extends BaseModule {
     logInfo(`Joining room: ${roomJid}`)
     await this.deps.sendStanza(presence)
 
-    // Start timeout - if no self-presence received within timeout, will retry or give up
-    this.startJoinTimeout(roomJid, nickname, options)
+    // Start timeout - if no self-presence received within timeout, will retry or give up.
+    // Remember the RESOLVED password so a retry re-sends it and the success path
+    // knows which password actually got us in.
+    this.startJoinTimeout(roomJid, nickname, { ...options, password })
   }
 
   /**
@@ -1829,7 +1871,9 @@ export class MUC extends BaseModule {
    * @param options.name - Display name for the room
    * @param options.nick - Nickname to use when joining
    * @param options.autojoin - If true, automatically join on connect
-   * @param options.password - Room password (if required)
+   * @param options.password - Room password. Omit to keep the password already
+   *   known for the room (a publish replaces the whole bookmark, so omitting it
+   *   would otherwise erase it); pass an empty string to clear it.
    * @param options.notifyAll - If true, notify on all messages
    *
    * @example
@@ -1854,10 +1898,16 @@ export class MUC extends BaseModule {
     roomJid: string,
     options: { name: string; nick: string; autojoin?: boolean; password?: string; notifyAll?: boolean }
   ): Promise<void> {
+    // A bookmark publish REPLACES the stored item, so an unrelated write (renaming
+    // the bookmark, toggling autojoin) would drop the room password — ours or one
+    // another client stored. Omitting `password` therefore means "keep what we
+    // know"; pass an empty string to deliberately clear it (issue #1126).
+    const password = options.password ?? this.deps.stores?.room.getRoom(roomJid)?.password
+
     // Build conference element children
     const confChildren: Element[] = [xml('nick', {}, options.nick)]
-    if (options.password) {
-      confChildren.push(xml('password', {}, options.password))
+    if (password) {
+      confChildren.push(xml('password', {}, password))
     }
 
     // Add extensions element with notify setting if notifyAll is enabled
@@ -1894,7 +1944,7 @@ export class MUC extends BaseModule {
         name: options.name,
         nick: options.nick,
         autojoin: options.autojoin,
-        password: options.password,
+        password: password || undefined,
         notifyAll: options.notifyAll,
       },
     })

--- a/packages/fluux-sdk/src/core/modules/Presence.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Presence.test.ts
@@ -437,6 +437,66 @@ describe('XMPPClient Presence', () => {
     })
   })
 
+  // Issue #1126: the per-module tests call `muc.handle(stanza)` directly, so they
+  // could not catch Roster claiming EVERY presence type='error' ahead of MUC in
+  // the router — which swallowed join errors and left the room stuck at
+  // "Joining…" until the 60s timeout instead of reporting "password required".
+  // These drive the real router, so they pin the module order down.
+  describe('MUC join error routing', () => {
+    /** Error presence as ejabberd sends it: echoes <x muc> (the request), no muc#user. */
+    const joinError = (from: string, condition: string, type: string) =>
+      createMockElement('presence', { from, type: 'error' }, [
+        { name: 'x', attrs: { xmlns: 'http://jabber.org/protocol/muc' } },
+        {
+          name: 'error',
+          attrs: { type },
+          children: [{ name: condition, attrs: { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' } }],
+        },
+      ])
+
+    it('fails the join on a 401 instead of leaving it pending', async () => {
+      await connectClient()
+      await xmppClient.muc.joinRoom('secret@conference.example.com', 'mynick')
+      const result = xmppClient.muc.joinResult('secret@conference.example.com')
+
+      mockXmppClientInstance._emit(
+        'stanza',
+        joinError('secret@conference.example.com/mynick', 'not-authorized', 'auth')
+      )
+
+      await expect(result).rejects.toMatchObject({ condition: 'not-authorized', errorType: 'auth' })
+      // The room must not be filed as a contact presence error either.
+      expect(emitSDKSpy).not.toHaveBeenCalledWith('roster:presence-error', expect.anything())
+    })
+
+    it('fails the join on a nickname conflict', async () => {
+      await connectClient()
+      await xmppClient.muc.joinRoom('room@conference.example.com', 'taken')
+      const result = xmppClient.muc.joinResult('room@conference.example.com')
+
+      mockXmppClientInstance._emit(
+        'stanza',
+        joinError('room@conference.example.com/taken', 'conflict', 'cancel')
+      )
+
+      await expect(result).rejects.toMatchObject({ condition: 'conflict' })
+    })
+
+    it('still routes a contact presence error to the roster', async () => {
+      await connectClient()
+
+      mockXmppClientInstance._emit(
+        'stanza',
+        joinError('contact@example.com/phone', 'service-unavailable', 'cancel')
+      )
+
+      expect(emitSDKSpy).toHaveBeenCalledWith('roster:presence-error', {
+        jid: 'contact@example.com',
+        error: expect.any(String),
+      })
+    })
+  })
+
   describe('subscription requests', () => {
     it('should add subscription request to inbox for new contact', async () => {
       await connectClient()

--- a/packages/fluux-sdk/src/core/sessionLifecycle.test.ts
+++ b/packages/fluux-sdk/src/core/sessionLifecycle.test.ts
@@ -108,6 +108,25 @@ describe('SessionLifecycleEngine', () => {
     expect(modules.roster.fetchRoster).toHaveBeenCalledTimes(2)
   })
 
+  // Issue #1126: unattended rejoining of a password-protected room depends on
+  // the bookmark's password reaching joinRoom on connect.
+  it('autojoins a bookmarked room with its stored password', async () => {
+    modules.muc.fetchBookmarks.mockResolvedValue({
+      roomsToAutojoin: [{ jid: 'secret@conference.example.com', nick: 'mynick', password: 'from-bookmark' }],
+      allRoomJids: ['secret@conference.example.com'],
+    })
+
+    await engine.handleConnectionSuccess(false)
+    // The autojoin runs in a detached async task after a disco#info probe.
+    await vi.waitFor(() => expect(modules.muc.joinRoom).toHaveBeenCalled())
+
+    expect(modules.muc.joinRoom).toHaveBeenCalledWith(
+      'secret@conference.example.com',
+      'mynick',
+      expect.objectContaining({ password: 'from-bookmark' })
+    )
+  })
+
   it('merges the server conversation list through the injected chat binding', () => {
     stores.roster.getContact.mockReturnValue(undefined)
 

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -780,6 +780,9 @@ export const createMockXMPPClientForHooks = () => ({
   },
   muc: {
     joinRoom: vi.fn(),
+    // Resolves by default: callers that await the join outcome (acceptInvitation)
+    // treat a rejection as "the server refused", so the neutral default is success.
+    joinResult: vi.fn().mockResolvedValue(undefined),
     leaveRoom: vi.fn(),
     setBookmark: vi.fn(),
     removeBookmark: vi.fn(),

--- a/packages/fluux-sdk/src/core/test-utils.ts
+++ b/packages/fluux-sdk/src/core/test-utils.ts
@@ -53,6 +53,7 @@ export const createMockRoom = (jid: string, overrides: Partial<Room> = {}): Room
   mentionsCount: overrides.mentionsCount ?? 0,
   typingUsers: overrides.typingUsers ?? new Set(),
   isBookmarked: overrides.isBookmarked ?? false,
+  isQuickChat: overrides.isQuickChat,
   autojoin: overrides.autojoin,
   password: overrides.password,
   notifyAll: overrides.notifyAll,

--- a/packages/fluux-sdk/src/core/types/room.ts
+++ b/packages/fluux-sdk/src/core/types/room.ts
@@ -209,7 +209,8 @@ export interface RoomEntity {
   isBookmarked: boolean
   /** Auto-join on connect (from bookmark) */
   autojoin?: boolean
-  /** Room password (from bookmark) */
+  /** Room password, from the bookmark or a successful join. Re-sent automatically
+   *  by joinRoom() so a password-protected room rejoins without re-prompting. */
   password?: string
 
   // Quick Chat (transient room)

--- a/packages/fluux-sdk/src/demo/DemoClient.join.test.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.join.test.ts
@@ -5,14 +5,21 @@
  * must settle it (via muc.confirmSimulatedJoin) — otherwise awaiting
  * joinResult() (as JoinRoomModal does) hangs forever in demo mode.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { DemoClient } from './DemoClient'
+import { roomStore } from '../stores/roomStore'
+
+/** A DemoClient wired up enough to answer join presences. */
+function makeClient() {
+  const client = new DemoClient()
+  ;(client as unknown as { currentJid: string | null }).currentJid = 'you@fluux.chat'
+  ;(client as unknown as { selfJid: string }).selfJid = 'you@fluux.chat'
+  return client
+}
 
 describe('DemoClient MUC join', () => {
   it('settles joinResult() for a simulated join (no hang)', async () => {
-    const client = new DemoClient()
-    ;(client as unknown as { currentJid: string | null }).currentJid = 'you@fluux.chat'
-    ;(client as unknown as { selfJid: string }).selfJid = 'you@fluux.chat'
+    const client = makeClient()
 
     const roomJid = 'demoroom@conference.fluux.chat'
     await client.muc.joinRoom(roomJid, 'me')
@@ -20,5 +27,51 @@ describe('DemoClient MUC join', () => {
     // If the demo failed to settle the deferred, this await would never resolve
     // and the test would hit the vitest timeout (i.e. fail loudly).
     await expect(client.muc.joinResult(roomJid)).resolves.toBeUndefined()
+  })
+
+  // Issue #1126: the demo simulates a password-protected room so the whole
+  // unlock path (401 -> prompt -> retry -> remembered) is exercisable offline.
+  describe('password-protected room', () => {
+    const ROOM = 'board@conference.fluux.chat'
+
+    const seed = (client: DemoClient) => {
+      ;(client as unknown as { roomPasswords: Map<string, string> }).roomPasswords.set(ROOM, 'fluux')
+    }
+
+    it('refuses a join that carries no password, as a real service does', async () => {
+      const client = makeClient()
+      seed(client)
+
+      await client.muc.joinRoom(ROOM, 'me')
+      const result = client.muc.joinResult(ROOM)
+
+      await expect(result).rejects.toMatchObject({ condition: 'not-authorized' })
+      // Not left spinning: the row must become interactive again.
+      expect(roomStore.getState().getRoom(ROOM)?.isJoining).toBe(false)
+    })
+
+    it('refuses a wrong password', async () => {
+      const client = makeClient()
+      seed(client)
+
+      await client.muc.joinRoom(ROOM, 'me', { password: 'nope' })
+
+      await expect(client.muc.joinResult(ROOM)).rejects.toMatchObject({ condition: 'not-authorized' })
+    })
+
+    it('accepts the right password and remembers it for the next join', async () => {
+      const client = makeClient()
+      seed(client)
+
+      await client.muc.joinRoom(ROOM, 'me', { password: 'fluux' })
+      await expect(client.muc.joinResult(ROOM)).resolves.toBeUndefined()
+
+      // The password that worked is now on the room, so a rejoin needs no prompt.
+      await vi.waitFor(() => expect(roomStore.getState().getRoom(ROOM)?.password).toBe('fluux'))
+
+      await client.muc.leaveRoom(ROOM)
+      await client.muc.joinRoom(ROOM, 'me')
+      await expect(client.muc.joinResult(ROOM)).resolves.toBeUndefined()
+    })
   })
 })

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -43,6 +43,7 @@ const NS_DISCO_INFO = 'http://jabber.org/protocol/disco#info'
 const NS_DISCO_ITEMS = 'http://jabber.org/protocol/disco#items'
 const NS_RSM = 'http://jabber.org/protocol/rsm'
 const NS_MUC = 'http://jabber.org/protocol/muc'
+const NS_MUC_USER = 'http://jabber.org/protocol/muc#user'
 const NS_MUC_OWNER = 'http://jabber.org/protocol/muc#owner'
 const NS_MUC_ADMIN = 'http://jabber.org/protocol/muc#admin'
 const NS_VCARD_TEMP = 'vcard-temp'
@@ -75,6 +76,8 @@ interface MockElement {
   children: MockElement[]
   getChild: (name: string, xmlns?: string) => MockElement | undefined
   getChildren: (name: string) => MockElement[]
+  /** Matches ltx/@xmpp Element.is(), used by the module stanza handlers. */
+  is: (name: string) => boolean
   getChildText: (name: string) => string | null
   getText: () => string
   /** Text content as a method — matches ltx/@xmpp Element.text() used by parseDataForm/version parsing. */
@@ -112,6 +115,8 @@ export class DemoClient extends XMPPClient {
   private seededRoomOccupants = new Map<string, RoomOccupant[]>()
   private seededContacts = new Map<string, Contact>()
   private seededRooms = new Map<string, Room>()
+  // Rooms the simulated MUC service protects with a password (XEP-0045 §7.2.6).
+  private roomPasswords = new Map<string, string>()
   // Simulated XEP-0490 MDS PEP node: conversation bare JID → last-displayed
   // marker. Backs the pubsub publish/items/retract IQs so client.mds.* and the
   // fresh-session seed (fetchAllDisplayed) work in demo mode.
@@ -380,15 +385,23 @@ export class DemoClient extends XMPPClient {
     }
 
     // Rooms: add, mark joined, populate occupants and messages
-    for (const { room, occupants, messages } of data.rooms) {
+    for (const { room, occupants, messages, requiredPassword } of data.rooms) {
       this.emitSDK('room:added', { room })
-      this.emitSDK('room:joined', { roomJid: room.jid, joined: true })
+      // `joined: false` seeds a bookmarked room the user still has to enter
+      // (its cached history shows, its occupant list does not) - the state a
+      // password-protected room is in right after a restart.
+      const startsJoined = room.joined !== false
+      if (requiredPassword) this.roomPasswords.set(room.jid, requiredPassword)
 
-      const selfOccupant = occupants.find(o => o.jid === data.self.jid)
-      if (selfOccupant) {
-        this.emitSDK('room:self-occupant', { roomJid: room.jid, occupant: selfOccupant })
+      if (startsJoined) {
+        this.emitSDK('room:joined', { roomJid: room.jid, joined: true })
+
+        const selfOccupant = occupants.find(o => o.jid === data.self.jid)
+        if (selfOccupant) {
+          this.emitSDK('room:self-occupant', { roomJid: room.jid, occupant: selfOccupant })
+        }
+        this.emitSDK('room:occupants-batch', { roomJid: room.jid, occupants })
       }
-      this.emitSDK('room:occupants-batch', { roomJid: room.jid, occupants })
 
       for (const message of messages) {
         this.emitSDK('room:message', { roomJid: room.jid, message: withDefaultStanzaId(message) })
@@ -668,6 +681,22 @@ export class DemoClient extends XMPPClient {
     const roomJid = to.slice(0, slashIdx)
     const nick = to.slice(slashIdx + 1)
 
+    // XEP-0045 §7.2.6: a password-protected room refuses a join that carries no
+    // <password/>, or the wrong one. Answer exactly as a real service does so the
+    // client runs its own failure path (issue #1126).
+    const required = this.roomPasswords.get(roomJid)
+    if (required !== undefined) {
+      const supplied = stanza.getChild?.('x', NS_MUC)?.getChildText?.('password')
+      if (supplied !== required) {
+        // A task, not a microtask: joinRoom() only registers the pending join
+        // AFTER its `await sendStanza(...)` resumes, and MUC ignores an error
+        // presence for a room with no join in flight. Microtasks would run
+        // first and the refusal would be dropped (leaving "Joining…" forever).
+        setTimeout(() => this.refuseJoin(roomJid, nick), 0)
+        return
+      }
+    }
+
     // Emit join events asynchronously so MUC.startJoinTimeout() runs first,
     // then our events clear the pending join (same timing as a real server).
     queueMicrotask(() => {
@@ -701,6 +730,18 @@ export class DemoClient extends XMPPClient {
       // JoinRoomModal) would hang forever in demo mode.
       this.muc.confirmSimulatedJoin(roomJid)
 
+      // For a password-protected room, also run the REAL post-join bookkeeping by
+      // routing a status-110 self-presence: that is what records the password
+      // that worked, so a later rejoin in this session needs no prompt
+      // (issue #1126). Scoped to these rooms so the plain demo join keeps its
+      // long-standing lightweight path. Deferred to a task for the same reason
+      // refuseJoin is: the pending join only exists once joinRoom() resumes.
+      if (this.roomPasswords.has(roomJid)) {
+        setTimeout(() => {
+          this.muc.handle(this.selfPresence(roomJid, selfOccupant) as unknown as Parameters<typeof this.muc.handle>[0])
+        }, 0)
+      }
+
       // Populate occupants: restore seeded occupants or create minimal list
       const occupants = seededOccupants ?? [selfOccupant]
       this.emitSDK('room:occupants-batch', { roomJid, occupants })
@@ -716,6 +757,39 @@ export class DemoClient extends XMPPClient {
       })
       roomStore.setState({ mamQueryStates: mamStates })
     })
+  }
+
+  /** Build the status-110 self-presence a MUC service sends on a successful join. */
+  private selfPresence(roomJid: string, occupant: RoomOccupant): MockElement {
+    return this.mockElement('presence', { from: `${roomJid}/${occupant.nick}`, to: this.selfJid }, [
+      this.mockElement('x', { xmlns: NS_MUC_USER }, [
+        this.mockElement('item', {
+          affiliation: occupant.affiliation,
+          role: occupant.role,
+          ...(occupant.jid ? { jid: occupant.jid } : {}),
+        }),
+        this.mockElement('status', { code: '110' }),
+      ]),
+    ])
+  }
+
+  /**
+   * Refuse a join the way a password-protected room does: a 401 error presence
+   * routed through the real MUC handler, so the SDK clears `isJoining`, rejects
+   * joinResult() with `not-authorized`, and logs the console event — the client
+   * behaves exactly as it does against a real server.
+   */
+  private refuseJoin(roomJid: string, nick: string): void {
+    const error = this.mockElement('error', { type: 'auth', code: '401' }, [
+      this.mockElement('not-authorized', { xmlns: 'urn:ietf:params:xml:ns:xmpp-stanzas' }),
+    ])
+    // Real services echo the request's <x muc/>, NOT muc#user.
+    const presence = this.mockElement(
+      'presence',
+      { from: `${roomJid}/${nick}`, to: this.selfJid, type: 'error' },
+      [this.mockElement('x', { xmlns: NS_MUC }), error]
+    )
+    this.muc.handle(presence as unknown as Parameters<typeof this.muc.handle>[0])
   }
 
   // -------------------------------------------------------------------------
@@ -738,6 +812,7 @@ export class DemoClient extends XMPPClient {
         children.find(c => c.name === childName && (!xmlns || c.attrs.xmlns === xmlns)),
       getChildren: (childName: string) =>
         children.filter(c => c.name === childName),
+      is: (elName: string) => name === elName,
       getChildText: (childName: string) => {
         const child = children.find(c => c.name === childName)
         return child?._text ?? null

--- a/packages/fluux-sdk/src/demo/DemoClient.ts
+++ b/packages/fluux-sdk/src/demo/DemoClient.ts
@@ -447,6 +447,7 @@ export class DemoClient extends XMPPClient {
     // Seed room invitations so the Rooms "Invitations" banner is visible in demo.
     for (const inv of data.mucInvitations ?? []) {
       eventsStore.getState().addMucInvitation(inv.roomJid, inv.from, inv.reason)
+      if (inv.requiredPassword) this.roomPasswords.set(inv.roomJid, inv.requiredPassword)
     }
 
     // Seed stranger messages so the Messages "Message requests" banner is visible in demo.

--- a/packages/fluux-sdk/src/demo/types.ts
+++ b/packages/fluux-sdk/src/demo/types.ts
@@ -89,7 +89,17 @@ export interface DemoData {
   /** Bare JIDs that have sent a presence-subscription (add-contact) request. Seeded into eventsStore. */
   subscriptionRequests?: string[]
   /** Pending room invitations to seed into eventsStore (Rooms "Invitations" banner). */
-  mucInvitations?: Array<{ roomJid: string; from: string; reason?: string }>
+  mucInvitations?: Array<{
+    roomJid: string
+    from: string
+    reason?: string
+    /**
+     * Password the simulated service demands for this room, mirroring
+     * {@link DemoRoomData.requiredPassword}. The invitation itself carries no
+     * password, so accepting it has to ask the user for one.
+     */
+    requiredPassword?: string
+  }>
   /** Stranger (non-roster) messages to seed into eventsStore (Messages "Message requests" banner). */
   strangerMessages?: Array<{ from: string; body: string }>
   ownResources?: DemoOwnResource[]

--- a/packages/fluux-sdk/src/demo/types.ts
+++ b/packages/fluux-sdk/src/demo/types.ts
@@ -36,6 +36,15 @@ export interface DemoRoomData {
   room: Room
   occupants: RoomOccupant[]
   messages: RoomMessage[]
+  /**
+   * Password the simulated MUC service demands (XEP-0045 §7.2.6). A join
+   * presence without it - or with the wrong one - is refused with the same
+   * `not-authorized` error presence a real server sends, so the client's
+   * password prompt and its bookmark round-trip are exercisable offline.
+   *
+   * Pair with `room.joined: false` for a room the user has to unlock.
+   */
+  requiredPassword?: string
 }
 
 /** A timed event in the demo animation sequence. */

--- a/packages/fluux-sdk/src/hooks/useEvents.test.tsx
+++ b/packages/fluux-sdk/src/hooks/useEvents.test.tsx
@@ -8,6 +8,7 @@ import { useEvents } from './useEvents'
 import { eventsStore, connectionStore, chatStore } from '../stores'
 import { XMPPProvider } from '../provider'
 import { createMockXMPPClientForHooks } from '../core/test-utils'
+import { RoomJoinError } from '../core/errors'
 
 // Mock localStorage for chatStore.reset()
 const localStorageMock = {
@@ -256,6 +257,61 @@ describe('useEvents hook', () => {
         'myuser',
         { password: 'secret123', isQuickChat: false }
       )
+    })
+
+    // Issue #1126: joinRoom() resolves once the presence is SENT. Accepting used
+    // to drop the invitation right there, so a refused join (password-protected
+    // room, members-only, nickname taken) failed silently AND stranded the user
+    // with no invitation left to retry from.
+    it('keeps the invitation and rethrows when the server refuses the join', async () => {
+      const { result } = renderHook(() => useEvents(), { wrapper })
+
+      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+      // ...Once: the mock client is shared across tests and vi.clearAllMocks()
+      // keeps implementations, so a persistent rejection would leak into them.
+      mockClient.muc.joinResult.mockRejectedValueOnce(
+        new RoomJoinError('room@conference.example.com', 'not-authorized')
+      )
+
+      act(() => {
+        connectionStore.getState().setJid('myuser@example.com/resource')
+        eventsStore.getState().addMucInvitation('room@conference.example.com', 'alice@example.com')
+      })
+
+      await act(async () => {
+        await expect(
+          result.current.acceptInvitation('room@conference.example.com')
+        ).rejects.toMatchObject({ condition: 'not-authorized' })
+      })
+
+      expect(result.current.mucInvitations).toHaveLength(1)
+    })
+
+    it('retries with a password supplied by the caller, overriding the invitation one', async () => {
+      const { result } = renderHook(() => useEvents(), { wrapper })
+
+      mockClient.muc.joinRoom.mockResolvedValue(undefined)
+
+      act(() => {
+        connectionStore.getState().setJid('myuser@example.com/resource')
+        eventsStore.getState().addMucInvitation(
+          'room@conference.example.com',
+          'alice@example.com',
+          'Private room',
+          'stale-from-invite'
+        )
+      })
+
+      await act(async () => {
+        await result.current.acceptInvitation('room@conference.example.com', 'typed-by-user')
+      })
+
+      expect(mockClient.muc.joinRoom).toHaveBeenCalledWith(
+        'room@conference.example.com',
+        'myuser',
+        { password: 'typed-by-user', isQuickChat: false }
+      )
+      expect(result.current.mucInvitations).toHaveLength(0)
     })
 
     it('should join room with isQuickChat flag from invitation', async () => {

--- a/packages/fluux-sdk/src/hooks/useEvents.ts
+++ b/packages/fluux-sdk/src/hooks/useEvents.ts
@@ -57,7 +57,10 @@ import type { Conversation } from '../core'
  *         <li key={inv.roomJid}>
  *           {inv.from} invited you to {inv.roomName || inv.roomJid}
  *           {inv.reason && <p>{inv.reason}</p>}
- *           <button onClick={() => acceptInvitation(inv.roomJid)}>Join</button>
+ *           // Rejects with a RoomJoinError when the server refuses the join
+ *           // (password required, members-only, …). The invitation is kept, so
+ *           // the user can retry — e.g. after supplying a password.
+ *           <button onClick={() => acceptInvitation(inv.roomJid).catch(showError)}>Join</button>
  *           <button onClick={() => declineInvitation(inv.roomJid)}>Decline</button>
  *         </li>
  *       ))}
@@ -181,13 +184,21 @@ export function useEvents() {
       const { jid: currentJid, ownNickname } = connectionStore.getState()
       // Prefer the profile username (XEP-0172 nick) over the bare-JID local part.
       const defaultNick = resolveDefaultMucNick(ownNickname, currentJid) || 'user'
-      const roomPassword = invitation?.password || password
+      // An explicit password wins over the one carried by the invitation: a caller
+      // only passes one after the invitation's own was refused (issue #1126).
+      const roomPassword = password || invitation?.password
 
       // Join the room with isQuickChat flag from invitation
       await client.muc.joinRoom(roomJid, defaultNick, {
         password: roomPassword,
         isQuickChat: invitation?.isQuickChat,
       })
+
+      // joinRoom() resolves once the join presence is SENT; the server may still
+      // refuse it (password required, members-only, nickname taken). Wait for the
+      // outcome so the failure reaches the caller and the invitation survives —
+      // dropping it on a refusal would strand the user with no way to retry.
+      await client.muc.joinResult(roomJid)
 
       // Remove from invitations
       removeMucInvitation(roomJid)


### PR DESCRIPTION
Fixes #1126.

Joining a password-protected room from anywhere but the Join Room modal dead-ended: the room sat at "Joining..." for 60s (its sidebar row inert, since clicks are blocked while joining) and then reported a generic timeout instead of asking for the password.

Two independent causes:

**Join errors were swallowed.** `Roster` claims every `presence type='error'` and ran before `MUC` in the stanza router, so MUC join errors (401 password-required, but also conflict, members-only, banned, room-full) never reached `failJoin()` and the join deferred stayed pending until it timed out. MUC now goes first; it only claims presence it recognises, so contact presence still falls through to Roster.

**The password was never persisted or reused.** It went to `joinRoom()` and nowhere else: the auto-bookmark wrote no `<password/>`, and an unrelated bookmark publish (rename, autojoin toggle) erased one another client had stored. `joinRoom()` now falls back to the password known for the room, a password that works is saved to its XEP-0402 bookmark, and `setBookmark()` preserves a password it was not given (pass `''` to clear).

The join paths outside the modal prompt for the password on a 401 and retry, reusing the existing translations so all 33 locales are covered: sidebar double-click, the room-view join prompt, and accepting an invitation.

**Accepting an invitation** had a sharper variant of the same bug: `acceptInvitation()` awaited `joinRoom()`, which resolves once the presence is *sent*, then dropped the invitation unconditionally — so a refused join failed silently **and** removed the invitation, leaving no way back into the room. It now awaits `joinResult()` and only consumes the invitation once the server confirms the join.

Demo mode gains a password-protected room ("Board", password `fluux`, bookmarked but not joined) and a password-protected invitation, both refused by the simulated service with a real error presence, so the unlock paths are exercisable without a server. Note this adds a room to the demo sidebar, so screenshots will need regenerating.

Remaining gap, tracked in #1132: Browse Rooms reuses a stored password but has no way to supply a new one.