### PR TITLE
perf(sdk): stop force-flushing safe coverage transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ CLAUDE.md
 .runtime/
 .beads/
 .logs/
+
+# Benchmark output (regenerated; the numbers that matter live in the design doc)
+packages/fluux-sdk/bench/results/

--- a/docs/superpowers/specs/2026-07-24-throttled-persist-design.md
+++ b/docs/superpowers/specs/2026-07-24-throttled-persist-design.md
@@ -429,8 +429,8 @@ preserves the coverage claiming there is no hole.
 so a store-level helper cannot compare two `bottomId`s and decide which is deeper. Any rule that
 depends on ordering ids is unimplementable here.
 
-**Resolution.** Force these transitions out of the window, keeping the throttle for ordinary
-monotone advances:
+**Resolution shipped by #1133.** Force these transitions out of the window, keeping the throttle
+for ordinary monotone advances:
 
 | Map | Transition | Treatment |
 |---|---|---|
@@ -440,14 +440,9 @@ monotone advances:
 | coverage | key **added**, `bottomId` **changed**, key **removed** | force-flush |
 | coverage | `topId`-only change (re-entry marker) | throttle |
 
-> **The coverage rows above are SUPERSEDED by
-> [#1138](2026-07-28-coverage-persistence-cost-design.md).** The "measured follow-up" at the end of
-> this section turned out to understate the problem: measurement showed the conservative
-> `bottomId`-changed rule cost the *entire* benefit of the throttle on a first session — 400 writes
-> and 88.9 MB on the reference profile, identical to the pre-throttle baseline. `created` and
-> `deepened` are now throttled, signalled by `CoverageTransition` out of
-> `syncCoverageAfterArchiveMerge`; only `replaced` and removal still force a flush. **The gap rows
-> are unchanged.** See that document for the current decision table.
+> **The coverage rows above are superseded by
+> [#1138](2026-07-28-coverage-persistence-cost-design.md).** The gap rows remain current; the
+> follow-up owns the current coverage decision table and its measurements.
 
 **Why the gap rule keys on the lower BOUNDARY, not just the key.** Key-presence alone does not catch
 an in-place interval **advance** — the same id's gap moving from `{ start: 1000 }` to
@@ -502,42 +497,11 @@ gapped entities page concurrently and could otherwise have shared a window, and 
 per gapped entity ceiling. One non-catch-up path also became structural — `clearRoomGapAnchor` strips
 `startId` on an archive purge — costing one forced write on a rare path.
 
-**`bottomId`-changed is deliberately conservative, and the cost is flush FREQUENCY.** It force-flushes
-the provable deepening in `syncCoverageAfterArchiveMerge`'s plain-backward branch too, which is safe to
-throttle in principle. Since ids cannot be ordered at this layer, distinguishing it would mean
-threading a "was this monotone" signal out of the sync functions. The decision stands — but the
-justification is *not* that a coverage record is small. Size is the wrong axis: the record rides in the
-chat blob, so what a force-flush costs is one whole-blob serialization, and the question is how OFTEN.
-Three sources, counted honestly:
-
-1. **Coverage bootstrap** ([mamCoverage.ts:136-140](../../../packages/fluux-sdk/src/stores/shared/mamCoverage.ts))
-   fires once for every entity that has no record and completes a forward catch-up. On the first
-   session after this ships that is essentially *every* conversation: at the 400-conversation profile,
-   ~400 O(conversations) blob serializations — the same order as the ~180 writes this work exists to
-   remove. Steady state is free (`if (coverage.get(id)) return coverage`).
-2. **Phase B read-pointer stitch** loops up to `MAM_POINTER_STITCH_MAX_PAGES` = 10 backward queries
-   per entity per session ([MAM.ts:1561-1577](../../../packages/fluux-sdk/src/core/modules/MAM.ts)),
-   each advancing `bottomId` and so force-flushing.
-3. **A multiplier on top of both:** `flushKey` **closes** the window
-   ([throttledStorage.ts:141-142](../../../packages/fluux-sdk/src/stores/shared/throttledStorage.ts)),
-   so the *next* mutation is a fresh leading edge instead of being coalesced. Measured on the room
-   gap-formation scenario: 3 writes where a pure throttle produces 1.
-
-All three are first-session / launch-window costs, and all three are still strictly better than the
-pre-branch baseline, which serialized the blob on **every** mutation unconditionally. The burst test
-cannot see any of it — `collapses a long burst…` drives only `setMAMLoading`, so gaps and coverage stay
-empty and this path never runs. That is a limitation of the test, not evidence of no cost.
-
-**Measured follow-up, deliberately out of scope here.** A `flushKey` variant that writes the pending
-thunk but leaves the timer ARMED would remove multiplier (3) for free. It is a semantic change to a
-shared primitive — `recordPendingRetraction` uses `flushKey` too, and it wants the window closed — so
-it needs its own change with its own tests, not a rider on this one.
-
-> Measured in [#1138](2026-07-28-coverage-persistence-cost-design.md) §3.2 and **not taken**: it can
-> only recover the window-closing half of a structural write, so on an all-structural workload it
-> saves nothing, and on a gap-heavy mixed one about 2×. Sources (1) and (2) were removed instead, by
-> throttling `created` and `deepened`. The bounding scenario stays in the benchmark for whoever picks
-> it up.
+**The conservative coverage rule required the measured follow-up.** #1133 could not distinguish a
+safe deepening from an unsafe replacement because archive ids are non-sequential, so it force-flushed
+both and identified bootstrap, Phase B, and `flushKey` closing the window as launch-window costs.
+[#1138](2026-07-28-coverage-persistence-cost-design.md) owns the measurements, current rule, and the
+decision not to change `flushKey`.
 
 Ordinary termination — tab close, app quit, mobile backgrounding — loses nothing, provided §4.1
 lands.
@@ -653,10 +617,9 @@ are wired to it. A helper left calling `localStorage.setItem` directly passes ev
 
 - **Both sides of the §4.2 bound, per map.** The force-flush tests are one-directional: an
   implementation that flushed on *every* gap or coverage write would pass all of them, and the whole
-  suite besides. Each map therefore needs a coalescing guard for the transition §4.2 still throttles —
-  a gap shrink, and a coverage `topId` refresh. Both take **three** writes, for the reason in §5.5:
-  one to establish the baseline (the first write of a session force-flushes on the unknown baseline and
-  *closes* the window), one to re-open it, and the one that must be coalesced.
+  suite besides. The gap shrink remains the coalescing guard for gaps. The current coverage
+  decision table and its bidirectional tests are owned by
+  [#1138 §5](2026-07-28-coverage-persistence-cost-design.md#5-tests).
 
 ### 5.6 `stores/shared/durableMapPersist.test.ts`
 
@@ -664,9 +627,9 @@ The store suites prove the funnels are wired and the end-to-end durability prope
 cheaply reach every row of §4.2's table, and they do not reach the module's two documented baseline
 invariants at all. Direct tests over `scheduleDurableMaps`:
 
-- the full decision table — gap added → flush; gap `start` or `startId` advance → flush; gap
-  end-only shrink/close/removal → throttle; coverage added / `bottomId` changed / removed → flush;
-  `topId`-only → throttle;
+- the gap decision table — gap added → flush; gap `start` or `startId` advance → flush; gap
+  end-only shrink/close/removal → throttle. The superseding coverage decision table and tests are
+  owned by [#1138 §5](2026-07-28-coverage-persistence-cost-design.md#5-tests);
 - **A → B → A:** the baseline advances on *throttled* writes too, so a there-and-back gap still
   force-flushes. Frozen-baseline mutant → red;
 - `cancelDurableMaps` drops the baseline (observed through whether the following write was coalesced,

--- a/docs/superpowers/specs/2026-07-24-throttled-persist-design.md
+++ b/docs/superpowers/specs/2026-07-24-throttled-persist-design.md
@@ -440,6 +440,15 @@ monotone advances:
 | coverage | key **added**, `bottomId` **changed**, key **removed** | force-flush |
 | coverage | `topId`-only change (re-entry marker) | throttle |
 
+> **The coverage rows above are SUPERSEDED by
+> [#1138](2026-07-28-coverage-persistence-cost-design.md).** The "measured follow-up" at the end of
+> this section turned out to understate the problem: measurement showed the conservative
+> `bottomId`-changed rule cost the *entire* benefit of the throttle on a first session — 400 writes
+> and 88.9 MB on the reference profile, identical to the pre-throttle baseline. `created` and
+> `deepened` are now throttled, signalled by `CoverageTransition` out of
+> `syncCoverageAfterArchiveMerge`; only `replaced` and removal still force a flush. **The gap rows
+> are unchanged.** See that document for the current decision table.
+
 **Why the gap rule keys on the lower BOUNDARY, not just the key.** Key-presence alone does not catch
 an in-place interval **advance** — the same id's gap moving from `{ start: 1000 }` to
 `{ start: 99000 }`, which is the *normal* shape of a multi-page forward catch-up, where each
@@ -523,6 +532,12 @@ empty and this path never runs. That is a limitation of the test, not evidence o
 thunk but leaves the timer ARMED would remove multiplier (3) for free. It is a semantic change to a
 shared primitive — `recordPendingRetraction` uses `flushKey` too, and it wants the window closed — so
 it needs its own change with its own tests, not a rider on this one.
+
+> Measured in [#1138](2026-07-28-coverage-persistence-cost-design.md) §3.2 and **not taken**: it can
+> only recover the window-closing half of a structural write, so on an all-structural workload it
+> saves nothing, and on a gap-heavy mixed one about 2×. Sources (1) and (2) were removed instead, by
+> throttling `created` and `deepened`. The bounding scenario stays in the benchmark for whoever picks
+> it up.
 
 Ordinary termination — tab close, app quit, mobile backgrounding — loses nothing, provided §4.1
 lands.

--- a/docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md
+++ b/docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md
@@ -1,0 +1,248 @@
+# Coverage persistence cost — measurement and decision (#1138)
+
+Follow-up to [#1133](2026-07-24-throttled-persist-design.md), which added a per-key
+leading+trailing persistence throttle and force-flushed every structural gap and coverage
+transition. Its §4.2 flagged the coverage half as *deliberately conservative* and deferred the
+measurement here.
+
+**Result: the conservatism cost the entire benefit of the throttle on a first session.** On the
+reference 400-conversation profile, the shipped implementation wrote exactly as many times, and
+serialized exactly as many bytes, as the pre-#1133 write-on-every-mutation code it replaced.
+
+---
+
+## 1. Method
+
+Two harnesses, both driving the **real** stores through their real persistence funnels.
+
+### 1.1 `packages/fluux-sdk/bench/persistCost.bench.ts` — write counts
+
+```bash
+npm run bench:persist -w @fluux/sdk
+```
+
+Counts `JSON.stringify` calls, `localStorage.setItem` calls, bytes and CPU per storage key, under a
+counting object mock. Results land in `bench/results/persistCost.json`.
+
+Five variants, all exercising the same store code so the comparison isolates the persistence rule:
+
+| Variant | What it is |
+|---|---|
+| `legacy` | pre-#1133 — `schedule` made to write through, which is byte-for-byte what the replaced call sites did |
+| `merged` | #1133 as shipped — every coverage `bottomId` change force-flushes, re-created over the shipped primitives |
+| `coverageThrottled` | the **ceiling** for candidate 2: coverage dropped from structural detection entirely. Not shippable — it loses replacement durability — but it bounds the achievable win |
+| `allThrottled` | pure throttle, no structural detection at all. Bounds **candidate 1**, which can only ever recover the window-closing part of a structural write, never the write itself |
+| `optimized` | what this change ships |
+
+Wall clock is simulated with fake timers (the throttle window is a `setTimeout`), `performance` is
+left real. Real catch-up is paced by MAM round-trips at `concurrency = 2`
+(`MAM.catchUpAllConversations`), so **inter-merge spacing** is the axis that matters and every
+scenario runs at 0 / 25 / 100 ms — 25 ms ≈ a 50 ms RTT, 100 ms ≈ a 200 ms mobile RTT.
+
+Checking out the parent commit was rejected as the baseline: it would vary the store as well as the
+persistence rule, which is not the comparison the issue asks for.
+
+### 1.2 `packages/fluux-sdk/bench/browser/` — main-thread blocking
+
+```bash
+npm run bench:persist:browser -w @fluux/sdk
+```
+
+Vite + Playwright, driving the same store in **Chromium and WebKit** against each engine's real
+`localStorage`, where `setItem` is a synchronous disk write. WebKit is the engine behind the
+iOS/macOS WebView and the Linux WebKitGTK build.
+
+Both rules run in-page over identical mutations: `rule1133` is re-created by reporting an
+invalidation for every changed `bottomId` (exactly what that version force-flushed on), `rule1138`
+is the code as it now stands.
+
+`blockedMs` sums per-mutation deltas, which **WebKit quantizes to 1 ms** — at 400 samples that is
+enough rounding noise to swamp the quantity. The comparable figure is `probedMs`: a 50-write batch
+timed as one block gives a per-write cost above the quantum, multiplied by the writes each rule
+actually performed.
+
+---
+
+## 2. Results
+
+Reference profile: 400 conversations, each with a full `lastMessage` in `conversationMeta` —
+a **238 KB** chat blob. Rooms carry coverage in their own small key (~12 KB), which is the storage
+shape difference the issue asks about.
+
+### 2.1 Writes and bytes (25 ms spacing)
+
+| Scenario | legacy | merged (#1133) | ceiling | **optimized** |
+|---|---|---|---|---|
+| S1 cold coverage bootstrap, chat | 400 / 88.9 MB | **400 / 88.9 MB** | 11 / 2.4 MB | **11 / 2.4 MB** |
+| S2 warm session, chat | 400 / 92.3 MB | 11 / 2.5 MB | 11 / 2.5 MB | 11 / 2.5 MB |
+| S3 Phase B stitch (50 × 10 pages), chat | 500 / 115.5 MB | **500 / 115.5 MB** | 14 / 3.2 MB | **14 / 3.2 MB** |
+| S4 forward catch-up churn (180 mutations) | 180 / 41.6 MB | 21 / 4.9 MB | 21 / 4.9 MB | 21 / 4.9 MB |
+| S5a cold coverage bootstrap, rooms | 400 / 4.90 MB | 400 / 4.90 MB | 11 / 0.13 MB | 12 / 0.14 MB |
+| S5b Phase B stitch, rooms | 500 / 11.2 MB | 500 / 11.2 MB | 14 / 0.31 MB | 15 / 0.34 MB |
+| S6 gapped forward catch-up (10 × 3 pages) | 30 / 6.4 MB | 30 / 6.4 MB | 30 / 6.4 MB | **30 / 6.4 MB** |
+
+The three findings:
+
+1. **On the cold path #1133 was worth nothing.** S1 and S3 are identical for `legacy` and `merged`.
+   Every merge created or advanced a record, every one force-flushed, and `flushKey` closes the
+   window — so every mutation took a fresh leading edge, which is precisely the pre-throttle
+   behaviour.
+2. **The throttle was already working everywhere else.** S2 (warm) and S4 (the original
+   180-mutation workload) show `merged` at the ceiling. Nothing in this change touches them.
+3. **S6 is unchanged by design.** Gap formation and boundary advance stay force-flushed;
+   `optimized` matches `merged` exactly.
+
+The room numbers make the shape difference concrete: the same 400 forced writes cost 4.9 MB against
+a dedicated key versus 88.9 MB against the chat blob. Frequency was always the problem, not record
+size — as #1133's own §4.2 said. `optimized` is one write above the ceiling for rooms: the first
+coverage write of a session has no baseline, cannot rule out a removal, and force-flushes. One small
+write, deliberately kept.
+
+### 2.2 Main-thread blocking, real engines
+
+Per-write cost measured on this machine (Apple silicon, 238 KB blob): **Chromium 1.09 ms,
+WebKit 0.86 ms**. That figure moves with machine load across runs (observed 0.8–1.3 ms); the
+**write counts and bytes are exact and run-invariant**, so the ratio is the stable quantity and the
+absolute milliseconds are the order of magnitude.
+
+| Engine | Scenario | writes | MB | probedMs | blockedMs |
+|---|---|---|---|---|---|
+| Chromium | bootstrap / #1133 | 400 | 88.9 | 437.6 | 1033.5 |
+| Chromium | bootstrap / **#1138** | **12** | **2.7** | **13.1** | **53.9** |
+| Chromium | stitch / #1133 | 500 | 115.5 | 547.0 | 1349.3 |
+| Chromium | stitch / **#1138** | **14** | **3.2** | **15.3** | **68.2** |
+| WebKit | bootstrap / #1133 | 400 | 88.9 | 344.0 | 860.0 |
+| WebKit | bootstrap / **#1138** | **13** | **2.9** | **11.2** | **40.0** |
+| WebKit | stitch / #1133 | 500 | 115.5 | 430.0 | 1119.0 |
+| WebKit | stitch / **#1138** | **15** | **3.5** | **12.9** | **65.0** |
+
+**~0.8 s of main-thread time removed from the launch window** on desktop-class hardware
+(bootstrap + stitch, either engine), along with ~200 MB of serialization.
+
+No single mutation exceeded 50 ms in any run — the worst was ~6 ms. This was never one long task;
+it is 900 chunks of 1–6 ms spread across the launch window, competing with first paint, stanza
+parsing and IndexedDB commits. On phone-class hardware the per-write cost is several times higher.
+
+---
+
+## 3. Decision
+
+**GO on candidate 2** (thread explicit transition semantics out of the merge functions).
+**NO-GO on candidate 1** (a `flushKey` variant that leaves the timer armed), for now.
+
+### 3.1 Why candidate 2
+
+The measured win is the whole first-session cost, and it is available without weakening any
+durability guarantee — because the transition that must survive a hard kill is a strict subset of
+what #1133 force-flushed, and the subset is decidable at the merge.
+
+### 3.2 Why not candidate 1
+
+Candidate 1 can only recover the *window-closing* half of a structural write, never the forced write
+itself. Measured with `allThrottled` as its lower bound:
+
+| Scenario (25 ms) | merged | candidate-1 lower bound (`allThrottled`) |
+|---|---|---|
+| S6 gapped forward catch-up — every write structural | 30 | 2 |
+| S7 gap transitions interleaved with 5× ordinary churn | 61 | 6 |
+
+S6 is the honest reading: when every mutation is structural — which is the shape of a multi-page
+gapped catch-up — candidate 1 saves **nothing**, because each forced write must still happen. Its
+entire value is S7's mixed shape, where it would coalesce the ordinary writes that currently take a
+fresh leading edge behind each flush: roughly 61 → ~31, a 2× improvement on a gap-heavy workload.
+
+Real, but an order of magnitude smaller than candidate 2's 36×, on a workload that is not the
+cold-start profile this issue is about — and it is a semantic change to a primitive that
+`recordPendingRetraction` also uses and that *wants* the window closed. #1133 said it "needs its own
+change with its own tests, not a rider on this one"; that still holds. The scenario, the bound and
+the harness are committed, so it can be picked up on its own evidence.
+
+After this change the remaining force-flush paths are gap formation/boundary advance (≤ 3 per
+gapped entity per catch-up), coverage replacement and removal (both rare), and one write per key per
+session for the unknown baseline. There is not much left for candidate 1 to multiply.
+
+---
+
+## 4. Design
+
+### 4.1 The classification has to come from the merge
+
+The unsafe transition is *an existing record being overwritten by a walk that did not prove
+contiguity with it* — `syncCoverageAfterArchiveMerge`'s fetch-latest branch with `sawCoverageTop`
+false and a record present. Every other `bottomId` change errs **shallow** when lost:
+
+| Transition | Loss on a hard kill | Treatment |
+|---|---|---|
+| `created` | disk holds NO record. The next session re-seeds from the local downloaded edge, which is shallower. **Asserts nothing** | throttle |
+| `deepened` | disk holds the shallower previous bottom, which is still true. Phase B re-walks covered ground | throttle |
+| `topRefreshed` | stale re-entry marker; one extra walked page | throttle |
+| `replaced` | **disk keeps the record whose contiguity this walk disproved, and Phase B seeds its backward walk from it — skipping the disconnected interval** | **force-flush** |
+| removal | same class as `replaced` | **force-flush** |
+
+`durableMapPersist` cannot derive this: archive ids are non-sequential (`mamGap`), so no comparison
+of two `bottomId`s can tell a deepening from a replacement. That is exactly why #1133 was
+conservative, and the fix is not a cleverer comparison — it is to ask the one function that knows.
+
+### 4.2 Shape
+
+- `syncCoverageAfterArchiveMerge` returns `{ coverage, transition }` instead of the bare map.
+  One funnel, so the classification cannot drift from the transition it describes.
+- `durableMapPersist` gains `noteCoverageTransition(key, id, transition)`. Callers report
+  **unconditionally**; the policy of which transitions are unsafe lives in the durability layer, not
+  as an `=== 'replaced'` literal repeated at three call sites where a fourth unsafe transition would
+  mean remembering all of them.
+- Coverage **removal stays derived** from the baseline, so `clearConversationCoverage`,
+  `clearRoomCoverage`, `deleteConversation` and `removeRoom` need no changes at all.
+- The baseline now stores the coverage **id set** rather than id → `bottomId`. Keeping the values
+  would invite a future reader to resurrect the comparison this change measured out.
+
+### 4.3 Where the report is made
+
+Both stores report where the value actually **enters the state**, not where it is computed. On the
+deferred path — a transition gated behind the IndexedDB commit (`mustGateOnChain`) — reporting at
+merge time would arm the flush for a write that still carries the *old* record and leave the real one
+throttled. `chatStore` reports in the non-deferred branch and again inside `scheduleDeferredCommit`;
+`roomStore` passes it through `saveCoverageToStorage` at both sites.
+
+A signal that somehow found no write to attach to forces one extra flush on the following write,
+never skips one.
+
+---
+
+## 5. Tests
+
+Every row of the table is pinned in both directions, because a mutant that force-flushes everything
+is perfectly durable and silently undoes the optimization, while a mutant that force-flushes nothing
+passes every write-count assertion. Neither is sufficient alone.
+
+- `mamCoverage.test.ts` — every branch's reported transition, `none` included.
+- `durableMapPersist.test.ts` — the decision table (`created` / `deepened` / `topRefreshed`
+  throttled; signalled `replaced` and derived removal flushed), plus the signal's lifecycle:
+  consumed by exactly one write, effective even when the write omits the coverage map, dropped by
+  `cancelDurableMaps` and `forgetAllDurableMapBaselines`.
+- `chatStore.persist.test.ts` / `roomStore.throttledPersist.test.ts` — the same properties driven
+  through real store actions, since module tests cannot see whether the funnels are wired.
+
+**Control runs, both directions** (§5.5 of #1133's spec — hollow tests are this repo's recurring
+defect):
+
+| Mutation | Tests that went red |
+|---|---|
+| `noteCoverageTransition` made a no-op | 5 — the module's replacement + signal-lifecycle rows, **and both stores' end-to-end `persists a coverage REPLACEMENT that was coalesced into an open window`** |
+| force-flush restored on every coverage write (#1133's rule) | 6 — `coverage key ADDED stays throttled`, `bottomId DEEPENED stays throttled`, `topId-only stays throttled`, `is consumed by exactly one write`, and both stores' new `coalesces …` tests |
+
+The clear-path signal tests write an **empty** coverage map on purpose. Dropping the baseline makes
+the next non-empty write structural on its own, which would mask a leaked signal entirely — §5.5's
+"a test cannot cover a guard a preceding guard renders unreachable". With an empty map the unknown
+baseline is quiet, so the only thing that can force a flush is a signal that outlived the clear.
+
+---
+
+## 6. What did not change
+
+- Hard-kill durability of gap formation and `start` / `startId` boundary advances (S6 identical).
+- Hard-kill durability of coverage replacement and removal.
+- Synchronous durability of pending retractions — `flushKey` and its window-closing semantics are
+  untouched, which is also why candidate 1 stays out of this change.
+- Account-switch flushing, cancel-before-remove, Tauri's synchronous shutdown flush, lazy
+  serialization, per-key throttle isolation.

--- a/packages/fluux-sdk/bench/README.md
+++ b/packages/fluux-sdk/bench/README.md
@@ -1,0 +1,20 @@
+# Persistence cost benchmark (#1138)
+
+Measures what the store persistence layer actually costs on a cold start, so a change to the
+throttle/force-flush rules can be argued from numbers rather than from reasoning about the rules.
+
+```bash
+npm run bench:persist -w @fluux/sdk          # write counts, bytes, CPU (vitest, in-memory)
+npm run bench:persist:browser -w @fluux/sdk  # main-thread blocking (Chromium + WebKit, real localStorage)
+```
+
+Results land in `bench/results/`. The full method, the variant definitions and the decision they
+supported are in
+[docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md](../../../docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md).
+
+Both harnesses drive the **real** stores. Historical implementations are re-created over the shipped
+primitives rather than checked out, so every variant exercises the same store code and the only
+thing varying is the persistence rule.
+
+Not part of `npm test` — it is a measurement, not an assertion, and it takes far longer than a unit
+test. It IS typechecked by `npm run typecheck -w @fluux/sdk`, so it cannot rot silently.

--- a/packages/fluux-sdk/bench/browser/index.html
+++ b/packages/fluux-sdk/bench/browser/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Fluux persistence cost — browser bench (#1138)</title>
+  </head>
+  <body>
+    <pre id="out">loading…</pre>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/fluux-sdk/bench/browser/main.ts
+++ b/packages/fluux-sdk/bench/browser/main.ts
@@ -1,0 +1,271 @@
+/**
+ * Browser half of the persistence cost benchmark (issue #1138).
+ *
+ * The vitest harness measures WRITE COUNTS against an in-memory store — a
+ * floor. This page runs the same store code against a real engine's real
+ * `localStorage`, where `setItem` is a synchronous disk write, and reports the
+ * main-thread block that produces.
+ *
+ * Each scenario is run under both persistence rules over the SAME 400 merges and
+ * the SAME blob, so the pair is a faithful A/B using nothing but production code
+ * paths:
+ *
+ * - `rule1133` re-creates the shipped-in-#1133 rule by signalling an
+ *   invalidation for EVERY `bottomId` that changed, which is exactly what that
+ *   version force-flushed on.
+ * - `rule1138` is the code as it now stands.
+ *
+ * - `bootstrap` — no coverage records: every merge creates one.
+ * - `stitch`    — the Phase B read-pointer walk, `bottomId` advancing id-exactly
+ *   on each of 10 pages per entity.
+ */
+
+import { chatStore } from '../../src/stores/chatStore'
+import { flush, _resetForTesting } from '../../src/stores/shared/throttledStorage'
+import { forgetAllDurableMapBaselines, noteCoverageTransition } from '../../src/stores/shared/durableMapPersist'
+import type { Message } from '../../src/core/types'
+import type { CoverageRecord } from '../../src/stores/shared/mamCoverage'
+
+const CONVERSATIONS = 400
+const STITCH_ENTITIES = 50
+const STITCH_PAGES = 10
+const CHAT_KEY = 'xmpp-chat-storage'
+
+function jid(i: number): string {
+  return `contact${i}@example.com`
+}
+
+function lastMessage(id: string, i: number): Message {
+  return {
+    type: 'chat',
+    id: `msg-${i}-a1b2c3d4-e5f6-4789-a0b1-c2d3e4f5a6b7`,
+    stanzaId: `arc-${i}-0000000000000000`,
+    originId: `orig-${i}-a1b2c3d4e5f6`,
+    conversationId: id,
+    from: id,
+    body: 'Thanks — I pushed the branch, can you take a look when you get a minute?',
+    timestamp: new Date(1_760_000_000_000 + i * 60_000),
+    isOutgoing: i % 3 === 0,
+  }
+}
+
+function seed(count: number, coverage?: Map<string, CoverageRecord>): void {
+  const entities = new Map<string, unknown>()
+  const meta = new Map<string, unknown>()
+  for (let i = 0; i < count; i++) {
+    const id = jid(i)
+    entities.set(id, { id, name: `Contact Number ${i}`, type: 'chat' })
+    meta.set(id, {
+      unreadCount: i % 7,
+      lastMessage: lastMessage(id, i),
+      historyFloor: new Date(1_750_000_000_000 + i * 1000),
+    })
+  }
+  chatStore.setState({
+    conversationEntities: entities as never,
+    conversationMeta: meta as never,
+    conversationCoverage: (coverage ?? new Map()) as never,
+  })
+}
+
+function bootstrapCoverage(count: number): Map<string, CoverageRecord> {
+  const map = new Map<string, CoverageRecord>()
+  for (let i = 0; i < count; i++) map.set(jid(i), { bottomId: `boot-${i}` })
+  return map
+}
+
+// --- instrumentation -------------------------------------------------------
+
+interface Counters {
+  writes: number
+  bytes: number
+  /** Time inside `setItem` alone — the engine's synchronous disk write. */
+  setItemMs: number
+  maxSetItemMs: number
+}
+
+let counters: Counters = { writes: 0, bytes: 0, setItemMs: 0, maxSetItemMs: 0 }
+let recording = false
+
+const nativeSetItem = Storage.prototype.setItem
+Storage.prototype.setItem = function patched(this: Storage, key: string, value: string): void {
+  if (!recording || key !== CHAT_KEY) return nativeSetItem.call(this, key, value)
+  const t0 = performance.now()
+  nativeSetItem.call(this, key, value)
+  const dt = performance.now() - t0
+  counters.writes += 1
+  counters.bytes += value.length
+  counters.setItemMs += dt
+  if (dt > counters.maxSetItemMs) counters.maxSetItemMs = dt
+}
+
+export interface Result {
+  scenario: string
+  mutations: number
+  writes: number
+  bytes: number
+  blobBytes: number
+  /** Sum of every mutation's synchronous duration — total main-thread block. */
+  blockedMs: number
+  /** Worst single mutation. */
+  maxMutationMs: number
+  /** Mutations that blocked the main thread for >50 ms (the long-task bar). */
+  longTasks: number
+  setItemMs: number
+  maxSetItemMs: number
+  wallMs: number
+}
+
+/** Run `mutate(i)` `count` times, timing each synchronous mutation. */
+function drive(scenario: string, count: number, spacingMs: number, mutate: (i: number) => void): Promise<Result> {
+  return new Promise((resolve) => {
+    counters = { writes: 0, bytes: 0, setItemMs: 0, maxSetItemMs: 0 }
+    recording = true
+    let blockedMs = 0
+    let maxMutationMs = 0
+    let longTasks = 0
+    const wall0 = performance.now()
+    let i = 0
+
+    const step = (): void => {
+      const t0 = performance.now()
+      mutate(i)
+      const dt = performance.now() - t0
+      blockedMs += dt
+      if (dt > maxMutationMs) maxMutationMs = dt
+      if (dt > 50) longTasks += 1
+      i += 1
+      if (i < count) {
+        // A real timeout, so the throttle's 1 s window advances with real time.
+        setTimeout(step, spacingMs)
+        return
+      }
+      flush()
+      const wallMs = performance.now() - wall0
+      recording = false
+      resolve({
+        scenario,
+        mutations: count,
+        writes: counters.writes,
+        bytes: counters.bytes,
+        blobBytes: localStorage.getItem(CHAT_KEY)?.length ?? 0,
+        blockedMs: Number(blockedMs.toFixed(1)),
+        maxMutationMs: Number(maxMutationMs.toFixed(2)),
+        longTasks,
+        setItemMs: Number(counters.setItemMs.toFixed(1)),
+        maxSetItemMs: Number(counters.maxSetItemMs.toFixed(2)),
+        wallMs: Number(wallMs.toFixed(1)),
+      })
+    }
+    step()
+  })
+}
+
+function resetWorld(): void {
+  _resetForTesting()
+  chatStore.getState().reset()
+  _resetForTesting()
+  forgetAllDurableMapBaselines()
+  localStorage.clear()
+}
+
+type Rule = 'rule1133' | 'rule1138'
+
+/**
+ * #1133's rule, re-created over the shipped primitives: signal an invalidation
+ * for every `bottomId` that differs from the previous merge, which is precisely
+ * what that version force-flushed on. Called BEFORE the mutation, so the signal
+ * is armed for the write the mutation triggers.
+ */
+function applyRule1133(id: string, nextBottomId: string, seen: Map<string, string>): void {
+  if (seen.get(id) === nextBottomId) return
+  seen.set(id, nextBottomId)
+  noteCoverageTransition(CHAT_KEY, id, 'replaced')
+}
+
+async function bootstrapScenario(rule: Rule, spacingMs: number): Promise<Result> {
+  resetWorld()
+  seed(CONVERSATIONS)
+  flush() // baseline write is setup, not workload
+  const seen = new Map<string, string>()
+  return drive(`bootstrap/${rule}`, CONVERSATIONS, spacingMs, (i) => {
+    const cursor = `arc-${i}-cursor`
+    if (rule === 'rule1133') applyRule1133(jid(i), cursor, seen)
+    chatStore.getState().mergeMAMMessages(
+      jid(i), [], {}, true, 'forward', false, false, { initialAfter: cursor },
+    )
+  })
+}
+
+async function stitchScenario(rule: Rule, spacingMs: number): Promise<Result> {
+  resetWorld()
+  seed(CONVERSATIONS, bootstrapCoverage(CONVERSATIONS))
+  flush()
+  const bottoms = new Map<string, string>()
+  for (let i = 0; i < STITCH_ENTITIES; i++) bottoms.set(jid(i), `boot-${i}`)
+  const seen = new Map<string, string>()
+  return drive(`stitch/${rule}`, STITCH_ENTITIES * STITCH_PAGES, spacingMs, (n) => {
+    const i = n % STITCH_ENTITIES
+    const page = Math.floor(n / STITCH_ENTITIES)
+    const id = jid(i)
+    const from = bottoms.get(id)!
+    const to = `deep-${i}-${page}`
+    if (rule === 'rule1133') applyRule1133(id, to, seen)
+    chatStore.getState().mergeMAMMessages(
+      id, [], { first: to }, false, 'backward', false, false, { initialBefore: from },
+    )
+    bottoms.set(id, to)
+  })
+}
+
+/**
+ * Per-write cost, measured as ONE timed batch.
+ *
+ * The per-mutation timings above are summed from 400–500 individual
+ * `performance.now()` deltas, and WebKit quantizes that clock to 1 ms — enough
+ * rounding noise, at 400 samples, to swamp the quantity being measured. Timing
+ * `BATCH` serializations + writes as a single block puts the measurement far
+ * above the quantum, so `perWriteMs × writes` is the figure to compare engines
+ * on; `blockedMs` above stays useful for Chromium and as a shape check.
+ */
+function writeCostProbe(): { perWriteMs: number; batchMs: number; bytes: number } {
+  const BATCH = 50
+  const state = chatStore.getState()
+  const payload = { state: { conversationEntities: Array.from(state.conversationEntities.entries()), conversationMeta: Array.from(state.conversationMeta.entries()) } }
+  const wasRecording = recording
+  recording = false
+  const t0 = performance.now()
+  let bytes = 0
+  for (let i = 0; i < BATCH; i++) {
+    const json = JSON.stringify(payload)
+    bytes += json.length
+    localStorage.setItem('bench-probe', json)
+  }
+  const batchMs = performance.now() - t0
+  recording = wasRecording
+  localStorage.removeItem('bench-probe')
+  return { perWriteMs: Number((batchMs / BATCH).toFixed(3)), batchMs: Number(batchMs.toFixed(1)), bytes: Math.round(bytes / BATCH) }
+}
+
+declare global {
+  interface Window {
+    runBench: (spacingMs: number) => Promise<Result[] | { rows: Result[]; probe: ReturnType<typeof writeCostProbe> }>
+  }
+}
+
+window.runBench = async (spacingMs: number) => {
+  const rows: Result[] = []
+  for (const rule of ['rule1133', 'rule1138'] as Rule[]) {
+    rows.push(await bootstrapScenario(rule, spacingMs))
+    rows.push(await stitchScenario(rule, spacingMs))
+  }
+  resetWorld()
+  seed(CONVERSATIONS)
+  const probe = writeCostProbe()
+  const out = document.getElementById('out')
+  if (out) out.textContent = JSON.stringify({ rows, probe }, null, 2)
+  return { rows, probe }
+}
+
+const out = document.getElementById('out')
+if (out) out.textContent = 'ready'

--- a/packages/fluux-sdk/bench/browser/run.mjs
+++ b/packages/fluux-sdk/bench/browser/run.mjs
@@ -1,0 +1,94 @@
+/**
+ * Playwright driver for the browser half of the #1138 persistence benchmark.
+ *
+ * Starts a Vite dev server over `bench/browser`, loads the page in Chromium and
+ * WebKit, and runs every scenario. WebKit is the one that matters: it is the
+ * engine behind the iOS/macOS WebView and the Linux WebKitGTK build, and its
+ * `localStorage.setItem` is a synchronous disk write.
+ *
+ * Run: `npm run bench:persist:browser -w @fluux/sdk`
+ */
+
+import { createServer } from 'vite'
+import { chromium, webkit } from 'playwright'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const SPACING_MS = Number(process.env.BENCH_SPACING_MS ?? 25)
+
+const server = await createServer({
+  root: here,
+  configFile: false,
+  server: { port: 0 },
+  // The bench imports the SDK's own sources, which live above `root`.
+  resolve: { preserveSymlinks: false },
+})
+await server.listen()
+const url = server.resolvedUrls.local[0]
+
+const results = []
+const probes = []
+
+for (const [name, launcher] of [['chromium', chromium], ['webkit', webkit]]) {
+  const browser = await launcher.launch()
+  const page = await browser.newPage()
+  const errors = []
+  page.on('pageerror', (e) => errors.push(String(e)))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(m.text())
+  })
+  await page.goto(url, { waitUntil: 'load' })
+  await page.waitForFunction(() => typeof window.runBench === 'function', null, { timeout: 30_000 })
+  const { rows, probe } = await page.evaluate((spacing) => window.runBench(spacing), SPACING_MS)
+  for (const row of rows) {
+    results.push({
+      engine: name,
+      spacingMs: SPACING_MS,
+      ...row,
+      // Quantization-free total: per-write cost from a timed batch, times the
+      // writes this rule actually performed. See main.ts's writeCostProbe.
+      probedBlockMs: Number((probe.perWriteMs * row.writes).toFixed(1)),
+      perWriteMs: probe.perWriteMs,
+    })
+  }
+  probes.push({ engine: name, ...probe })
+  if (errors.length) {
+    process.stderr.write(`\n[${name}] page errors:\n${errors.join('\n')}\n`)
+  }
+  await browser.close()
+}
+
+await server.close()
+
+const out = resolve(here, '../results/persistCost.browser.json')
+mkdirSync(dirname(out), { recursive: true })
+writeFileSync(out, JSON.stringify(results, null, 2))
+
+const header =
+  `  ${'engine'.padEnd(10)}${'scenario'.padEnd(22)}${'muts'.padStart(6)}${'writes'.padStart(8)}` +
+  `${'MB'.padStart(9)}${'probedMs'.padStart(10)}${'blockedMs'.padStart(11)}` +
+  `${'maxMut'.padStart(9)}${'>50ms'.padStart(7)}`
+const lines = [
+  '',
+  '='.repeat(header.length),
+  `BROWSER PERSISTENCE COST — issue #1138 (spacing ${SPACING_MS}ms, blob ${(results[0]?.blobBytes ?? 0) / 1024 | 0} KB)`,
+  '='.repeat(header.length),
+  `  per-write cost (timed 50-write batch): ${probes.map((p) => `${p.engine} ${p.perWriteMs}ms`).join(', ')}`,
+  '',
+  header,
+]
+for (const r of results) {
+  lines.push(
+    `  ${r.engine.padEnd(10)}${r.scenario.padEnd(22)}${String(r.mutations).padStart(6)}` +
+    `${String(r.writes).padStart(8)}${(r.bytes / 1048576).toFixed(2).padStart(9)}` +
+    `${r.probedBlockMs.toFixed(1).padStart(10)}${r.blockedMs.toFixed(1).padStart(11)}` +
+    `${r.maxMutationMs.toFixed(2).padStart(9)}${String(r.longTasks).padStart(7)}`,
+  )
+}
+lines.push('')
+lines.push('  probedMs = per-write cost x writes (quantization-free; the number to compare)')
+lines.push('  blockedMs = summed per-mutation deltas (Chromium reliable; WebKit quantizes performance.now to 1ms)')
+lines.push('')
+process.stdout.write(`${lines.join('\n')}\n`)

--- a/packages/fluux-sdk/bench/persistCost.bench.ts
+++ b/packages/fluux-sdk/bench/persistCost.bench.ts
@@ -60,6 +60,7 @@ vi.mock('../src/stores/shared/durableMapPersist', async (importOriginal) => {
 
   return {
     ...actual,
+    resetMergedBottomsForBench: () => mergedBottoms.clear(),
     scheduleDurableMaps: (
       key: string,
       maps: { gaps?: ReadonlyMap<string, unknown>; coverage?: ReadonlyMap<string, { bottomId: string }> },
@@ -80,11 +81,11 @@ vi.mock('../src/stores/shared/durableMapPersist', async (importOriginal) => {
         // addition, a monotone deepening or a replacement — the conservatism
         // #1138 measured. Removal and the unknown-baseline case are unchanged
         // between the two rules, so they are left to the production path.
-        const previous = mergedBottoms.get(key)
-        const bottoms = new Map<string, string>()
+        const bottoms = mergedBottoms.get(key) ?? new Map<string, string>()
         for (const [id, record] of maps.coverage) {
+          const previous = bottoms.get(id)
           bottoms.set(id, record.bottomId)
-          if (previous?.get(id) !== record.bottomId) actual.noteCoverageTransition(key, id, 'replaced')
+          if (previous !== record.bottomId) actual.noteCoverageTransition(key, id, 'replaced')
         }
         mergedBottoms.set(key, bottoms)
       }
@@ -96,7 +97,13 @@ vi.mock('../src/stores/shared/durableMapPersist', async (importOriginal) => {
 const { chatStore } = await import('../src/stores/chatStore')
 const { roomStore } = await import('../src/stores/roomStore')
 const { flush, _resetForTesting } = await import('../src/stores/shared/throttledStorage')
-const { forgetAllDurableMapBaselines } = await import('../src/stores/shared/durableMapPersist')
+const {
+  forgetAllDurableMapBaselines,
+  resetMergedBottomsForBench,
+} = await import('../src/stores/shared/durableMapPersist') as
+  typeof import('../src/stores/shared/durableMapPersist') & {
+    resetMergedBottomsForBench: () => void
+  }
 const { _resetStorageScopeForTesting } = await import('../src/utils/storageScope')
 const { _clearAllRoomReadStateForTesting } = await import('../src/stores/shared/readStateStorage')
 const { createRoom } = await import('../src/stores/roomStore.testHelpers')
@@ -433,6 +440,7 @@ function resetWorld(): void {
   roomStore.getState().reset()
   _resetForTesting()
   forgetAllDurableMapBaselines()
+  resetMergedBottomsForBench()
   countingStorage.reset()
 }
 

--- a/packages/fluux-sdk/bench/persistCost.bench.ts
+++ b/packages/fluux-sdk/bench/persistCost.bench.ts
@@ -1,0 +1,519 @@
+/**
+ * Persistence cost benchmark for issue #1138.
+ *
+ * Drives the REAL stores through their real persistence funnels, under a
+ * counting `localStorage`, and reports the metrics the issue asks for:
+ * `JSON.stringify` calls, `setItem` calls, bytes written, CPU time.
+ *
+ * ## What is simulated, and what is not
+ *
+ * - The stores, the persist adapters, `throttledStorage` and
+ *   `durableMapPersist` are the production modules.
+ * - The pre-#1133 baseline (`legacy`) is SIMULATED by making `schedule`
+ *   write through. That is byte-for-byte what the replaced call sites did:
+ *   `localStorage.setItem(key, serialize(...))` on every mutation. Checking
+ *   out the parent commit would measure a different store as well as a
+ *   different persistence layer, which is not the comparison the issue wants.
+ * - `coverageThrottled` is not a shippable rule. It drops coverage from
+ *   structural detection entirely, so it measures the CEILING of any
+ *   coverage-transition refinement — the number candidate 2 can approach but
+ *   never beat.
+ * - Wall clock is simulated with fake timers, because the throttle window is a
+ *   `setTimeout`. Real catch-up is paced by MAM round-trips at
+ *   `concurrency = 2` (`MAM.catchUpAllConversations`), so the interesting axis
+ *   is inter-merge SPACING, and each scenario is run at several spacings.
+ *   `cpuMs` is real: `performance` is deliberately left unfaked.
+ *
+ * Run: `npm run bench:persist -w @fluux/sdk`
+ */
+
+import { describe, it, beforeEach, afterEach } from 'vitest'
+import {
+  installStorage, countingStorage, measure, setVariant,
+  type Metrics, type Variant,
+} from './persistCost.harness'
+import { vi } from 'vitest'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+installStorage()
+
+vi.mock('../src/stores/shared/throttledStorage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/stores/shared/throttledStorage')>()
+  const { getVariant: variant, legacyWrite: writeThrough } = await import('./persistCost.harness')
+  return {
+    ...actual,
+    schedule: (key: string, produce: () => string) => {
+      if (variant() === 'legacy') return writeThrough(key, produce)
+      return actual.schedule(key, produce)
+    },
+  }
+})
+
+vi.mock('../src/stores/shared/durableMapPersist', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/stores/shared/durableMapPersist')>()
+  const { getVariant: variant } = await import('./persistCost.harness')
+
+  /** `merged`'s own baseline: id → `bottomId` at that variant's previous write. */
+  const mergedBottoms = new Map<string, Map<string, string>>()
+
+  return {
+    ...actual,
+    scheduleDurableMaps: (
+      key: string,
+      maps: { gaps?: ReadonlyMap<string, unknown>; coverage?: ReadonlyMap<string, { bottomId: string }> },
+      produce: () => string,
+    ) => {
+      const v = variant()
+      // The ceiling models: coverage (candidate 2), or nothing at all
+      // (the pure-throttle floor that bounds candidate 1).
+      if (v === 'coverageThrottled') {
+        return actual.scheduleDurableMaps(key, { gaps: maps.gaps } as never, produce)
+      }
+      if (v === 'allThrottled') {
+        return actual.scheduleDurableMaps(key, {} as never, produce)
+      }
+      if (v === 'merged' && maps.coverage) {
+        // #1133's rule, re-created over the shipped primitives: EVERY `bottomId`
+        // that differs from the previous write force-flushes, whether it is an
+        // addition, a monotone deepening or a replacement — the conservatism
+        // #1138 measured. Removal and the unknown-baseline case are unchanged
+        // between the two rules, so they are left to the production path.
+        const previous = mergedBottoms.get(key)
+        const bottoms = new Map<string, string>()
+        for (const [id, record] of maps.coverage) {
+          bottoms.set(id, record.bottomId)
+          if (previous?.get(id) !== record.bottomId) actual.noteCoverageTransition(key, id, 'replaced')
+        }
+        mergedBottoms.set(key, bottoms)
+      }
+      return actual.scheduleDurableMaps(key, maps as never, produce)
+    },
+  }
+})
+
+const { chatStore } = await import('../src/stores/chatStore')
+const { roomStore } = await import('../src/stores/roomStore')
+const { flush, _resetForTesting } = await import('../src/stores/shared/throttledStorage')
+const { forgetAllDurableMapBaselines } = await import('../src/stores/shared/durableMapPersist')
+const { _resetStorageScopeForTesting } = await import('../src/utils/storageScope')
+const { _clearAllRoomReadStateForTesting } = await import('../src/stores/shared/readStateStorage')
+const { createRoom } = await import('../src/stores/roomStore.testHelpers')
+
+type Message = import('../src/core/types').Message
+type CoverageRecord = import('../src/stores/shared/mamCoverage').CoverageRecord
+
+const CHAT_KEY = 'xmpp-chat-storage'
+const ROOM_COVERAGE_KEY = 'fluux-room-coverage'
+
+/** The issue's profile size. */
+const CONVERSATIONS = 400
+/** `MAM_POINTER_STITCH_MAX_PAGES`. */
+const STITCH_PAGES = 10
+/** Entities that still owe a read pointer on a cold start and so run Phase B. */
+const STITCH_ENTITIES = 50
+/**
+ * Inter-merge spacing, ms. Catch-up runs at concurrency 2, so this is
+ * (server RTT / 2). 0 brackets an impossibly fast local server; 100 is a
+ * ~200 ms RTT, which is a realistic mobile figure.
+ */
+const SPACINGS = [0, 25, 100]
+
+const VARIANTS: Variant[] = ['legacy', 'merged', 'coverageThrottled', 'allThrottled', 'optimized']
+
+function jid(i: number): string {
+  return `contact${i}@example.com`
+}
+
+function roomJid(i: number): string {
+  return `room${i}@conference.example.com`
+}
+
+/**
+ * A representative last message — the field that dominates blob size, since
+ * `conversationMeta` carries a whole `Message` per conversation.
+ */
+function lastMessage(id: string, i: number): Message {
+  return {
+    type: 'chat',
+    id: `msg-${i}-a1b2c3d4-e5f6-4789-a0b1-c2d3e4f5a6b7`,
+    stanzaId: `arc-${i}-0000000000000000`,
+    originId: `orig-${i}-a1b2c3d4e5f6`,
+    conversationId: id,
+    from: id,
+    body: 'Thanks — I pushed the branch, can you take a look when you get a minute?',
+    timestamp: new Date(1_760_000_000_000 + i * 60_000),
+    isOutgoing: i % 3 === 0,
+  }
+}
+
+/**
+ * Seed a profile directly through `setState`.
+ *
+ * Setup fidelity here only has to produce a representative BLOB; driving 400
+ * `addConversation` calls would measure the seeding, not the workload. Both
+ * `conversationEntities` and `conversationMeta` are written — a fixture with
+ * only one of them silently produces an unrepresentative blob.
+ */
+function seedChatProfile(count: number, coverage?: Map<string, CoverageRecord>): void {
+  const entities = new Map<string, { id: string; name: string; type: 'chat' }>()
+  const meta = new Map<string, { unreadCount: number; lastMessage: Message; historyFloor: Date }>()
+  for (let i = 0; i < count; i++) {
+    const id = jid(i)
+    entities.set(id, { id, name: `Contact Number ${i}`, type: 'chat' })
+    meta.set(id, {
+      unreadCount: i % 7,
+      lastMessage: lastMessage(id, i),
+      historyFloor: new Date(1_750_000_000_000 + i * 1000),
+    })
+  }
+  chatStore.setState({
+    conversationEntities: entities as never,
+    conversationMeta: meta as never,
+    conversationCoverage: coverage ?? new Map(),
+  })
+}
+
+/**
+ * `mergeRoomMAMMessages` no-ops for a room absent from the derived `rooms`
+ * compat map, so rooms are seeded through `addRoom` rather than `setState`.
+ * That also writes the room's own persisted keys — which is why the room
+ * scenarios report per-key numbers for `fluux-room-coverage`.
+ */
+function seedRoomProfile(count: number, coverage?: Map<string, CoverageRecord>): void {
+  for (let i = 0; i < count; i++) {
+    const id = roomJid(i)
+    roomStore.getState().addRoom(createRoom(id, {
+      name: `Room Number ${i}`,
+      joined: true,
+      isBookmarked: true,
+      subject: 'Weekly sync and release coordination',
+      unreadCount: i % 7,
+    }))
+  }
+  if (coverage) roomStore.setState({ roomCoverage: coverage })
+}
+
+function bootstrapCoverage(count: number, prefix: (i: number) => string): Map<string, CoverageRecord> {
+  const map = new Map<string, CoverageRecord>()
+  for (let i = 0; i < count; i++) map.set(prefix(i), { bottomId: `boot-${i}` })
+  return map
+}
+
+/** A page the merge will NOT write to IndexedDB, so transitions apply
+ *  synchronously instead of deferring behind the durable commit. */
+function unstoredPage(id: string, conversationId: string, timestamp: Date): Message[] {
+  return [{
+    type: 'chat', id, conversationId, from: conversationId, body: id, timestamp,
+    isOutgoing: false, noLocalStore: true,
+  } as Message]
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+/**
+ * S1 — cold coverage bootstrap: every conversation completes a forward
+ * catch-up with a resume cursor and no existing record, so
+ * `syncCoverageAfterArchiveMerge`'s bootstrap branch creates one each time.
+ */
+function coldBootstrapChat(spacing: number): void {
+  for (let i = 0; i < CONVERSATIONS; i++) {
+    chatStore.getState().mergeMAMMessages(
+      jid(i), [], {}, true, 'forward', false, false, { initialAfter: `arc-${i}-cursor` },
+    )
+    if (spacing) vi.advanceTimersByTime(spacing)
+  }
+  flush()
+}
+
+/** S2 — warm session: every record already exists, so the bootstrap branch
+ *  returns the same map and only `mamQueryStates` churns. */
+function warmSessionChat(spacing: number): void {
+  coldBootstrapChat(spacing)
+}
+
+/**
+ * S3 — Phase B read-pointer stitch: `STITCH_ENTITIES` entities each walk
+ * `STITCH_PAGES` backward pages, every page advancing `bottomId` through the
+ * plain-backward branch. Interleaved two at a time, matching catch-up's
+ * concurrency.
+ */
+function phaseBStitchChat(spacing: number): void {
+  const bottoms = new Map<string, string>()
+  for (let i = 0; i < STITCH_ENTITIES; i++) bottoms.set(jid(i), `boot-${i}`)
+  for (let page = 0; page < STITCH_PAGES; page++) {
+    for (let i = 0; i < STITCH_ENTITIES; i++) {
+      const id = jid(i)
+      const from = bottoms.get(id)!
+      const to = `deep-${i}-${page}`
+      chatStore.getState().mergeMAMMessages(
+        id, [], { first: to }, false, 'backward', false, false, { initialBefore: from },
+      )
+      bottoms.set(id, to)
+      if (spacing) vi.advanceTimersByTime(spacing)
+    }
+  }
+  flush()
+}
+
+/** S4 — the original 180-mutation forward catch-up workload: pure lagging-mirror
+ *  churn, no structural transition anywhere. */
+function forwardCatchUp180(spacing: number): void {
+  for (let i = 0; i < 180; i++) {
+    chatStore.getState().setMAMLoading(jid(i % CONVERSATIONS), i % 2 === 0)
+    vi.advanceTimersByTime(spacing || 110)
+  }
+  flush()
+}
+
+/** S5a — the same cold bootstrap against roomStore, whose coverage lives in
+ *  its OWN small key rather than inside the big blob. */
+function coldBootstrapRooms(spacing: number): void {
+  for (let i = 0; i < CONVERSATIONS; i++) {
+    roomStore.getState().mergeRoomMAMMessages(
+      roomJid(i), [], {}, true, 'forward', false, false, { initialAfter: `arc-${i}-cursor` },
+    )
+    if (spacing) vi.advanceTimersByTime(spacing)
+  }
+  flush()
+}
+
+/** S5b — Phase B against roomStore. */
+function phaseBStitchRooms(spacing: number): void {
+  const bottoms = new Map<string, string>()
+  for (let i = 0; i < STITCH_ENTITIES; i++) bottoms.set(roomJid(i), `boot-${i}`)
+  for (let page = 0; page < STITCH_PAGES; page++) {
+    for (let i = 0; i < STITCH_ENTITIES; i++) {
+      const id = roomJid(i)
+      const from = bottoms.get(id)!
+      const to = `deep-${i}-${page}`
+      roomStore.getState().mergeRoomMAMMessages(
+        id, [], { first: to }, false, 'backward', false, false, { initialBefore: from },
+      )
+      bottoms.set(id, to)
+      if (spacing) vi.advanceTimersByTime(spacing)
+    }
+  }
+  flush()
+}
+
+/** S6 — multi-page forward catch-up forming and ADVANCING gaps: the one
+ *  structural class #1138 must NOT relax. Included so the report can show it
+ *  is unchanged. */
+function gappedForwardCatchUp(spacing: number): void {
+  const GAPPED = 10
+  for (let page = 0; page < 3; page++) {
+    for (let i = 0; i < GAPPED; i++) {
+      const id = jid(i)
+      chatStore.getState().mergeMAMMessages(
+        id,
+        unstoredPage(`p${page}-${i}`, id, new Date(1_760_000_000_000 + page * 3_600_000)),
+        { last: `arc-${i}-${page}` }, false, 'forward',
+      )
+      if (spacing) vi.advanceTimersByTime(spacing)
+    }
+  }
+  flush()
+}
+
+/**
+ * S7 — the ONE shape candidate 1 targets: structural gap transitions
+ * interleaved with ordinary lagging-mirror churn. Every force-flush closes the
+ * window, so each ordinary mutation that follows one takes a fresh leading edge
+ * instead of coalescing. A `flushKey` that left the timer armed would recover
+ * exactly this delta, and nothing else; `allThrottled` bounds it from below.
+ */
+function mixedGapAndChurn(spacing: number): void {
+  const GAPPED = 10
+  for (let page = 0; page < 3; page++) {
+    for (let i = 0; i < GAPPED; i++) {
+      const id = jid(i)
+      chatStore.getState().mergeMAMMessages(
+        id,
+        unstoredPage(`p${page}-${i}`, id, new Date(1_760_000_000_000 + page * 3_600_000)),
+        { last: `arc-${i}-${page}` }, false, 'forward',
+      )
+      if (spacing) vi.advanceTimersByTime(spacing)
+      // Five ordinary mutations behind every structural one.
+      for (let k = 0; k < 5; k++) {
+        chatStore.getState().setMAMLoading(jid(100 + ((i * 5 + k) % 200)), k % 2 === 0)
+        if (spacing) vi.advanceTimersByTime(spacing)
+      }
+    }
+  }
+  flush()
+}
+
+interface Scenario {
+  name: string
+  /** Fresh state for each variant × spacing run. */
+  setup: () => void
+  run: (spacing: number) => void
+  /** The key whose writes the scenario is about. */
+  key: string
+  spacings?: number[]
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    name: 'S1 cold coverage bootstrap (chat, 400 convs, no records)',
+    setup: () => seedChatProfile(CONVERSATIONS),
+    run: coldBootstrapChat,
+    key: CHAT_KEY,
+  },
+  {
+    name: 'S2 warm session (chat, 400 convs, records present)',
+    setup: () => seedChatProfile(CONVERSATIONS, bootstrapCoverage(CONVERSATIONS, jid)),
+    run: warmSessionChat,
+    key: CHAT_KEY,
+  },
+  {
+    name: `S3 Phase B stitch (chat, ${STITCH_ENTITIES} entities x ${STITCH_PAGES} pages)`,
+    setup: () => seedChatProfile(CONVERSATIONS, bootstrapCoverage(CONVERSATIONS, jid)),
+    run: phaseBStitchChat,
+    key: CHAT_KEY,
+  },
+  {
+    name: 'S4 forward catch-up churn (180 mutations, no structural transition)',
+    setup: () => seedChatProfile(CONVERSATIONS, bootstrapCoverage(CONVERSATIONS, jid)),
+    run: forwardCatchUp180,
+    key: CHAT_KEY,
+    spacings: [110],
+  },
+  {
+    name: 'S5a cold coverage bootstrap (rooms, 400 rooms, own key)',
+    setup: () => seedRoomProfile(CONVERSATIONS),
+    run: coldBootstrapRooms,
+    key: ROOM_COVERAGE_KEY,
+  },
+  {
+    name: `S5b Phase B stitch (rooms, ${STITCH_ENTITIES} entities x ${STITCH_PAGES} pages)`,
+    setup: () => seedRoomProfile(CONVERSATIONS, bootstrapCoverage(CONVERSATIONS, roomJid)),
+    run: phaseBStitchRooms,
+    key: ROOM_COVERAGE_KEY,
+  },
+  {
+    name: 'S6 gapped multi-page forward catch-up (10 entities x 3 pages)',
+    setup: () => seedChatProfile(CONVERSATIONS),
+    run: gappedForwardCatchUp,
+    key: CHAT_KEY,
+  },
+  {
+    name: 'S7 gap transitions interleaved with ordinary churn (candidate 1 target)',
+    setup: () => seedChatProfile(CONVERSATIONS),
+    run: mixedGapAndChurn,
+    key: CHAT_KEY,
+  },
+]
+
+interface Row {
+  scenario: string
+  variant: Variant
+  spacing: number
+  key: string
+  writes: number
+  keyWrites: number
+  bytes: number
+  keyBytes: number
+  stringifyCalls: number
+  cpuMs: number
+}
+
+const rows: Row[] = []
+
+function resetWorld(): void {
+  _resetForTesting()
+  _resetStorageScopeForTesting()
+  _clearAllRoomReadStateForTesting()
+  chatStore.getState().reset()
+  roomStore.getState().reset()
+  _resetForTesting()
+  forgetAllDurableMapBaselines()
+  countingStorage.reset()
+}
+
+describe('persistence cost (#1138)', () => {
+  beforeEach(() => {
+    // `performance` stays REAL so cpuMs measures work, not simulated clock.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  for (const scenario of SCENARIOS) {
+    for (const spacing of scenario.spacings ?? SPACINGS) {
+      for (const variant of VARIANTS) {
+        it(`${scenario.name} — ${variant} @ ${spacing}ms`, () => {
+          resetWorld()
+          setVariant(variant)
+          scenario.setup()
+          // Establish the on-disk baseline outside the measured region: the
+          // first write of a session force-flushes on an unknown baseline in
+          // every variant, and that one write is setup, not workload.
+          flush()
+          const m: Metrics = measure(() => scenario.run(spacing))
+          rows.push({
+            scenario: scenario.name,
+            variant,
+            spacing,
+            key: scenario.key,
+            writes: m.writes,
+            keyWrites: m.byKey[scenario.key]?.writes ?? 0,
+            bytes: m.bytes,
+            keyBytes: m.byKey[scenario.key]?.bytes ?? 0,
+            stringifyCalls: m.stringifyCalls,
+            cpuMs: Number(m.cpuMs.toFixed(1)),
+          })
+        })
+      }
+    }
+  }
+
+  afterAll(() => {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const out = resolve(here, 'results/persistCost.json')
+    mkdirSync(dirname(out), { recursive: true })
+    writeFileSync(out, JSON.stringify(rows, null, 2))
+    report(rows)
+  })
+})
+
+function mb(bytes: number): string {
+  return `${(bytes / 1_048_576).toFixed(2)} MB`
+}
+
+function report(all: Row[]): void {
+  const lines: string[] = []
+  lines.push('')
+  lines.push('='.repeat(112))
+  lines.push('PERSISTENCE COST — issue #1138')
+  lines.push('='.repeat(112))
+  for (const scenario of SCENARIOS) {
+    const subset = all.filter((r) => r.scenario === scenario.name)
+    if (subset.length === 0) continue
+    lines.push('')
+    lines.push(scenario.name)
+    lines.push(
+      `  ${'spacing'.padEnd(9)}${'variant'.padEnd(20)}${'writes'.padStart(8)}` +
+      `${'key writes'.padStart(12)}${'stringify'.padStart(11)}${'bytes'.padStart(12)}${'cpu ms'.padStart(9)}`,
+    )
+    for (const row of subset) {
+      lines.push(
+        `  ${`${row.spacing}ms`.padEnd(9)}${row.variant.padEnd(20)}` +
+        `${String(row.writes).padStart(8)}${String(row.keyWrites).padStart(12)}` +
+        `${String(row.stringifyCalls).padStart(11)}${mb(row.bytes).padStart(12)}` +
+        `${row.cpuMs.toFixed(1).padStart(9)}`,
+      )
+    }
+  }
+  lines.push('')
+  // `process.stdout` rather than `console.log`: vitest buffers console output
+  // from hooks and this report has to survive to the terminal.
+  process.stdout.write(`${lines.join('\n')}\n`)
+}

--- a/packages/fluux-sdk/bench/persistCost.bench.ts
+++ b/packages/fluux-sdk/bench/persistCost.bench.ts
@@ -81,11 +81,11 @@ vi.mock('../src/stores/shared/durableMapPersist', async (importOriginal) => {
         // addition, a monotone deepening or a replacement — the conservatism
         // #1138 measured. Removal and the unknown-baseline case are unchanged
         // between the two rules, so they are left to the production path.
-        const bottoms = mergedBottoms.get(key) ?? new Map<string, string>()
+        const previous = mergedBottoms.get(key)
+        const bottoms = new Map<string, string>()
         for (const [id, record] of maps.coverage) {
-          const previous = bottoms.get(id)
           bottoms.set(id, record.bottomId)
-          if (previous !== record.bottomId) actual.noteCoverageTransition(key, id, 'replaced')
+          if (previous?.get(id) !== record.bottomId) actual.noteCoverageTransition(key, id, 'replaced')
         }
         mergedBottoms.set(key, bottoms)
       }

--- a/packages/fluux-sdk/bench/persistCost.harness.ts
+++ b/packages/fluux-sdk/bench/persistCost.harness.ts
@@ -1,0 +1,160 @@
+/**
+ * Shared instrumentation for the persistence cost benchmark (issue #1138).
+ *
+ * Counts what the issue asks for, per storage key, and nothing else:
+ * `JSON.stringify` invocations, `localStorage.setItem` invocations, bytes
+ * written, and CPU time.
+ *
+ * `setItem` count is the serialization count on every path measured here —
+ * both the throttle's `write()` and the simulated pre-#1133 write-through
+ * evaluate the thunk exactly once per `setItem`. Total `JSON.stringify` calls
+ * are counted separately as a cross-check, because a serializer that calls it
+ * more than once per blob would otherwise hide inside the setItem count.
+ *
+ * @module Bench/PersistCost
+ */
+
+import { vi } from 'vitest'
+
+export interface KeyMetrics {
+  writes: number
+  bytes: number
+}
+
+export interface Metrics {
+  /** Per storage key, so a small side-key write is never confused with a blob. */
+  byKey: Record<string, KeyMetrics>
+  writes: number
+  bytes: number
+  stringifyCalls: number
+  /** CPU milliseconds spent inside the measured region (fake timers do not move it). */
+  cpuMs: number
+}
+
+/** Counting `localStorage` — an object mock, so the code under test is the
+ *  production write path (design §5.5's fourth guard). */
+function createCountingLocalStorage() {
+  let store: Record<string, string> = {}
+  const byKey: Record<string, KeyMetrics> = {}
+  let recording = false
+
+  return {
+    mock: {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value
+        if (recording) {
+          const entry = (byKey[key] ??= { writes: 0, bytes: 0 })
+          entry.writes += 1
+          entry.bytes += value.length
+        }
+      },
+      removeItem: (key: string) => {
+        delete store[key]
+      },
+      clear: () => {
+        store = {}
+      },
+      key: (index: number) => Object.keys(store)[index] ?? null,
+      get length() {
+        return Object.keys(store).length
+      },
+    },
+    start(): void {
+      for (const key of Object.keys(byKey)) delete byKey[key]
+      recording = true
+    },
+    stop(): Record<string, KeyMetrics> {
+      recording = false
+      return JSON.parse(JSON.stringify(byKey)) as Record<string, KeyMetrics>
+    },
+    reset(): void {
+      store = {}
+    },
+  }
+}
+
+export const countingStorage = createCountingLocalStorage()
+
+/**
+ * Implementation under measurement.
+ *
+ * - `legacy`      — pre-#1133: serialize and write on every mutation.
+ * - `merged`      — #1133 as shipped: every coverage `bottomId` change forces a
+ *   flush. Re-created over the shipped primitives (see the bench's mock), not
+ *   checked out, so both variants exercise the same store code.
+ * - `coverageThrottled` — the CEILING on any coverage-transition refinement
+ *   (candidate 2): coverage is dropped from structural detection entirely, so
+ *   no coverage transition ever forces a flush. Not a shippable rule — it
+ *   loses the replacement/removal durability #1133 added — but it bounds the
+ *   win, which is what the go/no-go needs before an implementation exists.
+ * - `allThrottled` — no structural detection at all: a pure throttle. Bounds
+ *   candidate 1 (a `flushKey` that leaves the window armed), which can only
+ *   ever recover the WINDOW-CLOSING part of the structural cost, never the
+ *   forced write itself.
+ * - `optimized`   — the implementation actually shipped for #1138.
+ */
+export type Variant = 'legacy' | 'merged' | 'coverageThrottled' | 'allThrottled' | 'optimized'
+
+let variant: Variant = 'merged'
+
+export function setVariant(next: Variant): void {
+  variant = next
+}
+
+export function getVariant(): Variant {
+  return variant
+}
+
+/** Wrap `JSON.stringify` once, for the whole process. */
+let stringifyCalls = 0
+const realStringify = JSON.stringify.bind(JSON)
+JSON.stringify = ((...args: Parameters<typeof realStringify>) => {
+  stringifyCalls += 1
+  return realStringify(...args)
+}) as typeof JSON.stringify
+
+/**
+ * Run `body` under measurement.
+ *
+ * `body` is synchronous on purpose: every scenario drives store actions
+ * directly and advances fake timers, so there is no real waiting to overlap
+ * and `cpuMs` stays a clean measure of serialization + write cost.
+ */
+export function measure(body: () => void): Metrics {
+  countingStorage.start()
+  const stringifyBefore = stringifyCalls
+  const t0 = performance.now()
+  body()
+  const cpuMs = performance.now() - t0
+  const byKey = countingStorage.stop()
+
+  let writes = 0
+  let bytes = 0
+  for (const entry of Object.values(byKey)) {
+    writes += entry.writes
+    bytes += entry.bytes
+  }
+  return { byKey, writes, bytes, stringifyCalls: stringifyCalls - stringifyBefore, cpuMs }
+}
+
+/**
+ * Install the counting storage and the variant-aware module mocks.
+ *
+ * Called from the bench file's top level (before the store imports), because
+ * `chatStore` resolves `localStorage` and its persistence modules at import.
+ */
+export function installStorage(): void {
+  Object.defineProperty(globalThis, 'localStorage', { value: countingStorage.mock, writable: true })
+}
+
+/** Simulated pre-#1133 write-through: serialize and write, absorbing errors. */
+export function legacyWrite(key: string, produce: () => string): void {
+  try {
+    localStorage.setItem(key, produce())
+  } catch {
+    // Every replaced call site swallowed storage errors and continued.
+  }
+}
+
+export { vi }

--- a/packages/fluux-sdk/bench/persistCost.harness.ts
+++ b/packages/fluux-sdk/bench/persistCost.harness.ts
@@ -127,6 +127,7 @@ export function measure(body: () => void): Metrics {
   const t0 = performance.now()
   body()
   const cpuMs = performance.now() - t0
+  const stringifyAfter = stringifyCalls
   const byKey = countingStorage.stop()
 
   let writes = 0
@@ -135,7 +136,7 @@ export function measure(body: () => void): Metrics {
     writes += entry.writes
     bytes += entry.bytes
   }
-  return { byKey, writes, bytes, stringifyCalls: stringifyCalls - stringifyBefore, cpuMs }
+  return { byKey, writes, bytes, stringifyCalls: stringifyAfter - stringifyBefore, cpuMs }
 }
 
 /**

--- a/packages/fluux-sdk/package.json
+++ b/packages/fluux-sdk/package.json
@@ -77,13 +77,15 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.bench.json",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
     "clean": "rm -rf dist",
-    "clean:all": "rm -rf dist node_modules docs"
+    "clean:all": "rm -rf dist node_modules docs",
+    "bench:persist": "vitest run --config vitest.bench.config.ts",
+    "bench:persist:browser": "node bench/browser/run.mjs"
   },
   "dependencies": {
     "@xmpp/client": "^0.14.0",

--- a/packages/fluux-sdk/src/stores/chatStore.persist.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.persist.test.ts
@@ -3,6 +3,13 @@ import { localStorageMock } from '../core/sideEffects.testHelpers'
 
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
 
+// Needed only by the deferred-commit case at the bottom: a merge carrying
+// persistable messages gates its coverage transition on the IndexedDB write.
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return { ...actual, saveMessages: vi.fn().mockResolvedValue(true) }
+})
+
 import { chatStore } from './chatStore'
 import { _resetForTesting, flush } from './shared/throttledStorage'
 import { forgetAllDurableMapBaselines } from './shared/durableMapPersist'
@@ -188,6 +195,22 @@ describe('chat gap/coverage structural durability', () => {
     )
   }
 
+  /** The bootstrap branch: a COMPLETED forward catch-up with a resume cursor
+   *  seeds the record for an entity that has none. */
+  function bootstrapCoverage(cid: string, initialAfter: string): void {
+    chatStore.getState().mergeMAMMessages(
+      cid, [], {}, true, 'forward', false, false, { initialAfter }
+    )
+  }
+
+  /** A Phase B page: a plain backward query resumed id-exactly from the
+   *  recorded bottom, extending the same contiguous run. */
+  function deepenCoverage(cid: string, from: string, to: string): void {
+    chatStore.getState().mergeMAMMessages(
+      cid, [], { first: to }, false, 'backward', false, false, { initialBefore: from }
+    )
+  }
+
   it('persists a gap FORMATION that was coalesced into an open window', () => {
     seedConversation(CID) // leading edge writes a blob with NO gap, opens the window
     localStorageMock.setItem.mockClear()
@@ -247,6 +270,100 @@ describe('chat gap/coverage structural durability', () => {
     chatStore.getState().mergeMAMMessages(
       CID, [], { first: 'new-shallow' }, true, 'backward', true, false, { sawCoverageTop: false }
     )
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'new-shallow' })
+
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'new-shallow' })
+  })
+
+  /**
+   * #1138's headline: the coverage bootstrap.
+   *
+   * `syncCoverageAfterArchiveMerge` seeds a record for every entity that has
+   * none and completes a forward catch-up, which on a first session is
+   * essentially every conversation. #1133 force-flushed each one, so a
+   * 400-conversation profile paid ~400 whole-blob serializations — the same
+   * order as the burst the throttle exists to remove, and measurably identical
+   * to the pre-throttle baseline.
+   *
+   * A creation is safe to coalesce because losing it leaves NO record: the next
+   * session re-seeds from the local downloaded edge, which is shallower. The
+   * write-count assertion is the one that fails under the old rule; the
+   * REPLACEMENT tests above are what stop "coalesce everything" from passing.
+   */
+  it('coalesces the coverage bootstrap across conversations', () => {
+    seedConversation(CID) // leading edge (both maps empty → not structural), window OPEN
+    seedConversation(CID2) // coalesced
+    expect(writeCount()).toBe(1)
+
+    bootstrapCoverage(CID, 'edge-1')
+    bootstrapCoverage(CID2, 'edge-2')
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'edge-1' })
+    expect(chatStore.getState().getConversationCoverage(CID2)).toEqual({ bottomId: 'edge-2' })
+
+    // Under #1133's "bottomId changed → force-flush" this is 3.
+    expect(writeCount()).toBe(1)
+    expect(coverageOnDisk().size).toBe(0)
+
+    flush()
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'edge-1' })
+    expect(coverageOnDisk().get(CID2)).toEqual({ bottomId: 'edge-2' })
+  })
+
+  /**
+   * The other half of the measured cost: Phase B's read-pointer stitch walks up
+   * to `MAM_POINTER_STITCH_MAX_PAGES` (10) backward pages per entity per
+   * session, each advancing `bottomId` id-exactly from the recorded one. Losing
+   * one leaves the shallower bottom, which is still true.
+   */
+  it('coalesces a Phase B bottomId deepening', () => {
+    seedConversation(CID)
+    createCoverage(CID, 'deep-0', 'top-1') // creation → throttled
+    expect(writeCount()).toBe(1)
+
+    deepenCoverage(CID, 'deep-0', 'deep-1')
+    deepenCoverage(CID, 'deep-1', 'deep-2')
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+
+    expect(writeCount()).toBe(1) // 3 under #1133
+    flush()
+    expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+  })
+
+  /**
+   * The DEFERRED replacement.
+   *
+   * When the merge carries persistable messages, the coverage transition waits
+   * for the IndexedDB commit (`mustGateOnChain`) and lands from
+   * `scheduleDeferredCommit`, not from the merge's own `set`. Reporting the
+   * transition at merge time would arm the flush for a write that still carries
+   * the OLD record and leave the real one sitting in the throttle window — a
+   * durability hole that the synchronous replacement test above cannot see,
+   * because it deliberately uses unstored pages.
+   *
+   * Timers are never advanced and `flush()` is never called: the record reaches
+   * disk only if the deferred write force-flushed.
+   */
+  it('persists a DEFERRED coverage replacement that was coalesced into an open window', async () => {
+    seedConversation(CID)
+    createCoverage(CID, 'deep-old', 'top-1') // creation → throttled, window OPEN
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+    // The window is open and nothing coverage-related has reached disk, so the
+    // ordinary throttled path demonstrably would NOT persist what follows.
+    expect(coverageOnDisk().has(CID)).toBe(false)
+
+    // A storable page, so the transition defers behind the durable write.
+    const stored: Message[] = [{
+      type: 'chat', id: 'p1', conversationId: CID, from: CID, body: 'p1',
+      timestamp: new Date('2026-05-14T09:00:00Z'), isOutgoing: false, stanzaId: 'new-shallow',
+    } as Message]
+    chatStore.getState().mergeMAMMessages(
+      CID, stored, { first: 'new-shallow' }, true, 'backward', true, false, { sawCoverageTop: false }
+    )
+    // Deliberately still the old record: the transition has NOT applied yet.
+    expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+
+    // Drain the save chain's microtasks WITHOUT advancing the throttle timer.
+    for (let i = 0; i < 10; i++) await Promise.resolve()
     expect(chatStore.getState().getConversationCoverage(CID)).toEqual({ bottomId: 'new-shallow' })
 
     expect(coverageOnDisk().get(CID)).toEqual({ bottomId: 'new-shallow' })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -57,7 +57,7 @@ import { MAM_POINTER_RECOUNT_CACHE_LIMIT } from '../utils/mamCatchUpUtils'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
 import { flushKey, flush as flushThrottledStorage } from './shared/throttledStorage'
-import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines } from './shared/durableMapPersist'
+import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './shared/durableMapPersist'
 // Sliding-window bound (messages kept resident per conversation; rest live in IndexedDB + MAM).
 // Read via getResidentWindowSize() so a DEV/DEMO/TEST caller can shrink it — see shared/residentWindow.ts.
 import { getResidentWindowSize } from './shared/residentWindow'
@@ -2840,7 +2840,7 @@ export const chatStore = createStore<ChatState>()(
           // past a page with persistable messages must wait for the durable
           // commit: the record must never point past unstored data. A merge
           // with nothing persistable (signal-only give-up) applies now.
-          const newCoverage = syncCoverageAfterArchiveMerge({
+          const { coverage: newCoverage, transition: coverageTransition } = syncCoverageAfterArchiveMerge({
             coverage: state.conversationCoverage,
             id: conversationId,
             direction,
@@ -2859,6 +2859,13 @@ export const chatStore = createStore<ChatState>()(
             newCoverage !== state.conversationCoverage &&
             mustGateOnChain
           const coverageAfterMerge = deferCoverageCommit ? state.conversationCoverage : newCoverage
+          // Reported where the value actually enters the state (#1138):
+          // reporting at merge time on the DEFERRED path would arm the flush for
+          // a write that still carries the old record, and leave the real one
+          // throttled. `noteCoverageTransition` no-ops for the safe transitions.
+          if (!deferCoverageCommit) {
+            noteCoverageTransition(getScopedStorageKey(), conversationId, coverageTransition)
+          }
 
           // Deferred commit of the gap/coverage transitions, gated on the
           // given promise (this page's write chained behind every earlier
@@ -2890,6 +2897,9 @@ export const chatStore = createStore<ChatState>()(
                     const next = new Map(s.conversationCoverage)
                     next.set(conversationId, target)
                     out.conversationCoverage = next
+                    // The deferred half of the report above: THIS is the write
+                    // that first carries the new record.
+                    noteCoverageTransition(getScopedStorageKey(), conversationId, coverageTransition)
                   }
                 }
                 return Object.keys(out).length > 0 ? out : s

--- a/packages/fluux-sdk/src/stores/roomStore.throttledPersist.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.throttledPersist.test.ts
@@ -3,6 +3,13 @@ import { localStorageMock } from '../core/sideEffects.testHelpers'
 
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
 
+// Needed only by the deferred-commit case at the bottom: a merge carrying
+// persistable messages gates its coverage transition on the IndexedDB write.
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return { ...actual, saveRoomMessages: vi.fn().mockResolvedValue(true) }
+})
+
 import { roomStore } from './roomStore'
 import { _resetForTesting, flush } from './shared/throttledStorage'
 import { forgetAllDurableMapBaselines } from './shared/durableMapPersist'
@@ -334,6 +341,14 @@ describe('roomStore gap/coverage structural durability', () => {
     )
   }
 
+  /** A Phase B page: a plain backward query resumed id-exactly from the
+   *  recorded bottom, extending the same contiguous run. */
+  function deepenCoverage(room: string, from: string, to: string): void {
+    roomStore.getState().mergeRoomMAMMessages(
+      room, [], { first: to }, false, 'backward', false, false, { initialBefore: from }
+    )
+  }
+
   it('persists a gap FORMATION that was coalesced into an open window', () => {
     // TWO throttled writes are needed before the formation, and the order is
     // load-bearing (§5.5).
@@ -563,6 +578,88 @@ describe('roomStore gap/coverage structural durability', () => {
 
     flush()
     expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'cov-bottom', topId: 'top-3' })
+  })
+
+  /**
+   * #1138, room side. Room coverage lives under its OWN key rather than inside
+   * a whole-store blob, so each forced write is cheap — but the FREQUENCY is
+   * the same, and every one of them still closes the window for the next.
+   *
+   * Three rooms, because the first coverage write of a session has no baseline
+   * and force-flushes on that rule alone (closing the window), the second takes
+   * a fresh leading edge (opening it), and only the third is genuinely the
+   * coalesced case (§5.5).
+   */
+  it('coalesces coverage bootstraps across rooms', () => {
+    for (const room of [ROOM, ROOM2, ROOM3]) {
+      roomStore.getState().addRoom(createRoom(room, { joined: true }))
+    }
+    localStorageMock.setItem.mockClear()
+
+    createCoverage(ROOM, 'cov-1', 'top-1') // unknown baseline → forced, window CLOSED
+    createCoverage(ROOM2, 'cov-2', 'top-1') // creation → throttled → leading edge, window OPEN
+    expect(writeCount()).toBe(2)
+
+    createCoverage(ROOM3, 'cov-3', 'top-1') // creation → coalesced
+
+    // 3 under #1133's "key added → force-flush".
+    expect(writeCount()).toBe(2)
+    expect(coverageOnDisk().has(ROOM3)).toBe(false)
+
+    flush()
+    expect(coverageOnDisk().get(ROOM3)).toEqual({ bottomId: 'cov-3', topId: 'top-1' })
+  })
+
+  it('coalesces a Phase B bottomId deepening', () => {
+    for (const room of [ROOM, ROOM2]) {
+      roomStore.getState().addRoom(createRoom(room, { joined: true }))
+    }
+    localStorageMock.setItem.mockClear()
+
+    createCoverage(ROOM, 'deep-0', 'top-1') // unknown baseline → forced, window CLOSED
+    createCoverage(ROOM2, 'other', 'top-1') // creation → leading edge, window OPEN
+    expect(writeCount()).toBe(2)
+
+    deepenCoverage(ROOM, 'deep-0', 'deep-1')
+    deepenCoverage(ROOM, 'deep-1', 'deep-2')
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+
+    expect(writeCount()).toBe(2) // 4 under #1133
+    flush()
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'deep-2', topId: 'top-1' })
+  })
+
+  /**
+   * The DEFERRED replacement — the room twin of the chat case.
+   *
+   * A merge carrying persistable messages gates its coverage transition on the
+   * IndexedDB commit, so the record lands from `scheduleDeferredCommit` rather
+   * than from the merge's own `set`. Reporting the transition at merge time
+   * would arm the flush for a write that still carries the OLD record. Timers
+   * are never advanced and `flush()` is never called.
+   */
+  it('persists a DEFERRED coverage replacement that was coalesced into an open window', async () => {
+    for (const room of [ROOM, ROOM2]) {
+      roomStore.getState().addRoom(createRoom(room, { joined: true }))
+    }
+    createCoverage(ROOM, 'deep-old', 'top-1') // unknown baseline → forced, window CLOSED
+    createCoverage(ROOM2, 'other', 'top-1') // creation → leading edge, window OPEN
+    localStorageMock.setItem.mockClear()
+
+    // A storable page, so the transition defers behind the durable write.
+    roomStore.getState().mergeRoomMAMMessages(
+      ROOM,
+      [createMessage('p1', ROOM, 'a', 'p1', false, new Date('2026-05-14T09:00:00Z'))],
+      { first: 'new-shallow' }, true, 'backward', false, true, { sawCoverageTop: false },
+    )
+    // Deliberately still the old record: the transition has NOT applied yet.
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'deep-old', topId: 'top-1' })
+
+    // Drain the save chain's microtasks WITHOUT advancing the throttle timer.
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    expect(roomStore.getState().getRoomCoverage(ROOM)).toEqual({ bottomId: 'new-shallow' })
+
+    expect(coverageOnDisk().get(ROOM)).toEqual({ bottomId: 'new-shallow' })
   })
 
   it('persists a coverage REMOVAL that was coalesced into an open window', () => {

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -31,6 +31,7 @@ import {
   serializeCoverage,
   deserializeCoverage,
   type CoverageRecord,
+  type CoverageTransition,
   type MergeArchiveExtras,
 } from './shared/mamCoverage'
 import {
@@ -75,7 +76,7 @@ import { MAM_POINTER_RECOUNT_CACHE_LIMIT } from '../utils/mamCatchUpUtils'
 import { connectionStore } from './connectionStore'
 import { buildScopedStorageKey, getStorageScopeJid } from '../utils/storageScope'
 import { schedule, flush as flushThrottledStorage } from './shared/throttledStorage'
-import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines } from './shared/durableMapPersist'
+import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './shared/durableMapPersist'
 // Sliding-window bound (messages kept resident per room; rest live in IndexedDB + MAM). Read via
 // getResidentWindowSize() so a DEV/DEMO/TEST caller can shrink it — see shared/residentWindow.ts.
 import { getResidentWindowSize } from './shared/residentWindow'
@@ -247,11 +248,22 @@ function loadCoverageFromStorage(jid?: string | null): Map<string, CoverageRecor
   return new Map()
 }
 
-function saveCoverageToStorage(coverage: Map<string, CoverageRecord>, jid?: string | null): void {
-  // A record appearing, its `bottomId` changing or the record being dropped
-  // must not sit in the throttle window: the stale one on disk asserts a
-  // contiguity that was just disproven. A `topId`-only refresh stays throttled.
+/**
+ * @param transition - What the merge that produced `coverage` did to
+ *   `transition.roomJid`'s record. `durableMapPersist` owns the policy of which
+ *   transitions must escape the throttle window (#1138); this only reports.
+ *   Removal IS derivable there, so the clear paths pass nothing.
+ */
+function saveCoverageToStorage(
+  coverage: Map<string, CoverageRecord>,
+  jid?: string | null,
+  transition?: { roomJid: string; kind: CoverageTransition },
+): void {
+  // A record being invalidated must not sit in the throttle window: the stale
+  // one on disk asserts a contiguity that was just disproven. Creation, a
+  // `bottomId` deepening and a `topId`-only refresh all stay throttled.
   const key = getRoomCoverageStorageKey(jid)
+  if (transition) noteCoverageTransition(key, transition.roomJid, transition.kind)
   scheduleDurableMaps(key, { coverage }, () => serializeCoverage(coverage))
 }
 
@@ -3827,7 +3839,7 @@ export const roomStore = createStore<RoomState>()(
       // page with persistable messages must wait for the durable commit: the
       // record must never point past unstored data. A merge with nothing
       // persistable (signal-only give-up) applies now.
-      const newCoverage = syncCoverageAfterArchiveMerge({
+      const { coverage: newCoverage, transition: coverageTransition } = syncCoverageAfterArchiveMerge({
         coverage: state.roomCoverage,
         id: roomJid,
         direction,
@@ -3846,7 +3858,9 @@ export const roomStore = createStore<RoomState>()(
         newCoverage !== state.roomCoverage &&
         mustGateOnChain
       const coverageAfterMerge = deferCoverageCommit ? state.roomCoverage : newCoverage
-      if (coverageAfterMerge !== state.roomCoverage) saveCoverageToStorage(coverageAfterMerge)
+      if (coverageAfterMerge !== state.roomCoverage) {
+        saveCoverageToStorage(coverageAfterMerge, undefined, { roomJid, kind: coverageTransition })
+      }
 
       // Deferred commit of the gap/coverage transitions, gated on the given
       // promise (this page's write chained behind every earlier in-flight
@@ -3877,7 +3891,9 @@ export const roomStore = createStore<RoomState>()(
               if (target) {
                 const next = new Map(s.roomCoverage)
                 next.set(roomJid, target)
-                saveCoverageToStorage(next)
+                // Signalled HERE, not at merge time: this is the first write
+                // that carries the replacing record.
+                saveCoverageToStorage(next, undefined, { roomJid, kind: coverageTransition })
                 out.roomCoverage = next
               }
             }

--- a/packages/fluux-sdk/src/stores/shared/durableMapPersist.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/durableMapPersist.test.ts
@@ -3,7 +3,7 @@ import { localStorageMock } from '../../core/sideEffects.testHelpers'
 
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
 
-import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines } from './durableMapPersist'
+import { scheduleDurableMaps, cancelDurableMaps, forgetAllDurableMapBaselines, noteCoverageTransition } from './durableMapPersist'
 import type { DurableMaps } from './durableMapPersist'
 import { _resetForTesting, flush } from './throttledStorage'
 import type { GapInterval } from './mamGap'
@@ -91,22 +91,59 @@ describe('durableMapPersist — §4.2 decision table', () => {
     expect(onDisk()).toBe('removal')
   })
 
-  it('coverage key ADDED forces the coalesced write out of the window', () => {
+  /**
+   * #1138. A creation asserts nothing that a hard kill could falsify: losing it
+   * leaves NO record on disk, and the next session re-seeds from the local
+   * downloaded edge, which is shallower. #1133 force-flushed it only because
+   * this layer could not tell it from a replacement — which is now signalled.
+   *
+   * This is the row that carried the whole cold-start cost: one forced
+   * whole-blob serialization per conversation with no record, ~400 on the
+   * reference profile.
+   */
+  it('coverage key ADDED stays throttled', () => {
     write({ coverage: coverage({ a: { bottomId: 'x', topId: 't1' } }) }, 'baseline')
     write({ coverage: coverage({ a: { bottomId: 'x', topId: 't2' } }) }, 'opener') // topId only
     expect(writeCount()).toBe(2)
 
     write({ coverage: coverage({ a: { bottomId: 'x', topId: 't2' }, b: { bottomId: 'y' } }) }, 'added')
 
-    expect(writeCount()).toBe(3)
+    expect(writeCount()).toBe(2)
+    expect(onDisk()).toBe('opener')
+    flush()
     expect(onDisk()).toBe('added')
   })
 
-  it('coverage bottomId CHANGED forces the coalesced write out of the window', () => {
+  /**
+   * #1138. Phase B's read-pointer stitch advances `bottomId` on up to 10 pages
+   * per entity per session, each one an id-exact extension of the SAME
+   * contiguous run. Losing one leaves the shallower bottom, which is still
+   * true, and costs a re-walk of covered ground.
+   */
+  it('coverage bottomId DEEPENED without a signal stays throttled', () => {
     write({ coverage: coverage({ a: { bottomId: 'deep-old', topId: 't1' } }) }, 'baseline')
     write({ coverage: coverage({ a: { bottomId: 'deep-old', topId: 't2' } }) }, 'opener')
     expect(writeCount()).toBe(2)
 
+    write({ coverage: coverage({ a: { bottomId: 'deeper', topId: 't2' } }) }, 'deepened')
+
+    expect(writeCount()).toBe(2)
+    expect(onDisk()).toBe('opener')
+    flush()
+    expect(onDisk()).toBe('deepened')
+  })
+
+  /**
+   * The unsafe one. Same shape of write as `deepened` above — a `bottomId`
+   * change on an existing id — and the ONLY thing that distinguishes them is
+   * the signal, which is why both rows have to be here.
+   */
+  it('coverage REPLACEMENT, signalled, forces the coalesced write out of the window', () => {
+    write({ coverage: coverage({ a: { bottomId: 'deep-old', topId: 't1' } }) }, 'baseline')
+    write({ coverage: coverage({ a: { bottomId: 'deep-old', topId: 't2' } }) }, 'opener')
+    expect(writeCount()).toBe(2)
+
+    noteCoverageTransition(KEY, 'a', 'replaced')
     write({ coverage: coverage({ a: { bottomId: 'new-shallow' } }) }, 'replacement')
 
     expect(writeCount()).toBe(3)
@@ -215,10 +252,101 @@ describe('durableMapPersist — baseline lifecycle', () => {
 
     forgetAllDurableMapBaselines()
 
-    // Unknown baseline → the record present reads as an addition → force-flush,
-    // landing what would otherwise be a coalesced topId refresh.
+    // Unknown baseline → a removal is undetectable, so any record present is
+    // treated as structural → force-flush, landing what would otherwise be a
+    // coalesced topId refresh.
     write({ coverage: coverage({ a: { bottomId: 'x', topId: 't3' } }) }, 'after-forget')
     expect(writeCount()).toBe(3)
+    expect(onDisk()).toBe('after-forget')
+  })
+})
+
+/**
+ * The replacement signal (#1138).
+ *
+ * With creation and deepening throttled, this signal is the ONLY thing standing
+ * between a disproven coverage record and a hard kill, so its lifecycle needs
+ * pinning as tightly as the transition rows themselves. Every test here opens
+ * the window first, on this key, so the ordinary path would not have persisted.
+ */
+describe('durableMapPersist — coverage invalidation signal', () => {
+  function openWindow(): void {
+    write({ coverage: coverage({ a: { bottomId: 'x', topId: 't1' } }) }, 'baseline') // force-flush, CLOSED
+    write({ coverage: coverage({ a: { bottomId: 'x', topId: 't2' } }) }, 'opener') // throttled, OPEN
+    expect(writeCount()).toBe(2)
+  }
+
+  /** One signal must not make every LATER write durable too — that would put
+   *  back most of the cost this change removes. */
+  it('is consumed by exactly one write', () => {
+    openWindow()
+
+    noteCoverageTransition(KEY, 'a', 'replaced')
+    write({ coverage: coverage({ a: { bottomId: 'replaced' } }) }, 'replacement')
+    expect(writeCount()).toBe(3) // flushed, window CLOSED
+
+    write({ coverage: coverage({ a: { bottomId: 'replaced', topId: 't9' } }) }, 'after-1') // leading edge
+    expect(writeCount()).toBe(4)
+    write({ coverage: coverage({ a: { bottomId: 'replaced', topId: 't10' } }) }, 'after-2')
+    expect(writeCount()).toBe(4) // coalesced — the signal did not carry over
+    expect(onDisk()).toBe('after-1')
+  })
+
+  /**
+   * The signal means "this key's next write must be durable" and does not
+   * depend on the write declaring the coverage map. Neither store can currently
+   * produce that sequence — chat carries both maps in one blob, rooms give
+   * coverage its own key — but a signal silently swallowed by an undeclared map
+   * is the failure this module must not have.
+   */
+  it('forces the flush even when the write omits the coverage map', () => {
+    openWindow()
+
+    noteCoverageTransition(KEY, 'a', 'replaced')
+    write({}, 'undeclared')
+
+    expect(writeCount()).toBe(3)
+    expect(onDisk()).toBe('undeclared')
+  })
+
+  /**
+   * Both clear-path tests below write an EMPTY coverage map, and that is the
+   * whole trick.
+   *
+   * Dropping the baseline makes the next non-empty write structural on its own
+   * (`hasCoverageRemoval` cannot rule out a removal without a baseline), which
+   * would mask a leaked signal completely — §5.5's "a test cannot cover a guard
+   * a preceding guard renders unreachable". With an empty map the unknown
+   * baseline is quiet, so the only thing that can force a flush is a signal
+   * that outlived the clear.
+   */
+  it('cancelDurableMaps drops a pending signal with the write it was waiting for', () => {
+    openWindow()
+
+    noteCoverageTransition(KEY, 'a', 'replaced')
+    cancelDurableMaps(KEY) // closes the window, so the next write is a leading edge
+
+    write({ coverage: coverage({}) }, 'after-cancel')
+    expect(writeCount()).toBe(3)
+
+    // Discriminating step: a leaked signal would have force-flushed
+    // 'after-cancel' and CLOSED the window, making this a fresh leading edge.
+    write({ coverage: coverage({}) }, 'coalesced')
+    expect(writeCount()).toBe(3)
+    expect(onDisk()).toBe('after-cancel')
+  })
+
+  it('forgetAllDurableMapBaselines drops a pending signal', () => {
+    openWindow() // window left OPEN — this one needs no extra step
+
+    noteCoverageTransition(KEY, 'a', 'replaced')
+    forgetAllDurableMapBaselines()
+
+    write({ coverage: coverage({}) }, 'after-forget')
+
+    expect(writeCount()).toBe(2)
+    expect(onDisk()).toBe('opener')
+    flush()
     expect(onDisk()).toBe('after-forget')
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/durableMapPersist.ts
+++ b/packages/fluux-sdk/src/stores/shared/durableMapPersist.ts
@@ -32,32 +32,52 @@
  * | gaps     | key ADDED (formation)                          | force-flush  |
  * | gaps     | `start` / `startId` CHANGED (boundary moves up) | force-flush |
  * | gaps     | shrink / close / removal (`end` moves down)    | throttle     |
- * | coverage | key ADDED, `bottomId` CHANGED, key REMOVED     | force-flush  |
+ * | coverage | record REPLACED (contiguity disproven)         | force-flush  |
+ * | coverage | key REMOVED                                    | force-flush  |
+ * | coverage | key ADDED (bootstrap / first-ever walk)        | throttle     |
+ * | coverage | `bottomId` DEEPENED (Phase B, id-exact resume) | throttle     |
  * | coverage | `topId`-only change (re-entry marker)          | throttle     |
  *
- * `bottomId`-changed is deliberately conservative: it also force-flushes the
- * *provable* deepening in `syncCoverageAfterArchiveMerge`'s plain-backward
- * branch, which would be safe to throttle. Archive ids are NON-SEQUENTIAL
- * (`mamGap`), so this layer cannot compare two `bottomId`s to tell a deepening
- * from a replacement, and distinguishing them would mean threading a
- * "was this monotone" signal out of the pure sync functions. Not worth the
- * coupling — but the cost is flush FREQUENCY, not record size, and it is not
- * zero: the coverage bootstrap fires once per entity that has no record, so the
- * FIRST session after this ships pays one forced chat-blob serialization per
- * conversation, and Phase B's read-pointer stitch advances `bottomId` on up to
- * 10 backward pages per entity per session. Both are launch-window costs on a
- * path that previously wrote unconditionally on every mutation, and the steady
- * state is free (`if (coverage.get(id)) return coverage`). Design §4.2 has the
- * full accounting.
+ * The coverage half of that table is #1138's change. #1133 shipped it as
+ * "key added, `bottomId` changed, or key removed → force-flush", because this
+ * layer cannot order two `bottomId`s (archive ids are NON-SEQUENTIAL, see
+ * `mamGap`) and so could not tell a safe deepening from an unsafe replacement.
+ * Measured on the reference 400-conversation profile (238 KB blob), that
+ * conservatism cost the ENTIRE benefit of the throttle on a first session:
+ * coverage bootstrap fires once per entity with no record, and every one of
+ * those force-flushed the whole chat blob — 400 writes and 88.9 MB serialized,
+ * identical to the pre-#1133 write-on-every-mutation baseline, and 350-550 ms
+ * of main-thread time (Chromium and WebKit alike) inside the launch window.
+ * Phase B's read-pointer stitch added a second helping: 500 writes, 115 MB,
+ * 400-650 ms. Both drop to ~13 writes and ~15 ms here. Full method and
+ * numbers in `docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md`;
+ * the harness is `packages/fluux-sdk/bench`.
+ *
+ * The fix is not a cleverer comparison — no comparison exists. It is
+ * {@link CoverageTransition}, computed by `syncCoverageAfterArchiveMerge`, which
+ * is the only place that knows whether a walk PROVED contiguity with the record
+ * it is overwriting. Creation and deepening err SHALLOW when lost (the next
+ * session re-seeds or re-walks); only replacement can leave disk asserting
+ * coverage that memory has disproven. See that type for the per-branch analysis.
  *
  * ## How the transition is detected
  *
- * Per storage key, this module remembers a SNAPSHOT of the previous write's
- * structural signature — each gap id's lower boundary (`start` + `startId`), and
- * each coverage id's `bottomId` — and compares the next write against it.
- * Detection therefore lives at the single
- * write funnel of each store (roomStore's two save helpers, chatStore's persist
- * adapter) instead of being an obligation ~13 mutation sites must each remember.
+ * Two mechanisms, because the two maps differ in what is derivable here:
+ *
+ * - **Gaps, and coverage REMOVAL, are detected locally.** Per storage key, this
+ *   module remembers a SNAPSHOT of the previous write's structural signature —
+ *   each gap id's lower boundary (`start` + `startId`), and the set of coverage
+ *   ids — and compares the next write against it. Detection therefore lives at
+ *   the single write funnel of each store (roomStore's two save helpers,
+ *   chatStore's persist adapter) instead of being an obligation ~13 mutation
+ *   sites must each remember.
+ * - **Coverage REPLACEMENT is signalled**, via {@link noteCoverageTransition},
+ *   by the one caller that can classify it. The signal is consumed by the next
+ *   write on that key — which for both stores is the write the same mutation
+ *   triggers, synchronously: roomStore calls `saveCoverageToStorage` on the next
+ *   line, and zustand's persist adapter runs inside chatStore's `set()`. A
+ *   signal that somehow found no write to attach to would force one extra flush
+ *   on the following write, never skip one.
  *
  * - Keyed by the RESOLVED storage key, so a baseline can never be consulted
  *   across accounts: a different account is a different key (same principle as
@@ -65,9 +85,11 @@
  * - A snapshot, not the live map reference, so it is immune to a map mutated in
  *   place and to the reassigned-binding trap that `persistRoomReadState`
  *   documents.
- * - An UNKNOWN baseline (first write of a session, or after a reset) is treated
- *   as empty, so anything present reads as structural. That costs at most one
- *   extra flush per key per session and never a missed one.
+ * - An UNKNOWN baseline (first write of a session, or after a reset) makes
+ *   anything present read as structural — including a non-empty coverage map,
+ *   whose ids cannot be told apart from a removal without a baseline to remove
+ *   them from. That costs at most one extra flush per key per session and never
+ *   a missed one.
  * - `cancelDurableMaps` drops the baseline with the pending write, because a
  *   cancelled write means the disk no longer matches the baseline: keeping it
  *   would let a later formation compare equal to a state that was never
@@ -84,7 +106,7 @@
 
 import { schedule, flushKey, cancel } from './throttledStorage'
 import type { GapInterval } from './mamGap'
-import type { CoverageRecord } from './mamCoverage'
+import type { CoverageRecord, CoverageTransition } from './mamCoverage'
 
 /** The maps carried by this key's blob. Omit one to leave its baseline alone. */
 export interface DurableMaps {
@@ -103,11 +125,49 @@ function gapAnchor(gap: GapInterval): GapAnchor {
 interface Baseline {
   /** Id → lower-boundary anchor at the previous write. */
   gapAnchors?: Map<string, GapAnchor>
-  /** Id → `bottomId` at the previous write (`topId` is deliberately absent). */
-  coverageBottoms?: Map<string, string>
+  /**
+   * Ids carrying a record at the previous write.
+   *
+   * Deliberately not the `bottomId`s: a `bottomId` change is no longer a
+   * durability signal on its own (see the module doc), and keeping the values
+   * would invite a future reader to resurrect the comparison that #1138
+   * measured out.
+   */
+  coverageIds?: Set<string>
 }
 
 const baselines = new Map<string, Baseline>()
+
+/**
+ * Storage key → ids whose coverage record was invalidated since that key's last
+ * write. Consumed and cleared by the next {@link scheduleDurableMaps} on the key.
+ */
+const invalidatedCoverage = new Map<string, Set<string>>()
+
+/**
+ * Report what a merge did to `id`'s coverage record, so the next write on `key`
+ * can be forced out of the throttle window if it has to be.
+ *
+ * Callers pass the transition UNCONDITIONALLY and this decides — the policy
+ * ("which transitions are unsafe to lose") belongs to the durability layer, not
+ * repeated as an `=== 'replaced'` literal at each of the three call sites, where
+ * adding a fourth unsafe transition would mean remembering all of them.
+ *
+ * Must be called BEFORE the write that carries the transition. Both stores do
+ * this on the same synchronous path as the `set()` that commits it; a
+ * transition that is DEFERRED behind an IndexedDB commit must be reported at
+ * the deferred commit instead, not at the merge, or the signal is consumed by a
+ * write that does not carry the new record yet.
+ */
+export function noteCoverageTransition(key: string, id: string, transition: CoverageTransition): void {
+  // `created` / `deepened` / `topRefreshed` all err SHALLOW when lost, and
+  // `none` changed nothing. Only a replacement can leave disk asserting
+  // coverage that memory has disproven — see CoverageTransition's table.
+  if (transition !== 'replaced') return
+  const ids = invalidatedCoverage.get(key)
+  if (ids) ids.add(id)
+  else invalidatedCoverage.set(key, new Set([id]))
+}
 
 /**
  * A gap APPEARING for an id that had none, or an existing gap's lower BOUNDARY
@@ -175,23 +235,23 @@ function hasGapStructuralChange(
 }
 
 /**
- * A record appearing, its `bottomId` changing, or the record disappearing.
+ * A record being invalidated: REPLACED (signalled) or REMOVED (derived).
  *
- * `previous.get(id) !== bottomId` covers both the appearance (undefined never
- * equals a string) and the change; there is no ordering comparison here, by
- * necessity — archive ids are non-sequential.
+ * Additions and `bottomId` advances are deliberately absent — see the module
+ * doc's table and {@link CoverageTransition}. Both leave disk holding either no
+ * record or a shallower one, and neither can assert coverage that does not
+ * exist; force-flushing them was #1133's conservatism and #1138's measured cost.
  */
-function hasCoverageStructuralChange(
-  previous: Map<string, string> | undefined,
+function hasCoverageRemoval(
+  previous: Set<string> | undefined,
   coverage: ReadonlyMap<string, CoverageRecord>,
 ): boolean {
-  for (const [id, record] of coverage) {
-    if (previous?.get(id) !== record.bottomId) return true
-  }
-  if (previous) {
-    for (const id of previous.keys()) {
-      if (!coverage.has(id)) return true
-    }
+  // No baseline: a removal is undetectable (nothing to be missing FROM), so
+  // anything present has to be treated as structural. One flush per key per
+  // session.
+  if (!previous) return coverage.size > 0
+  for (const id of previous) {
+    if (!coverage.has(id)) return true
   }
   return false
 }
@@ -212,7 +272,15 @@ export function scheduleDurableMaps(key: string, maps: DurableMaps, produce: () 
   // comparing against an older baseline, which can hide a there-and-back
   // transition (A → B → A reads as "unchanged" against the pre-A baseline).
   const gapFormed = maps.gaps !== undefined && hasGapStructuralChange(baseline?.gapAnchors, maps.gaps)
-  const coverageMoved = maps.coverage !== undefined && hasCoverageStructuralChange(baseline?.coverageBottoms, maps.coverage)
+  // The signal stands on its own, independent of whether this write declares
+  // the coverage map: it means "the next write on this key must be durable",
+  // and consuming it without acting would silently drop a replacement. The
+  // derived half (removal) still needs the map, like the gap half.
+  const invalidated = invalidatedCoverage.get(key)
+  invalidatedCoverage.delete(key)
+  const coverageInvalidated =
+    (invalidated !== undefined && invalidated.size > 0) ||
+    (maps.coverage !== undefined && hasCoverageRemoval(baseline?.coverageIds, maps.coverage))
 
   const next: Baseline = { ...baseline }
   if (maps.gaps !== undefined) {
@@ -221,14 +289,12 @@ export function scheduleDurableMaps(key: string, maps: DurableMaps, produce: () 
     next.gapAnchors = anchors
   }
   if (maps.coverage !== undefined) {
-    const bottoms = new Map<string, string>()
-    for (const [id, record] of maps.coverage) bottoms.set(id, record.bottomId)
-    next.coverageBottoms = bottoms
+    next.coverageIds = new Set(maps.coverage.keys())
   }
   baselines.set(key, next)
 
   schedule(key, produce)
-  if (gapFormed || coverageMoved) flushKey(key)
+  if (gapFormed || coverageInvalidated) flushKey(key)
 }
 
 /**
@@ -239,6 +305,10 @@ export function scheduleDurableMaps(key: string, maps: DurableMaps, produce: () 
 export function cancelDurableMaps(key: string): void {
   cancel(key)
   baselines.delete(key)
+  // The cancelled write is what the signal was waiting for. Keeping it would
+  // force-flush the next unrelated write on this key for a record the clear
+  // path has just removed anyway.
+  invalidatedCoverage.delete(key)
 }
 
 /**
@@ -247,4 +317,5 @@ export function cancelDurableMaps(key: string): void {
  */
 export function forgetAllDurableMapBaselines(): void {
   baselines.clear()
+  invalidatedCoverage.clear()
 }

--- a/packages/fluux-sdk/src/stores/shared/durableMapPersist.ts
+++ b/packages/fluux-sdk/src/stores/shared/durableMapPersist.ts
@@ -42,16 +42,9 @@
  * "key added, `bottomId` changed, or key removed → force-flush", because this
  * layer cannot order two `bottomId`s (archive ids are NON-SEQUENTIAL, see
  * `mamGap`) and so could not tell a safe deepening from an unsafe replacement.
- * Measured on the reference 400-conversation profile (238 KB blob), that
- * conservatism cost the ENTIRE benefit of the throttle on a first session:
- * coverage bootstrap fires once per entity with no record, and every one of
- * those force-flushed the whole chat blob — 400 writes and 88.9 MB serialized,
- * identical to the pre-#1133 write-on-every-mutation baseline, and 350-550 ms
- * of main-thread time (Chromium and WebKit alike) inside the launch window.
- * Phase B's read-pointer stitch added a second helping: 500 writes, 115 MB,
- * 400-650 ms. Both drop to ~13 writes and ~15 ms here. Full method and
- * numbers in `docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md`;
- * the harness is `packages/fluux-sdk/bench`.
+ * Measurement showed that conservatism erased the throttle's first-session
+ * benefit. The method and numbers are owned by
+ * `docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md`.
  *
  * The fix is not a cleverer comparison — no comparison exists. It is
  * {@link CoverageTransition}, computed by `syncCoverageAfterArchiveMerge`, which

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -29,20 +29,20 @@ const base = (over: Partial<ArchiveMergeCoverageInput> = {}): ArchiveMergeCovera
 describe('syncCoverageAfterArchiveMerge', () => {
   it('fetch-latest establishes the record from the walk extent', () => {
     const out = syncCoverageAfterArchiveMerge(base({ rsmFirst: 'deep', fetchLatestTopId: 'top' }))
-    expect(out.get('a@b')).toEqual({ bottomId: 'deep', topId: 'top' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'deep', topId: 'top' })
   })
 
   it('signal-only give-up (zero messages, rsm.first set) still establishes the record', () => {
     // Codex r3 #4: the walked window IS proven contiguous coverage even with
     // zero displayable messages — this is the durable resume for the cap.
     const out = syncCoverageAfterArchiveMerge(base({ rsmFirst: 'page5-first', fetchLatestTopId: 'page1-last' }))
-    expect(out.get('a@b')).toEqual({ bottomId: 'page5-first', topId: 'page1-last' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'page5-first', topId: 'page1-last' })
   })
 
   it('disjoint fetch-latest REPLACES a stale record', () => {
     const coverage = new Map([['a@b', { bottomId: 'old-deep', topId: 'old-top' }]])
     const out = syncCoverageAfterArchiveMerge(base({ coverage, rsmFirst: 'new-deep', fetchLatestTopId: 'new-top' }))
-    expect(out.get('a@b')).toEqual({ bottomId: 'new-deep', topId: 'new-top' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'new-deep', topId: 'new-top' })
   })
 
   it('a walk that SAW the existing topId keeps the deeper bottom, refreshes topId', () => {
@@ -52,7 +52,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     const out = syncCoverageAfterArchiveMerge(
       base({ coverage, rsmFirst: 'shallow', fetchLatestTopId: 'new-top', sawCoverageTop: true })
     )
-    expect(out.get('a@b')).toEqual({ bottomId: 'deep', topId: 'new-top' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'deep', topId: 'new-top' })
   })
 
   it('dedupe against arbitrary local data does NOT keep the old bottom (island overlap is no proof)', () => {
@@ -65,7 +65,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
     const out = syncCoverageAfterArchiveMerge(
       base({ coverage, rsmFirst: 'id-301', fetchLatestTopId: 'id-400', sawCoverageTop: false })
     )
-    expect(out.get('a@b')).toEqual({ bottomId: 'id-301', topId: 'id-400' })
+    expect(out.coverage.get('a@b')).toEqual({ bottomId: 'id-301', topId: 'id-400' })
   })
 
   it('a walk that carried modifications never certifies coverage (their cache writes are fire-and-forget)', () => {
@@ -77,12 +77,12 @@ describe('syncCoverageAfterArchiveMerge', () => {
     const empty = new Map<string, CoverageRecord>()
     expect(syncCoverageAfterArchiveMerge(
       base({ coverage: empty, rsmFirst: 'deep', fetchLatestTopId: 'top', walkCarriedModifications: true })
-    )).toBe(empty)
+    ).coverage).toBe(empty)
 
     const existing = new Map([['a@b', { bottomId: 'deep', topId: 'top' }]])
     expect(syncCoverageAfterArchiveMerge(
       base({ coverage: existing, isFetchLatest: false, initialBefore: 'deep', rsmFirst: 'deeper', walkCarriedModifications: true })
-    )).toBe(existing)
+    ).coverage).toBe(existing)
   })
 
   it('plain backward page extends the bottom only when resumed exactly from it', () => {
@@ -90,18 +90,18 @@ describe('syncCoverageAfterArchiveMerge', () => {
     const extended = syncCoverageAfterArchiveMerge(
       base({ coverage, isFetchLatest: false, initialBefore: 'deep', rsmFirst: 'deeper' })
     )
-    expect(extended.get('a@b')).toEqual({ bottomId: 'deeper', topId: 'top' })
+    expect(extended.coverage.get('a@b')).toEqual({ bottomId: 'deeper', topId: 'top' })
     const stray = syncCoverageAfterArchiveMerge(
       base({ coverage, isFetchLatest: false, initialBefore: 'elsewhere', rsmFirst: 'x' })
     )
-    expect(stray).toBe(coverage) // copy-on-write no-op
+    expect(stray.coverage).toBe(coverage) // copy-on-write no-op
   })
 
   it('never touches the record for preserveGapMarker (windowed) or forward merges', () => {
     const coverage = new Map([['a@b', { bottomId: 'deep' }]])
-    expect(syncCoverageAfterArchiveMerge(base({ coverage, preserveGapMarker: true, rsmFirst: 'x' }))).toBe(coverage)
+    expect(syncCoverageAfterArchiveMerge(base({ coverage, preserveGapMarker: true, rsmFirst: 'x' })).coverage).toBe(coverage)
     expect(
-      syncCoverageAfterArchiveMerge(base({ coverage, direction: 'forward', isFetchLatest: false, rsmFirst: 'x' }))
+      syncCoverageAfterArchiveMerge(base({ coverage, direction: 'forward', isFetchLatest: false, rsmFirst: 'x' })).coverage
     ).toBe(coverage)
   })
 
@@ -117,27 +117,27 @@ describe('syncCoverageAfterArchiveMerge', () => {
 
     it('a completed forward catch-up seeds the record from its resume cursor', () => {
       const out = syncCoverageAfterArchiveMerge(fwd({ complete: true, initialAfter: 'local-edge' }))
-      expect(out.get('a@b')).toEqual({ bottomId: 'local-edge' })
+      expect(out.coverage.get('a@b')).toEqual({ bottomId: 'local-edge' })
     })
 
     it('an INCOMPLETE forward catch-up seeds nothing (it never reached live)', () => {
       const coverage = new Map<string, CoverageRecord>()
       expect(
-        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: false, initialAfter: 'local-edge' }))
+        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: false, initialAfter: 'local-edge' })).coverage
       ).toBe(coverage)
     })
 
     it('a completed forward catch-up never shallows an existing, deeper record', () => {
       const coverage = new Map([['a@b', { bottomId: 'much-deeper', topId: 'top' }]])
       expect(
-        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true, initialAfter: 'local-edge' }))
+        syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true, initialAfter: 'local-edge' })).coverage
       ).toBe(coverage)
     })
 
     it('a completed forward catch-up with no resume cursor seeds nothing', () => {
       // `start`-filtered or cursorless catch-up: no archive id to anchor on.
       const coverage = new Map<string, CoverageRecord>()
-      expect(syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true }))).toBe(coverage)
+      expect(syncCoverageAfterArchiveMerge(fwd({ coverage, complete: true })).coverage).toBe(coverage)
     })
 
     it('a completed forward catch-up that carried modifications never seeds', () => {
@@ -148,7 +148,7 @@ describe('syncCoverageAfterArchiveMerge', () => {
       expect(
         syncCoverageAfterArchiveMerge(
           fwd({ coverage, complete: true, initialAfter: 'local-edge', walkCarriedModifications: true })
-        )
+        ).coverage
       ).toBe(coverage)
     })
 
@@ -157,19 +157,80 @@ describe('syncCoverageAfterArchiveMerge', () => {
       expect(
         syncCoverageAfterArchiveMerge(
           fwd({ coverage, complete: true, initialAfter: 'local-edge', preserveGapMarker: true })
-        )
+        ).coverage
       ).toBe(coverage)
     })
   })
 
   it('empty fetch-latest with no rsm.first (empty archive) is a no-op', () => {
     const coverage = new Map<string, CoverageRecord>()
-    expect(syncCoverageAfterArchiveMerge(base({ coverage }))).toBe(coverage)
+    expect(syncCoverageAfterArchiveMerge(base({ coverage })).coverage).toBe(coverage)
   })
 
   it('returns the same reference when the computed record is unchanged', () => {
     const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top' }]])
-    expect(syncCoverageAfterArchiveMerge(base({ coverage, rsmFirst: 'deep', fetchLatestTopId: 'top' }))).toBe(coverage)
+    expect(syncCoverageAfterArchiveMerge(base({ coverage, rsmFirst: 'deep', fetchLatestTopId: 'top' })).coverage).toBe(coverage)
+  })
+})
+
+/**
+ * The reported {@link CoverageTransition} is what the persistence layer keys its
+ * hard-kill durability decision on (#1138), so every branch has to be pinned —
+ * not just the one that force-flushes. A mutant that reported `'replaced'`
+ * everywhere would be perfectly correct about the MAP and would silently undo
+ * the whole optimization; a mutant that reported it nowhere would silently undo
+ * #1133's durability. Both directions are asserted below.
+ */
+describe('syncCoverageAfterArchiveMerge — reported transition', () => {
+  it('reports `replaced` ONLY when an existing record is overwritten with contiguity unproven', () => {
+    const coverage = new Map([['a@b', { bottomId: 'old-deep', topId: 'old-top' }]])
+    expect(
+      syncCoverageAfterArchiveMerge(base({ coverage, rsmFirst: 'new-deep', fetchLatestTopId: 'new-top' })).transition
+    ).toBe('replaced')
+  })
+
+  it('reports `created` for the first-ever fetch-latest — there is no assertion to overwrite', () => {
+    expect(
+      syncCoverageAfterArchiveMerge(base({ rsmFirst: 'deep', fetchLatestTopId: 'top' })).transition
+    ).toBe('created')
+  })
+
+  it('reports `created` for the forward-catch-up bootstrap', () => {
+    expect(
+      syncCoverageAfterArchiveMerge(
+        base({ direction: 'forward', isFetchLatest: false, complete: true, initialAfter: 'local-edge' })
+      ).transition
+    ).toBe('created')
+  })
+
+  it('reports `deepened` for a plain backward page resumed id-exactly from the bottom', () => {
+    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top' }]])
+    expect(
+      syncCoverageAfterArchiveMerge(
+        base({ coverage, isFetchLatest: false, initialBefore: 'deep', rsmFirst: 'deeper' })
+      ).transition
+    ).toBe('deepened')
+  })
+
+  it('reports `topRefreshed` when contiguity WAS proven and only the re-entry marker moves', () => {
+    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'old-top' }]])
+    expect(
+      syncCoverageAfterArchiveMerge(
+        base({ coverage, rsmFirst: 'shallow', fetchLatestTopId: 'new-top', sawCoverageTop: true })
+      ).transition
+    ).toBe('topRefreshed')
+  })
+
+  it('reports `none` for every branch that leaves the map alone', () => {
+    const coverage = new Map([['a@b', { bottomId: 'deep', topId: 'top' }]])
+    const none = (over: Partial<ArchiveMergeCoverageInput>) =>
+      syncCoverageAfterArchiveMerge(base({ coverage, ...over })).transition
+    expect(none({ preserveGapMarker: true, rsmFirst: 'x' })).toBe('none')
+    expect(none({ walkCarriedModifications: true, rsmFirst: 'x' })).toBe('none')
+    expect(none({ rsmFirst: undefined })).toBe('none')
+    expect(none({ rsmFirst: 'deep', fetchLatestTopId: 'top' })).toBe('none') // identical record
+    expect(none({ isFetchLatest: false, initialBefore: 'elsewhere', rsmFirst: 'x' })).toBe('none')
+    expect(none({ direction: 'forward', isFetchLatest: false, complete: true, initialAfter: 'edge' })).toBe('none')
   })
 })
 

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.ts
@@ -30,6 +30,41 @@ export interface CoverageRecord {
   topId?: string
 }
 
+/**
+ * What a merge did to the record — the persistence layer's durability input.
+ *
+ * Only ONE of these can leave disk asserting something memory has disproven,
+ * and it is the only one that has to escape the persistence throttle:
+ *
+ * | Transition     | Loss on a hard kill                                        | Durability |
+ * |----------------|------------------------------------------------------------|------------|
+ * | `none`         | nothing changed                                            | —          |
+ * | `created`      | disk holds NO record; next session re-seeds from the local downloaded edge, which is shallower. Asserts nothing. | throttle |
+ * | `deepened`     | disk holds the SHALLOWER previous bottom; Phase B re-walks covered ground. | throttle |
+ * | `topRefreshed` | disk holds a stale re-entry marker; one extra walked page.  | throttle   |
+ * | `replaced`     | **disk keeps the record whose contiguity this walk just DISPROVED, and Phase B seeds its backward walk from it — skipping the disconnected interval.** | **force-flush** |
+ *
+ * The asymmetry is the whole point: every safe transition errs SHALLOW (costing
+ * a re-walk), and only `replaced` can leave disk claiming coverage that does not
+ * exist. Removal is equally unsafe, but it needs no signal — the persistence
+ * layer sees a key disappear.
+ *
+ * This classification exists here, and not in the persistence layer, because
+ * archive ids are NON-SEQUENTIAL (see `mamGap`): nothing downstream can compare
+ * two `bottomId`s and tell a deepening from a replacement. Before #1138 the
+ * layer could only be conservative and force-flush every `bottomId` change,
+ * which cost one whole-blob serialization per conversation on a first session
+ * (~400 on the reference profile) and one per Phase B page.
+ */
+export type CoverageTransition = 'none' | 'created' | 'deepened' | 'topRefreshed' | 'replaced'
+
+/** {@link syncCoverageAfterArchiveMerge}'s result: the map, and what happened. */
+export interface CoverageSyncResult {
+  /** Copy-on-write: the SAME reference as the input when nothing changed. */
+  coverage: Map<string, CoverageRecord>
+  transition: CoverageTransition
+}
+
 /** Extra merge inputs carried on the mam-messages emit (both entity kinds). */
 export interface MergeArchiveExtras {
   /** The `before` cursor the query was started with ('' = fetch-latest). */
@@ -108,17 +143,21 @@ export interface ArchiveMergeCoverageInput {
  *   prove nothing about the live-contiguous bottom → no-op.
  *
  * Copy-on-write: returns the SAME map reference when nothing changes.
+ *
+ * The returned {@link CoverageTransition} is what the persistence layer keys its
+ * durability decision on — see that type for the loss analysis per branch.
  */
-export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput): Map<string, CoverageRecord> {
+export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput): CoverageSyncResult {
   const {
     coverage, id, direction, isFetchLatest, preserveGapMarker, complete, initialAfter,
     rsmFirst, fetchLatestTopId, initialBefore, sawCoverageTop, walkCarriedModifications,
   } = input
-  if (preserveGapMarker) return coverage
+  const unchanged: CoverageSyncResult = { coverage, transition: 'none' }
+  if (preserveGapMarker) return unchanged
   // Applies to BOTH directions: a walk whose corrections/retractions/reactions
   // were written fire-and-forget is not durably confirmed, so it may not certify
   // coverage — the forward bootstrap anchor included (Codex r4 #2).
-  if (walkCarriedModifications) return coverage
+  if (walkCarriedModifications) return unchanged
 
   if (direction !== 'backward') {
     // Bootstrap. Without this the record can only be born in the fetch-latest
@@ -136,37 +175,42 @@ export function syncCoverageAfterArchiveMerge(input: ArchiveMergeCoverageInput):
     // existing record, so a bottom already proven deeper always wins. Erring
     // shallow only costs Phase B a re-walk of covered ground; erring deep would
     // skip real history, and this path cannot do that.
-    if (!complete || !initialAfter) return coverage
-    if (coverage.get(id)) return coverage
+    if (!complete || !initialAfter) return unchanged
+    if (coverage.get(id)) return unchanged
     const next = new Map(coverage)
     next.set(id, { bottomId: initialAfter })
-    return next
+    return { coverage: next, transition: 'created' }
   }
 
   const existing = coverage.get(id)
 
   if (isFetchLatest) {
-    if (!rsmFirst) return coverage
+    if (!rsmFirst) return unchanged
     if (sawCoverageTop && existing) {
       if (fetchLatestTopId && fetchLatestTopId !== existing.topId) {
         const next = new Map(coverage)
         next.set(id, { ...existing, topId: fetchLatestTopId })
-        return next
+        return { coverage: next, transition: 'topRefreshed' }
       }
-      return coverage
+      return unchanged
     }
-    if (existing && existing.bottomId === rsmFirst && existing.topId === fetchLatestTopId) return coverage
+    if (existing && existing.bottomId === rsmFirst && existing.topId === fetchLatestTopId) return unchanged
     const next = new Map(coverage)
     next.set(id, { bottomId: rsmFirst, ...(fetchLatestTopId ? { topId: fetchLatestTopId } : {}) })
-    return next
+    // With a record present and contiguity with it NOT proven, this overwrites
+    // an assertion rather than making a first one — the one unsafe transition.
+    return { coverage: next, transition: existing ? 'replaced' : 'created' }
   }
 
   if (existing && rsmFirst && initialBefore === existing.bottomId && rsmFirst !== existing.bottomId) {
     const next = new Map(coverage)
     next.set(id, { ...existing, bottomId: rsmFirst })
-    return next
+    // The query resumed id-EXACTLY from the recorded bottom, so the new bottom
+    // extends the same contiguous run: losing it leaves the shallower one,
+    // which is still true.
+    return { coverage: next, transition: 'deepened' }
   }
-  return coverage
+  return unchanged
 }
 
 /**

--- a/packages/fluux-sdk/tsconfig.bench.json
+++ b/packages/fluux-sdk/tsconfig.bench.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "bench/**/*.ts",
+    "src/**/*.ts"
+  ]
+}

--- a/packages/fluux-sdk/vitest.bench.config.ts
+++ b/packages/fluux-sdk/vitest.bench.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * The persistence cost benchmark (issue #1138).
+ *
+ * Kept out of the default suite: it is a measurement, not an assertion, and it
+ * takes far longer than a unit test. Run it with `npm run bench:persist`.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    include: ['bench/**/*.bench.ts'],
+    // No `silent` — the report goes to stdout.
+    testTimeout: 120_000,
+    // Sequential: the stores and the throttle are module-level singletons, and
+    // a second worker's CPU contention would show up in `cpuMs`.
+    fileParallelism: false,
+    pool: 'forks',
+    maxForks: 1,
+    minForks: 1,
+  },
+})


### PR DESCRIPTION
Closes #1138.

#1133 force-flushed every coverage `bottomId` change, because the persistence layer cannot order archive ids and so could not tell a monotone deepening from an unsafe replacement. Measured on the reference 400-conversation profile, that conservatism cost the **entire** benefit of the throttle on a first session: coverage bootstrap fires once per entity with no record, and `flushKey` closes the window, so every mutation took a fresh leading edge.

| Scenario (25 ms spacing) | pre-#1133 | #1133 | this PR |
|---|---|---|---|
| Cold coverage bootstrap, chat | 400 writes / 88.9 MB | **400 / 88.9 MB** | **11 / 2.4 MB** |
| Phase B read-pointer stitch | 500 / 115.5 MB | **500 / 115.5 MB** | **14 / 3.2 MB** |
| Warm session | 400 / 92.3 MB | 11 / 2.5 MB | 11 / 2.5 MB |
| Gapped forward catch-up | 30 | 30 | 30 (unchanged, by design) |

In real engines: ~520 ms → ~16 ms of main-thread time in Chromium, ~330 ms → ~11 ms in WebKit, per scenario. Never one long task — 900 chunks of 1–6 ms competing with first paint.

## What changed

`syncCoverageAfterArchiveMerge` returns `{ coverage, transition }`. Only `replaced` — an existing record overwritten by a walk that did not prove contiguity with it — can leave disk asserting coverage memory has disproven. `created` and `deepened` err shallow when lost (no record at all, or the older-but-still-true bottom), costing a re-seed or a re-walk.

`durableMapPersist` keeps deriving removal from its baseline, so the clear paths need no changes, and takes the replacement as a signal from the one caller that can classify it. Gap rules are untouched. Both stores report where the value enters the state, not where it is computed: on the IndexedDB-gated path, reporting at merge time would arm the flush for a write still carrying the old record.

A `flushKey` variant leaving the window armed was measured and **not** taken — it can only recover the window-closing half, so it saves nothing when every mutation is structural, and it is a semantic change to a primitive `pendingRetractions` depends on. §3.2 of the design doc has the numbers.

Adds `packages/fluux-sdk/bench` (vitest write counts, Playwright Chromium/WebKit blocking) so the before/after is reproducible; full method and go/no-go in `docs/superpowers/specs/2026-07-28-coverage-persistence-cost-design.md`.