### PR TITLE
fix(mds): publish the newest resolvable 1:1 read position at or behind the pointer

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -51,6 +51,25 @@ function msg(id: string, stanzaId: string | undefined): Message {
   } as Message
 }
 
+/**
+ * Our OWN 1:1 message. The server does not reflect these back the way a MUC
+ * does, so an own send carries only a client `originId` and never acquires a
+ * server `stanzaId` — the state the at-or-behind fallback exists for.
+ */
+function ownMsg(id: string, stanzaId: string | undefined): Message {
+  return {
+    type: 'chat',
+    id,
+    stanzaId,
+    originId: `origin-${id}`,
+    conversationId: 'juliet@capulet.example',
+    from: 'romeo@montague.example',
+    body: id,
+    timestamp: timeFor(id),
+    isOutgoing: true,
+  } as Message
+}
+
 /** Seed messages directly into the store's messages Map (same as chatStore.mds.test.ts). */
 function seedMessages(cid: string, messages: Message[]): void {
   chatStore.setState((state) => {
@@ -99,6 +118,22 @@ function rmsg(room: string, id: string, stanzaId: string | undefined, t: number)
     body: id,
     timestamp: new Date(t),
     isOutgoing: false,
+  } as RoomMessage
+}
+
+/** Our own groupchat message — outgoing, and (until reflected) without a stanza-id. */
+function ownRoomMsg(room: string, id: string, stanzaId: string | undefined, t: number): RoomMessage {
+  return {
+    type: 'groupchat',
+    id,
+    stanzaId,
+    originId: `origin-${id}`,
+    roomJid: room,
+    from: `${room}/testuser`,
+    nick: 'testuser',
+    body: id,
+    timestamp: new Date(t),
+    isOutgoing: true,
   } as RoomMessage
 }
 
@@ -200,6 +235,30 @@ function setConvMamState(
   })
 }
 
