### PR TITLE
fix(notifications): format the saturated unread count in desktop notification titles (#1177)

### DIFF
--- a/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.posting.test.tsx
@@ -125,6 +125,34 @@ describe('useDesktopNotifications posting + guard', () => {
     expect(requestAttention).toHaveBeenCalledTimes(1)
   })
 
+  // The coalesced-backlog count in the title is human-visible text, so it must
+  // render through the shared formatUnreadCount and saturate as "999+" like the
+  // sidebar badge and the command palette. See useDesktopNotifications.unreadCount.test.tsx
+  // for the other half of the split (plural argument and payload stay numeric).
+  it('formats the coalesced unread count in the notification title', async () => {
+    renderHook(() => useDesktopNotifications())
+    await handlers.onConversationMessage?.(
+      { id: 'alice@example.com', name: 'Alice', unreadCount: 999 },
+      { id: 'message-1', from: 'alice@example.com' },
+    )
+    expect(invoke).toHaveBeenCalledWith(
+      'post_notification',
+      expect.objectContaining({ title: 'Alice (999+)' }),
+    )
+  })
+
+  it('renders an unsaturated coalesced count as the plain number', async () => {
+    renderHook(() => useDesktopNotifications())
+    await handlers.onConversationMessage?.(
+      { id: 'alice@example.com', name: 'Alice', unreadCount: 7 },
+      { id: 'message-1', from: 'alice@example.com' },
+    )
+    expect(invoke).toHaveBeenCalledWith(
+      'post_notification',
+      expect.objectContaining({ title: 'Alice (7)' }),
+    )
+  })
+
   it('keeps the plugin notification path on mobile Tauri', async () => {
     isMobileTauri.mockResolvedValue(true)
     renderHook(() => useDesktopNotifications())

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -16,6 +16,7 @@ import {
 } from './useNotificationPermission'
 import { getNotificationAvatarUrl } from '@/utils/notificationAvatar'
 import { newMessagesText } from '@/utils/swMessages'
+import { formatUnreadCount } from '@/utils/formatUnreadCount'
 import { formatLocalizedPreview } from '@/utils/messagePreviewText'
 import { notificationDebug } from '@/utils/notificationDebug'
 import { showWebNotification } from '@/utils/webNotification'
@@ -178,7 +179,11 @@ export function useDesktopNotifications(): void {
     const senderName = getLocalPart(message.from)
     const baseTitle = conv.name || senderName
     // When a reconnect backlog collapsed into one notification, surface the count.
-    const title = conv.unreadCount > 1 ? `${baseTitle} (${conv.unreadCount})` : baseTitle
+    // Human-visible text, so it renders through the shared formatter and saturates
+    // as "999+" like every other numeric unread surface.
+    const title = conv.unreadCount > 1
+      ? `${baseTitle} (${formatUnreadCount(conv.unreadCount)})`
+      : baseTitle
     const body = formatLocalizedPreview(message, t)
 
     notificationDebug.desktopNotification({
@@ -219,6 +224,10 @@ export function useDesktopNotifications(): void {
     } else {
       // Same-tag replacement swallows earlier messages, so surface the count in
       // the body (matches the SW push path; the title stays the plain name).
+      // Both remaining `conv.unreadCount` uses below stay raw numbers on purpose:
+      // newMessagesText's argument drives ICU plural selection, and the third
+      // argument is the machine-readable native payload's `count` field. Do not
+      // route either through formatUnreadCount.
       const coalesced = conv.unreadCount > 1
       await showWebNotification(
         baseTitle,
@@ -287,6 +296,9 @@ export function useDesktopNotifications(): void {
     } else {
       // Coalesced room notifications drop the per-message nick: the messages
       // may come from several senders, so the room name is the honest title.
+      // The room title never interpolates the count, so there is nothing to format
+      // here; as on the conversation path, the plural argument and the payload
+      // `count` field stay raw numbers.
       const coalesced = room.unreadCount > 1
       await showWebNotification(
         coalesced ? room.name : title,

--- a/apps/fluux/src/hooks/useDesktopNotifications.ts
+++ b/apps/fluux/src/hooks/useDesktopNotifications.ts
@@ -226,8 +226,8 @@ export function useDesktopNotifications(): void {
       // the body (matches the SW push path; the title stays the plain name).
       // Both remaining `conv.unreadCount` uses below stay raw numbers on purpose:
       // newMessagesText's argument drives ICU plural selection, and the third
-      // argument is the machine-readable native payload's `count` field. Do not
-      // route either through formatUnreadCount.
+      // argument is the machine-readable notification navigation payload's
+      // `count` field. Do not route either through formatUnreadCount.
       const coalesced = conv.unreadCount > 1
       await showWebNotification(
         baseTitle,

--- a/apps/fluux/src/hooks/useDesktopNotifications.unreadCount.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.unreadCount.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Pins the deliberate split in useDesktopNotifications' unread-count handling:
+ * the human-visible title formats through formatUnreadCount (covered in
+ * useDesktopNotifications.posting.test.tsx, which mocks isTauri: true), while the
+ * i18n plural argument and the native payload's `count` field stay raw numbers.
+ * Formatting either of the latter would break ICU plural selection or turn a
+ * machine-readable field into a string — a future "route every count through the
+ * formatter" sweep must not touch them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const showWebNotification = vi.fn()
+
+let handlers: {
+  onConversationMessage?: (conv: unknown, msg: unknown) => unknown
+  onRoomMessage?: (room: unknown, msg: unknown) => unknown
+} = {}
+
+vi.mock('./useNotificationEvents', () => ({
+  useNotificationEvents: (h: typeof handlers) => { handlers = h },
+}))
+vi.mock('./useNotificationPermission', () => ({
+  useNotificationPermission: () => {},
+  getNotificationPermissionGranted: () => true,
+  isTauri: false,
+}))
+vi.mock('./useNavigateToTarget', () => ({
+  useNavigateToTarget: () => ({
+    navigateToConversation: vi.fn(),
+    navigateToRoom: vi.fn(),
+  }),
+}))
+vi.mock('@/utils/webNotification', () => ({
+  showWebNotification: (...args: unknown[]) => showWebNotification(...args),
+}))
+vi.mock('@/utils/notificationAvatar', () => ({
+  getNotificationAvatarUrl: () => Promise.resolve(undefined),
+}))
+vi.mock('@/utils/messagePreviewText', () => ({
+  formatLocalizedPreview: () => 'body text',
+}))
+vi.mock('@/utils/notificationDebug', () => ({
+  notificationDebug: { desktopNotification: vi.fn() },
+}))
+vi.mock('@/utils/notificationRouting', () => ({ routeNotificationTarget: vi.fn() }))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('@fluux/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@fluux/sdk')>()
+  return {
+    ...actual,
+    rosterStore: { getState: () => ({ getContact: () => undefined }) },
+    connectionStore: { getState: () => ({ jid: 'me@example.com' }) },
+    usePresence: () => ({ presenceStatus: 'online' }),
+    useConnectionStatus: () => ({ status: 'disconnected' }),
+  }
+})
+
+import { useDesktopNotifications } from './useDesktopNotifications'
+import { newMessagesText } from '@/utils/swMessages'
+
+describe('useDesktopNotifications saturated unread count', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    handlers = {}
+  })
+
+  it('keeps the conversation plural argument and payload count numeric', async () => {
+    renderHook(() => useDesktopNotifications())
+    await handlers.onConversationMessage?.(
+      { id: 'alice@example.com', name: 'Alice', unreadCount: 999 },
+      { id: 'message-1', from: 'alice@example.com' },
+    )
+    const [title, options, payload] = showWebNotification.mock.calls[0]
+    expect(title).toBe('Alice')
+    // Plural selection ran on the number, not on the "999+" string.
+    expect(options.body).toBe(newMessagesText('en', 999))
+    expect(options.body).not.toContain('999+')
+    expect(payload).toEqual({
+      from: 'alice@example.com',
+      type: 'conversation',
+      count: 999,
+    })
+    expect(typeof payload.count).toBe('number')
+  })
+
+  it('keeps the room plural argument and payload count numeric', async () => {
+    renderHook(() => useDesktopNotifications())
+    await handlers.onRoomMessage?.(
+      { jid: 'team@conf.example.com', name: 'Team', unreadCount: 1200 },
+      { id: 'room-message-1', nick: 'bob' },
+    )
+    const [title, options, payload] = showWebNotification.mock.calls[0]
+    // The coalesced room title is the room name — it never interpolates a count.
+    expect(title).toBe('Team')
+    expect(options.body).toBe(newMessagesText('en', 1200))
+    expect(payload).toEqual({
+      from: 'team@conf.example.com',
+      type: 'room',
+      count: 1200,
+    })
+    expect(typeof payload.count).toBe('number')
+  })
+})

--- a/apps/fluux/src/hooks/useDesktopNotifications.unreadCount.test.tsx
+++ b/apps/fluux/src/hooks/useDesktopNotifications.unreadCount.test.tsx
@@ -4,7 +4,8 @@
  * Pins the deliberate split in useDesktopNotifications' unread-count handling:
  * the human-visible title formats through formatUnreadCount (covered in
  * useDesktopNotifications.posting.test.tsx, which mocks isTauri: true), while the
- * i18n plural argument and the native payload's `count` field stay raw numbers.
+ * i18n plural argument and the web navigation payload's `count` field stay raw
+ * numbers.
  * Formatting either of the latter would break ICU plural selection or turn a
  * machine-readable field into a string — a future "route every count through the
  * formatter" sweep must not touch them.

--- a/apps/fluux/src/utils/formatUnreadCount.ts
+++ b/apps/fluux/src/utils/formatUnreadCount.ts
@@ -2,10 +2,11 @@
  * Read-state PR B, Task 12: the ONE shared formatter every numeric unread surface renders
  * through — the sidebar counter (`ConversationList`), the "New messages" divider
  * (`NewMessageMarker`), the floating marker pill (`JumpToLastReadPill`), the scroll-to-bottom
- * FAB badge (`MessageList`), and the room row tooltip (`utils/roomTooltip.ts`). Routing every
- * surface through this single function is what guarantees they render the canonical count
- * identically — a per-surface literal (e.g. a stray `> 99 ? '99+' : n`) is exactly the drift
- * this design removes.
+ * FAB badge (`MessageList`), the room row tooltip (`utils/roomTooltip.ts`), and the coalesced
+ * conversation notification title (`useDesktopNotifications`). Routing every surface through
+ * this single function is what guarantees they render the canonical count identically — a
+ * per-surface literal (e.g. a stray `> 99 ? '99+' : n`) is exactly the drift this design
+ * removes.
  *
  * The store caps the persisted count at 999 (see chatStore/roomStore's recount + on-arrival
  * paths, both `Math.min(999, ...)`) and never reaches 1000. The threshold is therefore

--- a/docs/superpowers/specs/2026-07-23-read-state-unread-count-single-source-acceptance.md
+++ b/docs/superpowers/specs/2026-07-23-read-state-unread-count-single-source-acceptance.md
@@ -8,6 +8,11 @@ computations feeding five numeric renderings** (conversation sidebar, room toolt
 floating pill, FAB badge) that today disagree, and specifies the acceptance tests PR B must
 pass.
 
+The five-surface inventory below records PR B's scope. The current surface inventory and display
+cap contract are owned by the doc comment on
+`apps/fluux/src/utils/formatUnreadCount.ts`; later human-visible numeric surfaces use that same
+formatter.
+
 ## The principle
 
 **There is exactly one unread count per conversation/room: the number of eligible messages


### PR DESCRIPTION
Closes #1177.

`useDesktopNotifications` rendered the coalesced unread count raw, so a saturated count showed as `999` in the desktop notification title while every other numeric surface shows `999+` through the shared `formatUnreadCount`. The #1155 formatter sweep missed this hook.

The title now routes through `formatUnreadCount`. That is the only behavioural change — the other counts in this hook stay raw numbers on purpose, and each is annotated inline so a future sweep does not "fix" them:

- `newMessagesText(i18n.language, count)` — the argument drives ICU plural selection; a `999+` string would break pluralisation.
- the notification navigation payload's `count` — a machine-readable field, not display text.
- the room path — its coalesced title is deliberately just the room name (coalesced messages may come from several senders), so there is no count to format there.

The `formatUnreadCount` doc comment now lists the notification title among the surfaces it owns, and the read-state acceptance spec points at it for the current inventory instead of duplicating a stale one.