### PR TITLE
fix(muc): prompt for a password when joining from Browse Rooms (#1126)

### DIFF
--- a/apps/fluux/src/components/BrowseRoomsModal.test.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@fluux/sdk', () => ({
     getRoomInfo: vi.fn().mockResolvedValue(null),
     acknowledgeNonAnonymousRoom: vi.fn(),
     isNonAnonymousRoomAcknowledged: () => false,
+    // useRoomPasswordPrompt sources the join through here; same mocks as useRoom
+    // so the assertions below cover both entry points.
+    joinRoom: mockJoinRoom,
+    joinResult: mockJoinResult,
   }),
   WELL_KNOWN_MUC_SERVERS: ['conference.process-one.net', 'muc.xmpp.org'],
   getLocalPart: (jid: string) => jid.split('@')[0],
@@ -506,6 +510,62 @@ describe('BrowseRoomsModal', () => {
         expect(screen.getByText('rooms.membersOnly')).toBeInTheDocument()
       })
       expect(mockOnClose).not.toHaveBeenCalled()
+    })
+
+    // Issue #1126: a public listing can include password-protected rooms. The
+    // modal showed "password required" on its error line with nowhere to type it.
+    describe('password-protected room', () => {
+      const openAndJoin = async () => {
+        render(<BrowseRoomsModal onClose={mockOnClose} />)
+        await waitFor(() => expect(screen.getByText('General Chat')).toBeInTheDocument())
+        fireEvent.click(screen.getAllByText('rooms.join')[0])
+      }
+
+      it('prompts for the password on a 401 and retries with it', async () => {
+        mockJoinRoom.mockResolvedValue(undefined)
+        mockJoinResult
+          .mockRejectedValueOnce(
+            new RoomJoinError('general@conference.example.com', 'not-authorized'),
+          )
+          .mockResolvedValue(undefined)
+
+        await openAndJoin()
+
+        const input = await screen.findByLabelText('rooms.roomPassword')
+        fireEvent.change(input, { target: { value: 's3cret' } })
+        fireEvent.submit(input)
+
+        await waitFor(() =>
+          expect(mockJoinRoom).toHaveBeenLastCalledWith(
+            'general@conference.example.com',
+            'testuser',
+            { password: 's3cret' },
+          ),
+        )
+        await waitFor(() => {
+          expect(mockSetActiveRoom).toHaveBeenCalledWith('general@conference.example.com')
+          expect(mockOnClose).toHaveBeenCalled()
+        })
+      })
+
+      it('keeps the browser open when the password prompt is cancelled', async () => {
+        mockJoinRoom.mockResolvedValue(undefined)
+        mockJoinResult.mockRejectedValue(
+          new RoomJoinError('general@conference.example.com', 'not-authorized'),
+        )
+
+        await openAndJoin()
+
+        fireEvent.click(await screen.findByText('common.cancel'))
+
+        await waitFor(() =>
+          expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument(),
+        )
+        // Still browsing: the room was not opened and the modal stayed put.
+        expect(mockSetActiveRoom).not.toHaveBeenCalled()
+        expect(mockOnClose).not.toHaveBeenCalled()
+        expect(screen.getByText('General Chat')).toBeInTheDocument()
+      })
     })
 
     it('should show error when trying to join with whitespace-only nickname', async () => {

--- a/apps/fluux/src/components/BrowseRoomsModal.tsx
+++ b/apps/fluux/src/components/BrowseRoomsModal.tsx
@@ -3,6 +3,7 @@ import { TextInput } from './ui/TextInput'
 import { useTranslation } from 'react-i18next'
 import { useModalInput, useListKeyboardNav } from '@/hooks'
 import { useRoomJoinWarning } from '@/hooks/useRoomJoinWarning'
+import { useRoomPasswordPrompt } from '@/hooks/useRoomPasswordPrompt'
 import {
   useConnection,
   useRoom,
@@ -41,8 +42,9 @@ interface BrowseRoomsModalProps {
 export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
   const { t } = useTranslation()
   const { jid: userJid, ownNickname } = useConnection()
-  const { browsePublicRooms, joinRoom, joinResult, getRoom, setActiveRoom, mucServiceJid } = useRoom()
+  const { browsePublicRooms, getRoom, setActiveRoom, mucServiceJid } = useRoom()
   const { confirmJoin, warningDialog } = useRoomJoinWarning()
+  const { joinRoomWithPassword, passwordDialog } = useRoomPasswordPrompt()
   // NOTE: Use direct store subscription to avoid re-renders from activeMessages changes
   const setActiveConversation = useChatStore((s) => s.setActiveConversation)
   const [rooms, setRooms] = useState<{ jid: string; name: string; occupants?: number }[]>([])
@@ -250,8 +252,9 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
     try {
       // Issue #37: warn before joining a room that would expose the user's real JID.
       if (!(await confirmJoin(roomJid))) return
-      await joinRoom(roomJid, nickname.trim())
-      await joinResult(roomJid)
+      // Issue #1126: a public listing can still include password-protected rooms;
+      // ask for the password on a 401 rather than dead-ending on the error line.
+      if (!(await joinRoomWithPassword(roomJid, nickname.trim()))) return
       void setActiveConversation(null)
       void setActiveRoom(roomJid)
       onClose()
@@ -502,6 +505,7 @@ export function BrowseRoomsModal({ onClose }: BrowseRoomsModalProps) {
         </div>
     </ModalShell>
     {warningDialog}
+    {passwordDialog}
     </>
   )
 }

--- a/apps/fluux/src/components/ModalOverlay.escape.test.tsx
+++ b/apps/fluux/src/components/ModalOverlay.escape.test.tsx
@@ -45,4 +45,55 @@ describe('ModalOverlay Escape handling', () => {
       window.removeEventListener('keydown', windowKeydown)
     }
   })
+
+  // Issue #1126: the room-password prompt opens OVER Browse Rooms, and the
+  // real-JID warning opens over the join modals. Each overlay listens on
+  // document, and stopPropagation does not stop a sibling listener on the same
+  // node — so one Escape used to collapse the whole stack.
+  describe('stacked modals', () => {
+    it('dismisses only the topmost modal', () => {
+      const closeOuter = vi.fn()
+      const closeInner = vi.fn()
+      render(
+        <>
+          <ModalOverlay onClose={closeOuter}>
+            <button type="button">outer</button>
+          </ModalOverlay>
+          <ModalOverlay onClose={closeInner}>
+            <button type="button">inner</button>
+          </ModalOverlay>
+        </>,
+      )
+
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+
+      expect(closeInner).toHaveBeenCalledTimes(1)
+      expect(closeOuter).not.toHaveBeenCalled()
+    })
+
+    it('dismisses the remaining modal once the top one is gone', () => {
+      const closeOuter = vi.fn()
+      const { rerender } = render(
+        <>
+          <ModalOverlay onClose={closeOuter}>
+            <button type="button">outer</button>
+          </ModalOverlay>
+          <ModalOverlay onClose={vi.fn()}>
+            <button type="button">inner</button>
+          </ModalOverlay>
+        </>,
+      )
+
+      rerender(
+        <>
+          <ModalOverlay onClose={closeOuter}>
+            <button type="button">outer</button>
+          </ModalOverlay>
+        </>,
+      )
+      fireEvent.keyDown(document.body, { key: 'Escape' })
+
+      expect(closeOuter).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/apps/fluux/src/components/ModalOverlay.tsx
+++ b/apps/fluux/src/components/ModalOverlay.tsx
@@ -98,6 +98,8 @@ export function ModalOverlay({
   children,
 }: ModalOverlayProps) {
   const panelRef = useRef<HTMLDivElement>(null)
+  /** The overlay root — used to tell whether this modal is the topmost one. */
+  const rootRef = useRef<HTMLDivElement>(null)
   const { panelClass, scrimClass, requestClose } = useModalTransition(
     panelInClass ? { panelInClass } : undefined,
   )
@@ -119,6 +121,16 @@ export function ModalOverlay({
     if (!closeOnEscape || !dismissable) return
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
+      // Only the TOPMOST modal dismisses. Stacked modals (the room-password
+      // prompt over Browse Rooms, the real-JID warning over any join modal) each
+      // register their own document listener, and stopPropagation cannot stop a
+      // sibling listener on the same node — so without this, one Escape would
+      // close the whole stack instead of just the dialog on top. A stacked dialog
+      // is rendered after the modal it opens over (nested in it or as its next
+      // sibling), so the LAST overlay in document order is the one on top — which
+      // is also the one painted last, since they share a z-index.
+      const modals = document.querySelectorAll('[data-modal="true"]')
+      if (modals.length > 1 && modals[modals.length - 1] !== rootRef.current) return
       // CONSUME the Escape (mirroring useCloseOnEscape) so it cannot also reach
       // the app's window-level shortcut handler, whose Escape branch falls
       // through to onConversationEscape (scroll-to-bottom + mark-read). Without
@@ -133,6 +145,7 @@ export function ModalOverlay({
 
   return (
     <div
+      ref={rootRef}
       data-modal="true"
       className={`fixed inset-0 flex ${ALIGN_CLASS[align]} justify-center z-50`}
     >

--- a/apps/fluux/src/hooks/useRoomPasswordPrompt.test.tsx
+++ b/apps/fluux/src/hooks/useRoomPasswordPrompt.test.tsx
@@ -64,7 +64,7 @@ describe('useRoomPasswordPrompt', () => {
 
     await waitFor(() => expect(onResult).toHaveBeenCalledWith('joined'))
     expect(screen.queryByLabelText('rooms.roomPassword')).not.toBeInTheDocument()
-    expect(mockJoinRoom).toHaveBeenCalledWith(ROOM, 'mynick', undefined)
+    expect(mockJoinRoom).toHaveBeenCalledWith(ROOM, 'mynick')
   })
 
   it('prompts on a 401 and retries with the password', async () => {

--- a/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
+++ b/apps/fluux/src/hooks/useRoomPasswordPrompt.tsx
@@ -99,8 +99,11 @@ export function useRoomPasswordPrompt() {
   const joinRoomWithPassword = useCallback(
     (roomJid: string, nickname: string) =>
       withPasswordPrompt(async (password) => {
-        // Room passwords are opaque XMPP strings - never trim them.
-        await joinRoom(roomJid, nickname, password !== undefined ? { password } : undefined)
+        // Room passwords are opaque XMPP strings - never trim them. The
+        // unprompted attempt passes no options at all, so joinRoom() falls back
+        // to whatever password it already knows for the room.
+        if (password === undefined) await joinRoom(roomJid, nickname)
+        else await joinRoom(roomJid, nickname, { password })
         await joinResult(roomJid)
       }),
     [withPasswordPrompt, joinRoom, joinResult]


### PR DESCRIPTION
Closes #1132. Follow-up to #1131, which left this path out.

A public room listing can still include password-protected rooms. Browse Rooms surfaced the server's refusal on its inline error line but offered nowhere to type the password, so those rooms were unreachable from there. It now joins through the shared password prompt (`useRoomPasswordPrompt`): a 401 asks and retries, every other failure keeps the existing inline error, and cancelling leaves the browser open.

**Modal stacking.** This is the first place the prompt opens *over* another modal, which exposed a pre-existing bug: every `ModalOverlay` registers its own `document` keydown listener, and `stopPropagation()` cannot stop a sibling listener on the same node — so one Escape collapsed the whole stack. Only the topmost overlay now dismisses. That also fixes the real-JID warning dialog, which has been stacking over the join modals since #37.

`joinRoomWithPassword()` no longer passes an explicit `undefined` as `joinRoom()`'s options on the unprompted attempt, keeping the call shape callers already assert on.

Verified in demo mode against the password-protected "Board" room, which the simulated service lists publicly and refuses without a password: the prompt stacks over Browse Rooms, Escape closes only the prompt, and the right password joins and closes the browser.