### PR TITLE
fix: gate the MessageList test probes on a flag that is on in the Dev build

### DIFF
--- a/apps/fluux/scripts/tauri-build.sh
+++ b/apps/fluux/scripts/tauri-build.sh
@@ -72,6 +72,12 @@ done
 # Apply the dev identity override to every `tauri build` invocation below.
 EXTRA_ARGS+=(--config "$DEV_CONF")
 
+# Local builds carry the anomaly instrumentation. `tauri build` runs the
+# PRODUCTION vite build via beforeBuildCommand, so import.meta.env.DEV is false
+# here — this variable is the only thing that distinguishes "Fluux Messenger Dev"
+# from a release build. See apps/fluux/src/anomaly/gate.ts.
+export FLUUX_ANOMALY=1
+
 # Sign local builds with a stable identity when one is available, so the macOS
 # notification grant survives Rust rebuilds. Ad-hoc signing (the default when no
 # identity is set) re-pins the grant to the binary's CDHash, so every Rust

--- a/apps/fluux/src/anomaly/gate.test.ts
+++ b/apps/fluux/src/anomaly/gate.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAnomalyGate } from './gate'
+
+/**
+ * The gate matrix, asserted directly against the single function both
+ * `vite.config.ts` and `vitest.config.ts` call — rather than trusting the two
+ * configs and two shell scripts to agree with each other.
+ */
+describe('resolveAnomalyGate', () => {
+  it('is off for a production build with no override', () => {
+    expect(resolveAnomalyGate('production', {})).toBe(false)
+  })
+
+  it('is on for the dev server', () => {
+    expect(resolveAnomalyGate('development', {})).toBe(true)
+  })
+
+  it('is on for a production build with FLUUX_ANOMALY=1 (the Dev bundle)', () => {
+    // `tauri build` runs the PRODUCTION vite build, so this is the only signal that
+    // distinguishes `Fluux Messenger Dev` from a release build.
+    expect(resolveAnomalyGate('production', { FLUUX_ANOMALY: '1' })).toBe(true)
+  })
+
+  it('is off when explicitly disabled, even in development', () => {
+    // The escape hatch for ruling the instrumentation out while chasing a
+    // performance regression in the Dev build itself.
+    expect(resolveAnomalyGate('development', { FLUUX_ANOMALY: '0' })).toBe(false)
+  })
+
+  it('ignores a value that is neither "1" nor "0"', () => {
+    expect(resolveAnomalyGate('production', { FLUUX_ANOMALY: 'true' })).toBe(false)
+    expect(resolveAnomalyGate('development', { FLUUX_ANOMALY: 'yes' })).toBe(true)
+  })
+
+  it('exposes the constant to application code at runtime', () => {
+    expect(typeof __FLUUX_ANOMALY__).toBe('boolean')
+  })
+})

