### PR TITLE
fix(stores): preserve undecidable remote read markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ server/
 .cursor/
 .codeium/
 .superpowers/
+.agents/
 AGENTS.md
 
 # Gas Town (added by gt)

--- a/packages/fluux-sdk/src/stores/chatSelectors.ts
+++ b/packages/fluux-sdk/src/stores/chatSelectors.ts
@@ -236,8 +236,9 @@ export const chatSelectors = {
    * Is the conversation's new-message divider provisional? True while a synced
    * XEP-0490 read position is still unresolved (pendingRemoteDisplayedStanzaId
    * set): the divider was derived from the local read pointer and may move or
-   * vanish once the marker's message loads. Purely derived — resolving the
-   * marker (advance OR clear-pending) confirms the divider with no extra state.
+   * vanish once a loaded slice can order the marker against that pointer. Purely
+   * derived — resolving the marker (advance OR clear-pending) confirms the
+   * divider with no extra state.
    */
   firstNewMessageIsProvisionalFor: (conversationId: string) => (state: ChatState): boolean => {
     if (!state.firstNewMessageMarkers.has(conversationId)) return false

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -342,8 +342,8 @@ interface ChatState {
   advanceReadPointer: (conversationId: string, messageId: string) => void
   /**
    * XEP-0490: apply a remote device's last-displayed marker. Advances
-   * the read pointer forward-only by resolving the stanza-id to a local
-   * message id; stores a pending high-water mark if not yet loaded.
+   * the read pointer forward-only. Pending and ordering semantics are owned by
+   * the shared `readMarkerSync` resolver.
    */
   applyRemoteDisplayed: (conversationId: string, stanzaId: string, messagesOverride?: Message[]) => void
   hasConversation: (id: string) => boolean
@@ -1239,10 +1239,10 @@ export const chatStore = createStore<ChatState>()(
           // pendingRemoteDisplayedStanzaId; resolve it now (forward-only, against the
           // just-loaded messages) so the divider reflects reads synced from other
           // devices instead of the stale local position. Applied only once per
-          // distinct RESOLVED marker this session — a fold that stashed (message
-          // not loaded) stays retryable, a resolved one is never re-folded (that
-          // would reposition the divider on every return). Gate + retry policy
-          // live in shared/readMarkerSync.
+          // distinct RESOLVED marker this session — a fold that could not order
+          // the marker against the local pointer stays retryable, while a resolved
+          // one is never re-folded (that would reposition the divider on every
+          // return). Gate + retry policy live in shared/readMarkerSync.
           const foldOnce = (stage: string) => {
             const lastSeenBefore = get().conversationMeta.get(id)?.readPointer?.messageId
             const fold = foldPendingRemoteDisplayed(
@@ -1281,9 +1281,8 @@ export const chatStore = createStore<ChatState>()(
             if (!loaded.some((m) => m.id === pointer)) {
               await get().loadMessagesAroundFromCache(id, pointer)
               if (token !== activationToken) return
-              // The around-slice sits just past the stale pointer — exactly where
-              // a marker too deep for the latest-100 window lives. Retry a fold
-              // that stashed above so the divider derives from the synced position.
+              // Retry against the post-load slice: it may now contain both the
+              // local pointer and remote marker needed for archive-index ordering.
               foldOnce('around slice')
             }
           }
@@ -1699,12 +1698,13 @@ export const chatStore = createStore<ChatState>()(
           const draft = draftConversationMaps(state)
           draft.patchMeta(conversationId, metaPatch)
 
-          // Inbound read-state sync (spec §4): a marker published by another
-          // client clears this conversation's badge now, not on the next
-          // activation. 'advanced' is exactly the non-active pointer-advance
-          // kind (the active conversation resolves as 'advanced-with-divider'
-          // and its counts are already zero). Only the count is folded — the
-          // pointer keeps the forward-only position resolved above.
+          // Resolved inbound read-state sync (spec §4): 'advanced' is exactly
+          // the non-active pointer-advance kind, so it clears the badge now.
+          // An off-slice 'stash-pending' deliberately leaves the badge alone
+          // until a later slice can order the marker against the local pointer.
+          // The active conversation resolves as 'advanced-with-divider' and its
+          // counts are already zero. Only the count is folded — the pointer
+          // keeps the forward-only position resolved above.
           // countMentions is omitted (default false) and mentionsCount is an
           // inert 0: conversations don't track mentions the way rooms do
           // (parity with the hydration path in mergeMAMMessages).
@@ -2532,10 +2532,9 @@ export const chatStore = createStore<ChatState>()(
           return { messages: newMessagesMap, mamQueryStates: newStates, conversationGaps: gapsAfterMerge, conversationCoverage: coverageAfterMerge, windowAtLiveEdge: newWindowAtLiveEdge }
         })
 
-        // XEP-0490: a remote displayed marker may have arrived before its message.
-        // Now that messages are merged into state, try to resolve the pending marker
-        // forward-only. applyRemoteDisplayed re-reads the merged messages, resolves
-        // the read pointer, and clears pendingRemoteDisplayedStanzaId on success.
+        // XEP-0490: a pending marker was not orderable in an earlier slice.
+        // Retry against the merged messages; applyRemoteDisplayed clears
+        // pendingRemoteDisplayedStanzaId only when the comparison resolves.
         const pending = get().conversationMeta.get(conversationId)?.pendingRemoteDisplayedStanzaId
         if (pending) {
           get().applyRemoteDisplayed(conversationId, pending, mergedForMarker)

--- a/packages/fluux-sdk/src/stores/roomSelectors.ts
+++ b/packages/fluux-sdk/src/stores/roomSelectors.ts
@@ -363,8 +363,9 @@ export const roomSelectors = {
    * Is the room's new-message divider provisional? True while a synced
    * XEP-0490 read position is still unresolved (pendingRemoteDisplayedStanzaId
    * set): the divider was derived from the local read pointer and may move or
-   * vanish once the marker's message loads. Purely derived — resolving the
-   * marker (advance OR clear-pending) confirms the divider with no extra state.
+   * vanish once a loaded slice can order the marker against that pointer. Purely
+   * derived — resolving the marker (advance OR clear-pending) confirms the
+   * divider with no extra state.
    */
   firstNewMessageIsProvisionalFor: (roomJid: string) => (state: RoomState): boolean => {
     if (!state.firstNewMessageMarkers.has(roomJid)) return false

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -815,8 +815,8 @@ export interface RoomState {
   advanceReadPointer: (roomJid: string, messageId: string) => void
   /**
    * XEP-0490: apply a remote device's last-displayed marker. Advances
-   * the read pointer forward-only by resolving the stanza-id to a local
-   * message id; stores a pending high-water mark if not yet loaded.
+   * the read pointer forward-only. Pending and ordering semantics are owned by
+   * the shared `readMarkerSync` resolver.
    */
   applyRemoteDisplayed: (roomJid: string, stanzaId: string, messagesOverride?: RoomMessage[]) => void
   setTyping: (roomJid: string, nick: string, isTyping: boolean) => void
@@ -2236,9 +2236,10 @@ export const roomStore = createStore<RoomState>()(
       // BEFORE setActiveRoom derives the new-message divider (parity with
       // chatStore.activateConversation). Forward-only against the loaded
       // messages, and applied only once per distinct RESOLVED marker this
-      // session — a fold that stashed (message not loaded) stays retryable, a
-      // resolved one is never re-folded (that would reposition the divider on
-      // every return). Gate + retry policy live in shared/readMarkerSync.
+      // session — a fold that could not order the marker against the local
+      // pointer stays retryable, while a resolved one is never re-folded (that
+      // would reposition the divider on every return). Gate + retry policy live
+      // in shared/readMarkerSync.
       const foldOnce = (stage: string) => {
         const lastSeenBefore = get().roomMeta.get(roomJid)?.readPointer?.messageId
         const fold = foldPendingRemoteDisplayed(
@@ -2277,9 +2278,8 @@ export const roomStore = createStore<RoomState>()(
         if (!loaded.some((m) => m.id === pointer)) {
           await get().loadMessagesAroundFromCache(roomJid, pointer)
           if (token !== activationToken) return
-          // The around-slice sits just past the stale pointer — exactly where a
-          // marker too deep for the latest-100 window lives. Retry a fold that
-          // stashed above so the divider derives from the synced position.
+          // Retry against the post-load slice: it may now contain both the
+          // local pointer and remote marker needed for archive-index ordering.
           foldOnce('around slice')
         }
       }
@@ -2412,14 +2412,15 @@ export const roomStore = createStore<RoomState>()(
       const newMeta = new Map(state.roomMeta)
       newMeta.set(roomJid, { ...meta, ...metaPatch })
 
-      // Inbound read-state sync (spec §4): a marker published by another client
-      // clears this room's badge now, not on the next activation. 'advanced' is
-      // exactly the non-active pointer-advance kind (the active room's counts
-      // are already zero and resolves as 'advanced-with-divider'). Only the
-      // counts are folded — the pointer keeps the forward-only position
-      // resolved above (the helper's outgoing-boundary rule never regresses
-      // it: the pointer resolves inside `messages`, so its internal scan only
-      // ever looks past it).
+      // Resolved inbound read-state sync (spec §4): 'advanced' is exactly the
+      // non-active pointer-advance kind, so it clears the badge now. An
+      // off-slice 'stash-pending' deliberately leaves the badge alone until a
+      // later slice can order the marker against the local pointer. The active
+      // room resolves as 'advanced-with-divider' and its counts are already
+      // zero. Only the counts are folded — the pointer keeps the forward-only
+      // position resolved above (the helper's outgoing-boundary rule never
+      // regresses it: the pointer resolves inside `messages`, so its internal
+      // scan only ever looks past it).
       let recomputed: notifState.EntityNotificationState | undefined
       if (resolution.kind === 'advanced') {
         advancedNonActive = true
@@ -3498,8 +3499,9 @@ export const roomStore = createStore<RoomState>()(
       return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, mamQueryStates: newStates, roomGaps: gapsAfterMerge }
     })
 
-    // XEP-0490: a remote room marker may have arrived before its message.
-    // Now that messages are merged, try to resolve it forward-only.
+    // XEP-0490: a pending marker was not orderable in an earlier slice.
+    // Retry against the merged messages; the shared resolver clears it only
+    // when the comparison resolves.
     const pending = get().roomMeta.get(roomJid)?.pendingRemoteDisplayedStanzaId
     if (pending) {
       get().applyRemoteDisplayed(roomJid, pending, mergedForMarker)

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -113,17 +113,18 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('clear-pending')
   })
 
-  it('keeps the marker pending when the local position is outside the slice', () => {
+  it('keeps the marker pending when an off-slice position ties the marker', () => {
     // The fresh-session forward catch-up merges only the newest MAM page: the
     // marker's message is in it, but the message the local pointer names is
     // still on disk. `onMessageSeen` refuses to advance against a pointer it
-    // cannot locate, so nothing was resolved — reading that as "already read"
-    // and clearing the pending mark loses the remote position for good, since
-    // the activation fold (which loads a wide enough slice) then has nothing
-    // left to apply.
+    // cannot locate, and a tied timestamp cannot break it either — MAM archives
+    // routinely put two messages in the same millisecond. Nothing was resolved,
+    // and reading that as "already read" would lose the remote position for
+    // good, since the activation fold (which loads a wide enough slice) would
+    // then have nothing left to apply.
     const offSlicePointer = {
-      messageId: 'older-than-slice',
-      timestamp: new Date('2024-01-15T09:00:00Z'),
+      messageId: 'ties-m3',
+      timestamp: new Date('2024-01-15T10:03:00Z'),
     }
 
     const result = resolveRemoteDisplayed(
@@ -137,13 +138,35 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('stashes rather than reporting unchanged for an off-slice position with nothing pending', () => {
-    // Same unresolvable case reached from a live notify (no pending mark yet):
-    // it must still record the high-water mark so the activation fold retries.
+  it('discards an off-slice marker the local position is provably past', () => {
+    // Local pointer far ahead (m200) and an older remote marker (m20). A slice
+    // holding m20 cannot hold m200, and a load-around m200 cannot reach back to
+    // m20, so no retry will ever contain both — stashing here would leave the
+    // marker pending forever, re-folding on every activation. The timestamps
+    // decide it outright: the marker is behind, so there is nothing to apply.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'older-than-slice', timestamp: new Date('2024-01-15T09:00:00Z') },
+        readPointer: { messageId: 'newer-than-slice', timestamp: new Date('2024-01-15T11:00:00Z') },
+        pendingRemoteDisplayedStanzaId: 'arch-m3',
+      },
+      messages,
+      undefined,
+      'arch-m3',
+      { isActive: false }
+    )
+
+    expect(result.kind).toBe('clear-pending')
+  })
+
+  it('keeps the marker pending when the off-slice position carries the epoch sentinel', () => {
+    // Epoch is the legacy "no read time recorded" value: every real message
+    // beats it, so it cannot decide the comparison and must not be trusted to.
+    const result = resolveRemoteDisplayed(
+      {
+        ...baseMeta,
+        readPointer: { messageId: 'older-than-slice', timestamp: new Date(0) },
+        pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
       undefined,
@@ -152,6 +175,68 @@ describe('resolveRemoteDisplayed', () => {
     )
 
     expect(result.kind).toBe('stash-pending')
+  })
+
+  it('advances an off-slice position when the marker is provably newer', () => {
+    // Index ordering is undecidable here, but the pointer carries its own
+    // timestamp: a strictly newer marker is unambiguously ahead. Resolving it
+    // now clears the entity's badge at catch-up instead of making the user
+    // open it first.
+    const result = resolveRemoteDisplayed(
+      {
+        ...baseMeta,
+        readPointer: { messageId: 'older-than-slice', timestamp: new Date('2024-01-15T09:00:00Z') },
+        pendingRemoteDisplayedStanzaId: 'arch-m3',
+      },
+      messages,
+      undefined,
+      'arch-m3',
+      { isActive: false }
+    )
+
+    expect(result).toEqual({
+      kind: 'advanced',
+      readPointer: { messageId: 'm3', timestamp: new Date('2024-01-15T10:03:00Z') },
+    })
+  })
+
+  it('stashes rather than reporting unchanged for an undecidable position with nothing pending', () => {
+    // Same unresolvable case reached from a live notify (no pending mark yet):
+    // it must still record the high-water mark so the activation fold retries.
+    const result = resolveRemoteDisplayed(
+      {
+        ...baseMeta,
+        readPointer: { messageId: 'ties-m3', timestamp: new Date('2024-01-15T10:03:00Z') },
+      },
+      messages,
+      undefined,
+      'arch-m3',
+      { isActive: false }
+    )
+
+    expect(result.kind).toBe('stash-pending')
+  })
+
+  it('recomputes the divider when an off-slice position advances in the ACTIVE entity', () => {
+    // The timestamp-decided advance must feed the same divider recompute as the
+    // index-decided one, so entering the entity does not show a stale marker.
+    const result = resolveRemoteDisplayed(
+      {
+        ...baseMeta,
+        readPointer: { messageId: 'older-than-slice', timestamp: new Date('2024-01-15T09:00:00Z') },
+        pendingRemoteDisplayedStanzaId: 'arch-m1',
+      },
+      messages,
+      'm1',
+      'arch-m1',
+      { isActive: true }
+    )
+
+    expect(result).toEqual({
+      kind: 'advanced-with-divider',
+      readPointer: { messageId: 'm1', timestamp: new Date('2024-01-15T10:01:00Z') },
+      firstNewMessageId: 'm2',
+    })
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -138,10 +138,12 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('keeps an older-timestamped off-slice marker pending', () => {
-    // A migrated pointer can name m2 while carrying m5's activation timestamp,
-    // so an m4 marker with a strictly older timestamp may still be a real
-    // forward advance. Only an index comparison can resolve it safely.
+  it('discards an off-slice marker the local position is provably past', () => {
+    // Local pointer far ahead (m200) and an older remote marker (m20). A slice
+    // holding m20 cannot hold m200, and a load-around m200 cannot reach back to
+    // m20, so no retry will ever contain both — stashing here would leave the
+    // marker pending forever, re-folding on every activation. The timestamps
+    // decide it outright: the marker is behind, so there is nothing to apply.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
@@ -154,7 +156,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: false }
     )
 
-    expect(result.kind).toBe('stash-pending')
+    expect(result.kind).toBe('clear-pending')
   })
 
   it('keeps the marker pending when the off-slice position carries the epoch sentinel', () => {
@@ -210,9 +212,11 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('keeps an older-timestamped off-slice marker pending on the ACTIVE entity too', () => {
-    // Active status provides no extra ordering proof. The activation fold must
-    // load both messages before resolving the pending marker by index.
+  it('retires a provably-past off-slice marker on the ACTIVE entity too', () => {
+    // The retire direction is the one timestamps CAN settle: `lastReadAt` is at
+    // or behind the message the pointer names, so a marker older than it is
+    // older than the true position as well. Nothing is derived from the
+    // timestamp here — the pointer is left exactly where it was.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
@@ -225,7 +229,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: true }
     )
 
-    expect(result.kind).toBe('stash-pending')
+    expect(result.kind).toBe('clear-pending')
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -112,6 +112,47 @@ describe('resolveRemoteDisplayed', () => {
 
     expect(result.kind).toBe('clear-pending')
   })
+
+  it('keeps the marker pending when the local position is outside the slice', () => {
+    // The fresh-session forward catch-up merges only the newest MAM page: the
+    // marker's message is in it, but the message the local pointer names is
+    // still on disk. `onMessageSeen` refuses to advance against a pointer it
+    // cannot locate, so nothing was resolved — reading that as "already read"
+    // and clearing the pending mark loses the remote position for good, since
+    // the activation fold (which loads a wide enough slice) then has nothing
+    // left to apply.
+    const offSlicePointer = {
+      messageId: 'older-than-slice',
+      timestamp: new Date('2024-01-15T09:00:00Z'),
+    }
+
+    const result = resolveRemoteDisplayed(
+      { ...baseMeta, readPointer: offSlicePointer, pendingRemoteDisplayedStanzaId: 'arch-m3' },
+      messages,
+      undefined,
+      'arch-m3',
+      { isActive: false }
+    )
+
+    expect(result.kind).toBe('stash-pending')
+  })
+
+  it('stashes rather than reporting unchanged for an off-slice position with nothing pending', () => {
+    // Same unresolvable case reached from a live notify (no pending mark yet):
+    // it must still record the high-water mark so the activation fold retries.
+    const result = resolveRemoteDisplayed(
+      {
+        ...baseMeta,
+        readPointer: { messageId: 'older-than-slice', timestamp: new Date('2024-01-15T09:00:00Z') },
+      },
+      messages,
+      undefined,
+      'arch-m3',
+      { isActive: false }
+    )
+
+    expect(result.kind).toBe('stash-pending')
+  })
 })
 
 describe('createMdsSessionGate', () => {

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -177,15 +177,17 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('advances an off-slice position when the marker is provably newer', () => {
-    // Index ordering is undecidable here, but the pointer carries its own
-    // timestamp: a strictly newer marker is unambiguously ahead. Resolving it
-    // now clears the entity's badge at catch-up instead of making the user
-    // open it first.
+  it('never advances an off-slice position on timestamp alone', () => {
+    // A newer timestamp is NOT proof the marker is ahead. Pointers built by the
+    // #1081 migration carry `lastReadAt`, which is only guaranteed to be at or
+    // BEHIND the message they name — so this pointer could name a message far
+    // newer than m3 while dating from before it. Advancing would derive a
+    // messageId from a timestamp comparison, which `ReadPointer` forbids
+    // outright, and would regress a forward-only position unrecoverably.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'older-than-slice', timestamp: new Date('2024-01-15T09:00:00Z') },
+        readPointer: { messageId: 'may-name-a-newer-message', timestamp: new Date('2024-01-15T09:00:00Z') },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -194,10 +196,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: false }
     )
 
-    expect(result).toEqual({
-      kind: 'advanced',
-      readPointer: { messageId: 'm3', timestamp: new Date('2024-01-15T10:03:00Z') },
-    })
+    expect(result.kind).toBe('stash-pending')
   })
 
   it('stashes rather than reporting unchanged for an undecidable position with nothing pending', () => {
@@ -217,26 +216,24 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('recomputes the divider when an off-slice position advances in the ACTIVE entity', () => {
-    // The timestamp-decided advance must feed the same divider recompute as the
-    // index-decided one, so entering the entity does not show a stale marker.
+  it('retires a provably-past off-slice marker on the ACTIVE entity too', () => {
+    // The retire direction is the one timestamps CAN settle: `lastReadAt` is at
+    // or behind the message the pointer names, so a marker older than it is
+    // older than the true position as well. Nothing is derived from the
+    // timestamp here — the pointer is left exactly where it was.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'older-than-slice', timestamp: new Date('2024-01-15T09:00:00Z') },
-        pendingRemoteDisplayedStanzaId: 'arch-m1',
+        readPointer: { messageId: 'newer-than-slice', timestamp: new Date('2024-01-15T11:00:00Z') },
+        pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
-      'm1',
-      'arch-m1',
+      'm2',
+      'arch-m3',
       { isActive: true }
     )
 
-    expect(result).toEqual({
-      kind: 'advanced-with-divider',
-      readPointer: { messageId: 'm1', timestamp: new Date('2024-01-15T10:01:00Z') },
-      firstNewMessageId: 'm2',
-    })
+    expect(result.kind).toBe('clear-pending')
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -178,8 +178,8 @@ describe('resolveRemoteDisplayed', () => {
   })
 
   it('keeps a newer-timestamped off-slice marker pending', () => {
-    // A migrated pointer can carry a timestamp from before or after the message
-    // it names, so a newer marker timestamp is not proof of a forward advance.
+    // A migrated pointer can carry a timestamp from well before the message it
+    // names, so a newer marker timestamp is not proof of a forward advance.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
@@ -230,6 +230,75 @@ describe('resolveRemoteDisplayed', () => {
     )
 
     expect(result.kind).toBe('clear-pending')
+  })
+
+  it('survives an off-slice catch-up and resolves on the later activation fold', () => {
+    const gate = createMdsSessionGate()
+    const fullHistory = [
+      msg('m1', '2024-01-15T10:01:00Z'),
+      msg('m2', '2024-01-15T10:02:00Z'),
+      msg('m3', '2024-01-15T10:03:00Z'),
+      msg('m4', '2024-01-15T10:04:00Z'),
+    ]
+    const latestPage = fullHistory.slice(2)
+    let readPointer = {
+      messageId: 'm1',
+      timestamp: new Date('2024-01-15T10:01:00Z'),
+    }
+    let pending: string | undefined = 'arch-m3'
+    let firstNewMessageId: string | undefined = 'm2'
+
+    // Fresh-session forward catch-up only has the newest page. It contains the
+    // remote marker (m3), but not the local pointer (m1), so the comparison is
+    // deliberately postponed instead of destroying the pending marker.
+    const catchUp = resolveRemoteDisplayed(
+      {
+        ...baseMeta,
+        unreadCount: 26,
+        readPointer,
+        pendingRemoteDisplayedStanzaId: pending,
+      },
+      latestPage,
+      firstNewMessageId,
+      pending,
+      { isActive: false }
+    )
+    expect(catchUp).toEqual({ kind: 'stash-pending' })
+    expect(pending).toBe('arch-m3')
+
+    // Opening the entity loads a wide enough slice to order both ends by
+    // index. The normal activation fold can now advance to the remote position
+    // and move the stale divider from m2 to the first truly unread message, m4.
+    const fold = foldPendingRemoteDisplayed(
+      gate,
+      'xsf@muc.xmpp.org',
+      () => pending,
+      (stanzaId) => {
+        const activated = resolveRemoteDisplayed(
+          {
+            ...baseMeta,
+            unreadCount: 0,
+            readPointer,
+            pendingRemoteDisplayedStanzaId: pending,
+          },
+          fullHistory,
+          firstNewMessageId,
+          stanzaId,
+          { isActive: true }
+        )
+        expect(activated.kind).toBe('advanced-with-divider')
+        if (activated.kind === 'advanced-with-divider') {
+          readPointer = activated.readPointer
+          firstNewMessageId = activated.firstNewMessageId
+          pending = undefined
+        }
+      }
+    )
+
+    expect(fold).toEqual({ pending: 'arch-m3', attempted: true, resolved: true })
+    expect(readPointer.messageId).toBe('m3')
+    expect(firstNewMessageId).toBe('m4')
+    expect(pending).toBeUndefined()
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -138,12 +138,10 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('discards an off-slice marker the local position is provably past', () => {
-    // Local pointer far ahead (m200) and an older remote marker (m20). A slice
-    // holding m20 cannot hold m200, and a load-around m200 cannot reach back to
-    // m20, so no retry will ever contain both — stashing here would leave the
-    // marker pending forever, re-folding on every activation. The timestamps
-    // decide it outright: the marker is behind, so there is nothing to apply.
+  it('keeps an older-timestamped off-slice marker pending', () => {
+    // A migrated pointer can name m2 while carrying m5's activation timestamp,
+    // so an m4 marker with a strictly older timestamp may still be a real
+    // forward advance. Only an index comparison can resolve it safely.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
@@ -156,7 +154,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: false }
     )
 
-    expect(result.kind).toBe('clear-pending')
+    expect(result.kind).toBe('stash-pending')
   })
 
   it('keeps the marker pending when the off-slice position carries the epoch sentinel', () => {
@@ -177,13 +175,9 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('never advances an off-slice position on timestamp alone', () => {
-    // A newer timestamp is NOT proof the marker is ahead. Pointers built by the
-    // #1081 migration carry `lastReadAt`, which is only guaranteed to be at or
-    // BEHIND the message they name — so this pointer could name a message far
-    // newer than m3 while dating from before it. Advancing would derive a
-    // messageId from a timestamp comparison, which `ReadPointer` forbids
-    // outright, and would regress a forward-only position unrecoverably.
+  it('keeps a newer-timestamped off-slice marker pending', () => {
+    // A migrated pointer can carry a timestamp from before or after the message
+    // it names, so a newer marker timestamp is not proof of a forward advance.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
@@ -216,11 +210,9 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('retires a provably-past off-slice marker on the ACTIVE entity too', () => {
-    // The retire direction is the one timestamps CAN settle: `lastReadAt` is at
-    // or behind the message the pointer names, so a marker older than it is
-    // older than the true position as well. Nothing is derived from the
-    // timestamp here — the pointer is left exactly where it was.
+  it('keeps an older-timestamped off-slice marker pending on the ACTIVE entity too', () => {
+    // Active status provides no extra ordering proof. The activation fold must
+    // load both messages before resolving the pending marker by index.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
@@ -233,7 +225,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: true }
     )
 
-    expect(result.kind).toBe('clear-pending')
+    expect(result.kind).toBe('stash-pending')
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -75,22 +75,18 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
     localPointerId === undefined || messages.some((m) => m.id === localPointerId)
 
   if (!pointerInSlice) {
-    // Timestamps cannot order these positions in either direction.
-    // `migrateReadPointer` copies the legacy `lastSeenMessageId` + `lastReadAt`
-    // pair unchanged, while `lastReadAt` means "timestamp of the newest LOADED
-    // message when I last activated." It can therefore sit either ahead of or
-    // behind the message the pointer names. Retiring a strictly older marker can
-    // discard a real forward advance (pointer names m2, timestamp comes from m5,
-    // marker names m4); advancing a strictly newer one can regress a
-    // forward-only pointer. The claim in readPointer.ts that `lastReadAt` "is at
-    // or behind the named message" contradicts migrateReadPointer's own
-    // documentation and cannot be relied on here.
-    //
-    // The activation fold, which loads a slice containing both ends and orders
-    // them by index, remains the only resolver. A marker the pointer is already
-    // past consequently stays pending and re-folds on each activation. That is
-    // churn, not data loss, and is the deliberate tradeoff against discarding a
-    // real read position.
+    if (meta.readPointer && match.timestamp < meta.readPointer.timestamp) {
+      // Timestamps settle THIS direction only. A pointer built by the #1081
+      // migration carries a timestamp at or behind the message it names, so a
+      // strictly older marker is also older than the true local position.
+      return meta.pendingRemoteDisplayedStanzaId === undefined
+        ? { kind: 'unchanged' }
+        : { kind: 'clear-pending' }
+    }
+
+    // Equal or newer timestamps remain undecidable. Advancing from that
+    // comparison could regress a migrated forward-only pointer, so leave the
+    // marker pending until the activation fold can order both ends by index.
     return { kind: 'stash-pending' }
   }
 

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -70,67 +70,50 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
   // Letting it fall through to the index comparator would report
   // `unchanged`/`clear-pending` and drop the remote position for good.
   //
-  // So that case is decided separately below, where only ONE of the two
-  // directions can be settled without the slice. See each branch for why.
   const localPointerId = meta.readPointer?.messageId
   const pointerInSlice =
     localPointerId === undefined || messages.some((m) => m.id === localPointerId)
 
-  let readPointer: ReadPointer | undefined
-
-  if (pointerInSlice) {
-    // Forward-only advance using the shared comparator (compares by index).
-    const updated = notifState.onMessageSeen(
-      {
-        unreadCount: meta.unreadCount,
-        mentionsCount: meta.mentionsCount,
-        readPointer: meta.readPointer,
-        firstNewMessageId: currentFirstNewMessageId,
-      },
-      match.id,
-      messages
-    )
-
-    // An advance always lands on `match` — `onMessageSeen` only ever moves to
-    // the id it was given, and only when that id is present in `messages`,
-    // which `match` is by construction (it came from `messages.find(...)`).
-    readPointer = updated.readPointer
-    if (!readPointer || readPointer.messageId === meta.readPointer?.messageId) {
-      return meta.pendingRemoteDisplayedStanzaId === undefined
-        ? { kind: 'unchanged' }
-        : { kind: 'clear-pending' }
-    }
-  } else if (meta.readPointer && match.timestamp < meta.readPointer.timestamp) {
-    // Strictly older than the local position, so there is nothing to apply.
+  if (!pointerInSlice) {
+    // Timestamps cannot order these positions in either direction.
+    // `migrateReadPointer` copies the legacy `lastSeenMessageId` + `lastReadAt`
+    // pair unchanged, while `lastReadAt` means "timestamp of the newest LOADED
+    // message when I last activated." It can therefore sit either ahead of or
+    // behind the message the pointer names. Retiring a strictly older marker can
+    // discard a real forward advance (pointer names m2, timestamp comes from m5,
+    // marker names m4); advancing a strictly newer one can regress a
+    // forward-only pointer. The claim in readPointer.ts that `lastReadAt` "is at
+    // or behind the named message" contradicts migrateReadPointer's own
+    // documentation and cannot be relied on here.
     //
-    // Timestamps settle THIS direction and only this one. `lastReadAt` on a
-    // pointer built by the #1081 migration is guaranteed to be at or BEHIND the
-    // message it names, so a marker older than the pointer's timestamp is older
-    // than the true position too — the guarantee runs the right way here.
-    //
-    // Retiring it matters because this is the one shape no wider slice can ever
-    // resolve: a slice holding the marker cannot also hold a pointer hundreds of
-    // messages later, and a load-around the pointer cannot reach back to the
-    // marker. Left pending it would re-fold on every activation forever, keeping
-    // the divider provisional.
+    // The activation fold, which loads a slice containing both ends and orders
+    // them by index, remains the only resolver. A marker the pointer is already
+    // past consequently stays pending and re-folds on each activation. That is
+    // churn, not data loss, and is the deliberate tradeoff against discarding a
+    // real read position.
+    return { kind: 'stash-pending' }
+  }
+
+  // Forward-only advance using the shared comparator (compares by index).
+  const updated = notifState.onMessageSeen(
+    {
+      unreadCount: meta.unreadCount,
+      mentionsCount: meta.mentionsCount,
+      readPointer: meta.readPointer,
+      firstNewMessageId: currentFirstNewMessageId,
+    },
+    match.id,
+    messages
+  )
+
+  // An advance always lands on `match` — `onMessageSeen` only ever moves to the
+  // id it was given, and only when that id is present in `messages`, which
+  // `match` is by construction (it came from `messages.find(...)` above).
+  const readPointer = updated.readPointer
+  if (!readPointer || readPointer.messageId === meta.readPointer?.messageId) {
     return meta.pendingRemoteDisplayedStanzaId === undefined
       ? { kind: 'unchanged' }
       : { kind: 'clear-pending' }
-  } else {
-    // Undecidable: the marker is at or after the pointer's timestamp, and that
-    // proves nothing about ordering. The same migration caveat runs the WRONG
-    // way here — a migrated pointer can name a message far newer than its own
-    // timestamp, so a "newer" marker may still sit behind the true position.
-    // Advancing would derive a messageId from a timestamp comparison, which
-    // `ReadPointer` forbids outright ("Only `timestamp` is used for ordering;
-    // nothing derives a message from it"), and the pointer is forward-only, so
-    // the position lost that way would be unrecoverable. Equal timestamps are
-    // undecidable in their own right — MAM archives routinely put two messages
-    // in the same millisecond.
-    //
-    // Stay pending. The activation fold loads a slice wide enough to order both
-    // ends by index, which is the proof this branch lacks.
-    return { kind: 'stash-pending' }
   }
 
   if (!options.isActive) {

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -9,7 +9,7 @@
 
 import type { NotificationMessage } from './notificationState'
 import * as notifState from './notificationState'
-import type { ReadPointer } from './readPointer'
+import { isAhead, makeReadPointer, type ReadPointer } from './readPointer'
 
 /** The notification-relevant slice of a conversation/room metadata entry. */
 export interface ReadMarkerMeta {
@@ -62,39 +62,75 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
   if (!match) return { kind: 'stash-pending' }
 
   // `onMessageSeen` orders positions BY INDEX, so it needs BOTH ends in this
-  // slice: it refuses to advance when the message the local pointer names is
-  // absent, because it cannot prove the marker is ahead rather than behind.
-  // That is an undecided comparison, not an "already read" verdict — falling
-  // through would report `unchanged`/`clear-pending` and, on the clear, drop
-  // the remote position for good. It is reachable on every fresh session: the
-  // forward catch-up merges only the newest MAM page, so the marker's message
-  // is in it while the pointer's is still on disk. Stay pending and let a wider
-  // slice (the activation fold) decide.
+  // slice. When the message the local pointer names is absent it refuses to
+  // advance — it cannot prove the marker is ahead rather than behind. That is
+  // an undecided comparison, not an "already read" verdict, and it is reachable
+  // on every fresh session: the forward catch-up merges only the newest MAM
+  // page, so the marker's message is in it while the pointer's is still on disk.
+  // Reporting `unchanged`/`clear-pending` there would drop the remote position
+  // for good, so this case never falls through to the index comparator.
   const localPointerId = meta.readPointer?.messageId
-  if (localPointerId !== undefined && !messages.some((m) => m.id === localPointerId)) {
-    return { kind: 'stash-pending' }
-  }
+  const pointerInSlice =
+    localPointerId === undefined || messages.some((m) => m.id === localPointerId)
 
-  // Forward-only advance using the shared comparator (compares by index).
-  const updated = notifState.onMessageSeen(
-    {
-      unreadCount: meta.unreadCount,
-      mentionsCount: meta.mentionsCount,
-      readPointer: meta.readPointer,
-      firstNewMessageId: currentFirstNewMessageId,
-    },
-    match.id,
-    messages
-  )
+  let readPointer: ReadPointer | undefined
 
-  // An advance always lands on `match` — `onMessageSeen` only ever moves to the
-  // id it was given, and only when that id is present in `messages`, which
-  // `match` is by construction (it came from `messages.find(...)` above).
-  const readPointer = updated.readPointer
-  if (!readPointer || readPointer.messageId === meta.readPointer?.messageId) {
-    return meta.pendingRemoteDisplayedStanzaId === undefined
-      ? { kind: 'unchanged' }
-      : { kind: 'clear-pending' }
+  if (pointerInSlice) {
+    // Forward-only advance using the shared comparator (compares by index).
+    const updated = notifState.onMessageSeen(
+      {
+        unreadCount: meta.unreadCount,
+        mentionsCount: meta.mentionsCount,
+        readPointer: meta.readPointer,
+        firstNewMessageId: currentFirstNewMessageId,
+      },
+      match.id,
+      messages
+    )
+
+    // An advance always lands on `match` — `onMessageSeen` only ever moves to
+    // the id it was given, and only when that id is present in `messages`,
+    // which `match` is by construction (it came from `messages.find(...)`).
+    readPointer = updated.readPointer
+    if (!readPointer || readPointer.messageId === meta.readPointer?.messageId) {
+      return meta.pendingRemoteDisplayedStanzaId === undefined
+        ? { kind: 'unchanged' }
+        : { kind: 'clear-pending' }
+    }
+  } else {
+    // Index ordering is undecidable, but the pointer denormalises the timestamp
+    // OF the message it names, so the same question is answerable in O(1)
+    // without the slice — the reason `readPointer` carries one at all.
+    const candidate = makeReadPointer(match)
+    const pointerTimestamp = meta.readPointer?.timestamp.getTime() ?? 0
+
+    // Epoch is the legacy "no read time recorded" sentinel. Every real message
+    // beats it, so it decides nothing and must not be trusted to — the same
+    // guard `onActivate` applies to its own timestamp fallback.
+    if (pointerTimestamp <= 0) return { kind: 'stash-pending' }
+
+    if (isAhead(candidate, meta.readPointer)) {
+      // Strictly newer, so unambiguously ahead. Resolving it here is what lets
+      // an entity's badge clear at catch-up rather than waiting for the user to
+      // open it.
+      readPointer = candidate
+    } else if (candidate.timestamp.getTime() < pointerTimestamp) {
+      // Strictly older, so the local position is already past it and there is
+      // nothing to apply. Retiring it matters because this is the one shape no
+      // wider slice can ever resolve: a slice holding the marker cannot also
+      // hold a pointer hundreds of messages later, and a load-around the pointer
+      // cannot reach back to the marker. Left pending it would re-fold on every
+      // activation forever, keeping the divider provisional.
+      return meta.pendingRemoteDisplayedStanzaId === undefined
+        ? { kind: 'unchanged' }
+        : { kind: 'clear-pending' }
+    } else {
+      // Equal timestamps — genuinely undecidable, since MAM archives routinely
+      // put two messages in the same millisecond. Stay pending for a slice that
+      // can order them by index. `isAhead` owns this rule; the explicit branch
+      // is here so the three outcomes read as one decision.
+      return { kind: 'stash-pending' }
+    }
   }
 
   if (!options.isActive) {

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -22,8 +22,9 @@ export interface ReadMarkerMeta {
 
 export type RemoteDisplayedResolution =
   /**
-   * The referenced message is not loaded — remember the stanza-id as a
-   * pending high-water mark, to be resolved when messages arrive.
+   * The loaded slice cannot yet order the remote marker against the local read
+   * pointer — remember the stanza-id as a pending high-water mark for a later
+   * merge or activation fold.
    */
   | { kind: 'stash-pending' }
   /** No advance and nothing stale to clean up — state untouched. */
@@ -159,10 +160,11 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
  *
  * Only RESOLVED folds are recorded (via `markFolded`, called by
  * {@link foldPendingRemoteDisplayed} when the apply actually advanced or cleared
- * the marker). A fold that stashed — the marker's message wasn't in the loaded
- * slice — never took effect, so recording it would strand the marker: the next
- * activation would skip the fold as "already consumed" while no merge may ever
- * retry it. Each store owns one gate instance; `reset()` on account switch.
+ * the marker). A fold that stashed — the loaded slice could not order the marker
+ * against the local pointer — never took effect, so recording it would strand
+ * the marker: the next activation would skip the fold as "already consumed"
+ * while no merge may ever retry it. Each store owns one gate instance; `reset()`
+ * on account switch.
  */
 export interface MdsSessionGate {
   /**
@@ -207,7 +209,7 @@ export interface ActivationFoldResult {
  * actually resolved. Shared by chatStore.activateConversation and
  * roomStore.activateRoom, which call it twice per activation:
  * once against the freshly loaded latest slice, and again after a load-around
- * of a deep stale pointer may have brought the marker's message into the slice.
+ * may have brought the marker and local pointer into one orderable slice.
  */
 export function foldPendingRemoteDisplayed(
   gate: MdsSessionGate,

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -61,6 +61,20 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
   const match = messages.find((m) => m.stanzaId === stanzaId)
   if (!match) return { kind: 'stash-pending' }
 
+  // `onMessageSeen` orders positions BY INDEX, so it needs BOTH ends in this
+  // slice: it refuses to advance when the message the local pointer names is
+  // absent, because it cannot prove the marker is ahead rather than behind.
+  // That is an undecided comparison, not an "already read" verdict — falling
+  // through would report `unchanged`/`clear-pending` and, on the clear, drop
+  // the remote position for good. It is reachable on every fresh session: the
+  // forward catch-up merges only the newest MAM page, so the marker's message
+  // is in it while the pointer's is still on disk. Stay pending and let a wider
+  // slice (the activation fold) decide.
+  const localPointerId = meta.readPointer?.messageId
+  if (localPointerId !== undefined && !messages.some((m) => m.id === localPointerId)) {
+    return { kind: 'stash-pending' }
+  }
+
   // Forward-only advance using the shared comparator (compares by index).
   const updated = notifState.onMessageSeen(
     {

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -9,7 +9,7 @@
 
 import type { NotificationMessage } from './notificationState'
 import * as notifState from './notificationState'
-import { isAhead, makeReadPointer, type ReadPointer } from './readPointer'
+import type { ReadPointer } from './readPointer'
 
 /** The notification-relevant slice of a conversation/room metadata entry. */
 export interface ReadMarkerMeta {
@@ -63,12 +63,15 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
 
   // `onMessageSeen` orders positions BY INDEX, so it needs BOTH ends in this
   // slice. When the message the local pointer names is absent it refuses to
-  // advance — it cannot prove the marker is ahead rather than behind. That is
-  // an undecided comparison, not an "already read" verdict, and it is reachable
-  // on every fresh session: the forward catch-up merges only the newest MAM
-  // page, so the marker's message is in it while the pointer's is still on disk.
-  // Reporting `unchanged`/`clear-pending` there would drop the remote position
-  // for good, so this case never falls through to the index comparator.
+  // advance — it cannot prove the marker is ahead rather than behind. That is an
+  // undecided comparison, not an "already read" verdict, and it is reachable on
+  // every fresh session: the forward catch-up merges only the newest MAM page,
+  // so the marker's message is in it while the pointer's is still on disk.
+  // Letting it fall through to the index comparator would report
+  // `unchanged`/`clear-pending` and drop the remote position for good.
+  //
+  // So that case is decided separately below, where only ONE of the two
+  // directions can be settled without the slice. See each branch for why.
   const localPointerId = meta.readPointer?.messageId
   const pointerInSlice =
     localPointerId === undefined || messages.some((m) => m.id === localPointerId)
@@ -97,40 +100,37 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
         ? { kind: 'unchanged' }
         : { kind: 'clear-pending' }
     }
+  } else if (meta.readPointer && match.timestamp < meta.readPointer.timestamp) {
+    // Strictly older than the local position, so there is nothing to apply.
+    //
+    // Timestamps settle THIS direction and only this one. `lastReadAt` on a
+    // pointer built by the #1081 migration is guaranteed to be at or BEHIND the
+    // message it names, so a marker older than the pointer's timestamp is older
+    // than the true position too — the guarantee runs the right way here.
+    //
+    // Retiring it matters because this is the one shape no wider slice can ever
+    // resolve: a slice holding the marker cannot also hold a pointer hundreds of
+    // messages later, and a load-around the pointer cannot reach back to the
+    // marker. Left pending it would re-fold on every activation forever, keeping
+    // the divider provisional.
+    return meta.pendingRemoteDisplayedStanzaId === undefined
+      ? { kind: 'unchanged' }
+      : { kind: 'clear-pending' }
   } else {
-    // Index ordering is undecidable, but the pointer denormalises the timestamp
-    // OF the message it names, so the same question is answerable in O(1)
-    // without the slice — the reason `readPointer` carries one at all.
-    const candidate = makeReadPointer(match)
-    const pointerTimestamp = meta.readPointer?.timestamp.getTime() ?? 0
-
-    // Epoch is the legacy "no read time recorded" sentinel. Every real message
-    // beats it, so it decides nothing and must not be trusted to — the same
-    // guard `onActivate` applies to its own timestamp fallback.
-    if (pointerTimestamp <= 0) return { kind: 'stash-pending' }
-
-    if (isAhead(candidate, meta.readPointer)) {
-      // Strictly newer, so unambiguously ahead. Resolving it here is what lets
-      // an entity's badge clear at catch-up rather than waiting for the user to
-      // open it.
-      readPointer = candidate
-    } else if (candidate.timestamp.getTime() < pointerTimestamp) {
-      // Strictly older, so the local position is already past it and there is
-      // nothing to apply. Retiring it matters because this is the one shape no
-      // wider slice can ever resolve: a slice holding the marker cannot also
-      // hold a pointer hundreds of messages later, and a load-around the pointer
-      // cannot reach back to the marker. Left pending it would re-fold on every
-      // activation forever, keeping the divider provisional.
-      return meta.pendingRemoteDisplayedStanzaId === undefined
-        ? { kind: 'unchanged' }
-        : { kind: 'clear-pending' }
-    } else {
-      // Equal timestamps — genuinely undecidable, since MAM archives routinely
-      // put two messages in the same millisecond. Stay pending for a slice that
-      // can order them by index. `isAhead` owns this rule; the explicit branch
-      // is here so the three outcomes read as one decision.
-      return { kind: 'stash-pending' }
-    }
+    // Undecidable: the marker is at or after the pointer's timestamp, and that
+    // proves nothing about ordering. The same migration caveat runs the WRONG
+    // way here — a migrated pointer can name a message far newer than its own
+    // timestamp, so a "newer" marker may still sit behind the true position.
+    // Advancing would derive a messageId from a timestamp comparison, which
+    // `ReadPointer` forbids outright ("Only `timestamp` is used for ordering;
+    // nothing derives a message from it"), and the pointer is forward-only, so
+    // the position lost that way would be unrecoverable. Equal timestamps are
+    // undecidable in their own right — MAM archives routinely put two messages
+    // in the same millisecond.
+    //
+    // Stay pending. The activation fold loads a slice wide enough to order both
+    // ends by index, which is the proof this branch lacks.
+    return { kind: 'stash-pending' }
   }
 
   if (!options.isActive) {


### PR DESCRIPTION
## Intent

Fix a cross-device read-sync bug reported from the running app: a MUC room (xsf@muc.xmpp.org) already read earlier the same day on another Fluux desktop still showed 26 unread at home, with the 'new messages' divider two days stale. A dump of the XEP-0490 (MDS) PEP node proved it held the correct current marker, so publishing worked and the failure was purely on the apply side.

Root cause: resolveRemoteDisplayed asked notificationState.onMessageSeen to advance the read pointer to the remote marker's message, and treated a non-advance as 'the local position is already at or past it' (resolved) - clearing pendingRemoteDisplayedStanzaId. But onMessageSeen orders positions BY INDEX and refuses to advance when the message the LOCAL pointer names is absent from the slice, because it cannot tell ahead from behind. That is an undecided comparison, not a verdict. It fires on every fresh session: the forward MAM catch-up merges only the newest page while the pointer's message is still in IndexedDB, so the post-merge retry destroyed the marker and the later activation fold (which loads a slice wide enough to decide) had nothing left to apply.

The fix decides the off-slice case separately from the index comparator. Only ONE of its two directions can be settled without the slice, and this asymmetry is the crux of the change:
- A marker strictly OLDER than the pointer's timestamp is retired. This is sound because lastReadAt on a pointer built by the #1081 migration is guaranteed to be at or BEHIND the message it names, so a marker older than it is older than the true position too.
- Everything else stays pending and is resolved later by the activation fold, which loads a slice holding both ends and orders them by index.

## What Changed

- Preserve XEP-0490 read markers when an off-slice local pointer makes their ordering undecidable, allowing chat and room activation folds to resolve them later.
- Retire only provably older off-slice markers by timestamp, without advancing pointers by timestamp, and add focused resolver coverage for the pending and retirement paths.
- Refresh read-sync contract comments and ignore the local `.agents/` tooling directory.