### PR TITLE
Refactor scroll persistence behind a value-only adapter

### DIFF
--- a/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
+++ b/apps/fluux/src/components/conversation/liveScrollOwnership.test.ts
@@ -32,6 +32,13 @@ const viewportSessionSource = readFileSync(
   ),
   'utf8',
 )
+const scrollPersistenceAdapterSource = readFileSync(
+  resolve(
+    process.cwd(),
+    'src/components/conversation/scrollPersistenceAdapter.ts',
+  ),
+  'utf8',
+)
 const appHooksIndexPath = resolve(process.cwd(), 'src/hooks/index.ts')
 const appHooksIndexSource = readFileSync(appHooksIndexPath, 'utf8')
 const legacyMessageScrollPath = resolve(
@@ -41,6 +48,8 @@ const legacyMessageScrollPath = resolve(
 
 const directMessageListWrite =
   /\bscrollRef\.current\.(?:scrollTo\s*\(|scrollTop\s*=)/
+const directScrollPersistenceCall =
+  /\bscrollStateManager\.(?:clearSavedScrollState|saveScrollPosition|leaveConversation|markAsLeft|isInitialized|enterConversation|getSavedScrollTop|getSavedAnchor|getSavedReadPositionId)\s*\(/
 
 function interfaceMemberNames(
   sourceText: string,
@@ -103,6 +112,55 @@ describe('live message-list scroll ownership', () => {
     expect(viewportSessionSource).not.toMatch(/\b(?:HTMLElement|Element|MessageVirtualizer)\b/)
     expect(viewportSessionSource).not.toMatch(/\b(?:scrollTop|scrollTo|scrollIntoView)\b/)
     expect(viewportSessionSource).not.toMatch(/\brequestAnimationFrame\b/)
+  })
+
+  it('keeps scroll persistence behind its adapter boundary', () => {
+    expect(hookSource).not.toMatch(directScrollPersistenceCall)
+  })
+
+  it('keeps the persistence adapter value-only and unable to position', () => {
+    expect(scrollPersistenceAdapterSource).not.toMatch(
+      /\b(?:HTMLElement|Element|MessageVirtualizer)\b/,
+    )
+    expect(scrollPersistenceAdapterSource).not.toMatch(
+      /\b(?:scrollTo|scrollIntoView|requestAnimationFrame)\b/,
+    )
+    expect(scrollPersistenceAdapterSource).not.toMatch(
+      /\.scrollTop\s*=/,
+    )
+  })
+
+  it('persists the outgoing viewport before resetting the session for entry', () => {
+    const leave = hookSource.indexOf(
+      'scrollPersistenceRef.current?.leaveConversation',
+    )
+    const reset = hookSource.indexOf(
+      'viewportSessionRef.current?.enterConversation',
+    )
+
+    expect(leave).toBeGreaterThan(-1)
+    expect(reset).toBeGreaterThan(leave)
+  })
+
+  it('would reject resetting entry evidence before persisting the room left', () => {
+    const wrongOrder = `
+      viewportSessionRef.current?.enterConversation(nextConversationId)
+      scrollPersistenceRef.current?.leaveConversation(previousConversationId)
+    `
+
+    expect(
+      wrongOrder.indexOf('viewportSessionRef.current?.enterConversation'),
+    ).toBeLessThan(
+      wrongOrder.indexOf('scrollPersistenceRef.current?.leaveConversation'),
+    )
+  })
+
+  it('would reject a direct scroll-state-manager save from the hook', () => {
+    expect(
+      directScrollPersistenceCall.test(
+        'scrollStateManager.saveScrollPosition(conversationId, top, height, client)',
+      ),
+    ).toBe(true)
   })
 
   it('would reject a viewport session that acquired a pixel-write port', () => {

--- a/apps/fluux/src/components/conversation/scrollPersistenceAdapter.test.ts
+++ b/apps/fluux/src/components/conversation/scrollPersistenceAdapter.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ScrollPersistenceAdapter,
+  type ScrollEntryAction,
+  type ScrollPersistenceStore,
+} from './scrollPersistenceAdapter'
+import type { ViewportSessionSnapshot } from './viewportSession'
+
+function createStore(overrides: Partial<ScrollPersistenceStore> = {}) {
+  const store: ScrollPersistenceStore = {
+    isInitialized: vi.fn(() => false),
+    enterConversation: vi.fn((): ScrollEntryAction => 'scroll-to-bottom'),
+    getSavedScrollTop: vi.fn(() => null),
+    getSavedAnchor: vi.fn(() => null),
+    getSavedReadPositionId: vi.fn(() => undefined),
+    saveScrollPosition: vi.fn(),
+    leaveConversation: vi.fn(),
+    markAsLeft: vi.fn(),
+    clearSavedScrollState: vi.fn(),
+    ...overrides,
+  }
+  return store
+}
+
+function snapshot(
+  conversationId: string,
+  options: {
+    hasGenuineInput?: boolean
+    top?: number
+  } = {},
+): ViewportSessionSnapshot {
+  return {
+    conversationId,
+    geometry: {
+      top: options.top ?? 320,
+      height: 2_000,
+      client: 500,
+    },
+    bottomAnchor: { messageId: 'message-12', fraction: 0.75 },
+    measuredAtLiveEdge: false,
+    hasGenuineInput: options.hasGenuineInput ?? true,
+    previousScrollHeight: 2_000,
+    lastProgrammaticScrollAt: 0,
+    lastUserIntentAt: 1_000,
+    travelledAwayFromTop: false,
+    travelledAwayFromBottom: false,
+  }
+}
+
+describe('ScrollPersistenceAdapter', () => {
+  it('captures first-open status before entry and returns one entry snapshot', () => {
+    const callOrder: string[] = []
+    const store = createStore({
+      isInitialized: vi.fn(() => {
+        callOrder.push('is-initialized')
+        return false
+      }),
+      enterConversation: vi.fn((): ScrollEntryAction => {
+        callOrder.push('enter')
+        return 'restore-position'
+      }),
+      getSavedScrollTop: vi.fn(() => 240),
+      getSavedAnchor: vi.fn(() => ({
+        messageId: 'message-9',
+        fraction: 0.5,
+      })),
+      getSavedReadPositionId: vi.fn(() => 'message-8'),
+    })
+
+    const entry = new ScrollPersistenceAdapter(store).enterConversation(
+      'room-a',
+      42,
+    )
+
+    expect(callOrder).toEqual(['is-initialized', 'enter'])
+    expect(entry).toEqual({
+      firstOpenThisSession: true,
+      action: 'restore-position',
+      savedOffsetPx: 240,
+      savedAnchor: { messageId: 'message-9', fraction: 0.5 },
+      savedReadPositionId: 'message-8',
+    })
+  })
+
+  it('saves only genuine, current, non-controller viewport evidence after the throttle', () => {
+    const store = createStore()
+    const adapter = new ScrollPersistenceAdapter(store, 100)
+
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-a', { hasGenuineInput: false }),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: false,
+      now: 101,
+    })).toBe(false)
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-a'),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: true,
+      now: 101,
+    })).toBe(false)
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-b'),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: false,
+      now: 101,
+    })).toBe(false)
+
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-a'),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: false,
+      now: 100,
+    })).toBe(false)
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-a'),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: false,
+      now: 101,
+    })).toBe(true)
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-a', { top: 360 }),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: false,
+      now: 201,
+    })).toBe(false)
+    expect(adapter.persistViewport({
+      conversationId: 'room-a',
+      snapshot: snapshot('room-a', { top: 380 }),
+      readPositionId: 'message-8',
+      controllerOwnsPixels: false,
+      now: 202,
+    })).toBe(true)
+
+    expect(store.saveScrollPosition).toHaveBeenNthCalledWith(
+      1,
+      'room-a',
+      320,
+      2_000,
+      500,
+      { messageId: 'message-12', fraction: 0.75 },
+      'message-8',
+    )
+    expect(store.saveScrollPosition).toHaveBeenNthCalledWith(
+      2,
+      'room-a',
+      380,
+      2_000,
+      500,
+      { messageId: 'message-12', fraction: 0.75 },
+      'message-8',
+    )
+  })
+
+  it('saves an eligible outgoing snapshot and otherwise only marks the room left', () => {
+    const store = createStore()
+    const adapter = new ScrollPersistenceAdapter(store)
+
+    expect(
+      adapter.leaveConversation(
+        'room-a',
+        snapshot('room-a'),
+        'message-8',
+      ),
+    ).toBe('saved')
+    expect(store.leaveConversation).toHaveBeenCalledWith(
+      'room-a',
+      320,
+      2_000,
+      500,
+      { messageId: 'message-12', fraction: 0.75 },
+      'message-8',
+    )
+
+    expect(
+      adapter.leaveConversation(
+        'room-b',
+        snapshot('room-b', { hasGenuineInput: false }),
+        'message-20',
+      ),
+    ).toBe('marked-left')
+    expect(
+      adapter.leaveConversation(
+        'room-c',
+        snapshot('stale-room'),
+        'message-30',
+      ),
+    ).toBe('marked-left')
+    expect(store.markAsLeft).toHaveBeenNthCalledWith(1, 'room-b')
+    expect(store.markAsLeft).toHaveBeenNthCalledWith(2, 'room-c')
+    expect(store.leaveConversation).toHaveBeenCalledTimes(1)
+  })
+
+  it('delegates explicit saved-position clearing', () => {
+    const store = createStore()
+    const adapter = new ScrollPersistenceAdapter(store)
+
+    adapter.clearSavedPosition('room-a')
+
+    expect(store.clearSavedScrollState).toHaveBeenCalledWith('room-a')
+  })
+})