+/** Force a room's MAM query state (catch-up gate input, room twin). */
+function setRoomMamState(
+  jid: string,
+  patch: Partial<{
+    isLoading: boolean
+    hasQueried: boolean
+    isCaughtUpToLive: boolean
+    error: string | null
+  }>
+): void {
+  roomStore.setState((state) => {
+    const next = new Map(state.mamQueryStates)
+    next.set(jid, {
+      isLoading: false,
+      hasQueried: false,
+      error: null,
+      isHistoryComplete: false,
+      isCaughtUpToLive: false,
+      ...patch,
+    } as never)
+    return { mamQueryStates: next }
+  })
+}
+
 describe('setupMdsSideEffects', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -249,6 +308,207 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  // ==========================================================================
+  // The at-or-behind fallback for a pointer naming our own unarchived 1:1 send.
+  //
+  // The test directly above passes for BOTH behaviours: its fixture holds a
+  // single stanza-id-less message, so there is nothing at-or-behind to fall back
+  // to either way. That made it an accidental rather than a deliberate pin, so
+  // the contract is stated explicitly here — in both directions.
+  // ==========================================================================
+
+  it('publishes the newest resolvable position at or behind a pointer naming our own unarchived 1:1 send', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // 1:1 sends are never reflected back, so ours carries no stanza-id — ever.
+    seedMessages(cid, [msg('m1', 's1'), ownMsg('m2', undefined)])
+    // Start POINTERLESS: an initial pointer on m1 would resolve to s1 on its own
+    // and this would pass without the fallback ever running.
+    seedMeta(cid)
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m2')
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    cleanup()
+  })
+
+  it('does not publish when nothing at or behind the pointer is resolvable', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // Every candidate at-or-behind is our own, unarchived: nothing to fall back
+    // to, and the fallback must not invent one.
+    seedMessages(cid, [ownMsg('m1', undefined), ownMsg('m2', undefined)])
+    seedMeta(cid)
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('never publishes a position ahead of the read pointer', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // m3 arrived AFTER our own m2 and has NOT been read. The fallback walks
+    // back from the pointer, so it must never reach forward to s3.
+    seedMessages(cid, [msg('m1', 's1'), ownMsg('m2', undefined), msg('m3', 's3')])
+    seedMeta(cid)
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(chatStore.getState().conversationMeta.get(cid)?.readPointer?.messageId).toBe('m2')
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
+    cleanup()
+  })
+
+  it('uses the pointer archive-order key to reject an unread same-millisecond sibling', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // IndexedDB orders equal-timestamp chat messages by id. The pointer names
+    // m2, so m3 is still ahead even though all three messages share a timestamp.
+    const sameTimestamp = new Date('2026-01-01T00:00:02Z')
+    seedMessages(cid, [
+      { ...msg('m1', 's1'), timestamp: sameTimestamp },
+      { ...ownMsg('m2', undefined), timestamp: sameTimestamp },
+      { ...msg('m3', 's3'), timestamp: sameTimestamp },
+    ])
+    seedMeta(cid)
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(
+      chatStore.getState().conversationMeta.get(cid)?.readPointer?.archiveOrderKey
+    ).toEqual({ kind: 'chat', id: 'm2' })
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
+    cleanup()
+  })
+
+  it('keeps a keyless legacy-migrated pointer conservative, ordering by its lastReadAt alone', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    seedMessages(cid, [msg('m1', 's1'), msg('m3', 's3'), ownMsg('m4', undefined)])
+    seedMeta(cid)
+    // A pointer migrated from the pre-#1081 lastSeenMessageId + lastReadAt pair
+    // has NO archiveOrderKey, and its timestamp is lastReadAt — documented as at
+    // or behind the message it names (readPointer.ts). Ordering by it therefore
+    // under-advances: m3 sits past lastReadAt=2s and must not be selected.
+    patchMeta(cid, { readPointer: { messageId: 'm4', timestamp: timeFor('m2') } })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
+    cleanup()
+  })
+
+  it('does not publish when the pointer is off-slice and every resident message is newer', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // The resident window is a NEWER slice; the pointed-at message was evicted.
+    // Ordering against the pointer keeps the fallback from over-advancing onto
+    // the window (the shape issue #1175 describes).
+    seedMessages(cid, [msg('m9', 's9'), msg('m10', 's10')])
+    seedMeta(cid)
+    patchMeta(cid, { readPointer: { messageId: 'evicted-m2', timestamp: timeFor('m2') } })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('does not re-assert an unchanged fallback as further own sends advance the pointer', async () => {
+    const cid = 'juliet@capulet.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    seedMessages(cid, [msg('m1', 's1'), ownMsg('m2', undefined)])
+    seedMeta(cid)
+    chatStore.getState().advanceReadPointer(cid, 'm2')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+
+    // A further own send advances the pointer, but resolves to the same
+    // fallback: the exact-equal skip must suppress a redundant publish.
+    seedMessages(cid, [msg('m1', 's1'), ownMsg('m2', undefined), ownMsg('m4', undefined)])
+    chatStore.getState().advanceReadPointer(cid, 'm4')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('does NOT apply the fallback to rooms, whose own messages are reflected with a stanza-id', async () => {
+    const room = 'tech@conference.example'
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    // Our own groupchat message, momentarily before the room reflects it back.
+    seedRoom(room, [rmsg(room, 'r1', 'rs1', 1_000), ownRoomMsg(room, 'r2', undefined, 2_000)], 'r2')
+    setRoomMamState(room, { hasQueried: true, isCaughtUpToLive: true })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    // Deliberate asymmetry: the room branch keeps the exact-position contract.
+    // It is safe because the wait is transient — MUC reflection supplies the
+    // stanza-id — and it avoids degrading a path that already reports the true
+    // position. A room that never injected stanza-ids would have nothing
+    // resolvable at-or-behind either, so a fallback could not help it.
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // The reflection lands and backfills the stanza-id; #1142's retry then
+    // publishes the TRUE position rather than an approximation of it.
+    roomStore.setState((s) => {
+      const runtime = new Map(s.roomRuntime)
+      const entry = runtime.get(room)!
+      runtime.set(room, {
+        ...entry,
+        messages: entry.messages.map((m) => (m.id === 'r2' ? { ...m, stanzaId: 'rs2' } : m)),
+      })
+      return { roomRuntime: runtime }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(room, 'rs2', room)
     cleanup()
   })
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -31,6 +31,7 @@ import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
 import { roomStore } from '../stores/roomStore'
 import { createKeyedCoalescer } from '../utils/keyedCoalescer'
+import { compareOrder, makeArchiveOrderKey, type OrderPosition } from '../stores/shared/readState'
 import { getBareJid } from './jid'
 import { logInfo } from './logger'
 
@@ -177,7 +178,79 @@ export function setupMdsSideEffects(
     return pendingRemoteDisplayed(jid) === nodeId ? 'retry' : 'publish'
   }
 
-  /** Resolve the stanza-id of the message a conversation's/room's read pointer names. */
+  /**
+   * The newest stanza-id at or behind `pointer` among `messages`.
+   *
+   * In a 1:1 the read pointer normally comes to rest on the user's OWN send,
+   * and that message never acquires a `stanza-id`: unlike a MUC — which
+   * reflects our message back carrying a room-assigned one — the server does not
+   * echo our own 1:1 messages to us, so the only id it ever has is the
+   * client-generated `origin-id`, in RAM and in IndexedDB alike. XEP-0490 admits
+   * exactly one `<stanza-id/>` and a receiver MUST ignore an id it cannot find,
+   * so an `origin-id` is not publishable. Without a fallback the position is
+   * therefore unresolvable *permanently* — not "not yet" — and #1142's retry has
+   * nothing to retry into: 1:1 read positions never reach the user's other
+   * devices once they reply.
+   *
+   * Falling back to the newest message that DOES carry a stanza-id and is at or
+   * behind the pointer restores the sync. It is safe in the direction that
+   * matters, and cheap in the direction it costs:
+   *
+   * - It can never be AHEAD of the read position: candidates strictly after the
+   *   pointer are filtered out. Ordering uses the pointer's own
+   *   timestamp/`archiveOrderKey` rather than its index, so the pointer's
+   *   message need not be resident — a newer resident window cannot drag the
+   *   result forward. A keyless (#1081-migrated) pointer orders by `lastReadAt`,
+   *   which is documented as at or behind the message it names, so it
+   *   under-advances further rather than past. Under-advancing is the direction
+   *   this module already prefers (`compareOrder`: "unresolved sorts first →
+   *   under-advance → over-count (safe)").
+   * - It cannot regress the node: `publishDecision` is unchanged, and the one
+   *   value we must never publish over — a remote marker we could not order — is
+   *   still refused there. XEP-0490's receiver-side "MUST ignore older" rule is
+   *   a second layer, never the primary defence.
+   * - What it gives up is only precision, and only over the user's OWN trailing
+   *   sends: in a 1:1 a message lacking a stanza-id IS one of ours (the server
+   *   stamps inbound). So the published position still means "I have read
+   *   everything you sent" — it withholds only "and I also read my own
+   *   replies", which no receiver derives anything from, because unread
+   *   counting excludes outgoing messages everywhere.
+   *
+   * Rooms deliberately do NOT get this fallback — see {@link resolveSeenStanzaId}.
+   */
+  function newestResolvableAtOrBehind(
+    messages: Array<{ stanzaId?: string; from?: string; id: string; timestamp: Date }>,
+    pointer: { timestamp: Date; archiveOrderKey?: OrderPosition['archiveOrderKey'] }
+  ): string | undefined {
+    const pointerPos: OrderPosition = {
+      timestamp: pointer.timestamp.getTime(),
+      archiveOrderKey: pointer.archiveOrderKey,
+    }
+    let best: { pos: OrderPosition; stanzaId: string } | undefined
+    for (const m of messages) {
+      if (!m.stanzaId) continue
+      const pos: OrderPosition = {
+        timestamp: m.timestamp.getTime(),
+        archiveOrderKey: makeArchiveOrderKey(m, 'chat'),
+      }
+      if (compareOrder(pos, pointerPos) > 0) continue // ahead of the pointer — never publish
+      if (!best || compareOrder(pos, best.pos) > 0) best = { pos, stanzaId: m.stanzaId }
+    }
+    return best?.stanzaId
+  }
+
+  /**
+   * Resolve the stanza-id of the message a conversation's/room's read pointer names.
+   *
+   * The two branches differ deliberately. A MUC reflects our own message back
+   * with a room-assigned `stanza-id`, so a room pointer resolves exactly, and
+   * the only unresolvable window is the brief one before the reflection arrives
+   * — which #1142's retry already closes when the backfill lands. Giving rooms
+   * the 1:1 fallback would therefore trade an exact position for an
+   * approximation on a path that is not broken, and a room that never injected
+   * stanza-ids at all would have nothing resolvable at or behind the pointer for
+   * a fallback to find. So the asymmetry is the point, not an omission.
+   */
   function resolveSeenStanzaId(jid: string): string | undefined {
     if (isRoom(jid)) {
       const seenId = roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
@@ -192,7 +265,8 @@ export function setupMdsSideEffects(
         ?? roomStore.getState().rooms.get(jid)?.lastMessage
       return last?.id === seenId ? last.stanzaId : undefined
     }
-    const seenId = chatStore.getState().conversationMeta.get(jid)?.readPointer?.messageId
+    const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
+    const seenId = pointer?.messageId
     if (!seenId) return undefined
     const messages = chatStore.getState().messages.get(jid) || []
     const fromSlice = messages.find((m) => m.id === seenId)?.stanzaId
@@ -200,7 +274,11 @@ export function setupMdsSideEffects(
     // Same eviction fallback for backgrounded 1:1 conversations.
     const last = chatStore.getState().conversationMeta.get(jid)?.lastMessage
       ?? chatStore.getState().conversations.get(jid)?.lastMessage
-    return last?.id === seenId ? last.stanzaId : undefined
+    if (last?.id === seenId && last.stanzaId) return last.stanzaId
+    // The pointer names a message with no stanza-id — in 1:1 the normal resting
+    // state once the user has replied. Publish the newest position we CAN
+    // address at or behind it rather than staying silent for the session.
+    return newestResolvableAtOrBehind(messages, pointer)
   }
 
   /**


### PR DESCRIPTION
## Problem

A 1:1 read pointer normally comes to rest on the user's own outgoing message. The server does not
reflect our own 1:1 messages back the way a MUC room does, so such a message only ever carries the
client-generated `origin-id` — never a server `stanza-id`, in RAM or in IndexedDB. XEP-0490 admits
exactly one `<stanza-id/>` and requires a receiver to ignore an id it cannot resolve, so the
`origin-id` is not publishable.

`resolveSeenStanzaId` therefore returned `undefined` and the publisher bailed. Because the missing id
never arrives, this is a permanent state rather than a transient one, and #1142's retry had nothing
to retry into: **once a user replies in a 1:1, their read position stops reaching their other
devices.** Long-standing, not a regression.

## Change

Fall back to the newest message that does carry a `stanza-id` and is at or behind the read pointer.

Ordering uses the pointer's own timestamp and `archiveOrderKey` rather than its index, which buys two
properties: the result can never be **ahead** of what the user read, and the pointer's own message
need not be resident, so a newer resident window cannot drag the result forward. `publishDecision` is
deliberately untouched, so the no-regressive-publish guards still refuse the one value we must never
publish over — a remote marker we could not order.

The precision given up covers only the user's own trailing sends: in a 1:1 a message lacking a
`stanza-id` *is* one of ours, since the server stamps inbound ones. The published position still means
"I have read everything you sent", withholding only "and I also read my own replies" — which no
receiver derives anything from, because unread counting excludes outgoing messages everywhere.

## Rooms are deliberately excluded

A MUC reflects our own message back with a room-assigned `stanza-id`, so a room pointer resolves
exactly and the only unresolvable window is the brief one before the reflection lands — already closed
by the existing retry. Giving rooms the fallback would trade an exact position for an approximation on
a path that is not broken, and a room that never injected `stanza-id`s would have nothing resolvable
at or behind the pointer anyway. A test pins the asymmetry and the self-heal that justifies it.

## A pointer-side alternative was considered and rejected

The appealing variant is to exclude our own messages from the read position itself, so the pointer
never rests on an unpublishable message and no publish-time fallback is needed. Its premise holds —
unread counting already excludes outgoing messages, so it is counting-neutral.

It was rejected primarily because **the read pointer is persisted**. Every existing 1:1 pointer
already names one of the user's own sends, so that variant repairs new advances only, and fixing
existing users would additionally require a load-time normalisation that rewrites durable read state.
It also has to hold the invariant at seven separate pointer-mint sites — including both
`mark-all-read` paths, which mint from the newest message — degrades the working MUC path for no gain
there, and reverts a deliberate earlier read-state decision.

This change needs no migration: it derives what to publish from an unchanged stored pointer, so
existing users are repaired on the next publish. The pointer-level model is tracked separately as
read-state semantics work; if it ever lands, it makes this fallback dead rather than wrong.

The tests are added beside the existing "no stanza-id does not publish" case, which passed either way
because its fixture had nothing resolvable behind the pointer — an accidental contract, now pinned in
both directions.

Full comparison of the candidates behind this choice, including the measurements that rejected the
others: `data/fluux-mds-1to1-resolution-strategy/report.md` (internal record, not in this repo).
