### PR TITLE
fix(sdk): catch up rooms that join after an SM resume

### DIFF
--- a/docs/MAM_CATCHUP.md
+++ b/docs/MAM_CATCHUP.md
@@ -17,7 +17,7 @@ The SDK uses a **hybrid lazy + background** approach organized into five layers:
 | **Preview refresh** | Connect | All non-archived conversations | Fast (max=5, concurrency=3) |
 | **Conversation catch-up** | After preview refresh | All non-archived conversations | Slow (max=100, concurrency=2) |
 | **Roster discovery** | Connect | Roster contacts without a conversation | Slow (max=50, concurrency=2) |
-| **Room catch-up** | 10 s after fresh-session setup | Confirmed, inactive MAM-enabled rooms | Slow (max=100, concurrency=2) |
+| **Room catch-up** | 10 s after fresh-session setup; per room on SM resume | Confirmed, inactive MAM-enabled rooms | Slow (max=100, concurrency=2) |
 | **Lazy fetch** | User opens a conversation/room | Single conversation or room | On demand |
 
 Additionally, once per day, archived conversations are checked for new activity and auto-unarchived if new incoming messages are found.
@@ -70,6 +70,20 @@ Triggered 10 seconds after fresh-session setup, giving rooms time to finish join
   handed to this background path rather than issuing overlapping queries.
 - Runs at **concurrency 2**.
 - The 10-second timer is cancelled on disconnect and cleaned up on subscription teardown.
+
+On an SM resume the delayed pass never runs, so room coverage comes from the
+resume seed instead: rooms joined, MAM-enabled, inactive, and **not** already
+caught up to live are queried with `catchUpRoom`. Caught-up rooms are skipped —
+SM replayed their traffic, and re-querying them on every resume is exactly the
+cost this predicate avoids.
+
+The seed is evaluated per room rather than once, because `handleSmResumption`
+re-fetches bookmarks after a long disconnect and joins any room that is not
+currently joined — hundreds of milliseconds after the resume event. Such a room
+is not in `joinedRooms()` when the resume handler runs, and the fresh-session
+triggers that would otherwise cover it (the `room:joined` catch-up, the late-MAM
+retry, the `mucJoined` preview fetch) are all disabled on a resumed session. It
+therefore joins and is caught up as it becomes eligible, once per session.
 
 ### 5. Lazy Fetch (on demand)
 

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -1701,6 +1701,140 @@ describe('setupBackgroundSyncSideEffects', () => {
         expect.anything(),
       )
     })
