### PR TITLE
fix(scroll): preserve a scrolled-up reader when a message is inserted above them

### DIFF
--- a/apps/fluux/src/anomaly/detectors/sentinelFanout.ts
+++ b/apps/fluux/src/anomaly/detectors/sentinelFanout.ts
@@ -23,12 +23,12 @@ import { CTX, ID, TAG, type Opaque } from '../values'
 /**
  * Loop label to tag, EXHAUSTIVE over `ReassertLoopLabel`.
  *
- * The `Record<ReassertLoopLabel, …>` is the guarantee: adding a ninth loop kind to
+ * The `Record<ReassertLoopLabel, …>` is the guarantee: adding a tenth loop kind to
  * the union fails to compile here until it gets a tag. An earlier version keyed
  * this on `string` and leaned on a test that grepped `useMessageListScroll.ts` for
  * literal call arguments — which silently stopped covering `media-anchor` and
- * `divider-anchor` the moment those started reaching `begin()` through a variable.
- * A type states the invariant the grep only approximated.
+ * the layout-preservation anchors the moment those started reaching `begin()` through
+ * a variable. A type states the invariant the grep only approximated.
  *
  * The type import is erased at build time, so this adds no runtime edge from the
  * anomaly tree into the component tree.
@@ -37,6 +37,7 @@ const LOOP_TAGS: Readonly<Record<ReassertLoopLabel, Opaque>> = Object.freeze({
   'pin-bottom': TAG.loopPinBottom,
   'media-anchor': TAG.loopMediaAnchor,
   'divider-anchor': TAG.loopDividerAnchor,
+  'insertion-anchor': TAG.loopInsertionAnchor,
   prepend: TAG.loopPrepend,
   'restore-anchor': TAG.loopRestoreAnchor,
   marker: TAG.loopMarker,

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -98,6 +98,7 @@ export const TAG = Object.freeze({
   loopPinBottom: mint('loop:pin-bottom', 'tag'),
   loopMediaAnchor: mint('loop:media-anchor', 'tag'),
   loopDividerAnchor: mint('loop:divider-anchor', 'tag'),
+  loopInsertionAnchor: mint('loop:insertion-anchor', 'tag'),
   loopPrepend: mint('loop:prepend', 'tag'),
   loopRestoreAnchor: mint('loop:restore-anchor', 'tag'),
   loopMarker: mint('loop:marker', 'tag'),

--- a/apps/fluux/src/components/ChatView.test.tsx
+++ b/apps/fluux/src/components/ChatView.test.tsx
@@ -180,6 +180,13 @@ vi.mock('@fluux/sdk', () => ({
 
 // Mock React store hooks (from @fluux/sdk/react)
 vi.mock('@fluux/sdk/react', () => ({
+  useChatStore: (selector: (state: {
+    activeConversationId: null
+    interiorPlacementVersions: Map<string, number>
+  }) => unknown) => selector({
+    activeConversationId: null,
+    interiorPlacementVersions: new Map(),
+  }),
   useConnectionStore: (selector: (state: { jid: string; ownAvatar: null; ownNickname: string; status: string }) => unknown) => {
     return selector({
       jid: 'me@example.com/resource',

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -9,7 +9,7 @@ import { useToastStore } from '@/stores/toastStore'
 import { useConversationPlaintextOverrideStore } from '@/stores/conversationPlaintextOverrideStore'
 import { VerifyPeerDialog } from './VerifyPeerDialog'
 import { KeyChangeBanner } from './KeyChangeBanner'
-import { useConnectionStore } from '@fluux/sdk/react'
+import { useChatStore, useConnectionStore } from '@fluux/sdk/react'
 import { useFileUpload, useLinkPreview, useTypeToFocus, useMessageCopy, useMode, useMessageSelection, useMessageHoverState, useDragAndDrop, useConversationDraft, useTimeFormat } from '@/hooks'
 import { Upload, Loader2 } from 'lucide-react'
 import { MessageBubble, MessageList as MessageListComponent, shouldShowAvatar, ownGroupKey as computeOwnGroupKey, buildReplyContext } from './conversation'
@@ -57,6 +57,10 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
   // Use useChatActive instead of useChat to avoid subscribing to the conversation list.
   // This prevents re-renders during background MAM sync of other conversations.
   const { activeConversation, firstNewMessageId, firstNewMessageIsProvisional, readPointerId, activeMessages, activeTypingUsers, sendMessage, sendReaction, sendCorrection, retractMessage, retryMessage, sendChatState, isArchived, archiveConversation, unarchiveConversation, setDraft, getDraft, clearDraft, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, activeMAMState, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueChatCatchUp, targetMessageId, clearTargetMessageId } = useChatActive()
+  const interiorPlacementVersion = useChatStore((state) => {
+    const id = state.activeConversationId
+    return id ? state.interiorPlacementVersions.get(id) ?? 0 : 0
+  })
   // Use useContactIdentities instead of useRoster() to avoid re-renders on
   // presence changes. ChatView only needs contact names and avatars for display.
   const contactsByJid = useContactIdentities()
@@ -522,6 +526,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
         <MediaAutoloadProvider autoLoad={mediaAutoLoad}>
           <ChatMessageList
             messages={activeMessages}
+            interiorPlacementVersion={interiorPlacementVersion}
             contactsByJid={contactsByJid}
             typingUsers={activeTypingUsers}
             scrollerRef={scrollRef}
@@ -631,6 +636,7 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
 
 export const ChatMessageList = memo(function ChatMessageList({
   messages,
+  interiorPlacementVersion = 0,
   contactsByJid,
   typingUsers,
   scrollerRef,
@@ -679,6 +685,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   isCatchingUp,
 }: {
   messages: Message[]
+  interiorPlacementVersion?: number
   contactsByJid: Map<string, ContactIdentity>
   typingUsers: string[]
   scrollerRef: React.RefObject<HTMLElement | null>
@@ -809,6 +816,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       // external singleton keyed by conversation id).
       key={conversationId}
       messages={messages}
+      interiorPlacementVersion={interiorPlacementVersion}
       conversationId={conversationId}
       firstNewMessageId={firstNewMessageId}
       firstNewMessageIsProvisional={firstNewMessageIsProvisional}

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -99,6 +99,10 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   // management actions come from the focused hooks below (they subscribe to no
   // store, so they add no re-render triggers).
   const { activeRoom, activeMessages, activeTypingUsers, sendMessage, sendWhisper, sendReaction, sendCorrection, retractMessage, sendChatState, sendWhisperChatState, activeAnimation, sendEasterEgg, clearAnimation, clearFirstNewMessageId, resyncDividerToReadPointer, advanceReadPointer, fetchOlderHistory, loadMessagesAround, loadNewer, recenterToLatest, windowAtLiveEdge, continueRoomCatchUp, activeMAMState, targetMessageId, clearTargetMessageId, firstNewMessageId, firstNewMessageIsProvisional, readPointerId } = useRoomActive()
+  const interiorPlacementVersion = useRoomStore((state) => {
+    const jid = state.activeRoomJid
+    return jid ? state.interiorPlacementVersions.get(jid) ?? 0 : 0
+  })
   const { sendPoll, votePoll, closePoll } = usePolls()
   const { moderateMessage, setAffiliation, setRole } = useRoomModeration()
   const { setRoomNotifyAll, setRoomAvatar, clearRoomAvatar, submitRoomConfig, setSubject, destroyRoom } = useRoomManagement()
@@ -581,6 +585,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
           <MediaAutoloadProvider autoLoad={mediaAutoLoad}>
             <RoomMessageList
               messages={displayMessages}
+              interiorPlacementVersion={interiorPlacementVersion}
               scrollerRef={scrollRef}
               isAtBottomRef={isAtBottomRef}
               onLiveEdgeMeasured={reportLiveEdge}
@@ -870,6 +875,7 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
 
 export const RoomMessageList = memo(function RoomMessageList({
   messages,
+  interiorPlacementVersion = 0,
   scrollerRef,
   isAtBottomRef,
   onLiveEdgeMeasured,
@@ -921,6 +927,7 @@ export const RoomMessageList = memo(function RoomMessageList({
   isCatchingUp,
 }: {
   messages: RoomMessage[]
+  interiorPlacementVersion?: number
   scrollerRef: React.RefObject<HTMLElement | null>
   isAtBottomRef: React.MutableRefObject<boolean>
   onLiveEdgeMeasured?: (atEdge: boolean) => void
@@ -1209,6 +1216,7 @@ export const RoomMessageList = memo(function RoomMessageList({
       // between rooms. Restoration survives via scrollStateManager (keyed by room jid).
       key={room.jid}
       messages={messages}
+      interiorPlacementVersion={interiorPlacementVersion}
       conversationId={room.jid}
       firstNewMessageId={firstNewMessageId}
       firstNewMessageIsProvisional={firstNewMessageIsProvisional}

--- a/apps/fluux/src/components/conversation/MessageList.tsx
+++ b/apps/fluux/src/components/conversation/MessageList.tsx
@@ -71,6 +71,7 @@ export interface MessageListProps<T extends BaseMessage> {
   messages: T[]
   /** Unique identifier for this conversation/room */
   conversationId: string
