### PR TITLE
fix(ui): let the typing indicator label wrap to two lines

### DIFF
--- a/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
+++ b/apps/fluux/src/components/__snapshots__/ChatView.test.tsx.snap
@@ -610,7 +610,7 @@ exports[`ChatView > Snapshots > should match snapshot with typing indicator 1`] 
                 />
               </span>
               <span
-                class="truncate"
+                class="line-clamp-2 break-words"
                 dir="auto"
               >
                 Alice Smith is typing...

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -915,16 +915,18 @@ export function MessageList<T extends BaseMessage>({
           Geometry is unchanged from the overlay: pt-2 above the pill + the footer's pb-2 inside the
           scroller put ~16px between the last message and the pill, and pb-0.5 leaves it just off the
           composer. Sizing the band from the pill (rather than a fixed height) keeps that true if the
-          pill's height changes; compact mode truncates to one line today (multi-line labels: issue
-          #1151). max-w keeps it clear of the bottom-end FAB, which still floats at its own bottom-4
-          and so does not move when the band appears. */}
+          pill's height changes, which is what lets the label take a second line: a crowded room or a
+          wordier locale wraps instead of being cut off (issue #1151). Two lines is the cap — beyond
+          that the band would take enough of the message area that clipping is the better trade.
+          max-w keeps it clear of the bottom-end FAB, which still floats at its own bottom-4 and so
+          does not move when the band appears. */}
       {typingUsers.length > 0 && (
         <div className="shrink-0 px-4 pt-2 pb-0.5 pointer-events-none">
           <div
             data-typing-pill
             className="inline-block max-w-[calc(100%-4rem)] rounded-full bg-fluux-float border border-fluux-border shadow-lg px-3 py-1.5 animate-toast-in"
           >
-            <TypingIndicator typingUsers={typingUsers} formatUser={formatTypingUser} variant="compact" />
+            <TypingIndicator typingUsers={typingUsers} formatUser={formatTypingUser} variant="compact" maxLines={2} />
           </div>
         </div>
       )}

--- a/apps/fluux/src/components/conversation/TypingIndicator.test.tsx
+++ b/apps/fluux/src/components/conversation/TypingIndicator.test.tsx
@@ -143,4 +143,38 @@ describe('TypingIndicator', () => {
       expect(container.querySelectorAll('.typing-dot').length).toBe(3)
     })
   })
+
+  describe('line clamping', () => {
+    const label = (container: HTMLElement) => container.querySelector('[dir="auto"]') as HTMLElement
+
+    it('keeps the compact label on a single ellipsised line by default (sidebar preview)', () => {
+      const { container } = render(
+        <TypingIndicator typingUsers={['Alice']} variant="compact" />,
+      )
+      expect(label(container).className).toContain('truncate')
+      expect(label(container).className).not.toContain('line-clamp-2')
+    })
+
+    it('lets the compact label wrap to two lines when asked (conversation band)', () => {
+      const { container } = render(
+        <TypingIndicator typingUsers={['Alice']} variant="compact" maxLines={2} />,
+      )
+      // truncate carries whitespace-nowrap, so it must be gone for wrapping to be possible at all
+      expect(label(container).className).not.toContain('truncate')
+      expect(label(container).className).toContain('line-clamp-2')
+    })
+
+    it('breaks long words so an unspaced name cannot overflow the pill', () => {
+      const { container } = render(
+        <TypingIndicator typingUsers={['A'.repeat(80)]} variant="compact" maxLines={2} />,
+      )
+      expect(label(container).className).toContain('break-words')
+    })
+
+    it('never clamps the default variant', () => {
+      const { container } = render(<TypingIndicator typingUsers={['Alice']} />)
+      expect(label(container).className).not.toContain('truncate')
+      expect(label(container).className).not.toContain('line-clamp-2')
+    })
+  })
 })

--- a/apps/fluux/src/components/conversation/TypingIndicator.tsx
+++ b/apps/fluux/src/components/conversation/TypingIndicator.tsx
@@ -21,6 +21,15 @@ export interface TypingIndicatorProps {
    * padding and uses text-xs so it fits a sidebar preview line.
    */
   variant?: 'default' | 'compact'
+  /**
+   * How many lines the label may occupy before it is clipped with an ellipsis.
+   * Clamping is a property of the slot, not of the density: a sidebar preview
+   * row has exactly one line to give, while the in-conversation band grows with
+   * the pill and can afford a second one for long or multi-typer labels.
+   *
+   * Defaults to 1 in `compact` and to no clamp at all in `default`.
+   */
+  maxLines?: 1 | 2
 }
 
 /**
@@ -38,7 +47,13 @@ export interface TypingIndicatorProps {
  * // For rooms - use nicknames directly
  * <TypingIndicator typingUsers={['Alice', 'Bob']} />
  */
