### PR TITLE
feat: add the first three anomaly detectors

### DIFF
--- a/apps/fluux/scripts/anomalyBuildAudit.test.ts
+++ b/apps/fluux/scripts/anomalyBuildAudit.test.ts
@@ -25,11 +25,37 @@ describe('auditBundle', () => {
     expect(() => auditBundle(withAnomaly, false)).toThrow(/anomaly/i)
   })
 
+  it('fails a production bundle containing anomaly-only support', () => {
+    const withSupport = {
+      'assets/index-abc.js': {
+        type: 'chunk',
+        modules: {
+          '/repo/apps/fluux/src/utils/viewportScroller.ts': {},
+          '/repo/apps/fluux/src/ChatView.tsx': {},
+        },
+      },
+    }
+    expect(() => auditBundle(withSupport, false)).toThrow(/viewportScroller\.ts/)
+  })
+
   it('fails a Dev bundle that is MISSING the anomaly modules', () => {
     // The direction that would silently regress to "eliminated everywhere,
     // including where it was supposed to run" — which is what import.meta.env.DEV
     // did before #1167. Asserting only absence would pass vacuously here.
     expect(() => auditBundle(withoutAnomaly, true)).toThrow(/expected/i)
+  })
+
+  it('fails a Dev bundle containing only anomaly support', () => {
+    const withSupportOnly = {
+      'assets/index-abc.js': {
+        type: 'chunk',
+        modules: {
+          '/repo/apps/fluux/src/utils/viewportScroller.ts': {},
+          '/repo/apps/fluux/src/ChatView.tsx': {},
+        },
+      },
+    }
+    expect(() => auditBundle(withSupportOnly, true)).toThrow(/expected/i)
   })
 
   it('passes a Dev bundle containing the anomaly modules', () => {

--- a/apps/fluux/scripts/anomalyBuildAudit.ts
+++ b/apps/fluux/scripts/anomalyBuildAudit.ts
@@ -1,5 +1,6 @@
 /**
- * Build-time assertion that the anomaly tree is present exactly where it should be.
+ * Build-time assertion that anomaly instrumentation is present exactly where it
+ * should be, including support modules outside `src/anomaly/`.
  *
  * Inspects each emitted chunk's `modules` collection rather than chunk filenames: a
  * module inlined into an existing chunk has no distinguishing filename, so a
@@ -17,6 +18,7 @@ import type { Plugin } from 'vite'
 
 /** `src/anomaly/` on either path separator, and not `src/anomalyReports/`. */
 const ANOMALY_PATH = /[\\/]src[\\/]anomaly[\\/]/
+const ANOMALY_SUPPORT_PATH = /[\\/]src[\\/]utils[\\/]viewportScroller\.ts$/
 
 interface ChunkLike {
   type?: string
@@ -26,27 +28,31 @@ interface ChunkLike {
 /**
  * @internal Exported for testing.
  * @param bundle - Rollup/Rolldown's emitted bundle, keyed by file name.
- * @param expectPresent - whether this build is supposed to contain the tree.
+ * @param expectPresent - whether this build is supposed to contain the runtime.
  */
 export function auditBundle(bundle: Record<string, ChunkLike>, expectPresent: boolean): void {
-  const found: string[] = []
+  const runtimeModules: string[] = []
+  const supportModules: string[] = []
   for (const chunk of Object.values(bundle)) {
     if (chunk.type !== 'chunk') continue
     for (const moduleId of Object.keys(chunk.modules ?? {})) {
-      if (ANOMALY_PATH.test(moduleId)) found.push(moduleId)
+      if (ANOMALY_PATH.test(moduleId)) runtimeModules.push(moduleId)
+      else if (ANOMALY_SUPPORT_PATH.test(moduleId)) supportModules.push(moduleId)
     }
   }
 
-  if (!expectPresent && found.length > 0) {
+  const instrumentationModules = [...runtimeModules, ...supportModules]
+
+  if (!expectPresent && instrumentationModules.length > 0) {
     throw new Error(
-      `[anomaly-build-audit] ${found.length} anomaly module(s) survived into a ` +
-        `production bundle — dead-code elimination regressed:\n  ${found.join('\n  ')}\n` +
+      `[anomaly-build-audit] ${instrumentationModules.length} anomaly module(s) survived into a ` +
+        `production bundle — dead-code elimination regressed:\n  ${instrumentationModules.join('\n  ')}\n` +
         'Check that every call site is guarded by `if (__FLUUX_ANOMALY__)` and that no ' +
         'module imports src/anomaly/ unconditionally.',
     )
   }
 
-  if (expectPresent && found.length === 0) {
+  if (expectPresent && runtimeModules.length === 0) {
     throw new Error(
       '[anomaly-build-audit] expected the anomaly modules in this build, but none were ' +
         'emitted. The gate is off where it should be on — check that FLUUX_ANOMALY=1 ' +

--- a/apps/fluux/src/anomaly/detectors/fabAtLiveEdge.test.ts
+++ b/apps/fluux/src/anomaly/detectors/fabAtLiveEdge.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { createFabAtLiveEdgeDetector, type FabSample } from './fabAtLiveEdge'
+
+/** The failing condition: FAB up while the viewport is already at the bottom. */
+function bad(overrides: Partial<FabSample> = {}): FabSample {
+  return { fabShown: true, distFromBottom: 10, windowAtLiveEdge: true, ...overrides }
+}
+
+describe('fabAtLiveEdge — fires', () => {
+  it('reports once the disagreement has held for the full window', () => {
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    expect(d.observe(bad(), 0)).toBeNull()
+    expect(d.observe(bad(), 999)).toBeNull()
+    const v = d.observe(bad(), 1000)
+
+    expect(v).not.toBeNull()
+    expect(v!.distFromBottom).toBe(10)
+    expect(v!.heldMs).toBe(1000)
+  })
+
+  it('fires at the boundary of the at-bottom threshold', () => {
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000, atBottomPx: 150 })
+    d.observe(bad({ distFromBottom: 150 }), 0)
+    expect(d.observe(bad({ distFromBottom: 150 }), 1000)).not.toBeNull()
+  })
+
+  it('reports once per episode', () => {
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    d.observe(bad(), 0)
+    const verdicts = [1000, 2000, 3000].map((t) => d.observe(bad(), t))
+    expect(verdicts.filter(Boolean)).toHaveLength(1)
+  })
+})
+
+describe('fabAtLiveEdge — stays silent', () => {
+  it('when the FAB is hidden', () => {
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    d.observe(bad({ fabShown: false }), 0)
+    expect(d.observe(bad({ fabShown: false }), 5000)).toBeNull()
+  })
+
+  it('when the viewport is genuinely scrolled up', () => {
+    // The normal reason the FAB exists. 400px is past both thresholds.
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000, atBottomPx: 150 })
+    d.observe(bad({ distFromBottom: 400 }), 0)
+    expect(d.observe(bad({ distFromBottom: 400 }), 5000)).toBeNull()
+  })
+
+  it('while the loaded window has slid up, where the FAB means "jump to latest"', () => {
+    // The case that fired on every healthy demo session before `windowAtLiveEdge`
+    // was part of the sample. `fabVisible` is `showScrollToBottom || windowSlidUp`,
+    // so a slid-up window legitimately shows the button with the viewport at the
+    // bottom of what is loaded.
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    d.observe(bad({ windowAtLiveEdge: false }), 0)
+    expect(d.observe(bad({ windowAtLiveEdge: false }), 5000)).toBeNull()
+  })
+
+  it('when no viewport could be measured', () => {
+    // An unmounted list or an untracked view. Guessing would invent a verdict from
+    // an absence of evidence.
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    d.observe(bad({ distFromBottom: null }), 0)
+    expect(d.observe(bad({ distFromBottom: null }), 5000)).toBeNull()
+  })
+
+  it('during a settle shorter than the hold window', () => {
+    // THE false-positive case this detector must survive: React state lands a
+    // commit behind the DOM, so the two disagree for a few frames on every scroll
+    // back to the bottom.
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 200)
+    expect(d.observe(bad({ fabShown: false }), 400)).toBeNull()
+    expect(d.observe(bad(), 1200)).toBeNull() // clock restarted, not resumed
+  })
+
+  it('when the user scrolls away and back inside one window', () => {
+    const d = createFabAtLiveEdgeDetector({ holdMs: 1000 })
+    d.observe(bad(), 0)
+    d.observe(bad({ distFromBottom: 900 }), 500)
+    d.observe(bad(), 900)
+    expect(d.observe(bad(), 1500)).toBeNull() // only 600ms of held condition
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/fabAtLiveEdge.ts
+++ b/apps/fluux/src/anomaly/detectors/fabAtLiveEdge.ts
@@ -1,0 +1,131 @@
+/**
+ * `scroll/fab-at-live-edge` — the scroll-to-bottom affordance offering to do
+ * something already done.
+ *
+ * NOT a check on `shouldShowScrollToBottomFab`. That function cannot produce this
+ * state: it shows the FAB above `FAB_THRESHOLD` (300px) while "at the bottom" means
+ * under `AT_BOTTOM_THRESHOLD` (150px), so the two are separated by a dead band and a
+ * detector comparing them would be unfalsifiable.
+ *
+ * The bug is STALENESS. `showScrollToBottom` is React state written from the scroll
+ * handler; if the handler stops firing after the list returns to the bottom, the FAB
+ * stays up over a viewport that is already at the live edge.
+ *
+ * Catching that requires a measurement the scroll hook had no part in — hence
+ * `utils/viewportScroller.ts` rather than the hook's own `isAtBottomRef`. A detector
+ * reading the suspect value cannot disagree with it, and would fall silent exactly
+ * when the bug is present.
+ *
+ * PURE: the measurement is passed in.
+ *
+ * @module Anomaly/Detectors/FabAtLiveEdge
+ */
+
+export interface FabSample {
+  /** Is the FAB actually offered to the user — rendered AND not inert. */
+  fabShown: boolean
+  /**
+   * Independently measured distance to the content bottom, or `null` when no
+   * viewport could be measured — an unmounted list, or a view we do not track.
+   */
+  distFromBottom: number | null
+  /**
+   * Is the LOADED WINDOW at the tail of the archive.
+   *
+   * Required, because the FAB means two things. `fabVisible` is
+   * `showScrollToBottom || windowSlidUp` (`MessageList.tsx:735`): when the window has
+   * slid up, the button offers "jump to the latest", which is a real and useful
+   * affordance even though the viewport sits at the bottom of what is loaded.
+   *
+   * Omitting this fired on every healthy demo session — the control test caught it.
+   * Only when the window IS at the live edge does a shown FAB mean nothing is left to
+   * scroll to.
+   */
+  windowAtLiveEdge: boolean
+}
+
+/*
+ * On the pin-to-bottom loop, deliberately absent.
+ *
+ * An earlier draft took a `pinningToBottom` flag, mirroring the suppression inside
+ * `shouldShowScrollToBottomFab`. It is not publicly observable — the claim lives in a
+ * hook-internal ref — and hardcoding `false` at the only real call site would ship a
+ * tested branch that nothing exercises, which is hollow by a different route.
+ *
+ * Two guards cover it instead. The hook clears the FAB EAGERLY when a pin loop lands
+ * at the bottom (`useMessageListScroll.ts:693`), and the hold window below outlasts
+ * the few frames a loop spends approaching from beyond the FAB threshold to inside the
+ * at-bottom one. And on reflection the suppression was never quite right: a FAB still
+ * shown a full second after the viewport reached the bottom IS the staleness this
+ * detector is for, whether or not a loop is running.
+ *
+ * If real logs show false positives here, exposing the pin claim is the first move.
+ */
+
+export interface FabVerdict {
+  distFromBottom: number
+  heldMs: number
+}
+
+export interface FabAtLiveEdgeDetector {
+  observe(sample: FabSample, now: number): FabVerdict | null
+}
+
+/**
+ * How close counts as the live edge. Matches `AT_BOTTOM_THRESHOLD` rather than
+ * `FAB_THRESHOLD`: the claim is "the user is already at the newest message", which is
+ * the same question the rest of the app answers with this number.
+ */
+const AT_BOTTOM_PX = 150
+/**
+ * How long the disagreement must persist.
+ *
+ * During a normal settle the rendered FAB and a fresh measurement legitimately
+ * disagree for a few frames — React state lands a commit behind the DOM. Reporting
+ * that would make the detector fire on healthy scrolling, and by the design's own
+ * rule a detector that cries wolf gets deleted rather than tuned.
+ */
+const DEFAULT_HOLD_MS = 1000
+
+export interface FabAtLiveEdgeOptions {
+  atBottomPx?: number
+  holdMs?: number
+}
+
+export function createFabAtLiveEdgeDetector(
+  opts: FabAtLiveEdgeOptions = {},
+): FabAtLiveEdgeDetector {
+  const atBottomPx = opts.atBottomPx ?? AT_BOTTOM_PX
+  const holdMs = opts.holdMs ?? DEFAULT_HOLD_MS
+
+  let since: number | null = null
+  let reported = false
+
+  return {
+    observe(sample: FabSample, now: number): FabVerdict | null {
+      const holds =
+        sample.fabShown &&
+        sample.windowAtLiveEdge &&
+        sample.distFromBottom !== null &&
+        sample.distFromBottom <= atBottomPx
+
+      if (!holds || sample.distFromBottom === null) {
+        since = null
+        reported = false
+        return null
+      }
+
+      if (since === null) {
+        since = now
+        return null
+      }
+
+      const heldMs = now - since
+      if (heldMs < holdMs) return null
+      if (reported) return null
+
+      reported = true
+      return { distFromBottom: sample.distFromBottom, heldMs }
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest'
-import { FANOUT_IDS, knownLoopLabels, recordForSignal } from './sentinelFanout'
+import { FANOUT_IDS, knownLoopLabels, recordForSignal } from './signalRecords'
 import { createRecorder } from '../recorder'
 import { createMemorySink } from '../sinks/memory'
 import { serialize } from '../serializer'
 import { initTokenizer, resetValuesForTesting, tokenKeyId } from '../values'
+import { warmConversation, warmRoom } from '../identity'
 import type { AnomalySignal } from '../../utils/anomalySignal'
 
 /** The prose the monitors emit is not tested here — see each monitor's own suite. */
@@ -173,6 +174,15 @@ describe('every fan-out record survives the privacy gate', () => {
     { name: 'scroll/resize-loop', fires: 340, threshold: 60, elapsedMs: 980 },
     { name: 'scroll/slow-correction', durationMs: 210, thresholdMs: 32, rows: 1840 },
     { name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 },
+    {
+      name: 'read-state/unread-survives-focus',
+      kind: 'conversation',
+      id: 'bob@x.tld',
+      unreadCount: 3,
+      heldMs: 2000,
+    },
+    { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
+    { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'msg-1' },
   ]
 
   it('serializes each one rather than being rejected for provenance', () => {
@@ -254,6 +264,132 @@ describe('every fan-out record survives the privacy gate', () => {
   })
 })
 
+describe('stage-3 detector mappings', () => {
+  beforeEach(async () => {
+    resetValuesForTesting()
+    await initTokenizer()
+  })
+
+  it('records the conversation in the jid namespace for a 1:1', () => {
+    const record = recordForSignal({
+      name: 'read-state/unread-survives-focus',
+      kind: 'conversation',
+      id: 'bob@x.tld/laptop',
+      unreadCount: 3,
+      heldMs: 2000,
+    })
+
+    expect(record?.id.s).toBe('read-state/unread-survives-focus')
+    expect(record?.sev).toBe('suspect')
+    expect(record?.expected).toBe(0)
+    expect(record?.observed).toBe(3)
+    expect(record?.ctx?.map(([k]) => k.s)).toEqual(['conv', 'heldMs'])
+  })
+
+  it('resolves to the unresolved sentinel when the token was never warmed', () => {
+    // `tokenSync` cannot hash on the spot — HMAC is async — so an unwarmed
+    // conversation yields the sentinel. That is safe but USELESS: every record
+    // would be uncorrelatable. The driver must warm on the conversation it starts
+    // watching; this test is the reason that requirement exists.
+    const record = recordForSignal({
+      name: 'read-state/unread-survives-focus',
+      kind: 'conversation',
+      id: 'never-warmed@x.tld',
+      unreadCount: 1,
+      heldMs: 2000,
+    })
+    expect((record!.ctx![0][1] as { s: string }).s).toBe('c:unresolved')
+  })
+
+  it('records a room in the room namespace, not the jid one', async () => {
+    // The same bare JID can name a contact on one server and a MUC on another.
+    // Sharing one token space would assert an identity that does not exist.
+    await warmConversation('same@x.tld')
+    await warmRoom('same@x.tld')
+
+    const conv = recordForSignal({
+      name: 'read-state/unread-survives-focus',
+      kind: 'conversation',
+      id: 'same@x.tld',
+      unreadCount: 1,
+      heldMs: 2000,
+    })
+    const room = recordForSignal({
+      name: 'read-state/unread-survives-focus',
+      kind: 'room',
+      id: 'same@x.tld',
+      unreadCount: 1,
+      heldMs: 2000,
+    })
+
+    expect(room?.ctx?.map(([k]) => k.s)).toEqual(['room', 'heldMs'])
+    const convTok = (conv!.ctx![0][1] as { s: string }).s
+    const roomTok = (room!.ctx![0][1] as { s: string }).s
+    expect(convTok).not.toBe('c:unresolved')
+    expect(roomTok).not.toBe('c:unresolved')
+    expect(convTok).not.toBe(roomTok)
+  })
+
+  it('never lets a JID reach the record', () => {
+    const JID = 'verysecretuser@private.example'
+    const record = recordForSignal({
+      name: 'read-state/unread-survives-focus',
+      kind: 'conversation',
+      id: JID,
+      unreadCount: 3,
+      heldMs: 2000,
+    })
+    const line = JSON.stringify(record?.ctx)
+    for (let i = 0; i + 6 <= JID.length; i++) {
+      expect(line, `leaked a substring of the JID at ${i}`).not.toContain(JID.slice(i, i + 6))
+    }
+  })
+
+  it('maps a FAB-at-live-edge to the measured distance', () => {
+    const record = recordForSignal({
+      name: 'scroll/fab-at-live-edge',
+      distFromBottom: 10,
+      heldMs: 1000,
+    })
+
+    expect(record?.sev).toBe('bug')
+    expect(record?.expected).toBe(0)
+    expect(record?.observed).toBe(10)
+    expect(record?.ctx?.map(([k, v]) => [k.s, v])).toEqual([['heldMs', 1000]])
+  })
+
+  it('maps a jump-target miss with a message ref and a signed distance', () => {
+    const record = recordForSignal({
+      name: 'scroll/jump-target-miss',
+      offBy: -80,
+      messageId: 'stanza-abc',
+    })
+
+    expect(record?.sev).toBe('bug')
+    expect(record?.expected).toBe(true)
+    expect(record?.observed).toBe(false)
+    expect(record?.ctx?.map(([k]) => k.s)).toEqual(['msg', 'offBy'])
+    // A session-local ref, never the raw id.
+    expect((record!.ctx![0][1] as { s: string }).s).toMatch(/^s:m\d+$/)
+    expect(JSON.stringify(record?.ctx)).not.toContain('stanza-abc')
+  })
+
+  it('keeps the offBy sign, so a review can tell overshoot from undershoot', () => {
+    const above = recordForSignal({
+      name: 'scroll/jump-target-miss',
+      offBy: -80,
+      messageId: 'a',
+    })
+    const below = recordForSignal({
+      name: 'scroll/jump-target-miss',
+      offBy: 200,
+      messageId: 'b',
+    })
+    expect(above?.ctx?.find(([k]) => k.s === 'offBy')?.[1]).toBe(-80)
+    expect(below?.ctx?.find(([k]) => k.s === 'offBy')?.[1]).toBe(200)
+  })
+})
+
 describe('FANOUT_IDS', () => {
   it('lists exactly the ids the mapping can produce', () => {
     // Guards the registry parity chain: values.test.ts asserts ID matches the
@@ -267,6 +403,15 @@ describe('FANOUT_IDS', () => {
           { name: 'scroll/resize-loop', fires: 340, threshold: 60, elapsedMs: 980 },
           { name: 'scroll/slow-correction', durationMs: 210, thresholdMs: 32, rows: 1840 },
           { name: 'perf/main-thread-stall', blockedMs: 2500, thresholdMs: 1000 },
+          {
+            name: 'read-state/unread-survives-focus',
+            kind: 'conversation',
+            id: 'bob@x.tld',
+            unreadCount: 3,
+            heldMs: 2000,
+          },
+          { name: 'scroll/fab-at-live-edge', distFromBottom: 10, heldMs: 1000 },
+          { name: 'scroll/jump-target-miss', offBy: -80, messageId: 'm' },
         ] as AnomalySignal[]
       ).map((s) => recordForSignal(s)!.id.s),
     )

--- a/apps/fluux/src/anomaly/detectors/signalRecords.ts
+++ b/apps/fluux/src/anomaly/detectors/signalRecords.ts
@@ -1,22 +1,26 @@
 /**
- * The anomaly side of the sentinel fan-out.
+ * Signal to record: the single translation point between an observation and a line
+ * in the log.
  *
- * Stage 2 adds NO detection logic. `reassertLoopMonitor`, `resizeLoopMonitor`,
- * `slowCorrectionMonitor` and `stallSentinel` already decide correctly and already
- * emit their prose; all that happens here is translating one of their observations
- * into a record. If this file ever starts deciding whether something is an anomaly,
- * the decision has escaped the monitor that owns it.
+ * NO decision logic lives here, and none ever should. Two kinds of caller feed it and
+ * both have already decided: the always-shipped monitors (`reassertLoopMonitor`,
+ * `resizeLoopMonitor`, `slowCorrectionMonitor`, `stallSentinel`), which also emit
+ * their own prose; and the dev-only detectors in this directory, each a pure function
+ * with its own tests. If this file ever starts deciding whether something is an
+ * anomaly, the decision has escaped the module that owns it.
  *
  * The translation is where the privacy boundary is crossed, and it is one-way by
- * construction: the incoming signal carries plain numbers plus, in one case, a loop
- * label — and that label is mapped through a CLOSED table to a `TAG` constant. An
- * unrecognised label yields no ctx entry rather than reaching the record, so a new
- * loop kind added without a registry entry loses a detail, never leaks one.
+ * construction. A signal carries plain numbers plus, in a few cases, a caller string:
+ * a loop label, a conversation id, a message id. None reaches the record as itself —
+ * the label goes through a CLOSED table to a `TAG`, and the ids through the HMAC
+ * tokenizer or the session-local ref map. An unmapped label yields no ctx entry
+ * rather than passing through, so a new loop kind loses a detail, never leaks one.
  *
- * @module Anomaly/Detectors/SentinelFanout
+ * @module Anomaly/Detectors/SignalRecords
  */
 import type { ReassertLoopLabel } from '../../components/conversation/reassertLoopMonitor'
 import type { AnomalySignal } from '../../utils/anomalySignal'
+import { convToken, messageRef, roomToken } from '../identity'
 import type { RecordInput } from '../recorder'
 import { CTX, ID, TAG, type Opaque } from '../values'
 
@@ -126,6 +130,56 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
         ctx: [],
       }
 
+    case 'read-state/unread-survives-focus':
+      // `suspect`, not `bug`, on its first outing: the app marks read on focus
+      // regain, so a count lingering for the hold window is more likely a
+      // propagation delay than a broken invariant. `bug` has to keep meaning "an
+      // invariant broke" or it stops meaning anything.
+      //
+      // The conversation IS recorded here, unlike slow-correction: this signal
+      // carries its kind, so the token lands in the right namespace instead of
+      // splitting one entity across two.
+      return {
+        id: ID.unreadSurvivesFocus,
+        sev: 'suspect',
+        expected: 0,
+        observed: signal.unreadCount,
+        ctx: [
+          signal.kind === 'room'
+            ? [CTX.room, roomToken(signal.id)]
+            : [CTX.conv, convToken(signal.id)],
+          [CTX.heldMs, signal.heldMs],
+        ],
+      }
+
+    case 'scroll/fab-at-live-edge':
+      // `expected: 0` reads as "no FAB while at the live edge". The observed value
+      // is the independently measured distance, which is what makes the record
+      // reviewable: a reader can see how far from the bottom the app actually was.
+      return {
+        id: ID.fabAtLiveEdge,
+        sev: 'bug',
+        expected: 0,
+        observed: signal.distFromBottom,
+        ctx: [[CTX.heldMs, signal.heldMs]],
+      }
+
+    case 'scroll/jump-target-miss': {
+      // A session-local ref, not a token: a message id is seen once, so hashing it
+      // into the cross-session space would fill the cache with singletons and
+      // resolve to the unresolved sentinel anyway.
+      const ref = messageRef(signal.messageId)
+      return {
+        id: ID.jumpTargetMiss,
+        sev: 'bug',
+        expected: true,
+        observed: false,
+        // `null` under ref pressure: omit the message rather than substitute
+        // anything for it.
+        ctx: ref ? [[CTX.msg, ref], [CTX.offBy, signal.offBy]] : [[CTX.offBy, signal.offBy]],
+      }
+    }
+
     default:
       // Unreachable while the union and this switch agree. Reached only if a
       // signal is added without a case here, in which case dropping it is the
@@ -134,13 +188,23 @@ export function recordForSignal(signal: AnomalySignal): RecordInput | null {
   }
 }
 
-/** Every invariant id this stage can produce, for the registry parity test. */
+/**
+ * Every invariant id this mapping can produce.
+ *
+ * Closes the third link of the parity chain: `values.test.ts` ties `ID` to the
+ * registry document, and `signalRecords.test.ts` ties this list to what the switch
+ * above actually returns. Without it an id could be declared and documented while
+ * being unreachable — a registry row for something that can never appear.
+ */
 export const FANOUT_IDS: readonly Opaque[] = Object.freeze([
   ID.reassertOverlap,
   ID.reassertNonConverging,
   ID.resizeLoop,
   ID.slowCorrection,
   ID.mainThreadStall,
+  ID.unreadSurvivesFocus,
+  ID.fabAtLiveEdge,
+  ID.jumpTargetMiss,
 ])
 
 /** Loop labels this build knows how to attribute. */

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { startDetectorTick, type TickWorld } from './tick'
+import {
+  clearAnomalySignalHandler,
+  setAnomalySignalHandler,
+  type AnomalySignal,
+} from '../../utils/anomalySignal'
+import {
+  _resetViewportScrollerRegistryForTesting,
+  registerViewportScroller,
+} from '../../utils/viewportScroller'
+import {
+  _resetViewportRegistryForTesting,
+  registerViewportBottomRef,
+} from '../../utils/viewportAtBottom'
+import { initTokenizer, resetValuesForTesting, tokenSync } from '../values'
+
+const ACTIVE = { kind: 'conversation' as const, id: 'bob@x.tld' }
+
+/** A world in the failing state for both timed detectors. */
+function world(overrides: Partial<TickWorld> = {}): TickWorld {
+  let clock = 0
+  return {
+    activeConversation: () => ACTIVE,
+    unreadCount: () => 3,
+    scopeKey: () => 'acct-1',
+    focused: () => true,
+    fabShown: () => true,
+    windowAtLiveEdge: () => true,
+    distFromBottom: () => 10,
+    now: () => (clock += 1000),
+    ...overrides,
+  }
+}
+
+let seen: AnomalySignal[] = []
+
+beforeEach(() => {
+  seen = []
+  setAnomalySignalHandler((s) => seen.push(s))
+  _resetViewportRegistryForTesting()
+  _resetViewportScrollerRegistryForTesting()
+  resetValuesForTesting()
+  // Both detectors need the viewport at the bottom to fire.
+  registerViewportBottomRef('conversation', ACTIVE.id, { current: true })
+})
+
+afterEach(() => {
+  clearAnomalySignalHandler()
+  vi.useRealTimers()
+})
+
+describe('detector tick', () => {
+  it('emits both timed detectors once their windows elapse', () => {
+    const tick = startDetectorTick(world())
+    for (let i = 0; i < 5; i++) tick.sample()
+    tick.stop()
+
+    expect(seen.map((s) => s.name).sort()).toEqual([
+      'read-state/unread-survives-focus',
+      'scroll/fab-at-live-edge',
+    ])
+  })
+
+  it('emits nothing from a healthy world', () => {
+    // The control. A driver that signals unconditionally would pass the test above.
+    const tick = startDetectorTick(
+      world({ unreadCount: () => 0, fabShown: () => false, distFromBottom: () => 900 }),
+    )
+    for (let i = 0; i < 10; i++) tick.sample()
+    tick.stop()
+
+    expect(seen).toEqual([])
+  })
+
+  it('reports the measured distance, not the hook at-bottom boolean', () => {
+    // The reason fab-at-live-edge exists: it must be able to disagree with the hook.
+    // Here the hook says NOT at bottom while the DOM says otherwise — the detector
+    // must trust its own measurement.
+    registerViewportBottomRef('conversation', ACTIVE.id, { current: false })
+    const tick = startDetectorTick(world({ distFromBottom: () => 42 }))
+    for (let i = 0; i < 5; i++) tick.sample()
+    tick.stop()
+
+    const fab = seen.find((s) => s.name === 'scroll/fab-at-live-edge')
+    expect(fab).toBeDefined()
+    expect(fab).toMatchObject({ distFromBottom: 42 })
+    // ...and unread stayed silent, because THAT one does depend on the viewport ref.
+    expect(seen.some((s) => s.name === 'read-state/unread-survives-focus')).toBe(false)
+  })
+
+  it('warms the conversation token, so records are correlatable', async () => {
+    // Discovered by signalRecords.test.ts: tokenSync cannot hash on demand, so an
+    // unwarmed conversation serializes as `c:unresolved` — safe but naming no entity.
+    await initTokenizer()
+    const tick = startDetectorTick(world())
+    tick.sample()
+    tick.stop()
+
+    // Warming is async; let the microtask and the HMAC settle.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(tokenSync('jid', ACTIVE.id).s).not.toBe('c:unresolved')
+  })
+
+  it('warms a room in the room namespace', async () => {
+    await initTokenizer()
+    const room = { kind: 'room' as const, id: 'muc@conf.x.tld' }
+    const tick = startDetectorTick(world({ activeConversation: () => room }))
+    tick.sample()
+    tick.stop()
+
+    await new Promise((r) => setTimeout(r, 0))
+    expect(tokenSync('room', room.id).s).not.toBe('c:unresolved')
+    // The jid space must NOT have been populated: they are disjoint identities.
+    expect(tokenSync('jid', room.id).s).toBe('c:unresolved')
+  })
+
+  it('warms once per conversation, not once per tick', async () => {
+    await initTokenizer()
+    const tick = startDetectorTick(world())
+    for (let i = 0; i < 5; i++) tick.sample()
+    tick.stop()
+    await new Promise((r) => setTimeout(r, 0))
+
+    // A token is cached after the first warm, so re-warming is cheap but pointless.
+    // The observable proof is that the unresolved counter never advanced.
+    expect(tokenSync('jid', ACTIVE.id).s).not.toBe('c:unresolved')
+  })
+
+  it('samples on its interval', () => {
+    vi.useFakeTimers()
+    const samples: number[] = []
+    let clock = 0
+    const tick = startDetectorTick(
+      world({
+        now: () => (clock += 1000),
+        activeConversation: () => {
+          samples.push(clock)
+          return ACTIVE
+        },
+      }),
+      1000,
+    )
+
+    vi.advanceTimersByTime(3000)
+    tick.stop()
+    expect(samples).toHaveLength(3)
+
+    // ...and stops when told to.
+    vi.advanceTimersByTime(5000)
+    expect(samples).toHaveLength(3)
+  })
+
+  it('is inert with no signal handler registered', () => {
+    // The release-build shape: nothing listening, so sampling must not throw.
+    clearAnomalySignalHandler()
+    const tick = startDetectorTick(world())
+    expect(() => {
+      for (let i = 0; i < 5; i++) tick.sample()
+    }).not.toThrow()
+    tick.stop()
+  })
+
+  it('treats no active conversation as nothing to check', () => {
+    const tick = startDetectorTick(world({ activeConversation: () => null }))
+    for (let i = 0; i < 5; i++) tick.sample()
+    tick.stop()
+    expect(seen).toEqual([])
+  })
+
+  it('goes quiet while the loaded window has slid up', () => {
+    // The FAB then means "jump to latest", which is a real affordance. This fired on
+    // every healthy demo session until windowAtLiveEdge joined the sample.
+    const tick = startDetectorTick(world({ windowAtLiveEdge: () => false }))
+    for (let i = 0; i < 5; i++) tick.sample()
+    tick.stop()
+    expect(seen.some((s) => s.name === 'scroll/fab-at-live-edge')).toBe(false)
+  })
+
+  it('goes quiet when an unmeasurable viewport makes the FAB check blind', () => {
+    // measureViewport returns null for an unmounted or untracked list. A verdict
+    // from an absence of evidence would be a guess.
+    const tick = startDetectorTick(world({ distFromBottom: () => null }))
+    for (let i = 0; i < 5; i++) tick.sample()
+    tick.stop()
+    expect(seen.some((s) => s.name === 'scroll/fab-at-live-edge')).toBe(false)
+  })
+})
+
+describe('browserWorld readings', () => {
+  it('measures the viewport through the scroller registry', async () => {
+    const { browserWorld } = await import('./tick')
+    const el = document.createElement('div')
+    Object.defineProperty(el, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 500, configurable: true })
+    el.scrollTop = 480
+    document.body.appendChild(el)
+    registerViewportScroller('conversation', ACTIVE.id, { current: el })
+
+    const w = browserWorld(
+      () => ACTIVE,
+      () => 0,
+      () => 'acct-1',
+      () => true,
+    )
+    expect(w.distFromBottom('conversation', ACTIVE.id)).toBe(20)
+  })
+
+  it('treats an inert FAB as withdrawn, not as shown', async () => {
+    // The button is ALWAYS in the DOM; its wrapper carries `inert={!fabVisible}`.
+    // A presence-only check reads `true` forever, which fired the detector on every
+    // healthy session.
+    const { browserWorld } = await import('./tick')
+    const w = browserWorld(
+      () => ACTIVE,
+      () => 0,
+      () => 'acct-1',
+      () => true,
+    )
+    expect(w.fabShown()).toBe(false)
+
+    const wrapper = document.createElement('div')
+    const fab = document.createElement('button')
+    fab.setAttribute('data-fab', 'scroll-to-bottom')
+    wrapper.appendChild(fab)
+    document.body.appendChild(wrapper)
+
+    wrapper.setAttribute('inert', '')
+    expect(w.fabShown()).toBe(false)
+
+    wrapper.removeAttribute('inert')
+    expect(w.fabShown()).toBe(true)
+
+    wrapper.remove()
+    expect(w.fabShown()).toBe(false)
+  })
+
+  it('finds a live FAB even when a hidden one comes first in the document', async () => {
+    // querySelector would stop at the inert one and report the affordance withdrawn.
+    const { browserWorld } = await import('./tick')
+    const w = browserWorld(
+      () => ACTIVE,
+      () => 0,
+      () => 'acct-1',
+      () => true,
+    )
+    for (const inert of [true, false]) {
+      const wrapper = document.createElement('div')
+      if (inert) wrapper.setAttribute('inert', '')
+      const fab = document.createElement('button')
+      fab.setAttribute('data-fab', 'scroll-to-bottom')
+      wrapper.appendChild(fab)
+      document.body.appendChild(wrapper)
+    }
+    expect(w.fabShown()).toBe(true)
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -100,7 +100,7 @@ describe('detector tick', () => {
     tick.stop()
 
     // Warming is async; let the microtask and the HMAC settle.
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     expect(tokenSync('jid', ACTIVE.id).s).not.toBe('c:unresolved')
   })
 
@@ -111,7 +111,7 @@ describe('detector tick', () => {
     tick.sample()
     tick.stop()
 
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     expect(tokenSync('room', room.id).s).not.toBe('c:unresolved')
     // The jid space must NOT have been populated: they are disjoint identities.
     expect(tokenSync('jid', room.id).s).toBe('c:unresolved')
@@ -122,7 +122,7 @@ describe('detector tick', () => {
     const tick = startDetectorTick(world())
     for (let i = 0; i < 5; i++) tick.sample()
     tick.stop()
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
 
     // A token is cached after the first warm, so re-warming is cheap but pointless.
     // The observable proof is that the unresolved counter never advanced.
@@ -144,13 +144,13 @@ describe('detector tick', () => {
     const tick = startDetectorTick(world({ activeConversation: () => startup }))
 
     tick.sample() // tokenizer NOT ready: nothing can be warmed
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     expect(tokenSync('jid', startup.id).s).toBe('c:unresolved')
 
     await initTokenizer() // key arrives
 
     tick.sample()
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     tick.stop()
 
     expect(
@@ -174,13 +174,13 @@ describe('detector tick', () => {
     const tick = startDetectorTick(world({ activeConversation: () => episode }))
 
     tick.sample() // t=1000, unready — starts the unread clock
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     await initTokenizer()
 
     tick.sample() // t=2000, held 1000ms
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     tick.sample() // t=3000, held 2000ms -> verdict
-    await new Promise((r) => setTimeout(r, 0))
+    await tick.warmSettled()
     tick.stop()
 
     const unreadRecord = records.find(

--- a/apps/fluux/src/anomaly/detectors/tick.test.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.test.ts
@@ -15,6 +15,7 @@ import {
   registerViewportBottomRef,
 } from '../../utils/viewportAtBottom'
 import { initTokenizer, resetValuesForTesting, tokenSync } from '../values'
+import { recordForSignal } from './signalRecords'
 
 const ACTIVE = { kind: 'conversation' as const, id: 'bob@x.tld' }
 
@@ -126,6 +127,72 @@ describe('detector tick', () => {
     // A token is cached after the first warm, so re-warming is cheap but pointless.
     // The observable proof is that the unresolved counter never advanced.
     expect(tokenSync('jid', ACTIVE.id).s).not.toBe('c:unresolved')
+  })
+
+  it('warms on a later tick when the tokenizer was not ready on the first', async () => {
+    // The startup window. `warmToken` is a silent no-op before the HMAC key exists,
+    // so a latch taken on that call suppresses every retry and leaves the
+    // conversation unwarmed for the whole episode — losing the entity on precisely
+    // the first anomaly of the session, the one that says something just started
+    // going wrong.
+    //
+    // A dedicated id, because `warmToken` writes AFTER an await: a warm started by an
+    // earlier test can resolve past `resetValuesForTesting()` and repopulate the map,
+    // which made this pass in file order while failing in isolation.
+    const startup = { kind: 'conversation' as const, id: 'startup-window@x.tld' }
+    registerViewportBottomRef('conversation', startup.id, { current: true })
+    const tick = startDetectorTick(world({ activeConversation: () => startup }))
+
+    tick.sample() // tokenizer NOT ready: nothing can be warmed
+    await new Promise((r) => setTimeout(r, 0))
+    expect(tokenSync('jid', startup.id).s).toBe('c:unresolved')
+
+    await initTokenizer() // key arrives
+
+    tick.sample()
+    await new Promise((r) => setTimeout(r, 0))
+    tick.stop()
+
+    expect(
+      tokenSync('jid', startup.id).s,
+      'the conversation was never re-warmed after the tokenizer became ready',
+    ).not.toBe('c:unresolved')
+  })
+
+  it('names the entity on the first record of an episode that began before readiness', async () => {
+    // The consequence the warm exists to prevent, asserted end to end: the record is
+    // built at signal time exactly as install.ts builds it.
+    const episode = { kind: 'conversation' as const, id: 'first-anomaly@x.tld' }
+    registerViewportBottomRef('conversation', episode.id, { current: true })
+
+    const records: (ReturnType<typeof recordForSignal>)[] = []
+    setAnomalySignalHandler((s) => {
+      seen.push(s)
+      records.push(recordForSignal(s))
+    })
+
+    const tick = startDetectorTick(world({ activeConversation: () => episode }))
+
+    tick.sample() // t=1000, unready — starts the unread clock
+    await new Promise((r) => setTimeout(r, 0))
+    await initTokenizer()
+
+    tick.sample() // t=2000, held 1000ms
+    await new Promise((r) => setTimeout(r, 0))
+    tick.sample() // t=3000, held 2000ms -> verdict
+    await new Promise((r) => setTimeout(r, 0))
+    tick.stop()
+
+    const unreadRecord = records.find(
+      (r) => r?.id.s === 'read-state/unread-survives-focus',
+    )
+    expect(unreadRecord, 'the unread detector never reported').toBeDefined()
+
+    const convToken = unreadRecord!.ctx!.find(([k]) => k.s === 'conv')![1] as { s: string }
+    expect(
+      convToken.s,
+      'the first record of the episode named no entity — it is uncorrelatable',
+    ).not.toBe('c:unresolved')
   })
 
   it('samples on its interval', () => {

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -1,0 +1,160 @@
+/**
+ * The sampling clock for the timed detectors.
+ *
+ * `unread-survives-focus` and `fab-at-live-edge` both ask whether something held
+ * CONTINUOUSLY, so both need a clock rather than an event. One interval drives both;
+ * `jump-target-miss` is event-driven and does not appear here.
+ *
+ * Sampling is deliberately shallow: read the world, hand it to pure functions, forward
+ * whatever they return. No decision lives in this file, so a wrong verdict is always a
+ * bug in a detector with its own tests rather than in untested glue.
+ *
+ * Two of the readings deliberately bypass React:
+ *
+ * - the FAB is read from the DOM by its `data-fab` attribute, not from
+ *   `showScrollToBottom`. The whole point of `fab-at-live-edge` is to catch that state
+ *   going stale, and a detector reading the suspect value could never disagree with it.
+ * - the viewport is measured through `utils/viewportScroller.ts`, for the same reason.
+ *
+ * @module Anomaly/Detectors/Tick
+ */
+import { signalAnomaly } from '../../utils/anomalySignal'
+import { isViewportAtBottom, type ViewportKind } from '../../utils/viewportAtBottom'
+import { measureViewport } from '../../utils/viewportScroller'
+import { warmConversation, warmRoom } from '../identity'
+import { createFabAtLiveEdgeDetector } from './fabAtLiveEdge'
+import { createUnreadSurvivesFocusDetector } from './unreadSurvivesFocus'
+
+/** How often the world is sampled. */
+const TICK_MS = 1000
+
+/** The FAB's marker attribute, shared with the scroll e2e suite. */
+const FAB_SELECTOR = '[data-fab="scroll-to-bottom"]'
+
+/**
+ * What the tick needs from the app.
+ *
+ * Injected rather than imported so the driver is testable without a store, a DOM or a
+ * React tree. The production wiring supplies it in `install.ts`.
+ */
+export interface TickWorld {
+  /** The conversation on screen, or null. */
+  activeConversation(): { kind: ViewportKind; id: string } | null
+  /** The canonical unread count for that conversation. */
+  unreadCount(kind: ViewportKind, id: string): number
+  /** Account / storage scope — the only generation-ish signal public before stage 5. */
+  scopeKey(): string
+  /** Is the window focused AND visible. */
+  focused(): boolean
+  /** Is the FAB actually offered to the user. */
+  fabShown(): boolean
+  /** Is the loaded message window at the tail of the archive. */
+  windowAtLiveEdge(kind: ViewportKind, id: string): boolean
+  /** Independently measured distance to the content bottom, or null. */
+  distFromBottom(kind: ViewportKind, id: string): number | null
+  now(): number
+}
+
+/** Read the real app. */
+export function browserWorld(
+  activeConversation: () => { kind: ViewportKind; id: string } | null,
+  unreadCount: (kind: ViewportKind, id: string) => number,
+  scopeKey: () => string,
+  windowAtLiveEdge: (kind: ViewportKind, id: string) => boolean,
+): TickWorld {
+  return {
+    activeConversation,
+    unreadCount,
+    scopeKey,
+    windowAtLiveEdge,
+    // `hasFocus` alone is not enough: a visible-but-unfocused window and a hidden one
+    // are different states, and only the first means someone might be reading.
+    focused: () => document.hasFocus() && document.visibilityState === 'visible',
+    // Rendered is NOT shown. The button is always in the DOM; the wrapper carries
+    // `inert={!fabVisible}` (`MessageList.tsx:966`), so presence alone reads `true`
+    // forever — which made the detector fire on every healthy session until the
+    // control test caught it. An inert ancestor means the affordance is withdrawn.
+    // `querySelectorAll`, not `querySelector`: with more than one list in the tree the
+    // first match may be a hidden one, and a single-element read would then report
+    // "withdrawn" while a live FAB sits further down the document.
+    fabShown: () =>
+      Array.from(document.querySelectorAll(FAB_SELECTOR)).some(
+        (fab) => fab.closest('[inert]') === null,
+      ),
+    distFromBottom: (kind, id) => measureViewport(kind, id)?.distFromBottom ?? null,
+    now: () => Date.now(),
+  }
+}
+
+export interface DetectorTick {
+  /** Sample once and emit any verdicts. Exposed so a test need not wait a second. */
+  sample(): void
+  stop(): void
+}
+
+export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): DetectorTick {
+  const unread = createUnreadSurvivesFocusDetector()
+  const fab = createFabAtLiveEdgeDetector()
+
+  /** Which conversation we have already asked the tokenizer to warm. */
+  let warmedFor: string | null = null
+
+  function sample(): void {
+    const now = world.now()
+    const active = world.activeConversation()
+
+    // Warm the token BEFORE any record can reference this conversation. `tokenSync`
+    // cannot hash on demand — HMAC is async — so an unwarmed conversation serializes
+    // as `c:unresolved`, which is safe but uncorrelatable: the record would name no
+    // entity at all. Warming on change costs one HMAC per conversation opened.
+    if (active) {
+      const target = `${active.kind}:${active.id}`
+      if (warmedFor !== target) {
+        warmedFor = target
+        void (active.kind === 'room' ? warmRoom(active.id) : warmConversation(active.id))
+      }
+    }
+
+    const unreadVerdict = unread.observe(
+      {
+        active,
+        focused: world.focused(),
+        viewportAtBottom: active ? isViewportAtBottom(active.kind, active.id) : false,
+        unreadCount: active ? world.unreadCount(active.kind, active.id) : 0,
+        scopeKey: world.scopeKey(),
+      },
+      now,
+    )
+    if (unreadVerdict) {
+      signalAnomaly({
+        name: 'read-state/unread-survives-focus',
+        kind: unreadVerdict.active.kind,
+        id: unreadVerdict.active.id,
+        unreadCount: unreadVerdict.unreadCount,
+        heldMs: unreadVerdict.heldMs,
+      })
+    }
+
+    const fabVerdict = fab.observe(
+      {
+        fabShown: world.fabShown(),
+        distFromBottom: active ? world.distFromBottom(active.kind, active.id) : null,
+        windowAtLiveEdge: active ? world.windowAtLiveEdge(active.kind, active.id) : false,
+      },
+      now,
+    )
+    if (fabVerdict) {
+      signalAnomaly({
+        name: 'scroll/fab-at-live-edge',
+        distFromBottom: fabVerdict.distFromBottom,
+        heldMs: fabVerdict.heldMs,
+      })
+    }
+  }
+
+  const id = setInterval(sample, intervalMs)
+  return {
+    sample,
+    stop: () => clearInterval(id),
+  }
+}

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -90,6 +90,16 @@ export function browserWorld(
 export interface DetectorTick {
   /** Sample once and emit any verdicts. Exposed so a test need not wait a second. */
   sample(): void
+  /**
+   * Resolves once the warm started by the most recent `sample()` has settled.
+   *
+   * Test-only, and a seam rather than a sleep on purpose: the warm ends in an async
+   * WebCrypto HMAC, so waiting a fixed macrotask is a race that a slow machine loses —
+   * it lost one in CI. Polling `tokenSync` instead is not an option either: it starts
+   * its own warm on a miss, so a polled assertion would pass whether or not the tick
+   * ever warmed anything.
+   */
+  warmSettled(): Promise<void>
   stop(): void
 }
 
@@ -114,6 +124,8 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
    * is only set on resolution.
    */
   let warmInFlight: string | null = null
+  /** The most recent warm, so a test can await exactly what it started. */
+  let pendingWarm: Promise<void> = Promise.resolve()
 
   function sample(): void {
     const now = world.now()
@@ -130,13 +142,18 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
       // rejected warm also retries rather than being recorded as done.
       if (warmedFor !== target && warmInFlight !== target && isTokenizerReady()) {
         warmInFlight = target
-        void (active.kind === 'room' ? warmRoom(active.id) : warmConversation(active.id))
+        pendingWarm = (active.kind === 'room' ? warmRoom(active.id) : warmConversation(active.id))
           .then(() => {
             warmedFor = target
+          })
+          .catch(() => {
+            // Swallowed so a failed warm cannot surface as an unhandled rejection.
+            // `warmedFor` stays unset, so the next tick retries.
           })
           .finally(() => {
             if (warmInFlight === target) warmInFlight = null
           })
+        void pendingWarm
       }
     }
 
@@ -180,6 +197,7 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
   const id = setInterval(sample, intervalMs)
   return {
     sample,
+    warmSettled: () => pendingWarm,
     stop: () => clearInterval(id),
   }
 }

--- a/apps/fluux/src/anomaly/detectors/tick.ts
+++ b/apps/fluux/src/anomaly/detectors/tick.ts
@@ -21,6 +21,7 @@
 import { signalAnomaly } from '../../utils/anomalySignal'
 import { isViewportAtBottom, type ViewportKind } from '../../utils/viewportAtBottom'
 import { measureViewport } from '../../utils/viewportScroller'
+import { isTokenizerReady } from '../values'
 import { warmConversation, warmRoom } from '../identity'
 import { createFabAtLiveEdgeDetector } from './fabAtLiveEdge'
 import { createUnreadSurvivesFocusDetector } from './unreadSurvivesFocus'
@@ -96,8 +97,23 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
   const unread = createUnreadSurvivesFocusDetector()
   const fab = createFabAtLiveEdgeDetector()
 
-  /** Which conversation we have already asked the tokenizer to warm. */
+  /**
+   * Which conversation the tokenizer has CONFIRMED warm.
+   *
+   * Not "which one we asked about": `warmToken` returns silently when the tokenizer
+   * holds no key yet, so a latch taken on the call rather than on its result marks a
+   * conversation warm that nothing warmed, and every later tick then skips it. The
+   * episode keeps running with the entity unresolved — and the record that loses it is
+   * the FIRST of the session, the one that says something just started going wrong.
+   */
   let warmedFor: string | null = null
+  /**
+   * A warm already asked for and not yet resolved.
+   *
+   * Without it a slow HMAC would start a fresh warm on every tick, since `warmedFor`
+   * is only set on resolution.
+   */
+  let warmInFlight: string | null = null
 
   function sample(): void {
     const now = world.now()
@@ -109,9 +125,18 @@ export function startDetectorTick(world: TickWorld, intervalMs = TICK_MS): Detec
     // entity at all. Warming on change costs one HMAC per conversation opened.
     if (active) {
       const target = `${active.kind}:${active.id}`
-      if (warmedFor !== target) {
-        warmedFor = target
+      // Skip entirely until the tokenizer holds its key: warming before then is a
+      // no-op, and the next tick retries. Latch only once the warm has RESOLVED, so a
+      // rejected warm also retries rather than being recorded as done.
+      if (warmedFor !== target && warmInFlight !== target && isTokenizerReady()) {
+        warmInFlight = target
         void (active.kind === 'room' ? warmRoom(active.id) : warmConversation(active.id))
+          .then(() => {
+            warmedFor = target
+          })
+          .finally(() => {
+            if (warmInFlight === target) warmInFlight = null
+          })
       }
     }
 

--- a/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.test.ts
+++ b/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createUnreadSurvivesFocusDetector,
+  type UnreadFocusSample,
+} from './unreadSurvivesFocus'
+
+const ACTIVE = { kind: 'conversation' as const, id: 'bob@x.tld' }
+
+/** The failing condition: active, focused, at the live edge, still unread. */
+function bad(overrides: Partial<UnreadFocusSample> = {}): UnreadFocusSample {
+  return {
+    active: ACTIVE,
+    focused: true,
+    viewportAtBottom: true,
+    unreadCount: 3,
+    scopeKey: 'acct-1',
+    ...overrides,
+  }
+}
+
+describe('unreadSurvivesFocus — fires', () => {
+  it('reports once the condition has held for the full window', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    expect(d.observe(bad(), 0)).toBeNull() // first sample only starts the clock
+    expect(d.observe(bad(), 1999)).toBeNull() // one ms short
+    const v = d.observe(bad(), 2000)
+
+    expect(v).not.toBeNull()
+    expect(v!.unreadCount).toBe(3)
+    expect(v!.heldMs).toBe(2000)
+    expect(v!.active).toEqual(ACTIVE)
+  })
+
+  it('reports once per episode, not once per tick', () => {
+    // A stuck badge is sampled every second. Without a latch it would produce a
+    // record per tick and the suppression count would carry no information.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    const verdicts = [3000, 4000, 5000, 6000].map((t) => d.observe(bad(), t))
+
+    expect(verdicts.filter(Boolean)).toHaveLength(1)
+  })
+
+  it('reports again after the condition breaks and recurs', () => {
+    // The latch must not be permanent: a recurrence is a separate event, and the
+    // recorder's per-id cooldown is what bounds frequency.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    expect(d.observe(bad(), 2000)).not.toBeNull()
+
+    d.observe(bad({ unreadCount: 0 }), 3000) // read at last — condition breaks
+
+    d.observe(bad(), 4000)
+    expect(d.observe(bad(), 6000)).not.toBeNull()
+  })
+})
+
+describe('unreadSurvivesFocus — stays silent', () => {
+  // The control cases. A detector that fires on everything passes a firing test,
+  // so each precondition gets its own proof of silence.
+
+  it('while the window is not focused', () => {
+    // The whole premise is that the user is looking at it.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ focused: false }), 0)
+    expect(d.observe(bad({ focused: false }), 5000)).toBeNull()
+  })
+
+  it('while the viewport is not at the live edge', () => {
+    // Scrolled up in history with unread below is the normal, correct state.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ viewportAtBottom: false }), 0)
+    expect(d.observe(bad({ viewportAtBottom: false }), 5000)).toBeNull()
+  })
+
+  it('when there is nothing unread', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ unreadCount: 0 }), 0)
+    expect(d.observe(bad({ unreadCount: 0 }), 5000)).toBeNull()
+  })
+
+  it('when no conversation is open', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ active: null }), 0)
+    expect(d.observe(bad({ active: null }), 5000)).toBeNull()
+  })
+
+  it('when the count clears inside the window', () => {
+    // The ordinary success path: focus regain marks it read a beat later.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad(), 500)
+    expect(d.observe(bad({ unreadCount: 0 }), 1000)).toBeNull()
+    expect(d.observe(bad(), 3000)).toBeNull() // clock restarted, not resumed
+  })
+})
+
+describe('unreadSurvivesFocus — resets', () => {
+  it('restarts the clock when the active conversation changes', () => {
+    // Elapsed time on one conversation says nothing about the next. Without this,
+    // opening a second unread conversation would inherit the first one's timer and
+    // report immediately.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad({ active: { kind: 'conversation', id: 'carol@x.tld' } }), 1900)
+    expect(
+      d.observe(bad({ active: { kind: 'conversation', id: 'carol@x.tld' } }), 2100),
+    ).toBeNull()
+  })
+
+  it('treats the same id in the other namespace as a different conversation', () => {
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad({ active: { kind: 'room', id: 'bob@x.tld' } }), 1900)
+    expect(d.observe(bad({ active: { kind: 'room', id: 'bob@x.tld' } }), 2100)).toBeNull()
+  })
+
+  it('discards a pending observation when the account scope changes', () => {
+    // The one generation-ish signal available before stage 5. An observation
+    // spanning a store rebuild describes two different worlds.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad(), 0)
+    d.observe(bad({ scopeKey: 'acct-2' }), 1900)
+    expect(d.observe(bad({ scopeKey: 'acct-2' }), 2100)).toBeNull()
+  })
+
+  it('still reports after a scope change once the window elapses again', () => {
+    // Control for the reset: it must delay a verdict, not disable the detector.
+    const d = createUnreadSurvivesFocusDetector({ holdMs: 2000 })
+    d.observe(bad({ scopeKey: 'acct-2' }), 0)
+    d.observe(bad({ scopeKey: 'acct-2' }), 100)
+    expect(d.observe(bad({ scopeKey: 'acct-2' }), 2200)).not.toBeNull()
+  })
+})

--- a/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.ts
+++ b/apps/fluux/src/anomaly/detectors/unreadSurvivesFocus.ts
@@ -1,0 +1,131 @@
+/**
+ * `read-state/unread-survives-focus` — an unread count that outlives being read.
+ *
+ * When a conversation is active, the window is focused, and the newest message is
+ * actually on screen, the user is reading it. `useWindowVisibility` marks it read on
+ * focus regain, so an unread count that persists in that state means the clearing
+ * path did not run or did not stick.
+ *
+ * The "actually on screen" part is why this uses the VIEWPORT, not the SDK's
+ * `windowAtLiveEdge`: the latter is true for any backgrounded conversation parked at
+ * the tail, so it is not evidence anyone saw anything. See
+ * `utils/viewportAtBottom.ts`.
+ *
+ * PURE: every input is passed in, including the clock. The detector holds only the
+ * timestamp the condition began and which conversation it is watching.
+ *
+ * @module Anomaly/Detectors/UnreadSurvivesFocus
+ */
+
+/** Everything the verdict depends on, sampled at one instant. */
+export interface UnreadFocusSample {
+  /** Active conversation, or null when none is open. */
+  active: { kind: 'conversation' | 'room'; id: string } | null
+  /** Is the app window focused AND visible. */
+  focused: boolean
+  /** Is the newest message actually on screen — viewport truth, not window truth. */
+  viewportAtBottom: boolean
+  /** The canonical unread count for the active conversation. */
+  unreadCount: number
+  /**
+   * Account / storage scope.
+   *
+   * The ONLY generation-ish signal publicly observable before stage 5. A change
+   * means the store was rebuilt under us, so any pending observation is void.
+   */
+  scopeKey: string
+}
+
+export interface UnreadFocusVerdict {
+  /** How long the condition had held when it was reported. */
+  heldMs: number
+  unreadCount: number
+  active: { kind: 'conversation' | 'room'; id: string }
+}
+
+export interface UnreadSurvivesFocusDetector {
+  /** Evaluate one sample. Returns a verdict at most once per episode. */
+  observe(sample: UnreadFocusSample, now: number): UnreadFocusVerdict | null
+}
+
+/** How long the condition must hold continuously before it is reportable. */
+const DEFAULT_HOLD_MS = 2000
+
+export interface UnreadSurvivesFocusOptions {
+  holdMs?: number
+}
+
+export function createUnreadSurvivesFocusDetector(
+  opts: UnreadSurvivesFocusOptions = {},
+): UnreadSurvivesFocusDetector {
+  const holdMs = opts.holdMs ?? DEFAULT_HOLD_MS
+
+  /** The conversation currently under observation, as `kind:id`. */
+  let watching: string | null = null
+  let since: number | null = null
+  let scope: string | null = null
+  /**
+   * Episodes already reported, so one stuck badge produces one record rather than
+   * one per tick. Cleared whenever the condition breaks, so a LATER recurrence on
+   * the same conversation is still reported — the recorder's per-id cooldown is what
+   * bounds frequency, and suppressing forever would hide a regression.
+   */
+  let reported: string | null = null
+
+  function reset(): void {
+    watching = null
+    since = null
+    reported = null
+  }
+
+  return {
+    observe(sample: UnreadFocusSample, now: number): UnreadFocusVerdict | null {
+      // A scope CHANGE means the store was rebuilt. Drop everything: an observation
+      // spanning the rebuild describes two different worlds.
+      //
+      // Adopting the first scope is not a change. Treating it as one made the very
+      // first sample reset the detector, so every episode started its clock a tick
+      // late and the hold window was effectively one tick longer than configured.
+      if (scope === null) {
+        scope = sample.scopeKey
+      } else if (scope !== sample.scopeKey) {
+        scope = sample.scopeKey
+        reset()
+        return null
+      }
+
+      const holds =
+        sample.active !== null &&
+        sample.focused &&
+        sample.viewportAtBottom &&
+        sample.unreadCount > 0
+
+      if (!holds || sample.active === null) {
+        reset()
+        return null
+      }
+
+      const target = `${sample.active.kind}:${sample.active.id}`
+      if (watching !== target) {
+        // Switching conversations restarts the clock; the previous conversation's
+        // elapsed time says nothing about this one.
+        watching = target
+        since = now
+        reported = null
+        return null
+      }
+
+      if (since === null) {
+        since = now
+        return null
+      }
+
+      const heldMs = now - since
+      if (heldMs < holdMs) return null
+      if (reported === target) return null
+
+      reported = target
+      return { heldMs, unreadCount: sample.unreadCount, active: sample.active }
+    },
+  }
+}

--- a/apps/fluux/src/anomaly/install.test.ts
+++ b/apps/fluux/src/anomaly/install.test.ts
@@ -181,6 +181,36 @@ describe('the sentinel fan-out seam', () => {
   })
 })
 
+describe('the detector tick', () => {
+  it('arms one sampler per attachment and releases it with the last hold', () => {
+    // Counted rather than inspected: two intervals sampling would double every
+    // verdict, and the per-id cooldown would file the duplicate as a phantom
+    // suppression rather than a visible fault.
+    vi.useFakeTimers()
+    try {
+      const baseline = vi.getTimerCount()
+
+      const cleanup1 = install()
+      const armed = vi.getTimerCount()
+      expect(armed).toBeGreaterThan(baseline)
+
+      // Second hold: the sampler is already running, so nothing new is armed.
+      const cleanup2 = install()
+      expect(vi.getTimerCount()).toBe(armed)
+
+      // First cleanup runs while the second hold is still live — the interleaving
+      // the refcount exists for. The sampler must survive it.
+      cleanup1()
+      expect(vi.getTimerCount()).toBe(armed)
+
+      cleanup2()
+      expect(vi.getTimerCount()).toBe(baseline)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
 describe('the session record', () => {
   it('announces the session exactly once across a StrictMode cycle', async () => {
     // The emission belongs to the runtime, not to an attachment. If each install()

--- a/apps/fluux/src/anomaly/install.ts
+++ b/apps/fluux/src/anomaly/install.ts
@@ -8,15 +8,19 @@
  * relies on while the session kept its id. Only SUBSCRIPTIONS are attached and
  * detached — the runtime outlives them.
  *
- * The only thing attached so far is the sentinel fan-out: the existing scroll and
- * stall monitors keep their prose and additionally signal into a neutral seam,
- * which is connected here. No detection logic lives in this tree.
+ * Two things attach here. The signal-to-record adapter connects the neutral signal
+ * seam used by both always-shipped monitors and dev-only detectors. The detector tick
+ * samples the app once a second for the two timed detectors. Nothing decides in this
+ * file: the monitors and the pure detectors under `detectors/` own their verdicts.
  *
  * @module Anomaly/Install
  */
+import { chatStore, getStorageScopeJid, roomStore } from '@fluux/sdk'
 import { clearAnomalySignalHandler, setAnomalySignalHandler } from '../utils/anomalySignal'
+import type { ViewportKind } from '../utils/viewportAtBottom'
 import { isTauri } from '../utils/tauri'
-import { recordForSignal } from './detectors/sentinelFanout'
+import { recordForSignal } from './detectors/signalRecords'
+import { browserWorld, startDetectorTick, type DetectorTick } from './detectors/tick'
 import { markAnomalyBuild } from './gate'
 import { createRecorder, type Recorder } from './recorder'
 import { createMemorySink } from './sinks/memory'
@@ -70,6 +74,48 @@ let attachments = 0
 let attachRefs = 0
 let digestTimer: ReturnType<typeof setInterval> | null = null
 let detachListener: (() => void) | null = null
+let detectorTick: DetectorTick | null = null
+
+/**
+ * Read the active conversation from the vanilla stores.
+ *
+ * A room takes precedence: both ids can be set at once (the last conversation stays in
+ * `chatStore` while a room is open), and the ROOM is what is on screen. Getting this
+ * backwards would attribute a room's unread count to a stale 1:1 — a wrong entity in
+ * the log, which is worse than no record.
+ */
+function readActiveConversation(): { kind: ViewportKind; id: string } | null {
+  const roomJid = roomStore.getState().activeRoomJid
+  if (roomJid) return { kind: 'room', id: roomJid }
+  const conversationId = chatStore.getState().activeConversationId
+  if (conversationId) return { kind: 'conversation', id: conversationId }
+  return null
+}
+
+/** The one canonical unread count for whichever entity is on screen. */
+function readUnreadCount(kind: ViewportKind, id: string): number {
+  const meta =
+    kind === 'room'
+      ? roomStore.getState().roomMeta.get(id)
+      : chatStore.getState().conversationMeta.get(id)
+  // Absent meta is 0, not "unknown": a conversation with no metadata has nothing
+  // unread, and inventing a non-zero count would fabricate an anomaly.
+  return meta?.unreadCount ?? 0
+}
+
+/**
+ * Is the loaded window at the tail of the archive.
+ *
+ * Rooms keep it on `roomRuntime`, conversations in a `windowAtLiveEdge` map — one fact
+ * in two shapes. Defaults to `false`, the conservative direction: an unknown window is
+ * treated as possibly slid up, which suppresses `fab-at-live-edge` rather than
+ * reporting a FAB that may be legitimately offering "jump to latest".
+ */
+function readWindowAtLiveEdge(kind: ViewportKind, id: string): boolean {
+  return kind === 'room'
+    ? (roomStore.getState().roomRuntime.get(id)?.windowAtLiveEdge ?? false)
+    : (chatStore.getState().windowAtLiveEdge.get(id) ?? false)
+}
 
 function runtime(): Recorder {
   if (!recorder) {
@@ -176,6 +222,18 @@ export function install(): () => void {
       if (input) rec.record(input)
     })
 
+    // The timed detectors. Started here rather than at module scope so it shares the
+    // refcount: a StrictMode remount must not leave two intervals sampling, which
+    // would double every verdict and turn the duplicate into a phantom suppression.
+    detectorTick = startDetectorTick(
+      browserWorld(
+        readActiveConversation,
+        readUnreadCount,
+        () => getStorageScopeJid() ?? '',
+        readWindowAtLiveEdge,
+      ),
+    )
+
     digestTimer = setInterval(() => rec.flushDigest(DIGEST_INTERVAL_MS), DIGEST_INTERVAL_MS)
 
     const onVisibility = () => {
@@ -198,6 +256,8 @@ export function install(): () => void {
     if (attachRefs > 0) return
 
     clearAnomalySignalHandler()
+    detectorTick?.stop()
+    detectorTick = null
     detachListener?.()
     detachListener = null
     if (digestTimer) clearInterval(digestTimer)
@@ -213,6 +273,8 @@ export function setSessionRetryDelayForTesting(ms: number): void {
 /** Test-only: tears down the runtime as well as the subscriptions. */
 export function resetInstallForTesting(): void {
   clearAnomalySignalHandler()
+  detectorTick?.stop()
+  detectorTick = null
   detachListener?.()
   detachListener = null
   if (digestTimer) clearInterval(digestTimer)

--- a/apps/fluux/src/anomaly/values.ts
+++ b/apps/fluux/src/anomaly/values.ts
@@ -114,6 +114,9 @@ export const ID = Object.freeze({
   resizeLoop: mint('scroll/resize-loop', 'id'),
   slowCorrection: mint('scroll/slow-correction', 'id'),
   mainThreadStall: mint('perf/main-thread-stall', 'id'),
+  unreadSurvivesFocus: mint('read-state/unread-survives-focus', 'id'),
+  fabAtLiveEdge: mint('scroll/fab-at-live-edge', 'id'),
+  jumpTargetMiss: mint('scroll/jump-target-miss', 'id'),
 })
 
 /** Permitted `ctx` keys. */
@@ -129,6 +132,12 @@ export const CTX = Object.freeze({
   rows: mint('rows', 'ctx'),
   /** Measured window length, where a count alone would not be interpretable. */
   elapsedMs: mint('elapsedMs', 'ctx'),
+  /** Independently measured distance from the content bottom, in px. */
+  distFromBottom: mint('distFromBottom', 'ctx'),
+  /** How long a condition had held continuously when it was reported. */
+  heldMs: mint('heldMs', 'ctx'),
+  /** Signed px by which a jump target sat outside the viewport. */
+  offBy: mint('offBy', 'ctx'),
 })
 
 /**

--- a/apps/fluux/src/components/ChatView.tsx
+++ b/apps/fluux/src/components/ChatView.tsx
@@ -33,6 +33,7 @@ import { computeMediaAutoload } from '@/utils/mediaAutoload'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { auroraSenderColor } from '@/utils/senderColor'
 import { registerViewportBottomRef } from '@/utils/viewportAtBottom'
+import { registerViewportScroller } from '@/utils/viewportScroller'
 import { ReactionMentions } from './conversation/ReactionMentions'
 import { reactionMentionStore } from '@/stores/reactionMentionStore'
 import { EasterEggMentions } from './conversation/EasterEggMentions'
@@ -165,6 +166,17 @@ export function ChatView({ onBack, onSwitchToMessages, onSearchInConversation, o
     const id = activeConversation?.id
     if (!id) return
     return registerViewportBottomRef('conversation', id, isAtBottomRef)
+  }, [activeConversation?.id])
+
+  // Publish the scroll element too. Unlike the ref above this is not consumed in
+  // release builds; it exists so a dev-only check can measure the viewport WITHOUT
+  // going through the scroll hook's own at-bottom state, which is exactly the value
+  // under suspicion when the list and its affordances disagree.
+  useEffect(() => {
+    if (!__FLUUX_ANOMALY__) return
+    const id = activeConversation?.id
+    if (!id) return
+    return registerViewportScroller('conversation', id, scrollRef)
   }, [activeConversation?.id])
 
   // Stable handler for the send-animation: clears the highlight after 400 ms.

--- a/apps/fluux/src/components/RoomView.tsx
+++ b/apps/fluux/src/components/RoomView.tsx
@@ -43,6 +43,7 @@ import { useSettingsStore } from '@/stores/settingsStore'
 import { getRoomJoinErrorMessage } from '@/utils/roomJoinError'
 import { auroraSenderColor, nickColorSeed } from '@/utils/senderColor'
 import { registerViewportBottomRef } from '@/utils/viewportAtBottom'
+import { registerViewportScroller } from '@/utils/viewportScroller'
 import { ReactionMentions } from './conversation/ReactionMentions'
 import { reactionMentionStore } from '@/stores/reactionMentionStore'
 import { EasterEggMentions } from './conversation/EasterEggMentions'
@@ -266,6 +267,16 @@ export function RoomView({ onBack, mainContentRef, composerRef, showOccupants = 
   useEffect(() => {
     if (!activeRoomJid) return
     return registerViewportBottomRef('room', activeRoomJid, isAtBottomRef)
+  }, [activeRoomJid])
+
+  // Publish the scroll element too. Unlike the ref above this is not consumed in
+  // release builds; it exists so a dev-only check can measure the viewport WITHOUT
+  // going through the scroll hook's own at-bottom state, which is exactly the value
+  // under suspicion when the list and its affordances disagree.
+  useEffect(() => {
+    if (!__FLUUX_ANOMALY__) return
+    if (!activeRoomJid) return
+    return registerViewportScroller('room', activeRoomJid, scrollRef)
   }, [activeRoomJid])
 
   // Composer handle ref for focusing after staging attachment

--- a/apps/fluux/src/components/conversation/jumpTargetVisibility.test.ts
+++ b/apps/fluux/src/components/conversation/jumpTargetVisibility.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateJumpTarget } from './jumpTargetVisibility'
+
+const VIEWPORT = { top: 100, bottom: 700 }
+
+describe('jumpTargetMiss — fires', () => {
+  it('reports a row left above the viewport, with the distance', () => {
+    const v = evaluateJumpTarget({
+      outcome: 'settled',
+      applied: true,
+      target: { top: -60, bottom: 20 },
+      viewport: VIEWPORT,
+    })
+    expect(v).not.toBeNull()
+    expect(v!.offBy).toBe(-80) // target.bottom 20 - viewport.top 100
+  })
+
+  it('reports a row left below the viewport', () => {
+    const v = evaluateJumpTarget({
+      outcome: 'best-effort',
+      applied: true,
+      target: { top: 900, bottom: 980 },
+      viewport: VIEWPORT,
+    })
+    expect(v!.offBy).toBe(200) // target.top 900 - viewport.bottom 700
+  })
+
+  it('signs the distance so a review can tell which way it missed', () => {
+    // Overshoot and undershoot have different causes; one number that could not
+    // distinguish them would send a reader looking in the wrong place.
+    const above = evaluateJumpTarget({
+      outcome: 'settled',
+      applied: true,
+      target: { top: -100, bottom: -20 },
+      viewport: VIEWPORT,
+    })
+    const below = evaluateJumpTarget({
+      outcome: 'settled',
+      applied: true,
+      target: { top: 800, bottom: 880 },
+      viewport: VIEWPORT,
+    })
+    expect(above!.offBy).toBeLessThan(0)
+    expect(below!.offBy).toBeGreaterThan(0)
+  })
+})
+
+describe('jumpTargetMiss — stays silent', () => {
+  it('when the row is fully visible', () => {
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: true,
+        target: { top: 300, bottom: 380 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+  })
+
+  it('when the row is only partly visible', () => {
+    // Partial visibility is imprecise positioning, not a miss — the user can see it.
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: true,
+        target: { top: 650, bottom: 760 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: true,
+        target: { top: 40, bottom: 160 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+  })
+
+  it('when the row touches the viewport edge by a single pixel', () => {
+    // The boundary of "intersects". A strict-inequality slip here would report
+    // every jump that landed a row exactly at the edge.
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: true,
+        target: { top: 20, bottom: 101 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: true,
+        target: { top: 699, bottom: 800 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+  })
+
+  it('when the jump did not apply', () => {
+    // Superseded or aborted. Its target being off screen is the expected outcome.
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: false,
+        target: { top: 900, bottom: 980 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+  })
+
+  it('when the user takes over after a position was applied', () => {
+    expect(
+      evaluateJumpTarget({
+        outcome: 'user-takeover',
+        applied: true,
+        target: { top: 900, bottom: 980 },
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+  })
+
+  it('when the row is not in the DOM at all', () => {
+    // DELIBERATE non-case: a load/windowing failure with a different cause. Folding
+    // it in would give one invariant id two meanings. See the invariant registry.
+    expect(
+      evaluateJumpTarget({
+        outcome: 'settled',
+        applied: true,
+        target: null,
+        viewport: VIEWPORT,
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/fluux/src/components/conversation/jumpTargetVisibility.ts
+++ b/apps/fluux/src/components/conversation/jumpTargetVisibility.ts
@@ -1,0 +1,77 @@
+/**
+ * Did a settled go-to-message actually put the row on screen?
+ *
+ * Lives with the scroll code rather than under `src/anomaly/`, for two reasons. It is
+ * a scroll invariant — the same kind of pure decision as `fabVisibility.ts` — and its
+ * only caller is `useMessageListScroll`, which ships in release builds and therefore
+ * must not import the anomaly tree at all. A static import there would pull the
+ * recorder and serializer into the production bundle even behind a dead branch.
+ *
+ * The check is not timed: the explicit-target executor has an exact settle point
+ * (`complete()`), which already knows whether the position was applied and already
+ * re-finds the row. There is nothing to wait for.
+ *
+ * DELIBERATELY NOT A CASE: the row not existing at all. That is a load or windowing
+ * failure with a different cause and a different fix, and folding it in would give
+ * one invariant id two meanings — so a review could no longer tell from the id what
+ * went wrong. It is recorded as a non-case in the invariant registry.
+ *
+ * PURE: rectangles are passed in, so this is testable without a layout engine.
+ *
+ * @module Conversation/JumpTargetVisibility
+ */
+import type { ExplicitTargetCompletion } from './positioningController'
+
+/** The part of a DOMRect this check needs. Vertical only — the list scrolls one way. */
+export interface Bounds {
+  top: number
+  bottom: number
+}
+
+export interface JumpSample {
+  outcome: ExplicitTargetCompletion
+  /** Did the executor report that it applied a position. */
+  applied: boolean
+  /** The target row's bounds, or `null` when the row is not in the DOM. */
+  target: Bounds | null
+  /** The scroll viewport's bounds. */
+  viewport: Bounds
+}
+
+export interface JumpVerdict {
+  /**
+   * How far off screen the row was, in px — negative when it sits above the
+   * viewport, positive below. Zero is impossible: it would mean intersecting.
+   */
+  offBy: number
+}
+
+/**
+ * Decide whether a settled jump missed.
+ *
+ * @returns a verdict when the jump claimed success but left the row outside the
+ * viewport, else `null`.
+ */
+export function evaluateJumpTarget(sample: JumpSample): JumpVerdict | null {
+  if (sample.outcome !== 'settled' && sample.outcome !== 'best-effort') return null
+
+  // A jump that did not apply was superseded or aborted. Its target being off
+  // screen is the expected outcome, not a miss.
+  if (!sample.applied) return null
+
+  // Not the case this invariant covers — see the module comment.
+  if (sample.target === null) return null
+
+  const { target, viewport } = sample
+
+  // Any overlap counts as a hit. Partial visibility is a positioning imprecision,
+  // not a miss: the user can see the row.
+  const intersects = target.bottom > viewport.top && target.top < viewport.bottom
+  if (intersects) return null
+
+  const offBy =
+    target.bottom <= viewport.top
+      ? target.bottom - viewport.top // negative: above
+      : target.top - viewport.bottom // positive: below
+  return { offBy }
+}

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -37,6 +37,7 @@ import { decideRowGrowth } from './rowGrowthDecision'
 import { createPinRepaintBurst, pinBurstProbeLine, type PinRepaintBurst } from './pinRepaintBurst'
 import { createRenderCostProbe, type RenderCostProbe } from '@/utils/renderCostProbe'
 import { signalAnomaly } from '@/utils/anomalySignal'
+import { evaluateJumpTarget } from './jumpTargetVisibility'
 import { shouldShowScrollToBottomFab } from './fabVisibility'
 import type { MessageVirtualizer } from './messageVirtualizer'
 import { notifyUserInput } from '@/utils/renderLoopDetector'
@@ -1936,6 +1937,31 @@ export function useMessageListScroll({
         outcome,
         highlighted: Boolean(element && applied),
       })
+
+      // The jump has settled, which makes this the one moment the claim "the target
+      // is on screen" can be checked. Measured from the live rects rather than from
+      // any scroll bookkeeping, so a wrong offset cannot hide behind agreeing state.
+      if (__FLUUX_ANOMALY__) {
+        const settledScroller = scrollerRef.current
+        if (settledScroller) {
+          const viewport = settledScroller.getBoundingClientRect()
+          const target = element?.getBoundingClientRect() ?? null
+          const miss = evaluateJumpTarget({
+            outcome,
+            applied,
+            target: target ? { top: target.top, bottom: target.bottom } : null,
+            viewport: { top: viewport.top, bottom: viewport.bottom },
+          })
+          if (miss) {
+            signalAnomaly({
+              name: 'scroll/jump-target-miss',
+              offBy: Math.round(miss.offBy),
+              messageId: request.desired.messageId,
+            })
+          }
+        }
+      }
+
       if (consumeStoreTarget) onTargetMessageConsumedRef.current?.()
     },
   }), [

--- a/apps/fluux/src/utils/anomalySignal.ts
+++ b/apps/fluux/src/utils/anomalySignal.ts
@@ -1,6 +1,5 @@
 /**
- * The seam between the always-present diagnostic sentinels and the dev-only
- * anomaly tree.
+ * The neutral observation seam into the dev-only anomaly runtime.
  *
  * The sentinels live in production code — `useMessageListScroll` and
  * `stallSentinel` ship in every build, because their `console.warn` prose is the
@@ -14,14 +13,15 @@
  * `signalAnomaly` is a null check on a path that is already rate-limited to once
  * per five seconds — and no anomaly module is reachable from here.
  *
- * This is fan-out, not re-pointing: every caller emits its prose exactly as before
- * and signals IN ADDITION. Nothing is removed from `fluux.log`.
+ * For the always-shipped monitors this is fan-out, not re-pointing: each still emits
+ * its prose and signals in addition. Dev-only detectors use the same seam after
+ * reaching their own verdicts.
  *
  * @module Utils/AnomalySignal
  */
 
 /**
- * One observation, as the sentinel that made it describes it.
+ * One observation, as its source describes it.
  *
  * A discriminated union rather than a bag of optional fields: the anomaly side
  * must map each case to a specific invariant id with the right `expected` and
@@ -68,6 +68,27 @@ export type AnomalySignal =
       /** How long the main thread was blocked, beyond the expected tick gap. */
       blockedMs: number
       thresholdMs: number
+    }
+  | {
+      name: 'read-state/unread-survives-focus'
+      /** Which conversation, so the record adapter can use the right token namespace. */
+      kind: 'conversation' | 'room'
+      id: string
+      unreadCount: number
+      heldMs: number
+    }
+  | {
+      name: 'scroll/fab-at-live-edge'
+      /** Independently measured — NOT the scroll hook's own at-bottom state. */
+      distFromBottom: number
+      heldMs: number
+    }
+  | {
+      name: 'scroll/jump-target-miss'
+      /** Signed px outside the viewport: negative above, positive below. */
+      offBy: number
+      /** The target message id, mapped to a session-local ref by the record adapter. */
+      messageId: string
     }
 
 export type AnomalySignalHandler = (signal: AnomalySignal) => void

--- a/apps/fluux/src/utils/viewportScroller.test.ts
+++ b/apps/fluux/src/utils/viewportScroller.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  _resetViewportScrollerRegistryForTesting,
+  measureViewport,
+  registerViewportScroller,
+} from './viewportScroller'
+
+/** A scroller with settable metrics — jsdom gives every element zeros otherwise. */
+function makeScroller(metrics: {
+  scrollHeight: number
+  scrollTop: number
+  clientHeight: number
+}): HTMLElement {
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'scrollHeight', { value: metrics.scrollHeight, configurable: true })
+  Object.defineProperty(el, 'clientHeight', { value: metrics.clientHeight, configurable: true })
+  el.scrollTop = metrics.scrollTop
+  document.body.appendChild(el)
+  return el
+}
+
+beforeEach(() => {
+  _resetViewportScrollerRegistryForTesting()
+  document.body.innerHTML = ''
+})
+
+describe('viewportScroller', () => {
+  it('measures a registered viewport', () => {
+    const el = makeScroller({ scrollHeight: 1000, scrollTop: 400, clientHeight: 500 })
+    registerViewportScroller('conversation', 'a@x.tld', { current: el })
+
+    expect(measureViewport('conversation', 'a@x.tld')).toEqual({
+      distFromBottom: 100,
+      scrollTop: 400,
+      clientHeight: 500,
+    })
+  })
+
+  it('returns null for an unknown id rather than inventing a measurement', () => {
+    // The same rule viewportAtBottom follows: a position must never be fabricated
+    // for a view we cannot see. Zeros would read as "pinned to the bottom".
+    expect(measureViewport('conversation', 'nobody@x.tld')).toBeNull()
+  })
+
+  it('returns null when the ref is registered but still empty', () => {
+    // The registering effect runs before the list has mounted in some orders.
+    registerViewportScroller('conversation', 'a@x.tld', { current: null })
+    expect(measureViewport('conversation', 'a@x.tld')).toBeNull()
+  })
+
+  it('returns null for a detached element instead of reporting zeros', () => {
+    // A detached element reports 0 for every metric, which computes to
+    // distFromBottom 0 — a confident "at the bottom" for a view that is gone.
+    const el = makeScroller({ scrollHeight: 1000, scrollTop: 400, clientHeight: 500 })
+    registerViewportScroller('conversation', 'a@x.tld', { current: el })
+    el.remove()
+
+    expect(measureViewport('conversation', 'a@x.tld')).toBeNull()
+  })
+
+  it('keeps conversation and room namespaces separate', () => {
+    // The same bare JID can name a contact on one server and a MUC on another.
+    const conv = makeScroller({ scrollHeight: 1000, scrollTop: 500, clientHeight: 500 })
+    const room = makeScroller({ scrollHeight: 2000, scrollTop: 0, clientHeight: 500 })
+    registerViewportScroller('conversation', 'same@x.tld', { current: conv })
+    registerViewportScroller('room', 'same@x.tld', { current: room })
+
+    expect(measureViewport('conversation', 'same@x.tld')?.distFromBottom).toBe(0)
+    expect(measureViewport('room', 'same@x.tld')?.distFromBottom).toBe(1500)
+  })
+
+  it('reads through the ref, so a late-attached element is still measurable', () => {
+    // Why the ref object is registered rather than the element: the list can mount
+    // after the view's effect has already run.
+    const ref: { current: HTMLElement | null } = { current: null }
+    registerViewportScroller('conversation', 'a@x.tld', ref)
+    expect(measureViewport('conversation', 'a@x.tld')).toBeNull()
+
+    ref.current = makeScroller({ scrollHeight: 800, scrollTop: 100, clientHeight: 400 })
+    expect(measureViewport('conversation', 'a@x.tld')?.distFromBottom).toBe(300)
+  })
+
+  it('replaces the registration on remount', () => {
+    const first = makeScroller({ scrollHeight: 1000, scrollTop: 0, clientHeight: 500 })
+    const second = makeScroller({ scrollHeight: 1000, scrollTop: 500, clientHeight: 500 })
+    registerViewportScroller('conversation', 'a@x.tld', { current: first })
+    registerViewportScroller('conversation', 'a@x.tld', { current: second })
+
+    expect(measureViewport('conversation', 'a@x.tld')?.scrollTop).toBe(500)
+  })
+
+  it('a stale unregister cannot drop the live registration', () => {
+    // React can run a previous effect's cleanup after the next effect has mounted.
+    // The same hazard viewportAtBottom guards, and the same guard.
+    const first = makeScroller({ scrollHeight: 1000, scrollTop: 0, clientHeight: 500 })
+    const second = makeScroller({ scrollHeight: 1000, scrollTop: 500, clientHeight: 500 })
+    const unregisterFirst = registerViewportScroller('conversation', 'a@x.tld', { current: first })
+    registerViewportScroller('conversation', 'a@x.tld', { current: second })
+
+    unregisterFirst()
+
+    expect(measureViewport('conversation', 'a@x.tld')?.scrollTop).toBe(500)
+  })
+
+  it('unregisters its own slot', () => {
+    const el = makeScroller({ scrollHeight: 1000, scrollTop: 0, clientHeight: 500 })
+    const unregister = registerViewportScroller('conversation', 'a@x.tld', { current: el })
+    unregister()
+    expect(measureViewport('conversation', 'a@x.tld')).toBeNull()
+  })
+})

--- a/apps/fluux/src/utils/viewportScroller.ts
+++ b/apps/fluux/src/utils/viewportScroller.ts
@@ -1,0 +1,83 @@
+/**
+ * Viewport scroller registry.
+ *
+ * A sibling of `viewportAtBottom.ts`, and deliberately not a field on it: that one
+ * registers the at-bottom BOOLEAN maintained by `useMessageListScroll`, which is the
+ * right answer for "did the user see the newest message" but the wrong one for any
+ * check on the hook's own correctness. A detector reading that boolean cannot
+ * disagree with the hook, so it goes silent precisely when the hook is wrong.
+ *
+ * This registers the scroll ELEMENT instead, so a caller can measure the viewport
+ * itself and reach a verdict the hook had no part in.
+ *
+ * Same conventions as `viewportAtBottom`: the same key shape, re-registering
+ * replaces (view remount), unregistering only drops the slot it still owns, and an
+ * unknown id yields nothing rather than a fabricated measurement.
+ *
+ * The REF OBJECT is registered, not the element, for the same reason
+ * `viewportAtBottom` does it: the element does not exist when the registering effect
+ * first runs if the list mounts later than its view, and keying the effect on
+ * something that changes when the element appears would re-register on every
+ * message. Reading `.current` at measure time sidesteps both.
+ *
+ * @module Utils/ViewportScroller
+ */
+import type { ViewportKind } from './viewportAtBottom'
+
+interface ElementRef {
+  current: HTMLElement | null
+}
+
+const scrollers = new Map<string, ElementRef>()
+
+function key(kind: ViewportKind, id: string): string {
+  return `${kind}:${id}`
+}
+
+/**
+ * Register a view's scroll-element ref. Returns an unregister function for effect
+ * cleanup. Re-registering the same key replaces the previous ref.
+ */
+export function registerViewportScroller(
+  kind: ViewportKind,
+  id: string,
+  ref: ElementRef,
+): () => void {
+  const k = key(kind, id)
+  scrollers.set(k, ref)
+  return () => {
+    // Only drop it if we still own the slot — a remount may have replaced it.
+    if (scrollers.get(k) === ref) scrollers.delete(k)
+  }
+}
+
+/** One independent measurement of a view's scroll viewport. */
+export interface ViewportMetrics {
+  /** Pixels between the viewport bottom and the content bottom. */
+  distFromBottom: number
+  scrollTop: number
+  clientHeight: number
+}
+
+/**
+ * Measure a registered viewport, right now.
+ *
+ * @returns `null` when nothing is registered for `id`, or when the element has been
+ * detached from the document. A detached element reports zeros for every metric,
+ * which would read as "pinned to the bottom" — a confident wrong answer, and worse
+ * than admitting we cannot see.
+ */
+export function measureViewport(kind: ViewportKind, id: string): ViewportMetrics | null {
+  const element = scrollers.get(key(kind, id))?.current
+  if (!element || !element.isConnected) return null
+  return {
+    distFromBottom: element.scrollHeight - element.scrollTop - element.clientHeight,
+    scrollTop: element.scrollTop,
+    clientHeight: element.clientHeight,
+  }
+}
+
+/** Test-only: drop all registrations. */
+export function _resetViewportScrollerRegistryForTesting(): void {
+  scrollers.clear()
+}

--- a/docs/ANOMALY_INVARIANTS.md
+++ b/docs/ANOMALY_INVARIANTS.md
@@ -50,7 +50,20 @@ Each entry below is added by the stage that introduces it.
 
 ### `read-state/`
 
-_(stage 3: `unread-survives-focus`; stage 5: `badge-vs-pointer`, `pointer-regression`)_
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `read-state/unread-survives-focus` | suspect | A conversation was active, the window focused, and the newest message actually on screen, yet the unread count stayed above zero for `ctx.heldMs`. `observed` is the count | The mark-read path on focus regain did not run or did not stick. Check the read pointer for that conversation and whether a recount overwrote it |
+
+`suspect` rather than `bug` on purpose: the app marks read on focus regain, so a count
+lingering briefly is more likely propagation delay than a broken invariant, and `bug`
+has to keep meaning "an invariant broke". Promote it if the log shows it is not noisy.
+
+This uses the **viewport**, not the SDK's `windowAtLiveEdge` — the latter is true for
+any backgrounded conversation parked at the tail, so it is not evidence anyone saw
+anything.
+
+_(stage 5 adds `badge-vs-pointer` and `pointer-regression`, both of which need SDK
+seams that do not exist yet.)_
 
 ### `xmpp-traffic/`
 
@@ -58,7 +71,7 @@ _(stage 5: `mam-page-yield`, `redundant-query`, `iq-unanswered`)_
 
 ### `scroll/`
 
-These are **fan-out, not new detection.** The monitors in
+The first four entries are **fan-out, not new detection.** The monitors in
 `apps/fluux/src/components/conversation/` decide, log their prose to `fluux.log`
 exactly as they always have, and additionally signal a record. So every id here has
 a matching `console.warn` line: when one is puzzling, the prose has the detail that
@@ -71,8 +84,27 @@ could not be recorded (overlapping loop labels, the conversation, the scrollHeig
 | `scroll/resize-loop` | suspect | The message-list `ResizeObserver` fired `observed` times in `ctx.elapsedMs` (`expected` is the threshold per window) | Oscillating content — classically a `<video controls>` on WebKitGTK — driving a correction feedback loop. Not itself a failure; a sustained one is |
 | `scroll/slow-correction` | suspect | A scroll correction took `observed` ms (`expected` is the threshold), with `ctx.rows` rows rendered | Reflow cost scaling with the rendered backlog. Correlate with `ctx.rows`: a high count means virtualization is not engaged |
 
-_(stage 3 adds `fab-at-live-edge` and `jump-target-miss` in this family — those are
-genuinely new detectors, not fan-out.)_
+These two are genuine detectors rather than fan-out, so they have **no** matching
+`console.warn`:
+
+| id | sev | Meaning | What to do |
+|---|---|---|---|
+| `scroll/fab-at-live-edge` | bug | The scroll-to-bottom button was shown for `ctx.heldMs` while an independent measurement put the viewport `observed` px from the content bottom — already at the newest message | Stale `showScrollToBottom` React state: the scroll handler stopped firing after the list returned to the bottom. Not a fault in `shouldShowScrollToBottomFab`, which cannot produce this state |
+| `scroll/jump-target-miss` | bug | A go-to-message reported that it applied a position, but the target row landed `ctx.offBy` px outside the viewport — negative above, positive below | The anchor resolved to the wrong offset, or content grew after the jump settled. `ctx.msg` is the session-local ref for the target |
+
+**Named non-cases**, so a later reader does not think they were forgotten:
+
+- `fab-at-live-edge` does **not** fire while the loaded window has slid up. `fabVisible`
+  is `showScrollToBottom || windowSlidUp`, so there the button means "jump to the
+  latest" — a real affordance, even with the viewport at the bottom of what is loaded.
+- `fab-at-live-edge` reads the FAB's `inert` state, not its presence. The button is
+  always in the DOM; only its wrapper's `inert` attribute says whether it is offered.
+- `jump-target-miss` does **not** fire when the target row is absent from the DOM. That
+  is a load or windowing failure with a different cause, and one id with two meanings
+  would stop telling a reader where to look.
+- `fab-at-live-edge` measures through `utils/viewportScroller.ts`, deliberately not the
+  scroll hook's own at-bottom state — a detector reading the suspect value cannot
+  disagree with it, and would go silent exactly when the bug is present.
 
 ### `perf/`
 

--- a/docs/superpowers/plans/2026-07-30-anomaly-log-stage-3.md
+++ b/docs/superpowers/plans/2026-07-30-anomaly-log-stage-3.md
@@ -1,0 +1,194 @@
+# Stage 3 — the first real detectors
+
+Design: `docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md` §5.1, §5.3.
+Stages 0–2 shipped (#1167, #1178, #1187). Stage 2 was fan-out: no detection logic. This stage adds
+the first three detectors that actually decide something.
+
+This plan preserves implementation history. The current emitted contracts, severities, context
+fields, and named non-cases are owned by `docs/ANOMALY_INVARIANTS.md`.
+
+**No SDK change.** Everything here is observable from public app surfaces.
+
+---
+
+## 0. What changed since the spec was written
+
+Three findings from reading the current code. Each changes a detector's design, so they come first.
+
+### 0.1 `fab-at-live-edge` cannot be written as the spec words it
+
+The spec says "FAB visible while the list is at the bottom". That state is **unreachable** from the
+rule that decides FAB visibility:
+
+```ts
+// fabVisibility.ts
+if (pinningToBottom) return false
+return distFromBottom > threshold      // FAB_THRESHOLD = 300
+```
+
+`AT_BOTTOM_THRESHOLD` is 150. So "at the bottom" and "FAB shown" are separated by a 150px dead band
+and cannot both hold — a detector comparing them would be **unfalsifiable**, the hollow-test failure
+mode this repo keeps rediscovering.
+
+The real bug class is **stale state**: `showScrollToBottom` is React state written from the scroll
+handler in `useMessageListScroll.ts`. If the handler stops firing after the list returns to the
+bottom, the FAB stays up while the viewport is at the live edge. That is what users see, and it is
+what `project_fab_flash_open_at_bottom` was about.
+
+So the detector must compare the **rendered FAB state** against a **fresh, independent measurement**.
+This is load-bearing: reading the hook's own `isAtBottomRef` would make the detector blind exactly
+when the bug is present, which §5.1 calls the worst possible detector failure.
+
+→ **Requires a new measurement seam.** See §1.2 and Decision D1.
+
+### 0.2 `unread-survives-focus` has a ready-made "at live edge" oracle
+
+`src/utils/viewportAtBottom.ts` already exists for precisely this distinction, and its module comment
+makes the argument the detector needs:
+
+> `windowAtLiveEdge` (SDK) says where the *loaded message window* sits; it is true for any
+> backgrounded conversation parked at the tail […] It is therefore NOT evidence that the user saw
+> anything. The only real evidence is the scroll viewport.
+
+`isViewportAtBottom(kind, id)` is the correct oracle, and unknown ids return `false` — it never
+invents a read position. `ChatView` and `RoomView` already register their refs.
+
+Using `windowAtLiveEdge` instead would fire on every backgrounded conversation. Named here because it
+is the obvious wrong choice.
+
+### 0.3 `jump-target-miss` has an exact settle point already
+
+The explicit-target executor's `complete(request, outcome, applied)`
+in `useMessageListScroll.ts` runs after the jump settles, already re-finds the element via
+`findMessageTargetElement`, and already knows whether the position was `applied`. No new seam.
+
+---
+
+## 1. Surfaces
+
+### 1.1 Existing, reused as-is
+
+| Surface | Use |
+|---|---|
+| `isViewportAtBottom(kind, id)` (`utils/viewportAtBottom.ts`) | Did the user actually see the newest message |
+| `document.hasFocus()` / `visibilityState` | Focused |
+| SDK `chatStore` / `roomStore` state | `unreadCount`, active conversation id + kind |
+| Explicit-target `complete()` callback | `jump-target-miss` settle point |
+| `signalAnomaly` (`utils/anomalySignal.ts`) | The stage-2 seam, extended with detector variants |
+
+### 1.2 New: a scroller-element registry
+
+`src/utils/viewportScroller.ts` — mirrors `viewportAtBottom.ts` exactly (same key shape, same
+replace-on-remount semantics, same unknown-id-is-safe rule), but registers the scroller **ref**
+rather than a boolean ref, so a detector can measure `scrollHeight - scrollTop - clientHeight`
+itself.
+
+Registered from `ChatView` and `RoomView`, alongside their existing boolean-ref registrations.
+The registrations are guarded by `__FLUUX_ANOMALY__`, and the build audit treats this support module
+as instrumentation so a release fails if it survives dead-code elimination.
+
+---
+
+## 2. The detectors
+
+Each decision lives in a pure detector with focused firing and healthy-control coverage. See
+`docs/ANOMALY_INVARIANTS.md` for the current record semantics rather than duplicating them here.
+
+---
+
+## 3. The evaluation tick
+
+`unread-survives-focus` and `fab-at-live-edge` both need "held continuously for N ms", so both need a
+clock. One gated `setInterval` (1s) inside the anomaly tree drives both evaluators;
+`jump-target-miss` is event-driven and needs no tick.
+
+Mounted from `install()`'s refcounted attach block, alongside the digest timer and the signal handler
+— so a StrictMode remount cannot produce two tickers, which the stage-2 refcount already proves.
+
+`AnomalyInstaller` mounts inside `XMPPProvider` in `main.tsx` so SDK state is reachable, but
+outside `HashRouter` — no route access, which is fine since no detector needs it.
+
+---
+
+## 4. Registry and value additions
+
+| Addition | Where |
+|---|---|
+| `ID.unreadSurvivesFocus`, `ID.fabAtLiveEdge`, `ID.jumpTargetMiss` | `values.ts` |
+| Rows for all three, plus their named non-cases | `docs/ANOMALY_INVARIANTS.md` |
+| `CTX.distFromBottom`, `CTX.heldMs`, `CTX.offBy` | `values.ts` |
+| Three new `AnomalySignal` variants | `utils/anomalySignal.ts` |
+
+Parity between `ID` and the registry doc is already enforced by `values.test.ts`.
+
+---
+
+## 5. Tasks
+
+| # | Task | Gate |
+|---|---|---|
+| 1 | `viewportScroller.ts` registry + tests; register in ChatView/RoomView | unit |
+| 2 | `unreadSurvivesFocus.ts` pure detector + tests (fire, control, every reset) | unit |
+| 3 | `fabAtLiveEdge.ts` pure detector + tests (fire and healthy-settle controls) | unit |
+| 4 | `jumpTargetMiss.ts` pure predicate + wire into `complete()`; tests | unit |
+| 5 | Registry/value/signal additions; extend `signalRecords` mapping | unit + parity |
+| 6 | Tick driver in `install()`; StrictMode test | unit |
+| 7 | Demo-mode validation of at least one detector firing and staying silent | manual + Playwright |
+| 8 | Full gates: `npm test`, `typecheck`, `lint`, `check:anomaly:prod`/`:dev`, `test:scroll` | all |
+
+Break checks per §7.1: revert each guarantee, confirm the matching test fails.
+
+---
+
+## 5b. What the browser found that the unit tests could not
+
+The e2e control test — "a healthy demo session trips none of the detectors" — failed on
+its first run with **both** timed detectors firing. Every unit test passed at the time.
+Three defects, all in the SAMPLING rather than in the detectors:
+
+1. **The FAB is always in the DOM.** Visibility is `inert={!fabVisible}` on its wrapper
+   in `MessageList.tsx`, so `querySelector(...) !== null` read `true` forever. Fixed
+   by requiring no inert ancestor, and by using `querySelectorAll` so a hidden FAB
+   earlier in the document cannot mask a live one.
+2. **`fabVisible` is `showScrollToBottom || windowSlidUp`** in `MessageList.tsx`.
+   With the window slid up the button legitimately means "jump to the latest", even
+   with the viewport at the bottom of what is loaded. `windowAtLiveEdge` is now part of
+   the sample, and the detector's premise is narrower for it.
+3. **The demo could not reach a read state.** `markAsRead` runs on a focus TRANSITION
+   (`useWindowVisibility.ts`) or on leaving a tab (`useViewNavigation.ts`) — never
+   while a page stays focused, which is a headless page's whole life. The control now
+   drives a real transition and asserts the count reached 0, so it cannot pass by
+   watching nothing.
+
+None of these were fixable by weakening a detector, and the second one narrowed a
+detector that would otherwise have been deleted for crying wolf. This is the argument
+for the system-level control test as a gate rather than a nicety.
+
+## 6. Decisions — settled 2026-07-30
+
+- **D1 → ship the scroller registry** (option a). `fab-at-live-edge` stays in stage 3 with an
+  independent measurement.
+- **D2 → `suspect`, not `bug`.** `bug` keeps meaning "an invariant broke". Promote only if the
+  daily-driver log shows it is not noisy.
+- **D3 → 2s / 1s as written**, understood to be guesses pending real log data, and subject to §6.1:
+  a detector that keeps crying wolf gets deleted, not tuned forever.
+
+Original framing, kept for the record:
+
+
+
+**D1 — the scroller registry (§1.2).** It is the only way `fab-at-live-edge` is not blind when the
+bug fires. Its guarded registrations let release builds eliminate the module, and the build audit
+fails if that support code survives. Alternatives: (a) keep the registry in anomaly builds; (b)
+drop `fab-at-live-edge` from stage 3 and revisit with the stage-5 SDK seams; (c) write it against the
+hook's own state and accept that it cannot see the bug — **not recommended**, it is a hollow
+detector by construction.
+
+**D2 — `unread-survives-focus` severity.** Spec says `bug`. But the app marks read on focus regain
+(`useWindowVisibility`), so a lingering count for 2s is more likely a *propagation* delay than a
+broken invariant. `suspect` would keep the log's `bug` class meaning "an invariant broke". Recommend
+`suspect` for its first outing, promote to `bug` once the daily-driver log shows it is not noisy.
+
+**D3 — hold windows.** 2s (spec) and 1s (my choice). Both are guesses until there is real log data.
+Fine to ship and tune, but tuning must not become indefinite — §6.1 says a detector that keeps
+producing false positives gets deleted, not tuned forever.

--- a/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
+++ b/docs/superpowers/specs/2026-07-29-client-anomaly-detection-log-design.md
@@ -448,12 +448,15 @@ belt-and-braces against a malformed record shape, not the privacy mechanism itse
 
 ## 5. Detector catalogue
 
+This is the design-time catalogue. Once an id ships, `docs/ANOMALY_INVARIANTS.md` owns its current
+record contract, severity, context fields, and named non-cases.
+
 ### 5.1 `read-state/`
 
 | id | check | sev | stage |
 |---|---|---|---|
 | `pointer-regression` | every pointer write must satisfy `isAhead` (`stores/shared/readPointer.ts:89`) | bug | **5 — blocked** |
-| `unread-survives-focus` | active + focused + at live edge for >2s, yet `unreadCount > 0` | bug | 3 |
+| `unread-survives-focus` | See the runtime invariant registry | registry | 3 |
 | `badge-vs-pointer` | archive-derived recount vs displayed count | bug | **5 — blocked** |
 
 **`pointer-regression` moves to stage 5, because generations are not observable.** "Forward-only"

--- a/scripts/anomaly-smoke.ts
+++ b/scripts/anomaly-smoke.ts
@@ -1,4 +1,34 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
+
+const DEMO_ROOM_JID = 'team@conference.fluux.chat'
+
+/**
+ * Open a room in demo mode.
+ *
+ * Activated through the store before the hash flips, mirroring the scroll suite: the
+ * rooms sidebar auto-selects, and a click races that. Waiting for a mounted row is
+ * what proves the list is live, which the sampler needs.
+ */
+async function openDemoRoom(page: Page): Promise<void> {
+  await page.evaluate(
+    (jid) =>
+      (window as unknown as { __roomStore?: { getState(): { activateRoom(j: string): unknown } } })
+        .__roomStore?.getState()
+        .activateRoom(jid),
+    DEMO_ROOM_JID,
+  )
+  await page.waitForFunction(
+    (jid) =>
+      (window as unknown as { __roomStore?: { getState(): { activeRoomJid?: string } } })
+        .__roomStore?.getState().activeRoomJid === jid,
+    DEMO_ROOM_JID,
+    { timeout: 15_000 },
+  )
+  await page.evaluate((jid) => {
+    window.location.hash = '#/rooms/' + encodeURIComponent(jid)
+  }, DEMO_ROOM_JID)
+  await page.waitForSelector('[data-index], .message-row', { timeout: 15_000 })
+}
 
 /**
  * The bundle checks prove the anomaly code is PRESENT in a Dev build. They cannot
@@ -114,5 +144,168 @@ test.describe('anomaly runtime', () => {
     // A ceiling in a freshly loaded demo would mean the budget accounting is wrong.
     expect(summary.ceilings).toBe(0)
     expect(summary.rejected).toBe(0)
+  })
+
+  test('a healthy demo session trips none of the detectors', async ({ page }) => {
+    // The system-level CONTROL. Every detector has unit tests proving it stays quiet
+    // on synthetic healthy input, but only a real browser proves the SAMPLING is
+    // healthy too — that the world it reads is the world it thinks it reads. A
+    // detector wired to a wrong reading fires on a working app, and by the design's
+    // own rule would then be deleted rather than fixed.
+    await page.goto('/demo.html?tutorial=false')
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              ((window as unknown as { __fluuxAnomalies?: string[] }).__fluuxAnomalies ?? [])
+                .length,
+          ),
+        { message: 'the anomaly runtime never installed' },
+      )
+      .toBeGreaterThan(0)
+
+    // Open a room so the sampler has something to look at.
+    await openDemoRoom(page)
+
+    // Let the list settle at the live edge FIRST. The mark-read below is gated on the
+    // viewport actually being at the bottom, so firing it mid-settle is skipped.
+    await page.waitForTimeout(2000)
+
+    // Then drive a real blur → focus transition. This is not test decoration: the app
+    // marks the active view read on the focus TRANSITION
+    // (`useWindowVisibility.ts`, gated on the viewport being at the bottom), and a
+    // headless page starts already focused, so that transition never happens on its
+    // own. Without it the demo sits on a permanently unread room and
+    // unread-survives-focus reports correctly on a state no real user would be in.
+    // `handleFocusChange` reads `document.hasFocus()` rather than the event type, so a
+    // bare synthetic blur changes nothing — the transition has to be driven through
+    // that reading.
+    await page.evaluate(() => {
+      const real = document.hasFocus.bind(document)
+      Object.defineProperty(document, 'hasFocus', { value: () => false, configurable: true })
+      window.dispatchEvent(new Event('blur'))
+      Object.defineProperty(document, 'hasFocus', { value: real, configurable: true })
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    // Prove the mark-read actually landed. Otherwise a future change to that gate
+    // would turn this control test into an assertion that nothing was watching.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            (jid) =>
+              (
+                window as unknown as {
+                  __roomStore: { getState(): { roomMeta: Map<string, { unreadCount: number }> } }
+                }
+              ).__roomStore.getState().roomMeta.get(jid)?.unreadCount,
+            DEMO_ROOM_JID,
+          ),
+        {
+          timeout: 10_000,
+          message: 'focus regain did not clear the room unread count — the control is unsound',
+        },
+      )
+      .toBe(0)
+
+    // Sit longer than the longest hold window (2s for unread-survives-focus).
+    await page.waitForTimeout(4000)
+
+    const detectorRecords = await page.evaluate(() => {
+      const ids = new Set([
+        'read-state/unread-survives-focus',
+        'scroll/fab-at-live-edge',
+        'scroll/jump-target-miss',
+      ])
+      return (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+        .map((l) => JSON.parse(l) as { id?: string })
+        .filter((r) => r.id !== undefined && ids.has(r.id))
+        .map((r) => r.id)
+    })
+
+    expect(
+      detectorRecords,
+      'a detector fired on a healthy demo session — it is miswired, not finding bugs',
+    ).toEqual([])
+  })
+
+  test('the sampler is actually running, so the control above means something', async ({
+    page,
+  }) => {
+    // Guard for the guard. "No detector fired" is also what a sampler that never
+    // ticks produces, so the previous test passes vacuously unless the loop is
+    // proven alive. Forcing a real anomaly is the only way to show it is.
+    await page.goto('/demo.html?tutorial=false')
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              ((window as unknown as { __fluuxAnomalies?: string[] }).__fluuxAnomalies ?? [])
+                .length,
+          ),
+        { message: 'the anomaly runtime never installed' },
+      )
+      .toBeGreaterThan(0)
+
+    await openDemoRoom(page)
+
+    // Let the list reach the live edge, then un-hide the REAL FAB. Its wrapper carries
+    // `inert={!fabVisible}`, so clearing that is precisely the stale state the detector
+    // is for: the affordance offered while there is nothing to scroll to. Forced
+    // rather than provoked because the genuine race needs a WebKit timing window we
+    // cannot reproduce on demand.
+    await page.waitForTimeout(2000)
+
+    // Strip `inert` and KEEP it stripped. React owns that attribute
+    // (`inert={!fabVisible}`), so any re-render — a typing indicator, an animation
+    // frame — puts it straight back, and the detector needs the state to hold for a
+    // full second. A one-shot removal passed most runs and failed occasionally, which
+    // is worse than failing every time.
+    await page.evaluate(() => {
+      const strip = () => {
+        for (const fab of document.querySelectorAll('[data-fab="scroll-to-bottom"]')) {
+          fab.closest('[inert]')?.removeAttribute('inert')
+        }
+      }
+      strip()
+      new MutationObserver(strip).observe(document.body, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['inert'],
+      })
+    })
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+              .map((l) => JSON.parse(l) as { id?: string })
+              .some((r) => r.id === 'scroll/fab-at-live-edge'),
+          ),
+        {
+          timeout: 15_000,
+          message: 'the detector sampler never fired — the control test above is vacuous',
+        },
+      )
+      .toBe(true)
+
+    const record = await page.evaluate(
+      () =>
+        (window as unknown as { __fluuxAnomalies: string[] }).__fluuxAnomalies
+          .map((l) => JSON.parse(l) as Record<string, unknown>)
+          .find((r) => r.id === 'scroll/fab-at-live-edge')!,
+    )
+    expect(record.sev).toBe('bug')
+    expect(record.expected).toBe(0)
+    // The measured distance, proving the reading came from the scroller registry
+    // rather than being assumed.
+    expect(typeof record.observed).toBe('number')
+    expect(record.observed as number).toBeLessThanOrEqual(150)
   })
 })


### PR DESCRIPTION
Stages 0–2 built the recording substrate and fanned the existing scroll and stall monitors into it. These are the first three checks that decide something new, so the log can start finding problems rather than only recording them.

| id | sev | Fires when |
|---|---|---|
| `read-state/unread-survives-focus` | suspect | A conversation is active, the window focused, and the newest message actually on screen, yet the unread count stays above zero for 2s |
| `scroll/fab-at-live-edge` | bug | The scroll-to-bottom button is offered while the viewport is already at the newest message |
| `scroll/jump-target-miss` | bug | A go-to-message reports success without putting the target row on screen |

Each is a pure function with its clock passed in, and each lands with a control case proving it stays silent on healthy input. The two timed ones share one sampler, started inside the refcounted attach block so a StrictMode remount cannot leave two running.

### Why the FAB check measures for itself

`fab-at-live-edge` cannot be written as a check on `shouldShowScrollToBottomFab`: that function shows the button above 300px while "at the bottom" means under 150px, so the two cannot both hold and the check would be unfalsifiable. The real bug is stale React state, which needs a measurement the scroll hook had no part in — hence a small scroller registry alongside the existing `viewportAtBottom` one, and a DOM read of the FAB's `inert` state. Reading the hook's own values would go silent exactly when the bug is present.

That registry is gated so it leaves production entirely, and the build audit now tracks runtime and support modules separately: production forbids both, while a Dev build must contain the runtime on its own rather than being satisfied by a support module.

### What a real browser caught

A system-level control test — no detector fires on a healthy demo session — failed on its first run with both timed detectors reporting, while every unit test passed. Three sampling defects:

- the FAB is always in the DOM; only its wrapper's `inert` attribute says whether it is offered;
- `fabVisible` is `showScrollToBottom || windowSlidUp`, so a slid-up window legitimately shows the button as "jump to latest";
- the demo could not reach a read state at all, because `markAsRead` runs only on a focus transition.

The second of those narrowed a detector that would otherwise have fired on every session. `jump-target-miss` similarly evaluates only settled and best-effort completions: a user takeover still reports `applied` once a positioning frame has landed, so keying on `applied` alone would have reported a healthy session where someone simply scrolled away mid-jump.

Every id is documented in `docs/ANOMALY_INVARIANTS.md`, including the named non-cases, so a review can read the log without reading the code.
