### PR TITLE
fix(scroll): bound the directional history snapshot to the load that armed it

### DIFF
--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -2577,11 +2577,20 @@ export function useMessageListScroll({
   ): void => {
     const settle = () => {
       saved.loadSettled = true
-      const frame = requestAnimationFrame(() => {
-        directionalReleaseFrames().delete(frame)
+      const frames = directionalReleaseFrames()
+      // The handle is only known AFTER requestAnimationFrame returns, but the callback can run
+      // BEFORE it does — jsdom suites stub rAF to invoke synchronously. So the handle is a
+      // reassignable `let` the callback reads defensively (a `const` closed over here would be in
+      // its temporal dead zone), and it is tracked for cancellation only if a frame is really
+      // pending. Run synchronously, there is nothing to cancel and nothing to track.
+      let frame: number | null = null
+      let pending = true
+      frame = requestAnimationFrame(() => {
+        pending = false
+        if (frame !== null) frames.delete(frame)
         releaseUnshiftedDirectionalHistory(saved, ownerConversationId)
       })
-      directionalReleaseFrames().add(frame)
+      if (pending) frames.add(frame)
     }
 
     let result: unknown

--- a/apps/fluux/src/components/conversation/useMessageListScroll.ts
+++ b/apps/fluux/src/components/conversation/useMessageListScroll.ts
@@ -294,7 +294,9 @@ export interface UseMessageListScrollOptions {
   externalScrollerRef?: React.RefObject<HTMLElement | null>
   externalIsAtBottomRef?: React.MutableRefObject<boolean>
   clearFirstNewMessageId?: () => void  // Called when user scrolls past the new message marker
-  onScrollToTop?: () => void
+  /** Load the next-older history slice. Any returned promise is treated as the load's lifetime:
+   *  it bounds how long the directional-history snapshot may claim the next window shift. */
+  onScrollToTop?: () => unknown
   /**
    * Hydrate the resident message window with the cache slice CONTAINING a specific message.
    * Called by the restore path when a saved content anchor (or a navigation target) is older than
@@ -307,8 +309,8 @@ export interface UseMessageListScrollOptions {
   isLoadingOlder?: boolean
   /** Sliding window: load the next-newer cache slice when the reader scrolls back down to the
    *  bottom of a slid-up window (mirror of onScrollToTop for the newer direction). Fired only
-   *  when windowAtLiveEdge is false. */
-  onLoadNewer?: () => void
+   *  when windowAtLiveEdge is false. Its returned promise bounds the snapshot the same way. */
+  onLoadNewer?: () => unknown
   isLoadingNewer?: boolean
   /** Sliding window: whether the resident window includes the newest message. `false` = slid up,
    *  which enables the load-newer trigger (the resident bottom is NOT the live edge). Absent/true
@@ -397,6 +399,9 @@ interface DirectionalHistorySnapshot {
   generation?: number
   restored?: boolean
   restoredAt?: number
+  /** Whether the load this snapshot was armed for has finished running (delivered or not). It is
+   *  what bounds the snapshot's claim on the next window shift — see runDirectionalHistoryLoad. */
+  loadSettled?: boolean
 }
 
 // ============================================================================
@@ -609,6 +614,13 @@ export function useMessageListScroll({
   // then restore it AFTER React renders the new messages.
   // Using element-based positioning is more reliable than pure scroll math.
   const prependRef = useRef<DirectionalHistorySnapshot | null>(null)
+  // Frames on which settled-without-shift snapshots are released (see runDirectionalHistoryLoad).
+  // A set, not a single slot: two loads can be in flight across a fast re-trigger and settle in
+  // either order, so one snapshot's frame must never displace another's. Cancelled on unmount.
+  // Same lazy-ref idiom as pinBottomClaim below — stable identity, no per-render allocation.
+  const directionalReleaseFramesRef = useRef<Set<number> | null>(null)
+  const directionalReleaseFrames = () =>
+    (directionalReleaseFramesRef.current ??= new Set<number>())
 
   // Throttling/cooldown
   const lastLoadTimeRef = useRef(0)
@@ -2509,6 +2521,84 @@ export function useMessageListScroll({
     return { saved, anchor }
   }
 
+  /**
+   * Drop a directional snapshot whose load is over and which never saw the window shift it was
+   * armed for. Guarded so it is a no-op the moment anything else has taken the snapshot over: the
+   * batch landed and restored it, a newer load replaced it, or the conversation changed.
+   *
+   * Going through `cancelDirectionalHistoryWithoutShift` (the same primitive the returned-to-live-
+   * edge case uses) matters twice over: it clears the controller's pending `history-preservation`
+   * request, which the positioning model treats as a position the reader is still waiting to reach
+   * — while it stands, EVERY ambient layout preservation (insertion, divider) is refused.
+   */
+  const releaseUnshiftedDirectionalHistory = (
+    saved: DirectionalHistorySnapshot,
+    ownerConversationId: string,
+  ) => {
+    if (prependRef.current !== saved || saved.restored) return
+    if (activeConversationIdRef.current !== ownerConversationId) return
+    // The window DID shift after all — the restore effect owns this snapshot, not us.
+    if ((liveWindowRef.current.firstMessageId ?? '') !== saved.oldFirstId) return
+
+    debugLog('DIRECTIONAL HISTORY RELEASE (settled without a window shift)', {
+      oldFirstId: saved.oldFirstId,
+      oldMessageCount: saved.oldMessageCount,
+      messageCount: liveWindowRef.current.messageCount,
+      generation: saved.generation,
+    })
+    if (saved.generation !== undefined) {
+      positioningControllerRef.current?.cancelDirectionalHistoryWithoutShift({
+        conversationId: ownerConversationId,
+        generation: saved.generation,
+      })
+    }
+    if (prependRef.current === saved) prependRef.current = null
+  }
+
+  /**
+   * Run the load a snapshot was armed for, and bound the snapshot's lifetime to it.
+   *
+   * The snapshot's whole purpose is to catch the window shift its load produces, and it recognises
+   * that shift as a `firstMessageId` change. A load that settles WITHOUT delivering rows — an
+   * exhausted archive, a query that returns only duplicates, a fetch that bails before it starts —
+   * never produces one, so the restore effect just keeps waiting. Left armed, the snapshot claims
+   * the next first-id change from ANY source (a live arrival evicting the oldest row at the
+   * resident bound is one) and restores the reader to a position that stopped meaning anything
+   * loads ago; meanwhile its pending controller request blocks insertion preservation outright.
+   *
+   * So the loader's own promise is the snapshot's deadline. Releasing is deferred one frame, and
+   * re-checked when it fires: a commit that delivers the batch takes the snapshot first, which is
+   * what keeps successful pagination — the case this must never break — restoring as before.
+   */
+  const runDirectionalHistoryLoad = (
+    saved: DirectionalHistorySnapshot,
+    ownerConversationId: string,
+    run: () => unknown,
+  ): void => {
+    const settle = () => {
+      saved.loadSettled = true
+      const frame = requestAnimationFrame(() => {
+        directionalReleaseFrames().delete(frame)
+        releaseUnshiftedDirectionalHistory(saved, ownerConversationId)
+      })
+      directionalReleaseFrames().add(frame)
+    }
+
+    let result: unknown
+    try {
+      result = run()
+    } catch (error) {
+      settle()
+      throw error
+    }
+    const thenable = result as PromiseLike<unknown> | null | undefined
+    if (typeof thenable?.then === 'function') {
+      thenable.then(settle, settle)
+      return
+    }
+    settle()
+  }
+
   const triggerLoadOlder = () => {
     if (!canLoadMore) return
     const scroller = scrollerRef.current
@@ -2545,7 +2635,7 @@ export function useMessageListScroll({
         messageCount,
       })
 
-      onScrollToTop?.()
+      runDirectionalHistoryLoad(saved, conversationId, () => onScrollToTop?.())
     }
   }
 
@@ -2572,9 +2662,9 @@ export function useMessageListScroll({
     lastLoadTimeRef.current = now
     viewportSessionRef.current?.clearTravel(conversationId, 'bottom')
 
-    beginDirectionalHistoryLoad(scroller)
+    const { saved } = beginDirectionalHistoryLoad(scroller)
 
-    onLoadNewer?.()
+    runDirectionalHistoryLoad(saved, conversationId, () => onLoadNewer?.())
   }
 
   const handleLoadEarlier = () => {
@@ -2596,7 +2686,7 @@ export function useMessageListScroll({
       messageCount,
     })
 
-    onScrollToTop?.()
+    runDirectionalHistoryLoad(saved, conversationId, () => onScrollToTop?.())
   }
 
   // ==========================================================================
@@ -3496,6 +3586,11 @@ export function useMessageListScroll({
         cancelAnimationFrame(correctionRafRef.current)
         correctionRafRef.current = null
       }
+      const pendingReleaseFrames = directionalReleaseFramesRef.current
+      if (pendingReleaseFrames) {
+        for (const frame of pendingReleaseFrames) cancelAnimationFrame(frame)
+        pendingReleaseFrames.clear()
+      }
     }
   }, [])
 
@@ -3503,10 +3598,11 @@ export function useMessageListScroll({
   // EFFECT: Returned to the live edge → drop any stale directional-load anchor.
   // ==========================================================================
   // A directional load that returns NOTHING never changes firstMessageId, so the restore effect
-  // below never fires and never clears its prependRef — the anchor lingers. The reachable case is
-  // load-newer hitting the tail: windowAtLiveEdge flips false→true with a stashed (never-restored)
-  // anchor. Left in place, a LATER unrelated firstMessageId change — e.g. a live message evicting
-  // the oldest at the cap — would fire that stale restore. Clearing on the false→true TRANSITION
+  // below never fires. `runDirectionalHistoryLoad` is what releases the snapshot in that case, on
+  // the load's own settlement; this effect stays as the semantic signal for one specific shape of
+  // it — load-newer hitting the tail, where windowAtLiveEdge flips false→true with a stashed
+  // (never-restored) anchor and the reader is demonstrably back at the live edge, whether or not
+  // that load has finished running. Clearing on the false→true TRANSITION
   // targets exactly "we just returned to the live edge": normal under-cap load-older keeps
   // windowAtLiveEdge true (no transition) and a slide keeps it false, so their in-flight restores
   // are untouched. This is a passive useEffect so it runs AFTER the restore useLayoutEffect — a
@@ -3555,12 +3651,15 @@ export function useMessageListScroll({
     // firstId AND grows the count, so this is unchanged for the common case.
     const firstIdChanged = firstMessageId !== saved.oldFirstId
 
+    // Waiting is bounded: the snapshot is released once the load that armed it settles without
+    // delivering a shift (runDirectionalHistoryLoad), so this branch cannot hold it indefinitely.
     if (!firstIdChanged) {
       debugLog('PREPEND WAITING', {
         messageCount,
         oldMessageCount: saved.oldMessageCount,
         firstMessageId,
         oldFirstId: saved.oldFirstId,
+        loadSettled: Boolean(saved.loadSettled),
         firstIdChanged,
       })
       return

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -3301,14 +3301,13 @@ test.describe('Insertion drift while scrolled up', () => {
   // snapshot. Left pending, the next UNRELATED firstMessageId change is misread as that load
   // completing — and at the resident bound an interior delayed arrival evicts the oldest row, which
   // is exactly such a change. The stale top anchor is then restored and insertion preservation is
-  // skipped, so the reader is thrown back to where the abandoned load-older would have put them.
+  // skipped (its pending controller request refuses every ambient layout preservation), so the
+  // reader is thrown back to where the abandoned load-older would have put them.
   //
-  // KNOWN-FAILING, deliberately. This staleness is PRE-EXISTING on main — this test is RED on plain
-  // 179b78b3, before any of this branch's work — and correcting it needs directional-snapshot
-  // re-arm semantics that would change pagination behaviour. That is out of scope here and tracked
-  // as fluux-directional-snapshot-lifecycle, with this test as its starting RED case. Marked
-  // test.fail so the suite stays honest AND tells us the moment the follow-up makes it pass.
-  test.fail('invariant-14g: an abandoned load-older does not defeat a later insertion at the resident bound', async ({ page }) => {
+  // The snapshot is now bounded by the lifetime of the load it was armed for, so an abandoned
+  // load-older releases it instead of leaving it to claim someone else's window change. See
+  // invariant-14k/14l for the other half: that bound must not cut a load-older's batch short.
+  test('invariant-14g: an abandoned load-older does not defeat a later insertion at the resident bound', async ({ page }) => {
     await openScrolledUp(page, FULL_WINDOW_INSERTION_URL)
 
     // Neutralise both older-history sources so the load below genuinely returns nothing while still
@@ -3422,5 +3421,192 @@ test.describe('Insertion drift while scrolled up', () => {
       r.drift,
       `legacy reading position drifted ${r.drift}px after a coalesced interior and tail arrival`,
     ).toBeLessThan(INSERTION_DRIFT_PX)
+  })
+
+  // ── The other half of the snapshot lifecycle: it must NOT be released too eagerly ──────────
+  //
+  // Releasing the directional snapshot whenever an interior arrival lands is the obvious way to
+  // stop a stale snapshot claiming an unrelated first-id change (invariant-14g). It is also wrong:
+  // a load-older that is still IN FLIGHT when the arrival lands comes back to an empty snapshot and
+  // gets no restore. The two tests below hold a load-older open across an interior arrival — once
+  // under the resident cap, once at it — and require the reader to be held either way.
+  //
+  // 14l is the one that discriminates, and it is RED-verified: with the snapshot cancelled on every
+  // interior-placement advance, the tracked row is not merely drifted but WINDOWED OUT ENTIRELY
+  // (afterTop null), and it is the only failure in the whole suite — insertion preservation quietly
+  // absorbs the under-cap case (14k), so nothing else here notices the loss.
+
+  /** Total drift budget for a sequence that both preserves an insertion AND restores a prepend.
+   *  Two settles compound, so this is wider than either alone — but a dropped restore is ~3000px
+   *  (a 50-row batch) and a dropped preservation ~450px, so both regressions stay unmissable. */
+  const IN_FLIGHT_DRIFT_PX = 60
+
+  /**
+   * Hold the demo's older-history MAM answer open, so an arrival can be injected while a
+   * load-older is genuinely IN FLIGHT, then let the batch land and report how far the tracked
+   * reading row moved across the whole sequence.
+   */
+  async function insertDuringInFlightLoadOlder(page: Page, body: string) {
+    // Gate the synthetic MAM batch. The cache path in front of it returns nothing in demo mode
+    // (all seeded messages are already resident), so this is the whole delivery of a load-older.
+    const gated = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const demo = (window as any).__demoClient
+      if (!demo?.chat) return false
+      const original = demo.chat.queryRoomMAM.bind(demo.chat)
+      let open: () => void = () => {}
+      const gate = new Promise<void>((resolve) => {
+        open = resolve
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).__releaseOlderLoad = open
+      demo.chat.queryRoomMAM = async (options: unknown) => {
+        await gate
+        return original(options)
+      }
+      return true
+    })
+    expect(gated, 'the demo older-history answer must be gateable for this scenario').toBe(true)
+
+    const before = await readView(page)
+    expect(before, 'the message list must be readable').not.toBeNull()
+    expect(
+      before!.distFromBottom,
+      'precondition: the reader must be clear of the bottom',
+    ).toBeGreaterThanOrEqual(CLEAR_OF_BOTTOM_PX)
+    expect(
+      before!.visible.length,
+      'precondition: several fully-visible rows to track',
+    ).toBeGreaterThan(3)
+
+    const track = before!.visible[before!.visible.length - 2]
+    const topIdx = before!.ids.indexOf(before!.visible[0].id)
+    expect(topIdx, 'precondition: the top-visible row is in the resident array').toBeGreaterThan(12)
+    const insertTs = before!.stamps[topIdx - 10]
+
+    // Arm the directional snapshot WITHOUT moving the reader: handleLoadEarlier, not a
+    // scroll-to-top, so the reader stays mid-history with content above and below.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const trigger = (window as any).__fluuxTriggerLoadOlder
+      if (typeof trigger === 'function') trigger()
+    })
+    await page.waitForTimeout(200)
+
+    const inFlight = await page.evaluate((jid) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return Boolean((window as any).__roomStore.getState().getRoomMAMQueryState(jid)?.isLoading)
+    }, STRESS_ROOM_JID)
+    expect(inFlight, 'precondition: the load-older must still be in flight').toBe(true)
+
+    // The delayed arrival lands while that load is still waiting for its batch.
+    await page.evaluate(([jid, ts, text]) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).__roomStore.getState().addMessage(jid as string, {
+        type: 'groupchat',
+        id: 'delayed-arrival-0',
+        stanzaId: 'sid-delayed-arrival-0',
+        from: `${jid}/DelayedSender`,
+        nick: 'DelayedSender',
+        body: text as string,
+        timestamp: new Date(ts as number),
+        isOutgoing: false,
+        isDelayed: true,
+        roomJid: jid as string,
+      })
+    }, [STRESS_ROOM_JID, insertTs, body] as const)
+    await page.waitForTimeout(400)
+
+    const midway = await readView(page)
+
+    // Let the load-older deliver its batch.
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(window as any).__releaseOlderLoad?.()
+    })
+    await page.waitForTimeout(2000)
+
+    const after = await readView(page)
+    const trackedTop = await page.evaluate((id) => {
+      const s = document.querySelector('[data-message-list]') as HTMLElement | null
+      const el = s?.querySelector(
+        `.message-row[data-message-id="${CSS.escape(id)}"]`,
+      ) as HTMLElement | null
+      if (!s || !el) return null
+      return el.getBoundingClientRect().top - s.getBoundingClientRect().top
+    }, track.id)
+
+    // Read placement from the MIDWAY array: the batch that lands afterwards renumbers every index.
+    const insertedIndex = midway!.ids.indexOf('delayed-arrival-0')
+    const midwayTopIndex = midway!.visible.length > 0
+      ? midway!.ids.indexOf(midway!.visible[0].id)
+      : -1
+    return {
+      trackedId: track.id,
+      beforeTop: Math.round(track.top),
+      afterTop: trackedTop === null ? null : Math.round(trackedTop),
+      drift: trackedTop === null ? Number.POSITIVE_INFINITY : Math.abs(trackedTop - track.top),
+      insertedAboveViewport:
+        insertedIndex >= 0 && midwayTopIndex >= 0 && insertedIndex < midwayTopIndex,
+      firstIdBefore: before!.ids[0],
+      firstIdMidway: midway!.ids[0],
+      firstIdAfter: after!.ids[0],
+      residentCountBefore: before!.ids.length,
+      residentCountMidway: midway!.ids.length,
+      residentCountAfter: after!.ids.length,
+      scrollTopBefore: before!.scrollTop,
+      scrollTopAfter: after!.scrollTop,
+    }
+  }
+
+  test('invariant-14k: an interior arrival during an in-flight load-older does not cost the batch its restore', async ({ page }) => {
+    await openScrolledUp(page)
+    const r = await insertDuringInFlightLoadOlder(
+      page,
+      'delayed arrival during an in-flight load-older\n'.repeat(18),
+    )
+    console.log('── INSERTION-DRIFT in-flight-load-older ──', JSON.stringify(r))
+    expect(r.insertedAboveViewport, 'the arrival must land ABOVE the viewport').toBe(true)
+    expect(
+      r.firstIdMidway,
+      'precondition: under the resident cap the arrival must not move the first id',
+    ).toBe(r.firstIdBefore)
+    expect(
+      r.firstIdAfter,
+      `precondition: the gated load-older must have delivered its batch — ${JSON.stringify(r)}`,
+    ).not.toBe(r.firstIdBefore)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px when a batch landed after an interior arrival`,
+    ).toBeLessThan(IN_FLIGHT_DRIFT_PX)
+  })
+
+  test('invariant-14l: an interior arrival at the resident bound holds the reading position across an in-flight load-older', async ({ page }) => {
+    await openScrolledUp(page, FULL_WINDOW_INSERTION_URL)
+    const r = await insertDuringInFlightLoadOlder(
+      page,
+      'bound delayed arrival during an in-flight load-older\n'.repeat(18),
+    )
+    console.log('── INSERTION-DRIFT bound-in-flight-load-older ──', JSON.stringify(r))
+    expect(r.insertedAboveViewport, 'the arrival must land ABOVE the viewport').toBe(true)
+    // At the bound the arrival EVICTS the oldest row, so it moves the first id without any window
+    // shift — the exact signal the pending snapshot discriminates on. Whichever of the two owners
+    // ends up holding the reader, the reader must not move.
+    expect(
+      r.firstIdMidway,
+      `precondition: at the resident bound the arrival must evict the oldest row — ${JSON.stringify(r)}`,
+    ).not.toBe(r.firstIdBefore)
+    expect(
+      r.residentCountMidway,
+      'precondition: the resident window must stay at its bound',
+    ).toBe(r.residentCountBefore)
+    expect(
+      r.firstIdAfter,
+      `precondition: the gated load-older must have delivered its batch — ${JSON.stringify(r)}`,
+    ).not.toBe(r.firstIdMidway)
+    expect(
+      r.drift,
+      `reading position drifted ${r.drift}px when a batch landed after an eviction at the bound`,
+    ).toBeLessThan(IN_FLIGHT_DRIFT_PX)
   })
 })


### PR DESCRIPTION
A load-older that settles **without delivering rows** never changes `firstMessageId`, so the
directional restore effect neither fires nor releases its snapshot. Left armed indefinitely, that
snapshot does two things it should not:

- it **claims the next first-id change from any source** — a live arrival evicting the oldest row at
  the resident bound is one — and restores the reader to a position that stopped meaning anything
  loads ago;
- its pending `history-preservation` request makes the positioning model refuse **every** ambient
  layout preservation (`scrollPositionModel.ts`: `layoutPreservationWhilePositioning`), so insertion
  preservation is silently disabled for that conversation.

The fix gives the snapshot a deadline: **the lifetime of the load that armed it.** The loader's own
promise is that signal. When the load is over and no window shift arrived, the snapshot is released
through the same `cancelDirectionalHistoryWithoutShift` the returned-to-live-edge case already uses,
which also clears the controller request that was blocking preservation.

Releasing is deferred one frame and re-checked. That is deliberate: a commit that delivers the batch
claims the snapshot first, so successful pagination restores exactly as before.

Nothing about **what** pagination fetches, or **when** it triggers, changes — only when a snapshot is
armed and released.

## Who owns the scroll position

Three subsystems write scroll position. They are disjoint by state, not by convention:

| State | Owner | Entered by | Left by |
| --- | --- | --- | --- |
| Reader at the live edge | **pin loop** | `distFromBottom < AT_BOTTOM_THRESHOLD` | reader scrolls away |
| Reader scrolled up, no load in flight | **insertion preservation** (`layout-preservation` / `message-insertion`) | resident array mutates above them | the mutation settles |
| Reader scrolled up, directional load in flight | **directional history restore** (`history-preservation`) | a load-older/newer is triggered | the load's batch lands, **or** the load settles with no shift |

The middle two never overlap, and it is the model that guarantees it rather than the hook: while a
`history-preservation` request is active and unsettled, `acceptPositionRequest` rejects
`layout-preservation` outright. That is why an unbounded snapshot was not merely a stale anchor — it
was a permanent veto on preservation. Bounding the snapshot is what makes the third state genuinely
transient, and therefore what makes the table above true.

### Snapshot lifecycle

```
                 load-older / load-newer triggered
                                │
                                ▼
                            ┌───────┐
                            │ ARMED │  controller: history-preservation pending
                            └───┬───┘  (layout preservation is refused here)
              first id changed  │  load settled, first id unchanged
                   ┌────────────┴────────────┐
                   ▼                         ▼
             ┌───────────┐             ┌──────────┐
             │ RESTORING │             │ RELEASED │  cancelDirectionalHistoryWithoutShift
             └─────┬─────┘             └────┬─────┘
                   │ applied                │
                   ▼                        ▼
             ┌──────────┐               ┌──────┐
             │ COOLDOWN │──────────────▶│ IDLE │
             └──────────┘  500 ms       └──────┘
```

Two other transitions out of ARMED already existed and are unchanged: a wheel takes over
(`user-takeover`), and a conversation switch drops the snapshot.

**RESTORING wins ties.** When the settlement commit also carries the batch, the first-id branch is
evaluated first — that is what protects successful pagination, and it is why the release is deferred
a frame rather than taken the instant the loader resolves.

## Tests

- `invariant-14g` loses its `test.fail` marker and passes. It was RED on plain `main` (reader thrown
  from `scrollTop` 6288 → 814, tracked row unmounted entirely); it is now drift **0**, with
  `scrollTop` moving +374 — exactly the inserted height.
- `invariant-14k` / `invariant-14l` are new and cover the opposite failure: a load-older held **in
  flight** across an interior arrival must still get its restore. `14l` runs at the resident bound,
  where the arrival evicts the oldest row and so moves the first id without any window shift.

`14l` is RED-verified against a deliberately over-eager release (cancelling the snapshot on every
interior-placement advance — the approach that regressed pagination when it was tried before). Under
that release the tracked row is not merely drifted but **windowed out entirely**, and it is the
**only** failure in the whole 48-test suite: insertion preservation quietly absorbs the under-cap
case, so nothing else notices the loss.

## Known, unchanged

A snapshot armed by a loader that never starts (offline, invalid target) is released on the first
commit after its promise settles. If that same commit carried an unrelated first-id change, the
restore branch still wins. The window is one frame wide and the anchor is one the reader was at
moments earlier, so this is bounded rather than indefinite — but it is not zero, and it is not new.
