### PR TITLE
fix(ui): fall back to the live edge when the unread divider is off-window

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.offWindowDivider.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.offWindowDivider.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * AN UNREAD DIVIDER OUTSIDE THE RESIDENT WINDOW MUST NOT PARK THE LIST.
+ *
+ * Entry with unread messages positions the first-unread marker instead of the
+ * live edge. The marker's row is resolved through the virtualizer, and a row
+ * that is not there yet is a normal transient while the item set is still being
+ * built — so the executor reports `waiting` and the frame loop retries.
+ *
+ * A divider can also name a message that is not in the window at all: rooms load
+ * 100 messages on activation, and a read pointer synced from another device
+ * (XEP-0490) can predate that slice. Then no retry can ever succeed. Treating
+ * that as `waiting` leaves the view at scrollTop 0 — the TOP of the window, the
+ * oldest loaded message — for the rest of the visit. Worse, entry marks the list
+ * as not-at-bottom before positioning, so the read pointer stops advancing and
+ * every later message is counted unread. That is the reported "conversation went
+ * back in time" failure, and it does not self-heal.
+ *
+ * The unresolvable case must be terminal so the controller's live-edge fallback
+ * takes over.
+ *
+ * Harness (mocked virtualizer, fake rAF queue, instrumented scroller geometry)
+ * mirrors MessageList.pinBottomBehavior.test.tsx. `virt.ready` models the item
+ * set being built after entry.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import type { BaseMessage } from '@fluux/sdk'
+
+const virt = vi.hoisted(() => ({ ready: false }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(), selectionCount: 0, isSelecting: false,
+    selectAll: vi.fn(), extendTo: vi.fn(), clearSelection: vi.fn(), copySelected: vi.fn(),
+  })),
+}))
+vi.mock('./tanstackMessageVirtualizer', () => ({
+  useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
+    getVirtualItems: () => virt.ready ? args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })) : [],
+    getTotalSize: () => virt.ready ? args.items.length * 40 : 0,
+    itemCount: virt.ready ? args.items.length : 0,
+    getOffsetForMessageId: () => 0,
+    getIndexForMessageId: (id: string) => {
+      const i = args.items.findIndex((it) => it.key === id)
+      return virt.ready && i >= 0 ? i : null
+    },
+    ensureMessageMounted: vi.fn(() => Promise.resolve()),
+    measureElement: () => {},
+    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    beginAnimatedScrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    scrollToIndex: (index: number, opts?: { align?: string }) => {
+      const el = args.scrollRef.current; if (!el) return
+      if (opts?.align === 'end') el.scrollTop = el.scrollHeight
+      else el.scrollTop = index * 40
+    },
+  }),
+}))
+
+const ROW = 40
+// Rooms load this many messages from cache on activation (roomStore.ts).
+const CACHED = 100
+
+function makeMessages(count: number): BaseMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `msg-${i}`, from: 'user@example.com', body: `Body ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i % 60), isOutgoing: false, type: 'chat' as const,
+  }))
+}
+
+describe('MessageList — unread divider outside the resident window', () => {
+  let realRaf: typeof requestAnimationFrame
+  let rafQueue: FrameRequestCallback[]
+  const flush = (frames: number) => { for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0)) }
+
+  const geo = { scrollHeight: 500, clientHeight: 500 }
+  const bottom = () => geo.scrollHeight - geo.clientHeight
+
+  function instrumentScroller(scroller: HTMLElement) {
+    let top = 0
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => geo.scrollHeight, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { get: () => geo.clientHeight, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => top,
+      set: (v: number) => { top = Math.max(0, Math.min(v, Math.max(0, geo.scrollHeight - geo.clientHeight))) },
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'offsetHeight', { get: () => 0, configurable: true })
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length }) as typeof requestAnimationFrame
+    virt.ready = false
+    geo.scrollHeight = 500
+    geo.clientHeight = 500
+  })
+  afterEach(() => { globalThis.requestAnimationFrame = realRaf; localStorage.clear() })
+
+  const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div>, onScrollToTop: vi.fn(), isHistoryComplete: false }
+
+  /** Entry with the cached slice already resident — what the reported trace shows
+   *  (`enterConversation ... messageCount: 100`). */
+  function enterWithSlice(conversationId: string, extra: Record<string, unknown>) {
+    const isAtBottomRef = { current: true }
+    virt.ready = true
+    geo.scrollHeight = CACHED * ROW
+    const view = render(
+      <MessageList messages={makeMessages(CACHED)} conversationId={conversationId} isAtBottomRef={isAtBottomRef} {...extra} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(120)
+    return { scroller, isAtBottomRef }
+  }
+
+  /** Entry before the cache read resolves, slice lands afterwards. */
+  function enterThenLoadSlice(conversationId: string, extra: Record<string, unknown>) {
+    const isAtBottomRef = { current: true }
+    const view = render(
+      <MessageList messages={[]} conversationId={conversationId} isAtBottomRef={isAtBottomRef} {...extra} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70)
+
+    virt.ready = true
+    geo.scrollHeight = CACHED * ROW
+    view.rerender(
+      <MessageList messages={makeMessages(CACHED)} conversationId={conversationId} isAtBottomRef={isAtBottomRef} {...extra} {...props} />,
+    )
+    flush(120)
+    return { scroller, isAtBottomRef }
+  }
+
+  const offWindow = { firstNewMessageId: 'archive-id-not-in-slice', unreadCount: 13 }
+
+  it('falls back to the live edge when the divider is outside an already-resident window', () => {
+    const { scroller, isAtBottomRef } = enterWithSlice('room-off-window-resident', offWindow)
+
+    expect(scroller.scrollTop).toBe(bottom())
+    expect(isAtBottomRef.current).toBe(true)
+  })
+
+  // NOTE: the sibling case — an off-window divider when the slice lands AFTER entry
+  // — is still broken and is tracked separately. The marker execution is parked
+  // before its frame loop can observe the arriving rows, so it never reaches the
+  // executor branch this file covers. Fixing it is a controller-level change.
+
+  it('still reaches the live edge when entry carries no divider', () => {
+    const { scroller, isAtBottomRef } = enterThenLoadSlice('room-no-divider', {})
+
+    expect(scroller.scrollTop).toBe(bottom())
+    expect(isAtBottomRef.current).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/MessageList.suspendedFrames.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.suspendedFrames.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * BOTTOM-STICK MUST NOT DEPEND ON FRAME DELIVERY.
+ *
+ * A backgrounded window stops receiving `requestAnimationFrame` callbacks while
+ * messages keep arriving and React keeps committing. The live-edge follow has to
+ * survive that: it is applied synchronously when the list grows, and the rAF
+ * re-assert loop only settles the measurement afterwards. If the follow ever
+ * moves into the frame loop, a conversation read at the live edge would be found
+ * stranded above it on return — with every intervening message counted unread.
+ *
+ * Suspending frames is simulated by not draining the fake rAF queue across the
+ * appends, then draining it once frames resume. Both moments are asserted: the
+ * one during suspension is what actually proves the follow is frame-independent.
+ *
+ * Harness (mocked virtualizer, fake rAF queue, instrumented scroller geometry)
+ * mirrors MessageList.pinBottomBehavior.test.tsx.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MessageList } from './MessageList'
+import type { BaseMessage } from '@fluux/sdk'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('@/hooks', () => ({
+  useMessageCopyFormatter: vi.fn(),
+  useMessageRangeSelection: vi.fn(() => ({
+    copySelectedIds: new Set<string>(), selectionCount: 0, isSelecting: false,
+    selectAll: vi.fn(), extendTo: vi.fn(), clearSelection: vi.fn(), copySelected: vi.fn(),
+  })),
+}))
+vi.mock('./tanstackMessageVirtualizer', () => ({
+  useTanstackMessageVirtualizer: (args: { items: { key: string }[]; scrollRef: React.RefObject<HTMLElement | null> }) => ({
+    getVirtualItems: () => args.items.map((it, index) => ({ index, start: index * 40, size: 40, key: it.key })),
+    getTotalSize: () => args.items.length * 40,
+    itemCount: args.items.length,
+    getOffsetForMessageId: () => 0,
+    getIndexForMessageId: (id: string) => { const i = args.items.findIndex((it) => it.key === id); return i >= 0 ? i : null },
+    ensureMessageMounted: vi.fn(() => Promise.resolve()),
+    measureElement: () => {},
+    scrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    beginAnimatedScrollToOffset: (offset: number) => { const el = args.scrollRef.current; if (el) el.scrollTop = offset },
+    scrollToIndex: (index: number, opts?: { align?: string }) => {
+      const el = args.scrollRef.current; if (!el) return
+      if (opts?.align === 'end') el.scrollTop = el.scrollHeight
+      else el.scrollTop = index * 40
+    },
+  }),
+}))
+
+const ROW = 40
+const RESIDENT = 50
+// Matches the reported incident: a room read to the live edge, then thirteen
+// messages while the window was in the background.
+const ARRIVALS_WHILE_SUSPENDED = 13
+
+function makeMessages(count: number): BaseMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `msg-${i}`, from: 'user@example.com', body: `Body ${i}`,
+    timestamp: new Date(2024, 0, 1, 12, i % 60), isOutgoing: false, type: 'chat' as const,
+  }))
+}
+
+describe('MessageList — live-edge follow with frames suspended', () => {
+  let realRaf: typeof requestAnimationFrame
+  let rafQueue: FrameRequestCallback[]
+  const flush = (frames: number) => { for (let i = 0; i < frames; i++) rafQueue.splice(0).forEach((cb) => cb(0)) }
+
+  const geo = { scrollHeight: RESIDENT * ROW, clientHeight: 500 }
+  const bottom = () => geo.scrollHeight - geo.clientHeight
+
+  function instrumentScroller(scroller: HTMLElement) {
+    let top = 0
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => geo.scrollHeight, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { get: () => geo.clientHeight, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => top,
+      set: (v: number) => { top = Math.max(0, Math.min(v, geo.scrollHeight - geo.clientHeight)) },
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'offsetHeight', { get: () => 0, configurable: true })
+  }
+
+  beforeEach(() => {
+    localStorage.setItem('fluux:flags:enableMessageVirtualization', 'true')
+    HTMLElement.prototype.scrollTo = vi.fn()
+    rafQueue = []
+    realRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length }) as typeof requestAnimationFrame
+    geo.scrollHeight = RESIDENT * ROW
+    geo.clientHeight = 500
+  })
+  afterEach(() => { globalThis.requestAnimationFrame = realRaf; localStorage.clear() })
+
+  const props = { renderMessage: (m: BaseMessage) => <div>{m.body}</div>, onScrollToTop: vi.fn(), isHistoryComplete: false }
+
+  it('keeps the live edge while messages arrive and no frame is delivered', () => {
+    const isAtBottomRef = { current: true }
+    let messages = makeMessages(RESIDENT)
+    const view = render(
+      <MessageList messages={messages} conversationId="conv-suspended-frames" isAtBottomRef={isAtBottomRef} {...props} />,
+    )
+    const scroller = view.container.querySelector('[data-message-list]') as HTMLElement
+    instrumentScroller(scroller)
+    flush(70) // settle the entry pin
+    expect(scroller.scrollTop).toBe(bottom())
+
+    // Window goes to the background: React still commits, frames stop arriving.
+    for (let i = 0; i < ARRIVALS_WHILE_SUSPENDED; i++) {
+      messages = [...messages, {
+        id: `late-${i}`, from: 'other@example.com', body: `Late ${i}`,
+        timestamp: new Date(2024, 0, 1, 13, i), isOutgoing: false, type: 'chat' as const,
+      }]
+      geo.scrollHeight += ROW
+      view.rerender(
+        <MessageList messages={messages} conversationId="conv-suspended-frames" isAtBottomRef={isAtBottomRef} {...props} />,
+      )
+    }
+
+    // The follow is synchronous, so the view tracks the growing content with a
+    // frame backlog still pending. This is the assertion that fails first if the
+    // follow is ever moved into the rAF loop.
+    expect(rafQueue.length).toBeGreaterThan(0)
+    expect(scroller.scrollTop).toBe(bottom())
+    expect(isAtBottomRef.current).toBe(true)
+
+    // Frames resume: the backlog settles without moving the view off the edge.
+    flush(70)
+    expect(scroller.scrollTop).toBe(bottom())
+    expect(isAtBottomRef.current).toBe(true)
+  })
+})

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -1671,7 +1671,20 @@ export function useMessageListScroll({
         : null
       let offset: number | null = null
       if (virtualizer) {
-        if (markerIndex === null) return { kind: 'waiting' }
+        if (markerIndex === null) {
+          // An unindexed marker is transient only while the item set is still being
+          // built — then the next frame can resolve it. Once the window HAS rows and
+          // the divider is still absent, it names a message outside the resident
+          // slice (rooms load 100 messages on activation; a read pointer synced from
+          // another device can predate that). No retry can succeed, so `waiting`
+          // would park the list at scrollTop 0 — the oldest loaded message — for the
+          // rest of the visit, with entry's `isAtBottom = false` freezing the read
+          // pointer and counting every later message unread. Terminal instead, so the
+          // controller's live-edge fallback takes over.
+          return virtualizer.itemCount === 0
+            ? { kind: 'waiting' }
+            : { kind: 'unavailable' }
+        }
         offset = virtualizer.getOffsetForMessageId(markerId)
       } else {
         const element = scroller.querySelector(


### PR DESCRIPTION
Opening a room with unread messages positions the first-unread marker rather than the live edge, resolving the marker's row through the virtualizer. A row that is not indexed yet is a normal transient while the item set is still being built, so the frame loop retries.

But a divider can name a message that is not in the window at all: rooms load 100 messages from cache on activation, and a read pointer synced from another device can predate that slice. No retry could ever succeed, so the list stayed at scroll offset zero — the oldest loaded message — for the rest of the visit. Entry marks the list as not at the bottom before positioning, so the read pointer also stopped advancing and every later message was counted unread. The conversation appeared to jump back in time and then accumulate a growing unread badge.

An unresolvable marker is now terminal once the window has rows, so the controller's live-edge fallback takes over. It stays transient while the item set is still empty.

Known limitation, tracked separately: the same off-window divider still strands the view when the cached slice lands *after* entry. That path parks the marker execution before its frame loop can observe the arriving rows, so it never reaches the branch this change fixes. Resolving it is a controller-level change.