### PR TITLE
feat(fluux): render Markdown strikethrough in messages

### DIFF
--- a/apps/fluux/src/utils/messageStyles.test.tsx
+++ b/apps/fluux/src/utils/messageStyles.test.tsx
@@ -149,6 +149,83 @@ describe('renderStyledMessage', () => {
     })
   })
 
+  describe('Markdown strikethrough (~~text~~)', () => {
+    it('renders strikethrough and consumes both tilde pairs', () => {
+      const container = renderText('Hello ~~world~~')
+      expect(container.querySelector('del')?.textContent).toBe('world')
+      expect(container.textContent).toBe('Hello world')
+    })
+
+    it('renders a single-character body', () => {
+      const container = renderText('Hello ~~x~~')
+      expect(container.querySelector('del')?.textContent).toBe('x')
+      expect(container.textContent).toBe('Hello x')
+    })
+
+    it('renders multiple Markdown strikethrough segments', () => {
+      const container = renderText('~~one~~ and ~~two~~')
+      const strikes = container.querySelectorAll('del')
+      expect(strikes).toHaveLength(2)
+      expect(strikes[0].textContent).toBe('one')
+      expect(strikes[1].textContent).toBe('two')
+      expect(container.textContent).toBe('one and two')
+    })
+
+    it('keeps the XEP-0393 single-tilde form working alongside it', () => {
+      const container = renderText('~~markdown~~ and ~xep~')
+      const strikes = container.querySelectorAll('del')
+      expect(strikes).toHaveLength(2)
+      expect(strikes[0].textContent).toBe('markdown')
+      expect(strikes[1].textContent).toBe('xep')
+      expect(container.textContent).toBe('markdown and xep')
+    })
+
+    it('renders Markdown strikethrough with bold, italic and code', () => {
+      const container = renderText('**bold** and _italic_ and ~~strike~~ and `code`')
+      expect(container.querySelector('strong')?.textContent).toBe('bold')
+      expect(container.querySelector('em')?.textContent).toBe('italic')
+      expect(container.querySelector('del')?.textContent).toBe('strike')
+      expect(container.querySelector('code')?.textContent).toBe('code')
+      expect(container.textContent).toBe('bold and italic and strike and code')
+    })
+
+    it('does not strike when the markers wrap whitespace', () => {
+      const container = renderText('Hello ~~ world ~~ again')
+      expect(container.querySelector('del')).toBeFalsy()
+      expect(container.textContent).toBe('Hello ~~ world ~~ again')
+    })
+
+    it('leaves an unmatched ~~ literal', () => {
+      const container = renderText('Hello ~~world')
+      expect(container.querySelector('del')).toBeFalsy()
+      expect(container.textContent).toBe('Hello ~~world')
+    })
+
+    it('leaves a lone ~~ literal', () => {
+      const container = renderText('Hello ~~ there')
+      expect(container.querySelector('del')).toBeFalsy()
+      expect(container.textContent).toBe('Hello ~~ there')
+    })
+
+    it('suppresses strikethrough when the leading tilde is escaped', () => {
+      const container = renderText('Use \\~~not strike~~')
+      expect(container.querySelector('del')).toBeFalsy()
+      expect(container.textContent).toContain('~~not strike~~')
+    })
+
+    it('keeps tildes literal inside inline code', () => {
+      const container = renderText('Type `~~not strike~~` here')
+      expect(container.querySelector('del')).toBeFalsy()
+      expect(container.querySelector('code')?.textContent).toBe('~~not strike~~')
+    })
+
+    it('keeps tildes literal inside a fenced code block', () => {
+      const container = renderText('```\n~~not strike~~\n```')
+      expect(container.querySelector('del')).toBeFalsy()
+      expect(container.querySelector('pre code')?.textContent).toContain('~~not strike~~')
+    })
+  })
+
   describe('inline code (`text`)', () => {
     it('renders inline code', () => {
       const container = renderText('Hello `world`')

--- a/apps/fluux/src/utils/messageStyles.tsx
+++ b/apps/fluux/src/utils/messageStyles.tsx
@@ -4,7 +4,7 @@
  * Renders styled text with support for:
  * - *bold* (XEP-0393 strong) or **bold** (Markdown strong)
  * - _italic_ (emphasis)
- * - ~strikethrough~
+ * - ~strikethrough~ (XEP-0393) or ~~strikethrough~~ (Markdown)
  * - `code` (inline preformatted)
  * - ```code block``` (preformatted block)
  * - > blockquote (lines starting with >)
@@ -250,13 +250,15 @@ function parseStyledText(
   segments: StyledSegment[],
   escapeMap: Map<string, string>
 ): void {
-  // Regex for inline styles: **bold** (Markdown), *bold* (XEP-0393), _italic_, ~strike~, `code`
+  // Regex for inline styles: **bold** (Markdown), *bold* (XEP-0393), _italic_,
+  // ~~strike~~ (Markdown), ~strike~ (XEP-0393), `code`
   // Per XEP-0393: markers must be at word boundaries (start/end of string, whitespace, or punctuation)
   // Opening marker: not followed by whitespace
   // Closing marker: not preceded by whitespace
   // Uses lookbehind (?<=...) and lookahead (?=...) for boundary checks
-  // IMPORTANT: **bold** patterns must come BEFORE *bold* patterns to match correctly
-  const styleRegex = /(?<=^|[\s\p{P}])(\*\*[^\s*][^*]*[^\s*]\*\*|\*\*[^\s*]\*\*|\*[^\s*][^*]*[^\s*]\*|\*[^\s*]\*|_[^\s_][^_]*[^\s_]_|_[^\s_]_|~[^\s~][^~]*[^\s~]~|~[^\s~]~|`[^`]+`)(?=$|[\s\p{P}])/gu
+  // IMPORTANT: **bold** patterns must come BEFORE *bold* patterns to match correctly,
+  // and ~~strike~~ patterns before ~strike~ for the same reason
+  const styleRegex = /(?<=^|[\s\p{P}])(\*\*[^\s*][^*]*[^\s*]\*\*|\*\*[^\s*]\*\*|\*[^\s*][^*]*[^\s*]\*|\*[^\s*]\*|_[^\s_][^_]*[^\s_]_|_[^\s_]_|~~[^\s~][^~]*[^\s~]~~|~~[^\s~]~~|~[^\s~][^~]*[^\s~]~|~[^\s~]~|`[^`]+`)(?=$|[\s\p{P}])/gu
 
   let lastIndex = 0
   let match
@@ -270,13 +272,19 @@ function parseStyledText(
 
     const styled = match[0]
 
-    // Detect double asterisk (Markdown bold) vs single asterisk (XEP-0393 bold)
+    // Detect doubled markers (Markdown bold / strikethrough) vs single ones
+    // (XEP-0393). The regex alternation already prefers the doubled form, so a
+    // two-character marker here is unambiguously the Markdown variant.
     let type: StyledSegment['type'] = 'text'
     let inner: string
 
     if (styled.startsWith('**') && styled.endsWith('**')) {
       // Markdown-style bold: **text**
       type = 'bold'
+      inner = styled.slice(2, -2)
+    } else if (styled.startsWith('~~') && styled.endsWith('~~')) {
+      // Markdown-style strikethrough: ~~text~~
+      type = 'strike'
       inner = styled.slice(2, -2)
     } else {
       // XEP-0393 style: single character markers


### PR DESCRIPTION
## Intent

Add Markdown-style strikethrough (~~text~~) to the Fluux message renderer in apps/fluux/src/utils/messageStyles.tsx, so it matches the renderer's existing pattern of accepting both the XEP-0393 marker and its Markdown equivalent (as it already does for *bold* / **bold**).

Before this change the renderer supported single-tilde ~strike~ only, so ~~text~~ rendered WRONG rather than being ignored: the leading ~ was left as literal text, ~text~ matched as strikethrough, and the trailing ~ was left literal. The SDK preview path (packages/fluux-sdk/src/utils/messagePreview.ts, stripMessageStyling) already strips ~~text~~ before ~text~, so conversation-list previews and rendered message bodies disagreed on the same input. Closing that gap is the point of the change.

Deliberate decisions made while doing the work, so they are intentional and not oversights:
- The double-tilde alternative is placed BEFORE the single-tilde one in the inline style regex on purpose, mirroring how **bold** precedes *bold* in that same regex and how stripMessageStyling orders its two strikethrough replacements. Order is load-bearing; do not 'tidy' it.
- XEP-0393 single-tilde ~strike~ compatibility is non-negotiable and must keep working exactly as before. Both forms are supported by design; the Markdown form is an extension, not a replacement.
- The content-slicing branch was extended with an explicit startsWith('~~') && endsWith('~~') case alongside the existing '**' case. This is unambiguous because the regex alternation already prefers the doubled form, and the single-tilde alternatives require a non-tilde first and last inner character.
- No new logic was added for escaping, boundary lookaround, or inline-code precedence: those fall out of the existing machinery unchanged. 6 of the 11 new tests (escaped \~~, tildes inside inline code, tildes inside a fenced block, whitespace-wrapped ~~ ~~, unmatched ~~, lone ~~) already passed before the implementation change. They were kept deliberately as guards proving the new alternative did not loosen those rules, not because they were driving the implementation. 5 tests failed before and pass now.

Explicit scope decisions the user set:
- Scope was limited to messageStyles.tsx and its colocated test file. Broadening this into general Markdown support (tables, link syntax, task lists) was explicitly ruled out.
- messagePreview.ts was deliberately NOT changed. It was to be touched only if it had a genuine defect in its existing double-tilde handling; none was found.
- The message composer was checked for a strikethrough shortcut or formatting affordance, as requested. It has none at all: no toolbar, no keybinding, no marker insertion anywhere in MessageComposer.tsx. So nothing was changed there. This task was about rendering, not about changing what the composer emits.
- The module docstring at the top of messageStyles.tsx was updated to document both forms, as required.

Verification performed: messageStyles.test.tsx 153/153 with no existing expectation edited (no existing test encoded the old broken ~~ output); all app utils 977 passed / 2 skipped; SDK messagePreview.test.ts 63 passed; npm run typecheck and npm run lint clean across both workspaces (0 errors). Renderer/preview agreement was verified with a throwaway differential test asserting renderStyledMessage(x).textContent === stripMessageStyling(x) over 16 inputs including ~~~a~~~, 'a ~~b~ c', 'a ~b~~ c', 'x ~~y~~z~~w~~ q', 'pre~~inner~~post' and '(~~paren~~)'; all 16 agreed. That scratch file was deleted before committing and is intentionally not part of the diff.

Known pre-existing divergence, deliberately left alone and reported rather than fixed: stripMessageStyling strips inline code first, so for a code span containing tildes the preview text drops the markers while the renderer correctly keeps them literal. This is not new and is not specific to the double-tilde form - it behaves identically for single-tilde and for *bold* inside code spans. It is an ordering issue in the preview stripper, outside this task's scope.

## What Changed

- Render Markdown `~~strikethrough~~` in message bodies while preserving XEP-0393 `~strikethrough~` support.
- Document both marker forms and add regression coverage for mixed styles, multiple segments, malformed markers, escapes, and code spans/blocks.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves single-tilde compatibility, correctly prioritizes and slices double-tilde markers, and adds focused coverage for the required behavior and existing parsing invariants.

## Testing

At target `fa9fb48`, the exact two-file scope and load-bearing regex order were confirmed. After installing missing locked dependencies, the focused renderer and SDK preview tests passed, and real `renderStyledMessage` output was captured as standalone HTML demonstrating both strikethrough forms plus the inline-code guard. The demo server started, but no supported browser backend was available for a live screenshot; the rendered HTML supplies reviewer-visible evidence. All transient worktree artifacts were removed and the worktree is clean.

<details>
<summary>Evidence: Markdown strikethrough rendered HTML</summary>

<code>Real renderer output shows both `~~world~~` and `~world~` as clean `&lt;del&gt;` elements without leaked markers; inline-code tildes remain literal.</code>

```text
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Fluux Markdown strikethrough evidence</title>
  <style>
    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #11131a; color: #f4f6fb; }
    * { box-sizing: border-box; }
    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top left, #242948 0, #151824 38%, #0e1016 100%); }
    main { width: min(760px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 56px; }
    .eyebrow { color: #9ba6ff; font-size: 12px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
    h1 { margin: 8px 0 10px; font-size: clamp(28px, 5vw, 42px); letter-spacing: -.035em; }
    .intro { margin: 0 0 28px; color: #b9bfd0; line-height: 1.6; }
    .stack { display: grid; gap: 14px; }
    .sample { min-width: 0; padding: 18px; border: 1px solid #30364a; border-radius: 16px; background: rgba(25, 29, 42, .92); box-shadow: 0 14px 36px rgba(0,0,0,.2); }
    .label { margin-bottom: 12px; color: #d8dcff; font-size: 13px; font-weight: 700; }
    .source { display: flex; gap: 10px; align-items: baseline; min-width: 0; color: #81899f; font-size: 12px; }
    .source code { min-width: 0; overflow-wrap: anywhere; color: #aeb5c9; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
    .bubble { width: fit-content; max-width: 100%; margin-top: 10px; padding: 11px 14px; border-radius: 6px 16px 16px 16px; background: #2a3044; color: #f7f8fc; font-size: 16px; line-height: 1.5; overflow-wrap: anywhere; }
    del.line-through { text-decoration-line: line-through; opacity: .7; }
    code.bg-fluux-bg\/50 { padding: 2px 6px; border-radius: 5px; background: rgba(17,19,26,.55); color: #aeb7ff; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 14px; }
    .note { margin-top: 24px; padding: 14px 16px; border-left: 3px solid #7784ff; background: rgba(119,132,255,.08); color: #b9bfd0; font-size: 13px; line-height: 1.55; }
  </style>
</head>
<body>
  <main>
    <div class="eyebrow">No-mistakes test evidence</div>
    <h1>Fluux message renderer</h1>
    <p class="intro">The message bubbles below contain static markup generated directly by <code>renderStyledMessage</code> at target commit fa9fb48.</p>
    <div class="stack">
        <section class="sample">
          <div class="label">Markdown extension</div>
          <div class="source"><span>Input</span><code>Hello ~~world~~</code></div>
          <div class="bubble">Hello <del class="line-through opacity-70">world</del></div>
        </section>

        <section class="sample">
          <div class="label">XEP-0393 compatibility</div>
          <div class="source"><span>Input</span><code>Hello ~world~</code></div>
          <div class="bubble">Hello <del class="line-through opacity-70">world</del></div>
        </section>

        <section class="sample">
          <div class="label">Both forms together</div>
          <div class="source"><span>Input</span><code>~~Markdown~~ and ~XEP-0393~</code></div>
          <div class="bubble"><del class="line-through opacity-70">Markdown</del> and <del class="line-through opacity-70">XEP-0393</del></div>
        </section>

        <section class="sample">
          <div class="label">Inline-code guard</div>
          <div class="source"><span>Input</span><code>Type `~~literal tildes~~` here</code></div>
          <div class="bubble">Type <code class="bg-fluux-bg/50 text-fluux-brand px-1.5 py-0.5 rounded text-sm font-mono">~~literal tildes~~</code> here</div>
        </section></div>
    <div class="note">Expected result: both doubled Markdown tildes and single XEP-0393 tildes become one clean strikethrough span with no marker leakage; tildes inside inline code stay literal.</div>
  </main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git rev-parse HEAD` and `git merge-base HEAD 3af67f3215c94c05af3484697c0f82f9d8fd150f`</code>
- `git diff 3af67f3215c94c05af3484697c0f82f9d8fd150f..fa9fb48c3df235d456c3d58dade56a073c611b42 -- apps/fluux/src/utils/messageStyles.tsx apps/fluux/src/utils/messageStyles.test.tsx`
- <code>`npm ci` to remedy missing local test dependencies</code>
- `cd apps/fluux && npx vitest run src/utils/messageStyles.test.tsx`
- `cd packages/fluux-sdk && npx vitest run src/utils/messagePreview.test.ts`
- <code>`cd apps/fluux &amp;&amp; npx vitest run src/utils/messageStyles.evidence.test.tsx` using a temporary evidence-only test, removed afterward</code>
- <code>Inspected generated HTML to confirm both marker forms render as `&lt;del&gt;` without literal tildes and inline-code markers remain literal</code>
- <code>`npm run dev -- --host 127.0.0.1` and attempted supported browser capture; browser discovery returned no available browser</code>
- <code>Removed transient `node_modules` and evidence-test source, then confirmed `git status --short --branch` was clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
