### PR TITLE
Stick to the bottom when a late fastening grows a resident row

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -116,6 +116,64 @@ describe('MessageList — live-edge executor cost control', () => {
     return { ...view, isAtBottomRef }
   }
 
+  // A link-preview (OGP) fastening lands SECONDS after its message, as an in-place update: same
+  // message id, same message count, no reactions change, and LinkPreviewCard deliberately never
+  // calls onMediaLoad. Under virtualization the content ResizeObserver is disabled too, so nothing
+  // else can notice the growth — the card used to render below the fold and stay there.
+  const linked: BaseMessage = {
+    id: 'linked-1', from: 'me@example.com', body: 'look at https://example.com',
+    timestamp: new Date(2024, 0, 1, 13, 0), isOutgoing: true, type: 'chat',
+  }
+  const preview = { url: 'https://example.com', title: 'Example', description: 'An example page' }
+
+  function renderWithLinkMessage(isAtBottomRef: { current: boolean }) {
+    const view = render(
+      <MessageList messages={[...makeMessages(50), linked]} conversationId="conv-fastening" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70) // settle the entry pin completely
+    scrollToEndCalls.count = 0
+    return { view, scroller }
+  }
+
+  const fastenPreview = (view: { rerender: (ui: React.ReactElement) => void }, isAtBottomRef: { current: boolean }) =>
+    view.rerender(
+      <MessageList messages={[...makeMessages(50), { ...linked, linkPreview: preview }]} conversationId="conv-fastening" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+
+  // The card's height reaches the scroller a frame or two AFTER the commit that mounts it: under
+  // virtualization scrollHeight is the @tanstack spacer (getTotalSize()), which only grows once the
+  // row's ResizeObserver has re-measured. So the commit and the growth are two separate steps.
+  const PREVIEW_CARD_PX = 260
+
+  it('re-pins the bottom when a late link-preview fastening grows a resident row', () => {
+    const isAtBottomRef = { current: true }
+    const { view, scroller } = renderWithLinkMessage(isAtBottomRef)
+
+    fastenPreview(view, isAtBottomRef) // the fastening commits — spacer not grown yet
+    flush(1)
+    geo.scrollHeight += PREVIEW_CARD_PX // the row re-measures; the spacer catches up
+    flush(10)
+
+    expect(scrollToEndCalls.count).toBeGreaterThan(0)
+    expect(scroller.scrollTop).toBe(geo.scrollHeight - geo.clientHeight)
+  })
+
+  it('does not yank a scrolled-up reader down when a link-preview fastening lands', () => {
+    const isAtBottomRef = { current: true } // deliberately left latched true — geometry must decide
+    const { view, scroller } = renderWithLinkMessage(isAtBottomRef)
+
+    scroller.scrollTop = 400 // the reader scrolled up into history
+    fastenPreview(view, isAtBottomRef)
+    flush(1)
+    geo.scrollHeight += PREVIEW_CARD_PX
+    flush(10)
+
+    expect(scrollToEndCalls.count).toBe(0)
+    expect(scroller.scrollTop).toBe(400)
+  })
+
   it('stops the re-assert loop early once geometry is stable (convergence exit)', () => {
     const { rerender, isAtBottomRef } = renderPinned()
 

--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -133,6 +133,10 @@ describe('MessageList — live-edge executor cost control', () => {
     const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
     instrumentScroller(scroller)
     flush(70) // settle the entry pin completely
+    // Seed the geometry baseline the way a real browser does — scroll events fire constantly, and
+    // the growth correction in the row-growth gate reads the last one. Without this the harness
+    // leaves a pre-instrumentation baseline the real app never has.
+    act(() => { scroller.dispatchEvent(new Event('scroll')) })
     scrollToEndCalls.count = 0
     return { view, scroller }
   }
@@ -142,18 +146,22 @@ describe('MessageList — live-edge executor cost control', () => {
       <MessageList messages={[...makeMessages(50), { ...linked, linkPreview: preview }]} conversationId="conv-fastening" isAtBottomRef={isAtBottomRef} {...props} />,
     )
 
-  // The card's height reaches the scroller a frame or two AFTER the commit that mounts it: under
-  // virtualization scrollHeight is the @tanstack spacer (getTotalSize()), which only grows once the
-  // row's ResizeObserver has re-measured. So the commit and the growth are two separate steps.
+  // The card's height is in the scroller AS SOON AS the commit that mounts it lands: the row is
+  // absolutely positioned inside the @tanstack spacer and @tanstack re-measures it in the same
+  // frame, so scrollHeight already includes the growth when the layout effect runs. Verified in
+  // both engines — see the fastening tests in scripts/scroll-invariants.ts. Modelling this as a
+  // delayed growth is what let an earlier version of the geometry gate look correct here while
+  // failing in a real browser, so the growth is applied together with the rerender below.
+  // Deliberately larger than AT_BOTTOM_THRESHOLD (150): a gate reading POST-growth geometry must
+  // fail this test rather than squeak under the threshold.
   const PREVIEW_CARD_PX = 260
 
   it('re-pins the bottom when a late link-preview fastening grows a resident row', () => {
     const isAtBottomRef = { current: true }
     const { view, scroller } = renderWithLinkMessage(isAtBottomRef)
 
-    fastenPreview(view, isAtBottomRef) // the fastening commits — spacer not grown yet
-    flush(1)
-    geo.scrollHeight += PREVIEW_CARD_PX // the row re-measures; the spacer catches up
+    geo.scrollHeight += PREVIEW_CARD_PX // the card is in the layout the moment it commits
+    fastenPreview(view, isAtBottomRef)
     flush(10)
 
     expect(scrollToEndCalls.count).toBeGreaterThan(0)
@@ -165,9 +173,8 @@ describe('MessageList — live-edge executor cost control', () => {
     const { view, scroller } = renderWithLinkMessage(isAtBottomRef)
 
     scroller.scrollTop = 400 // the reader scrolled up into history
-    fastenPreview(view, isAtBottomRef)
-    flush(1)
     geo.scrollHeight += PREVIEW_CARD_PX
+    fastenPreview(view, isAtBottomRef)
     flush(10)
 
     expect(scrollToEndCalls.count).toBe(0)

--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -133,9 +133,12 @@ describe('MessageList — live-edge executor cost control', () => {
     const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
     instrumentScroller(scroller)
     flush(70) // settle the entry pin completely
-    // Seed the geometry baseline the way a real browser does — scroll events fire constantly, and
-    // the growth correction in the row-growth gate reads the last one. Without this the harness
-    // leaves a pre-instrumentation baseline the real app never has.
+    // Put the list in the state these tests are about: pinned at the bottom, with the geometry
+    // baseline seeded the way a real browser seeds it (scroll events fire constantly, and the
+    // growth correction reads the last one). The entry pin runs before instrumentScroller replaces
+    // the scrollTop accessor, so without this the harness starts at scrollTop=0 with a baseline the
+    // real app never has — and every gate downstream reads nonsense.
+    scroller.scrollTop = geo.scrollHeight
     act(() => { scroller.dispatchEvent(new Event('scroll')) })
     scrollToEndCalls.count = 0
     return { view, scroller }

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -45,6 +45,7 @@ import {
 import { MessageTargetProvider } from './messageTargetContext'
 import { useRowMetrics, ROW_METRICS_FALLBACK } from './useRowMetrics'
 import { estimateRowHeight } from './rowHeightEstimator'
+import { computeRowGrowthSignature } from './rowGrowthSignature'
 import { isEstimateDebugEnabled, estimateDebugLog } from '@/utils/scrollDebug'
 import {
   getCachedHeights,
@@ -245,20 +246,15 @@ export function MessageList<T extends BaseMessage>({
   // Compute derived values for scroll hook
   const firstMessageId = deduplicatedMessages[0]?.id
   const lastMessage = messages[messages.length - 1]
-  // Signature of every resident message's reactions — changes when a reaction is added/removed
-  // anywhere in the window, which grows/shrinks that row. Cheap: only messages that actually carry
-  // reactions contribute, so the common no-reaction rows cost a bare iteration. Drives an instant
-  // bottom re-pin while the reader is sticked to the bottom, so reaction growth is absorbed above
-  // (previous messages scroll up) instead of shoving the newest message down (see the reactions
-  // effect in useMessageListScroll).
-  const reactionsSignature = useMemo(() => {
-    let sig = ''
-    for (const m of deduplicatedMessages) {
-      const r = m.reactions
-      if (r && Object.keys(r).length > 0) sig += `${m.id}:${JSON.stringify(r)};`
-    }
-    return sig
-  }, [deduplicatedMessages])
+  // Signature of every in-place row-height change across the window — a reaction, a link-preview or
+  // attachment fastening, a correction, a retraction. Drives an instant bottom re-pin while the
+  // reader is sticked to the bottom, so the growth is absorbed above (previous messages scroll up)
+  // instead of shoving the newest message below the fold (see the row-growth effect in
+  // useMessageListScroll).
+  const rowGrowthSignature = useMemo(
+    () => computeRowGrowthSignature(deduplicatedMessages),
+    [deduplicatedMessages],
+  )
 
   // --------------------------------------------------------------------------
   // SCROLL BEHAVIOR (delegated to hook)
@@ -540,7 +536,7 @@ export function MessageList<T extends BaseMessage>({
     isLoadingNewer,
     windowAtLiveEdge,
     isHistoryComplete,
-    reactionsSignature,
+    rowGrowthSignature,
     hasTypingIndicator: typingUsers.length > 0,
     lastMessageIsOutgoing: lastMessage?.isOutgoing ?? false,
     lastMessageId: lastMessage?.id,

--- a/apps/fluux/src/components/conversation/pinLoopClaim.test.ts
+++ b/apps/fluux/src/components/conversation/pinLoopClaim.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { createPinLoopClaim, PIN_CLAIM_STALE_MS } from './pinLoopClaim'
+
+function fakeClock() {
+  let t = 1_000
+  return { now: () => t, advance: (ms: number) => { t += ms } }
+}
+
+describe('createPinLoopClaim', () => {
+  it('is not held before any loop runs', () => {
+    const clock = fakeClock()
+    expect(createPinLoopClaim(clock.now).isHeld()).toBe(false)
+  })
+
+  it('is held while a loop owns the bottom, and released when it finishes', () => {
+    const clock = fakeClock()
+    const claim = createPinLoopClaim(clock.now)
+
+    claim.renew()
+    expect(claim.isHeld()).toBe(true)
+    claim.release()
+    expect(claim.isHeld()).toBe(false)
+  })
+
+  it('stays held across a long-running loop that keeps renewing', () => {
+    const clock = fakeClock()
+    const claim = createPinLoopClaim(clock.now)
+
+    // A slow WebKit frame rate can stretch the 60-frame budget well past the stale window; as long
+    // as frames keep arriving the claim must not expire under the running loop.
+    for (let frame = 0; frame < 60; frame += 1) {
+      claim.renew()
+      clock.advance(PIN_CLAIM_STALE_MS / 2)
+      expect(claim.isHeld()).toBe(true)
+    }
+  })
+
+  // THE REGRESSION THIS TYPE EXISTS FOR. A loop dropped without its finish callback (a lease that
+  // silently stopped being current mid-flight) used to latch a plain boolean forever, and a latched
+  // claim suppresses every later bottom re-pin — a link-preview fastening, an attachment, a reaction
+  // — for the whole life of the mounted list. That is the "it never sticks to the bottom" report.
+  it('expires on its own when a loop is dropped without ever releasing it', () => {
+    const clock = fakeClock()
+    const claim = createPinLoopClaim(clock.now)
+
+    claim.renew() // loop starts…
+    // …and is abandoned here: no further frames, and release() is never called.
+    expect(claim.isHeld()).toBe(true)
+
+    clock.advance(PIN_CLAIM_STALE_MS + 1)
+
+    expect(claim.isHeld()).toBe(false)
+  })
+
+  it('can be re-taken after expiry', () => {
+    const clock = fakeClock()
+    const claim = createPinLoopClaim(clock.now)
+
+    claim.renew()
+    clock.advance(PIN_CLAIM_STALE_MS + 1)
+    expect(claim.isHeld()).toBe(false)
+
+    claim.renew()
+    expect(claim.isHeld()).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/pinLoopClaim.ts
+++ b/apps/fluux/src/components/conversation/pinLoopClaim.ts
@@ -29,6 +29,13 @@ export interface PinLoopClaim {
   release: () => void
   /** Whether a loop currently owns the bottom. */
   isHeld: () => boolean
+  /**
+   * Milliseconds until the claim lapses if nothing renews it (0 when not held). A caller that had
+   * to defer because the claim was held uses this to schedule its retry: the claim cannot outlive
+   * this window without a live loop renewing it, so the retry either finds it released or finds a
+   * loop that is genuinely still pinning.
+   */
+  msUntilExpiry: () => number
 }
 
 export function createPinLoopClaim(now: () => number = Date.now): PinLoopClaim {
@@ -41,5 +48,6 @@ export function createPinLoopClaim(now: () => number = Date.now): PinLoopClaim {
       heldUntil = 0
     },
     isHeld: () => heldUntil > now(),
+    msUntilExpiry: () => Math.max(0, heldUntil - now()),
   }
 }

--- a/apps/fluux/src/components/conversation/pinLoopClaim.ts
+++ b/apps/fluux/src/components/conversation/pinLoopClaim.ts
@@ -29,13 +29,6 @@ export interface PinLoopClaim {
   release: () => void
   /** Whether a loop currently owns the bottom. */
   isHeld: () => boolean
-  /**
-   * Milliseconds until the claim lapses if nothing renews it (0 when not held). A caller that had
-   * to defer because the claim was held uses this to schedule its retry: the claim cannot outlive
-   * this window without a live loop renewing it, so the retry either finds it released or finds a
-   * loop that is genuinely still pinning.
-   */
-  msUntilExpiry: () => number
 }
 
 export function createPinLoopClaim(now: () => number = Date.now): PinLoopClaim {
@@ -48,6 +41,5 @@ export function createPinLoopClaim(now: () => number = Date.now): PinLoopClaim {
       heldUntil = 0
     },
     isHeld: () => heldUntil > now(),
-    msUntilExpiry: () => Math.max(0, heldUntil - now()),
   }
 }

--- a/apps/fluux/src/components/conversation/pinLoopClaim.ts
+++ b/apps/fluux/src/components/conversation/pinLoopClaim.ts
@@ -1,0 +1,45 @@
+/**
+ * The "a pin-bottom loop already owns the bottom" claim.
+ *
+ * Two callers skip their own work while a pin loop is in flight: the row-growth re-pin (it would
+ * only stack a second loop — the running one re-reads scrollHeight every frame and picks the growth
+ * up itself, and restarting costs a synchronous forced layout + repaint, the WebKitGTK hot path),
+ * and the scroll-to-bottom FAB (a growth-driven scroll event fires at the pre-repin scrollTop, which
+ * would flash the FAB while the loop is settling AT the bottom).
+ *
+ * Held as a DEADLINE, not a boolean. A boolean is cleared only by the loop's finish callback, so any
+ * path that drops a loop without finishing it — a lease that silently stops being current mid-flight
+ * — latches the claim forever. A latched claim silently suppresses EVERY later bottom re-pin (a
+ * link-preview fastening, an attachment, a reaction) for the whole life of that mounted list, which
+ * is exactly the "it never sticks to the bottom" report. A running loop renews the claim on every
+ * frame, so a claim that has gone this long without one is provably stale and heals itself instead
+ * of wedging the list.
+ *
+ * The failure mode of expiring too early is benign and self-correcting: one extra pin loop, which
+ * supersedes the stale one and re-pins an already-pinned bottom.
+ */
+
+/** How long a claim survives without a loop frame renewing it. Well past any real frame gap. */
+export const PIN_CLAIM_STALE_MS = 2000
+
+export interface PinLoopClaim {
+  /** Take (or renew) the claim. Called when the loop starts and on every frame it runs. */
+  renew: () => void
+  /** Drop the claim — the loop finished. */
+  release: () => void
+  /** Whether a loop currently owns the bottom. */
+  isHeld: () => boolean
+}
+
+export function createPinLoopClaim(now: () => number = Date.now): PinLoopClaim {
+  let heldUntil = 0
+  return {
+    renew: () => {
+      heldUntil = now() + PIN_CLAIM_STALE_MS
+    },
+    release: () => {
+      heldUntil = 0
+    },
+    isHeld: () => heldUntil > now(),
+  }
+}

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { decideRowGrowth, type RowGrowthFacts } from './rowGrowthDecision'
+import { carryDeferral, decideRowGrowth, type RowGrowthFacts } from './rowGrowthDecision'
 
 /** At the bottom, with a 260px card just mounted — the canonical fastening case. */
 const atBottomAfterCard = (over: Partial<RowGrowthFacts> = {}): RowGrowthFacts => ({
@@ -100,5 +100,31 @@ describe('decideRowGrowth', () => {
     ['the reader was scrolled up', { distanceFromBottom: 1360, growth: 260 }],
   ])('skips outright when %s, even with the claim held', (_label, over) => {
     expect(decideRowGrowth(atBottomAfterCard({ ...over, pinClaimHeld: true }))).toBe('skip')
+  })
+})
+
+describe('carryDeferral', () => {
+  const fresh = { at: 2000, scrollTop: 1500 }
+
+  it('uses the fresh deferral when nothing is pending', () => {
+    expect(carryDeferral(null, fresh)).toBe(fresh)
+  })
+
+  // THE REGRESSION. A preview card defers behind a pin loop; its own scroll event advances the
+  // geometry baseline to the grown height. A reaction arriving before the claim lapses must NOT
+  // restart from that baseline — it would see only the reaction's few pixels, read the card's height
+  // as "the reader is scrolled up", and terminally skip a growth that was eligible and still
+  // pending, leaving the list unpinned for good.
+  it('keeps the EARLIEST pending deferral when a newer growth arrives', () => {
+    const pending = { at: 1000, scrollTop: 1200 }
+    expect(carryDeferral(pending, fresh)).toBe(pending)
+  })
+
+  // The earliest deferral is also what the takeover checks compare against, so preserving it keeps
+  // "did the reader move since we started waiting?" anchored to the original moment.
+  it('preserves the original timestamp and scrollTop, not the newer ones', () => {
+    const pending = { at: 1000, scrollTop: 1200 }
+    const carried = carryDeferral(pending, fresh)
+    expect(carried).toEqual({ at: 1000, scrollTop: 1200 })
   })
 })

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
@@ -11,6 +11,7 @@ const atBottomAfterCard = (over: Partial<RowGrowthFacts> = {}): RowGrowthFacts =
   navigationInFlight: false,
   readerTookOver: false,
   isRetry: false,
+  eligibilityEstablished: false,
   ...over,
 })
 
@@ -59,6 +60,37 @@ describe('decideRowGrowth', () => {
       atBottomAfterCard({ pinClaimHeld: true, navigationInFlight: true }),
     )
     expect(decision).toBe('defer')
+  })
+
+  // THE RETRY REGRESSION. By the time a deferred growth is retried, the growth has fired its own
+  // scroll event and the baseline has moved forward to the GROWN height — so a freshly derived
+  // growth is 0 and the card's own 260px reads as "the reader is scrolled up". Re-deriving
+  // eligibility there skips the growth forever and the deferral buys nothing.
+  it('pins a retry whose baseline has caught up, so growth now derives as 0', () => {
+    const decision = decideRowGrowth(
+      atBottomAfterCard({ isRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260 }),
+    )
+    expect(decision).toBe('pin')
+  })
+
+  it('still refuses that retry if the reader took over in the meantime', () => {
+    const decision = decideRowGrowth(
+      atBottomAfterCard({
+        isRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
+        readerTookOver: true,
+      }),
+    )
+    expect(decision).toBe('skip')
+  })
+
+  it('still refuses that retry if a navigation started in the meantime', () => {
+    const decision = decideRowGrowth(
+      atBottomAfterCard({
+        isRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
+        navigationInFlight: true,
+      }),
+    )
+    expect(decision).toBe('skip')
   })
 
   // Ordering guard: a reader who has moved, or who was never at the bottom, must lose to nothing —

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
@@ -4,7 +4,7 @@ import { decideRowGrowth, type RowGrowthFacts } from './rowGrowthDecision'
 /** At the bottom, with a 260px card just mounted — the canonical fastening case. */
 const atBottomAfterCard = (over: Partial<RowGrowthFacts> = {}): RowGrowthFacts => ({
   distanceFromBottom: 260,
-  growth: 260,
+  heightDelta: 260,
   atBottomThreshold: 150,
   pinClaimHeld: false,
   navigationInFlight: false,
@@ -19,16 +19,44 @@ describe('decideRowGrowth', () => {
   // The growth lands in the measured distance. Without subtracting it, a card taller than the
   // threshold reads as "scrolled away" and the re-pin is refused in the very case it exists for.
   it('pins even when the growth alone exceeds the at-bottom threshold', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 900, growth: 900 }))).toBe('pin')
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 900, heightDelta: 900 }))).toBe('pin')
   })
 
   // A distance of ~0 means the spacer has not taken the growth yet, not that the bottom is pinned.
   it('pins when the growth is not measured yet', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, growth: 0 }))).toBe('pin')
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, heightDelta: 0 }))).toBe('pin')
+  })
+
+  // An untrustworthy baseline (stale, or captured before the list had real geometry) is reported as
+  // null, and must stay eligible — a genuine growth not yet measured looks the same from here.
+  it('pins with no trustworthy baseline when the list still reads as near the bottom', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 20, heightDelta: null }))).toBe('pin')
+  })
+
+  it('skips with no trustworthy baseline when the reader is plainly scrolled up', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 900, heightDelta: null }))).toBe('skip')
+  })
+
+  // THE SIGN REGRESSION. Clamping the delta at 0 made a measured SHRINK indistinguishable from an
+  // unmeasured growth. A reader sitting 300px up, a retraction (or a reaction removed) shrinking the
+  // content by 250px: the post-shrink distance is 50px, a clamped delta is 0, and 50 - 0 lands under
+  // the threshold — so the reader was yanked to the bottom by content DISAPPEARING.
+  it('skips a measured shrink instead of reading it as an unmeasured growth', () => {
+    expect(
+      decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 50, heightDelta: -250 })),
+    ).toBe('skip')
+  })
+
+  // Nothing was pushed below the fold, and the browser clamps scrollTop itself when content shrinks
+  // past it — the same reason a typing indicator turning off needs no re-pin.
+  it('skips a shrink even for a reader sitting exactly at the bottom', () => {
+    expect(
+      decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, heightDelta: -120 })),
+    ).toBe('skip')
   })
 
   it('skips when the reader was genuinely scrolled up before the growth', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, growth: 260 }))).toBe('skip')
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, heightDelta: 260 }))).toBe('skip')
   })
 
   it('skips rather than cancel a navigation the reader asked for', () => {
@@ -45,7 +73,7 @@ describe('decideRowGrowth', () => {
 
   it('lets the reader-scrolled-up check win over a held claim', () => {
     expect(
-      decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, growth: 260, pinClaimHeld: true })),
+      decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, heightDelta: 260, pinClaimHeld: true })),
     ).toBe('skip')
   })
 })

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
@@ -10,7 +10,7 @@ const atBottomAfterCard = (over: Partial<RowGrowthFacts> = {}): RowGrowthFacts =
   pinClaimHeld: false,
   navigationInFlight: false,
   readerTookOver: false,
