### PR TITLE
feat(demo): silence the notification sound by default

### DIFF
--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -68,6 +68,13 @@ if (densityParam === 'compact' || densityParam === 'comfortable') {
   // Drive the store directly (the store is already created by this point via the import)
   useSettingsStore.getState().setDensityMode(densityParam)
 }
+// Demo mode is silent by default: the scripted animation and automated runs (screenshots,
+// e2e, agent-driven checks) deliver messages continuously, and the notification "ding" on
+// every arrival is noise. Pass ?sound=true to hear it (or flip the toggle in Settings).
+// setState (not setSoundEnabled) so we don't write 'fluux-sound' — demo.html and the real
+// app share a localStorage origin, and the demo must not change the app's saved preference.
+useSettingsStore.setState({ soundEnabled: params.get('sound') === 'true' })
+
 // Clear IndexedDB caches (async, best-effort)
 indexedDB.deleteDatabase('fluux-message-cache')
 indexedDB.deleteDatabase('fluux-avatar-cache')

--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -15,6 +15,7 @@ Then open **http://localhost:5173/demo.html**
 | Parameter  | Default | Description                                                                              |
 |------------|---------|------------------------------------------------------------------------------------------|
 | `tutorial` | `true`  | Set to `false` to disable tutorial tooltips (useful for video recording and screenshots) |
+| `sound`    | `false` | Set to `true` to enable the notification sound (off by default so the scripted demo and automated runs stay silent) |
 
 Example: **http://localhost:5173/demo.html?tutorial=false**
 


### PR DESCRIPTION
The demo's scripted animation and automated runs (screenshots, e2e, agent-driven checks) deliver messages continuously, so the notification "ding" on every arrival is pure noise.

Demo mode now starts silent. Pass `?sound=true` to hear it, or flip the toggle in Settings › Accessibility at runtime.

The seam uses `setState` rather than `setSoundEnabled` so the demo never writes `fluux-sound`: `demo.html` and the real app share a localStorage origin, and the demo must not change the app's saved preference.