### PR TITLE
i18n(ko): make Korean selectable and enforce locale registration parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 - **14 Built-in Themes** - Catppuccin, Nord, Dracula, Gruvbox, Tokyo Night, Rosé Pine, Solarized, and more — plus light/dark mode
 - **Custom Themes** - Import/export themes as JSON, pick a custom accent color, or write CSS overrides in the built-in editor
 - **Synced Across Devices** - Theme, accent, and font size preferences are stored server-side and follow you everywhere
-- **Internationalization** - 33 languages including complete EU coverage
+- **Internationalization** - 34 languages including complete EU coverage
 
 ### Privacy & Security
 - **Self-hostable** - Connect to any XMPP server, no vendor lock-in, no third-party dependency

--- a/apps/fluux/src/components/settings-components/LanguageSettings.tsx
+++ b/apps/fluux/src/components/settings-components/LanguageSettings.tsx
@@ -4,42 +4,7 @@ import { Globe, Clock } from 'lucide-react'
 import { useSettingsStore, type TimeFormat } from '@/stores/settingsStore'
 import { Select } from '@/components/ui/Select'
 import { SettingsSection } from '@/components/ui/SettingsSection'
-
-const languages = [
-  { code: 'ar', name: 'العربية' },
-  { code: 'be', name: 'Беларускі' },
-  { code: 'bg', name: 'Български' },
-  { code: 'ca', name: 'Català' },
-  { code: 'cs', name: 'Čeština' },
-  { code: 'da', name: 'Dansk' },
-  { code: 'de', name: 'Deutsch' },
-  { code: 'el', name: 'Ελληνικά' },
-  { code: 'en', name: 'English' },
-  { code: 'es', name: 'Español' },
-  { code: 'et', name: 'Eesti' },
-  { code: 'fi', name: 'Suomi' },
-  { code: 'fr', name: 'Français' },
-  { code: 'ga', name: 'Gaeilge' },
-  { code: 'he', name: 'עברית' },
-  { code: 'hr', name: 'Hrvatski' },
-  { code: 'hu', name: 'Magyar' },
-  { code: 'is', name: 'Íslenska' },
-  { code: 'it', name: 'Italiano' },
-  { code: 'lt', name: 'Lietuvių' },
-  { code: 'lv', name: 'Latviešu' },
-  { code: 'mt', name: 'Malti' },
-  { code: 'nb', name: 'Norsk bokmål' },
-  { code: 'nl', name: 'Nederlands' },
-  { code: 'pl', name: 'Polski' },
-  { code: 'pt', name: 'Português' },
-  { code: 'ro', name: 'Română' },
-  { code: 'ru', name: 'Русский' },
-  { code: 'sk', name: 'Slovenčina' },
-  { code: 'sl', name: 'Slovenščina' },
-  { code: 'sv', name: 'Svenska' },
-  { code: 'uk', name: 'Українська' },
-  { code: 'zh-CN', name: '简体中文' },
-]
+import { languageNames as languages } from '@/i18n/languages'
 
 const timeFormatOptions: { value: TimeFormat; labelKey: string }[] = [
   { value: 'auto', labelKey: 'settings.timeFormatAuto' },

--- a/apps/fluux/src/i18n/i18n.test.ts
+++ b/apps/fluux/src/i18n/i18n.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import { supportedLanguages, languageNames } from './languages'
+import { newMessagesText } from '@/utils/swMessages'
 
 // Auto-discover all locale files via Vite eager glob
 const localeModules = import.meta.glob('./locales/*.json', { eager: true }) as Record<
@@ -102,6 +104,51 @@ describe('i18n', () => {
     })
   })
 
