### PR TITLE
chore: ignore local CLAUDE.md agent guidance files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ server/
 .superpowers/
 .agents/
 AGENTS.md
+CLAUDE.md
 
 # Gas Town (added by gt)
 .runtime/


### PR DESCRIPTION
CLAUDE.md files are per-developer agent guidance, generated locally and not part of the repository, exactly like the `AGENTS.md` entry directly above it. Ignoring them keeps them out of `git status` as untracked noise.

The pattern has no leading slash, so it matches at every level — the repository root and nested package directories alike, matching how `AGENTS.md` already behaves.