### PR TITLE
feat: fan the scroll and stall sentinels out into the anomaly log

### DIFF
--- a/apps/fluux/src/anomaly/detectors/sentinelFanout.test.ts
+++ b/apps/fluux/src/anomaly/detectors/sentinelFanout.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { FANOUT_IDS, knownLoopLabels, recordForSignal } from './sentinelFanout'
+import { createRecorder } from '../recorder'
+import { createMemorySink } from '../sinks/memory'
+import { serialize } from '../serializer'
+import { initTokenizer, resetValuesForTesting, tokenKeyId } from '../values'
+import type { AnomalySignal } from '../../utils/anomalySignal'
+
+/** The prose the monitors emit is not tested here — see each monitor's own suite. */
+describe('recordForSignal', () => {
+  it('maps an overlap to a bug against the healthy count, not the threshold', () => {
+    const record = recordForSignal({
+      name: 'scroll/reassert-overlap',
+      active: 3,
+      threshold: 2,
+    })
+
+    expect(record?.id.s).toBe('scroll/reassert-overlap')
+    expect(record?.sev).toBe('bug')
+    // 1, not 2: a reader must be able to see how far from correct the app was,
+    // and the threshold is only where the monitor starts complaining.
+    expect(record?.expected).toBe(1)
+    expect(record?.observed).toBe(3)
+  })
+
+  it('maps a non-converging loop and attributes its kind', () => {
+    const record = recordForSignal({
+      name: 'scroll/reassert-nonconverging',
+      label: 'prepend',
+      writes: 41,
+      threshold: 40,
+    })
+
+    expect(record?.id.s).toBe('scroll/reassert-nonconverging')
+    expect(record?.sev).toBe('bug')
+    expect(record?.expected).toBe(40)
+    expect(record?.observed).toBe(41)
+    expect(record?.ctx?.map(([k, v]) => [k.s, (v as { s: string }).s])).toEqual([
+      ['loop', 'loop:prepend'],
+    ])
+  })
+
+  it('maps a resize runaway with the window its count was measured over', () => {
+    const record = recordForSignal({
+      name: 'scroll/resize-loop',
+      fires: 340,
+      threshold: 60,
+      elapsedMs: 980,
+    })
+
+    expect(record?.id.s).toBe('scroll/resize-loop')
+    expect(record?.sev).toBe('suspect')
+    expect(record?.expected).toBe(60)
+    expect(record?.observed).toBe(340)
+    expect(record?.ctx?.map(([k, v]) => [k.s, v])).toEqual([['elapsedMs', 980]])
+  })
+
+  it('maps a slow correction with the row count that drives the reflow', () => {
+    const record = recordForSignal({
+      name: 'scroll/slow-correction',
+      durationMs: 210,
+      thresholdMs: 32,
+      rows: 1840,
+    })
+
+    expect(record?.id.s).toBe('scroll/slow-correction')
+    expect(record?.sev).toBe('suspect')
+    expect(record?.expected).toBe(32)
+    expect(record?.observed).toBe(210)
+    expect(record?.ctx?.map(([k, v]) => [k.s, v])).toEqual([['rows', 1840]])
+  })
+
+  it('maps a main-thread stall', () => {
+    const record = recordForSignal({
+      name: 'perf/main-thread-stall',
+      blockedMs: 2500,
+      thresholdMs: 1000,
+    })
+
+    expect(record?.id.s).toBe('perf/main-thread-stall')
+    expect(record?.sev).toBe('suspect')
+    expect(record?.expected).toBe(1000)
+    expect(record?.observed).toBe(2500)
+    expect(record?.ctx).toEqual([])
+  })
+
+  it('drops the ctx entry for a loop label it does not know, keeping the record', () => {
+    // The conservative direction. A loop kind added without a registry entry
+    // loses attribution; it must never pass the raw label through, and it must
+    // not suppress the anomaly itself either — a non-converging loop is worth
+    // recording even unattributed.
+    const record = recordForSignal({
+      name: 'scroll/reassert-nonconverging',
+      label: 'brand-new-loop',
+      writes: 41,
+      threshold: 40,
+    })
+
+    expect(record).not.toBeNull()
+    expect(record?.observed).toBe(41)
+    expect(record?.ctx).toEqual([])
+  })
+})
+
+describe('loop-label coverage', () => {
+  // Exhaustiveness itself is enforced by the COMPILER: `LOOP_TAGS` is declared
+  // `Record<ReassertLoopLabel, Opaque>`, so a new loop kind cannot be added to the
+  // union without a tag. There is deliberately no test asserting that, because a
+  // test cannot fail for something that does not build.
+  //
+  // A previous version of this suite grepped `useMessageListScroll.ts` for literal
+  // `beginControllerFrameLoop('…')` arguments. It passed while missing two labels
+  // once those began arriving through a variable — the exact silent drift it was
+  // written to catch. What remains is the part a type cannot state: what happens to
+  // a label that is not in the union at runtime.
+
+  it('maps every label to a distinct tag', () => {
+    // A copy-paste that pointed two labels at one tag would make two different
+    // loop kinds indistinguishable in the log, and no type catches that.
+    const labels = knownLoopLabels()
+    const tags = labels.map(
+      (label) =>
+        recordForSignal({
+          name: 'scroll/reassert-nonconverging',
+          label,
+          writes: 41,
+          threshold: 40,
+        })?.ctx?.[0]?.[1],
+    )
+
+    expect(tags.every((t) => t !== undefined)).toBe(true)
+    expect(new Set(tags.map((t) => (t as { s: string }).s)).size).toBe(labels.length)
+  })
+
+  it('prefixes every loop tag so it cannot collide with another tag namespace', () => {
+    for (const label of knownLoopLabels()) {
+      const tag = recordForSignal({
+        name: 'scroll/reassert-nonconverging',
+        label,
+        writes: 41,
+        threshold: 40,
+      })?.ctx?.[0]?.[1] as { s: string }
+      expect(tag.s).toBe(`loop:${label}`)
+    }
+  })
+
+  it('ignores an inherited property name rather than resolving it to a tag', () => {
+    // `LOOP_TAGS[label]` on a plain object would resolve 'constructor' and
+    // 'toString' to something non-undefined, and a truthiness check would then
+    // treat them as valid tags.
+    for (const inherited of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+      const record = recordForSignal({
+        name: 'scroll/reassert-nonconverging',
+        label: inherited,
+        writes: 41,
+        threshold: 40,
+      })
+      expect(record?.ctx, `'${inherited}' must not resolve to a tag`).toEqual([])
+    }
+  })
+})
+
+describe('every fan-out record survives the privacy gate', () => {
+  beforeEach(async () => {
+    resetValuesForTesting()
+    await initTokenizer()
+  })
+
+  const SIGNALS: AnomalySignal[] = [
+    { name: 'scroll/reassert-overlap', active: 2, threshold: 2 },
+    { name: 'scroll/reassert-nonconverging', label: 'marker', writes: 41, threshold: 40 },
+    { name: 'scroll/resize-loop', fires: 340, threshold: 60, elapsedMs: 980 },
+    { name: 'scroll/slow-correction', durationMs: 210, thresholdMs: 32, rows: 1840 },
+    { name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 },
+  ]
+
+  it('serializes each one rather than being rejected for provenance', () => {
+    // The mapping is where TAG and CTX constants are chosen. A plain string
+    // anywhere would be dropped by the serializer and would only ever show up as
+    // a `rejected-value` counter, so assert it end to end.
+    for (const signal of SIGNALS) {
+      const input = recordForSignal(signal)
+      expect(input, signal.name).not.toBeNull()
+
+      const line = serialize({
+        v: 1,
+        t: '2026-07-30T00:00:00.000Z',
+        sid: 'sid',
+        build: 'test',
+        tokenKeyId: tokenKeyId(),
+        kind: 'anomaly',
+        id: input!.id,
+        sev: input!.sev,
+        expected: input!.expected,
+        observed: input!.observed,
+        ctx: input!.ctx ?? [],
+        crumbs: [],
+      })
+
+      expect(line, `${signal.name} was rejected by the serializer`).not.toBeNull()
+      expect(JSON.parse(line!).id).toBe(signal.name)
+    }
+  })
+
+  it('writes one record per signal through a real recorder', () => {
+    const sink = createMemorySink()
+    const recorder = createRecorder({
+      sink,
+      now: () => 1_700_000_000_000,
+      build: 'test',
+      sid: 'sid',
+    })
+
+    for (const signal of SIGNALS) {
+      const input = recordForSignal(signal)
+      if (input) recorder.record(input)
+    }
+
+    const written = (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+    expect(written.map((l) => JSON.parse(l).id)).toEqual(SIGNALS.map((s) => s.name))
+  })
+
+  it('never lets an unmapped loop label reach the log', () => {
+    // The adversarial case: a label is the one caller-supplied string in the
+    // whole fan-out, so it is the only place a body could be smuggled in.
+    const SECRET = 'SECRET-BODY-abcdefghijklmnop'
+    const input = recordForSignal({
+      name: 'scroll/reassert-nonconverging',
+      label: SECRET,
+      writes: 41,
+      threshold: 40,
+    })
+
+    const line = serialize({
+      v: 1,
+      t: '2026-07-30T00:00:00.000Z',
+      sid: 'sid',
+      build: 'test',
+      tokenKeyId: tokenKeyId(),
+      kind: 'anomaly',
+      id: input!.id,
+      sev: input!.sev,
+      expected: input!.expected,
+      observed: input!.observed,
+      ctx: input!.ctx ?? [],
+      crumbs: [],
+    })
+
+    expect(line).not.toBeNull()
+    for (let i = 0; i + 6 <= SECRET.length; i++) {
+      expect(line, `leaked a substring of the label at ${i}`).not.toContain(SECRET.slice(i, i + 6))
+    }
+  })
+})
+
+describe('FANOUT_IDS', () => {
+  it('lists exactly the ids the mapping can produce', () => {
+    // Guards the registry parity chain: values.test.ts asserts ID matches the
+    // document, and this asserts the mapping matches ID. Without it a new id
+    // could be declared and documented but never actually reachable.
+    const produced = new Set(
+      (
+        [
+          { name: 'scroll/reassert-overlap', active: 2, threshold: 2 },
+          { name: 'scroll/reassert-nonconverging', label: 'marker', writes: 41, threshold: 40 },
+          { name: 'scroll/resize-loop', fires: 340, threshold: 60, elapsedMs: 980 },
+          { name: 'scroll/slow-correction', durationMs: 210, thresholdMs: 32, rows: 1840 },
+          { name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 },
+        ] as AnomalySignal[]
+      ).map((s) => recordForSignal(s)!.id.s),
+    )
+
+    expect([...produced].sort()).toEqual(FANOUT_IDS.map((c) => c.s).sort())
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/sentinelFanout.ts
+++ b/apps/fluux/src/anomaly/detectors/sentinelFanout.ts
@@ -1,0 +1,149 @@
+/**
+ * The anomaly side of the sentinel fan-out.
+ *
+ * Stage 2 adds NO detection logic. `reassertLoopMonitor`, `resizeLoopMonitor`,
+ * `slowCorrectionMonitor` and `stallSentinel` already decide correctly and already
+ * emit their prose; all that happens here is translating one of their observations
+ * into a record. If this file ever starts deciding whether something is an anomaly,
+ * the decision has escaped the monitor that owns it.
+ *
+ * The translation is where the privacy boundary is crossed, and it is one-way by
+ * construction: the incoming signal carries plain numbers plus, in one case, a loop
+ * label — and that label is mapped through a CLOSED table to a `TAG` constant. An
+ * unrecognised label yields no ctx entry rather than reaching the record, so a new
+ * loop kind added without a registry entry loses a detail, never leaks one.
+ *
+ * @module Anomaly/Detectors/SentinelFanout
+ */
+import type { ReassertLoopLabel } from '../../components/conversation/reassertLoopMonitor'
+import type { AnomalySignal } from '../../utils/anomalySignal'
+import type { RecordInput } from '../recorder'
+import { CTX, ID, TAG, type Opaque } from '../values'
+
+/**
+ * Loop label to tag, EXHAUSTIVE over `ReassertLoopLabel`.
+ *
+ * The `Record<ReassertLoopLabel, …>` is the guarantee: adding a ninth loop kind to
+ * the union fails to compile here until it gets a tag. An earlier version keyed
+ * this on `string` and leaned on a test that grepped `useMessageListScroll.ts` for
+ * literal call arguments — which silently stopped covering `media-anchor` and
+ * `divider-anchor` the moment those started reaching `begin()` through a variable.
+ * A type states the invariant the grep only approximated.
+ *
+ * The type import is erased at build time, so this adds no runtime edge from the
+ * anomaly tree into the component tree.
+ */
+const LOOP_TAGS: Readonly<Record<ReassertLoopLabel, Opaque>> = Object.freeze({
+  'pin-bottom': TAG.loopPinBottom,
+  'media-anchor': TAG.loopMediaAnchor,
+  'divider-anchor': TAG.loopDividerAnchor,
+  prepend: TAG.loopPrepend,
+  'restore-anchor': TAG.loopRestoreAnchor,
+  marker: TAG.loopMarker,
+  target: TAG.loopTarget,
+  'resident-top': TAG.loopResidentTop,
+})
+
+/**
+ * Look up a tag for a label that arrived as a plain string.
+ *
+ * The signal seam is deliberately dependency-free, so `label` is typed `string`
+ * there and the runtime value could be anything. `Object.hasOwn` rather than a
+ * truthiness check on the index, so an inherited property name cannot resolve.
+ */
+function loopTag(label: string): Opaque | undefined {
+  return Object.hasOwn(LOOP_TAGS, label)
+    ? LOOP_TAGS[label as ReassertLoopLabel]
+    : undefined
+}
+
+/**
+ * Translate one signal into a record.
+ *
+ * Exported separately from the handler so the mapping is testable without a
+ * recorder, a sink or a tokenizer — the thing worth asserting is which id, which
+ * severity and which numbers, not that a write happened.
+ *
+ * @returns the record to file, or `null` for a signal this build does not know.
+ */
+export function recordForSignal(signal: AnomalySignal): RecordInput | null {
+  switch (signal.name) {
+    case 'scroll/reassert-overlap':
+      // `expected` is what a healthy run looks like — one loop — not the
+      // threshold, which is the count at which the monitor starts complaining.
+      // A reader comparing observed against a threshold learns nothing about how
+      // far from correct the app was.
+      return {
+        id: ID.reassertOverlap,
+        sev: 'bug',
+        expected: 1,
+        observed: signal.active,
+        ctx: [],
+      }
+
+    case 'scroll/reassert-nonconverging': {
+      const tag = loopTag(signal.label)
+      return {
+        id: ID.reassertNonConverging,
+        sev: 'bug',
+        expected: signal.threshold,
+        observed: signal.writes,
+        ctx: tag ? [[CTX.loop, tag]] : [],
+      }
+    }
+
+    case 'scroll/resize-loop':
+      // A fire count is meaningless without the window it was counted over, so
+      // the window travels as ctx rather than being folded into the number.
+      return {
+        id: ID.resizeLoop,
+        sev: 'suspect',
+        expected: signal.threshold,
+        observed: signal.fires,
+        ctx: [[CTX.elapsedMs, signal.elapsedMs]],
+      }
+
+    case 'scroll/slow-correction':
+      // The conversation is deliberately absent. It is in the prose line, but a
+      // token here would have to pick between the `jid` and `room` namespaces and
+      // the scroll hook has no conversation-type discriminator — guessing would
+      // split one entity across two token spaces, which is worse than omitting it.
+      return {
+        id: ID.slowCorrection,
+        sev: 'suspect',
+        expected: signal.thresholdMs,
+        observed: signal.durationMs,
+        ctx: [[CTX.rows, signal.rows]],
+      }
+
+    case 'perf/main-thread-stall':
+      // The route is deliberately absent: it carries the conversation JID.
+      return {
+        id: ID.mainThreadStall,
+        sev: 'suspect',
+        expected: signal.thresholdMs,
+        observed: signal.blockedMs,
+        ctx: [],
+      }
+
+    default:
+      // Unreachable while the union and this switch agree. Reached only if a
+      // signal is added without a case here, in which case dropping it is the
+      // conservative outcome.
+      return null
+  }
+}
+
+/** Every invariant id this stage can produce, for the registry parity test. */
+export const FANOUT_IDS: readonly Opaque[] = Object.freeze([
+  ID.reassertOverlap,
+  ID.reassertNonConverging,
+  ID.resizeLoop,
+  ID.slowCorrection,
+  ID.mainThreadStall,
+])
+
+/** Loop labels this build knows how to attribute. */
+export function knownLoopLabels(): string[] {
+  return Object.keys(LOOP_TAGS)
+}

--- a/apps/fluux/src/anomaly/install.test.ts
+++ b/apps/fluux/src/anomaly/install.test.ts
@@ -9,6 +9,7 @@ import {
   whenReady,
 } from './install'
 import { CTX, METRIC, resetValuesForTesting } from './values'
+import { hasAnomalySignalHandler, signalAnomaly } from '../utils/anomalySignal'
 
 type WindowWithSink = Record<string, unknown> & { __fluuxAnomalies?: string[] }
 const w = () => window as unknown as WindowWithSink
@@ -128,6 +129,55 @@ describe('attach and detach', () => {
     install()()
     expect(remove).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
     remove.mockRestore()
+  })
+})
+
+describe('the sentinel fan-out seam', () => {
+  it('is inert before install, so a release build records nothing', () => {
+    expect(hasAnomalySignalHandler()).toBe(false)
+    signalAnomaly({ name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 })
+    expect(lines()).toHaveLength(0)
+  })
+
+  it('records a signal once installed and the tokenizer is ready', async () => {
+    install()
+    await whenReady()
+
+    signalAnomaly({ name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 })
+
+    const stall = records().find((r) => r.id === 'perf/main-thread-stall')
+    expect(stall).toBeDefined()
+    expect(stall.observed).toBe(2500)
+    expect(stall.expected).toBe(1000)
+  })
+
+  it('stops recording once the last hold is released', async () => {
+    const cleanup = install()
+    await whenReady()
+    cleanup()
+
+    signalAnomaly({ name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 })
+
+    expect(records().filter((r) => r.id === 'perf/main-thread-stall')).toHaveLength(0)
+  })
+
+  it('survives a StrictMode cycle with exactly one handler', async () => {
+    // The same interleaving the refcount exists for: the first cleanup runs AFTER
+    // the second install. A handler cleared unconditionally on cleanup would leave
+    // the seam disconnected for the rest of the session — silently, since a
+    // missing record looks exactly like a healthy app.
+    const cleanup1 = install()
+    const cleanup2 = install()
+    cleanup1()
+    await whenReady()
+
+    expect(hasAnomalySignalHandler()).toBe(true)
+    signalAnomaly({ name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 })
+
+    // One record, not two: a second registration would have stacked handlers.
+    expect(records().filter((r) => r.id === 'perf/main-thread-stall')).toHaveLength(1)
+    cleanup2()
+    expect(hasAnomalySignalHandler()).toBe(false)
   })
 })
 

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -8,11 +8,15 @@
  * relies on while the session kept its id. Only SUBSCRIPTIONS are attached and
  * detached — the runtime outlives them.
  *
- * Stage 1 registers NO detectors. This establishes the contract they attach to.
+ * The only thing attached so far is the sentinel fan-out: the existing scroll and
+ * stall monitors keep their prose and additionally signal into a neutral seam,
+ * which is connected here. No detection logic lives in this tree.
  *
  * @module Anomaly/Install
  */
+import { clearAnomalySignalHandler, setAnomalySignalHandler } from '../utils/anomalySignal'
 import { isTauri } from '../utils/tauri'
+import { recordForSignal } from './detectors/sentinelFanout'
 import { markAnomalyBuild } from './gate'
 import { createRecorder, type Recorder } from './recorder'
 import { createMemorySink } from './sinks/memory'
@@ -162,6 +166,16 @@ export function install(): () => void {
   if (attachRefs === 1) {
     attachments++
 
+    // The sentinels in `useMessageListScroll` and `stallSentinel` cannot import
+    // this tree — they ship in release builds. They signal into a neutral seam
+    // instead, and this is where the seam is connected. Registration is idempotent
+    // (the handler is a fresh closure over the same runtime), so a StrictMode
+    // remount replaces it rather than stacking a second one.
+    setAnomalySignalHandler((signal) => {
+      const input = recordForSignal(signal)
+      if (input) rec.record(input)
+    })
+
     digestTimer = setInterval(() => rec.flushDigest(DIGEST_INTERVAL_MS), DIGEST_INTERVAL_MS)
 
     const onVisibility = () => {
@@ -183,6 +197,7 @@ export function install(): () => void {
     attachRefs--
     if (attachRefs > 0) return
 
+    clearAnomalySignalHandler()
     detachListener?.()
     detachListener = null
     if (digestTimer) clearInterval(digestTimer)
@@ -197,6 +212,7 @@ export function setSessionRetryDelayForTesting(ms: number): void {
 
 /** Test-only: tears down the runtime as well as the subscriptions. */
 export function resetInstallForTesting(): void {
+  clearAnomalySignalHandler()
   detachListener?.()
   detachListener = null
   if (digestTimer) clearInterval(digestTimer)

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -92,12 +92,28 @@ export const TAG = Object.freeze({
   mamResult: mint('mam:result', 'tag'),
   ahead: mint('ahead', 'tag'),
   behind: mint('behind', 'tag'),
+  // The message list's re-assert loop kinds. Closed constants rather than the
+  // caller's label string: the label is code-controlled today, but an unmapped
+  // free string reaching a record is exactly the hole the registries close.
+  loopPinBottom: mint('loop:pin-bottom', 'tag'),
+  loopMediaAnchor: mint('loop:media-anchor', 'tag'),
+  loopDividerAnchor: mint('loop:divider-anchor', 'tag'),
+  loopPrepend: mint('loop:prepend', 'tag'),
+  loopRestoreAnchor: mint('loop:restore-anchor', 'tag'),
+  loopMarker: mint('loop:marker', 'tag'),
+  loopTarget: mint('loop:target', 'tag'),
+  loopResidentTop: mint('loop:resident-top', 'tag'),
 })
 
 /** Invariant ids. One entry per row in docs/ANOMALY_INVARIANTS.md. */
 export const ID = Object.freeze({
   sessionStart: mint('recorder/session-start', 'id'),
   ceilingReached: mint('recorder/ceiling-reached', 'id'),
+  reassertOverlap: mint('scroll/reassert-overlap', 'id'),
+  reassertNonConverging: mint('scroll/reassert-nonconverging', 'id'),
+  resizeLoop: mint('scroll/resize-loop', 'id'),
+  slowCorrection: mint('scroll/slow-correction', 'id'),
+  mainThreadStall: mint('perf/main-thread-stall', 'id'),
 })
 
 /** Permitted `ctx` keys. */
@@ -107,6 +123,12 @@ export const CTX = Object.freeze({
   route: mint('route', 'ctx'),
   msg: mint('msg', 'ctx'),
   query: mint('query', 'ctx'),
+  /** Which re-assert loop kind — a TAG constant, never the raw label. */
+  loop: mint('loop', 'ctx'),
+  /** Rendered message rows at the time of the observation. */
+  rows: mint('rows', 'ctx'),
+  /** Measured window length, where a count alone would not be interpretable. */
+  elapsedMs: mint('elapsedMs', 'ctx'),
 })
 
 /**

--- a/apps/fluux/src/components/conversation/controllerFrameLoop.ts
+++ b/apps/fluux/src/components/conversation/controllerFrameLoop.ts
@@ -1,4 +1,4 @@
-import type { ReassertLoopHandle } from './reassertLoopMonitor'
+import type { ReassertLoopHandle, ReassertLoopWarning } from './reassertLoopMonitor'
 
 export interface ControllerFrameLoop {
   schedule: (callback: () => void) => void
@@ -27,7 +27,15 @@ export interface CreateControllerFrameLoopOptions {
   requestFrame: (callback: () => void) => number
   cancelFrame: (id: number) => void
   now: () => number
-  warn: (warning: string) => void
+  /**
+   * Forward a detection to the caller, verbatim.
+   *
+   * The whole warning travels rather than just its prose: the caller logs
+   * `warning.message` and, in a Dev build, also records the numbers structurally.
+   * Rendering the line here would strip the numbers and force a consumer to
+   * re-parse the sentence to recover them.
+   */
+  warn: (warning: ReassertLoopWarning) => void
   lifecycle?: ControllerFrameLoopLifecycle
 }
 

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.test.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { createReassertLoopMonitor } from './reassertLoopMonitor'
+import {
+  createReassertLoopMonitor,
+  reassertLoopSignal,
+  type ReassertLoopWarning,
+} from './reassertLoopMonitor'
 
 /**
  * Pure, deterministic tests — timestamps are passed in explicitly so there is
@@ -9,7 +13,7 @@ describe('createReassertLoopMonitor', () => {
   it('stays silent for a single converged loop that writes only a few times', () => {
     const m = createReassertLoopMonitor({ writeThreshold: 40 })
     const loop = m.begin('prepend', 0)
-    let last: string | null = 'x'
+    let last: ReassertLoopWarning | null = null
     // 60 frames, scroll write only on the first 3 (then converged/idle).
     for (let f = 0; f < 60; f++) last = loop.frame(f * 16, f < 3)
     loop.end()
@@ -19,13 +23,22 @@ describe('createReassertLoopMonitor', () => {
   it('warns once when a single loop keeps writing past the threshold (non-converging)', () => {
     const m = createReassertLoopMonitor({ writeThreshold: 10, cooldownMs: 5000 })
     const loop = m.begin('prepend', 0)
-    const out: (string | null)[] = []
+    const out: (ReassertLoopWarning | null)[] = []
     // Writes on EVERY frame — the signature of a loop that never settles.
     for (let f = 0; f < 30; f++) out.push(loop.frame(f * 16, true))
-    const warnings = out.filter((r): r is string => r !== null)
+    const warnings = out.filter((r): r is ReassertLoopWarning => r !== null)
     expect(warnings).toHaveLength(1) // cooldown outlasts the ~480ms span
-    expect(warnings[0]).toMatch(/prepend/)
-    expect(warnings[0]).toMatch(/reassert/i)
+    expect(warnings[0].message).toMatch(/prepend/)
+    expect(warnings[0].message).toMatch(/reassert/i)
+
+    // The structured view must agree with the prose, or the anomaly log and
+    // fluux.log describe two different events.
+    const w = warnings[0]
+    expect(w.reason).toBe('non-converging')
+    expect(w.reason === 'non-converging' && w.label).toBe('prepend')
+    expect(w.reason === 'non-converging' && w.writes).toBe(11) // first frame past 10
+    expect(w.threshold).toBe(10)
+    expect(w.message).toContain('issued 11 scroll writes')
   })
 
   it('warns when two re-assert loops run concurrently (overlap), naming both', () => {
@@ -35,9 +48,13 @@ describe('createReassertLoopMonitor', () => {
     const b = m.begin('prepend', 20) // a second prepend before the first finished
     const w = b.frame(32, false)
     expect(w).not.toBeNull()
-    expect(w).toMatch(/overlap/i)
+    expect(w!.message).toMatch(/overlap/i)
     // Both concurrent labels are surfaced so the log identifies the pair.
-    expect(w).toMatch(/prepend.*prepend|prepend x2|2 .*prepend/i)
+    expect(w!.message).toMatch(/prepend.*prepend|prepend x2|2 .*prepend/i)
+
+    expect(w!.reason).toBe('overlap')
+    expect(w!.reason === 'overlap' && w!.active).toBe(2)
+    expect(w!.threshold).toBe(2)
   })
 
   it('does not warn for loops that run sequentially (no temporal overlap)', () => {
@@ -54,14 +71,14 @@ describe('createReassertLoopMonitor', () => {
     const m = createReassertLoopMonitor({ cooldownMs: 5000 })
     const a = m.begin('prepend', 0)
     const b = m.begin('marker', 0)
-    const out: (string | null)[] = []
+    const out: (ReassertLoopWarning | null)[] = []
     for (let f = 0; f < 40; f++) {
       // Collect from BOTH loops — the single allowed warning may land on either,
       // since they share the monitor-wide overlap cooldown.
       out.push(a.frame(f * 16, false))
       out.push(b.frame(f * 16, false))
     }
-    const warnings = out.filter((r): r is string => r !== null)
+    const warnings = out.filter((r): r is ReassertLoopWarning => r !== null)
     expect(warnings).toHaveLength(1) // 40 frames ≈ 640ms < 5000ms cooldown
   })
 
@@ -87,5 +104,44 @@ describe('createReassertLoopMonitor', () => {
     expect(m.activeLabels()).toEqual(['prepend'])
     b.end()
     expect(m.activeLabels()).toEqual([])
+  })
+})
+
+describe('reassertLoopSignal', () => {
+  it('routes an overlap to its own invariant', () => {
+    expect(
+      reassertLoopSignal({ message: 'ignored', reason: 'overlap', active: 3, threshold: 2 }),
+    ).toEqual({ name: 'scroll/reassert-overlap', active: 3, threshold: 2 })
+  })
+
+  it('routes a non-converging loop to a different invariant, keeping its label', () => {
+    // The two modes have different causes and different fixes, so collapsing them
+    // into one id would make the log unable to tell them apart.
+    expect(
+      reassertLoopSignal({
+        message: 'ignored',
+        reason: 'non-converging',
+        label: 'prepend',
+        writes: 41,
+        threshold: 40,
+      }),
+    ).toEqual({
+      name: 'scroll/reassert-nonconverging',
+      label: 'prepend',
+      writes: 41,
+      threshold: 40,
+    })
+  })
+
+  it('does not carry the prose into the record', () => {
+    // The overlap message names every concurrent loop; the record must carry
+    // only the count.
+    const signal = reassertLoopSignal({
+      message: '[ScrollReassertLoop] 2 loops active concurrently (prepend, marker)',
+      reason: 'overlap',
+      active: 2,
+      threshold: 2,
+    })
+    expect(JSON.stringify(signal)).not.toContain('ScrollReassertLoop')
   })
 })

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -30,21 +30,67 @@
  * shows up in `fluux.log` on the real Tauri/WebKitGTK build. Pure, O(1) per
  * frame, timestamps passed in so it is deterministic and unit-testable.
  */
+import type { AnomalySignal } from '@/utils/anomalySignal'
+
+/**
+ * Every loop kind the message list can start.
+ *
+ * A closed union rather than `string`, so adding a ninth loop is a COMPILE error
+ * everywhere the set matters — in particular the anomaly fan-out's label table.
+ * Two of these labels reach `begin()` through a variable rather than a literal, so
+ * a source grep cannot enumerate them; only the type can.
+ */
+export type ReassertLoopLabel =
+  | 'pin-bottom'
+  | 'media-anchor'
+  | 'divider-anchor'
+  | 'prepend'
+  | 'restore-anchor'
+  | 'marker'
+  | 'target'
+  | 'resident-top'
+
+/**
+ * A detected loop failure.
+ *
+ * `message` is the prose line, assembled here so it stays byte-identical to what
+ * `fluux.log` has always carried; the discriminated fields ride alongside so the
+ * dev-only anomaly log can record the observation structurally rather than by
+ * re-parsing the prose. See `src/utils/anomalySignal.ts`.
+ */
+export type ReassertLoopWarning =
+  | {
+      message: string
+      reason: 'overlap'
+      /** Loops alive at the same time, all fighting over scrollTop. */
+      active: number
+      threshold: number
+    }
+  | {
+      message: string
+      reason: 'non-converging'
+      /** The loop kind that failed to settle. */
+      label: ReassertLoopLabel
+      /** Cumulative scroll writes issued by this one loop. */
+      writes: number
+      threshold: number
+    }
+
 export interface ReassertLoopHandle {
   /**
    * Record one frame of this loop at `now` (ms, monotonic e.g.
    * performance.now()). `wrote` is true when this frame issued a scroll write
-   * (scrollToOffset/scrollToIndex). Returns a warning string to log (overlap
-   * takes priority over non-converging), or null.
+   * (scrollToOffset/scrollToIndex). Returns a warning to log (overlap takes
+   * priority over non-converging), or null.
    */
-  frame(now: number, wrote: boolean): string | null
+  frame(now: number, wrote: boolean): ReassertLoopWarning | null
   /** Mark this loop finished. Idempotent — a double call cannot drop a sibling. */
   end(): void
 }
 
 export interface ReassertLoopMonitor {
   /** Register the start of a re-assert loop; `label` names the loop kind. */
-  begin(label: string, now: number): ReassertLoopHandle
+  begin(label: ReassertLoopLabel, now: number): ReassertLoopHandle
   /** Labels of the currently-active loops (for tests/diagnostics). */
   activeLabels(): string[]
 }
@@ -76,36 +122,45 @@ export function createReassertLoopMonitor(
   let lastOverlapWarnAt = Number.NEGATIVE_INFINITY
 
   return {
-    begin(label: string, _now: number): ReassertLoopHandle {
+    begin(label: ReassertLoopLabel, _now: number): ReassertLoopHandle {
       const id = nextId++
       active.set(id, label)
       let writeCount = 0
       let lastHotWarnAt = Number.NEGATIVE_INFINITY
 
       return {
-        frame(now: number, wrote: boolean): string | null {
+        frame(now: number, wrote: boolean): ReassertLoopWarning | null {
           if (wrote) writeCount++
 
           // OVERLAP (checked first — a fight between loops is the worse signal).
           if (active.size >= overlapThreshold && now - lastOverlapWarnAt >= cooldownMs) {
             lastOverlapWarnAt = now
             const labels = Array.from(active.values()).sort().join(', ')
-            return (
-              `[ScrollReassertLoop] ${active.size} message-list scroll re-assert loops active ` +
-              `concurrently (${labels}) — they fight over scrollTop. Likely a WebKit-only ` +
-              `overlap (e.g. a second MAM prepend before the first re-assert finished). ` +
-              `Diagnostic only; loops are not cancelled.`
-            )
+            return {
+              message:
+                `[ScrollReassertLoop] ${active.size} message-list scroll re-assert loops active ` +
+                `concurrently (${labels}) — they fight over scrollTop. Likely a WebKit-only ` +
+                `overlap (e.g. a second MAM prepend before the first re-assert finished). ` +
+                `Diagnostic only; loops are not cancelled.`,
+              reason: 'overlap',
+              active: active.size,
+              threshold: overlapThreshold,
+            }
           }
 
           // NON-CONVERGING — one loop keeps writing instead of settling.
           if (writeCount > writeThreshold && now - lastHotWarnAt >= cooldownMs) {
             lastHotWarnAt = now
-            return (
-              `[ScrollReassertLoop] the '${label}' scroll re-assert loop has issued ` +
-              `${writeCount} scroll writes without settling (threshold ${writeThreshold}) — ` +
-              `it is not converging on a stable anchor. Diagnostic only; loop is not cancelled.`
-            )
+            return {
+              message:
+                `[ScrollReassertLoop] the '${label}' scroll re-assert loop has issued ` +
+                `${writeCount} scroll writes without settling (threshold ${writeThreshold}) — ` +
+                `it is not converging on a stable anchor. Diagnostic only; loop is not cancelled.`,
+              reason: 'non-converging',
+              label,
+              writes: writeCount,
+              threshold: writeThreshold,
+            }
           }
 
           return null
@@ -120,4 +175,26 @@ export function createReassertLoopMonitor(
       return Array.from(active.values())
     },
   }
+}
+
+/**
+ * Translate a warning into the signal the anomaly log records.
+ *
+ * The two failure modes are distinct invariants, so the branch belongs with the
+ * monitor that knows them apart rather than at the call site, which is buried
+ * inside a rAF loop and cannot be unit-tested.
+ */
+export function reassertLoopSignal(warning: ReassertLoopWarning): AnomalySignal {
+  return warning.reason === 'overlap'
+    ? {
+        name: 'scroll/reassert-overlap',
+        active: warning.active,
+        threshold: warning.threshold,
+      }
+    : {
+        name: 'scroll/reassert-nonconverging',
+        label: warning.label,
+        writes: warning.writes,
+        threshold: warning.threshold,
+      }
 }

--- a/apps/fluux/src/components/conversation/resizeLoopMonitor.test.ts
+++ b/apps/fluux/src/components/conversation/resizeLoopMonitor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { createResizeLoopMonitor } from './resizeLoopMonitor'
+import {
+  createResizeLoopMonitor,
+  resizeLoopSignal,
+  type ResizeLoopWarning,
+} from './resizeLoopMonitor'
 
 /**
  * Pure, deterministic tests — timestamps are passed in explicitly so there is
@@ -8,34 +12,77 @@ import { createResizeLoopMonitor } from './resizeLoopMonitor'
 describe('createResizeLoopMonitor', () => {
   it('stays silent while the fire rate is at or under the threshold', () => {
     const m = createResizeLoopMonitor({ threshold: 5, windowMs: 1000, cooldownMs: 5000 })
-    let last: string | null = 'x'
+    let last: ResizeLoopWarning | null = null
     for (let i = 0; i < 5; i++) last = m.record(i * 100) // 5 fires across 400ms
     expect(last).toBeNull()
   })
 
   it('warns once when fires exceed the threshold inside the window', () => {
     const m = createResizeLoopMonitor({ threshold: 5, windowMs: 1000, cooldownMs: 5000 })
-    const out: (string | null)[] = []
+    const out: (ResizeLoopWarning | null)[] = []
     for (let i = 0; i < 9; i++) out.push(m.record(i * 40)) // 9 fires in 320ms
-    const warnings = out.filter((r): r is string => r !== null)
+    const warnings = out.filter((r): r is ResizeLoopWarning => r !== null)
     expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toMatch(/resize/i)
+    expect(warnings[0].message).toMatch(/resize/i)
   })
 
   it('rate-limits to one warning per cooldown during a sustained runaway', () => {
     const m = createResizeLoopMonitor({ threshold: 3, windowMs: 1000, cooldownMs: 5000 })
-    const out: (string | null)[] = []
+    const out: (ResizeLoopWarning | null)[] = []
     for (let i = 0; i < 40; i++) out.push(m.record(i * 50)) // 40 fires over 1950ms
-    const warnings = out.filter((r): r is string => r !== null)
+    const warnings = out.filter((r): r is ResizeLoopWarning => r !== null)
     expect(warnings).toHaveLength(1) // cooldown (5000ms) outlasts the 1950ms span
   })
 
   it('does not warn for normal bursts spread across separate windows', () => {
     const m = createResizeLoopMonitor({ threshold: 10, windowMs: 1000, cooldownMs: 5000 })
-    let last: string | null = 'x'
+    let last: ResizeLoopWarning | null = null
     for (let s = 0; s < 6; s++) {
       for (let k = 0; k < 3; k++) last = m.record(s * 1000 + k * 120) // 3 fires/sec
     }
     expect(last).toBeNull()
+  })
+
+  it('reports the numbers the prose quotes, so the fan-out need not re-parse it', () => {
+    // The structured fields and the message are two views of one observation; if
+    // they can disagree, the anomaly log and fluux.log describe different events.
+    const m = createResizeLoopMonitor({ threshold: 5, windowMs: 1000, cooldownMs: 5000 })
+    let warning: ResizeLoopWarning | null = null
+    for (let i = 0; i < 9 && !warning; i++) warning = m.record(i * 40)
+
+    expect(warning).not.toBeNull()
+    expect(warning!.threshold).toBe(5)
+    expect(warning!.fires).toBe(6) // the fire that first crossed the threshold
+    expect(warning!.elapsedMs).toBe(200) // 6th fire at t=200, window opened at t=0
+    expect(warning!.message).toContain(`fired ${warning!.fires} times`)
+    expect(warning!.message).toContain(`in ${warning!.elapsedMs}ms`)
+    expect(warning!.message).toContain(`threshold ${warning!.threshold}/1000ms`)
+  })
+})
+
+describe('resizeLoopSignal', () => {
+  it('carries the warning through without reordering the numbers', () => {
+    // `fires`, `threshold` and `elapsedMs` are all plain numbers, so a swapped
+    // pair typechecks and would silently invert what the anomaly log reports.
+    expect(
+      resizeLoopSignal({ message: 'ignored', fires: 340, threshold: 60, elapsedMs: 980 }),
+    ).toEqual({
+      name: 'scroll/resize-loop',
+      fires: 340,
+      threshold: 60,
+      elapsedMs: 980,
+    })
+  })
+
+  it('does not carry the prose into the record', () => {
+    // The message is for fluux.log. Everything in a signal reaches the anomaly
+    // record, where a free string has no admissible position.
+    const signal = resizeLoopSignal({
+      message: '[ScrollResizeLoop] anything at all',
+      fires: 340,
+      threshold: 60,
+      elapsedMs: 980,
+    })
+    expect(JSON.stringify(signal)).not.toContain('ScrollResizeLoop')
   })
 })

--- a/apps/fluux/src/components/conversation/resizeLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/resizeLoopMonitor.ts
@@ -19,13 +19,33 @@
  * firing thousands of times per second). Timestamps are passed in so the logic
  * is deterministic and unit-testable.
  */
+import type { AnomalySignal } from '@/utils/anomalySignal'
+
+/**
+ * A detected runaway.
+ *
+ * `message` is the prose line, assembled here so it stays byte-identical to what
+ * `fluux.log` has always carried; the numeric fields ride alongside it so the
+ * dev-only anomaly log can record the observation structurally without re-parsing
+ * the prose. See `src/utils/anomalySignal.ts`.
+ */
+export interface ResizeLoopWarning {
+  message: string
+  /** Observer fires counted in this window. */
+  fires: number
+  /** Count above which a window is a runaway. */
+  threshold: number
+  /** How long the counted window actually ran. */
+  elapsedMs: number
+}
+
 export interface ResizeLoopMonitor {
   /**
    * Record one observer fire at `now` (ms, monotonic e.g. performance.now()).
-   * Returns a warning string to log once per cooldown when a runaway is
-   * detected, or null otherwise.
+   * Returns a warning once per cooldown when a runaway is detected, or null
+   * otherwise.
    */
-  record(now: number): string | null
+  record(now: number): ResizeLoopWarning | null
 }
 
 export interface ResizeLoopMonitorOptions {
@@ -51,7 +71,7 @@ export function createResizeLoopMonitor(opts: ResizeLoopMonitorOptions = {}): Re
   let lastWarnAt = Number.NEGATIVE_INFINITY
 
   return {
-    record(now: number): string | null {
+    record(now: number): ResizeLoopWarning | null {
       if (!started || now - windowStart > windowMs) {
         windowStart = now
         count = 0
@@ -62,13 +82,35 @@ export function createResizeLoopMonitor(opts: ResizeLoopMonitorOptions = {}): Re
       if (count > threshold && now - lastWarnAt >= cooldownMs) {
         lastWarnAt = now
         const elapsed = Math.max(1, Math.round(now - windowStart))
-        return (
-          `[ScrollResizeLoop] message-list ResizeObserver fired ${count} times in ${elapsed}ms ` +
-          `(threshold ${threshold}/${windowMs}ms) — likely a WebKitGTK scroll-correction feedback loop. ` +
-          `Scroll correction is rAF-coalesced; this log is a diagnostic only.`
-        )
+        return {
+          message:
+            `[ScrollResizeLoop] message-list ResizeObserver fired ${count} times in ${elapsed}ms ` +
+            `(threshold ${threshold}/${windowMs}ms) — likely a WebKitGTK scroll-correction feedback loop. ` +
+            `Scroll correction is rAF-coalesced; this log is a diagnostic only.`,
+          fires: count,
+          threshold,
+          elapsedMs: elapsed,
+        }
       }
       return null
     },
+  }
+}
+
+/**
+ * Translate a warning into the signal the anomaly log records.
+ *
+ * Lives here rather than at the call site because there are TWO observers using
+ * this monitor — the content one and the scroller one — and a mapping written
+ * twice is a mapping that can disagree with itself. It is also the only way this
+ * translation gets a unit test at all: the call sites are buried inside a rAF
+ * loop in `useMessageListScroll`.
+ */
+export function resizeLoopSignal(warning: ResizeLoopWarning): AnomalySignal {
+  return {
+    name: 'scroll/resize-loop',
+    fires: warning.fires,
+    threshold: warning.threshold,
+    elapsedMs: warning.elapsedMs,
   }
 }

--- a/apps/fluux/src/components/conversation/slowCorrectionMonitor.test.ts
+++ b/apps/fluux/src/components/conversation/slowCorrectionMonitor.test.ts
@@ -1,28 +1,60 @@
 import { describe, it, expect } from 'vitest'
-import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
+import { createSlowCorrectionMonitor, slowCorrectionSignal } from './slowCorrectionMonitor'
 
 describe('slowCorrectionMonitor', () => {
   it('stays silent for corrections under the threshold', () => {
     const monitor = createSlowCorrectionMonitor({ thresholdMs: 32, cooldownMs: 5000 })
-    expect(monitor.record(0, 1000)).toBe(false)
-    expect(monitor.record(31, 2000)).toBe(false)
+    expect(monitor.record(0, 1000)).toBeNull()
+    expect(monitor.record(31, 2000)).toBeNull()
   })
 
   it('reports a correction at or above the threshold', () => {
     const monitor = createSlowCorrectionMonitor({ thresholdMs: 32, cooldownMs: 5000 })
-    expect(monitor.record(32, 1000)).toBe(true)
+    expect(monitor.record(32, 1000)).not.toBeNull()
   })
 
   it('rate-limits reports within the cooldown window', () => {
     const monitor = createSlowCorrectionMonitor({ thresholdMs: 32, cooldownMs: 5000 })
-    expect(monitor.record(100, 1000)).toBe(true)
-    expect(monitor.record(100, 2000)).toBe(false) // within cooldown
-    expect(monitor.record(100, 6001)).toBe(true) // cooldown elapsed
+    expect(monitor.record(100, 1000)).not.toBeNull()
+    expect(monitor.record(100, 2000)).toBeNull() // within cooldown
+    expect(monitor.record(100, 6001)).not.toBeNull() // cooldown elapsed
   })
 
   it('uses defaults when no options given', () => {
     const monitor = createSlowCorrectionMonitor()
-    expect(monitor.record(31, 0)).toBe(false)
-    expect(monitor.record(33, 0)).toBe(true)
+    expect(monitor.record(31, 0)).toBeNull()
+    expect(monitor.record(33, 0)).not.toBeNull()
+  })
+
+  it('reports the threshold it actually applied, not the default', () => {
+    // The caller cannot know an overridden threshold, and the anomaly record's
+    // `expected` is exactly that number. Hardcoding the default at the call site
+    // would silently misreport every configured monitor.
+    const monitor = createSlowCorrectionMonitor({ thresholdMs: 80, cooldownMs: 5000 })
+    expect(monitor.record(100, 1000)?.thresholdMs).toBe(80)
+
+    const defaulted = createSlowCorrectionMonitor()
+    expect(defaulted.record(100, 1000)?.thresholdMs).toBe(32)
+  })
+})
+
+describe('slowCorrectionSignal', () => {
+  it('combines the monitor threshold with the caller measurements', () => {
+    // Duration and rows are the caller's; the threshold is the monitor's. A
+    // signal built with two of the three swapped still typechecks.
+    expect(slowCorrectionSignal({ thresholdMs: 32 }, 210, 1840)).toEqual({
+      name: 'scroll/slow-correction',
+      durationMs: 210,
+      thresholdMs: 32,
+      rows: 1840,
+    })
+  })
+
+  it('reports the observed duration, not the threshold that let it through', () => {
+    // Control: a mapping that reported thresholdMs for both would pass the shape
+    // check above if the two happened to match.
+    const signal = slowCorrectionSignal({ thresholdMs: 32 }, 210, 1840)
+    expect(signal).toMatchObject({ durationMs: 210, thresholdMs: 32 })
+    expect(signal.name).toBe('scroll/slow-correction')
   })
 })

--- a/apps/fluux/src/components/conversation/slowCorrectionMonitor.ts
+++ b/apps/fluux/src/components/conversation/slowCorrectionMonitor.ts
@@ -16,13 +16,29 @@
  *
  * Pure fixed-window logic, timestamps passed in, unit-testable.
  */
+import type { AnomalySignal } from '@/utils/anomalySignal'
+
+/**
+ * A reportable correction.
+ *
+ * Unlike the other monitors this one does NOT carry the prose: the log line needs
+ * the row count, the scrollHeight and the conversation, and those reads are not
+ * free, so they stay on the caller's warn path where they have always been. What
+ * travels back is the threshold that was crossed, which the caller cannot
+ * otherwise know once it has been overridden.
+ */
+export interface SlowCorrectionReport {
+  /** The duration at or above which a correction became reportable. */
+  thresholdMs: number
+}
+
 export interface SlowCorrectionMonitor {
   /**
    * Record one correction that took `durationMs`, finishing at `now` (ms,
-   * monotonic e.g. performance.now()). Returns true when the caller should
-   * log a diagnostic line (duration ≥ threshold and cooldown elapsed).
+   * monotonic e.g. performance.now()). Returns a report when the caller should
+   * log a diagnostic line (duration ≥ threshold and cooldown elapsed), else null.
    */
-  record(durationMs: number, now: number): boolean
+  record(durationMs: number, now: number): SlowCorrectionReport | null
 }
 
 export interface SlowCorrectionMonitorOptions {
@@ -45,11 +61,32 @@ export function createSlowCorrectionMonitor(
   let lastReportAt = Number.NEGATIVE_INFINITY
 
   return {
-    record(durationMs: number, now: number): boolean {
-      if (durationMs < thresholdMs) return false
-      if (now - lastReportAt < cooldownMs) return false
+    record(durationMs: number, now: number): SlowCorrectionReport | null {
+      if (durationMs < thresholdMs) return null
+      if (now - lastReportAt < cooldownMs) return null
       lastReportAt = now
-      return true
+      return { thresholdMs }
     },
+  }
+}
+
+/**
+ * Translate a report into the signal the anomaly log records.
+ *
+ * Takes the caller's numbers too, because unlike the other monitors this one
+ * never sees them: the duration is measured around the correction and the row
+ * count is a warn-path DOM read. Kept here anyway so the mapping is unit-tested
+ * rather than living only inside a rAF callback.
+ */
+export function slowCorrectionSignal(
+  report: SlowCorrectionReport,
+  durationMs: number,
+  rows: number,
+): AnomalySignal {
+  return {
+    name: 'scroll/slow-correction',
+    durationMs,
+    thresholdMs: report.thresholdMs,
+    rows,
   }
 }

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -19,9 +19,13 @@
 
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
 import { scrollStateManager, AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
-import { createResizeLoopMonitor } from './resizeLoopMonitor'
-import { createSlowCorrectionMonitor } from './slowCorrectionMonitor'
-import { createReassertLoopMonitor } from './reassertLoopMonitor'
+import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
+import { createSlowCorrectionMonitor, slowCorrectionSignal } from './slowCorrectionMonitor'
+import {
+  createReassertLoopMonitor,
+  reassertLoopSignal,
+  type ReassertLoopLabel,
+} from './reassertLoopMonitor'
 import {
   createControllerFrameLoop,
   type ControllerFrameLoopLifecycle,
@@ -32,6 +36,7 @@ import { createPinLoopClaim, type PinLoopClaim } from './pinLoopClaim'
 import { decideRowGrowth } from './rowGrowthDecision'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
+import { signalAnomaly } from '@/utils/anomalySignal'
 import { isProgrammaticScroll } from './scrollGate'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
@@ -769,7 +774,11 @@ export function useMessageListScroll({
           if (!slowCorrectionMonitorRef.current) {
             slowCorrectionMonitorRef.current = createSlowCorrectionMonitor()
           }
-          if (slowCorrectionMonitorRef.current.record(correctionEnd - correctionStart, correctionEnd)) {
+          const slow = slowCorrectionMonitorRef.current.record(
+            correctionEnd - correctionStart,
+            correctionEnd,
+          )
+          if (slow) {
             // Context reads are warn-path only (rate-limited): querySelectorAll
             // over the backlog is not free.
             const rows = currentScroller.querySelectorAll('.message-row').length
@@ -779,6 +788,11 @@ export function useMessageListScroll({
               `conversation=${latestRef.current.conversationId}) — ` +
               `reflow cost scales with the rendered backlog.`
             )
+            if (__FLUUX_ANOMALY__) {
+              signalAnomaly(
+                slowCorrectionSignal(slow, Math.round(correctionEnd - correctionStart), rows),
+              )
+            }
           }
         }
       }
@@ -858,7 +872,10 @@ export function useMessageListScroll({
         // can't see. Log-rate-limited; never disconnects.
         if (!resizeMonitorRef.current) resizeMonitorRef.current = createResizeLoopMonitor()
         const warning = resizeMonitorRef.current.record(performance.now())
-        if (warning) console.warn(warning)
+        if (warning) {
+          console.warn(warning.message)
+          if (__FLUUX_ANOMALY__) signalAnomaly(resizeLoopSignal(warning))
+        }
 
         // Coalesce the measure + correction into a single rAF no matter how many
         // times the observer fires this frame. This breaks the read-scrollHeight
@@ -947,7 +964,7 @@ export function useMessageListScroll({
   }, [])
 
   const beginControllerFrameLoop = useCallback((
-    label: string,
+    label: ReassertLoopLabel,
     lease: PositionExecutionLease,
     lifecycle?: ControllerFrameLoopLifecycle,
   ) => {
@@ -964,7 +981,12 @@ export function useMessageListScroll({
       requestFrame: (callback) => requestAnimationFrame(callback),
       cancelFrame: (id) => cancelAnimationFrame(id),
       now: () => performance.now(),
-      warn: (warning) => console.warn(warning),
+      // The adapter forwards whatever the monitor produced; deciding what to do with it
+      // belongs here. Fan-out, not re-pointing: the prose is untouched.
+      warn: (warning) => {
+        console.warn(warning.message)
+        if (__FLUUX_ANOMALY__) signalAnomaly(reassertLoopSignal(warning))
+      },
       lifecycle,
     })
   }, [])
@@ -3659,7 +3681,17 @@ export function useMessageListScroll({
       // Log-rate-limited; never disconnects.
       if (!monitor) monitor = createResizeLoopMonitor()
       const warning = monitor.record(performance.now())
-      if (warning) console.warn(warning)
+      if (warning) {
+        console.warn(warning.message)
+        if (__FLUUX_ANOMALY__) {
+          signalAnomaly({
+            name: 'scroll/resize-loop',
+            fires: warning.fires,
+            threshold: warning.threshold,
+            elapsedMs: warning.elapsedMs,
+          })
+        }
+      }
 
       // Track the latest height and coalesce the correction into one rAF per
       // frame, no matter how many times the observer fires this frame. The

--- a/apps/fluux/src/utils/anomalySignal.test.ts
+++ b/apps/fluux/src/utils/anomalySignal.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  clearAnomalySignalHandler,
+  hasAnomalySignalHandler,
+  setAnomalySignalHandler,
+  signalAnomaly,
+  type AnomalySignal,
+} from './anomalySignal'
+
+const STALL: AnomalySignal = {
+  name: 'perf/main-thread-stall',
+  blockedMs: 2500,
+  thresholdMs: 1000,
+}
+
+describe('anomalySignal', () => {
+  beforeEach(() => {
+    clearAnomalySignalHandler()
+  })
+
+  afterEach(() => {
+    clearAnomalySignalHandler()
+    vi.restoreAllMocks()
+  })
+
+  it('is a no-op with nothing registered', () => {
+    // The release-build state. Sentinels signal unconditionally at their call
+    // sites once the gate is on; with no runtime attached this must be inert.
+    expect(hasAnomalySignalHandler()).toBe(false)
+    expect(() => signalAnomaly(STALL)).not.toThrow()
+  })
+
+  it('delivers the signal verbatim to a registered handler', () => {
+    const seen: AnomalySignal[] = []
+    setAnomalySignalHandler((s) => seen.push(s))
+
+    signalAnomaly(STALL)
+
+    expect(seen).toEqual([STALL])
+  })
+
+  it('stops delivering once cleared', () => {
+    const handler = vi.fn()
+    setAnomalySignalHandler(handler)
+    signalAnomaly(STALL)
+    clearAnomalySignalHandler()
+    signalAnomaly(STALL)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces the handler rather than stacking them', () => {
+    // A StrictMode remount re-registers. Stacking would double every record and
+    // the per-id cooldown would turn the duplicate into a phantom suppression
+    // rather than a visible fault.
+    const first = vi.fn()
+    const second = vi.fn()
+    setAnomalySignalHandler(first)
+    setAnomalySignalHandler(second)
+
+    signalAnomaly(STALL)
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('contains a throwing handler instead of taking down the caller', () => {
+    // The callers are a rAF scroll loop and a heartbeat interval. A detector bug
+    // must never break the scrolling it was watching.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setAnomalySignalHandler(() => {
+      throw new Error('detector bug')
+    })
+
+    expect(() => signalAnomaly(STALL)).not.toThrow()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('signal handler threw'))
+  })
+
+  it('keeps routing after a handler throws', () => {
+    // Control for the case above: containment must not silently disconnect the
+    // seam, or one bad signal would end recording for the rest of the session.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let calls = 0
+    setAnomalySignalHandler(() => {
+      calls++
+      if (calls === 1) throw new Error('detector bug')
+    })
+
+    signalAnomaly(STALL)
+    signalAnomaly(STALL)
+
+    expect(calls).toBe(2)
+  })
+})

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -1,0 +1,113 @@
+/**
+ * The seam between the always-present diagnostic sentinels and the dev-only
+ * anomaly tree.
+ *
+ * The sentinels live in production code — `useMessageListScroll` and
+ * `stallSentinel` ship in every build, because their `console.warn` prose is the
+ * troubleshooting path in `fluux.log`. They must therefore never import anything
+ * under `src/anomaly/`: a static import would put the recorder, the serializer and
+ * the token layer into the release bundle, which is precisely what the build audit
+ * forbids.
+ *
+ * So the direction is INVERTED. This module holds a nullable handler that the
+ * anomaly runtime installs into. In a release build nothing ever registers, so
+ * `signalAnomaly` is a null check on a path that is already rate-limited to once
+ * per five seconds — and no anomaly module is reachable from here.
+ *
+ * This is fan-out, not re-pointing: every caller emits its prose exactly as before
+ * and signals IN ADDITION. Nothing is removed from `fluux.log`.
+ *
+ * @module Utils/AnomalySignal
+ */
+
+/**
+ * One observation, as the sentinel that made it describes it.
+ *
+ * A discriminated union rather than a bag of optional fields: the anomaly side
+ * must map each case to a specific invariant id with the right `expected` and
+ * `observed`, and a shared shape would let a new case silently arrive with
+ * neither.
+ *
+ * `name` is deliberately the invariant id verbatim. It is not the id CONSTANT —
+ * that lives in `values.ts`, which this module may not import — so the two are
+ * held in parity by a test rather than by construction.
+ */
+export type AnomalySignal =
+  | {
+      name: 'scroll/reassert-overlap'
+      /** Concurrently active re-assert loops. */
+      active: number
+      /** Count at or above which the monitor reports. */
+      threshold: number
+    }
+  | {
+      name: 'scroll/reassert-nonconverging'
+      /** The loop's kind, e.g. `prepend`. Mapped to a TAG constant, or dropped. */
+      label: string
+      /** Cumulative scroll writes by this one loop. */
+      writes: number
+      threshold: number
+    }
+  | {
+      name: 'scroll/resize-loop'
+      /** Observer fires counted in the window. */
+      fires: number
+      threshold: number
+      /** Length of the window the fires were counted over. */
+      elapsedMs: number
+    }
+  | {
+      name: 'scroll/slow-correction'
+      durationMs: number
+      thresholdMs: number
+      /** Rendered rows — the reflow cost scales with them, so this is the driver. */
+      rows: number
+    }
+  | {
+      name: 'perf/main-thread-stall'
+      /** How long the main thread was blocked, beyond the expected tick gap. */
+      blockedMs: number
+      thresholdMs: number
+    }
+
+export type AnomalySignalHandler = (signal: AnomalySignal) => void
+
+let handler: AnomalySignalHandler | null = null
+
+/**
+ * Route signals to the anomaly runtime.
+ *
+ * Last registration wins. The runtime is a module-level singleton installed
+ * behind a refcount, so a StrictMode remount re-registers the same handler rather
+ * than stacking two.
+ */
+export function setAnomalySignalHandler(fn: AnomalySignalHandler): void {
+  handler = fn
+}
+
+/** Stop routing. Signals become no-ops again. */
+export function clearAnomalySignalHandler(): void {
+  handler = null
+}
+
+/**
+ * Report one observation, if anything is listening.
+ *
+ * Never throws: a detector bug on the anomaly side must not take down the scroll
+ * loop that reported it, and the resulting silence is visible anyway — the
+ * recorder's own `rejected-value` counter is the intended channel for a malformed
+ * record, and a thrown handler is a strictly worse version of the same bug.
+ */
+export function signalAnomaly(signal: AnomalySignal): void {
+  if (!handler) return
+  try {
+    handler(signal)
+  } catch (err) {
+    console.warn(`[Anomaly] signal handler threw: ${String(err)}`)
+  }
+}
+
+/** Test-only: is anything listening? */
+export function hasAnomalySignalHandler(): boolean {
+  return handler !== null
+}

--- a/apps/fluux/src/utils/stallSentinel.test.ts
+++ b/apps/fluux/src/utils/stallSentinel.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { createStallSentinel } from './stallSentinel'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createStallSentinel, startStallSentinel } from './stallSentinel'
+import {
+  clearAnomalySignalHandler,
+  setAnomalySignalHandler,
+  type AnomalySignal,
+} from './anomalySignal'
 
 const OPTS = { intervalMs: 500, stallThresholdMs: 1000, cooldownMs: 5000 }
 
@@ -19,9 +24,25 @@ describe('stallSentinel', () => {
   it('reports a stall when the gap exceeds interval + threshold', () => {
     const sentinel = createStallSentinel(OPTS)
     sentinel.tick(1000, false)
-    const message = sentinel.tick(4000, false) // gap 3000ms, ~2500ms blocked
-    expect(message).toContain('[MainThreadStall]')
-    expect(message).toContain('~2500ms')
+    const warning = sentinel.tick(4000, false) // gap 3000ms, ~2500ms blocked
+    expect(warning!.message).toContain('[MainThreadStall]')
+    expect(warning!.message).toContain('~2500ms')
+
+    // The structured view must agree with the prose: they are one observation
+    // reported twice, and the anomaly log records only the numbers.
+    expect(warning!.blockedMs).toBe(2500)
+    expect(warning!.thresholdMs).toBe(1000)
+  })
+
+  it('carries no route in its structured fields, only in the prose', () => {
+    // The prose context is a route, and a route contains the conversation JID.
+    // It must reach fluux.log and never a structured record.
+    const sentinel = createStallSentinel({ ...OPTS, getContext: () => 'route: #/chat/bob@x.tld' })
+    sentinel.tick(1000, false)
+    const warning = sentinel.tick(4000, false)
+
+    expect(warning!.message).toContain('bob@x.tld')
+    expect(Object.keys(warning!).sort()).toEqual(['blockedMs', 'message', 'thresholdMs'])
   })
 
   it('rate-limits stall reports within the cooldown window', () => {
@@ -40,5 +61,58 @@ describe('stallSentinel', () => {
     expect(sentinel.tick(120000, false)).toBeNull()
     // ...but a real stall after re-baselining is still caught
     expect(sentinel.tick(125000, false)).not.toBeNull()
+  })
+})
+
+/**
+ * The fan-out promise: `fluux.log` is untouched. The anomaly record is a SECOND
+ * output, never a replacement, and the prose must not shift by a byte whether or
+ * not anything is listening.
+ */
+describe('startStallSentinel prose preservation', () => {
+  const EXPECTED =
+    '[MainThreadStall] main thread blocked ~2500ms (route: /) — ' +
+    'heartbeat expected every 500ms, fired after 3000ms'
+
+  afterEach(() => {
+    clearAnomalySignalHandler()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  /** Drive one baseline tick then one late tick, returning what console.warn saw. */
+  function runOneStall(): string[][] {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let clock = 1000
+    vi.spyOn(performance, 'now').mockImplementation(() => clock)
+
+    const stop = startStallSentinel(OPTS)
+    vi.advanceTimersByTime(500) // baseline at t=1000
+    clock = 4000
+    vi.advanceTimersByTime(500) // fires 3000ms after the baseline
+    stop()
+
+    return warn.mock.calls as string[][]
+  }
+
+  it('logs the line verbatim, with no extra arguments', () => {
+    const calls = runOneStall()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual([EXPECTED])
+  })
+
+  it('logs the identical line while the anomaly runtime is listening', () => {
+    const seen: AnomalySignal[] = []
+    setAnomalySignalHandler((s) => seen.push(s))
+
+    const calls = runOneStall()
+
+    expect(calls[0]).toEqual([EXPECTED])
+    // ...and the record was produced IN ADDITION, so this is fan-out and not a
+    // test that merely proves nothing happened.
+    expect(seen).toEqual([
+      { name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 },
+    ])
   })
 })

--- a/apps/fluux/src/utils/stallSentinel.ts
+++ b/apps/fluux/src/utils/stallSentinel.ts
@@ -15,12 +15,31 @@
  * Pure tick logic (timestamps and visibility passed in) for unit testing;
  * `startStallSentinel` wires it to setInterval + document.hidden.
  */
+import { signalAnomaly } from './anomalySignal'
+
+/**
+ * A detected stall.
+ *
+ * `message` is the prose line, assembled here so it stays byte-identical to what
+ * `fluux.log` has always carried; the numbers ride alongside so the dev-only
+ * anomaly log can record the observation structurally. Note that the prose
+ * context (the active route) deliberately does NOT travel: a route carries the
+ * conversation JID, which may not reach a structured record.
+ */
+export interface StallWarning {
+  message: string
+  /** How long the main thread was blocked beyond the expected tick gap. */
+  blockedMs: number
+  /** Overshoot at or above which a late tick counts as a stall. */
+  thresholdMs: number
+}
+
 export interface StallSentinel {
   /**
-   * Record one heartbeat at `now` (ms, monotonic). Returns a log line when a
+   * Record one heartbeat at `now` (ms, monotonic). Returns a warning when a
    * stall is detected (rate-limited), null otherwise.
    */
-  tick(now: number, hidden: boolean): string | null
+  tick(now: number, hidden: boolean): StallWarning | null
 }
 
 export interface StallSentinelOptions {
@@ -49,7 +68,7 @@ export function createStallSentinel(opts: StallSentinelOptions = {}): StallSenti
   let lastReportAt = Number.NEGATIVE_INFINITY
 
   return {
-    tick(now: number, hidden: boolean): string | null {
+    tick(now: number, hidden: boolean): StallWarning | null {
       if (hidden) {
         // Timer clamping in hidden windows mimics a stall — don't evaluate,
         // and make the next visible tick re-baseline instead of comparing
@@ -74,10 +93,13 @@ export function createStallSentinel(opts: StallSentinelOptions = {}): StallSenti
       lastReportAt = now
 
       const context = getContext ? ` (${getContext()})` : ''
-      return (
-        `[MainThreadStall] main thread blocked ~${Math.round(blockedMs)}ms` +
-        `${context} — heartbeat expected every ${intervalMs}ms, fired after ${Math.round(gap)}ms`
-      )
+      return {
+        message:
+          `[MainThreadStall] main thread blocked ~${Math.round(blockedMs)}ms` +
+          `${context} — heartbeat expected every ${intervalMs}ms, fired after ${Math.round(gap)}ms`,
+        blockedMs: Math.round(blockedMs),
+        thresholdMs: stallThresholdMs,
+      }
     },
   }
 }
@@ -96,7 +118,17 @@ export function startStallSentinel(opts: StallSentinelOptions = {}): () => void 
 
   const id = setInterval(() => {
     const warning = sentinel.tick(performance.now(), document.hidden)
-    if (warning) console.warn(warning)
+    if (!warning) return
+    console.warn(warning.message)
+    // Fan-out, not re-pointing: the prose above is untouched and still the
+    // troubleshooting path. In a release build nothing is listening.
+    if (__FLUUX_ANOMALY__) {
+      signalAnomaly({
+        name: 'perf/main-thread-stall',
+        blockedMs: warning.blockedMs,
+        thresholdMs: warning.thresholdMs,
+      })
+    }
   }, intervalMs)
 
   return () => clearInterval(id)

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -46,8 +46,7 @@ Counter names (digest only, not invariant ids):
 
 ## Detector families
 
-No detectors ship in stage 1. Each entry below is added by the stage that
-introduces it.
+Each entry below is added by the stage that introduces it.
 
 ### `read-state/`
 
@@ -59,7 +58,30 @@ _(stage 5: `mam-page-yield`, `redundant-query`, `iq-unanswered`)_
 
 ### `scroll/`
 
-_(stage 2: existing sentinels; stage 3: `fab-at-live-edge`, `jump-target-miss`)_
+These are **fan-out, not new detection.** The monitors in
+`apps/fluux/src/components/conversation/` decide, log their prose to `fluux.log`
+exactly as they always have, and additionally signal a record. So every id here has
+a matching `console.warn` line: when one is puzzling, the prose has the detail that
+could not be recorded (overlapping loop labels, the conversation, the scrollHeight).
+
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `scroll/reassert-overlap` | bug | Two or more message-list re-assert loops were alive at once, fighting over `scrollTop`. `observed` is how many; `expected` is 1 | A loop started without superseding the previous one. Historically a second MAM prepend beginning before the first re-assert finished |
+| `scroll/reassert-nonconverging` | bug | One loop issued `observed` scroll writes without settling on a stable anchor (`expected` is the threshold) | Two anchors disagree by more than the tolerance and the loop ping-pongs. `ctx.loop` names the loop kind |
+| `scroll/resize-loop` | suspect | The message-list `ResizeObserver` fired `observed` times in `ctx.elapsedMs` (`expected` is the threshold per window) | Oscillating content — classically a `<video controls>` on WebKitGTK — driving a correction feedback loop. Not itself a failure; a sustained one is |
+| `scroll/slow-correction` | suspect | A scroll correction took `observed` ms (`expected` is the threshold), with `ctx.rows` rows rendered | Reflow cost scaling with the rendered backlog. Correlate with `ctx.rows`: a high count means virtualization is not engaged |
+
+_(stage 3 adds `fab-at-live-edge` and `jump-target-miss` in this family — those are
+genuinely new detectors, not fan-out.)_
+
+### `perf/`
+
+`stallSentinel` is route-wide and fires for freezes that have nothing to do with
+the message list.
+
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `perf/main-thread-stall` | suspect | The main thread was blocked ~`observed` ms (`expected` is the threshold) | Any freeze class, including ones with no React render. The prose line carries the route; the record deliberately does not, because a route contains a JID |
 
 ### `resource/`
 


### PR DESCRIPTION
The four diagnostic scroll and stall monitors already detect correctly and already write prose to `fluux.log`. They now emit a structured record in addition, so recurring failures become countable and correlatable instead of needing someone to notice them in the log.

Five invariant ids land: `scroll/reassert-overlap`, `scroll/reassert-nonconverging`, `scroll/resize-loop`, `scroll/slow-correction` and `perf/main-thread-stall`, each documented in `docs/ANOMALY_INVARIANTS.md`.

**Nothing is removed.** Each monitor returns its measured numbers alongside the message it has always produced, so the prose stays byte-identical and remains the troubleshooting path in release builds.

The sentinels ship in production and so cannot import the dev-only anomaly tree. They signal into a neutral seam instead, which the anomaly runtime registers into on install; with nothing registered the call is inert. The one caller-supplied string — a re-assert loop label — is mapped through a closed table to a tag constant, so an unmapped label loses attribution rather than reaching the log.

Two details are deliberately omitted from the records: the route from the stall (it contains a JID) and the conversation from the slow correction (the scroll hook has no room/1:1 discriminator, and guessing between token namespaces would split one entity across two spaces). Both remain in the prose.
