### PR TITLE
fix(scroll): route Home through the virtualizer so a superseded pin cannot re-assert

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomBehavior.test.tsx
@@ -44,6 +44,8 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
     ensureMessageMounted: vi.fn(() => Promise.resolve()),
     measureElement: () => {},
     scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    // jsdom has no smooth-scroll animation, so an animated scroll lands immediately.
+    beginAnimatedScrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
     scrollToIndex: (_index: number, opts?: { align?: string }) => {
       const el = args.scrollRef.current; if (!el) return
       if (opts?.align === 'end') { scrollToEndCalls.count += 1; el.scrollTop = el.scrollHeight }

--- a/apps/fluux/src/components/conversation/MessageList.pinBottomRepaint.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.pinBottomRepaint.test.tsx
@@ -43,6 +43,8 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
     ensureMessageMounted: vi.fn(() => Promise.resolve()),
     measureElement: () => {},
     scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    // jsdom has no smooth-scroll animation, so an animated scroll lands immediately.
+    beginAnimatedScrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
     scrollToIndex: (_index: number, opts?: { align?: string }) => {
       const el = args.scrollRef.current; if (!el) return
       if (opts?.align === 'end') { scrollToEndCalls.count += 1; el.scrollTop = el.scrollHeight }

--- a/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.reassertSingleFlight.test.tsx
@@ -78,6 +78,11 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
       const el = args.scrollRef.current
       if (el) el.scrollTop = offset
     },
+    // jsdom has no smooth-scroll animation, so an animated scroll lands immediately.
+    beginAnimatedScrollToOffset: (offset: number) => {
+      const el = args.scrollRef.current
+      if (el) el.scrollTop = offset
+    },
     scrollToIndex: (index: number, opts?: { align?: string }) => {
       const el = args.scrollRef.current
       if (!el) return

--- a/apps/fluux/src/components/conversation/MessageList.virtualized.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualized.test.tsx
@@ -73,6 +73,7 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
       measureElement: () => {},
       scrollToOffset: () => {},
       scrollToIndex: () => {},
+      beginAnimatedScrollToOffset: () => {},
     }
     return stub
   },

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -30,6 +30,10 @@ const getOffsetForMessageId = vi.fn((_id: string): number | null => 0)
 // path). A direct scrollTop write does NOT go through here, so this distinguishes a
 // virtualizer-aware restore (re-windows before paint) from a raw scrollTop write (blank).
 const scrollToOffsetCalls: number[] = []
+// Records every offset pushed through beginAnimatedScrollToOffset — the animated commands the
+// app owns (Home / resident top). Kept apart from scrollToOffsetCalls so a test can prove an
+// animated navigation retargets the virtualizer rather than writing the scroller behind its back.
+const animatedScrollToOffsetCalls: number[] = []
 // Records the align of every scrollToIndex. A bottom re-pin goes through
 // scrollToIndex(last,'end') (re-windows the virtualizer); a raw scrollTop write does not.
 // Lets a test prove the composer-resize correction routes through the virtualizer.