+
+    // The resume seed is evaluated ONCE, synchronously, when 'resumed' fires —
+    // but handleSmResumption re-fetches bookmarks after a long disconnect and
+    // joins every room that is not currently joined, which lands hundreds of ms
+    // LATER. Such a room was not in joinedRooms() when the predicate ran, so it
+    // never got a seed; and every other trigger that could have covered it is
+    // gated on a FRESH session (the room:joined catch-up and the late-MAM retry)
+    // or on `!isSmResumed()` (the mucJoined preview fetch). It therefore received
+    // no archive coverage at all for the whole session: no preview, sidebar order
+    // pinned at epoch 0, and `isCaughtUpToLive` false, which keeps the unread
+    // recount deferring behind the coverage gate.
+    it('catches up a room that joins AFTER resumption (bookmark re-join)', async () => {
+      addRoom('late@conference.example.com')
+      roomStore.getState().setRoomJoined('late@conference.example.com', false)
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+      await vi.advanceTimersByTimeAsync(300)
+      // Nothing was eligible at resume time — the room was still unjoined.
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+
+      roomStore.getState().setRoomJoined('late@conference.example.com', true)
+      mockClient._emitSDK('room:joined', {
+        roomJid: 'late@conference.example.com', joined: true,
+      })
+
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+      })
+      expect(
+        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      ).toBe('late@conference.example.com')
+    })
+
+    it('catches up a room whose MAM support resolves AFTER it joins on a resumed session', async () => {
+      // The post-join disco re-query (MUC) can flip supportsMAM well after
+      // self-presence. On a fresh session the late-MAM retry covers that; on a
+      // resumed one it must too, or the disco race reopens the same hole.
+      addRoom('latemam@conference.example.com', { supportsMAM: false })
+      roomStore.getState().setRoomJoined('latemam@conference.example.com', false)
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+      await vi.advanceTimersByTimeAsync(300)
+
+      roomStore.getState().setRoomJoined('latemam@conference.example.com', true)
+      mockClient._emitSDK('room:joined', {
+        roomJid: 'latemam@conference.example.com', joined: true,
+      })
+      await vi.advanceTimersByTimeAsync(100)
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+
+      roomStore.getState().updateRoom('latemam@conference.example.com', { supportsMAM: true })
+
+      await vi.waitFor(() => {
+        expect(mockClient.mam.catchUpRoom).toHaveBeenCalledTimes(1)
+      })
+      expect(
+        (mockClient.mam.catchUpRoom as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      ).toBe('latemam@conference.example.com')
+    })
+
+    // Discrimination for the two tests above: seeding EVERY room that joins on a
+    // resumed session would satisfy them while re-querying archives SM already
+    // covered — the exact cost the coverage predicate exists to avoid. A room
+    // that is caught up to live must still be skipped when it re-joins.
+    it('does not catch up a caught-up room that re-joins on a resumed session', async () => {
+      addRoom('livelate@conference.example.com')
+      markCaughtUp('livelate@conference.example.com')
+      roomStore.getState().setRoomJoined('livelate@conference.example.com', false)
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+      await vi.advanceTimersByTimeAsync(300)
+
+      roomStore.getState().setRoomJoined('livelate@conference.example.com', true)
+      mockClient._emitSDK('room:joined', {
+        roomJid: 'livelate@conference.example.com', joined: true,
+      })
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+    })
+
+    // Second discrimination axis: the seed must be scoped to RESUMED sessions.
+    // A fresh session owns its rooms through the delayed pass
+    // (catchUpRoomHistory, which carries the session-start cursor and read-pointer
+    // stitching); routing them through catchUpRoom as well would double-query
+    // every room on every fresh connect.
+    it('does not seed a fresh-session join through the resume path', async () => {
+      addRoom('fresh@conference.example.com')
+      roomStore.getState().setRoomJoined('fresh@conference.example.com', false)
+      connectionStore.getState().setServerInfo({
+        identities: [], domain: 'example.com', features: [NS_MAM],
+      })
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateFreshSession(mockClient)
+      await vi.advanceTimersByTimeAsync(300)
+
+      roomStore.getState().setRoomJoined('fresh@conference.example.com', true)
+      mockClient._emitSDK('room:joined', {
+        roomJid: 'fresh@conference.example.com', joined: true,
+      })
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+    })
+
+    // A room joining while the transport is DOWN must not seed either: the
+    // offline transition ends the session, and the next 'online'/'resumed' owns
+    // the catch-up decision.
+    it('does not seed a join that lands after the session went offline', async () => {
+      addRoom('offline@conference.example.com')
+      roomStore.getState().setRoomJoined('offline@conference.example.com', false)
+      connectionStore.getState().setStatus('disconnected')
+      cleanup = setupBackgroundSyncSideEffects(mockClient)
+
+      simulateSmResumption(mockClient)
+      await vi.advanceTimersByTimeAsync(100)
+      connectionStore.getState().setStatus('reconnecting')
+
+      roomStore.getState().setRoomJoined('offline@conference.example.com', true)
+      mockClient._emitSDK('room:joined', {
+        roomJid: 'offline@conference.example.com', joined: true,
+      })
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      expect(mockClient.mam.catchUpRoom).not.toHaveBeenCalled()
+    })
   })
 
   describe('room member discovery (Stage 5)', () => {

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -10,8 +10,10 @@
  * own them; released room work can be handed back after the room becomes inactive.
  *
  * Uses client events to distinguish fresh-session bulk sync from SM resumption.
- * Resume only seeds rooms whose archives are not caught up to live; a synthetic
- * post-resume `online` can then upgrade the same transport to fresh setup.
+ * Resume only seeds rooms whose archives are not caught up to live — including
+ * rooms that join after the resume event, which the one-shot predicate cannot
+ * see. A synthetic post-resume `online` can then upgrade the same transport to
+ * fresh setup.
  *
  * @module Core/BackgroundSync
  */
@@ -72,6 +74,13 @@ export function setupBackgroundSyncSideEffects(
   let backgroundSyncDone = false
   // Whether the current session is fresh (set by 'online' event, cleared on disconnect)
   let isFreshSession = false
+  // Whether the current session came up via SM resumption (set by 'resumed',
+  // cleared on 'online' and on disconnect). Distinct from `!isFreshSession`,
+  // which is also true while the transport is down.
+  let isResumedSession = false
+  // Rooms already given a resume seed this session, so a room that joins,
+  // leaves, and rejoins can't re-query the archive repeatedly.
+  const resumeSeededRooms = new Set<string>()
   // Timer for delayed room catch-up (cleared on cleanup or disconnect)
   let roomCatchUpTimer: ReturnType<typeof setTimeout> | undefined
   // Epoch ms of the current fresh session's connection. Used as the forward
@@ -254,6 +263,54 @@ export function setupBackgroundSyncSideEffects(
       },
       2,
     )
+  }
+
+  /**
+   * Give one room its single resume seed, re-checking the resume predicate at
+   * call time.
+   *
+   * The `'resumed'` handler evaluates `selectRoomsNeedingResumeSeed` once,
+   * synchronously, against the rooms joined at that instant. Rooms that join
+   * later in the same session — `handleSmResumption` re-fetches bookmarks after
+   * a long disconnect and joins everything not currently joined — were never
+   * offered to that predicate, and no other trigger covers them: the
+   * `room:joined` catch-up and the late-MAM retry both require a FRESH session,
+   * and the `mucJoined` preview fetch is skipped outright while SM-resumed. This
+   * closes that hole by running the same predicate per room, as each one becomes
+   * eligible.
+   *
+   * Deliberately still gated on `isCaughtUpToLive`: a room SM genuinely replayed
+   * for is skipped, so this adds queries only for rooms whose archive coverage
+   * was never established this session — never a blanket re-query on resume.
+   */
+  async function seedResumeRoomOnce(
+    roomJid: string,
+    generation: number,
+  ): Promise<void> {
+    if (!isResumedSession || generation !== sessionGeneration) return
+    if (resumeSeededRooms.has(roomJid)) return
+    if (connectionStore.getState().status !== 'online' || !client.isConnected()) {
+      return
+    }
+    const state = roomStore.getState()
+    const room = state.rooms.get(roomJid)
+    if (!room) return
+    const [eligible] = selectRoomsNeedingResumeSeed(
+      [room],
+      (jid) => state.getRoomMAMQueryState(jid).isCaughtUpToLive,
+      state.activeRoomJid,
+    )
+    if (!eligible) return
+
+    resumeSeededRooms.add(roomJid)
+    logInfo(`Background sync: SM resumption — catching up late-joined room ${roomJid}`)
+    try {
+      await client.mam.catchUpRoom(roomJid, sessionStartTime)
+    } catch {
+      // Best-effort, exactly like the resume pass this mirrors. The seed stays
+      // recorded so a failing room can't be retried on every presence change;
+      // the next session re-evaluates it from scratch.
+    }
   }
 
   // --- E2EE capability warm-up ---
@@ -467,6 +524,8 @@ export function setupBackgroundSyncSideEffects(
     sessionGeneration += 1
     backgroundSyncDone = false
     isFreshSession = true
+    isResumedSession = false
+    resumeSeededRooms.clear()
     if (!followsUninterruptedResume) {
       sessionStartTime = Date.now()
       invalidateRoomMemberships(client)
@@ -505,10 +564,13 @@ export function setupBackgroundSyncSideEffects(
     sessionGeneration += 1
     uninterruptedResumeMayEmitSyntheticOnline = true
     isFreshSession = false
+    isResumedSession = true
     sessionStartTime = Date.now()
     freshSessionJoinedRooms.clear()
+    resumeSeededRooms.clear()
     resetRoomRetryState()
 
+    const resumeGeneration = sessionGeneration
     const state = roomStore.getState()
     const eligible = selectRoomsNeedingResumeSeed(
       state.joinedRooms(),
@@ -516,7 +578,9 @@ export function setupBackgroundSyncSideEffects(
       state.activeRoomJid,
     )
     if (eligible.length === 0) {
-      logInfo('Background sync: SM resumption — all rooms caught up')
+      // Says nothing about rooms not yet joined — the bookmark re-join runs
+      // later in handleSmResumption and is covered by seedResumeRoomOnce.
+      logInfo('Background sync: SM resumption — no already-joined room needs catch-up')
       return
     }
 
@@ -524,11 +588,7 @@ export function setupBackgroundSyncSideEffects(
     void (async () => {
       for (const room of eligible) {
         if (!client.isConnected()) break
-        try {
-          await client.mam.catchUpRoom(room.jid, sessionStartTime)
-        } catch {
-          // Best-effort — a per-room failure shouldn't block the others.
-        }
+        await seedResumeRoomOnce(room.jid, resumeGeneration)
       }
     })()
   })
@@ -544,7 +604,9 @@ export function setupBackgroundSyncSideEffects(
         sessionGeneration += 1
         uninterruptedResumeMayEmitSyntheticOnline = false
         isFreshSession = false
+        isResumedSession = false
         freshSessionJoinedRooms.clear()
+        resumeSeededRooms.clear()
         resetRoomRetryState()
         if (roomCatchUpTimer) {
           clearTimeout(roomCatchUpTimer)
@@ -566,9 +628,20 @@ export function setupBackgroundSyncSideEffects(
         .sort()
         .join(','),
     () => {
+      if (!client.isConnected()) return
+
+      // A resumed session has no initial pass to wait for; its seed is per-room
+      // and the same disco race applies, so cover it here too.
+      if (isResumedSession) {
+        for (const room of roomStore.getState().joinedRooms()) {
+          if (!room.supportsMAM || room.isQuickChat) continue
+          void seedResumeRoomOnce(room.jid, sessionGeneration)
+        }
+        return
+      }
+
       // Only retry after the initial pass; before it, the pass will cover them.
       if (!initialRoomPassDone || !isFreshSession) return
-      if (!client.isConnected()) return
 
       const activeRoomJid = roomStore.getState().activeRoomJid
       for (const room of roomStore.getState().joinedRooms()) {
@@ -596,6 +669,12 @@ export function setupBackgroundSyncSideEffects(
       }
       recordRoomMembership(client, roomJid, true)
       freshSessionJoinedRooms.add(roomJid)
+      if (isResumedSession) {
+        // Joined after the one-shot resume seed already ran — SM never replayed
+        // this room's history, so it needs the seed the predicate couldn't offer.
+        void seedResumeRoomOnce(roomJid, sessionGeneration)
+        return
+      }
       if (!initialRoomPassDone || !isFreshSession) return
       if (mamHandledRooms.has(roomJid)) return
       const room = roomStore.getState().rooms.get(roomJid)


### PR DESCRIPTION
A joined room could show an unread dot with no timestamp and no message preview, never moving in the sidebar no matter what arrived in it.

The SM-resume seed evaluated its "which rooms need catch-up" predicate once, synchronously, when `resumed` fired — against whatever was joined at that instant. But after a long disconnect the bookmark re-fetch joins every room that is not currently joined, landing hundreds of milliseconds later. Those rooms were never offered to the predicate, and every other trigger that could have covered them is gated on a fresh session (the `room:joined` catch-up, the late-MAM retry) or skipped outright while SM-resumed (the join-time preview fetch).

The result was no archive coverage at all for that room, for the whole session: no `lastMessage`, so the sidebar sorted it at epoch 0 and fell back to rendering the room subject, and `isCaughtUpToLive` stayed false, which keeps the archive-derived unread recount deferring behind the coverage gate. Only the active room escaped, because its own join handler has no session-type gate.

Rooms are now seeded individually as each becomes eligible. The coverage predicate itself is unchanged: a room Stream Management genuinely replayed for is still skipped, so a steady-state resume issues no extra queries — only rooms whose coverage was never established are fetched, and each at most once per session.