--- a/apps/fluux/src/anomaly/gate.ts
+++ b/apps/fluux/src/anomaly/gate.ts
@@ -1,0 +1,40 @@
+/**
+ * Build-time gate for the anomaly instrumentation tree.
+ *
+ * `__FLUUX_ANOMALY__` is substituted as a literal by Vite, so every
+ * `if (__FLUUX_ANOMALY__)` branch is dead-code eliminated in a release build and
+ * the guarded modules are never emitted.
+ *
+ * It is deliberately NOT `import.meta.env.DEV`. `Fluux Messenger Dev` is produced
+ * by `tauri build`, whose `beforeBuildCommand` runs the PRODUCTION Vite build — so
+ * `import.meta.env.DEV` is **false** in the one build whose usage we most want to
+ * observe, and equally false in release. A gate that is off everywhere is not a
+ * gate.
+ *
+ * @module Anomaly/Gate
+ */
+
+/**
+ * Resolve the gate for a build.
+ *
+ * Shared by `vite.config.ts` and `vitest.config.ts` so the matrix below has exactly
+ * one definition rather than two that can drift:
+ *
+ * | Build path                                  | Gate |
+ * |---------------------------------------------|------|
+ * | Release desktop and PWA web (CI)             | off  |
+ * | `Fluux Messenger Dev` (`tauri-build.sh`)     | on   |
+ * | Demo build and Playwright (`build-e2e.mjs`)  | on   |
+ * | `npm run dev` / `npm run tauri:dev`          | on   |
+ *
+ * @param mode - Vite mode (`'development'` | `'production'` | …)
+ * @param env - `process.env`, or a subset in tests
+ */
+export function resolveAnomalyGate(
+  mode: string,
+  env: { FLUUX_ANOMALY?: string },
+): boolean {
+  if (env.FLUUX_ANOMALY === '1') return true
+  if (env.FLUUX_ANOMALY === '0') return false
+  return mode !== 'production'
+}

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -491,10 +491,14 @@ export function MessageList<T extends BaseMessage>({
   }
   const getTopDate = useCallback(() => getTopVisibleDateRef.current(), [])
 
-  // Dev-only: expose virtualizer offset lookup for Playwright test assertions (invariant-1).
+  // Expose virtualizer offset lookup for Playwright test assertions (invariant-1).
   // Allows tests to check anchor position without requiring the row to be in the DOM window.
+  //
+  // Gated on __FLUUX_ANOMALY__, NOT import.meta.env.DEV: `tauri build` runs the
+  // production vite build, so DEV is false in the packaged "Fluux Messenger Dev"
+  // bundle and this probe never installed there. See src/anomaly/gate.ts.
   useEffect(() => {
-    if (!import.meta.env.DEV || !activeVirtualizer || typeof window === 'undefined') return
+    if (!__FLUUX_ANOMALY__ || !activeVirtualizer || typeof window === 'undefined') return
 
     const devWindow = window as unknown as Record<string, unknown>
     const getVirtOffset = (id: string) => activeVirtualizer.getOffsetForMessageId(id)
@@ -645,11 +649,13 @@ export function MessageList<T extends BaseMessage>({
     }
   }, [requestMessageTarget, scrollToBottom, staticMode])
 
-  // Dev-only: expose the full load-earlier trigger (saves anchor + calls onScrollToTop)
-  // so tests can fire it without scrolling to 0, which would change findAnchorElement's
+  // Expose the full load-earlier trigger (saves anchor + calls onScrollToTop) so
+  // tests can fire it without scrolling to 0, which would change findAnchorElement's
   // anchor to firstMessageId instead of the actual top-visible message at that scrollTop.
+  //
+  // Gated on __FLUUX_ANOMALY__ — see the note on the offset probe above.
   useEffect(() => {
-    if (!import.meta.env.DEV || typeof window === 'undefined') return
+    if (!__FLUUX_ANOMALY__ || typeof window === 'undefined') return
 
     const devWindow = window as unknown as Record<string, unknown>
     devWindow.__fluuxTriggerLoadOlder = handleLoadEarlier

--- a/apps/fluux/src/vite-env.d.ts
+++ b/apps/fluux/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 // Build-time injected constants
 declare const __APP_VERSION__: string
 declare const __GIT_COMMIT__: string
+/** Anomaly instrumentation gate — see src/anomaly/gate.ts for the build matrix. */
+declare const __FLUUX_ANOMALY__: boolean
 
 // Environment variables (VITE_* prefix)
 interface ImportMetaEnv {

--- a/apps/fluux/vite.config.ts
+++ b/apps/fluux/vite.config.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process'
 import { readFileSync, rmSync } from 'fs'
 import { resolve } from 'path'
 import { createRequire } from 'module'
+import { resolveAnomalyGate } from './src/anomaly/gate'
 
 // Resolve packages via Node's module resolution (walks up parent dirs) instead of
 // a hardcoded ../../node_modules path. The latter assumes apps/fluux sits directly
@@ -48,7 +49,7 @@ const appVersion = getVersion()
  */
 const isE2EBuild = process.env.FLUUX_E2E_BUILD === '1'
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   base: './',
   plugins: [
     react(),
@@ -149,6 +150,9 @@ export default defineConfig({
     // Inject version info at build time
     __APP_VERSION__: JSON.stringify(appVersion),
     __GIT_COMMIT__: JSON.stringify(gitCommit),
+    // Anomaly instrumentation gate. A build-time literal, so the guarded tree is
+    // dead-code eliminated in release. See src/anomaly/gate.ts for the matrix.
+    __FLUUX_ANOMALY__: JSON.stringify(resolveAnomalyGate(mode, process.env)),
   },
   optimizeDeps: {
     exclude: ['@fluux/sdk'], // Don't pre-bundle local SDK so changes are picked up
@@ -206,4 +210,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))

--- a/apps/fluux/vitest.config.ts
+++ b/apps/fluux/vitest.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
+import { resolveAnomalyGate } from './src/anomaly/gate'
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    // Same resolver as vite.config.ts, so the gate matrix has one definition.
+    // Tests run as 'development', so the instrumentation is on unless a run
+    // explicitly sets FLUUX_ANOMALY=0.
+    __FLUUX_ANOMALY__: JSON.stringify(resolveAnomalyGate('development', process.env)),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),

--- a/scripts/build-e2e.mjs
+++ b/scripts/build-e2e.mjs
@@ -32,9 +32,9 @@ const APP = join(ROOT, 'apps', 'fluux')
 const DIST = join(APP, 'dist')
 
 /**
- * Seams installed behind `import.meta.env.DEV` in MessageList.tsx, and used by
- * scripts/scroll-invariants.ts. These specifically discriminate a development build from
- * a production one — the other `__fluux*` globals are installed unconditionally and
+ * Seams installed behind `__FLUUX_ANOMALY__` in MessageList.tsx, and used by
+ * scripts/scroll-invariants.ts. These specifically discriminate a gated build from
+ * an ungated one — the other `__fluux*` globals are installed unconditionally and
  * survive a production build, so asserting those would prove nothing.
  */
 const DEV_ONLY_SEAMS = ['__fluuxGetVirtOffset', '__fluuxTriggerLoadOlder', '__fluuxTriggerMediaLoad']
@@ -42,7 +42,14 @@ const DEV_ONLY_SEAMS = ['__fluuxGetVirtOffset', '__fluuxTriggerLoadOlder', '__fl
 const build = spawnSync('npx', ['vite', 'build'], {
   cwd: APP,
   stdio: 'inherit',
-  env: { ...process.env, FLUUX_E2E_BUILD: '1', NODE_ENV: 'development' },
+  env: {
+    ...process.env,
+    FLUUX_E2E_BUILD: '1',
+    NODE_ENV: 'development',
+    // The harness seams below are gated on __FLUUX_ANOMALY__, not on
+    // import.meta.env.DEV. See apps/fluux/src/anomaly/gate.ts.
+    FLUUX_ANOMALY: '1',
+  },
 })
 
 if (build.status !== 0) {
@@ -72,7 +79,8 @@ const missing = DEV_ONLY_SEAMS.filter(seam => !bundle.includes(seam))
 if (missing.length > 0) {
   fail(
     `the bundle is missing ${missing.length} of ${DEV_ONLY_SEAMS.length} dev-only harness seam(s): ${missing.join(', ')}.\n` +
-      'This means import.meta.env.DEV resolved false — check that NODE_ENV=development reaches vite.\n' +
+      'This means the gate resolved false — check that FLUUX_ANOMALY=1 reaches vite\n' +
+      '(see apps/fluux/src/anomaly/gate.ts).\n' +
       'Without these the e2e suites fail deep inside unrelated assertions.',
   )
 }


### PR DESCRIPTION
The Playwright harness probes in `MessageList` were gated on `import.meta.env.DEV`.
`tauri build` runs the **production** Vite build through `beforeBuildCommand`, so
`DEV` is false in the packaged "Fluux Messenger Dev" bundle exactly as it is in
release. Those probes therefore never installed in the build used daily, and the
gate was effectively off everywhere.

This replaces it with `__FLUUX_ANOMALY__`, a build-time constant resolved by a
single function shared between `vite.config.ts` and `vitest.config.ts`, so those
two configs cannot disagree about the matrix:

| Build path | Gate |
|---|---|
| Release desktop and PWA web | off |
| `Fluux Messenger Dev` (`tauri-build.sh`) | on |
| Demo and Playwright build (`build-e2e.mjs`) | on |
| `npm run dev` / `npm run tauri:dev` | on |

The two build scripts still opt in independently by exporting `FLUUX_ANOMALY=1`;
nothing yet enforces that they agree with the table above. `build-e2e.mjs` at
least fails loudly when the seams are missing from its own output. A CI assertion
covering both directions — absent in a release build, present in a Dev one — is
the piece that would make this a guarantee rather than a convention, and is not
part of this change.

Because it is a literal rather than a runtime read, guarded code is dead-code
eliminated in release rather than merely skipped. Measured on real bundles, the
three probes appear in one chunk each with the flag set and in none without it;
the previous gate produced none in either. That measurement was manual, not yet
enforced.

`vite.config.ts` moves to the function form of `defineConfig` to read `mode`.

The constant is named for the anomaly-detection instrumentation it will also gate
later; this change ships only the gate and the probe fix.
