### PR TITLE
fix(mds): resolve the read-position stanza-id from the cache, not only the resident slice

### DIFF
--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Protocol-level integration evidence for cache-resolved XEP-0490 positions.
+ *
+ * Unlike mdsSideEffects.cache.test.ts, this file uses the real messageCache
+ * implementation against fake IndexedDB. It proves the backgrounded store
+ * shape can flow through IndexedDB resolution into the MDS publish boundary.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import 'fake-indexeddb/auto'
+import { IDBFactory } from 'fake-indexeddb'
+import { setupMdsSideEffects } from './mdsSideEffects'
+import { chatStore } from '../stores/chatStore'
+import { connectionStore } from '../stores/connectionStore'
+import { roomStore } from '../stores/roomStore'
+import * as messageCache from '../utils/messageCache'
+import { _resetStorageScopeForTesting, setStorageScopeJid } from '../utils/storageScope'
+import { localStorageMock } from './sideEffects.testHelpers'
+import type { Message, Room, RoomMessage } from './types'
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+})
+
+const OWN_BARE = 'romeo@montague.example'
+const OWN_JID = `${OWN_BARE}/phone`
+const EXACT_CHAT = 'juliet@capulet.example'
+const FALLBACK_CHAT = 'benvolio@montague.example'
+const ROOM = 'tech@conference.example'
+
+function chatMessage(
+  conversationId: string,
+  id: string,
+  stanzaId: string | undefined,
+  timestamp: number,
+  isOutgoing = false
+): Message {
+  return {
+    type: 'chat',
+    id,
+    stanzaId,
+    originId: isOutgoing ? `origin-${id}` : undefined,
+    conversationId,
+    from: isOutgoing ? OWN_BARE : conversationId,
+    body: id,
+    timestamp: new Date(timestamp),
+    isOutgoing,
+  } as Message
+}
+
+function roomMessage(id: string, stanzaId: string, from: string): RoomMessage {
+  return {
+    type: 'groupchat',
+    id,
+    stanzaId,
+    roomJid: ROOM,
+    from,
+    nick: from.split('/')[1],
+    body: `${from}:${id}`,
+    timestamp: new Date(8_000),
+    isOutgoing: false,
+  } as RoomMessage
+}
+
+function makeClient() {
+  const handlers: Record<string, Array<(payload?: unknown) => void>> = {}
+  const register = (event: string, handler: (payload?: unknown) => void) => {
+    ;(handlers[event] ||= []).push(handler)
+    return () => {
+      handlers[event] = (handlers[event] ?? []).filter((candidate) => candidate !== handler)
+    }
+  }
+  const mds = {
+    publishDisplayed: vi.fn().mockResolvedValue(undefined),
+    fetchAllDisplayed: vi.fn().mockResolvedValue([]),
+    fetchAllDisplayedResult: vi.fn().mockResolvedValue({
+      status: 'authoritative' as const,
+      markers: [],
+    }),
+    retractDisplayed: vi.fn().mockResolvedValue(undefined),
+  }
+  return {
+    on: register,
+    subscribe: register,
+    _emit: (event: string, payload?: unknown) => {
+      for (const handler of handlers[event] ?? []) handler(payload)
+    },
+    mds,
+  }
+}
+
+async function waitForPublishes(
+  publishDisplayed: ReturnType<typeof vi.fn>,
+  expected: number
+): Promise<void> {
+  await vi.waitFor(() => {
+    expect(publishDisplayed).toHaveBeenCalledTimes(expected)
+  }, { timeout: 3_000, interval: 20 })
+}
+
+describe('mdsSideEffects real IndexedDB cache integration', () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory()
+    messageCache._resetDBForTesting()
+    _resetStorageScopeForTesting()
+    setStorageScopeJid(OWN_BARE)
+    connectionStore.getState().reset()
+    chatStore.getState().reset()
+    roomStore.getState().reset()
+    localStorageMock.clear()
+  })
+
+  afterEach(() => {
+    messageCache._resetDBForTesting()
+    _resetStorageScopeForTesting()
+    vi.restoreAllMocks()
+  })
+
+  it('publishes exact chat, conservative chat fallback, and exact room positions from the real cache', async () => {
+    await messageCache.saveMessages([
+      chatMessage(EXACT_CHAT, 'exact-7', 'exact-stanza-7', 7_000),
+      chatMessage(FALLBACK_CHAT, 'fallback-3', 'fallback-stanza-3', 3_000),
+      chatMessage(FALLBACK_CHAT, 'own-4', undefined, 4_000, true),
+      // Newer unread cache data must not move the published marker ahead.
+      chatMessage(FALLBACK_CHAT, 'unread-5', 'unread-stanza-5', 5_000),
+    ])
+
+    const alice = `${ROOM}/alice`
+    const bob = `${ROOM}/bob`
+    await messageCache.saveRoomMessages([
+      roomMessage('shared-id', 'alice-stanza', alice),
+      roomMessage('shared-id', 'bob-stanza', bob),
+    ])
+
+    chatStore.getState().addConversation({
+      id: EXACT_CHAT,
+      name: EXACT_CHAT,
+      type: 'chat',
+      unreadCount: 0,
+    })
+    chatStore.getState().addConversation({
+      id: FALLBACK_CHAT,
+      name: FALLBACK_CHAT,
+      type: 'chat',
+      unreadCount: 0,
+    })
+    const room: Room = {
+      jid: ROOM,
+      name: 'tech',
+      nickname: 'romeo',
+      joined: true,
+      isBookmarked: false,
+      occupants: new Map(),
+      messages: [],
+      unreadCount: 0,
+      mentionsCount: 0,
+      typingUsers: new Set(),
+    }
+    roomStore.getState().addRoom(room)
+
+    // These are genuinely backgrounded store shapes: no resident arrays and no
+    // lastMessage previews can satisfy the resolver before it reaches IndexedDB.
+    expect(chatStore.getState().messages.has(EXACT_CHAT)).toBe(false)
+    expect(chatStore.getState().messages.has(FALLBACK_CHAT)).toBe(false)
+    expect(roomStore.getState().roomRuntime.get(ROOM)?.messages).toEqual([])
+
+    const client = makeClient()
+    connectionStore.setState({ status: 'online', jid: OWN_JID } as never)
+    const cleanup = setupMdsSideEffects(client as never)
+    client._emit('online')
+    await vi.waitFor(() => {
+      expect(client.mds.fetchAllDisplayedResult).toHaveBeenCalledTimes(1)
+    })
+
+    chatStore.setState((state) => {
+      const conversationMeta = new Map(state.conversationMeta)
+      conversationMeta.set(EXACT_CHAT, {
+        ...conversationMeta.get(EXACT_CHAT)!,
+        readPointer: {
+          messageId: 'exact-7',
+          timestamp: new Date(7_000),
+          archiveOrderKey: { kind: 'chat', id: 'exact-7' },
+        },
+      })
+      conversationMeta.set(FALLBACK_CHAT, {
+        ...conversationMeta.get(FALLBACK_CHAT)!,
+        readPointer: {
+          messageId: 'own-4',
+          timestamp: new Date(4_000),
+          archiveOrderKey: { kind: 'chat', id: 'own-4' },
+        },
+      })
+      return { conversationMeta }
+    })
+    roomStore.setState((state) => {
+      const roomMeta = new Map(state.roomMeta)
+      roomMeta.set(ROOM, {
+        ...roomMeta.get(ROOM)!,
+        readPointer: {
+          messageId: 'shared-id',
+          timestamp: new Date(8_000),
+          archiveOrderKey: { kind: 'room', from: alice, id: 'shared-id' },
+        },
+      })
+      return { roomMeta }
+    })
+
+    await waitForPublishes(client.mds.publishDisplayed, 3)
+
+    const calls = client.mds.publishDisplayed.mock.calls
+    expect(calls).toContainEqual([EXACT_CHAT, 'exact-stanza-7', OWN_BARE])
+    expect(calls).toContainEqual([FALLBACK_CHAT, 'fallback-stanza-3', OWN_BARE])
+    expect(calls).not.toContainEqual([FALLBACK_CHAT, 'unread-stanza-5', OWN_BARE])
+    expect(calls).toContainEqual([ROOM, 'alice-stanza', ROOM])
+    expect(calls).not.toContainEqual([ROOM, 'bob-stanza', ROOM])
+
+    if (process.env.MDS_EVIDENCE === '1') {
+      console.info('MDS_EVIDENCE', JSON.stringify({
+        cache: 'real messageCache over fake IndexedDB',
+        residentArrays: {
+          exactChat: false,
+          fallbackChat: false,
+          roomMessageCount: 0,
+        },
+        published: calls,
+        suppressed: [
+          [FALLBACK_CHAT, 'unread-stanza-5', OWN_BARE],
+          [ROOM, 'bob-stanza', ROOM],
+        ],
+      }, null, 2))
+    }
+
+    cleanup()
+  })
+})

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -694,6 +694,54 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     cleanup()
   })
 