+  interiorPlacementVersion?: number
   /** ID of the first unread message (for new message marker) */
   firstNewMessageId?: string
   /** Divider derived while a synced XEP-0490 read position is still unresolved — rendered muted */
@@ -179,6 +180,7 @@ export interface MessageListProps<T extends BaseMessage> {
 export function MessageList<T extends BaseMessage>({
   messages,
   conversationId,
+  interiorPlacementVersion = 0,
   firstNewMessageId,
   firstNewMessageIsProvisional = false,
   clearFirstNewMessageId,
@@ -537,6 +539,7 @@ export function MessageList<T extends BaseMessage>({
   } = useMessageListScroll({
     conversationId,
     messageCount: messages.length,
+    interiorPlacementVersion,
     firstMessageId,
     firstNewMessageId,
     readPointerId,

--- a/apps/fluux/src/components/conversation/positioningController.test.ts
+++ b/apps/fluux/src/components/conversation/positioningController.test.ts
@@ -881,6 +881,7 @@ describe('positioning controller live-edge ownership', () => {
           fraction: messageFraction(0.4),
         },
       },
+      reason: 'divider-mutation',
       executor,
     })
 

--- a/apps/fluux/src/components/conversation/positioningController.ts
+++ b/apps/fluux/src/components/conversation/positioningController.ts
@@ -15,6 +15,7 @@ import {
   type EntryPositionFacts,
   type ExplicitTargetRequest,
   type LayoutPreservationRequest,
+  type LayoutPreservationReason,
   type LiveEdgeRequest,
   type LiveEdgeNavigationFacts,
   type MediaPreservationRequest,
@@ -707,11 +708,13 @@ export class PositioningController {
   beginLayoutPreservation(input: {
     conversationId: string
     desired: LayoutPreservationRequest['desired']
+    reason: LayoutPreservationReason
     executor: AnchorPreservationExecutor
   }): LayoutPreservationRequest | null {
+    const { reason, ...rest } = input
     return this.beginAnchorPreservation({
-      ...input,
-      source: { kind: 'layout-preservation', reason: 'divider-mutation' },
+      ...rest,
+      source: { kind: 'layout-preservation', reason },
     }) as LayoutPreservationRequest | null
   }
 

--- a/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
+++ b/apps/fluux/src/components/conversation/reassertLoopMonitor.ts
@@ -35,15 +35,16 @@ import type { AnomalySignal } from '@/utils/anomalySignal'
 /**
  * Every loop kind the message list can start.
  *
- * A closed union rather than `string`, so adding a ninth loop is a COMPILE error
+ * A closed union rather than `string`, so adding a tenth loop is a COMPILE error
  * everywhere the set matters — in particular the anomaly fan-out's label table.
- * Two of these labels reach `begin()` through a variable rather than a literal, so
+ * Three of these labels reach `begin()` through a variable rather than a literal, so
  * a source grep cannot enumerate them; only the type can.
  */
 export type ReassertLoopLabel =
   | 'pin-bottom'
   | 'media-anchor'
   | 'divider-anchor'
+  | 'insertion-anchor'
   | 'prepend'
   | 'restore-anchor'
   | 'marker'

--- a/apps/fluux/src/components/conversation/scrollPositionModel.ts
+++ b/apps/fluux/src/components/conversation/scrollPositionModel.ts
@@ -165,7 +165,7 @@ export type PositionRequest =
       Extract<UnavailablePolicy, { kind: 'warn-and-stop' }>
     >
   | Request<
-      { kind: 'layout-preservation'; reason: 'divider-mutation' },
+      { kind: 'layout-preservation'; reason: LayoutPreservationReason },
       BottomFractionAnchorPosition,
       Extract<UnavailablePolicy, { kind: 'warn-and-stop' }>
     >
@@ -244,9 +244,19 @@ export type MediaPreservationRequest = Extract<
   { source: { kind: 'media-preservation'; reason: 'remeasure' } }
 >
 
+/**
+ * Ambient layout mutations ABOVE a scrolled-up reader, which must hold the reading position without
+ * ever counting as navigation. `divider-mutation` is the "New messages" divider appearing or moving;
+ * `message-insertion` is a delayed arrival (offline replay, gateway/MUC history, the MAM `{ids}`
+ * fetch) that appendLive sorts into the MIDDLE of the resident array rather than at the live edge.
+ * Both change layout above the viewport without the reader asking for anything, so both are subject
+ * to the same rejection-while-positioning rule below.
+ */
+export type LayoutPreservationReason = 'divider-mutation' | 'message-insertion'
+
 export type LayoutPreservationRequest = Extract<
   PositionRequest,
-  { source: { kind: 'layout-preservation'; reason: 'divider-mutation' } }
+  { source: { kind: 'layout-preservation'; reason: LayoutPreservationReason } }
 >
 
 export type AnchorPreservationRequest =

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -254,13 +254,24 @@ function findBottomAnchor(scroller: HTMLElement): ScrollAnchor | null {
  * Restore scroll so the viewport bottom sits at the saved FRACTION through the anchor message,
  * using the message's CURRENT measured height. Returns false if the anchor message isn't currently
  * mounted (scrolled up beyond the re-hydrated/virtualized window) so the caller can fall back.
+ *
+ * Measured with getBoundingClientRect, NOT offsetTop — the exact inverse of the basis
+ * {@link findBottomAnchor} captures on, and for the same reason it documents. `offsetTop` is
+ * relative to the element's offsetParent, which under virtualization is the row's own
+ * `position:absolute` `[data-index]` wrapper (so it reads ~0 for EVERY row) and in normal flow is
+ * whichever positioned ancestor happens to be nearest — not necessarily the scroller. A rect-based
+ * capture paired with an offsetTop-based restore was therefore never a true inverse. Deriving both
+ * sides from rects makes an unchanged capture→restore an exact no-op, so repeated restorations
+ * cannot accumulate error.
  */
 function restoreToAnchor(scroller: HTMLElement, anchor: ScrollAnchor): boolean {
   const el = scroller.querySelector(
     `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`
   ) as HTMLElement | null
   if (!el || el.offsetHeight <= 0) return false
-  scroller.scrollTop = el.offsetTop + anchor.fraction * el.offsetHeight - scroller.clientHeight
+  const rect = el.getBoundingClientRect()
+  const contentTop = rect.top - scroller.getBoundingClientRect().top + scroller.scrollTop
+  scroller.scrollTop = contentTop + anchor.fraction * rect.height - scroller.clientHeight
   return true
 }
 
@@ -272,6 +283,7 @@ function restoreToAnchor(scroller: HTMLElement, anchor: ScrollAnchor): boolean {
 export interface UseMessageListScrollOptions {
   conversationId: string
   messageCount: number
+  interiorPlacementVersion?: number
   firstMessageId: string | undefined
   firstNewMessageId?: string  // ID of the first unread message (for new message marker)
   /** Forward-only local id of the furthest read message, including XEP-0490 sync. */
@@ -393,6 +405,7 @@ interface DirectionalHistorySnapshot {
 export function useMessageListScroll({
   conversationId,
   messageCount,
+  interiorPlacementVersion = 0,
   firstMessageId,
   firstNewMessageId,
   readPointerId,
@@ -615,6 +628,24 @@ export function useMessageListScroll({
   const dividerTrackingRef = useRef({
     conversationId,
     dividerId: firstNewMessageId,
+  })
+
+  // A mid-array message insertion is the same shape of ambient layout mutation as a divider move,
+  // so it keeps its own pre-mutation anchor on the same terms. Tracked by BOTH ends of the resident
+  // array, not by count: at the resident bound `appendLive` trims the oldest row as it inserts, so
+  // the count does not change and only the first id moves.
+  const insertionAnchorRef = useRef<ScrollAnchor | null>(null)
+  const insertionGeometryRef = useRef<{
+    scrollTop: number
+    scrollHeight: number
+    clientHeight: number
+  } | null>(null)
+  const insertionTrackingRef = useRef({
+    conversationId,
+    messageCount,
+    firstMessageId,
+    lastMessageId,
+    interiorPlacementVersion,
   })
 
   // Track whether user has scrolled at least once since the marker was set.
@@ -925,8 +956,8 @@ export function useMessageListScroll({
   const { setScrollContainerRef, setContentRef } = stableSettersRef.current
 
   // Apply one virtualized bottom-fraction anchor write from CURRENT measurements. Saved-position
-  // restoration and media preservation share this browser geometry while the positioning controller
-  // owns both frame-loop lifecycles.
+  // restoration and fixed-anchor media/layout preservation share this browser geometry while the
+  // positioning controller owns every frame-loop lifecycle.
   const applyVirtualizedAnchorFrame = useCallback((anchor: ScrollAnchor): number | null => {
     const v = virtualizerRef.current
     const s = scrollerRef.current
@@ -945,7 +976,22 @@ export function useMessageListScroll({
     const size = item?.size
     const start = size ? v.getOffsetForMessageId(anchor.messageId) : null
     if (size && start !== null) {
-      v.scrollToOffset(Math.max(0, start + anchor.fraction * size - s.clientHeight))
+      // Measure the ROW when it is mounted, not the virtualizer's item. `findBottomAnchor` captures
+      // the fraction against the `.message-row` rect, while `start`/`size` describe the enclosing
+      // `[data-index]` wrapper — they differ by the inter-row gap, so capture and restore are not
+      // inverses and each preservation leaves a small residual behind. Invisible once; across a
+      // burst of arrivals it compounds into a visible drift. Deriving the target from the row's own
+      // rect makes an unchanged capture→restore an exact no-op. The WRITE still goes through the
+      // virtualizer (never a raw scrollTop), so it re-windows and cannot fight @tanstack's pending
+      // scroll reconciler.
+      const row = s.querySelector(
+        `.message-row[data-message-id="${CSS.escape(anchor.messageId)}"]`
+      ) as HTMLElement | null
+      const rect = row && row.offsetHeight > 0 ? row.getBoundingClientRect() : null
+      const target = rect
+        ? rect.top - s.getBoundingClientRect().top + s.scrollTop + anchor.fraction * rect.height - s.clientHeight
+        : start + anchor.fraction * size - s.clientHeight
+      v.scrollToOffset(Math.max(0, target))
     } else {
       // Anchor not yet in the measured window (or fraction===1): mount it / pin its bottom to the
       // viewport bottom. Once it measures in, later frames take the fractional branch above.
@@ -1264,7 +1310,7 @@ export function useMessageListScroll({
   }, [rememberBottomIntent])
 
   const createAnchorPreservationExecutor = useCallback(
-    (loopLabel: 'media-anchor' | 'divider-anchor'): AnchorPreservationExecutor => ({
+    (loopLabel: 'media-anchor' | 'divider-anchor' | 'insertion-anchor'): AnchorPreservationExecutor => ({
       reachability: (desired) => deriveReachabilityForDesired({
         desired,
         hasRows: messageCount > 0 && firstMessageId !== undefined,
@@ -1395,6 +1441,7 @@ export function useMessageListScroll({
           positioningControllerRef.current?.beginLayoutPreservation({
             conversationId,
             desired,
+            reason: 'divider-mutation',
             executor: createAnchorPreservationExecutor('divider-anchor'),
           })
         },
@@ -1409,6 +1456,144 @@ export function useMessageListScroll({
     createAnchorPreservationExecutor,
     firstNewMessageId,
     showScrollToBottom,
+  ])
+
+  const refreshInsertionAnchor = useCallback(
+    (scroller: HTMLElement, measuredAnchor?: ScrollAnchor | null) => {
+      const { scrollTop, scrollHeight, clientHeight } = scroller
+      insertionGeometryRef.current = { scrollTop, scrollHeight, clientHeight }
+      if (scrollHeight - scrollTop - clientHeight < AT_BOTTOM_THRESHOLD) {
+        insertionAnchorRef.current = null
+        return
+      }
+      const anchor =
+        measuredAnchor === undefined ? findBottomAnchor(scroller) : measuredAnchor
+      insertionAnchorRef.current = anchor
+    },
+    [],
+  )
+
+  // Keep a pre-mutation insertion anchor while the reader is scrolled up, on the same terms as the
+  // divider anchor above: on the render where the resident array mutates, the mismatch below stops
+  // this effect replacing the old geometry with a post-mutation measurement.
+  //
+  // No dependency array. The anchor has to survive a virtualizer RE-MEASURE, which re-renders and
+  // moves every row's content offset without changing the message identifiers, `bottomVisibleMessageId`,
+  // or firing a scroll event — keyed on any of those the snapshot silently ages out and the restore
+  // lands on geometry the reader already left. `findBottomAnchor` is a per-row measurement scan, so
+  // it is gated on the two cheap scalar reads that between them cover every way the geometry can
+  // move: `scrollTop` (the reader scrolled) and `scrollHeight` (rows re-measured, viewport resized).
+  useLayoutEffect(() => {
+    const tracked = insertionTrackingRef.current
+    if (
+      tracked.conversationId !== conversationId ||
+      tracked.messageCount !== messageCount ||
+      tracked.firstMessageId !== firstMessageId ||
+      tracked.lastMessageId !== lastMessageId ||
+      tracked.interiorPlacementVersion !== interiorPlacementVersion
+    ) {
+      return
+    }
+    const scroller = scrollerRef.current
+    if (!scroller) return
+    const { scrollTop, scrollHeight, clientHeight } = scroller
+    const geometry = insertionGeometryRef.current
+    if (
+      geometry &&
+      geometry.scrollTop === scrollTop &&
+      geometry.scrollHeight === scrollHeight &&
+      geometry.clientHeight === clientHeight
+    ) {
+      return
+    }
+    refreshInsertionAnchor(scroller)
+  })
+
+  // A delayed arrival — offline replay, gateway/MUC history, the MAM `{ids}` fetch — reaches the
+  // LIVE path carrying an OLD timestamp, so `appendLive` sorts it into the MIDDLE of the resident
+  // array. Landing above a scrolled-up reader it pushes the reading position down by the inserted
+  // height: the reader drifts backwards in time.
+  //
+  // Nothing else covers it. The media-growth compensation is reachable only from `onMediaLoad` and
+  // an insertion fires no media event; the new-message effect deliberately does nothing for an
+  // incoming message while scrolled up; and browser-native CSS scroll anchoring — which does handle
+  // this in normal flow — is inert under virtualization, because the virtualizer rewrites every
+  // row's inline `top` on each commit, and WebKit does not implement it at all.
+  //
+  // Like divider movement this is ambient layout preservation, NOT navigation: it goes through the
+  // same request source, so the model rejects it while an entry restore, explicit target, or
+  // Home/End command is still in flight rather than superseding what the reader asked for.
+  useLayoutEffect(() => {
+    const tracked = insertionTrackingRef.current
+    const next = {
+      conversationId,
+      messageCount,
+      firstMessageId,
+      lastMessageId,
+      interiorPlacementVersion,
+    }
+    if (tracked.conversationId !== conversationId) {
+      insertionTrackingRef.current = next
+      insertionAnchorRef.current = null
+      insertionGeometryRef.current = null
+      return
+    }
+
+    // A live-edge arrival moves the LAST row: the reader is scrolled up, so content added below
+    // cannot move them, and the bottom-pin loop owns that case when they are at the bottom.
+    const bottomMoved = tracked.lastMessageId !== lastMessageId
+    // A load-older/load-newer batch also changes the resident array without moving the bottom row,
+    // and owns its own directional-history restore, which must not be fought here. It is
+    // distinguished by an in-flight snapshot that is landing in THIS commit — not merely by a
+    // first-id change, because at the resident bound an insertion evicts the oldest row and so
+    // moves the first id too. This effect is declared before the directional restore effect, so
+    // the snapshot is still unrestored here when its load genuinely lands.
+    const pendingDirectional = prependRef.current
+    const directionalLoad =
+      !!pendingDirectional &&
+      !pendingDirectional.restored &&
+      pendingDirectional.oldFirstId !== firstMessageId
+    const residentChanged =
+      tracked.messageCount !== messageCount || tracked.firstMessageId !== firstMessageId
+
+    const anchor = insertionAnchorRef.current
+    const interiorPlacementAdvanced =
+      interiorPlacementVersion > tracked.interiorPlacementVersion
+    const inserted =
+      !directionalLoad &&
+      (interiorPlacementAdvanced || (residentChanged && !bottomMoved))
+
+    if (inserted && anchor) {
+      runScrollShadowSafely({
+        event: 'insertion-anchor-preservation',
+        conversationId,
+        fallback: undefined,
+        observe: () => {
+          const desired: AnchorPreservationRequest['desired'] = {
+            kind: 'anchor',
+            messageId: anchor.messageId,
+            placement: {
+              kind: 'bottom-fraction',
+              fraction: messageFraction(anchor.fraction),
+            },
+          }
+          positioningControllerRef.current?.beginLayoutPreservation({
+            conversationId,
+            desired,
+            reason: 'message-insertion',
+            executor: createAnchorPreservationExecutor('insertion-anchor'),
+          })
+        },
+      })
+    }
+    insertionTrackingRef.current = next
+  }, [
+    conversationId,
+    createAnchorPreservationExecutor,
+    firstMessageId,
+    interiorPlacementVersion,
+    lastMessageId,
+    messageCount,
   ])
 
   const createDirectionalHistoryExecutor = useCallback(
@@ -2537,6 +2722,19 @@ export function useMessageListScroll({
       controllerOwnsPixels: programmaticScroll,
       now,
     })
+    // Keep the pre-mutation insertion anchor current on the same measurement the session already
+    // took — only while the resident array is unchanged, so the commit that mutates it still sees
+    // the geometry from BEFORE the mutation.
+    const insertionTracking = insertionTrackingRef.current
+    if (
+      insertionTracking.conversationId === conversationId &&
+      insertionTracking.messageCount === messageCount &&
+      insertionTracking.firstMessageId === firstMessageId &&
+      insertionTracking.lastMessageId === lastMessageId &&
+      insertionTracking.interiorPlacementVersion === interiorPlacementVersion
+    ) {
+      refreshInsertionAnchor(el, bottomAnchor)
+    }
     // Do NOT recompute at-bottom from a GROWTH-driven scroll event fired while a programmatic loop
     // owns scrollTop. The pin-bottom comment's assumption that "programmatic growth doesn't move
     // scrollTop, so it never flips isAtBottom" is FALSE on WebKitGTK (Tauri): when the just-pinned

--- a/docs/2026-07-23-scroll-positioning-contract.md
+++ b/docs/2026-07-23-scroll-positioning-contract.md
@@ -35,14 +35,16 @@ frame scheduling, stale-work cancellation, convergence, and live-edge fallback. 
 message targets it owns supersession, one around-load attempt, mounting and center-position
 convergence, user takeover, and completion. For live edge it owns entry/FAB/outgoing generations,
 same-generation content stimuli, global-tail recentering, the 60-frame/8-stable-frame convergence
-budget, and user cancellation. Media growth and unread-divider movement while reading history share
-one fixed-anchor execution machine with the former 90-frame/8-stable-frame/8px contract. Divider
-movement has distinct `layout-preservation` provenance and is ambient: it is rejected rather than
-superseding an unsettled entry restore, explicit target, or user navigation. Hook executors
+budget, and user cancellation. Media growth, unread-divider movement, and delayed live-path
+insertions while reading history share one fixed-anchor execution machine with the former
+90-frame/8-stable-frame/8px contract. Divider movement and delayed insertion have distinct
+`layout-preservation` reasons and are ambient: they are rejected rather than superseding an
+unsettled entry restore, explicit target, or user navigation. Hook executors
 translate accepted requests into browser/virtualizer writes, and every frame must hold the current
 controller lease before it can write. Directional history is accepted before a load begins, remains
-pending until the first resident ID changes, then performs its pre-paint anchor/fallback write and
-the former full 60-frame late-measurement budget under one lease. Its executor retains WebKit
+pending until the first resident ID changes or the load settles without a window shift, then either
+performs its pre-paint anchor/fallback write or releases the request. A landed shift retains the
+former full 60-frame late-measurement budget under one lease. Its executor retains WebKit
 kinetic-scroll cancellation, 2px target-shift correction, 5px clamp recovery, and bounded
 distance-from-bottom fallback. Boundary input while the load is still pending retains the captured
 anchor because no pixel owner exists yet; takeover becomes cancellable after the initial
@@ -141,8 +143,8 @@ WebKit paint correctness.
 - **Live edge:** keep following appended messages and bottom-of-list UI until genuine user takeover.
 - **Fixed anchor:** keep a point in one message at a stable viewport placement. Its placement is a
   discriminated type, so the two geometries cannot be mixed:
-  - `bottom-fraction`: saved reading position, media preservation, and divider-layout preservation.
-    The fraction is validated in
+  - `bottom-fraction`: saved reading position, media preservation, and ambient layout preservation
+    for divider movement or delayed insertion. The fraction is validated in
     `[0, 1]`, where `0` is the row top and `1` its bottom. The exact equation is
     `rowTop + fraction * rowHeight = scrollTop + viewportHeight`;
   - `top-offset`: directional history preservation. The equation is
@@ -185,16 +187,19 @@ Sources distinguish:
 - an outgoing message that deliberately returns the sender to live edge;
 - directional history preservation;
 - media remeasurement preservation;
-- ambient layout preservation when the unread divider moves;
+- ambient layout preservation when the unread divider moves or a delayed live-path message is
+  inserted inside the resident window;
 - late XEP-0490/MDS supersession.
 
-Incoming messages, reactions, typing, composer/container/viewport resize, media measurement, and MAM
-completion are normally **reconciliation stimuli for the current request**, not new competing
-requests. An outgoing send is different: current behavior deliberately moves a reader out of
-history, so it creates a live-edge request. The attempt is dropped while a directional-load or
-entry-restore preservation step is still pending, matching the existing send-stick suppression;
-the preservation owner releases after its first position is applied, not after the entire
-measurement-settle loop. Later ordinary stimuli handle content from any dropped attempt.
+Incoming messages at the resident live edge, reactions, typing, composer/container/viewport resize,
+media measurement, and MAM completion are normally **reconciliation stimuli for the current
+request**, not new competing requests. A delayed live-path message placed inside the resident
+window is the ambient-layout exception described above. An outgoing send is different: current
+behavior deliberately moves a reader out of history, so it creates a live-edge request. The attempt
+is dropped while a directional-load or entry-restore preservation step is still pending, matching
+the existing send-stick suppression; the preservation owner releases after its first position is
+applied, not after the entire measurement-settle loop. Later ordinary stimuli handle content from
+any dropped attempt.
 
 ## Entry arbitration and later supersession
 
@@ -319,12 +324,13 @@ abort valid deep growth and media-settle runs.
 | Jump-to-last-read | Message at start | Reuses unread-marker placement |
 | FAB or live-edge keyboard command | Unread marker, then live edge | If the marker is still below the viewport, first activation visits it (virtualized start alignment; current non-virtualized path uses top-third); a later activation goes live |
 | Outgoing message | Live edge | Deliberately supersedes a fixed historical position after its first landing releases preservation ownership; it need not wait for full convergence |
-| Incoming message | Existing live edge only | Must not make a fixed anchor follow |
+| Incoming message at the resident live edge | Existing live edge only | Must not make a fixed anchor follow |
+| Delayed live-path message inserted inside the resident window while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; reject the ambient request while requested navigation is unsettled |
 | Late MDS live-edge state | Live edge | Newer automatic request only before user takeover |
 | Media at live edge | Existing live edge | Debounced measurement stimulus |
 | Media while reading history | Fixed bottom-relative fractional anchor | Preserve the reading point through remeasurement |
 | Unread divider moves while reading history | Fixed bottom-relative fractional anchor | Preserve a continuously captured pre-mutation reading point; reject the ambient request while requested navigation is unsettled |
-| Load older/newer | Fixed top-relative offset anchor | Wait for the directional window change; if the anchor disappears, preserve captured distance from bottom and clamp |
+| Load older/newer | Fixed top-relative offset anchor | Wait for the directional window change; release if the load settles without one; if the anchor disappears after a shift, preserve captured distance from bottom and clamp |
 | Home / resident-top command | Resident top | Does not itself trigger load-older; later genuine user travel can re-arm ordinary boundary loading |
 | Reaction, typing, resize, MAM completion | Current live edge, when active | Geometry stimulus, not a new position request |
 
@@ -334,16 +340,17 @@ is already visible or above the viewport, the same activation goes directly to l
 ## Ownership boundary
 
 The controller-owned mechanisms retain leased browser reconcilers for saved anchors, unread markers,
-explicit center-aligned targets, live edge, fixed-anchor media/divider preservation, directional
+explicit center-aligned targets, live edge, fixed-anchor media/layout preservation, directional
 history, and resident top. These
 reconcilers implement measurement convergence; they are not separate positioning authorities.
 There is no independent positioning frame-loop implementation left inside `useMessageListScroll`.
 
-Unread-divider preservation is entirely inside the scroll owner. `MessageList` no longer receives
-raw anchor capture/restore callbacks, and the virtualized executor corrects through
-`scrollToOffset`/`scrollToIndex` so TanStack's pending-scroll reconciler is retargeted rather than
-raced by an unleased `scrollTop` write. The pre-mutation anchor is still captured continuously and
-the accepted request performs its first correction in the post-commit, pre-paint layout effect.
+Ambient layout preservation is entirely inside the scroll owner. `MessageList` receives only the
+store-owned interior-placement version; it receives no raw anchor capture/restore callbacks. The
+virtualized executor corrects through `scrollToOffset`/`scrollToIndex` so TanStack's pending-scroll
+reconciler is retargeted rather than raced by an unleased `scrollTop` write. Pre-mutation anchors
+for divider movement and delayed insertion are captured continuously, and the accepted request
+performs its first correction in the post-commit, pre-paint layout effect.
 
 Every leased reconciler uses `controllerFrameLoop`. It owns the concrete scheduled frame and
 diagnostic handle, and finishes exactly once when the lease is stale before scheduling, becomes

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -317,6 +317,14 @@ interface ChatState {
   // EPHEMERAL: never persisted (absent from partialize). A restored arrival
   // would be re-read as a fresh delivery on the next launch.
   lastArrivedMessage: Map<string, Message>
+  /**
+   * Monotonic per-conversation versions incremented whenever `appendLive`
+   * places a genuine arrival before the resident timeline's live edge.
+   *
+   * @remarks
+   * Stable public API. The versions are ephemeral and reset with the store.
+   */
+  interiorPlacementVersions: Map<string, number>
 
   // Computed
   activeConversation: () => Conversation | null
@@ -1142,7 +1150,7 @@ function deserializeState(persisted: PersistedState, storageKey: string): Pick<C
   }
 }
 
-function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
+function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'activationPending' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage' | 'interiorPlacementVersions'> {
   return {
     conversationEntities: new Map(),
     conversationMeta: new Map(),
@@ -1162,6 +1170,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
     firstNewMessageMarkers: new Map(),
     windowAtLiveEdge: new Map(),
     lastArrivedMessage: new Map(),
+    interiorPlacementVersions: new Map(),
   }
 }
 
@@ -1171,7 +1180,7 @@ function createEmptyChatState(): Pick<ChatState, 'conversationEntities' | 'conve
  * Legacy versions stored chat data under a single unscoped key. For safety, we only migrate
  * conversation lists (active + archived classification) and intentionally skip drafts/messages.
  */
-function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> | null {
+function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage' | 'interiorPlacementVersions'> | null {
   if (!jid) return null
 
   const legacyKey = getLegacyStorageKey()
@@ -1213,7 +1222,7 @@ function migrateLegacyConversationListsToScoped(jid: string | null): Pick<ChatSt
   }
 }
 
-function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage'> {
+function loadScopedChatState(jid: string | null): Pick<ChatState, 'conversationEntities' | 'conversationMeta' | 'conversations' | 'messages' | 'activeConversationId' | 'archivedConversations' | 'typingStates' | 'activeAnimation' | 'drafts' | 'mamQueryStates' | 'conversationGaps' | 'conversationCoverage' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'windowAtLiveEdge' | 'lastArrivedMessage' | 'interiorPlacementVersions'> {
   const baseState = createEmptyChatState()
   const scopedStorageKey = getScopedStorageKey(jid)
 
@@ -1664,7 +1673,14 @@ export const chatStore = createStore<ChatState>()(
           // at the live edge; a slid window gates the append so a fresh
           // message never splices after an OLD one), and window trim.
           const atLiveEdge = state.windowAtLiveEdge.get(msg.conversationId) !== false
-          const append = timeline.appendLive(convMessages, msg, atLiveEdge, chatTimelineConfig())
+          const appendObservation: timeline.AppendLiveObservation = {}
+          const append = timeline.appendLive(
+            convMessages,
+            msg,
+            atLiveEdge,
+            chatTimelineConfig(),
+            appendObservation
+          )
 
           if (append.kind === 'duplicate-unchanged') return state
           if (append.kind === 'duplicate-backfilled') {
@@ -1691,6 +1707,14 @@ export const chatStore = createStore<ChatState>()(
             msg.conversationId,
             append.kind === 'appended' ? append.messages : convMessages
           )
+          const interiorPlacementPatch = appendObservation.placement === 'interior'
+            ? {
+                interiorPlacementVersions: new Map(state.interiorPlacementVersions).set(
+                  msg.conversationId,
+                  (state.interiorPlacementVersions.get(msg.conversationId) ?? 0) + 1
+                ),
+              }
+            : {}
 
           // Record the arrival. Both surviving append kinds are genuine
           // deliveries — 'appended' spliced into the resident window, 'gated'
@@ -1782,14 +1806,15 @@ export const chatStore = createStore<ChatState>()(
                   archivedConversations: newArchived,
                   firstNewMessageMarkers: newMarkers,
                   lastArrivedMessage: newArrived,
+                  ...interiorPlacementPatch,
                 }
               }
             }
 
-            return { messages: newMessages, ...draft.commit(), firstNewMessageMarkers: newMarkers, lastArrivedMessage: newArrived }
+            return { messages: newMessages, ...draft.commit(), firstNewMessageMarkers: newMarkers, lastArrivedMessage: newArrived, ...interiorPlacementPatch }
           }
 
-          return { messages: newMessages, lastArrivedMessage: newArrived }
+          return { messages: newMessages, lastArrivedMessage: newArrived, ...interiorPlacementPatch }
         })
 
         // Task 9: a coalesce/moved-earlier overlay change doesn't get a

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -817,6 +817,14 @@ export interface RoomState {
   // Session-only new-message divider per room (jid -> messageId). Derived at
   // activation from the read pointer; never persisted.
   firstNewMessageMarkers: Map<string, string>
+  /**
+   * Monotonic per-room versions incremented whenever `appendLive` places a
+   * genuine arrival before the resident timeline's live edge.
+   *
+   * @remarks
+   * Stable public API. The versions are ephemeral and reset with the store.
+   */
+  interiorPlacementVersions: Map<string, number>
 
   // Actions
   addRoom: (room: Room) => void
@@ -1072,7 +1080,7 @@ function createEmptyRoomState(
   acknowledgedNonAnonymousRooms: Set<string> = new Set(),
   roomCoverage: Map<string, CoverageRecord> = new Map(),
   pendingRetractions: Map<string, PendingRetraction[]> = new Map(),
-): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'roomCoverage' | 'acknowledgedNonAnonymousRooms' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers'> {
+): Pick<RoomState, 'rooms' | 'roomEntities' | 'roomMeta' | 'roomRuntime' | 'activeRoomJid' | 'activationPending' | 'activeAnimation' | 'drafts' | 'votedPollIds' | 'dismissedPollIds' | 'mamQueryStates' | 'roomGaps' | 'roomCoverage' | 'acknowledgedNonAnonymousRooms' | 'pendingRetractions' | 'targetMessageId' | 'firstNewMessageMarkers' | 'interiorPlacementVersions'> {
   return {
     rooms: new Map(),
     roomEntities: new Map(),
@@ -1091,6 +1099,7 @@ function createEmptyRoomState(
     acknowledgedNonAnonymousRooms,
     targetMessageId: null,
     firstNewMessageMarkers: new Map(),
+    interiorPlacementVersions: new Map(),
   }
 }
 
@@ -1924,7 +1933,14 @@ export const roomStore = createStore<RoomState>()(
       // IndexedDB (above) and the preview/unread updates below still run;
       // they reload on jump-to-latest.
       const atLiveEdge = state.roomRuntime.get(roomJid)?.windowAtLiveEdge !== false
-      const append = timeline.appendLive(existing.messages, messageToAdd, atLiveEdge, roomTimelineConfig())
+      const appendObservation: timeline.AppendLiveObservation = {}
+      const append = timeline.appendLive(
+        existing.messages,
+        messageToAdd,
+        atLiveEdge,
+        roomTimelineConfig(),
+        appendObservation
+      )
 
       if (append.kind === 'duplicate-unchanged') return state
       if (append.kind === 'duplicate-backfilled') {
@@ -1946,6 +1962,14 @@ export const roomStore = createStore<RoomState>()(
       // incoming message after the window slid off the live edge).
       const appendedMessages = append.kind === 'appended' ? append.messages : [...existing.messages, messageToAdd]
       const newMessages = append.kind === 'appended' ? append.messages : existing.messages
+      const interiorPlacementPatch = appendObservation.placement === 'interior'
+        ? {
+            interiorPlacementVersions: new Map(state.interiorPlacementVersions).set(
+              roomJid,
+              (state.interiorPlacementVersions.get(roomJid) ?? 0) + 1
+            ),
+          }
+        : {}
 
       // Delegate notification state to pure function
       const isActive = state.activeRoomJid === roomJid
@@ -2081,7 +2105,7 @@ export const roomStore = createStore<RoomState>()(
       if (updated.firstNewMessageId) newMarkers.set(roomJid, updated.firstNewMessageId)
       else newMarkers.delete(roomJid)
 
-      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, firstNewMessageMarkers: newMarkers }
+      return { rooms: newRooms, roomRuntime: newRuntime, roomMeta: newMeta, firstNewMessageMarkers: newMarkers, ...interiorPlacementPatch }
     })
 
     // Task 9: a coalesce/moved-earlier overlay change doesn't get a

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -69,11 +69,16 @@ export type AppendLiveResult<T> =
    */
   | { kind: 'gated' }
 
+export interface AppendLiveObservation {
+  placement?: 'live-edge' | 'interior'
+}
+
 export function appendLive<T extends TimelineMessage>(
   messages: T[],
   incoming: T,
   atLiveEdge: boolean,
-  config: TimelineConfig<T>
+  config: TimelineConfig<T>,
+  observation?: AppendLiveObservation
 ): AppendLiveResult<T> {
   const existingKeys = buildMessageKeySet(messages, config.getKeys)
   if (isMessageDuplicate(incoming, existingKeys, config.getKeys)) {
@@ -94,9 +99,16 @@ export function appendLive<T extends TimelineMessage>(
   // under-count, the unrecoverable direction. `sortMessagesByTimestamp` is the
   // SAME comparator `loadOlderSlice`/`loadNewerSlice`/`latestSlice` already use
   // here, so all resident-array construction paths agree with the archive walk.
+  const sorted = sortMessagesByTimestamp([...messages, incoming], config.kind)
+  const trimmed = trimMessages(sorted, config.windowSize)
+  const residentIndex = trimmed.indexOf(incoming)
+  if (observation && residentIndex >= 0) {
+    observation.placement =
+      residentIndex === trimmed.length - 1 ? 'live-edge' : 'interior'
+  }
   return {
     kind: 'appended',
-    messages: trimMessages(sortMessagesByTimestamp([...messages, incoming], config.kind), config.windowSize),
+    messages: trimmed,
   }
 }
 

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -63,6 +63,7 @@ const PREPEND_DRIFT_PX = 20  // acceptable anchor-position drift after prepend (
 const PREPEND_DRIFT_WEBKIT_PX = 48
 const LARGE_JUMP_PX = 150     // frame-to-frame jump threshold signalling instability
 const AT_BOTTOM_OK_PX = 150   // distance-from-bottom still considered "stuck to bottom"
+const FAB_THRESHOLD_PX = 300
 // Distance-from-bottom a test must reach before it can claim the reader is NOT at the bottom.
 // Deliberately several times AT_BOTTOM_OK_PX: engines differ in how much of a wheel gesture they
 // apply per scroll event, so a margin this wide is what makes "the reader has left the bottom" an
@@ -119,7 +120,7 @@ test.afterEach(async ({ page }) => {
  * 'messages'), so the rooms auto-select guard fires with `activeRoomJid` already
  * set when we later flip the hash.
  */
-async function navigateToStressRoom(page: Page): Promise<void> {
+async function navigateToStressRoom(page: Page, virtualized = true): Promise<void> {
   // Step 1: activate while sidebarView='messages' (auto-select for rooms won't race)
   await page.evaluate((jid) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,8 +138,10 @@ async function navigateToStressRoom(page: Page): Promise<void> {
     window.location.hash = '#/rooms/' + encodeURIComponent(jid)
   }, STRESS_ROOM_JID)
 
-  // Wait for at least one virtualized row to mount ([data-index] exists)
-  await page.waitForSelector('[data-index]', { timeout: 15_000 })
+  await page.waitForSelector(
+    virtualized ? '[data-index]' : '.message-row[data-message-id]',
+    { timeout: 15_000 },
+  )
   await page.waitForTimeout(SETTLE_MS)
 }
 
@@ -2987,5 +2990,437 @@ test.describe('Fastening + reaction stick diagnostic (1:1)', () => {
       `list not pinned after the message+preview+reaction burst — distFromBottom=${state.distFromBottom}`,
     ).toBeLessThan(AT_BOTTOM_OK_PX)
     expect(state.visible, 'the fastened message was left below the fold').toBe(true)
+  })
+})
+
+// ── 14: A mid-array insertion above a scrolled-up reader must not move the reading position ──────
+//
+// A DELAYED arrival — offline replay, gateway/MUC history, the MAM `{ids}` fetch — reaches the LIVE
+// path carrying an OLD timestamp, so appendLive's sort places it chronologically: in the MIDDLE of
+// the resident array, above a reader who has scrolled up. That is a different event from the media
+// growth invariant-11 covers (it changes the element COUNT, not the height of an existing element),
+// and it reaches none of the same machinery: no media event fires, the new-message effect
+// deliberately does nothing for an incoming message while scrolled up, and browser-native scroll
+// anchoring is inert under virtualization because the virtualizer rewrites each row's inline `top`
+// every commit. RED before the fix (the reader drifts down by ~the inserted height: ~50px for one
+// row, ~424px for a tall one, ~248px for a 10-message burst); GREEN once the insertion re-anchors
+// the scrolled-up reading position.
+//
+// The window bound is deliberately left at its default: appendLive only GATES an out-of-order
+// arrival once the window has slid off the live edge, which needs ~100 load-older triggers at the
+// production windowSize, so a normal scrolled-up reader is always in the ungated case this covers.
+test.describe('Insertion drift while scrolled up', () => {
+  const INSERTION_URL =
+    '/demo.html?tutorial=false&virt=1&stress=rooms:1,messages:200,mode:live,msgStep:0'
+  const FULL_WINDOW_INSERTION_URL =
+    '/demo.html?tutorial=false&virt=1&window=200&stress=rooms:1,messages:200,mode:live,msgStep:0'
+
+  /** Open the stress room and scroll clear of the bottom, with content above AND below. */
+  async function openScrolledUp(
+    page: Page,
+    url = INSERTION_URL,
+    targetDistanceFromBottom?: number,
+    virtualized = true,
+  ): Promise<void> {
+    await bootDemo(page, url)
+    await page.evaluate(() => {
+      ;(
+        window as Window & { __fluuxScrollShadow?: (reset?: boolean) => unknown }
+      ).__fluuxScrollShadow?.(true)
+    })
+    if (!virtualized) {
+      await page.evaluate(() => {
+        localStorage.setItem('fluux:flags:enableMessageVirtualization', 'false')
+      })
+    }
+    await navigateToStressRoom(page, virtualized)
+    const list = page.locator('[data-message-list]').first()
+    await list.evaluate((element, { targetDistance, virtualized: usesVirtualizer }) => {
+      const scroller = element as HTMLElement
+      if (!usesVirtualizer) scroller.style.overflowAnchor = 'none'
+      const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
+      scroller.scrollTop = targetDistance === undefined
+        ? Math.max(800, Math.min(maxScrollTop - 800, maxScrollTop * 0.55))
+        : Math.max(0, maxScrollTop - targetDistance)
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+    }, { targetDistance: targetDistanceFromBottom, virtualized })
+    const box = await list.boundingBox()
+    if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.waitForTimeout(SETTLE_MS)
+  }
+
+  /** Rendered rows (scroller-relative) plus the resident array, read together. */
+  const readView = (page: Page) => page.evaluate((jid) => {
+    const s = document.querySelector('[data-message-list]') as HTMLElement | null
+    if (!s) return null
+    const sr = s.getBoundingClientRect()
+    const rows = (Array.from(s.querySelectorAll('.message-row[data-message-id]')) as HTMLElement[])
+      .map((el) => {
+        const r = el.getBoundingClientRect()
+        return { id: el.dataset.messageId!, top: r.top - sr.top, bottom: r.bottom - sr.top }
+      })
+      .sort((a, b) => a.top - b.top)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const msgs: any[] = (window as any).__roomStore.getState().rooms.get(jid)?.messages ?? []
+    return {
+      scrollTop: Math.round(s.scrollTop),
+      distFromBottom: Math.round(s.scrollHeight - s.scrollTop - s.clientHeight),
+      visible: rows.filter((r) => r.top >= 5 && r.bottom <= sr.height - 5),
+      ids: msgs.map((m) => m.id as string),
+      stamps: msgs.map((m) => new Date(m.timestamp).getTime()),
+    }
+  }, STRESS_ROOM_JID)
+
+  /**
+   * Inject `bodies` as delayed arrivals through the REAL live path (roomStore.addMessage →
+   * appendLive — the same action the `room:message` binding calls), timestamped to sort in ABOVE
+   * the viewport, and report how far the tracked reading row moved.
+   */
+  async function insertAboveViewport(
+    page: Page,
+    bodies: string[],
+    options: {
+      coalescedTail?: boolean
+      maxDistanceFromBottom?: number
+      minDistanceFromBottom?: number
+      userTakeover?: boolean
+    } = {},
+  ) {
+    const before = await readView(page)
+    expect(before, 'the message list must be readable').not.toBeNull()
+    expect(
+      before!.distFromBottom,
+      'precondition: the reader must be clear of the bottom',
+    ).toBeGreaterThanOrEqual(options.minDistanceFromBottom ?? CLEAR_OF_BOTTOM_PX)
+    if (options.maxDistanceFromBottom !== undefined) {
+      expect(
+        before!.distFromBottom,
+        'precondition: the reader must remain below the requested distance',
+      ).toBeLessThan(options.maxDistanceFromBottom)
+    }
+    expect(
+      before!.scrollTop,
+      'precondition: there must be content ABOVE the viewport to insert into',
+    ).toBeGreaterThan(600)
+    expect(
+      before!.visible.length,
+      'precondition: several fully-visible rows to track',
+    ).toBeGreaterThan(3)
+
+    // Track a row in the LOWER half of the viewport; insert 10 messages ABOVE the top-visible row
+    // so the insertion is genuinely off-screen above rather than at the live edge.
+    const track = before!.visible[before!.visible.length - 2]
+    const topIdx = before!.ids.indexOf(before!.visible[0].id)
+    expect(topIdx, 'precondition: the top-visible row is in the resident array').toBeGreaterThan(12)
+    const insertTs = before!.stamps[topIdx - 10]
+    let scrollTopBeforeTakeover: number | null = null
+
+    if (options.coalescedTail) {
+      expect(bodies).toHaveLength(1)
+      await page.evaluate(([jid, ts, body, tailTs]) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const store = (window as any).__roomStore.getState()
+        store.addMessage(jid as string, {
+          type: 'groupchat',
+          id: 'delayed-arrival-0',
+          stanzaId: 'sid-delayed-arrival-0',
+          from: `${jid}/DelayedSender`,
+          nick: 'DelayedSender',
+          body: body as string,
+          timestamp: new Date(ts as number),
+          isOutgoing: false,
+          isDelayed: true,
+          roomJid: jid as string,
+        })
+        store.addMessage(jid as string, {
+          type: 'groupchat',
+          id: 'coalesced-tail-arrival',
+          stanzaId: 'sid-coalesced-tail-arrival',
+          from: `${jid}/TailSender`,
+          nick: 'TailSender',
+          body: 'live tail arrival in the same commit',
+          timestamp: new Date(tailTs as number),
+          isOutgoing: false,
+          roomJid: jid as string,
+        })
+      }, [
+        STRESS_ROOM_JID,
+        insertTs,
+        bodies[0],
+        before!.stamps[before!.stamps.length - 1] + 1_000,
+      ] as const)
+    } else {
+      for (let i = 0; i < bodies.length; i++) {
+        await page.evaluate(([jid, ts, idx, body]) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(window as any).__roomStore.getState().addMessage(jid as string, {
+            type: 'groupchat',
+            id: `delayed-arrival-${idx}`,
+            stanzaId: `sid-delayed-arrival-${idx}`,
+            from: `${jid}/DelayedSender`,
+            nick: 'DelayedSender',
+            body: body as string,
+            timestamp: new Date(ts as number),
+            isOutgoing: false,
+            isDelayed: true,
+            roomJid: jid as string,
+          })
+        }, [STRESS_ROOM_JID, insertTs, i, bodies[i]] as const)
+        if (i === 0 && options.userTakeover) {
+          await page.waitForFunction(
+            (baseline) => {
+              const scroller = document.querySelector('[data-message-list]') as HTMLElement | null
+              return scroller !== null && scroller.scrollTop > baseline + 200
+            },
+            before!.scrollTop,
+          )
+          scrollTopBeforeTakeover = await page.locator('[data-message-list]').first().evaluate(
+            (element) => (element as HTMLElement).scrollTop,
+          )
+          await page.mouse.wheel(0, 600)
+        }
+        await page.waitForTimeout(80)
+      }
+    }
+    await page.waitForTimeout(1200) // let any re-anchor / measurement settle
+
+    const after = await readView(page)
+    const trackedTop = await page.evaluate((id) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const el = s?.querySelector(
+        `.message-row[data-message-id="${CSS.escape(id)}"]`,
+      ) as HTMLElement | null
+      if (!s || !el) return null
+      return el.getBoundingClientRect().top - s.getBoundingClientRect().top
+    }, track.id)
+
+    const insertedIndexes = bodies.map((_, i) => after!.ids.indexOf(`delayed-arrival-${i}`))
+    return {
+      trackedId: track.id,
+      beforeTop: Math.round(track.top),
+      afterTop: trackedTop === null ? null : Math.round(trackedTop),
+      // A tracked row that unmounted entirely is a gross mis-position, not a small drift — report
+      // it as such rather than silently passing on a missing element.
+      drift: trackedTop === null ? Number.POSITIVE_INFINITY : Math.abs(trackedTop - track.top),
+      allInsertedAboveViewport: insertedIndexes.every((k) => k >= 0 && k < topIdx),
+      residentCountBefore: before!.ids.length,
+      residentCountAfter: after!.ids.length,
+      scrollTopBefore: before!.scrollTop,
+      scrollTopAfter: after!.scrollTop,
+      scrollTopBeforeTakeover,
+      tailAtResidentEnd:
+        after!.ids.indexOf('coalesced-tail-arrival') === after!.ids.length - 1,
+    }
+  }
+
+  // Tolerance: a re-anchor settles against measured row heights, so a sub-row residual is expected.
+  // Well under the smallest real regression this catches (a single inserted row is ~50px+, and the
+  // uncompensated tall/burst cases are 250-425px).
+  const INSERTION_DRIFT_PX = 40
+
+  test('invariant-14: a single delayed arrival inserted above the viewport holds the reading position', async ({ page }) => {
+    const probes: string[] = []
+    page.on('console', (m) => { const t=m.text(); if (t.includes('[AnchorProbe]')||t.includes('[RestoreProbe]')) probes.push(t) })
+    await openScrolledUp(page)
+    const r = await insertAboveViewport(page, ['delayed arrival (offline replay)'])
+    console.log('── INSERTION-DRIFT single ──', JSON.stringify(r))
+    console.log('── ANCHOR PROBES ──\n' + probes.join('\n'))
+    expect(r.allInsertedAboveViewport, 'the arrival must land ABOVE the viewport, not at the live edge').toBe(true)
+    expect(
+      r.residentCountAfter,
+      `the insertion must not have provoked a pagination load — ${JSON.stringify(r)}`,
+    ).toBe(r.residentCountBefore + 1)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after a message was inserted above the viewport`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14b: a TALL delayed arrival above the viewport holds the reading position', async ({ page }) => {
+    await openScrolledUp(page)
+    // Far taller than a normal row, so an uncompensated insertion drifts by hundreds of px — this
+    // is what proves the hold is a real re-anchor and not a fixed small correction.
+    const r = await insertAboveViewport(page, ['delayed arrival line\n'.repeat(18)])
+    console.log('── INSERTION-DRIFT tall ──', JSON.stringify(r))
+    expect(r.allInsertedAboveViewport, 'the arrival must land ABOVE the viewport').toBe(true)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after a TALL message was inserted above the viewport`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14c: a BURST of delayed arrivals above the viewport holds the reading position', async ({ page }) => {
+    await openScrolledUp(page)
+    // The offline-replay shape: a reconnect flushes a backlog, so the arrivals land as a run rather
+    // than singly, and each one re-triggers the compensation.
+    const r = await insertAboveViewport(page, Array.from({ length: 10 }, (_, i) => `replayed backlog message ${i}`))
+    console.log('── INSERTION-DRIFT burst ──', JSON.stringify(r))
+    expect(r.allInsertedAboveViewport, 'every arrival must land ABOVE the viewport').toBe(true)
+    expect(
+      r.residentCountAfter,
+      `the burst must not have provoked a pagination load — ${JSON.stringify(r)}`,
+    ).toBe(r.residentCountBefore + 10)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after a 10-message burst was inserted above the viewport`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14d: a delayed arrival at the resident bound holds the reading position', async ({ page }) => {
+    await openScrolledUp(page, FULL_WINDOW_INSERTION_URL)
+    const r = await insertAboveViewport(page, ['full-window delayed arrival\n'.repeat(18)])
+    console.log('── INSERTION-DRIFT full-window ──', JSON.stringify(r))
+    expect(r.allInsertedAboveViewport, 'the arrival must land ABOVE the viewport').toBe(true)
+    expect(
+      r.residentCountAfter,
+      `the resident window must stay at its configured bound — ${JSON.stringify(r)}`,
+    ).toBe(r.residentCountBefore)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after a full-window insertion`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14e: user input takes over insertion preservation', async ({ page }) => {
+    await openScrolledUp(page)
+    const r = await insertAboveViewport(
+      page,
+      ['delayed arrival before user takeover\n'.repeat(18)],
+      { userTakeover: true },
+    )
+    console.log('── INSERTION-DRIFT user-takeover ──', JSON.stringify(r))
+    expect(r.scrollTopBeforeTakeover, 'the insertion must settle before wheel takeover').not.toBeNull()
+    expect(
+      r.scrollTopAfter - r.scrollTopBeforeTakeover!,
+      `the insertion restore overrode the reader's wheel movement — ${JSON.stringify(r)}`,
+    ).toBeGreaterThan(500)
+  })
+
+  // A load-older that delivers NOTHING leaves no trace of itself: windowAtLiveEdge stays true and
+  // firstMessageId never moves, so the directional-history restore neither fires nor releases its
+  // snapshot. Left pending, the next UNRELATED firstMessageId change is misread as that load
+  // completing — and at the resident bound an interior delayed arrival evicts the oldest row, which
+  // is exactly such a change. The stale top anchor is then restored and insertion preservation is
+  // skipped, so the reader is thrown back to where the abandoned load-older would have put them.
+  //
+  // KNOWN-FAILING, deliberately. This staleness is PRE-EXISTING on main — this test is RED on plain
+  // 179b78b3, before any of this branch's work — and correcting it needs directional-snapshot
+  // re-arm semantics that would change pagination behaviour. That is out of scope here and tracked
+  // as fluux-directional-snapshot-lifecycle, with this test as its starting RED case. Marked
+  // test.fail so the suite stays honest AND tells us the moment the follow-up makes it pass.
+  test.fail('invariant-14g: an abandoned load-older does not defeat a later insertion at the resident bound', async ({ page }) => {
+    await openScrolledUp(page, FULL_WINDOW_INSERTION_URL)
+
+    // Neutralise both older-history sources so the load below genuinely returns nothing while still
+    // being STARTED (the snapshot is taken when the load begins, not when it resolves).
+    const stubbed = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const store = (window as any).__roomStore
+      if (!store) return false
+      store.setState({ loadOlderMessagesFromCache: async () => 0 })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const demo = (window as any).__demoClient
+      if (demo?.chat) demo.chat.queryRoomMAM = async () => {}
+      return true
+    })
+    expect(stubbed, 'the older-history loaders must be stubbable for this scenario').toBe(true)
+
+    const firstIdBefore = (await readView(page))!.ids[0]
+
+    // Start a load-older that will deliver nothing, and let it settle.
+    await scrollToTopAndLoad(page)
+    await page.waitForTimeout(SETTLE_MS)
+
+    const afterAbandoned = await readView(page)
+    expect(
+      afterAbandoned!.ids[0],
+      'precondition: the abandoned load must not have delivered any older rows',
+    ).toBe(firstIdBefore)
+
+    // Return to mid-history so the reader is scrolled up but clear of the top boundary.
+    await page.locator('[data-message-list]').first().evaluate((element) => {
+      const scroller = element as HTMLElement
+      const maxScrollTop = scroller.scrollHeight - scroller.clientHeight
+      scroller.scrollTop = Math.max(800, Math.min(maxScrollTop - 800, maxScrollTop * 0.55))
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }))
+    })
+    await page.waitForTimeout(SETTLE_MS)
+
+    const r = await insertAboveViewport(page, ['delayed arrival after an abandoned load-older\n'.repeat(18)])
+    console.log('── INSERTION-DRIFT abandoned-load-older ──', JSON.stringify(r))
+    expect(r.allInsertedAboveViewport, 'the arrival must land ABOVE the viewport').toBe(true)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after an abandoned load-older preceded the insertion`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14f: a scroller resize refreshes the insertion anchor', async ({ page }) => {
+    await openScrolledUp(page)
+    const resized = await page.locator('[data-message-list]').first().evaluate((element) => {
+      const scroller = element as HTMLElement
+      const before = scroller.clientHeight
+      scroller.style.flex = 'none'
+      scroller.style.height = `${before - 96}px`
+      return { before, after: scroller.clientHeight }
+    })
+    expect(resized.after, 'the scroller must shrink before insertion').toBeLessThan(resized.before)
+    await page.waitForTimeout(100)
+
+    const r = await insertAboveViewport(page, ['delayed arrival after scroller resize\n'.repeat(18)])
+    console.log('── INSERTION-DRIFT scroller-resize ──', JSON.stringify(r))
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after a scroller resize and insertion`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14h: insertion preservation starts at the semantic live-edge threshold', async ({ page }) => {
+    await openScrolledUp(page, INSERTION_URL, 225)
+    const r = await insertAboveViewport(
+      page,
+      ['delayed arrival inside the FAB threshold gap\n'.repeat(18)],
+      {
+        minDistanceFromBottom: AT_BOTTOM_OK_PX,
+        maxDistanceFromBottom: FAB_THRESHOLD_PX,
+      },
+    )
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px inside the live-edge/FAB threshold gap`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14i: a capped coalesced interior and tail arrival holds the reading position', async ({ page }) => {
+    await openScrolledUp(page, FULL_WINDOW_INSERTION_URL)
+    const r = await insertAboveViewport(
+      page,
+      ['coalesced delayed interior arrival\n'.repeat(18)],
+      { coalescedTail: true },
+    )
+    expect(r.allInsertedAboveViewport, 'the delayed arrival must land above the viewport').toBe(true)
+    expect(r.tailAtResidentEnd, 'the coalesced live arrival must land at the resident tail').toBe(true)
+    expect(r.residentCountAfter, 'the resident window must remain at its bound').toBe(
+      r.residentCountBefore,
+    )
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px after a capped coalesced interior and tail arrival`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  test('invariant-14j: a legacy coalesced interior and tail arrival holds the reading position', async ({ page }) => {
+    await openScrolledUp(page, INSERTION_URL, undefined, false)
+    const r = await insertAboveViewport(
+      page,
+      ['legacy delayed interior arrival\n'.repeat(18)],
+      { coalescedTail: true },
+    )
+    expect(r.allInsertedAboveViewport, 'the delayed arrival must land above the viewport').toBe(true)
+    expect(r.tailAtResidentEnd, 'the coalesced live arrival must land at the resident tail').toBe(true)
+    expect(
+      r.drift,
+      `legacy reading position drifted ${r.drift}px after a coalesced interior and tail arrival`,
+    ).toBeLessThan(INSERTION_DRIFT_PX)
   })
 })


### PR DESCRIPTION
A delayed arrival — offline replay, gateway/MUC history, the MAM `{ids}` fetch — reaches the live
path carrying an old timestamp, so `appendLive` sorts it into the **middle** of the resident array.
Landing above a reader who has scrolled up, it pushed their reading position down by the inserted
height: the conversation drifted backwards in time with nothing on screen to explain it.

Nothing covered this. The media-growth compensation is reachable only from `onMediaLoad` and an
insertion fires no media event; the new-message effect deliberately does nothing for an incoming
message while scrolled up; and browser-native CSS scroll anchoring — which does handle it in normal
flow — is inert under virtualization, because the virtualizer rewrites every row's inline `top` on
each commit, and WebKit does not implement it at all.

## Where it lives

Insertion is the same shape of ambient layout mutation as divider movement, so it becomes a second
**layout-preservation reason** on the generation-aware controller that already owns divider
preservation.

That placement is load-bearing, not cosmetic: the model rejects layout preservation while an entry
restore, explicit target, or Home/End command is in flight, so holding a reading position can never
supersede a navigation the reader actually asked for. This also **structurally answers the deferred
request-precedence question for the insertion case without adding any precedence rules** — the
broader arbitration work stays tracked separately as `fluux-positioning-request-precedence`, and the
two converge at that same boundary.

## Detection uses a signal, not inference

`appendLive` already knows when it placed a message interior rather than at the live edge. The
stores now expose that as a per-conversation `interiorPlacementVersions` counter — additive, named
for timeline placement rather than for scroll, no existing consumer changed.

Endpoint-id and index inference could not see two reachable cases, which is why the signal exists:
virtualization opted out, and a single commit carrying **both** an interior insertion and a tail
arrival at the resident bound, where the trim cancels the index shift.

## Also corrected

The virtualized anchor frame derived its target from the `[data-index]` wrapper while the anchor was
captured against the `.message-row`. Capture and restore were therefore not inverses, so each
preservation left a small residual that compounded across a burst. It now measures the row when
mounted; the write still goes through the virtualizer, never a raw `scrollTop`.

## Known gap, deliberately not fixed here

**Insertion preservation does not fire while a stale directional snapshot is pending.** A load-older
that delivers nothing never releases its snapshot, so a later unrelated first-id change is misread
as that load completing.

**This staleness is pre-existing on `main`, not introduced here** — `invariant-14g` is RED on plain
`179b78b3`, before any of this branch's work. Correcting it needs directional-snapshot re-arm
semantics that would change pagination behaviour, so it is split out as
`fluux-directional-snapshot-lifecycle`. `invariant-14g` ships marked `test.fail`, which keeps the
suite honest and will report the moment the follow-up makes it pass.