### PR TITLE
fix(sdk): re-derive the unread count when a conversation or room is opened

### DIFF
--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -1167,4 +1167,70 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       }, { timeout: 2000 })
     })
   })
+
+  // ---------------------------------------------------------------------
+  // The ACTIVATION trigger (room twin: roomStore.archiveUnread.test.ts).
+  // final-fix-2's two triggers are both reached only by the read pointer
+  // MOVING: advanceReadPointer recounts `if (pointerAdvanced)`, and
+  // onMessageSeen returns its input unchanged once the pointer sits on the
+  // newest loaded message. Opening a conversation already at the live edge
+  // with the pointer already at newest therefore moves nothing and triggers
+  // nothing — the deactivation trigger repairs it only on the way out, so the
+  // badge is stuck precisely while it is being looked at.
+  // ---------------------------------------------------------------------
+
+  describe('activation re-derives the count for the conversation being entered', () => {
+    it('opening a conversation whose pointer is already at the newest message clears the stale badge', async () => {
+      const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })
+      const m1 = archiveMsg('m1', 1000)
+      await messageCache.saveMessages([anchor, m1])
+      // Fully read: the pointer already sits on the newest message, so the
+      // viewport observer has nothing left to advance.
+      setMeta({
+        unreadCount: 5, // stale — distinct from the correct 0
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } },
+      })
+      seedCoverage('anchor-stanza')
+      chatStore.setState({ messages: new Map([[CID, [anchor, m1]]]) })
+
+      // Open it. advanceReadPointer is never called, and there is no previous
+      // conversation, so the deactivation trigger cannot fire either —
+      // activation is the only trigger under test.
+      chatStore.getState().setActiveConversation(CID)
+      expect(chatStore.getState().activeConversationId).toBe(CID)
+
+      await vi.waitFor(() => {
+        expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(0)
+      }, { timeout: 2000 })
+      expect(chatStore.getState().activeConversationId).toBe(CID)
+    })
+
+    // Discrimination control, per final-fix-3 above: seed-5/assert-0 would
+    // also be satisfied by a force-zero on activation — the very behaviour
+    // FIX 2 walked back. With the pointer SHORT of newest, force-zero lands on
+    // 0 (wrong), a missing trigger leaves 5 (wrong), only a real derivation
+    // lands on 2.
+    it('opening a conversation with the pointer short of the newest message derives the true remainder, not zero', async () => {
+      const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })
+      const p0 = archiveMsg('p0', 1000)
+      const u1 = archiveMsg('u1', 1001)
+      const u2 = archiveMsg('u2', 1002)
+      await messageCache.saveMessages([anchor, p0, u1, u2])
+      setMeta({
+        unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      })
+      seedCoverage('anchor-stanza')
+      chatStore.setState({ messages: new Map([[CID, [anchor, p0, u1, u2]]]) })
+
+      chatStore.getState().setActiveConversation(CID)
+
+      await vi.waitFor(() => {
+        expect(chatStore.getState().conversationMeta.get(CID)?.unreadCount).toBe(2)
+      }, { timeout: 2000 })
+
+      // ...and the divider the reader is looking at survives the recount.
+      expect(chatStore.getState().firstNewMessageMarkers.get(CID)).toBe('u1')
+    })
+  })
 })

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1376,6 +1376,22 @@ export const chatStore = createStore<ChatState>()(
             if (prevId && prevId !== id && worthReconcilingOnDeactivate(get().conversationMeta.get(prevId))) {
               void get().recomputeUnreadForConversation(prevId)
             }
+            // ...and reconcile the entity we just ENTERED — the room twin of
+            // this trigger carries the full rationale. In short: Task 11's
+            // convergence is a side effect of the read pointer MOVING, and
+            // onMessageSeen returns its input unchanged once the pointer sits
+            // on the newest loaded message. Opening a conversation already at
+            // the live edge with the pointer already at newest therefore makes
+            // every viewport report a no-op, schedules no recount, and strands
+            // a stale badge for as long as the conversation stays open.
+            // Activation was the one entry point without a recount of its own.
+            //
+            // A DERIVATION against the current pointer, not FIX 2's removed
+            // unconditional zero: real unread keeps a real count, and the
+            // divider is repositioned rather than retired while active.
+            if (activated.unreadCount > 0) {
+              void get().recomputeUnreadForConversation(id, { allowActive: true })
+            }
             return
           }
         }

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -1147,4 +1147,109 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       }, { timeout: 2000 })
     })
   })
