### PR TITLE
ci: run only the jobs a change can affect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,56 @@ on:
     branches: [main, devel]
 
 jobs:
+  # Decide which of the jobs below the diff can actually affect. The workflow
+  # still triggers on every PR and the jobs are suppressed with `if:` rather
+  # than a workflow-level `paths:` filter — a skipped job reports a conclusion,
+  # a workflow that never ran does not, so required status checks (should any
+  # be added to main later) stay satisfiable.
+  changes:
+    name: Detect changed scopes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      js: ${{ steps.classify.outputs.js }}
+      rust: ${{ steps.classify.outputs.rust }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # The gatekeeper validates itself before it gates anything. Sub-second.
+      - name: Test the classifier
+        run: scripts/ci-changed-scopes.test.sh
+
+      # The PR's file list comes from the API rather than `git diff`: it is the
+      # diff GitHub itself computes, so it is immune to force-pushes, rebases
+      # and shallow clones, and needs no fetch-depth tuning. A failure here
+      # fails this job red — downstream jobs are then skipped and the workflow
+      # is visibly broken rather than quietly green.
+      - name: Classify changed files
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' > changed-files.txt
+
+          echo "Changed files ($(wc -l < changed-files.txt)):"
+          sed 's/^/  /' changed-files.txt
+
+          scripts/ci-changed-scopes.sh < changed-files.txt | tee -a "$GITHUB_OUTPUT"
+
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     # Backstop against a hung step (default GitHub timeout is 6h). A healthy run is ~7min.
     timeout-minutes: 15
@@ -101,6 +149,8 @@ jobs:
 
   e2e-scroll:
     name: Scroll invariants (e2e)
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     # Backstop against a hung dev server / browser install (default GitHub timeout is 6h).
     # A healthy run is ~7min; the Playwright OS-dep apt install can be slow on an unlucky
@@ -196,6 +246,8 @@ jobs:
 
   rust:
     name: Rust
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     # Backstop against a hung build/test (default GitHub timeout is 6h). A cached run is ~5min.
     timeout-minutes: 20
@@ -242,6 +294,8 @@ jobs:
 
   rust-windows:
     name: Rust (Windows)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     timeout-minutes: 25
 

--- a/docs/superpowers/plans/2026-07-28-ci-selective-tests.md
+++ b/docs/superpowers/plans/2026-07-28-ci-selective-tests.md
@@ -1,0 +1,130 @@
+# Selective CI: run only the jobs a change can affect
+
+**Goal:** A pull request should only pay for the CI jobs its diff can actually break. A docs-only PR runs nothing; a Rust-only PR skips the Node and Playwright jobs; a TypeScript-only PR skips the two Rust jobs.
+
+**Architecture:** A pure classifier (`scripts/ci-changed-scopes.sh`) maps a list of changed paths to two booleans, `js` and `rust`. A new `changes` job in `.github/workflows/ci.yml` fetches the PR's file list from the GitHub API, pipes it through the classifier, and publishes the booleans as job outputs. The four existing jobs gain `needs: changes` and an `if:` guard. No job's own steps change.
+
+**Tech stack:** bash (`set -euo pipefail`), `gh` CLI (preinstalled on GitHub runners), GitHub Actions job outputs.
+
+## Why this shape
+
+The repo is public, so Actions minutes are free — the payoff is wall-clock and signal-to-noise, not cost. Measured over three recent runs, the four jobs run in parallel at roughly:
+
+| Job | Duration |
+|---|---|
+| Scroll invariants (e2e) | 9–15 min |
+| Test | ~6.5 min |
+| Rust | ~2.5 min |
+| Rust (Windows) | ~2 min |
+
+Because they are parallel, a PR's wall-clock is the longest surviving job. That makes the docs-only and Rust-only cases the real wins (15 min → ~0 and 15 min → ~2.5 min); skipping the Rust jobs on a TypeScript PR saves only free compute, since they were never on the critical path.
+
+`main` currently has no required status checks (its ruleset carries `pull_request`, `deletion`, `non_fast_forward` only), so the classic "workflow-level `paths:` filter leaves a required check pending forever" trap does not bite today. The design avoids it anyway: the workflow still triggers on every PR, and jobs are suppressed with `if:` — a skipped job reports a conclusion, an unrun workflow does not. Adding required checks later stays safe.
+
+## Global constraints
+
+- **Fail-safe by default.** Any path not matched by an explicit rule classifies as *both* scopes. Forgetting to add a pattern can only waste free minutes; it can never silence a job.
+- **Rule order is load-bearing.** `apps/fluux/src-tauri/**` must be tested before `apps/fluux/**`, or every Tauri change would classify as `js`.
+- The classifier does no I/O beyond stdin/stdout — no git, no network — so it is runnable and testable locally.
+- Empty input classifies as both scopes.
+- The GitHub `pulls/{n}/files` endpoint caps at 3000 files; hitting that count is treated as truncation and classifies as both scopes.
+- If the API call fails, the `changes` job fails red. Downstream jobs are then skipped and the workflow is visibly broken — never silently green.
+- Never include a Claude footer in commit messages.
+- Commits are SSH-signed; run `ssh-add` first if signing fails.
+
+## File structure
+
+**Created:**
+- `scripts/ci-changed-scopes.sh` — the classifier.
+- `scripts/ci-changed-scopes.test.sh` — table-driven test for the classifier.
+
+**Modified:**
+- `.github/workflows/ci.yml` — new `changes` job; `needs:` + `if:` on `test`, `e2e-scroll`, `rust`, `rust-windows`.
+
+**Deliberately untouched:**
+- `scripts/test-affected.sh` — a local-iteration tool. Its own header documents the large reverse-dependency fan-in of `vitest related` for stores and shared utils. Good for a fast inner loop, wrong as a merge gate. CI keeps running each workspace's full suite.
+- `release.yml`, `pages.yml`, `playwright-cache.yml`, `windows-test-build.yml` — none are `pull_request`-triggered.
+
+## Classification rules
+
+Evaluated top to bottom, first match wins.
+
+| # | Paths | Scope |
+|---|---|---|
+| 1 | `.github/workflows/**`, `package.json`, `package-lock.json`, `tsconfig*.json` | both |
+| 2 | `**/*.md`, `docs/**`, `assets/**`, `screenshots/**`, `.claude/**`, `LICENSE`, `*.doap`, `renovate.json`, `.gitignore` | neither |
+| 3 | `apps/fluux/src-tauri/**`, `packaging/**`, `scripts/check-linux-packaging.sh`, `scripts/test-deb-build.sh` | rust |
+| 4 | `packages/**`, `apps/fluux/**`, `playwright*.config.ts`, `scripts/scroll-invariants.ts`, `scripts/composer-geometry.ts` | js |
+| 5 | anything else | both |
+
+Two placements that are not obvious:
+
+- **`packaging/**` is a Rust-job path.** The Rust job — not any Node job — runs `scripts/check-linux-packaging.sh`, which validates `packaging/debian/fluux-messenger.desktop`.
+- **The rest of `scripts/**` falls through to rule 5 (both).** `select-icon-variant.mjs` and `check-sdk-link.mjs` are `pre*` hooks on every build and typecheck script, so a change there can break anything.
+
+`docs/**` classifying as neither means this plan document is itself a zero-job PR.
+
+## Implementation
+
+### Task 1 — the classifier
+
+- [ ] Create `scripts/ci-changed-scopes.sh`, executable, `set -euo pipefail`.
+- [ ] Read paths from stdin, one per line. Ignore blank lines.
+- [ ] For each path, walk the rule table in order using `case` globs; accumulate into `js` / `rust` flags.
+- [ ] Short-circuit once both flags are set.
+- [ ] If the input had zero non-blank lines, or the line count is >= 3000, set both flags.
+- [ ] Emit exactly two lines: `js=true|false` and `rust=true|false`.
+- [ ] Header comment explaining the fail-safe default and the order dependency, matching the commenting density of `test-affected.sh`.
+
+### Task 2 — the test
+
+- [ ] Create `scripts/ci-changed-scopes.test.sh`, executable.
+- [ ] Table of cases, each asserting the full two-line output:
+  - `README.md` → neither
+  - `docs/foo.md`, `.claude/CLAUDE.md`, `renovate.json` → neither
+  - `apps/fluux/src-tauri/src/lib.rs` → rust only
+  - `packaging/debian/fluux-messenger.desktop` → rust only
+  - `packages/fluux-sdk/src/core/XMPPClient.ts` → js only
+  - `apps/fluux/src/App.tsx` → js only
+  - **order trap:** `apps/fluux/src-tauri/src/lib.rs` + `apps/fluux/src/App.tsx` → both, and `apps/fluux/src-tauri/src/lib.rs` alone must *not* yield js
+  - `package-lock.json` → both
+  - `.github/workflows/ci.yml` → both
+  - `scripts/select-icon-variant.mjs` (unmatched → rule 5) → both
+  - `apps/fluux/src-tauri/README.md` (rule 2 beats rule 3) → neither
+  - empty input → both
+- [ ] Print a pass/fail line per case; exit non-zero if any case fails.
+- [ ] **Control check:** confirm the suite actually fails when the classifier is wrong — temporarily invert one rule, watch the expected cases go red, then revert. A test table that passes against a broken classifier is worse than none.
+
+### Task 3 — wire ci.yml
+
+- [ ] Add job `changes`: `runs-on: ubuntu-latest`, `timeout-minutes: 5`, `permissions: { contents: read, pull-requests: read }`, outputs `js` and `rust`.
+- [ ] Steps: checkout → run `scripts/ci-changed-scopes.test.sh` → fetch and classify.
+- [ ] The self-test runs *first*, on every PR (<1s). The gatekeeper validates itself before it gates anything.
+- [ ] Fetch with `gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR/files" --jq '.[].filename'`, with `GH_TOKEN: ${{ github.token }}`. Use the API rather than `git diff`: it is the diff GitHub itself computes, so it is immune to force-pushes, rebases and shallow clones, and needs no `fetch-depth` tuning.
+- [ ] Echo the changed file list and the resulting scopes into the log — when a job is skipped, the log must show why.
+- [ ] Append the classifier output to `$GITHUB_OUTPUT`.
+- [ ] Add `needs: changes` to all four jobs, plus:
+  - `test`, `e2e-scroll`: `if: needs.changes.outputs.js == 'true'`
+  - `rust`, `rust-windows`: `if: needs.changes.outputs.rust == 'true'`
+- [ ] Leave every existing step untouched.
+
+### Task 4 — verify
+
+- [ ] Run `scripts/ci-changed-scopes.test.sh` locally; all cases pass.
+- [ ] Replay real diffs: for a handful of recent merged PRs, pipe their actual file lists through the classifier and confirm each verdict is defensible.
+- [ ] Validate the workflow YAML parses.
+- [ ] Open the PR. This PR touches `.github/workflows/**` and `scripts/**` (rule 1 and rule 5), so it classifies as both scopes and runs the full matrix — which is exactly the wanted self-check.
+
+## Expected outcome
+
+| PR type | Before | After |
+|---|---|---|
+| Docs only | ~15 min, 4 jobs | ~20 s, 0 jobs |
+| Rust only | ~15 min | ~2.5 min |
+| TypeScript only | ~15 min | ~15 min, 2 jobs instead of 4 |
+| Mixed | ~15 min | ~15 min |
+
+## Out of scope
+
+- Narrowing `e2e-scroll` to a subset of TypeScript paths. It is the largest remaining win, but this project's scroll regressions have repeatedly come from indirect changes — stores, read pointers, reactions — so a path-based gate there would trade real safety for time.
+- Splitting the `Test` job per workspace (lint/typecheck only the touched one). ~1–2 min for a noticeable jump in workflow complexity.

--- a/scripts/ci-changed-scopes.sh
+++ b/scripts/ci-changed-scopes.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Classify a set of changed paths into the CI scopes they can affect.
+#
+# Reads one path per line on stdin, writes exactly two lines on stdout in
+# GITHUB_OUTPUT format:
+#
+#   js=true|false     -> run the Test and Scroll invariants (e2e) jobs
+#   rust=true|false   -> run the Rust and Rust (Windows) jobs
+#
+# Both false means the diff cannot break any job (docs, assets, metadata).
+#
+# Usage:
+#   printf 'README.md\n' | scripts/ci-changed-scopes.sh
+#   git diff --name-only main... | scripts/ci-changed-scopes.sh
+#
+# Two properties this file must keep:
+#
+#   1. Fail-safe. A path that matches no explicit rule falls through to the
+#      catch-all and enables BOTH scopes. Forgetting a pattern can only waste
+#      CI minutes (this repo is public, so they are free) — it can never
+#      silence a job that should have run.
+#
+#   2. Rule order is load-bearing. The cases below are evaluated top to bottom
+#      and the first match wins, so a narrow path must precede the broader one
+#      that contains it. Concretely: apps/fluux/src-tauri/* is tested before
+#      apps/fluux/*, otherwise every Tauri change would classify as `js`.
+#
+# No git, no network — a pure stdin -> stdout function, so it is testable
+# locally and by scripts/ci-changed-scopes.test.sh.
+#
+set -euo pipefail
+
+# GitHub's pulls/{n}/files endpoint returns at most 3000 entries. At that count
+# the list may be truncated, so we cannot trust it to be complete.
+readonly API_FILE_LIMIT=3000
+
+js=false
+rust=false
+count=0
+
+while IFS= read -r path || [ -n "$path" ]; do
+    [ -n "$path" ] || continue
+    count=$((count + 1))
+
+    # Both scopes already on: nothing left to learn from the remaining paths.
+    if [ "$js" = true ] && [ "$rust" = true ]; then
+        continue
+    fi
+
+    case "$path" in
+        # --- Rule 1: shared foundations — affect everything -------------------
+        .github/workflows/* | package.json | package-lock.json | tsconfig*.json)
+            js=true
+            rust=true
+            ;;
+
+        # --- Rule 2: documentation and metadata — affect nothing --------------
+        # Placed above the source rules so that, say, a README inside src-tauri
+        # is still recognised as documentation.
+        *.md | docs/* | assets/* | screenshots/* | .claude/* | LICENSE | *.doap | renovate.json | .gitignore)
+            ;;
+
+        # --- Rule 3: Rust / desktop packaging ---------------------------------
+        # packaging/* belongs here because the Rust job — not any Node job —
+        # runs scripts/check-linux-packaging.sh, which validates the Debian
+        # .desktop file.
+        apps/fluux/src-tauri/* | packaging/* | scripts/check-linux-packaging.sh | scripts/test-deb-build.sh)
+            rust=true
+            ;;
+
+        # --- Rule 4: TypeScript / JavaScript ----------------------------------
+        # The two scripts named explicitly are the bodies of the Playwright
+        # suites run by the e2e job.
+        packages/* | apps/fluux/* | playwright*.config.ts | scripts/scroll-invariants.ts | scripts/composer-geometry.ts)
+            js=true
+            ;;
+
+        # --- Rule 5: catch-all — fail safe ------------------------------------
+        # Anything unrecognised runs everything. Note this deliberately catches
+        # the rest of scripts/: select-icon-variant.mjs and check-sdk-link.mjs
+        # are pre* hooks on every build and typecheck script, so a change there
+        # can break any job.
+        *)
+            js=true
+            rust=true
+            ;;
+    esac
+done
+
+# No input at all, or a file list we have reason to believe was truncated:
+# we do not know what changed, so run everything.
+if [ "$count" -eq 0 ] || [ "$count" -ge "$API_FILE_LIMIT" ]; then
+    js=true
+    rust=true
+fi
+
+echo "js=$js"
+echo "rust=$rust"

--- a/scripts/ci-changed-scopes.test.sh
+++ b/scripts/ci-changed-scopes.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Table-driven test for scripts/ci-changed-scopes.sh.
+#
+# This runs as the first step of the CI `changes` job: the gatekeeper validates
+# itself before it decides which jobs to skip. It takes well under a second.
+#
+# Usage: scripts/ci-changed-scopes.test.sh
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLASSIFY="$ROOT/scripts/ci-changed-scopes.sh"
+
+failures=0
+
+# expect <description> <expected js> <expected rust> <path>...
+expect() {
+    local desc="$1" want_js="$2" want_rust="$3"
+    shift 3
+
+    local input=""
+    local p
+    for p in "$@"; do input+="$p"$'\n'; done
+
+    local got want
+    got="$(printf '%s' "$input" | bash "$CLASSIFY")"
+    want="js=$want_js"$'\n'"rust=$want_rust"
+
+    if [ "$got" = "$want" ]; then
+        echo "  ok   $desc"
+    else
+        echo "  FAIL $desc"
+        echo "         paths:    $*"
+        echo "         expected: ${want//$'\n'/, }"
+        echo "         got:      ${got//$'\n'/, }"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "ci-changed-scopes:"
+
+# --- Rule 2: docs and metadata affect nothing ---------------------------------
+expect "root README"                 false false README.md
+expect "nested doc"                  false false docs/superpowers/plans/2026-07-28-ci-selective-tests.md
+expect "agent instructions"          false false .claude/CLAUDE.md
+expect "renovate config"             false false renovate.json
+expect "project metadata"            false false fluux-messenger.doap
+expect "marketing assets"            false false assets/readme/fluux-logo.svg
+expect "several docs at once"        false false README.md CHANGELOG.md docs/RELEASE.md
+
+# --- Rule 3: Rust and desktop packaging ---------------------------------------
+expect "tauri source"                false true  apps/fluux/src-tauri/src/lib.rs
+expect "tauri generated schema"      false true  apps/fluux/src-tauri/gen/schemas/capabilities.json
+expect "cargo lockfile"              false true  apps/fluux/src-tauri/Cargo.lock
+expect "debian desktop entry"        false true  packaging/debian/fluux-messenger.desktop
+expect "linux packaging check"       false true  scripts/check-linux-packaging.sh
+
+# --- Rule 4: TypeScript -------------------------------------------------------
+expect "sdk source"                  true  false packages/fluux-sdk/src/core/XMPPClient.ts
+expect "app source"                  true  false apps/fluux/src/App.tsx
+expect "workspace tsconfig"          true  false apps/fluux/tsconfig.json
+expect "playwright scroll config"    true  false playwright.scroll.config.ts
+expect "e2e suite body"              true  false scripts/scroll-invariants.ts
+
+# --- Rule ordering ------------------------------------------------------------
+# src-tauri/* must be matched before apps/fluux/*, or a Tauri change would be
+# classified as `js` and the Rust jobs would be skipped on a Rust-only PR.
+expect "tauri source is not js"      false true  apps/fluux/src-tauri/src/notification.rs
+expect "tauri + app source"          true  true  apps/fluux/src-tauri/src/lib.rs apps/fluux/src/App.tsx
+# Docs are matched before source, so a README inside src-tauri stays docs.
+expect "readme inside src-tauri"     false false apps/fluux/src-tauri/README.md
+
+# --- Rule 1: shared foundations -----------------------------------------------
+expect "root manifest"               true  true  package.json
+expect "lockfile"                    true  true  package-lock.json
+expect "root tsconfig"               true  true  tsconfig.base.json
+expect "the CI workflow itself"      true  true  .github/workflows/ci.yml
+
+# --- Rule 5: fail-safe catch-all ----------------------------------------------
+# select-icon-variant.mjs is a pre* hook on every build script.
+expect "unlisted build script"       true  true  scripts/select-icon-variant.mjs
+expect "brand new top-level dir"     true  true  services/gateway/main.go
+expect "one unknown among docs"      true  true  README.md scripts/prepare-release.js
+
+# --- Degenerate input ---------------------------------------------------------
+expect "empty input"                 true  true
+
+echo ""
+if [ "$failures" -ne 0 ]; then
+    echo "$failures case(s) failed."
+    exit 1
+fi
+echo "All cases passed."


### PR DESCRIPTION
A pull request now pays only for the CI jobs its diff can break: a docs-only PR runs nothing, a Rust-only PR skips the Node and Playwright jobs, and a TypeScript-only PR skips the two Rust jobs.

`scripts/ci-changed-scopes.sh` maps a list of changed paths to two booleans, `js` and `rust`. A new `changes` job fetches the PR's file list from the GitHub API — the diff GitHub itself computes, so it is immune to force-pushes, rebases and shallow clones — pipes it through the classifier, and publishes the result as job outputs. The four existing jobs gain `needs` and an `if` guard; none of their steps change.

Two properties the classifier must keep, both covered by `scripts/ci-changed-scopes.test.sh`:

- **Fail-safe.** A path matching no explicit rule enables both scopes, so forgetting a pattern can only waste minutes (free on a public repo), never silence a job.
- **Rule order is load-bearing.** `apps/fluux/src-tauri/*` is matched before `apps/fluux/*`, otherwise every Tauri change would classify as `js`.

Jobs are suppressed with `if:` rather than a workflow-level `paths:` filter: a skipped job reports a conclusion, a workflow that never ran does not, so required status checks stay satisfiable if any are added to `main` later.

### Measured effect

Over the last 50 merged PRs: 2 classify as Rust-only (15 min → 2.5 min), 38 as TypeScript-only, 10 as both, 0 as docs-only. The TypeScript-only case drops two checks without moving wall-clock, since the Rust jobs were never on the critical path.

Narrowing `e2e-scroll` — the only job on the critical path at 9–15 min — would reach that majority, but is deliberately out of scope: this project's scroll regressions have repeatedly come from indirect changes to stores and read pointers, so a path gate there would trade real safety for time.