### PR TITLE
fix(read-state): stop persisting the read pointer's tie-break id

### DIFF
--- a/docs/superpowers/plans/2026-07-23-read-state-b-unread-count-derivation.md
+++ b/docs/superpowers/plans/2026-07-23-read-state-b-unread-count-derivation.md
@@ -162,6 +162,10 @@ export function isValidArchiveOrderKey(v: unknown): v is ArchiveOrderKey {
 
 ### Task 2: Persist a validated `archiveOrderKey` on the read pointer
 
+> **Historical step:** This records PR B's original full-key encoding. The current
+> on-disk contract is owned by `stores/shared/readPointer.ts` and summarized in the
+> authoritative design: hydration reconstructs `id` from `messageId`.
+
 **Files:** `readPointer.ts`; `readStateStorage.ts:161,99`; `stateSnapshot.ts:187,203`; `chatStore.ts:894,924`; tests in `readPointer.test.ts`, `readStateStorage.test.ts`.
 
 **Interfaces:** `ReadPointer { messageId; timestamp; archiveOrderKey? }`; `makeReadPointer(msg: { id: string; from?: string; timestamp: Date }, kind: 'chat' | 'room'): ReadPointer`. `deserializeReadPointer` **validates** the persisted key with `isValidArchiveOrderKey` and drops it when invalid (never passes untrusted JSON through).

--- a/docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-22-read-state-model-consolidation-design.md
@@ -157,9 +157,11 @@ it needs no data migration: a persisted pointer without it uses the timestamp fa
 a writer replaces it. Populating it is not one edit but several — the shared
 `makeReadPointer` cannot infer a room's `(from, id)` from a `PointerSource { id, timestamp }`,
 so it takes an explicit order key (or splits into chat/room constructors), and every
-serialization surface must round-trip the field: chat `conversationMeta` persistence, room
-`readStateStorage`, the SDK `stateSnapshot`, and their deserializers, each with a round-trip
-test.)
+persistence surface must round-trip the in-memory field. `readPointer.ts` owns the on-disk
+encoding: serializers omit the key's redundant `id` and hydration reconstructs it from
+`messageId`, while preserving the room-only `from` component that cannot be reconstructed.
+Chat `conversationMeta` still persists the in-memory object through plain JSON, but hydration
+uses the same reconstruction path and never trusts that legacy duplicate `id`.)
 
 To be precise about decision 3: the *field name* `lastReadAt` disappears, but the value it
 was supposed to hold survives — corrected — as `readPointer.timestamp`. Nothing is lost;
@@ -479,12 +481,14 @@ row = one position, and everything below needs no dedup:
   it, so `m2` is counted. When the pointer has no `archiveOrderKey` (a migrated `lastReadAt`),
   fall back to at-or-after-timestamp — this can recount the equal-ms set, which over-counts
   in the safe direction.
-- **The order key must be persisted on the pointer, not recovered from memory.** The whole
+- **The order key must be reconstructible from the persisted pointer, not recovered from memory.** The whole
   reason the count exists is that a backgrounded entity's resident array is *evicted* — so
   "locate the pointer by the resident message's fields" fails exactly when it is needed, and
