### PR TITLE
fix(mds): stop the fresh-session seed silencing an unpublished read position (#1145)

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -144,17 +144,30 @@ function makeClient() {
       handlers[ev] = (handlers[ev] || []).filter((h) => h !== cb)
     }
   }
+  const mds = {
+    publishDisplayed: vi.fn().mockResolvedValue(undefined),
+    fetchAllDisplayed: vi.fn().mockResolvedValue([]),
+    fetchAllDisplayedResult: vi.fn(),
+    retractDisplayed: vi.fn().mockResolvedValue(undefined),
+  }
+  mds.fetchAllDisplayedResult.mockImplementation(async () => {
+    try {
+      return {
+        status: 'authoritative' as const,
+        markers: await mds.fetchAllDisplayed(),
+      }
+    } catch {
+      return { status: 'unknown' as const }
+    }
+  })
+
   return {
     // Connection lifecycle events ('online'/'resumed') use client.on(...).
     on: register,
     // SDK events ('read:displayed-synced') use client.subscribe(...).
     subscribe: register,
     _emit: (ev: string, p?: unknown) => (handlers[ev] || []).forEach((h) => h(p)),
-    mds: {
-      publishDisplayed: vi.fn().mockResolvedValue(undefined),
-      fetchAllDisplayed: vi.fn().mockResolvedValue([]),
-      retractDisplayed: vi.fn().mockResolvedValue(undefined),
-    },
+    mds,
   }
 }
 
@@ -783,6 +796,95 @@ describe('setupMdsSideEffects', () => {
 
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
     restarted()
+  })
+
+  it('does not sweep local positions when the node fetch fails', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    client.mds.fetchAllDisplayed = vi.fn().mockRejectedValue(new Error('timeout'))
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    seedMessages(cid, [msg('m1', 's1')])
+    seedMeta(cid, 'm1')
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('rechecks a queued position when a peer marker arrives during the debounce', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    seedMessages(cid, [msg('m1', 's1')])
+    seedMeta(cid, 'm1')
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(0)
+
+    chatStore.getState().applyRemoteDisplayed(cid, 's9')
+    client._emit('read:displayed-synced', { conversationId: cid, stanzaId: 's9' })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('publishes a local position removed from the node between fresh sessions', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValueOnce([{ conversationJid: cid, stanzaId: 's1' }])
+      .mockResolvedValueOnce([])
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    seedMessages(cid, [msg('m1', 's1')])
+    seedMeta(cid, 'm1')
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    connectionStore.setState({ status: 'offline' } as never)
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    cleanup()
+  })
+
+  it('preserves a live marker that arrives while the node seed is in flight', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    let resolveFetch!: (markers: Array<{ conversationJid: string; stanzaId: string }>) => void
+    client.mds.fetchAllDisplayed = vi.fn().mockImplementation(
+      () => new Promise((resolve) => {
+        resolveFetch = resolve
+      })
+    )
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    seedMessages(cid, [msg('m1', 's1')])
+    seedMeta(cid, 'm1')
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(0)
+
+    chatStore.getState().applyRemoteDisplayed(cid, 's9')
+    client._emit('read:displayed-synced', { conversationId: cid, stanzaId: 's9' })
+    resolveFetch([{ conversationJid: cid, stanzaId: 's5' }])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
   })
 
   it('retracts the MDS marker when a conversation is deleted while online+synced', async () => {

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -262,9 +262,12 @@ describe('setupMdsSideEffects', () => {
     const client = makeClient()
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
-    // Conversation already exists with a settled local read position at m1 before
-    // the side effect starts, so the fresh-session seed snapshots m1 as the last
-    // considered position (no spurious publish for the existing position).
+    // Conversation already exists with a SETTLED local read position at m1: the
+    // node holds that same position, so the seed has nothing left to publish for
+    // it and the test isolates the echo of the s2 marker that follows.
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1' }])
     seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
     seedMeta(cid, 'm1')
 
@@ -294,6 +297,11 @@ describe('setupMdsSideEffects', () => {
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
     // Seed the room (rooms + roomRuntime + roomMeta) so isRoom()/routing works.
+    // The node already holds the settled position m1/s1, so the only publish the
+    // test can observe is the m2 advance below.
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's1' }])
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)], 'm1')
 
     const cleanup = setupMdsSideEffects(client as never)
@@ -369,8 +377,11 @@ describe('setupMdsSideEffects', () => {
     const client = makeClient()
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
 
-    // Known room with a settled local read position at m1 before the side effect
-    // starts, so the seed snapshots m1 as the last considered position.
+    // Known room with a SETTLED local read position at m1 — the node holds that
+    // same position, so the seed has nothing left to publish for it.
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: ROOM, stanzaId: 's1' }])
     seedRoom(ROOM, [rmsg(ROOM, 'm1', 's1', 1), rmsg(ROOM, 'm2', 's2', 2)], 'm1')
 
     const cleanup = setupMdsSideEffects(client as never)
