### PR TITLE
fix(ui): keep the live-edge fallback honest when rows arrive after entry

### DIFF
--- a/apps/fluux/src/components/conversation/MessageList.offWindowDivider.test.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.offWindowDivider.test.tsx
@@ -20,6 +20,15 @@
  * The unresolvable case must be terminal so the controller's live-edge fallback
  * takes over.
  *
+ * Both entry orders are covered, because they fail differently. When the slice is
+ * already resident, the executor answers `unavailable` on the first frame. When
+ * the slice lands after entry, the fallback is promoted from inside a rAF frame,
+ * so the live-edge executor it carries was built during the empty entry render —
+ * and a reachability probe that still describes THAT window reports
+ * `empty-window`, parking the promoted execution in `pending` with no frame loop.
+ * Nothing revives it: the refresh effect that would re-drive a parked live edge
+ * ran on the arriving-rows commit, before the fallback existed.
+ *
  * Harness (mocked virtualizer, fake rAF queue, instrumented scroller geometry)
  * mirrors MessageList.pinBottomBehavior.test.tsx. `virt.ready` models the item
  * set being built after entry.
@@ -152,10 +161,12 @@ describe('MessageList — unread divider outside the resident window', () => {
     expect(isAtBottomRef.current).toBe(true)
   })
 
-  // NOTE: the sibling case — an off-window divider when the slice lands AFTER entry
-  // — is still broken and is tracked separately. The marker execution is parked
-  // before its frame loop can observe the arriving rows, so it never reaches the
-  // executor branch this file covers. Fixing it is a controller-level change.
+  it('falls back to the live edge when the divider is outside a slice that lands after entry', () => {
+    const { scroller, isAtBottomRef } = enterThenLoadSlice('room-off-window-late-slice', offWindow)
+
+    expect(scroller.scrollTop).toBe(bottom())
+    expect(isAtBottomRef.current).toBe(true)
+  })
 
   it('still reaches the live edge when entry carries no divider', () => {
     const { scroller, isAtBottomRef } = enterThenLoadSlice('room-no-divider', {})

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -587,6 +587,14 @@ export function useMessageListScroll({
   const reconcileLiveEdgeRef = useRef<(trigger: string) => boolean>(
     () => false,
   )
+  // The resident window as it is NOW, for reachability probes that run outside the render that
+  // created them. Executors capture their scroller and virtualizer through refs already; these
+  // three scalars were the only render-time captures left, so an executor stored by the controller
+  // and consulted a frame later still described the window it was born in. Assigned during render
+  // (like shadowReachabilityRef below) so a probe never has to wait for an effect to catch up.
+  const liveWindowRef = useRef({ messageCount, firstMessageId, windowAtLiveEdge })
+  liveWindowRef.current = { messageCount, firstMessageId, windowAtLiveEdge }
+
   const shadowReachabilityRef = useRef<(desired: DesiredPosition) => ReachabilityFacts>(
     () => ({ kind: 'empty-window' }),
   )
@@ -1059,10 +1067,18 @@ export function useMessageListScroll({
     }
 
     return {
+      // Window facts come from the ref, not this render's props. A live-edge executor can outlive
+      // the render that built it: the unread-marker fallback carries one from entry and promotes it
+      // from inside a rAF frame, long after the cached slice landed. Describing the entry window
+      // there reports `empty-window` for a window that has since filled, which parks the promoted
+      // execution in `pending` with no frame loop — and no later stimulus revives it, because the
+      // refresh effect already ran before the fallback existed. See the ref's declaration.
       reachability: () => deriveReachabilityForDesired({
         desired: { kind: 'live-edge', follow: true },
-        hasRows: messageCount > 0 && firstMessageId !== undefined,
-        windowAtLiveEdge: windowAtLiveEdge !== false,
+        hasRows:
+          liveWindowRef.current.messageCount > 0 &&
+          liveWindowRef.current.firstMessageId !== undefined,
+        windowAtLiveEdge: liveWindowRef.current.windowAtLiveEdge !== false,
         virtualizer: virtualizerRef.current,
         scroller: scrollerRef.current,
         loadAround: 'unavailable',
@@ -1236,7 +1252,6 @@ export function useMessageListScroll({
     }
   }, [
     beginControllerFrameLoop,
-    firstMessageId,
     isLoadingNewer,
     lastMessageId,
     messageCount,


### PR DESCRIPTION
## Intent

Opening a room whose unread divider names a message outside the cached slice should land the
reader at the live edge, with the read pointer still advancing — including when the slice
arrives *after* the room is entered.

#1162 fixed the case where the slice is already resident. This is the sibling ordering, which
that change explicitly left open.

## What changed

Enter a room before its cached slice lands (`messages: []`) with a `firstNewMessageId` outside
that slice, and the list stayed at scroll offset zero for the rest of the visit. Entry marks the
list as not at the bottom before positioning, so the read pointer also stopped advancing and
every later message was counted unread.

The marker executor was not at fault. Its frame loop ran, observed the arriving rows, and
correctly reported the marker unreachable so the controller could promote its live-edge fallback
— 71 frames, well inside the 120-frame budget.

The fallback was the problem. `createLiveEdgeExecutor` derived its window facts (`hasRows`,
`windowAtLiveEdge`) from the render that built it, while reading its scroller and virtualizer
through refs. The unread-marker executor carries one of these from entry and promotes it from
inside a `requestAnimationFrame` callback, long after the window filled — so the promoted
execution was told the window was still empty. That resolves to a `pending` phase, and
`driveLiveEdge` parks there with no frame loop and no scroll write.

Nothing revived it. `refreshLiveEdge` exists precisely to re-drive a parked live edge, but its
layout effect ran on the commit that delivered the rows, *before* the fallback execution existed
(probes showed `hasExecution: false` on both of its runs). In a quiet room no further prop change
follows, so the park is permanent.

The fix reads the window through a ref assigned during render — the idiom already used by
`shadowReachabilityRef` a few lines below. With truthful facts the phase resolves to
`reconciling`, the loop runs, and the list reaches the live edge. A genuinely empty window still
parks and still self-heals, because there `refreshLiveEdge` does find the execution when rows
arrive.