### PR TITLE
refactor(read-state): rename ArchiveOrderKey to CacheOrderKey and the pointer field to tiebreak

### DIFF
--- a/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
+++ b/packages/fluux-sdk/src/core/XMPPClient.e2ee.test.ts
@@ -636,7 +636,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       const readPointer = {
         messageId: 'read-msg',
         timestamp: new Date('2026-06-10T00:00:00Z'),
-        archiveOrderKey: { kind: 'chat' as const, id: 'read-msg' },
+        tiebreak: { kind: 'chat' as const, id: 'read-msg' },
       }
       chatStore.setState((s) => {
         const conversationMeta = new Map(s.conversationMeta)
@@ -667,7 +667,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // the floor (proving coverage reaches at least that far back).
       vi.mocked(messageCache.resolveArchivePosition).mockResolvedValueOnce({
         timestamp: new Date('2026-06-09T23:00:00Z').getTime(),
-        archiveOrderKey: { kind: 'chat', id: 'archive-anchor' },
+        tiebreak: { kind: 'chat', id: 'archive-anchor' },
       })
       // Only the genuinely-unread message remains once the reaction ghost drops.
       vi.mocked(messageCache.countUnreadInArchive).mockResolvedValueOnce({ unread: 1 })
@@ -916,7 +916,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       const readPointer = {
         messageId: 'read-msg',
         timestamp: new Date('2026-06-10T00:00:00Z'),
-        archiveOrderKey: { kind: 'room' as const, from: `${ROOM}/alice`, id: 'read-msg' },
+        tiebreak: { kind: 'room' as const, from: `${ROOM}/alice`, id: 'read-msg' },
       }
       roomStore.setState((s) => {
         const roomMeta = new Map(s.roomMeta)
@@ -935,7 +935,7 @@ describe('XMPPClient.retryPendingDecrypts()', () => {
       // the floor (proving coverage reaches at least that far back).
       vi.mocked(messageCache.resolveArchivePosition).mockResolvedValueOnce({
         timestamp: new Date('2026-06-09T23:00:00Z').getTime(),
-        archiveOrderKey: { kind: 'room', from: `${ROOM}/alice`, id: 'archive-anchor' },
+        tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'archive-anchor' },
       })
       // Only one message is genuinely unread once the archive is consulted.
       vi.mocked(messageCache.countRoomUnreadInArchive).mockResolvedValueOnce({ unread: 1 })

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.integration.test.ts
@@ -179,7 +179,7 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
         readPointer: {
           messageId: 'exact-7',
           timestamp: new Date(7_000),
-          archiveOrderKey: { kind: 'chat', id: 'exact-7' },
+          tiebreak: { kind: 'chat', id: 'exact-7' },
         },
       })
       conversationMeta.set(FALLBACK_CHAT, {
@@ -187,7 +187,7 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
         readPointer: {
           messageId: 'own-4',
           timestamp: new Date(4_000),
-          archiveOrderKey: { kind: 'chat', id: 'own-4' },
+          tiebreak: { kind: 'chat', id: 'own-4' },
         },
       })
       return { conversationMeta }
@@ -199,7 +199,7 @@ describe('mdsSideEffects real IndexedDB cache integration', () => {
         readPointer: {
           messageId: 'shared-id',
           timestamp: new Date(8_000),
-          archiveOrderKey: { kind: 'room', from: alice, id: 'shared-id' },
+          tiebreak: { kind: 'room', from: alice, id: 'shared-id' },
         },
       })
       return { roomMeta }

--- a/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.cache.test.ts
@@ -68,23 +68,23 @@ function timeFor(id: string): Date {
 
 /**
  * A read pointer as `makeReadPointer` builds one: the named message's own
- * timestamp AND its archive order key. A pointer without a key is the
+ * timestamp AND its cache order key. A pointer without a key is the
  * pre-#1081 migrated shape, covered separately in mdsSideEffects.test.ts.
  */
 function pointerAt(id: string): {
   messageId: string
   timestamp: Date
-  archiveOrderKey: { kind: 'chat'; id: string }
+  tiebreak: { kind: 'chat'; id: string }
 } {
-  return { messageId: id, timestamp: timeFor(id), archiveOrderKey: { kind: 'chat', id } }
+  return { messageId: id, timestamp: timeFor(id), tiebreak: { kind: 'chat', id } }
 }
 
 function roomPointerAt(id: string, from = `${ROOM}/alice`): {
   messageId: string
   timestamp: Date
-  archiveOrderKey: { kind: 'room'; from: string; id: string }
+  tiebreak: { kind: 'room'; from: string; id: string }
 } {
-  return { messageId: id, timestamp: timeFor(id), archiveOrderKey: { kind: 'room', from, id } }
+  return { messageId: id, timestamp: timeFor(id), tiebreak: { kind: 'room', from, id } }
 }
 
 /** A cached (IndexedDB) 1:1 row, incoming so it carries a server stanza-id. */

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -167,7 +167,7 @@ function seedRoom(jid: string, messages: RoomMessage[], seenMessageId?: string):
         readPointer: {
           messageId: seenMessageId,
           timestamp: seen?.timestamp ?? new Date(0),
-          archiveOrderKey: seen
+          tiebreak: seen
             ? { kind: 'room', from: seen.from, id: seenMessageId }
             : undefined,
         },
@@ -408,7 +408,7 @@ describe('setupMdsSideEffects', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(
-      chatStore.getState().conversationMeta.get(cid)?.readPointer?.archiveOrderKey
+      chatStore.getState().conversationMeta.get(cid)?.readPointer?.tiebreak
     ).toEqual({ kind: 'chat', id: 'm2' })
     expect(client.mds.publishDisplayed).toHaveBeenCalledWith(cid, 's1', 'romeo@montague.example')
     expect(client.mds.publishDisplayed).not.toHaveBeenCalledWith(cid, 's3', 'romeo@montague.example')
@@ -426,7 +426,7 @@ describe('setupMdsSideEffects', () => {
     seedMessages(cid, [msg('m1', 's1'), msg('m3', 's3'), ownMsg('m4', undefined)])
     seedMeta(cid)
     // A pointer migrated from the pre-#1081 lastSeenMessageId + lastReadAt pair
-    // has NO archiveOrderKey, and its timestamp is lastReadAt — documented as at
+    // has NO tiebreak, and its timestamp is lastReadAt — documented as at
     // or behind the message it names (readPointer.ts). Ordering by it therefore
     // under-advances: m3 sits past lastReadAt=2s and must not be selected.
     patchMeta(cid, { readPointer: { messageId: 'm4', timestamp: timeFor('m2') } })
@@ -712,7 +712,7 @@ describe('setupMdsSideEffects', () => {
         readPointer: {
           messageId: newest.id,
           timestamp: newest.timestamp,
-          archiveOrderKey: { kind: 'room', from: newest.from, id: newest.id },
+          tiebreak: { kind: 'room', from: newest.from, id: newest.id },
         },
       })
       return { roomMeta: meta }
@@ -825,7 +825,7 @@ describe('setupMdsSideEffects', () => {
         readPointer: {
           messageId: 'm2',
           timestamp: new Date(2),
-          archiveOrderKey: { kind: 'room', from: `${ROOM}/alice`, id: 'm2' },
+          tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm2' },
         },
       })
       return { roomMeta: meta }

--- a/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.test.ts
@@ -387,7 +387,7 @@ describe('setupMdsSideEffects', () => {
     cleanup()
   })
 
-  it('uses the pointer archive-order key to reject an unread same-millisecond sibling', async () => {
+  it('uses the pointer cache-order key to reject an unread same-millisecond sibling', async () => {
     const cid = 'juliet@capulet.example'
     const client = makeClient()
     connectionStore.setState({ status: 'online', jid: 'romeo@montague.example/phone' } as never)

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -301,7 +301,7 @@ export function setupMdsSideEffects(
   /**
    * Resolve the exact `(sender, id)` target named by a room pointer.
    *
-   * Room client ids are unique only per sender. Without a room archive-order
+   * Room client ids are unique only per sender. Without a room cache-order
    * key, choosing any matching row would risk publishing a WRONG forward-only
    * MDS position that no device can walk back. Refusing to resolve preserves the
    * exact-position contract and costs only a retryable delay.

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -60,7 +60,7 @@ const PUBLISH_DEBOUNCE_MS = 1_500
  * re-runs on later store changes.
  *
  * The IndexedDB `conv_timestamp` index bounds these 50 rows by TIMESTAMP ALONE;
- * `newestResolvableAtOrBehind` applies archive-order filtering afterwards.
+ * `newestResolvableAtOrBehind` applies cache-order filtering afterwards.
  * More than 50 rows sharing the pointer's millisecond and sorting after it can
  * therefore crowd the pointer row out. That containment deliberately fails in
  * the safe UNDER-ADVANCE direction: the position stays unresolved and retryable,

--- a/packages/fluux-sdk/src/core/mdsSideEffects.ts
+++ b/packages/fluux-sdk/src/core/mdsSideEffects.ts
@@ -37,7 +37,7 @@ import { chatStore } from '../stores/chatStore'
 import { connectionStore } from '../stores/connectionStore'
 import { roomStore } from '../stores/roomStore'
 import { createKeyedCoalescer } from '../utils/keyedCoalescer'
-import { compareOrder, makeArchiveOrderKey, type OrderPosition } from '../stores/shared/readState'
+import { compareOrder, makeCacheOrderKey, type OrderPosition } from '../stores/shared/readState'
 import type { ReadPointer } from '../stores/shared/readPointer'
 import { getBareJid } from './jid'
 import { logInfo } from './logger'
@@ -239,7 +239,7 @@ export function setupMdsSideEffects(
    *
    * - It can never be AHEAD of the read position: candidates strictly after the
    *   pointer are filtered out. Ordering uses the pointer's own
-   *   timestamp/`archiveOrderKey` rather than its index, so the pointer's
+   *   timestamp/`tiebreak` rather than its index, so the pointer's
    *   message need not be resident — a newer resident window cannot drag the
    *   result forward. A keyless (#1081-migrated) pointer orders by `lastReadAt`,
    *   which is documented as at or behind the message it names, so it
@@ -261,18 +261,18 @@ export function setupMdsSideEffects(
    */
   function newestResolvableAtOrBehind(
     messages: Array<{ stanzaId?: string; from?: string; id: string; timestamp: Date }>,
-    pointer: { timestamp: Date; archiveOrderKey?: OrderPosition['archiveOrderKey'] }
+    pointer: { timestamp: Date; tiebreak?: OrderPosition['tiebreak'] }
   ): string | undefined {
     const pointerPos: OrderPosition = {
       timestamp: pointer.timestamp.getTime(),
-      archiveOrderKey: pointer.archiveOrderKey,
+      tiebreak: pointer.tiebreak,
     }
     let best: { pos: OrderPosition; stanzaId: string } | undefined
     for (const m of messages) {
       if (!m.stanzaId) continue
       const pos: OrderPosition = {
         timestamp: m.timestamp.getTime(),
-        archiveOrderKey: makeArchiveOrderKey(m, 'chat'),
+        tiebreak: makeCacheOrderKey(m, 'chat'),
       }
       if (compareOrder(pos, pointerPos) > 0) continue // ahead of the pointer — never publish
       if (!best || compareOrder(pos, best.pos) > 0) best = { pos, stanzaId: m.stanzaId }
@@ -288,7 +288,7 @@ export function setupMdsSideEffects(
 
   function pointerIdentity(pointer: ReadPointer | undefined): string | undefined {
     if (!pointer) return undefined
-    const key = pointer.archiveOrderKey
+    const key = pointer.tiebreak
     return JSON.stringify([
       pointer.messageId,
       pointer.timestamp.getTime(),
@@ -308,7 +308,7 @@ export function setupMdsSideEffects(
    */
   function exactRoomPointerTarget(jid: string): { messageId: string; from: string } | undefined {
     const pointer = roomStore.getState().roomMeta.get(jid)?.readPointer
-    const key = pointer?.archiveOrderKey
+    const key = pointer?.tiebreak
     if (!pointer?.messageId || key?.kind !== 'room' || key.from.length === 0) return undefined
     return { messageId: pointer.messageId, from: key.from }
   }

--- a/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
+++ b/packages/fluux-sdk/src/core/modules/stateSnapshot.test.ts
@@ -215,10 +215,10 @@ describe('StateSnapshot', () => {
       expect(persisted?.readPointer).toEqual({ messageId: 'msg-7', timestamp: readAt.getTime() })
     })
 
-    // Task 2 (#1102): the structured archiveOrderKey rides through this
+    // Task 2 (#1102): the structured tiebreak rides through this
     // surface too — round-tripped on both halves (write via flush, read back
     // via hydrate), not assumed from the plain-field case above.
-    it('round-trips the archiveOrderKey through flush and hydrate', async () => {
+    it('round-trips the tiebreak through flush and hydrate', async () => {
       const readAt = new Date('2026-04-21T09:20:00Z')
       const pointer = makeReadPointer({ id: 'msg-8', from: 'room@conf.example.com/alice', timestamp: readAt }, 'room')
       roomStore.getState().addRoom(makeRoom('room@conf.example.com', { readPointer: pointer }))
@@ -230,7 +230,9 @@ describe('StateSnapshot', () => {
       }>
       // The tie-break's `id` is NOT persisted: it is `messageId`, and storing a
       // second copy made a disagreement representable on disk. Only `from`,
-      // which the pointer cannot reconstruct, rides through.
+      // which the pointer cannot reconstruct, rides through. The persisted
+      // property keeps its historical name `archiveOrderKey`; only the
+      // in-memory field is `tiebreak`.
       expect(persisted?.readPointer?.archiveOrderKey).toEqual({
         kind: 'room',
         from: 'room@conf.example.com/alice',
@@ -240,7 +242,7 @@ describe('StateSnapshot', () => {
       // with `id` reconstructed from `messageId`.
       roomStore.getState().removeRoom('room@conf.example.com')
       await snapshot.hydrate('user@example.com')
-      expect(roomStore.getState().rooms.get('room@conf.example.com')?.readPointer?.archiveOrderKey).toEqual({
+      expect(roomStore.getState().rooms.get('room@conf.example.com')?.readPointer?.tiebreak).toEqual({
         kind: 'room',
         from: 'room@conf.example.com/alice',
         id: 'msg-8',

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -558,9 +558,9 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // unsorted resident array can let that guard make the WRONG forward/no-op
   // decision, landing the stored pointer on the wrong message and skewing the
   // later archive-derived count. 'z-msg' arrives FIRST (wall-clock) but
-  // archive-sorts AFTER 'a-msg' (id tie-break) — arrival order deliberately
-  // disagrees with archive order, the exact case the fix reconciles.
-  it('two same-millisecond live arrivals land in archive order, so the viewport-advance pointer and derived count are both correct', async () => {
+  // cache-sorts AFTER 'a-msg' (id tie-break) — arrival order deliberately
+  // disagrees with cache order, the exact case the fix reconciles.
+  it('two same-millisecond live arrivals land in cache order, so the viewport-advance pointer and derived count are both correct', async () => {
     await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
     seedCoverage('anchor-stanza')
     chatStore.setState({ activeConversationId: CID })
@@ -573,7 +573,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
 
     // A same-millisecond sibling arrives live, SECOND.
     chatStore.getState().addMessage(archiveMsg('a-msg', T))
-    // The resident array must be in ARCHIVE order (id-ascending), not arrival
+    // The resident array must be in CACHE order (id-ascending), not arrival
     // order — the load-bearing invariant messageTimeline.test.ts pins at the
     // pure-function level; here it is asserted through the real store.
     expect(chatStore.getState().messages.get(CID)?.map((m) => m.id)).toEqual(['a-msg', 'z-msg'])

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -121,7 +121,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 99, // stale — must be overwritten by the exact derivation
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -131,7 +131,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     expect(chatStore.getState().conversations.get(CID)?.unreadCount).toBe(3)
   })
 
-  it('a migrated pointer with no archiveOrderKey over-counts same-millisecond rows rather than reporting zero', async () => {
+  it('a migrated pointer with no tiebreak over-counts same-millisecond rows rather than reporting zero', async () => {
     await messageCache.saveMessages([
       archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
       archiveMsg('p0', 1000),
@@ -141,7 +141,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 0,
-      // Legacy/migrated shape: no archiveOrderKey at all.
+      // Legacy/migrated shape: no tiebreak at all.
       readPointer: { messageId: 'p0', timestamp: new Date(1000) },
     })
     seedCoverage('anchor-stanza')
@@ -167,7 +167,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       JSON.stringify({
         state: {
           conversationEntities: [[CID, { id: CID, name: CID, type: 'chat' }]],
-          conversationMeta: [[CID, { unreadCount: 3, readPointer: { messageId: 'p0', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 'p0' } } }]],
+          conversationMeta: [[CID, { unreadCount: 3, readPointer: { messageId: 'p0', timestamp: 1000, tiebreak: { kind: 'chat', id: 'p0' } } }]],
           conversations: [[CID, { id: CID, name: CID, type: 'chat', unreadCount: 3 }]],
           archivedConversations: [],
         },
@@ -190,7 +190,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // ---------------------------------------------------------------------
 
   it('a forward MAM merge into a non-active conversation with new messages triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } } })
     chatStore.setState({ activeConversationId: 'someone-else@example.com' })
     const original = chatStore.getState().recomputeUnreadForConversation
     const spy = vi.fn(original)
@@ -230,7 +230,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
   // ---------------------------------------------------------------------
 
   it('a remote marker advancing a non-active conversation triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } } })
     chatStore.setState({ activeConversationId: 'someone-else@example.com' })
     const original = chatStore.getState().recomputeUnreadForConversation
     const spy = vi.fn(original)
@@ -267,7 +267,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     // tell a real recompute from a no-op.
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'chat', id: 'anchor' } },
+      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({ activeConversationId: CID })
@@ -361,7 +361,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       archiveMsg('u2', 1002),
     ])
     seedCoverage('anchor-stanza')
-    setMeta({ unreadCount: 7, readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } } })
+    setMeta({ unreadCount: 7, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } } })
 
     await chatStore.getState().recomputeUnreadForConversation(CID)
 
@@ -464,7 +464,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 5, // the persisted/trusted value
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     // Coverage IS proven and resolvable — but mamQueryStates is left at its
     // default (NOT caught up to live), so the caught-up gate is the single
@@ -485,7 +485,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     chatStore.setState((state) => {
       const mamQueryStates = new Map(state.mamQueryStates)
@@ -503,7 +503,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 6,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     // bottomId names an archive stanza-id that was never saved — unresolvable.
     seedCoverage('nonexistent-stanza-id')
@@ -534,7 +534,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 8, // trusted — must survive untouched
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('gap-anchor-stanza')
 
@@ -614,7 +614,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'chat', id: 'anchor' } },
+      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     // Active + focused (default windowVisible), but viewportAtLiveEdge is
@@ -667,7 +667,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -697,7 +697,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 5,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -760,7 +760,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -803,7 +803,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 5, // stale — the slow recompute below would derive 1 (u1) from THIS pointer
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({ activeConversationId: CID })
@@ -827,7 +827,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       meta.set(CID, {
         ...meta.get(CID)!,
         unreadCount: 0,
-        readPointer: { messageId: 'u1', timestamp: new Date(1001), archiveOrderKey: { kind: 'chat', id: 'u1' } },
+        readPointer: { messageId: 'u1', timestamp: new Date(1001), tiebreak: { kind: 'chat', id: 'u1' } },
       })
       return { conversationMeta: meta }
     })
@@ -863,7 +863,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     // A stale marker left over from before the boundary moved, on the ACTIVE
@@ -897,7 +897,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 1,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({
@@ -933,7 +933,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages(resident)
     setMeta({
       unreadCount: 1,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState({ messages: new Map([[CID, resident]]) })
@@ -963,7 +963,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await messageCache.saveMessages([anchor, p0])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     chatStore.setState((state) => {
@@ -1002,7 +1002,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       setMeta({
         unreadCount: 5,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1026,7 +1026,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       setMeta({
         unreadCount: 3,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       vi.mocked(messageCache.countUnreadInArchive).mockResolvedValueOnce(null)
@@ -1052,7 +1052,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     ])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     // One never-archived (noLocalStore) message, after the pointer.
@@ -1076,7 +1076,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
       setMeta({
         unreadCount: 0,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
     })
@@ -1177,7 +1177,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0 derived below
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'chat', id: 'anchor' } },
+        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       // Active + focused (default windowVisible), with the full history
@@ -1211,7 +1211,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 and the correct 2
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'chat', id: 'anchor' } },
+        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'chat', id: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.setState({
@@ -1241,7 +1241,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // above) while unreadCount is stale.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } },
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.getState().addConversation(createConversation('someone-else@example.com'))
@@ -1281,7 +1281,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // here), same as the fully-read sibling test above.
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.getState().addConversation(createConversation('someone-else@example.com'))
@@ -1368,7 +1368,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       ])
       setMeta({
         unreadCount: 3,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1391,7 +1391,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       ])
       setMeta({
         unreadCount: 4,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1441,7 +1441,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       ])
       setMeta({
         unreadCount: 1,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1482,7 +1482,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       // viewport observer has nothing left to advance.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } },
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.setState({ messages: new Map([[CID, [anchor, m1]]]) })
@@ -1512,7 +1512,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       await messageCache.saveMessages([anchor, p0, u1, u2])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       chatStore.setState({ messages: new Map([[CID, [anchor, p0, u1, u2]]]) })

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -167,7 +167,7 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
       JSON.stringify({
         state: {
           conversationEntities: [[CID, { id: CID, name: CID, type: 'chat' }]],
-          conversationMeta: [[CID, { unreadCount: 3, readPointer: { messageId: 'p0', timestamp: 1000, tiebreak: { kind: 'chat', id: 'p0' } } }]],
+          conversationMeta: [[CID, { unreadCount: 3, readPointer: { messageId: 'p0', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 'p0' } } }]],
           conversations: [[CID, { id: CID, name: CID, type: 'chat', unreadCount: 3 }]],
           archivedConversations: [],
         },

--- a/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.archiveUnread.test.ts
@@ -181,6 +181,20 @@ describe('chatStore.recomputeUnreadForConversation — archive-derived unread (P
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(spy).toHaveBeenCalledWith(CID)
+    // Assert the KEY, not just that a recount was scheduled. The fixture above
+    // is a real on-disk blob, so it has to carry the PERSISTED property name
+    // `archiveOrderKey` — the in-memory field is `tiebreak`, and
+    // `deserializeReadPointer` deliberately ignores that never-written name. A
+    // fixture written under the wrong name still restores a pointer, just a
+    // KEYLESS one, so a test that only checks the recount stays green while the
+    // hydrated position silently degrades to the at-or-after-timestamp
+    // fallback. This assertion is what makes that failure loud: the `id` is
+    // reconstructed from `messageId`, so a keyed hydration is only possible
+    // when the fixture used the on-disk name.
+    expect(chatStore.getState().conversationMeta.get(CID)?.readPointer?.tiebreak).toEqual({
+      kind: 'chat',
+      id: 'p0',
+    })
     // Restore the un-wrapped action so later tests aren't left with a spy.
     chatStore.setState({ recomputeUnreadForConversation: original })
   })

--- a/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.readPointerMigration.test.ts
@@ -236,17 +236,17 @@ describe('post-rehydrate readPointer backfill', () => {
   })
 
   // Task 2 (#1102): `deserializeState`'s NEW-FORMAT branch (conversationEntities +
-  // conversationMeta) round-trips the structured archiveOrderKey — asserted
+  // conversationMeta) round-trips the structured tiebreak — asserted
   // directly rather than assumed from the plain messageId/timestamp case above.
-  it('round-trips a persisted archiveOrderKey through the new-format deserialize branch', async () => {
+  it('round-trips a persisted tiebreak through the new-format deserialize branch', async () => {
     persistConversations([
       [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'chat', id: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
 
-    expect(pointerOf(CONV)?.archiveOrderKey).toEqual({ kind: 'chat', id: 'm2' })
-    expect(chatStore.getState().conversations.get(CONV)?.readPointer?.archiveOrderKey).toEqual({
+    expect(pointerOf(CONV)?.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
+    expect(chatStore.getState().conversations.get(CONV)?.readPointer?.tiebreak).toEqual({
       kind: 'chat',
       id: 'm2',
     })
@@ -255,7 +255,7 @@ describe('post-rehydrate readPointer backfill', () => {
   // The legacy-format branch (no conversationEntities/conversationMeta on disk —
   // pre-Task-6b combined `conversations` map) goes through the same
   // `deserializeReadPointer` call and must round-trip the key too.
-  it('round-trips a persisted archiveOrderKey through the legacy-format deserialize branch', async () => {
+  it('round-trips a persisted tiebreak through the legacy-format deserialize branch', async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
@@ -276,20 +276,37 @@ describe('post-rehydrate readPointer backfill', () => {
 
     await chatStore.persist.rehydrate()
 
-    expect(pointerOf(CONV)?.archiveOrderKey).toEqual({ kind: 'chat', id: 'm2' })
+    expect(pointerOf(CONV)?.tiebreak).toEqual({ kind: 'chat', id: 'm2' })
   })
 
   // A malformed persisted key must be DROPPED at this real persistence surface
   // too, not just at the deserializeReadPointer unit level — the pointer itself
   // (messageId/timestamp) survives.
-  it('drops a malformed persisted archiveOrderKey but keeps the rest of the pointer', async () => {
+  // The chat blob is a verbatim JSON.stringify of the live objects, so renaming
+  // the in-memory field would leak the new name to disk and orphan every stored
+  // pointer. The persisted property stays `archiveOrderKey`.
+  it('persists the tie-break under its on-disk name, not the in-memory one', async () => {
+    persistConversations([
+      [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'chat', id: 'm2' } } }],
+    ])
+
+    await chatStore.persist.rehydrate()
+    chatStore.setState((state) => ({ conversationMeta: new Map(state.conversationMeta) }))
+    flushThrottledStorage()
+
+    const onDisk = diskEntry('conversationMeta', CONV).readPointer as Record<string, unknown>
+    expect(onDisk.archiveOrderKey).toEqual({ kind: 'chat', id: 'm2' })
+    expect('tiebreak' in onDisk).toBe(false)
+  })
+
+  it('drops a malformed persisted tiebreak but keeps the rest of the pointer', async () => {
     persistConversations([
       [CONV, { readPointer: { messageId: 'm2', timestamp: 2000, archiveOrderKey: { kind: 'room', id: 'm2' } } }],
     ])
 
     await chatStore.persist.rehydrate()
 
-    expect(pointerOf(CONV)?.archiveOrderKey).toBeUndefined() // missing `from` → invalid → dropped
+    expect(pointerOf(CONV)?.tiebreak).toBeUndefined() // missing `from` → invalid → dropped
     expect(pointerOf(CONV)?.messageId).toBe('m2')
   })
 })
@@ -392,10 +409,10 @@ describe('unmigrated legacy read state survives the persist', () => {
     persistConversations([[CONV, { lastSeenMessageId: 'm2' }]])
 
     relaunch()
-    // toMatchObject: this path resolves the message from cache and stamps an
-    // archiveOrderKey onto the pointer (unlike the both-fields branch above,
+    // toMatchObject: this path resolves the message from cache and stamps a
+    // tiebreak onto the pointer (unlike the both-fields branch above,
     // which copies the legacy pair through verbatim) — the point of this
-    // assertion is messageId/timestamp, not the archive key's exact shape.
+    // assertion is messageId/timestamp, not the tie-break's exact shape.
     await vi.waitFor(() => expect(pointerOf(CONV)).toMatchObject({ messageId: 'm2', timestamp: at(2000) }), { timeout: 2000 })
     // This assertion means to observe the final persisted blob, not a
     // mid-pass write still sitting in the throttle's pending thunk.

--- a/packages/fluux-sdk/src/stores/chatStore.test.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.test.ts
@@ -1183,7 +1183,7 @@ describe('chatStore', () => {
           readPointer: {
             messageId: 'msg-150',
             timestamp: new Date(150 * 60_000),
-            archiveOrderKey: { kind: 'chat', id: 'msg-150' },
+            tiebreak: { kind: 'chat', id: 'msg-150' },
           },
         })
         return { conversationMeta: meta }

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -22,7 +22,7 @@ import {
   pointerlessDefers,
   worthReconcilingOnDeactivate,
   compareOrder,
-  makeArchiveOrderKey,
+  makeCacheOrderKey,
   isRenderableStoredMessage,
   type OrderPosition,
 } from './shared/readState'
@@ -50,7 +50,14 @@ import { derivePreviewAfterMerge } from './shared/previewState'
 import { draftConversationMaps, rebuildCompatEntry } from './shared/conversationMaps'
 import { addPendingRetraction, applyPendingRetractions, type PendingRetraction } from './shared/pendingRetractions'
 import { resolveRemoteDisplayed, createMdsSessionGate, foldPendingRemoteDisplayed } from './shared/readMarkerSync'
-import { advance, deserializeReadPointer, makeReadPointer, type ReadPointer } from './shared/readPointer'
+import {
+  advance,
+  deserializeReadPointer,
+  makeReadPointer,
+  toPersistedReadPointer,
+  type PersistedReadPointer,
+  type ReadPointer,
+} from './shared/readPointer'
 import * as notifState from './shared/notificationState'
 import { markerDebugLog } from '../utils/markerDebug'
 import { connectionStore } from './connectionStore'
@@ -619,8 +626,16 @@ interface LegacyReadState {
   lastReadAt?: Date
 }
 
-type PersistedConversationMetadata = ConversationMetadata & PersistedReadState
-type PersistedConversation = Conversation & PersistedReadState
+/**
+ * On disk the pointer's tie-break keeps its historical property name
+ * `archiveOrderKey`; only the in-memory field is `tiebreak`. This blob is a
+ * verbatim `JSON.stringify` of the live objects, so the boundary has to be in
+ * the persisted TYPE as well as in the value (see {@link PersistedReadPointer}).
+ */
+type PersistedConversationMetadata = Omit<ConversationMetadata, 'readPointer'> &
+  PersistedReadState & { readPointer?: PersistedReadPointer }
+type PersistedConversation = Omit<Conversation, 'readPointer'> &
+  PersistedReadState & { readPointer?: PersistedReadPointer }
 
 /**
  * Legacy read state still waiting to become a `readPointer`, keyed by the
@@ -701,12 +716,16 @@ interface PersistedState {
 function withUnmigratedReadState<T extends { readPointer?: ReadPointer }>(
   entries: Map<string, T>,
   legacy: Map<string, LegacyReadState> | undefined
-): [string, T & PersistedReadState][] {
-  if (!legacy || legacy.size === 0) return Array.from(entries.entries())
-  const out: [string, T & PersistedReadState][] = []
+): [string, Omit<T, 'readPointer'> & PersistedReadState & { readPointer?: PersistedReadPointer }][] {
+  // Every entry passes through `onDisk` so the pointer is written under its
+  // on-disk property name (see {@link PersistedReadPointer}).
+  const onDisk = (value: T): Omit<T, 'readPointer'> & { readPointer?: PersistedReadPointer } =>
+    value.readPointer ? { ...value, readPointer: toPersistedReadPointer(value.readPointer) } : value
+  if (!legacy || legacy.size === 0) return Array.from(entries.entries(), ([id, value]) => [id, onDisk(value)])
+  const out: [string, Omit<T, 'readPointer'> & PersistedReadState & { readPointer?: PersistedReadPointer }][] = []
   for (const [id, value] of entries) {
     const carry = value.readPointer ? undefined : legacy.get(id)
-    out.push(carry ? [id, { ...value, ...carry }] : [id, value])
+    out.push(carry ? [id, { ...onDisk(value), ...carry }] : [id, onDisk(value)])
   }
   return out
 }
@@ -1485,7 +1504,7 @@ export const chatStore = createStore<ChatState>()(
           //
           // The DIVIDER does not depend on this load. `onActivate` derives it by
           // archive POSITION — the first renderable incoming message strictly
-          // after the pointer in `(timestamp, archiveOrderKey)` order — so an
+          // after the pointer in `(timestamp, tiebreak)` order — so an
           // off-slice pointer places it exactly as well as a resident one. The
           // stale-pointer fallback ladder that made an off-slice pointer a
           // degraded case is gone. What a cache miss costs is CONTEXT: the
@@ -1646,7 +1665,7 @@ export const chatStore = createStore<ChatState>()(
           const before = transientCounts(scopeKey, undefined).unread
           const result = noteTransient(
             scopeKey,
-            { position: { timestamp: msg.timestamp.getTime(), archiveOrderKey: makeArchiveOrderKey(msg, 'chat') } },
+            { position: { timestamp: msg.timestamp.getTime(), tiebreak: makeCacheOrderKey(msg, 'chat') } },
             transientIdentity({ id: msg.id }, 'chat'),
             transientAliases({ id: msg.id }, 'chat')
           )
@@ -1861,7 +1880,7 @@ export const chatStore = createStore<ChatState>()(
           if (updated.readPointer && updated.readPointer !== notifInput.readPointer) {
             pruneTransient(chatTransientScopeKey(conversationId), {
               timestamp: updated.readPointer.timestamp.getTime(),
-              archiveOrderKey: updated.readPointer.archiveOrderKey,
+              tiebreak: updated.readPointer.tiebreak,
             })
           }
 
@@ -1905,7 +1924,7 @@ export const chatStore = createStore<ChatState>()(
           // entry to a later recompute trigger.
           pruneTransient(chatTransientScopeKey(conversationId), {
             timestamp: readPointer.timestamp.getTime(),
-            archiveOrderKey: readPointer.archiveOrderKey,
+            tiebreak: readPointer.tiebreak,
           })
 
           const draft = draftConversationMaps(state)
@@ -2010,7 +2029,7 @@ export const chatStore = createStore<ChatState>()(
           if (updated.readPointer) {
             pruneTransient(chatTransientScopeKey(conversationId), {
               timestamp: updated.readPointer.timestamp.getTime(),
-              archiveOrderKey: updated.readPointer.archiveOrderKey,
+              tiebreak: updated.readPointer.tiebreak,
             })
           }
 
@@ -2590,7 +2609,7 @@ export const chatStore = createStore<ChatState>()(
         // coverage bottom sharing its exact millisecond; a historyFloor-derived
         // floor has no such key (unresolved sorts conservatively).
         const floorPos: OrderPosition = metaNow.readPointer
-          ? { timestamp: metaNow.readPointer.timestamp.getTime(), archiveOrderKey: metaNow.readPointer.archiveOrderKey }
+          ? { timestamp: metaNow.readPointer.timestamp.getTime(), tiebreak: metaNow.readPointer.tiebreak }
           : { timestamp: floor.getTime() }
 
         // Task 9 safety net: this recompute is one of the "pointer advance /

--- a/packages/fluux-sdk/src/stores/chatStore.ts
+++ b/packages/fluux-sdk/src/stores/chatStore.ts
@@ -1503,7 +1503,7 @@ export const chatStore = createStore<ChatState>()(
           // advanced the pointer to the synced position.
           //
           // The DIVIDER does not depend on this load. `onActivate` derives it by
-          // archive POSITION — the first renderable incoming message strictly
+          // cache POSITION — the first renderable incoming message strictly
           // after the pointer in `(timestamp, tiebreak)` order — so an
           // off-slice pointer places it exactly as well as a resident one. The
           // stale-pointer fallback ladder that made an off-slice pointer a

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -139,7 +139,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 99, // stale — must be overwritten by the exact derivation
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -161,7 +161,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -171,7 +171,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     expect(roomStore.getState().roomMeta.get(ROOM)?.unreadCount).toBe(2)
   })
 
-  it('a migrated pointer with no archiveOrderKey over-counts same-millisecond rows rather than reporting zero', async () => {
+  it('a migrated pointer with no tiebreak over-counts same-millisecond rows rather than reporting zero', async () => {
     await messageCache.saveRoomMessages([
       archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }),
       archiveMsg('p0', 1000),
@@ -181,7 +181,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 0,
-      // Legacy/migrated shape: no archiveOrderKey at all.
+      // Legacy/migrated shape: no tiebreak at all.
       readPointer: { messageId: 'p0', timestamp: new Date(1000) },
     })
     seedCoverage('anchor-stanza')
@@ -207,7 +207,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // ---------------------------------------------------------------------
 
   it('a forward MAM merge into a non-active room with new messages triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } } })
     roomStore.setState({ activeRoomJid: 'someone-else@conference.example.com' })
     const original = roomStore.getState().recomputeUnreadForRoom
     const spy = vi.fn(original)
@@ -247,7 +247,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // ---------------------------------------------------------------------
 
   it('a remote marker advancing a non-active room triggers a recount', () => {
-    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } } })
+    setMeta({ unreadCount: 0, readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } } })
     roomStore.setState({ activeRoomJid: 'someone-else@conference.example.com' })
     const original = roomStore.getState().recomputeUnreadForRoom
     const spy = vi.fn(original)
@@ -274,7 +274,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
     setMeta({
       unreadCount: 5,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -306,7 +306,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // tell a real recompute from a no-op.
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -383,7 +383,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 5, // the persisted/trusted value
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     // Coverage IS proven and resolvable — but mamQueryStates is left at its
     // default (NOT caught up to live), so the caught-up gate is the single
@@ -404,7 +404,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     roomStore.setState((state) => {
       const mamQueryStates = new Map(state.mamQueryStates)
@@ -422,7 +422,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('p0', 1000), archiveMsg('u1', 1001)])
     setMeta({
       unreadCount: 6,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     // bottomId names an archive stanza-id that was never saved — unresolvable.
     seedCoverage('nonexistent-stanza-id')
@@ -453,7 +453,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 8, // trusted — must survive untouched
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('gap-anchor-stanza')
 
@@ -494,7 +494,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     // Viewport observer reports zulu's message seen while it is the only resident message.
     roomStore.getState().advanceReadPointer(ROOM, 'm1')
     expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.messageId).toBe('m1')
-    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.archiveOrderKey).toMatchObject({ from: `${ROOM}/zulu` })
+    expect(roomStore.getState().roomMeta.get(ROOM)?.readPointer?.tiebreak).toMatchObject({ from: `${ROOM}/zulu` })
 
     // A same-millisecond message from a DIFFERENT occupant arrives live, SECOND.
     roomStore.getState().addMessage(ROOM, archiveMsg('m2', T, { from: `${ROOM}/alice`, nick: 'alice' }))
@@ -543,7 +543,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+      readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
     })
     seedCoverage('anchor-stanza')
     // Active + focused (default windowVisible), but viewportAtLiveEdge is
@@ -592,7 +592,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -622,7 +622,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 5,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -666,7 +666,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 7,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
 
@@ -705,7 +705,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 5, // stale — the slow recompute below would derive 1 (u1) from THIS pointer
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -729,7 +729,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       meta.set(ROOM, {
         ...meta.get(ROOM)!,
         unreadCount: 0,
-        readPointer: { messageId: 'u1', timestamp: new Date(1001), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'u1' } },
+        readPointer: { messageId: 'u1', timestamp: new Date(1001), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'u1' } },
       })
       return { roomMeta: meta }
     })
@@ -773,7 +773,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     seedActiveWithStaleMarker([anchor, p0, u1])
@@ -797,7 +797,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([anchor, p0, u1])
     setMeta({
       unreadCount: 1,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState((state) => {
@@ -831,7 +831,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     await messageCache.saveRoomMessages([anchor, p0])
     setMeta({
       unreadCount: 99,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     roomStore.setState((state) => {
@@ -867,7 +867,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 5,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -891,7 +891,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 3,
         mentionsCount: SEEDED_MENTIONS,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       vi.mocked(messageCache.countRoomUnreadInArchive).mockResolvedValueOnce(null)
@@ -917,7 +917,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
     ])
     setMeta({
       unreadCount: 0,
-      readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+      readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
     })
     seedCoverage('anchor-stanza')
     // One never-archived (noLocalStore) message, after the pointer.
@@ -946,7 +946,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' }), archiveMsg('p0', 1000)])
       setMeta({
         unreadCount: 0,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
     })
@@ -1057,7 +1057,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0 derived below
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       // Active + focused (default windowVisible), with the full history
@@ -1088,7 +1088,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([anchor, m1, m2, m3])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 and the correct 2
-        readPointer: { messageId: 'anchor', timestamp: new Date(500), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
+        readPointer: { messageId: 'anchor', timestamp: new Date(500), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'anchor' } },
       })
       seedCoverage('anchor-stanza')
       roomStore.setState({ activeRoomJid: ROOM })
@@ -1116,7 +1116,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // above) while unreadCount is stale.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       roomStore.getState().addRoom(createRoom('other-room@conference.example.com'))
@@ -1156,7 +1156,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // here), same as the fully-read sibling test above.
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       roomStore.getState().addRoom(createRoom('other-room@conference.example.com'))
@@ -1249,7 +1249,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 3,
         mentionsCount: 4,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1274,7 +1274,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       setMeta({
         unreadCount: 4,
         mentionsCount: 4,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1326,7 +1326,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       ])
       setMeta({
         unreadCount: 1,
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
 
@@ -1379,7 +1379,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       // can never schedule a recount. This is the reported defect.
       setMeta({
         unreadCount: 5, // stale — distinct from the correct 0
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       seedResident([anchor, m1])
@@ -1413,7 +1413,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       await messageCache.saveRoomMessages([anchor, p0, u1, u2])
       setMeta({
         unreadCount: 5, // stale — distinct from BOTH 0 (naive force-zero) and the correct 2
-        readPointer: { messageId: 'p0', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
+        readPointer: { messageId: 'p0', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'p0' } },
       })
       seedCoverage('anchor-stanza')
       seedResident([anchor, p0, u1, u2])
@@ -1438,7 +1438,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
       ])
       setMeta({
         unreadCount: 0, // nothing to correct downward
-        readPointer: { messageId: 'm1', timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
+        readPointer: { messageId: 'm1', timestamp: new Date(1000), tiebreak: { kind: 'room', from: ROOM + '/alice', id: 'm1' } },
       })
       seedCoverage('anchor-stanza')
       vi.mocked(messageCache.countRoomUnreadInArchive).mockClear()

--- a/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.archiveUnread.test.ts
@@ -5,7 +5,7 @@
  * Mirrors chatStore.archiveUnread.test.ts (Task 7) — see that file for the
  * shared derivation's full rationale. This file additionally covers the
  * room-specific control: two messages sharing an `id` but sent by different
- * occupants (`from`) are two distinct archive positions, not one.
+ * occupants (`from`) are two distinct cache positions, not one.
  *
  * Unlike roomStore.test.ts / roomStore.mds.test.ts, this file does NOT fully
  * mock `../utils/messageCache` — `countRoomUnreadInArchive` and
@@ -481,10 +481,10 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
   // guard), so an unsorted resident array can let that guard make the WRONG
   // forward/no-op decision, landing the stored pointer on the wrong message
   // and skewing the later archive-derived count. The 'zulu' occupant's
-  // message arrives FIRST (wall-clock) but archive-sorts AFTER the 'alice'
-  // occupant's ((from) tie-break) — arrival order deliberately disagrees with
-  // archive order, the exact case the fix reconciles.
-  it('two same-millisecond live arrivals land in archive order, so the viewport-advance pointer and derived count are both correct', async () => {
+  // message arrives FIRST (wall-clock) but cache-sorts AFTER the 'alice'
+  // occupant's `(from, id)` tie-break — arrival order deliberately disagrees with
+  // cache order, the exact case the fix reconciles.
+  it('two same-millisecond live arrivals land in cache order, so the viewport-advance pointer and derived count are both correct', async () => {
     await messageCache.saveRoomMessages([archiveMsg('anchor', 500, { stanzaId: 'anchor-stanza' })])
     seedCoverage('anchor-stanza')
     roomStore.setState({ activeRoomJid: ROOM })
@@ -498,7 +498,7 @@ describe('roomStore.recomputeUnreadForRoom — archive-derived unread (PR B, Tas
 
     // A same-millisecond message from a DIFFERENT occupant arrives live, SECOND.
     roomStore.getState().addMessage(ROOM, archiveMsg('m2', T, { from: `${ROOM}/alice`, nick: 'alice' }))
-    // The resident array must be in ARCHIVE order ((from, id) ascending — alice
+    // The resident array must be in CACHE order ((from, id) ascending — alice
     // before zulu), not arrival order — the load-bearing invariant
     // messageTimeline.test.ts pins at the pure-function level; here it is
     // asserted through the real store.

--- a/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
@@ -199,7 +199,7 @@ describe('room read state persistence', () => {
     // The markReadToNewest save is the one under test, and it coalesced behind
     // addRoom's leading edge.
     flushThrottledStorage()
-    // toMatchObject: makeReadPointer also stamps an archiveOrderKey onto the
+    // toMatchObject: makeReadPointer also stamps an tiebreak onto the
     // pointer; this assertion only cares about messageId/timestamp.
     expect(loadRoomReadState(JID).get(ROOM)?.readPointer).toMatchObject({
       messageId: 'm2',

--- a/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.readState.test.ts
@@ -199,7 +199,7 @@ describe('room read state persistence', () => {
     // The markReadToNewest save is the one under test, and it coalesced behind
     // addRoom's leading edge.
     flushThrottledStorage()
-    // toMatchObject: makeReadPointer also stamps an tiebreak onto the
+    // toMatchObject: makeReadPointer also stamps a tiebreak onto the
     // pointer; this assertion only cares about messageId/timestamp.
     expect(loadRoomReadState(JID).get(ROOM)?.readPointer).toMatchObject({
       messageId: 'm2',

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -6359,7 +6359,7 @@ describe('setActiveRoom new-message marker — delayed history unified with chat
       meta.set(ROOM, {
         ...existing,
         // KEYED, as every pointer `makeReadPointer` writes is — the divider is
-        // derived by archive POSITION now, and a keyless pointer cannot certify
+        // derived by cache POSITION now, and a keyless pointer cannot certify
         // its own (it would land the divider on the seen message itself).
         readPointer: makeReadPointer(seenMsg, 'room'),
       })
@@ -6374,7 +6374,7 @@ describe('setActiveRoom new-message marker — delayed history unified with chat
    * `createMessage`'s default `new Date()` would make the "already read" message
    * the NEWEST in the fixture while sitting first in the array — an ordering the
    * resident array never has in production (PR B gave `messageArrayUtils` the
-   * same `compareOrder` tie-break, so index order and archive order agree).
+   * same `compareOrder` tie-break, so index order and cache order agree).
    */
   const seenMsg = (): RoomMessage =>
     createMessage('seen', ROOM, 'alice', 'seen message', false, new Date('2025-01-15T09:00:00Z'))
@@ -6417,7 +6417,7 @@ describe('setActiveRoom new-message marker — delayed history unified with chat
       [
         seenMsg(),
         // isDelayed defaults to false; timestamped explicitly so the array is
-        // in archive order (see seenMsg above).
+        // in cache order (see seenMsg above).
         createMessage('live', ROOM, 'bob', 'live message', false, new Date('2025-01-15T10:00:00Z')),
       ],
       'seen',

--- a/packages/fluux-sdk/src/stores/roomStore.test.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.test.ts
@@ -2506,7 +2506,7 @@ describe('roomStore', () => {
       // roomMeta.readPointer directly mimics a persisted read pointer
       // from a prior session (no live activation has run yet in this test).
       // KEYED, as every persisted pointer is: `makeReadPointer` always writes
-      // the archive order key and `deserializeReadPointer` reads it back.
+      // the cache order key and `deserializeReadPointer` reads it back.
       // Without it the pointer cannot certify its own position, and the message
       // it NAMES sorts after the boundary (a missing key sorts first — see
       // `compareOrder`), so the divider would correctly-but-conservatively land
@@ -2520,7 +2520,7 @@ describe('roomStore', () => {
           readPointer: {
             messageId: 'msg-150',
             timestamp: new Date(150 * 60_000),
-            archiveOrderKey: { kind: 'room', from: `${roomJid}/alice`, id: 'msg-150' },
+            tiebreak: { kind: 'room', from: `${roomJid}/alice`, id: 'msg-150' },
           },
         })
         return { roomMeta: meta }

--- a/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.testHelpers.ts
@@ -44,7 +44,7 @@ export function createRoom(jid: string, options: Partial<Room> = {}): Room {
  *
  * NOT because a same-millisecond pair can never advance — read-state PR C
  * (task 1) changed exactly that. Two KEYED positions sharing a millisecond now
- * break the tie on the archive order key: `isAhead`
+ * break the tie on the cache order key: `isAhead`
  * (shared/readPointer.ts, ~line 99) does it, and `advanceReadPointer` routes
  * through `onMessageSeen`'s keyed `compareOrder`, which does it too. The bare
  * "equal timestamps are NOT an advance" rule now applies ONLY when either side

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -2018,7 +2018,7 @@ export const roomStore = createStore<RoomState>()(
       // incoming message even when the window has slid off the live edge.
       //
       // FIX 5 (read-state PR B, final whole-branch review) now has appendLive
-      // sort its result into archive order (`sortMessagesByTimestamp`) instead
+      // sort its result into cache order (`sortMessagesByTimestamp`) instead
       // of appending in arrival order — so on the ordinary `append.kind ===
       // 'appended'` path, `appendedMessages` is already chronological and
       // `findLastNonIgnoredMessage`'s backward scan finds the true newest
@@ -2870,7 +2870,7 @@ export const roomStore = createStore<RoomState>()(
       // the pointer to the synced position.
       //
       // The DIVIDER does not depend on this load. `onActivate` derives it by
-      // archive POSITION — the first renderable incoming message strictly after
+      // cache POSITION — the first renderable incoming message strictly after
       // the pointer in `(timestamp, tiebreak)` order — so an off-slice
       // pointer places it exactly as well as a resident one. The stale-pointer
       // fallback ladder that made an off-slice pointer a degraded case is gone.

--- a/packages/fluux-sdk/src/stores/roomStore.ts
+++ b/packages/fluux-sdk/src/stores/roomStore.ts
@@ -39,7 +39,7 @@ import {
   pointerlessDefers,
   worthReconcilingOnDeactivate,
   compareOrder,
-  makeArchiveOrderKey,
+  makeCacheOrderKey,
   isRenderableStoredMessage,
   type OrderPosition,
 } from './shared/readState'
@@ -1904,7 +1904,7 @@ export const roomStore = createStore<RoomState>()(
       }
       const result = noteTransient(
         scopeKey,
-        { position: { timestamp: messageToAdd.timestamp.getTime(), archiveOrderKey: makeArchiveOrderKey(messageToAdd, 'room') } },
+        { position: { timestamp: messageToAdd.timestamp.getTime(), tiebreak: makeCacheOrderKey(messageToAdd, 'room') } },
         transientIdentity(identityFields, 'room'),
         transientAliases(identityFields, 'room')
       )
@@ -2426,7 +2426,7 @@ export const roomStore = createStore<RoomState>()(
     // coverage bottom sharing its exact millisecond; a historyFloor-derived
     // floor has no such key (unresolved sorts conservatively).
     const floorPos: OrderPosition = metaNow.readPointer
-      ? { timestamp: metaNow.readPointer.timestamp.getTime(), archiveOrderKey: metaNow.readPointer.archiveOrderKey }
+      ? { timestamp: metaNow.readPointer.timestamp.getTime(), tiebreak: metaNow.readPointer.tiebreak }
       : { timestamp: floor.getTime() }
 
     // Task 9 safety net: this recompute is one of the "pointer advance /
@@ -2580,7 +2580,7 @@ export const roomStore = createStore<RoomState>()(
       if (updated.readPointer && updated.readPointer !== notifInput.readPointer) {
         pruneTransient(roomTransientScopeKey(roomJid), {
           timestamp: updated.readPointer.timestamp.getTime(),
-          archiveOrderKey: updated.readPointer.archiveOrderKey,
+          tiebreak: updated.readPointer.tiebreak,
         })
       }
 
@@ -2637,7 +2637,7 @@ export const roomStore = createStore<RoomState>()(
       // entry to a later recompute trigger.
       pruneTransient(roomTransientScopeKey(roomJid), {
         timestamp: read.readPointer.timestamp.getTime(),
-        archiveOrderKey: read.readPointer.archiveOrderKey,
+        tiebreak: read.readPointer.tiebreak,
       })
 
       const committed = commitRoomUpdate(state, roomJid, read)
@@ -2871,7 +2871,7 @@ export const roomStore = createStore<RoomState>()(
       //
       // The DIVIDER does not depend on this load. `onActivate` derives it by
       // archive POSITION — the first renderable incoming message strictly after
-      // the pointer in `(timestamp, archiveOrderKey)` order — so an off-slice
+      // the pointer in `(timestamp, tiebreak)` order — so an off-slice
       // pointer places it exactly as well as a resident one. The stale-pointer
       // fallback ladder that made an off-slice pointer a degraded case is gone.
       // What a cache miss costs is CONTEXT: the latest slice is kept, the
@@ -2983,7 +2983,7 @@ export const roomStore = createStore<RoomState>()(
       if (updated.readPointer) {
         pruneTransient(roomTransientScopeKey(roomJid), {
           timestamp: updated.readPointer.timestamp.getTime(),
-          archiveOrderKey: updated.readPointer.archiveOrderKey,
+          tiebreak: updated.readPointer.tiebreak,
         })
       }
 

--- a/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/mamCoverage.test.ts
@@ -315,7 +315,7 @@ describe('resolveCoverageBottom', () => {
   it('resolves a bottomId that is cached to its archive position', async () => {
     await messageCache.saveMessage(mockMessage({ stanzaId: 'archive-42', timestamp: new Date(9000) }))
     const out = await resolveCoverageBottom(CONV, { bottomId: 'archive-42' }, false)
-    expect(out).toEqual({ timestamp: 9000, archiveOrderKey: { kind: 'chat', id: 'client-id-1' } })
+    expect(out).toEqual({ timestamp: 9000, tiebreak: { kind: 'chat', id: 'client-id-1' } })
   })
 
   it('resolves a bottomId scoped to a room, distinct from the chat lookup', async () => {
@@ -323,7 +323,7 @@ describe('resolveCoverageBottom', () => {
     const out = await resolveCoverageBottom(ROOM, { bottomId: 'archive-42' }, true)
     expect(out).toEqual({
       timestamp: 7000,
-      archiveOrderKey: { kind: 'room', from: `${ROOM}/alice`, id: 'client-id-1' },
+      tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'client-id-1' },
     })
   })
 

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -191,8 +191,8 @@ export function backfillArchiveIds<T extends ArchiveIdentifiableMessage>(
  * room by `from` then `id`. This is deliberately NOT a generic `from`-then-`id`
  * comparator — chat messages carry `from` too, so inferring the tiebreak from
  * field presence would silently apply the room rule to chat. The resident
- * array and the IndexedDB archive must agree on this order, or the read
- * pointer (positioned in archive order) and the viewport observer (walking
+ * array and IndexedDB must agree on this order, or the read pointer
+ * (positioned in cache order) and the viewport observer (walking
  * this resident order) can disagree about which message came second.
  *
  * @param messages - Array of messages to sort

--- a/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageArrayUtils.ts
@@ -5,7 +5,7 @@
  * to reduce code duplication for common message array operations.
  */
 
-import { compareOrder, makeArchiveOrderKey } from './readState'
+import { compareOrder, makeCacheOrderKey } from './readState'
 
 /**
  * Generic interface for messages with a timestamp.
@@ -186,7 +186,7 @@ export function backfillArchiveIds<T extends ArchiveIdentifiableMessage>(
 /**
  * Sort messages by timestamp in ascending order (oldest first).
  *
- * Same-millisecond ties break by the archive's own tie-break key
+ * Same-millisecond ties break by the message cache's own tie-break key
  * (`readState.ts`'s `compareOrder`), kind-discriminated: chat by `id` only,
  * room by `from` then `id`. This is deliberately NOT a generic `from`-then-`id`
  * comparator — chat messages carry `from` too, so inferring the tiebreak from
@@ -205,8 +205,8 @@ export function sortMessagesByTimestamp<T extends TimestampedMessage>(
 ): T[] {
   return [...messages].sort((a, b) =>
     compareOrder(
-      { timestamp: a.timestamp.getTime(), archiveOrderKey: makeArchiveOrderKey(a, kind) },
-      { timestamp: b.timestamp.getTime(), archiveOrderKey: makeArchiveOrderKey(b, kind) }
+      { timestamp: a.timestamp.getTime(), tiebreak: makeCacheOrderKey(a, kind) },
+      { timestamp: b.timestamp.getTime(), tiebreak: makeCacheOrderKey(b, kind) }
     )
   )
 }

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -90,15 +90,15 @@ export function appendLive<T extends TimelineMessage>(
   if (!atLiveEdge) return { kind: 'gated' }
 
   // FIX 5 (read-state PR B, final whole-branch review): sort before trimming.
-  // Live arrivals land in ARRIVAL order, but the archive orders same-millisecond
+  // Live arrivals land in ARRIVAL order, but the cache orders same-millisecond
   // rows by the shared comparator (id for chat, (from, id) for room — see
   // `compareOrder`/`makeCacheOrderKey`). The viewport observer advances the
   // read pointer by RESIDENT INDEX, so an unsorted resident array can place a
-  // same-ms sibling later than the archive would — the pointer then advances
-  // past it while the archive walk still counts it as unread: a silent
+  // same-ms sibling later than the cache would — the pointer then advances
+  // past it while the cache walk still counts it as unread: a silent
   // under-count, the unrecoverable direction. `sortMessagesByTimestamp` is the
   // SAME comparator `loadOlderSlice`/`loadNewerSlice`/`latestSlice` already use
-  // here, so all resident-array construction paths agree with the archive walk.
+  // here, so all resident-array construction paths agree with the cache walk.
   const sorted = sortMessagesByTimestamp([...messages, incoming], config.kind)
   const trimmed = trimMessages(sorted, config.windowSize)
   const residentIndex = trimmed.indexOf(incoming)

--- a/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
+++ b/packages/fluux-sdk/src/stores/shared/messageTimeline.ts
@@ -92,7 +92,7 @@ export function appendLive<T extends TimelineMessage>(
   // FIX 5 (read-state PR B, final whole-branch review): sort before trimming.
   // Live arrivals land in ARRIVAL order, but the archive orders same-millisecond
   // rows by the shared comparator (id for chat, (from, id) for room — see
-  // `compareOrder`/`makeArchiveOrderKey`). The viewport observer advances the
+  // `compareOrder`/`makeCacheOrderKey`). The viewport observer advances the
   // read pointer by RESIDENT INDEX, so an unsorted resident array can place a
   // same-ms sibling later than the archive would — the pointer then advances
   // past it while the archive walk still counts it as unread: a silent

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -457,7 +457,7 @@ describe('onActivate', () => {
 
   // Residency is no longer a case distinction. There is ONE rule — the divider
   // is the first renderable incoming message strictly after the boundary in
-  // `(timestamp, archiveOrderKey)` order — and it is the same rule whether or
+  // `(timestamp, tiebreak)` order — and it is the same rule whether or
   // not the pointer's own message happens to be in the slice. The old
   // "stale-pointer fallback" ladder these tests were named after is gone; what
   // they now pin is that the one rule keeps giving the right answer when the
@@ -1096,7 +1096,7 @@ describe('onMessageSeen — position comparison (PR C, D4)', () => {
     expect(r.readPointer?.messageId).toBe('m2')
   })
 
-  // OFF-SLICE + same millisecond: nothing but the archive order key can decide
+  // OFF-SLICE + same millisecond: nothing but the cache order key can decide
   // this one. The same-ms test above keeps the pointer's OWN message resident,
   // so deleting the keyed branch entirely still answers it correctly by array
   // index; here the index path finds no current position (currentIdx === -1,
@@ -1715,7 +1715,7 @@ describe('readPointer on the remaining pointer-writing transitions (#1081)', () 
     const byId = new Map(messages.map((m) => [m.id, m.timestamp]))
     // Tagged so a failure names the transition that broke the invariant.
     // messageId/timestamp are compared explicitly (not the whole pointer):
-    // archiveOrderKey is not this invariant's concern, and a `kind` constant
+    // tiebreak is not this invariant's concern, and a `kind` constant
     // across every call here would otherwise make it trivially match.
     const coherent = (st: EntityNotificationState, label: string) => {
       const p = st.readPointer

--- a/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.test.ts
@@ -665,7 +665,7 @@ describe('onActivate stale pointer', () => {
   // Replaces 'snaps pointer to the message before the derived divider, not to
   // the newest' — the snap is gone (see the D5 suite's 'never moves the read
   // pointer'). What survives is that an OFF-SLICE pointer still positions a
-  // divider, now purely by archive order.
+  // divider, now purely by cache order.
   it('positions a divider from an off-slice pointer without touching it', () => {
     const mkMsg = (id: string, minutesAgo: number): NotificationMessage => ({
       id, timestamp: new Date(Date.now() - minutesAgo * 60_000), isOutgoing: false, isDelayed: true, body: 'hi',

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -25,7 +25,7 @@ import {
   compareOrder,
   computeFloor,
   isRenderableStoredMessage,
-  makeArchiveOrderKey,
+  makeCacheOrderKey,
   type OrderPosition,
   type RenderabilityCheckFields,
 } from './readState'
@@ -91,7 +91,7 @@ export interface NotificationMessage extends RenderabilityCheckFields {
   isOutgoing: boolean
   isDelayed?: boolean
   isMention?: boolean
-  /** Sender's JID — feeds the ROOM archive order key's (from, id) tie-break. */
+  /** Sender's JID — feeds the ROOM cache order key's (from, id) tie-break. */
   from?: string
 }
 
@@ -267,7 +267,7 @@ export function isUnseenIncomingMessage(
  *
  * The divider is **the first message the canonical count would count** (read-state
  * PR C, D5): incoming, renderable, and strictly after the read boundary in
- * `(timestamp, archiveOrderKey)` order. Sharing the count's exact predicate AND
+ * `(timestamp, tiebreak)` order. Sharing the count's exact predicate AND
  * its exact floor is what makes "the divider labels the count" true by
  * construction rather than by coincidence — see `countUnreadInArchive`.
  *
@@ -280,7 +280,7 @@ export function isUnseenIncomingMessage(
  * The old fallback ladder — a `lastReadAt` timestamp probe, an Nth-from-end
  * placement driven by `unreadCount`, and a resume-preserving snap — is gone. All
  * of it existed because the pointer could not be located outside the resident
- * slice, which a durably reconstructible `archiveOrderKey` now solves, and the
+ * slice, which a durably reconstructible `tiebreak` now solves, and the
  * snap was a pointer write inside a function whose job is to place a divider.
  *
  * With neither a pointer nor a `historyFloor` there is no boundary, so there is
@@ -297,7 +297,7 @@ export function onActivate(
   let firstNewMessageId: string | undefined = undefined
   if (floor) {
     const floorPos: OrderPosition = state.readPointer
-      ? { timestamp: state.readPointer.timestamp.getTime(), archiveOrderKey: state.readPointer.archiveOrderKey }
+      ? { timestamp: state.readPointer.timestamp.getTime(), tiebreak: state.readPointer.tiebreak }
       : { timestamp: floor.getTime() }
 
     for (const m of messages) {
@@ -305,7 +305,7 @@ export function onActivate(
       if (!isRenderableStoredMessage(m)) continue
       const pos: OrderPosition = {
         timestamp: m.timestamp.getTime(),
-        archiveOrderKey: makeArchiveOrderKey(m, kind),
+        tiebreak: makeCacheOrderKey(m, kind),
       }
       if (compareOrder(pos, floorPos) > 0) {
         firstNewMessageId = m.id
@@ -435,7 +435,7 @@ export function onWindowBecameVisible(
  * moving on a fabricated timestamp would push a forward-only floor past unread
  * messages for good.
  *
- * A KEYED current pointer (carries `archiveOrderKey`) is ordered by archive
+ * A KEYED current pointer (carries `tiebreak`) is ordered by archive
  * POSITION via `compareOrder`, not by array index — its position is provable
  * without being resident in `messages` (PR C, D4). The off-slice guard and the
  * `atLiveEdge` escape hatch below apply only to a KEYLESS (migrated) pointer,
@@ -471,11 +471,11 @@ export function onMessageSeen(
   // advance. Safe against the resident array because PR B gave
   // `messageArrayUtils` the same `compareOrder` tie-break, so array index and
   // archive order agree.
-  if (state.readPointer.archiveOrderKey) {
+  if (state.readPointer.tiebreak) {
     const target = messages[newIdx]
     return compareOrder(
-      { timestamp: target.timestamp.getTime(), archiveOrderKey: makeArchiveOrderKey(target, kind) },
-      { timestamp: state.readPointer.timestamp.getTime(), archiveOrderKey: state.readPointer.archiveOrderKey }
+      { timestamp: target.timestamp.getTime(), tiebreak: makeCacheOrderKey(target, kind) },
+      { timestamp: state.readPointer.timestamp.getTime(), tiebreak: state.readPointer.tiebreak }
     ) > 0
       ? advanced()
       : state

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -435,7 +435,7 @@ export function onWindowBecameVisible(
  * moving on a fabricated timestamp would push a forward-only floor past unread
  * messages for good.
  *
- * A KEYED current pointer (carries `tiebreak`) is ordered by archive
+ * A KEYED current pointer (carries `tiebreak`) is ordered by cache
  * POSITION via `compareOrder`, not by array index — its position is provable
  * without being resident in `messages` (PR C, D4). The off-slice guard and the
  * `atLiveEdge` escape hatch below apply only to a KEYLESS (migrated) pointer,

--- a/packages/fluux-sdk/src/stores/shared/notificationState.ts
+++ b/packages/fluux-sdk/src/stores/shared/notificationState.ts
@@ -466,11 +466,11 @@ export function onMessageSeen(
   // No read position yet: any resolvable message is an advancement.
   if (!state.readPointer) return advanced()
 
-  // Keyed pointer: compare archive POSITIONS. The pointer no longer has to be
+  // Keyed pointer: compare cache POSITIONS. The pointer no longer has to be
   // resident, and a same-millisecond sibling that sorts after it is a genuine
   // advance. Safe against the resident array because PR B gave
   // `messageArrayUtils` the same `compareOrder` tie-break, so array index and
-  // archive order agree.
+  // cache order agree.
   if (state.readPointer.tiebreak) {
     const target = messages[newIdx]
     return compareOrder(

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -57,7 +57,7 @@ describe('resolveRemoteDisplayed', () => {
 
     // Whole-object assertion: the resolution carries one read position, and its
     // timestamp is the resolved message's own (#1081). toMatchObject rather
-    // than toEqual: the resolved pointer also carries an tiebreak,
+    // than toEqual: the resolved pointer also carries a tiebreak,
     // which is not what this test is about.
     expect(result).toMatchObject({
       kind: 'advanced',

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.test.ts
@@ -57,7 +57,7 @@ describe('resolveRemoteDisplayed', () => {
 
     // Whole-object assertion: the resolution carries one read position, and its
     // timestamp is the resolved message's own (#1081). toMatchObject rather
-    // than toEqual: the resolved pointer also carries an archiveOrderKey,
+    // than toEqual: the resolved pointer also carries an tiebreak,
     // which is not what this test is about.
     expect(result).toMatchObject({
       kind: 'advanced',

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -9,7 +9,7 @@
 
 import type { NotificationMessage } from './notificationState'
 import * as notifState from './notificationState'
-import { compareOrder, makeArchiveOrderKey } from './readState'
+import { compareOrder, makeCacheOrderKey } from './readState'
 import { makeReadPointer, type ReadPointer } from './readPointer'
 
 /** The notification-relevant slice of a conversation/room metadata entry. */
@@ -81,11 +81,11 @@ function resolveAdvance<T extends NotificationMessage & { stanzaId?: string }>(
 ): ReadPointer | 'no-advance' | 'undecidable' {
   if (!current) return makeReadPointer(match, kind)
 
-  if (current.archiveOrderKey) {
+  if (current.tiebreak) {
     const ahead =
       compareOrder(
-        { timestamp: match.timestamp.getTime(), archiveOrderKey: makeArchiveOrderKey(match, kind) },
-        { timestamp: current.timestamp.getTime(), archiveOrderKey: current.archiveOrderKey }
+        { timestamp: match.timestamp.getTime(), tiebreak: makeCacheOrderKey(match, kind) },
+        { timestamp: current.timestamp.getTime(), tiebreak: current.tiebreak }
       ) > 0
     return ahead ? makeReadPointer(match, kind) : 'no-advance'
   }

--- a/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
+++ b/packages/fluux-sdk/src/stores/shared/readMarkerSync.ts
@@ -63,7 +63,7 @@ export type RemoteDisplayedResolution =
  *   did before PR C (an undefined pointer made the residency check vacuously
  *   true, so `onMessageSeen` took its own no-pointer path); it is preserved
  *   explicitly so it cannot be lost by refactoring.
- * - **Keyed pointer** — decide by archive position, with no residency
+ * - **Keyed pointer** — decide by cache position, with no residency
  *   requirement. The key certifies that the pointer's timestamp is its named
  *   message's own, which is exactly the guarantee the old comment here said we
  *   lacked.

--- a/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.test.ts
@@ -7,23 +7,23 @@ import {
   deserializeReadPointer,
 } from './readPointer'
 import type { ReadPointer } from './readPointer'
-import { isValidArchiveOrderKey } from './readState'
+import { isValidCacheOrderKey } from './readState'
 
 const at = (ms: number) => new Date(ms)
 
 describe('makeReadPointer', () => {
-  it('captures the id and timestamp of the message it names, plus its archive order key', () => {
+  it('captures the id and timestamp of the message it names, plus its cache order key', () => {
     expect(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat')).toEqual({
       messageId: 'm1',
       timestamp: at(1000),
-      archiveOrderKey: { kind: 'chat', id: 'm1' },
+      tiebreak: { kind: 'chat', id: 'm1' },
     })
   })
 
-  it('round-trips a room pointer with its archiveOrderKey', () => {
+  it('round-trips a room pointer with its tiebreak', () => {
     const p = makeReadPointer({ id: 'm1', from: 'r@c/alice', timestamp: at(1000) }, 'room')
-    expect(p.archiveOrderKey).toEqual({ kind: 'room', from: 'r@c/alice', id: 'm1' })
-    expect(deserializeReadPointer(serializeReadPointer(p))!.archiveOrderKey)
+    expect(p.tiebreak).toEqual({ kind: 'room', from: 'r@c/alice', id: 'm1' })
+    expect(deserializeReadPointer(serializeReadPointer(p))!.tiebreak)
       .toEqual({ kind: 'room', from: 'r@c/alice', id: 'm1' })
   })
 })
@@ -144,16 +144,16 @@ describe('serialization', () => {
   // The persisted key is untrusted input too: a malformed one must not ride
   // through into ordering comparisons. Dropping only the key (not the whole
   // pointer) keeps the id/timestamp that are otherwise fine.
-  it('drops a malformed persisted archiveOrderKey instead of trusting it', () => {
+  it('drops a malformed persisted tiebreak instead of trusting it', () => {
     const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, archiveOrderKey: { kind: 'room', id: 'x' } })
-    expect(back!.archiveOrderKey).toBeUndefined() // missing `from` → invalid → dropped
+    expect(back!.tiebreak).toBeUndefined() // missing `from` → invalid → dropped
     expect(back!.messageId).toBe('m') // the pointer itself survives
   })
 
   // A pointer migrated from the pre-#1081 legacy fields has no message
   // position to derive a key from — absence here is legitimate, not corrupt.
-  it('a legacy pointer with no key deserializes with archiveOrderKey undefined', () => {
-    expect(deserializeReadPointer({ messageId: 'm', timestamp: 1000 })!.archiveOrderKey).toBeUndefined()
+  it('a legacy pointer with no key deserializes with tiebreak undefined', () => {
+    expect(deserializeReadPointer({ messageId: 'm', timestamp: 1000 })!.tiebreak).toBeUndefined()
   })
 })
 
@@ -197,7 +197,7 @@ describe('serialization: the tie-break id is not persisted', () => {
   it('reads a legacy on-disk key that still carries its id (lossless)', () => {
     expect(
       deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat', id: 'm1' } })
-    ).toEqual({ messageId: 'm1', timestamp: at(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } })
+    ).toEqual({ messageId: 'm1', timestamp: at(1000), tiebreak: { kind: 'chat', id: 'm1' } })
 
     expect(
       deserializeReadPointer({
@@ -208,7 +208,7 @@ describe('serialization: the tie-break id is not persisted', () => {
     ).toEqual({
       messageId: 'm2',
       timestamp: at(1000),
-      archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm2' },
+      tiebreak: { kind: 'room', from: 'room@x/nick', id: 'm2' },
     })
   })
 
@@ -218,7 +218,7 @@ describe('serialization: the tie-break id is not persisted', () => {
     ).toEqual({
       messageId: 'm1',
       timestamp: at(1000),
-      archiveOrderKey: { kind: 'chat', id: 'm1' },
+      tiebreak: { kind: 'chat', id: 'm1' },
     })
   })
 
@@ -232,14 +232,14 @@ describe('serialization: the tie-break id is not persisted', () => {
       timestamp: 1000,
       archiveOrderKey: { kind: 'chat', id: 'm9-ahead' },
     })
-    expect(back!.archiveOrderKey).toEqual({ kind: 'chat', id: 'm1' })
+    expect(back!.tiebreak).toEqual({ kind: 'chat', id: 'm1' })
 
     const roomBack = deserializeReadPointer({
       messageId: 'm1',
       timestamp: 1000,
       archiveOrderKey: { kind: 'room', from: 'room@x/nick', id: 'm9-ahead' },
     })
-    expect(roomBack!.archiveOrderKey).toEqual({ kind: 'room', from: 'room@x/nick', id: 'm1' })
+    expect(roomBack!.tiebreak).toEqual({ kind: 'room', from: 'room@x/nick', id: 'm1' })
   })
 
   // ...and the disagreement cannot be written back out either: what a
@@ -255,7 +255,7 @@ describe('serialization: the tie-break id is not persisted', () => {
   })
 
   // Compatibility 2 — new data, old build. An older build validates the
-  // persisted key with `isValidArchiveOrderKey`, which requires
+  // persisted key with `isValidCacheOrderKey`, which requires
   // `typeof k.id === 'string'`. The id-less form fails that guard, so an old
   // build DROPS the key and degrades to the documented at-or-after-timestamp
   // fallback, which over-counts — the safe, recoverable direction. Asserted
@@ -264,8 +264,8 @@ describe('serialization: the tie-break id is not persisted', () => {
   it('an old build drops the new id-less key rather than mis-reading it', () => {
     const chat = serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))
     const room = serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(1000) }, 'room'))
-    expect(isValidArchiveOrderKey(chat.archiveOrderKey)).toBe(false)
-    expect(isValidArchiveOrderKey(room.archiveOrderKey)).toBe(false)
+    expect(isValidCacheOrderKey(chat.archiveOrderKey)).toBe(false)
+    expect(isValidCacheOrderKey(room.archiveOrderKey)).toBe(false)
   })
 
   // The pointer itself must still load on an old build: only the key degrades.
@@ -286,7 +286,43 @@ describe('serialization: the tie-break id is not persisted', () => {
     ['a non-object key', 'chat'],
   ])('drops %s', (_label, archiveOrderKey) => {
     const back = deserializeReadPointer({ messageId: 'm', timestamp: 1000, archiveOrderKey })
-    expect(back!.archiveOrderKey).toBeUndefined()
+    expect(back!.tiebreak).toBeUndefined()
     expect(back!.messageId).toBe('m')
+  })
+})
+
+// The in-memory field is `tiebreak`; the PERSISTED property is still
+// `archiveOrderKey`. Renaming the on-disk name would orphan every stored
+// pointer, so it is deliberately unchanged — asserted against literal JSON so
+// the format cannot drift with the next rename.
+describe('the on-disk property name is not renamed with the field', () => {
+  it('writes the exact bytes the previous build wrote', () => {
+    expect(JSON.stringify(serializeReadPointer(makeReadPointer({ id: 'm1', timestamp: at(1000) }, 'chat'))))
+      .toBe('{"messageId":"m1","timestamp":1000,"archiveOrderKey":{"kind":"chat"}}')
+
+    expect(
+      JSON.stringify(
+        serializeReadPointer(makeReadPointer({ id: 'm2', from: 'room@x/nick', timestamp: at(2000) }, 'room'))
+      )
+    ).toBe('{"messageId":"m2","timestamp":2000,"archiveOrderKey":{"kind":"room","from":"room@x/nick"}}')
+  })
+
+  it('never writes the in-memory name to disk', () => {
+    const p = makeReadPointer({ id: 'm1', from: 'room@x/nick', timestamp: at(1000) }, 'room')
+    expect(JSON.stringify(serializeReadPointer(p))).not.toContain('tiebreak')
+  })
+
+  it('hydrates a pointer stored by the previous build', () => {
+    expect(deserializeReadPointer({ messageId: 'm1', timestamp: 1000, archiveOrderKey: { kind: 'chat' } })).toEqual({
+      messageId: 'm1',
+      timestamp: at(1000),
+      tiebreak: { kind: 'chat', id: 'm1' },
+    })
+  })
+
+  it('ignores a pointer stored under the in-memory name (never a written format)', () => {
+    expect(
+      deserializeReadPointer({ messageId: 'm1', timestamp: 1000, tiebreak: { kind: 'chat' } })!.tiebreak
+    ).toBeUndefined()
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -58,7 +58,7 @@ export interface ReadPointer {
  * for a forward-only pointer. Not persisting the second copy makes that
  * disagreement unrepresentable rather than merely rejected at read time.
  *
- * `from` stays: it is the room archive's own `(from, id)` tie-break component
+ * `from` stays: it is the room cache's `(from, id)` tie-break component
  * and is NOT derivable from the pointer.
  */
 export type SerializedCacheOrderKey = { kind: 'chat' } | { kind: 'room'; from: string }
@@ -152,14 +152,15 @@ export function advance(current: ReadPointer | undefined, candidate: ReadPointer
 
 /**
  * Write the pointer, with the tie-break stripped of its redundant `id` (see
- * {@link SerializedCacheOrderKey}). The in-memory shape is unchanged; only
- * the on-disk form shrinks.
+ * {@link SerializedCacheOrderKey}). The in-memory key keeps its full shape;
+ * only the on-disk form omits the redundant `id`.
  *
- * An OLDER build reading this format validates the key with
- * `isValidCacheOrderKey`, which requires `typeof k.id === 'string'` — so it
- * drops the key and degrades to the at-or-after-timestamp fallback, which
- * over-counts rather than under-counts (the safe, recoverable direction). The
- * `messageId` and `timestamp` it needs are untouched.
+ * An OLDER build reading this format validates the key with the equivalent
+ * guard (now called `isValidCacheOrderKey`), which requires
+ * `typeof k.id === 'string'` — so it drops the key and degrades to the
+ * at-or-after-timestamp fallback, which over-counts rather than under-counts
+ * (the safe, recoverable direction). The `messageId` and `timestamp` it needs
+ * are untouched.
  */
 export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointer {
   const key = pointer.tiebreak
@@ -225,7 +226,8 @@ function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | 
  * writes) or an ISO string (what a chat pointer riding inside `conversationMeta`
  * becomes after a plain `JSON.stringify` turns its `Date` into a string). Both
  * encodings exist on disk today — this is the one place that reads either back.
- * We still only ever WRITE epoch ms; the string branch is read-only tolerance.
+ * {@link serializeReadPointer} writes epoch ms; the chat storage blob writes an
+ * ISO string through its plain `JSON.stringify`.
  *
  * `tiebreak` is rebuilt by {@link hydrateCacheOrderKey} — never taken
  * verbatim — and DROPPED when what it carries is unusable. Storage is untrusted

--- a/packages/fluux-sdk/src/stores/shared/readPointer.ts
+++ b/packages/fluux-sdk/src/stores/shared/readPointer.ts
@@ -15,7 +15,7 @@
  * All functions here are pure.
  */
 
-import { compareOrder, makeArchiveOrderKey, type ArchiveOrderKey } from './readState'
+import { compareOrder, makeCacheOrderKey, type CacheOrderKey } from './readState'
 
 /**
  * Where the user has read to. Written atomically or not at all.
@@ -36,7 +36,7 @@ export interface ReadPointer {
   /** Timestamp OF that message (see the migration caveat above). */
   timestamp: Date
   /**
-   * The archive's own tie-break key for `messageId`, for counting unread
+   * The message cache's tie-break key for `messageId`, for counting unread
    * strictly-after a POSITION rather than a timestamp alone (two messages can
    * share a millisecond). OPTIONAL, deliberately: a pointer migrated from the
    * pre-#1081 legacy `lastSeenMessageId` + `lastReadAt` pair has only a
@@ -44,7 +44,7 @@ export interface ReadPointer {
    * absent — counting then falls back to at-or-after-timestamp, which can
    * over-count the equal-ms set (the safe direction) rather than under-count.
    */
-  archiveOrderKey?: ArchiveOrderKey
+  tiebreak?: CacheOrderKey
 }
 
 /**
@@ -61,19 +61,30 @@ export interface ReadPointer {
  * `from` stays: it is the room archive's own `(from, id)` tie-break component
  * and is NOT derivable from the pointer.
  */
-export type SerializedArchiveOrderKey = { kind: 'chat' } | { kind: 'room'; from: string }
+export type SerializedCacheOrderKey = { kind: 'chat' } | { kind: 'room'; from: string }
 
-/** JSON-safe form for localStorage. */
+/**
+ * JSON-safe form for localStorage.
+ *
+ * The persisted property is `archiveOrderKey`, NOT `tiebreak`. The in-memory
+ * field was renamed because the key never held an archive id — it is the
+ * IndexedDB cursor tie-break built from the CLIENT message id — but the ON-DISK
+ * name is deliberately left alone: every pointer already stored carries
+ * `archiveOrderKey`, and renaming it here would silently orphan all of them,
+ * degrading each to the keyless at-or-after-timestamp fallback. Do not "finish
+ * the rename" on this side without a migration and its own compatibility
+ * argument.
+ */
 export interface SerializedReadPointer {
   messageId: string
   timestamp: number
-  archiveOrderKey?: SerializedArchiveOrderKey
+  archiveOrderKey?: SerializedCacheOrderKey
 }
 
 /** The minimal message shape a pointer can be built from. */
 export interface PointerSource {
   id: string
-  /** Sender's JID — needed for the ROOM archive order key's (from, id) tie-break. */
+  /** Sender's JID — needed for the ROOM cache order key's (from, id) tie-break. */
   from?: string
   timestamp: Date
 }
@@ -82,21 +93,21 @@ export interface PointerSource {
  * Build a pointer naming `message`. `kind` is required rather than guessed:
  * this module has no way to know whether it is serving a chat or a room, and
  * the two kinds break same-millisecond ties differently (see
- * {@link ArchiveOrderKey}) — the caller (chat store vs. room store) always
+ * {@link CacheOrderKey}) — the caller (chat store vs. room store) always
  * knows which, and must say so.
  */
 export function makeReadPointer(message: PointerSource, kind: 'chat' | 'room'): ReadPointer {
   return {
     messageId: message.id,
     timestamp: message.timestamp,
-    archiveOrderKey: makeArchiveOrderKey(message, kind),
+    tiebreak: makeCacheOrderKey(message, kind),
   }
 }
 
 /**
  * Is `candidate` strictly further along than `current`?
  *
- * Timestamp first. A same-millisecond tie is broken by the archive order key —
+ * Timestamp first. A same-millisecond tie is broken by the cache order key —
  * but ONLY when both sides carry one (read-state PR C, D2). A key is what
  * certifies that a pointer's timestamp is its named message's own: pointers
  * built by `makeReadPointer` always have one, while a pointer migrated from the
@@ -118,14 +129,14 @@ export function isAhead(candidate: ReadPointer, current: ReadPointer | undefined
   const currentMs = current.timestamp.getTime()
   if (candidateMs !== currentMs) return candidateMs > currentMs
 
-  const candidateKey = candidate.archiveOrderKey
-  const currentKey = current.archiveOrderKey
+  const candidateKey = candidate.tiebreak
+  const currentKey = current.tiebreak
   if (!candidateKey || !currentKey) return false
 
   return (
     compareOrder(
-      { timestamp: candidateMs, archiveOrderKey: candidateKey },
-      { timestamp: currentMs, archiveOrderKey: currentKey }
+      { timestamp: candidateMs, tiebreak: candidateKey },
+      { timestamp: currentMs, tiebreak: currentKey }
     ) > 0
   )
 }
@@ -141,21 +152,48 @@ export function advance(current: ReadPointer | undefined, candidate: ReadPointer
 
 /**
  * Write the pointer, with the tie-break stripped of its redundant `id` (see
- * {@link SerializedArchiveOrderKey}). The in-memory shape is unchanged; only
+ * {@link SerializedCacheOrderKey}). The in-memory shape is unchanged; only
  * the on-disk form shrinks.
  *
  * An OLDER build reading this format validates the key with
- * `isValidArchiveOrderKey`, which requires `typeof k.id === 'string'` — so it
+ * `isValidCacheOrderKey`, which requires `typeof k.id === 'string'` — so it
  * drops the key and degrades to the at-or-after-timestamp fallback, which
  * over-counts rather than under-counts (the safe, recoverable direction). The
  * `messageId` and `timestamp` it needs are untouched.
  */
 export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointer {
-  const key = pointer.archiveOrderKey
+  const key = pointer.tiebreak
   return {
     messageId: pointer.messageId,
     timestamp: pointer.timestamp.getTime(),
+    // On-disk name kept as `archiveOrderKey` on purpose — see {@link SerializedReadPointer}.
     ...(key ? { archiveOrderKey: key.kind === 'room' ? { kind: 'room', from: key.from } : { kind: 'chat' } } : {}),
+  }
+}
+
+/**
+ * The pointer as the CHAT storage blob carries it: the live object handed to a
+ * plain `JSON.stringify` (so `timestamp` becomes an ISO string on disk, and the
+ * tie-break keeps its `id`) — unlike {@link serializeReadPointer}, which is the
+ * epoch-ms, id-less form used by room read state and the state snapshot.
+ *
+ * It exists only to hold the on-disk property name `archiveOrderKey` while the
+ * in-memory field is `tiebreak`: the chat store persists its metadata verbatim,
+ * so without this the rename would leak to disk and orphan every stored pointer
+ * (see {@link SerializedReadPointer}). Nothing else about the shape changes.
+ */
+export interface PersistedReadPointer {
+  messageId: string
+  timestamp: Date
+  archiveOrderKey?: CacheOrderKey
+}
+
+/** Rename boundary for the verbatim-persisted chat blob. See {@link PersistedReadPointer}. */
+export function toPersistedReadPointer(pointer: ReadPointer): PersistedReadPointer {
+  return {
+    messageId: pointer.messageId,
+    timestamp: pointer.timestamp,
+    ...(pointer.tiebreak ? { archiveOrderKey: pointer.tiebreak } : {}),
   }
 }
 
@@ -170,7 +208,7 @@ export function serializeReadPointer(pointer: ReadPointer): SerializedReadPointe
  * and `from` for a room key. Anything else yields no key at all, which degrades
  * to the at-or-after-timestamp fallback (over-count, the safe direction).
  */
-function hydrateArchiveOrderKey(raw: unknown, messageId: string): ArchiveOrderKey | undefined {
+function hydrateCacheOrderKey(raw: unknown, messageId: string): CacheOrderKey | undefined {
   if (!raw || typeof raw !== 'object') return undefined
   const k = raw as Record<string, unknown>
   if (k.kind === 'chat') return { kind: 'chat', id: messageId }
@@ -189,7 +227,7 @@ function hydrateArchiveOrderKey(raw: unknown, messageId: string): ArchiveOrderKe
  * encodings exist on disk today — this is the one place that reads either back.
  * We still only ever WRITE epoch ms; the string branch is read-only tolerance.
  *
- * `archiveOrderKey` is rebuilt by {@link hydrateArchiveOrderKey} — never taken
+ * `tiebreak` is rebuilt by {@link hydrateCacheOrderKey} — never taken
  * verbatim — and DROPPED when what it carries is unusable. Storage is untrusted
  * input, so a corrupt key must not ride through into ordering comparisons.
  * Dropping it alone (keeping the rest of the pointer) is deliberate: it degrades
@@ -199,24 +237,26 @@ function hydrateArchiveOrderKey(raw: unknown, messageId: string): ArchiveOrderKe
  */
 export function deserializeReadPointer(raw: unknown): ReadPointer | undefined {
   if (!raw || typeof raw !== 'object') return undefined
+  // `archiveOrderKey` is the on-disk property name, deliberately unchanged by the
+  // in-memory `tiebreak` rename — see {@link SerializedReadPointer}.
   const { messageId, timestamp, archiveOrderKey } = raw as {
     messageId?: unknown
     timestamp?: unknown
     archiveOrderKey?: unknown
   }
   if (typeof messageId !== 'string' || messageId.length === 0) return undefined
-  const validKey = hydrateArchiveOrderKey(archiveOrderKey, messageId)
+  const validKey = hydrateCacheOrderKey(archiveOrderKey, messageId)
 
   if (typeof timestamp === 'number') {
     return Number.isFinite(timestamp)
-      ? { messageId, timestamp: new Date(timestamp), ...(validKey ? { archiveOrderKey: validKey } : {}) }
+      ? { messageId, timestamp: new Date(timestamp), ...(validKey ? { tiebreak: validKey } : {}) }
       : undefined
   }
   if (typeof timestamp === 'string') {
     const parsed = new Date(timestamp)
     return Number.isNaN(parsed.getTime())
       ? undefined
-      : { messageId, timestamp: parsed, ...(validKey ? { archiveOrderKey: validKey } : {}) }
+      : { messageId, timestamp: parsed, ...(validKey ? { tiebreak: validKey } : {}) }
   }
   return undefined
 }

--- a/packages/fluux-sdk/src/stores/shared/readState.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { compareOrder, computeFloor, makeArchiveOrderKey, pointerlessDefers, isValidArchiveOrderKey } from './readState'
+import { compareOrder, computeFloor, makeCacheOrderKey, pointerlessDefers, isValidCacheOrderKey } from './readState'
 import { makeReadPointer } from './readPointer'
 
 describe('compareOrder', () => {
@@ -7,17 +7,17 @@ describe('compareOrder', () => {
     expect(compareOrder({ timestamp: 1 }, { timestamp: 2 })).toBeLessThan(0)
   })
   it('room ties break by (from, id)', () => {
-    const a = { timestamp: 5, archiveOrderKey: makeArchiveOrderKey({ from: 'r@c/al', id: 'z' }, 'room') }
-    const b = { timestamp: 5, archiveOrderKey: makeArchiveOrderKey({ from: 'r@c/bo', id: 'a' }, 'room') }
+    const a = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/al', id: 'z' }, 'room') }
+    const b = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'r@c/bo', id: 'a' }, 'room') }
     expect(compareOrder(a, b)).toBeLessThan(0) // 'al' < 'bo' wins over id
   })
   it('chat ties break by id ONLY, ignoring from', () => {
-    const a = { timestamp: 5, archiveOrderKey: makeArchiveOrderKey({ from: 'zed@x', id: 'a' }, 'chat') }
-    const b = { timestamp: 5, archiveOrderKey: makeArchiveOrderKey({ from: 'amy@x', id: 'b' }, 'chat') }
+    const a = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'zed@x', id: 'a' }, 'chat') }
+    const b = { timestamp: 5, tiebreak: makeCacheOrderKey({ from: 'amy@x', id: 'b' }, 'chat') }
     expect(compareOrder(a, b)).toBeLessThan(0) // id 'a' < 'b'; `from` must not participate
   })
   it('a missing key sorts before a present one at equal timestamp (conservative)', () => {
-    const k = { timestamp: 5, archiveOrderKey: makeArchiveOrderKey({ id: 'a' }, 'chat') }
+    const k = { timestamp: 5, tiebreak: makeCacheOrderKey({ id: 'a' }, 'chat') }
     expect(compareOrder({ timestamp: 5 }, k)).toBeLessThan(0)
   })
 })
@@ -37,10 +37,10 @@ describe('pointerlessDefers', () => {
   it('allows a pointerless zero (genuinely fresh)', () => expect(pointerlessDefers(undefined, 0)).toBe(false))
 })
 
-describe('isValidArchiveOrderKey', () => {
+describe('isValidCacheOrderKey', () => {
   it('rejects untrusted shapes', () => {
-    expect(isValidArchiveOrderKey({ kind: 'room', id: 'x' })).toBe(false) // missing from
-    expect(isValidArchiveOrderKey({ kind: 'nope', id: 'x' })).toBe(false)
-    expect(isValidArchiveOrderKey({ kind: 'chat', id: 'x' })).toBe(true)
+    expect(isValidCacheOrderKey({ kind: 'room', id: 'x' })).toBe(false) // missing from
+    expect(isValidCacheOrderKey({ kind: 'nope', id: 'x' })).toBe(false)
+    expect(isValidCacheOrderKey({ kind: 'chat', id: 'x' })).toBe(true)
   })
 })

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -19,8 +19,13 @@ import type { ReadPointer } from './readPointer'
 export { isRenderableStoredMessage, type RenderabilityCheckFields } from '../../utils/messageRenderability'
 
 /**
- * The archive's own tie-break key for a message, kind-discriminated because
- * chat and room break same-millisecond ties differently:
+ * The IndexedDB message cache's own tie-break key for a message, built from the
+ * CLIENT message id. It has never held an archive id, and could not: XEP-0313
+ * §6.2 makes archive ids opaque strings with no guarantee of being numeric,
+ * sequenced or globally unique, and unique only per archive — they carry no
+ * ordering. This key is chosen to agree with the cache's cursors, and is
+ * kind-discriminated because chat and room break same-millisecond ties
+ * differently:
  *
  * - Chat breaks ties by `id` only (the chat store's `keyPath: 'id'`,
  *   `messageCache.ts:140`).
@@ -30,17 +35,17 @@ export { isRenderableStoredMessage, type RenderabilityCheckFields } from '../../
  * would be wrong for chat — the `kind` discriminant is what keeps the two
  * apart. Do not generalise this into a single shape.
  */
-export type ArchiveOrderKey = { kind: 'chat'; id: string } | { kind: 'room'; from: string; id: string }
+export type CacheOrderKey = { kind: 'chat'; id: string } | { kind: 'room'; from: string; id: string }
 
 /** Build the kind-appropriate order key for a message. */
-export function makeArchiveOrderKey(msg: { from?: string; id: string }, kind: 'chat' | 'room'): ArchiveOrderKey {
+export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'chat' | 'room'): CacheOrderKey {
   return kind === 'room' ? { kind: 'room', from: msg.from ?? '', id: msg.id } : { kind: 'chat', id: msg.id }
 }
 
 /** A position in archive order: a timestamp, optionally refined by an order key. */
 export interface OrderPosition {
   timestamp: number
-  archiveOrderKey?: ArchiveOrderKey
+  tiebreak?: CacheOrderKey
 }
 
 /**
@@ -51,8 +56,8 @@ export interface OrderPosition {
  */
 export function compareOrder(a: OrderPosition, b: OrderPosition): number {
   if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp
-  const ak = a.archiveOrderKey,
-    bk = b.archiveOrderKey
+  const ak = a.tiebreak,
+    bk = b.tiebreak
   if (!ak && !bk) return 0
   if (!ak) return -1 // unresolved sorts first → under-advance → over-count (safe)
   if (!bk) return 1
@@ -106,7 +111,7 @@ export function worthReconcilingOnDeactivate(
 }
 
 /**
- * Runtime guard for an `ArchiveOrderKey` read back from untrusted storage.
+ * Runtime guard for an `CacheOrderKey` read back from untrusted storage.
  *
  * No longer on the hydration path: `deserializeReadPointer` rebuilds the key
  * and takes its `id` from `messageId` instead of validating a persisted one.
@@ -116,7 +121,7 @@ export function worthReconcilingOnDeactivate(
  * fallback (over-count, the safe direction) instead of mis-reading it. That
  * compatibility claim is asserted against this function in `readPointer.test.ts`.
  */
-export function isValidArchiveOrderKey(v: unknown): v is ArchiveOrderKey {
+export function isValidCacheOrderKey(v: unknown): v is CacheOrderKey {
   if (!v || typeof v !== 'object') return false
   const k = v as Record<string, unknown>
   if (k.kind === 'chat') return typeof k.id === 'string'

--- a/packages/fluux-sdk/src/stores/shared/readState.ts
+++ b/packages/fluux-sdk/src/stores/shared/readState.ts
@@ -3,7 +3,8 @@
  *
  * This is the total-order comparator and read-boundary floor that every later
  * PR-B derivation builds on. It knows nothing about stores, IndexedDB, or React
- * — only how to order two archive positions and where the read boundary sits.
+ * — only how to order two message-cache positions and where the read boundary
+ * sits.
  *
  * All functions here are pure.
  */
@@ -42,14 +43,14 @@ export function makeCacheOrderKey(msg: { from?: string; id: string }, kind: 'cha
   return kind === 'room' ? { kind: 'room', from: msg.from ?? '', id: msg.id } : { kind: 'chat', id: msg.id }
 }
 
-/** A position in archive order: a timestamp, optionally refined by an order key. */
+/** A position in message-cache order: a timestamp, optionally refined by a key. */
 export interface OrderPosition {
   timestamp: number
   tiebreak?: CacheOrderKey
 }
 
 /**
- * Total order over archive positions: timestamp first, then the kind-aware
+ * Total order over cached message positions: timestamp first, then the kind-aware
  * tie-break key. A missing key sorts BEFORE a present one at an equal
  * timestamp — unresolved sorts first, which under-advances rather than
  * over-advances (over-counting unread is the recoverable direction).
@@ -111,7 +112,7 @@ export function worthReconcilingOnDeactivate(
 }
 
 /**
- * Runtime guard for an `CacheOrderKey` read back from untrusted storage.
+ * Runtime guard for a `CacheOrderKey` read back from untrusted storage.
  *
  * No longer on the hydration path: `deserializeReadPointer` rebuilds the key
  * and takes its `id` from `messageId` instead of validating a persisted one.

--- a/packages/fluux-sdk/src/stores/shared/readStateStorage.test.ts
+++ b/packages/fluux-sdk/src/stores/shared/readStateStorage.test.ts
@@ -44,7 +44,7 @@ describe('room read-state persistence', () => {
       readPointer: {
         messageId: 'm7',
         timestamp: at(7000),
-        archiveOrderKey: { kind: 'room', from: 'room@conf.example.com/alice', id: 'm7' },
+        tiebreak: { kind: 'room', from: 'room@conf.example.com/alice', id: 'm7' },
       },
       historyFloor: at(100),
     })

--- a/packages/fluux-sdk/src/utils/messageCache.test.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.test.ts
@@ -1431,7 +1431,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } },
+      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 2 })
   })
@@ -1444,7 +1444,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } },
+      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1457,7 +1457,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), archiveOrderKey: { kind: 'chat', id: 'm1' } },
+      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1470,7 +1470,7 @@ describe('countUnreadInArchive (chat)', () => {
     ])
     const res = await messageCache.countUnreadInArchive(CONV, {
       floor: t,
-      pointer: { timestamp: t, archiveOrderKey: { kind: 'chat', id: 'm1' } },
+      pointer: { timestamp: t, tiebreak: { kind: 'chat', id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1494,14 +1494,14 @@ describe('countUnreadInArchive (chat)', () => {
     expect(res!.unread).toBe(3)
   })
 
-  it('missing archiveOrderKey falls back to strict-after-timestamp (over-counts, safe)', async () => {
+  it('missing tiebreak falls back to strict-after-timestamp (over-counts, safe)', async () => {
     const t = new Date(5000)
     await messageCache.saveMessages([
       createMockMessage(CONV, { id: 'm1', timestamp: t, isOutgoing: false }),
       createMockMessage(CONV, { id: 'm2', timestamp: t, isOutgoing: false }),
       createMockMessage(CONV, { id: 'm3', timestamp: new Date(6000), isOutgoing: false }),
     ])
-    // No archiveOrderKey on the pointer (migrated legacy pointer): per compareOrder,
+    // No tiebreak on the pointer (migrated legacy pointer): per compareOrder,
     // an unresolved key sorts BEFORE any resolved one at an equal timestamp, so BOTH
     // m1 (the pointer's own message) and m2 (its same-ms sibling) resolve as "after"
     // the pointer — the read boundary itself gets re-counted rather than a genuinely
@@ -1539,7 +1539,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
+      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 2 })
   })
@@ -1552,7 +1552,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
+      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1565,7 +1565,7 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: new Date(1000),
-      pointer: { timestamp: new Date(1000), archiveOrderKey: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
+      pointer: { timestamp: new Date(1000), tiebreak: { kind: 'room', from: `${ROOM}/user`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
@@ -1578,12 +1578,12 @@ describe('countRoomUnreadInArchive (room)', () => {
     ])
     const res = await messageCache.countRoomUnreadInArchive(ROOM, {
       floor: t,
-      pointer: { timestamp: t, archiveOrderKey: { kind: 'room', from: `${ROOM}/alice`, id: 'm1' } },
+      pointer: { timestamp: t, tiebreak: { kind: 'room', from: `${ROOM}/alice`, id: 'm1' } },
     })
     expect(res).toEqual({ unread: 1 })
   })
 
-  it('missing archiveOrderKey falls back to strict-after-timestamp (over-counts, safe)', async () => {
+  it('missing tiebreak falls back to strict-after-timestamp (over-counts, safe)', async () => {
     const t = new Date(5000)
     await messageCache.saveRoomMessages([
       createMockRoomMessage(ROOM, { id: 'm1', from: `${ROOM}/alice`, timestamp: t, isOutgoing: false }),

--- a/packages/fluux-sdk/src/utils/messageCache.ts
+++ b/packages/fluux-sdk/src/utils/messageCache.ts
@@ -12,10 +12,10 @@ import type { Message, RoomMessage } from '../core/types'
 import { getStorageScopeJid } from './storageScope'
 import { roomCanonicalKey, roomIdentityKeys, roomStanzaKey, roomOriginKey } from './roomMessageIdentity'
 import {
-  makeArchiveOrderKey,
+  makeCacheOrderKey,
   compareOrder,
   isRenderableStoredMessage,
-  type ArchiveOrderKey,
+  type CacheOrderKey,
   type OrderPosition,
 } from '../stores/shared/readState'
 
@@ -849,7 +849,7 @@ export interface UnreadCountArgs {
   /**
    * The read pointer's position, for a strict-after-POSITION test rather than a
    * timestamp-only test — two messages can share a millisecond. When
-   * `archiveOrderKey` is omitted (a pointer migrated from the pre-#1081 legacy
+   * `tiebreak` is omitted (a pointer migrated from the pre-#1081 legacy
    * fields), `compareOrder` treats the pointer's key as unresolved, and an
    * unresolved key sorts BEFORE any resolved one at an equal timestamp — so
    * every row at the pointer's exact millisecond, including the pointer's own
@@ -860,7 +860,7 @@ export interface UnreadCountArgs {
    * message permanently). Omitting `pointer` entirely counts everything from
    * `floor`.
    */
-  pointer?: { timestamp: Date; archiveOrderKey?: ArchiveOrderKey }
+  pointer?: { timestamp: Date; tiebreak?: CacheOrderKey }
   /** Cap on the reported `unread` count. Default {@link DEFAULT_UNREAD_CAP}. */
   unreadCap?: number
 }
@@ -873,7 +873,7 @@ export interface ArchiveCount {
 
 /** The pointer's position as an `OrderPosition`, or `undefined` when there is no pointer. */
 function toPointerPosition(pointer: UnreadCountArgs['pointer']): OrderPosition | undefined {
-  return pointer ? { timestamp: pointer.timestamp.getTime(), archiveOrderKey: pointer.archiveOrderKey } : undefined
+  return pointer ? { timestamp: pointer.timestamp.getTime(), tiebreak: pointer.tiebreak } : undefined
 }
 
 /**
@@ -927,7 +927,7 @@ export async function countUnreadInArchive(
         if (!message.isOutgoing && isRenderableStoredMessage(message)) {
           const position: OrderPosition = {
             timestamp: stored.timestamp,
-            archiveOrderKey: makeArchiveOrderKey(message, 'chat'),
+            tiebreak: makeCacheOrderKey(message, 'chat'),
           }
           if (isStrictlyAfterPointer(position, pointerPosition)) {
             unread++
@@ -1345,7 +1345,7 @@ export async function countRoomUnreadInArchive(roomJid: string, args: UnreadCoun
         if (!message.isOutgoing && isRenderableStoredMessage(message)) {
           const position: OrderPosition = {
             timestamp: stored.timestamp,
-            archiveOrderKey: makeArchiveOrderKey(message, 'room'),
+            tiebreak: makeCacheOrderKey(message, 'room'),
           }
           if (isStrictlyAfterPointer(position, pointerPosition)) {
             unread++
@@ -1392,7 +1392,7 @@ export async function resolveArchivePosition(
   if (!message) return null
   return {
     timestamp: message.timestamp.getTime(),
-    archiveOrderKey: makeArchiveOrderKey(message, isRoom ? 'room' : 'chat'),
+    tiebreak: makeCacheOrderKey(message, isRoom ? 'room' : 'chat'),
   }
 }
 

--- a/scripts/scroll-invariants.ts
+++ b/scripts/scroll-invariants.ts
@@ -2728,7 +2728,7 @@ test.describe('Jump-to-last-read pill', () => {
       const readPointer = {
         messageId: pointerId,
         timestamp: msgs[pIdx].timestamp,
-        archiveOrderKey: { kind: 'room', from: msgs[pIdx].from ?? '', id: pointerId },
+        tiebreak: { kind: 'room', from: msgs[pIdx].from ?? '', id: pointerId },
       }
       const roomMeta = new Map(s.roomMeta)
       const meta = roomMeta.get(jid)


### PR DESCRIPTION
Renames the pointer tie-break so its name says what it is. `ArchiveOrderKey` becomes `CacheOrderKey`, `makeArchiveOrderKey`/`isValidArchiveOrderKey` follow, and the in-memory `ReadPointer.archiveOrderKey` field becomes `tiebreak`.

The old name was a misnomer with a cost. The key is built from the **client** message id and exists to agree with the IndexedDB cursors (`conv_timestamp` for chat, `room_ts_from_id` for room) — it has never held an archive id, and it could not: XEP-0313 §6.2 makes archive ids opaque strings with no guarantee of being numeric, sequenced or globally unique, and unique only per archive, so they carry no ordering at all. A recent design investigation concluded the name itself produced its central, wrong question. Behaviour is unchanged; this is a rename, not a refactor.

### Breaking change to the exported `ReadPointer`

`ReadPointer` is exported from `packages/fluux-sdk/src/index.ts`, so renaming its field is a breaking change to the SDK's public type. This is deliberate and is taken now precisely because the SDK has not yet been published as an SDK: the cost of the break is zero today and only grows. No deprecated alias was added, on purpose — an alias would reintroduce two names for one field with the misnomer among them, which is exactly the shape this work exists to make unrepresentable.

### The on-disk name is deliberately unchanged

The persisted property stays `archiveOrderKey`. Renaming it would orphan every stored pointer, degrading each to the keyless at-or-after-timestamp fallback. The boundary is documented everywhere it appears and asserted against literal on-disk JSON, so nobody "finishes the rename" later.

Two write paths needed that boundary, not one. `serializeReadPointer` (room read state, state snapshot) was the obvious one. The chat store persists its conversation metadata **verbatim** through a plain `JSON.stringify` of the live objects, so the rename would have leaked to disk there; `toPersistedReadPointer` and the widened persisted metadata types hold the name on that path. That is the only non-mechanical part of this change and it exists solely to keep the format identical.

### A green suite hid real damage

Review caught one persisted `localStorage` fixture that the global rename wrongly gave the in-memory name. The whole suite stayed green anyway, because that test asserted only that a recount was **scheduled** — never that the restored pointer still carried its key. A fixture under the wrong name still hydrates a pointer, just a keyless one, so the position silently degrades. The fixture is fixed and the test now asserts the hydrated `tiebreak`, verified to fail when the fixture carries the wrong on-disk name and pass when it carries the right one. That turns a documented blind spot into a regression test for this exact class of mistake, which is worth more than the fixture fix itself. A sweep confirmed no other persisted fixture carries the in-memory name; the other persisted fixtures already assert their key.

### Scope of the terminology sweep

The sweep was deliberately scoped to references that name the **field**. References to archive **order** as an ordering concept — "sorts a same-millisecond live arrival into archive order" (`messageTimeline.test.ts`), "in archive order" (`mamCoverage.ts`) — were left untouched on purpose: there the phrase names an idea, not the tie-break, and it is a true statement, since the local cache order is deliberately built to agree with the archive order. Rewriting it would be prose churn that risks obscuring something correct. The distinction this whole line of work turns on is the name of a field versus the name of an idea.

One line was reclassified during review: `mdsSideEffects.ts:63`, "applies archive-order filtering afterwards", was first sorted as ordering prose but describes filtering **by the key**, which makes it the field misnomer. It was renamed with the rest of that category.