-  isRetry: false,
+  isTimerRetry: false,
   eligibilityEstablished: false,
   ...over,
 })
@@ -38,14 +38,32 @@ describe('decideRowGrowth', () => {
     expect(decideRowGrowth(atBottomAfterCard({ navigationInFlight: true }))).toBe('skip')
   })
 
-  it('skips a RETRY whose bottom the deferring loop already pinned', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ isRetry: true, distanceFromBottom: 2, growth: 2 }))).toBe('skip')
+  it('skips a TIMER RETRY whose bottom the deferring loop already pinned', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ isTimerRetry: true, distanceFromBottom: 2, growth: 2 }))).toBe('skip')
   })
 
-  // On the first attempt a distance of ~0 means the spacer has not taken the growth yet, not that
+  // On a first attempt a distance of ~0 means the spacer has not taken the growth yet, not that
   // the bottom is pinned. Skipping there would drop a growth no loop is going to absorb.
   it('still pins a FIRST attempt measuring ~0 distance (spacer has not caught up)', () => {
     expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, growth: 0 }))).toBe('pin')
+  })
+
+  // THE CONFLATION REGRESSION. A newer signature can carry an earlier deferral — that establishes
+  // eligibility, but it is still a FIRST attempt at the newly arrived growth, which is typically not
+  // measured yet (distance ~0). Treating it as a timer retry lets the already-pinned shortcut skip
+  // it; if the deferring loop has since released its claim, nothing remains to absorb that growth
+  // and the list is stranded.
+  it('pins a signature-triggered attempt that carries a deferral but is not yet measured', () => {
+    const decision = decideRowGrowth(
+      atBottomAfterCard({
+        eligibilityEstablished: true, // carried from the pending deferral
+        isTimerRetry: false,          // …but this is a fresh signature, not the timer
+        distanceFromBottom: 0,
+        growth: 0,
+        pinClaimHeld: false,          // the old loop already released
+      }),
+    )
+    expect(decision).toBe('pin')
   })
 
   // THE REGRESSION. A held claim is a BET that the running loop absorbs the growth. If that loop was
@@ -68,7 +86,7 @@ describe('decideRowGrowth', () => {
   // eligibility there skips the growth forever and the deferral buys nothing.
   it('pins a retry whose baseline has caught up, so growth now derives as 0', () => {
     const decision = decideRowGrowth(
-      atBottomAfterCard({ isRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260 }),
+      atBottomAfterCard({ isTimerRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260 }),
     )
     expect(decision).toBe('pin')
   })
@@ -76,7 +94,7 @@ describe('decideRowGrowth', () => {
   it('still refuses that retry if the reader took over in the meantime', () => {
     const decision = decideRowGrowth(
       atBottomAfterCard({
-        isRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
+        isTimerRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
         readerTookOver: true,
       }),
     )
@@ -86,7 +104,7 @@ describe('decideRowGrowth', () => {
   it('still refuses that retry if a navigation started in the meantime', () => {
     const decision = decideRowGrowth(
       atBottomAfterCard({
-        isRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
+        isTimerRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
         navigationInFlight: true,
       }),
     )

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { decideRowGrowth, type RowGrowthFacts } from './rowGrowthDecision'
+
+/** At the bottom, with a 260px card just mounted — the canonical fastening case. */
+const atBottomAfterCard = (over: Partial<RowGrowthFacts> = {}): RowGrowthFacts => ({
+  distanceFromBottom: 260,
+  growth: 260,
+  atBottomThreshold: 150,
+  pinnedTolerance: 4,
+  pinClaimHeld: false,
+  navigationInFlight: false,
+  readerTookOver: false,
+  isRetry: false,
+  ...over,
+})
+
+describe('decideRowGrowth', () => {
+  it('pins when the reader was at the bottom before the row grew', () => {
+    expect(decideRowGrowth(atBottomAfterCard())).toBe('pin')
+  })
+
+  // The growth lands in the measured distance. Without subtracting it, a card taller than the
+  // threshold reads as "scrolled away" and the re-pin is refused in the very case it exists for.
+  it('pins even when the growth alone exceeds the at-bottom threshold', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 900, growth: 900 }))).toBe('pin')
+  })
+
+  it('skips when the reader was genuinely scrolled up before the growth', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, growth: 260 }))).toBe('skip')
+  })
+
+  it('skips when the reader has scrolled since the growth was queued', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ readerTookOver: true }))).toBe('skip')
+  })
+
+  it('skips rather than cancel a navigation the reader asked for', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ navigationInFlight: true }))).toBe('skip')
+  })
+
+  it('skips a RETRY whose bottom the deferring loop already pinned', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ isRetry: true, distanceFromBottom: 2, growth: 2 }))).toBe('skip')
+  })
+
+  // On the first attempt a distance of ~0 means the spacer has not taken the growth yet, not that
+  // the bottom is pinned. Skipping there would drop a growth no loop is going to absorb.
+  it('still pins a FIRST attempt measuring ~0 distance (spacer has not caught up)', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, growth: 0 }))).toBe('pin')
+  })
+
+  // THE REGRESSION. A held claim is a BET that the running loop absorbs the growth. If that loop was
+  // abandoned its claim lingers until it lapses, and because a signature change is consumed exactly
+  // once, `skip` here would drop the fastening for good — it would never be pinned at all.
+  it('DEFERS (never skips) while a pin loop holds the claim, so the caller can retry', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ pinClaimHeld: true }))).toBe('defer')
+  })
+
+  it('defers ahead of the navigation guard — a lapsed claim must still get its retry', () => {
+    const decision = decideRowGrowth(
+      atBottomAfterCard({ pinClaimHeld: true, navigationInFlight: true }),
+    )
+    expect(decision).toBe('defer')
+  })
+
+  // Ordering guard: a reader who has moved, or who was never at the bottom, must lose to nothing —
+  // not even a held claim should turn those into a retry that could later yank them.
+  it.each([
+    ['the reader took over', { readerTookOver: true }],
+    ['the reader was scrolled up', { distanceFromBottom: 1360, growth: 260 }],
+  ])('skips outright when %s, even with the claim held', (_label, over) => {
+    expect(decideRowGrowth(atBottomAfterCard({ ...over, pinClaimHeld: true }))).toBe('skip')
+  })
+})

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.test.ts
@@ -1,17 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { carryDeferral, decideRowGrowth, type RowGrowthFacts } from './rowGrowthDecision'
+import { decideRowGrowth, type RowGrowthFacts } from './rowGrowthDecision'
 
 /** At the bottom, with a 260px card just mounted — the canonical fastening case. */
 const atBottomAfterCard = (over: Partial<RowGrowthFacts> = {}): RowGrowthFacts => ({
   distanceFromBottom: 260,
   growth: 260,
   atBottomThreshold: 150,
-  pinnedTolerance: 4,
   pinClaimHeld: false,
   navigationInFlight: false,
-  readerTookOver: false,
-  isTimerRetry: false,
-  eligibilityEstablished: false,
   ...over,
 })
 
@@ -26,123 +22,30 @@ describe('decideRowGrowth', () => {
     expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 900, growth: 900 }))).toBe('pin')
   })
 
-  it('skips when the reader was genuinely scrolled up before the growth', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, growth: 260 }))).toBe('skip')
+  // A distance of ~0 means the spacer has not taken the growth yet, not that the bottom is pinned.
+  it('pins when the growth is not measured yet', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, growth: 0 }))).toBe('pin')
   })
 