+  it('publishes a same-id room pointer from a new sender after the prior pointer completed', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const alice = `${ROOM}/alice`
+    const bob = `${ROOM}/bob`
+    getRoomMessage.mockImplementation(async (_roomJid: string, id: string, from?: string) =>
+      from === alice ? cachedRoomMsg(id, 'alice-stanza', alice) : cachedRoomMsg(id, 'bob-stanza', bob)
+    )
+
+    seedBackgroundedRoom('shared-id', alice)
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'alice-stanza', ROOM)
+
+    roomStore.setState((state) => {
+      const roomMeta = new Map(state.roomMeta)
+      roomMeta.set(ROOM, {
+        ...roomMeta.get(ROOM)!,
+        readPointer: roomPointerAt('shared-id', bob),
+      })
+      return { roomMeta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'shared-id', bob)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(2)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
+    cleanup()
+  })
+
+  it('refuses to guess a room cache row for a keyless pointer', async () => {
+    const { client, cleanup } = await armedPublisher()
+    getRoomMessage.mockResolvedValue(cachedRoomMsg('shared-id', 'guessed-stanza', `${ROOM}/bob`))
+
+    seedBackgroundedRoom()
+    roomStore.setState((state) => {
+      const roomMeta = new Map(state.roomMeta)
+      roomMeta.set(ROOM, {
+        ...roomMeta.get(ROOM)!,
+        readPointer: { messageId: 'shared-id', timestamp: timeFor('shared-id') },
+      })
+      return { roomMeta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getRoomMessage).not.toHaveBeenCalled()
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
   it('does NOT give rooms an at-or-behind cache fallback', async () => {
     const { client, cleanup } = await armedPublisher()
 

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -1,0 +1,624 @@
+/**
+ * Tests for cache-resolved MDS (XEP-0490) read positions (#1175).
+ *
+ * A backgrounded entity keeps NO resident message array — `setActiveConversation`
+ * deletes the entry — so `resolveSeenStanzaId` had nothing to scan and the
+ * position stayed unresolved until something re-triggered it. These tests pin
+ * the IndexedDB-cache resolution that closes that gap, for BOTH the exact
+ * pointer row and the at-or-behind fallback #1189 added.
+ *
+ * They also pin the concurrency contract the async conversion forces:
+ * a LATEST-WINS SERIAL DRAIN per JID (at most one resolution in flight, the
+ * newest pending position re-run on completion), plus a revalidation of every
+ * input the in-flight resolution was computed against.
+ *
+ * This does NOT and cannot address the 1:1 own-send case: a message we sent in
+ * a 1:1 never acquires a stanza-id, in RAM and in IndexedDB alike. #1189's
+ * at-or-behind fallback owns that; here it is only extended to read the cache.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock localStorage before importing stores (chatStore persist middleware).
+import { localStorageMock } from './sideEffects.testHelpers'
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+})
+
+// Only the read paths the publisher uses are stubbed; every other cache export
+// stays real so chatStore's own persistence calls behave normally.
+vi.mock('../utils/messageCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/messageCache')>()
+  return {
+    ...actual,
+    // happy-dom has no IndexedDB; report the cache as present so the publisher
+    // takes the path a real browser/Tauri runtime takes.
+    isMessageCacheAvailable: vi.fn(() => true),
+    getMessage: vi.fn(async () => null),
+    getMessages: vi.fn(async () => []),
+    getRoomMessage: vi.fn(async () => null),
+  }
+})
+
+import { setupMdsSideEffects } from './mdsSideEffects'
+import { chatStore } from '../stores/chatStore'
+import { connectionStore } from '../stores/connectionStore'
+import { roomStore } from '../stores/roomStore'
+import * as messageCache from '../utils/messageCache'
+import { setStorageScopeJid, _resetStorageScopeForTesting } from '../utils/storageScope'
+import type { Message } from './types/chat'
+import type { Room, RoomMessage } from './types/room'
+import { getLocalPart } from './jid'
+
+const CID = 'juliet@capulet.example'
+const OWN_JID = 'romeo@montague.example/phone'
+const OWN_BARE = 'romeo@montague.example'
+const ROOM = 'tech@conference.example'
+
+const getMessage = messageCache.getMessage as unknown as ReturnType<typeof vi.fn>
+const getMessages = messageCache.getMessages as unknown as ReturnType<typeof vi.fn>
+const getRoomMessage = messageCache.getRoomMessage as unknown as ReturnType<typeof vi.fn>
+
+/** Deterministic per-id timestamp: 'm3' → base + 3s (mirrors mdsSideEffects.test.ts). */
+const BASE_TIME = new Date('2026-01-01T00:00:00Z').getTime()
+function timeFor(id: string): Date {
+  return new Date(BASE_TIME + (Number(id.replace(/\D/g, '')) || 0) * 1000)
+}
+
+/**
+ * A read pointer as `makeReadPointer` builds one: the named message's own
+ * timestamp AND its archive order key. A pointer without a key is the
+ * pre-#1081 migrated shape, covered separately in mdsSideEffects.test.ts.
+ */
+function pointerAt(id: string): {
+  messageId: string
+  timestamp: Date
+  archiveOrderKey: { kind: 'chat'; id: string }
+} {
+  return { messageId: id, timestamp: timeFor(id), archiveOrderKey: { kind: 'chat', id } }
+}
+
+/** A cached (IndexedDB) 1:1 row, incoming so it carries a server stanza-id. */
+function cachedMsg(id: string, stanzaId: string | undefined): Message {
+  return {
+    type: 'chat',
+    id,
+    stanzaId,
+    conversationId: CID,
+    from: CID,
+    body: id,
+    timestamp: timeFor(id),
+    isOutgoing: false,
+  } as Message
+}
+
+/** A cached row for one of OUR OWN 1:1 sends — never assigned a stanza-id. */
+function cachedOwnMsg(id: string): Message {
+  return {
+    type: 'chat',
+    id,
+    originId: `origin-${id}`,
+    conversationId: CID,
+    from: OWN_BARE,
+    body: id,
+    timestamp: timeFor(id),
+    isOutgoing: true,
+  } as Message
+}
+
+function cachedRoomMsg(id: string, stanzaId: string | undefined): RoomMessage {
+  return {
+    type: 'groupchat',
+    id,
+    stanzaId,
+    roomJid: ROOM,
+    from: `${ROOM}/alice`,
+    nick: 'alice',
+    body: id,
+    timestamp: timeFor(id),
+    isOutgoing: false,
+  } as RoomMessage
+}
+
+/**
+ * A BACKGROUNDED 1:1 conversation: it has meta (and therefore a read pointer),
+ * but no resident `messages` entry and no `lastMessage` preview to fall back to.
+ * This is exactly the state `setActiveConversation` leaves behind.
+ */
+function seedBackgroundedConversation(pointerId?: string): void {
+  const readPointer = pointerId === undefined ? undefined : pointerAt(pointerId)
+  chatStore.setState((state) => {
+    const meta = new Map(state.conversationMeta)
+    meta.set(CID, { unreadCount: 0, readPointer })
+    const convs = new Map(state.conversations)
+    convs.set(CID, { id: CID, name: CID, type: 'chat', unreadCount: 0, readPointer })
+    const messages = new Map(state.messages)
+    messages.delete(CID)
+    return { conversationMeta: meta, conversations: convs, messages }
+  })
+}
+
+function patchMeta(
+  patch: Partial<{ readPointer: ReturnType<typeof pointerAt>; unreadCount: number }>
+): void {
+  chatStore.setState((state) => {
+    const meta = new Map(state.conversationMeta)
+    meta.set(CID, { ...meta.get(CID)!, ...patch })
+    return { conversationMeta: meta }
+  })
+}
+
+/** A backgrounded room: joined and known, but its runtime message array is empty. */
+function seedBackgroundedRoom(pointerId?: string): void {
+  const room: Room = {
+    jid: ROOM,
+    name: getLocalPart(ROOM),
+    nickname: 'testuser',
+    joined: true,
+    isBookmarked: false,
+    occupants: new Map(),
+    messages: [],
+    unreadCount: 0,
+    mentionsCount: 0,
+    typingUsers: new Set(),
+  }
+  roomStore.getState().addRoom(room)
+  if (pointerId !== undefined) {
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt(pointerId) })
+      return { roomMeta: meta }
+    })
+  }
+}
+
+function setConvMamState(
+  patch: Partial<{ isLoading: boolean; hasQueried: boolean; isCaughtUpToLive: boolean; error: string | null }>
+): void {
+  chatStore.setState((state) => {
+    const next = new Map(state.mamQueryStates)
+    next.set(CID, {
+      isLoading: false,
+      hasQueried: false,
+      error: null,
+      isHistoryComplete: false,
+      isCaughtUpToLive: false,
+      ...patch,
+    } as never)
+    return { mamQueryStates: next }
+  })
+}
+
+function makeClient() {
+  const handlers: Record<string, Array<(p?: unknown) => void>> = {}
+  const register = (ev: string, cb: (p?: unknown) => void) => {
+    ;(handlers[ev] ||= []).push(cb)
+    return () => {
+      handlers[ev] = (handlers[ev] || []).filter((h) => h !== cb)
+    }
+  }
+  const mds = {
+    publishDisplayed: vi.fn().mockResolvedValue(undefined),
+    fetchAllDisplayed: vi.fn().mockResolvedValue([]),
+    fetchAllDisplayedResult: vi.fn().mockResolvedValue({ status: 'authoritative' as const, markers: [] }),
+    retractDisplayed: vi.fn().mockResolvedValue(undefined),
+  }
+  return {
+    on: register,
+    subscribe: register,
+    _emit: (ev: string, p?: unknown) => (handlers[ev] || []).forEach((h) => h(p)),
+    mds,
+  }
+}
+
+/** A promise whose settlement the test controls, to hold a resolution in flight. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** Let queued microtasks (the resolution chain) run without advancing the debounce. */
+async function flushMicrotasks(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0)
+}
+
+async function armedPublisher() {
+  const client = makeClient()
+  connectionStore.setState({ status: 'online', jid: OWN_JID } as never)
+  const cleanup = setupMdsSideEffects(client as never)
+  client._emit('online')
+  await vi.runOnlyPendingTimersAsync()
+  return { client, cleanup }
+}
+
+describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    connectionStore.getState().reset()
+    chatStore.getState().reset()
+    roomStore.getState().reset()
+    localStorageMock.clear()
+    _resetStorageScopeForTesting()
+    getMessage.mockReset().mockResolvedValue(null)
+    getMessages.mockReset().mockResolvedValue([])
+    getRoomMessage.mockReset().mockResolvedValue(null)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    _resetStorageScopeForTesting()
+  })
+
+  // ==========================================================================
+  // Acceptance 1 — a backgrounded conversation resolves and publishes.
+  // ==========================================================================
+
+  it('resolves a backgrounded conversation pointer from the cache and publishes it', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    // The pointer's own row is the newest thing at or behind itself, so the
+    // bounded cache window resolves the EXACT position when it is cached.
+    getMessages.mockResolvedValue([cachedMsg('m1', 's1'), cachedMsg('m7', 's7')])
+    patchMeta({ readPointer: pointerAt('m7') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getMessages).toHaveBeenCalledWith(CID, expect.objectContaining({ limit: expect.any(Number) }))
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
+  it('does not read the cache when the resident slice already resolves the pointer', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    chatStore.setState((state) => {
+      const messages = new Map(state.messages)
+      messages.set(CID, [cachedMsg('m1', 's1'), cachedMsg('m2', 's2')])
+      return { messages }
+    })
+    patchMeta({ readPointer: pointerAt('m2') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's2', OWN_BARE)
+    expect(getMessage).not.toHaveBeenCalled()
+    expect(getMessages).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  // ==========================================================================
+  // Acceptance 2 — the at-or-behind fallback resolves from the cache too.
+  // ==========================================================================
+
+  it('falls back to the newest cached stanza-id at or behind a backgrounded pointer on our own send', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    // The pointer rests on one of OUR sends: cached, but with no stanza-id, in
+    // RAM and in IndexedDB alike. Only the at-or-behind fallback can resolve it.
+    getMessages.mockResolvedValue([cachedMsg('m1', 's1'), cachedMsg('m3', 's3'), cachedOwnMsg('m4')])
+    patchMeta({ readPointer: pointerAt('m4') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's3', OWN_BARE)
+    cleanup()
+  })
+
+  it('never publishes a cached position ahead of the read pointer', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    // m5/m6 arrived after our own m4 and are UNREAD. The cache window may hand
+    // them over; the at-or-behind ordering must reject them.
+    getMessages.mockResolvedValue([
+      cachedMsg('m1', 's1'),
+      cachedOwnMsg('m4'),
+      cachedMsg('m5', 's5'),
+      cachedMsg('m6', 's6'),
+    ])
+    patchMeta({ readPointer: pointerAt('m4') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's1', OWN_BARE)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's5', OWN_BARE)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's6', OWN_BARE)
+    cleanup()
+  })
+
+  it('publishes nothing when the cache holds nothing resolvable at or behind the pointer', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedConversation()
+    getMessages.mockResolvedValue([cachedOwnMsg('m2'), cachedOwnMsg('m4')])
+    patchMeta({ readPointer: pointerAt('m4') })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  // ==========================================================================
+  // The latest-wins serial drain — BOTH properties, not one (#1142's lesson).
+  // ==========================================================================
+
+  it('keeps at most one resolution in flight per JID and publishes once under interleaving', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValue(gate.promise)
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+    expect(getMessages).toHaveBeenCalledTimes(1)
+
+    // Unrelated meta churn re-considers the SAME position while the first
+    // resolution is still in flight: it must not start a second one.
+    patchMeta({ unreadCount: 3 })
+    patchMeta({ unreadCount: 4 })
+    await flushMicrotasks()
+    expect(getMessages).toHaveBeenCalledTimes(1)
+
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
+  it('publishes the newest pointer that arrived while an earlier resolution was in flight', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const first = deferred<Message[]>()
+    getMessages.mockReturnValueOnce(first.promise).mockResolvedValue([cachedMsg('m8', 's8')])
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+    expect(getMessages).toHaveBeenCalledTimes(1)
+
+    // A NEWER position lands mid-flight. Suppressing it (a bare in-flight guard)
+    // would lose it forever — the exact failure #1142 fixed.
+    patchMeta({ readPointer: pointerAt('m8') })
+    await flushMicrotasks()
+
+    first.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getMessages).toHaveBeenCalledTimes(2)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's8', OWN_BARE)
+    // The superseded position must never be published: the pointer moved.
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
+  // ==========================================================================
+  // Post-await revalidation — every input the resolution was computed against.
+  // ==========================================================================
+
+  it('discards a resolution the pointer has already moved past, even across a full debounce', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const first = deferred<Message[]>()
+    const second = deferred<Message[]>()
+    getMessages.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    patchMeta({ readPointer: pointerAt('m8') })
+    await flushMicrotasks()
+
+    // The superseded resolution lands, and a whole debounce window elapses
+    // before the current one does — so an unrevalidated result would have
+    // reached the node on its own, not merely been coalesced away.
+    first.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    second.resolve([cachedMsg('m8', 's8')])
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's8', OWN_BARE)
+    cleanup()
+  })
+
+  it('discards a resolution whose account storage scope changed mid-flight', async () => {
+    const { client, cleanup } = await armedPublisher()
+    setStorageScopeJid(OWN_BARE)
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValue(gate.promise)
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    setStorageScopeJid('other@account.example')
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('discards a resolution whose connected account changed mid-flight', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValue(gate.promise)
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    connectionStore.setState({ jid: 'someone@else.example/desktop' } as never)
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('discards a resolution whose session ended mid-flight', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValue(gate.promise)
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    connectionStore.setState({ status: 'disconnected' } as never)
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('discards a resolution that spans a reconnect, even though publishing is armed again', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValueOnce(gate.promise).mockResolvedValue([])
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    // Drop and come back: a new session re-seeds the node, so a value resolved
+    // against the OLD session's node state must not be published into the new one.
+    connectionStore.setState({ status: 'disconnected' } as never)
+    connectionStore.setState({ status: 'online', jid: OWN_JID } as never)
+    client._emit('online')
+    await vi.runOnlyPendingTimersAsync()
+
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
+  it('discards a resolution whose archive stopped being trustworthy mid-flight, and retries later', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValueOnce(gate.promise).mockResolvedValue([cachedMsg('m7', 's7')])
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+    const idleTimers = vi.getTimerCount()
+
+    // A catch-up starts during the resolution: the publish must never speak
+    // from an archive we know is partial.
+    setConvMamState({ hasQueried: true, isLoading: true })
+    gate.resolve([cachedMsg('m7', 's7')])
+    await flushMicrotasks()
+
+    // Not merely dropped at flush time by the existing gate — never enqueued at
+    // all, so no debounce window is armed for it.
+    expect(vi.getTimerCount()).toBe(idleTimers)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    // The position stayed UNHANDLED, so catch-up completing republishes it
+    // without needing a further local read advance (#1142).
+    setConvMamState({ hasQueried: true, isCaughtUpToLive: true })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
+  it('discards a resolution whose JID became a known room mid-flight', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValue(gate.promise)
+
+    // A bookmarked room's JID can still be sitting in chat state when the
+    // resolution starts; classifying it as a room later changes both the
+    // resolver and the XEP-0359 `by` we would publish under.
+    chatStore.setState((state) => {
+      const meta = new Map(state.conversationMeta)
+      meta.set(ROOM, { unreadCount: 0, readPointer: pointerAt('m7') })
+      return { conversationMeta: meta }
+    })
+    await flushMicrotasks()
+
+    // The room arrives carrying the SAME pointer, so classification is the only
+    // input that changed — the chat-resolved value must still be discarded.
+    seedBackgroundedRoom('m7')
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('does not publish a resolution that completes after teardown', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValue(gate.promise)
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    cleanup()
+    await flushMicrotasks()
+    const timersAfterTeardown = vi.getTimerCount()
+
+    gate.resolve([cachedMsg('m7', 's7')])
+    await flushMicrotasks()
+
+    // Nothing new is even SCHEDULED: a resolution completing after teardown must
+    // not arm a fresh debounce timer on a torn-down side effect.
+    expect(vi.getTimerCount()).toBe(timersAfterTeardown)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+  })
+
+  // ==========================================================================
+  // Rooms — cache-resolved exactly, and still WITHOUT the at-or-behind fallback.
+  // ==========================================================================
+
+  it('resolves a backgrounded room pointer from the cache and publishes it', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedRoom()
+    getRoomMessage.mockResolvedValue(cachedRoomMsg('r5', 'rs5'))
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt('r5') })
+      return { roomMeta: meta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'r5')
+    // Rooms publish under the room's own archive (XEP-0359 `by`).
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
+    cleanup()
+  })
+
+  it('does NOT give rooms an at-or-behind cache fallback', async () => {
+    const { client, cleanup } = await armedPublisher()
+
+    seedBackgroundedRoom()
+    // Our own groupchat message, not yet reflected back with a room stanza-id.
+    getRoomMessage.mockResolvedValue({ ...cachedRoomMsg('r5', undefined), isOutgoing: true })
+    roomStore.setState((s) => {
+      const meta = new Map(s.roomMeta)
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt('r5') })
+      return { roomMeta: meta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    // The deliberate asymmetry (#1189): MUC reflection supplies the exact
+    // stanza-id shortly, so an approximation would degrade a working path.
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+    cleanup()
+  })
+})

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -535,6 +535,27 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     cleanup()
   })
 
+  it('retries a buffered cache resolution after SM resume without store churn', async () => {
+    const { client, cleanup } = await armedPublisher()
+    getMessages.mockResolvedValue([cachedMsg('m7', 's7')])
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+
+    expect(getMessages).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    connectionStore.setState({ status: 'disconnected' } as never)
+    connectionStore.setState({ status: 'online', jid: OWN_JID } as never)
+    client._emit('resumed')
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getMessages).toHaveBeenCalledTimes(2)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
   it('discards a resolution whose archive stopped being trustworthy mid-flight, and retries later', async () => {
     const { client, cleanup } = await armedPublisher()
     const gate = deferred<Message[]>()

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -279,7 +279,12 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     patchMeta({ readPointer: pointerAt('m7') })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(getMessages).toHaveBeenCalledWith(CID, expect.objectContaining({ limit: expect.any(Number) }))
+    expect(getMessages).toHaveBeenCalledTimes(1)
+    expect(getMessages).toHaveBeenCalledWith(CID, {
+      after: new Date(0),
+      before: new Date(timeFor('m7').getTime() + 1),
+      limit: 50,
+    })
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
     cleanup()
   })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -79,6 +79,14 @@ function pointerAt(id: string): {
   return { messageId: id, timestamp: timeFor(id), archiveOrderKey: { kind: 'chat', id } }
 }
 
+function roomPointerAt(id: string, from = `${ROOM}/alice`): {
+  messageId: string
+  timestamp: Date
+  archiveOrderKey: { kind: 'room'; from: string; id: string }
+} {
+  return { messageId: id, timestamp: timeFor(id), archiveOrderKey: { kind: 'room', from, id } }
+}
+
 /** A cached (IndexedDB) 1:1 row, incoming so it carries a server stanza-id. */
 function cachedMsg(id: string, stanzaId: string | undefined): Message {
   return {
@@ -107,14 +115,18 @@ function cachedOwnMsg(id: string): Message {
   } as Message
 }
 
-function cachedRoomMsg(id: string, stanzaId: string | undefined): RoomMessage {
+function cachedRoomMsg(
+  id: string,
+  stanzaId: string | undefined,
+  from = `${ROOM}/alice`
+): RoomMessage {
   return {
     type: 'groupchat',
     id,
     stanzaId,
     roomJid: ROOM,
-    from: `${ROOM}/alice`,
-    nick: 'alice',
+    from,
+    nick: getLocalPart(from),
     body: id,
     timestamp: timeFor(id),
     isOutgoing: false,
@@ -150,7 +162,7 @@ function patchMeta(
 }
 
 /** A backgrounded room: joined and known, but its runtime message array is empty. */
-function seedBackgroundedRoom(pointerId?: string): void {
+function seedBackgroundedRoom(pointerId?: string, pointerFrom = `${ROOM}/alice`): void {
   const room: Room = {
     jid: ROOM,
     name: getLocalPart(ROOM),
@@ -167,7 +179,7 @@ function seedBackgroundedRoom(pointerId?: string): void {
   if (pointerId !== undefined) {
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
-      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt(pointerId) })
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: roomPointerAt(pointerId, pointerFrom) })
       return { roomMeta: meta }
     })
   }
@@ -501,6 +513,28 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     cleanup()
   })
 
+  it('retries a discarded cache resolution after SM resume without store churn', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const gate = deferred<Message[]>()
+    getMessages.mockReturnValueOnce(gate.promise).mockResolvedValue([cachedMsg('m7', 's7')])
+
+    seedBackgroundedConversation()
+    patchMeta({ readPointer: pointerAt('m7') })
+    await flushMicrotasks()
+    expect(getMessages).toHaveBeenCalledTimes(1)
+
+    connectionStore.setState({ status: 'disconnected' } as never)
+    connectionStore.setState({ status: 'online', jid: OWN_JID } as never)
+    client._emit('resumed')
+
+    gate.resolve([cachedMsg('m7', 's7')])
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getMessages).toHaveBeenCalledTimes(2)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(CID, 's7', OWN_BARE)
+    cleanup()
+  })
+
   it('discards a resolution whose archive stopped being trustworthy mid-flight, and retries later', async () => {
     const { client, cleanup } = await armedPublisher()
     const gate = deferred<Message[]>()
@@ -592,14 +626,71 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     getRoomMessage.mockResolvedValue(cachedRoomMsg('r5', 'rs5'))
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
-      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt('r5') })
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: roomPointerAt('r5') })
       return { roomMeta: meta }
     })
     await vi.advanceTimersByTimeAsync(2_000)
 