+
+  // ---------------------------------------------------------------------
+  // The ACTIVATION trigger. final-fix-2 gave the count two triggers —
+  // advanceReadPointer and deactivation — but both are reached only by the
+  // read pointer MOVING: advanceReadPointer recounts `if (pointerAdvanced)`,
+  // and onMessageSeen returns its input unchanged once the pointer sits on
+  // the newest loaded message. A reader who opens a room already at the live
+  // edge with the pointer already at newest therefore moves nothing, triggers
+  // nothing, and watches a stale badge for as long as the room stays open —
+  // the deactivation trigger repairs it only once they leave, so the badge is
+  // stuck precisely while it is being looked at. Activation was the one entry
+  // point with no recount of its own.
+  // ---------------------------------------------------------------------
+
+  describe('activation re-derives the count for the room being entered', () => {
+    /** Seed the room's resident window (roomRuntime.messages) directly. */
+    function seedResident(messages: RoomMessage[]): void {
+      roomStore.setState((state) => {
+        const runtime = new Map(state.roomRuntime)
+        runtime.set(ROOM, { ...runtime.get(ROOM)!, messages })
+        return { roomRuntime: runtime }
+      })
+    }
+
+    it('opening a room whose pointer is already at the newest message clears the stale badge', async () => {
+      const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })
+      const m1 = archiveMsg('m1', 1000)
+      await messageCache.saveRoomMessages([anchor, m1])
+      // Fully read: the pointer already sits on the newest message, so the
+      // viewport observer has nothing left to advance and advanceReadPointer
+      // can never schedule a recount. This is the reported defect.
+      setMeta({
+        unreadCount: 5, // stale — distinct from the correct 0
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+      })
+      seedCoverage('anchor-stanza')
+      seedResident([anchor, m1])
+
+      // Open the room. advanceReadPointer is never called in this test, and
+      // there is no previous room, so the deactivation trigger cannot fire
+      // either — activation is the only trigger under test.
+      roomStore.getState().setActiveRoom(ROOM)
+      expect(roomStore.getState().activeRoomJid).toBe(ROOM)
+
+      await vi.waitFor(() => {
+        expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(0)
+      }, { timeout: 2000 })
+      // Still active — the badge cleared while the reader sits in the room,
+      // which is the whole point (deactivation already covered the rest).
+      expect(roomStore.getState().activeRoomJid).toBe(ROOM)
+    })
+
+    // The discrimination control, in the spirit of final-fix-3 above: the test
+    // above seeds 5 and asserts 0, which a naive "force-zero on activation"
+    // would also satisfy — and force-zeroing on activation is exactly the
+    // behaviour FIX 2 walked back. Here the pointer stops SHORT of the newest
+    // message, so genuinely unread messages remain: force-zero lands on 0
+    // (wrong), a missing trigger leaves the stale 5 (wrong), and only a real
+    // archive derivation lands on 2.
+    it('opening a room with the pointer short of the newest message derives the true remainder, not zero', async () => {
+      const anchor = archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })
+      const p0 = archiveMsg('p0', 1000)
+      const u1 = archiveMsg('u1', 1001)
+      const u2 = archiveMsg('u2', 1002)
+      await messageCache.saveRoomMessages([anchor, p0, u1, u2])
+      setMeta({
+        unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      })
+      seedCoverage('anchor-stanza')
+      seedResident([anchor, p0, u1, u2])
+
+      roomStore.getState().setActiveRoom(ROOM)
+
+      await vi.waitFor(() => {
+        expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
+      }, { timeout: 2000 })
+
+      // ...and the "New messages" divider the reader is looking at survives.
+      // recomputeUnreadForRoom is reposition-only while the room is ACTIVE;
+      // a recount that retired the divider here would reintroduce the defect
+      // commit ca26ff35 fixed (divider vanishing right after opening).
+      expect(roomStore.getState().firstNewMessageMarkers.get(ROOM)).toBe('u1')
+    })
+
+    it('opening a room whose badge is already clear does not read the archive', async () => {
+      await messageCache.saveRoomMessages([
+        archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
+        archiveMsg('m1', 1000),
+      ])
+      setMeta({
+        unreadCount: 0, // nothing to correct downward
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+      })
+      seedCoverage('anchor-stanza')
+      vi.mocked(messageCache.countRoomUnreadInArchive).mockClear()
+
+      roomStore.getState().setActiveRoom(ROOM)
+
+      // The guard keeps the common case (opening an already-read room) free of
+      // a cache read; an arrival would recount anyway.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(messageCache.countRoomUnreadInArchive).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2755,6 +2755,36 @@ export const roomStore = createStore<RoomState>()(
         if (prevJid && prevJid !== roomJid && worthReconcilingOnDeactivate(get().roomMeta.get(prevJid))) {
           void get().recomputeUnreadForRoom(prevJid)
         }
+        // ...and reconcile the room we just ENTERED. Task 11's convergence is
+        // implemented as a SIDE EFFECT of the read pointer moving:
+        // advanceReadPointer only schedules a recount `if (pointerAdvanced)`,
+        // and onMessageSeen returns its input unchanged once the pointer sits
+        // on the newest loaded message. So a reader who opens a room already at
+        // the live edge, with the pointer already at the newest message, makes
+        // every viewport report a no-op — the pointer has nowhere left to move,
+        // no recount is ever scheduled, and a stale count sits in the sidebar
+        // for as long as the room stays open. Activation was the one entry
+        // point with no recount of its own (arrival, remote XEP-0490 marker,
+        // MAM merge and DEACTIVATION all had one), which is exactly why the
+        // gap was invisible: leaving the room repaired it, so the badge only
+        // looked stuck while you were looking at it.
+        //
+        // This does NOT reinstate the unconditional zero that FIX 2 removed.
+        // That zero was a WRITE — it forced 0 while snapping the pointer only
+        // to just-before-the-divider, leaving a count of zero beside a divider
+        // marking genuinely unread messages. This is a DERIVATION against the
+        // current pointer: a room with real unread keeps a real count, and the
+        // divider is repositioned, never retired, while the room is active (see
+        // the reposition-only branch in recomputeUnreadForRoom). `allowActive`
+        // is required — the room is active by the `set()` above — and mirrors
+        // advanceReadPointer's own trigger.
+        //
+        // Guarded on a nonzero count: with the badge already clear there is
+        // nothing to correct downward, and an arrival would recount anyway, so
+        // an unguarded call would buy a cache read on every room open.
+        if (activated.unreadCount > 0) {
+          void get().recomputeUnreadForRoom(roomJid, { allowActive: true })
+        }
         return
       }
     }


### PR DESCRIPTION
## Summary

- The archive-derived unread count converged only as a side effect of the read pointer *moving*: `advanceReadPointer` recounts `if (pointerAdvanced)`, and `onMessageSeen` returns its input unchanged once the pointer sits on the newest loaded message. Opening an entity already at the live edge with the pointer already at newest moved nothing and scheduled nothing, so a stale badge stayed lit for as long as the entity was open — deactivation repaired it only on the way out, leaving the badge stuck precisely while it was being looked at.
- Activation was the one entry point without a recount of its own (arrival, remote XEP-0490 marker, MAM merge and deactivation all had one). It now schedules the same recount, with `allowActive`, guarded on a non-zero count so an already-clear entity costs no cache read.
- This is a derivation against the current pointer, not the unconditional zero removed earlier: real unread keeps a real count, and the divider is repositioned rather than retired while the entity is active.
- Applied to rooms and to the 1:1 twin, which had the identical gap.