### PR TITLE
chore(deps): upgrade to react-router 8.3.0

### DIFF
--- a/apps/fluux/package.json
+++ b/apps/fluux/package.json
@@ -46,7 +46,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-i18next": "^17.0.0",
-    "react-router-dom": "^7.12.0",
+    "react-router": "^8.3.0",
     "shiki": "^4.0.2",
     "xstate": "^5.25.1",
     "zustand": "^5.0.0"

--- a/apps/fluux/src/App.reconnect.test.tsx
+++ b/apps/fluux/src/App.reconnect.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import App from './App'
 
 // Stub the Tauri IPC modules so the real `@tauri-apps/api/{core,event}` are

--- a/apps/fluux/src/App.routes.test.tsx
+++ b/apps/fluux/src/App.routes.test.tsx
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import App from './App'
 
 // Stub the Tauri IPC modules so the real `@tauri-apps/api/{core,event}` are

--- a/apps/fluux/src/App.tsx
+++ b/apps/fluux/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { useConnectionStatus, useXMPPContext, hasFastToken, getBareJid, getDomain } from '@fluux/sdk'
 import { registerE2EEPlugins } from './e2ee/registerPlugins'

--- a/apps/fluux/src/components/AppBar.test.tsx
+++ b/apps/fluux/src/components/AppBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { AppBar } from './AppBar'
 
 // Reactive gates — toggled per test.
@@ -17,8 +17,8 @@ vi.mock('@/hooks/useFullscreen', () => ({
 }))
 
 const navigateSpy = vi.fn()
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>()
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>()
   return { ...actual, useNavigate: () => navigateSpy }
 })
 

--- a/apps/fluux/src/components/AppBar.tsx
+++ b/apps/fluux/src/components/AppBar.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
-import { useNavigate, useLocation, useNavigationType } from 'react-router-dom'
+import { useNavigate, useLocation, useNavigationType } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useIsDesktop } from '@/hooks/useIsDesktop'

--- a/apps/fluux/src/components/ChatLayout.test.tsx
+++ b/apps/fluux/src/components/ChatLayout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom'
+import { MemoryRouter, NavLink, useLocation, useNavigate } from 'react-router'
 import { ChatLayout } from './ChatLayout'
 import type { Contact, PresenceStatus } from '@fluux/sdk'
 
