### PR TITLE
fix(fluux): prevent typing indicator from covering messages

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -586,10 +586,11 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
           </div>
         </div>
         <div
-          class="absolute bottom-0.5 start-4 z-30 max-w-[calc(100%-5rem)] pointer-events-none animate-toast-in"
+          class="shrink-0 px-4 pt-2 pb-0.5 pointer-events-none"
         >
           <div
-            class="rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5"
+            class="inline-block max-w-[calc(100%-4rem)] rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5 animate-toast-in"
+            data-typing-pill="true"
           >
             <div
               class="text-xs text-fluux-muted italic flex items-center gap-1.5 min-w-0 "

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -289,12 +289,8 @@ describe('MessageList scroll behavior', () => {
   })
 
   describe('typing indicator scroll', () => {
-    // The typing indicator floats OVER the list (it is not part of the scroll content); toggling it
-    // never changes scroll height on its own. But the footer reserves extra bottom padding to clear
-    // the pill while it's shown, and that DOES grow the scroll content — so while genuinely sticked
-    // to the bottom, reassertBottom re-pins to reveal the new clearance (same shared helper new
-    // messages use — a one-shot smooth nudge lands short because a virtualized footer needs a
-    // remeasure pass first). A reader scrolled up must never be yanked back (issue #918).
+    // MessageList owns the typing-band layout; these tests cover useMessageListScroll's edge
+    // contract: follow the band at the live edge, but never yank a reader out of history (#918).
     it('re-pins to the bottom when typing starts while sticked', () => {
       const messages = createTestMessages(5)
       const scrollSpy = vi.fn()
@@ -339,7 +335,7 @@ describe('MessageList scroll behavior', () => {
           />
         )
 
-        // Sticked to the bottom → the grown footer clearance is revealed by a re-pin to bottom.
+        // At the live edge, the typing edge re-pins.
         expect(scrollSpy).toHaveBeenCalledWith(1000)
       }
     })
@@ -403,7 +399,7 @@ describe('MessageList scroll behavior', () => {
   describe('reactions scroll', () => {
     // A reaction grows a message's row. While the reader is sticked to the bottom we keep the newest
     // message glued to the bottom edge via reassertBottom — the same shared helper new messages and the
-    // typing footer use. On the non-virtualized path that's an INSTANT scrollTop = scrollHeight write
+    // typing band use. On the non-virtualized path that's an INSTANT scrollTop = scrollHeight write
     // (no smooth animation, which is what used to visibly shove the newest message down). It is gated
     // on LIVE geometry, so a reader scrolled up into history is never re-pinned.
     const reactOnLast = (msgs: ReturnType<typeof createTestMessages>) => {

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -96,6 +96,11 @@ class MockResizeObserver {
   // Helper to trigger resize. Width is optional so existing height-only callers
   // are unaffected (contentRect.width stays undefined → the width branch is inert).
   triggerResize(height: number, width?: number) {
+    // ResizeObserver fires after layout: keep the observed element's live geometry
+    // in sync with the entry instead of leaving jsdom's clientHeight stale.
+    for (const target of this.targets) {
+      Object.defineProperty(target, 'clientHeight', { value: height, configurable: true })
+    }
     this.callback(
       [{ contentRect: { height, width } } as ResizeObserverEntry],
       this
@@ -495,7 +500,10 @@ describe('MessageList scroll behavior', () => {
       Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
       Object.defineProperty(container, 'scrollTop', {
         get: () => scrollTopValue,
-        set: (v) => { scrollTopValue = v; scrollSpy(v) },
+        set: (v) => {
+          scrollSpy(v)
+          scrollTopValue = Math.min(v, container.scrollHeight - container.clientHeight)
+        },
         configurable: true,
       })
 
@@ -738,8 +746,8 @@ describe('MessageList scroll behavior', () => {
         Object.defineProperty(container, 'scrollTop', {
           get: () => scrollTopValue,
           set: (v) => {
-            scrollTopValue = v
             scrollSpy(v)
+            scrollTopValue = Math.min(v, container.scrollHeight - container.clientHeight)
           },
           configurable: true,
         })

--- a/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.scroll.test.tsx
@@ -810,8 +810,8 @@ describe('MessageList scroll behavior', () => {
         Object.defineProperty(container, 'scrollTop', {
           get: () => scrollTopValue,
           set: (v) => {
-            scrollTopValue = v
             scrollSpy(v)
+            scrollTopValue = Math.min(v, container.scrollHeight - container.clientHeight)
           },
           configurable: true,
         })
@@ -828,8 +828,9 @@ describe('MessageList scroll behavior', () => {
             observer.triggerResize(460)
           })
 
-          // Should have scrolled to bottom after each resize
-          expect(scrollSpy).toHaveBeenCalled()
+          // The first observation establishes the baseline; each of the three
+          // subsequent shrinks should re-pin to the live edge.
+          expect(scrollSpy).toHaveBeenCalledTimes(3)
           // The last call should be scrolling to bottom
           expect(scrollSpy).toHaveBeenLastCalledWith(1000)
         }

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -914,9 +914,10 @@ export function MessageList<T extends BaseMessage>({
 
           Geometry is unchanged from the overlay: pt-2 above the pill + the footer's pb-2 inside the
           scroller put ~16px between the last message and the pill, and pb-0.5 leaves it just off the
-          composer. Sizing the band from the pill (rather than a fixed height) keeps that true when a
-          long "X, Y and Z are typing…" wraps. max-w keeps it clear of the bottom-end FAB, which still
-          floats at its own bottom-4 and so does not move when the band appears. */}
+          composer. Sizing the band from the pill (rather than a fixed height) keeps that true if the
+          pill's height changes; compact mode truncates to one line today (multi-line labels: issue
+          #1151). max-w keeps it clear of the bottom-end FAB, which still floats at its own bottom-4
+          and so does not move when the band appears. */}
       {typingUsers.length > 0 && (
         <div className="shrink-0 px-4 pt-2 pb-0.5 pointer-events-none">
           <div

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -694,16 +694,14 @@ export function MessageList<T extends BaseMessage>({
         )
       }
       case 'footer':
-        // Typing indicator is NOT rendered here — it floats over the list (see below). The footer's
-        // padding grows to pb-12 (clears the pill's ~46px height) only while it's shown, and shrinks
-        // back to pb-2 otherwise, so idle conversations don't carry the pill's clearance as dead
-        // space. The grow edge is paired with a live-geometry-gated nudge in useMessageListScroll
-        // (only when already at the bottom) so this never re-pins a reader scrolled up into history —
-        // the #918 bug was a stale isAtBottomRef latch, not a reactive footer height per se.
+        // Typing indicator is NOT rendered here — it lives in a band BELOW the scrollport (see the
+        // typing band after the scroller). Breathing room only; it stays a fixed pb-2 whether or not
+        // anyone is typing, so the footer row's measured height never changes and can never re-pin
+        // the list (the reason #918 moved the indicator out of the scroll content in the first place).
         return (
           <div data-row-kind="footer">
             {extraContent}
-            <div className={typingUsers.length > 0 ? 'pb-12' : 'pb-2'} />
+            <div className="pb-2" />
           </div>
         )
     }
@@ -880,11 +878,9 @@ export function MessageList<T extends BaseMessage>({
           {/* Extra content after messages */}
           {extraContent}
 
-          {/* Bottom breathing room. The typing indicator floats over the list (see below) rather
-              than living here. The padding grows to pb-12 (clears the pill) only while it's shown
-              and shrinks back to pb-2 otherwise — see the footer render case above for the safety
-              rationale (live-geometry-gated nudge, never re-pins a reader scrolled up). */}
-          <div className={typingUsers.length > 0 ? 'pb-12' : 'pb-2'} />
+          {/* Bottom breathing room. The typing indicator lives in its own band below the scrollport
+              (see after the scroller), so this stays constant — see the footer render case above. */}
+          <div className="pb-2" />
         </div>
         ))}
       </div>
@@ -901,17 +897,32 @@ export function MessageList<T extends BaseMessage>({
         onJump={scrollToMarker}
       />
 
-      {/* Floating typing indicator — anchored to the bottom of the message area rather than living
-          inside the scroll content, so it (a) stays visible whether the user is at the bottom or
-          scrolled up in history, and (b) never changes the scroll height (toggling it inline used to
-          re-pin the viewport and fight an upward scroll — issue #918). The spacer above grows to
-          pb-12 (48px) while typing; bottom-0.5 centres the ~30px pill vertically in that band so it
-          sits evenly (~16px each side) between the last message and the composer instead of hugging
-          the message. start-4 keeps it aligned under the messages and clear of the bottom-end FAB;
-          pointer-events-none so it never intercepts taps on the message beneath. */}
+      {/* Typing indicator — a band BELOW the scrollport, not inside the scroll content and not an
+          overlay on top of it.
+
+          Out of the scroll content because toggling it there changes scrollHeight, which re-pinned
+          the viewport and fought an upward scroll (issue #918); it also has to stay visible whether
+          the reader is at the bottom or up in history.
+
+          Out of the overlay position it had after #918 because an overlay pinned to the VIEWPORT
+          bottom cannot be cleared by padding reserved in the CONTENT: the two only line up when the
+          scroller sits at its exact bottom, and every other offset slides the last message down under
+          a pill that does not move. The reserved band was 48px against a 30px pill, so a 20px offset
+          — a small trackpad nudge, or the residual left after the composer grows to two lines —
+          already clipped the last line. As real layout the band cannot be scrolled into: the
+          scrollport simply ends above it.
+
+          Geometry is unchanged from the overlay: pt-2 above the pill + the footer's pb-2 inside the
+          scroller put ~16px between the last message and the pill, and pb-0.5 leaves it just off the
+          composer. Sizing the band from the pill (rather than a fixed height) keeps that true when a
+          long "X, Y and Z are typing…" wraps. max-w keeps it clear of the bottom-end FAB, which still
+          floats at its own bottom-4 and so does not move when the band appears. */}
       {typingUsers.length > 0 && (
-        <div className="absolute bottom-0.5 start-4 z-30 max-w-[calc(100%-5rem)] pointer-events-none animate-toast-in">
-          <div className="rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5">
+        <div className="shrink-0 px-4 pt-2 pb-0.5 pointer-events-none">
+          <div
+            data-typing-pill
+            className="inline-block max-w-[calc(100%-4rem)] rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5 animate-toast-in"
+          >
             <TypingIndicator typingUsers={typingUsers} formatUser={formatTypingUser} variant="compact" />
           </div>
         </div>

--- a/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.virtualizedScroll.test.tsx
@@ -582,7 +582,11 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     localStorage.clear()
   })
 
-  function instrumentScroller(scroller: HTMLElement, initialHeight: number) {
+  function instrumentScroller(
+    scroller: HTMLElement,
+    initialHeight: number,
+    clampScrollTop = false,
+  ) {
     let scrollHeightVal = initialHeight
     let scrollTopVal = 0
     const scrollTopSets: number[] = []
@@ -591,8 +595,10 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
     Object.defineProperty(scroller, 'scrollTop', {
       get: () => scrollTopVal,
       set: (v: number) => {
-        scrollTopVal = v
         scrollTopSets.push(v)
+        scrollTopVal = clampScrollTop
+          ? Math.min(v, scrollHeightVal - scroller.clientHeight)
+          : v
       },
       configurable: true,
     })
@@ -1054,8 +1060,20 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
       targets: Element[] = []
       constructor(cb: ResizeObserverCallback) {
         this.cb = cb
-        observers.push({ targets: this.targets, fire: (height: number) =>
-          this.cb([{ contentRect: { height } } as ResizeObserverEntry], this as unknown as ResizeObserver) })
+        observers.push({
+          targets: this.targets,
+          fire: (height: number) => {
+            // ResizeObserver reports post-layout geometry. Mirror that in jsdom so
+            // the live distance-from-bottom check sees the shrunken scrollport.
+            for (const target of this.targets) {
+              Object.defineProperty(target, 'clientHeight', { value: height, configurable: true })
+            }
+            this.cb(
+              [{ contentRect: { height } } as ResizeObserverEntry],
+              this as unknown as ResizeObserver,
+            )
+          },
+        })
       }
       observe(t: Element) { this.targets.push(t) }
       unobserve() {}
@@ -1067,7 +1085,7 @@ describe('MessageList — virtualized bottom-stick re-asserts as rows measure', 
         <MessageList messages={makeMessages(50)} conversationId="conv-grow" {...props} />,
       )
       const scroller = container.querySelector('[data-message-list]') as HTMLElement
-      const { grow } = instrumentScroller(scroller, 5000)
+      const { grow } = instrumentScroller(scroller, 5000, true)
       void grow
 
       // Sit at the bottom and let the scroll handler record isAtBottom = true.

--- a/apps/fluux/src/components/conversation/rowHeightEstimator.ts
+++ b/apps/fluux/src/components/conversation/rowHeightEstimator.ts
@@ -9,7 +9,7 @@ export interface RowChrome {
   newMarker: number       // the "New messages" divider rendered above a first-new row
   date: number            // a date separator row
   loadEarlierHeader: number // the load-earlier / history-start header row
-  footer: number          // the footer (typing indicator + bottom padding)
+  footer: number          // footer content (extra content + constant bottom padding)
 }
 
 export interface RowEstimatorContext {

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -299,11 +299,10 @@ export interface UseMessageListScrollOptions {
    *  while the reader is sticked to the bottom, so the growth is absorbed above (previous messages
    *  scroll up) instead of shoving the newest message down. */
   rowGrowthSignature: string
-  /** Whether the floating typing-indicator pill is currently shown. The footer reserves extra bottom
-   *  padding to clear the pill only while this is true; the 0→true edge drives the same instant
-   *  bottom re-pin as a reaction growing a row, gated on live geometry (see the reactions
-   *  effect) so it never fires for a reader scrolled up into history — the #918 "fight" was a stale
-   *  isAtBottomRef latch, not the padding change itself. */
+  /** Whether the in-flow typing-indicator band below the scrollport is currently shown. Its 0→true
+   *  edge shrinks the scrollport and drives the same instant bottom re-pin as a reaction growing a
+   *  row, gated on live geometry (see the typing effect) so it never fires for a reader scrolled up
+   *  into history — the #918 "fight" was a stale isAtBottomRef latch. */
   hasTypingIndicator?: boolean
   /** Whether the newest message is the local user's own (outgoing). When a NEW such message
    *  appears we scroll to the bottom regardless of position — you always want to see what you
@@ -3374,8 +3373,8 @@ export function useMessageListScroll({
   // last one: a row grown in the middle of the viewport would otherwise push everything below it
   // (including the newest message) down.
   //
-  // We route through the controller-owned live-edge convergence that new
-  // messages and the typing footer use) rather than a one-shot scrollToIndex, because the row's
+  // We route through the controller-owned live-edge convergence that new messages and the typing
+  // band use rather than a one-shot scrollToIndex, because the row's
   // ResizeObserver reports the grown height a frame or two AFTER the chip mounts — a single
   // synchronous pin would land on the pre-growth height and still let the bottom dip. The loop polls
   // scrollHeight per frame and re-pins instantly (no smooth easing, so nothing visibly animates),

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3441,18 +3441,18 @@ export function useMessageListScroll({
   }, [rowGrowthSignature, conversationId, staticMode])
 
   // ==========================================================================
-  // EFFECT: Typing indicator appears — reveal its footer clearance while sticked
+  // EFFECT: Typing indicator appears — re-pin under the band it takes from the scrollport
   // ==========================================================================
 
-  // The footer reserves extra bottom padding only while the typing pill is shown (see
-  // MessageList's footer render), so that clearance grows when typing starts. Unlike a reaction's
-  // few-pixel growth, the virtualized footer row needs a remeasure pass before the virtualizer's
-  // computed end offset accounts for the taller padding — a one-shot scrollToIndex lands short (the
-  // spacer hasn't caught up yet), leaving a residual gap under the pill. So this routes through the
-  // shared controller-owned live-edge loop (the same convergence new messages use)
-  // instead of the reactions effect's single smooth nudge. Same two safeguards though: live-geometry
-  // gate (not the latchable isAtBottomRef) and a same-conversation check. Only the false→true edge
-  // nudges; typing stopping SHRINKS the footer, which the browser clamps scrollTop for on its own.
+  // The typing indicator is a band BELOW the scrollport (see MessageList), so showing it shrinks the
+  // scroller by the band's height and leaves a reader who was sticked to the bottom that many pixels
+  // short of it. The scroller's own ResizeObserver would also catch this, but only a frame later
+  // (its correction is rAF-deferred, see the container-resize effect); re-pinning here, in the same
+  // commit that mounts the band, avoids that frame of visible drift. Routed through the shared
+  // controller-owned live-edge loop (the same convergence new messages use) so the virtualized path
+  // re-windows rather than taking a raw scrollTop write. Two safeguards: a live-geometry gate (not
+  // the latchable isAtBottomRef) and a same-conversation check. Only the false→true edge re-pins;
+  // typing stopping GROWS the scroller back, which the browser clamps scrollTop for on its own.
   const prevHasTypingRef = useRef(hasTypingIndicator)
   const typingConvRef = useRef(conversationId)
   useLayoutEffect(() => {
@@ -3461,7 +3461,7 @@ export function useMessageListScroll({
     const prevHasTyping = prevHasTypingRef.current
     prevHasTypingRef.current = hasTypingIndicator
     if (!sameConversation) return // conversation switch → rebaseline, never nudge
-    if (!hasTypingIndicator || prevHasTyping) return // only the off→on edge grows the footer
+    if (!hasTypingIndicator || prevHasTyping) return // only the off→on edge shrinks the scrollport
 
     const scroller = scrollerRef.current
     if (!scroller || staticMode) return

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -3505,10 +3505,11 @@ export function useMessageListScroll({
 
       const shrunk = lastHeight - newHeight
       if (shrunk > 0 && scrollerRef.current) {
-        const wasNear = getDistanceFromBottom(scrollerRef.current) <= shrunk + AT_BOTTOM_THRESHOLD
+        const distanceFromBottom = getDistanceFromBottom(scrollerRef.current)
+        const wasNear = distanceFromBottom <= shrunk + AT_BOTTOM_THRESHOLD
         // Route through live-edge reconciliation so the virtualized path re-windows rather
         // than a raw scrollTop write that would leave the mounted window stale → blank/clipped.
-        if (wasNear) {
+        if (wasNear && distanceFromBottom > BOTTOM_PIN_TOLERANCE) {
           reconcileLiveEdgeRef.current('container-shrink')
         }
       } else if (

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -1789,6 +1789,33 @@ test.describe('Typing indicator never covers message text', () => {
   /** "Glued", not merely "near" (AT_BOTTOM_OK_PX is 150) — only sub-pixel rounding is allowed. */
   const GLUED_TOLERANCE_PX = 2
 
+  function capturePinStarts(page: Page): () => Promise<string[]> {
+    const pending: Array<Promise<string | null>> = []
+    page.on('console', (message) => {
+      if (!message.text().includes('[Scroll] PIN start')) return
+      const data = message.args()[1]
+      if (!data) return
+      pending.push(
+        data
+          .jsonValue()
+          .then((value) => {
+            const trigger = (value as { trigger?: unknown } | null)?.trigger
+            return typeof trigger === 'string' ? trigger : null
+          })
+          .catch(() => null),
+      )
+    })
+    return async () =>
+      (await Promise.all(pending)).filter((trigger): trigger is string => trigger !== null)
+  }
+
+  async function enableScrollDebug(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).__fluuxScrollDebug?.(true)
+    })
+  }
+
   interface OverlapProbe {
     pillFound: boolean
     pillHeight: number
@@ -1900,6 +1927,9 @@ test.describe('Typing indicator never covers message text', () => {
     await startTyping(page, AVA)
     await page.waitForTimeout(SETTLE_MS)
 
+    const readPinStarts = capturePinStarts(page)
+    await enableScrollDebug(page)
+
     /** Drive the draft the way React's controlled textarea expects, then let layout settle. */
     const setDraft = async (value: string) => {
       await page.evaluate((v) => {
@@ -1925,6 +1955,10 @@ test.describe('Typing indicator never covers message text', () => {
     const shrunk = await probeOverlap(page, 0)
     expect(shrunk.pillFound && shrunk.visibleRows > 0, 'pill/rows missing after composer shrank').toBe(true)
     expect(shrunk.worstOverlap, `pill covers ${shrunk.worstRowId} after the composer shrank back`).toBe(0)
+
+    expect(await readPinStarts(), 'composer growth must retain container-shrink reconciliation').toContain(
+      'container-shrink',
+    )
   })
 
   /** React on the newest message through the real store path, so its row genuinely grows. */
@@ -1980,12 +2014,18 @@ test.describe('Typing indicator never covers message text', () => {
     const lastId = await reactToNewest(page, AVA)
     await scrollToBottom(page)
 
+    const readPinStarts = capturePinStarts(page)
+    await enableScrollDebug(page)
     await startTyping(page, AVA)
     await page.waitForTimeout(SETTLE_MS)
 
     const glued = await measureGlued(page, lastId)
     expect(glued.dist, 'view left off the bottom after typing started').toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
     expect(glued.belowFold, 'reaction chip on the last message left below the fold').toBeLessThanOrEqual(0)
+
+    const pinStarts = await readPinStarts()
+    expect(pinStarts.filter((trigger) => trigger === 'typing')).toHaveLength(1)
+    expect(pinStarts.filter((trigger) => trigger === 'container-shrink')).toHaveLength(0)
   })
 
   test('a reaction landing on the last message while typing shows stays glued to the bottom', async ({ page }) => {

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -1773,6 +1773,238 @@ test.describe('At-bottom stick diagnostic (1:1)', () => {
 })
 
 // ── DIAGNOSTIC: send sticks to the bottom even when the optimistic row is reconciled ────────────
+// The typing indicator is a floating pill anchored to the BOTTOM OF THE VIEWPORT (issue #918 moved
+// it out of the scroll content so toggling it can't re-pin the list). Its clearance, though, used to
+// be reserved as CONTENT padding at the end of the list — the two only line up when the scroller sits
+// at its exact bottom. Every other scroll offset slides the content down under a pill that does not
+// move, so the last message ends up behind it: measured on the demo (30px pill, 48px content spacer)
+// the clearance was a mere 16px, and an offset of 20px already clipped the last line.
+// The fix reserves the band OUTSIDE the scrollport, so no scroll offset can put text under the pill.
+test.describe('Typing indicator never covers message text', () => {
+  const AVA = 'ava@fluux.chat'
+
+  /** Distances from the bottom to park the viewport at. 16-48 is the window the old bug lived in. */
+  const OFFSETS_PX = [0, 8, 16, 20, 24, 32, 40, 48, 96, 240]
+
+  /** "Glued", not merely "near" (AT_BOTTOM_OK_PX is 150) — only sub-pixel rounding is allowed. */
+  const GLUED_TOLERANCE_PX = 2
+
+  interface OverlapProbe {
+    pillFound: boolean
+    pillHeight: number
+    pillWidth: number
+    visibleRows: number
+    /** Largest vertical intersection (px) between the pill and any VISIBLE part of a message row. */
+    worstOverlap: number
+    worstRowId: string | null
+  }
+
+  /**
+   * Emit `composing` and wait for the LIVE list's pill to be laid out. Scoped to the live list's
+   * own container rather than a bare document query: other MessageLists can be mounted (search /
+   * activity previews), and a zero-width one would satisfy a document-wide selector while telling
+   * us nothing about the conversation under test.
+   */
+  async function startTyping(page: Page, jid: string): Promise<void> {
+    await page.evaluate((j) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      if (!c) throw new Error('no __demoClient')
+      c.emitSDK('chat:typing', { conversationId: j, jid: j, isTyping: true })
+    }, jid)
+    await page.waitForFunction(() => {
+      const s = document.querySelector('[data-message-list]')
+      const pill = s?.parentElement?.querySelector('[data-typing-pill]') as HTMLElement | null
+      if (!pill) return false
+      const r = pill.getBoundingClientRect()
+      return r.width > 0 && r.height > 0
+    }, undefined, { timeout: 5_000 })
+  }
+
+  /**
+   * Park the viewport `offset` px above the bottom and measure how deeply the pill cuts into
+   * message text. Rows are clipped to the scrollport first: the virtualizer keeps overscan rows
+   * mounted below the fold, and those are not on screen — only pixels the reader can actually see
+   * count as covered.
+   */
+  async function probeOverlap(page: Page, offset: number): Promise<OverlapProbe> {
+    return page.evaluate((off) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const pill = s?.parentElement?.querySelector('[data-typing-pill]') as HTMLElement | null
+      if (!s || !pill) {
+        return { pillFound: false, pillHeight: 0, pillWidth: 0, visibleRows: 0, worstOverlap: 0, worstRowId: null }
+      }
+
+      s.scrollTop = s.scrollHeight - s.clientHeight - off
+      const sRect = s.getBoundingClientRect()
+      const p = pill.getBoundingClientRect()
+
+      let visibleRows = 0
+      let worstOverlap = 0
+      let worstRowId: string | null = null
+      for (const el of Array.from(s.querySelectorAll('[data-message-id]'))) {
+        const r = el.getBoundingClientRect()
+        const visTop = Math.max(r.top, sRect.top)
+        const visBottom = Math.min(r.bottom, sRect.bottom)
+        if (visBottom - visTop <= 0) continue // clipped out of the scrollport
+        visibleRows++
+        const overlapY = Math.min(visBottom, p.bottom) - Math.max(visTop, p.top)
+        const overlapX = Math.min(r.right, p.right) - Math.max(r.left, p.left)
+        if (overlapY > 0 && overlapX > 0 && overlapY > worstOverlap) {
+          worstOverlap = overlapY
+          worstRowId = el.getAttribute('data-message-id')
+        }
+      }
+      return {
+        pillFound: true,
+        pillHeight: Math.round(p.height),
+        pillWidth: Math.round(p.width),
+        visibleRows,
+        worstOverlap: Math.round(worstOverlap),
+        worstRowId,
+      }
+    }, offset)
+  }
+
+  test('no scroll offset puts a visible message row under the pill', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+    await startTyping(page, AVA)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const results: Array<{ offset: number; probe: OverlapProbe }> = []
+    for (const offset of OFFSETS_PX) {
+      const probe = await probeOverlap(page, offset)
+      // Guard against a hollow pass: an unmounted pill or an empty list would trivially
+      // report zero overlap.
+      expect(probe.pillFound, `typing pill not rendered at offset ${offset}`).toBe(true)
+      expect(probe.pillHeight, `typing pill has no height at offset ${offset}`).toBeGreaterThan(10)
+      expect(probe.pillWidth, `typing pill has no width at offset ${offset}`).toBeGreaterThan(10)
+      expect(probe.visibleRows, `no message rows visible at offset ${offset}`).toBeGreaterThan(0)
+      results.push({ offset, probe })
+    }
+
+    const covered = results.filter((r) => r.probe.worstOverlap > 0)
+    expect(
+      covered,
+      'typing pill covers message text at ' +
+        covered.map((r) => `offset=${r.offset}px (${r.probe.worstOverlap}px of ${r.probe.worstRowId})`).join(', '),
+    ).toEqual([])
+  })
+
+  test('growing the composer to two lines and shrinking it back never parks text under the pill', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+    await startTyping(page, AVA)
+    await page.waitForTimeout(SETTLE_MS)
+
+    /** Drive the draft the way React's controlled textarea expects, then let layout settle. */
+    const setDraft = async (value: string) => {
+      await page.evaluate((v) => {
+        const ta = document.querySelector('textarea') as HTMLTextAreaElement | null
+        if (!ta) throw new Error('no composer textarea')
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!
+        setter.call(ta, v)
+        ta.dispatchEvent(new Event('input', { bubbles: true }))
+      }, value)
+      await page.waitForTimeout(SETTLE_MS)
+    }
+
+    const twoLines =
+      'This draft is long enough to wrap the composer onto a second line, which shrinks the ' +
+      'message viewport under a pill that does not move with it.'
+
+    await setDraft(twoLines)
+    const grown = await probeOverlap(page, 0)
+    expect(grown.pillFound && grown.visibleRows > 0, 'pill/rows missing after composer grew').toBe(true)
+    expect(grown.worstOverlap, `pill covers ${grown.worstRowId} while the composer is two lines`).toBe(0)
+
+    await setDraft('')
+    const shrunk = await probeOverlap(page, 0)
+    expect(shrunk.pillFound && shrunk.visibleRows > 0, 'pill/rows missing after composer shrank').toBe(true)
+    expect(shrunk.worstOverlap, `pill covers ${shrunk.worstRowId} after the composer shrank back`).toBe(0)
+  })
+
+  /** React on the newest message through the real store path, so its row genuinely grows. */
+  async function reactToNewest(page: Page, jid: string): Promise<string> {
+    const lastId = await page.evaluate((j) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const st = (window as any).__chatStore.getState()
+      const msgs = st.messages.get(j) ?? []
+      const last = msgs[msgs.length - 1]
+      if (!last) return null
+      st.updateReactions(j, last.id, j, ['👍'])
+      return last.id as string
+    }, jid)
+    expect(lastId, 'precondition: a newest message to react to').toBeTruthy()
+    await page.waitForFunction(
+      (id) => {
+        const s = document.querySelector('[data-message-list]')
+        return !!s?.querySelector(`[data-message-id="${CSS.escape(id)}"]`)?.textContent?.includes('👍')
+      },
+      lastId as string,
+      { timeout: 5_000 },
+    )
+    return lastId as string
+  }
+
+  /** How far off the bottom we are, and how far the reacted row hangs below the fold. */
+  async function measureGlued(page: Page, id: string): Promise<{ dist: number; belowFold: number }> {
+    return page.evaluate((msgId) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const el = s?.querySelector(`[data-message-id="${CSS.escape(msgId)}"]`) as HTMLElement | null
+      if (!s || !el) return { dist: -1, belowFold: 9999 }
+      return {
+        dist: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+        // How far the reacted row's bottom (chip included) sits BELOW the scrollport's bottom edge.
+        belowFold: Math.round(el.getBoundingClientRect().bottom - s.getBoundingClientRect().bottom),
+      }
+    }, id)
+  }
+
+  // Reported alongside the overlap: "we don't stick perfectly to the bottom when the last message
+  // ALSO has reactions". These two pin the combination down at both orders (they exercise different
+  // effects: the typing re-pin vs the reaction nudge). Both were already GREEN on the pre-band code
+  // in Chromium and WebKit — the re-pin runs in a layout effect, so it lands before paint and no dip
+  // is observable here; what the reader was seeing was almost certainly the overlap itself, a chip
+  // hidden under the pill reading as "not stuck to the bottom". Kept as guards: with the indicator
+  // out of the scroll content, showing it must not move content at all, and the reacted row must
+  // stay whole. Tolerance is tight on purpose — this asserts "glued", not "near".
+  test('typing starting on a last message that carries a reaction stays glued to the bottom', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+
+    const lastId = await reactToNewest(page, AVA)
+    await scrollToBottom(page)
+
+    await startTyping(page, AVA)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const glued = await measureGlued(page, lastId)
+    expect(glued.dist, 'view left off the bottom after typing started').toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
+    expect(glued.belowFold, 'reaction chip on the last message left below the fold').toBeLessThanOrEqual(0)
+  })
+
+  test('a reaction landing on the last message while typing shows stays glued to the bottom', async ({ page }) => {
+    await loadDemo(page)
+    await activateChat(page, AVA)
+    await scrollToBottom(page)
+
+    await startTyping(page, AVA)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const lastId = await reactToNewest(page, AVA)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const glued = await measureGlued(page, lastId)
+    expect(glued.dist, 'view left off the bottom after a reaction landed under the pill').toBeLessThanOrEqual(GLUED_TOLERANCE_PX)
+    expect(glued.belowFold, 'reaction chip on the last message left below the fold').toBeLessThanOrEqual(0)
+  })
+})
+
 // "I sent a message and the view didn't stick to the bottom." A send REPLACES the optimistic last
 // row in place (reconciled to the server id) WITHOUT growing messageCount, so the old count-only
 // new-message effect never re-pinned. The reconciled row often measures taller (final layout), so

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -717,7 +717,7 @@ test.describe('Virtualization scroll invariants', () => {
       const last = rows[rows.length - 1] as HTMLElement
       const sRect = scroller.getBoundingClientRect()
       const lRect = last.getBoundingClientRect()
-      // Accept a bottom gap of 120px (FAB / padding / typing indicator overlap)
+      // This legacy blank-window check is loose; the strict message/pill overlap check lives below.
       return lRect.top >= sRect.top - 10 && lRect.bottom <= sRect.bottom + 120
     })
     expect(isLastVisible, 'last message row is not in viewport after FAB click — blank/short window').toBe(true)
@@ -1541,8 +1541,8 @@ test.describe('At-bottom stick diagnostic (1:1)', () => {
     await activateChat(page, AVA)
     await scrollToBottom(page)
 
-    // Real-world sequence: the other party is typing (indicator grows the footer), THEN the
-    // message lands (indicator clears + message appends).
+    // Real-world sequence: the other party is typing (a band appears below the scrollport), THEN
+    // the message lands (the band disappears and the message appends).
     await page.evaluate((jid) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const c = (window as any).__demoClient
@@ -1773,13 +1773,9 @@ test.describe('At-bottom stick diagnostic (1:1)', () => {
 })
 
 // ── DIAGNOSTIC: send sticks to the bottom even when the optimistic row is reconciled ────────────
-// The typing indicator is a floating pill anchored to the BOTTOM OF THE VIEWPORT (issue #918 moved
-// it out of the scroll content so toggling it can't re-pin the list). Its clearance, though, used to
-// be reserved as CONTENT padding at the end of the list — the two only line up when the scroller sits
-// at its exact bottom. Every other scroll offset slides the content down under a pill that does not
-// move, so the last message ends up behind it: measured on the demo (30px pill, 48px content spacer)
-// the clearance was a mere 16px, and an offset of 20px already clipped the last line.
-// The fix reserves the band OUTSIDE the scrollport, so no scroll offset can put text under the pill.
+// Regression for the overlay/content-coordinate mismatch documented beside the typing band in
+// MessageList. In the old layout a 30px pill had only 16px clearance at the exact bottom, and a
+// 20px scroll offset already clipped the last line.
 test.describe('Typing indicator never covers message text', () => {
   const AVA = 'ava@fluux.chat'
 
@@ -2004,8 +2000,8 @@ test.describe('Typing indicator never covers message text', () => {
   // in Chromium and WebKit — the re-pin runs in a layout effect, so it lands before paint and no dip
   // is observable here; what the reader was seeing was almost certainly the overlap itself, a chip
   // hidden under the pill reading as "not stuck to the bottom". Kept as guards: with the indicator
-  // out of the scroll content, showing it must not move content at all, and the reacted row must
-  // stay whole. Tolerance is tight on purpose — this asserts "glued", not "near".
+  // out of the scroll content, showing it must not change the content height, and the reacted row
+  // must stay whole. Tolerance is tight on purpose — this asserts "glued", not "near".
   test('typing starting on a last message that carries a reaction stays glued to the bottom', async ({ page }) => {
     await loadDemo(page)
     await activateChat(page, AVA)


### PR DESCRIPTION
- Move the typing indicator into an in-flow band below the message scrollport so it cannot cover visible messages.
- Preserve live-edge positioning while avoiding duplicate resize reconciliation when the typing band appears.
- Add scroll regression coverage for near-bottom offsets, composer resizing, and typing/reaction ordering, with updated snapshots and documentation.