--- a/apps/fluux/src/components/conversation/scrollPersistenceAdapter.ts
+++ b/apps/fluux/src/components/conversation/scrollPersistenceAdapter.ts
@@ -1,0 +1,146 @@
+import {
+  scrollStateManager,
+  type ScrollAnchor,
+} from '@/utils/scrollStateManager'
+import type { ViewportSessionSnapshot } from './viewportSession'
+
+export type ScrollEntryAction =
+  | 'scroll-to-bottom'
+  | 'restore-position'
+  | 'no-action'
+
+export interface ScrollPersistenceEntry {
+  firstOpenThisSession: boolean
+  action: ScrollEntryAction
+  savedOffsetPx: number | null
+  savedAnchor: ScrollAnchor | null
+  savedReadPositionId: string | undefined
+}
+
+export interface ScrollPersistenceStore {
+  isInitialized(conversationId: string): boolean
+  enterConversation(
+    conversationId: string,
+    messageCount: number,
+  ): ScrollEntryAction
+  getSavedScrollTop(conversationId: string): number | null
+  getSavedAnchor(conversationId: string): ScrollAnchor | null
+  getSavedReadPositionId(conversationId: string): string | undefined
+  saveScrollPosition(
+    conversationId: string,
+    scrollTop: number,
+    scrollHeight: number,
+    clientHeight: number,
+    anchor?: ScrollAnchor,
+    readPositionId?: string,
+  ): void
+  leaveConversation(
+    conversationId: string,
+    scrollTop: number,
+    scrollHeight: number,
+    clientHeight: number,
+    anchor?: ScrollAnchor,
+    readPositionId?: string,
+  ): void
+  markAsLeft(conversationId: string): void
+  clearSavedScrollState(conversationId: string): void
+}
+
+export interface PersistViewportFacts {
+  conversationId: string
+  snapshot: ViewportSessionSnapshot | null
+  readPositionId: string | undefined
+  controllerOwnsPixels: boolean
+  now: number
+}
+
+export type LeaveConversationOutcome = 'saved' | 'marked-left'
+
+const DEFAULT_SAVE_THROTTLE_MS = 100
+
+/**
+ * Conversation persistence policy for the live viewport.
+ *
+ * The adapter consumes immutable viewport-session snapshots and owns no DOM, virtualizer, frame,
+ * or pixel-write capability. ScrollStateManager remains the in-memory store; this boundary owns
+ * when the hook may enter, save, leave, or clear it.
+ */
+export class ScrollPersistenceAdapter {
+  private lastSaveAt = 0
+
+  constructor(
+    private readonly store: ScrollPersistenceStore = scrollStateManager,
+    private readonly saveThrottleMs = DEFAULT_SAVE_THROTTLE_MS,
+  ) {}
+
+  enterConversation(
+    conversationId: string,
+    messageCount: number,
+  ): ScrollPersistenceEntry {
+    const firstOpenThisSession = !this.store.isInitialized(conversationId)
+    const action = this.store.enterConversation(conversationId, messageCount)
+    return {
+      firstOpenThisSession,
+      action,
+      savedOffsetPx: this.store.getSavedScrollTop(conversationId),
+      savedAnchor: this.store.getSavedAnchor(conversationId),
+      savedReadPositionId:
+        this.store.getSavedReadPositionId(conversationId),
+    }
+  }
+
+  persistViewport(facts: PersistViewportFacts): boolean {
+    const { snapshot } = facts
+    if (
+      facts.controllerOwnsPixels ||
+      snapshot?.conversationId !== facts.conversationId ||
+      !snapshot.geometry ||
+      !snapshot.hasGenuineInput ||
+      facts.now - this.lastSaveAt <= this.saveThrottleMs
+    ) {
+      return false
+    }
+
+    const { top, height, client } = snapshot.geometry
+    this.lastSaveAt = facts.now
+    this.store.saveScrollPosition(
+      facts.conversationId,
+      top,
+      height,
+      client,
+      snapshot.bottomAnchor ?? undefined,
+      facts.readPositionId,
+    )
+    return true
+  }
+
+  leaveConversation(
+    conversationId: string,
+    snapshot: ViewportSessionSnapshot | null,
+    readPositionId: string | undefined,
+  ): LeaveConversationOutcome {
+    if (
+      snapshot?.conversationId === conversationId &&
+      snapshot.geometry &&
+      snapshot.hasGenuineInput
+    ) {
+      const { top, height, client } = snapshot.geometry
+      this.store.leaveConversation(
+        conversationId,
+        top,
+        height,
+        client,
+        snapshot.bottomAnchor ?? undefined,
+        readPositionId,
+      )
+      return 'saved'
+    }
+
+    this.store.markAsLeft(conversationId)
+    return 'marked-left'
+  }
+
+  clearSavedPosition(conversationId: string): void {
+    this.store.clearSavedScrollState(conversationId)
+  }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -18,7 +18,7 @@
  */
 
 import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react'
-import { scrollStateManager, AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
+import { AT_BOTTOM_THRESHOLD, type ScrollAnchor } from '@/utils/scrollStateManager'
 import { createResizeLoopMonitor, resizeLoopSignal } from './resizeLoopMonitor'
 import { createSlowCorrectionMonitor, slowCorrectionSignal } from './slowCorrectionMonitor'
 import {
@@ -41,6 +41,7 @@ import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
 import { ViewportSession } from './viewportSession'
+import { ScrollPersistenceAdapter } from './scrollPersistenceAdapter'
 import {
   PositioningController,
   type DirectionalHistoryExecutor,
@@ -128,7 +129,6 @@ function debugLog(action: string, data?: Record<string, unknown>) {
 const FAB_THRESHOLD = 300 // pixels from bottom to show "scroll to bottom" button
 const LOAD_COOLDOWN_MS = 500 // minimum time between load triggers
 const LOAD_NEWER_THRESHOLD = 4 // px from the resident-window bottom to auto-load newer (slid-up windows)
-const SAVE_THROTTLE_MS = 100 // minimum time between position saves
 const PREPEND_COOLDOWN_MS = 500 // time to keep prepend flag after restore (prevents re-trigger)
 const MEDIA_LOAD_DEBOUNCE_MS = 150 // debounce time for batching image load events
 // How long a jumped-to message keeps its highlight tint, for both the controller-owned live path
@@ -468,6 +468,10 @@ export function useMessageListScroll({
   if (viewportSessionRef.current === null) {
     viewportSessionRef.current = new ViewportSession(conversationId)
   }
+  const scrollPersistenceRef = useRef<ScrollPersistenceAdapter | null>(null)
+  if (scrollPersistenceRef.current === null) {
+    scrollPersistenceRef.current = new ScrollPersistenceAdapter()
+  }
 
   // Read-state PR B, Task 11: latest `onLiveEdgeMeasured` callback, read imperatively
   // by `setMeasuredAtBottom` below (never closed over directly, so a caller passing a
@@ -593,7 +597,6 @@ export function useMessageListScroll({
   const prependRef = useRef<DirectionalHistorySnapshot | null>(null)
 
   // Throttling/cooldown
-  const lastSaveTimeRef = useRef(0)
   const lastLoadTimeRef = useRef(0)
   const lastRestoreTimeRef = useRef(0) // Track when we last restored position
   // Tracks the previous windowAtLiveEdge so we can detect the false→true transition (returning to
@@ -680,7 +683,7 @@ export function useMessageListScroll({
     setMarkerAboveViewport(false)
     // At the bottom the newest message is visible → 0 new below the fold (anchor is the last row).
     setBottomVisibleMessageId(bottomAnchor?.messageId ?? null)
-    scrollStateManager.clearSavedScrollState(conversationId)
+    scrollPersistenceRef.current?.clearSavedPosition(conversationId)
   }, [conversationId, isAtBottomRef])
 
   // ==========================================================================
@@ -2667,29 +2670,16 @@ export function useMessageListScroll({
       }
     }
 
-    // Save position for cross-conversation persistence (throttled). Capture the
-    // bottom-most-visible anchor here too — throttled so the DOM query is bounded,
-    // and during scroll because at switch time the DOM is already the new room.
-    // Skipped while a programmatic loop is positioning the list (see programmaticScroll above):
-    // saving the transient entry position would poison the next re-entry's restore decision.
-    // Also skipped until the user has GENUINELY scrolled this entry: a post-restore scroll caused
-    // by media/measurement settling must not overwrite the saved anchor (that drift compounded
-    // across re-opens — see the viewport session's genuine-input evidence).
-    if (
-      !programmaticScroll &&
-      viewportSessionRef.current?.hasGenuineInput(conversationId) &&
-      now - lastSaveTimeRef.current > SAVE_THROTTLE_MS
-    ) {
-      lastSaveTimeRef.current = now
-      scrollStateManager.saveScrollPosition(
-        conversationId,
-        scrollTop,
-        scrollHeight,
-        clientHeight,
-        bottomAnchor ?? undefined,
-        readPointerId,
-      )
-    }
+    // Persist only through the adapter. It consumes the snapshot recorded above and owns the
+    // genuine-input, active-controller, conversation, and throttle gates.
+    scrollPersistenceRef.current?.persistViewport({
+      conversationId,
+      snapshot:
+        viewportSessionRef.current?.snapshotFor(conversationId) ?? null,
+      readPositionId: readPointerId,
+      controllerOwnsPixels: programmaticScroll,
+      now,
+    })
 
     // Track if the USER scrolled away from top (allows a later return to re-trigger load). A
     // controller-owned animation can cross this threshold too — most notably Home's smooth trip
@@ -2790,22 +2780,12 @@ export function useMessageListScroll({
     // visit. Otherwise keep its existing saved anchor untouched (markAsLeft): the live scroll data
     // may have drifted from media/measurement after the restore, and persisting it would make the
     // position creep older on the next open.
-    if (
-      prevConversationRef.current &&
-      previousViewport?.geometry &&
-      previousViewport.hasGenuineInput
-    ) {
-      const { top, height, client } = previousViewport.geometry
-      scrollStateManager.leaveConversation(
+    if (prevConversationRef.current) {
+      scrollPersistenceRef.current?.leaveConversation(
         prevConversationRef.current,
-        top,
-        height,
-        client,
-        previousViewport.bottomAnchor ?? undefined,
+        previousViewport ?? null,
         previousReadPositionRef.current,
       )
-    } else if (prevConversationRef.current) {
-      scrollStateManager.markAsLeft(prevConversationRef.current)
     }
     if (
       prevConversationRef.current &&
@@ -2844,21 +2824,26 @@ export function useMessageListScroll({
       isAtBottomRef.current = false
       debugLog('CONVERSATION SWITCH: static mode, skipping scroll')
     } else {
-      // Diagnostic only: is this the FIRST open of this conversation this session? (Captured BEFORE
-      // enterConversation, which flips the manager's `initialized` flag.) The "synced marker only on
+      // Diagnostic only: is this the FIRST open of this conversation this session? The persistence
+      // adapter captures it before entry flips the manager's `initialized` flag. The "synced marker only on
       // first open" concern is handled at the SOURCE — the SDK gates the XEP-0490 entry fold to the
       // first activation per session (chatStore/roomStore), so the divider here already reflects the
       // intended read position. Gating the scroll branch on first-open was the wrong layer: it could
       // not distinguish a stale/synced marker from a genuine "new message arrived while away" marker
       // and suppressed the latter on re-entry. See
       // docs/superpowers/specs/2026-06-29-mds-sync-marker-first-open-design.md.
-      const firstOpenThisSession = !scrollStateManager.isInitialized(conversationId)
-
-      // Decide: restore position or scroll to bottom?
-      let action = scrollStateManager.enterConversation(conversationId, messageCount)
-      const savedPos = scrollStateManager.getSavedScrollTop(conversationId)
-      const savedAnchor = scrollStateManager.getSavedAnchor(conversationId)
-      const savedReadPositionId = scrollStateManager.getSavedReadPositionId(conversationId)
+      const persistenceEntry =
+        scrollPersistenceRef.current?.enterConversation(
+          conversationId,
+          messageCount,
+        )
+      const firstOpenThisSession =
+        persistenceEntry?.firstOpenThisSession ?? true
+      let action = persistenceEntry?.action ?? 'scroll-to-bottom'
+      const savedPos = persistenceEntry?.savedOffsetPx ?? null
+      const savedAnchor = persistenceEntry?.savedAnchor ?? null
+      const savedReadPositionId =
+        persistenceEntry?.savedReadPositionId
       const syncedLiveEdge =
         action === 'restore-position' &&
         firstNewMessageId === undefined &&
@@ -2872,7 +2857,7 @@ export function useMessageListScroll({
         // downloaded row, a saved position tied to an older pointer must not win merely because
         // there was never an unread divider.
         if (syncedLiveEdge) {
-          scrollStateManager.clearSavedScrollState(conversationId)
+          scrollPersistenceRef.current?.clearSavedPosition(conversationId)
           pendingSyncedLiveEdgeRef.current = null
           action = 'scroll-to-bottom'
           debugLog('MDS LIVE EDGE: synced read supersedes saved position on entry', {
@@ -3029,7 +3014,7 @@ export function useMessageListScroll({
     if (readPointerId !== lastMessageId || readPointerId === pending.savedReadPositionId) return
 
     pendingSyncedLiveEdgeRef.current = null
-    scrollStateManager.clearSavedScrollState(conversationId)
+    scrollPersistenceRef.current?.clearSavedPosition(conversationId)
     isAtBottomRef.current = true
     debugLog('MDS LIVE EDGE: late synced read supersedes restored position', {
       conversationId,
@@ -3158,11 +3143,11 @@ export function useMessageListScroll({
     windowAtLiveEdge,
   ])
 
-  // Cleanup: properly leave conversation in scrollStateManager only when the message list
-  // actually unmounts. The conversation-switch effect above intentionally has broad deps
-  // (message count, target, marker) so it sees the current entry state, but a cleanup attached
-  // there would also run on same-conversation updates and mark the singleton manager "left"
-  // while the room is still mounted.
+  // Cleanup: leave through the persistence adapter only when the message list actually unmounts.
+  // The conversation-switch effect above intentionally has broad deps (message count, target,
+  // marker) so it sees the current entry state, but a cleanup attached there would also run on
+  // same-conversation updates and mark the underlying singleton store "left" while the room is
+  // still mounted.
   useLayoutEffect(() => {
     unmountDeactivationTokenRef.current = null
     return () => {
@@ -3183,8 +3168,9 @@ export function useMessageListScroll({
         })
       }
       if (prevConversationRef.current) {
+        const outgoingConversationId = prevConversationRef.current
         const viewportSnapshot = viewportSessionRef.current?.snapshotFor(
-          prevConversationRef.current,
+          outgoingConversationId,
         )
         // Same gate as the conversation-switch leave: only persist the live scroll data when the
         // user genuinely scrolled this visit; otherwise keep the existing saved anchor (markAsLeft)
@@ -3197,26 +3183,24 @@ export function useMessageListScroll({
           // stale or already at-bottom, the next entry restores wrong / jumps to bottom — so this
           // shows exactly what was persisted at the moment the screen was torn down.
           debugLog('UNMOUNT leaveConversation (save)', {
-            conversationId: prevConversationRef.current,
+            conversationId: outgoingConversationId,
             top, height, client,
             distFromBottom: height - top - client,
             anchorMessageId: viewportSnapshot.bottomAnchor?.messageId,
             anchorFraction: viewportSnapshot.bottomAnchor?.fraction,
           })
-          scrollStateManager.leaveConversation(
-            prevConversationRef.current,
-            top,
-            height,
-            client,
-            viewportSnapshot.bottomAnchor ?? undefined,
-            previousReadPositionRef.current,
-          )
         } else {
           // No scroll data, or the user never scrolled this visit → don't overwrite the saved
           // position; just mark the conversation left so a return is detected as a switch.
-          debugLog('UNMOUNT markAsLeft (no user scroll / no scroll data)', { conversationId: prevConversationRef.current })
-          scrollStateManager.markAsLeft(prevConversationRef.current)
+          debugLog('UNMOUNT markAsLeft (no user scroll / no scroll data)', {
+            conversationId: outgoingConversationId,
+          })
         }
+        scrollPersistenceRef.current?.leaveConversation(
+          outgoingConversationId,
+          viewportSnapshot ?? null,
+          previousReadPositionRef.current,
+        )
       }
       userInputCleanupRef.current?.()
       userInputCleanupRef.current = null

--- a/apps/fluux/src/utils/scrollStateManager.ts
+++ b/apps/fluux/src/utils/scrollStateManager.ts
@@ -1,9 +1,9 @@
 /**
  * Scroll State Manager
  *
- * A dedicated module for managing scroll positions across conversation switches.
- * Isolates scroll persistence logic from the MessageList component for better
- * testability and reliability.
+ * Conversation-scoped in-memory state for scroll positions across switches.
+ * ScrollPersistenceAdapter owns when the live MessageList may enter, save, leave,
+ * or clear this store.
  *
  * Key features:
  * - Explicit state transitions with timestamps for debugging

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -63,6 +63,11 @@ no DOM element, virtualizer, frame scheduler, or pixel-write operation crosses i
 Conversation entry resets every fact, and observations tagged for the room just left are rejected,
 so delayed controller callbacks cannot mutate the new room's evidence.
 
+Scroll persistence is mediated by a value-only `ScrollPersistenceAdapter`. It consumes immutable
+viewport-session snapshots and owns entry reads, throttled continuous saves, leave-versus-mark-left
+decisions, and explicit saved-position clearing. The adapter rejects stale-room snapshots and
+controller-owned scroll events and has no DOM, virtualizer, scheduler, or pixel-write capability.
+
 Explicit target convergence uses immediate center writes. The former reply/poll/find helper's
 native smooth animation is intentionally not retained: restarting a smooth animation while
 remeasurement moves the target makes convergence samples unreliable and recreates scroll fighting.
@@ -467,7 +472,7 @@ kinetic scrolling and stale-paint behavior.
    - [x] Extract a conversation-scoped, observation-only viewport session for current geometry,
      bottom anchor, measured-live-edge and genuine-input evidence, measurement settling, and
      top/bottom travel latches.
-   - [ ] Move enter/leave/save/clear behavior and throttling behind a persistence adapter consuming
+   - [x] Move enter/leave/save/clear behavior and throttling behind a persistence adapter consuming
      viewport-session snapshots.
    - [ ] Extract directional history load eligibility, invocation, and completion into a window
      coordinator that owns no positioning.


### PR DESCRIPTION
Extract scroll persistence into a value-only adapter that owns conversation entry, throttled saves, leave handling, and clearing.

The adapter consumes viewport-session snapshots and rejects stale-room or controller-owned observations, keeping persistence from becoming a second live-list pixel owner. Ownership and behavior regression coverage protects room switching and restoration.