-  it('skips when the reader has scrolled since the growth was queued', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ readerTookOver: true }))).toBe('skip')
+  it('skips when the reader was genuinely scrolled up before the growth', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, growth: 260 }))).toBe('skip')
   })
 
   it('skips rather than cancel a navigation the reader asked for', () => {
     expect(decideRowGrowth(atBottomAfterCard({ navigationInFlight: true }))).toBe('skip')
   })
 
-  it('skips a TIMER RETRY whose bottom the deferring loop already pinned', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ isTimerRetry: true, distanceFromBottom: 2, growth: 2 }))).toBe('skip')
+  // ACCEPTED GAP, pinned here so it is a decision and not a surprise: a held claim skips, betting
+  // the running loop absorbs the growth. If that loop was abandoned the bet is wrong and THIS growth
+  // is never pinned — the claim's expiry bounds how long further growths stay suppressed, but it
+  // does not replay one already consumed. See the module doc.
+  it('skips while a pin loop holds the claim, betting that loop absorbs the growth', () => {
+    expect(decideRowGrowth(atBottomAfterCard({ pinClaimHeld: true }))).toBe('skip')
   })
 
-  // On a first attempt a distance of ~0 means the spacer has not taken the growth yet, not that
-  // the bottom is pinned. Skipping there would drop a growth no loop is going to absorb.
-  it('still pins a FIRST attempt measuring ~0 distance (spacer has not caught up)', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 0, growth: 0 }))).toBe('pin')
-  })
-
-  // THE CONFLATION REGRESSION. A newer signature can carry an earlier deferral — that establishes
-  // eligibility, but it is still a FIRST attempt at the newly arrived growth, which is typically not
-  // measured yet (distance ~0). Treating it as a timer retry lets the already-pinned shortcut skip
-  // it; if the deferring loop has since released its claim, nothing remains to absorb that growth
-  // and the list is stranded.
-  it('pins a signature-triggered attempt that carries a deferral but is not yet measured', () => {
-    const decision = decideRowGrowth(
-      atBottomAfterCard({
-        eligibilityEstablished: true, // carried from the pending deferral
-        isTimerRetry: false,          // …but this is a fresh signature, not the timer
-        distanceFromBottom: 0,
-        growth: 0,
-        pinClaimHeld: false,          // the old loop already released
-      }),
-    )
-    expect(decision).toBe('pin')
-  })
-
-  // THE REGRESSION. A held claim is a BET that the running loop absorbs the growth. If that loop was
-  // abandoned its claim lingers until it lapses, and because a signature change is consumed exactly
-  // once, `skip` here would drop the fastening for good — it would never be pinned at all.
-  it('DEFERS (never skips) while a pin loop holds the claim, so the caller can retry', () => {
-    expect(decideRowGrowth(atBottomAfterCard({ pinClaimHeld: true }))).toBe('defer')
-  })
-
-  it('defers ahead of the navigation guard — a lapsed claim must still get its retry', () => {
-    const decision = decideRowGrowth(
-      atBottomAfterCard({ pinClaimHeld: true, navigationInFlight: true }),
-    )
-    expect(decision).toBe('defer')
-  })
-
-  // THE RETRY REGRESSION. By the time a deferred growth is retried, the growth has fired its own
-  // scroll event and the baseline has moved forward to the GROWN height — so a freshly derived
-  // growth is 0 and the card's own 260px reads as "the reader is scrolled up". Re-deriving
-  // eligibility there skips the growth forever and the deferral buys nothing.
-  it('pins a retry whose baseline has caught up, so growth now derives as 0', () => {
-    const decision = decideRowGrowth(
-      atBottomAfterCard({ isTimerRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260 }),
-    )
-    expect(decision).toBe('pin')
-  })
-
-  it('still refuses that retry if the reader took over in the meantime', () => {
-    const decision = decideRowGrowth(
-      atBottomAfterCard({
-        isTimerRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
-        readerTookOver: true,
-      }),
-    )
-    expect(decision).toBe('skip')
-  })
-
-  it('still refuses that retry if a navigation started in the meantime', () => {
-    const decision = decideRowGrowth(
-      atBottomAfterCard({
-        isTimerRetry: true, eligibilityEstablished: true, growth: 0, distanceFromBottom: 260,
-        navigationInFlight: true,
-      }),
-    )
-    expect(decision).toBe('skip')
-  })
-
-  // Ordering guard: a reader who has moved, or who was never at the bottom, must lose to nothing —
-  // not even a held claim should turn those into a retry that could later yank them.
-  it.each([
-    ['the reader took over', { readerTookOver: true }],
-    ['the reader was scrolled up', { distanceFromBottom: 1360, growth: 260 }],
-  ])('skips outright when %s, even with the claim held', (_label, over) => {
-    expect(decideRowGrowth(atBottomAfterCard({ ...over, pinClaimHeld: true }))).toBe('skip')
-  })
-})
-
-describe('carryDeferral', () => {
-  const fresh = { at: 2000, scrollTop: 1500 }
-
-  it('uses the fresh deferral when nothing is pending', () => {
-    expect(carryDeferral(null, fresh)).toBe(fresh)
-  })
-
-  // THE REGRESSION. A preview card defers behind a pin loop; its own scroll event advances the
-  // geometry baseline to the grown height. A reaction arriving before the claim lapses must NOT
-  // restart from that baseline — it would see only the reaction's few pixels, read the card's height
-  // as "the reader is scrolled up", and terminally skip a growth that was eligible and still
-  // pending, leaving the list unpinned for good.
-  it('keeps the EARLIEST pending deferral when a newer growth arrives', () => {
-    const pending = { at: 1000, scrollTop: 1200 }
-    expect(carryDeferral(pending, fresh)).toBe(pending)
-  })
-
-  // The earliest deferral is also what the takeover checks compare against, so preserving it keeps
-  // "did the reader move since we started waiting?" anchored to the original moment.
-  it('preserves the original timestamp and scrollTop, not the newer ones', () => {
-    const pending = { at: 1000, scrollTop: 1200 }
-    const carried = carryDeferral(pending, fresh)
-    expect(carried).toEqual({ at: 1000, scrollTop: 1200 })
+  it('lets the reader-scrolled-up check win over a held claim', () => {
+    expect(
+      decideRowGrowth(atBottomAfterCard({ distanceFromBottom: 1360, growth: 260, pinClaimHeld: true })),
+    ).toBe('skip')
   })
 })

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.ts
@@ -1,0 +1,57 @@
+/**
+ * What to do about a row that grew in place (a fastening, an attachment, a reaction, a correction).
+ *
+ * The distinction that matters is SKIP vs DEFER. A row-growth signature change is consumed exactly
+ * once — nothing re-runs the effect for the same signature — so a guard that returns `skip` throws
+ * the change away for good. That is right when the answer cannot change later (the reader is not at
+ * the bottom; a navigation owns the position). It is WRONG for "a pin loop already owns the bottom",
+ * which is a bet that the running loop absorbs the growth: if that loop was abandoned, its claim
+ * lingers until it lapses and the growth is never pinned at all. That case must `defer` so the
+ * caller can retry once the claim has lapsed.
+ */
+export type RowGrowthDecision = 'pin' | 'skip' | 'defer'
+
+export interface RowGrowthFacts {
+  /** Live distance from the bottom, measured AFTER the row grew. */
+  distanceFromBottom: number
+  /** How much the content grew, or 0 when there is no trustworthy baseline. */
+  growth: number
+  /** Distance within which the list counts as "following the bottom". */
+  atBottomThreshold: number
+  /** Sub-row tolerance: at or under this the bottom is already pinned, so a re-pin is pure cost. */
+  pinnedTolerance: number
+  /** A pin-bottom loop currently claims the bottom. */
+  pinClaimHeld: boolean
+  /** The controller is converging on a position the reader explicitly asked for. */
+  navigationInFlight: boolean
+  /** The reader has scrolled of their own accord since this growth was first seen. */
+  readerTookOver: boolean
+  /** Whether this is a retry of a previously deferred growth rather than the first attempt. */
+  isRetry: boolean
+}
+
+export function decideRowGrowth(facts: RowGrowthFacts): RowGrowthDecision {
+  // The reader moved after the growth was queued — their position wins, permanently.
+  if (facts.readerTookOver) return 'skip'
+
+  // Was the reader at the bottom BEFORE the row grew? The growth lands in the measured distance, so
+  // it has to come back out; otherwise a card taller than the threshold reads as "scrolled away"
+  // and the re-pin is refused in exactly the case it exists for.
+  if (facts.distanceFromBottom - facts.growth >= facts.atBottomThreshold) return 'skip'
+
+  // A running loop re-reads the height every frame and absorbs this itself. DEFER, never skip: the
+  // claim lapses on its own if that loop was abandoned, and the caller retries then.
+  if (facts.pinClaimHeld) return 'defer'
+
+  // Row growth is ambient — the reader did not ask for it, so it must not cancel a position they
+  // did ask for (Home, jump-to-message, saved-position restore).
+  if (facts.navigationInFlight) return 'skip'
+
+  // On a RETRY only: the loop we deferred behind may have pinned the bottom already, so re-pinning
+  // would buy nothing but a forced layout. This must not apply to the first attempt — the spacer
+  // often has not taken the growth yet at that point, so a distance of ~0 there means "not measured
+  // yet", not "already pinned", and skipping would drop the growth the loop never absorbed.
+  if (facts.isRetry && facts.distanceFromBottom <= facts.pinnedTolerance) return 'skip'
+
+  return 'pin'
+}

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.ts
@@ -11,6 +11,31 @@
  */
 export type RowGrowthDecision = 'pin' | 'skip' | 'defer'
 
+/** What a deferred row-growth remembers so its retry judges the SAME situation, not a later one. */
+export interface DeferredRowGrowth {
+  /** When the growth was first seen — deliberate scroll intent after this means the reader moved. */
+  at: number
+  /** scrollTop at that moment; a smaller value later means the reader scrolled up since. */
+  scrollTop: number
+}
+
+/**
+ * Which deferral a newly-arrived growth should be judged against.
+ *
+ * The EARLIEST unresolved one wins. A growth that deferred has already had its eligibility proven,
+ * and its own scroll event has since advanced the geometry baseline to the grown height — so
+ * restarting from current geometry sees only the newer (typically much smaller) delta, reads the
+ * earlier card's height as "the reader is scrolled up", and terminally skips. That loses a growth
+ * that was eligible and still pending: a preview card deferred behind a pin loop, followed by a
+ * reaction before the claim lapsed, left the list unpinned for good.
+ */
+export function carryDeferral(
+  pending: DeferredRowGrowth | null,
+  fresh: DeferredRowGrowth,
+): DeferredRowGrowth {
+  return pending ?? fresh
+}
+
 export interface RowGrowthFacts {
   /** Live distance from the bottom, measured AFTER the row grew. */
   distanceFromBottom: number

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.ts
@@ -28,6 +28,14 @@ export interface RowGrowthFacts {
   readerTookOver: boolean
   /** Whether this is a retry of a previously deferred growth rather than the first attempt. */
   isRetry: boolean
+  /**
+   * Whether "the reader was at the bottom before the row grew" is ALREADY established and must not
+   * be re-derived. Set on a retry: the deferral proved it, and by the time the retry runs the growth
+   * has fired its own scroll event, which moves the baseline forward to the grown height. Re-deriving
+   * then yields growth=0 and reads the card's own height as "the reader is scrolled up", so the
+   * deferred growth is skipped forever — the deferral would have bought nothing.
+   */
+  eligibilityEstablished: boolean
 }
 
 export function decideRowGrowth(facts: RowGrowthFacts): RowGrowthDecision {
@@ -36,8 +44,14 @@ export function decideRowGrowth(facts: RowGrowthFacts): RowGrowthDecision {
 
   // Was the reader at the bottom BEFORE the row grew? The growth lands in the measured distance, so
   // it has to come back out; otherwise a card taller than the threshold reads as "scrolled away"
-  // and the re-pin is refused in exactly the case it exists for.
-  if (facts.distanceFromBottom - facts.growth >= facts.atBottomThreshold) return 'skip'
+  // and the re-pin is refused in exactly the case it exists for. Skipped once established — see
+  // eligibilityEstablished.
+  if (
+    !facts.eligibilityEstablished &&
+    facts.distanceFromBottom - facts.growth >= facts.atBottomThreshold
+  ) {
+    return 'skip'
+  }
 
   // A running loop re-reads the height every frame and absorbs this itself. DEFER, never skip: the
   // claim lapses on its own if that loop was abandoned, and the caller retries then.

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.ts
@@ -51,8 +51,16 @@ export interface RowGrowthFacts {
   navigationInFlight: boolean
   /** The reader has scrolled of their own accord since this growth was first seen. */
   readerTookOver: boolean
-  /** Whether this is a retry of a previously deferred growth rather than the first attempt. */
-  isRetry: boolean
+  /**
+   * Whether this attempt comes from the RETRY TIMER, as opposed to a signature change.
+   *
+   * It gates the already-pinned shortcut and nothing else, so it must be false for a
+   * signature-triggered attempt even when that attempt carries an earlier deferral. A newly arrived
+   * growth is typically not measured yet — distance reads ~0 — and treating it as a timer retry
+   * makes the shortcut conclude "already pinned" and skip. If the deferring loop has since released
+   * its claim, nothing is left to absorb that growth and the list is stranded.
+   */
+  isTimerRetry: boolean
   /**
    * Whether "the reader was at the bottom before the row grew" is ALREADY established and must not
    * be re-derived. Set on a retry: the deferral proved it, and by the time the retry runs the growth
@@ -86,11 +94,11 @@ export function decideRowGrowth(facts: RowGrowthFacts): RowGrowthDecision {
   // did ask for (Home, jump-to-message, saved-position restore).
   if (facts.navigationInFlight) return 'skip'
 
-  // On a RETRY only: the loop we deferred behind may have pinned the bottom already, so re-pinning
-  // would buy nothing but a forced layout. This must not apply to the first attempt — the spacer
-  // often has not taken the growth yet at that point, so a distance of ~0 there means "not measured
-  // yet", not "already pinned", and skipping would drop the growth the loop never absorbed.
-  if (facts.isRetry && facts.distanceFromBottom <= facts.pinnedTolerance) return 'skip'
+  // Timer retries ONLY: the loop we deferred behind may have pinned the bottom already, so
+  // re-pinning would buy nothing but a forced layout. Never for an attempt triggered by a signature
+  // change — the spacer usually has not taken that growth yet, so a distance of ~0 means "not
+  // measured yet", not "already pinned", and skipping would drop a growth nothing else will absorb.
+  if (facts.isTimerRetry && facts.distanceFromBottom <= facts.pinnedTolerance) return 'skip'
 
   return 'pin'
 }

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.ts
@@ -17,8 +17,18 @@ export type RowGrowthDecision = 'pin' | 'skip'
 export interface RowGrowthFacts {
   /** Live distance from the bottom, measured AFTER the row grew. */
   distanceFromBottom: number
-  /** How much the content grew, or 0 when there is no trustworthy baseline. */
-  growth: number
+  /**
+   * SIGNED height change since the last geometry the reader saw, or null when there is no
+   * trustworthy baseline to measure against.
+   *
+   * The sign carries information a clamp would destroy. A negative delta is a measured SHRINK — a
+   * retraction, a reaction removed — and shrinking pulls the bottom TOWARD the reader, so the
+   * reduced distance is not evidence they were following it. Clamping that to 0 made a shrink
+   * indistinguishable from an unmeasured growth and pinned a reader who was 300px up: shrink 250px,
+   * post-shrink distance 50px, and 50 - 0 lands under the threshold. null (no baseline) stays
+   * eligible, because a genuine growth that has not been measured yet also reads as ~0.
+   */
+  heightDelta: number | null
   /** Distance within which the list counts as "following the bottom". */
   atBottomThreshold: number
   /** A pin-bottom loop currently claims the bottom. */
@@ -28,10 +38,16 @@ export interface RowGrowthFacts {
 }
 
 export function decideRowGrowth(facts: RowGrowthFacts): RowGrowthDecision {
+  // A measured shrink is not a growth. Nothing was pushed below the fold, and the browser clamps
+  // scrollTop on its own when content shrinks past it — the same reason a typing indicator turning
+  // OFF needs no re-pin. Only a proven shrink skips here; an unknown delta stays eligible.
+  if (facts.heightDelta !== null && facts.heightDelta < 0) return 'skip'
+
   // Was the reader at the bottom BEFORE the row grew? The growth lands in the measured distance, so
   // it has to come back out; otherwise a card taller than the threshold reads as "scrolled away"
   // and the re-pin is refused in exactly the case it exists for.
-  if (facts.distanceFromBottom - facts.growth >= facts.atBottomThreshold) return 'skip'
+  const growth = facts.heightDelta ?? 0
+  if (facts.distanceFromBottom - growth >= facts.atBottomThreshold) return 'skip'
 
   // A running loop re-reads the height every frame and absorbs this itself — see the known gap above.
   if (facts.pinClaimHeld) return 'skip'

--- a/apps/fluux/src/components/conversation/rowGrowthDecision.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthDecision.ts
@@ -1,40 +1,18 @@
 /**
  * What to do about a row that grew in place (a fastening, an attachment, a reaction, a correction).
  *
- * The distinction that matters is SKIP vs DEFER. A row-growth signature change is consumed exactly
- * once — nothing re-runs the effect for the same signature — so a guard that returns `skip` throws
- * the change away for good. That is right when the answer cannot change later (the reader is not at
- * the bottom; a navigation owns the position). It is WRONG for "a pin loop already owns the bottom",
- * which is a bet that the running loop absorbs the growth: if that loop was abandoned, its claim
- * lingers until it lapses and the growth is never pinned at all. That case must `defer` so the
- * caller can retry once the claim has lapsed.
- */
-export type RowGrowthDecision = 'pin' | 'skip' | 'defer'
-
-/** What a deferred row-growth remembers so its retry judges the SAME situation, not a later one. */
-export interface DeferredRowGrowth {
-  /** When the growth was first seen — deliberate scroll intent after this means the reader moved. */
-  at: number
-  /** scrollTop at that moment; a smaller value later means the reader scrolled up since. */
-  scrollTop: number
-}
-
-/**
- * Which deferral a newly-arrived growth should be judged against.
+ * A row-growth signature change is consumed exactly once — nothing re-runs the effect for the same
+ * signature — so every `skip` is final.
  *
- * The EARLIEST unresolved one wins. A growth that deferred has already had its eligibility proven,
- * and its own scroll event has since advanced the geometry baseline to the grown height — so
- * restarting from current geometry sees only the newer (typically much smaller) delta, reads the
- * earlier card's height as "the reader is scrolled up", and terminally skips. That loses a growth
- * that was eligible and still pending: a preview card deferred behind a pin loop, followed by a
- * reaction before the claim lapsed, left the list unpinned for good.
+ * KNOWN GAP, accepted deliberately: when a pin loop already claims the bottom we skip, betting that
+ * the loop absorbs the growth itself. If that loop was abandoned without releasing its claim, the
+ * bet is wrong and this growth is never pinned. The claim self-expires, so the window in which that
+ * can happen is bounded — but expiry only stops FUTURE growths being suppressed; it does not replay
+ * the one already consumed. Recovering that growth needs the reader to move, or another growth to
+ * arrive after the claim lapses. The underlying defect is the controller path that can abandon a
+ * frame loop without calling finish(); fixing that closes this gap at the source.
  */
-export function carryDeferral(
-  pending: DeferredRowGrowth | null,
-  fresh: DeferredRowGrowth,
-): DeferredRowGrowth {
-  return pending ?? fresh
-}
+export type RowGrowthDecision = 'pin' | 'skip'
 
 export interface RowGrowthFacts {
   /** Live distance from the bottom, measured AFTER the row grew. */
@@ -43,62 +21,24 @@ export interface RowGrowthFacts {
   growth: number
   /** Distance within which the list counts as "following the bottom". */
   atBottomThreshold: number
-  /** Sub-row tolerance: at or under this the bottom is already pinned, so a re-pin is pure cost. */
-  pinnedTolerance: number
   /** A pin-bottom loop currently claims the bottom. */
   pinClaimHeld: boolean
   /** The controller is converging on a position the reader explicitly asked for. */
   navigationInFlight: boolean
-  /** The reader has scrolled of their own accord since this growth was first seen. */
-  readerTookOver: boolean
-  /**
-   * Whether this attempt comes from the RETRY TIMER, as opposed to a signature change.
-   *
-   * It gates the already-pinned shortcut and nothing else, so it must be false for a
-   * signature-triggered attempt even when that attempt carries an earlier deferral. A newly arrived
-   * growth is typically not measured yet — distance reads ~0 — and treating it as a timer retry
-   * makes the shortcut conclude "already pinned" and skip. If the deferring loop has since released
-   * its claim, nothing is left to absorb that growth and the list is stranded.
-   */
-  isTimerRetry: boolean
-  /**
-   * Whether "the reader was at the bottom before the row grew" is ALREADY established and must not
-   * be re-derived. Set on a retry: the deferral proved it, and by the time the retry runs the growth
-   * has fired its own scroll event, which moves the baseline forward to the grown height. Re-deriving
-   * then yields growth=0 and reads the card's own height as "the reader is scrolled up", so the
-   * deferred growth is skipped forever — the deferral would have bought nothing.
-   */
-  eligibilityEstablished: boolean
 }
 
 export function decideRowGrowth(facts: RowGrowthFacts): RowGrowthDecision {
-  // The reader moved after the growth was queued — their position wins, permanently.
-  if (facts.readerTookOver) return 'skip'
-
   // Was the reader at the bottom BEFORE the row grew? The growth lands in the measured distance, so
   // it has to come back out; otherwise a card taller than the threshold reads as "scrolled away"
-  // and the re-pin is refused in exactly the case it exists for. Skipped once established — see
-  // eligibilityEstablished.
-  if (
-    !facts.eligibilityEstablished &&
-    facts.distanceFromBottom - facts.growth >= facts.atBottomThreshold
-  ) {
-    return 'skip'
-  }
+  // and the re-pin is refused in exactly the case it exists for.
+  if (facts.distanceFromBottom - facts.growth >= facts.atBottomThreshold) return 'skip'
 
-  // A running loop re-reads the height every frame and absorbs this itself. DEFER, never skip: the
-  // claim lapses on its own if that loop was abandoned, and the caller retries then.
-  if (facts.pinClaimHeld) return 'defer'
+  // A running loop re-reads the height every frame and absorbs this itself — see the known gap above.
+  if (facts.pinClaimHeld) return 'skip'
 
   // Row growth is ambient — the reader did not ask for it, so it must not cancel a position they
   // did ask for (Home, jump-to-message, saved-position restore).
   if (facts.navigationInFlight) return 'skip'
-
-  // Timer retries ONLY: the loop we deferred behind may have pinned the bottom already, so
-  // re-pinning would buy nothing but a forced layout. Never for an attempt triggered by a signature
-  // change — the spacer usually has not taken that growth yet, so a distance of ~0 means "not
-  // measured yet", not "already pinned", and skipping would drop a growth nothing else will absorb.
-  if (facts.isTimerRetry && facts.distanceFromBottom <= facts.pinnedTolerance) return 'skip'
 
   return 'pin'
 }

--- a/apps/fluux/src/components/conversation/rowGrowthSignature.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthSignature.test.ts
@@ -26,6 +26,23 @@ describe('computeRowGrowthSignature', () => {
     expect(computeRowGrowthSignature(after)).not.toBe(computeRowGrowthSignature(before))
   })
 
+  // Bodies render with `whitespace-pre-wrap` in proportional text, so equal length does NOT mean
+  // equal height. A length-only fingerprint collided here and missed the re-pin entirely.
+  it('changes on a same-length correction that re-wraps the row', () => {
+    const oneLine = [{ ...text('a', 'aaaaa'), isEdited: true }]
+    const threeLines = [{ ...text('a', 'a\na\na'), isEdited: true }]
+    expect(oneLine[0].body).toHaveLength(threeLines[0].body!.length) // premise: same length
+
+    expect(computeRowGrowthSignature(threeLines)).not.toBe(computeRowGrowthSignature(oneLine))
+  })
+
+  it('changes on a same-length correction that only reorders characters', () => {
+    const before = [{ ...text('a', 'iii mmm'), isEdited: true }]
+    const after = [{ ...text('a', 'mmm iii'), isEdited: true }]
+
+    expect(computeRowGrowthSignature(after)).not.toBe(computeRowGrowthSignature(before))
+  })
+
   it('changes on a correction, and again on a second correction of different length', () => {
     const original = [text('a', 'hi')]
     const edited = [{ ...text('a', 'hi there'), isEdited: true }]

--- a/apps/fluux/src/components/conversation/rowGrowthSignature.test.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthSignature.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { computeRowGrowthSignature, type RowGrowthMessage } from './rowGrowthSignature'
+
+const text = (id: string, body = 'hello'): RowGrowthMessage => ({ id, body })
+
+describe('computeRowGrowthSignature', () => {
+  it('contributes nothing for plain text rows', () => {
+    expect(computeRowGrowthSignature([text('a'), text('b'), text('c')])).toBe('')
+  })
+
+  it('is stable across re-renders of unchanged messages', () => {
+    const messages = [text('a'), { ...text('b'), reactions: { '👍': ['x@y'] } }]
+    expect(computeRowGrowthSignature(messages)).toBe(computeRowGrowthSignature([...messages]))
+  })
+
+  // Each of these lands on an ALREADY-rendered row without touching the message count or the
+  // last-message id, so the signature is the only thing that can notice the height change.
+  it.each([
+    ['a link-preview fastening', { linkPreview: { url: 'https://example.com' } }],
+    ['an attachment fastening', { attachment: { url: 'https://example.com/f.pdf' } }],
+    ['a reaction', { reactions: { '👍': ['x@y'] } }],
+    ['a retraction', { isRetracted: true }],
+  ])('changes when %s lands on a resident row', (_label, update) => {
+    const before = [text('a'), text('b')]
+    const after = [text('a'), { ...text('b'), ...update }]
+    expect(computeRowGrowthSignature(after)).not.toBe(computeRowGrowthSignature(before))
+  })
+
+  it('changes on a correction, and again on a second correction of different length', () => {
+    const original = [text('a', 'hi')]
+    const edited = [{ ...text('a', 'hi there'), isEdited: true }]
+    const reEdited = [{ ...text('a', 'hi there, at greater length'), isEdited: true }]
+
+    const sigs = [original, edited, reEdited].map(computeRowGrowthSignature)
+    expect(new Set(sigs).size).toBe(3)
+  })
+
+  it('does not collide when adjacent rows carry different payloads', () => {
+    const a = [{ ...text('a'), linkPreview: { url: 'u' } }, text('b')]
+    const b = [text('a'), { ...text('b'), linkPreview: { url: 'u' } }]
+    expect(computeRowGrowthSignature(a)).not.toBe(computeRowGrowthSignature(b))
+  })
+})

--- a/apps/fluux/src/components/conversation/rowGrowthSignature.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthSignature.ts
@@ -1,0 +1,60 @@
+/**
+ * Signature of everything that can change a RESIDENT row's height IN PLACE.
+ *
+ * Rows normally change height by appearing (a new message) — the new-message effect handles that.
+ * But several payloads land on a message that is ALREADY rendered, growing its row without touching
+ * the message count or the last-message id:
+ *
+ *   - reactions (XEP-0444)          — adds/removes the reactions strip
+ *   - link previews (XEP-0422/OGP)  — a fastening that arrives seconds later, after the OGP fetch
+ *   - attachments                   — a fastening, or a decrypted-on-download media swap
+ *   - corrections (XEP-0308)        — a new body re-wraps to a different number of lines
+ *   - retractions                   — the body collapses into a tombstone
+ *
+ * While the reader is sticked to the bottom, that growth must be absorbed ABOVE (previous messages
+ * scroll up) instead of shoving the newest message below the fold. Nothing else can see it: under
+ * virtualization the content ResizeObserver is deliberately disabled (it feeds back into the
+ * @tanstack spacer churn), and the media components either never notify (LinkPreviewCard has a fixed
+ * aspect box) or notify only when a bitmap decodes. So this signature IS the trigger — see the
+ * row-growth effect in useMessageListScroll.
+ *
+ * Cheap by construction: a message contributes only when it actually carries one of these, so the
+ * common plain-text row costs a bare iteration.
+ */
+
+export interface RowGrowthMessage {
+  id: string
+  body?: string
+  reactions?: Record<string, string[]>
+  attachment?: unknown
+  linkPreview?: unknown
+  isEdited?: boolean
+  isRetracted?: boolean
+}
+
+export function computeRowGrowthSignature(messages: readonly RowGrowthMessage[]): string {
+  let sig = ''
+  for (const m of messages) {
+    const reactions = m.reactions
+    const hasReactions = reactions !== undefined && Object.keys(reactions).length > 0
+    if (
+      !hasReactions &&
+      m.linkPreview == null &&
+      m.attachment == null &&
+      !m.isEdited &&
+      !m.isRetracted
+    ) {
+      continue
+    }
+    sig += m.id
+    if (hasReactions) sig += `r${JSON.stringify(reactions)}`
+    if (m.linkPreview != null) sig += 'l'
+    if (m.attachment != null) sig += 'a'
+    // A correction replaces the body; its LENGTH is what re-wraps the row, and it is what changes
+    // between two successive corrections (isEdited stays true after the first one).
+    if (m.isEdited) sig += `e${m.body?.length ?? 0}`
+    if (m.isRetracted) sig += 'x'
+    sig += ';'
+  }
+  return sig
+}

--- a/apps/fluux/src/components/conversation/rowGrowthSignature.ts
+++ b/apps/fluux/src/components/conversation/rowGrowthSignature.ts
@@ -32,6 +32,20 @@ export interface RowGrowthMessage {
   isRetracted?: boolean
 }
 
+/**
+ * djb2 over the body, as unsigned base-36. Keeps the signature a fixed few chars per edited row
+ * instead of embedding whole message bodies (this string is rebuilt and compared every render).
+ * A hash collision costs one missed re-pin, which the next stimulus corrects — the previous
+ * length-only fingerprint collided on every same-length rewrap instead.
+ */
+function hashBody(body: string): string {
+  let hash = 5381
+  for (let i = 0; i < body.length; i += 1) {
+    hash = (((hash << 5) + hash) ^ body.charCodeAt(i)) | 0
+  }
+  return (hash >>> 0).toString(36)
+}
+
 export function computeRowGrowthSignature(messages: readonly RowGrowthMessage[]): string {
   let sig = ''
   for (const m of messages) {
@@ -50,9 +64,11 @@ export function computeRowGrowthSignature(messages: readonly RowGrowthMessage[])
     if (hasReactions) sig += `r${JSON.stringify(reactions)}`
     if (m.linkPreview != null) sig += 'l'
     if (m.attachment != null) sig += 'a'
-    // A correction replaces the body; its LENGTH is what re-wraps the row, and it is what changes
-    // between two successive corrections (isEdited stays true after the first one).
-    if (m.isEdited) sig += `e${m.body?.length ?? 0}`
+    // A correction replaces the body, and `isEdited` stays true across successive corrections, so
+    // the body itself has to be fingerprinted. Length alone is not enough: bodies render with
+    // `whitespace-pre-wrap` in proportional text, so two same-length bodies can be different
+    // heights — `aaaaa` is one line, `a\na\na` is three.
+    if (m.isEdited) sig += `e${hashBody(m.body ?? '')}`
     if (m.isRetracted) sig += 'x'
     sig += ';'
   }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.loadNewer.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.loadNewer.test.tsx
@@ -38,7 +38,7 @@ function Harness({
     conversationId: 'room@conf.example.com',
     messageCount: 20,
     firstMessageId: 'm-0',
-    reactionsSignature: '',
+    rowGrowthSignature: '',
     lastMessageId: 'm-19',
     onLoadNewer,
     isLoadingNewer,

--- a/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.restore.test.tsx
@@ -93,7 +93,7 @@ function HookHarness({
     readPointerId,
     clearFirstNewMessageId,
     onLoadAround,
-    reactionsSignature: '',
+    rowGrowthSignature: '',
     lastMessageId: ids.at(-1),
   })
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3425,10 +3425,18 @@ export function useMessageListScroll({
    * `deferredAt` is the timestamp of the original stimulus: a retry is abandoned if the reader has
    * genuinely scrolled since, so a deferred pin can never yank someone who moved away in between.
    */
-  const tryRowGrowthRepin = useCallback((deferred: DeferredRowGrowth | null): boolean => {
+  /**
+   * `deferred` carries an earlier growth's established eligibility and takeover anchors.
+   * `isTimerRetry` says the retry TIMER fired, which is a separate question — a signature-triggered
+   * attempt can carry a deferral and still be a first attempt at the newly arrived growth.
+   */
+  const tryRowGrowthRepin = useCallback((
+    deferred: DeferredRowGrowth | null,
+    isTimerRetry: boolean,
+  ): boolean => {
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return true
-    const isRetry = deferred !== null
+    const carried = deferred !== null
 
     // Correct ONLY against a plausible baseline. A mounted list is always at least a viewport tall,
     // so anything smaller is a stale or not-yet-measured snapshot; trusting it would inflate `growth`
@@ -3460,13 +3468,13 @@ export function useMessageListScroll({
       // (wheel/touch/key), a genuine scroll of any kind (this is what catches a scrollbar drag), and
       // a scrollTop that has moved UP since the deferral — proof regardless of input, since growth
       // never moves scrollTop and a pin only moves it down toward the bottom.
-      readerTookOver: isRetry && (
+      readerTookOver: carried && (
         userScrollIntentAtRef.current > deferred.at ||
         lastGenuineScrollAtRef.current > deferred.at ||
         scroller.scrollTop < deferred.scrollTop - BOTTOM_PIN_TOLERANCE
       ),
-      isRetry,
-      eligibilityEstablished: isRetry,
+      isTimerRetry,
+      eligibilityEstablished: carried,
     })
     if (decision === 'defer') return false
     if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
@@ -3495,7 +3503,7 @@ export function useMessageListScroll({
       at: Date.now(),
       scrollTop: scrollerRef.current?.scrollTop ?? 0,
     })
-    if (tryRowGrowthRepin(pendingRowGrowthRef.current)) {
+    if (tryRowGrowthRepin(pendingRowGrowthRef.current, false)) {
       pendingRowGrowthRef.current = null
       return
     }
@@ -3510,7 +3518,7 @@ export function useMessageListScroll({
       rowGrowthRetryRef.current = setTimeout(() => {
         rowGrowthRetryRef.current = null
         if (activeConversationIdRef.current !== conversationId) return
-        if (tryRowGrowthRepin(deferred)) {
+        if (tryRowGrowthRepin(deferred, true)) {
           pendingRowGrowthRef.current = null
           return
         }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -356,6 +356,14 @@ export interface UseMessageListScrollResult {
   scrollToMarker: () => void
 }
 
+/** What a deferred row-growth remembers so its retry judges the SAME situation, not a later one. */
+interface DeferredRowGrowth {
+  /** When the growth was first seen — deliberate scroll intent after this means the reader moved. */
+  at: number
+  /** scrollTop at that moment; a smaller value on retry means the reader scrolled up since. */
+  scrollTop: number
+}
+
 interface DirectionalHistorySnapshot {
   anchorMessageId: string
   anchorOffsetFromTop: number
@@ -572,6 +580,11 @@ export function useMessageListScroll({
   // Timestamp of the last DELIBERATE user scroll (FAB click / wheel). The controller receives the
   // same input directly; this timestamp also supports marker clearing and resize heuristics.
   const userScrollIntentAtRef = useRef(0)
+  // Timestamp of the last GENUINE user scroll of any kind, including a scrollbar drag (which fires
+  // no input event and is recognised only by the height-unchanged discriminator in handleScroll).
+  // Separate from userScrollIntentAtRef on purpose: this one answers "did the reader move?", not
+  // "did the reader press something", and only takeover checks may read it.
+  const lastGenuineScrollAtRef = useRef(0)
 
   // Media load batching (for images, videos, link previews)
   // When multiple media elements load in quick succession, we batch them and apply
@@ -2471,6 +2484,11 @@ export function useMessageListScroll({
       ) && prevScrollHeightRef.current === scrollHeight
     if (genuineUserScroll) {
       userHasScrolledSinceEntryRef.current = true
+      // This branch is the ONLY place a scrollbar drag is recognised — it fires no wheel, touch or
+      // keydown. Stamp a dedicated timestamp for it rather than userScrollIntentAtRef: that ref
+      // means "deliberate INPUT", and marker clearing relies on it to tell a programmatic
+      // scroll-to-bottom from a user one, so widening it clears the unread marker on re-entry.
+      lastGenuineScrollAtRef.current = Date.now()
       positioningControllerRef.current?.observeUserInput(conversationId)
       runScrollShadowSafely({
         event: 'settled-user-geometry',
@@ -3413,9 +3431,10 @@ export function useMessageListScroll({
    * `deferredAt` is the timestamp of the original stimulus: a retry is abandoned if the reader has
    * genuinely scrolled since, so a deferred pin can never yank someone who moved away in between.
    */
-  const tryRowGrowthRepin = useCallback((deferredAt: number, isRetry: boolean): boolean => {
+  const tryRowGrowthRepin = useCallback((deferred: DeferredRowGrowth | null): boolean => {
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return true
+    const isRetry = deferred !== null
 
     // Correct ONLY against a plausible baseline. A mounted list is always at least a viewport tall,
     // so anything smaller is a stale or not-yet-measured snapshot; trusting it would inflate `growth`
@@ -3439,8 +3458,21 @@ export function useMessageListScroll({
         active.request.desired.kind !== 'live-edge' &&
         active.phase.kind !== 'settled',
       ),
-      readerTookOver: userScrollIntentAtRef.current > deferredAt,
+      // Two independent takeover signals, because neither covers everything on its own: the
+      // timestamp misses nothing now that scrollbar drags stamp it, but a scrollTop that has moved
+      // UP since the deferral is proof regardless of which input produced it (growth never moves
+      // scrollTop, and a pin only moves it down toward the bottom).
+      // Three independent takeover signals, because none covers everything alone: deliberate input
+      // (wheel/touch/key), a genuine scroll of any kind (this is what catches a scrollbar drag), and
+      // a scrollTop that has moved UP since the deferral — proof regardless of input, since growth
+      // never moves scrollTop and a pin only moves it down toward the bottom.
+      readerTookOver: isRetry && (
+        userScrollIntentAtRef.current > deferred.at ||
+        lastGenuineScrollAtRef.current > deferred.at ||
+        scroller.scrollTop < deferred.scrollTop - BOTTOM_PIN_TOLERANCE
+      ),
       isRetry,
+      eligibilityEstablished: isRetry,
     })
     if (decision === 'defer') return false
     if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
@@ -3459,8 +3491,11 @@ export function useMessageListScroll({
     if (!sameConversation) return // conversation switch → rebaseline, never re-pin
     if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
 
-    const deferredAt = Date.now()
-    if (tryRowGrowthRepin(deferredAt, false)) return
+    if (tryRowGrowthRepin(null)) return
+    const deferred: DeferredRowGrowth = {
+      at: Date.now(),
+      scrollTop: scrollerRef.current?.scrollTop ?? 0,
+    }
 
     // Deferred. Re-check when the claim can no longer be held without a live loop renewing it, so a
     // lingering claim from an abandoned loop cannot swallow this growth. Bounded: each retry either
@@ -3471,7 +3506,7 @@ export function useMessageListScroll({
       rowGrowthRetryRef.current = setTimeout(() => {
         rowGrowthRetryRef.current = null
         if (activeConversationIdRef.current !== conversationId) return
-        if (!tryRowGrowthRepin(deferredAt, true)) scheduleRetry(attempt + 1)
+        if (!tryRowGrowthRepin(deferred)) scheduleRetry(attempt + 1)
       }, pinBottomClaim().msUntilExpiry() + ROW_GROWTH_RETRY_MARGIN_MS)
     }
     scheduleRetry(1)

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3329,11 +3329,22 @@ export function useMessageListScroll({
   // scrollHeight per frame and re-pins instantly (no smooth easing, so nothing visibly animates),
   // converging in a handful of frames. It's pure imperative scroll work — no React re-render.
   //
-  // Two safeguards keep it from ever fighting a scroll: (1) it's gated on LIVE geometry, not the
-  // latchable isAtBottomRef — a reader scrolled up into history reads distFromBottom >= threshold and
-  // is never re-pinned (a stale-true latch is what made a typing toggle "fight" the scroll in #918);
-  // (2) it fires only on an actual row-height change WITHIN the same conversation, so a conversation
-  // switch / restore is never disturbed.
+  // Two safeguards keep it from ever fighting a scroll: (1) it's gated on geometry, not the
+  // latchable isAtBottomRef — a reader scrolled up into history is never re-pinned (a stale-true
+  // latch is what made a typing toggle "fight" the scroll in #918); (2) it fires only on an actual
+  // row-height change WITHIN the same conversation, so a conversation switch / restore is never
+  // disturbed.
+  //
+  // The gate must read the geometry from BEFORE the growth, which is why it subtracts the height
+  // delta rather than measuring distance-from-bottom directly. By the time this layout effect runs
+  // the row has already grown, and that growth lands in the distance: a ~260px preview card reads as
+  // "260px from the bottom", i.e. further than the threshold, so a naive live-geometry gate refuses
+  // to re-pin the very case it exists for. Worse, the post-commit geometry is not even self
+  // consistent under virtualization — the grown row is absolutely positioned and overflows the
+  // @tanstack spacer, so the row can hang below the fold while scrollHeight (still the pre-growth
+  // spacer) reports a comfortable distance. Both engines reproduce this; see the fastening tests in
+  // scripts/scroll-invariants.ts. lastScrollDataRef is refreshed on every scroll event and by every
+  // bottom pin, so it is the last geometry the reader actually saw.
   const prevRowGrowthKeyRef = useRef(rowGrowthSignature)
   const rowGrowthConvRef = useRef(conversationId)
   useLayoutEffect(() => {
@@ -3346,8 +3357,17 @@ export function useMessageListScroll({
 
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return
-    // Live-geometry gate: only re-pin when genuinely at/near the bottom right now.
-    if (getDistanceFromBottom(scroller) >= AT_BOTTOM_THRESHOLD) return
+    // Correct ONLY against a plausible baseline. A mounted list is always at least a viewport tall,
+    // so anything smaller is a stale or not-yet-measured snapshot; trusting it would inflate `growth`
+    // and make a scrolled-up reader look as if they had been at the bottom — a yank, the harmful
+    // direction. With no usable baseline we fall back to the raw distance, whose worst case is a
+    // MISSED re-pin that the next stimulus corrects.
+    const baseline = lastScrollDataRef.current?.height ?? 0
+    const growth =
+      baseline >= scroller.clientHeight
+        ? Math.max(0, scroller.scrollHeight - baseline)
+        : 0
+    if (getDistanceFromBottom(scroller) - growth >= AT_BOTTOM_THRESHOLD) return
     // A running pin loop already keeps the bottom pinned — don't stack a second one.
     if (pinBottomClaim().isHeld()) return
 

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -25,7 +25,7 @@ import { createReassertLoopMonitor } from './reassertLoopMonitor'
 import type { ReassertLoopHandle } from './reassertLoopMonitor'
 import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
-import { decideRowGrowth } from './rowGrowthDecision'
+import { carryDeferral, decideRowGrowth, type DeferredRowGrowth } from './rowGrowthDecision'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { isProgrammaticScroll } from './scrollGate'
@@ -354,14 +354,6 @@ export interface UseMessageListScrollResult {
    *  pill's click handler; also the routine the conversation-switch entry effect uses. No-op when
    *  there is no current marker. */
   scrollToMarker: () => void
-}
-
-/** What a deferred row-growth remembers so its retry judges the SAME situation, not a later one. */
-interface DeferredRowGrowth {
-  /** When the growth was first seen — deliberate scroll intent after this means the reader moved. */
-  at: number
-  /** scrollTop at that moment; a smaller value on retry means the reader scrolled up since. */
-  scrollTop: number
 }
 
 interface DirectionalHistorySnapshot {
@@ -3423,6 +3415,8 @@ export function useMessageListScroll({
   const prevRowGrowthKeyRef = useRef(rowGrowthSignature)
   const rowGrowthConvRef = useRef(conversationId)
   const rowGrowthRetryRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The earliest unresolved deferral. Survives newer signatures — see carryDeferral.
+  const pendingRowGrowthRef = useRef<DeferredRowGrowth | null>(null)
 
   /**
    * Try to absorb a row-growth change. Returns false when the attempt was DEFERRED and must be
@@ -3488,14 +3482,24 @@ export function useMessageListScroll({
       clearTimeout(rowGrowthRetryRef.current)
       rowGrowthRetryRef.current = null
     }
-    if (!sameConversation) return // conversation switch → rebaseline, never re-pin
+    if (!sameConversation) {
+      pendingRowGrowthRef.current = null // conversation switch → rebaseline, never re-pin
+      return
+    }
     if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
 
-    if (tryRowGrowthRepin(null)) return
-    const deferred: DeferredRowGrowth = {
+    // Judge against the EARLIEST unresolved deferral, never from current geometry: the pending
+    // growth's own scroll event has already advanced the baseline, so a fresh derivation would see
+    // only this newer delta and terminally skip the growth still waiting.
+    const deferred = carryDeferral(pendingRowGrowthRef.current, {
       at: Date.now(),
       scrollTop: scrollerRef.current?.scrollTop ?? 0,
+    })
+    if (tryRowGrowthRepin(pendingRowGrowthRef.current)) {
+      pendingRowGrowthRef.current = null
+      return
     }
+    pendingRowGrowthRef.current = deferred
 
     // Deferred. Re-check when the claim can no longer be held without a live loop renewing it, so a
     // lingering claim from an abandoned loop cannot swallow this growth. Bounded: each retry either
@@ -3506,7 +3510,12 @@ export function useMessageListScroll({
       rowGrowthRetryRef.current = setTimeout(() => {
         rowGrowthRetryRef.current = null
         if (activeConversationIdRef.current !== conversationId) return
-        if (!tryRowGrowthRepin(deferred)) scheduleRetry(attempt + 1)
+        if (tryRowGrowthRepin(deferred)) {
+          pendingRowGrowthRef.current = null
+          return
+        }
+        if (attempt + 1 > ROW_GROWTH_RETRY_ATTEMPTS) pendingRowGrowthRef.current = null
+        scheduleRetry(attempt + 1)
       }, pinBottomClaim().msUntilExpiry() + ROW_GROWTH_RETRY_MARGIN_MS)
     }
     scheduleRetry(1)

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3413,6 +3413,20 @@ export function useMessageListScroll({
     if (getDistanceFromBottom(scroller) - growth >= AT_BOTTOM_THRESHOLD) return
     // A running pin loop already keeps the bottom pinned — don't stack a second one.
     if (pinBottomClaim().isHeld()) return
+    // Never override an explicit navigation. A row growing is ambient: the reader did not ask for
+    // it, so it must not supersede a position the reader DID ask for — Home/resident-top, a
+    // jump-to-message, a saved-position restore. Without this, a fastening or reaction landing while
+    // a navigation is still converging turns into a live-edge request that cancels it and pins to
+    // the bottom, so the reader is dumped back at the newest message mid-keypress.
+    const active = positioningControllerRef.current?.snapshot().active
+    if (
+      active &&
+      active.request.conversationId === conversationId &&
+      active.request.desired.kind !== 'live-edge' &&
+      active.phase.kind !== 'settled'
+    ) {
+      return
+    }
 
     reconcileLiveEdge('row-growth')
   }, [rowGrowthSignature, conversationId, reconcileLiveEdge, staticMode])

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3390,23 +3390,14 @@ export function useMessageListScroll({
   // scripts/scroll-invariants.ts. lastScrollDataRef is refreshed on every scroll event and by every
   // bottom pin, so it is the last geometry the reader actually saw.
   //
-  // A signature change is consumed EXACTLY ONCE, so a bail must be a real decision — not a silent
-  // drop. Two of the guards are terminal (the reader is not at the bottom; a navigation owns the
-  // position — in both cases pinning later would be wrong), but "a pin loop already owns the bottom"
-  // is only a DEFERRAL: it assumes that loop absorbs the growth. If that loop was abandoned, its
-  // claim lingers until it lapses and the growth would never be pinned at all, because nothing
-  // re-runs this effect once the signature has been consumed. Deferrals therefore schedule a retry
-  // at the claim's own expiry.
+  // A signature change is consumed EXACTLY ONCE — nothing re-runs this effect for the same
+  // signature — so every skip is final. That includes the skip taken while a pin loop already claims
+  // the bottom, which is a bet that the running loop absorbs the growth itself. The claim
+  // self-expires, so it can never latch permanently and suppress growths forever; but expiry does
+  // not replay a growth already consumed. See the accepted-gap contract on rowGrowthDecision.
   const prevRowGrowthKeyRef = useRef(rowGrowthSignature)
   const rowGrowthConvRef = useRef(conversationId)
 
-  /**
-   * Try to absorb a row-growth change. Returns false when the attempt was DEFERRED and must be
-   * retried; true when it was handled or deliberately declined.
-   *
-   * `deferredAt` is the timestamp of the original stimulus: a retry is abandoned if the reader has
-   * genuinely scrolled since, so a deferred pin can never yank someone who moved away in between.
-   */
   useLayoutEffect(() => {
     const sameConversation = rowGrowthConvRef.current === conversationId
     rowGrowthConvRef.current = conversationId
@@ -3418,19 +3409,17 @@ export function useMessageListScroll({
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return
 
-    // Correct ONLY against a plausible baseline. A mounted list is always at least a viewport tall,
-    // so anything smaller is a stale or not-yet-measured snapshot; trusting it would inflate `growth`
-    // and make a scrolled-up reader look as if they had been at the bottom — a yank, the harmful
-    // direction. With no usable baseline we fall back to the raw distance, whose worst case is a
-    // MISSED re-pin that the next stimulus corrects.
+    // Measure against the last geometry the reader actually saw, and keep the SIGN. A mounted list
+    // is always at least a viewport tall, so a smaller baseline is a stale or not-yet-measured
+    // snapshot — report null rather than a number, so the decision treats it as "unknown" instead of
+    // trusting it. Trusting a bogus baseline would inflate the delta and make a scrolled-up reader
+    // look as if they had been at the bottom, which is the harmful direction.
     const baseline = lastScrollDataRef.current?.height ?? 0
     const active = positioningControllerRef.current?.snapshot().active
     const decision = decideRowGrowth({
       distanceFromBottom: getDistanceFromBottom(scroller),
-      growth:
-        baseline >= scroller.clientHeight
-          ? Math.max(0, scroller.scrollHeight - baseline)
-          : 0,
+      heightDelta:
+        baseline >= scroller.clientHeight ? scroller.scrollHeight - baseline : null,
       atBottomThreshold: AT_BOTTOM_THRESHOLD,
       pinClaimHeld: pinBottomClaim().isHeld(),
       navigationInFlight: Boolean(

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -25,6 +25,7 @@ import { createReassertLoopMonitor } from './reassertLoopMonitor'
 import type { ReassertLoopHandle } from './reassertLoopMonitor'
 import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
+import { decideRowGrowth } from './rowGrowthDecision'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { isProgrammaticScroll } from './scrollGate'
@@ -133,6 +134,11 @@ const TARGET_HIGHLIGHT_MS = 1500
 // no-op once truly pinned, so this converges and cannot oscillate. Sub-row tolerance keeps it from
 // firing on harmless subpixel rounding.
 const BOTTOM_PIN_TOLERANCE = 4
+// A row-growth re-pin deferred behind a running pin loop re-checks this many times before giving
+// up. Each retry waits out the loop's remaining claim, so a genuinely long-running loop is what
+// consumes the attempts — an abandoned one lapses on the first.
+const ROW_GROWTH_RETRY_ATTEMPTS = 3
+const ROW_GROWTH_RETRY_MARGIN_MS = 32 // ~2 frames past the claim's expiry, so it has truly lapsed
 // A pin run whose cumulative forced work (layout flushes + scroll writes + repaints) reaches this
 // is worth one rate-limited [PinLoopProbe] line in fluux.log — it attributes the layoutPaint cost
 // RenderCostProbe can only measure in aggregate. ~3 frame budgets; healthy runs stay far below.
@@ -3388,48 +3394,92 @@ export function useMessageListScroll({
   // spacer) reports a comfortable distance. Both engines reproduce this; see the fastening tests in
   // scripts/scroll-invariants.ts. lastScrollDataRef is refreshed on every scroll event and by every
   // bottom pin, so it is the last geometry the reader actually saw.
+  //
+  // A signature change is consumed EXACTLY ONCE, so a bail must be a real decision — not a silent
+  // drop. Two of the guards are terminal (the reader is not at the bottom; a navigation owns the
+  // position — in both cases pinning later would be wrong), but "a pin loop already owns the bottom"
+  // is only a DEFERRAL: it assumes that loop absorbs the growth. If that loop was abandoned, its
+  // claim lingers until it lapses and the growth would never be pinned at all, because nothing
+  // re-runs this effect once the signature has been consumed. Deferrals therefore schedule a retry
+  // at the claim's own expiry.
   const prevRowGrowthKeyRef = useRef(rowGrowthSignature)
   const rowGrowthConvRef = useRef(conversationId)
-  useLayoutEffect(() => {
-    const sameConversation = rowGrowthConvRef.current === conversationId
-    rowGrowthConvRef.current = conversationId
-    const prevKey = prevRowGrowthKeyRef.current
-    prevRowGrowthKeyRef.current = rowGrowthSignature
-    if (!sameConversation) return // conversation switch → rebaseline, never re-pin
-    if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
+  const rowGrowthRetryRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  /**
+   * Try to absorb a row-growth change. Returns false when the attempt was DEFERRED and must be
+   * retried; true when it was handled or deliberately declined.
+   *
+   * `deferredAt` is the timestamp of the original stimulus: a retry is abandoned if the reader has
+   * genuinely scrolled since, so a deferred pin can never yank someone who moved away in between.
+   */
+  const tryRowGrowthRepin = useCallback((deferredAt: number, isRetry: boolean): boolean => {
     const scroller = scrollerRef.current
-    if (!scroller || staticMode) return
+    if (!scroller || staticMode) return true
+
     // Correct ONLY against a plausible baseline. A mounted list is always at least a viewport tall,
     // so anything smaller is a stale or not-yet-measured snapshot; trusting it would inflate `growth`
     // and make a scrolled-up reader look as if they had been at the bottom — a yank, the harmful
     // direction. With no usable baseline we fall back to the raw distance, whose worst case is a
     // MISSED re-pin that the next stimulus corrects.
     const baseline = lastScrollDataRef.current?.height ?? 0
-    const growth =
-      baseline >= scroller.clientHeight
-        ? Math.max(0, scroller.scrollHeight - baseline)
-        : 0
-    if (getDistanceFromBottom(scroller) - growth >= AT_BOTTOM_THRESHOLD) return
-    // A running pin loop already keeps the bottom pinned — don't stack a second one.
-    if (pinBottomClaim().isHeld()) return
-    // Never override an explicit navigation. A row growing is ambient: the reader did not ask for
-    // it, so it must not supersede a position the reader DID ask for — Home/resident-top, a
-    // jump-to-message, a saved-position restore. Without this, a fastening or reaction landing while
-    // a navigation is still converging turns into a live-edge request that cancels it and pins to
-    // the bottom, so the reader is dumped back at the newest message mid-keypress.
     const active = positioningControllerRef.current?.snapshot().active
-    if (
-      active &&
-      active.request.conversationId === conversationId &&
-      active.request.desired.kind !== 'live-edge' &&
-      active.phase.kind !== 'settled'
-    ) {
-      return
-    }
+    const decision = decideRowGrowth({
+      distanceFromBottom: getDistanceFromBottom(scroller),
+      growth:
+        baseline >= scroller.clientHeight
+          ? Math.max(0, scroller.scrollHeight - baseline)
+          : 0,
+      atBottomThreshold: AT_BOTTOM_THRESHOLD,
+      pinnedTolerance: BOTTOM_PIN_TOLERANCE,
+      pinClaimHeld: pinBottomClaim().isHeld(),
+      navigationInFlight: Boolean(
+        active &&
+        active.request.conversationId === activeConversationIdRef.current &&
+        active.request.desired.kind !== 'live-edge' &&
+        active.phase.kind !== 'settled',
+      ),
+      readerTookOver: userScrollIntentAtRef.current > deferredAt,
+      isRetry,
+    })
+    if (decision === 'defer') return false
+    if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
+    return true
+  }, [staticMode])
 
-    reconcileLiveEdge('row-growth')
-  }, [rowGrowthSignature, conversationId, reconcileLiveEdge, staticMode])
+  useLayoutEffect(() => {
+    const sameConversation = rowGrowthConvRef.current === conversationId
+    rowGrowthConvRef.current = conversationId
+    const prevKey = prevRowGrowthKeyRef.current
+    prevRowGrowthKeyRef.current = rowGrowthSignature
+    if (rowGrowthRetryRef.current !== null) {
+      clearTimeout(rowGrowthRetryRef.current)
+      rowGrowthRetryRef.current = null
+    }
+    if (!sameConversation) return // conversation switch → rebaseline, never re-pin
+    if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
+
+    const deferredAt = Date.now()
+    if (tryRowGrowthRepin(deferredAt, false)) return
+
+    // Deferred. Re-check when the claim can no longer be held without a live loop renewing it, so a
+    // lingering claim from an abandoned loop cannot swallow this growth. Bounded: each retry either
+    // resolves or reschedules against a strictly-lapsing claim, and a conversation switch, a newer
+    // signature, or unmount clears it.
+    const scheduleRetry = (attempt: number) => {
+      if (attempt > ROW_GROWTH_RETRY_ATTEMPTS) return
+      rowGrowthRetryRef.current = setTimeout(() => {
+        rowGrowthRetryRef.current = null
+        if (activeConversationIdRef.current !== conversationId) return
+        if (!tryRowGrowthRepin(deferredAt, true)) scheduleRetry(attempt + 1)
+      }, pinBottomClaim().msUntilExpiry() + ROW_GROWTH_RETRY_MARGIN_MS)
+    }
+    scheduleRetry(1)
+  }, [rowGrowthSignature, conversationId, tryRowGrowthRepin])
+
+  useEffect(() => () => {
+    if (rowGrowthRetryRef.current !== null) clearTimeout(rowGrowthRetryRef.current)
+  }, [])
 
   // ==========================================================================
   // EFFECT: Typing indicator appears — reveal its footer clearance while sticked

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -25,7 +25,7 @@ import { createReassertLoopMonitor } from './reassertLoopMonitor'
 import type { ReassertLoopHandle } from './reassertLoopMonitor'
 import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
 import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
-import { carryDeferral, decideRowGrowth, type DeferredRowGrowth } from './rowGrowthDecision'
+import { decideRowGrowth } from './rowGrowthDecision'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { isProgrammaticScroll } from './scrollGate'
@@ -134,11 +134,6 @@ const TARGET_HIGHLIGHT_MS = 1500
 // no-op once truly pinned, so this converges and cannot oscillate. Sub-row tolerance keeps it from
 // firing on harmless subpixel rounding.
 const BOTTOM_PIN_TOLERANCE = 4
-// A row-growth re-pin deferred behind a running pin loop re-checks this many times before giving
-// up. Each retry waits out the loop's remaining claim, so a genuinely long-running loop is what
-// consumes the attempts — an abandoned one lapses on the first.
-const ROW_GROWTH_RETRY_ATTEMPTS = 3
-const ROW_GROWTH_RETRY_MARGIN_MS = 32 // ~2 frames past the claim's expiry, so it has truly lapsed
 // A pin run whose cumulative forced work (layout flushes + scroll writes + repaints) reaches this
 // is worth one rate-limited [PinLoopProbe] line in fluux.log — it attributes the layoutPaint cost
 // RenderCostProbe can only measure in aggregate. ~3 frame budgets; healthy runs stay far below.
@@ -572,11 +567,6 @@ export function useMessageListScroll({
   // Timestamp of the last DELIBERATE user scroll (FAB click / wheel). The controller receives the
   // same input directly; this timestamp also supports marker clearing and resize heuristics.
   const userScrollIntentAtRef = useRef(0)
-  // Timestamp of the last GENUINE user scroll of any kind, including a scrollbar drag (which fires
-  // no input event and is recognised only by the height-unchanged discriminator in handleScroll).
-  // Separate from userScrollIntentAtRef on purpose: this one answers "did the reader move?", not
-  // "did the reader press something", and only takeover checks may read it.
-  const lastGenuineScrollAtRef = useRef(0)
 
   // Media load batching (for images, videos, link previews)
   // When multiple media elements load in quick succession, we batch them and apply
@@ -2476,11 +2466,6 @@ export function useMessageListScroll({
       ) && prevScrollHeightRef.current === scrollHeight
     if (genuineUserScroll) {
       userHasScrolledSinceEntryRef.current = true
-      // This branch is the ONLY place a scrollbar drag is recognised — it fires no wheel, touch or
-      // keydown. Stamp a dedicated timestamp for it rather than userScrollIntentAtRef: that ref
-      // means "deliberate INPUT", and marker clearing relies on it to tell a programmatic
-      // scroll-to-bottom from a user one, so widening it clears the unread marker on re-entry.
-      lastGenuineScrollAtRef.current = Date.now()
       positioningControllerRef.current?.observeUserInput(conversationId)
       runScrollShadowSafely({
         event: 'settled-user-geometry',
@@ -3414,9 +3399,6 @@ export function useMessageListScroll({
   // at the claim's own expiry.
   const prevRowGrowthKeyRef = useRef(rowGrowthSignature)
   const rowGrowthConvRef = useRef(conversationId)
-  const rowGrowthRetryRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // The earliest unresolved deferral. Survives newer signatures — see carryDeferral.
-  const pendingRowGrowthRef = useRef<DeferredRowGrowth | null>(null)
 
   /**
    * Try to absorb a row-growth change. Returns false when the attempt was DEFERRED and must be
@@ -3425,18 +3407,16 @@ export function useMessageListScroll({
    * `deferredAt` is the timestamp of the original stimulus: a retry is abandoned if the reader has
    * genuinely scrolled since, so a deferred pin can never yank someone who moved away in between.
    */
-  /**
-   * `deferred` carries an earlier growth's established eligibility and takeover anchors.
-   * `isTimerRetry` says the retry TIMER fired, which is a separate question — a signature-triggered
-   * attempt can carry a deferral and still be a first attempt at the newly arrived growth.
-   */
-  const tryRowGrowthRepin = useCallback((
-    deferred: DeferredRowGrowth | null,
-    isTimerRetry: boolean,
-  ): boolean => {
+  useLayoutEffect(() => {
+    const sameConversation = rowGrowthConvRef.current === conversationId
+    rowGrowthConvRef.current = conversationId
+    const prevKey = prevRowGrowthKeyRef.current
+    prevRowGrowthKeyRef.current = rowGrowthSignature
+    if (!sameConversation) return // conversation switch → rebaseline, never re-pin
+    if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
+
     const scroller = scrollerRef.current
-    if (!scroller || staticMode) return true
-    const carried = deferred !== null
+    if (!scroller || staticMode) return
 
     // Correct ONLY against a plausible baseline. A mounted list is always at least a viewport tall,
     // so anything smaller is a stale or not-yet-measured snapshot; trusting it would inflate `growth`
@@ -3452,7 +3432,6 @@ export function useMessageListScroll({
           ? Math.max(0, scroller.scrollHeight - baseline)
           : 0,
       atBottomThreshold: AT_BOTTOM_THRESHOLD,
-      pinnedTolerance: BOTTOM_PIN_TOLERANCE,
       pinClaimHeld: pinBottomClaim().isHeld(),
       navigationInFlight: Boolean(
         active &&
@@ -3460,78 +3439,9 @@ export function useMessageListScroll({
         active.request.desired.kind !== 'live-edge' &&
         active.phase.kind !== 'settled',
       ),
-      // Two independent takeover signals, because neither covers everything on its own: the
-      // timestamp misses nothing now that scrollbar drags stamp it, but a scrollTop that has moved
-      // UP since the deferral is proof regardless of which input produced it (growth never moves
-      // scrollTop, and a pin only moves it down toward the bottom).
-      // Three independent takeover signals, because none covers everything alone: deliberate input
-      // (wheel/touch/key), a genuine scroll of any kind (this is what catches a scrollbar drag), and
-      // a scrollTop that has moved UP since the deferral — proof regardless of input, since growth
-      // never moves scrollTop and a pin only moves it down toward the bottom.
-      readerTookOver: carried && (
-        userScrollIntentAtRef.current > deferred.at ||
-        lastGenuineScrollAtRef.current > deferred.at ||
-        scroller.scrollTop < deferred.scrollTop - BOTTOM_PIN_TOLERANCE
-      ),
-      isTimerRetry,
-      eligibilityEstablished: carried,
     })
-    if (decision === 'defer') return false
     if (decision === 'pin') reconcileLiveEdgeRef.current('row-growth')
-    return true
-  }, [staticMode])
-
-  useLayoutEffect(() => {
-    const sameConversation = rowGrowthConvRef.current === conversationId
-    rowGrowthConvRef.current = conversationId
-    const prevKey = prevRowGrowthKeyRef.current
-    prevRowGrowthKeyRef.current = rowGrowthSignature
-    if (rowGrowthRetryRef.current !== null) {
-      clearTimeout(rowGrowthRetryRef.current)
-      rowGrowthRetryRef.current = null
-    }
-    if (!sameConversation) {
-      pendingRowGrowthRef.current = null // conversation switch → rebaseline, never re-pin
-      return
-    }
-    if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
-
-    // Judge against the EARLIEST unresolved deferral, never from current geometry: the pending
-    // growth's own scroll event has already advanced the baseline, so a fresh derivation would see
-    // only this newer delta and terminally skip the growth still waiting.
-    const deferred = carryDeferral(pendingRowGrowthRef.current, {
-      at: Date.now(),
-      scrollTop: scrollerRef.current?.scrollTop ?? 0,
-    })
-    if (tryRowGrowthRepin(pendingRowGrowthRef.current, false)) {
-      pendingRowGrowthRef.current = null
-      return
-    }
-    pendingRowGrowthRef.current = deferred
-
-    // Deferred. Re-check when the claim can no longer be held without a live loop renewing it, so a
-    // lingering claim from an abandoned loop cannot swallow this growth. Bounded: each retry either
-    // resolves or reschedules against a strictly-lapsing claim, and a conversation switch, a newer
-    // signature, or unmount clears it.
-    const scheduleRetry = (attempt: number) => {
-      if (attempt > ROW_GROWTH_RETRY_ATTEMPTS) return
-      rowGrowthRetryRef.current = setTimeout(() => {
-        rowGrowthRetryRef.current = null
-        if (activeConversationIdRef.current !== conversationId) return
-        if (tryRowGrowthRepin(deferred, true)) {
-          pendingRowGrowthRef.current = null
-          return
-        }
-        if (attempt + 1 > ROW_GROWTH_RETRY_ATTEMPTS) pendingRowGrowthRef.current = null
-        scheduleRetry(attempt + 1)
-      }, pinBottomClaim().msUntilExpiry() + ROW_GROWTH_RETRY_MARGIN_MS)
-    }
-    scheduleRetry(1)
-  }, [rowGrowthSignature, conversationId, tryRowGrowthRepin])
-
-  useEffect(() => () => {
-    if (rowGrowthRetryRef.current !== null) clearTimeout(rowGrowthRetryRef.current)
-  }, [])
+  }, [rowGrowthSignature, conversationId, staticMode])
 
   // ==========================================================================
   // EFFECT: Typing indicator appears — reveal its footer clearance while sticked

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -24,6 +24,7 @@ import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
 import { createReassertLoopMonitor } from './reassertLoopMonitor'
 import type { ReassertLoopHandle } from './reassertLoopMonitor'
 import { createPinRunTracker, readPinRepaintMode, shouldForceRepaint } from './pinBottomRun'
+import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { isProgrammaticScroll } from './scrollGate'
@@ -143,7 +144,7 @@ const CONTENT_ARRIVAL_TRIGGERS: ReadonlySet<string> = new Set([
   'new-message',
   'content-growth',
   'media-load',
-  'reaction',
+  'row-growth',
   'mam-catchup-complete',
 ])
 
@@ -290,11 +291,12 @@ export interface UseMessageListScrollOptions {
    *  ⇒ at the live edge — unchanged behavior. */
   windowAtLiveEdge?: boolean
   isHistoryComplete?: boolean
-  /** Signature of the reactions across the resident window. Changes when a reaction is added/removed on
-   *  ANY row (growing/shrinking it); drives an instant bottom re-pin while the reader is sticked to the
-   *  bottom, so the growth is absorbed above (previous messages scroll up) instead of shoving the
-   *  newest message down. */
-  reactionsSignature: string
+  /** Signature of every IN-PLACE row-height change across the resident window — a reaction, a
+   *  link-preview or attachment fastening, a correction, a retraction (see rowGrowthSignature.ts).
+   *  Any of them grows/shrinks a row that is already rendered; this drives an instant bottom re-pin
+   *  while the reader is sticked to the bottom, so the growth is absorbed above (previous messages
+   *  scroll up) instead of shoving the newest message down. */
+  rowGrowthSignature: string
   /** Whether the floating typing-indicator pill is currently shown. The footer reserves extra bottom
    *  padding to clear the pill only while this is true; the 0→true edge drives the same instant
    *  bottom re-pin as a reaction growing a row, gated on live geometry (see the reactions
@@ -380,7 +382,7 @@ export function useMessageListScroll({
   isLoadingNewer,
   windowAtLiveEdge,
   isHistoryComplete,
-  reactionsSignature,
+  rowGrowthSignature,
   hasTypingIndicator = false,
   lastMessageIsOutgoing = false,
   lastMessageId,
@@ -409,10 +411,15 @@ export function useMessageListScroll({
   // supersedes whatever is in flight so bottom, message, restore, media, and history targets cannot
   // fight over scrollTop. Single-flight: latest accepted generation wins with a fresh budget.
   const reassertLoopRef = useRef<{ raf: number; handle: ReassertLoopHandle } | null>(null)
-  // True while a pin-bottom re-assert loop is in flight. The typing/reactions re-pin defers to an
-  // active loop (it re-checks scrollHeight every frame and picks the change up itself) instead of
-  // restarting it — the restart's synchronous forced layout + repaint is the WebKitGTK hot path.
-  const pinBottomActiveRef = useRef(false)
+  // Whether a pin-bottom re-assert loop is in flight. The row-growth re-pin defers to an active loop
+  // (it re-checks scrollHeight every frame and picks the change up itself) instead of restarting it
+  // — the restart's synchronous forced layout + repaint is the WebKitGTK hot path. A self-expiring
+  // claim rather than a boolean, so a loop dropped without finishing cannot latch it: see
+  // pinLoopClaim.ts.
+  const pinBottomClaimRef = useRef<PinLoopClaim | null>(null)
+  // Same lazy-ref idiom as pinRunProbeRef / pinRepaintBurstRef below: a ref is stable, so reading it
+  // at the use sites keeps the exhaustive-deps rule satisfied without a dependency.
+  const pinBottomClaim = () => (pinBottomClaimRef.current ??= createPinLoopClaim())
   // Rate-limits the [PinLoopProbe] fluux.log line to one per cooldown (like RenderCostProbe).
   const pinRunProbeRef = useRef<RenderCostProbe | null>(null)
   // Coalesces forced repaints across a BURST of content-arrival pins (each superseding the last).
@@ -429,7 +436,7 @@ export function useMessageListScroll({
       reassertLoopRef.current.handle.end()
       reassertLoopRef.current = null
     }
-    pinBottomActiveRef.current = false
+    pinBottomClaimRef.current?.release()
   })
 
   // Track scroll position - always create internal ref to follow rules of hooks
@@ -1014,12 +1021,18 @@ export function useMessageListScroll({
       beginLoop: (lease) => {
         const loop = beginControllerFrameLoop('pin-bottom', lease)
         if (!loop) return null
-        pinBottomActiveRef.current = true
+        pinBottomClaim().renew()
         return {
           ...loop,
+          // Every frame the loop actually runs renews the claim, so it stays held for as long as
+          // the loop lives — and expires on its own if the loop is ever dropped without finishing.
+          recordFrame: (wrote: boolean) => {
+            pinBottomClaim().renew()
+            loop.recordFrame(wrote)
+          },
           finish: () => {
             loop.finish()
-            pinBottomActiveRef.current = false
+            pinBottomClaim().release()
           },
         }
       },
@@ -2339,7 +2352,7 @@ export function useMessageListScroll({
     // scrollTop: on WebKit a tall bottom row's post-paint growth fires 'scroll' events reporting a
     // transiently large distFromBottom before the loop re-pins, which would otherwise flash the FAB
     // on open-at-bottom (intermittent race). The loop settles AT the bottom, so the FAB stays hidden.
-    const shouldShowFab = shouldShowScrollToBottomFab(distFromBottom, FAB_THRESHOLD, pinBottomActiveRef.current)
+    const shouldShowFab = shouldShowScrollToBottomFab(distFromBottom, FAB_THRESHOLD, pinBottomClaim().isHeld())
     setShowScrollToBottom(prev => prev !== shouldShowFab ? shouldShowFab : prev)
 
     // Jump-to-last-read pill visibility: is the first-new-message divider currently scrolled
@@ -3296,14 +3309,18 @@ export function useMessageListScroll({
   }, [firstNewMessageId])
 
   // ==========================================================================
-  // EFFECT: Reaction added/removed — keep the bottom glued (only when sticked)
+  // EFFECT: A resident row grew in place — keep the bottom glued (only when sticked)
   // ==========================================================================
 
-  // A reaction grows (or shrinks) its message row. While the reader is sticked to the bottom we keep
-  // the newest message glued to the bottom edge and let the growth be absorbed ABOVE (previous
-  // messages scroll up) — rather than letting the row growth shove the newest message down. This runs
-  // for a reaction on ANY resident row, not just the last one: a reaction in the middle of the
-  // viewport would otherwise push everything below it (including the newest message) down.
+  // A reaction, a link-preview or attachment fastening, a correction or a retraction grows (or
+  // shrinks) a message row that is ALREADY rendered — without changing the message count or the
+  // last-message id, so the new-message effect never sees it. The OGP fastening is the slowest of
+  // them: it lands seconds after the send, once the metadata fetch and the round-trip complete.
+  // While the reader is sticked to the bottom we keep the newest message glued to the bottom edge
+  // and let the growth be absorbed ABOVE (previous messages scroll up) — rather than letting the row
+  // growth shove the newest message down. This runs for a change on ANY resident row, not just the
+  // last one: a row grown in the middle of the viewport would otherwise push everything below it
+  // (including the newest message) down.
   //
   // We route through the controller-owned live-edge convergence that new
   // messages and the typing footer use) rather than a one-shot scrollToIndex, because the row's
@@ -3315,27 +3332,27 @@ export function useMessageListScroll({
   // Two safeguards keep it from ever fighting a scroll: (1) it's gated on LIVE geometry, not the
   // latchable isAtBottomRef — a reader scrolled up into history reads distFromBottom >= threshold and
   // is never re-pinned (a stale-true latch is what made a typing toggle "fight" the scroll in #918);
-  // (2) it fires only on an actual reactions change WITHIN the same conversation, so a conversation
+  // (2) it fires only on an actual row-height change WITHIN the same conversation, so a conversation
   // switch / restore is never disturbed.
-  const prevReactionsKeyRef = useRef(reactionsSignature)
-  const reactionsConvRef = useRef(conversationId)
+  const prevRowGrowthKeyRef = useRef(rowGrowthSignature)
+  const rowGrowthConvRef = useRef(conversationId)
   useLayoutEffect(() => {
-    const sameConversation = reactionsConvRef.current === conversationId
-    reactionsConvRef.current = conversationId
-    const prevKey = prevReactionsKeyRef.current
-    prevReactionsKeyRef.current = reactionsSignature
+    const sameConversation = rowGrowthConvRef.current === conversationId
+    rowGrowthConvRef.current = conversationId
+    const prevKey = prevRowGrowthKeyRef.current
+    prevRowGrowthKeyRef.current = rowGrowthSignature
     if (!sameConversation) return // conversation switch → rebaseline, never re-pin
-    if (prevKey === reactionsSignature) return // no actual reactions change (unrelated re-render)
+    if (prevKey === rowGrowthSignature) return // no actual row change (unrelated re-render)
 
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return
     // Live-geometry gate: only re-pin when genuinely at/near the bottom right now.
     if (getDistanceFromBottom(scroller) >= AT_BOTTOM_THRESHOLD) return
     // A running pin loop already keeps the bottom pinned — don't stack a second one.
-    if (pinBottomActiveRef.current) return
+    if (pinBottomClaim().isHeld()) return
 
-    reconcileLiveEdge('reaction')
-  }, [reactionsSignature, conversationId, reconcileLiveEdge, staticMode])
+    reconcileLiveEdge('row-growth')
+  }, [rowGrowthSignature, conversationId, reconcileLiveEdge, staticMode])
 
   // ==========================================================================
   // EFFECT: Typing indicator appears — reveal its footer clearance while sticked

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2116,3 +2116,128 @@ test.describe('Jump-to-last-read pill', () => {
     expect(after.markerIdx, 'the divider must snap FORWARD toward the read pointer').toBeGreaterThan(after.dividerIdx)
   })
 })
+
+test.describe('Fastening stick diagnostic (1:1)', () => {
+  const AVA = 'ava@fluux.chat'
+
+  /**
+   * The reported bug, end to end in a real engine: you send a message containing a link, and the
+   * OGP preview card is fastened onto that ALREADY-RENDERED row seconds later. Nothing about the
+   * message list changes except the row's height — same message count, same last-message id, no
+   * reactions — so this exercises the only trigger that can notice it (the row-growth signature)
+   * AND the real spacer/row geometry the jsdom harness can only approximate.
+   */
+  async function emitLinkMessage(page: Page, jid: string, id: string): Promise<void> {
+    await page.evaluate(([j, i]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      if (!c) throw new Error('no __demoClient')
+      c.emitSDK('chat:message', {
+        message: {
+          type: 'chat', conversationId: j, from: j, id: i,
+          body: 'look at this https://example.invalid/article',
+          timestamp: new Date(), isOutgoing: false,
+        },
+      })
+    }, [jid, id] as const)
+  }
+
+  async function fastenPreview(page: Page, jid: string, id: string, url: string): Promise<void> {
+    await page.evaluate(([j, i, u]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      c.emitSDK('chat:message-updated', {
+        conversationId: j,
+        messageId: i,
+        updates: {
+          linkPreview: {
+            url: u,
+            title: 'A fastened link preview card',
+            description:
+              'Fastened after the fact. Long enough that the card is several lines tall, so the ' +
+              'row it grows genuinely pushes the newest message below the fold when nothing re-pins.',
+            siteName: 'example.invalid',
+            // An image gives the card an aspect-video box, so the row grows by well over the
+            // at-bottom threshold — without it the growth stays under the threshold and the test
+            // passes even with a gate that reads post-growth geometry.
+            image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+          },
+        },
+      })
+    }, [jid, id, url] as const)
+  }
+
+  async function bottomState(page: Page, msgId: string) {
+    return page.evaluate((id) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return { visible: false, distFromBottom: -1, scrollHeight: -1 }
+      const el = s.querySelector(`[data-message-id="${CSS.escape(id)}"]`) as HTMLElement | null
+      const sRect = s.getBoundingClientRect()
+      const visible = !!el && el.getBoundingClientRect().bottom <= sRect.bottom + 8
+      return {
+        visible,
+        distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+        scrollHeight: s.scrollHeight,
+      }
+    }, msgId)
+  }
+
+  test('a link-preview fastening on the newest row keeps the view stuck to the bottom', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+
+    const id = `fastened-${Date.now()}`
+    const url = `https://example.invalid/${id}`
+    await emitLinkMessage(page, AVA, id)
+    await page.waitForSelector(`[data-message-id="${id}"]`, { timeout: 5_000 })
+    await page.waitForTimeout(SETTLE_MS)
+
+    const before = await bottomState(page, id)
+    expect(before.distFromBottom, 'precondition: must start stuck to the bottom').toBeLessThan(AT_BOTTOM_OK_PX)
+
+    await fastenPreview(page, AVA, id, url)
+    // Wait for the REAL card to be in the DOM — this is the growth the scroll layer must absorb.
+    await page.waitForSelector(`a[href="${url}"]`, { timeout: 5_000 })
+    await page.waitForTimeout(600)
+
+    const after = await bottomState(page, id)
+    // The growth must exceed the at-bottom threshold, otherwise a gate that reads POST-growth
+    // geometry still squeaks under the threshold and the test proves nothing.
+    expect(
+      after.scrollHeight - before.scrollHeight,
+      `the preview card must grow the content by more than the at-bottom threshold (before=${before.scrollHeight}, after=${after.scrollHeight}) — otherwise this test is vacuous`,
+    ).toBeGreaterThan(AT_BOTTOM_OK_PX)
+    expect(
+      after.distFromBottom,
+      `view not re-pinned after the fastening — distFromBottom=${after.distFromBottom}`,
+    ).toBeLessThan(AT_BOTTOM_OK_PX)
+    expect(after.visible, `the fastened message "${id}" was pushed below the fold`).toBe(true)
+  })
+
+  test('a link-preview fastening does not yank a scrolled-up reader to the bottom', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+
+    const id = `fastened-up-${Date.now()}`
+    const url = `https://example.invalid/${id}`
+    await emitLinkMessage(page, AVA, id)
+    await page.waitForSelector(`[data-message-id="${id}"]`, { timeout: 5_000 })
+    await page.waitForTimeout(SETTLE_MS)
+
+    await setScrollTop(page, 200)
+    await page.waitForTimeout(SETTLE_MS)
+    const before = await getScrollTop(page)
+
+    await fastenPreview(page, AVA, id, url)
+    await page.waitForSelector(`a[href="${url}"]`, { timeout: 5_000 })
+    await page.waitForTimeout(600)
+
+    const after = await getScrollTop(page)
+    expect(
+      Math.abs(after - before),
+      `a scrolled-up reader was moved by the fastening (${before} -> ${after})`,
+    ).toBeLessThan(AT_BOTTOM_OK_PX)
+  })
+})

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2310,16 +2310,17 @@ test.describe('Fastening stick diagnostic (1:1)', () => {
 test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
   const AVA = 'ava@fluux.chat'
 
-  // End-to-end sanity for the reported sequence: an incoming message, its preview card, and a
-  // reaction landing in quick succession must leave the list stuck to the bottom, with no user
-  // movement anywhere.
+  // SCOPE: a burst of successive in-place changes on the same row — the message, then its preview
+  // card, then a reaction — must leave the list stuck to the bottom, with no user movement anywhere.
+  // What it demonstrates is that the ACTIVE pin loop absorbs them as they land.
   //
-  // NOTE ON SCOPE: this does NOT guard the deferral path specifically. Staging that needs the
-  // preview to commit while the message's pin loop still holds its claim, and the loop converges
-  // faster than emits can be interleaved from here — the test passes with and without the
-  // carry-the-earliest-deferral fix. The invariant itself is pinned by carryDeferral's unit test,
-  // which does break-check. Do not treat a green run here as covering that path.
-  test('an incoming message, its preview and a reaction in quick succession leave the list pinned', async ({ page }) => {
+  // What it does NOT cover: a growth skipped because a pin loop still claimed the bottom. There is
+  // no second chance for such a growth — nothing re-runs the effect for a consumed signature — so
+  // waiting longer here proves nothing and would only imply a recovery that does not exist. Staging
+  // that case is not possible from here anyway: it needs the preview to commit while the loop still
+  // holds its claim, and the loop converges in ~130ms, faster than emits can be interleaved. The gap
+  // is documented on rowGrowthDecision and pinned by its unit test.
+  test('an active pin loop absorbs a burst of in-place changes on the same row', async ({ page }) => {
     await loadDemo(page)
     await activateChat(page, AVA)
     await scrollToBottom(page)
@@ -2328,10 +2329,9 @@ test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
     const url = `https://example.invalid/${id}`
 
     // The whole sequence runs INSIDE the page: a Playwright round-trip is far longer than the pin
-    // loop's convergence, so emitting these from separate evaluate() calls lets the loop finish and
-    // release its claim, and nothing is ever deferred. Emitted together, the preview lands while the
-    // incoming message's pin loop still holds the claim — the deferral this test is about — and the
-    // reaction follows as a NEWER row-growth signature before that claim lapses.
+    // loop's convergence, so emitting these from separate evaluate() calls spaces them out beyond
+    // anything a real client would produce. In-page they arrive in the burst this is meant to cover
+    // — message, then its preview, then a reaction on the same row.
     await page.evaluate(async ([j, i, u]) => {
       const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2343,8 +2343,8 @@ test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
           timestamp: new Date(), isOutgoing: false,
         },
       })
-      // Separate ticks, or React batches all three into ONE signature change and the
-      // newer-signature-cancels-pending-retry sequence never happens.
+      // Separate ticks, or React batches all three into ONE render and this collapses into a single
+      // row-growth signature change — which is not the sequence under test.
       await wait(30)
       c.emitSDK('chat:message-updated', {
         conversationId: j, messageId: i,
@@ -2365,8 +2365,10 @@ test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
     }, [AVA, id, url] as const)
     await page.waitForSelector(`a[href="${url}"]`, { timeout: 5_000 })
 
-    // Well past the pin claim's stale window, so any deferred retry has had its chance.
-    await page.waitForTimeout(2_500)
+    // A normal settle, matching the sibling fastening tests. Deliberately NOT the claim's stale
+    // window: no re-pin is owed after that window, so a longer wait would suggest a second chance
+    // the implementation does not offer.
+    await page.waitForTimeout(600)
 
     const state = await page.evaluate((msgId) => {
       const s = document.querySelector('[data-message-list]') as HTMLElement | null
@@ -2381,7 +2383,7 @@ test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
 
     expect(
       state.distFromBottom,
-      `list stranded after preview+reaction — distFromBottom=${state.distFromBottom}`,
+      `list not pinned after the message+preview+reaction burst — distFromBottom=${state.distFromBottom}`,
     ).toBeLessThan(AT_BOTTOM_OK_PX)
     expect(state.visible, 'the fastened message was left below the fold').toBe(true)
   })

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2306,3 +2306,83 @@ test.describe('Fastening stick diagnostic (1:1)', () => {
     ).toBeLessThan(AT_BOTTOM_OK_PX)
   })
 })
+
+test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
+  const AVA = 'ava@fluux.chat'
+
+  // End-to-end sanity for the reported sequence: an incoming message, its preview card, and a
+  // reaction landing in quick succession must leave the list stuck to the bottom, with no user
+  // movement anywhere.
+  //
+  // NOTE ON SCOPE: this does NOT guard the deferral path specifically. Staging that needs the
+  // preview to commit while the message's pin loop still holds its claim, and the loop converges
+  // faster than emits can be interleaved from here — the test passes with and without the
+  // carry-the-earliest-deferral fix. The invariant itself is pinned by carryDeferral's unit test,
+  // which does break-check. Do not treat a green run here as covering that path.
+  test('an incoming message, its preview and a reaction in quick succession leave the list pinned', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+
+    const id = `pending-${Date.now()}`
+    const url = `https://example.invalid/${id}`
+
+    // The whole sequence runs INSIDE the page: a Playwright round-trip is far longer than the pin
+    // loop's convergence, so emitting these from separate evaluate() calls lets the loop finish and
+    // release its claim, and nothing is ever deferred. Emitted together, the preview lands while the
+    // incoming message's pin loop still holds the claim — the deferral this test is about — and the
+    // reaction follows as a NEWER row-growth signature before that claim lapses.
+    await page.evaluate(async ([j, i, u]) => {
+      const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      c.emitSDK('chat:message', {
+        message: {
+          type: 'chat', conversationId: j, from: j, id: i,
+          body: 'look at this https://example.invalid/article',
+          timestamp: new Date(), isOutgoing: false,
+        },
+      })
+      // Separate ticks, or React batches all three into ONE signature change and the
+      // newer-signature-cancels-pending-retry sequence never happens.
+      await wait(30)
+      c.emitSDK('chat:message-updated', {
+        conversationId: j, messageId: i,
+        updates: {
+          linkPreview: {
+            url: u, title: 'A fastened link preview card',
+            description: 'Fastened after the fact, tall enough to push the newest message below the fold.',
+            siteName: 'example.invalid',
+            image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+          },
+        },
+      })
+      await wait(60)
+      c.emitSDK('chat:message-updated', {
+        conversationId: j, messageId: i,
+        updates: { reactions: { '\u{1F44D}': ['someone@fluux.chat'] } },
+      })
+    }, [AVA, id, url] as const)
+    await page.waitForSelector(`a[href="${url}"]`, { timeout: 5_000 })
+
+    // Well past the pin claim's stale window, so any deferred retry has had its chance.
+    await page.waitForTimeout(2_500)
+
+    const state = await page.evaluate((msgId) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      if (!s) return { visible: false, distFromBottom: -1 }
+      const el = s.querySelector(`[data-message-id="${CSS.escape(msgId)}"]`) as HTMLElement | null
+      const sRect = s.getBoundingClientRect()
+      return {
+        visible: !!el && el.getBoundingClientRect().bottom <= sRect.bottom + 8,
+        distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+      }
+    }, id)
+
+    expect(
+      state.distFromBottom,
+      `list stranded after preview+reaction — distFromBottom=${state.distFromBottom}`,
+    ).toBeLessThan(AT_BOTTOM_OK_PX)
+    expect(state.visible, 'the fastened message was left below the fold').toBe(true)
+  })
+})


### PR DESCRIPTION
A link-preview (OGP) fastening lands seconds after its message as an in-place update: same message count, same last-message id, no reactions change. `LinkPreviewCard` deliberately never calls `onMediaLoad`, and under virtualization the content ResizeObserver is disabled — so nothing in the scroll layer could see the row grow, and the card rendered below the fold and stayed there.

Generalizes the reactions-only re-pin trigger into a row-growth signature covering every in-place height change: reactions, link previews, attachments, corrections, retractions.

The gate reads pre-growth geometry, because by the time the layout effect runs the growth is already in the measured distance — a card taller than the at-bottom threshold would otherwise read as "the reader scrolled away" and be refused in exactly the case it exists for. The height delta is signed: a measured shrink (a retraction, a reaction removed) must not be mistaken for an unmeasured growth, and an untrustworthy baseline is reported as unknown rather than folded into zero.

The re-pin never overrides an explicit navigation. Row growth is ambient — the reader did not ask for it, so it must not cancel a position they did (Home/resident-top, jump-to-message, saved-position restore).

## Known gap

The guard that stops a second pin loop stacking on a running one is a self-expiring claim rather than a boolean. A boolean was cleared only by the loop's `finish()` callback, so a loop dropped without finishing latched it for the life of the mounted list and silently suppressed every later re-pin.

While that claim is held the re-pin skips, betting the running loop absorbs the growth. If the loop was abandoned the bet is wrong. **The expiring claim prevents a permanent latch — it bounds how long further growths stay suppressed — but it cannot replay a fastening already consumed.** Recovering that one needs the reader to move, or another growth after the claim lapses.

The root cause is the controller path that can abandon a frame loop without calling `finish()`, tracked separately; fixing it closes this gap at the source. Against the behaviour before this branch it is still a clear net gain: every late fastening used to be lost, not only those landing inside an abandoned loop's claim.

The delay before the card appears is unchanged — that is the OGP fetch plus the fastening round-trip.