-    expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'r5')
+    expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'r5', `${ROOM}/alice`)
     // Rooms publish under the room's own archive (XEP-0359 `by`).
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'rs5', ROOM)
+    cleanup()
+  })
+
+  it('resolves a colliding room client id for the pointer sender only', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const alice = `${ROOM}/alice`
+    const bob = `${ROOM}/bob`
+    getRoomMessage.mockImplementation(async (_roomJid: string, id: string, from?: string) =>
+      from === alice ? cachedRoomMsg(id, 'alice-stanza', alice) : cachedRoomMsg(id, 'bob-stanza', bob)
+    )
+
+    seedBackgroundedRoom('shared-id', alice)
+    roomStore.setState((state) => {
+      const roomMeta = new Map(state.roomMeta)
+      roomMeta.set(ROOM, {
+        ...roomMeta.get(ROOM)!,
+        lastMessage: cachedRoomMsg('shared-id', 'bob-stanza', bob),
+      })
+      return { roomMeta }
+    })
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(getRoomMessage).toHaveBeenCalledWith(ROOM, 'shared-id', alice)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'alice-stanza', ROOM)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
+    cleanup()
+  })
+
+  it('discards a room resolution after the pointer moves between same-id senders', async () => {
+    const { client, cleanup } = await armedPublisher()
+    const alice = `${ROOM}/alice`
+    const bob = `${ROOM}/bob`
+    const first = deferred<RoomMessage | null>()
+    const second = deferred<RoomMessage | null>()
+    getRoomMessage.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    seedBackgroundedRoom('shared-id', alice)
+    await flushMicrotasks()
+
+    roomStore.setState((state) => {
+      const roomMeta = new Map(state.roomMeta)
+      roomMeta.set(ROOM, {
+        ...roomMeta.get(ROOM)!,
+        readPointer: roomPointerAt('shared-id', bob),
+      })
+      return { roomMeta }
+    })
+    await flushMicrotasks()
+
+    first.resolve(cachedRoomMsg('shared-id', 'alice-stanza', alice))
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).not.toHaveBeenCalled()
+
+    second.resolve(cachedRoomMsg('shared-id', 'bob-stanza', bob))
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledTimes(1)
+    expect(client.mds.publishDisplayed).toHaveBeenCalledWith(ROOM, 'bob-stanza', ROOM)
     cleanup()
   })
 
