### PR TITLE
test(timeline): characterise appendLive's handling of delayed arrivals (#1176)

### DIFF
--- a/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
+++ b/docs/superpowers/specs/2026-07-28-read-state-c-writer-restriction-design.md
@@ -638,6 +638,5 @@ Carried forward, to be raised when PR C lands — not to evaporate:
 3. **Mention derivation.** `isMention` is set only on the live stanza path; persisting a
    mention classification at ingest is a prerequisite before any scan may raise *or* lower
    `mentionsCount`.
-4. **Smaller PR B deferrals:** `appendLive`'s sort also repositions delayed arrivals
-   (untested); `useDesktopNotifications` renders the count unformatted; replace the fixed-tick
-   `for (i<5) await setTimeout(0)` convergence idiom with `vi.waitFor`.
+4. **Smaller PR B deferrals:** `useDesktopNotifications` renders the count unformatted;
+   replace the fixed-tick `for (i<5) await setTimeout(0)` convergence idiom with `vi.waitFor`.

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -5112,3 +5112,106 @@ describe('chatStore parity drift regressions', () => {
     })
   })
 })
+
+/**
+ * Issue #1176 — characterisation of how the live-append path treats a DELAYED
+ * arrival (offline replay, gateway history, the MAM `{ids}` fetch behind
+ * deferred poll-closed verification): a live-path message carrying an older
+ * timestamp.
+ *
+ * `appendLive` sorts the whole resident array (FIX 5, #1155), so a delayed
+ * arrival is placed in timestamp order rather than at the live edge — and when
+ * it is older than the window's oldest resident message and the window is
+ * already at its bound, keep-newest drops it again in the same call. The pure
+ * positioning/trim behaviour is pinned in `shared/messageTimeline.test.ts`;
+ * this file pins the STORE-level consequence the pure function cannot show —
+ * the durable cache write happens anyway, so the message is persisted while
+ * being absent from the resident array the UI renders.
+ */
+describe('chatStore delayed live arrivals (#1176)', () => {
+  const convId = 'peer@example.com'
+
+  beforeEach(() => {
+    _resetStorageScopeForTesting()
+    localStorageMock.clear()
+    chatStore.setState({
+      conversationEntities: new Map(),
+      conversationMeta: new Map(),
+      conversations: new Map(),
+      messages: new Map(),
+      activeConversationId: null,
+      archivedConversations: new Set(),
+      firstNewMessageMarkers: new Map(),
+      windowAtLiveEdge: new Map(),
+      mamQueryStates: new Map(),
+      conversationGaps: new Map(),
+    })
+    vi.clearAllMocks()
+    _clearAllTransientForTesting()
+    chatStore.getState().addConversation(createConversation(convId))
+  })
+
+  afterEach(() => {
+    setResidentWindowSize(5000)
+  })
+
+  function arrival(id: string, iso: string, extra: Partial<Message> = {}): Message {
+    return {
+      type: 'chat',
+      id,
+      conversationId: convId,
+      from: convId,
+      body: id,
+      timestamp: new Date(iso),
+      isOutgoing: false,
+      ...extra,
+    }
+  }
+
+  it('persists a delayed arrival trimmed out of the resident window to the durable cache', () => {
+    setResidentWindowSize(3)
+    // Fill the resident window to its bound with live messages.
+    for (const [id, iso] of [
+      ['live-1', '2024-01-15T10:01:00Z'],
+      ['live-2', '2024-01-15T10:02:00Z'],
+      ['live-3', '2024-01-15T10:03:00Z'],
+    ] as const) {
+      chatStore.getState().addMessage(arrival(id, iso))
+    }
+    vi.mocked(messageCache.saveMessage).mockClear()
+
+    // Offline replay: reaches the live path now, stamped BEFORE the window's
+    // oldest resident message.
+    const delayed = arrival('offline-replay', '2024-01-15T09:00:00Z', { isDelayed: true })
+    chatStore.getState().addMessage(delayed)
+
+    const resident = chatStore.getState().messages.get(convId) || []
+    // Sorted to the front, then dropped by keep-newest: not resident at all.
+    expect(resident.map((m) => m.id)).toEqual(['live-1', 'live-2', 'live-3'])
+    expect(resident.some((m) => m.id === 'offline-replay')).toBe(false)
+    // ...yet it WAS written to IndexedDB, so it is durable-only: invisible in
+    // the timeline until a cache slice pages it back in.
+    expect(messageCache.saveMessage).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(messageCache.saveMessage).mock.calls[0][0]).toMatchObject({ id: 'offline-replay' })
+  })
+
+  it('positions a delayed arrival inside the resident window in timestamp order', () => {
+    setResidentWindowSize(10) // above the fixture: the trim never engages here
+    for (const [id, iso] of [
+      ['live-1', '2024-01-15T10:01:00Z'],
+      ['live-2', '2024-01-15T10:03:00Z'],
+      ['live-3', '2024-01-15T10:05:00Z'],
+    ] as const) {
+      chatStore.getState().addMessage(arrival(id, iso))
+    }
+
+    chatStore.getState().addMessage(arrival('offline-replay', '2024-01-15T10:02:00Z', { isDelayed: true }))
+
+    const resident = chatStore.getState().messages.get(convId) || []
+    expect(resident.map((m) => m.id)).toEqual(['live-1', 'offline-replay', 'live-2', 'live-3'])
+    // The sidebar preview is deliberately NOT dragged back by the delayed
+    // arrival (see `shouldReplaceLastMessage` at the addMessage call site) —
+    // pinned here so the two policies stay visibly independent.
+    expect(chatStore.getState().conversationMeta.get(convId)?.lastMessage?.id).toBe('live-3')
+  })
+})

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.test.ts
@@ -113,6 +113,62 @@ describe('messageTimeline', () => {
         ])
       }
     })