+  // A locale is only really shipped once three lists agree: the JSON file exists,
+  // `supportedLanguages` registers it with i18next, and the Settings picker offers it.
+  // `ko` shipped registered-but-unlisted, so a Korean browser got a Korean UI while the
+  // picker read "English" and no user could select Korean at all. Nothing checked that,
+  // so CI was green. These assertions are that check.
+  describe('locale registration parity', () => {
+    const pickerCodes: string[] = languageNames.map(l => l.code)
+    const registeredCodes: string[] = [...supportedLanguages]
+
+    it('offers every registered language in the settings picker', () => {
+      const unselectable = registeredCodes.filter(code => !pickerCodes.includes(code))
+      expect(unselectable).toEqual([])
+    })
+
+    it('registers every language offered in the settings picker', () => {
+      const unregistered = pickerCodes.filter(code => !registeredCodes.includes(code))
+      expect(unregistered).toEqual([])
+    })
+
+    it('ships a locale file for every registered language', () => {
+      const withoutTranslations = registeredCodes.filter(code => !languageCodes.includes(code))
+      expect(withoutTranslations).toEqual([])
+    })
+
+    it('registers every locale file that ships', () => {
+      const unregistered = languageCodes.filter(code => !registeredCodes.includes(code))
+      expect(unregistered).toEqual([])
+    })
+
+    it('gives the picker a non-empty display name for every language', () => {
+      const unnamed = languageNames.filter(l => !l.name.trim()).map(l => l.code)
+      expect(unnamed).toEqual([])
+    })
+
+    // The service worker cannot run i18next, so it carries its own string table keyed by
+    // base language. A locale missing there silently renders notifications in English.
+    it('has a service-worker notification form for every registered base language', () => {
+      const englishText = newMessagesText('en', 3)
+      const fallingBackToEnglish = registeredCodes.filter(
+        code => code !== 'en' && newMessagesText(code, 3) === englishText
+      )
+      expect(fallingBackToEnglish).toEqual([])
+    })
+  })
+
   describe('interpolation', () => {
     it('should interpolate reconnecting status with seconds and attempt', () => {
       const result = testI18n.t('status.reconnectingIn', { seconds: 5, attempt: 2 })
@@ -193,6 +240,15 @@ describe('i18n', () => {
       expect(testI18n.t('rooms.unreadMessages', { count: 998, displayCount: '998' })).toBe('998 unread messages')
       expect(testI18n.t('rooms.unreadMessages', { count: 999, displayCount: '999+' })).toBe('999+ unread messages')
       expect(testI18n.t('rooms.unreadMessages', { count: 1000, displayCount: '999+' })).toBe('999+ unread messages')
+    })
+
+    // Korean has a single plural category, so both forms share one template — but it still
+    // has to interpolate `displayCount` to get the cap, not the raw `count`.
+    it('renders the capped displayCount in Korean too', async () => {
+      await testI18n.changeLanguage('ko')
+      expect(testI18n.t('rooms.unreadMessages', { count: 3, displayCount: '3' })).toBe('읽지 않은 메시지 3개')
+      expect(testI18n.t('rooms.unreadMessages', { count: 1000, displayCount: '999+' })).toBe('읽지 않은 메시지 999+개')
+      expect(testI18n.t('chat.newMessagesCount', { count: 1000, displayCount: '999+' })).toBe('새 메시지 999+개')
     })
   })
 

--- a/apps/fluux/src/i18n/i18n.test.ts
+++ b/apps/fluux/src/i18n/i18n.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import { supportedLanguages, languageNames } from './languages'
-import { newMessagesText } from '@/utils/swMessages'
+import { newMessagesText, serviceWorkerNotificationBaseLanguages } from '@/utils/swMessages'
 
 // Auto-discover all locale files via Vite eager glob
 const localeModules = import.meta.glob('./locales/*.json', { eager: true }) as Record<
@@ -112,6 +112,7 @@ describe('i18n', () => {
   describe('locale registration parity', () => {
     const pickerCodes: string[] = languageNames.map(l => l.code)
     const registeredCodes: string[] = [...supportedLanguages]
+    const registeredBaseCodes = registeredCodes.map(code => code.toLowerCase().split('-')[0])
 
     it('offers every registered language in the settings picker', () => {
       const unselectable = registeredCodes.filter(code => !pickerCodes.includes(code))
@@ -146,6 +147,13 @@ describe('i18n', () => {
         code => code !== 'en' && newMessagesText(code, 3) === englishText
       )
       expect(fallingBackToEnglish).toEqual([])
+    })
+
+    it('registers every service-worker notification base language', () => {
+      const unregistered = serviceWorkerNotificationBaseLanguages.filter(
+        code => !registeredBaseCodes.includes(code)
+      )
+      expect(unregistered).toEqual([])
     })
   })
 

--- a/apps/fluux/src/i18n/index.ts
+++ b/apps/fluux/src/i18n/index.ts
@@ -2,12 +2,9 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import resourcesToBackend from 'i18next-resources-to-backend'
+import { supportedLanguages } from './languages'
 
-export const supportedLanguages = [
-  'ar', 'be', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'fi', 'fr',
-  'ga', 'he', 'hr', 'hu', 'is', 'it', 'ko', 'lt', 'lv', 'mt', 'nb', 'nl',
-  'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'uk', 'zh-CN',
-] as const
+export { supportedLanguages, languageNames, type SupportedLanguage } from './languages'
 
 const RTL_LANGUAGES = new Set(['ar', 'he'])
 

--- a/apps/fluux/src/i18n/languages.ts
+++ b/apps/fluux/src/i18n/languages.ts
@@ -1,0 +1,56 @@
+/**
+ * The locale registry, kept free of side effects so it can be imported by
+ * tests and by the service-worker string table without booting i18next.
+ *
+ * `supportedLanguages` is what i18next will load; `languageNames` is what the
+ * Settings picker renders. The two must agree in both directions — a locale
+ * registered but not listed cannot be chosen by anyone, and a locale listed but
+ * not registered would silently resolve to the English fallback. The i18n
+ * parity suite enforces that, so adding a locale means touching both lists.
+ */
+
+export const supportedLanguages = [
+  'ar', 'be', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'fi', 'fr',
+  'ga', 'he', 'hr', 'hu', 'is', 'it', 'ko', 'lt', 'lv', 'mt', 'nb', 'nl',
+  'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'uk', 'zh-CN',
+] as const
+
+export type SupportedLanguage = (typeof supportedLanguages)[number]
+
+/** Display name for each supported locale, written in that locale. */
+export const languageNames: { code: SupportedLanguage; name: string }[] = [
+  { code: 'ar', name: 'العربية' },
+  { code: 'be', name: 'Беларускі' },
+  { code: 'bg', name: 'Български' },
+  { code: 'ca', name: 'Català' },
+  { code: 'cs', name: 'Čeština' },
+  { code: 'da', name: 'Dansk' },
+  { code: 'de', name: 'Deutsch' },
+  { code: 'el', name: 'Ελληνικά' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Español' },
+  { code: 'et', name: 'Eesti' },
+  { code: 'fi', name: 'Suomi' },
+  { code: 'fr', name: 'Français' },
+  { code: 'ga', name: 'Gaeilge' },
+  { code: 'he', name: 'עברית' },
+  { code: 'hr', name: 'Hrvatski' },
+  { code: 'hu', name: 'Magyar' },
+  { code: 'is', name: 'Íslenska' },
+  { code: 'it', name: 'Italiano' },
+  { code: 'ko', name: '한국어' },
+  { code: 'lt', name: 'Lietuvių' },
+  { code: 'lv', name: 'Latviešu' },
+  { code: 'mt', name: 'Malti' },
+  { code: 'nb', name: 'Norsk bokmål' },
+  { code: 'nl', name: 'Nederlands' },
+  { code: 'pl', name: 'Polski' },
+  { code: 'pt', name: 'Português' },
+  { code: 'ro', name: 'Română' },
+  { code: 'ru', name: 'Русский' },
+  { code: 'sk', name: 'Slovenčina' },
+  { code: 'sl', name: 'Slovenščina' },
+  { code: 'sv', name: 'Svenska' },
+  { code: 'uk', name: 'Українська' },
+  { code: 'zh-CN', name: '简体中文' },
+]

--- a/apps/fluux/src/i18n/languages.ts
+++ b/apps/fluux/src/i18n/languages.ts
@@ -2,11 +2,11 @@
  * The locale registry, kept free of side effects so it can be imported by
  * tests and by the service-worker string table without booting i18next.
  *
- * `supportedLanguages` is what i18next will load; `languageNames` is what the
- * Settings picker renders. The two must agree in both directions — a locale
- * registered but not listed cannot be chosen by anyone, and a locale listed but
- * not registered would silently resolve to the English fallback. The i18n
- * parity suite enforces that, so adding a locale means touching both lists.
+ * A shipped locale has four registrations: `supportedLanguages` tells i18next
+ * what to load, `languageNames` populates the Settings picker, a matching JSON
+ * file supplies the app strings, and `utils/swMessages.ts` supplies notification
+ * text without i18next. The i18n parity suite enforces agreement in both
+ * directions, so adding a locale means updating all four.
  */
 
 export const supportedLanguages = [

--- a/apps/fluux/src/i18n/locales/ko.json
+++ b/apps/fluux/src/i18n/locales/ko.json
@@ -140,7 +140,7 @@
         "enterName": "이름 입력",
         "pleaseEnterName": "이름을 입력하세요",
         "failedToRename": "연락처 이름 변경 실패",
-        "nicknameLabel": "별명",
+        "nicknameLabel": "닉네임",
         "nicknameOptional": "(선택사항)",
         "nicknamePlaceholder": "표시 이름",
         "jidLabel": "JID (Jabber ID)",
@@ -195,7 +195,7 @@
             "glanceDisabled": "암호화 꺼짐",
             "glanceLocked": "암호화됨, 잠김"
         },
-        "actionsMenu": "더 보기"
+        "actionsMenu": "작업 더 보기"
     },
     "rooms": {
         "backToRooms": "대화방 목록으로",
@@ -242,7 +242,7 @@
         "registeredNicknameRequired": "이 대화방은 등록된 닉네임이 필요합니다.",
         "roomNotFound": "대화방을 찾을 수 없습니다.",
         "nonAnonWarningTitle": "비익명 채널에 참여하시겠습니까?",
-        "nonAnonWarningMessage": "\"{{room}}\"의 모든 사람이 귀하의 실제 주소(XMPP/Jabber ID)를 볼 수 있습니다. 그래도 참여하시겠습니까?",
+        "nonAnonWarningMessage": "\"{{room}}\"의 모든 사람이 내 실제 주소(XMPP/Jabber ID)를 볼 수 있습니다. 그래도 참여하시겠습니까?",
         "nonAnonWarningConfirm": "참여",
         "joinToParticipate": "참여하여 대화하기",
         "cachedHistoryWarning": "{{date}}까지의 캐시된 기록입니다. 최신 메시지를 가져오려면 참여하세요.",
@@ -431,8 +431,8 @@
         "nickEdgeWhitespace": "이름의 가장자리에 여분의 공백이 있습니다",
         "nickHiddenChars": "이름에 숨겨진 문자가 포함되어 있습니다",
         "mentionSuggestions": "멘션 제안",
-        "unreadMessages": "읽지 않은 메시지 {{count}}개",
-        "unreadMessages_other": "읽지 않은 메시지 {{count}}개"
+        "unreadMessages": "읽지 않은 메시지 {{displayCount}}개",
+        "unreadMessages_other": "읽지 않은 메시지 {{displayCount}}개"
     },
     "events": {
         "invitedBy": "{{name}}이(가) 초대함",
@@ -447,7 +447,7 @@
             "copied": "클립보드에 복사됨"
         },
         "me": "나",
-        "you": "당신",
+        "you": "나",
         "messageTo": "{{name}}에게 메시지",
         "messageRoom": "#{{name}}에 메시지",
         "editMessage": "메시지 수정",
@@ -460,13 +460,13 @@
         "forwardMessage": "메시지 전달 (곧 출시)",
         "moreReactions": "더 많은 반응",
         "reactionOthers": "외 {{count}}명",
-        "moreOptions": "더 보기",
+        "moreOptions": "옵션 더 보기",
         "reactWith": "{{emoji}}로 반응",
         "noMessages": "아직 메시지가 없습니다. 인사해보세요!",
         "loadingMessages": "메시지 불러오는 중...",
         "newMessages": "새 메시지",
-        "newMessagesCount": "새 메시지 {{count}}개",
-        "newMessagesCount_other": "새 메시지 {{count}}개",
+        "newMessagesCount": "새 메시지 {{displayCount}}개",
+        "newMessagesCount_other": "새 메시지 {{displayCount}}개",
         "youWereAway": "자리를 비우셨습니다",
         "jumpToLastRead": "마지막으로 읽은 메시지로 이동",
         "historyStart": "대화 시작",
@@ -989,7 +989,7 @@
         "edition": "커뮤니티 에디션",
         "description": "사용하기 쉬운 강력하고 생산적인 메시징 클라이언트입니다.",
         "madeBy": "제작자",
-        "commercialLicense": "상업용 라이센스 사용 가능.",
+        "commercialLicense": "상업용 라이선스 사용 가능.",
         "contactUs": "문의하기",
         "viewOnGithub": "GitHub에서 보기",
         "copyVersionInfo": "버전 정보 복사"
@@ -1276,7 +1276,7 @@
         "muc#roomconfig_membersonly": "활성화하면 멤버 목록에 있는 사용자만 참여할 수 있습니다. 다른 사용자는 초대를 받아야 합니다.",
         "muc#roomconfig_allowinvites": "참가자가 다른 사람을 대화방에 초대할 수 있도록 허용합니다.",
         "muc#roomconfig_changesubject": "참가자가 대화방 제목을 변경할 수 있도록 허용합니다.",
-        "muc#roomconfig_moderatedroom": "중재 대화방에서는 중재자 이상만 메시지를 보낼 수 있습니다. 발언권이 부여되지 않는 한.",
+        "muc#roomconfig_moderatedroom": "중재 대화방에서는 발언권이 부여되지 않는 한 중재자 이상만 메시지를 보낼 수 있습니다.",
         "muc#roomconfig_whois": "참가자의 실제 JID(주소)를 볼 수 있는 사람을 제어합니다. 중재자만 또는 모두.",
         "muc#roomconfig_passwordprotectedroom": "대화방에 참여하려면 비밀번호가 필요합니다.",
         "muc#roomconfig_roomsecret": "대화방에 참여하는 데 필요한 비밀번호입니다.",
@@ -1352,15 +1352,15 @@
         },
         "me": {
             "desc": "액션 메시지 보내기",
-            "usage": "/me <액션>"
+            "usage": "/me <action>"
         },
         "say": {
             "desc": "슬래시로 시작하더라도 텍스트를 그대로 보내기",
-            "usage": "/say <텍스트>"
+            "usage": "/say <text>"
         },
         "nick": {
             "desc": "이 대화방에서 닉네임 변경",
-            "usage": "/nick <새닉네임>",
+            "usage": "/nick <newnick>",
             "changed": "이제 {{nick}}(으)로 알려져 있습니다"
         },
         "part": {
@@ -1369,24 +1369,24 @@
         },
         "topic": {
             "desc": "대화방 제목 보기 또는 설정",
-            "usage": "/topic [텍스트]",
+            "usage": "/topic [text]",
             "set": "제목이 업데이트되었습니다",
             "current": "현재 제목: {{subject}}",
             "none": "제목이 설정되지 않았습니다"
         },
         "kick": {
             "desc": "대화방에서 누군가 제거",
-            "usage": "/kick <닉네임> [사유]",
+            "usage": "/kick <nick> [reason]",
             "done": "{{nick}}을(를) 강퇴했습니다"
         },
         "ban": {
             "desc": "대화방에서 누군가 차단",
-            "usage": "/ban <닉네임|jid> [사유]",
+            "usage": "/ban <nick|jid> [reason]",
             "done": "{{target}}을(를) 차단했습니다"
         },
         "invite": {
             "desc": "대화방에 누군가 초대",
-            "usage": "/invite [jid] [사유]",
+            "usage": "/invite [jid] [reason]",
             "done": "{{target}}에게 초대를 보냈습니다"
         },
         "config": {

--- a/apps/fluux/src/utils/swMessages.ts
+++ b/apps/fluux/src/utils/swMessages.ts
@@ -135,6 +135,9 @@ const FORMS: Record<string, PluralForms> = {
   zh: { other: '{count}条新消息' },
 }
 
+/** Normalized base-language codes supported by the runtime notification string table. */
+export const serviceWorkerNotificationBaseLanguages: readonly string[] = Object.freeze(Object.keys(FORMS))
+
 /** Localized "N new messages" for a coalesced notification body. */
 export function newMessagesText(locale: string, count: number): string {
   const base = locale.toLowerCase().split('-')[0]

--- a/apps/fluux/src/utils/swMessages.ts
+++ b/apps/fluux/src/utils/swMessages.ts
@@ -72,6 +72,7 @@ const FORMS: Record<string, PluralForms> = {
     many: '{count} nuovi messaggi',
     other: '{count} nuovi messaggi',
   },
+  ko: { other: '새 메시지 {count}개' },
   lt: {
     one: '{count} nauja žinutė',
     few: '{count} naujos žinutės',

--- a/screenshots/OVERVIEW.md
+++ b/screenshots/OVERVIEW.md
@@ -82,7 +82,7 @@ All screenshots are generated automatically from the [demo mode](../docs/DEMO_MO
 | French                                                                                | Greek                                                                                |
 |---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | <a href="./19-chat-fr.png"><img src="./19-chat-fr.png" width="400" alt="French"/></a> | <a href="./20-chat-el.png"><img src="./20-chat-el.png" width="400" alt="Greek"/></a> |
-| *33 languages including all EU official languages and RTL languages*                  |                                                                                      |
+| *All EU official languages, plus RTL language support*                                |                                                                                      |
 
 | Arabic (RTL)                                                                          | Hebrew (RTL)                                                                          |
 |---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|

--- a/screenshots/OVERVIEW.md
+++ b/screenshots/OVERVIEW.md
@@ -82,7 +82,7 @@ All screenshots are generated automatically from the [demo mode](../docs/DEMO_MO
 | French                                                                                | Greek                                                                                |
 |---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | <a href="./19-chat-fr.png"><img src="./19-chat-fr.png" width="400" alt="French"/></a> | <a href="./20-chat-el.png"><img src="./20-chat-el.png" width="400" alt="Greek"/></a> |
-| *All EU official languages, plus RTL language support*                                |                                                                                      |
+| *34 languages including all EU official languages and RTL languages*                  |                                                                                      |
 
 | Arabic (RTL)                                                                          | Hebrew (RTL)                                                                          |
 |---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|

--- a/scripts/installer-art/shared.css
+++ b/scripts/installer-art/shared.css
@@ -7,7 +7,7 @@
  *
  * No @font-face here on purpose — the artwork carries no words beyond the
  * brand lockup (an SVG). The installers localize their own copy, so baking
- * English into the bitmaps would be wrong in 32 of our 33 locales.
+ * English into the bitmaps would be wrong for every non-English locale.
  */
 :root {
   /* The aurora quartet, same stops as the app icon and the blog heroes. */

--- a/scripts/video/storyboard.ts
+++ b/scripts/video/storyboard.ts
@@ -218,7 +218,7 @@ export const storyboard: Scene[] = [
     run: async (d) => {
       await d.navigateTo('messages')
       await d.selectItem('Emma Wilson')
-      await d.caption('33 languages · full RTL', 'Right-to-left layouts, fully mirrored')
+      await d.caption('34 languages · full RTL', 'Right-to-left layouts, fully mirrored')
       await d.setLanguage('ar', 3000)
       await d.setLanguage('en', 800)
       await d.clearCaption()


### PR DESCRIPTION
Completes the Korean locale contributed by @nikescar in #1124. That PR added a clean, audited translation; this follow-up wires up the three registration points it could not have known about and adds the test that should have caught them. The translation itself is his work.

### Korean was not selectable

`ko` was registered in `supportedLanguages` but missing from the Settings language picker's own list. A user whose browser locale was Korean got a fully Korean UI while the selector contradictorily read "English", and no user could choose Korean at all.

### Notifications fell back to English

`ko` was the only supported base language absent from the per-locale table in `swMessages.ts`, which both the service worker and the desktop notification path use because the service worker cannot run i18next.

### Stale placeholder on four keys

`main` renamed `{{count}}` to `{{displayCount}}` in the unread and new-message templates after #1124 branched, so those values were correct when written but had since started bypassing the saturation cap — Korean would render `1000` where every other locale shows `999+`. The plural structure is deliberately unchanged: Korean has a single plural category, and the bare-key-plus-`_other` shape is correct.

### The parity test

Nothing checked that the picker and `supportedLanguages` agree, which is why green CI shipped an unselectable locale. The locale registry now lives in a side-effect-free `i18n/languages.ts` so it can be asserted on without booting i18next, and the i18n suite checks that the picker, `supportedLanguages`, the shipped locale files, and the service-worker table all cover the same set — in both directions. Each direction was proven to fail before being made to pass.

### Translation polish

First-person `나` for the current user in reactor lists (matching `chat.me`, which was already correct), standard `라이선스`, `닉네임` for consistency with the room and command labels, distinct labels for three different "more" actions, one folded sentence in the moderated-room hint, one stray formal pronoun dropped to match the file's own convention, and command usage metavariables reverted to English to match the other 33 locales after confirming they are display-only.

Two things intentionally left alone: `common.forward` is the browser-history button, correctly paired with `common.back`, and the message sense is correctly `전달` elsewhere; and the 19 values identical to English are placeholders, command syntax, and proper nouns.

Language counts updated from 33 to 34 in the README, the screenshots overview, and the video storyboard caption. `docs/UX_REVIEW.md` keeps its 33 on purpose — it is a dated review, and rewriting its numbers would falsify a record.