@@ -611,7 +702,7 @@ describe('mdsSideEffects — cache-resolved read positions (#1175)', () => {
     getRoomMessage.mockResolvedValue({ ...cachedRoomMsg('r5', undefined), isOutgoing: true })
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
-      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt('r5') })
+      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: roomPointerAt('r5') })
       return { roomMeta: meta }
     })
     await vi.advanceTimersByTimeAsync(2_000)

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -164,7 +164,13 @@ function seedRoom(jid: string, messages: RoomMessage[], seenMessageId?: string):
       const existing = meta.get(jid)!
       meta.set(jid, {
         ...existing,
-        readPointer: { messageId: seenMessageId, timestamp: seen?.timestamp ?? new Date(0) },
+        readPointer: {
+          messageId: seenMessageId,
+          timestamp: seen?.timestamp ?? new Date(0),
+          archiveOrderKey: seen
+            ? { kind: 'room', from: seen.from, id: seenMessageId }
+            : undefined,
+        },
       })
       return { roomMeta: meta }
     })
@@ -701,7 +707,14 @@ describe('setupMdsSideEffects', () => {
     // known message id with NO resident messages loaded to resolve it from.
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
-      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: { messageId: newest.id, timestamp: newest.timestamp } })
+      meta.set(ROOM, {
+        ...meta.get(ROOM)!,
+        readPointer: {
+          messageId: newest.id,
+          timestamp: newest.timestamp,
+          archiveOrderKey: { kind: 'room', from: newest.from, id: newest.id },
+        },
+      })
       return { roomMeta: meta }
     })
 