+
+    // ------------------------------------------------------------------------
+    // DELAYED arrivals (issue #1176 characterisation)
+    //
+    // A "delayed" arrival reaches appendLive on the LIVE path but carries an
+    // older timestamp: offline replay, gateway/MUC history, the MAM `{ids}`
+    // fetch behind deferred poll-closed verification. FIX 5's sort is a total
+    // order over the whole resident array, so it does not distinguish these
+    // from same-millisecond siblings — it repositions them too. The two tests
+    // below pin that consequence, which no test covered before.
+    // ------------------------------------------------------------------------
+
+    it('places a DELAYED arrival in timestamp order rather than at the end of the resident array', () => {
+      // windowSize 10 keeps the trim out of it — this pins POSITION alone.
+      const wideCfg = { ...cfg, windowSize: 10 }
+      const resident = [
+        msg('live-1', '2024-01-15T10:01:00Z'),
+        msg('live-2', '2024-01-15T10:03:00Z'),
+        msg('live-3', '2024-01-15T10:05:00Z'),
+      ]
+      // Arrives now (last), but stamped between live-1 and live-2.
+      const delayed = msg('offline-replay', '2024-01-15T10:02:00Z')
+
+      const result = appendLive(resident, delayed, true, wideCfg)
+
+      expect(result.kind).toBe('appended')
+      if (result.kind === 'appended') {
+        expect(result.messages.map((m) => m.id)).toEqual(['live-1', 'offline-replay', 'live-2', 'live-3'])
+        // Explicitly NOT at the live edge, where arrival order would have put
+        // it (pre-FIX-5 this was `[live-1, live-2, live-3, offline-replay]`).
+        expect(result.messages[result.messages.length - 1].id).toBe('live-3')
+      }
+    })
+
+    it('trims a DELAYED arrival older than the window entirely out of the resident array', () => {
+      // Resident array already AT the window bound (windowSize 3).
+      const resident = [
+        msg('live-1', '2024-01-15T10:01:00Z'),
+        msg('live-2', '2024-01-15T10:02:00Z'),
+        msg('live-3', '2024-01-15T10:03:00Z'),
+      ]
+      // Older than the window's OLDEST resident message.
+      const delayed = msg('offline-replay', '2024-01-15T09:00:00Z')
+
+      const result = appendLive(resident, delayed, true, cfg)
+
+      // Still reported as 'appended' — the caller has no signal that the
+      // message it just accepted is absent from the array it received.
+      expect(result.kind).toBe('appended')
+      if (result.kind === 'appended') {
+        // The sort puts it at index 0, then keep-newest(3) drops it again: the
+        // resident array comes back with exactly its prior contents.
+        expect(result.messages.map((m) => m.id)).toEqual(['live-1', 'live-2', 'live-3'])
+        expect(result.messages.some((m) => m.id === 'offline-replay')).toBe(false)
+      }
+    })
   })
 
   describe('mergeArchive', () => {


### PR DESCRIPTION
Closes #1176.

`appendLive` sorts the whole resident array on every live append (added in #1155 for same-millisecond ordering). Because that sort is a total order over the array, it also repositions **delayed** arrivals — offline replay, gateway history, the MAM `{ids}` fetch behind deferred poll-closed verification — into chronological order rather than at the live edge. A delayed arrival older than a full window can additionally be trimmed straight back out while staying persisted in IndexedDB. None of that was covered, so a later change to the sort or the trim could have altered it silently.

This characterises the current behaviour. No behaviour change.

Four tests, split by what each level can actually observe:

- `messageTimeline.test.ts` — a delayed arrival lands in timestamp order rather than at the end; one older than the window's oldest resident message is trimmed out of the returned array entirely, while still reported as `appended`.
- `chatStore.test.ts` — that trimmed-out arrival is still written to the durable cache, so it is persisted-but-not-resident; and a delayed arrival that fits the window is positioned chronologically without dragging the sidebar preview back to an older message.

`appendLive` is pure over the array and cannot see the cache, so the persistence half is only observable at the store level. The two positioning tests deliberately use a window larger than their fixture so the trim never engages and they pin position alone.

Each test was checked against mutations of the source rather than assumed falsifiable: removing the sort fails all four, flipping the trim to keep-oldest fails both trim tests, and gating the cache write on residency fails the cache test.

### On whether the behaviour is right

It is, and nothing here changes it.

Sorting is correct because every other resident-array construction path uses the same comparator and the durable cache is timestamp-ordered — appending at the end would leave the resident array disagreeing with itself across a reload. More importantly the read pointer advances by *resident index* while the archive walk counts unread in timestamp order, so a resident array out of archive order risks advancing the pointer past a still-unread message: a silent unread under-count, the unrecoverable direction. A delayed arrival is off by minutes or hours rather than a millisecond, so it is a stronger case for sorting than the case #1155 targeted.

Trimming out while cached is correct because the resident window is a bounded view over the durable store — most messages in a long conversation are already non-resident. The trimmed arrival is still saved, still indexed for search, still increments unread, and pages back in on scroll-up.

One latent sharp edge is now pinned rather than fixed: `appendLive` reports `appended` even when the message is absent from the array it returns. No caller depends on the distinction today — `chatStore` persists unconditionally on that branch and the preview policy compares against `meta.lastMessage` directly rather than by array position — so changing the signal would be a behaviour change and is out of scope here.
