### PR TITLE
fix(mds): never order an off-slice read position by timestamp

### DIFF
--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -138,16 +138,18 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('discards an off-slice marker the local position is provably past', () => {
-    // Local pointer far ahead (m200) and an older remote marker (m20). A slice
-    // holding m20 cannot hold m200, and a load-around m200 cannot reach back to
-    // m20, so no retry will ever contain both — stashing here would leave the
-    // marker pending forever, re-folding on every activation. The timestamps
-    // decide it outright: the marker is behind, so there is nothing to apply.
+  it('keeps an older-timestamped off-slice marker pending (a migrated pointer may lead its message)', () => {
+    // A pointer whose timestamp is LATER than the marker still proves nothing.
+    // `migrateReadPointer` copies the pre-#1081 pair through unchanged, and that
+    // `lastReadAt` meant "timestamp of the newest LOADED message when I last
+    // activated" — so it can sit AHEAD of the message it names. This pointer may
+    // really be at m2 while carrying m5's timestamp, in which case the marker at
+    // m4 is a valid forward advance and retiring it would discard a genuine
+    // cross-device read.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'newer-than-slice', timestamp: new Date('2024-01-15T11:00:00Z') },
+        readPointer: { messageId: 'may-lag-its-timestamp', timestamp: new Date('2024-01-15T11:00:00Z') },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -156,7 +158,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: false }
     )
 
-    expect(result.kind).toBe('clear-pending')
+    expect(result.kind).toBe('stash-pending')
   })
 
   it('keeps the marker pending when the off-slice position carries the epoch sentinel', () => {
@@ -212,15 +214,13 @@ describe('resolveRemoteDisplayed', () => {
     expect(result.kind).toBe('stash-pending')
   })
 
-  it('retires a provably-past off-slice marker on the ACTIVE entity too', () => {
-    // The retire direction is the one timestamps CAN settle: `lastReadAt` is at
-    // or behind the message the pointer names, so a marker older than it is
-    // older than the true position as well. Nothing is derived from the
-    // timestamp here — the pointer is left exactly where it was.
+  it('keeps an off-slice marker pending on the ACTIVE entity too', () => {
+    // Being active changes nothing: the slice still cannot order the two ends,
+    // so the marker survives here exactly as it does on an inactive entity.
     const result = resolveRemoteDisplayed(
       {
         ...baseMeta,
-        readPointer: { messageId: 'newer-than-slice', timestamp: new Date('2024-01-15T11:00:00Z') },
+        readPointer: { messageId: 'may-lag-its-timestamp', timestamp: new Date('2024-01-15T11:00:00Z') },
         pendingRemoteDisplayedStanzaId: 'arch-m3',
       },
       messages,
@@ -229,7 +229,7 @@ describe('resolveRemoteDisplayed', () => {
       { isActive: true }
     )
 
-    expect(result.kind).toBe('clear-pending')
+    expect(result.kind).toBe('stash-pending')
   })
 
   it('survives an off-slice catch-up and resolves on the later activation fold', () => {

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -76,18 +76,25 @@ export function resolveRemoteDisplayed<T extends NotificationMessage & { stanzaI
     localPointerId === undefined || messages.some((m) => m.id === localPointerId)
 
   if (!pointerInSlice) {
-    if (meta.readPointer && match.timestamp < meta.readPointer.timestamp) {
-      // Timestamps settle THIS direction only. A pointer built by the #1081
-      // migration carries a timestamp at or behind the message it names, so a
-      // strictly older marker is also older than the true local position.
-      return meta.pendingRemoteDisplayedStanzaId === undefined
-        ? { kind: 'unchanged' }
-        : { kind: 'clear-pending' }
-    }
-
-    // Equal or newer timestamps remain undecidable. Advancing from that
-    // comparison could regress a migrated forward-only pointer, so leave the
-    // marker pending until the activation fold can order both ends by index.
+    // Timestamps settle NEITHER direction, so nothing is decided here.
+    //
+    // `migrateReadPointer` copies the pre-#1081 `lastSeenMessageId` +
+    // `lastReadAt` pair through unchanged, and that `lastReadAt` meant
+    // "timestamp of the newest LOADED message when I last activated" — not the
+    // timestamp of the message actually read up to. A migrated pointer's
+    // timestamp can therefore sit on EITHER side of the message it names, which
+    // breaks both comparisons: a strictly-older marker may still be a valid
+    // forward advance (discarding it loses a real cross-device read), and a
+    // strictly-newer one may sit behind the true position (advancing to it
+    // regresses a forward-only pointer, unrecoverably).
+    //
+    // Note that the `ReadPointer` doc comment claiming `lastReadAt` "is at or
+    // behind the named message" contradicts `migrateReadPointer`'s own comment.
+    // Do not build ordering on either statement until one is proven.
+    //
+    // Accepted cost: a marker the pointer is already past stays pending and
+    // re-folds on each activation. That is churn, not data loss — the safe
+    // direction to err in, given the alternative is dropping a read position.
     return { kind: 'stash-pending' }
   }
 


### PR DESCRIPTION
Follow-up to #1140.

## What is wrong on main

`resolveRemoteDisplayed` retires a remote marker whose timestamp is older than the local read pointer's, on this premise:

> A pointer built by the #1081 migration carries a timestamp at or behind the message it names, so a strictly older marker is also older than the true local position.

That premise does not hold. `migrateReadPointer` copies the pre-#1081 `lastSeenMessageId` + `lastReadAt` pair through unchanged, and that `lastReadAt` meant *"timestamp of the newest LOADED message when I last activated"* — not the timestamp of the message actually read up to. Its own doc comment says so.

So a migrated pointer can name `m2` while carrying `m5`'s timestamp. An off-slice marker at `m4` is then older than the pointer's timestamp, gets retired, and a valid forward advance is discarded. That is a read position synced from another device being silently dropped: the same failure #1140 set out to fix, reached from the other side.

The mirrored case is why advancing on a newer timestamp was already rejected in #1140 — the timestamp can sit on **either** side of the message it names, so neither direction is sound. Only one half of that reasoning made it into the merged code.

## The fix

Off-slice always stays pending. The activation fold, which loads a slice holding both ends and orders them by index, is the only resolver — the one comparison with an actual proof behind it.

**Accepted cost:** a marker the local pointer is already past stays pending and re-folds on each activation. That is churn, not data loss, and it is the right direction to err in when the alternative is discarding a real read position.

The `ReadPointer` doc comment claiming `lastReadAt` *"is at or behind the named message"* contradicts `migrateReadPointer`'s own comment. The code no longer relies on either statement, and the discrepancy is called out at the point where it misled. Reconciling the two comments (and establishing pointer provenance, which would make the retire direction decidable) is left alone deliberately — it changes the `ReadPointer` contract and belongs in its own change.

## Scope

Two files, `readMarkerSync.ts` and its test. No change to `ReadPointer`, `migrateReadPointer`, or either store. The in-slice index-comparator path is untouched, so everything #1140 actually fixed still holds — the fresh-session case that started this (marker destroyed while the pointer sat on disk) remains fixed.