@@ -491,9 +491,7 @@ vi.mock('./Sidebar', () => ({
     onSelectContact: (contact: Contact) => void
     onStartChat: (contact: Contact) => void
   }) => {
-    // Use NavLink from react-router-dom for navigation
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { NavLink, useLocation } = require('react-router-dom')
+    // Use NavLink from react-router for navigation
     const location = useLocation()
     // Derive sidebarView from URL path for display
     const pathToView: Record<string, string> = {

--- a/apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
+++ b/apps/fluux/src/components/Sidebar.archiveToggle.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 
 // Mock ConversationList and ArchiveList before importing Sidebar
 vi.mock('./sidebar-components/ConversationList', () => ({

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router'
 import { useEffect, type ReactNode } from 'react'
 import { IconRailNavLink } from './IconRailNavLink'
 import { MessageCircle, Hash } from 'lucide-react'

--- a/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
+++ b/apps/fluux/src/components/sidebar-components/IconRailNavLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { Tooltip } from '../Tooltip'
 import type { SidebarView } from './types'
 

--- a/apps/fluux/src/demo.tsx
+++ b/apps/fluux/src/demo.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { HashRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router'
 import { XMPPProvider, E2EEManager, InMemoryStorageBackend } from '@fluux/sdk'
 import { DemoClient, setResidentWindowSize } from '@fluux/sdk/demo'
 import { adminStore, chatStore, ignoreStore, roomStore } from '@fluux/sdk/stores'

--- a/apps/fluux/src/hooks/useDeepLink.test.tsx
+++ b/apps/fluux/src/hooks/useDeepLink.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router'
 import { useEffect, type ReactNode } from 'react'
 
 // Mock the SDK hooks

--- a/apps/fluux/src/hooks/useNavigateToTarget.test.tsx
+++ b/apps/fluux/src/hooks/useNavigateToTarget.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router'
 import { useEffect, type ReactNode } from 'react'
 import { useNavigateToTarget } from './useNavigateToTarget'
 

--- a/apps/fluux/src/hooks/useNavigateToTarget.ts
+++ b/apps/fluux/src/hooks/useNavigateToTarget.ts
@@ -8,7 +8,7 @@
  * Phase 2.4: Uses React Router for navigation instead of callback handlers.
  */
 import { useRef, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useChatStore, useRoomStore } from '@fluux/sdk/react'
 import { dismissNotification } from '@/utils/dismissNotification'
 

--- a/apps/fluux/src/hooks/useRouteSync.test.tsx
+++ b/apps/fluux/src/hooks/useRouteSync.test.tsx
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router'
 import { useRouteSync, getViewPath } from './useRouteSync'
 import type { ReactNode } from 'react'
 

--- a/apps/fluux/src/hooks/useRouteSync.ts
+++ b/apps/fluux/src/hooks/useRouteSync.ts
@@ -25,7 +25,7 @@
  * - Back/up navigation uses `replace` (clean return to list)
  */
 import { useCallback, useMemo } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router'
 import type { SidebarView } from '@/components/sidebar-components/types'
 
 /** Options for navigation functions to control history behavior */

--- a/apps/fluux/src/hooks/useViewNavigation.test.tsx
+++ b/apps/fluux/src/hooks/useViewNavigation.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
 import { useEffect, type ReactNode } from 'react'
 import { useViewNavigation } from './useViewNavigation'
 

--- a/apps/fluux/src/main.tsx
+++ b/apps/fluux/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { HashRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router'
 import { XMPPProvider } from '@fluux/sdk'
 import { ThemeProvider } from './providers/ThemeProvider'
 import { RenderLoopBoundary, RenderLoopWarningBanner } from './components/RenderLoopBoundary'

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.22.0"
       }
     },
     "apps/fluux": {
@@ -54,7 +54,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^17.0.0",
-        "react-router-dom": "^7.12.0",
+        "react-router": "^8.3.0",
         "shiki": "^4.0.2",
         "xstate": "^5.25.1",
         "zustand": "^5.0.0"
@@ -86,6 +86,27 @@
         "vite": "^8.0.16",
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.1.0"
+      }
+    },
+    "apps/fluux/node_modules/react-router": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7557,18 +7578,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -12284,44 +12298,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.15.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
     "node_modules/react-scan": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/react-scan/-/react-scan-0.5.7.tgz",
@@ -12907,12 +12883,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.22.0"
   },
   "dependencies": {
     "@tauri-apps/plugin-deep-link": "^2.4.7"


### PR DESCRIPTION
Upgrades React Router from 7.15.1 to 8.3.0.

v8 removes the `react-router-dom` re-export package (its last release is 7.18.1), so this is a package swap rather than a version bump — all imports move to `react-router`. Every API the app uses (`HashRouter`, `MemoryRouter`, `Routes`, `Route`, `Navigate`, `NavLink`, `useNavigate`, `useLocation`, `useParams`, `useNavigationType`) is exported from the main entry, so the `react-router/dom` subpath is not needed.

v8 is ESM-only, so the `require()` in `ChatLayout.test.tsx` is replaced by the existing top-level import.

The app is declarative-mode only (no loaders, actions, `meta`, or `createBrowserRouter`), so none of the v8 future flags apply and the `data` -> `loaderData` rename is a no-op here. `engines.node` moves to `>=22.22.0` to match the v8 floor; React 19.2.7 and Vite 8 already satisfy the rest.

This clears five advisories against react-router 7.15.1, including the high-severity open redirect via backslash in `<Link>` and `useNavigate` (CVE-2025-68470 bypass).