@@ -585,6 +596,193 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
     expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
     cleanup()
+  })
+
+  // #1145: the fresh-session seed used to clear `lastConsideredSeenId` and then
+  // immediately re-fill it from the current read pointers, re-recording a position
+  // that was never published as already handled. consider() then short-circuited
+  // on it for the whole session, and only a FURTHER local read advance could ever
+  // recover it — so the user's other devices never learned the position.
+  it('publishes a read position left unpublished by the previous session, with no further read advance', async () => {
+    const cid = 'juliet@capulet.example'
+
+    // --- Session 1: the position advances but never resolves to a stanza-id, so
+    // it is never published (the #1142 shape, now retried rather than silenced).
+    const first = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    seedMeta(cid)
+    seedMessages(cid, [msg('m2', undefined)])
+
+    const stopFirst = setupMdsSideEffects(first as never)
+    first._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    patchMeta(cid, { readPointer: pointerAt('m2') })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(first.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    connectionStore.setState({ status: 'offline' } as never)
+    stopFirst()
+
+    // --- Session 2 (restart): the read pointer survives in localStorage, and the
+    // reloaded slice now names a stanza-id for it. The node still holds an OLDER
+    // marker for this conversation, which is the ordinary shape once any position
+    // has ever been published — the seed must not treat that as "handled".
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    const second = makeClient()
+    second.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: cid, stanzaId: 's1' }])
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    const stopSecond = setupMdsSideEffects(second as never)
+    second._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    // No local read advance happened in session 2 — the seed itself must publish.
+    expect(second.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(second.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's2', 'romeo@montague.example')
+    stopSecond()
+  })
+
+  // #1145, the other half: dropping the seed snapshot must NOT open a regressive
+  // publish. The seed's applyRemoteDisplayed resolves as `stash-pending` when the
+  // loaded slice cannot order the node's marker against the local pointer, and the
+  // local pointer may then be BEHIND the node. MDS positions are forward-only, so
+  // publishing there would move every other device backward unrecoverably.
+  it('does not publish a local position while the node holds a marker it cannot order (stash-pending)', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    // The node is ahead at s9, whose message is NOT in the loaded slice → the seed
+    // can only stash it as pendingRemoteDisplayedStanzaId.
+    client.mds.fetchAllDisplayed = vi
+      .fn()
+      .mockResolvedValue([{ conversationJid: cid, stanzaId: 's9' }])
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    seedMessages(cid, [msg('m1', 's1')])
+    seedMeta(cid, 'm1')
+    // Active, so the merge below keeps a resident array (memory windowing evicts
+    // every other conversation's) and can resolve the stashed marker.
+    chatStore.setState({ activeConversationId: cid })
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    // Publishing s1 here would walk every other device back from s9 to s1.
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // It is a HOLD, not a silence: once the merge brings s9 into the slice the
+    // marker resolves, the pointer advances onto it, and there is nothing to send…
+    chatStore.getState().mergeMAMMessages(
+      cid,
+      [msg('m1', 's1'), msg('m9', 's9'), msg('m10', 's10')],
+      {},
+      true,
+      'forward'
+    )
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBeUndefined()
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // …and a genuine advance past the node's position publishes normally.
+    chatStore.getState().advanceReadPointer(cid, 'm10')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's10', 'romeo@montague.example')
+    cleanup()
+  })
+
+  // Same protection for a marker that stashes AFTER the seed: a peer device
+  // publishes a position we cannot order, and our own (behind) position must not
+  // be published over it on the next metadata change.
+  it('does not publish over a live remote marker it cannot order', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    seedMeta(cid, 'm1')
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    // The empty node learns our position m1/s1 from the seed sweep.
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+
+    // A peer device publishes s9, off-slice → the binding can only stash it.
+    chatStore.getState().applyRemoteDisplayed(cid, 's9')
+    client._emit('read:displayed-synced', { conversationId: cid, stanzaId: 's9' })
+    expect(chatStore.getState().conversationMeta.get(cid)?.pendingRemoteDisplayedStanzaId).toBe('s9')
+
+    // A local advance to m2 is still BEHIND s9, and nothing here can prove
+    // otherwise — publishing it would regress the peer.
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  // Cold-start burst shape (#1145). The seed's sweep is what makes an unpublished
+  // position recoverable, so its cost is one publish IQ per entity whose position
+  // the node does NOT already hold — and nothing for the ones it does. That is
+  // what keeps the burst a one-time migration rather than a per-launch cost:
+  // after the first pass the node holds every marker and the next start sweeps
+  // for free. `doPublish` awaits each IQ in turn, so these are serial, never a
+  // concurrent flood.
+  it('sweeps a cold-start roster with one publish per position the node lacks', async () => {
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+
+    // Five conversations, each read to its newest message. No resident arrays —
+    // memory windowing is the realistic cold-start shape, so the pointers resolve
+    // through the lastMessage preview.
+    const jids = Array.from({ length: 5 }, (_, i) => `contact${i}@example.com`)
+    chatStore.setState((state) => {
+      const meta = new Map(state.conversationMeta)
+      const convs = new Map(state.conversations)
+      for (const cid of jids) {
+        const newest = { ...msg('m2', `${cid}-s2`), id: `${cid}-m2`, conversationId: cid }
+        const readPointer = { messageId: newest.id, timestamp: newest.timestamp }
+        meta.set(cid, { unreadCount: 0, readPointer, lastMessage: newest } as never)
+        convs.set(cid, { id: cid, name: cid, type: 'chat', unreadCount: 0, readPointer } as never)
+      }
+      return { conversationMeta: meta, conversations: convs }
+    })
+
+    // The node already holds the first two positions.
+    client.mds.fetchAllDisplayed = vi.fn().mockResolvedValue(
+      jids.slice(0, 2).map((cid) => ({ conversationJid: cid, stanzaId: `${cid}-s2` }))
+    )
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    const published = client.mds.publishDisplayed.mock.calls.map((c) => c[0])
+    expect(published.sort()).toEqual(jids.slice(2))
+
+    // Second start against the now-complete node: nothing left to publish.
+    cleanup()
+    client.mds.publishDisplayed.mockClear()
+    client.mds.fetchAllDisplayed = vi.fn().mockResolvedValue(
+      jids.map((cid) => ({ conversationJid: cid, stanzaId: `${cid}-s2` }))
+    )
+    const restarted = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    restarted()
   })
 
   it('retracts the MDS marker when a conversation is deleted while online+synced', async () => {

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -814,6 +814,34 @@ describe('setupMdsSideEffects', () => {
     cleanup()
   })
 
+  it('does not publish over a prior-session marker after a reconnect fetch fails', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    seedMessages(cid, [msg('m1', 's1'), msg('m2', 's2')])
+    seedMeta(cid)
+
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(0)
+
+    chatStore.getState().advanceReadPointer(cid, 'm1')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+
+    connectionStore.setState({ status: 'offline' } as never)
+    client.mds.fetchAllDisplayed = vi.fn().mockRejectedValue(new Error('timeout'))
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    client._emit('online')
+    await vi.advanceTimersByTimeAsync(0)
+
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
   it('rechecks a queued position when a peer marker arrives during the debounce', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -493,7 +493,7 @@ export function setupMdsSideEffects(
     currentSessionConfirmedNodeJids.clear()
     void (async () => {
       const seedStartedAtRevision = nodeRevision
-      let result: DisplayedMarkerFetchResult = { status: 'unknown' }
+      let result: DisplayedMarkerFetchResult
       try {
         result = await client.mds.fetchAllDisplayedResult()
       } catch {

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -61,6 +61,7 @@ export function setupMdsSideEffects(
   const lastKnownNodeRevision = new Map<string, number>()
   let nodeRevision = 0
   let nodeSnapshotAuthoritative = false
+  const currentSessionConfirmedNodeJids = new Set<string>()
   // The read-pointer message id we last HANDLED per JID, to detect advances.
   // "Handled" means the position was resolved to a stanza-id and then either
   // enqueued or judged not ahead of the node — never merely "seen". A position
@@ -80,6 +81,7 @@ export function setupMdsSideEffects(
   function recordKnownNodeStanzaId(jid: string, stanzaId: string): void {
     lastKnownNodeStanzaId.set(jid, stanzaId)
     lastKnownNodeRevision.set(jid, ++nodeRevision)
+    currentSessionConfirmedNodeJids.add(jid)
   }
 
   /** Is this JID a known room (bookmarked or joined)? Routes accessors per-store. */
@@ -158,6 +160,12 @@ export function setupMdsSideEffects(
    * the one value we must never publish over.
    */
   function publishDecision(jid: string, stanzaId: string): 'publish' | 'skip' | 'retry' {
+    // A failed fresh-session read makes every prior-session entry unproven.
+    // Until an authoritative reconnect or a current-session live update confirms
+    // a JID, its position stays unpublished: delay is recoverable, overwriting a
+    // newer forward-only MDS marker is not.
+    if (!nodeSnapshotAuthoritative && !currentSessionConfirmedNodeJids.has(jid)) return 'retry'
+
     const nodeId = lastKnownNodeStanzaId.get(jid)
     if (!nodeId) return nodeSnapshotAuthoritative ? 'publish' : 'retry'
 
@@ -361,6 +369,7 @@ export function setupMdsSideEffects(
   function evictJid(jid: string): void {
     lastKnownNodeStanzaId.delete(jid)
     lastKnownNodeRevision.delete(jid)
+    currentSessionConfirmedNodeJids.delete(jid)
     lastConsideredSeenId.delete(jid)
     unroutedSeedMarkers.delete(jid)
     dirty.delete(jid)
@@ -481,6 +490,7 @@ export function setupMdsSideEffects(
   const unsubscribeOnline = client.on('online', () => {
     syncEnabled = false
     nodeSnapshotAuthoritative = false
+    currentSessionConfirmedNodeJids.clear()
     void (async () => {
       const seedStartedAtRevision = nodeRevision
       let result: DisplayedMarkerFetchResult = { status: 'unknown' }

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -25,7 +25,7 @@
  */
 
 import type { XMPPClient } from './XMPPClient'
-import type { DisplayedMarker } from './modules/Mds'
+import type { DisplayedMarker, DisplayedMarkerFetchResult } from './modules/Mds'
 import type { SideEffectsOptions } from './chatSideEffects'
 import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
@@ -58,6 +58,9 @@ export function setupMdsSideEffects(
   const dirty = createKeyedCoalescer<string, string>()
   // Highest stanza-id we believe is on the node per JID (seed + our publishes).
   const lastKnownNodeStanzaId = new Map<string, string>()
+  const lastKnownNodeRevision = new Map<string, number>()
+  let nodeRevision = 0
+  let nodeSnapshotAuthoritative = false
   // The read-pointer message id we last HANDLED per JID, to detect advances.
   // "Handled" means the position was resolved to a stanza-id and then either
   // enqueued or judged not ahead of the node — never merely "seen". A position
@@ -73,6 +76,11 @@ export function setupMdsSideEffects(
   // Live conversation/room JIDs, to detect user deletes (retraction). Maintained
   // while disarmed; the removed delta is retracted only while armed (syncEnabled).
   let trackedJids = new Set<string>()
+
+  function recordKnownNodeStanzaId(jid: string, stanzaId: string): void {
+    lastKnownNodeStanzaId.set(jid, stanzaId)
+    lastKnownNodeRevision.set(jid, ++nodeRevision)
+  }
 
   /** Is this JID a known room (bookmarked or joined)? Routes accessors per-store. */
   function isRoom(jid: string): boolean {
@@ -132,8 +140,8 @@ export function setupMdsSideEffects(
   /**
    * What to do with a resolved local position for `jid`:
    *
-   * - `publish` — strictly ahead of what we believe the node holds, or the node
-   *   holds nothing for this JID (nothing there to regress).
+   * - `publish` — strictly ahead of what we believe the node holds, or an
+   *   authoritative snapshot proves the node holds nothing for this JID.
    * - `skip` — at or behind the node; handled, nothing to send.
    * - `retry` — we cannot PROVE the position is not regressive. The caller must
    *   leave it unhandled so a later merge or activation fold re-considers it.
@@ -151,7 +159,7 @@ export function setupMdsSideEffects(
    */
   function publishDecision(jid: string, stanzaId: string): 'publish' | 'skip' | 'retry' {
     const nodeId = lastKnownNodeStanzaId.get(jid)
-    if (!nodeId) return 'publish'
+    if (!nodeId) return nodeSnapshotAuthoritative ? 'publish' : 'retry'
 
     const candidateIdx = indexOfStanza(jid, stanzaId)
     const nodeIdx = indexOfStanza(jid, nodeId)
@@ -239,9 +247,15 @@ export function setupMdsSideEffects(
         lastConsideredSeenId.delete(jid)
         continue
       }
+      const decision = publishDecision(jid, stanzaId)
+      if (decision === 'retry') {
+        lastConsideredSeenId.delete(jid)
+        continue
+      }
+      if (decision === 'skip') continue
       try {
         await client.mds.publishDisplayed(jid, stanzaId, by)
-        lastKnownNodeStanzaId.set(jid, stanzaId)
+        recordKnownNodeStanzaId(jid, stanzaId)
       } catch {
         // Best-effort; keep the position handled as documented above.
       }
@@ -320,8 +334,8 @@ export function setupMdsSideEffects(
     if (decision === 'retry') return
 
     // Resolved AND ordered → handled from here on, whether we enqueue below or
-    // decide the node is already at/ahead of it (a verdict that cannot flip:
-    // message order within a slice is stable).
+    // decide the node is already at/ahead of it. Enqueued positions are checked
+    // again at flush time because live node state can change during the debounce.
     lastConsideredSeenId.set(jid, seenId)
     if (decision === 'skip') return
 
@@ -346,6 +360,7 @@ export function setupMdsSideEffects(
    */
   function evictJid(jid: string): void {
     lastKnownNodeStanzaId.delete(jid)
+    lastKnownNodeRevision.delete(jid)
     lastConsideredSeenId.delete(jid)
     unroutedSeedMarkers.delete(jid)
     dirty.delete(jid)
@@ -465,20 +480,47 @@ export function setupMdsSideEffects(
   // disabled for the whole async seed so the seeded positions aren't republished.
   const unsubscribeOnline = client.on('online', () => {
     syncEnabled = false
+    nodeSnapshotAuthoritative = false
     void (async () => {
-      let markers: DisplayedMarker[] = []
+      const seedStartedAtRevision = nodeRevision
+      let result: DisplayedMarkerFetchResult = { status: 'unknown' }
       try {
-        markers = await client.mds.fetchAllDisplayed()
+        result = await client.mds.fetchAllDisplayedResult()
       } catch {
-        // Node may not exist yet — proceed with an empty seed.
+        result = { status: 'unknown' }
       }
 
-      // Reset the unrouted-marker stash for this seed (mirrors dirty.drop below).
+      dirty.drop()
+      dirty.open()
+      lastConsideredSeenId.clear()
+
+      if (result.status === 'unknown') {
+        syncEnabled = true
+        trackedJids = liveJids()
+        logInfo('MDS: node state unavailable; publishing remains guarded')
+        return
+      }
+
+      const effectiveMarkers = new Map<string, DisplayedMarker>()
+      for (const marker of result.markers) {
+        const bare = getBareJid(marker.conversationJid)
+        effectiveMarkers.set(bare, { ...marker, conversationJid: bare })
+      }
+      for (const [jid, revision] of lastKnownNodeRevision) {
+        if (revision <= seedStartedAtRevision) continue
+        const stanzaId = lastKnownNodeStanzaId.get(jid)
+        if (stanzaId) effectiveMarkers.set(jid, { conversationJid: jid, stanzaId })
+      }
+
+      lastKnownNodeStanzaId.clear()
+      lastKnownNodeRevision.clear()
+      for (const [jid, { stanzaId }] of effectiveMarkers) {
+        recordKnownNodeStanzaId(jid, stanzaId)
+      }
+      nodeSnapshotAuthoritative = true
       unroutedSeedMarkers.clear()
 
-      for (const { conversationJid, stanzaId, legacy } of markers) {
-        const bare = getBareJid(conversationJid)
-        lastKnownNodeStanzaId.set(bare, stanzaId)
+      for (const [bare, { stanzaId, legacy }] of effectiveMarkers) {
         // Route the seed by membership. The fresh-session seed runs BEFORE
         // bookmarks load (online fires before fetchBookmarks populates
         // roomStore.rooms), so a bookmarked room is typically NOT yet known
@@ -504,10 +546,6 @@ export function setupMdsSideEffects(
         }
       }
 
-      // Open the coalescer window for the publishing phase.
-      dirty.drop()
-      dirty.open()
-
       // A fresh session starts with NOTHING recorded as handled.
       //
       // This used to re-snapshot the current pointers from both stores, which
@@ -518,8 +556,6 @@ export function setupMdsSideEffects(
       // set for every node marker, so publishDecision() answers `skip` for a
       // position the node already holds and `retry` for one it holds a marker we
       // could not order against.
-      lastConsideredSeenId.clear()
-
       syncEnabled = true
       // Rebuild the delete-detection baseline to the current live set so the
       // fresh-session population is never seen as deletions.
@@ -545,7 +581,7 @@ export function setupMdsSideEffects(
   const unsubscribeDisplayedSynced = client.subscribe(
     'read:displayed-synced',
     ({ conversationId, stanzaId }) => {
-      lastKnownNodeStanzaId.set(getBareJid(conversationId), stanzaId)
+      recordKnownNodeStanzaId(getBareJid(conversationId), stanzaId)
     }
   )
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -16,9 +16,10 @@
  * roomStore.rooms gains that JID (bookmark loaded later in the same session).
  *
  * localStorage remains the durable source for read positions, but pending
- * in-memory work is DROPPED on disconnect. A later genuine read advance can
- * publish; fresh-session seeding intentionally snapshots the current pointer
- * and is not a general retry queue.
+ * in-memory work is DROPPED on disconnect. The fresh-session seed therefore
+ * re-considers every entity once publishing is armed, so a position the previous
+ * session never managed to publish is retried without waiting for a further
+ * local read advance (#1145).
  *
  * @module Core/MdsSideEffects
  */
@@ -112,6 +113,52 @@ export function setupMdsSideEffects(
       ? roomStore.getState().roomRuntime.get(jid)?.messages ?? []
       : chatStore.getState().messages.get(jid) || []
     return messages.findIndex((m) => m.stanzaId === stanzaId)
+  }
+
+  /**
+   * The remote marker this entity has STASHED, if any.
+   *
+   * `readMarkerSync` records `pendingRemoteDisplayedStanzaId` exactly when the
+   * loaded slice could not order an incoming XEP-0490 marker against the local
+   * read pointer, so a value here means "the node may be ahead of us and we
+   * cannot tell".
+   */
+  function pendingRemoteDisplayed(jid: string): string | undefined {
+    return isRoom(jid)
+      ? roomStore.getState().roomMeta.get(jid)?.pendingRemoteDisplayedStanzaId
+      : chatStore.getState().conversationMeta.get(jid)?.pendingRemoteDisplayedStanzaId
+  }
+
+  /**
+   * What to do with a resolved local position for `jid`:
+   *
+   * - `publish` — strictly ahead of what we believe the node holds, or the node
+   *   holds nothing for this JID (nothing there to regress).
+   * - `skip` — at or behind the node; handled, nothing to send.
+   * - `retry` — we cannot PROVE the position is not regressive. The caller must
+   *   leave it unhandled so a later merge or activation fold re-considers it.
+   *
+   * The last case is the whole point of this helper. When either side is off the
+   * loaded slice, index order proves nothing, and MDS positions are forward-only:
+   * publishing a position that happens to be BEHIND the node moves every other
+   * device backward, unrecoverably. What still makes an off-slice node value safe
+   * to overwrite is that we have ORDERED it against our pointer at some point:
+   * `applyRemoteDisplayed` is forward-only, so a marker it RESOLVED left our
+   * pointer at or past it, and the local pointer only ever advances from there —
+   * the same forward-only local marker the exact-equal skip in `doPublish` relies
+   * on. A marker it could NOT order is still stashed on the entity, and that is
+   * the one value we must never publish over.
+   */
+  function publishDecision(jid: string, stanzaId: string): 'publish' | 'skip' | 'retry' {
+    const nodeId = lastKnownNodeStanzaId.get(jid)
+    if (!nodeId) return 'publish'
+
+    const candidateIdx = indexOfStanza(jid, stanzaId)
+    const nodeIdx = indexOfStanza(jid, nodeId)
+    if (candidateIdx !== -1 && nodeIdx !== -1) {
+      return candidateIdx > nodeIdx ? 'publish' : 'skip'
+    }
+    return pendingRemoteDisplayed(jid) === nodeId ? 'retry' : 'publish'
   }
 
   /** Resolve the stanza-id of the message a conversation's/room's read pointer names. */
@@ -264,23 +311,19 @@ export function setupMdsSideEffects(
     // (#1142). The key means "this position is handled", not "we have seen it".
     if (!stanzaId) return
 
-    // Resolved → handled from here on, whether we enqueue below or decide the
-    // node is already at/ahead of it (a verdict that cannot flip: message order
-    // within a slice is stable).
-    lastConsideredSeenId.set(jid, seenId)
+    // No regressive publish: only publish when we can show the position is not
+    // behind what we believe is already on the node for this JID.
+    const decision = publishDecision(jid, stanzaId)
+    // Unprovable → leave the de-dup key UNCOMMITTED (same contract as the
+    // unresolved case above), so the merge or activation fold that resolves the
+    // stashed marker re-considers this position instead of silencing it.
+    if (decision === 'retry') return
 
-    // No regressive publish: only publish if strictly ahead (by message index)
-    // of what we believe is already on the node for this JID.
-    const nodeId = lastKnownNodeStanzaId.get(jid)
-    if (nodeId) {
-      const candidateIdx = indexOfStanza(jid, stanzaId)
-      const nodeIdx = indexOfStanza(jid, nodeId)
-      // When nodeIdx === -1 the node's high-water message is outside the loaded
-      // window, so we can't prove the candidate is ahead — publish optimistically
-      // and rely on the local marker being forward-only. A later genuine read
-      // advance supersedes any rare backward node move.
-      if (candidateIdx !== -1 && nodeIdx !== -1 && candidateIdx <= nodeIdx) return
-    }
+    // Resolved AND ordered → handled from here on, whether we enqueue below or
+    // decide the node is already at/ahead of it (a verdict that cannot flip:
+    // message order within a slice is stable).
+    lastConsideredSeenId.set(jid, seenId)
+    if (decision === 'skip') return
 
     dirty.add(jid, stanzaId)
     schedulePublish()
@@ -465,20 +508,29 @@ export function setupMdsSideEffects(
       dirty.drop()
       dirty.open()
 
-      // Snapshot the current per-JID read positions (both stores) so the seed
-      // isn't republished; only later advances past these will enqueue.
+      // A fresh session starts with NOTHING recorded as handled.
+      //
+      // This used to re-snapshot the current pointers from both stores, which
+      // re-recorded an UNPUBLISHED position as handled: consider() then
+      // short-circuited on it for the whole session, and only a further local
+      // read advance could ever recover it (#1145). The seed does not need that
+      // snapshot to avoid republishing itself — `lastKnownNodeStanzaId` was just
+      // set for every node marker, so publishDecision() answers `skip` for a
+      // position the node already holds and `retry` for one it holds a marker we
+      // could not order against.
       lastConsideredSeenId.clear()
-      for (const [jid, meta] of chatStore.getState().conversationMeta) {
-        lastConsideredSeenId.set(jid, meta.readPointer?.messageId)
-      }
-      for (const [jid, meta] of roomStore.getState().roomMeta) {
-        lastConsideredSeenId.set(jid, meta.readPointer?.messageId)
-      }
 
       syncEnabled = true
       // Rebuild the delete-detection baseline to the current live set so the
       // fresh-session population is never seen as deletions.
       trackedJids = liveJids()
+      // Sweep once now that publishing is armed. Every entity is re-considered
+      // against the freshly seeded node state, so a position the previous session
+      // never managed to publish goes out now instead of waiting for incidental
+      // store churn to happen to re-consider it. Positions the node already holds
+      // cost nothing here — publishDecision() skips them without an IQ.
+      considerConversations()
+      considerRooms()
       logInfo('MDS: seeded read positions and enabled publishing')
     })()
   })

--- a/packages/fluux-sdk/src/core/modules/Mds.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.test.ts
@@ -144,6 +144,21 @@ describe('Mds.fetchAllDisplayed', () => {
     })
   })
 
+  // A brand-new account has no MDS node, so recognising its absence is what lets
+  // the read-position seed publish at all. Some servers surface the condition only
+  // in the error text, which is why this goes through the shared
+  // `hasErrorCondition` helper rather than reading `.condition` directly.
+  it('recognises a missing node when the condition rides only in the error text', async () => {
+    const mds = new Mds(
+      makeDeps(vi.fn().mockRejectedValue(new Error('IQ error: item-not-found')))
+    )
+
+    expect(await mds.fetchAllDisplayedResult()).toEqual({
+      status: 'authoritative',
+      markers: [],
+    })
+  })
+
   it('reports transport and timeout failures as unknown', async () => {
     const mds = new Mds(makeDeps(vi.fn().mockRejectedValue(new Error('timeout'))))
 

--- a/packages/fluux-sdk/src/core/modules/Mds.test.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.test.ts
@@ -130,4 +130,30 @@ describe('Mds.fetchAllDisplayed', () => {
     const mds2 = new Mds(makeDeps(sendIQErr))
     expect(await mds2.fetchAllDisplayed()).toEqual([])
   })
+
+  it('reports a missing node as an authoritative empty result', async () => {
+    const error = Object.assign(new Error('item-not-found'), {
+      name: 'StanzaError',
+      condition: 'item-not-found',
+    })
+    const mds = new Mds(makeDeps(vi.fn().mockRejectedValue(error)))
+
+    expect(await mds.fetchAllDisplayedResult()).toEqual({
+      status: 'authoritative',
+      markers: [],
+    })
+  })
+
+  it('reports transport and timeout failures as unknown', async () => {
+    const mds = new Mds(makeDeps(vi.fn().mockRejectedValue(new Error('timeout'))))
+
+    expect(await mds.fetchAllDisplayedResult()).toEqual({ status: 'unknown' })
+    expect(await mds.fetchAllDisplayed()).toEqual([])
+  })
+
+  it('reports a malformed result without pubsub items as unknown', async () => {
+    const mds = new Mds(makeDeps(vi.fn().mockResolvedValue(xml('iq', { type: 'result' }))))
+
+    expect(await mds.fetchAllDisplayedResult()).toEqual({ status: 'unknown' })
+  })
 })

--- a/packages/fluux-sdk/src/core/modules/Mds.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.ts
@@ -19,6 +19,16 @@ export interface DisplayedMarker {
   legacy?: boolean
 }
 
+export type DisplayedMarkerFetchResult =
+  | { status: 'authoritative'; markers: DisplayedMarker[] }
+  | { status: 'unknown' }
+
+function isMissingNodeError(error: unknown): boolean {
+  return error instanceof Error
+    && error.name === 'StanzaError'
+    && (error as Error & { condition?: string }).condition === 'item-not-found'
+}
+
 /**
  * Parse the `<items/>` of an MDS node into markers.
  * Accepts the XEP-0490 payload (`<displayed xmlns='urn:xmpp:mds:displayed:0'>`
@@ -124,12 +134,22 @@ export class Mds {
   }
 
   /**
-   * Fetch all per-conversation displayed markers from our own MDS node.
-   * Returns an empty array if the node does not exist yet.
+   * Best-effort fetch of all displayed markers from our own MDS node.
+   * Returns an empty array when the node is absent or its state is unavailable.
    */
   async fetchAllDisplayed(timeoutMs?: number): Promise<DisplayedMarker[]> {
+    const result = await this.fetchAllDisplayedResult(timeoutMs)
+    return result.status === 'authoritative' ? result.markers : []
+  }
+
+  /**
+   * Fetch all displayed markers while preserving whether the node response was
+   * authoritative. A missing node is authoritative and contains no markers;
+   * transport, timeout, and unexpected failures are unknown.
+   */
+  async fetchAllDisplayedResult(timeoutMs?: number): Promise<DisplayedMarkerFetchResult> {
     const currentJid = this.deps.getCurrentJid()
-    if (!currentJid) return []
+    if (!currentJid) return { status: 'unknown' }
 
     const bareJid = getBareJid(currentJid)
     const iq = xml('iq', { type: 'get', to: bareJid, id: `mds_get_${generateUUID()}` },
@@ -141,10 +161,15 @@ export class Mds {
     try {
       const result = await this.deps.sendIQ(iq, timeoutMs)
       const items = result.getChild('pubsub', NS_PUBSUB)?.getChild('items')
-      if (!items) return []
-      return parseMdsItems(items)
-    } catch {
-      return []
+      if (!items) return { status: 'unknown' }
+      return {
+        status: 'authoritative',
+        markers: parseMdsItems(items),
+      }
+    } catch (error) {
+      return isMissingNodeError(error)
+        ? { status: 'authoritative', markers: [] }
+        : { status: 'unknown' }
     }
   }
 }

--- a/packages/fluux-sdk/src/core/modules/Mds.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.ts
@@ -3,6 +3,7 @@ import type { Element } from '@xmpp/client'
 import { getBareJid } from '../jid'
 import { generateUUID } from '../../utils/uuid'
 import { NS_PUBSUB, NS_MDS, NS_CHAT_MARKERS, NS_STANZA_ID } from '../namespaces'
+import { hasErrorCondition } from '../../utils/xmppError'
 import type { ModuleDependencies } from './BaseModule'
 
 /** A per-conversation last-displayed marker (XEP-0490). */
@@ -23,10 +24,19 @@ export type DisplayedMarkerFetchResult =
   | { status: 'authoritative'; markers: DisplayedMarker[] }
   | { status: 'unknown' }
 
+/**
+ * Is this rejection the server telling us the MDS node does not exist?
+ *
+ * That answer is AUTHORITATIVE — there is genuinely nothing published — and the
+ * distinction matters: a brand-new account has no node, and reading its absence
+ * as "unknown" would stop the read-position seed from ever publishing.
+ *
+ * Uses the shared {@link hasErrorCondition} rather than matching `.condition`
+ * directly, so a server that carries the condition only in the error text is
+ * still recognised.
+ */
 function isMissingNodeError(error: unknown): boolean {
-  return error instanceof Error
-    && error.name === 'StanzaError'
-    && (error as Error & { condition?: string }).condition === 'item-not-found'
+  return hasErrorCondition(error, 'item-not-found')
 }
 
 /**

--- a/packages/fluux-sdk/src/core/modules/Mds.ts
+++ b/packages/fluux-sdk/src/core/modules/Mds.ts
@@ -62,8 +62,8 @@ export function parseMdsItems(itemsEl: Element): DisplayedMarker[] {
  *
  * Publishes/fetches the per-conversation last-displayed stanza-id to the private
  * PEP node `urn:xmpp:mds:displayed:0` (item id = conversation bare JID, payload =
- * an XEP-0333 `<displayed/>`). Request/response only — incoming `+notify` events
- * are handled in PubSub.
+ * an XEP-0490 `<displayed/>` wrapper containing an XEP-0359 `<stanza-id/>`).
+ * Request/response only — incoming `+notify` events are handled in PubSub.
  */
 export class Mds {
   private deps: ModuleDependencies


### PR DESCRIPTION
Closes #1145. Follow-up to #1142 and #1143, which fixed the two places where `lastConsideredSeenId` was committed ahead of a step that can fail. This is the remaining hole in the same map.

## The defect

The fresh-session seed cleared `lastConsideredSeenId` and then immediately re-filled it from the current `conversationMeta` / `roomMeta` read pointers. A position that never reached the XEP-0490 node was therefore recorded as *handled* again at the next session start, so `consider()` short-circuited on it for the whole session. Only a further local read advance could recover it. The user's own read state was fine — it survives in localStorage — it just never reached their other devices, leaving a stale divider and inflated unread badge there.

## Why the snapshot could not simply be dropped

The seed calls `applyRemoteDisplayed` per node marker, and that resolves as `stash-pending` when the loaded slice cannot order the marker against the local pointer. The local pointer may then be *behind* the node. Publishing unconditionally would move every other device backward, and MDS positions being forward-only makes that unrecoverable.

So the safety the snapshot was providing by accident moved into the no-regressive guard, where it can be *proven*. The seed now records nothing as handled, and `publishDecision()` returns `publish` / `skip` / `retry`:

- Both positions on the loaded slice → decide by archive order, as before.
- Off-slice → publish only when the believed node value is not the marker the entity still has stashed. A marker `applyRemoteDisplayed` **resolved** left our pointer at or past it, and the local pointer only ever advances, so publishing over it cannot regress. A marker it **could not** order may be ahead of us, and that is the one value we never publish over.
- `retry` deliberately leaves the de-dup key uncommitted — the contract #1142 established — so a later merge or activation fold re-considers instead of silencing.

The seed also sweeps once publishing is armed, so a position the previous session never published goes out without waiting for incidental store churn.