-  a room's `id` alone is not unique within the room. So the pointer persists a **structured**
-  `archiveOrderKey`, not a delimiter-joined string (whose lexical order need not match the
-  tuple order and could collide on a delimiter):
+  a room's `id` alone is not unique within the room. The persisted pointer therefore keeps
+  the structured key's non-derivable `from`; its `id` is the pointer's `messageId` and is
+  reconstructed during hydration. The in-memory key remains structured, not a
+  delimiter-joined string (whose lexical order need not match the tuple order and could
+  collide on the delimiter):
 
   ```ts
   type ArchiveOrderKey =
@@ -550,7 +554,7 @@ later trigger.
 
 | Module | Purpose | Sync? |
 |---|---|---|
-| `messageCache.ts` *(+2 fns)* | `countUnreadInArchive(conversationId, {pointer, floor, cap})` and a room twin `countRoomUnreadInArchive` returning `{unread}` only. A cursor from the floor timestamp forward — chat over `conv_timestamp`, room over the `room_ts_from_id` index B0 added — counting `!isOutgoing && isRenderableStoredMessage` strictly after the pointer's **position** in `(timestamp, orderKey)` order (matching the row's stable `(from, id)` / `id` against the pointer's persisted `archiveOrderKey`; at-or-after-timestamp fallback when it is absent), early-out at `cap` (999). No dedup — B0 guarantees one row per logical message. Only touches the index range at/after the floor → O(unread)-capped over the *local* archive. A cursor, not `index.count()`, which can neither filter nor honor the tiebreak. It does not scan mentions; see [Mention counts remain live-only](#mention-counts-remain-live-only). | async |
+| `messageCache.ts` *(+2 fns)* | `countUnreadInArchive(conversationId, {pointer, floor, cap})` and a room twin `countRoomUnreadInArchive` returning `{unread}` only. A cursor from the floor timestamp forward — chat over `conv_timestamp`, room over the `room_ts_from_id` index B0 added — counting `!isOutgoing && isRenderableStoredMessage` strictly after the pointer's **position** in `(timestamp, orderKey)` order (matching the row's stable `(from, id)` / `id` against the pointer's hydrated `archiveOrderKey`; at-or-after-timestamp fallback when it is absent), early-out at `cap` (999). No dedup — B0 guarantees one row per logical message. Only touches the index range at/after the floor → O(unread)-capped over the *local* archive. A cursor, not `index.count()`, which can neither filter nor honor the tiebreak. It does not scan mentions; see [Mention counts remain live-only](#mention-counts-remain-live-only). | async |
 | `stores/shared/readState.ts` *(new, pure)* | `computeFloor(pointer, historyFloor)`; the derivation's outcome + defer logic (`exact | deferred | unavailable`, and the coverage / pointerless-with-count / un-migrated / pending-marker defer conditions); the `(timestamp, archiveOrderKey)` comparator used by the resident sort and the count; re-exports the single `isRenderableStoredMessage` predicate that both the cache walk and the live `+1` path use, so they cannot drift. | sync |
 | `chatStore` / `roomStore` | `recomputeUnreadForConversation` rewritten to gate on coverage, compute the floor (pure), call `countUnreadInArchive`, and write the count **only on an `exact` outcome**; a new parallel `recomputeUnreadForRoom` (rooms inline their recount today). | async |
 
@@ -578,7 +582,7 @@ counted and the pointer advances through the run** (the tie bug), chat and room;
 **IndexedDB opens but holds only part of the unread range (mid-catch-up / gap below live) →
 `deferred`, persisted count untouched, never zeroed** (the partial-archive trap);
 **pointerless conversation with a non-zero persisted count → `deferred`, count preserved**;
-**a same-ms pointer absent from memory after restart → located via persisted `archiveOrderKey`,
+**a same-ms pointer absent from memory after restart → located via its durably reconstructed `archiveOrderKey`,
 not a resident lookup**; **two room messages sharing an `id` but different `(from)` senders →
 counted as two distinct positions** (the room-id-not-unique case); **a pointer created before
 its `stanzaId` arrives → still resolvable after restart / MAM reconciliation** (the stable
@@ -613,7 +617,7 @@ including the decisive straddle case (fallback row at `t1`, stanza row for the s
 
 **PR B task order** (on a store B0 has normalised). Pure `readState` core (the
 `(timestamp, archiveOrderKey)` comparator, `computeFloor`, the outcome/defer logic) and delete
-PR A's `readFloor` → persist `archiveOrderKey` (the explicit-structured-order-key constructor
+PR A's `readFloor` → persist enough to reconstruct `archiveOrderKey` (the explicit-structured-order-key constructor
 change, plus chat persistence, room `readStateStorage`, `stateSnapshot`, their deserializers,
 and round-trip tests) → resident-sort tiebreak in `messageArrayUtils` (isolated,
 `test:scroll`-gated, lands before anything depends on the shared order) → cache primitive

--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
@@ -228,13 +228,16 @@ describe('StateSnapshot', () => {
       const [persisted] = adapterData.store.get('user@example.com')!.rooms as Array<{
         readPointer?: { messageId: string; timestamp: number; archiveOrderKey?: unknown }
       }>
+      // The tie-break's `id` is NOT persisted: it is `messageId`, and storing a
+      // second copy made a disagreement representable on disk. Only `from`,
+      // which the pointer cannot reconstruct, rides through.
       expect(persisted?.readPointer?.archiveOrderKey).toEqual({
         kind: 'room',
         from: 'room@conf.example.com/alice',
-        id: 'msg-8',
       })
 
-      // Read back: a fresh hydrate into an empty room store must recover it.
+      // Read back: a fresh hydrate into an empty room store must recover it,
+      // with `id` reconstructed from `messageId`.
       roomStore.getState().removeRoom('room@conf.example.com')
       await snapshot.hydrate('user@example.com')
       expect(roomStore.getState().rooms.get('room@conf.example.com')?.readPointer?.archiveOrderKey).toEqual({

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -280,8 +280,8 @@ export function isUnseenIncomingMessage(
  * The old fallback ladder — a `lastReadAt` timestamp probe, an Nth-from-end
  * placement driven by `unreadCount`, and a resume-preserving snap — is gone. All
  * of it existed because the pointer could not be located outside the resident
- * slice, which a persisted `archiveOrderKey` now solves, and the snap was a
- * pointer write inside a function whose job is to place a divider.
+ * slice, which a durably reconstructible `archiveOrderKey` now solves, and the
+ * snap was a pointer write inside a function whose job is to place a divider.
  *
  * With neither a pointer nor a `historyFloor` there is no boundary, so there is
  * no divider — the same stand-down the count makes when `computeFloor` yields

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -7,6 +7,7 @@ import {
   deserializeReadPointer,
 } from './readPointer'
 import type { ReadPointer } from './readPointer'
+import { isValidArchiveOrderKey } from './readState'
 
 const at = (ms: number) => new Date(ms)
 
@@ -153,5 +154,129 @@ describe('serialization', () => {
   // position to derive a key from — absence here is legitimate, not corrupt.
   it('a legacy pointer with no key deserializes with archiveOrderKey undefined', () => {
     expect(deserializeReadPointer({ messageId: 'm', timestamp: 1000 })!.archiveOrderKey).toBeUndefined()
+  })
+})
+
+// The tie-break's `id` IS `messageId` — the same message named twice. Storing
+// them independently made a disagreement representable on disk, and the
+// ordering scan trusts the key as the at-or-behind boundary, so an inconsistent
+// restored pointer could select a row that is actually AHEAD — the
+// unrecoverable direction for a forward-only position. The on-disk form now
+// omits the id entirely, which makes the disagreement unrepresentable rather
+// than merely rejected.
+describe('serialization: the tie-break id is not persisted', () => {
+  it('omits `id` from a persisted chat key', () => {
+    const p = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    expect(serializeReadPointer(p).archiveOrderKey).toEqual({ kind: 'chat' })
+  })
+
+  it('omits `id` from a persisted room key but keeps `from` (the room tie-break needs it)', () => {
+    const p = makeReadPointer({ id: 'm1', from: 'room@x/nick', timestamp: at(1000) }, 'room')
+    expect(serializeReadPointer(p).archiveOrderKey).toEqual({ kind: 'room', from: 'room@x/nick' })
+  })
+
+  it('no persisted pointer carries an id beside the messageId', () => {
+    const chat = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    const room = makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room')
+    for (const p of [chat, room]) {
+      const onDisk = JSON.parse(JSON.stringify(serializeReadPointer(p)))
+      expect(onDisk.archiveOrderKey).not.toHaveProperty('id')
+    }
+  })
+
+  it('hydration reconstructs the key id from messageId, so the round trip is unchanged in memory', () => {
+    const chat = makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')
+    const room = makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room')
+    for (const p of [chat, room]) {
+      expect(deserializeReadPointer(JSON.parse(JSON.stringify(serializeReadPointer(p))))).toEqual(p)
+    }
+  })
+
+  // Compatibility 1 — old data, new build. Any persisted `id` is ignored and
+  // `messageId` is used instead. Lossless: they were always the same value.
+  it('reads a legacy on-disk key that still carries its id (lossless)', () => {
+    expect(
+      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 'm1' } })
+    ).toEqual({ messageId: 'm1', timestamp: at(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } })
+
+    expect(
+      deserializeReadPointer({
+        messageId: 'm2',
+        timestamp: 1000,
+        archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm2' },
+      })
+    ).toEqual({
+      messageId: 'm2',
+      timestamp: at(1000),
+      archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm2' },
+    })
+  })
+
+  // Compatibility 3 — inconsistent legacy data. This is the defect being
+  // closed: a stored pointer whose persisted id disagreed with `messageId` now
+  // resolves to `messageId`, so the boundary can no longer name a different
+  // (possibly newer) row than the pointer does.
+  it('resolves an inconsistent legacy key to messageId, not to the persisted id', () => {
+    const back = deserializeReadPointer({
+      messageId: 'm1',
+      timestamp: 1000,
+      archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
+    })
+    expect(back!.archiveOrderKey).toEqual({ kind: 'chat', id: 'm1' })
+
+    const roomBack = deserializeReadPointer({
+      messageId: 'm1',
+      timestamp: 1000,
+      archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm9-ahead' },
+    })
+    expect(roomBack!.archiveOrderKey).toEqual({ kind: 'room', from: 'room@x/nick', id: 'm1' })
+  })
+
+  // ...and the disagreement cannot be written back out either: what a
+  // re-persist emits carries no id at all, so the inconsistency does not
+  // survive a load/save cycle in any form.
+  it('cannot write the disagreement back out', () => {
+    const back = deserializeReadPointer({
+      messageId: 'm1',
+      timestamp: 1000,
+      archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
+    })!
+    expect(JSON.stringify(serializeReadPointer(back))).not.toContain('m9-ahead')
+  })
+
+  // Compatibility 2 — new data, old build. An older build validates the
+  // persisted key with `isValidArchiveOrderKey`, which requires
+  // `typeof k.id === 'string'`. The id-less form fails that guard, so an old
+  // build DROPS the key and degrades to the documented at-or-after-timestamp
+  // fallback, which over-counts — the safe, recoverable direction. Asserted
+  // here rather than assumed, because shipping a format an older build
+  // mis-read in the unsafe direction would be unrecoverable.
+  it('an old build drops the new id-less key rather than mis-reading it', () => {
+    const chat = serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))
+    const room = serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room'))
+    expect(isValidArchiveOrderKey(chat.archiveOrderKey)).toBe(false)
+    expect(isValidArchiveOrderKey(room.archiveOrderKey)).toBe(false)
+  })
+
+  // The pointer itself must still load on an old build: only the key degrades.
+  it('leaves messageId and timestamp readable in the old on-disk shape', () => {
+    const onDisk = JSON.parse(
+      JSON.stringify(serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')))
+    )
+    expect(onDisk.messageId).toBe('m1')
+    expect(onDisk.timestamp).toBe(1000)
+  })
+
+  // A key whose `kind` is unrecognisable, or a room key with no usable `from`,
+  // still yields no key at all — storage stays untrusted input.
+  it.each([
+    ['an unknown kind', { kind: 'nope' }],
+    ['a room key with no from', { kind: 'room' }],
+    ['a room key with a non-string from', { kind: 'room', from: 7 }],
+    ['a non-object key', 'chat'],
+  ])('drops %s', (_label, archiveOrderKey) => {
+    const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, archiveOrderKey })
+    expect(back!.archiveOrderKey).toBeUndefined()
+    expect(back!.messageId).toBe('m')
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -212,6 +212,16 @@ describe('serialization: the tie-break id is not persisted', () => {
     })
   })
 
+  it('accepts a legacy chat key with a non-string id because messageId is authoritative', () => {
+    expect(
+      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 42 } })
+    ).toEqual({
+      messageId: 'm1',
+      timestamp: at(1000),
+      archiveOrderKey: { kind: 'chat', id: 'm1' },
+    })
+  })
+
   // Compatibility 3 — inconsistent legacy data. This is the defect being
   // closed: a stored pointer whose persisted id disagreed with `messageId` now
   // resolves to `messageId`, so the boundary can no longer name a different

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -15,7 +15,7 @@
  * All functions here are pure.
  */
 
-import { compareOrder, makeArchiveOrderKey, isValidArchiveOrderKey, type ArchiveOrderKey } from './readState'
+import { compareOrder, makeArchiveOrderKey, type ArchiveOrderKey } from './readState'
 
 /**
  * Where the user has read to. Written atomically or not at all.
@@ -47,11 +47,27 @@ export interface ReadPointer {
   archiveOrderKey?: ArchiveOrderKey
 }
 
+/**
+ * The tie-break as it is written to disk: everything the key needs EXCEPT its
+ * `id`, which is `messageId` and is reconstructed at hydration.
+ *
+ * The id was stored twice — once as `messageId`, once inside the key — and
+ * nothing checked the two agreed. Since the ordering scan trusts the key as the
+ * at-or-behind boundary, a disagreeing restored pointer could select a row that
+ * is actually AHEAD of the read position, which is the unrecoverable direction
+ * for a forward-only pointer. Not persisting the second copy makes that
+ * disagreement unrepresentable rather than merely rejected at read time.
+ *
+ * `from` stays: it is the room archive's own `(from, id)` tie-break component
+ * and is NOT derivable from the pointer.
+ */
+export type SerializedArchiveOrderKey = { kind: 'chat' } | { kind: 'room'; from: string }
+
 /** JSON-safe form for localStorage. */
 export interface SerializedReadPointer {
   messageId: string
   timestamp: number
-  archiveOrderKey?: ArchiveOrderKey
+  archiveOrderKey?: SerializedArchiveOrderKey
 }
 
 /** The minimal message shape a pointer can be built from. */
@@ -123,12 +139,43 @@ export function advance(current: ReadPointer | undefined, candidate: ReadPointer
   return isAhead(candidate, current) ? candidate : current
 }
 
+/**
+ * Write the pointer, with the tie-break stripped of its redundant `id` (see
+ * {@link SerializedArchiveOrderKey}). The in-memory shape is unchanged; only
+ * the on-disk form shrinks.
+ *
+ * An OLDER build reading this format validates the key with
+ * `isValidArchiveOrderKey`, which requires `typeof k.id === 'string'` — so it
+ * drops the key and degrades to the at-or-after-timestamp fallback, which
+ * over-counts rather than under-counts (the safe, recoverable direction). The
+ * `messageId` and `timestamp` it needs are untouched.
+ */
 export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointer {
+  const key = pointer.archiveOrderKey
   return {
     messageId: pointer.messageId,
     timestamp: pointer.timestamp.getTime(),
-    archiveOrderKey: pointer.archiveOrderKey,
+    ...(key ? { archiveOrderKey: key.kind === 'room' ? { kind: 'room', from: key.from } : { kind: 'chat' } } : {}),
   }
+}
+
+/**
+ * Rebuild the tie-break from an untrusted persisted key, taking the id from
+ * `messageId` — the pointer's one name for the message it points at.
+ *
+ * Any `id` still on disk (every key written before this format) is IGNORED
+ * rather than read: it was always the same value, so ignoring it is lossless
+ * for consistent data and is exactly the fix for inconsistent data. What
+ * remains validated is what cannot be reconstructed: the `kind` discriminant,
+ * and `from` for a room key. Anything else yields no key at all, which degrades
+ * to the at-or-after-timestamp fallback (over-count, the safe direction).
+ */
+function hydrateArchiveOrderKey(raw: unknown, messageId: string): ArchiveOrderKey | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const k = raw as Record<string, unknown>
+  if (k.kind === 'chat') return { kind: 'chat', id: messageId }
+  if (k.kind === 'room' && typeof k.from === 'string') return { kind: 'room', from: k.from, id: messageId }
+  return undefined
 }
 
 /**
@@ -142,12 +189,13 @@ export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointe
  * encodings exist on disk today — this is the one place that reads either back.
  * We still only ever WRITE epoch ms; the string branch is read-only tolerance.
  *
- * `archiveOrderKey` is validated with {@link isValidArchiveOrderKey} and DROPPED
- * when malformed — storage is untrusted input, so a corrupt key must not ride
- * through verbatim into ordering comparisons. Dropping it alone (keeping the
- * rest of the pointer) is deliberate: it degrades to the at-or-after-timestamp
- * fallback, which can over-count rather than under-count (safe direction),
- * without discarding a message id and timestamp that are otherwise fine.
+ * `archiveOrderKey` is rebuilt by {@link hydrateArchiveOrderKey} — never taken
+ * verbatim — and DROPPED when what it carries is unusable. Storage is untrusted
+ * input, so a corrupt key must not ride through into ordering comparisons.
+ * Dropping it alone (keeping the rest of the pointer) is deliberate: it degrades
+ * to the at-or-after-timestamp fallback, which can over-count rather than
+ * under-count (safe direction), without discarding a message id and timestamp
+ * that are otherwise fine.
  */
 export function deserializeReadPointer(raw: unknown): ReadPointer | undefined {
   if (!raw || typeof raw !== 'object') return undefined
@@ -157,7 +205,7 @@ export function deserializeReadPointer(raw: unknown): ReadPointer | undefined {
     archiveOrderKey?: unknown
   }
   if (typeof messageId !== 'string' || messageId.length === 0) return undefined
-  const validKey = isValidArchiveOrderKey(archiveOrderKey) ? archiveOrderKey : undefined
+  const validKey = hydrateArchiveOrderKey(archiveOrderKey, messageId)
 
   if (typeof timestamp === 'number') {
     return Number.isFinite(timestamp)

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -105,7 +105,17 @@ export function worthReconcilingOnDeactivate(
   return meta.readPointer !== undefined || meta.unreadCount > 0
 }
 
-/** Runtime guard for an `ArchiveOrderKey` read back from untrusted storage. */
+/**
+ * Runtime guard for an `ArchiveOrderKey` read back from untrusted storage.
+ *
+ * No longer on the hydration path: `deserializeReadPointer` rebuilds the key
+ * and takes its `id` from `messageId` instead of validating a persisted one.
+ * It is kept because it still describes how an OLDER build reads today's
+ * on-disk form — the `typeof k.id === 'string'` requirement is what makes an
+ * old build drop the new id-less key and degrade to the at-or-after-timestamp
+ * fallback (over-count, the safe direction) instead of mis-reading it. That
+ * compatibility claim is asserted against this function in `readPointer.test.ts`.
+ */
 export function isValidArchiveOrderKey(v: unknown): v is ArchiveOrderKey {
   if (!v || typeof v !== 'object') return false
   const k = v as Record<string, unknown>


### PR DESCRIPTION
The read pointer named one message twice: `messageId`, and the `id` inside its `archiveOrderKey` tie-break. The two were stored independently and nothing checked they agreed — `deserializeReadPointer` validated the persisted key only structurally — while the unread scan trusts the key as the at-or-behind boundary. An inconsistent restored pointer could therefore select a row that is actually *ahead* of the read position, which is the unrecoverable direction for a forward-only pointer.

The on-disk tie-break now omits its `id`, serializing as `{kind:'chat'}` or `{kind:'room', from}`, and hydration reconstructs the `id` from `messageId`. That makes the disagreement unrepresentable on disk rather than merely rejected at read time. `from` stays because the room archive's `(from, id)` tie-break cannot reconstruct it. The in-memory shape, the public API and every consumer are unchanged, and no stored position is rewritten.

### Compatibility

All three directions are covered by tests rather than assumed, since this touches persisted read state.

- **Old data, new build** — legacy keys that still carry their `id` hydrate to the same pointer. Lossless: the two values were always the same.
- **New data, old build** — **the safe direction holds, confirmed rather than inherited.** `isValidArchiveOrderKey` requires `typeof k.id === 'string'`, so an older build fails that guard on the new id-less key, drops it, and degrades to the documented at-or-after-timestamp fallback, which over-counts. `messageId` and `timestamp` stay readable in the old shape. The assertion runs directly against `isValidArchiveOrderKey`, and the guard is kept and documented for exactly that reason.
- **Inconsistent legacy data** — a stored pointer whose persisted `id` disagreed with `messageId` now resolves to `messageId`, and the disagreement cannot be written back out.

One deliberate edge-case change: a legacy chat key whose persisted `id` was not a string used to be dropped and is now accepted, because the reconstructed `id` comes from the already-validated `messageId` and is authoritative rather than corrupt.

### Scope note

The chat path persists `conversationMeta` verbatim through a plain `JSON.stringify` rather than through `serializeReadPointer`, so that blob still writes an `id`. It cannot produce a disagreement — in-memory pointers are always minted consistently — and hydration is the only way a persisted pointer re-enters memory, so no disagreement is readable from either path. Routing that blob through `serializeReadPointer` would also change its timestamp encoding, which is a broader on-disk change than this one makes.