@@ -807,7 +820,14 @@ describe('setupMdsSideEffects', () => {
 
     roomStore.setState((s) => {
       const meta = new Map(s.roomMeta)
-      meta.set(ROOM, { ...meta.get(ROOM)!, readPointer: pointerAt('m2') })
+      meta.set(ROOM, {
+        ...meta.get(ROOM)!,
+        readPointer: {
+          messageId: 'm2',
+          timestamp: new Date(2),
+          archiveOrderKey: { kind: 'room', from: `${ROOM}/alice`, id: 'm2' },
+        },
+      })
       return { roomMeta: meta }
     })
     await vi.advanceTimersByTimeAsync(2_000)

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -38,6 +38,7 @@ import { connectionStore } from '../stores/connectionStore'
 import { roomStore } from '../stores/roomStore'
 import { createKeyedCoalescer } from '../utils/keyedCoalescer'
 import { compareOrder, makeArchiveOrderKey, type OrderPosition } from '../stores/shared/readState'
+import type { ReadPointer } from '../stores/shared/readPointer'
 import { getBareJid } from './jid'
 import { logInfo } from './logger'
 import * as messageCache from '../utils/messageCache'
@@ -49,12 +50,21 @@ const PUBLISH_DEBOUNCE_MS = 1_500
 /**
  * How many cached rows at or behind the pointer the cache resolution reads.
  *
- * The pointer's OWN row is the newest thing at or behind itself, so this window
- * resolves the exact position whenever it is cached, and degrades into the
- * at-or-behind fallback only when it is not resolvable. Bounding it keeps the
- * read cheap on the path that cannot resolve at all (a 1:1 whose whole tail is
- * our own unarchived sends), where nothing may be committed as handled and the
- * lookup therefore re-runs on later store changes.
+ * Fifty rows is one small page: enough to cover a short unresolved own-send tail
+ * without making every retry scan an unbounded archive. The pointer's OWN row is
+ * the newest thing at or behind itself, so this window resolves the exact
+ * position whenever it is cached, and degrades into the at-or-behind fallback
+ * only when it is not resolvable. Bounding it keeps the read cheap on the path
+ * that cannot resolve at all (a 1:1 whose whole tail is our own unarchived
+ * sends), where nothing may be committed as handled and the lookup therefore
+ * re-runs on later store changes.
+ *
+ * The IndexedDB `conv_timestamp` index bounds these 50 rows by TIMESTAMP ALONE;
+ * `newestResolvableAtOrBehind` applies archive-order filtering afterwards.
+ * More than 50 rows sharing the pointer's millisecond and sorting after it can
+ * therefore crowd the pointer row out. That containment deliberately fails in
+ * the safe UNDER-ADVANCE direction: the position stays unresolved and retryable,
+ * and is never published ahead of the true read position.
  */
 const CACHE_LOOKBACK = 50
 
@@ -270,11 +280,20 @@ export function setupMdsSideEffects(
     return best?.stanzaId
   }
 
-  /** The read-pointer message id this entity currently names, if any. */
-  function pointerMessageId(jid: string): string | undefined {
+  function readPointer(jid: string): ReadPointer | undefined {
     return isRoom(jid)
-      ? roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
-      : chatStore.getState().conversationMeta.get(jid)?.readPointer?.messageId
+      ? roomStore.getState().roomMeta.get(jid)?.readPointer
+      : chatStore.getState().conversationMeta.get(jid)?.readPointer
+  }
+
+  function sameReadPointer(a: ReadPointer | undefined, b: ReadPointer | undefined): boolean {
+    if (!a || !b) return a === b
+    if (a.messageId !== b.messageId || a.timestamp.getTime() !== b.timestamp.getTime()) return false
+    const aKey = a.archiveOrderKey
+    const bKey = b.archiveOrderKey
+    if (!aKey || !bKey) return aKey === bKey
+    if (aKey.kind !== bKey.kind || aKey.id !== bKey.id) return false
+    return aKey.kind === 'chat' || (bKey.kind === 'room' && aKey.from === bKey.from)
   }
 
   /**
@@ -291,17 +310,19 @@ export function setupMdsSideEffects(
    */
   function resolveFromStores(jid: string): string | undefined {
     if (isRoom(jid)) {
-      const seenId = roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
+      const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
+      const seenId = pointer?.messageId
       if (!seenId) return undefined
+      const from = pointer.archiveOrderKey?.kind === 'room' ? pointer.archiveOrderKey.from : undefined
       const messages = roomStore.getState().roomRuntime.get(jid)?.messages ?? []
-      const fromSlice = messages.find((m) => m.id === seenId)?.stanzaId
+      const fromSlice = messages.find((m) => m.id === seenId && (!from || m.from === from))?.stanzaId
       if (fromSlice) return fromSlice
       // Non-active rooms keep no resident array (memory windowing); mark-all-read
       // points at the newest known message, whose stanza-id survives on the
       // lastMessage preview.
       const last = roomStore.getState().roomMeta.get(jid)?.lastMessage
         ?? roomStore.getState().rooms.get(jid)?.lastMessage
-      return last?.id === seenId ? last.stanzaId : undefined
+      return last?.id === seenId && (!from || last.from === from) ? last.stanzaId : undefined
     }
     const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
     const seenId = pointer?.messageId
@@ -344,9 +365,11 @@ export function setupMdsSideEffects(
   async function resolveFromCache(jid: string): Promise<string | undefined> {
     if (!messageCache.isMessageCacheAvailable()) return undefined
     if (isRoom(jid)) {
-      const seenId = roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
+      const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
+      const seenId = pointer?.messageId
       if (!seenId) return undefined
-      const cached = await messageCache.getRoomMessage(jid, seenId)
+      const from = pointer.archiveOrderKey?.kind === 'room' ? pointer.archiveOrderKey.from : undefined
+      const cached = await messageCache.getRoomMessage(jid, seenId, from)
       return cached?.stanzaId
     }
     const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
@@ -505,7 +528,8 @@ export function setupMdsSideEffects(
     // the current pointer once catch-up becomes trustworthy.
     if (!archiveIsTrustworthy(jid)) return
 
-    const seenId = pointerMessageId(jid)
+    const pointer = readPointer(jid)
+    const seenId = pointer?.messageId
     if (seenId === lastConsideredSeenId.get(jid)) return
 
     // Captured BEFORE the await, compared after it.
@@ -529,7 +553,7 @@ export function setupMdsSideEffects(
     if (isRoom(jid) !== wasRoom) return
     // The position itself: a newer pointer supersedes this one. The store
     // subscription that moved it has already asked for another pass.
-    if (pointerMessageId(jid) !== seenId) return
+    if (!sameReadPointer(readPointer(jid), pointer)) return
     if (!archiveIsTrustworthy(jid)) return
 
     // No resolvable stanza-id: neither the resident slice nor the cache can
@@ -846,6 +870,8 @@ export function setupMdsSideEffects(
     // Rebuild the delete-detection baseline to the current live set (mirrors the
     // fresh-session handler) so a resume's known entities aren't seen as deletes.
     trackedJids = liveJids()
+    considerConversations()
+    considerRooms()
   })
 
   // On disconnect: DROP pending work and cancel the timer. The canonical pointer

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -93,12 +93,12 @@ export function setupMdsSideEffects(
   let nodeRevision = 0
   let nodeSnapshotAuthoritative = false
   const currentSessionConfirmedNodeJids = new Set<string>()
-  // The read-pointer message id we last HANDLED per JID, to detect advances.
+  // The full read-pointer identity we last HANDLED per JID, to detect advances.
   // "Handled" means the position was resolved to a stanza-id and then either
   // enqueued or judged not ahead of the node — never merely "seen". A position
   // that could not be resolved stays out of this map so a later merge retries
   // it (#1142); recording it would silence the position for good.
-  const lastConsideredSeenId = new Map<string, string | undefined>()
+  const lastConsideredPointerIdentity = new Map<string, string>()
   // Seed markers (jid → marker) whose JID was NOT a known room at seed time.
   // The fresh-session seed runs before bookmarks load (roomStore.rooms is empty),
   // so a room's marker would otherwise route to chat and be dropped. We stash it
@@ -286,14 +286,31 @@ export function setupMdsSideEffects(
       : chatStore.getState().conversationMeta.get(jid)?.readPointer
   }
 
-  function sameReadPointer(a: ReadPointer | undefined, b: ReadPointer | undefined): boolean {
-    if (!a || !b) return a === b
-    if (a.messageId !== b.messageId || a.timestamp.getTime() !== b.timestamp.getTime()) return false
-    const aKey = a.archiveOrderKey
-    const bKey = b.archiveOrderKey
-    if (!aKey || !bKey) return aKey === bKey
-    if (aKey.kind !== bKey.kind || aKey.id !== bKey.id) return false
-    return aKey.kind === 'chat' || (bKey.kind === 'room' && aKey.from === bKey.from)
+  function pointerIdentity(pointer: ReadPointer | undefined): string | undefined {
+    if (!pointer) return undefined
+    const key = pointer.archiveOrderKey
+    return JSON.stringify([
+      pointer.messageId,
+      pointer.timestamp.getTime(),
+      key?.kind ?? null,
+      key?.kind === 'room' ? key.from : null,
+      key?.id ?? null,
+    ])
+  }
+
+  /**
+   * Resolve the exact `(sender, id)` target named by a room pointer.
+   *
+   * Room client ids are unique only per sender. Without a room archive-order
+   * key, choosing any matching row would risk publishing a WRONG forward-only
+   * MDS position that no device can walk back. Refusing to resolve preserves the
+   * exact-position contract and costs only a retryable delay.
+   */
+  function exactRoomPointerTarget(jid: string): { messageId: string; from: string } | undefined {
+    const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
+    const key = pointer?.archiveOrderKey
+    if (!pointer?.messageId || key?.kind !== 'room' || key.from.length === 0) return undefined
+    return { messageId: pointer.messageId, from: key.from }
   }
 
   /**
@@ -310,19 +327,18 @@ export function setupMdsSideEffects(
    */
   function resolveFromStores(jid: string): string | undefined {
     if (isRoom(jid)) {
-      const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
-      const seenId = pointer?.messageId
-      if (!seenId) return undefined
-      const from = pointer.archiveOrderKey?.kind === 'room' ? pointer.archiveOrderKey.from : undefined
+      const target = exactRoomPointerTarget(jid)
+      if (!target) return undefined
+      const { messageId: seenId, from } = target
       const messages = roomStore.getState().roomRuntime.get(jid)?.messages ?? []
-      const fromSlice = messages.find((m) => m.id === seenId && (!from || m.from === from))?.stanzaId
+      const fromSlice = messages.find((m) => m.id === seenId && m.from === from)?.stanzaId
       if (fromSlice) return fromSlice
       // Non-active rooms keep no resident array (memory windowing); mark-all-read
       // points at the newest known message, whose stanza-id survives on the
       // lastMessage preview.
       const last = roomStore.getState().roomMeta.get(jid)?.lastMessage
         ?? roomStore.getState().rooms.get(jid)?.lastMessage
-      return last?.id === seenId && (!from || last.from === from) ? last.stanzaId : undefined
+      return last?.id === seenId && last.from === from ? last.stanzaId : undefined
     }
     const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
     const seenId = pointer?.messageId
@@ -365,11 +381,9 @@ export function setupMdsSideEffects(
   async function resolveFromCache(jid: string): Promise<string | undefined> {
     if (!messageCache.isMessageCacheAvailable()) return undefined
     if (isRoom(jid)) {
-      const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
-      const seenId = pointer?.messageId
-      if (!seenId) return undefined
-      const from = pointer.archiveOrderKey?.kind === 'room' ? pointer.archiveOrderKey.from : undefined
-      const cached = await messageCache.getRoomMessage(jid, seenId, from)
+      const target = exactRoomPointerTarget(jid)
+      if (!target) return undefined
+      const cached = await messageCache.getRoomMessage(jid, target.messageId, target.from)
       return cached?.stanzaId
     }
     const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
@@ -445,18 +459,18 @@ export function setupMdsSideEffects(
       // buffered during the awaits above: the next meta change re-considers the
       // CURRENT pointer and re-checks this gate then.
       if (!archiveIsTrustworthy(jid)) {
-        lastConsideredSeenId.delete(jid)
+        lastConsideredPointerIdentity.delete(jid)
         continue
       }
       const by = stanzaIdBy(jid)
       if (!by) {
         // Own JID unknown (should not happen while online) — same re-arm.
-        lastConsideredSeenId.delete(jid)
+        lastConsideredPointerIdentity.delete(jid)
         continue
       }
       const decision = publishDecision(jid, stanzaId)
       if (decision === 'retry') {
-        lastConsideredSeenId.delete(jid)
+        lastConsideredPointerIdentity.delete(jid)
         continue
       }
       if (decision === 'skip') continue
@@ -529,8 +543,8 @@ export function setupMdsSideEffects(
     if (!archiveIsTrustworthy(jid)) return
 
     const pointer = readPointer(jid)
-    const seenId = pointer?.messageId
-    if (seenId === lastConsideredSeenId.get(jid)) return
+    const identity = pointerIdentity(pointer)
+    if (!identity || identity === lastConsideredPointerIdentity.get(jid)) return
 
     // Captured BEFORE the await, compared after it.
     const epoch = sessionEpoch
@@ -553,7 +567,7 @@ export function setupMdsSideEffects(
     if (isRoom(jid) !== wasRoom) return
     // The position itself: a newer pointer supersedes this one. The store
     // subscription that moved it has already asked for another pass.
-    if (!sameReadPointer(readPointer(jid), pointer)) return
+    if (pointerIdentity(readPointer(jid)) !== identity) return
     if (!archiveIsTrustworthy(jid)) return
 
     // No resolvable stanza-id: neither the resident slice nor the cache can
@@ -576,7 +590,7 @@ export function setupMdsSideEffects(
     // Resolved AND ordered → handled from here on, whether we enqueue below or
     // decide the node is already at/ahead of it. Enqueued positions are checked
     // again at flush time because live node state can change during the debounce.
-    lastConsideredSeenId.set(jid, seenId)
+    lastConsideredPointerIdentity.set(jid, identity)
     if (decision === 'skip') return
 
     dirty.add(jid, stanzaId)
@@ -636,7 +650,7 @@ export function setupMdsSideEffects(
     lastKnownNodeStanzaId.delete(jid)
     lastKnownNodeRevision.delete(jid)
     currentSessionConfirmedNodeJids.delete(jid)
-    lastConsideredSeenId.delete(jid)
+    lastConsideredPointerIdentity.delete(jid)
     unroutedSeedMarkers.delete(jid)
     resolutionOwed.delete(jid)
     dirty.delete(jid)
@@ -770,7 +784,7 @@ export function setupMdsSideEffects(
 
       dirty.drop()
       dirty.open()
-      lastConsideredSeenId.clear()
+      lastConsideredPointerIdentity.clear()
 
       if (result.status === 'unknown') {
         syncEnabled = true

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -21,6 +21,12 @@
  * session never managed to publish is retried without waiting for a further
  * local read advance (#1145).
  *
+ * Read positions resolve from resident state first and from the IndexedDB
+ * message cache second (#1175), so a BACKGROUNDED entity — which keeps no
+ * resident message array — still resolves and publishes. That makes resolution
+ * asynchronous, so `consider()` runs as a LATEST-WINS SERIAL DRAIN per JID and
+ * revalidates every input after the await; see `consider`/`considerOnce`.
+ *
  * @module Core/MdsSideEffects
  */
 
@@ -34,9 +40,23 @@ import { createKeyedCoalescer } from '../utils/keyedCoalescer'
 import { compareOrder, makeArchiveOrderKey, type OrderPosition } from '../stores/shared/readState'
 import { getBareJid } from './jid'
 import { logInfo } from './logger'
+import * as messageCache from '../utils/messageCache'
+import { getStorageScopeJid } from '../utils/storageScope'
 
 /** Debounce window for read-position publishes (ms). */
 const PUBLISH_DEBOUNCE_MS = 1_500
+
+/**
+ * How many cached rows at or behind the pointer the cache resolution reads.
+ *
+ * The pointer's OWN row is the newest thing at or behind itself, so this window
+ * resolves the exact position whenever it is cached, and degrades into the
+ * at-or-behind fallback only when it is not resolvable. Bounding it keeps the
+ * read cheap on the path that cannot resolve at all (a 1:1 whose whole tail is
+ * our own unarchived sends), where nothing may be committed as handled and the
+ * lookup therefore re-runs on later store changes.
+ */
+const CACHE_LOOKBACK = 50
 
 /**
  * Sets up the MDS read-position publisher side effect.
@@ -78,6 +98,17 @@ export function setupMdsSideEffects(
   // Live conversation/room JIDs, to detect user deletes (retraction). Maintained
   // while disarmed; the removed delta is retracted only while armed (syncEnabled).
   let trackedJids = new Set<string>()
+  // Latest-wins serial drain state: the JIDs whose resolution is in flight, and
+  // the JIDs owed another pass because they changed during one. See consider().
+  const resolutionInFlight = new Set<string>()
+  const resolutionOwed = new Set<string>()
+  // Bumped whenever the session boundary moves (fresh seed, disconnect). A
+  // resolution that spans a bump was ordered against node state the new session
+  // has re-derived, so it is discarded rather than published.
+  let sessionEpoch = 0
+  // Set by the returned teardown, so a resolution still in flight cannot publish
+  // after the side effect has been unsubscribed.
+  let disposed = false
 
   function recordKnownNodeStanzaId(jid: string, stanzaId: string): void {
     lastKnownNodeStanzaId.set(jid, stanzaId)
@@ -216,7 +247,7 @@ export function setupMdsSideEffects(
    *   replies", which no receiver derives anything from, because unread
    *   counting excludes outgoing messages everywhere.
    *
-   * Rooms deliberately do NOT get this fallback — see {@link resolveSeenStanzaId}.
+   * Rooms deliberately do NOT get this fallback — see {@link resolveFromStores}.
    */
   function newestResolvableAtOrBehind(
     messages: Array<{ stanzaId?: string; from?: string; id: string; timestamp: Date }>,
@@ -239,6 +270,13 @@ export function setupMdsSideEffects(
     return best?.stanzaId
   }
 
+  /** The read-pointer message id this entity currently names, if any. */
+  function pointerMessageId(jid: string): string | undefined {
+    return isRoom(jid)
+      ? roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
+      : chatStore.getState().conversationMeta.get(jid)?.readPointer?.messageId
+  }
+
   /**
    * Resolve the stanza-id of the message a conversation's/room's read pointer names.
    *
@@ -251,7 +289,7 @@ export function setupMdsSideEffects(
    * stanza-ids at all would have nothing resolvable at or behind the pointer for
    * a fallback to find. So the asymmetry is the point, not an omission.
    */
-  function resolveSeenStanzaId(jid: string): string | undefined {
+  function resolveFromStores(jid: string): string | undefined {
     if (isRoom(jid)) {
       const seenId = roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
       if (!seenId) return undefined
@@ -279,6 +317,66 @@ export function setupMdsSideEffects(
     // state once the user has replied. Publish the newest position we CAN
     // address at or behind it rather than staying silent for the session.
     return newestResolvableAtOrBehind(messages, pointer)
+  }
+
+  /**
+   * Resolve the pointer from the IndexedDB message cache (#1175).
+   *
+   * The store-backed resolution above can only see what is RESIDENT, and a
+   * backgrounded entity keeps no resident array at all — `setActiveConversation`
+   * deletes the entry. Its position therefore stayed unresolved until something
+   * happened to re-trigger it. The cache is the same archive, minus the memory
+   * windowing, so reading it closes that gap.
+   *
+   * The chat branch reads ONE bounded window — the newest {@link CACHE_LOOKBACK}
+   * cached rows at or before the pointer's timestamp — and hands it to the same
+   * {@link newestResolvableAtOrBehind} the resident fallback uses. That is
+   * deliberately one code path for two jobs: the pointer's own row is the newest
+   * thing at or behind itself, so an exactly-resolvable pointer yields its own
+   * stanza-id, and only an unresolvable one degrades to the #1189 approximation.
+   * Ordering against the pointer is what makes it safe in the direction that
+   * matters — a row newer than the pointer can never be selected, so this cannot
+   * publish ahead of the true read position, exactly as for the resident scan.
+   *
+   * Rooms keep the exact-position contract and get NO at-or-behind fallback, in
+   * the cache as in memory — see {@link resolveFromStores} for why.
+   */
+  async function resolveFromCache(jid: string): Promise<string | undefined> {
+    if (!messageCache.isMessageCacheAvailable()) return undefined
+    if (isRoom(jid)) {
+      const seenId = roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
+      if (!seenId) return undefined
+      const cached = await messageCache.getRoomMessage(jid, seenId)
+      return cached?.stanzaId
+    }
+    const pointer = chatStore.getState().conversationMeta.get(jid)?.readPointer
+    if (!pointer?.messageId) return undefined
+    // `before` is an exclusive upper bound, so probe one millisecond past the
+    // pointer to include the message sitting exactly on it; it also forces the
+    // backwards cursor, so `limit` yields the NEWEST rows rather than the
+    // oldest. `after` pins the range's lower end inside this conversation —
+    // without it the cursor walks every lower-sorting conversation's rows when
+    // this one has nothing to return (see messageCache.entityTimestampRange).
+    const rows = await messageCache.getMessages(jid, {
+      after: new Date(0),
+      before: new Date(pointer.timestamp.getTime() + 1),
+      limit: CACHE_LOOKBACK,
+    })
+    return newestResolvableAtOrBehind(rows, pointer)
+  }
+
+  /**
+   * Resolve the pointer, resident state first and the cache second.
+   *
+   * Ordering is a cost decision, not a correctness one: both sources answer with
+   * a position at or behind the pointer, so neither can over-advance. Preferring
+   * the resident answer keeps every case that resolves today free of an
+   * IndexedDB read — including the active-conversation #1189 fallback, where the
+   * cached copy of an own send has no stanza-id either, so the read could not
+   * have improved on it.
+   */
+  async function resolveSeenStanzaId(jid: string): Promise<string | undefined> {
+    return resolveFromStores(jid) ?? (await resolveFromCache(jid))
   }
 
   /**
@@ -389,26 +487,58 @@ export function setupMdsSideEffects(
     return !mam.isLoading && mam.isCaughtUpToLive
   }
 
-  /** Consider a conversation/room for publishing if its read position advanced. */
-  function consider(jid: string): void {
+  /**
+   * One consideration pass for a conversation/room: resolve its read position
+   * and enqueue it if it advanced.
+   *
+   * Resolution can touch IndexedDB, so this is async and every input it was
+   * computed against is revalidated after the await. A change to any of them
+   * invalidates the in-flight result INSTEAD of publishing it: the de-dup key
+   * stays uncommitted, so the position is re-considered rather than silenced.
+   * The account checks are not hypothetical — a cross-account pointer write of
+   * this shape was found during #1155.
+   */
+  async function considerOnce(jid: string): Promise<void> {
     if (!syncEnabled) return
     // Catch-up gate: never publish a position derived from a partial archive.
     // Skipping leaves the de-dup key unchanged; MAM-state changes re-consider
     // the current pointer once catch-up becomes trustworthy.
     if (!archiveIsTrustworthy(jid)) return
 
-    const seenId = isRoom(jid)
-      ? roomStore.getState().roomMeta.get(jid)?.readPointer?.messageId
-      : chatStore.getState().conversationMeta.get(jid)?.readPointer?.messageId
+    const seenId = pointerMessageId(jid)
     if (seenId === lastConsideredSeenId.get(jid)) return
 
-    const stanzaId = resolveSeenStanzaId(jid)
-    // No resolvable stanza-id yet: the entity's resident array is evicted and
-    // the pointer doesn't name the lastMessage preview. Leave the de-dup key
-    // UNCOMMITTED so the next meta change re-runs this resolve — committing it
-    // here would make every later call short-circuit on the equality check
-    // above, and the position would never be enqueued nor reach the node
-    // (#1142). The key means "this position is handled", not "we have seen it".
+    // Captured BEFORE the await, compared after it.
+    const epoch = sessionEpoch
+    const scope = getStorageScopeJid()
+    const owner = ownBareJid()
+    const wasRoom = isRoom(jid)
+
+    const stanzaId = await resolveSeenStanzaId(jid)
+
+    // Teardown, or a session that ended or restarted (a new seed re-derives the
+    // node state this result was ordered against).
+    if (disposed) return
+    if (!syncEnabled || sessionEpoch !== epoch) return
+    if (connectionStore.getState().status !== 'online') return
+    // Account: the storage scope the cache was read under, and the JID we would
+    // publish as. Either changing means this value belongs to another account.
+    if (getStorageScopeJid() !== scope || ownBareJid() !== owner) return
+    // Classification: a bookmark landing mid-flight moves the entity to the room
+    // stores and changes the XEP-0359 `by` we would publish under.
+    if (isRoom(jid) !== wasRoom) return
+    // The position itself: a newer pointer supersedes this one. The store
+    // subscription that moved it has already asked for another pass.
+    if (pointerMessageId(jid) !== seenId) return
+    if (!archiveIsTrustworthy(jid)) return
+
+    // No resolvable stanza-id: neither the resident slice nor the cache can
+    // address the pointer — in 1:1 the permanent state when the whole tail is
+    // our own unarchived sends. Leave the de-dup key UNCOMMITTED so the next
+    // meta change re-runs this resolve — committing it here would make every
+    // later call short-circuit on the equality check above, and the position
+    // would never be enqueued nor reach the node (#1142). The key means "this
+    // position is handled", not "we have seen it".
     if (!stanzaId) return
 
     // No regressive publish: only publish when we can show the position is not
@@ -427,6 +557,40 @@ export function setupMdsSideEffects(
 
     dirty.add(jid, stanzaId)
     schedulePublish()
+  }
+
+  /**
+   * Consider a conversation/room, serialised per JID with LATEST-WINS semantics.
+   *
+   * At most one resolution is in flight per JID; a call arriving during it marks
+   * another pass as owed and the drain re-runs when the current one finishes.
+   *
+   * A bare in-flight guard — suppressing the second call — would be WRONG: A is
+   * in flight, B arrives and is dropped, A completes, and nothing ever retries
+   * B. The position B named would then never be published, which is exactly the
+   * failure #1142 fixed. Re-running is what keeps it latest-wins: the rerun
+   * re-reads the CURRENT pointer, so the newest position is the one considered,
+   * however many were coalesced into the one owed pass.
+   */
+  function consider(jid: string): void {
+    if (!syncEnabled) return
+    if (resolutionInFlight.has(jid)) {
+      resolutionOwed.add(jid)
+      return
+    }
+    resolutionInFlight.add(jid)
+    void (async () => {
+      try {
+        do {
+          // Cleared BEFORE the pass so a request arriving DURING it is kept.
+          resolutionOwed.delete(jid)
+          await considerOnce(jid)
+        } while (resolutionOwed.has(jid) && !disposed)
+      } finally {
+        resolutionInFlight.delete(jid)
+        resolutionOwed.delete(jid)
+      }
+    })()
   }
 
   /** Current live set: 1:1 conversation entities ∪ known rooms. */
@@ -450,6 +614,7 @@ export function setupMdsSideEffects(
     currentSessionConfirmedNodeJids.delete(jid)
     lastConsideredSeenId.delete(jid)
     unroutedSeedMarkers.delete(jid)
+    resolutionOwed.delete(jid)
     dirty.delete(jid)
   }
 
@@ -567,6 +732,7 @@ export function setupMdsSideEffects(
   // disabled for the whole async seed so the seeded positions aren't republished.
   const unsubscribeOnline = client.on('online', () => {
     syncEnabled = false
+    sessionEpoch++
     nodeSnapshotAuthoritative = false
     currentSessionConfirmedNodeJids.clear()
     void (async () => {
@@ -690,6 +856,7 @@ export function setupMdsSideEffects(
     (status) => {
       if (status !== 'online' && previousStatus === 'online') {
         syncEnabled = false
+        sessionEpoch++
         // Clear the delete-detection baseline: a teardown is not a delete.
         trackedJids = new Set()
         dirty.drop()
@@ -704,6 +871,8 @@ export function setupMdsSideEffects(
   )
 
   return () => {
+    disposed = true
+    resolutionOwed.clear()
     unsubscribeConversationMeta()
     unsubscribeMessages()
     unsubscribeConversationMam()

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -880,6 +880,7 @@ export function setupMdsSideEffects(
   // SM resumption: server replays notifications; keep publishing enabled, no reseed.
   const unsubscribeResumed = client.on('resumed', () => {
     dirty.open()
+    lastConsideredPointerIdentity.clear()
     syncEnabled = true
     // Rebuild the delete-detection baseline to the current live set (mirrors the
     // fresh-session handler) so a resume's known entities aren't seen as deletes.


### PR DESCRIPTION
`resolveSeenStanzaId` could only see **resident** messages, and a backgrounded conversation or room keeps no resident array at all — `setActiveConversation` deletes the entry. Its read position therefore stayed unresolved and the XEP-0490 publisher stayed silent for it until something happened to re-trigger it.

Resolution now falls through to the IndexedDB message cache, for the exact pointer row and for the at-or-behind fallback alike. The chat branch reads one bounded window of cached rows at or before the pointer and hands it to the same `newestResolvableAtOrBehind` the resident scan uses, so the pointer's own row wins when it is addressable and only an unresolvable pointer degrades to the approximation. Ordering against the pointer is unchanged, so nothing newer than the true read position can be selected. Resident state is still consulted first, so every case that resolves today costs no cache read.

**This does not and cannot fix the 1:1 own-send case.** A message we send in a 1:1 is never reflected back and so never acquires a `stanza-id`, in RAM and in IndexedDB alike — reading the same row from the cache returns the same missing field. That defect is #1189's and is already fixed; this change only extends #1189's fallback to reach conversations that have no resident slice.

Closes #1175.

### Concurrency

Cache resolution makes `consider()` asynchronous. It runs as a latest-wins serial drain per JID: at most one resolution in flight, and a position arriving during one marks another pass as owed rather than being dropped, so the newest pointer is always the one considered. A bare in-flight guard would silently lose the newer position. Every input the resolution was computed against — session epoch, connection status, account storage scope and own JID, room/chat classification, full pointer identity, and archive trustworthiness — is revalidated after the await; a change discards the result instead of publishing it and leaves the position unhandled so it is retried rather than silenced.

`publishDecision` and the flush-time guards are untouched.

### Room pointer identity

Room client ids are unique only per `(room, sender)`, so resolving a room pointer by id alone could match a different occupant's row and publish the wrong `stanza-id` — the unrecoverable direction, since MDS positions are forward-only. Room resolution now uses the pointer's sender, and the handled-position register stores the full pointer identity rather than the message id alone.

A consequence worth calling out: a room pointer with no `archiveOrderKey` (the pre-#1081 migrated shape) can no longer be resolved at all, from the resident slice or the cache. When the identity cannot be established, refusing to resolve is the correct behaviour rather than a limitation — the position simply stays retryable, which costs hit-rate only in that corner.

### Known limitation, being addressed as a model

A restored read pointer carries **two names for the same message** — `messageId` and `archiveOrderKey.id` — and `deserializeReadPointer` validates only the second, only structurally. Nothing checks that the two agree. The at-or-behind ordering scan then trusts the key as its boundary, so a structurally valid but semantically inconsistent restored pointer could select a row that is actually ahead of the true read position.

This predates this change: the resident scan has trusted that same key since #1189. It is deliberately **not** guarded here. Guarding only the publisher would leave the same inconsistent pointer trusted by every other consumer — unread counts, the new-message divider, and the rest of read state — so it is being addressed as a pointer identity model rather than as a per-site guard, in a separate investigation for which this is the anchor.
