### PR TITLE
refactor(sdk): remove the unreachable room catch-up fallback

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.test.ts
@@ -872,7 +872,7 @@ describe('XMPPClient', () => {
       expect(fetchBookmarksSpy).toHaveBeenCalled()
     })
 
-    it('should skip MAM catch-up but fetch bookmarks on SM resumption when disconnect duration is unknown', async () => {
+    it('should fetch bookmarks on SM resumption when disconnect duration is unknown', async () => {
       const mockClientWithSM = createMockXmppClientWithSM('sm-id-catchup')
       mockClientFactory._setInstance(mockClientWithSM)
 
@@ -880,7 +880,6 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const catchUpSpy = vi.spyOn(newXmppClient.mam, 'catchUpAllRooms').mockResolvedValue()
       const bookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       const connectPromise = newXmppClient.connect({
@@ -903,12 +902,13 @@ describe('XMPPClient', () => {
 
       await connectPromise
 
-      // Unknown disconnect duration → SM replay covers messages, fetch bookmarks only
-      expect(catchUpSpy).not.toHaveBeenCalled()
+      // Unknown disconnect duration → SM replay covers messages; bookmarks are PEP
+      // items SM cannot replay, so they are refreshed. (No MAM assertion: the
+      // lifecycle engine holds no MAM dependency, so it cannot query the archive.)
       expect(bookmarksSpy).toHaveBeenCalled()
     })
 
-    it('should skip MAM catch-up on SM resumption for short disconnects', async () => {
+    it('should skip the bookmark fetch on SM resumption for short disconnects', async () => {
       const mockClientWithSM = createMockXmppClientWithSM('sm-id-short')
       mockClientFactory._setInstance(mockClientWithSM)
 
@@ -916,7 +916,6 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const catchUpSpy = vi.spyOn(newXmppClient.mam, 'catchUpAllRooms').mockResolvedValue()
       const bookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Simulate a reconnect with short disconnect: set the disconnectedAtTimestamp
@@ -945,8 +944,8 @@ describe('XMPPClient', () => {
 
       await connectPromise
 
-      // Short disconnect (30s < 120s threshold) → skip MAM catch-up and bookmarks
-      expect(catchUpSpy).not.toHaveBeenCalled()
+      // Short disconnect (30s < 120s threshold) → bookmarks cannot have drifted
+      // enough to be worth a PEP round-trip.
       expect(bookmarksSpy).not.toHaveBeenCalled()
     })
 
@@ -990,7 +989,7 @@ describe('XMPPClient', () => {
       expect(stores.room.hydratePreviewsFromCache).toHaveBeenCalled()
     })
 
-    it('should skip MAM catch-up but fetch bookmarks on SM resumption for long disconnects', async () => {
+    it('should fetch bookmarks on SM resumption for long disconnects', async () => {
       const mockClientWithSM = createMockXmppClientWithSM('sm-id-long')
       mockClientFactory._setInstance(mockClientWithSM)
 
@@ -998,7 +997,6 @@ describe('XMPPClient', () => {
       const newXmppClient = new XMPPClient({ debug: false })
       newXmppClient.bindStores(stores)
 
-      const catchUpSpy = vi.spyOn(newXmppClient.mam, 'catchUpAllRooms').mockResolvedValue()
       const bookmarksSpy = vi.spyOn(newXmppClient.muc, 'fetchBookmarks').mockResolvedValue({ roomsToAutojoin: [], allRoomJids: [] })
 
       // Simulate a reconnect with long disconnect (5 minutes ago)
@@ -1024,8 +1022,8 @@ describe('XMPPClient', () => {
 
       await connectPromise
 
-      // Long disconnect (300s > 120s threshold) → SM replay covers messages, fetch bookmarks only
-      expect(catchUpSpy).not.toHaveBeenCalled()
+      // Long disconnect (300s > 120s threshold) → SM replay covers messages; refresh
+      // bookmarks in case another client changed them while we were away.
       expect(bookmarksSpy).toHaveBeenCalled()
     })
 

--- a/packages/fluux-sdk/src/core/backgroundSync.test.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.test.ts
@@ -358,7 +358,28 @@ describe('setupBackgroundSyncSideEffects', () => {
 
     afterEach(() => {
       vi.useRealTimers()
+      roomStore.getState().setActiveRoom(null)
+      roomStore.getState().reset()
     })
+
+    const addRoom = (
+      jid: string,
+      overrides: { supportsMAM?: boolean; isQuickChat?: boolean; joined?: boolean } = {},
+    ) =>
+      roomStore.getState().addRoom({
+        jid, name: jid, nickname: 'me', joined: true, isBookmarked: true, supportsMAM: true,
+        occupants: new Map(), messages: [], unreadCount: 0, mentionsCount: 0, typingUsers: new Set(),
+        ...overrides,
+      })
+
+    /** Confirm the current-session join the fresh-session room pass requires. */
+    const confirmJoin = (jid: string) =>
+      mockClient._emitSDK('room:joined', { roomJid: jid, joined: true })
+
+    const caughtUpRooms = () =>
+      (mockClient.mam.catchUpRoomHistory as ReturnType<typeof vi.fn>).mock.calls
+        .map(([jid]) => jid as string)
+        .sort()
 
     it('should trigger catchUpAllConversations with concurrency 2', async () => {
       ;(mockClient.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
@@ -383,7 +404,19 @@ describe('setupBackgroundSyncSideEffects', () => {
       )
     })
 
-    it('should trigger catchUpAllRooms after a delay', async () => {
+    it('catches up rooms joined this session after the delay', async () => {
+      // The delayed pass covers exactly the rooms that confirmed a join during
+      // THIS fresh session and are not otherwise owned: not the active room
+      // (roomSideEffects owns it), not Quick Chat rooms, not MAM-less rooms, and
+      // not a room whose `joined` flag merely hydrated from persisted state (#1149).
+      addRoom('active@conference.example.com')
+      addRoom('a@conference.example.com')
+      addRoom('b@conference.example.com')
+      addRoom('quick@conference.example.com', { isQuickChat: true })
+      addRoom('nomam@conference.example.com', { supportsMAM: false })
+      addRoom('hydrated@conference.example.com') // joined in the store, never confirmed this session
+      roomStore.getState().setActiveRoom('active@conference.example.com')
+
       connectionStore.getState().setServerInfo({
         identities: [],
         domain: 'example.com',
@@ -394,17 +427,36 @@ describe('setupBackgroundSyncSideEffects', () => {
       cleanup = setupBackgroundSyncSideEffects(mockClient)
 
       simulateFreshSession(mockClient)
+      for (const jid of [
+        'active@conference.example.com',
+        'a@conference.example.com',
+        'b@conference.example.com',
+        'quick@conference.example.com',
+        'nomam@conference.example.com',
+      ]) {
+        confirmJoin(jid)
+      }
 
       await vi.advanceTimersByTimeAsync(1_000)
-      expect(mockClient.mam.catchUpAllRooms).not.toHaveBeenCalled()
+      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(10_000)
 
-      expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(1)
+      await vi.waitFor(() => {
+        expect(caughtUpRooms()).toEqual([
+          'a@conference.example.com',
+          'b@conference.example.com',
+        ])
+      })
       // Must pass the session-start time so the forward cursor excludes live
       // messages that arrive during the 10s catch-up window (silent-gap fix).
-      expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledWith(
-        expect.objectContaining({ concurrency: 2, sessionStartTime: expect.any(Number) })
+      expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledWith(
+        'a@conference.example.com',
+        expect.any(Array),
+        expect.objectContaining({
+          sessionStartTime: expect.any(Number),
+          stitchReadPointer: true,
+        }),
       )
     })
 
@@ -435,6 +487,8 @@ describe('setupBackgroundSyncSideEffects', () => {
     })
 
     it('retries pending decrypts again after room catch-up completes', async () => {
+      addRoom('room@conference.example.com')
+
       connectionStore.getState().setServerInfo({
         identities: [],
         domain: 'example.com',
@@ -445,6 +499,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       cleanup = setupBackgroundSyncSideEffects(mockClient)
 
       simulateFreshSession(mockClient)
+      confirmJoin('room@conference.example.com')
 
       // Conversation catch-up settles first and triggers its own retry.
       await vi.waitFor(() => {
@@ -460,7 +515,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       // retry so room messages stashed during that later pass also self-heal in-session.
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(1)
+        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
       await vi.waitFor(() => {
         expect(
@@ -470,6 +525,8 @@ describe('setupBackgroundSyncSideEffects', () => {
     })
 
     it('should cancel room catch-up timer on disconnect', async () => {
+      addRoom('room@conference.example.com')
+
       connectionStore.getState().setServerInfo({
         identities: [],
         domain: 'example.com',
@@ -480,17 +537,19 @@ describe('setupBackgroundSyncSideEffects', () => {
       cleanup = setupBackgroundSyncSideEffects(mockClient)
 
       simulateFreshSession(mockClient)
+      confirmJoin('room@conference.example.com')
 
       await vi.advanceTimersByTimeAsync(5_000)
       connectionStore.getState().setStatus('disconnected')
 
       await vi.advanceTimersByTimeAsync(10_000)
 
-      expect(mockClient.mam.catchUpAllRooms).not.toHaveBeenCalled()
+      expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
     })
 
     it('should re-trigger catch-up on reconnect', async () => {
       ;(mockClient.mam.catchUpAllConversations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+      addRoom('room@conference.example.com')
 
       connectionStore.getState().setServerInfo({
         identities: [],
@@ -502,31 +561,37 @@ describe('setupBackgroundSyncSideEffects', () => {
       cleanup = setupBackgroundSyncSideEffects(mockClient)
 
       simulateFreshSession(mockClient)
+      confirmJoin('room@conference.example.com')
       await vi.waitFor(() => {
         expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(1)
       })
 
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(1)
+        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(1)
       })
 
       connectionStore.getState().setStatus('disconnected')
 
       simulateFreshSession(mockClient)
+      confirmJoin('room@conference.example.com')
       await vi.waitFor(() => {
         expect(mockClient.mam.catchUpAllConversations).toHaveBeenCalledTimes(2)
       })
 
       await vi.advanceTimersByTimeAsync(10_000)
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledTimes(2)
+        expect(mockClient.mam.catchUpRoomHistory).toHaveBeenCalledTimes(2)
       })
     })
 
-    it('should pass exclude with activeRoomJid to catchUpAllRooms', async () => {
-      // Set active room before connecting
-      roomStore.getState().setActiveRoom('room@conference.example.com')
+    it('reads the active room at pass time, not at trigger time', async () => {
+      // The room active when sync starts can stop being active before the delayed
+      // pass fires. Exclusion must follow the room that is active THEN: the room
+      // released in the meantime still needs its catch-up.
+      addRoom('first@conference.example.com')
+      addRoom('second@conference.example.com')
+      roomStore.getState().setActiveRoom('first@conference.example.com')
 
       connectionStore.getState().setServerInfo({
         identities: [],
@@ -538,17 +603,18 @@ describe('setupBackgroundSyncSideEffects', () => {
       cleanup = setupBackgroundSyncSideEffects(mockClient)
 
       simulateFreshSession(mockClient)
+      confirmJoin('first@conference.example.com')
+      confirmJoin('second@conference.example.com')
+
+      // User switches rooms during the 10s window.
+      await vi.advanceTimersByTimeAsync(5_000)
+      roomStore.getState().setActiveRoom('second@conference.example.com')
 
       await vi.advanceTimersByTimeAsync(10_000)
 
       await vi.waitFor(() => {
-        expect(mockClient.mam.catchUpAllRooms).toHaveBeenCalledWith(
-          expect.objectContaining({ exclude: 'room@conference.example.com' })
-        )
+        expect(caughtUpRooms()).toEqual(['first@conference.example.com'])
       })
-
-      // Clean up
-      roomStore.getState().setActiveRoom(null)
     })
 
     it('does not catch up a newly active room without a current-session join', async () => {
@@ -581,7 +647,6 @@ describe('setupBackgroundSyncSideEffects', () => {
       roomStore.getState().setActiveRoom('b@conference.example.com')
       await vi.advanceTimersByTimeAsync(10_000)
 
-      expect(mockClient.mam.catchUpAllRooms).not.toHaveBeenCalled()
       expect(mockClient.mam.catchUpRoomHistory).not.toHaveBeenCalled()
       roomStore.getState().reset()
     })
@@ -596,23 +661,6 @@ describe('setupBackgroundSyncSideEffects', () => {
         roomStore.getState(),
         'loadMessagesFromCache',
       ).mockReturnValue(cache)
-      vi.mocked(mockClient.mam.catchUpAllRooms).mockImplementation(async ({
-        exclude,
-        sessionStartTime,
-      } = {}) => {
-        for (const room of roomStore.getState().joinedRooms()) {
-          if (!room.supportsMAM || room.isQuickChat || room.jid === exclude) continue
-          const messages = await roomStore.getState().loadMessagesFromCache(
-            room.jid,
-            { limit: 100, peek: true },
-          )
-          await mockClient.mam.catchUpRoomHistory(
-            room.jid,
-            messages,
-            { sessionStartTime, stitchReadPointer: true },
-          )
-        }
-      })
       for (const jid of ['a@conference.example.com', 'b@conference.example.com']) {
         roomStore.getState().addRoom({
           jid,
@@ -1574,7 +1622,7 @@ describe('setupBackgroundSyncSideEffects', () => {
       cleanup = setupBackgroundSyncSideEffects(mockClient)
       simulateFreshSession(mockClient)
 
-      // MAM resolves BEFORE the 10s pass — covered by catchUpAllRooms, not the watcher.
+      // MAM resolves BEFORE the 10s pass — covered by that pass, not the watcher.
       await vi.advanceTimersByTimeAsync(2_000)
       roomStore.getState().updateRoom('early@conference.example.com', { supportsMAM: true })
       await vi.advanceTimersByTimeAsync(100)

--- a/packages/fluux-sdk/src/core/backgroundSync.ts
+++ b/packages/fluux-sdk/src/core/backgroundSync.ts
@@ -459,22 +459,19 @@ export function setupBackgroundSyncSideEffects(
       void (async () => {
         try {
           logInfo('Background sync: room catch-up (delayed 10s)')
-          const joinedMAMRooms = roomStore.getState().joinedRooms()
+          // Only rooms that confirmed a join during THIS fresh session are
+          // eligible: a `joined` flag rehydrated from persisted state is not
+          // proof of current membership (#1149). The active room is owned by
+          // roomSideEffects and read here, at pass time, so a room released
+          // during the 10s window still gets covered.
+          const activeRoomJid = roomStore.getState().activeRoomJid
+          const candidates = roomStore.getState().joinedRooms()
             .filter((room) => (
               room.supportsMAM &&
               !room.isQuickChat &&
-              room.jid !== roomStore.getState().activeRoomJid
+              room.jid !== activeRoomJid &&
+              freshSessionJoinedRooms.has(room.jid)
             ))
-          const candidates = joinedMAMRooms.filter((room) =>
-            freshSessionJoinedRooms.has(room.jid),
-          )
-          if (joinedMAMRooms.length === 0) {
-            await client.mam.catchUpAllRooms({
-              concurrency: 2,
-              exclude: roomStore.getState().activeRoomJid,
-              sessionStartTime,
-            })
-          }
           await executeWithConcurrency(
             candidates,
             async (room) => {
@@ -551,8 +548,8 @@ export function setupBackgroundSyncSideEffects(
   })
 
   // SM resumption: the server replays undelivered stanzas, so no bulk MAM sync is
-  // needed for rooms already caught up to live. But the fresh-session room catch-up
-  // (`catchUpAllRooms`) never runs here, so a room NOT caught up to live this
+  // needed for rooms already caught up to live. But the delayed fresh-session room
+  // pass (Stage 4) never runs here, so a room NOT caught up to live this
   // session — an autojoined room the user never opened, or one whose forward
   // catch-up left an open gap (e.g. a flaky connection dropped before the 10s
   // fresh-session pass fired) — keeps an empty or stale sidebar preview until opened

--- a/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.catchup.test.ts
@@ -1,7 +1,7 @@
 /**
  * MAM Background Catch-Up Tests
  *
- * Tests for catchUpAllConversations(), catchUpAllRooms(), and
+ * Tests for catchUpAllConversations(), catchUpRoom(), and
  * discoverNewConversationsFromRoster() which populate full message
  * history in the background after connecting.
  */
@@ -1263,94 +1263,11 @@ describe('MAM Background Catch-Up', () => {
     })
   })
 
-  describe('catchUpAllRooms', () => {
-    it('should do nothing when there are no joined rooms', async () => {
-      await connectClient()
-
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([])
-      mockXmppClientInstance.iqCaller.request.mockClear()
-
-      await xmppClient.mam.catchUpAllRooms()
-
-      expect(emitSDKSpy).not.toHaveBeenCalledWith(
-        'console:event',
-        expect.objectContaining({
-          message: expect.stringContaining('Background catch-up for'),
-        })
-      )
-    })
-
-    it('should skip rooms without MAM support', async () => {
-      await connectClient()
-
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-        { jid: 'room2@conference.example.com', supportsMAM: false, isQuickChat: false, joined: true, messages: [] },
-      ] as any)
-
-      const queriedRooms: string[] = []
-      mockXmppClientInstance.iqCaller.request.mockImplementation(async (iq: any) => {
-        if (iq?.attrs?.to) {
-          queriedRooms.push(iq.attrs.to)
-        }
-        return createFinResponse()
-      })
-
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
-      await waitForAsyncOps(20, 100)
-      await catchUpPromise
-
-      expect(queriedRooms).toContain('room1@conference.example.com')
-      expect(queriedRooms).not.toContain('room2@conference.example.com')
-    })
-
-    it('should skip Quick Chat rooms', async () => {
-      await connectClient()
-
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-        { jid: 'quickchat@conference.example.com', supportsMAM: true, isQuickChat: true, joined: true, messages: [] },
-      ] as any)
-
-      const queriedRooms: string[] = []
-      mockXmppClientInstance.iqCaller.request.mockImplementation(async (iq: any) => {
-        if (iq?.attrs?.to) {
-          queriedRooms.push(iq.attrs.to)
-        }
-        return createFinResponse()
-      })
-
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
-      await waitForAsyncOps(20, 100)
-      await catchUpPromise
-
-      expect(queriedRooms).toContain('room1@conference.example.com')
-      expect(queriedRooms).not.toContain('quickchat@conference.example.com')
-    })
-
+  describe('catchUpRoom (per-room forward cursor policy)', () => {
     it('should query with forward start filter for rooms with cached messages', async () => {
       await connectClient()
 
       const cachedTimestamp = new Date('2026-01-20T10:00:00.000Z')
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        {
-          jid: 'room1@conference.example.com',
-          supportsMAM: true,
-          isQuickChat: false,
-          joined: true,
-          nickname: 'me',
-          messages: [{
-            type: 'groupchat' as const,
-            id: 'msg-1',
-            roomJid: 'room1@conference.example.com',
-            from: 'room1@conference.example.com/sender',
-            body: 'Hello',
-            timestamp: cachedTimestamp,
-            isOutgoing: false,
-            isDelayed: false,
-          }],
-        },
-      ] as any)
 
       // getRoom is needed by queryRoomArchive for the nickname.
       vi.mocked(mockStores.room.getRoom).mockReturnValue({
@@ -1358,7 +1275,7 @@ describe('MAM Background Catch-Up', () => {
         nickname: 'me',
       } as any)
 
-      // The forward cursor now comes from a PURE cache read (peek): catchUpRoom
+      // The forward cursor comes from a PURE cache read (peek): catchUpRoom
       // uses loadMessagesFromCache's RETURN value, not a store re-read.
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue([{
         type: 'groupchat' as const,
@@ -1373,7 +1290,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
+      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1393,10 +1310,6 @@ describe('MAM Background Catch-Up', () => {
     it('should query with before="" for rooms without cached messages', async () => {
       await connectClient()
 
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, nickname: 'me', messages: [] },
-      ] as any)
-
       vi.mocked(mockStores.room.getRoom).mockReturnValue({
         jid: 'room1@conference.example.com',
         nickname: 'me',
@@ -1404,7 +1317,7 @@ describe('MAM Background Catch-Up', () => {
 
       mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
 
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
+      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1416,79 +1329,6 @@ describe('MAM Background Catch-Up', () => {
         roomJid: 'room1@conference.example.com',
         direction: 'backward',
       }))
-    })
-
-    it('should respect concurrency limit', async () => {
-      await connectClient()
-
-      const rooms = Array.from({ length: 8 }, (_, i) => ({
-        jid: `room${i}@conference.example.com`,
-        supportsMAM: true,
-        isQuickChat: false,
-        joined: true,
-        messages: [],
-      }))
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue(rooms as any)
-
-      let maxConcurrent = 0
-      let currentConcurrent = 0
-
-      mockXmppClientInstance.iqCaller.request.mockImplementation(async () => {
-        currentConcurrent++
-        maxConcurrent = Math.max(maxConcurrent, currentConcurrent)
-        await new Promise(resolve => setTimeout(resolve, 10))
-        currentConcurrent--
-        return createFinResponse()
-      })
-
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms({ concurrency: 2 })
-      await waitForAsyncOps(100, 100)
-      await catchUpPromise
-
-      expect(maxConcurrent).toBeLessThanOrEqual(2)
-    })
-
-    it('should handle individual room errors gracefully', async () => {
-      await connectClient()
-
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-        { jid: 'room2@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-      ] as any)
-
-      let callCount = 0
-      mockXmppClientInstance.iqCaller.request.mockImplementation(async () => {
-        callCount++
-        if (callCount === 1) {
-          throw new Error('Network error')
-        }
-        return createFinResponse()
-      })
-
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
-      await waitForAsyncOps(30, 100)
-      await expect(catchUpPromise).resolves.not.toThrow()
-
-      expect(callCount).toBeGreaterThanOrEqual(2)
-    })
-
-    it('should emit console event on start', async () => {
-      await connectClient()
-
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-      ] as any)
-
-      mockXmppClientInstance.iqCaller.request.mockResolvedValue(createFinResponse())
-
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
-      await waitForAsyncOps(20, 100)
-      await catchUpPromise
-
-      expect(emitSDKSpy).toHaveBeenCalledWith('console:event', {
-        message: 'Background catch-up for 1 room(s)',
-        category: 'sm',
-      })
     })
 
     it('uses the newest PRE-session message as the forward cursor, ignoring a live message from this session', async () => {
@@ -1507,9 +1347,6 @@ describe('MAM Background Catch-Up', () => {
         { type: 'groupchat', id: 'old', roomJid: 'room1@conference.example.com', from: 'room1@conference.example.com/a', body: 'old', timestamp: monthOld, isOutgoing: false, isDelayed: false },
         { type: 'groupchat', id: 'live', roomJid: 'room1@conference.example.com', from: 'room1@conference.example.com/b', body: 'live', timestamp: liveThisSession, isOutgoing: false, isDelayed: false },
       ]
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, nickname: 'me', messages: roomMessages },
-      ] as any)
       vi.mocked(mockStores.room.getRoom).mockReturnValue({
         jid: 'room1@conference.example.com', nickname: 'me', messages: roomMessages,
       } as any)
@@ -1518,7 +1355,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue(roomMessages as any)
       const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms({ sessionStartTime })
+      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com', sessionStartTime)
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1535,9 +1372,6 @@ describe('MAM Background Catch-Up', () => {
       const roomMessages = [
         { type: 'groupchat', id: 'm1', roomJid: 'room1@conference.example.com', from: 'room1@conference.example.com/a', body: 'hi', timestamp: newest, isOutgoing: false, isDelayed: false },
       ]
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, nickname: 'me', messages: roomMessages },
-      ] as any)
       vi.mocked(mockStores.room.getRoom).mockReturnValue({
         jid: 'room1@conference.example.com', nickname: 'me', messages: roomMessages,
       } as any)
@@ -1546,7 +1380,7 @@ describe('MAM Background Catch-Up', () => {
       vi.mocked(mockStores.room.loadMessagesFromCache).mockResolvedValue(roomMessages as any)
       const querySpy = vi.spyOn(xmppClient.mam, 'queryRoomArchive').mockResolvedValue({ messages: [], complete: true, rsm: {} })
 
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms()
+      const catchUpPromise = xmppClient.mam.catchUpRoom('room1@conference.example.com')
       await waitForAsyncOps(20, 100)
       await catchUpPromise
 
@@ -1556,30 +1390,16 @@ describe('MAM Background Catch-Up', () => {
       }))
     })
 
-    it('should skip excluded room', async () => {
+    it('does nothing while the connection is not online', async () => {
       await connectClient()
 
-      vi.mocked(mockStores.room.joinedRooms).mockReturnValue([
-        { jid: 'room1@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-        { jid: 'room2@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-        { jid: 'room3@conference.example.com', supportsMAM: true, isQuickChat: false, joined: true, messages: [] },
-      ] as any)
+      vi.mocked(mockStores.connection.getStatus).mockReturnValue('disconnected')
+      mockXmppClientInstance.iqCaller.request.mockClear()
 
-      const queriedRooms: string[] = []
-      mockXmppClientInstance.iqCaller.request.mockImplementation(async (iq: any) => {
-        if (iq?.attrs?.to) {
-          queriedRooms.push(iq.attrs.to)
-        }
-        return createFinResponse()
-      })
+      await xmppClient.mam.catchUpRoom('room1@conference.example.com')
 
-      const catchUpPromise = xmppClient.mam.catchUpAllRooms({ exclude: 'room2@conference.example.com' })
-      await waitForAsyncOps(30, 100)
-      await catchUpPromise
-
-      expect(queriedRooms).toContain('room1@conference.example.com')
-      expect(queriedRooms).not.toContain('room2@conference.example.com')
-      expect(queriedRooms).toContain('room3@conference.example.com')
+      expect(mockStores.room.loadMessagesFromCache).not.toHaveBeenCalled()
+      expect(mockXmppClientInstance.iqCaller.request).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/fluux-sdk/src/core/modules/MAM.ts
+++ b/packages/fluux-sdk/src/core/modules/MAM.ts
@@ -1350,59 +1350,11 @@ export class MAM extends BaseModule {
   }
 
   /**
-   * Background catch-up for all joined MAM-enabled rooms.
-   *
-   * After being offline, this fetches the full message history for all rooms
-   * so messages are ready when the user opens them.
-   *
-   * Only processes rooms that are joined, support MAM, and are not Quick Chat rooms.
-   * Uses forward queries for efficiency.
-   *
-   * @param options - Optional configuration
-   * @param options.concurrency - Maximum parallel requests (default: 2)
-   * @param options.exclude - Room JID to skip (e.g., the active room already handled by side effects)
-   * @param options.sessionStartTime - Epoch ms when the current session connected. When
-   *   provided, the forward cursor is the newest message *before* this time, so a live
-   *   message arriving during the catch-up window can't poison the cursor and silently
-   *   skip the offline gap. Omit to fall back to the global newest message.
-   */
-  async catchUpAllRooms(options: { concurrency?: number; exclude?: string | null; sessionStartTime?: number } = {}): Promise<void> {
-    const { concurrency = 2, exclude, sessionStartTime } = options
-    const joinedRooms = this.deps.stores?.room.joinedRooms() || []
-
-    // Filter for MAM-enabled, non-Quick Chat rooms (and exclude active room if specified)
-    const mamRooms = joinedRooms.filter((r) => r.supportsMAM && !r.isQuickChat && (!exclude || r.jid !== exclude))
-    if (mamRooms.length === 0) return
-
-    logInfo(`Background catch-up for ${mamRooms.length} room(s)`)
-
-    this.deps.emitSDK('console:event', {
-      message: `Background catch-up for ${mamRooms.length} room(s)`,
-      category: 'sm',
-    })
-
-    await executeWithConcurrency(
-      mamRooms,
-      async (room) => {
-        try {
-          await this.catchUpRoom(room.jid, sessionStartTime)
-        } catch (_error) {
-          // Silently ignore — individual failures shouldn't affect others
-        }
-      },
-      concurrency
-    )
-
-    logInfo(`Background catch-up for ${mamRooms.length} room(s) — complete`)
-  }
-
-  /**
    * Forward catch-up for a single joined room (cache-aware, shared cursor policy).
    *
-   * Extracted so both the bulk `catchUpAllRooms()` pass and the late-MAM retry
-   * (a room whose disco resolves `supportsMAM` AFTER the initial background pass)
-   * use identical logic. The caller is responsible for filtering (joined, MAM,
-   * non-Quick-Chat, not the active room).
+   * The caller owns room selection and fan-out (joined, MAM, non-Quick-Chat, not
+   * the active room, confirmed join this session); `backgroundSync` runs the
+   * fresh-session pass and the SM-resume seed on top of this.
    *
    * @param roomJid - Room JID to catch up
    * @param sessionStartTime - Epoch ms of the current session; forward cursor
@@ -1580,7 +1532,7 @@ export class MAM extends BaseModule {
   /**
    * Force a full MAM catch-up for all joined rooms over a given time window.
    *
-   * Unlike `catchUpAllRooms()` which starts from the newest cached message,
+   * Unlike `catchUpRoom()` which starts from the newest cached message,
    * this method queries from a fixed start date (default: 45 days ago) to
    * fill any gaps left by previous incomplete catch-ups. The store's merge
    * logic deduplicates messages that already exist.
@@ -1770,7 +1722,7 @@ export class MAM extends BaseModule {
   async fetchPreviewForRoom(roomJid: string): Promise<void> {
     try {
       // Cache-first: try loading preview from IndexedDB before making a network query.
-      // Background catch-up (catchUpAllRooms) will correct the preview later if stale.
+      // The delayed background room catch-up will correct the preview later if stale.
       const cached = await this.deps.stores?.room.loadPreviewFromCache(roomJid)
       if (cached) return
 

--- a/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
+++ b/packages/fluux-sdk/src/core/sideEffects.testHelpers.ts
@@ -45,7 +45,6 @@ export function createMockClient() {
       refreshConversationPreviews: vi.fn().mockResolvedValue(undefined),
       refreshArchivedConversationPreviews: vi.fn().mockResolvedValue(undefined),
       catchUpAllConversations: vi.fn().mockResolvedValue(undefined),
-      catchUpAllRooms: vi.fn().mockResolvedValue(undefined),
       catchUpRoom: vi.fn().mockResolvedValue(undefined),
       catchUpConversationHistory: vi.fn().mockResolvedValue(undefined),
       catchUpRoomHistory: vi.fn().mockResolvedValue(undefined),

--- a/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
+++ b/packages/fluux-sdk/src/utils/mamCatchUpUtils.ts
@@ -235,7 +235,7 @@ export function selectCatchUpQuery(
 /**
  * Pick the joined rooms that need a MAM catch-up on SM resumption.
  *
- * The fresh-session background room catch-up (`catchUpAllRooms`) runs only on a
+ * The delayed fresh-session background room pass runs only on a
  * fresh `'online'` event, never on an SM `'resumed'` one. So a room not caught up
  * to live this session — an autojoined room the user never opened, or a room whose
  * forward catch-up left an open gap — keeps an empty or stale sidebar preview (and


### PR DESCRIPTION
## Summary

The delayed fresh-session room catch-up called `mam.catchUpAllRooms()` only when
`joinedMAMRooms.length === 0`. That method re-derives the same predicate
(`joined && supportsMAM && !isQuickChat`, minus the excluded active room) and
returns early on an empty set, so the guarded call could never do work: skipped
whenever a room was joined, a no-op whenever none was. The room filter is now a
single pass-time expression and the branch is gone.

That left `catchUpAllRooms()` with no caller anywhere, so it is removed from the
SDK. Note for the next release notes: this is a public API removal.

The sidebar "Catch up all rooms" action is unaffected — it calls
`forceCatchUpAllRooms()`, a separate manual repair path (fixed 45-day window,
`preserveGapMarker`) that never routed through the removed method.

## Test changes

The tests that covered the removed branch never reached it: they seeded no rooms,
so the fallback fired only in the fixture. They now seed rooms, confirm the
current-session join, and assert on `catchUpRoomHistory`, with negative controls
for the active room, Quick Chat, MAM-less, and hydrated-but-unconfirmed rooms.

Per-room cursor-policy coverage moves from the deleted `catchUpAllRooms` describe
onto `catchUpRoom()`, which previously had no direct test; the fan-out cases
(filtering, concurrency, exclude) go away with the method.

Three SM-resume assertions guarding against a bulk MAM catch-up are also removed:
`SessionLifecycleDeps` has no `mam` field, so the resume path cannot query the
archive and those assertions could not fail. Those tests keep their bookmark-fetch
assertions, which are load-bearing.
