### PR TITLE
fix(mds): keep an unpublished read position retryable

### DIFF
--- a/docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md
@@ -43,8 +43,9 @@ design generalises that one special case and deletes it.
 
 The resident slice bites in a third place too: `resolveSeenStanzaId`
 (`core/mdsSideEffects.ts`) resolves the pointer's stanza-id from the resident array with a
-`lastMessage`-only fallback, and silently returns `undefined` — dropping a publish —
-whenever neither matches.
+`lastMessage`-only fallback. When neither matches it returns `undefined`; the publisher
+now leaves that position unhandled and retries after relevant message or MAM state
+changes instead of dropping the publish (#1142).
 
 ### Rooms have no durable read pointer at all
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -75,6 +75,18 @@ function seedMeta(cid: string, seenMessageId?: string): void {
   })
 }
 
+/** Patch a conversationMeta entry in place (fires the conversationMeta subscription). */
+function patchMeta(
+  cid: string,
+  patch: Partial<{ readPointer: { messageId: string; timestamp: Date }; unreadCount: number }>
+): void {
+  chatStore.setState((state) => {
+    const newMeta = new Map(state.conversationMeta)
+    newMeta.set(cid, { ...newMeta.get(cid)!, ...patch })
+    return { conversationMeta: newMeta }
+  })
+}
+
 /** Build a RoomMessage (mirrors roomStore.mds.test.ts rmsg helper). */
 function rmsg(room: string, id: string, stanzaId: string, t: number): RoomMessage {
   return {
@@ -455,6 +467,85 @@ describe('setupMdsSideEffects', () => {
     cleanup()
   })
 
+  // #1142: consider() used to commit its de-dup key BEFORE resolving the
+  // stanza-id, so a position that failed to resolve once short-circuited every
+  // later consider() on the equality check and was never published. The key must
+  // mean "this position is handled", not merely "we have seen this position".
+  it('re-considers a 1:1 read position that could not be resolved when it first advanced', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    // Backgrounded conversation: meta exists, the resident array is evicted
+    // (memory windowing) and there is no lastMessage preview to fall back on.
+    seedMeta(cid)
+    seedMessages(cid, [])
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // The read position advances to m2 while nothing can resolve it to a
+    // stanza-id — e.g. the catch-up gate held the advance back and by the time
+    // it lifted the conversation had been backgrounded.
+    patchMeta(cid, { readPointer: pointerAt('m2') })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // A later merge brings m2 into the loaded slice and touches meta (as any
+    // merge does). The SAME position is now resolvable and must be published.
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    patchMeta(cid, { unreadCount: 1 })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+
+    // …and once handled it stays handled: further meta churn must not republish.
+    patchMeta(cid, { unreadCount: 2 })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('re-considers a room read position that could not be resolved when it first advanced', async () => {
+    const ROOM = 'room@conference.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    // Backgrounded room: no resident messages, no lastMessage preview.
+    seedRoom(ROOM, [])
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt('m2') })
+      return { roomMeta: meta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // The room is re-opened: its slice loads and roomMeta changes with it.
+    roomStore.setState((s) => {
+      const runtime = new Map(s.roomRuntime)
+      runtime.set(ROOM, {
+        ...runtime.get(ROOM)!,
+        messages: [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)],
+      })
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, unreadCount: 0 })
+      return { roomRuntime: runtime, roomMeta: meta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
+    cleanup()
+  })
+
   it('retracts the MDS marker when a conversation is deleted while online+synced', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
@@ -670,6 +761,31 @@ describe('setupMdsSideEffects catch-up gate', () => {
     chatStore.getState().advanceReadPointer(cid, 'm2')
     await vi.advanceTimersByTimeAsync(2_000)
 
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    cleanup()
+  })
+
+  // #1143: the gate is re-checked at FLUSH time, by which point the entry has
+  // already left the coalescer and consider() has marked the position handled.
+  // Dropping it there used to strand it — nothing could ever put it back.
+  it('re-arms a position dropped by the flush-time catch-up gate', async () => {
+    const { client, cleanup } = await armed()
+    setConvMamState(cid, { hasQueried: true, isCaughtUpToLive: true })
+
+    // Enqueued while the archive is trustworthy…
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    // …but a catch-up starts inside the 1500ms debounce window, so the flush
+    // must refuse to speak from the now-partial archive.
+    setConvMamState(cid, { isLoading: true, hasQueried: true })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // The catch-up completes. The SAME position must still be publishable.
+    setConvMamState(cid, { hasQueried: true, isCaughtUpToLive: true })
+    patchMeta(cid, { unreadCount: 1 })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
     cleanup()
   })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -551,6 +551,42 @@ describe('setupMdsSideEffects', () => {
     cleanup()
   })
 
+  it('re-arms a position dropped when the publishing JID is temporarily unavailable', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: undefined } as never)
+
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    seedMeta(cid, 'm1')
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    connectionStore.setState({
+      status: 'online',
+      jid: 'romeo@montague.example/phone',
+    } as never)
+    patchMeta(cid, { unreadCount: 1 })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(
+      cid,
+      's2',
+      'romeo@montague.example'
+    )
+
+    patchMeta(cid, { unreadCount: 2 })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
   it('retracts the MDS marker when a conversation is deleted while online+synced', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -88,7 +88,7 @@ function patchMeta(
 }
 
 /** Build a RoomMessage (mirrors roomStore.mds.test.ts rmsg helper). */
-function rmsg(room: string, id: string, stanzaId: string, t: number): RoomMessage {
+function rmsg(room: string, id: string, stanzaId: string | undefined, t: number): RoomMessage {
   return {
     type: 'groupchat',
     id,
@@ -476,26 +476,19 @@ describe('setupMdsSideEffects', () => {
     const client = makeClient()
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
-    // Backgrounded conversation: meta exists, the resident array is evicted
-    // (memory windowing) and there is no lastMessage preview to fall back on.
     seedMeta(cid)
-    seedMessages(cid, [])
+    seedMessages(cid, [msg('m2', undefined)])
+    chatStore.setState({ activeConversationId: cid })
 
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
     await vi.runOnlyPendingTimersAsync()
 
-    // The read position advances to m2 while nothing can resolve it to a
-    // stanza-id — e.g. the catch-up gate held the advance back and by the time
-    // it lifted the conversation had been backgrounded.
     patchMeta(cid, { readPointer: pointerAt('m2') })
     await vi.advanceTimersByTimeAsync(2_000)
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
 
-    // A later merge brings m2 into the loaded slice and touches meta (as any
-    // merge does). The SAME position is now resolvable and must be published.
-    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
-    patchMeta(cid, { unreadCount: 1 })
+    chatStore.getState().mergeMAMMessages(cid, [msg('m2', 's2')], {}, true, 'forward')
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
@@ -513,8 +506,8 @@ describe('setupMdsSideEffects', () => {
     const client = makeClient()
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
-    // Backgrounded room: no resident messages, no lastMessage preview.
-    seedRoom(ROOM, [])
+    seedRoom(ROOM, [rmsg(ROOM, 'm2', undefined, 2)])
+    roomStore.setState({ activeRoomJid: ROOM })
 
     const cleanup = setupMdsSideEffects(client as never)
     client._emit('online')
@@ -528,21 +521,25 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
 
-    // The room is re-opened: its slice loads and roomMeta changes with it.
-    roomStore.setState((s) => {
-      const runtime = new Map(s.roomRuntime)
-      runtime.set(ROOM, {
-        ...runtime.get(ROOM)!,
-        messages: [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)],
-      })
-      const meta = new Map(s.roomMeta)
-      meta.set(ROOM, { ...meta.get(ROOM)!, unreadCount: 0 })
-      return { roomRuntime: runtime, roomMeta: meta }
-    })
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [rmsg(ROOM, 'm2', 's2', 2)],
+      {},
+      true,
+      'forward'
+    )
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 's2', ROOM)
+
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, unreadCount: 1 })
+      return { roomMeta: meta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -780,9 +777,7 @@ describe('setupMdsSideEffects catch-up gate', () => {
     await vi.advanceTimersByTimeAsync(2_000)
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
 
-    // The catch-up completes. The SAME position must still be publishable.
-    setConvMamState(cid, { hasQueried: true, isCaughtUpToLive: true })
-    patchMeta(cid, { unreadCount: 1 })
+    chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward')
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -164,7 +164,15 @@ function addConversation(id: string): void {
 }
 
 /** Force a conversation's MAM query state (catch-up gate input). */
-function setConvMamState(cid: string, patch: Partial<{ isLoading: boolean; hasQueried: boolean; isCaughtUpToLive: boolean }>): void {
+function setConvMamState(
+  cid: string,
+  patch: Partial<{
+    isLoading: boolean
+    hasQueried: boolean
+    isCaughtUpToLive: boolean
+    error: string | null
+  }>
+): void {
   chatStore.setState((state) => {
     const next = new Map(state.mamQueryStates)
     next.set(cid, {
@@ -775,6 +783,23 @@ describe('setupMdsSideEffects catch-up gate', () => {
     // must refuse to speak from the now-partial archive.
     setConvMamState(cid, { isLoading: true, hasQueried: true })
     await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    cleanup()
+  })
+
+  it('does not publish after a failed first query and recovers after a successful merge', async () => {
+    const { client, cleanup } = await armed()
+    setConvMamState(cid, { error: 'timeout' })
+
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
 
     chatStore.getState().mergeMAMMessages(cid, [], {}, true, 'forward')

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -208,6 +208,10 @@ export function setupMdsSideEffects(
    * and MDS positions are forward-only — publishing a wrong one makes every
    * other device adopt it and leaves the real position unrecoverable.
    *
+   * A failed query is not trustworthy even when it is no longer loading and
+   * has not completed before. A later successful merge clears the error and
+   * re-enters the normal completion rules.
+   *
    * An entity that has NEVER been queried is allowed through: a conversation or
    * room created live during the session has no half-downloaded archive to
    * misreport, and gating it would silence read sync for new conversations
@@ -217,6 +221,7 @@ export function setupMdsSideEffects(
     const mam = isRoom(jid)
       ? roomStore.getState().getRoomMAMQueryState(jid)
       : chatStore.getState().getMAMQueryState(jid)
+    if (mam.error !== null) return false
     if (!mam.hasQueried && !mam.isLoading) return true // never queried — nothing partial
     return !mam.isLoading && mam.isCaughtUpToLive
   }

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -317,29 +317,43 @@ export function setupMdsSideEffects(
     trackedJids = current
   }
 
-  // Watch conversationMeta for read-position changes. On any change, re-consider
-  // every conversation; consider() de-dupes via lastConsideredSeenId so only
-  // actual advances enqueue a publish.
-  const unsubscribeStore = chatStore.subscribe(
-    (state) => state.conversationMeta,
-    () => {
-      if (!syncEnabled) return
-      for (const jid of chatStore.getState().conversationMeta.keys()) {
-        consider(jid)
-      }
+  function considerConversations(): void {
+    if (!syncEnabled) return
+    for (const jid of chatStore.getState().conversationMeta.keys()) {
+      consider(jid)
     }
-  )
+  }
 
-  // Mirror the conversationMeta watch for rooms: on any roomMeta change, re-consider
-  // every room. consider() de-dupes via lastConsideredSeenId and routes via isRoom().
-  const unsubscribeRoomStore = roomStore.subscribe(
-    (state) => state.roomMeta,
-    () => {
-      if (!syncEnabled) return
-      for (const jid of roomStore.getState().roomMeta.keys()) {
-        consider(jid)
-      }
+  function considerRooms(): void {
+    if (!syncEnabled) return
+    for (const jid of roomStore.getState().roomMeta.keys()) {
+      consider(jid)
     }
+  }
+
+  const unsubscribeConversationMeta = chatStore.subscribe(
+    (state) => state.conversationMeta,
+    considerConversations
+  )
+  const unsubscribeMessages = chatStore.subscribe(
+    (state) => state.messages,
+    considerConversations
+  )
+  const unsubscribeConversationMam = chatStore.subscribe(
+    (state) => state.mamQueryStates,
+    considerConversations
+  )
+  const unsubscribeRoomMeta = roomStore.subscribe(
+    (state) => state.roomMeta,
+    considerRooms
+  )
+  const unsubscribeRoomRuntime = roomStore.subscribe(
+    (state) => state.roomRuntime,
+    considerRooms
+  )
+  const unsubscribeRoomMam = roomStore.subscribe(
+    (state) => state.mamQueryStates,
+    considerRooms
   )
 
   // Self-heal for the seed-before-bookmarks ordering. The fresh-session seed
@@ -493,8 +507,12 @@ export function setupMdsSideEffects(
   )
 
   return () => {
-    unsubscribeStore()
-    unsubscribeRoomStore()
+    unsubscribeConversationMeta()
+    unsubscribeMessages()
+    unsubscribeConversationMam()
+    unsubscribeRoomMeta()
+    unsubscribeRoomRuntime()
+    unsubscribeRoomMam()
     unsubscribeRoomsSeedDrain()
     unsubscribeChatEntities()
     unsubscribeRoomEntities()

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -15,9 +15,10 @@
  * a JID that isn't yet a known room are stashed and re-applied once
  * roomStore.rooms gains that JID (bookmark loaded later in the same session).
  *
- * localStorage remains the durable buffer for read positions: pending in-memory
- * work is DROPPED on disconnect and re-published (ahead-of-node only) on the next
- * fresh session.
+ * localStorage remains the durable source for read positions, but pending
+ * in-memory work is DROPPED on disconnect. A later genuine read advance can
+ * publish; fresh-session seeding intentionally snapshots the current pointer
+ * and is not a general retry queue.
  *
  * @module Core/MdsSideEffects
  */
@@ -153,8 +154,8 @@ export function setupMdsSideEffects(
 
   /**
    * Flush the dirty buffer and publish each entry to the MDS node.
-   * Best-effort: on failure the marker stays in localStorage and is
-   * re-published (if still ahead of the node) on the next fresh session.
+   * A failed publish stays handled; a later genuine read advance supersedes it
+   * instead of retrying the same failing IQ on every metadata change.
    */
   async function doPublish(): Promise<void> {
     if (!syncEnabled) return
@@ -195,7 +196,7 @@ export function setupMdsSideEffects(
         await client.mds.publishDisplayed(jid, stanzaId, by)
         lastKnownNodeStanzaId.set(jid, stanzaId)
       } catch {
-        // Best-effort — localStorage keeps the read position; reconnect re-publishes.
+        // Best-effort; keep the position handled as documented above.
       }
     }
   }
@@ -230,8 +231,8 @@ export function setupMdsSideEffects(
   function consider(jid: string): void {
     if (!syncEnabled) return
     // Catch-up gate: never publish a position derived from a partial archive.
-    // Skipping is safe — localStorage holds the local pointer and the next
-    // advance (or the next fresh-session seed) re-considers it once caught up.
+    // Skipping leaves the de-dup key unchanged; MAM-state changes re-consider
+    // the current pointer once catch-up becomes trustworthy.
     if (!archiveIsTrustworthy(jid)) return
 
     const seenId = isRoom(jid)
@@ -261,8 +262,8 @@ export function setupMdsSideEffects(
       const nodeIdx = indexOfStanza(jid, nodeId)
       // When nodeIdx === -1 the node's high-water message is outside the loaded
       // window, so we can't prove the candidate is ahead — publish optimistically
-      // and rely on (a) the local marker being forward-only and (b) the next
-      // fresh-session seed re-reading the node to self-heal a rare backward move.
+      // and rely on the local marker being forward-only. A later genuine read
+      // advance supersedes any rare backward node move.
       if (candidateIdx !== -1 && nodeIdx !== -1 && candidateIdx <= nodeIdx) return
     }
 
@@ -282,8 +283,8 @@ export function setupMdsSideEffects(
    * Forget a JID's in-memory publisher state so a retract/recreate is clean.
    * `dirty.delete` drops a still-buffered (debounced) publish; a publish that
    * already flushed and is awaiting its IQ can still win the race and re-assert
-   * the marker after the retract. That is an accepted best-effort limitation
-   * (hygiene, not correctness) and self-heals on the next fresh-session seed.
+   * the marker after the retract. That is an accepted best-effort limitation of
+   * retract ordering.
    */
   function evictJid(jid: string): void {
     lastKnownNodeStanzaId.delete(jid)
@@ -490,8 +491,8 @@ export function setupMdsSideEffects(
     trackedJids = liveJids()
   })
 
-  // On disconnect: DROP pending work and cancel the timer. localStorage is the
-  // durable buffer; ahead-of-node markers are re-published on the next session.
+  // On disconnect: DROP pending work and cancel the timer. The canonical pointer
+  // remains in localStorage; see the module contract for retry semantics.
   let previousStatus = connectionStore.getState().status
   const unsubscribeConnection = connectionStore.subscribe(
     (state) => state.status,

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -56,7 +56,11 @@ export function setupMdsSideEffects(
   const dirty = createKeyedCoalescer<string, string>()
   // Highest stanza-id we believe is on the node per JID (seed + our publishes).
   const lastKnownNodeStanzaId = new Map<string, string>()
-  // The read-pointer message id we last considered per JID, to detect advances.
+  // The read-pointer message id we last HANDLED per JID, to detect advances.
+  // "Handled" means the position was resolved to a stanza-id and then either
+  // enqueued or judged not ahead of the node — never merely "seen". A position
+  // that could not be resolved stays out of this map so a later merge retries
+  // it (#1142); recording it would silence the position for good.
   const lastConsideredSeenId = new Map<string, string | undefined>()
   // Seed markers (jid → marker) whose JID was NOT a known room at seed time.
   // The fresh-session seed runs before bookmarks load (roomStore.rooms is empty),
@@ -169,12 +173,24 @@ export function setupMdsSideEffects(
       // Re-check the catch-up gate at FLUSH time, not just at enqueue: the
       // debounce window is long enough for a catch-up to start after the
       // position was buffered, and it is the publish itself that must never
-      // speak from a partial archive. Dropping the entry is safe — the local
-      // pointer lives in localStorage and is re-considered on the next advance
-      // or the next fresh-session seed.
-      if (!archiveIsTrustworthy(jid)) continue
+      // speak from a partial archive.
+      //
+      // Re-arm rather than discard (#1143). The entry has already left the
+      // coalescer via flush() and consider() marked this position handled when
+      // it enqueued, so nothing would ever put it back. Dropping the de-dup key
+      // instead of re-adding to `dirty` avoids clobbering a newer position
+      // buffered during the awaits above: the next meta change re-considers the
+      // CURRENT pointer and re-checks this gate then.
+      if (!archiveIsTrustworthy(jid)) {
+        lastConsideredSeenId.delete(jid)
+        continue
+      }
       const by = stanzaIdBy(jid)
-      if (!by) continue // own JID unknown (should not happen while online) — retry next advance
+      if (!by) {
+        // Own JID unknown (should not happen while online) — same re-arm.
+        lastConsideredSeenId.delete(jid)
+        continue
+      }
       try {
         await client.mds.publishDisplayed(jid, stanzaId, by)
         lastKnownNodeStanzaId.set(jid, stanzaId)
@@ -217,10 +233,20 @@ export function setupMdsSideEffects(
       ? roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
       : chatStore.getState().conversationMeta.get(jid)?.readPointer?.messageId
     if (seenId === lastConsideredSeenId.get(jid)) return
-    lastConsideredSeenId.set(jid, seenId)
 
     const stanzaId = resolveSeenStanzaId(jid)
-    if (!stanzaId) return // no resolvable stanza-id yet → skip (retry on next advance/merge)
+    // No resolvable stanza-id yet: the entity's resident array is evicted and
+    // the pointer doesn't name the lastMessage preview. Leave the de-dup key
+    // UNCOMMITTED so the next meta change re-runs this resolve — committing it
+    // here would make every later call short-circuit on the equality check
+    // above, and the position would never be enqueued nor reach the node
+    // (#1142). The key means "this position is handled", not "we have seen it".
+    if (!stanzaId) return
+
+    // Resolved → handled from here on, whether we enqueue below or decide the
+    // node is already at/ahead of it (a verdict that cannot flip: message order
+    // within a slice is stable).
+    lastConsideredSeenId.set(jid, seenId)
 
     // No regressive publish: only publish if strictly ahead (by message index)
     // of what we believe is already on the node for this JID.


### PR DESCRIPTION
`lastConsideredSeenId` was committed to the new read-pointer message id right after the "did the pointer change?" equality check, ahead of three steps that can each bail: the stanza-id resolve in `consider()`, and the flush-time catch-up gate and `by` lookup in `doPublish()`. Once committed, every later `consider()` call short-circuits on that same check, so the position is never enqueued and never reaches the XEP-0490 node. Other devices then keep a stale new-message divider and an inflated unread badge — the same user-visible symptom as #1140, reached from the publish side. The inline comments promised a retry ("retry on next advance/merge", "re-considered on the next fresh-session seed") that did not exist for the same `seenId`.

The key now means "handled", not "seen".

- `consider()` commits it only once the position resolved to a stanza-id, so an entity whose resident array is evicted stays retryable. Committing before the no-regressive-publish index guard remains intentional: that guard is a terminal verdict, since message order within a loaded slice is stable.
- `doPublish()` re-arms with `lastConsideredSeenId.delete(jid)` instead of discarding the flushed entry, on both the catch-up gate and the `by` bail. Deleting rather than re-adding to `dirty` avoids clobbering a newer position buffered during the loop's awaits: the next change re-considers the current pointer and re-checks the gate then.

Re-arming the key is only half of it — something has to trigger the retry. `consider()` was reachable only from the `conversationMeta` / `roomMeta` subscriptions, but `mergeMAMMessages` returns with no meta write on two ordinary paths (a duplicate page that backfills a stanza-id, and an active-conversation merge with no preview update), while every merge path writes `mamQueryStates`. The retry is now driven from the resolver-input boundary as well: `messages` + `mamQueryStates` for chats, `roomRuntime` + `mamQueryStates` for rooms.

That MAM-state subscription exposed a latent hole in `archiveIsTrustworthy()`. `setMAMError` writes `{ ...current, error, isLoading: false }` and never sets `hasQueried`, so a failed first query read as "never queried — nothing partial" and was allowed to publish from a partial archive. It is now gated on `error`, at the gate rather than at the subscription, which also closes the pre-existing meta-driven path. A successful merge resets `error` alongside `hasQueried`, so one transient failure does not silence a conversation, and a genuinely never-queried entity still publishes.

The module documentation is corrected along the way: several comments described a fresh-session republish that does not happen.

Not addressed here: the fresh-session seed still re-snapshots current pointers into `lastConsideredSeenId`, so a position that stays unresolvable for a whole session is lost across a restart. Dropping that snapshot is not safe while a `stash-pending` node marker can leave the local pointer behind the node. Tracked in #1145.

Fixes #1142
Fixes #1143