@@ -81,6 +85,13 @@ vi.mock('./tanstackMessageVirtualizer', () => ({
     // scrollTop = scrollHeight, matching the test expectations for bottom-stick behavior.
     scrollToOffset: (offset: number) => {
       scrollToOffsetCalls.push(offset)
+      const el = args.scrollRef.current
+      if (el) el.scrollTop = offset
+    },
+    // jsdom has no smooth-scroll animation, so an animated scroll lands immediately. Recorded
+    // separately from scrollToOffset so tests can tell an animated command from a re-window write.
+    beginAnimatedScrollToOffset: (offset: number) => {
+      animatedScrollToOffsetCalls.push(offset)
       const el = args.scrollRef.current
       if (el) el.scrollTop = offset
     },
@@ -155,6 +166,7 @@ describe('MessageList — virtualized scroll integration', () => {
     scrollToIndexCalls.length = 0
     scrollToIndexBehaviors.length = 0
     scrollToOffsetCalls.length = 0
+    animatedScrollToOffsetCalls.length = 0
     scrollToIndexStartOffsets.length = 0
     windowedOutKeys.clear()
   })
@@ -165,6 +177,26 @@ describe('MessageList — virtualized scroll integration', () => {
     renderList({ firstNewMessageId: 'msg-40' })
     await waitFor(() => expect(scrollToIndexCalls).toContain('start'))
     expect(ensureMessageMounted).not.toHaveBeenCalledWith('msg-40')
+  })
+
+  it('routes Home through the virtualizer so a superseded live-edge pin cannot re-assert over it', async () => {
+    // @tanstack keeps a pending-scroll reconciler armed for several seconds after the live-edge
+    // pin's scrollToIndex(last,'end'), and re-applies THAT target on every frame late measurement
+    // moves it. Cancelling the pin's controller execution does not retire it, so a Home animation
+    // written straight to the scroller gets snapped back to the bottom mid-flight (observed on the
+    // WebKitGTK CI runner, where rows are still measuring seconds after entry). Issuing the write
+    // through the virtualizer retargets that reconciler instead of racing it.
+    //
+    // The wrong implementation this must fail against is the previous one: a direct
+    // `scroller.scrollTo({ top: 0, behavior: 'smooth' })`, which leaves animatedScrollToOffsetCalls
+    // empty. Asserting scrollTop alone would NOT catch it — the mock scroller lands at 0 either way.
+    renderList()
+    await waitFor(() => expect(scrollToIndexCalls.length).toBeGreaterThan(0))
+    animatedScrollToOffsetCalls.length = 0
+
+    act(() => { fireEvent.keyDown(window, { key: 'Home' }) })
+
+    await waitFor(() => expect(animatedScrollToOffsetCalls).toEqual([0]))
   })
 
   it('centers the target row via scrollToIndex when a targetMessageId is set (reply / search jump)', async () => {

--- a/apps/fluux/src/components/conversation/messageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/messageVirtualizer.ts
@@ -61,4 +61,25 @@ export interface MessageVirtualizer {
    * behavior: 'auto' (instant) | 'smooth'
    */
   scrollToIndex(index: number, opts?: { align?: 'start' | 'center' | 'end' | 'auto'; behavior?: 'auto' | 'smooth' }): void
+  /**
+   * Start an ANIMATED scroll to `offset` and hand the virtualizer's own pending-scroll state
+   * over to it. Use this — never a raw `scroller.scrollTo({ behavior: 'smooth' })` — for any
+   * animated position the app owns on the virtualized path.
+   *
+   * Why it exists: @tanstack keeps a pending-scroll reconciler alive for several seconds after
+   * every scrollToIndex/scrollToOffset and re-applies ITS target on every frame that
+   * measurement moves it. That reconciler is invisible to the positioning controller's
+   * generations, so a superseded live-edge pin can still snap the list back to the bottom in
+   * the middle of a newer animation (worst on a slow engine, where rows are still measuring for
+   * the first time). Retargeting the reconciler is what makes the animation survive; it also
+   * suppresses @tanstack's own size-change scroll adjustments for the animation's duration.
+   *
+   * Distinct from `scrollToOffset(offset, { behavior: 'smooth' })`: that variant additionally
+   * pushes the target into @tanstack's offset callback so the window re-renders before paint,
+   * which is right for an instant write but wrong for an animation — it would claim the
+   * scroller had already arrived, re-windowing to the destination while the view is still at
+   * the origin (and retiring the reconciler immediately). Here the offset is left to be
+   * observed as the animation runs.
+   */
+  beginAnimatedScrollToOffset(offset: number): void
 }

--- a/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
+++ b/apps/fluux/src/components/conversation/tanstackMessageVirtualizer.ts
@@ -251,6 +251,14 @@ export function useTanstackMessageVirtualizer({
       // inside a lifecycle method" + a render-loop storm when called during the layout-effect commit.
       offsetCbRef.current?.(offset, false)
     },
+    // Deliberately WITHOUT the offsetCb push its two neighbours perform: during an animation
+    // the scroller has not arrived yet, so claiming the destination offset would re-window to it
+    // before paint and retire @tanstack's pending-scroll reconciler on its next frame — losing
+    // exactly the ownership this call is taken out to hold. The rAF-polled observeElementOffset
+    // tracks the animation frame by frame instead, so there is no scrollOffset desync to guard.
+    beginAnimatedScrollToOffset: (offset) => {
+      virtualizer.scrollToOffset(offset, { behavior: 'smooth' })
+    },
     scrollToIndex: (index, opts) => {
       virtualizer.scrollToIndex(index, opts)
       // Same scrollOffset-desync guard as scrollToOffset above, on the stick-to-bottom path.

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1915,7 +1915,15 @@ export function useMessageListScroll({
     start: (_request, lease) => {
       const scroller = scrollerRef.current
       if (!lease.isCurrent() || !scroller) return { kind: 'unavailable' }
-      scroller.scrollTo({ top: 0, behavior: 'smooth' })
+      const virtualizer = virtualizerRef.current
+      // One smooth write either way — but on the virtualized path it must be issued THROUGH the
+      // virtualizer. Cancelling the superseded live-edge execution only retires our own lease and
+      // frame loop; @tanstack's pending-scroll reconciler stays armed on the live edge for
+      // several more seconds and re-applies it whenever late row measurement moves its target,
+      // overriding this animation with no controller event to observe. Issuing the write through
+      // the virtualizer retargets that reconciler onto resident top instead of racing it.
+      if (virtualizer) virtualizer.beginAnimatedScrollToOffset(0)
+      else scroller.scrollTo({ top: 0, behavior: 'smooth' })
       return { kind: 'started' }
     },
     readScrollTop: () => scrollerRef.current?.scrollTop ?? null,

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -348,6 +348,26 @@ A later migration is incomplete until each in-scope owner either routes through 
 explicitly documented as an isolated, non-competing context. New controller code must replace and
 delete old owners rather than wrap them indefinitely.
 
+### The virtualizer is a position owner the generations cannot see
+
+`@tanstack/virtual-core` keeps its own pending-scroll reconciler: every `scrollToIndex` /
+`scrollToOffset` arms a `scrollState` that survives for up to five seconds and re-applies **its**
+target on each frame that measurement moves it. That reconciler is invisible to this contract's
+generations — cancelling a controller execution retires the lease and the frame loop, but the
+virtualizer keeps re-asserting the position the superseded owner asked for.
+
+Consequently, on the virtualized path an animated command must be issued **through** the virtualizer
+(`beginAnimatedScrollToOffset`), never as a raw `scroller.scrollTo({ behavior: 'smooth' })`. Doing so
+retargets the reconciler onto the new position instead of racing it, and additionally suppresses the
+virtualizer's own size-change scroll adjustments for the animation's duration. A raw smooth write
+loses to the previous owner whenever rows are still measuring — reliably so on a slow engine, where
+each layout pass costs long enough for the reconciler to re-fire several times mid-animation
+(observed as Home snapping back to the live edge on the WebKitGTK CI runner).
+
+An instant write may continue to use `scrollToOffset`/`scrollToIndex`, which additionally push the
+landed offset into the virtualizer's offset callback so the window re-renders before paint. That
+push is wrong for an animation: it claims the scroller has already arrived.
+
 ## Test standard
 
 Pure-model tests use paired controls that differ by one semantic fact. Every test must identify a

--- a/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
+++ b/docs/superpowers/specs/2026-07-27-resident-top-controller-design.md
@@ -40,6 +40,16 @@ The observation budget is 120 frames. If the browser does not reach resident
 top within that budget, the controller completes best-effort and does not snap.
 This preserves the current one-shot behavior and avoids a late visible jump.
 
+Budget exhaustion bounds how long the controller *watches*; it is not a licence
+for the list to come to rest somewhere else. An unopposed native smooth scroll
+always reaches resident top, so `best-effort` and "the list arrived" are not
+alternatives — a slow engine can simply stop being observed before it arrives.
+The real-engine test therefore asserts the two separately: its completion
+assertion is outcome-agnostic, and its position assertion carries a generous
+ceiling but fails fast on the one outcome that is always wrong — the list moving
+*away* from resident top after Home, which means a superseded owner re-asserted
+mid-animation.
+
 Instant per-frame convergence is rejected because it would remove the existing
 Home animation. A controller method that merely wraps the current direct call
 is also rejected because it would not own cancellation, supersession, or
@@ -81,8 +91,14 @@ write.
 
 - derives reachability from the current first resident row;
 - uses `beginControllerFrameLoop('resident-top', lease)`;
-- calls `scroller.scrollTo({ top: 0, behavior: 'smooth' })` exactly once from
-  the controller-owned executor;
+- starts the animation exactly once from the controller-owned executor, through
+  the virtualizer (`beginAnimatedScrollToOffset(0)`) on the virtualized path and
+  `scroller.scrollTo({ top: 0, behavior: 'smooth' })` otherwise — both emit the
+  same single DOM write. Routing through the virtualizer is not cosmetic:
+  `@tanstack` keeps a pending-scroll reconciler armed for seconds after the
+  live-edge pin's `scrollToIndex(last, 'end')` and re-applies that target
+  whenever late measurement moves it, which cancelling the pin's execution does
+  not retire. A raw smooth write races it and loses on a slow engine;
 - reports `scroller.scrollTop` without mutating it during observation.
 
 `lastLoadTimeRef.current = Date.now()` remains before the controller request.

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -462,45 +462,108 @@ test.describe('Controller-owned resident-top navigation', () => {
     await setScrollTop(page, 800)
     await page.waitForTimeout(300)
 
+    // The entry position must actually BE where this test put it. `> 1` used to pass vacuously at
+    // the live edge, so a run whose entry pin had already dragged the list back to the bottom
+    // still entered the body and then failed 5s later on the real assertion with no clue why
+    // (run 30267369388). Bracketing the start pins the failure to the setup instead.
     const initialScrollTop = await getScrollTop(page)
-    expect(initialScrollTop, 'precondition: resident window must start below its top').toBeGreaterThan(1)
+    expect(
+      initialScrollTop,
+      'precondition: resident window must start at the offset this test set, not at the live edge',
+    ).toBeGreaterThan(600)
+    expect(
+      initialScrollTop,
+      'precondition: entry positioning must have settled before Home is pressed',
+    ).toBeLessThan(1200)
 
-    await page.evaluate(() => {
+    // Record every scroll write AND watch, frame by frame, for the list moving AWAY from resident
+    // top after Home. A superseded live-edge owner re-asserting mid-animation is the regression
+    // this guards: it shows up as backward motion long before the position poll would time out,
+    // and it is visible even on an engine too slow to finish the animation inside the poll window.
+    await page.evaluate((startedAt) => {
       const scroller = document.querySelector('[data-message-list]') as HTMLDivElement | null
       if (!scroller) return
       const nativeScrollTo = scroller.scrollTo.bind(scroller)
       const writes: ScrollToOptions[] = []
-      ;(
-        window as Window & {
-          __fluuxResidentTopWrites?: ScrollToOptions[]
-        }
-      ).__fluuxResidentTopWrites = writes
+      const probe = window as Window & {
+        __fluuxResidentTopWrites?: ScrollToOptions[]
+        __fluuxResidentTopMaxBacktrack?: number
+      }
+      probe.__fluuxResidentTopWrites = writes
+      probe.__fluuxResidentTopMaxBacktrack = 0
       scroller.scrollTo = ((...args: Parameters<HTMLDivElement['scrollTo']>) => {
         const first = args[0]
         if (typeof first === 'object') writes.push({ ...first })
         return nativeScrollTo(...args)
       }) as HTMLDivElement['scrollTo']
-    })
+      let closestToTop = startedAt
+      const sample = () => {
+        closestToTop = Math.min(closestToTop, scroller.scrollTop)
+        probe.__fluuxResidentTopMaxBacktrack = Math.max(
+          probe.__fluuxResidentTopMaxBacktrack ?? 0,
+          scroller.scrollTop - closestToTop,
+        )
+        requestAnimationFrame(sample)
+      }
+      requestAnimationFrame(sample)
+    }, initialScrollTop)
 
     const scroller = page.locator('[data-message-list]').first()
     await scroller.focus()
     await page.keyboard.press('Home')
 
-    await expect.poll(() => getScrollTop(page), {
-      timeout: 5000,
+    const readProbe = () => page.evaluate(() => {
+      const probe = window as Window & {
+        __fluuxResidentTopWrites?: ScrollToOptions[]
+        __fluuxResidentTopMaxBacktrack?: number
+      }
+      return {
+        writes: probe.__fluuxResidentTopWrites ?? [],
+        backtrack: probe.__fluuxResidentTopMaxBacktrack ?? 0,
+      }
+    })
+
+    // Generous ceiling, not a relaxed contract: a green run reaches the top in well under a second,
+    // but the WebKitGTK CI runner has been measured at ~1.8s per MessageList layout+paint, and the
+    // per-test budget is 180s. The assertions below are what make a regression fail fast.
+    await expect.poll(async () => {
+      const top = await getScrollTop(page)
+      const { writes, backtrack } = await readProbe()
+      // Fail immediately, with the culprit named, rather than waiting out the timeout.
+      expect(
+        backtrack,
+        `Home navigation moved AWAY from resident top — a superseded position owner re-asserted mid-animation. Writes: ${JSON.stringify(writes)}`,
+      ).toBeLessThanOrEqual(1)
+      return top
+    }, {
+      timeout: 30_000,
       message: 'Home navigation must reach the resident-window top',
     }).toBeLessThanOrEqual(1)
+
     await expect.poll(() => trace.length, {
-      timeout: 5000,
+      timeout: 30_000,
       message: `resident-top controller did not settle: ${JSON.stringify(trace)}`,
     }).toBe(1)
 
-    const writes = await page.evaluate(() => (
-      window as Window & {
-        __fluuxResidentTopWrites?: ScrollToOptions[]
-      }
-    ).__fluuxResidentTopWrites ?? [])
-    expect(writes).toEqual([{ top: 0, behavior: 'smooth' }])
+    // The single-write contract, split into the two things it actually guarantees. Both are
+    // engine-speed independent, so this is what holds the line on a slow runner.
+    const { writes } = await readProbe()
+    // 1. The controller starts the animation once and never restarts it. A frame loop that
+    //    reissued the smooth write — the failure the original assertion was built to catch —
+    //    produces repeated smooth writes and fails here.
+    expect(
+      writes.filter((write) => write.behavior === 'smooth'),
+      `Home must issue exactly one smooth write: ${JSON.stringify(writes)}`,
+    ).toEqual([{ top: 0, behavior: 'smooth' }])
+    // 2. Nothing writes the scroller anywhere else for the duration. The virtualizer may add one
+    //    instant convergence write to the SAME offset when it retires the animated command
+    //    sub-pixel short of 0 (seen on Chromium, not WebKit) — that is the owner we handed the
+    //    navigation to finishing it. A competing owner re-asserting the live edge targets a
+    //    completely different offset and fails here.
+    expect(
+      writes.filter((write) => write.top !== 0),
+      `only resident top may be written during a Home navigation — another position owner wrote elsewhere: ${JSON.stringify(writes)}`,
+    ).toEqual([])
   })
 })
 


### PR DESCRIPTION
The resident-top scroll invariant added by #1130 was flaky on webkit in CI (observed on #1137, run 30267369388). It is a real bug, not a harness artifact.

## Cause

`@tanstack/virtual-core` keeps a private pending-scroll reconciler: every `scrollToIndex`/`scrollToOffset` arms a `scrollState` that survives for up to five seconds and re-applies **its** target on each frame that measurement moves it. That reconciler is invisible to the positioning controller's generations — cancelling the live-edge execution retires our lease and frame loop, but the virtualizer keeps re-asserting the live edge, with no controller event and no `[Scroll]` log to observe.

A Home navigation written straight to the scroller therefore loses to the entry pin whenever rows are still measuring. The trace from the failing run shows the list moving *away* from the top after Home — 800 → 4476 → 4520 — rather than an animation stalling partway. The WebKitGTK runner logs ~1.8s per MessageList layout+paint, so the reconciler re-fires several times mid-animation; a fast engine retires it within one frame, which is why it never reproduced locally.

Any user pressing Home or Mod+↑ shortly after opening a conversation is exposed to the same yank.

## Fix

Add `MessageVirtualizer.beginAnimatedScrollToOffset` and use it for resident top on the virtualized path. Same single DOM write, but it retargets the reconciler instead of racing it, and `behavior: 'smooth'` also makes @tanstack suppress its own size-change scroll adjustments for the animation's duration. It deliberately omits the offset-callback push its neighbours perform, which would claim the scroller had already arrived and retire the reconciler immediately.

## Test

The invariant is hardened, not relaxed. Its precondition was vacuous — `> 1` passes at the live edge, so a run whose setup had already been undone still entered the body and failed 5s later with no clue — and now brackets the start position. A per-frame watchdog fails fast, naming the writes, on any motion away from resident top: the one outcome that is always wrong, and one a slow engine cannot produce on its own. The single-write assertion is split into the two things it guarantees: exactly one smooth write, and no write to any other offset.

The new unit test was checked against the previous implementation and fails on it; asserting scrollTop alone would not have caught the regression, since the mock scroller lands at 0 either way.