-export function TypingIndicator({ typingUsers, formatUser, className = '', variant = 'default' }: TypingIndicatorProps) {
+export function TypingIndicator({
+  typingUsers,
+  formatUser,
+  className = '',
+  variant = 'default',
+  maxLines,
+}: TypingIndicatorProps) {
   const { t } = useTranslation()
 
   if (typingUsers.length === 0) return null
@@ -73,6 +88,12 @@ export function TypingIndicator({ typingUsers, formatUser, className = '', varia
       ? `text-xs text-fluux-muted italic flex items-center gap-1.5 min-w-0 ${className}`
       : `py-2 px-4 text-sm text-fluux-muted italic flex items-center gap-2 ${className}`
 
+  // `truncate` bundles whitespace-nowrap, so the two cases are mutually exclusive: a single line is
+  // ellipsised, two lines wrap first and are ellipsised on the second. break-words keeps an
+  // unspaced nickname from running past the pill instead of wrapping inside it.
+  const lines = maxLines ?? (variant === 'compact' ? 1 : undefined)
+  const labelClass = lines === 1 ? 'truncate' : lines === 2 ? 'line-clamp-2 break-words' : ''
+
   return (
     <div className={containerClass}>
       {/* Dots bounce and shimmer through the aurora hues (delays + colors in CSS). */}
@@ -81,7 +102,7 @@ export function TypingIndicator({ typingUsers, formatUser, className = '', varia
         <span className="size-1.5 rounded-full typing-dot" />
         <span className="size-1.5 rounded-full typing-dot" />
       </span>
-      <span dir="auto" className={variant === 'compact' ? 'truncate' : ''}>{text}</span>
+      <span dir="auto" className={labelClass}>{text}</span>
     </div>
   )
 }

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -1952,6 +1952,157 @@ test.describe('Typing indicator never covers message text', () => {
     )
   })
 
+  /** Emit `composing`/`paused` for a set of MUC nicks. `room:typing` carries one nick at a time. */
+  async function emitRoomTyping(page: Page, roomJid: string, nicks: string[], isTyping: boolean): Promise<void> {
+    await page.evaluate(({ jid, names, on }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = (window as any).__demoClient
+      if (!c) throw new Error('no __demoClient')
+      for (const nick of names) c.emitSDK('room:typing', { roomJid: jid, nick, isTyping: on })
+    }, { jid: roomJid, names: nicks, on: isTyping })
+  }
+
+  /**
+   * Replace the room's typing set outright: `previous` is stopped and the pill is allowed to
+   * unmount before `nicks` start. Going through empty is what makes the label deterministic —
+   * the store keeps typers in a Set, so a name that survives a transition keeps its original
+   * position and `nicks[0]` would not be the one the label leads with.
+   */
+  async function setRoomTypers(
+    page: Page,
+    roomJid: string,
+    nicks: string[],
+    previous: string[] = [],
+  ): Promise<void> {
+    if (previous.length > 0) {
+      await emitRoomTyping(page, roomJid, previous, false)
+      await page.waitForFunction(() => {
+        const s = document.querySelector('[data-message-list]')
+        return !s?.parentElement?.querySelector('[data-typing-pill]')
+      }, undefined, { timeout: 5_000 })
+    }
+    await emitRoomTyping(page, roomJid, nicks, true)
+    await page.waitForFunction((expected) => {
+      const s = document.querySelector('[data-message-list]')
+      const pill = s?.parentElement?.querySelector('[data-typing-pill]') as HTMLElement | null
+      if (!pill) return false
+      const r = pill.getBoundingClientRect()
+      return r.width > 0 && r.height > 0 && (pill.textContent ?? '').includes(expected)
+    }, nicks[0], { timeout: 5_000 })
+    await page.waitForTimeout(SETTLE_MS)
+  }
+
+  /** Height of the live list's pill, or 0 when it is not mounted. */
+  async function pillHeight(page: Page): Promise<number> {
+    return page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]')
+      const pill = s?.parentElement?.querySelector('[data-typing-pill]') as HTMLElement | null
+      return pill ? Math.round(pill.getBoundingClientRect().height) : 0
+    })
+  }
+
+  // Issue #1151: the compact label used to be `truncate`d, so a crowded room was cut off with an
+  // ellipsis rather than wrapping. It may now take a SECOND line — the band sizes itself from the
+  // pill, so it grows with it — and is capped there. Both halves of that need a browser: the
+  // clearance above the pill is the thing a taller pill could eat, and the clamp only exists once
+  // the text is really laid out.
+  test('a wrapped two-line room label grows the band instead of covering message text', async ({ page }) => {
+    // Narrow (but still the desktop layout — the mobile breakpoint is 768) so an ordinary
+    // multi-typer label wraps, which is where the truncation was most visible.
+    await page.setViewportSize({ width: 800, height: 800 })
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+    await scrollToBottom(page)
+
+    await setRoomTypers(page, STRESS_ROOM_JID, ['Ada'])
+    const single = await probeOverlap(page, 0)
+    expect(single.pillFound, 'typing pill not rendered for a single typer').toBe(true)
+    expect(single.pillHeight, 'single-line pill has no height').toBeGreaterThan(10)
+
+    const CROWD = [
+      'Sophia Reyes (Product Design)',
+      'Marcus Chen (Infrastructure)',
+      'Priya Raghunathan (Support)',
+      'Alexandre Dubois (Localisation)',
+    ]
+    await setRoomTypers(page, STRESS_ROOM_JID, CROWD, ['Ada'])
+    const wrapped = await probeOverlap(page, 0)
+
+    // Control: without this the overlap sweep below would pass on a one-line pill and prove
+    // nothing about wrapping. A regression to `truncate` fails HERE, not silently.
+    expect(
+      wrapped.pillHeight,
+      `crowded label did not wrap (pill still ${wrapped.pillHeight}px, single line is ${single.pillHeight}px)`,
+    ).toBeGreaterThan(single.pillHeight)
+
+    // The cap: an absurdly long label must still stop at two lines.
+    const OVERLONG = [
+      'Sophia Reyes, Head of Product Design and Research',
+      'Marcus Chen, Infrastructure and Platform Reliability',
+      ...CROWD.slice(2),
+    ]
+    await setRoomTypers(page, STRESS_ROOM_JID, OVERLONG, CROWD)
+    const clamped = await probeOverlap(page, 0)
+    expect(
+      clamped.pillHeight,
+      `label ran past two lines (${clamped.pillHeight}px vs ${wrapped.pillHeight}px for two)`,
+    ).toBe(wrapped.pillHeight)
+
+    // And the taller pill must not eat the clearance the band is there to provide, at any offset.
+    await setRoomTypers(page, STRESS_ROOM_JID, CROWD, OVERLONG)
+    const covered: Array<{ offset: number; probe: OverlapProbe }> = []
+    for (const offset of OFFSETS_PX) {
+      const probe = await probeOverlap(page, offset)
+      expect(probe.pillFound, `typing pill not rendered at offset ${offset}`).toBe(true)
+      expect(probe.visibleRows, `no message rows visible at offset ${offset}`).toBeGreaterThan(0)
+      if (probe.worstOverlap > 0) covered.push({ offset, probe })
+    }
+    expect(
+      covered,
+      'two-line typing pill covers message text at ' +
+        covered.map((r) => `offset=${r.offset}px (${r.probe.worstOverlap}px of ${r.probe.worstRowId})`).join(', '),
+    ).toEqual([])
+  })
+
+  // The cost of letting the label wrap: the band can now grow while it is ALREADY shown, which the
+  // off→on typing re-pin deliberately ignores (it only fires on the mount edge). A reader glued to
+  // the bottom when a second typer joins must not be left short of it — this is the case that says
+  // whether the scroller's own resize reconciliation is enough to cover the growth.
+  test('a typer joining mid-flight grows the pill without unsticking the bottom', async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 800 })
+    await loadDemo(page)
+    await navigateToStressRoom(page)
+    await scrollToBottom(page)
+
+    await setRoomTypers(page, STRESS_ROOM_JID, ['Sophia Reyes (Product Design)'])
+    const before = await pillHeight(page)
+    expect(before, 'typing pill not mounted for the first typer').toBeGreaterThan(10)
+
+    // Join, do not replace: the pill stays mounted and grows in place.
+    await emitRoomTyping(
+      page,
+      STRESS_ROOM_JID,
+      ['Marcus Chen (Infrastructure)', 'Priya Raghunathan (Support)', 'Alexandre Dubois (Localisation)'],
+      true,
+    )
+    await page.waitForTimeout(SETTLE_MS)
+
+    const after = await pillHeight(page)
+    // Control: a pill that did not actually grow makes the glue assertion below meaningless.
+    expect(after, `pill did not grow when typers joined (still ${after}px)`).toBeGreaterThan(before)
+
+    const dist = await page.evaluate(() => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      return s ? Math.round(s.scrollHeight - s.scrollTop - s.clientHeight) : -1
+    })
+    expect(dist, 'view left off the bottom when the typing pill grew to two lines').toBeLessThanOrEqual(
+      GLUED_TOLERANCE_PX,
+    )
+
+    const probe = await probeOverlap(page, 0)
+    expect(probe.worstOverlap, `grown pill covers ${probe.worstRowId}`).toBe(0)
+  })
+
   /** React on the newest message through the real store path, so its row genuinely grows. */
   async function reactToNewest(page: Page, jid: string): Promise<string> {
     const lastId = await page.evaluate((j) => {


### PR DESCRIPTION
The in-conversation typing pill applied `truncate`, so a crowded room or a wordier
locale was cut off with an ellipsis and could never wrap. It was most visible at
narrow widths.

`TypingIndicator` now takes a `maxLines` prop. The conversation band allows two
lines and grows with the pill, while the sidebar room preview keeps its single
ellipsised line. Two lines is the cap: beyond that the band would take enough of
the message area that clipping is the better trade.

Closes #1151.
